### PR TITLE
Handle corrupt perms where DB- and table-level perms coexist

### DIFF
--- a/src/metabase/permissions_rest/data_permissions/graph.clj
+++ b/src/metabase/permissions_rest/data_permissions/graph.clj
@@ -226,16 +226,26 @@
                                        [:not-in :db_id {:select [:id]
                                                         :from   [:metabase_database]
                                                         :where  [:not= :router_database_id nil]}]]})
+        ;; A given (group, db, perm-type) should have *either* a single DB-level row *or* table-level rows, never
+        ;; both. Instances upgraded from older versions can carry inconsistent state where both exist
+        ;; (see UXW-2868 / #68792), which previously crashed with a ClassCastException or silently dropped data
+        ;; depending on row order. To be robust, build the table-level (granular) entries first, and apply a DB-level
+        ;; row only when no granular map already exists. (i.e. specific and granular wins over broad)
+        {db-level-perms true, table-level-perms false} (group-by (comp nil? :table-id) data-perms)
+        granular-perms   (reduce
+                          (fn [graph {:keys [group-id value db-id schema table-id]
+                                      perm-type :type}]
+                            (assoc-in graph [group-id db-id perm-type (or schema "") table-id] value))
+                          {}
+                          table-level-perms)
         raw-graph  (reduce
-                    (fn [graph {:keys [group-id value db-id schema table-id]
+                    (fn [graph {:keys [group-id value db-id]
                                 perm-type :type}]
-                      (let [schema (or schema "")
-                            path   (if table-id
-                                     [group-id db-id perm-type schema table-id]
-                                     [group-id db-id perm-type])]
-                        (assoc-in graph path value)))
-                    {}
-                    data-perms)]
+                      (cond-> graph
+                        (not (map? (get-in graph [group-id db-id perm-type])))
+                        (assoc-in [group-id db-id perm-type] value)))
+                    granular-perms
+                    db-level-perms)]
     (update-vals raw-graph (fn [db-id->perms]
                              (update-vals db-id->perms collapse-uniform-view-data)))))
 

--- a/test/metabase/permissions_rest/data_permissions/graph_test.clj
+++ b/test/metabase/permissions_rest/data_permissions/graph_test.clj
@@ -554,6 +554,34 @@
                 (is (= nil
                        (perms)))))))))))
 
+(deftest data-permissions-graph-tolerates-mixed-db-and-table-rows-test
+  (testing "gracefully handle corrupt state from old versions (UXW-2868)"
+    (testing "a (group, db, perm-type) has both a DB-level row and table-level rows"
+      (mt/with-premium-features #{:advanced-permissions :sandboxes}
+        (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
+                       :model/Database         {db-id :id}    {}
+                       :model/Table            {t1 :id}       {:db_id db-id :schema "public"}
+                       :model/Table            {t2 :id}       {:db_id db-id :schema "public"}]
+          ;; Start from a clean slate for this group, then craft the inconsistent state: a DB-level
+          ;; :perms/view-data row coexisting with table-level :perms/view-data rows.
+          (t2/delete! :model/DataPermissions :group_id group-id :db_id db-id)
+          (t2/insert! :model/DataPermissions
+                      (for [[schema table value] [[nil nil :unrestricted]
+                                                  ["public" t1 :unrestricted]
+                                                  ["public" t2 :blocked]]]
+                        {:group_id    group-id
+                         :db_id       db-id
+                         :perm_type   :perms/view-data
+                         :perm_value  value
+                         :schema_name schema
+                         :table_id    table}))
+          ;; Table-level (granular) rows win over the stray DB-level row, and reading never throws.
+          (is (= {group-id
+                  {db-id
+                   {:perms/view-data {"public" {t1 :unrestricted
+                                                t2 :blocked}}}}}
+                 (data-perms.graph/data-permissions-graph :group-id group-id :db-id db-id))))))))
+
 (deftest no-op-partial-graph-updates
   (testing "Partial permission graphs with no changes to the existing graph do not error when run repeatedly (#25221)"
     (mt/with-additional-premium-features #{:advanced-permissions :sandboxes}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68792
Fixes UXW-2868.

### Description

Added a test that exactly reproduced the `ClassCastExeception` from the
bug report, and then fixed it. Old (0.58) bugs could result in
permissions rows for the same `(group, db, perm)` at both DB level and
table level, which breaks the preconditions.

By deliberately reading the table-level perms first, and only using the
DB-level if there are none, we get robust output.

### How to verify

Follow the repro steps on the bug, or use the test setup at the REPL.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
