### PR TITLE
Fix @tenant.slug tooltip to read 'system defined' on the create tenant user from

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/utils.tsx
@@ -111,9 +111,10 @@ export const getExtraAttributes = (
 
   // for newly created tenant users, we want to pre-populate their inherited attributes
   return {
+    // the slug is system defined and frozen, matching what the backend returns for existing users
     [TENANT_SLUG_ATTRIBUTE]: {
       value: tenant.slug,
-      source: "tenant",
+      source: "system",
       frozen: true,
     },
     ...Object.fromEntries(

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/utils.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/utils.unit.spec.tsx
@@ -1,0 +1,56 @@
+import type { StructuredUserAttributes } from "metabase-types/api";
+import { createMockTenant } from "metabase-types/api/mocks";
+
+import { getExtraAttributes } from "./utils";
+
+describe("getExtraAttributes", () => {
+  it("synthesizes @tenant.slug as a system-defined, frozen attribute for new tenant users", () => {
+    const tenant = createMockTenant({ slug: "ten01", attributes: {} });
+
+    const attributes = getExtraAttributes(undefined, tenant);
+
+    // must match what the backend returns for existing users so the
+    // "This attribute is system defined" tooltip shows on the create form too
+    expect(attributes?.["@tenant.slug"]).toEqual({
+      value: "ten01",
+      source: "system",
+      frozen: true,
+    });
+  });
+
+  it("synthesizes custom tenant attributes as overridable tenant attributes", () => {
+    const tenant = createMockTenant({
+      slug: "ten01",
+      attributes: { region: "emea" },
+    });
+
+    const attributes = getExtraAttributes(undefined, tenant);
+
+    expect(attributes?.region).toEqual({
+      value: "emea",
+      source: "tenant",
+      frozen: false,
+    });
+  });
+
+  it("returns existing structured attributes untouched when the slug is already present", () => {
+    const tenant = createMockTenant({ slug: "ten01" });
+    const structuredAttributes: StructuredUserAttributes = {
+      "@tenant.slug": { value: "ten01", source: "system", frozen: true },
+    };
+
+    expect(getExtraAttributes(structuredAttributes, tenant)).toBe(
+      structuredAttributes,
+    );
+  });
+
+  it("returns structured attributes unchanged when there is no tenant", () => {
+    const structuredAttributes: StructuredUserAttributes = {
+      region: { value: "emea", source: "tenant", frozen: false },
+    };
+
+    expect(getExtraAttributes(structuredAttributes, undefined)).toBe(
+      structuredAttributes,
+    );
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76318
### Description

Fixes [GIT-10387](https://linear.app/metabase/issue/GIT-10387/incorrect-tooltip-for-tenantslug-on-create-tenant-user-form).

On the Create-tenant-user form, the frozen `@tenant.slug` attribute showed the "inherited from the tenant, you can override it" tooltip instead of "This attribute is system defined".

**Cause:** the create flow synthesized `@tenant.slug` with a `tenant` source, while the backend reports it as `system` for existing users.
**Fix:** synthesize it as `system` so create and edit forms match.

### How to verify

- [ ] Admin → People → Tenant users → Create tenant user, pick a tenant, expand Attributes, hover the `@tenant.slug` info icon: tooltip reads "This attribute is system defined" and the value is disabled.

### Demo

#### Before

<img width="1004" height="653" alt="image" src="https://github.com/user-attachments/assets/c7202408-a6a9-44a8-a674-d58986da14fa" />

#### After

<img width="1998" height="947" alt="image" src="https://github.com/user-attachments/assets/926076a2-78a4-47ab-84e0-7aa4463dd2cb" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)