### PR TITLE
indicate dirty transforms nodes

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncedCollectionsSidebarSection/CollectionSyncStatusBadge.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncedCollectionsSidebarSection/CollectionSyncStatusBadge.tsx
@@ -10,6 +10,7 @@ export const CollectionSyncStatusBadge = () => (
       h="0.5rem"
       w="0.5rem"
       mr="xs"
+      flex="0 0 auto"
       data-testid="remote-sync-status"
     />
   </Tooltip>

--- a/frontend/src/metabase/transforms/pages/TransformListPage/TransformListPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformListPage/TransformListPage.tsx
@@ -25,7 +25,11 @@ import CS from "metabase/css/core/index.css";
 import { DataStudioBreadcrumbs } from "metabase/data-studio/common/components/DataStudioBreadcrumbs";
 import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
 import { PaneHeader } from "metabase/data-studio/common/components/PaneHeader";
-import { PLUGIN_REPLACEMENT, PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
+import {
+  PLUGIN_REMOTE_SYNC,
+  PLUGIN_REPLACEMENT,
+  PLUGIN_TRANSFORMS_PYTHON,
+} from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import { LockedTransformsBanner } from "metabase/transforms/components/LockedTransformsBanner/LockedTransformsBanner";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
@@ -56,6 +60,7 @@ import {
   buildTreeData,
   getDefaultExpandedIds,
   useGetTransformWarnings,
+  useIsNodeDirty,
 } from "./utils";
 
 const getNodeId = (node: TreeNode) => node.id;
@@ -144,6 +149,7 @@ export const TransformListPage = ({
   );
 
   const warningsByTransformId = useGetTransformWarnings(transforms);
+  const isNodeDirty = useIsNodeDirty();
 
   const treeData = useMemo(() => {
     const data = buildTreeData(collections, transforms);
@@ -192,6 +198,7 @@ export const TransformListPage = ({
             row,
             hasPythonTransformsFeature,
             warningsByTransformId,
+            isDirty: isNodeDirty(row.original),
           }),
       },
       {
@@ -265,7 +272,7 @@ export const TransformListPage = ({
           ) : null,
       },
     ];
-  }, [hasPythonTransformsFeature, warningsByTransformId]);
+  }, [hasPythonTransformsFeature, warningsByTransformId, isNodeDirty]);
 
   const getRowHref = useCallback((row: Row<TreeNode>) => {
     if (isRowDisabled(row)) {
@@ -375,10 +382,12 @@ function getNameCell({
   row,
   hasPythonTransformsFeature,
   warningsByTransformId,
+  isDirty,
 }: {
   row: Row<TreeNode>;
   hasPythonTransformsFeature: boolean;
   warningsByTransformId: Map<number, string>;
+  isDirty: boolean;
 }) {
   const getTooltipProps = (message: string | undefined) => {
     if (!message) {
@@ -409,6 +418,7 @@ function getNameCell({
     row.original.nodeType === "library" && !hasPythonTransformsFeature;
 
   const hasWarning = !!getWarningMessage();
+  const SyncStatusBadge = PLUGIN_REMOTE_SYNC.CollectionSyncStatusBadge;
 
   return (
     <Group gap="sm" wrap="nowrap" miw={0}>
@@ -419,6 +429,7 @@ function getNameCell({
         name={row.original.name}
         ellipsifiedProps={{ ...getTooltipProps(getWarningMessage()) }}
       />
+      {isDirty && SyncStatusBadge && <SyncStatusBadge />}
       {isLibraryWithoutFeature && <UpsellGem.New size={14} />}
     </Group>
   );

--- a/frontend/src/metabase/transforms/pages/TransformListPage/TransformListPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformListPage/TransformListPage.tsx
@@ -25,11 +25,7 @@ import CS from "metabase/css/core/index.css";
 import { DataStudioBreadcrumbs } from "metabase/data-studio/common/components/DataStudioBreadcrumbs";
 import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
 import { PaneHeader } from "metabase/data-studio/common/components/PaneHeader";
-import {
-  PLUGIN_REMOTE_SYNC,
-  PLUGIN_REPLACEMENT,
-  PLUGIN_TRANSFORMS_PYTHON,
-} from "metabase/plugins";
+import { PLUGIN_REPLACEMENT, PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import { LockedTransformsBanner } from "metabase/transforms/components/LockedTransformsBanner/LockedTransformsBanner";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
@@ -59,8 +55,8 @@ import { type TreeNode, getCollectionNodeId, isCollectionNode } from "./types";
 import {
   buildTreeData,
   getDefaultExpandedIds,
+  useGetNodeSyncColor,
   useGetTransformWarnings,
-  useIsNodeDirty,
 } from "./utils";
 
 const getNodeId = (node: TreeNode) => node.id;
@@ -149,7 +145,7 @@ export const TransformListPage = ({
   );
 
   const warningsByTransformId = useGetTransformWarnings(transforms);
-  const isNodeDirty = useIsNodeDirty();
+  const getNodeSyncColor = useGetNodeSyncColor();
 
   const treeData = useMemo(() => {
     const data = buildTreeData(collections, transforms);
@@ -198,7 +194,7 @@ export const TransformListPage = ({
             row,
             hasPythonTransformsFeature,
             warningsByTransformId,
-            isDirty: isNodeDirty(row.original),
+            syncColor: getNodeSyncColor(row.original),
           }),
       },
       {
@@ -272,7 +268,7 @@ export const TransformListPage = ({
           ) : null,
       },
     ];
-  }, [hasPythonTransformsFeature, warningsByTransformId, isNodeDirty]);
+  }, [hasPythonTransformsFeature, warningsByTransformId, getNodeSyncColor]);
 
   const getRowHref = useCallback((row: Row<TreeNode>) => {
     if (isRowDisabled(row)) {
@@ -382,12 +378,12 @@ function getNameCell({
   row,
   hasPythonTransformsFeature,
   warningsByTransformId,
-  isDirty,
+  syncColor,
 }: {
   row: Row<TreeNode>;
   hasPythonTransformsFeature: boolean;
   warningsByTransformId: Map<number, string>;
-  isDirty: boolean;
+  syncColor: ColorName | undefined;
 }) {
   const getTooltipProps = (message: string | undefined) => {
     if (!message) {
@@ -418,18 +414,20 @@ function getNameCell({
     row.original.nodeType === "library" && !hasPythonTransformsFeature;
 
   const hasWarning = !!getWarningMessage();
-  const SyncStatusBadge = PLUGIN_REMOTE_SYNC.CollectionSyncStatusBadge;
+  const iconColor = hasWarning
+    ? "warning"
+    : (syncColor ?? getNodeIconColor(row.original));
 
   return (
     <Group gap="sm" wrap="nowrap" miw={0}>
       <EntityNameCell
         data-testid="tree-node-name"
         icon={hasWarning ? "warning" : row.original.icon}
-        iconColor={hasWarning ? "warning" : getNodeIconColor(row.original)}
+        iconColor={iconColor}
+        nameColor={syncColor}
         name={row.original.name}
         ellipsifiedProps={{ ...getTooltipProps(getWarningMessage()) }}
       />
-      {isDirty && SyncStatusBadge && <SyncStatusBadge />}
       {isLibraryWithoutFeature && <UpsellGem.New size={14} />}
     </Group>
   );

--- a/frontend/src/metabase/transforms/pages/TransformListPage/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformListPage/utils.ts
@@ -1,18 +1,25 @@
-import { useMemo, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { t } from "ttag";
 
 import { getCollectionIcon } from "metabase/common/collections/utils";
+import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getLibQuery } from "metabase/transforms/utils";
 import * as Lib from "metabase-lib";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
-import type { Collection, CollectionId, Transform } from "metabase-types/api";
+import type {
+  Collection,
+  CollectionId,
+  RemoteSyncEntityModel,
+  Transform,
+} from "metabase-types/api";
 
 import {
   type TreeNode,
   getCollectionNodeId,
   getTransformNodeId,
+  isCollectionNode,
 } from "./types";
 
 export function getIncrementalWarning(
@@ -169,4 +176,69 @@ export function getDefaultExpandedIds(
   expandedIds[getCollectionNodeId(targetCollectionId)] = true;
 
   return expandedIds;
+}
+
+export function getDescendantCollectionIds(node: TreeNode): Set<number> {
+  const ids = new Set<number>();
+  const visit = (current: TreeNode) => {
+    if (isCollectionNode(current)) {
+      ids.add(current.collection.id as number);
+    }
+    current.children?.forEach(visit);
+  };
+  visit(node);
+  return ids;
+}
+
+const EMPTY_DIRTY_TRANSFORM_IDS = new Set<number>();
+
+const TRANSFORM_MODEL = "transform" satisfies RemoteSyncEntityModel;
+const PYTHON_LIBRARY_MODEL = "pythonlibrary" satisfies RemoteSyncEntityModel;
+
+export function useIsNodeDirty(): (node: TreeNode) => boolean {
+  const { isVisible: isRemoteSyncVisible } =
+    PLUGIN_REMOTE_SYNC.useGitSyncVisible();
+  const { dirty, hasDirtyInCollectionTree } =
+    PLUGIN_REMOTE_SYNC.useRemoteSyncDirtyState();
+
+  const dirtyTransformIds = useMemo(() => {
+    if (!isRemoteSyncVisible) {
+      return EMPTY_DIRTY_TRANSFORM_IDS;
+    }
+    return new Set(
+      dirty
+        .filter((entity) => entity.model === TRANSFORM_MODEL)
+        .map((entity) => entity.id),
+    );
+  }, [isRemoteSyncVisible, dirty]);
+
+  const isPythonLibraryDirty =
+    isRemoteSyncVisible &&
+    dirty.some((entity) => entity.model === PYTHON_LIBRARY_MODEL);
+
+  return useCallback(
+    (node: TreeNode): boolean => {
+      if (!isRemoteSyncVisible) {
+        return false;
+      }
+      if (node.nodeType === "transform") {
+        return (
+          node.transformId != null && dirtyTransformIds.has(node.transformId)
+        );
+      }
+      if (node.nodeType === "library") {
+        return isPythonLibraryDirty;
+      }
+      if (isCollectionNode(node)) {
+        return hasDirtyInCollectionTree(getDescendantCollectionIds(node));
+      }
+      return false;
+    },
+    [
+      isRemoteSyncVisible,
+      dirtyTransformIds,
+      isPythonLibraryDirty,
+      hasDirtyInCollectionTree,
+    ],
+  );
 }

--- a/frontend/src/metabase/transforms/pages/TransformListPage/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformListPage/utils.ts
@@ -6,12 +6,15 @@ import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getLibQuery } from "metabase/transforms/utils";
+import type { ColorName } from "metabase/ui/colors/types";
 import * as Lib from "metabase-lib";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   Collection,
   CollectionId,
+  RemoteSyncEntity,
   RemoteSyncEntityModel,
+  RemoteSyncEntityStatus,
   Transform,
 } from "metabase-types/api";
 
@@ -190,55 +193,101 @@ export function getDescendantCollectionIds(node: TreeNode): Set<number> {
   return ids;
 }
 
-const EMPTY_DIRTY_TRANSFORM_IDS = new Set<number>();
-
 const TRANSFORM_MODEL = "transform" satisfies RemoteSyncEntityModel;
+const COLLECTION_MODEL = "collection" satisfies RemoteSyncEntityModel;
 const PYTHON_LIBRARY_MODEL = "pythonlibrary" satisfies RemoteSyncEntityModel;
 
-export function useIsNodeDirty(): (node: TreeNode) => boolean {
+const SYNC_STATUS_COLOR: Record<RemoteSyncEntityStatus, ColorName> = {
+  create: "success",
+  update: "warning",
+  touch: "warning",
+  delete: "danger",
+  removed: "danger",
+};
+
+export function getSyncColorForEntities(
+  entities: RemoteSyncEntity[],
+): ColorName | undefined {
+  const colors = new Set(
+    entities.map((entity) => SYNC_STATUS_COLOR[entity.sync_status]),
+  );
+  if (colors.size === 0) {
+    return undefined;
+  }
+  if (colors.size === 1) {
+    const [color] = colors;
+    return color;
+  }
+  return SYNC_STATUS_COLOR.update;
+}
+
+export function getFolderSyncColor(
+  subtreeEntities: RemoteSyncEntity[],
+  folderCollectionId: number,
+): ColorName | undefined {
+  if (subtreeEntities.length === 0) {
+    return undefined;
+  }
+  const folderEntity = subtreeEntities.find(
+    (entity) =>
+      entity.model === COLLECTION_MODEL && entity.id === folderCollectionId,
+  );
+  const isNewFolder = folderEntity?.sync_status === "create";
+  return isNewFolder ? SYNC_STATUS_COLOR.create : SYNC_STATUS_COLOR.update;
+}
+
+export function useGetNodeSyncColor(): (
+  node: TreeNode,
+) => ColorName | undefined {
   const { isVisible: isRemoteSyncVisible } =
     PLUGIN_REMOTE_SYNC.useGitSyncVisible();
-  const { dirty, hasDirtyInCollectionTree } =
-    PLUGIN_REMOTE_SYNC.useRemoteSyncDirtyState();
+  const { dirty } = PLUGIN_REMOTE_SYNC.useRemoteSyncDirtyState();
 
-  const dirtyTransformIds = useMemo(() => {
-    if (!isRemoteSyncVisible) {
-      return EMPTY_DIRTY_TRANSFORM_IDS;
+  const { dirtyTransformById, dirtyPythonLibraries } = useMemo(() => {
+    const transformById = new Map<number, RemoteSyncEntity>();
+    const pythonLibraries: RemoteSyncEntity[] = [];
+    if (isRemoteSyncVisible) {
+      for (const entity of dirty) {
+        if (entity.model === TRANSFORM_MODEL) {
+          transformById.set(entity.id, entity);
+        } else if (entity.model === PYTHON_LIBRARY_MODEL) {
+          pythonLibraries.push(entity);
+        }
+      }
     }
-    return new Set(
-      dirty
-        .filter((entity) => entity.model === TRANSFORM_MODEL)
-        .map((entity) => entity.id),
-    );
+    return {
+      dirtyTransformById: transformById,
+      dirtyPythonLibraries: pythonLibraries,
+    };
   }, [isRemoteSyncVisible, dirty]);
 
-  const isPythonLibraryDirty =
-    isRemoteSyncVisible &&
-    dirty.some((entity) => entity.model === PYTHON_LIBRARY_MODEL);
-
   return useCallback(
-    (node: TreeNode): boolean => {
+    (node: TreeNode): ColorName | undefined => {
       if (!isRemoteSyncVisible) {
-        return false;
+        return undefined;
       }
       if (node.nodeType === "transform") {
-        return (
-          node.transformId != null && dirtyTransformIds.has(node.transformId)
-        );
+        const entity =
+          node.transformId != null
+            ? dirtyTransformById.get(node.transformId)
+            : undefined;
+        return getSyncColorForEntities(entity ? [entity] : []);
       }
       if (node.nodeType === "library") {
-        return isPythonLibraryDirty;
+        return getSyncColorForEntities(dirtyPythonLibraries);
       }
       if (isCollectionNode(node)) {
-        return hasDirtyInCollectionTree(getDescendantCollectionIds(node));
+        const collectionIds = getDescendantCollectionIds(node);
+        const entities = dirty.filter(
+          (entity) =>
+            (entity.collection_id != null &&
+              collectionIds.has(entity.collection_id)) ||
+            (entity.model === COLLECTION_MODEL && collectionIds.has(entity.id)),
+        );
+        return getFolderSyncColor(entities, node.collection.id as number);
       }
-      return false;
+      return undefined;
     },
-    [
-      isRemoteSyncVisible,
-      dirtyTransformIds,
-      isPythonLibraryDirty,
-      hasDirtyInCollectionTree,
-    ],
+    [isRemoteSyncVisible, dirty, dirtyTransformById, dirtyPythonLibraries],
   );
 }

--- a/frontend/src/metabase/transforms/pages/TransformListPage/utils.unit.spec.ts
+++ b/frontend/src/metabase/transforms/pages/TransformListPage/utils.unit.spec.ts
@@ -2,8 +2,13 @@ import { createMockMetadata } from "__support__/metadata";
 import { getLibQuery } from "metabase/transforms/utils";
 import * as Lib from "metabase-lib";
 import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
+import type {
+  RemoteSyncEntity,
+  RemoteSyncEntityStatus,
+} from "metabase-types/api";
 import {
   createMockCollection,
+  createMockRemoteSyncEntity,
   createMockStructuredDatasetQuery,
   createMockTemplateTag,
   createMockTransform,
@@ -14,8 +19,20 @@ import {
 import {
   buildTreeData,
   getDescendantCollectionIds,
+  getFolderSyncColor,
   getIncrementalWarning,
+  getSyncColorForEntities,
 } from "./utils";
+
+const dirtyEntity = (
+  status: RemoteSyncEntityStatus,
+  overrides: Partial<RemoteSyncEntity> = {},
+): RemoteSyncEntity =>
+  createMockRemoteSyncEntity({
+    model: "transform",
+    sync_status: status,
+    ...overrides,
+  });
 
 jest.mock("metabase/transforms/utils", () => ({
   getLibQuery: jest.fn(),
@@ -160,6 +177,85 @@ describe("getDescendantCollectionIds", () => {
     const [folderNode] = buildTreeData(collections, transforms);
 
     expect(getDescendantCollectionIds(folderNode)).toEqual(new Set([10]));
+  });
+});
+
+describe("getSyncColorForEntities", () => {
+  it("returns undefined when there are no changes", () => {
+    expect(getSyncColorForEntities([])).toBeUndefined();
+  });
+
+  it("colors a created entity green (success)", () => {
+    expect(getSyncColorForEntities([dirtyEntity("create")])).toBe("success");
+  });
+
+  it("colors an updated entity amber (warning)", () => {
+    expect(getSyncColorForEntities([dirtyEntity("update")])).toBe("warning");
+  });
+
+  it("colors a removed entity red (danger)", () => {
+    expect(getSyncColorForEntities([dirtyEntity("removed")])).toBe("danger");
+  });
+});
+
+describe("getFolderSyncColor", () => {
+  const collection = (id: number, status: RemoteSyncEntityStatus) =>
+    dirtyEntity(status, { id, model: "collection" });
+  const childTransform = (
+    collectionId: number,
+    status: RemoteSyncEntityStatus,
+  ) =>
+    dirtyEntity(status, {
+      id: 100 + collectionId,
+      collection_id: collectionId,
+    });
+
+  it("returns undefined when the subtree has no changes", () => {
+    expect(getFolderSyncColor([], 1)).toBeUndefined();
+  });
+
+  it("colors a brand-new folder green", () => {
+    expect(getFolderSyncColor([collection(1, "create")], 1)).toBe("success");
+  });
+
+  it("colors a renamed or moved folder amber, not green", () => {
+    expect(getFolderSyncColor([collection(1, "update")], 1)).toBe("warning");
+  });
+
+  it("colors an existing folder amber when it only contains new children", () => {
+    expect(getFolderSyncColor([childTransform(1, "create")], 1)).toBe(
+      "warning",
+    );
+  });
+
+  it("colors an existing folder amber when a child was removed", () => {
+    expect(getFolderSyncColor([childTransform(1, "removed")], 1)).toBe(
+      "warning",
+    );
+  });
+
+  it("keeps a brand-new folder green even with new children", () => {
+    expect(
+      getFolderSyncColor(
+        [collection(1, "create"), childTransform(1, "create")],
+        1,
+      ),
+    ).toBe("success");
+  });
+
+  it("keeps nested brand-new folders green (new folder > new folder > new transform)", () => {
+    const subtree = [
+      collection(1, "create"),
+      collection(2, "create"),
+      childTransform(2, "create"),
+    ];
+    expect(getFolderSyncColor(subtree, 1)).toBe("success");
+    expect(
+      getFolderSyncColor(
+        [collection(2, "create"), childTransform(2, "create")],
+        2,
+      ),
+    ).toBe("success");
   });
 });
 

--- a/frontend/src/metabase/transforms/pages/TransformListPage/utils.unit.spec.ts
+++ b/frontend/src/metabase/transforms/pages/TransformListPage/utils.unit.spec.ts
@@ -3,6 +3,7 @@ import { getLibQuery } from "metabase/transforms/utils";
 import * as Lib from "metabase-lib";
 import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import {
+  createMockCollection,
   createMockStructuredDatasetQuery,
   createMockTemplateTag,
   createMockTransform,
@@ -10,7 +11,11 @@ import {
   createMockTransformTarget,
 } from "metabase-types/api/mocks";
 
-import { buildTreeData, getIncrementalWarning } from "./utils";
+import {
+  buildTreeData,
+  getDescendantCollectionIds,
+  getIncrementalWarning,
+} from "./utils";
 
 jest.mock("metabase/transforms/utils", () => ({
   getLibQuery: jest.fn(),
@@ -120,6 +125,41 @@ describe("buildTreeData", () => {
     expect(result[1].owner).toMatchObject({ email: "external@example.com" });
     expect(result[1].owner_email).toBe("external@example.com");
     expect(result[2].owner).toBeUndefined();
+  });
+});
+
+describe("getDescendantCollectionIds", () => {
+  it("includes the folder's own collection id and all nested folder ids", () => {
+    const collections = [
+      createMockCollection({
+        id: 1,
+        name: "Parent",
+        children: [
+          createMockCollection({
+            id: 2,
+            name: "Child",
+            children: [createMockCollection({ id: 3, name: "Grandchild" })],
+          }),
+        ],
+      }),
+    ];
+
+    const [parentNode] = buildTreeData(collections, []);
+
+    expect(getDescendantCollectionIds(parentNode)).toEqual(new Set([1, 2, 3]));
+  });
+
+  it("ignores transform leaves and counts only collection ids", () => {
+    const collections = [
+      createMockCollection({ id: 10, name: "Folder", children: [] }),
+    ];
+    const transforms = [
+      createMockTransform({ id: 99, name: "T", collection_id: 10 }),
+    ];
+
+    const [folderNode] = buildTreeData(collections, transforms);
+
+    expect(getDescendantCollectionIds(folderNode)).toEqual(new Set([10]));
   });
 });
 

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/EntityNameCell/EntityNameCell.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/EntityNameCell/EntityNameCell.tsx
@@ -10,6 +10,7 @@ interface EntityNameCellProps {
   icon?: IconName;
   name: React.ReactNode;
   iconColor?: ColorName;
+  nameColor?: ColorName;
   wrap?: boolean;
   ellipsifiedProps?: ComponentProps<typeof Ellipsified>;
   tooltipOpenDelay?: number;
@@ -20,6 +21,7 @@ export const EntityNameCell = memo(function EntityNameCell({
   icon,
   name,
   iconColor = "core-brand",
+  nameColor,
   wrap = false,
   tooltipOpenDelay = 600,
   ellipsifiedProps,
@@ -29,11 +31,12 @@ export const EntityNameCell = memo(function EntityNameCell({
     <Group data-testid={testId} gap="sm" wrap="nowrap" miw={0}>
       {icon && <Icon name={icon} c={iconColor} className={CS.flexNoShrink} />}
       {wrap ? (
-        <Text flex={1} miw={0}>
+        <Text c={nameColor} flex={1} miw={0}>
           {name}
         </Text>
       ) : (
         <Ellipsified
+          c={nameColor}
           flex={1}
           miw={0}
           tooltipProps={{ openDelay: tooltipOpenDelay }}


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GHY-3903/highlight-transforms-that-have-not-been-synced-in-data-studio

### Description

Adds "dirty" indicator to the transforms tree in the data studio when instance has unsynced changes.

### Demo

https://www.loom.com/share/1cd302a1e046439dab2e7bb6e6326c3f

<img width="1511" height="851" alt="Screenshot 2026-06-22 at 9 13 26 PM" src="https://github.com/user-attachments/assets/b4d2903f-8c89-488f-bd00-de5f638f4013" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
