### PR TITLE
Log the reason for full remote-sync export/import fallback (GHY-3935)

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -536,7 +536,8 @@
 
                                      (not force-deletion?)
                                      (into (:deletion-conflicts @conflicts)))))
-            incremental-plan   (delay (incremental-import-plan snapshot last-imported-version))]
+            incremental-plan   (delay (incremental-import-plan snapshot last-imported-version))
+            dirty?             (delay (remote-sync.object/dirty?))]
         (cond
           merge?
           (import-merged! snapshot base-snapshot task-id sync-timestamp)
@@ -552,7 +553,7 @@
           ;; Incremental fast-path: not forced, no local drift, and the change is incrementally loadable.
           ;; Touches only changed files, so it can't wholesale-delete unsynced transforms — no conflict scan,
           ;; and only the cheap O(changes) diff is computed (never the full-tree get-conflicts read).
-          (and (not force?) (not (remote-sync.object/dirty?)) (not= incremental-not-possible @incremental-plan))
+          (and (not force?) (not @dirty?) (not= incremental-not-possible @incremental-plan))
           (incremental-load-snapshot! @incremental-plan snapshot-version task-id sync-timestamp :finalize! finalize!)
 
           (seq @blocking-conflicts)
@@ -566,7 +567,13 @@
 
           ;; No blocking conflicts: do the full reload.
           :else
-          (let [imported-data (load-snapshot! snapshot task-id sync-timestamp :finalize! finalize!)]
+          (let [reason        (cond
+                                force?        "forced"
+                                @dirty?       "local changes pending"
+                                first-import? "first import"
+                                :else         "changes not incrementally loadable")
+                _             (log/infof "Remote sync full import: %s" reason)
+                imported-data (load-snapshot! snapshot task-id sync-timestamp :finalize! finalize!)]
             (log/info "Successfully reloaded entities from git repository")
             {:status :success
              :version snapshot-version
@@ -886,7 +893,9 @@
           (cond
             ;; Forced overwrite — full re-serialize, replacing managed dirs (discards remote divergence).
             force?
-            (full-export! snapshot task-id message sync-timestamp)
+            (do
+              (log/info "Remote sync full export: forced overwrite")
+              (full-export! snapshot task-id message sync-timestamp))
 
             ;; Remote hasn't advanced and there's nothing to export: no dirty rows and no stale files in
             ;; now-disabled content dirs.
@@ -898,7 +907,9 @@
 
             ;; Remote hasn't advanced but a dirty row can't be applied incrementally → full re-serialize.
             (and (not diverged?) (= plan :remote-sync/unsyncable-batch))
-            (full-export! snapshot task-id message sync-timestamp)
+            (do
+              (log/info "Remote sync full export: a pending change can't be applied incrementally")
+              (full-export! snapshot task-id message sync-timestamp))
 
             ;; Remote hasn't advanced — incremental fast-path: write only the changed entities, deleting
             ;; their old paths plus files left behind in now-disabled content dirs, preserving every other.


### PR DESCRIPTION
## Summary

When remote sync's `export!` or `import!` falls back from the incremental fast-path to a full re-serialize / full reload, the logs didn't say why. This adds a log line at each full-sync fallback naming the reason, so an operator seeing a slow full sync can tell what forced it.

**Export** (`impl.clj`)
- forced → `Remote sync full export: forced overwrite`
- a dirty row can't be applied incrementally → `Remote sync full export: a pending change can't be applied incrementally`

**Import** (`impl.clj`)
- `Remote sync full import: <reason>` where reason is one of `forced` / `local changes pending` / `first import` / `changes not incrementally loadable`, derived from whichever guard knocked it off the incremental fast-path.

## Notes

- Small supporting refactor: import's `dirty?` is now bound as a `delay` so the fast-path check and the reason derivation share one query, without forcing it on the no-op/merge paths.
- Log-only change; no behavior change.

[GHY-3935](https://linear.app/metabase/issue/GHY-3935)