### PR TITLE
Bundle-size stats: upload per-bundle deltas, skip unchanged commits

### DIFF
--- a/.github/scripts/bundle-size-stats-prepare.js
+++ b/.github/scripts/bundle-size-stats-prepare.js
@@ -1,0 +1,102 @@
+/* eslint-disable import/no-commonjs */
+// Prepares the rows the bundle-size stats logger uploads to stats.metabase.com.
+//
+// For each measured (bundle, kind) it computes the delta — raw and gzipped bytes
+// plus percent — against the previously *plotted* data point (restored from a
+// rolling cache), so the deltas can be charted directly. It also decides whether
+// this commit is worth recording at all: a point is kept only when something
+// moved by at least MIN_DELTA_PERCENT (gzipped), keeping the time series to
+// commits that actually changed a bundle.
+const fs = require("fs");
+const path = require("path");
+
+const env = process.env;
+const threshold = Number(env.MIN_DELTA_PERCENT ?? 1);
+
+const readJson = filePath => (filePath && fs.existsSync(filePath) ? JSON.parse(fs.readFileSync(filePath, "utf8")) : null);
+const writeJson = (filePath, value) => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value));
+};
+const setOutput = (name, value) => {
+  if (env.GITHUB_OUTPUT) {
+    fs.appendFileSync(env.GITHUB_OUTPUT, `${name}=${value}\n`);
+  }
+};
+
+const measurements = readJson(env.CURRENT);
+if (!Array.isArray(measurements) || measurements.length === 0) {
+  console.error(`::error::No bundle measurements found at ${env.CURRENT}`);
+  process.exit(1);
+}
+
+// The last plotted point, as slim rows: [{ bundle, kind, rawBytes, gzipBytes }].
+const previous = readJson(env.LAST) || [];
+const previousOf = (bundle, kind) => previous.find(row => row.bundle === bundle && row.kind === kind);
+
+const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+const commit = (env.HEAD_SHA || "").slice(0, 12);
+
+// version.properties (extracted from the uberjar) carries the build's tag.
+// Non-release (master) builds report tag=vUNKNOWN, so leave Version empty there.
+const rawVersion =
+  env.VERSION_PROPS && fs.existsSync(env.VERSION_PROPS)
+    ? (fs.readFileSync(env.VERSION_PROPS, "utf8").match(/^tag=(.*)$/m)?.[1]?.trim() ?? "")
+    : "";
+const version = rawVersion === "vUNKNOWN" ? "" : rawVersion;
+
+const deltaPercent = (current, base) =>
+  base ? Math.round(((current - base) * 10000) / base) / 100 : "";
+
+let maxGzipDeltaPercent = 0;
+let hasNewSeries = false;
+
+const rows = measurements.map(measurement => {
+  const base = previousOf(measurement.bundle, measurement.kind);
+  if (!base) {
+    hasNewSeries = true;
+  } else {
+    maxGzipDeltaPercent = Math.max(
+      maxGzipDeltaPercent,
+      Math.abs(deltaPercent(measurement.gzipBytes, base.gzipBytes)),
+    );
+  }
+  return {
+    "Date": date,
+    "Version": version,
+    "Commit": commit,
+    "Bundle": measurement.bundle,
+    "Kind": measurement.kind, // "initial" or "total"
+    "Raw bytes": measurement.rawBytes,
+    "Gzip bytes": measurement.gzipBytes,
+    "Brotli bytes": measurement.brotliBytes ?? "", // as-served; empty when no .br shipped
+    "File count": measurement.fileCount,
+    "Raw bytes delta": base ? measurement.rawBytes - base.rawBytes : "",
+    "Gzip bytes delta": base ? measurement.gzipBytes - base.gzipBytes : "",
+    "Raw delta %": deltaPercent(measurement.rawBytes, base?.rawBytes),
+    "Gzip delta %": deltaPercent(measurement.gzipBytes, base?.gzipBytes),
+  };
+});
+
+const firstPoint = previous.length === 0;
+const significant = firstPoint || hasNewSeries || maxGzipDeltaPercent >= threshold;
+
+writeJson(env.ROWS_OUT, rows);
+
+// Stash the current sizes so the next run can diff against this point. The
+// workflow only persists this to the cache when we actually push, so the cached
+// reference always stays the last *plotted* point (cumulative drift is caught).
+writeJson(
+  env.CACHE_OUT,
+  measurements.map(({ bundle, kind, rawBytes, gzipBytes }) => ({ bundle, kind, rawBytes, gzipBytes })),
+);
+
+const reason = firstPoint
+  ? "first point"
+  : hasNewSeries
+    ? "new bundle/kind series"
+    : `max gzip Δ ${maxGzipDeltaPercent.toFixed(2)}% (threshold ${threshold}%)`;
+console.log(`${significant ? "RECORD" : "SKIP"} — ${reason}`);
+
+setOutput("significant", significant ? "true" : "false");
+setOutput("max_delta_percent", firstPoint || hasNewSeries ? "" : maxGzipDeltaPercent.toFixed(2));

--- a/.github/scripts/bundle-size-stats-prepare.js
+++ b/.github/scripts/bundle-size-stats-prepare.js
@@ -1,12 +1,12 @@
 /* eslint-disable import/no-commonjs */
 // Prepares the rows the bundle-size stats logger uploads to stats.metabase.com.
 //
-// For each measured (bundle, kind) it computes the delta — raw and gzipped bytes
-// plus percent — against the previously *plotted* data point (restored from a
-// rolling cache), so the deltas can be charted directly. It also decides whether
-// this commit is worth recording at all: a point is kept only when something
-// moved by at least MIN_DELTA_PERCENT (gzipped), keeping the time series to
-// commits that actually changed a bundle.
+// For each measured (bundle, kind) it computes the delta — raw, gzipped and
+// brotli (as-served) bytes plus percent — against the previously *plotted* data
+// point (restored from a rolling cache), so the deltas can be charted directly.
+// It also decides whether this commit is worth recording at all: a point is kept
+// when the as-served size moved by at least MIN_DELTA_PERCENT, when a new
+// bundle/kind appears, or when the build is a tagged release (always kept).
 const fs = require("fs");
 const path = require("path");
 
@@ -48,18 +48,21 @@ const version = rawVersion === "vUNKNOWN" ? "" : rawVersion;
 const deltaPercent = (current, base) =>
   base ? Math.round(((current - base) * 10000) / base) / 100 : "";
 
-let maxGzipDeltaPercent = 0;
+// The threshold tracks the as-served size: brotli where the build ships .br,
+// otherwise gzip (brotli is null when nothing in the bundle shipped a .br).
+let maxServedDeltaPercent = 0;
 let hasNewSeries = false;
 
 const rows = measurements.map(measurement => {
   const base = previousOf(measurement.bundle, measurement.kind);
+  const hasBrotli = measurement.brotliBytes != null && base?.brotliBytes != null;
+  const gzipDeltaPercent = deltaPercent(measurement.gzipBytes, base?.gzipBytes);
+  const brotliDeltaPercent = hasBrotli ? deltaPercent(measurement.brotliBytes, base.brotliBytes) : "";
   if (!base) {
     hasNewSeries = true;
   } else {
-    maxGzipDeltaPercent = Math.max(
-      maxGzipDeltaPercent,
-      Math.abs(deltaPercent(measurement.gzipBytes, base.gzipBytes)),
-    );
+    const servedDeltaPercent = hasBrotli ? brotliDeltaPercent : gzipDeltaPercent;
+    maxServedDeltaPercent = Math.max(maxServedDeltaPercent, Math.abs(servedDeltaPercent));
   }
   return {
     "Date": date,
@@ -73,13 +76,17 @@ const rows = measurements.map(measurement => {
     "File count": measurement.fileCount,
     "Raw bytes delta": base ? measurement.rawBytes - base.rawBytes : "",
     "Gzip bytes delta": base ? measurement.gzipBytes - base.gzipBytes : "",
+    "Brotli bytes delta": hasBrotli ? measurement.brotliBytes - base.brotliBytes : "",
     "Raw delta %": deltaPercent(measurement.rawBytes, base?.rawBytes),
-    "Gzip delta %": deltaPercent(measurement.gzipBytes, base?.gzipBytes),
+    "Gzip delta %": gzipDeltaPercent,
+    "Brotli delta %": brotliDeltaPercent,
   };
 });
 
+// Always keep a point for a tagged release, even when nothing moved.
+const isRelease = version !== "";
 const firstPoint = previous.length === 0;
-const significant = firstPoint || hasNewSeries || maxGzipDeltaPercent >= threshold;
+const significant = firstPoint || hasNewSeries || isRelease || maxServedDeltaPercent >= threshold;
 
 writeJson(env.ROWS_OUT, rows);
 
@@ -88,15 +95,23 @@ writeJson(env.ROWS_OUT, rows);
 // reference always stays the last *plotted* point (cumulative drift is caught).
 writeJson(
   env.CACHE_OUT,
-  measurements.map(({ bundle, kind, rawBytes, gzipBytes }) => ({ bundle, kind, rawBytes, gzipBytes })),
+  measurements.map(({ bundle, kind, rawBytes, gzipBytes, brotliBytes }) => ({
+    bundle,
+    kind,
+    rawBytes,
+    gzipBytes,
+    brotliBytes,
+  })),
 );
 
 const reason = firstPoint
   ? "first point"
   : hasNewSeries
     ? "new bundle/kind series"
-    : `max gzip Δ ${maxGzipDeltaPercent.toFixed(2)}% (threshold ${threshold}%)`;
+    : isRelease
+      ? `release ${version}`
+      : `max served Δ ${maxServedDeltaPercent.toFixed(2)}% (threshold ${threshold}%)`;
 console.log(`${significant ? "RECORD" : "SKIP"} — ${reason}`);
 
 setOutput("significant", significant ? "true" : "false");
-setOutput("max_delta_percent", firstPoint || hasNewSeries ? "" : maxGzipDeltaPercent.toFixed(2));
+setOutput("max_delta_percent", firstPoint || hasNewSeries ? "" : maxServedDeltaPercent.toFixed(2));

--- a/.github/workflows/bundle-size-stats.yml
+++ b/.github/workflows/bundle-size-stats.yml
@@ -8,7 +8,9 @@ on:
   workflow_run:
     workflows: ["Build Uberjar"]
     types: [completed]
-    branches: [master]
+    # release-* builds carry a real version tag and are always recorded; master
+    # builds are recorded only when a bundle's as-served size actually moved.
+    branches: [master, "release-*"]
 
 concurrency:
   group: bundle-size-stats-${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/bundle-size-stats.yml
+++ b/.github/workflows/bundle-size-stats.yml
@@ -21,6 +21,9 @@ jobs:
     timeout-minutes: 15
     env:
       HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      # Only record a data point when a bundle's gzipped size moved by at least
+      # this percent vs the last plotted point, keeping the chart to real changes.
+      MIN_DELTA_PERCENT: "1"
     steps:
       - name: Check out the code
         uses: actions/checkout@v6
@@ -78,9 +81,26 @@ jobs:
           mkdir -p artifacts resources/embedding-sdk
           if [ -n "$STATS_ZIP" ]; then unzip -o "$STATS_ZIP" -d artifacts; fi
           if [ -n "$PKG_ZIP" ]; then unzip -o "$PKG_ZIP" -d resources/embedding-sdk; fi
+      - name: Restore last plotted bundle sizes
+        uses: actions/cache/restore@v4
+        with:
+          path: bundle-size-cache
+          key: bundle-size-last-${{ github.run_id }}
+          restore-keys: |
+            bundle-size-last-
       - name: Measure bundle sizes
         run: node ./.github/scripts/measure-bundle-sizes.js | tee artifacts/bundle-sizes.json
-      - name: Upload sizes to Stats
+      - name: Compute deltas and decide whether to record this point
+        id: prepare
+        env:
+          CURRENT: artifacts/bundle-sizes.json
+          LAST: bundle-size-cache/last.json
+          CACHE_OUT: bundle-size-cache/last.json
+          ROWS_OUT: artifacts/upload-rows.json
+          VERSION_PROPS: artifacts/version.properties
+        run: node ./.github/scripts/bundle-size-stats-prepare.js
+      - name: Upload sizes (with deltas) to Stats
+        if: steps.prepare.outputs.significant == 'true'
         uses: actions/github-script@v9
         env:
           API_KEY: ${{ secrets.STATS_API_KEY }}
@@ -89,32 +109,9 @@ jobs:
             const fs = require("fs");
             const { uploadCsvToMb } = require("${{ github.workspace }}/.github/scripts/csv-to-mb.js");
 
-            const measurements = JSON.parse(
-              fs.readFileSync("${{ github.workspace }}/artifacts/bundle-sizes.json", "utf8"),
+            const data = JSON.parse(
+              fs.readFileSync("${{ github.workspace }}/artifacts/upload-rows.json", "utf8"),
             );
-
-            const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-            const commit = process.env.HEAD_SHA.slice(0, 12);
-
-            // version.properties (extracted from the uberjar) carries the build's tag.
-            // Non-release (master) builds report tag=vUNKNOWN, so leave Version empty there.
-            const versionProps = "${{ github.workspace }}/artifacts/version.properties";
-            const rawVersion = fs.existsSync(versionProps)
-              ? (fs.readFileSync(versionProps, "utf8").match(/^tag=(.*)$/m)?.[1]?.trim() ?? "")
-              : "";
-            const version = rawVersion === "vUNKNOWN" ? "" : rawVersion;
-
-            const data = measurements.map(measurement => ({
-              "Date": date,
-              "Version": version,
-              "Commit": commit,
-              "Bundle": measurement.bundle,
-              "Kind": measurement.kind, // "initial" or "total"
-              "Raw bytes": measurement.rawBytes,
-              "Gzip bytes": measurement.gzipBytes,
-              "Brotli bytes": measurement.brotliBytes ?? "", // as-served; empty when no .br shipped
-              "File count": measurement.fileCount,
-            }));
 
             console.table(data);
 
@@ -129,3 +126,9 @@ jobs:
               console.error("Error uploading bundle sizes:", error);
               process.exit(1);
             });
+      - name: Remember this as the last plotted point
+        if: steps.prepare.outputs.significant == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: bundle-size-cache
+          key: bundle-size-last-${{ github.run_id }}


### PR DESCRIPTION
## What

Three changes to the master bundle-size **stats logger** (`bundle-size-stats.yml`, which feeds the stats.metabase.com time-series chart):

1. **Uploads per-bundle deltas** vs the previous plotted point — raw, gzipped, and **brotli (as-served)** bytes plus percent — so the chart can render change directly. Each row (already split by `Kind` = `initial`/`total`) gains: `Raw bytes delta`, `Gzip bytes delta`, `Brotli bytes delta`, `Raw delta %`, `Gzip delta %`, `Brotli delta %`.
2. **Skips commits that didn't move a bundle.** A master point is recorded only when a bundle's **as-served** size (brotli where a `.br` ships, else gzip) changed by ≥ `MIN_DELTA_PERCENT` (default 1%) vs the last plotted point.
3. **Always records tagged releases.** `release-*` builds carry a real version tag and are recorded regardless of delta, so every release is a point on the chart. The `workflow_run` trigger is widened from `[master]` to `[master, release-*]` to let those builds reach the logger.

## How

The delta is computed the same way `compare.js` does (per `(bundle, kind)`), with the "base" being the last plotted point — remembered via a **rolling GitHub Actions cache** (`bundle-size-last-*`), updated only when we actually record, so cumulative sub-threshold drift is still caught once it adds up. Fail-open: a cache miss records the point.

`bundle-size-stats-prepare.js` does the diff + decision + row building; the upload step is gated on its `significant` output.

## ⚠️ Requires a table change before merge

The append now includes 6 new columns. `append-csv` needs the CSV columns to match the table, so **table 79417 needs `Raw bytes delta`, `Gzip bytes delta`, `Brotli bytes delta`, `Raw delta %`, `Gzip delta %`, `Brotli delta %` added first** (or a one-time `replace-csv` with the new shape). Until then the append will reject the schema.

## Notes / for review

- Threshold is `MIN_DELTA_PERCENT` (job env, default `1`); the gate tracks brotli when available, gzip otherwise (brotli is null when nothing shipped a `.br`).
- Delta is "since the last *recorded* point" (skipped commits are spanned) — the only sensible delta for a sparse chart.
- **Please confirm** release builds actually fire a `Build Uberjar` `workflow_run` on `release-*` branches (I couldn't verify); if they don't, the trigger addition is a harmless no-op and releases still won't be recorded.
- Concurrency: the per-SHA group lets two close builds run at once; both could restore the same cache and record. Rare, harmless.
