### PR TITLE
Allow field identifiers to grow in Data Studio Table page

### DIFF
--- a/frontend/src/metabase/metadata/components/FieldSection/DataSection/DataSection.tsx
+++ b/frontend/src/metabase/metadata/components/FieldSection/DataSection/DataSection.tsx
@@ -131,30 +131,31 @@ const DataSectionBase = ({
                   <SubInputIllustration />
                 )}
 
-                <Switch
-                  checked={isCasting}
-                  classNames={{
-                    body: S.switchBody,
-                  }}
-                  flex="1"
-                  label={t`Cast to a specific data type`}
-                  mt="md"
-                  size="xs"
-                  onChange={handleCastingChange}
-                />
+                <Stack>
+                  <Switch
+                    checked={isCasting}
+                    classNames={{
+                      body: S.switchBody,
+                    }}
+                    flex="1"
+                    label={t`Cast to a specific data type`}
+                    mt="md"
+                    size="xs"
+                    onChange={handleCastingChange}
+                  />
+                  {isCasting && (
+                    <CoercionStrategyPicker
+                      autoFocus={autoFocusCoercionPicker}
+                      baseType={field.base_type}
+                      dropdownOpened={isCoercionPickerOpen}
+                      value={field.coercion_strategy ?? undefined}
+                      onChange={handleCoercionStrategyChange}
+                      onDropdownClose={() => setIsCoercionPickerOpen(false)}
+                      onDropdownOpen={() => setIsCoercionPickerOpen(true)}
+                    />
+                  )}
+                </Stack>
               </Flex>
-
-              {isCasting && (
-                <CoercionStrategyPicker
-                  autoFocus={autoFocusCoercionPicker}
-                  baseType={field.base_type}
-                  dropdownOpened={isCoercionPickerOpen}
-                  value={field.coercion_strategy ?? undefined}
-                  onChange={handleCoercionStrategyChange}
-                  onDropdownClose={() => setIsCoercionPickerOpen(false)}
-                  onDropdownOpen={() => setIsCoercionPickerOpen(true)}
-                />
-              )}
             </>
           )}
         </Stack>

--- a/frontend/src/metabase/metadata/components/FieldSection/DataSection/DataSection.tsx
+++ b/frontend/src/metabase/metadata/components/FieldSection/DataSection/DataSection.tsx
@@ -9,7 +9,7 @@ import {
   getFieldRawName,
   getRawTableFieldId,
 } from "metabase/metadata/utils/field";
-import { Box, Flex, Group, Stack, Switch, rem } from "metabase/ui";
+import { Box, Flex, Stack, Switch, rem } from "metabase/ui";
 import type { Field } from "metabase-types/api";
 
 import { CoercionStrategyPicker } from "../../CoercionStrategyPicker";
@@ -111,7 +111,7 @@ const DataSectionBase = ({
 
   return (
     <TitledSection>
-      <Group align="start">
+      <Stack align="start">
         <Box flex={1}>
           <LabeledValue label={t`Field name`}>
             {getFieldRawName(field)}
@@ -158,7 +158,7 @@ const DataSectionBase = ({
             </>
           )}
         </Stack>
-      </Group>
+      </Stack>
     </TitledSection>
   );
 };

--- a/frontend/src/metabase/metadata/components/FieldSection/DataSection/illustrations/sub-input-follow.svg
+++ b/frontend/src/metabase/metadata/components/FieldSection/DataSection/illustrations/sub-input-follow.svg
@@ -1,4 +1,5 @@
-<svg width="9" height="48" viewBox="0 0 9 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M1 0V48" stroke="#DCDFE0" />
+<svg width="9" height="69" viewBox="0 0 9 69" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M1 0V68" stroke="#DCDFE0" />
   <path d="M1 24H9" stroke="#DCDFE0" />
+  <path d="M1 68H9" stroke="#DCDFE0" />
 </svg>

--- a/frontend/src/metabase/metadata/components/LabeledValue/LabeledValue.module.css
+++ b/frontend/src/metabase/metadata/components/LabeledValue/LabeledValue.module.css
@@ -1,0 +1,12 @@
+.badge {
+  height: auto;
+  min-height: 2rem;
+  line-height: 14px;
+}
+
+/* override Badge's single-line ellipsis truncation */
+.badgeLabel {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  text-align: start;
+}

--- a/frontend/src/metabase/metadata/components/LabeledValue/LabeledValue.module.css
+++ b/frontend/src/metabase/metadata/components/LabeledValue/LabeledValue.module.css
@@ -1,7 +1,6 @@
 .badge {
   height: auto;
   min-height: 2rem;
-  line-height: 14px;
 }
 
 /* override Badge's single-line ellipsis truncation */

--- a/frontend/src/metabase/metadata/components/LabeledValue/LabeledValue.tsx
+++ b/frontend/src/metabase/metadata/components/LabeledValue/LabeledValue.tsx
@@ -2,6 +2,8 @@ import { type ReactNode, useId } from "react";
 
 import { Badge, Stack, Text } from "metabase/ui";
 
+import S from "./LabeledValue.module.css";
+
 interface Props {
   children?: ReactNode;
   label: string;
@@ -20,8 +22,8 @@ export const LabeledValue = ({ children, label }: Props) => {
         aria-labelledby={id}
         bg="accent-gray-light"
         c="text-primary"
+        classNames={{ root: S.badge, label: S.badgeLabel }}
         fw="normal"
-        h={32}
         p="sm"
         radius="md"
         size="lg"

--- a/frontend/src/metabase/metadata/components/LabeledValue/LabeledValue.tsx
+++ b/frontend/src/metabase/metadata/components/LabeledValue/LabeledValue.tsx
@@ -29,6 +29,7 @@ export const LabeledValue = ({ children, label }: Props) => {
         size="lg"
         tt="none"
         variant="default"
+        lh="sm"
       >
         {children}
       </Badge>


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #75000
### Description

Remove fixed height and text truncation on Field Identifiers in Table Metadata pages (Both Data Studio and Admin).

There is another angle we could use here, which is to keep the truncation and add a tooltip instead.

### How to verify

1. Go to data studio
2. Select a table, and find a field in that table with a long name
3. If needed, that field name should now wrap as needed to render

### Demo

<img width="392" height="417" alt="image" src="https://github.com/user-attachments/assets/5e05bc49-d294-42e9-8f66-026a52eac589" />


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
