### PR TITLE
Enforce remote-sync dependency guard on card bulk-move (GHY-3791)

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/remote_sync/card_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/card_api_test.clj
@@ -1,0 +1,61 @@
+(ns ^:synchronous metabase-enterprise.remote-sync.card-api-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.remote-sync.card-api-test]}}}}}}
+  (:require
+   [clojure.test :refer :all]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(use-fixtures :each (fn [f]
+                      (mt/with-temporary-setting-values [remote-sync-type :read-write]
+                        (f))))
+
+(deftest bulk-move-into-remote-synced-with-non-remote-synced-deps-test
+  (testing "POST /api/card/collections rejects bulk-moving a card with non-remote-synced dependencies into a remote-synced collection (GHY-3791)"
+    (mt/with-temp [:model/Collection {regular-id :id} {:name "Regular" :location "/" :type nil}
+                   :model/Collection {synced-id :id} {:name "Remote-Synced" :location "/" :is_remote_synced true}
+                   :model/Card {source-card-id :id} {:name "Non-remote-synced source card"
+                                                     :collection_id regular-id
+                                                     :dataset_query (mt/native-query {:query "SELECT 1"})}
+                   ;; Card lives at the root (collection_id nil): its pre-update collection_id is the
+                   ;; short-circuit case in non-remote-synced-dependencies, exposing the stale-object bug.
+                   :model/Card {root-card-id :id} {:name "Card depending on non-synced source"
+                                                   :collection_id nil
+                                                   :dataset_query (mt/mbql-query nil {:source-table (str "card__" source-card-id)})}]
+      (let [response (mt/user-http-request :crowberto :post 400 "card/collections"
+                                           {:collection_id synced-id
+                                            :card_ids [root-card-id]})]
+        (is (= "Uses content that is not remote synced." (:message response))))
+      (testing "card is not moved - transaction rolled back"
+        (is (nil? (t2/select-one-fn :collection_id :model/Card root-card-id)))))))
+
+(deftest bulk-move-depended-on-card-out-of-remote-synced-test
+  (testing "POST /api/card/collections rejects bulk-moving a remote-synced card that is depended on by other remote-synced content out of the synced set (GHY-3791)"
+    (mt/with-temp [:model/Collection {synced-id :id} {:name "Remote-Synced" :location "/" :is_remote_synced true}
+                   :model/Collection {regular-id :id} {:name "Regular" :location "/" :type nil}
+                   :model/Card {source-card-id :id} {:name "Remote-synced source card"
+                                                     :collection_id synced-id
+                                                     :dataset_query (mt/native-query {:query "SELECT 1"})}
+                   :model/Card {_dependent-id :id} {:name "Remote-synced dependent card"
+                                                    :collection_id synced-id
+                                                    :dataset_query (mt/mbql-query nil {:source-table (str "card__" source-card-id)})}]
+      (let [response (mt/user-http-request :crowberto :post 400 "card/collections"
+                                           {:collection_id regular-id
+                                            :card_ids [source-card-id]})]
+        (is (= "Used by remote synced content." (:message response))))
+      (testing "card is not moved - transaction rolled back"
+        (is (= synced-id (t2/select-one-fn :collection_id :model/Card source-card-id)))))))
+
+(deftest bulk-move-into-remote-synced-with-remote-synced-deps-succeeds-test
+  (testing "POST /api/card/collections allows bulk-moving a card whose dependencies are all remote-synced into a remote-synced collection (GHY-3791)"
+    (mt/with-temp [:model/Collection {synced-id :id} {:name "Remote-Synced" :location "/" :is_remote_synced true}
+                   :model/Card {source-card-id :id} {:name "Remote-synced source card"
+                                                     :collection_id synced-id
+                                                     :dataset_query (mt/native-query {:query "SELECT 1"})}
+                   :model/Card {mover-id :id} {:name "Card depending on synced source"
+                                               :collection_id nil
+                                               :dataset_query (mt/mbql-query nil {:source-table (str "card__" source-card-id)})}]
+      (is (= {:status "ok"}
+             (mt/user-http-request :crowberto :post 200 "card/collections"
+                                   {:collection_id synced-id
+                                    :card_ids [mover-id]})))
+      (is (= synced-id (t2/select-one-fn :collection_id :model/Card mover-id))))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/dashboard_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/dashboard_api_test.clj
@@ -178,3 +178,24 @@
             "Copied dashboard should be in target collection")
         (is (not= dash-id (:id response))
             "Copied dashboard should have different ID")))))
+
+(deftest api-update-dashboard-add-non-remote-synced-dashcard-rejected-test
+  (testing "PUT /api/dashboard/:id rejects adding a dashcard that points to a non-remote-synced card (GHY-3791)"
+    (mt/with-temp [:model/Collection {non-remote-synced-id :id} {:name "Non-Remote-Synced" :location "/" :type nil}
+                   :model/Collection {remote-synced-id :id} {:name "Remote-Synced" :location "/" :is_remote_synced true}
+                   :model/Dashboard {dash-id :id} {:name "Remote-Synced Dashboard"
+                                                   :collection_id remote-synced-id}
+                   :model/Card {non-remote-synced-card-id :id} {:name "Non-Remote-Synced Card"
+                                                                :collection_id non-remote-synced-id
+                                                                :dataset_query (mt/native-query {:query "SELECT 1"})}]
+      (let [response (mt/user-http-request :crowberto :put 400 (str "dashboard/" dash-id)
+                                           {:dashcards [{:id      -1
+                                                         :card_id non-remote-synced-card-id
+                                                         :row     0
+                                                         :col     0
+                                                         :size_x  4
+                                                         :size_y  4}]
+                                            :tabs      []})]
+        (is (= "Uses content that is not remote synced." (:message response))))
+      (testing "dashcard was not added - transaction rolled back"
+        (is (zero? (t2/count :model/DashboardCard :dashboard_id dash-id)))))))

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -860,9 +860,6 @@
           (t2/update! (t2/table-name :model/Card)
                       {:id [:in (set cards-without-position)]}
                       {:collection_id new-collection-id-or-nil}))
-        ;; `cards` still hold their pre-update collection_id, so this re-selects each card's post-update
-        ;; state and checks both directions: rejects landing in a synced collection with non-synced
-        ;; dependencies, and rejects moving a depended-on card out of the synced set.
         (doseq [card cards]
           (collection/check-for-remote-sync-update card)))))
 

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -860,8 +860,11 @@
           (t2/update! (t2/table-name :model/Card)
                       {:id [:in (set cards-without-position)]}
                       {:collection_id new-collection-id-or-nil}))
+        ;; `cards` still hold their pre-update collection_id, so this re-selects each card's post-update
+        ;; state and checks both directions: rejects landing in a synced collection with non-synced
+        ;; dependencies, and rejects moving a depended-on card out of the synced set.
         (doseq [card cards]
-          (collection/check-non-remote-synced-dependencies card)))))
+          (collection/check-for-remote-sync-update card)))))
 
   (when new-collection-id-or-nil
     (events/publish-event! :event/collection-touch {:collection-id new-collection-id-or-nil :user-id api/*current-user-id*})))


### PR DESCRIPTION
Fixes GHY-3791

## Problem

Remote sync rejects edits that make a synced entity depend on content outside the synced set — except `POST /api/card/collections` (bulk move), which was the only mutation path that hand-rolled the guard instead of using `check-for-remote-sync-update`. It had two bugs:

1. It ran `check-non-remote-synced-dependencies` against the **stale pre-update card objects** (old `collection_id`). A root-level card (`collection_id nil`) short-circuits the dependency check, so moving it into a synced collection with a non-synced dependency was **not** rejected.
2. It **never** called `check-remote-synced-dependents`, so bulk-moving a depended-on synced card *out* of the sync set was allowed — inconsistent with the single-card `PUT /api/card/:id` path, which rejects it.

## Fix

`move-cards-to-collection!` now calls `check-for-remote-sync-update` (mirroring the single-card update path). Since the cards are selected before the `t2/update!`, the guard re-selects each card's post-update state and checks both directions inside the existing transaction, so a rejection rolls the move back.

## Tests

- New `card_api_test.clj`: failing-first repros for move-in (incl. root-level card) and move-out of a depended-on card, plus a happy-path test confirming valid moves aren't over-rejected.
- New test in `dashboard_api_test.clj`: rejecting a non-synced dashcard added via dashboard `PUT` — closes a pre-existing coverage gap (the path already worked, now it's locked down).

## Notes

- The ticket's original premise ("card edits are not guarded") was stale — single-card edits/moves have been guarded since the original Remote Sync PR. The real gap was the bulk-move endpoint, hence the small diff.
- **Transforms deferred**: Transform/PythonLibrary have no `serdes/descendants` method, so the dependency guard is a no-op for them. Enforcing transform→table references needs a descendants method first — recommend a separate ticket.

## Verification

- Enterprise card-api + dashboard-api suites: 11 tests, 30 assertions, 0 failures.
- OSS bulk-move regression tests pass (no over-rejection of normal moves).
- Kondo on changed files: 0 errors, 0 warnings.