### PR TITLE
remove color prop from Based On Icons, center with flex

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionSources.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionSources.tsx
@@ -46,10 +46,8 @@ export const QuestionSources = () => {
         {sourcesWithIcons.map(({ href, name, iconProps }, index) => (
           <Fragment key={`${href}-${name}`}>
             <Link to={href} variant="brand">
-              <Flex gap="sm" lh="1.25rem" maw="20rem">
-                {iconProps ? (
-                  <Icon mt={2} c="text-primary" {...iconProps} />
-                ) : null}
+              <Flex gap="sm" lh="1.25rem" maw="20rem" align="center">
+                {iconProps ? <Icon {...iconProps} /> : null}
                 {name}
               </Flex>
             </Link>


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75469
### Description

Small PR to remove color prop from Based On Icons in the Question Sidebar panel. This way, the Icons will pull the color from the link that is rendering them.

### How to verify

1. Go to an existing question
2. Open the Info Sidebar
3. Be delighted by the color of the icon in the Based On section

### Demo

<img width="408" height="328" alt="image" src="https://github.com/user-attachments/assets/c030e4c8-016b-4831-be1e-c82fc393bea3" />


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
