### PR TITLE
Fix dashboard question breadcrumb layout

### DIFF
--- a/frontend/src/metabase/nav/components/CollectionBreadcrumbs/CollectionBreadcrumbs.tsx
+++ b/frontend/src/metabase/nav/components/CollectionBreadcrumbs/CollectionBreadcrumbs.tsx
@@ -82,14 +82,12 @@ export const CollectionBreadcrumbs = ({
     );
 
   return (
-    <>
-      <Flex align="center" miw="0">
-        {content}
-        <CollectionBadge
-          collectionId={collection.id}
-          onClick={onClick ? () => onClick(collection) : undefined}
-        />
-      </Flex>
+    <Flex align="center" miw="0">
+      {content}
+      <CollectionBadge
+        collectionId={collection.id}
+        onClick={onClick ? () => onClick(collection) : undefined}
+      />
       {dashboard && (
         <>
           {separator}
@@ -99,7 +97,7 @@ export const CollectionBreadcrumbs = ({
           </Breadcrumb>
         </>
       )}
-    </>
+    </Flex>
   );
 };
 

--- a/frontend/src/metabase/nav/components/CollectionBreadcrumbs/CollectionBreadcrumbs.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/CollectionBreadcrumbs/CollectionBreadcrumbs.unit.spec.tsx
@@ -1,0 +1,59 @@
+import { Route } from "react-router";
+
+import { setupCollectionByIdEndpoint } from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import {
+  createMockCollection,
+  createMockDashboard,
+} from "metabase-types/api/mocks";
+
+import { CollectionBreadcrumbs } from "./CollectionBreadcrumbs";
+
+const COLLECTION = createMockCollection({
+  id: 3,
+  name: "Foo Collection",
+});
+
+const DASHBOARD = createMockDashboard({
+  id: 4,
+  name: "Bar Dashboard",
+  collection_id: 3,
+});
+
+function setup() {
+  setupCollectionByIdEndpoint({ collections: [COLLECTION] });
+
+  return renderWithProviders(
+    <Route
+      path="*"
+      component={() => (
+        <CollectionBreadcrumbs
+          baseCollectionId={null}
+          collection={COLLECTION}
+          dashboard={DASHBOARD}
+        />
+      )}
+    />,
+    { withRouter: true },
+  );
+}
+
+describe("CollectionBreadcrumbs", () => {
+  it("renders dashboard breadcrumbs inside the same wrapper as collection breadcrumbs (#76202)", async () => {
+    const { container } = setup();
+
+    const collectionLink = (await screen.findByText("Foo Collection")).closest(
+      "a",
+    );
+    const dashboardLink = screen.getByText("Bar Dashboard").closest("a");
+
+    expect(collectionLink).not.toBeNull();
+    expect(dashboardLink).not.toBeNull();
+    expect(collectionLink?.parentElement).toBe(dashboardLink?.parentElement);
+    expect(
+      Array.from(container.children).filter(
+        (child) => child.tagName.toLowerCase() !== "style",
+      ),
+    ).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76202
Closes https://linear.app/metabase/issue/UXW-4560/breadcrumbs-for-saved-questions-located-within-dashboards-look-broken

### Description

Fixes dashboard-question breadcrumbs stacking in the small app bar by rendering collection and dashboard breadcrumbs inside one flex wrapper.

### How to verify

1. Create a few nested collections, avoiding names that are too short.
2. Create a dashboard inside the most deeply nested collection.
3. Create a question in that dashboard. Save the dashboard.
4. In the dashboard page, click the question to open it.
5. On the question page, close the side nav if open, check out the breadcrumbs. The ellipsis "..." between collection names should be present, and the dashboard name should be vertically aligned.

### Demo
Before:
<img width="1156" height="170" alt="image" src="https://github.com/user-attachments/assets/6fbbb343-caee-494a-a41b-5ff63ffd0165" />

After:
<img width="1156" height="170" alt="image" src="https://github.com/user-attachments/assets/01315e53-b09e-4063-94b6-3b6ee3207866" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
