### PR TITLE
GDGT-2671: update API wiring

### DIFF
--- a/frontend/src/metabase-types/api/index-manager.ts
+++ b/frontend/src/metabase-types/api/index-manager.ts
@@ -1,7 +1,7 @@
 import type { TransformId } from "./transform";
 import type { UserId } from "./user";
 
-export type TableIndexId = number;
+export type TableIndexRequestId = number;
 
 export type IndexColumnDirection = "asc" | "desc";
 
@@ -83,21 +83,22 @@ export type StructuredIndex =
   | OrderByIndex
   | SkipIndex;
 
-export const TABLE_INDEX_STATUSES = [
+export const TABLE_INDEX_REQUEST_STATUSES = [
   "pending",
   "running",
   "succeeded",
   "failed",
   "dropped",
 ] as const;
-export type TableIndexStatus = (typeof TABLE_INDEX_STATUSES)[number];
+export type TableIndexRequestStatus =
+  (typeof TABLE_INDEX_REQUEST_STATUSES)[number];
 
-export type TableIndex = {
-  id: TableIndexId;
+export type TableIndexRequest = {
+  id: TableIndexRequestId;
   transform_id: TransformId;
   index_name: string;
   structured: StructuredIndex;
-  status: TableIndexStatus;
+  status: TableIndexRequestStatus;
   error_message: string | null;
   created_by: UserId | null;
   created_at: string;
@@ -117,7 +118,7 @@ export type TableIndexEntry = {
   is_valid: boolean;
   partial_predicate: string | null;
   access_method: string | null;
-  request?: TableIndex;
+  request?: TableIndexRequest;
 };
 
 export type ListTableIndexesRequest = {
@@ -134,6 +135,6 @@ export type CreateTableIndexRequest = {
 };
 
 export type UpdateTableIndexRequest = {
-  id: TableIndexId;
+  id: TableIndexRequestId;
   structured: StructuredIndex;
 };

--- a/frontend/src/metabase-types/api/index-manager.ts
+++ b/frontend/src/metabase-types/api/index-manager.ts
@@ -105,12 +105,27 @@ export type TableIndex = {
   last_executed_at: string | null;
 };
 
+export type TableIndexEntry = {
+  metabase_managed: boolean;
+  present_in_warehouse: boolean;
+  name: string | null;
+  kind: string;
+  key_columns: string[];
+  include_columns: (string | null)[];
+  is_unique: boolean;
+  is_primary: boolean;
+  is_valid: boolean;
+  partial_predicate: string | null;
+  access_method: string | null;
+  request?: TableIndex;
+};
+
 export type ListTableIndexesRequest = {
   "transform-id": TransformId;
 };
 
 export type ListTableIndexesResponse = {
-  data: TableIndex[];
+  data: TableIndexEntry[];
 };
 
 export type CreateTableIndexRequest = {

--- a/frontend/src/metabase-types/api/mocks/index-manager.ts
+++ b/frontend/src/metabase-types/api/mocks/index-manager.ts
@@ -1,8 +1,8 @@
-import type { TableIndex, TableIndexEntry } from "metabase-types/api";
+import type { TableIndexEntry, TableIndexRequest } from "metabase-types/api";
 
-export const createMockTableIndex = (
-  opts?: Partial<TableIndex>,
-): TableIndex => ({
+export const createMockTableIndexRequest = (
+  opts?: Partial<TableIndexRequest>,
+): TableIndexRequest => ({
   id: 1,
   transform_id: 1,
   index_name: "btree",
@@ -34,6 +34,6 @@ export const createMockTableIndexEntry = (
   is_valid: true,
   partial_predicate: null,
   access_method: null,
-  request: createMockTableIndex(),
+  request: createMockTableIndexRequest(),
   ...opts,
 });

--- a/frontend/src/metabase-types/api/mocks/index-manager.ts
+++ b/frontend/src/metabase-types/api/mocks/index-manager.ts
@@ -1,4 +1,4 @@
-import type { TableIndex } from "metabase-types/api";
+import type { TableIndex, TableIndexEntry } from "metabase-types/api";
 
 export const createMockTableIndex = (
   opts?: Partial<TableIndex>,
@@ -17,5 +17,23 @@ export const createMockTableIndex = (
   created_at: "2020-01-01T00:00:00.000Z",
   updated_at: "2020-01-01T00:00:00.000Z",
   last_executed_at: null,
+  ...opts,
+});
+
+export const createMockTableIndexEntry = (
+  opts?: Partial<TableIndexEntry>,
+): TableIndexEntry => ({
+  metabase_managed: true,
+  present_in_warehouse: true,
+  name: "btree",
+  kind: "btree",
+  key_columns: ["id"],
+  include_columns: [],
+  is_unique: false,
+  is_primary: false,
+  is_valid: true,
+  partial_predicate: null,
+  access_method: null,
+  request: createMockTableIndex(),
   ...opts,
 });

--- a/frontend/src/metabase/api/index-manager.ts
+++ b/frontend/src/metabase/api/index-manager.ts
@@ -3,6 +3,7 @@ import type {
   ListTableIndexesRequest,
   ListTableIndexesResponse,
   TableIndex,
+  TableIndexEntry,
   TableIndexId,
   UpdateTableIndexRequest,
 } from "metabase-types/api";
@@ -18,26 +19,29 @@ import {
 
 export const indexManagerApi = Api.injectEndpoints({
   endpoints: (builder) => ({
-    listTableIndexes: builder.query<TableIndex[], ListTableIndexesRequest>({
-      query: (params) => ({
-        method: "GET",
-        url: "/api/indexes",
-        params,
-      }),
-      transformResponse: (response: ListTableIndexesResponse) => response.data,
-      providesTags: (indexes = []) => provideTableIndexListTags(indexes),
-    }),
+    listTableIndexes: builder.query<TableIndexEntry[], ListTableIndexesRequest>(
+      {
+        query: (params) => ({
+          method: "GET",
+          url: "/api/indexes",
+          params,
+        }),
+        transformResponse: (response: ListTableIndexesResponse) =>
+          response.data,
+        providesTags: (indexes = []) => provideTableIndexListTags(indexes),
+      },
+    ),
     getTableIndex: builder.query<TableIndex, TableIndexId>({
       query: (id) => ({
         method: "GET",
-        url: `/api/indexes/${id}`,
+        url: `/api/indexes/request/${id}`,
       }),
       providesTags: (index) => (index ? provideTableIndexTags(index) : []),
     }),
     createTableIndex: builder.mutation<TableIndex, CreateTableIndexRequest>({
       query: (body) => ({
         method: "POST",
-        url: "/api/indexes",
+        url: "/api/indexes/request",
         body,
       }),
       invalidatesTags: (_index, error) =>
@@ -46,7 +50,7 @@ export const indexManagerApi = Api.injectEndpoints({
     updateTableIndex: builder.mutation<TableIndex, UpdateTableIndexRequest>({
       query: ({ id, structured }) => ({
         method: "PUT",
-        url: `/api/indexes/${id}`,
+        url: `/api/indexes/request/${id}`,
         body: { structured },
       }),
       invalidatesTags: (_index, error, { id }) =>
@@ -58,7 +62,7 @@ export const indexManagerApi = Api.injectEndpoints({
     deleteTableIndex: builder.mutation<void, TableIndexId>({
       query: (id) => ({
         method: "DELETE",
-        url: `/api/indexes/${id}`,
+        url: `/api/indexes/request/${id}`,
       }),
       invalidatesTags: (_index, error, id) =>
         invalidateTags(error, [

--- a/frontend/src/metabase/api/index-manager.ts
+++ b/frontend/src/metabase/api/index-manager.ts
@@ -2,9 +2,9 @@ import type {
   CreateTableIndexRequest,
   ListTableIndexesRequest,
   ListTableIndexesResponse,
-  TableIndex,
   TableIndexEntry,
-  TableIndexId,
+  TableIndexRequest,
+  TableIndexRequestId,
   UpdateTableIndexRequest,
 } from "metabase-types/api";
 
@@ -31,14 +31,17 @@ export const indexManagerApi = Api.injectEndpoints({
         providesTags: (indexes = []) => provideTableIndexListTags(indexes),
       },
     ),
-    getTableIndex: builder.query<TableIndex, TableIndexId>({
+    getTableIndex: builder.query<TableIndexRequest, TableIndexRequestId>({
       query: (id) => ({
         method: "GET",
         url: `/api/indexes/request/${id}`,
       }),
       providesTags: (index) => (index ? provideTableIndexTags(index) : []),
     }),
-    createTableIndex: builder.mutation<TableIndex, CreateTableIndexRequest>({
+    createTableIndex: builder.mutation<
+      TableIndexRequest,
+      CreateTableIndexRequest
+    >({
       query: (body) => ({
         method: "POST",
         url: "/api/indexes/request",
@@ -47,7 +50,10 @@ export const indexManagerApi = Api.injectEndpoints({
       invalidatesTags: (_index, error) =>
         invalidateTags(error, [listTag("table-index")]),
     }),
-    updateTableIndex: builder.mutation<TableIndex, UpdateTableIndexRequest>({
+    updateTableIndex: builder.mutation<
+      TableIndexRequest,
+      UpdateTableIndexRequest
+    >({
       query: ({ id, structured }) => ({
         method: "PUT",
         url: `/api/indexes/request/${id}`,
@@ -59,7 +65,7 @@ export const indexManagerApi = Api.injectEndpoints({
           idTag("table-index", id),
         ]),
     }),
-    deleteTableIndex: builder.mutation<void, TableIndexId>({
+    deleteTableIndex: builder.mutation<void, TableIndexRequestId>({
       query: (id) => ({
         method: "DELETE",
         url: `/api/indexes/request/${id}`,

--- a/frontend/src/metabase/api/tags/utils.ts
+++ b/frontend/src/metabase/api/tags/utils.ts
@@ -1,6 +1,7 @@
 import type { TagDescription } from "@reduxjs/toolkit/query";
 
 import { isVirtualDashCard } from "metabase/utils/dashboard";
+import { isNotNull } from "metabase/utils/types";
 import type {
   Alert,
   ApiKey,
@@ -47,6 +48,7 @@ import type {
   Segment,
   Table,
   TableIndex,
+  TableIndexEntry,
   TableRemapping,
   Task,
   TaskRun,
@@ -681,9 +683,15 @@ export function provideTableIndexTags(
 }
 
 export function provideTableIndexListTags(
-  indexes: TableIndex[],
+  indexes: TableIndexEntry[],
 ): TagDescription<TagType>[] {
-  return [listTag("table-index"), ...indexes.flatMap(provideTableIndexTags)];
+  return [
+    listTag("table-index"),
+    ...indexes
+      .map((index) => index.request)
+      .filter(isNotNull)
+      .flatMap(provideTableIndexTags),
+  ];
 }
 
 export function provideTableListTags(

--- a/frontend/src/metabase/api/tags/utils.ts
+++ b/frontend/src/metabase/api/tags/utils.ts
@@ -47,8 +47,8 @@ import type {
   SearchResult,
   Segment,
   Table,
-  TableIndex,
   TableIndexEntry,
+  TableIndexRequest,
   TableRemapping,
   Task,
   TaskRun,
@@ -674,7 +674,7 @@ export function provideSubscriptionTags(
 }
 
 export function provideTableIndexTags(
-  index: TableIndex,
+  index: TableIndexRequest,
 ): TagDescription<TagType>[] {
   return [
     idTag("table-index", index.id),

--- a/frontend/test/__support__/server-mocks/index-manager.ts
+++ b/frontend/test/__support__/server-mocks/index-manager.ts
@@ -15,16 +15,24 @@ export function setupTableIndexEndpoints(
   });
 
   indexRequests.forEach((index) => {
-    fetchMock.get(`path:/api/indexes/${index.id}`, index, {
+    fetchMock.get(`path:/api/indexes/request/${index.id}`, index, {
       name: `getTableIndex-${index.id}`,
     });
-    fetchMock.delete(`path:/api/indexes/${index.id}`, 204, {
+    fetchMock.delete(`path:/api/indexes/request/${index.id}`, 204, {
       name: `deleteTableIndex-${index.id}`,
     });
+    fetchMock.put(
+      `path:/api/indexes/request/${index.id}`,
+      async (call) => {
+        const lastCall = fetchMock.callHistory.lastCall(call.url);
+        return { ...index, ...(await lastCall?.request?.json()) };
+      },
+      { name: `updateTableIndex-${index.id}` },
+    );
   });
 
   fetchMock.post(
-    `path:/api/indexes`,
+    `path:/api/indexes/request`,
     async (call) => {
       const lastCall = fetchMock.callHistory.lastCall(call.url);
       return createMockTableIndexRequest(await lastCall?.request?.json());

--- a/frontend/test/__support__/server-mocks/index-manager.ts
+++ b/frontend/test/__support__/server-mocks/index-manager.ts
@@ -1,20 +1,20 @@
 import fetchMock from "fetch-mock";
 
-import type { TableIndex, TransformId } from "metabase-types/api";
-import { createMockTableIndex } from "metabase-types/api/mocks";
+import type { TableIndexRequest, TransformId } from "metabase-types/api";
+import { createMockTableIndexRequest } from "metabase-types/api/mocks";
 
 export function setupTableIndexEndpoints(
   transformId: TransformId,
-  indexes: TableIndex[] = [],
+  indexRequests: TableIndexRequest[] = [],
 ) {
   fetchMock.get({
     url: `path:/api/indexes`,
     query: { "transform-id": transformId },
-    response: { data: indexes },
+    response: { data: indexRequests },
     name: `listTableIndexes-${transformId}`,
   });
 
-  indexes.forEach((index) => {
+  indexRequests.forEach((index) => {
     fetchMock.get(`path:/api/indexes/${index.id}`, index, {
       name: `getTableIndex-${index.id}`,
     });
@@ -27,7 +27,7 @@ export function setupTableIndexEndpoints(
     `path:/api/indexes`,
     async (call) => {
       const lastCall = fetchMock.callHistory.lastCall(call.url);
-      return createMockTableIndex(await lastCall?.request?.json());
+      return createMockTableIndexRequest(await lastCall?.request?.json());
     },
     { name: `createTableIndex` },
   );


### PR DESCRIPTION
Closes [GDGT-2671: update API wiring](https://linear.app/metabase/issue/GDGT-2671/update-api-wiring)

### Description

The API has changed from the initial tech design doc and implementation. This PR updates it to the current format.

- separate better entities, `TableIndexEntry` and `TableIndexRequest`
- request CRUD APIs under `/api/indexes/request/`

### How to verify

### Demo 

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
