### PR TITLE
Make `/api/cache/invalidate` endpoint return 400 for missing filters

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
@@ -223,4 +223,10 @@
             (is (=? {:count pos-int?}
                     (invalidate! 200 :include :overrides :database (mt/id))))
             (is (=? {:cached nil :data some?}
-                    (run-query! card1-id {:dashboard_id (:id dash)})))))))))
+                    (run-query! card1-id {:dashboard_id (:id dash)}))))
+          (testing "calling without any target filter is a 400, not a misleading 404 (#66499)"
+            (is (re-find #"At least one of"
+                         (invalidate! 400)))
+            (testing "and `include=overrides` alone does not count as a target"
+              (is (re-find #"At least one of"
+                           (invalidate! 400 :include :overrides))))))))))

--- a/src/metabase/cache/api.clj
+++ b/src/metabase/cache/api.clj
@@ -122,7 +122,7 @@
 
 (mr/def ::cache-invalidate-response
   [:map
-   [:status [:enum 200 404]]
+   [:status [:= 200]]
    [:body   [:map
              [:count   :int]
              [:message :string]]]])
@@ -212,6 +212,12 @@
                                      (ms/QueryVectorOf ms/IntGreaterThanOrEqualToZero)]]]]
   (when-not (premium-features/enable-cache-granular-controls?)
     (throw (premium-features/ee-feature-error (tru "Granular Caching"))))
+  ;; Require at least one target. Without a filter there is nothing to invalidate, so the request is
+  ;; malformed rather than not-found: returning 404 here misled callers into thinking the endpoint
+  ;; itself did not exist (see #66499), and a 200 would falsely imply something was invalidated.
+  (when (every? empty? [database dashboard question])
+    (throw (ex-info (tru "At least one of `database`, `dashboard`, or `question` is required.")
+                    {:status-code 400})))
   (doseq [db-id database] (api/write-check :model/Database db-id))
   (doseq [dashboard-id dashboard] (api/write-check :model/Dashboard dashboard-id))
   (doseq [question-id question] (api/write-check :model/Card question-id))
@@ -219,7 +225,9 @@
                                        :dashboards      dashboard
                                        :questions       question
                                        :with-overrides? (= include :overrides)})]
-    {:status (if (= cnt -1) 404 200)
+    ;; A well-formed filter that simply matched no cached results is a successful no-op (200); the
+    ;; `:message` below explains what happened.
+    {:status 200
      :body   {:count   cnt
               ;; Use condp instead of case to avoid Clojure compiler warnings.
               :message (condp = [(= include :overrides) (if (pos? cnt) 1 cnt)]


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66499
Fixes UXW-4108.

### Description

When no `database`, `dashboard` or `question` parameter is supplied, the endpoint does not invalidate anything. It previously returned a 404 in that case, indicating that nothing was found to invalidate.

But since no attempt to invalidate anything is made without at least one of those parameters, the 404 was misleading. Instead, this malformed request should return a 400, which it now does.

No impact to the Metabase FE, which only ever calls this endpoint with the parameters supplied.

### How to verify

Make a request to `/api/cache/invalidate` with and without the parameters.

Note that this request requires EE `enable-cache-granular-controls?` and you to have write access to the entity.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
