### PR TITLE
Don't throw exceptions when user-local settings cannot be decoded

### DIFF
--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -375,7 +375,13 @@
   (let [{setting-name :name} (resolve-setting setting-definition-or-name)]
     ;; Update the atom in *user-local-values* with the new value before writing to the DB. This ensures that
     ;; subsequent setting updates within the same API request will not overwrite this value.
-    (swap! @*user-local-values* u/assoc-dissoc setting-name value)
+    ;;
+    ;; The atom normally holds a map, but if the user's `settings` column could not be decoded (e.g. it was
+    ;; encrypted with an encryption key that is no longer set) [[metabase.models.interface/encrypted-json-out]]
+    ;; returns the raw, undecodable string, which ends up here. Treat a non-map value as empty so we don't try to
+    ;; `assoc` onto a String and throw a ClassCastException; the undecodable value is unreadable anyway. (#69264)
+    (swap! @*user-local-values* (fn [current]
+                                  (u/assoc-dissoc (if (map? current) current {}) setting-name value)))
     (t2/update! 'User api/*current-user-id* {:settings (json/encode @@*user-local-values*)})))
 
 (def ^:dynamic *enforce-setting-access-checks*

--- a/test/metabase/users/settings_test.clj
+++ b/test/metabase/users/settings_test.clj
@@ -34,3 +34,17 @@
               (is (= (users.settings/last-used-native-database-id) id2))
               (mt/with-test-user :rasta
                 (is (= (users.settings/last-used-native-database-id) id1))))))))))
+
+;; Regression test for https://github.com/metabase/metabase/issues/69264
+;; When a user's `settings` column contains a non-decodable string (e.g., an encrypted value whose encryption key
+;; is no longer set), `encrypted-json-out` returns the raw string instead of a map. Setting a user-local setting
+;; then tried to `assoc` onto that string and threw
+;; `java.lang.ClassCastException: class java.lang.String cannot be cast to class clojure.lang.Associative`.
+(deftest set-user-local-setting-with-corrupted-settings-column-test
+  (testing "Setting a user-local setting should succeed even when *user-local-values* holds a non-map string (#69264)"
+    (mt/with-test-user :rasta
+      (setting/with-user-local-values (delay (atom "not-valid-json-this-is-broken"))
+        (is (= "light" (users.settings/color-scheme! "light"))
+            "setting a user-local-only setting should succeed even when the existing settings value was undecodable")
+        (is (= "light" (users.settings/color-scheme))
+            "the new value should be readable after the corrupted value was replaced")))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #69264
Fixes UXW-3044.

### Description

User-local settings are represented as a JSON string, which is encrypted
when `MB_ENCRYPTION_SECRET_KEY` is set. If the key gets rotated, or the
JSON string is otherwise malformed, then the Toucan transformation
returns the raw encrypted string instead of a map.

With this change, writing to user-local settings will replace a
non-`map?` settings value with `{}` and then make the requested change.
That will destroy any existing settings values for that user, but
they're already unreadable so it's no real loss.

### How to verify

1. Corrupt your `core_user.settings` string, either by a raw change of `MB_ENCRYPTION_SECRET_KEY` or a raw SQL `UPDATE` that sets it to nonsense instead of a valid JSON string.
2. Try to edit your user-local settings, e.g. by switching between dark and light modes.
3. Note that the UI updates, but with the bug you get a 500 and your dark/light mode reverts on a browser refresh.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
