### PR TITLE
Migrate normal-variant Radio usages to metabase/ui Radio

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
@@ -18,11 +18,10 @@ import {
 } from "metabase/common/components/Pickers/QuestionPicker";
 import { QuestionLoader } from "metabase/common/components/QuestionLoader";
 import { QuestionName } from "metabase/common/components/QuestionName";
-import { Radio } from "metabase/common/components/Radio";
 import { useToggle } from "metabase/common/hooks/use-toggle";
 import CS from "metabase/css/core/index.css";
 import { useTranslateContent } from "metabase/i18n/hooks";
-import { Button, Center, Icon, Loader } from "metabase/ui";
+import { Button, Center, Icon, Loader, Radio, Stack } from "metabase/ui";
 import { getName } from "metabase/utils/name";
 import type {
   GroupTableAccessPolicyDraft,
@@ -172,20 +171,23 @@ const EditSandboxingModal = ({
               <h4
                 className={CS.pb1}
               >{t`How do you want to filter this table?`}</h4>
-              <Radio
-                value={!shouldUseSavedQuestion}
-                options={[
-                  { name: t`Filter by a column in the table`, value: true },
-                  {
-                    name: t`Use a saved question to create a custom view for this table`,
-                    value: false,
-                  },
-                ]}
-                onChange={(shouldUseSavedQuestion) =>
-                  setShouldUseSavedQuestion(!shouldUseSavedQuestion)
+              <Radio.Group
+                value={shouldUseSavedQuestion ? "saved-question" : "column"}
+                onChange={(value) =>
+                  setShouldUseSavedQuestion(value === "saved-question")
                 }
-                vertical
-              />
+              >
+                <Stack gap="sm">
+                  <Radio
+                    value="column"
+                    label={t`Filter by a column in the table`}
+                  />
+                  <Radio
+                    value="saved-question"
+                    label={t`Use a saved question to create a custom view for this table`}
+                  />
+                </Stack>
+              </Radio.Group>
             </div>
           ) : (
             <div>

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.tsx
@@ -4,10 +4,9 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import { getInputTypes } from "metabase/actions/constants";
-import { Radio } from "metabase/common/components/Radio";
 import { Toggle } from "metabase/common/components/Toggle";
 import { useUniqueId } from "metabase/common/hooks/use-unique-id";
-import { Popover, UnstyledButton } from "metabase/ui";
+import { Popover, Radio, Stack, UnstyledButton } from "metabase/ui";
 import { TextInput } from "metabase/ui/components/inputs/TextInput";
 import type {
   FieldSettings,
@@ -135,14 +134,20 @@ function InputTypeSelect({
   onChange: (newInputType: InputSettingType) => void;
 }) {
   const inputTypes = useMemo(getInputTypes, []);
+  const options = inputTypes[fieldType ?? "string"];
 
   return (
-    <Radio
-      vertical
+    <Radio.Group
       value={value}
-      options={inputTypes[fieldType ?? "string"]}
-      onChange={onChange}
-    />
+      // Mantine's radio uses broad `string` type for value even though we supply specifically InputSettingType
+      onChange={(newInputType) => onChange(newInputType as InputSettingType)}
+    >
+      <Stack gap="sm">
+        {options.map((option) => (
+          <Radio key={option.value} value={option.value} label={option.name} />
+        ))}
+      </Stack>
+    </Radio.Group>
   );
 }
 

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceTypeModal.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceTypeModal.tsx
@@ -10,8 +10,6 @@ import {
 } from "metabase/api";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { ModalContent } from "metabase/common/components/ModalContent";
-import type { RadioOption } from "metabase/common/components/Radio";
-import { Radio } from "metabase/common/components/Radio";
 import type { SelectChangeEvent } from "metabase/common/components/Select";
 import { Option, Select } from "metabase/common/components/Select";
 import { SelectButton } from "metabase/common/components/SelectButton";
@@ -19,7 +17,7 @@ import { connect, useSelector } from "metabase/redux";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getLearnUrl } from "metabase/selectors/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
-import { Box, Button, Flex, Icon } from "metabase/ui";
+import { Box, Button, Flex, Icon, Radio, Stack } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import { getQuestionVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
@@ -152,6 +150,23 @@ interface SourceTypeOptionsProps {
   onChangeSourceConfig: (sourceConfig: ValuesSourceConfig) => void;
 }
 
+type SourceTypeOption = {
+  name: string;
+  value: ValuesSourceType;
+};
+
+// Mantine's Radio.Group only handles string values, so the null source type
+// ("From connected fields") is mapped to a sentinel string.
+const CONNECTED_FIELDS_SENTINEL_VALUE = "connected-fields";
+
+const serializeSourceType = (sourceType: ValuesSourceType): string =>
+  sourceType ?? CONNECTED_FIELDS_SENTINEL_VALUE;
+
+const deserializeSourceType = (value: string): ValuesSourceType =>
+  value === CONNECTED_FIELDS_SENTINEL_VALUE
+    ? null
+    : (value as ValuesSourceType);
+
 const SourceTypeOptions = ({
   parameter,
   parameterValues = [],
@@ -177,12 +192,20 @@ const SourceTypeOptions = ({
   );
 
   return (
-    <Radio
-      value={sourceType}
-      options={sourceTypeOptions}
-      vertical
-      onChange={handleSourceTypeChange}
-    />
+    <Radio.Group
+      value={serializeSourceType(sourceType)}
+      onChange={(value) => handleSourceTypeChange(deserializeSourceType(value))}
+    >
+      <Stack gap="sm">
+        {sourceTypeOptions.map((option) => (
+          <Radio
+            key={serializeSourceType(option.value)}
+            value={serializeSourceType(option.value)}
+            label={option.name}
+          />
+        ))}
+      </Stack>
+    </Radio.Group>
   );
 };
 
@@ -605,9 +628,7 @@ const getLabelColumns = (query: Lib.Query) => {
  * if !hasFields(parameter) then exclude the option to set the source type to
  * "From connected fields" i.e. values_source_type=null
  */
-const getSourceTypeOptions = (
-  parameter: UiParameter,
-): RadioOption<ValuesSourceType>[] => {
+const getSourceTypeOptions = (parameter: UiParameter): SourceTypeOption[] => {
   return [
     ...(hasFields(parameter)
       ? [{ name: t`From connected fields`, value: null }]

--- a/frontend/src/metabase/query_builder/components/LimitPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/LimitPopover.tsx
@@ -79,7 +79,7 @@ export const LimitPopover = ({
           <Radio value="custom" label={t`Set custom limit`} />
         </Stack>
       </Radio.Group>
-      <Box mt="sm" ml="1.25rem">
+      <Box mt="sm" ml="1.7rem">
         <LimitInput
           ref={inputRef}
           small

--- a/frontend/src/metabase/query_builder/components/LimitPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/LimitPopover.tsx
@@ -3,10 +3,9 @@ import { useEffect, useRef, useState } from "react";
 import { useLatest } from "react-use";
 import { t } from "ttag";
 
-import { Radio } from "metabase/common/components/Radio";
 import CS from "metabase/css/core/index.css";
 import { LimitInput } from "metabase/querying/components/LimitInput";
-import { Box } from "metabase/ui";
+import { Box, Radio, Stack } from "metabase/ui";
 import { formatNumber } from "metabase/utils/formatting";
 import { HARD_ROW_LIMIT } from "metabase-lib/v1/queries/utils";
 
@@ -60,20 +59,9 @@ export const LimitPopover = ({
         }
       }}
     >
-      <Radio
-        vertical
+      <Radio.Group
         value={isCustom ? "custom" : "maximum"}
-        options={[
-          {
-            name: t`Show maximum (first ${formatNumber(HARD_ROW_LIMIT)})`,
-            value: "maximum",
-          },
-          {
-            name: t`Set custom limit`,
-            value: "custom",
-          },
-        ]}
-        onChange={(selected: string) => {
+        onChange={(selected) => {
           if (selected === "maximum") {
             setIsCustom(false);
           } else {
@@ -82,7 +70,15 @@ export const LimitPopover = ({
             inputRef.current?.select();
           }
         }}
-      />
+      >
+        <Stack gap="sm">
+          <Radio
+            value="maximum"
+            label={t`Show maximum (first ${formatNumber(HARD_ROW_LIMIT)})`}
+          />
+          <Radio value="custom" label={t`Set custom limit`} />
+        </Stack>
+      </Radio.Group>
       <Box mt="sm" ml="1.25rem">
         <LimitInput
           ref={inputRef}


### PR DESCRIPTION
Contributes to [GDGT-2588](https://linear.app/metabase/issue/GDGT-2588)

### Description

The `metabase/common/components/Radio` component is deprecated in favor of `Radio` from `metabase/ui` (Mantine). This is the first of three PRs that retire it, covering the four call sites that render as plain vertical radio lists (the legacy `normal` variant): `LimitPopover`, the Action form `FieldSettingsPopover` (input type), `ValuesSourceTypeModal` (parameter value source), and the enterprise `EditSandboxingModal`.

The deprecated component took an `options`-array API and accepted arbitrary value types. Mantine's `Radio.Group` is composable (`Radio.Group` wrapping `Radio` children) and only handles **string** values, so two call sites needed a small adapter at the radio boundary:

- `EditSandboxingModal` used boolean option values → mapped to `"column"` / `"saved-question"`.
- `ValuesSourceTypeModal` has a `null` source type ("From connected fields", i.e. `values_source_type=null`) → mapped to a sentinel string via `serializeSourceType` / `deserializeSourceType`. `null` stays the domain type everywhere else (the modal branches on `sourceType === null` and persists it to the backend); the sentinel exists only inside the radio.

### How to verify

1. Query builder/notebook → **Row limit** popover → "Show maximum" / "Set custom limit" select as before.
2. Edit a dashboard or native-query **filter** → values source settings → **Edit** → "Where values should come from" radios (incl. "From connected fields" when the parameter is connected to fields).
3. Model **Action** editor (query action) → a form field's **gear** → input-type radios.
4. _(EE, `sandboxes` feature)_ Admin → Permissions → a table's **View data** → "Row and column security" → the "How do you want to filter this table?" radios in the modal.

Each now renders as a standard Mantine radio group; selection behavior is unchanged.

### Demo

<details>
<summary>Row limit popover</summary>

**Before**
<img width="298" height="180" alt="limit" src="https://github.com/user-attachments/assets/fee27976-fc70-4fa9-93c2-969868398489" />

**After**
<img width="296" height="182" alt="CleanShot 2026-06-24 at 10 25 43" src="https://github.com/user-attachments/assets/a0fca4b5-0b92-432c-9048-15c4ca770115" />



</details>

<details>
<summary>Filter values source — ValuesSourceTypeModal</summary>

**Before**
<img width="1158" height="877" alt="values" src="https://github.com/user-attachments/assets/11d315e4-767e-45ac-bcd5-648b395d86b5" />

**After**
<img width="617" height="331" alt="values" src="https://github.com/user-attachments/assets/4d071354-5f7d-486b-98fd-ea769dbca795" />


</details>

<details>
<summary>Action field input type — FieldSettingsPopover</summary>

**Before**
<img width="285" height="419" alt="model" src="https://github.com/user-attachments/assets/dec386f6-95b4-4ec8-adc4-8d43dc6c8891" />

**After**
<img width="294" height="458" alt="model" src="https://github.com/user-attachments/assets/fa990cd0-7de7-4187-af8c-968287e7e620" />


</details>

<details>
<summary>Sandboxing modal — EditSandboxingModal</summary>

**Before**
<img width="690" height="554" alt="sandbox" src="https://github.com/user-attachments/assets/ad042c84-1def-449a-88e5-df333e3cdd3b" />


**After**
<img width="666" height="538" alt="sandbox" src="https://github.com/user-attachments/assets/a4a94b69-10b6-41f2-af16-233fa36f3a9a" />


</details>

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
