### PR TITLE
[Metabot] Do not render images in markdown

### DIFF
--- a/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.tsx
+++ b/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.tsx
@@ -27,6 +27,9 @@ type AIMarkdownProps = MarkdownProps & {
   singleNewlinesAreParagraphs?: boolean;
 };
 
+// SEC-505: block all images; to support them we'll need detection for valid/allowed image sources
+const DISALLOWED_ELEMENTS = ["img"];
+
 const splitMessageLinesAsParagraphs = (message: string) =>
   message.replaceAll(/\r?\n|\r/g, "\n\n");
 
@@ -151,6 +154,8 @@ export const AIMarkdown = memo(
       <Markdown
         className={cx(S.aiMarkdown, className)}
         components={components}
+        disallowedElements={DISALLOWED_ELEMENTS}
+        unwrapDisallowed
         {...props}
       >
         {normalizedChildren}

--- a/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.unit.spec.tsx
@@ -61,6 +61,16 @@ describe("AIMarkdown", () => {
     expect(screen.getByRole("cell", { name: "$42" })).toBeInTheDocument();
   });
 
+  it("should not render images", async () => {
+    setup({
+      children: `start ![remote](https://example.com/cat.png) ![data](data:image/png;base64,iVBORw0KGgo=) end`,
+    });
+
+    expect(await screen.findByText(/start/)).toBeInTheDocument();
+    expect(screen.getByText(/end/)).toBeInTheDocument();
+    expect(document.querySelector("img")).not.toBeInTheDocument();
+  });
+
   it("should copy fenced code blocks", async () => {
     setup({
       children: `

--- a/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/AIMarkdown/AIMarkdown.unit.spec.tsx
@@ -68,7 +68,7 @@ describe("AIMarkdown", () => {
 
     expect(await screen.findByText(/start/)).toBeInTheDocument();
     expect(screen.getByText(/end/)).toBeInTheDocument();
-    expect(document.querySelector("img")).not.toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
   });
 
   it("should copy fenced code blocks", async () => {


### PR DESCRIPTION
### Description

Prevents rendering image in metabot chat

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
