### PR TITLE
Add agent-lib repair pass to fixup invalid lib/type for join clauses

### DIFF
--- a/src/metabase/agent_lib/representations.clj
+++ b/src/metabase/agent_lib/representations.clj
@@ -194,6 +194,7 @@
                 clause-shape?]]
    ::join     [:map
                {:closed false}
+               ["lib/type"   [:= "mbql/join"]]
                ["stages"     [:sequential {:min 1} [:ref ::stage]]]
                ["conditions" [:sequential {:min 1} [:ref ::clause]]]
                ["alias"      :string]

--- a/src/metabase/agent_lib/representations/repair.clj
+++ b/src/metabase/agent_lib/representations/repair.clj
@@ -7,7 +7,7 @@
   patch up the sort of shape drift that LLMs routinely produce:
 
     * missing `{}` options on clauses (LLMs forget to emit empty maps);
-    * missing `\"lib/type\"` marker on stages and on the top-level query;
+    * missing `\"lib/type\"` marker on stages, joins, and the top-level query;
     * stage / clause shape normalisations covering common LLM-authored variants
       (see the per-pass docstrings below).
 
@@ -1242,13 +1242,26 @@
        (contains? m "database")
        (contains? m "stages")))
 
+(defn- join-like-map?
+  "A map that looks like an explicit join: it carries join-only keys (`conditions`, or
+  `alias`+`stages`) that never appear on a stage or top-level query. We key on these rather
+  than on `\"fields\"` (which a join shares with a stage) so a join is not mistaken for a
+  stage by [[stage-like-map?]]."
+  [m]
+  (and (map? m)
+       (or (contains? m "conditions")
+           (and (contains? m "alias")
+                (contains? m "stages")))))
+
 (defn- stage-like-map?
   "A map that looks like an MBQL stage: has `\"source-table\"`, `\"source-card\"`, or any of the
   stage-body keys (`filters`, `aggregation`, `breakout`, `order-by`, `fields`, `joins`,
-  `expressions`, `limit`). Not a top-level query."
+  `expressions`, `limit`). Not a top-level query and not an explicit join (a join can carry
+  `\"fields\"`, so we exclude it explicitly)."
   [m]
   (and (map? m)
        (not (top-level-query-map? m))
+       (not (join-like-map? m))
        (boolean
         (some #(contains? m %)
               ["source-table" "source-card" "filters" "aggregation"
@@ -1257,6 +1270,11 @@
 (defn- infer-query-lib-type [m]
   (if (and (top-level-query-map? m) (not (contains? m "lib/type")))
     (assoc m "lib/type" "mbql/query")
+    m))
+
+(defn- infer-join-lib-type [m]
+  (if (and (join-like-map? m) (not (contains? m "lib/type")))
+    (assoc m "lib/type" "mbql/join")
     m))
 
 (defn- infer-stage-lib-type [m]
@@ -1268,7 +1286,7 @@
   (walk/postwalk
    (fn [node]
      (if (map? node)
-       (-> node infer-query-lib-type infer-stage-lib-type)
+       (-> node infer-query-lib-type infer-join-lib-type infer-stage-lib-type)
        node))
    form))
 
@@ -2612,7 +2630,7 @@
        join slip `\"mbql.join/join\"` → `\"mbql/join\"`);
     1.88. merge a trailing extra options-map back into position-1 options on fixed-arity
        tuple clauses (e.g. `[\"time-interval\" {} <expr> -1 \"month\" {\"include-current\" true}]`);
-    2. fill in missing `\"lib/type\"` markers on the query and stages;
+    2. fill in missing `\"lib/type\"` markers on the query, joins, and stages;
     3. rewrite inline aggregation expressions in `order-by` to aggregation references when
        they match an aggregation in the same stage's `aggregation:` list (synthesising the
        referenced aggregation's `lib/uuid` if needed);

--- a/src/metabase/agent_lib/representations/repair.clj
+++ b/src/metabase/agent_lib/representations/repair.clj
@@ -389,6 +389,27 @@
    form))
 
 ;;; ============================================================
+;;; Pass 1.87 -- rewrite known misspelled `lib/type` markers to their canonical value.
+;;;
+;;; Pass 2's `infer-*` helpers only FILL a missing marker; they never rewrite a present one.
+;;; This pass handles the present-but-wrong case via a small alias table, exactly like the
+;;; `rewrite-operator-name-aliases*` / `rewrite-temporal-bucket-aliases*` passes.
+;;; ============================================================
+
+(def ^:private lib-type-aliases
+  "Known LLM misspellings of a `lib/type` marker -> its canonical value."
+  {"mbql.join/join" "mbql/join"})
+
+(defn- rewrite-lib-type-aliases*
+  [form]
+  (walk/postwalk
+   (fn [node]
+     (if-let [canonical (and (map? node) (lib-type-aliases (get node "lib/type")))]
+       (assoc node "lib/type" canonical)
+       node))
+   form))
+
+;;; ============================================================
 ;;; Pass 1.88 -- merge a trailing extra options-map into the position-1 options.
 ;;;
 ;;; LLMs sometimes place a clause's options at the END of the vector instead of
@@ -2559,6 +2580,7 @@
       rewrite-operator-name-aliases*
       rewrite-temporal-bucket-aliases*
       rewrite-direction-aliases*
+      rewrite-lib-type-aliases*
       merge-trailing-options*
       merge-string-filter-trailing-options*
       wrap-iso-date-bounds*
@@ -2586,6 +2608,8 @@
     1.75. strip stray surrounding double-quotes from the string segments of `field` clauses'
        portable-FK vector targets, e.g. `\"col\"` → `col` (cross-stage string targets are left
        to the resolution-aware cross-stage matching in pass 5);
+    1.87. rewrite a known-misspelled `\"lib/type\"` marker to its canonical value (e.g. the
+       join slip `\"mbql.join/join\"` → `\"mbql/join\"`);
     1.88. merge a trailing extra options-map back into position-1 options on fixed-arity
        tuple clauses (e.g. `[\"time-interval\" {} <expr> -1 \"month\" {\"include-current\" true}]`);
     2. fill in missing `\"lib/type\"` markers on the query and stages;

--- a/test/metabase/agent_lib/representations/repair_test.clj
+++ b/test/metabase/agent_lib/representations/repair_test.clj
@@ -931,6 +931,46 @@
       (is (= once twice)))))
 
 ;;; ============================================================
+;;; Pass 1.87 - rewrite misspelled `lib/type` aliases
+;;; ============================================================
+
+(def ^:private lib-type-join-query
+  "ORDERS with an explicit join to PRODUCTS. The join `lib/type` is filled in by each test."
+  {"lib/type" "mbql/query"
+   "database" "Sample"
+   "stages"   [{"lib/type"     "mbql.stage/mbql"
+                "source-table" ["Sample" "PUBLIC" "ORDERS"]
+                "joins"        [{"alias"      "P"
+                                 "fields"     "none"
+                                 "conditions" [["=" {}
+                                                ["field" {} ["Sample" "PUBLIC" "ORDERS" "PRODUCT_ID"]]
+                                                ["field" {"join-alias" "P"} ["Sample" "PUBLIC" "PRODUCTS" "ID"]]]]
+                                 "stages"     [{"lib/type"     "mbql.stage/mbql"
+                                                "source-table" ["Sample" "PUBLIC" "PRODUCTS"]}]}]}]})
+
+(defn- join-lib-type [q]
+  (get-in q ["stages" 0 "joins" 0 "lib/type"]))
+
+(defn- with-join-lib-type [v]
+  (assoc-in lib-type-join-query ["stages" 0 "joins" 0 "lib/type"] v))
+
+(deftest ^:parallel rewrite-join-lib-type-test
+  (testing "a join with the misspelled `mbql.join/join` marker is rewritten to `mbql/join`"
+    (let [output (repair/repair trivial-mp (with-join-lib-type "mbql.join/join"))]
+      (is (= "mbql/join" (join-lib-type output))))))
+
+(deftest ^:parallel rewrite-join-lib-type-preserves-canonical-test
+  (testing "a join that already has the canonical `mbql/join` marker is left unchanged"
+    (let [output (repair/repair trivial-mp (with-join-lib-type "mbql/join"))]
+      (is (= "mbql/join" (join-lib-type output))))))
+
+(deftest ^:parallel rewrite-join-lib-type-idempotent-test
+  (testing "join `lib/type` correction is a fixed point"
+    (let [once  (repair/repair trivial-mp (with-join-lib-type "mbql.join/join"))
+          twice (repair/repair trivial-mp once)]
+      (is (= once twice)))))
+
+;;; ============================================================
 ;;; Pass 2 - fill in missing `lib/type`
 ;;; ============================================================
 

--- a/test/metabase/agent_lib/representations/repair_test.clj
+++ b/test/metabase/agent_lib/representations/repair_test.clj
@@ -1000,6 +1000,11 @@
     (let [input {"foo" "bar"}]
       (is (= input (repair/repair trivial-mp input))))))
 
+(deftest ^:parallel add-join-lib-type-test
+  (testing "a join with no lib/type gets mbql/join"
+    (let [output (repair/repair trivial-mp (update-in lib-type-join-query ["stages" 0 "joins" 0] dissoc "lib/type"))]
+      (is (= "mbql/join" (join-lib-type output))))))
+
 ;;; ============================================================
 ;;; Pass 1.9 - stamp top-level `database:` from the first stage's source
 ;;;

--- a/test/metabase/agent_lib/representations_test.clj
+++ b/test/metabase/agent_lib/representations_test.clj
@@ -11,7 +11,7 @@
 ;;; external-query->portable
 ;;; ============================================================
 
-(deftest external-query->portable-test
+(deftest ^:parallel external-query->portable-test
   (testing "stringifies map keys preserving namespace"
     (is (= {"lib/type"     "mbql/query"
             "database"     "Sample"
@@ -45,7 +45,7 @@
 ;;; validate-external-query
 ;;; ============================================================
 
-(deftest validate-external-query-happy-path-test
+(deftest ^:parallel validate-external-query-happy-path-test
   (testing "valid external-query with string-valued enums"
     (let [q {:lib/type "mbql/query"
              :database "Sample"
@@ -61,7 +61,7 @@
         (is (= ["Sample" "PUBLIC" "ORDERS"]
                (get-in decoded [:stages 0 :source-table])))))))
 
-(deftest validate-external-query-error-paths-test
+(deftest ^:parallel validate-external-query-error-paths-test
   (testing "missing :stages"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #"invalid structure"
@@ -79,7 +79,7 @@
     (catch clojure.lang.ExceptionInfo e
       (ex-data e))))
 
-(deftest validate-query-happy-path-test
+(deftest ^:parallel validate-query-happy-path-test
   (testing "minimal valid portable form"
     (let [parsed {"lib/type" "mbql/query"
                   "database" "Sample"
@@ -94,7 +94,7 @@
                                "aggregation"  [["count" {}]]}]}]
       (is (= parsed (repr/validate-query parsed))))))
 
-(deftest validate-query-error-paths-test
+(deftest ^:parallel validate-query-error-paths-test
   (testing "missing lib/type on query"
     (let [parsed {"database" "Sample"
                   "stages"   [{"lib/type"     "mbql.stage/mbql"

--- a/test/metabase/agent_lib/representations_test.clj
+++ b/test/metabase/agent_lib/representations_test.clj
@@ -122,3 +122,38 @@
                                       "stages"   [{"lib/type"     "mbql.stage/mbql"
                                                    "source-table" ["Sample" "PUBLIC" "ORDERS"]
                                                    "aggregation"  [["" {}]]}]})))))
+
+(defn- join-query-with-lib-type
+  "A minimal portable query with a single explicit join with `join-lib-type`.
+  `join-lib-type` is spliced into the join (or, when `nil`, the `lib/type` key is omitted)."
+  [join-lib-type]
+  (let [condition ["=" {}
+                   ["field" {} ["Sample" "PUBLIC" "ORDERS" "PRODUCT_ID"]]
+                   ["field" {"join-alias" "P"} ["Sample" "PUBLIC" "PRODUCTS" "ID"]]]
+        join      (cond-> {"alias"      "P"
+                           "conditions" [condition]
+                           "stages"     [{"lib/type"     "mbql.stage/mbql"
+                                          "source-table" ["Sample" "PUBLIC" "PRODUCTS"]}]}
+                    join-lib-type (assoc "lib/type" join-lib-type))]
+    {"lib/type" "mbql/query"
+     "database" "Sample"
+     "stages"   [{"lib/type"     "mbql.stage/mbql"
+                  "source-table" ["Sample" "PUBLIC" "ORDERS"]
+                  "joins"        [join]}]}))
+
+(deftest ^:parallel validate-query-canonical-join-lib-type-test
+  (testing "a join with the canonical `mbql/join` lib/type validates"
+    (let [parsed (join-query-with-lib-type "mbql/join")]
+      (is (= parsed (repr/validate-query parsed))))))
+
+(deftest ^:parallel validate-query-misspelled-join-lib-type-test
+  (testing "BOT-1657: a join with the misspelled `mbql.join/join` lib/type is rejected"
+    (let [data (validate-query-error (join-query-with-lib-type "mbql.join/join"))]
+      (is (= :invalid-representations-query (:error data)))
+      (is (= 400 (:status-code data))))))
+
+(deftest ^:parallel validate-query-missing-join-lib-type-test
+  (testing "a join with no lib/type is rejected"
+    (let [data (validate-query-error (join-query-with-lib-type nil))]
+      (is (= :invalid-representations-query (:error data)))
+      (is (= 400 (:status-code data))))))


### PR DESCRIPTION
Closes [BOT-1657: Question created via MCP is broken](https://linear.app/metabase/issue/BOT-1657/question-created-via-mcp-is-broken)

### Description

In BOT-1657, the LLM hallucinated an invalid `:lib/type :mbql.join/join` for the query's join clause (should be `:mbql/join`). Add some new repair passes to fix these up, and also validate the join's `:lib/type` in `metabase.agent-lib.representations/validate-query`. This prevents `construct_notebook_query` from returning such queries in the future.

Note: this PR does *not* add validation on the MBQL 5 query produced by `repr.resolve/resolve-query` since there are [similar changes](https://github.com/metabase/metabase/pull/76133/changes#diff-fc4817a0b820e2bca507f448572ce559dac91f839c8b76c6dbafa25ce6fdbd17R368) in flight in  #76133

* Add `metabase.agent-lib.representations.repair/rewrite-lib-type-aliases*`. Rewrite the hallucinated `:lib/type :mbql.join/join` to the corrected `:mbql/join`. Similar to the existing rewrite passes: `rewrite-operator-name-aliases*`, `rewrite-temporal-bucket-aliases*`, `rewrite-direction-aliases*`
* Fill in a missing `:lib/type` for join clauses in `metabase.agent-lib.representations.repair/ensure-lib-types*`. We already did this for stages and the top-level query.
* Validate `lib/type` for `::join` clause in `metabase.agent-lib.representations/validate-query`
* Mark all deftests `^:parallel` in `metabase.agent-lib.representations-test`

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
