### PR TITLE
Fix non-unique key props in SectionLayoutPreview

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/SectionLayoutPreview.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/SectionLayoutPreview.tsx
@@ -35,9 +35,9 @@ export function SectionLayoutPreview({ layout }: SectionLayoutPreviewProps) {
   return (
     <Flex align="center" justify="center">
       <Box pos="relative" w={WIDTH} mih={height}>
-        {layoutItems.map((item) => (
+        {layoutItems.map((item, index) => (
           <PreviewCard
-            key={item.id}
+            key={index}
             layout={item}
             cellWidth={CELL_WIDTH}
             cellHeight={CELL_HEIGHT}


### PR DESCRIPTION
Closes #75112

### Description

Previously, `item.id` was used as the key, but it's optional in `SectionDashboardCardAttrs` and was always undefined, leading to the warning.

The fix is to simply use the item index as the key. The number of items is constant for each preview, and `PreviewCard` holds no state, so using the index is sufficient.

### How to verify

1. Open a dashboard
2. Edit it
3. Click "Add section" button
4. Ensure you don't see any key prop violation errors in the console