### PR TITLE
Don't send Referer header on POST /oauth/authorize/decision

### DIFF
--- a/e2e/test/scenarios/admin/oauth-authorizations.cy.spec.ts
+++ b/e2e/test/scenarios/admin/oauth-authorizations.cy.spec.ts
@@ -64,6 +64,35 @@ describe("scenarios > admin > metabot > oauth authorizations", () => {
     });
   });
 
+  it("does not send the long authorization URL as a Referer header on submit (#76305)", () => {
+    // A long authorization URL (many scopes, PKCE challenge, etc.) sent as the Referer header on
+    // the consent form POST can exceed the server's header size limit and cause a 431. The consent
+    // page sets `<meta name="referrer" content="no-referrer">` so the browser omits it entirely.
+    // This needs a real browser navigation (cy.visit + click) — cy.request would not replicate the
+    // browser's automatic Referer behavior.
+    registerClient("E2E Referer Client", {
+      token_endpoint_auth_method: "client_secret_basic",
+    }).then((client) => {
+      const authorizeUrl =
+        `/oauth/authorize?client_id=${client.client_id}` +
+        `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
+        "&response_type=code&state=test-state";
+
+      // Stub a 204 so the browser does not follow the real 302 to the external redirect_uri,
+      // which would break Cypress with a cross-origin navigation.
+      cy.intercept("POST", "/oauth/authorize/decision", (req) => {
+        req.reply({ statusCode: 204, body: "" });
+      }).as("decision");
+
+      cy.visit(authorizeUrl);
+      cy.findByRole("button", { name: "Authorize" }).click();
+
+      cy.wait("@decision").then(({ request }) => {
+        expect(request.headers).to.not.have.property("referer");
+      });
+    });
+  });
+
   it("is accessible to superusers only", () => {
     cy.signInAsNormalUser();
     cy.request({

--- a/e2e/test/scenarios/admin/oauth-authorizations.cy.spec.ts
+++ b/e2e/test/scenarios/admin/oauth-authorizations.cy.spec.ts
@@ -78,10 +78,16 @@ describe("scenarios > admin > metabot > oauth authorizations", () => {
         `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
         "&response_type=code&state=test-state";
 
-      // Stub a 204 so the browser does not follow the real 302 to the external redirect_uri,
-      // which would break Cypress with a cross-origin navigation.
+      // Stub a same-origin HTML response so the browser navigates to it (firing a `load` event
+      // Cypress can wait on) instead of following the real 302 to the external redirect_uri, which
+      // would break Cypress with a cross-origin navigation. A 204 would leave the browser on the
+      // current page with no `load` event, so `cy.wait` would hang until the page-load timeout.
       cy.intercept("POST", "/oauth/authorize/decision", (req) => {
-        req.reply({ statusCode: 204, body: "" });
+        req.reply({
+          statusCode: 200,
+          headers: { "content-type": "text/html" },
+          body: "<html><body>ok</body></html>",
+        });
       }).as("decision");
 
       cy.visit(authorizeUrl);

--- a/src/metabase/oauth_server/consent_page.clj
+++ b/src/metabase/oauth_server/consent_page.clj
@@ -106,6 +106,10 @@
       [:html {:lang "en"}
        [:head
         [:meta {:charset "UTF-8"}]
+        ;; Prevent the browser from sending the (very long) authorization URL as the Referer
+        ;; header when the consent form is submitted, which could exceed the server's header
+        ;; size limit and cause a 431. The Referer is not used by the decision endpoint.
+        [:meta {:name "referrer" :content "no-referrer"}]
         [:meta {:name "viewport" :content "width=device-width, initial-scale=1.0"}]
         [:title "Authorize " (or client-name "Unknown Application")]
         [:style {:nonce nonce} (h/raw


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/76305

### Description

Adds a `no-referrer` HTML meta tag to the consent page, so that the Referer header is not sent.

One alternative could have been to use the HTTP header `Referrer-Policy: no-referrer`, but reverse proxies might interfere with this.

### How to verify

1. Use DCR to obtain a client ID:

```
curl -X POST https://worktree-fix-oauth-referer-431.metabase.localhost/oauth/register \
  -H 'Content-Type: application/json' \
  -d '{"client_name":"Referer Test",
       "redirect_uris":["https://example.com/callback"],
       "token_endpoint_auth_method":"client_secret_basic"}'
```

2. With the `client_id` from the response in the previous step, visit the OAuth consent page:

```
https://worktree-fix-oauth-referer-431.metabase.localhost/oauth/authorize?client_id=YOUR_CLIENT_ID&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&response_type=code&state=test
```

3. Click Authorize
4. Observe that the `POST /oauth/authorize/decision` request does not have a `Referer` header

### Demo

<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/a37f28aa-bf3f-4e91-b65f-9d017354b978" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
