### PR TITLE
Fix tooltips showing incorrect date ranges for native queries

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
@@ -722,39 +722,6 @@ describe("issue 22527", { tags: "@skip" }, () => {
   });
 });
 
-describe("issue 25007", () => {
-  const questionDetails = {
-    name: "11435",
-    display: "line",
-    native: {
-      query: `SELECT dateadd('day', CAST((1 - CASE WHEN ((iso_day_of_week("PUBLIC"."ORDERS"."CREATED_AT") + 1) % 7) = 0 THEN 7 ELSE ((iso_day_of_week("PUBLIC"."ORDERS"."CREATED_AT") + 1) % 7) END) AS long), CAST("PUBLIC"."ORDERS"."CREATED_AT" AS date)) AS "CREATED_AT", count(*) AS "count"
-  FROM "PUBLIC"."ORDERS"
-  GROUP BY dateadd('day', CAST((1 - CASE WHEN ((iso_day_of_week("PUBLIC"."ORDERS"."CREATED_AT") + 1) % 7) = 0 THEN 7 ELSE ((iso_day_of_week("PUBLIC"."ORDERS"."CREATED_AT") + 1) % 7) END) AS long), CAST("PUBLIC"."ORDERS"."CREATED_AT" AS date))
-  ORDER BY dateadd('day', CAST((1 - CASE WHEN ((iso_day_of_week("PUBLIC"."ORDERS"."CREATED_AT") + 1) % 7) = 0 THEN 7 ELSE ((iso_day_of_week("PUBLIC"."ORDERS"."CREATED_AT") + 1) % 7) END) AS long), CAST("PUBLIC"."ORDERS"."CREATED_AT" AS date)) ASC`,
-    },
-    visualization_settings: {
-      "graph.dimensions": ["CREATED_AT"],
-      "graph.metrics": ["count"],
-    },
-  };
-
-  const clickLineDot = ({ index } = {}) => {
-    // eslint-disable-next-line metabase/no-unsafe-element-filtering
-    H.cartesianChartCircle().eq(index).click({ force: true });
-  };
-
-  beforeEach(() => {
-    H.restore();
-    cy.signInAsAdmin();
-  });
-
-  it("should display weeks correctly in tooltips for native questions (metabase#25007)", () => {
-    H.createNativeQuestion(questionDetails, { visitQuestion: true });
-    clickLineDot({ index: 1 });
-    H.echartsTooltip().should("contain", "May 4–10, 2025");
-  });
-});
-
 describe("issue 25156", () => {
   const questionDetails = {
     name: "25156",

--- a/frontend/src/metabase/visualizations/lib/formatting/date.tsx
+++ b/frontend/src/metabase/visualizations/lib/formatting/date.tsx
@@ -1328,7 +1328,8 @@ export function formatDateTimeWithUnit(
   if (unit === "week") {
     if (
       (options.type === "tooltip" || options.type === "cell") &&
-      !options.noRange
+      !options.noRange &&
+      options.column?.source !== "native"
     ) {
       // tooltip show range like "January 1 - 7, 2017"
       return formatDateTimeRangeWithUnit([String(value)], unit, options);

--- a/frontend/src/metabase/visualizations/lib/formatting/date.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/lib/formatting/date.unit.spec.tsx
@@ -219,6 +219,17 @@ describe("formatDateTimeForParameter", () => {
       ).toEqual("July 7, 2019 – July 13, 2019");
     });
 
+    it("should not format week ranges for native queries (#73005)", () => {
+      expect(
+        formatDateTimeWithUnit("2019-07-07T00:00:00.000Z", "week", {
+          type: "tooltip",
+          column: {
+            source: "native",
+          },
+        }),
+      ).toEqual("July 7, 2019");
+    });
+
     it("should always format week ranges according to returned data", () => {
       dayjs.locale("es");
       dayjs.updateLocale(dayjs.locale(), { weekStart: 0 });


### PR DESCRIPTION
Closes #73005

### Description

For weekly data in tooltips, we display ranges like "July 18-24, 2026". This works by taking the returned weekly date value of July 18, adding 6 days to it, then formatting the range.

This makes sense for MBQL queries, because when bucketing by week the generated query truncates all dates to the start of the week. But we also apply the range formatting when we detect weekly values in a native query, which doesn't make sense - for a native query, we can't be sure whether the returned date represents the start or end of the range.

This PR fixes the issue by disabling the range formatting for native queries. This intentionally reverts the changes that fixed #25007 - see the discussion [here](https://metaboat.slack.com/archives/C096M2BBGHH/p1782746473227719).

### How to verify

Create a native query and visualize it as a line:

```sql
SELECT '2026-06-20' AS "dt", 142 AS "n" UNION ALL
SELECT '2026-06-27', 387 UNION ALL
SELECT '2026-07-04', 215 UNION ALL
SELECT '2026-07-11', 594 UNION ALL
SELECT '2026-07-18', 461 UNION ALL
SELECT '2026-07-25', 308 UNION ALL
SELECT '2026-08-01', 733 UNION ALL
SELECT '2026-08-08', 129 UNION ALL
SELECT '2026-08-15', 856 UNION ALL
SELECT '2026-08-22', 274
ORDER BY "dt"
```

Ensure that the tooltips show values like "July 18, 2026", not ranges like "July 18-24, 2026".

### Demo

Before:
<img width="1427" height="548" alt="image" src="https://github.com/user-attachments/assets/cde20783-a696-4395-86c9-b1e639882fd1" />

After:
<img width="1467" height="537" alt="image" src="https://github.com/user-attachments/assets/d822c1e3-824b-49b4-98aa-a4f7c595e2bf" />

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
