### PR TITLE
Emit error logging during tests.

### DIFF
--- a/test_config/log4j2-test.xml
+++ b/test_config/log4j2-test.xml
@@ -4,13 +4,7 @@
     <Console name="Console" target="SYSTEM_OUT" follow="true">
       <PatternLayout pattern="[%t] %-5level %logger{36} - %msg %notEmpty{%X}%n"/>
       <Filters>
-        <ThresholdFilter level="FATAL" onMatch="ACCEPT" onMismatch="DENY"/>
-      </Filters>
-    </Console>
-    <Console name="ConsoleInfoLevel" target="SYSTEM_OUT" follow="true">
-      <PatternLayout pattern="[%t] %-5level %logger{36} - %msg %notEmpty{%X}%n"/>
-      <Filters>
-        <ThresholdFilter level="FATAL" onMatch="ACCEPT" onMismatch="DENY"/>
+        <ThresholdFilter level="ERROR" onMatch="ACCEPT" onMismatch="DENY"/>
       </Filters>
     </Console>
     <File name="File" fileName="logs/test-log.json" append="false">
@@ -26,7 +20,6 @@
     <Logger name="metabase-enterprise" level="INFO"/>
 
     <Logger name="metabase.test.gentest" level="INFO" additivity="false">
-      <AppenderRef ref="ConsoleInfoLevel"/>
       <AppenderRef ref="Console"/>
       <AppenderRef ref="File"/>
     </Logger>


### PR DESCRIPTION
The test log configuration currently filters out anything below FATAL level logging, which is hardly ever used. Errors that happen during tests have their output excluded from stdout, making it difficult to debug when things go wrong.

In addition, there was a redundant appender called ConsoleInfoLevel (which did not actually log at info level at all) but just repeated the exact same configuration as the Console appender. I've removed this since it seems to serve no purpose.

There are a LOT of tests which deliberately cause errors but do not suppress logs. These will need to be fixed before this can be merged. Edit: it is probably not realistic to suppress all the expected error logging that would be needed to do this.