### PR TITLE
Properly include data app changes in `pull changes` modal

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_apps/sync.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/sync.clj
@@ -79,11 +79,27 @@
     (t2/update! :model/DataApp :name slug row)
     (t2/insert! :model/DataApp (assoc row :name slug))))
 
+(defn- app-content-changed?
+  "Whether the just-synced content differs from the `existing` row (nil = a new
+   app). Compares only content-bearing fields — a `last_synced_sha` /
+   `last_synced_at` bump on an otherwise-identical app is NOT a change, so callers
+   can count real changes (e.g. for the remote-sync pull summary)."
+  [existing {:keys [display_name bundle_path bundle_hash allowed_hosts]}]
+  (or (nil? existing)
+      (some? (:sync_error existing))
+      (not= (:display_name existing) display_name)
+      (not= (:bundle_path existing) bundle_path)
+      (not= (:bundle_hash existing) bundle_hash)
+      (not= (vec (or (:allowed_hosts existing) []))
+            (vec (or allowed_hosts [])))))
+
 (defn- sync-app!
   "Materialize one app. On bundle failure, the row's metadata is still upserted
    with `sync_error` set so the app appears in the list with its failure; the
-   previously cached bundle (if any) is kept."
-  [{:keys [slug display_name bundle sha read-file allowed_hosts]}]
+   previously cached bundle (if any) is kept. `existing` is the app's pre-sync row
+   (or nil); returns true when this sync actually changed the app's content (a new
+   app, differing bundle/metadata, or a new failure) so callers can count changes."
+  [existing {:keys [slug display_name bundle sha read-file allowed_hosts]}]
   (try
     (let [content (read-file bundle)
           _       (when-not content
@@ -94,20 +110,24 @@
         (throw (ex-info (tru "Bundle for \"{0}\" must be less than {1} MiB."
                              slug (quot max-bundle-bytes (* 1024 1024)))
                         {:status-code 413})))
-      (upsert-by-name! slug {:display_name    display_name
-                             :allowed_hosts   allowed_hosts
-                             :bundle_path     bundle
-                             :bundle          bytes
-                             :bundle_hash     (bytes-hash bytes)
-                             :last_synced_sha sha
-                             :last_synced_at  :%now
-                             :sync_error      nil}))
+      (let [fields {:display_name  display_name
+                    :allowed_hosts allowed_hosts
+                    :bundle_path   bundle
+                    :bundle_hash   (bytes-hash bytes)}]
+        (upsert-by-name! slug (assoc fields
+                                     :bundle          bytes
+                                     :last_synced_sha sha
+                                     :last_synced_at  :%now
+                                     :sync_error      nil))
+        (app-content-changed? existing fields)))
     (catch Throwable e
       (upsert-by-name! slug {:display_name  display_name
                              :allowed_hosts allowed_hosts
                              :bundle_path   bundle
                              :sync_error    (ex-message e)})
-      (log/warnf e "[data-app] failed to sync app %s" slug))))
+      (log/warnf e "[data-app] failed to sync app %s" slug)
+      ;; a failing app counts as a change unless it was already failing identically
+      (or (nil? existing) (not= (:sync_error existing) (ex-message e))))))
 
 (defn import-from-snapshot!
   "Materialize data apps from a synced repo `snapshot`:
@@ -118,38 +138,47 @@
 
    Discovers every `data_apps/<dir>/data_app.yml`, upserts a row per app, and
    prunes rows whose directory is gone — all in one transaction. Returns
-   `{:synced <n>, :sha <sha>, :config-errors [<message> ...]}`. A malformed
+   `{:synced <n>, :changed <n>, :sha <sha>, :config-errors [<message> ...]}`,
+   where `:changed` is how many apps this sync actually created/updated/removed
+   (a `last_synced_sha` bump on an unchanged app does not count). A malformed
    `data_app.yml` is isolated (collected into `:config-errors`, that app skipped)
    rather than aborting the others; per-app bundle failures are recorded on the
    row. Throws only on duplicate slugs, which make app identity ambiguous."
   [{:keys [read-file list-files sha]}]
   ;; realize discovery once (it calls read-file/parse per config); `results` is
   ;; then walked several times below
-  (let [results (vec (discover-app-configs list-files read-file))
-        good    (filter :slug results)
-        errors  (vec (keep :config-error results))
-        slugs   (map :slug good)]
+  (let [results  (vec (discover-app-configs list-files read-file))
+        good     (filter :slug results)
+        errors   (vec (keep :config-error results))
+        slugs    (map :slug good)
+        ;; pre-sync rows, so we can tell a real change from a sha/timestamp bump
+        existing (into {} (map (juxt :name identity))
+                       (t2/select [:model/DataApp :name :display_name :allowed_hosts
+                                   :bundle_path :bundle_hash :sync_error]))]
     (when (not= (count slugs) (count (distinct slugs)))
       (throw (ex-info (tru "Two data apps in the repository share a slug.")
                       {:status-code 400})))
-    (t2/with-transaction [_conn]
-      (doseq [{:keys [slug display_name bundle allowed_hosts]} good]
-        (sync-app! {:slug slug, :display_name display_name, :bundle bundle
-                    :allowed_hosts allowed_hosts
-                    :sha sha, :read-file read-file}))
-      ;; Prune apps whose directory is gone — but only when every config parsed.
-      ;; With an unparsed config we can't tell a removed app from one we failed to
-      ;; read this sync, so we leave existing rows alone rather than risk deleting
-      ;; a still-present app.
-      (when (empty? errors)
-        (let [orphans (set/difference (set (t2/select-fn-set :name :model/DataApp))
-                                      (set slugs))]
-          (when (seq orphans)
-            (t2/delete! :model/DataApp :name [:in orphans])
-            (log/infof "[data-app] pruned %d app(s) removed from the repo: %s"
-                       (count orphans) (str/join ", " orphans))))))
-    (log/infof "[data-app] synced sha=%s apps=%d errors=%d" sha (count good) (count errors))
-    {:synced (count good), :sha sha, :config-errors errors}))
+    (let [changed
+          (t2/with-transaction [_conn]
+            (let [upserted (reduce (fn [n cfg]
+                                     (cond-> n
+                                       (sync-app! (get existing (:slug cfg))
+                                                  (assoc cfg :sha sha :read-file read-file))
+                                       inc))
+                                   0 good)
+                  ;; Prune apps whose directory is gone — but only when every config
+                  ;; parsed. With an unparsed config we can't tell a removed app from
+                  ;; one we failed to read this sync, so we leave existing rows alone.
+                  orphans  (when (empty? errors)
+                             (set/difference (set (keys existing)) (set slugs)))]
+              (when (seq orphans)
+                (t2/delete! :model/DataApp :name [:in orphans])
+                (log/infof "[data-app] pruned %d app(s) removed from the repo: %s"
+                           (count orphans) (str/join ", " orphans)))
+              (+ upserted (count orphans))))]
+      (log/infof "[data-app] synced sha=%s apps=%d changed=%d errors=%d"
+                 sha (count good) changed (count errors))
+      {:synced (count good), :changed changed, :sha sha, :config-errors errors})))
 
 (defn sync-from-snapshot!
   "Entry point for the remote-sync import pipeline. Materializes data apps from

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -333,6 +333,19 @@
   (transduce (map count) + 0 (concat (vals (:by-entity-id imported-data))
                                      (vals (:by-path imported-data)))))
 
+(defn- fold-data-app-changes
+  "Fold the count of data apps changed by a pull into its `:outcome`. Data apps
+  live under `data_apps/` — outside serdes — and are materialized separately (see
+  [[materialize-data-apps!]]), so they're invisible to [[pulled-change-count]].
+  Without this, a pull whose only changes are data apps reports `pull-skipped` /
+  `count 0`. Caller guarantees `da-changed` is positive."
+  [outcome da-changed]
+  (case (:kind outcome)
+    "pull-skipped" {:kind "pulled" :count da-changed :branch (settings/remote-sync-branch)}
+    "pulled"       (update outcome :count (fnil + 0) da-changed)
+    "merged"       (update outcome :pulled (fnil + 0) da-changed)
+    outcome))
+
 (defn- incremental-import-plan
   "What an incremental load would touch, or [[incremental-not-possible]] if the change must fall back to a full
   import. On success returns `{:ingestable <ingestable-or-nil> :deleted-rsos <RemoteSyncObject rows>}`. Falls back
@@ -591,10 +604,14 @@
                                                  :branch (settings/remote-sync-branch)}}))]
         ;; Data apps ride the pull: re-materialize from the real source snapshot
         ;; (the repo file tree under `data_apps/`), not the synthetic merged
-        ;; snapshot `load-snapshot!` sees.
-        (when (= :success (:status result))
-          (materialize-data-apps! snapshot))
-        result)
+        ;; snapshot `load-snapshot!` sees. They're counted outside serdes, so fold
+        ;; their change count into the outcome — otherwise a data-app-only pull
+        ;; would report `pull-skipped` / `count 0`.
+        (if (= :success (:status result))
+          (let [da-changed (:changed (materialize-data-apps! snapshot) 0)]
+            (cond-> result
+              (pos? da-changed) (update :outcome fold-data-app-changes da-changed)))
+          result))
       (catch Exception e
         ;; A cancellation isn't a failure: log it and return nil. Otherwise log the error, count it, and
         ;; return a user-friendly :error result.

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/data_app_pull_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/data_app_pull_test.clj
@@ -43,7 +43,7 @@
 (def ^:private coll-file
   {coll-path (rs.test/generate-collection-yaml "M-Q4pcV0qkiyJ0kiSWECl" "Some Collection")})
 
-(defn- pull-outcome
+(defn- pull-outcome!
   "Establish `v0` as the baseline, then pull `v1` (a normal, non-forced pull) and
   return its `:outcome`."
   [v0 v1]
@@ -59,8 +59,8 @@
       (mt/with-premium-features #{:data-apps}
         (mt/with-temporary-setting-values [remote-sync-type :read-write remote-sync-transforms false]
           (mt/with-model-cleanup [:model/DataApp]
-            (let [outcome (pull-outcome (app-tree "sales" "BUNDLE-V1")
-                                        (app-tree "sales" "BUNDLE-V2"))]
+            (let [outcome (pull-outcome! (app-tree "sales" "BUNDLE-V1")
+                                         (app-tree "sales" "BUNDLE-V2"))]
               (is (= "pulled" (:kind outcome)) "not reported as skipped")
               (is (= 1 (:count outcome)) "the one changed data app is counted"))))))))
 
@@ -72,7 +72,7 @@
           (mt/with-model-cleanup [:model/DataApp :model/Collection]
             ;; v1 adds a collection; the data app is byte-for-byte the same as v0.
             (let [app     (app-tree "sales" "BUNDLE")
-                  outcome (pull-outcome app (merge coll-file app))]
+                  outcome (pull-outcome! app (merge coll-file app))]
               (is (= "pulled" (:kind outcome)))
               (is (= 1 (:count outcome)) "the collection counts; the unchanged app adds 0"))))))))
 
@@ -83,7 +83,7 @@
         (mt/with-temporary-setting-values [remote-sync-type :read-write remote-sync-transforms false]
           (mt/with-model-cleanup [:model/DataApp :model/Collection]
             ;; v1 adds a collection AND changes the data app's bundle.
-            (let [outcome (pull-outcome (app-tree "ops" "BUNDLE")
-                                        (merge coll-file (app-tree "ops" "BUNDLE-V2")))]
+            (let [outcome (pull-outcome! (app-tree "ops" "BUNDLE")
+                                         (merge coll-file (app-tree "ops" "BUNDLE-V2")))]
               (is (= "pulled" (:kind outcome)))
               (is (= 2 (:count outcome)) "the collection (1) plus the changed data app (1)"))))))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/data_app_pull_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/data_app_pull_test.clj
@@ -1,0 +1,89 @@
+(ns metabase-enterprise.remote-sync.data-app-pull-test
+  "A remote-sync pull's outcome (the \"N changes\" summary the admin sees) must
+  count data-app changes. Data apps live under `data_apps/` — outside serdes — and
+  are materialized separately (`metabase-enterprise.data-apps.sync`), so without
+  `impl/fold-data-app-changes` a pull whose only changes are data apps reports
+  `pull-skipped` / `count 0`. These cover the three pull shapes: data-app-only,
+  mixed (serdes + data apps), and serdes-only."
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.remote-sync.impl :as impl]
+   [metabase-enterprise.remote-sync.source.protocol :as source.p]
+   [metabase-enterprise.remote-sync.test-helpers :as rs.test]
+   [metabase.search.test-util :as search.tu]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db))
+(use-fixtures :each rs.test/clean-remote-sync-state rs.test/commit-with-temp)
+
+(defn- import-at!
+  "Run `import!` against the source's snapshot at `version`, complete the task (so
+  `last-version` advances for the next pull), and return the result."
+  [src version & {:keys [force?] :or {force? false}}]
+  (let [task   (t2/insert-returning-pk! :model/RemoteSyncTask
+                                        {:sync_task_type "import" :initiated_by (mt/user->id :rasta)})
+        result (impl/import! (source.p/snapshot-at src version) task :force? force?)]
+    (impl/handle-task-result! result task)
+    result))
+
+(defn- app-tree
+  "Repo files for one data app: its `data_app.yml` + a bundle at `dist/index.js`."
+  [slug bundle]
+  {(str "data_apps/" slug "/data_app.yml")  (str "name: " slug "\nslug: " slug "\npath: dist/index.js\n")
+   (str "data_apps/" slug "/dist/index.js") bundle})
+
+;; One self-contained serdes entity (a bare collection — no DB deps), used as the
+;; "data" change. Reuses the path/content shape the mock harness imports cleanly.
+(def ^:private coll-path
+  "collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/M-Q4pcV0qkiyJ0kiSWECl_some_collection.yaml")
+(def ^:private coll-file
+  {coll-path (rs.test/generate-collection-yaml "M-Q4pcV0qkiyJ0kiSWECl" "Some Collection")})
+
+(defn- pull-outcome
+  "Establish `v0` as the baseline, then pull `v1` (a normal, non-forced pull) and
+  return its `:outcome`."
+  [v0 v1]
+  (let [src (rs.test/versioned-source :trees {"v0" v0 "v1" v1} :current "v0")]
+    (is (= :success (:status (import-at! src "v0" :force? true))) "baseline import succeeds")
+    (let [result (import-at! src "v1")]
+      (is (= :success (:status result)) "pull succeeds")
+      (:outcome result))))
+
+(deftest data-app-only-pull-counts-app-changes-test
+  (testing "a pull whose only change is a data app is reported as a real pull, not pull-skipped / 0 changes"
+    (search.tu/with-index-disabled
+      (mt/with-premium-features #{:data-apps}
+        (mt/with-temporary-setting-values [remote-sync-type :read-write remote-sync-transforms false]
+          (mt/with-model-cleanup [:model/DataApp]
+            (let [outcome (pull-outcome (app-tree "sales" "BUNDLE-V1")
+                                        (app-tree "sales" "BUNDLE-V2"))]
+              (is (= "pulled" (:kind outcome)) "not reported as skipped")
+              (is (= 1 (:count outcome)) "the one changed data app is counted"))))))))
+
+(deftest data-only-pull-excludes-unchanged-apps-test
+  (testing "a serdes-only pull counts serdes content; unchanged data apps add nothing"
+    (search.tu/with-index-disabled
+      (mt/with-premium-features #{:data-apps}
+        (mt/with-temporary-setting-values [remote-sync-type :read-write remote-sync-transforms false]
+          (mt/with-model-cleanup [:model/DataApp :model/Collection]
+            ;; v1 adds a collection; the data app is byte-for-byte the same as v0.
+            (let [app     (app-tree "sales" "BUNDLE")
+                  outcome (pull-outcome app (merge coll-file app))]
+              (is (= "pulled" (:kind outcome)))
+              (is (= 1 (:count outcome)) "the collection counts; the unchanged app adds 0"))))))))
+
+(deftest mixed-pull-counts-serdes-and-apps-test
+  (testing "a mixed pull counts serdes content AND the changed data apps"
+    (search.tu/with-index-disabled
+      (mt/with-premium-features #{:data-apps}
+        (mt/with-temporary-setting-values [remote-sync-type :read-write remote-sync-transforms false]
+          (mt/with-model-cleanup [:model/DataApp :model/Collection]
+            ;; v1 adds a collection AND changes the data app's bundle.
+            (let [outcome (pull-outcome (app-tree "ops" "BUNDLE")
+                                        (merge coll-file (app-tree "ops" "BUNDLE-V2")))]
+              (is (= "pulled" (:kind outcome)))
+              (is (= 2 (:count outcome)) "the collection (1) plus the changed data app (1)"))))))))


### PR DESCRIPTION
Properly include data app changes in `pull changes` modal

Before:
<img width="1058" height="430" alt="image" src="https://github.com/user-attachments/assets/201a84e3-da2b-4a3a-8093-48f855aca350" />

After:
<img width="1036" height="494" alt="image" src="https://github.com/user-attachments/assets/c2819fbf-c527-4813-9949-8392da7d6861" />
