### PR TITLE
[perms] CSV uploads get `view-data: unrestricted` if whole schema has same

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -241,3 +241,24 @@
           blocked-groups    (into (or blocked-group-ids #{})
                                   sandbox-group-ids)]
       (zipmap group-ids (map #(if (blocked-groups %) :blocked :unrestricted) group-ids)))))
+
+(defenterprise new-table-sandboxed-groups
+  "Returns the subset of `group-ids` that must have new tables on `db-id` forced to `:blocked` view-data regardless of
+  the new table's schema, because they have a sandbox on a table in this DB. A sandbox is a stronger condition than
+  a few specific tables being blocked, so the presence of a sandbox on this DB for a group is sufficient to make any
+  new table `:blocked` for that group, even if the table came from a CSV upload.
+
+  OSS has no sandboxes, so in OSS and in EE without sandboxes enabled the set of sandboxed groups is empty."
+  :feature :advanced-permissions
+  [db-id group-ids]
+  (if (or (empty? group-ids)
+          (not (premium-features/enable-sandboxes?)))
+    #{}
+    (into #{}
+          (map :group_id)
+          (t2/query {:select-distinct [[:s.group_id :group_id]]
+                     :from   [[(t2/table-name :model/Sandbox) :s]]
+                     :join   [[(t2/table-name :model/Table) :t] [:= :t.id :s.table_id]]
+                     :where  [:and
+                              [:in :s.group_id group-ids]
+                              [:= :t.db_id db-id]]}))))

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -215,33 +215,6 @@
                                     (concat impersonation-group-ids sandbox-group-ids))]
       (zipmap group-ids (map #(if (blocked-groups %) :blocked :unrestricted) group-ids)))))
 
-(defenterprise new-table-view-data-permission-levels
-  "Returns a map of {group-id → permission-level} for multiple groups and a single DB."
-  :feature :advanced-permissions
-  [db-id group-ids]
-  (if (empty? group-ids)
-    {}
-    ;; We don't check for connection impersonations here, because impersonations are set at the
-    ;; DB-level, so a new table should get `:unrestricted` and inherit the DB-level impersonation policy.
-    (let [blocked-group-ids (t2/select-fn-set :group_id :model/DataPermissions
-                                              :db_id db-id
-                                              :perm_type :perms/view-data
-                                              :perm_value :blocked
-                                              :group_id [:in group-ids]
-                                              {:select-distinct [:group_id]})
-          sandbox-group-ids (when (premium-features/enable-sandboxes?)
-                              (into #{}
-                                    (map :group_id)
-                                    (t2/query {:select [[:s.group_id :group_id]]
-                                               :from   [[(t2/table-name :model/Sandbox) :s]]
-                                               :join   [[(t2/table-name :model/Table) :t] [:= :t.id :s.table_id]]
-                                               :where  [:and
-                                                        [:in :s.group_id group-ids]
-                                                        [:= :t.db_id db-id]]})))
-          blocked-groups    (into (or blocked-group-ids #{})
-                                  sandbox-group-ids)]
-      (zipmap group-ids (map #(if (blocked-groups %) :blocked :unrestricted) group-ids)))))
-
 (defenterprise new-table-sandboxed-groups
   "Returns the subset of `group-ids` that must have new tables on `db-id` forced to `:blocked` view-data regardless of
   the new table's schema, because they have a sandbox on a table in this DB. A sandbox is a stronger condition than
@@ -262,3 +235,22 @@
                      :where  [:and
                               [:in :s.group_id group-ids]
                               [:= :t.db_id db-id]]}))))
+
+(defenterprise new-table-view-data-permission-levels
+  "Returns a map of {group-id → permission-level} for multiple groups and a single DB."
+  :feature :advanced-permissions
+  [db-id group-ids]
+  (if (empty? group-ids)
+    {}
+    ;; We don't check for connection impersonations here, because impersonations are set at the
+    ;; DB-level, so a new table should get `:unrestricted` and inherit the DB-level impersonation policy.
+    (let [blocked-group-ids (t2/select-fn-set :group_id :model/DataPermissions
+                                              :db_id db-id
+                                              :perm_type :perms/view-data
+                                              :perm_value :blocked
+                                              :group_id [:in group-ids]
+                                              {:select-distinct [:group_id]})
+          sandbox-group-ids (new-table-sandboxed-groups db-id group-ids)
+          blocked-groups    (into (or blocked-group-ids #{})
+                                  sandbox-group-ids)]
+      (zipmap group-ids (map #(if (blocked-groups %) :blocked :unrestricted) group-ids)))))

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -208,3 +208,24 @@
           blocked-groups    (into (or blocked-group-ids #{})
                                   sandbox-group-ids)]
       (zipmap group-ids (map #(if (blocked-groups %) :blocked :unrestricted) group-ids)))))
+
+(defenterprise new-table-sandboxed-groups
+  "Returns the subset of `group-ids` that must have new tables on `db-id` forced to `:blocked` view-data regardless of
+  the new table's schema, because they have a sandbox on a table in this DB. A sandbox is a stronger condition than
+  a few specific tables being blocked, so the presence of a sandbox on this DB for a group is sufficient to make any
+  new table `:blocked` for that group, even if the table came from a CSV upload.
+
+  OSS has no sandboxes, so in OSS and in EE without sandboxes enabled the set of sandboxed groups is empty."
+  :feature :advanced-permissions
+  [db-id group-ids]
+  (if (or (empty? group-ids)
+          (not (premium-features/enable-sandboxes?)))
+    #{}
+    (into #{}
+          (map :group_id)
+          (t2/query {:select-distinct [[:s.group_id :group_id]]
+                     :from   [[(t2/table-name :model/Sandbox) :s]]
+                     :join   [[(t2/table-name :model/Table) :t] [:= :t.id :s.table_id]]
+                     :where  [:and
+                              [:in :s.group_id group-ids]
+                              [:= :t.db_id db-id]]}))))

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -193,22 +193,6 @@
                                     (concat impersonation-group-ids sandbox-group-ids))]
       (zipmap group-ids (map #(if (blocked-groups %) :blocked :unrestricted) group-ids)))))
 
-(defenterprise new-table-view-data-permission-levels
-  "Returns a map of {group-id → permission-level} for multiple groups and a single DB."
-  :feature :none ;; fail CLOSED if the feature is unavailable.
-  [db-id group-ids]
-  (if (empty? group-ids)
-    {}
-    ;; We don't check for connection impersonations here, because impersonations are set at the
-    ;; DB-level, so a new table should get `:unrestricted` and inherit the DB-level impersonation policy.
-    (let [blocked-group-ids (advanced-permissions.db/blocked-group-ids-for-database db-id group-ids)
-          sandbox-group-ids (into #{}
-                                  (map :group_id)
-                                  (advanced-permissions.db/sandboxed-group-ids-for-database db-id group-ids))
-          blocked-groups    (into (or blocked-group-ids #{})
-                                  sandbox-group-ids)]
-      (zipmap group-ids (map #(if (blocked-groups %) :blocked :unrestricted) group-ids)))))
-
 (defenterprise new-table-sandboxed-groups
   "Returns the subset of `group-ids` that must have new tables on `db-id` forced to `:blocked` view-data regardless of
   the new table's schema, because they have a sandbox on a table in this DB. A sandbox is a stronger condition than
@@ -223,9 +207,18 @@
     #{}
     (into #{}
           (map :group_id)
-          (t2/query {:select-distinct [[:s.group_id :group_id]]
-                     :from   [[(t2/table-name :model/Sandbox) :s]]
-                     :join   [[(t2/table-name :model/Table) :t] [:= :t.id :s.table_id]]
-                     :where  [:and
-                              [:in :s.group_id group-ids]
-                              [:= :t.db_id db-id]]}))))
+          (advanced-permissions.db/sandboxed-group-ids-for-database db-id group-ids))))
+
+(defenterprise new-table-view-data-permission-levels
+  "Returns a map of {group-id → permission-level} for multiple groups and a single DB."
+  :feature :none ;; fail CLOSED if the feature is unavailable.
+  [db-id group-ids]
+  (if (empty? group-ids)
+    {}
+    ;; We don't check for connection impersonations here, because impersonations are set at the
+    ;; DB-level, so a new table should get `:unrestricted` and inherit the DB-level impersonation policy.
+    (let [blocked-group-ids (advanced-permissions.db/blocked-group-ids-for-database db-id group-ids)
+          sandbox-group-ids (new-table-sandboxed-groups db-id group-ids)
+          blocked-groups    (into (or blocked-group-ids #{})
+                                  sandbox-group-ids)]
+      (zipmap group-ids (map #(if (blocked-groups %) :blocked :unrestricted) group-ids)))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -150,6 +150,36 @@
             (is (= :unrestricted (perm-value table-id-1)))
             (is (= :blocked (perm-value table-id-3)))))))))
 
+(deftest new-table-in-granted-schema-test
+  ;; Grant the "public" schema, block the "blocked" schema -- exactly the upload setup. The group
+  ;; therefore has a :blocked table in the DB, so the EE DB-wide override returns :blocked for any
+  ;; brand-new table (verified below). Uses the *real* enterprise functions, no redefs.
+  (mt/with-additional-premium-features #{:advanced-permissions}
+    (mt/with-temp [:model/PermissionsGroup {group-id :id}   {}
+                   :model/Database         {db-id :id}      {}
+                   :model/Table            {table-id-1 :id} {:db_id db-id :schema "public"}
+                   :model/Table            {table-id-2 :id} {:db_id db-id :schema "blocked"}]
+      (data-perms/set-table-permission! group-id table-id-1 :perms/view-data :unrestricted)
+      (data-perms/set-table-permission! group-id table-id-2 :perms/view-data :blocked)
+      (is (= {group-id :blocked}
+             (advanced-permissions.common/new-table-view-data-permission-levels db-id [group-id]))
+          "precondition: the DB-wide override would block a new table for this group")
+      (testing "Sync (default): a synced table in the granted schema fails safe to :blocked"
+        (mt/with-temp [:model/Table {table-id-3 :id} {:db_id db-id :schema "public"}]
+          (is (= :blocked
+                 (t2/select-one-fn :perm_value :model/DataPermissions
+                                   :db_id db-id :group_id group-id
+                                   :table_id table-id-3 :perm_type :perms/view-data)))))
+      (testing "Upload (binding true): an uploaded table in the granted schema inherits :unrestricted (UXW-3217)"
+        (data-perms/do-with-schema-consistent-new-table-perms
+         (fn []
+           (mt/with-temp [:model/Table {table-id-3 :id} {:db_id db-id :schema "public"}]
+             (is (= :unrestricted
+                    (t2/select-one-fn :perm_value :model/DataPermissions
+                                      :db_id db-id :group_id group-id
+                                      :table_id table-id-3 :perm_type :perms/view-data))
+                 "new table in the granted schema must inherit :unrestricted, not :blocked"))))))))
+
 (deftest new-group-view-data-permission-levels-test
   (mt/with-additional-premium-features #{:sandboxes :advanced-permissions}
     (mt/with-temp [:model/Database {db-id :id} {}]
@@ -932,6 +962,42 @@
             (mt/with-all-users-data-perms-graph! {db-id {:view-data      :unrestricted
                                                          :create-queries :query-builder-and-native}}
               (is (some? (upload-csv!))))))))))
+
+(deftest upload-csv-keeps-permissions-on-granted-schema-test
+  (testing "Upload to fully `:unrestricted` schema doesn't get `:blocked`, so uploads keep working (UXW-3217)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :uploads :schemas)
+      (mt/with-additional-premium-features #{:advanced-permissions}
+        (let [db-id        (mt/id)
+              schema-name  (sql.tx/session-schema driver/*driver*)
+              all-users-id (u/the-id (perms-group/all-users))]
+          (mt/with-restored-data-perms-for-group! all-users-id
+            ;; Grant the whole DB, then carve out a :blocked table in a *different* schema. This is the corrupting
+            ;; condition in UXW-3217: the group now has a blocked view-data row *anywhere* in the DB, so any new table
+            ;; would be forced to `:blocked`, except for the special handling of uploads being tested here.
+            (data-perms/set-database-permission! all-users-id db-id :perms/view-data :unrestricted)
+            (data-perms/set-database-permission! all-users-id db-id :perms/create-queries :query-builder)
+            (mt/with-temp [:model/Table {blocked-table :id} {:db_id  db-id
+                                                             :schema "uxw3217_other_schema"
+                                                             :active true}]
+              (data-perms/set-table-permission! all-users-id blocked-table :perms/view-data :blocked)
+              (is (= {all-users-id :blocked}
+                     (advanced-permissions.common/new-table-view-data-permission-levels db-id [all-users-id]))
+                  "precondition: the DB-wide override would block a new table for All Users")
+              (upload-test/do-with-uploaded-example-csv!
+               {:grant-permission? false
+                :schema-name       schema-name
+                :table-prefix      "uxw3217_"}
+               (fn [model]
+                 (let [uploaded-table  (t2/select-one [:model/Table :id :schema] :id (:table_id model))
+                       uploaded-schema (:schema uploaded-table)]
+                   (is (= :unrestricted
+                          (data-perms/table-permission-for-groups [all-users-id] :perms/view-data
+                                                                  db-id (:id uploaded-table)))
+                       "uploaded table in the granted schema must stay :unrestricted")
+                   (testing "so the user's effective schema permission stays :unrestricted and they can upload again"
+                     (is (= :unrestricted
+                            (data-perms/full-schema-permission-for-user
+                             (mt/user->id :rasta) :perms/view-data db-id uploaded-schema))))))))))))))
 
 (deftest update-csv-data-perms-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -165,6 +165,7 @@
             (is (= :unrestricted (perm-value table-id-1)))
             (is (= :blocked (perm-value table-id-3)))))))))
 
+
 (deftest new-table-view-data-permission-levels-without-premium-features-test
   (testing "A newly-synced table fails CLOSED to :blocked for a sandboxed group even when premium features are unavailable (UXW-4927)"
     ;; This is the incident path: a table is discovered during sync while the sandboxes /
@@ -188,6 +189,36 @@
                     "No DB-level perm is written")
                 (is (= :blocked (perm-value new-table-id))
                     "New table blocks the sandboxed group instead of leaking :unrestricted")))))))))
+
+(deftest new-table-in-granted-schema-test
+  ;; Grant the "public" schema, block the "blocked" schema -- exactly the upload setup. The group
+  ;; therefore has a :blocked table in the DB, so the EE DB-wide override returns :blocked for any
+  ;; brand-new table (verified below). Uses the *real* enterprise functions, no redefs.
+  (mt/with-additional-premium-features #{:advanced-permissions}
+    (mt/with-temp [:model/PermissionsGroup {group-id :id}   {}
+                   :model/Database         {db-id :id}      {}
+                   :model/Table            {table-id-1 :id} {:db_id db-id :schema "public"}
+                   :model/Table            {table-id-2 :id} {:db_id db-id :schema "blocked"}]
+      (data-perms/set-table-permission! group-id table-id-1 :perms/view-data :unrestricted)
+      (data-perms/set-table-permission! group-id table-id-2 :perms/view-data :blocked)
+      (is (= {group-id :blocked}
+             (advanced-permissions.common/new-table-view-data-permission-levels db-id [group-id]))
+          "precondition: the DB-wide override would block a new table for this group")
+      (testing "Sync (default): a synced table in the granted schema fails safe to :blocked"
+        (mt/with-temp [:model/Table {table-id-3 :id} {:db_id db-id :schema "public"}]
+          (is (= :blocked
+                 (t2/select-one-fn :perm_value :model/DataPermissions
+                                   :db_id db-id :group_id group-id
+                                   :table_id table-id-3 :perm_type :perms/view-data)))))
+      (testing "Upload (binding true): an uploaded table in the granted schema inherits :unrestricted (UXW-3217)"
+        (data-perms/do-with-schema-consistent-new-table-perms
+         (fn []
+           (mt/with-temp [:model/Table {table-id-3 :id} {:db_id db-id :schema "public"}]
+             (is (= :unrestricted
+                    (t2/select-one-fn :perm_value :model/DataPermissions
+                                      :db_id db-id :group_id group-id
+                                      :table_id table-id-3 :perm_type :perms/view-data))
+                 "new table in the granted schema must inherit :unrestricted, not :blocked"))))))))
 
 (deftest new-group-view-data-permission-levels-test
   (mt/with-additional-premium-features #{:sandboxes :advanced-permissions}
@@ -986,6 +1017,42 @@
             (mt/with-all-users-data-perms-graph! {db-id {:view-data      :unrestricted
                                                          :create-queries :query-builder-and-native}}
               (is (some? (upload-csv!))))))))))
+
+(deftest upload-csv-keeps-permissions-on-granted-schema-test
+  (testing "Upload to fully `:unrestricted` schema doesn't get `:blocked`, so uploads keep working (UXW-3217)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :uploads :schemas)
+      (mt/with-additional-premium-features #{:advanced-permissions}
+        (let [db-id        (mt/id)
+              schema-name  (sql.tx/session-schema driver/*driver*)
+              all-users-id (u/the-id (perms-group/all-users))]
+          (mt/with-restored-data-perms-for-group! all-users-id
+            ;; Grant the whole DB, then carve out a :blocked table in a *different* schema. This is the corrupting
+            ;; condition in UXW-3217: the group now has a blocked view-data row *anywhere* in the DB, so any new table
+            ;; would be forced to `:blocked`, except for the special handling of uploads being tested here.
+            (data-perms/set-database-permission! all-users-id db-id :perms/view-data :unrestricted)
+            (data-perms/set-database-permission! all-users-id db-id :perms/create-queries :query-builder)
+            (mt/with-temp [:model/Table {blocked-table :id} {:db_id  db-id
+                                                             :schema "uxw3217_other_schema"
+                                                             :active true}]
+              (data-perms/set-table-permission! all-users-id blocked-table :perms/view-data :blocked)
+              (is (= {all-users-id :blocked}
+                     (advanced-permissions.common/new-table-view-data-permission-levels db-id [all-users-id]))
+                  "precondition: the DB-wide override would block a new table for All Users")
+              (upload-test/do-with-uploaded-example-csv!
+               {:grant-permission? false
+                :schema-name       schema-name
+                :table-prefix      "uxw3217_"}
+               (fn [model]
+                 (let [uploaded-table  (t2/select-one [:model/Table :id :schema] :id (:table_id model))
+                       uploaded-schema (:schema uploaded-table)]
+                   (is (= :unrestricted
+                          (data-perms/table-permission-for-groups [all-users-id] :perms/view-data
+                                                                  db-id (:id uploaded-table)))
+                       "uploaded table in the granted schema must stay :unrestricted")
+                   (testing "so the user's effective schema permission stays :unrestricted and they can upload again"
+                     (is (= :unrestricted
+                            (data-perms/full-schema-permission-for-user
+                             (mt/user->id :rasta) :perms/view-data db-id uploaded-schema))))))))))))))
 
 (deftest update-csv-data-perms-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -41,6 +41,7 @@
   batch-delete-permissions!
   batch-insert-permissions!
   disable-perms-cache
+  do-with-schema-consistent-new-table-perms
   download-perms-level
   full-db-permission-for-user
   full-schema-permission-for-user

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -43,6 +43,7 @@
   batch-delete-permissions!
   batch-insert-permissions!
   disable-perms-cache
+  do-with-schema-consistent-new-table-perms
   download-perms-level
   full-database-permission-for-user
   full-schema-permission-for-user

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -990,6 +990,15 @@
   [_db-id group-ids]
   (zipmap group-ids (repeat :unrestricted)))
 
+(defenterprise new-table-sandboxed-groups
+  "Returns the subset of `group-ids` whose new tables on `db-id` have a sandbox somewhere in this DB, and must therefore
+  have their `view-data` forced to `:blocked` regardless of the new table's schema.
+
+  On OSS there are no sandboxes, so the set is always empty."
+  metabase-enterprise.advanced-permissions.common
+  [_db-id _group-ids]
+  #{})
+
 ;;; ---------------------------------------- Bulk permission functions ------------------------------------------------
 ;; These functions set permissions for newly-created entities (groups, databases, tables) using batch SQL operations
 ;; instead of per-row mutations. They are intended to be called from within a coarse cluster lock.
@@ -1129,6 +1138,27 @@
                         groups)]
       (batch-insert-permissions! perm-rows))))
 
+(def ^:dynamic *prefer-schema-consistency-for-new-tables?*
+  "When true, a newly-created table's view-data inherits its schema's unanimous value in preference to the usual
+  rule. (For enterprise, if any table on the DB is `:blocked` then so are new tables discovered by sync.)
+
+  Bind this only around creating a table the current user is explicitly authorized to create in this schema,
+  i.e. CSV uploads. There, the upload itself already requires `:unrestricted` access to the whole schema for at least
+  one group (UXW-3217). Left false for sync, where a newly-discovered table must fail safe to `:blocked` for any
+  group with partial access. See [[compute-actual-value]].
+
+  Use the helper [[do-with-schema-consistent-new-table-perms]] rather than binding this directly."
+  false)
+
+(defn do-with-schema-consistent-new-table-perms
+  "Runs `thunk` with [[*prefer-schema-consistency-for-new-tables?*]] bound true, so that any tables created during
+  `thunk` inherit their schema's unanimous view-data (if any) instead of failing safe to `:blocked`. Bind only around
+  creating a table the current user is authorized to create in its schema (CSV uploads). The binding must wrap the
+  table insert itself, since the `:model/Table` after-insert hook is what assigns the permissions."
+  [thunk]
+  (binding [*prefer-schema-consistency-for-new-tables?* true]
+    (thunk)))
+
 (defn- mk-perm-row [group-id perm-type perm-value db-id table-id schema]
   {:perm_type perm-type :group_id group-id :perm_value perm-value
    :db_id db-id :table_id table-id :schema_name schema})
@@ -1156,19 +1186,42 @@
                                  (update-in acc [group_id perm_type schema_name] (fnil conj #{}) perm_value))
                                {} table-level)
      :all-db-tables    (t2/select [:model/Table :id :db_id :schema] :db_id db-id :active true)
-     :view-data-levels (new-table-view-data-permission-levels db-id group-ids)}))
+     :view-data-levels (new-table-view-data-permission-levels db-id group-ids)
+     :sandboxed-groups (new-table-sandboxed-groups db-id group-ids)
+     :prefer-schema-consistency? *prefer-schema-consistency-for-new-tables?*}))
 
 (defn- compute-actual-value
-  "Per-entry resolution: enterprise view-data override, then schema-consistency
-  if all existing tables in the schema agree, else the caller's default."
-  [{:keys [view-data-levels schema-vals-idx]}
+  "Per-entry resolution for a new table's permission value for a given `group-id` and `perm-type`.
+
+  For perms other than `view-data`, the new table inherits its schema's value when all existing tables in that schema
+  agree, otherwise the default supplied by the caller.
+
+  For `view-data` the order depends on [[*prefer-schema-consistency-for-new-tables?*]]:
+
+  - Default (sync): the enterprise DB-wide override wins. If the group has *any* `:blocked` table (or a sandbox) in
+    the DB, then it has only partial access, so a newly-discovered, unclassified table fails safe to `:blocked`.
+  - Upload (`*prefer-schema-consistency-for-new-tables?*` bound true): if the permissions for all (active) tables in
+    the new table's schema are unanimously `:unrestricted`, then the new table is granted the same permission.
+    - This is a specific override for an uploaded table, since otherwise the user would be both locked out of their
+      own freshly uploaded table *and* prevented from making any further uploads! (Since uploads require at least one
+      group with unanimous `:unrestricted` access to the target schema. See UXW-3217.)
+
+  Note that if the group has a sandbox anywhere on this DB, the uploaded table is still `:blocked`, preventing any
+  leak of data to that group which should be sandboxed."
+  [{:keys [prefer-schema-consistency? sandboxed-groups schema-vals-idx view-data-levels]}
    {:keys [group-id perm-type default-value table]}]
-  (or (when (= perm-type :perms/view-data)
-        (get view-data-levels group-id))
-      (let [sv (get-in schema-vals-idx [group-id perm-type (:schema table)])]
-        (when (and (seq sv) (= (count sv) 1))
-          (first sv)))
-      default-value))
+  (let [view-data?   (= perm-type :perms/view-data)
+        schema-value (let [sv (get-in schema-vals-idx [group-id perm-type (:schema table)])]
+                       (when (and (seq sv) (= (count sv) 1))
+                         (first sv)))
+        override     (when view-data?
+                       (get view-data-levels group-id))]
+    (or (when (and view-data? (contains? sandboxed-groups group-id))
+          :blocked)
+        (if (and view-data? prefer-schema-consistency?)
+          (or schema-value override)
+          (or override schema-value))
+        default-value)))
 
 (defn- classify-key
   "For one `(group-id, perm-type)`, return `{:deletes [id?] :rows [perm-row...]}`.

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -1270,6 +1270,15 @@
   [_db-id group-ids]
   (zipmap group-ids (repeat :unrestricted)))
 
+(defenterprise new-table-sandboxed-groups
+  "Returns the subset of `group-ids` whose new tables on `db-id` have a sandbox somewhere in this DB, and must therefore
+  have their `view-data` forced to `:blocked` regardless of the new table's schema.
+
+  On OSS there are no sandboxes, so the set is always empty."
+  metabase-enterprise.advanced-permissions.common
+  [_db-id _group-ids]
+  #{})
+
 ;;; ---------------------------------------- Bulk permission functions ------------------------------------------------
 ;; These functions set permissions for newly-created entities (groups, databases, tables) using batch SQL operations
 ;; instead of per-row mutations. They are intended to be called from within a coarse cluster lock.
@@ -1401,6 +1410,27 @@
                         groups)]
       (batch-insert-permissions! perm-rows))))
 
+(def ^:dynamic *prefer-schema-consistency-for-new-tables?*
+  "When true, a newly-created table's view-data inherits its schema's unanimous value in preference to the usual
+  rule. (For enterprise, if any table on the DB is `:blocked` then so are new tables discovered by sync.)
+
+  Bind this only around creating a table the current user is explicitly authorized to create in this schema,
+  i.e. CSV uploads. There, the upload itself already requires `:unrestricted` access to the whole schema for at least
+  one group (UXW-3217). Left false for sync, where a newly-discovered table must fail safe to `:blocked` for any
+  group with partial access. See [[compute-actual-value]].
+
+  Use the helper [[do-with-schema-consistent-new-table-perms]] rather than binding this directly."
+  false)
+
+(defn do-with-schema-consistent-new-table-perms
+  "Runs `thunk` with [[*prefer-schema-consistency-for-new-tables?*]] bound true, so that any tables created during
+  `thunk` inherit their schema's unanimous view-data (if any) instead of failing safe to `:blocked`. Bind only around
+  creating a table the current user is authorized to create in its schema (CSV uploads). The binding must wrap the
+  table insert itself, since the `:model/Table` after-insert hook is what assigns the permissions."
+  [thunk]
+  (binding [*prefer-schema-consistency-for-new-tables?* true]
+    (thunk)))
+
 (defn- mk-perm-row [group-id perm-type perm-value db-id table-id schema]
   {:perm_type perm-type :group_id group-id :perm_value perm-value
    :db_id db-id :table_id table-id :schema_name schema})
@@ -1423,19 +1453,42 @@
                                  (update-in acc [group_id perm_type schema_name] (fnil conj #{}) perm_value))
                                {} table-level)
      :all-db-tables    (permissions.db/active-table-locations-for-database db-id)
-     :view-data-levels (new-table-view-data-permission-levels db-id group-ids)}))
+     :view-data-levels (new-table-view-data-permission-levels db-id group-ids)
+     :sandboxed-groups (new-table-sandboxed-groups db-id group-ids)
+     :prefer-schema-consistency? *prefer-schema-consistency-for-new-tables?*}))
 
 (defn- compute-actual-value
-  "Per-entry resolution: enterprise view-data override, then schema-consistency
-  if all existing tables in the schema agree, else the caller's default."
-  [{:keys [view-data-levels schema-vals-idx]}
+  "Per-entry resolution for a new table's permission value for a given `group-id` and `perm-type`.
+
+  For perms other than `view-data`, the new table inherits its schema's value when all existing tables in that schema
+  agree, otherwise the default supplied by the caller.
+
+  For `view-data` the order depends on [[*prefer-schema-consistency-for-new-tables?*]]:
+
+  - Default (sync): the enterprise DB-wide override wins. If the group has *any* `:blocked` table (or a sandbox) in
+    the DB, then it has only partial access, so a newly-discovered, unclassified table fails safe to `:blocked`.
+  - Upload (`*prefer-schema-consistency-for-new-tables?*` bound true): if the permissions for all (active) tables in
+    the new table's schema are unanimously `:unrestricted`, then the new table is granted the same permission.
+    - This is a specific override for an uploaded table, since otherwise the user would be both locked out of their
+      own freshly uploaded table *and* prevented from making any further uploads! (Since uploads require at least one
+      group with unanimous `:unrestricted` access to the target schema. See UXW-3217.)
+
+  Note that if the group has a sandbox anywhere on this DB, the uploaded table is still `:blocked`, preventing any
+  leak of data to that group which should be sandboxed."
+  [{:keys [prefer-schema-consistency? sandboxed-groups schema-vals-idx view-data-levels]}
    {:keys [group-id perm-type default-value table]}]
-  (or (when (= perm-type :perms/view-data)
-        (get view-data-levels group-id))
-      (let [sv (get-in schema-vals-idx [group-id perm-type (:schema table)])]
-        (when (and (seq sv) (= (count sv) 1))
-          (first sv)))
-      default-value))
+  (let [view-data?   (= perm-type :perms/view-data)
+        schema-value (let [sv (get-in schema-vals-idx [group-id perm-type (:schema table)])]
+                       (when (and (seq sv) (= (count sv) 1))
+                         (first sv)))
+        override     (when view-data?
+                       (get view-data-levels group-id))]
+    (or (when (and view-data? (contains? sandboxed-groups group-id))
+          :blocked)
+        (if (and view-data? prefer-schema-consistency?)
+          (or schema-value override)
+          (or override schema-value))
+        default-value)))
 
 (defn- classify-key
   "For one `(group-id, perm-type)`, return `{:deletes [id?] :rows [perm-row...]}`.

--- a/src/metabase/upload/impl.clj
+++ b/src/metabase/upload/impl.clj
@@ -569,10 +569,15 @@
           table-name              (some->> table-name (ddl.i/format-name driver))
           schema+table-name       (table-identifier {:schema schema :name table-name})
           {:keys [columns stats]} (create-from-csv! driver db schema+table-name filename file)
-          ;; Sync immediately to create the Table and its Fields; the scan is settings-dependent and can be async
-          table                   (sync/create-table! db {:name         table-name
-                                                          :schema       (not-empty schema)
-                                                          :display_name display-name})
+          ;; Sync immediately to create the Table and its Fields; the scan is settings-dependent and can be async.
+          ;; The uploader has already been checked to have unrestricted access to this schema (see
+          ;; `can-create-upload-error`), so the new table inherits the schema's permissions rather than failing
+          ;; safe to `:blocked` the way a sync-discovered table would (UXW-3217).
+          table                   (perms/do-with-schema-consistent-new-table-perms
+                                   (fn []
+                                     (sync/create-table! db {:name         table-name
+                                                             :schema       (not-empty schema)
+                                                             :display_name display-name})))
           _set_is_upload          (t2/update! :model/Table (:id table) {:is_upload      true
                                                                         :data_authority :authoritative
                                                                         :data_source    :upload

--- a/src/metabase/upload/impl.clj
+++ b/src/metabase/upload/impl.clj
@@ -550,10 +550,15 @@
           table-name              (some->> table-name (ddl.i/format-name driver))
           schema+table-name       (table-identifier {:schema schema :name table-name})
           {:keys [columns stats]} (create-from-csv! driver db schema+table-name filename file)
-          ;; Sync immediately to create the Table and its Fields; the scan is settings-dependent and can be async
-          table                   (sync/create-table! db {:name         table-name
-                                                          :schema       (not-empty schema)
-                                                          :display_name display-name})
+          ;; Sync immediately to create the Table and its Fields; the scan is settings-dependent and can be async.
+          ;; The uploader has already been checked to have unrestricted access to this schema (see
+          ;; `can-create-upload-error`), so the new table inherits the schema's permissions rather than failing
+          ;; safe to `:blocked` the way a sync-discovered table would (UXW-3217).
+          table                   (perms/do-with-schema-consistent-new-table-perms
+                                    (fn []
+                                      (sync/create-table! db {:name         table-name
+                                                              :schema       (not-empty schema)
+                                                              :display_name display-name})))
           _set_is_upload          (upload.db/mark-table-upload! (:id table))
           _sync                   (scan-and-sync-table! db table)
           _set_names              (set-display-names! (:id table) columns)

--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -966,6 +966,47 @@
                                                 :table_id table-id-4 :perm_type :perms/create-queries))
             "should inherit :query-builder from PUBLIC schema, not the :no default")))))
 
+(defn- new-table-view-data-perm!
+  "Setup helper that mirrors the UXW-3217 repro: schema `\"public\"` is fully granted to the group, schema
+  `\"blocked-schema\"` is blocked. Because the group has a `:blocked` table in the DB, the usual EE rules will make
+  a new table also `:blocked`. Uploads have a special case that this is intended to test.
+
+  Parameterized by the `:upload?` and `:sandboxed?` options.
+
+  Returns the new table's `view-data` permission."
+  [{:keys [upload? sandboxed?]}]
+  (mt/with-temp [:model/Database         {db-id :id}      {}
+                 :model/PermissionsGroup {group-id :id}   {}
+                 :model/Table            {table-id-1 :id} {:db_id db-id :schema "public"}
+                 :model/Table            {table-id-2 :id} {:db_id db-id :schema "public"}
+                 :model/Table            {table-id-3 :id} {:db_id db-id :schema "blocked-schema"}]
+    (data-perms/set-table-permission! group-id table-id-1 :perms/view-data :unrestricted)
+    (data-perms/set-table-permission! group-id table-id-2 :perms/view-data :unrestricted)
+    (data-perms/set-table-permission! group-id table-id-3 :perms/view-data :blocked)
+    (mt/with-temp [:model/Table {table-id-4 :id} {:db_id db-id :schema "public"}]
+      (t2/delete! :model/DataPermissions :group_id group-id :table_id table-id-4 :perm_type :perms/view-data)
+      (mt/with-dynamic-fn-redefs [data-perms/new-table-view-data-permission-levels
+                                  (fn [_db-id group-ids] (zipmap group-ids (repeat :blocked)))
+                                  data-perms/new-table-sandboxed-groups
+                                  (fn [_db-id group-ids] (if sandboxed? (set group-ids) #{}))]
+        (let [set-perms! #(data-perms/set-default-table-permissions!
+                           {:id table-id-4 :db_id db-id :schema "public"}
+                           [{:group-id group-id :perm-type :perms/view-data :default-value :unrestricted}])]
+          (if upload?
+            (data-perms/do-with-schema-consistent-new-table-perms set-perms!)
+            (set-perms!))))
+      (t2/select-one-fn :perm_value :model/DataPermissions
+                        :group_id group-id :db_id db-id
+                        :table_id table-id-4 :perm_type :perms/view-data))))
+
+(deftest set-default-table-permissions!-view-data-granted-schema-test
+  (testing "Sync (default): a new table fails safe to :blocked because the group has only partial DB access"
+    (is (= :blocked      (new-table-view-data-perm! {:upload? false :sandboxed? false}))))
+  (testing "Upload (binding true): a new table inherits the granted schema's :unrestricted (UXW-3217)"
+    (is (= :unrestricted (new-table-view-data-perm! {:upload? true  :sandboxed? false}))))
+  (testing "Upload (binding true) + sandbox: a sandbox still forces :blocked, schema be damned"
+    (is (= :blocked      (new-table-view-data-perm! {:upload? true  :sandboxed? true})))))
+
 (defn- distinct-schema-vals-count
   "Count the *distinct* (group, perm-type, schema, value) tuples for `db-id` —
   the bounded result set the fixed [[load-perm-context]] loads."

--- a/test/metabase/permissions/models/data_permissions_test.clj
+++ b/test/metabase/permissions/models/data_permissions_test.clj
@@ -1297,6 +1297,47 @@
                                                 :table_id table-id-4 :perm_type :perms/create-queries))
             "should inherit :query-builder from PUBLIC schema, not the :no default")))))
 
+(defn- new-table-view-data-perm!
+  "Setup helper that mirrors the UXW-3217 repro: schema `\"public\"` is fully granted to the group, schema
+  `\"blocked-schema\"` is blocked. Because the group has a `:blocked` table in the DB, the usual EE rules will make
+  a new table also `:blocked`. Uploads have a special case that this is intended to test.
+
+  Parameterized by the `:upload?` and `:sandboxed?` options.
+
+  Returns the new table's `view-data` permission."
+  [{:keys [upload? sandboxed?]}]
+  (mt/with-temp [:model/Database         {db-id :id}      {}
+                 :model/PermissionsGroup {group-id :id}   {}
+                 :model/Table            {table-id-1 :id} {:db_id db-id :schema "public"}
+                 :model/Table            {table-id-2 :id} {:db_id db-id :schema "public"}
+                 :model/Table            {table-id-3 :id} {:db_id db-id :schema "blocked-schema"}]
+    (data-perms/set-table-permission! group-id table-id-1 :perms/view-data :unrestricted)
+    (data-perms/set-table-permission! group-id table-id-2 :perms/view-data :unrestricted)
+    (data-perms/set-table-permission! group-id table-id-3 :perms/view-data :blocked)
+    (mt/with-temp [:model/Table {table-id-4 :id} {:db_id db-id :schema "public"}]
+      (t2/delete! :model/DataPermissions :group_id group-id :table_id table-id-4 :perm_type :perms/view-data)
+      (mt/with-dynamic-fn-redefs [data-perms/new-table-view-data-permission-levels
+                                  (fn [_db-id group-ids] (zipmap group-ids (repeat :blocked)))
+                                  data-perms/new-table-sandboxed-groups
+                                  (fn [_db-id group-ids] (if sandboxed? (set group-ids) #{}))]
+        (let [set-perms! #(data-perms/set-default-table-permissions!
+                           {:id table-id-4 :db_id db-id :schema "public"}
+                           [{:group-id group-id :perm-type :perms/view-data :default-value :unrestricted}])]
+          (if upload?
+            (data-perms/do-with-schema-consistent-new-table-perms set-perms!)
+            (set-perms!))))
+      (t2/select-one-fn :perm_value :model/DataPermissions
+                        :group_id group-id :db_id db-id
+                        :table_id table-id-4 :perm_type :perms/view-data))))
+
+(deftest set-default-table-permissions!-view-data-granted-schema-test
+  (testing "Sync (default): a new table fails safe to :blocked because the group has only partial DB access"
+    (is (= :blocked      (new-table-view-data-perm! {:upload? false :sandboxed? false}))))
+  (testing "Upload (binding true): a new table inherits the granted schema's :unrestricted (UXW-3217)"
+    (is (= :unrestricted (new-table-view-data-perm! {:upload? true  :sandboxed? false}))))
+  (testing "Upload (binding true) + sandbox: a sandbox still forces :blocked, schema be damned"
+    (is (= :blocked      (new-table-view-data-perm! {:upload? true  :sandboxed? true})))))
+
 (defn- distinct-schema-vals-count
   "Count the *distinct* (group, perm-type, schema, value) tuples for `db-id` —
   the bounded result set the fixed [[load-perm-context]] loads."


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70292
Fixes UXW-3217.

### Description

This change requires care, since it allows more permissions in some cases.

The `view-data` permission has a special rule in EE `:advanced-permissions`:
if a group has `:blocked` permissions or a sandbox for any table in this DB,
then any newly added table is also `:blocked`. This prevents leaking the
data of new tables discovered by sync, which is important.

**This PR *preserves* the above behaviour for tables discovered via sync.**

However, for CSV uploads, this has two unintended consequences if any
table in the DB, even in an unrelated schema, is `:blocked`:
- The new table the user just uploaded is `:blocked`
- Any further uploads are also blocked!

(Uploads are only allowed when a user is in a group where the entire upload
target schema has `view-data: unrestricted` and `create-queries: query-builder`)

This PR adds an upload-specific override using a `^:dynamic` var that
creates the newly uploaded table with `view-data: unrestricted` when all
the necessary conditions are met:
- The group has no sandboxes for this DB. (If it does, `:blocked`.)
- The group has unanimous `view-data: unrestricted` for the upload *schema*
  - Even if it has `:blocked` tables in other schemas; this is the change

That implies that any group which can allow a user to do the first upload
will still allow subsequent uploads, preventing both the unintended
consequences above.

Otherwise, the permissions model is unchanged: new tables discovered by sync
are still `:blocked` with sandboxes present or if any tables are `:blocked`.

### How to verify

Follow the repro steps in UXW-3217, or look at the setup of the tests:

0. EE with `:advanced-permissions` enabled.
1. Enable CSV uploads on a DB, targeting some schema.
2. Create a group with `view-data :unrestricted` permissions for the whole target schema but `:blocked` for at least one other table
3. Disallow `All Users` from accessing that DB, forcing our non-admin user to rely on the group above for access.
4. Do a CSV upload as a non-admin user who is a member of that group and no others.

Without this fix, the upload is allowed but the new table is `:blocked` and therefore further uploads are disallowed.

With the fix, the new table is `:unrestricted` and further uploads are likewise allowed.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~


#### PR Dependency Tree


* **PR #76351** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)