### PR TITLE
GDGT-2634: Add Index manager tab

### DIFF
--- a/frontend/src/metabase/transforms/components/TransformHeader/TransformTabs.tsx
+++ b/frontend/src/metabase/transforms/components/TransformHeader/TransformTabs.tsx
@@ -35,6 +35,10 @@ function getTabs(id: TransformId): PaneHeaderTab[] {
       label: t`Settings`,
       to: Urls.transformSettings(id),
     },
+    {
+      label: t`Indexes`,
+      to: Urls.transformIndexes(id),
+    },
   ];
 
   if (PLUGIN_TRANSFORMS_PYTHON.shouldShowInspectTab) {

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
@@ -1,0 +1,106 @@
+import { t } from "ttag";
+
+import {
+  skipToken,
+  useGetTransformQuery,
+  useListTableIndexesQuery,
+} from "metabase/api";
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
+import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
+import { Card, Center, Stack, Text } from "metabase/ui";
+import * as Urls from "metabase/urls";
+import type { TableIndexEntry, TransformId } from "metabase-types/api";
+
+import { TransformHeader } from "../../components/TransformHeader";
+
+export type TransformIndexesPageParams = {
+  transformId: string;
+};
+
+type TransformIndexesPageProps = {
+  params?: TransformIndexesPageParams;
+};
+
+export function TransformIndexesPage({ params }: TransformIndexesPageProps) {
+  const id = Urls.extractEntityId(params?.transformId);
+  const {
+    data: transform,
+    isLoading: isLoadingTransform,
+    error: transformError,
+  } = useGetTransformQuery(id ?? skipToken);
+  const { readOnly, isLoadingDatabases, databasesError } =
+    useTransformPermissions({ transform });
+  const isLoading = isLoadingTransform || isLoadingDatabases;
+  const error = transformError || databasesError;
+
+  if (id == null || transform == null || isLoading || error != null) {
+    return (
+      <Center h="100%">
+        <LoadingAndErrorWrapper loading={isLoading} error={error} />
+      </Center>
+    );
+  }
+
+  return (
+    <PageContainer data-testid="transforms-indexes-content">
+      <TransformHeader transform={transform} readOnly={readOnly} />
+      <TransformIndexesContent transformId={transform.id} />
+    </PageContainer>
+  );
+}
+
+function TransformIndexesContent({
+  transformId,
+}: {
+  transformId: TransformId;
+}) {
+  const {
+    data: indexes = [],
+    isLoading,
+    error,
+  } = useListTableIndexesQuery({ "transform-id": transformId });
+
+  if (isLoading || error != null) {
+    return (
+      <Center flex={1}>
+        <LoadingAndErrorWrapper loading={isLoading} error={error} />
+      </Center>
+    );
+  }
+
+  if (indexes.length === 0) {
+    return (
+      <Card flex={1} withBorder>
+        <Center h="100%">
+          <Text c="text-secondary">{t`No indexes defined for this transform.`}</Text>
+        </Center>
+      </Card>
+    );
+  }
+
+  return (
+    <Card flex={1} withBorder>
+      <Stack gap="md">
+        {indexes.map((index, indexPosition) => (
+          <TransformIndexRow
+            key={index.request?.id ?? index.name ?? indexPosition}
+            index={index}
+          />
+        ))}
+      </Stack>
+    </Card>
+  );
+}
+
+function TransformIndexRow({ index }: { index: TableIndexEntry }) {
+  const status = index.request?.status;
+  return (
+    <Stack gap={0}>
+      <Text fw="bold">{index.name ?? index.kind}</Text>
+      <Text c="text-secondary" size="sm">
+        {status ? `${index.kind} · ${status}` : index.kind}
+      </Text>
+    </Stack>
+  );
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
@@ -16,13 +16,13 @@ import type { TableIndexEntry, TransformId } from "metabase-types/api";
 import { TransformHeader } from "../../components/TransformHeader";
 
 type TransformIndexesPageProps = {
-  params?: {
+  params: {
     transformId?: string;
   };
 };
 
 export function TransformIndexesPage({ params }: TransformIndexesPageProps) {
-  const transformId = Urls.extractEntityId(params?.transformId);
+  const transformId = Urls.extractEntityId(params.transformId);
   const {
     data: transform,
     isLoading: isLoadingTransform,
@@ -33,12 +33,7 @@ export function TransformIndexesPage({ params }: TransformIndexesPageProps) {
   const isLoading = isLoadingTransform || isLoadingDatabases;
   const error = transformError || databasesError;
 
-  if (
-    transformId === undefined ||
-    transform === undefined ||
-    isLoading ||
-    !isNullOrUndefined(error)
-  ) {
+  if (transform === undefined || isLoading || !isNullOrUndefined(error)) {
     return (
       <Center h="100%">
         <LoadingAndErrorWrapper loading={isLoading} error={error} />

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
@@ -10,31 +10,35 @@ import { PageContainer } from "metabase/data-studio/common/components/PageContai
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
 import { Card, Center, Stack, Text } from "metabase/ui";
 import * as Urls from "metabase/urls";
+import { isNullOrUndefined } from "metabase/utils/types";
 import type { TableIndexEntry, TransformId } from "metabase-types/api";
 
 import { TransformHeader } from "../../components/TransformHeader";
 
-export type TransformIndexesPageParams = {
-  transformId: string;
-};
-
 type TransformIndexesPageProps = {
-  params?: TransformIndexesPageParams;
+  params?: {
+    transformId?: string;
+  };
 };
 
 export function TransformIndexesPage({ params }: TransformIndexesPageProps) {
-  const id = Urls.extractEntityId(params?.transformId);
+  const transformId = Urls.extractEntityId(params?.transformId);
   const {
     data: transform,
     isLoading: isLoadingTransform,
     error: transformError,
-  } = useGetTransformQuery(id ?? skipToken);
+  } = useGetTransformQuery(transformId ?? skipToken);
   const { readOnly, isLoadingDatabases, databasesError } =
     useTransformPermissions({ transform });
   const isLoading = isLoadingTransform || isLoadingDatabases;
   const error = transformError || databasesError;
 
-  if (id == null || transform == null || isLoading || error != null) {
+  if (
+    transformId === undefined ||
+    transform === undefined ||
+    isLoading ||
+    !isNullOrUndefined(error)
+  ) {
     return (
       <Center h="100%">
         <LoadingAndErrorWrapper loading={isLoading} error={error} />
@@ -61,7 +65,7 @@ function TransformIndexesContent({
     error,
   } = useListTableIndexesQuery({ "transform-id": transformId });
 
-  if (isLoading || error != null) {
+  if (isLoading || !isNullOrUndefined(error)) {
     return (
       <Center flex={1}>
         <LoadingAndErrorWrapper loading={isLoading} error={error} />

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.unit.spec.tsx
@@ -1,0 +1,107 @@
+import fetchMock from "fetch-mock";
+import { Route } from "react-router";
+
+import {
+  setupCollectionByIdEndpoint,
+  setupDatabasesEndpoints,
+  setupUserMetabotPermissionsEndpoint,
+} from "__support__/server-mocks";
+import {
+  renderWithProviders,
+  screen,
+  waitForLoaderToBeRemoved,
+} from "__support__/ui";
+import * as Urls from "metabase/urls";
+import type { TableIndexEntry, Transform } from "metabase-types/api";
+import {
+  createMockCollection,
+  createMockDatabase,
+  createMockTableIndexEntry,
+  createMockTableIndexRequest,
+  createMockTransform,
+} from "metabase-types/api/mocks";
+
+import { TransformIndexesPage } from "./TransformIndexesPage";
+
+type SetupOpts = {
+  transform?: Transform;
+  indexes?: TableIndexEntry[];
+};
+
+function setup({
+  transform = createMockTransform({ id: 1, name: "Test Transform" }),
+  indexes = [],
+}: SetupOpts = {}) {
+  setupDatabasesEndpoints([
+    createMockDatabase({ id: 1, transforms_permissions: "write" }),
+  ]);
+  setupCollectionByIdEndpoint({
+    collections: [createMockCollection({ id: "root" })],
+  });
+  setupUserMetabotPermissionsEndpoint();
+
+  fetchMock.get(`path:/api/transform/${transform.id}`, transform);
+  fetchMock.get({
+    url: "path:/api/indexes",
+    query: { "transform-id": transform.id },
+    response: { data: indexes },
+  });
+
+  const initialRoute = Urls.transformIndexes(transform.id);
+  const path = initialRoute.replace(`/${transform.id}/`, "/:transformId/");
+
+  renderWithProviders(<Route path={path} component={TransformIndexesPage} />, {
+    withRouter: true,
+    initialRoute,
+  });
+
+  return { transform };
+}
+
+describe("TransformIndexesPage", () => {
+  it("renders the empty state when there are no indexes", async () => {
+    setup({ indexes: [] });
+    await waitForLoaderToBeRemoved();
+
+    expect(
+      await screen.findByText("No indexes defined for this transform."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the list of indexes", async () => {
+    setup({
+      indexes: [
+        createMockTableIndexEntry({
+          name: "idx_orders_id",
+          kind: "btree",
+          request: createMockTableIndexRequest({ id: 1 }),
+        }),
+        createMockTableIndexEntry({
+          name: "idx_orders_total",
+          kind: "gin",
+          request: createMockTableIndexRequest({ id: 2 }),
+        }),
+      ],
+    });
+    await waitForLoaderToBeRemoved();
+
+    expect(await screen.findByText("idx_orders_id")).toBeInTheDocument();
+    expect(screen.getByText("idx_orders_total")).toBeInTheDocument();
+  });
+
+  it("falls back to the index kind when the index has no name", async () => {
+    setup({
+      indexes: [
+        createMockTableIndexEntry({
+          name: null,
+          kind: "distkey",
+          request: createMockTableIndexRequest({ status: "pending" }),
+        }),
+      ],
+    });
+    await waitForLoaderToBeRemoved();
+
+    expect(await screen.findByText("distkey")).toBeInTheDocument();
+    expect(screen.getByText("distkey · pending")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/index.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/index.ts
@@ -1,0 +1,1 @@
+export * from "./TransformIndexesPage";

--- a/frontend/src/metabase/transforms/routes.tsx
+++ b/frontend/src/metabase/transforms/routes.tsx
@@ -18,6 +18,7 @@ import {
 } from "./pages/NewTransformPage";
 import { RunListPage } from "./pages/RunListPage";
 import { TransformDependenciesPage } from "./pages/TransformDependenciesPage";
+import { TransformIndexesPage } from "./pages/TransformIndexesPage";
 import { TransformListPage } from "./pages/TransformListPage";
 import { TransformQueryPage } from "./pages/TransformQueryPage";
 import { TransformRunPage } from "./pages/TransformRunPage";
@@ -43,6 +44,7 @@ export function getDataStudioTransformRoutes() {
         <Route path=":transformId/edit" component={TransformQueryPage} />
         <Route path=":transformId/run" component={TransformRunPage} />
         <Route path=":transformId/settings" component={TransformSettingsPage} />
+        <Route path=":transformId/indexes" component={TransformIndexesPage} />
         {PLUGIN_TRANSFORMS_PYTHON.getInspectorRoutes()}
         {PLUGIN_DEPENDENCIES.isEnabled && (
           <Route

--- a/frontend/src/metabase/urls/transforms.ts
+++ b/frontend/src/metabase/urls/transforms.ts
@@ -71,6 +71,10 @@ export function transformSettings(transformId: TransformId) {
   return `${TRANSFORMS_ROOT_URL}/${transformId}/settings`;
 }
 
+export function transformIndexes(transformId: TransformId) {
+  return `${TRANSFORMS_ROOT_URL}/${transformId}/indexes`;
+}
+
 export function transformDependencies(transformId: TransformId) {
   return `${TRANSFORMS_ROOT_URL}/${transformId}/dependencies`;
 }


### PR DESCRIPTION
Closes [GDGT-2634: Add Index manager tab](https://linear.app/metabase/issue/GDGT-2634/add-index-manager-tab)

### Description

This change adds entrypoint (router and simple page) for index manager. We don't have any final designs yet so.

### How to verify

1. Create a transform and run it.
2. Index manager tab should be empty
3. Create index outside of Metabase (there's no UI to create transforms in Metabase yet). `CREATE INDEX index1 ON transorm_tabe (id);`
4. After page reload the index should be visible


### Demo

<img width="3774" height="2658" alt="image" src="https://github.com/user-attachments/assets/903e786f-681b-494e-ba29-a27cbe9d54eb" />

<img width="3730" height="2664" alt="image" src="https://github.com/user-attachments/assets/1080ca60-41db-4010-bf9f-f278ad56a175" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
