### PR TITLE
Make workspaces deletable from any database state (GHY-3954)

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/workspaces/api/workspace_manager.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api/workspace_manager.clj
@@ -134,13 +134,17 @@
                      [:schema :string]
                      [:user :string]
                      [:reason {:optional true} [:maybe :string]]]]]]
-  "Delete a Workspace. Tears down each database's warehouse isolation first
-  (blocking). Always succeeds; if the warehouse was unreachable for some databases,
-  the response includes `:orphaned_resources` and a `:message` describing the inert
-  schema/user objects left behind for manual cleanup."
-  [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
+  "Delete a Workspace. Tears down each `:provisioned` database's warehouse isolation
+  first (blocking). Refuses with a 409 if any database is still `:provisioning`/
+  `:deprovisioning` unless `ignore_pending=true`, in which case those databases are
+  left in the warehouse and only their app-DB rows are removed. If the warehouse was
+  unreachable for some `:provisioned` databases, the response includes
+  `:orphaned_resources` and a `:message` describing the inert schema/user objects
+  left behind for manual cleanup."
+  [{:keys [id]} :- [:map [:id ms/PositiveInt]]
+   {ignore-pending? :ignore-pending} :- [:map [:ignore-pending {:default false} [:maybe ms/BooleanValue]]]]
   (api/write-check :model/Workspace id)
-  (assoc (ws/delete-workspace! id) :id id))
+  (assoc (ws/delete-workspace! id (boolean ignore-pending?)) :id id))
 
 ;;; ------------------------------------------- Config download --------------------------------------------------
 

--- a/enterprise/backend/src/metabase_enterprise/workspaces/api/workspace_manager.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api/workspace_manager.clj
@@ -122,12 +122,25 @@
   (present-workspace (api/check-404 (ws/get-workspace id))))
 
 (api.macros/defendpoint :delete "/:id"
-  :- [:map [:id ms/PositiveInt] [:deleted :boolean]]
-  "Delete a Workspace. Deprovisions all databases first (blocking)."
+  :- [:map
+      [:id ms/PositiveInt]
+      [:deleted :boolean]
+      [:message {:optional true} :string]
+      [:orphaned_resources {:optional true}
+       [:sequential [:map
+                     [:workspace_database_id ms/PositiveInt]
+                     [:database_id ms/PositiveInt]
+                     [:driver :keyword]
+                     [:schema :string]
+                     [:user :string]
+                     [:reason {:optional true} [:maybe :string]]]]]]
+  "Delete a Workspace. Tears down each database's warehouse isolation first
+  (blocking). Always succeeds; if the warehouse was unreachable for some databases,
+  the response includes `:orphaned_resources` and a `:message` describing the inert
+  schema/user objects left behind for manual cleanup."
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
   (api/write-check :model/Workspace id)
-  (ws/delete-workspace! id)
-  {:id id :deleted true})
+  (assoc (ws/delete-workspace! id) :id id))
 
 ;;; ------------------------------------------- Config download --------------------------------------------------
 

--- a/enterprise/backend/src/metabase_enterprise/workspaces/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/core.clj
@@ -39,6 +39,7 @@
    [metabase.driver.sql :as driver.sql]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.settings.core :as setting]
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.workspaces.core :as ws]
    [toucan2.core :as t2]))
@@ -250,6 +251,8 @@
                        active)
         failures (filterv #(= :failure (:status %)) results)]
     (workspace/delete-workspace! id)
-    (cond-> {:deleted true}
-      (seq failures) (assoc :orphaned_resources failures
-                            :message (orphaned-resources-message id failures)))))
+    (if (seq failures)
+      (let [message (orphaned-resources-message id failures)]
+        (log/warn message)
+        {:deleted true :orphaned_resources failures :message message})
+      {:deleted true})))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/core.clj
@@ -31,6 +31,7 @@
          │                                                ▼
          └──────────────────────────────────────── provisioned"
   (:require
+   [clojure.string :as str]
    [metabase-enterprise.workspaces.models.workspace :as workspace]
    [metabase-enterprise.workspaces.models.workspace-database :as workspace-database]
    [metabase-enterprise.workspaces.provisioning :as provisioning]
@@ -222,10 +223,33 @@
           (provisioning/provision-single! wsd-id))
         (workspace/get-workspace (:id ws))))))
 
+(defn- orphaned-resources-message
+  [workspace-id failures]
+  (str (format "Workspace %d was deleted, but warehouse cleanup failed for %d database(s). "
+               workspace-id (count failures))
+       "These resources were left in place and may need to be removed manually:\n"
+       (str/join "\n"
+                 (for [{:keys [database_id driver schema user reason]} failures]
+                   (format "  - database %d (%s): schema \"%s\", user \"%s\" — not removed because: %s"
+                           database_id (name driver) schema user reason)))))
+
 (defn delete-workspace!
-  "Deprovision all databases (blocking), then delete the workspace."
+  "Tear down every database's warehouse isolation (best-effort, blocking), then
+  delete the workspace. Drives rows out of ANY state (`:provisioned`,
+  `:provisioning`, `:deprovisioning`) so a workspace is never undeletable.
+
+  Returns `{:deleted true}` on clean teardown, or
+  `{:deleted true :orphaned_resources [...] :message ..}` when the warehouse was
+  unreachable for some rows and inert schema/user objects were left behind. App-DB
+  `TableRemapping` rows are always cleared, so query routing is never left dangling."
   [id]
-  (let [ws (assert-workspace-exists id)]
-    (when (some #(= :provisioned (:status %)) (:databases ws))
-      (provisioning/deprovision-workspace! id))
-    (workspace/delete-workspace! id)))
+  (let [ws       (assert-workspace-exists id)
+        active   (remove #(= :unprovisioned (:status %)) (:databases ws))
+        results  (mapv #(provisioning/force-teardown-for-delete!
+                         % provisioning/dispatching-provisioner)
+                       active)
+        failures (filterv #(= :failure (:status %)) results)]
+    (workspace/delete-workspace! id)
+    (cond-> {:deleted true}
+      (seq failures) (assoc :orphaned_resources failures
+                            :message (orphaned-resources-message id failures)))))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/core.clj
@@ -234,25 +234,49 @@
                    (format "  - database %d (%s): schema \"%s\", user \"%s\" — not removed because: %s"
                            database_id (name driver) schema user reason)))))
 
+(defn- pending-database?
+  "True for a WorkspaceDatabase that is mid-provision/deprovision — a state we can't
+  safely tear down because warehouse work may still be in flight on another node."
+  [wsd]
+  (contains? #{:provisioning :deprovisioning} (:status wsd)))
+
 (defn delete-workspace!
-  "Tear down every database's warehouse isolation (best-effort, blocking), then
-  delete the workspace. Drives rows out of ANY state (`:provisioned`,
-  `:provisioning`, `:deprovisioning`) so a workspace is never undeletable.
+  "Tear down each `:provisioned` database's warehouse isolation (best-effort,
+  blocking), then delete the workspace.
+
+  `ignore-pending?` (default false) controls databases still `:provisioning` or
+  `:deprovisioning`: when false, refuses with a 409 (`:pending_databases` lists
+  them) since their warehouse work may be in flight; when true, those databases are
+  left untouched in the warehouse and only their app-DB rows are removed.
 
   Returns `{:deleted true}` on clean teardown, or
   `{:deleted true :orphaned_resources [...] :message ..}` when the warehouse was
-  unreachable for some rows and inert schema/user objects were left behind. App-DB
-  `TableRemapping` rows are always cleared, so query routing is never left dangling."
-  [id]
-  (let [ws       (assert-workspace-exists id)
-        active   (remove #(= :unprovisioned (:status %)) (:databases ws))
-        results  (mapv #(provisioning/force-teardown-for-delete!
-                         % provisioning/dispatching-provisioner)
-                       active)
-        failures (filterv #(= :failure (:status %)) results)]
-    (workspace/delete-workspace! id)
-    (if (seq failures)
-      (let [message (orphaned-resources-message id failures)]
-        (log/warn message)
-        {:deleted true :orphaned_resources failures :message message})
-      {:deleted true})))
+  unreachable for some `:provisioned` rows and inert schema/user objects were left
+  behind. App-DB `TableRemapping` rows are always cleared, so query routing is never
+  left dangling."
+  ([id] (delete-workspace! id false))
+  ([id ignore-pending?]
+   (let [ws       (assert-workspace-exists id)
+         databases (:databases ws)
+         pending  (filter pending-database? databases)
+         active   (filter #(= :provisioned (:status %)) databases)]
+     (when (and (seq pending) (not ignore-pending?))
+       (throw (ex-info "Cannot delete a workspace while some of its databases are still provisioning or deprovisioning"
+                       {:status-code       409
+                        :workspace_id      id
+                        :pending_databases (mapv (fn [wsd]
+                                                   {:database_id (:database_id wsd)
+                                                    :name        (:name (:database wsd))
+                                                    :status      (:status wsd)})
+                                                 pending)})))
+     (let [results  (mapv #(provisioning/force-teardown-for-delete!
+                            % provisioning/dispatching-provisioner)
+                          active)
+           failures (filterv #(= :failure (:status %)) results)]
+       (run! provisioning/ignore-pending-database! pending)
+       (workspace/delete-workspace! id)
+       (if (seq failures)
+         (let [message (orphaned-resources-message id failures)]
+           (log/warn message)
+           {:deleted true :orphaned_resources failures :message message})
+         {:deleted true})))))

--- a/enterprise/backend/src/metabase_enterprise/workspaces/provisioning.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/provisioning.clj
@@ -242,6 +242,9 @@
                       (destroy! provisioner driver db workspace)
                       {:status :success}
                       (catch Throwable t
+                        (log/warnf t (str "Workspace database %d: warehouse cleanup failed; leaving schema \"%s\" "
+                                          "and user \"%s\" on database %d for manual removal")
+                                   (:id wsd) schema user (:database_id wsd))
                         {:status                :failure
                          :workspace_database_id (:id wsd)
                          :database_id           (:database_id wsd)

--- a/enterprise/backend/src/metabase_enterprise/workspaces/provisioning.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/provisioning.clj
@@ -262,6 +262,19 @@
                   {:output_namespace "" :database_details {} :status :unprovisioned})
       result)))
 
+(defn ignore-pending-database!
+  "Delete-path helper for a WorkspaceDatabase the admin chose to delete while it is
+  still `:provisioning`/`:deprovisioning`. Does NOT touch the warehouse — the row may
+  be in flight on another node — it only clears the row's app-DB `TableRemapping`
+  rows and forces it to `:unprovisioned` so it can be cascade-deleted. Any warehouse
+  schema/user is intentionally left in place."
+  [wsd]
+  (with-workspace-database-lock (:id wsd)
+    (let [db (t2/select-one :model/Database :id (:database_id wsd))]
+      (binding [t2.connection/*current-connectable* nil]
+        (ws.remapping-cleanup/clear-mappings-for-iso! db (:database_id wsd) (:output_namespace wsd)))
+      (t2/update! :model/WorkspaceDatabase {:id (:id wsd)} {:status :unprovisioned}))))
+
 (defn deprovision-workspace!
   "Flip every `:provisioned` WorkspaceDatabase under `workspace-id` to
   `:deprovisioning`, then deprovision each one synchronously (blocking).

--- a/enterprise/backend/src/metabase_enterprise/workspaces/provisioning.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/provisioning.clj
@@ -207,6 +207,58 @@
              (log/warnf t "Failed to provision WorkspaceDatabase %s" id)))))
      triggered)))
 
+(defn force-teardown-for-delete!
+  "Best-effort warehouse teardown for a single WorkspaceDatabase, used only by the
+  delete path. Drops the iso schema + user (idempotent), always clears the row's
+  app-DB `TableRemapping` rows, then forces the row to `:unprovisioned` regardless
+  of the warehouse outcome.
+
+  Works from ANY non-`:unprovisioned` state: the iso schema and user names are
+  deterministic from the row id (see [[metabase.driver.util/workspace-isolation-namespace-name]]),
+  so the destroy target is reconstructable even for a row stuck in `:provisioning`
+  that never stored its `:output_namespace`/`:database_details`.
+
+  Returns `{:status :success}` when the warehouse objects were dropped, or
+  `{:status :failure :workspace_database_id .. :database_id .. :driver .. :schema ..
+  :user .. :reason ..}` when the warehouse was unreachable and inert objects were
+  left behind for manual cleanup."
+  [wsd provisioner]
+  (with-workspace-database-lock (:id wsd)
+    (let [db        (t2/select-one :model/Database :id (:database_id wsd))
+          driver    (driver.u/database->driver db)
+          iso-ws    {:id (:id wsd) :name (str "wsd-" (:id wsd))}
+          schema    (or (not-empty (:output_namespace wsd))
+                        (driver.u/workspace-isolation-namespace-name iso-ws))
+          user      (or (get-in wsd [:database_details :user])
+                        (driver.u/workspace-isolation-user-name iso-ws))
+          ;; prefer the stored details verbatim (some drivers stash more than :user
+          ;; there); synthesize a minimal map only for a crashed :provisioning row
+          ;; that never recorded anything.
+          details   (if (seq (:database_details wsd))
+                      (:database_details wsd)
+                      {:user user})
+          workspace (assoc iso-ws :schema schema :database_details details)
+          result    (try
+                      (destroy! provisioner driver db workspace)
+                      {:status :success}
+                      (catch Throwable t
+                        {:status                :failure
+                         :workspace_database_id (:id wsd)
+                         :database_id           (:database_id wsd)
+                         :driver                driver
+                         :schema                schema
+                         :user                  user
+                         :reason                (ex-message t)}))]
+      ;; App-DB cleanup needs no warehouse connection, so it ALWAYS runs — stale
+      ;; remappings would otherwise rewrite queries to a dropped schema and 500 the
+      ;; QP. Fresh autocommit connection to survive any surrounding tx rollback
+      ;; (mirrors `deprovision-workspace-database!`).
+      (binding [t2.connection/*current-connectable* nil]
+        (ws.remapping-cleanup/clear-mappings-for-iso! db (:database_id wsd) schema))
+      (t2/update! :model/WorkspaceDatabase {:id (:id wsd)}
+                  {:output_namespace "" :database_details {} :status :unprovisioned})
+      result)))
+
 (defn deprovision-workspace!
   "Flip every `:provisioned` WorkspaceDatabase under `workspace-id` to
   `:deprovisioning`, then deprovision each one synchronously (blocking).

--- a/enterprise/backend/test/metabase_enterprise/workspaces/api/workspace_manager_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api/workspace_manager_test.clj
@@ -8,7 +8,8 @@
    [metabase-enterprise.workspaces.provisioning :as provisioning]
    [metabase.permissions.test-util :as perms.test-util]
    [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures]))
+   [metabase.test.fixtures :as fixtures]
+   [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db))
 
@@ -48,6 +49,27 @@
             (testing "delete"
               (is (=? {:id ws-id :deleted true}
                       (mt/user-http-request :crowberto :delete 200 (str "ee/workspace-manager/" ws-id))))
+              (mt/user-http-request :crowberto :get 404 (str "ee/workspace-manager/" ws-id)))))))))
+
+(deftest delete-workspace-pending-databases-test
+  (testing "DELETE refuses a workspace with a pending database unless ignore_pending=true"
+    (mt/with-temp [:model/Database {db-id :id} {:engine   :postgres
+                                                :details  {}
+                                                :settings {:database-enable-workspaces true}}]
+      (mt/with-model-cleanup [:model/Workspace]
+        (with-redefs [provisioning/dispatching-provisioner (stub-provisioner)]
+          (let [{ws-id :id} (mt/user-http-request :crowberto :post 200 "ee/workspace-manager/"
+                                                  {:name "Pending" :database_ids [db-id]})
+                wsd-id      (t2/select-one-pk :model/WorkspaceDatabase :workspace_id ws-id)]
+            (t2/update! :model/WorkspaceDatabase {:id wsd-id} {:status :provisioning})
+            (testing "refused by default with a 409 listing the pending databases"
+              (is (=? {:pending_databases [{:database_id db-id :status "provisioning"}]}
+                      (mt/user-http-request :crowberto :delete 409 (str "ee/workspace-manager/" ws-id))))
+              (mt/user-http-request :crowberto :get 200 (str "ee/workspace-manager/" ws-id)))
+            (testing "ignore-pending=true deletes anyway"
+              (is (=? {:id ws-id :deleted true}
+                      (mt/user-http-request :crowberto :delete 200
+                                            (str "ee/workspace-manager/" ws-id "?ignore-pending=true"))))
               (mt/user-http-request :crowberto :get 404 (str "ee/workspace-manager/" ws-id)))))))))
 
 (deftest create-workspace-with-database-ids-test

--- a/enterprise/backend/test/metabase_enterprise/workspaces/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/core_test.clj
@@ -125,26 +125,40 @@
         (is (= {:deleted true} (ws/delete-workspace! (:id ws))))
         (is (nil? (ws/get-workspace (:id ws))))))))
 
-(deftest delete-workspace-with-stuck-status-test
-  (testing "GHY-3954: a workspace whose WorkspaceDatabase is stuck in an intermediate"
-    (testing "state (e.g. after a crash mid-provision) is still deletable"
-      (doseq [stuck-status [:provisioning :deprovisioning]]
-        (testing (str "status " stuck-status)
-          (mt/with-model-cleanup [:model/Workspace]
-            (let [ws     (ws/create-workspace! {:name       (str "Stuck " (name stuck-status))
-                                                :creator_id (mt/user->id :crowberto)})
-                  _      (with-redefs [provisioning/dispatching-provisioner (stub-provisioner)]
-                           (add-database! (:id ws) (mt/id) ["PUBLIC"]))
-                  wsd-id (t2/select-one-pk :model/WorkspaceDatabase :workspace_id (:id ws))]
-              ;; force the row into the stuck state. :provisioning rows that crashed
-              ;; never stored their iso details, so clear them too to exercise the
-              ;; deterministic-name reconstruction path.
-              (t2/update! :model/WorkspaceDatabase {:id wsd-id}
-                          (cond-> {:status stuck-status}
-                            (= stuck-status :provisioning)
-                            (assoc :output_namespace "" :database_details {})))
-              (with-redefs [provisioning/dispatching-provisioner (stub-provisioner)]
-                (is (= {:deleted true} (ws/delete-workspace! (:id ws)))))
+(deftest delete-workspace-with-pending-status-test
+  (testing "GHY-3954: a workspace with a database still :provisioning/:deprovisioning"
+    (doseq [pending-status [:provisioning :deprovisioning]]
+      (testing (str "status " pending-status)
+        (mt/with-model-cleanup [:model/Workspace]
+          (let [ws     (ws/create-workspace! {:name       (str "Pending " (name pending-status))
+                                              :creator_id (mt/user->id :crowberto)})
+                _      (with-redefs [provisioning/dispatching-provisioner (stub-provisioner)]
+                         (add-database! (:id ws) (mt/id) ["PUBLIC"]))
+                wsd-id (t2/select-one-pk :model/WorkspaceDatabase :workspace_id (:id ws))]
+            ;; force the row into the pending state. :provisioning rows that crashed
+            ;; never stored their iso details, so clear them too.
+            (t2/update! :model/WorkspaceDatabase {:id wsd-id}
+                        (cond-> {:status pending-status}
+                          (= pending-status :provisioning)
+                          (assoc :output_namespace "" :database_details {})))
+            (testing "is refused by default, listing the pending databases"
+              (is (thrown-with-msg?
+                   ExceptionInfo #"still provisioning or deprovisioning"
+                   (ws/delete-workspace! (:id ws))))
+              (is (=? {:status-code       409
+                       :pending_databases [{:database_id (mt/id) :status pending-status}]}
+                      (try (ws/delete-workspace! (:id ws))
+                           (catch ExceptionInfo e (ex-data e)))))
+              (is (some? (ws/get-workspace (:id ws)))
+                  "the workspace is left intact when the delete is refused"))
+            (testing "is deleted when ignore-pending? is true; the warehouse is left untouched"
+              ;; destroy! must NOT be called for a pending row — fail loudly if it is.
+              (let [exploding (reify provisioning/Provisioner
+                                (init!    [_ _ _ _]   nil)
+                                (grant!   [_ _ _ _ _] nil)
+                                (destroy! [_ _ _ _]   (throw (ex-info "destroy! must not run for a pending row" {}))))]
+                (with-redefs [provisioning/dispatching-provisioner exploding]
+                  (is (= {:deleted true} (ws/delete-workspace! (:id ws) true)))))
               (is (nil? (ws/get-workspace (:id ws))))
               (is (not (t2/exists? :model/WorkspaceDatabase :id wsd-id))))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/workspaces/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/core_test.clj
@@ -122,8 +122,58 @@
   (testing "delete workspace with no databases"
     (mt/with-model-cleanup [:model/Workspace]
       (let [ws (ws/create-workspace! {:name "Empty WS" :creator_id (mt/user->id :crowberto)})]
-        (ws/delete-workspace! (:id ws))
+        (is (= {:deleted true} (ws/delete-workspace! (:id ws))))
         (is (nil? (ws/get-workspace (:id ws))))))))
+
+(deftest delete-workspace-with-stuck-status-test
+  (testing "GHY-3954: a workspace whose WorkspaceDatabase is stuck in an intermediate"
+    (testing "state (e.g. after a crash mid-provision) is still deletable"
+      (doseq [stuck-status [:provisioning :deprovisioning]]
+        (testing (str "status " stuck-status)
+          (mt/with-model-cleanup [:model/Workspace]
+            (let [ws     (ws/create-workspace! {:name       (str "Stuck " (name stuck-status))
+                                                :creator_id (mt/user->id :crowberto)})
+                  _      (with-redefs [provisioning/dispatching-provisioner (stub-provisioner)]
+                           (add-database! (:id ws) (mt/id) ["PUBLIC"]))
+                  wsd-id (t2/select-one-pk :model/WorkspaceDatabase :workspace_id (:id ws))]
+              ;; force the row into the stuck state. :provisioning rows that crashed
+              ;; never stored their iso details, so clear them too to exercise the
+              ;; deterministic-name reconstruction path.
+              (t2/update! :model/WorkspaceDatabase {:id wsd-id}
+                          (cond-> {:status stuck-status}
+                            (= stuck-status :provisioning)
+                            (assoc :output_namespace "" :database_details {})))
+              (with-redefs [provisioning/dispatching-provisioner (stub-provisioner)]
+                (is (= {:deleted true} (ws/delete-workspace! (:id ws)))))
+              (is (nil? (ws/get-workspace (:id ws))))
+              (is (not (t2/exists? :model/WorkspaceDatabase :id wsd-id))))))))))
+
+(deftest delete-workspace-warehouse-unreachable-test
+  (testing "GHY-3954: delete still succeeds when warehouse teardown fails; the result"
+    (testing "names the orphaned schema/user and why they were left behind"
+      (mt/with-model-cleanup [:model/Workspace]
+        (let [ws     (ws/create-workspace! {:name "Unreachable WS" :creator_id (mt/user->id :crowberto)})
+              _      (with-redefs [provisioning/dispatching-provisioner (stub-provisioner)]
+                       (add-database! (:id ws) (mt/id) ["PUBLIC"]))
+              wsd-id (t2/select-one-pk :model/WorkspaceDatabase :workspace_id (:id ws))
+              boom   (reify provisioning/Provisioner
+                       (init!    [_ _ _ _]   nil)
+                       (grant!   [_ _ _ _ _] nil)
+                       (destroy! [_ _ _ _]   (throw (ex-info "Connection refused" {}))))
+              result (with-redefs [provisioning/dispatching-provisioner boom]
+                       (ws/delete-workspace! (:id ws)))]
+          (is (true? (:deleted result)))
+          (is (nil? (ws/get-workspace (:id ws)))
+              "the workspace is deleted even though warehouse cleanup failed")
+          (is (=? [{:status                :failure
+                    :workspace_database_id wsd-id
+                    :database_id           (mt/id)
+                    :schema                "mb_iso_stub"
+                    :user                  "stub_user"
+                    :reason                "Connection refused"}]
+                  (:orphaned_resources result)))
+          (is (re-find #"was deleted, but warehouse cleanup failed" (:message result)))
+          (is (re-find #"Connection refused" (:message result))))))))
 
 ;;; -------------------------------------------- Remappings ----------------------------------------------------
 

--- a/enterprise/frontend/src/metabase-enterprise/api/workspace-manager.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/workspace-manager.ts
@@ -1,5 +1,6 @@
 import type {
   CreateWorkspaceRequest,
+  DeleteWorkspaceRequest,
   DeleteWorkspaceResponse,
   UpdateWorkspaceRequest,
   Workspace,
@@ -23,6 +24,14 @@ export const workspaceManagerApi = EnterpriseApi.injectEndpoints({
       }),
       providesTags: (workspaces = []) => provideWorkspaceListTags(workspaces),
     }),
+    getWorkspace: builder.query<Workspace, WorkspaceId>({
+      query: (id) => ({
+        method: "GET",
+        url: `/api/ee/workspace-manager/${id}`,
+      }),
+      providesTags: (workspace) =>
+        workspace ? [idTag("workspace", workspace.id)] : [],
+    }),
     createWorkspace: builder.mutation<Workspace, CreateWorkspaceRequest>({
       query: (body) => ({
         method: "POST",
@@ -41,12 +50,16 @@ export const workspaceManagerApi = EnterpriseApi.injectEndpoints({
       invalidatesTags: (_, error, { id }) =>
         invalidateTags(error, [listTag("workspace"), idTag("workspace", id)]),
     }),
-    deleteWorkspace: builder.mutation<DeleteWorkspaceResponse, WorkspaceId>({
-      query: (id) => ({
+    deleteWorkspace: builder.mutation<
+      DeleteWorkspaceResponse,
+      DeleteWorkspaceRequest
+    >({
+      query: ({ id, ignorePending }) => ({
         method: "DELETE",
         url: `/api/ee/workspace-manager/${id}`,
+        params: ignorePending ? { "ignore-pending": true } : undefined,
       }),
-      invalidatesTags: (_, error, id) =>
+      invalidatesTags: (_, error, { id }) =>
         invalidateTags(error, [listTag("workspace"), idTag("workspace", id)]),
     }),
   }),
@@ -54,6 +67,7 @@ export const workspaceManagerApi = EnterpriseApi.injectEndpoints({
 
 export const {
   useListWorkspacesQuery,
+  useGetWorkspaceQuery,
   useCreateWorkspaceMutation,
   useUpdateWorkspaceMutation,
   useDeleteWorkspaceMutation,

--- a/enterprise/frontend/src/metabase-enterprise/api/workspace-manager.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/workspace-manager.ts
@@ -1,5 +1,6 @@
 import type {
   CreateWorkspaceRequest,
+  DeleteWorkspaceResponse,
   UpdateWorkspaceRequest,
   Workspace,
   WorkspaceId,
@@ -40,7 +41,7 @@ export const workspaceManagerApi = EnterpriseApi.injectEndpoints({
       invalidatesTags: (_, error, { id }) =>
         invalidateTags(error, [listTag("workspace"), idTag("workspace", id)]),
     }),
-    deleteWorkspace: builder.mutation<void, WorkspaceId>({
+    deleteWorkspace: builder.mutation<DeleteWorkspaceResponse, WorkspaceId>({
       query: (id) => ({
         method: "DELETE",
         url: `/api/ee/workspace-manager/${id}`,

--- a/enterprise/frontend/src/metabase-enterprise/workspaces/pages/WorkspaceListPage/DeleteWorkspaceModal/DeleteWorkspaceModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/workspaces/pages/WorkspaceListPage/DeleteWorkspaceModal/DeleteWorkspaceModal.tsx
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { useToast } from "metabase/common/hooks/use-toast";
 import {
   Form,
   FormErrorMessage,
@@ -52,9 +53,20 @@ function DeleteWorkspaceForm({
   onClose,
 }: DeleteWorkspaceFormProps) {
   const [deleteWorkspace] = useDeleteWorkspaceMutation();
+  const [sendToast] = useToast();
 
   const handleSubmit = async () => {
-    await deleteWorkspace(workspace.id).unwrap();
+    const result = await deleteWorkspace(workspace.id).unwrap();
+    // The workspace is deleted even when warehouse teardown partly fails; warn the
+    // admin so the leftover schema/user objects can be removed manually.
+    if (result.orphaned_resources?.length) {
+      sendToast({
+        message: result.message,
+        icon: "warning",
+        toastColor: "error",
+        timeout: null,
+      });
+    }
     onDelete();
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/workspaces/pages/WorkspaceListPage/DeleteWorkspaceModal/DeleteWorkspaceModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/workspaces/pages/WorkspaceListPage/DeleteWorkspaceModal/DeleteWorkspaceModal.tsx
@@ -7,9 +7,20 @@ import {
   FormProvider,
   FormSubmitButton,
 } from "metabase/forms";
-import { Button, FocusTrap, Group, Modal, Stack, Text } from "metabase/ui";
-import { useDeleteWorkspaceMutation } from "metabase-enterprise/api";
-import type { Workspace } from "metabase-types/api";
+import {
+  Button,
+  FocusTrap,
+  Group,
+  List,
+  Modal,
+  Stack,
+  Text,
+} from "metabase/ui";
+import {
+  useDeleteWorkspaceMutation,
+  useGetWorkspaceQuery,
+} from "metabase-enterprise/api";
+import type { Workspace, WorkspaceDatabase } from "metabase-types/api";
 
 export type DeleteWorkspaceModalProps = {
   workspace: Workspace;
@@ -17,6 +28,11 @@ export type DeleteWorkspaceModalProps = {
   onDelete: () => void;
   onClose: () => void;
 };
+
+function isPending(workspaceDatabase: WorkspaceDatabase) {
+  const { status } = workspaceDatabase;
+  return status === "provisioning" || status === "deprovisioning";
+}
 
 export function DeleteWorkspaceModal({
   workspace,
@@ -34,6 +50,7 @@ export function DeleteWorkspaceModal({
       <FocusTrap.InitialFocus />
       <DeleteWorkspaceForm
         workspace={workspace}
+        opened={opened}
         onDelete={onDelete}
         onClose={onClose}
       />
@@ -43,20 +60,36 @@ export function DeleteWorkspaceModal({
 
 type DeleteWorkspaceFormProps = {
   workspace: Workspace;
+  opened: boolean;
   onDelete: () => void;
   onClose: () => void;
 };
 
 function DeleteWorkspaceForm({
   workspace,
+  opened,
   onDelete,
   onClose,
 }: DeleteWorkspaceFormProps) {
   const [deleteWorkspace] = useDeleteWorkspaceMutation();
   const [sendToast] = useToast();
+  // The list page omits databases, so fetch the hydrated workspace to learn which
+  // databases are still provisioning/deprovisioning. Skipped while the modal is closed.
+  const { data: hydratedWorkspace, isLoading } = useGetWorkspaceQuery(
+    workspace.id,
+    { skip: !opened },
+  );
+
+  const pendingDatabases = (hydratedWorkspace?.databases ?? []).filter(
+    isPending,
+  );
+  const hasPendingDatabases = pendingDatabases.length > 0;
 
   const handleSubmit = async () => {
-    const result = await deleteWorkspace(workspace.id).unwrap();
+    const result = await deleteWorkspace({
+      id: workspace.id,
+      ignorePending: hasPendingDatabases,
+    }).unwrap();
     // The workspace is deleted even when warehouse teardown partly fails; warn the
     // admin so the leftover schema/user objects can be removed manually.
     if (result.orphaned_resources?.length) {
@@ -74,9 +107,25 @@ function DeleteWorkspaceForm({
     <FormProvider initialValues={{}} onSubmit={handleSubmit}>
       <Form>
         <Stack gap="lg">
-          <Text>
-            {t`This will delete the workspace as well as the temporary database users and schemas that were created for this workspace. This can't be undone.`}
-          </Text>
+          {hasPendingDatabases ? (
+            <Stack gap="sm">
+              <Text>
+                {t`Some of this workspace's databases are still being set up or torn down. Deleting now will remove the workspace, but their temporary database users and schemas will be left in place and must be removed manually:`}
+              </Text>
+              <List>
+                {pendingDatabases.map((workspaceDatabase) => (
+                  <List.Item key={workspaceDatabase.database_id}>
+                    {workspaceDatabase.database?.name ??
+                      t`Database ${workspaceDatabase.database_id}`}
+                  </List.Item>
+                ))}
+              </List>
+            </Stack>
+          ) : (
+            <Text>
+              {t`This will delete the workspace as well as the temporary database users and schemas that were created for this workspace. This can't be undone.`}
+            </Text>
+          )}
           <FormErrorMessage />
           <Group justify="flex-end">
             <Button onClick={onClose}>{t`Cancel`}</Button>
@@ -84,6 +133,7 @@ function DeleteWorkspaceForm({
               label={t`Delete workspace`}
               variant="filled"
               color="danger"
+              disabled={isLoading}
             />
           </Group>
         </Stack>

--- a/enterprise/frontend/src/metabase-enterprise/workspaces/pages/WorkspaceListPage/DeleteWorkspaceModal/DeleteWorkspaceModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/workspaces/pages/WorkspaceListPage/DeleteWorkspaceModal/DeleteWorkspaceModal.unit.spec.tsx
@@ -4,14 +4,18 @@ import fetchMock from "fetch-mock";
 import {
   setupDeleteWorkspaceEndpoint,
   setupDeleteWorkspaceEndpointError,
+  setupGetWorkspaceEndpoint,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { UndoListing } from "metabase/common/components/UndoListing";
-import { createMockWorkspace } from "metabase-types/api/mocks";
+import type { WorkspaceDatabase } from "metabase-types/api";
+import {
+  createMockDatabase,
+  createMockWorkspace,
+  createMockWorkspaceDatabase,
+} from "metabase-types/api/mocks";
 
 import { DeleteWorkspaceModal } from "./DeleteWorkspaceModal";
-
-const WORKSPACE = createMockWorkspace({ id: 1, name: "My workspace" });
 
 const ORPHAN_MESSAGE =
   'Workspace 1 was deleted, but warehouse cleanup failed for 1 database(s). These resources were left in place and may need to be removed manually:\n  - database 2 (postgres): schema "mb_iso_1", user "mb_iso_1" — not removed because: Connection refused';
@@ -19,11 +23,23 @@ const ORPHAN_MESSAGE =
 function setup({
   withError = false,
   withOrphans = false,
-}: { withError?: boolean; withOrphans?: boolean } = {}) {
+  databases = [],
+}: {
+  withError?: boolean;
+  withOrphans?: boolean;
+  databases?: WorkspaceDatabase[];
+} = {}) {
+  const workspace = createMockWorkspace({
+    id: 1,
+    name: "My workspace",
+    databases,
+  });
+  setupGetWorkspaceEndpoint(workspace);
+
   if (withError) {
-    setupDeleteWorkspaceEndpointError(WORKSPACE.id);
+    setupDeleteWorkspaceEndpointError(workspace.id);
   } else if (withOrphans) {
-    setupDeleteWorkspaceEndpoint(WORKSPACE.id, {
+    setupDeleteWorkspaceEndpoint(workspace.id, {
       message: ORPHAN_MESSAGE,
       orphaned_resources: [
         {
@@ -37,7 +53,7 @@ function setup({
       ],
     });
   } else {
-    setupDeleteWorkspaceEndpoint(WORKSPACE.id);
+    setupDeleteWorkspaceEndpoint(workspace.id);
   }
 
   const onDelete = jest.fn();
@@ -46,7 +62,7 @@ function setup({
   renderWithProviders(
     <>
       <DeleteWorkspaceModal
-        workspace={WORKSPACE}
+        workspace={workspace}
         opened
         onDelete={onDelete}
         onClose={onClose}
@@ -55,23 +71,57 @@ function setup({
     </>,
   );
 
-  return { onDelete, onClose };
+  return { workspace, onDelete, onClose };
+}
+
+async function clickDelete() {
+  const button = await screen.findByRole("button", {
+    name: "Delete workspace",
+  });
+  await waitFor(() => expect(button).toBeEnabled());
+  await userEvent.click(button);
 }
 
 describe("DeleteWorkspaceModal", () => {
   it("should delete the workspace and call the callback when the confirm button is clicked", async () => {
     const { onDelete } = setup();
 
-    await userEvent.click(
-      screen.getByRole("button", { name: "Delete workspace" }),
-    );
+    await clickDelete();
 
     await waitFor(() => {
       expect(
-        fetchMock.callHistory.called(
-          `path:/api/ee/workspace-manager/${WORKSPACE.id}`,
-          { method: "DELETE" },
-        ),
+        fetchMock.callHistory.called("path:/api/ee/workspace-manager/1", {
+          method: "DELETE",
+        }),
+      ).toBe(true);
+    });
+    await waitFor(() => expect(onDelete).toHaveBeenCalled());
+  });
+
+  it("should list pending databases and delete with ignore-pending when confirmed", async () => {
+    const { onDelete } = setup({
+      databases: [
+        createMockWorkspaceDatabase({
+          database_id: 7,
+          status: "provisioning",
+          database: createMockDatabase({ id: 7, name: "Pending DB" }),
+        }),
+      ],
+    });
+
+    expect(
+      await screen.findByText(/still being set up or torn down/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Pending DB")).toBeInTheDocument();
+
+    await clickDelete();
+
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory.called("path:/api/ee/workspace-manager/1", {
+          method: "DELETE",
+          query: { "ignore-pending": "true" },
+        }),
       ).toBe(true);
     });
     await waitFor(() => expect(onDelete).toHaveBeenCalled());
@@ -80,9 +130,7 @@ describe("DeleteWorkspaceModal", () => {
   it("should warn about orphaned warehouse resources but still delete when teardown partly fails", async () => {
     const { onDelete } = setup({ withOrphans: true });
 
-    await userEvent.click(
-      screen.getByRole("button", { name: "Delete workspace" }),
-    );
+    await clickDelete();
 
     expect(
       await screen.findByText(/warehouse cleanup failed/i),
@@ -94,9 +142,7 @@ describe("DeleteWorkspaceModal", () => {
   it("should show an error message and not call the callback when the request fails", async () => {
     const { onDelete } = setup({ withError: true });
 
-    await userEvent.click(
-      screen.getByRole("button", { name: "Delete workspace" }),
-    );
+    await clickDelete();
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "An error occurred",

--- a/enterprise/frontend/src/metabase-enterprise/workspaces/pages/WorkspaceListPage/DeleteWorkspaceModal/DeleteWorkspaceModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/workspaces/pages/WorkspaceListPage/DeleteWorkspaceModal/DeleteWorkspaceModal.unit.spec.tsx
@@ -6,15 +6,36 @@ import {
   setupDeleteWorkspaceEndpointError,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { UndoListing } from "metabase/common/components/UndoListing";
 import { createMockWorkspace } from "metabase-types/api/mocks";
 
 import { DeleteWorkspaceModal } from "./DeleteWorkspaceModal";
 
 const WORKSPACE = createMockWorkspace({ id: 1, name: "My workspace" });
 
-function setup({ withError = false }: { withError?: boolean } = {}) {
+const ORPHAN_MESSAGE =
+  'Workspace 1 was deleted, but warehouse cleanup failed for 1 database(s). These resources were left in place and may need to be removed manually:\n  - database 2 (postgres): schema "mb_iso_1", user "mb_iso_1" — not removed because: Connection refused';
+
+function setup({
+  withError = false,
+  withOrphans = false,
+}: { withError?: boolean; withOrphans?: boolean } = {}) {
   if (withError) {
     setupDeleteWorkspaceEndpointError(WORKSPACE.id);
+  } else if (withOrphans) {
+    setupDeleteWorkspaceEndpoint(WORKSPACE.id, {
+      message: ORPHAN_MESSAGE,
+      orphaned_resources: [
+        {
+          workspace_database_id: 1,
+          database_id: 2,
+          driver: "postgres",
+          schema: "mb_iso_1",
+          user: "mb_iso_1",
+          reason: "Connection refused",
+        },
+      ],
+    });
   } else {
     setupDeleteWorkspaceEndpoint(WORKSPACE.id);
   }
@@ -23,12 +44,15 @@ function setup({ withError = false }: { withError?: boolean } = {}) {
   const onClose = jest.fn();
 
   renderWithProviders(
-    <DeleteWorkspaceModal
-      workspace={WORKSPACE}
-      opened
-      onDelete={onDelete}
-      onClose={onClose}
-    />,
+    <>
+      <DeleteWorkspaceModal
+        workspace={WORKSPACE}
+        opened
+        onDelete={onDelete}
+        onClose={onClose}
+      />
+      <UndoListing />
+    </>,
   );
 
   return { onDelete, onClose };
@@ -50,6 +74,20 @@ describe("DeleteWorkspaceModal", () => {
         ),
       ).toBe(true);
     });
+    await waitFor(() => expect(onDelete).toHaveBeenCalled());
+  });
+
+  it("should warn about orphaned warehouse resources but still delete when teardown partly fails", async () => {
+    const { onDelete } = setup({ withOrphans: true });
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Delete workspace" }),
+    );
+
+    expect(
+      await screen.findByText(/warehouse cleanup failed/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Connection refused/i)).toBeInTheDocument();
     await waitFor(() => expect(onDelete).toHaveBeenCalled());
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/workspaces/pages/WorkspaceListPage/WorkspaceItem/WorkspaceItem.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/workspaces/pages/WorkspaceListPage/WorkspaceItem/WorkspaceItem.unit.spec.tsx
@@ -1,5 +1,6 @@
 import userEvent from "@testing-library/user-event";
 
+import { setupGetWorkspaceEndpoint } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
 import {
   createMockDatabase,
@@ -13,6 +14,8 @@ import { WorkspaceItem } from "./WorkspaceItem";
 const WORKSPACE = createMockWorkspace({ id: 1, name: "My workspace" });
 
 function setup({ workspace = WORKSPACE } = {}) {
+  // The delete modal fetches the hydrated workspace when opened.
+  setupGetWorkspaceEndpoint(workspace);
   renderWithProviders(<WorkspaceItem workspace={workspace} />);
 }
 

--- a/frontend/src/metabase-types/api/workspace-manager.ts
+++ b/frontend/src/metabase-types/api/workspace-manager.ts
@@ -36,3 +36,21 @@ export type UpdateWorkspaceRequest = {
   id: WorkspaceId;
   name?: string;
 };
+
+export type OrphanedWorkspaceResource = {
+  workspace_database_id: number;
+  database_id: DatabaseId;
+  driver: string;
+  schema: string;
+  user: string;
+  reason?: string | null;
+};
+
+export type DeleteWorkspaceResponse = {
+  id: WorkspaceId;
+  deleted: boolean;
+  // Present only when the warehouse was unreachable during teardown: the workspace
+  // is still deleted, but these inert schema/user objects were left behind.
+  message?: string;
+  orphaned_resources?: OrphanedWorkspaceResource[];
+};

--- a/frontend/src/metabase-types/api/workspace-manager.ts
+++ b/frontend/src/metabase-types/api/workspace-manager.ts
@@ -46,6 +46,14 @@ export type OrphanedWorkspaceResource = {
   reason?: string | null;
 };
 
+export type DeleteWorkspaceRequest = {
+  id: WorkspaceId;
+  // When the workspace has databases still provisioning/deprovisioning, the
+  // backend refuses unless this is set — then it leaves those databases'
+  // warehouse resources in place and removes only the app-DB rows.
+  ignorePending?: boolean;
+};
+
 export type DeleteWorkspaceResponse = {
   id: WorkspaceId;
   deleted: boolean;

--- a/frontend/test/__support__/server-mocks/workspace-manager.ts
+++ b/frontend/test/__support__/server-mocks/workspace-manager.ts
@@ -12,6 +12,10 @@ export function setupListWorkspacesEndpoint(workspaces: Workspace[]) {
   fetchMock.get(BASE_URL, workspaces);
 }
 
+export function setupGetWorkspaceEndpoint(workspace: Workspace) {
+  fetchMock.get(`${BASE_URL}/${workspace.id}`, workspace);
+}
+
 export function setupCreateWorkspaceEndpoint(workspace: Workspace) {
   fetchMock.post(BASE_URL, workspace);
 }

--- a/frontend/test/__support__/server-mocks/workspace-manager.ts
+++ b/frontend/test/__support__/server-mocks/workspace-manager.ts
@@ -1,6 +1,10 @@
 import fetchMock from "fetch-mock";
 
-import type { Workspace, WorkspaceId } from "metabase-types/api";
+import type {
+  DeleteWorkspaceResponse,
+  Workspace,
+  WorkspaceId,
+} from "metabase-types/api";
 
 const BASE_URL = "path:/api/ee/workspace-manager";
 
@@ -16,10 +20,14 @@ export function setupUpdateWorkspaceEndpoint(workspace: Workspace) {
   fetchMock.put(`${BASE_URL}/${workspace.id}`, workspace);
 }
 
-export function setupDeleteWorkspaceEndpoint(workspaceId: WorkspaceId) {
+export function setupDeleteWorkspaceEndpoint(
+  workspaceId: WorkspaceId,
+  response?: Partial<DeleteWorkspaceResponse>,
+) {
   fetchMock.delete(`${BASE_URL}/${workspaceId}`, {
     id: workspaceId,
     deleted: true,
+    ...response,
   });
 }
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76304
## Problem

Creating a workspace and then trying to delete it could fail with:

> Cannot delete a workspace with databases that are not :unprovisioned; deprovision them first (409)

`core/delete-workspace!` only deprovisioned rows in the `:provisioned` state, but the model-level guard (`models/workspace.clj`) rejects **any** `WorkspaceDatabase` row that isn't `:unprovisioned`. So a row stuck in `:provisioning` or `:deprovisioning` — after a crash mid-provision, or a warehouse teardown that failed and rolled the row back — made the workspace permanently undeletable from every API surface, with no recovery path. (Fixes GHY-3954; addresses the status-check inconsistency tracked in GHY-3542.)

## Fix

`delete-workspace!` now drives **every** active row to teardown regardless of state, then deletes:

- New `provisioning/force-teardown-for-delete!` — a best-effort, delete-only teardown (it never rolls back, unlike `deprovision-workspace-database!`). It reconstructs the iso schema/user names **deterministically** from the row id, so even a crashed `:provisioning` row that never stored its `output_namespace`/`database_details` is cleanable. It drops the warehouse schema + user idempotently and **always** clears the row's app-DB `TableRemapping` rows (that needs no warehouse connection, so query routing is never left dangling — the one genuinely dangerous orphan can't happen).
- When the warehouse is unreachable for some rows, the workspace is **still deleted**. The `:delete` endpoint still returns **200**, now carrying `:orphaned_resources` and a `:message` that names each inert schema/user left behind, its database/driver, and why it couldn't be removed.
- The model-level guard stays as defense-in-depth — by the time it runs, every row is already `:unprovisioned`.

## Scope

Strictly the delete path. Recovering a stuck row **without** deleting the workspace (startup reconciliation pass / admin force-unstick) remains **GHY-3550**, which can reuse `force-teardown-for-delete!`.

## Tests

- Stuck `:provisioning` and `:deprovisioning` rows both delete cleanly (the `:provisioning` case clears stored details to exercise the deterministic-name reconstruction).
- Warehouse-unreachable → 200 with `:orphaned_resources` + a message naming the schema/user and reason.
- Existing happy-path delete and manager API tests still pass.
