### PR TITLE
Use SQLite sample database in E2E tests

### DIFF
--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -23,10 +23,6 @@ process.env.MB_CUSTOM_VIZ_PLUGIN_DEV_MODE_ENABLED =
 // Expose the `en-ZZ` pseudo-locale in the Cypress backend's language pickers and API validation.
 process.env.MB_ENABLE_TEST_LOCALES = "true";
 
-// Use the H2 sample database in E2E tests. Production ships SQLite, but the test suite was written
-// against the H2 sample data; this defers migrating the tests to SQLite until after the release.
-process.env.MB_SAMPLE_DATABASE_ENGINE = "h2";
-
 if (!process.env.CI) {
   // Use a temporary copy of the sample db so it won't use and lock the db used for local development
   process.env.MB_INTERNAL_DO_NOT_USE_SAMPLE_DB_DIR = path.resolve(


### PR DESCRIPTION
Drop the MB_SAMPLE_DATABASE_ENGINE=h2 override so the Cypress backend uses the SQLite sample database we actually ship. This surfaces which E2E tests were written against H2-specific sample data behavior.

> [!IMPORTANT]
> For those employed by Metabase: if you are fixing a P0 or P1 issue, add a `backport` label to this PR. No action is needed otherwise. Refer to the [Backporting](https://app.notion.com/p/metabase/Branching-Strategy-and-Backports-6eb577d5f61142aa960a626d6bbdfeb3?source=copy_link#e71f6e7de2f945d99fbb2d6b764e6f36) section in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
