### PR TITLE
Address minor tech debt in Search code

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -45,10 +45,13 @@
    (some? semantic.db.datasource/db-url)
    (semantic.settings/semantic-search-enabled)))
 
-(defn- with-zero-semantic-distance
-  "Record `:semantic-distance` 0 on `results` that lack it, for a consistent merged-result score breakdown."
+(defn- with-zero-semantic-distance-score
+  "Record a 0 `:semantic-distance` score on `results` that lack it, for a consistent merged-result score breakdown.
+  The 0 is a score, not a distance -- it's the least-relevant end of the scale, the opposite of a zero cosine
+  distance (which would be a perfect match)."
   [search-ctx results]
-  ;; Fallback (appdb/in-place) results never went through vector search, so they carry no semantic distance.
+  ;; Fallback (appdb/in-place) results never went through vector search, so they carry no semantic distance;
+  ;; score them as least-relevant rather than omitting the breakdown entry.
   (let [entry {:name         :semantic-distance
                :score        0
                :weight       (search.config/weight search-ctx :semantic-distance)
@@ -101,7 +104,7 @@
                                        []))
                   fallback-results (take total-limit fallback-results)
                   _                (analytics/observe! :metabase-search/semantic-fallback-results-usage (count fallback-results))
-                  combined-results (concat results (with-zero-semantic-distance search-ctx fallback-results))
+                  combined-results (concat results (with-zero-semantic-distance-score search-ctx fallback-results))
                   deduped-results  (m/distinct-by (juxt :model :id) combined-results)]
               (take total-limit deduped-results)))))
       (catch Exception e

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -46,12 +46,11 @@
    (semantic.settings/semantic-search-enabled)))
 
 (defn- with-zero-semantic-distance-score
-  "Record a 0 `:semantic-distance` score on `results` that lack it, for a consistent merged-result score breakdown.
-  The 0 is a score, not a distance -- it's the least-relevant end of the scale, the opposite of a zero cosine
-  distance (which would be a perfect match)."
+  "Record a 0 `:semantic-distance` score on `results` that lack it, for a consistent merged-result score breakdown."
   [search-ctx results]
-  ;; Fallback (appdb/in-place) results never went through vector search, so they carry no semantic distance;
-  ;; score them as least-relevant rather than omitting the breakdown entry.
+  ;; Fallback (appdb/in-place) results never went through vector search, so they carry no semantic distance.
+  ;; Score them as least-relevant: the 0 below is a score, not a distance -- the opposite of a zero cosine
+  ;; distance, which would be a perfect match.
   (let [entry {:name         :semantic-distance
                :score        0
                :weight       (search.config/weight search-ctx :semantic-distance)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -624,16 +624,20 @@
 (defn- hnsw-search-query
   "Build the semantic vector subquery using the HNSW index, applying `filters` after candidate selection."
   [index embedding-literal filters]
-  ;; The inner `vector_candidates` CTE is a pure vector search (ORDER BY distance LIMIT) so the planner
-  ;; uses the HNSW index. The filters only run in the outer query, so this is approximate: when the
-  ;; globally-closest rows are dominated by a cluster the filters reject, slightly-further survivors that
-  ;; would have passed the filters never enter the candidate set. `brute-force-search-query` is exact.
+  ;; The inner `vector_candidates` CTE is a pure vector search (ORDER BY distance LIMIT) so the planner uses
+  ;; the HNSW index. HNSW is an approximate-nearest-neighbour index, so its results are approximate regardless
+  ;; of filtering -- that's the trade-off we accept for its speed. Running the filters only in the outer query
+  ;; adds a separate problem: under-fetch. The fixed-size candidate set is picked before the filters apply, so
+  ;; when the globally-closest rows are dominated by a cluster the filters reject, we can return fewer rows than
+  ;; asked for -- or none at all. `brute-force-search-query` sidesteps both by skipping the index and scanning
+  ;; every filtered row.
   ;; TODO: only pull in necessary extra columns from configured filters
   (let [hnsw-query {:select (into common-search-columns
                                   [[[:raw (str "embedding <=> " embedding-literal)] :distance]])
                     :from   [(keyword (:table-name index))]
                     :order-by [[[:raw (str "embedding <=> " embedding-literal)] :asc]]
                     :limit  (semantic-settings/semantic-search-results-limit)}
+        ;; `semantic_rank` feeds the RRF scorer; `semantic_distance` feeds the semantic-distance scorer.
         base-query {:with [[:vector_candidates hnsw-query]]
                     :select (into common-search-columns
                                   [[[:raw "row_number() OVER (ORDER BY distance ASC)"] :semantic_rank]
@@ -676,13 +680,17 @@
 
 (defn- semantic-search-query
   "Build the semantic vector subquery, dispatching on the resolved [[vector-search-strategy]].
-  `:brute-force` is exact and filter-first; `:hnsw` (the default) is approximate and index-backed."
+  `:brute-force` is exact and filter-first; `:hnsw` (the default) is approximate and index-backed. An
+  unrecognized strategy warns and falls back to `:hnsw`."
   [index embedding search-context]
   (let [filters           (search-filters search-context)
-        embedding-literal (format-embedding embedding)]
-    (case (vector-search-strategy search-context)
+        embedding-literal (format-embedding embedding)
+        strategy          (vector-search-strategy search-context)]
+    (case strategy
       :brute-force (brute-force-search-query index embedding-literal filters)
-      (hnsw-search-query index embedding-literal filters))))
+      :hnsw        (hnsw-search-query index embedding-literal filters)
+      (do (log/warnf "Unknown vector-search strategy %s; falling back to :hnsw" (pr-str strategy))
+          (hnsw-search-query index embedding-literal filters)))))
 
 (defn- flatten-ctes
   "Flatten nested :with clauses into a single top-level :with.
@@ -694,10 +702,11 @@
   (if-not (:with query)
     {:ctes [] :query query}
     (let [ctes (reduce
-                ;; `opts` carries any trailing CTE options (e.g. `:materialized`) so they survive hoisting.
-                (fn [acc [cte-name cte-query & opts]]
+                ;; `assoc` swaps the (possibly flattened) inner query back into the binding while preserving the
+                ;; CTE name and any trailing opts (e.g. `:materialized`), so they survive hoisting.
+                (fn [acc [_cte-name cte-query & _opts :as cte-binding]]
                   (let [{:keys [ctes query]} (flatten-ctes cte-query)]
-                    (into acc (conj ctes (into [cte-name query] opts)))))
+                    (into acc (conj ctes (assoc cte-binding 1 query)))))
                 []
                 (:with query))]
       {:ctes ctes

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -680,8 +680,7 @@
 
 (defn- semantic-search-query
   "Build the semantic vector subquery, dispatching on the resolved [[vector-search-strategy]].
-  `:brute-force` is exact and filter-first; `:hnsw` (the default) is approximate and index-backed. An
-  unrecognized strategy warns and falls back to `:hnsw`."
+  `:brute-force` is exact and filter-first; `:hnsw` (the default) is approximate and index-backed."
   [index embedding search-context]
   (let [filters           (search-filters search-context)
         embedding-literal (format-embedding embedding)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
@@ -77,9 +77,8 @@
   "Map a cosine `distance` (pgvector `<=>`, range [0, 2]) to a [0, 1] score.
   Linear for now: distance 0 scores 1, the maximum distance of 2 scores 0."
   [distance]
-  ;; TODO (Chris 2026-06-02) -- consider rescaling against the retrieval cutoff (index/max-cosine-distance) so the
-  ;; [0, cutoff] band spans the full [0, 1], and/or a non-linear curve. For now keep the raw distance as transparent
-  ;; as possible.
+  ;; TODO (Chris 2026-06-22) -- a non-linear curve might rank better than this straight-line map. Keeping it
+  ;; linear for now so the score stays as transparent as possible.
   [:- [:inline 1] [:/ distance [:inline cosine-distance-ceiling]]])
 
 (defn base-scorers
@@ -90,8 +89,9 @@
     ;; NOTE: we calculate scores even if the weight is zero, so that it's easy to consider how we could affect any
     ;; given set of results. At some point, we should optimize away the irrelevant scores for any given context.
     {:rrf        rrf-rank-exp
-     ;; Keyword-only hits have no vector distance, so treat them as maximally distant (score 0).
-     :semantic-distance (semantic-distance-score-expr [:coalesce :semantic_distance [:inline cosine-distance-ceiling]])
+     ;; Keyword-only hits have no vector distance; score them 0 directly rather than feeding the ceiling
+     ;; distance through the linear map.
+     :semantic-distance [:coalesce (semantic-distance-score-expr :semantic_distance) [:inline 0]]
      :view-count (view-count-expr index-table search.config/view-count-scaling-percentile)
      :pinned     (search.scoring/truthy :pinned)
      :recency    (search.scoring/inverse-duration

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -131,15 +131,15 @@
   (with-index-contents
     [{:model "card" :id 1 :name "Sales,  Revenue"}
      {:model "card" :id 2 :name "Sales Revenue Report"}]
-    (case (mdb/db-type)
-      :postgres
-      (testing "Exact matching ignores commas and collapses whitespace runs"
-        (is (= [["card" 1 "Sales,  Revenue"]
-                ["card" 2 "Sales Revenue Report"]]
-               (search-results :exact "sales revenue"))))
-      :h2
-      ;; TODO text ranking (probably in-memory)
-      nil)))
+    (testing "Exact matching ignores commas and collapses whitespace runs"
+      (let [expected [["card" 1 "Sales,  Revenue"]
+                      ["card" 2 "Sales Revenue Report"]]]
+        (case (mdb/db-type)
+          (:postgres :h2) (is (= expected (search-results :exact "sales revenue")))
+          ;; appdb search is gated to postgres and h2; make a new driver fail loudly rather than via case's
+          ;; opaque "No matching clause" error.
+          (throw (ex-info "exact-normalization-test has no expectation for this appdb"
+                          {:db-type (mdb/db-type)})))))))
 
 (deftest ^:parallel prefix-test
   (with-index-contents
@@ -152,10 +152,12 @@
 
 (deftest ^:parallel prefix-normalization-test
   (with-index-contents
-    [{:model "card" :id 1 :name "Sales, Revenue Quarterly"}
+    ;; The whitespace run sits inside the matched prefix ("Sales,   Revenue"), so the LIKE only matches
+    ;; "sales revenue%" once commas are dropped and the run is collapsed -- a stray double space would miss.
+    [{:model "card" :id 1 :name "Sales,   Revenue Quarterly"}
      {:model "card" :id 2 :name "Revenue and Sales"}]
     (testing "Prefix matching ignores commas and collapses whitespace runs"
-      (is (= [["card" 1 "Sales, Revenue Quarterly"]
+      (is (= [["card" 1 "Sales,   Revenue Quarterly"]
               ["card" 2 "Revenue and Sales"]]
              (search-results :prefix "sales revenue"))))))
 

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -132,14 +132,9 @@
     [{:model "card" :id 1 :name "Sales,  Revenue"}
      {:model "card" :id 2 :name "Sales Revenue Report"}]
     (testing "Exact matching ignores commas and collapses whitespace runs"
-      (let [expected [["card" 1 "Sales,  Revenue"]
-                      ["card" 2 "Sales Revenue Report"]]]
-        (case (mdb/db-type)
-          (:postgres :h2) (is (= expected (search-results :exact "sales revenue")))
-          ;; appdb search is gated to postgres and h2; make a new driver fail loudly rather than via case's
-          ;; opaque "No matching clause" error.
-          (throw (ex-info "exact-normalization-test has no expectation for this appdb"
-                          {:db-type (mdb/db-type)})))))))
+      (is (= [["card" 1 "Sales,  Revenue"]
+              ["card" 2 "Sales Revenue Report"]]
+             (search-results :exact "sales revenue"))))))
 
 (deftest ^:parallel prefix-test
   (with-index-contents


### PR DESCRIPTION
Follow-up to my comments on #76190 (the search-scoring backport to 62), applied here on **master**. 

No user observable behavior should change ; mostly clarifications + test improvements. Each change  links back to its originating comment.

##### `metabase-enterprise.semantic-search.core`
- Rename `with-zero-semantic-distance` → `with-zero-semantic-distance-score` to clarify that its the _opposite_ of a zero cosine distance. [[line: 48]](https://github.com/metabase/metabase/pull/76190#discussion_r3451916901)

##### `metabase-enterprise.semantic-search.index`
- Reword the HNSW comment to be clearer and more precise[[line: 631]](https://github.com/metabase/metabase/pull/76190#discussion_r3451933203)
- Note that `semantic_rank` feeds the RRF score. [[line: 639]](https://github.com/metabase/metabase/pull/76190#discussion_r3451964110)
- `semantic-search-query`: match `:hnsw` explicitly and log when hitting fallback branch. [[line: 685]](https://github.com/metabase/metabase/pull/76190#discussion_r3451971519)
- `flatten-ctes`: avoid rebuilding the vector. [[line: 700]](https://github.com/metabase/metabase/pull/76190#discussion_r3451946862)

##### `metabase-enterprise.semantic-search.scoring`
- Drop a stale TODO. [[line: 82]](https://github.com/metabase/metabase/pull/76190#discussion_r3451975592)
- Directly fall back to a zero score rather than using a fake distance value. [[line: 94]](https://github.com/metabase/metabase/pull/76190#discussion_r3451986470)
- _Not addressed:_ whether DB-side normalization for `:exact` is worth it given prefix normalizes in memory. [[line: 106]](https://github.com/metabase/metabase/pull/76190#discussion_r3451992563)

##### `metabase.search.appdb.scoring-test`
- `exact-normalization-test`: exercise the **h2** case too. [[line: 142]](https://github.com/metabase/metabase/pull/76190#discussion_r3452126579)
- `prefix-normalization-test`: actually cover whitespace collapse. [[line: 157]](https://github.com/metabase/metabase/pull/76190#discussion_r3452129057)