### PR TITLE
Don't destroy database during creation failure for cloud DBs.

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -94,6 +94,9 @@
          :dataset-filters-patterns (test-dataset-id db-def)
          :include-user-id-and-hash true))
 
+(defmethod driver/database-supports? [:bigquery-cloud-sdk :test/dynamic-dataset-loading]
+  [_driver _feature _database] false)
+
 ;;; -------------------------------------------------- Loading Data --------------------------------------------------
 
 (mu/defmethod sql.tx/qualified-name-components :bigquery-cloud-sdk

--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -445,8 +445,12 @@
     (load-dataset-data-if-needed! driver database-definition)
     (create-and-sync-Database! driver database-definition)
     (catch Throwable e
-      (log/errorf e "create-database! failed; destroying %s database %s" driver (pr-str database-name))
-      (tx/destroy-db! driver database-definition)
+      ;; Destroying the DB when there's a failure loading and syncing is fine
+      ;; for most DBs, but for cloud databases it makes things worse.
+      (when (driver/database-supports? driver :test/dynamic-dataset-loading nil)
+        #_{:clj-kondo/ignore [:discouraged-var]}
+        (log/errorf e "create-database! failed; destroying %s database %s" driver (pr-str database-name))
+        (tx/destroy-db! driver database-definition))
       (throw e))))
 
 (defn- create-database-with-bound-settings! [driver dbdef]


### PR DESCRIPTION
This seems to be a common cause of failure for bigquery; when there is some problem with one test, it gives up and deletes the database, which wrecks it for concurrent jobs as well.

Also mark bigquery as not supporting dynamic test loading, because it's a cloud DB.