### PR TITLE
Fix MCP embed bundle loading async chunks from wrong origin

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -175,6 +175,8 @@ const elements = [
     "frontend/src/metabase/app-main.js",
     "frontend/src/metabase/app-embed.ts",
     "frontend/src/metabase/app-embed-mcp.tsx",
+    "frontend/src/metabase/app-embed-mcp-public-path.ts",
+    "frontend/src/metabase/app-embed-mcp-public-path.unit.spec.ts",
     "frontend/src/metabase/app-public.ts",
     "frontend/src/metabase/AppComponent.tsx",
     "frontend/src/metabase/App.styled.tsx",

--- a/frontend/src/metabase/app-embed-mcp-public-path.ts
+++ b/frontend/src/metabase/app-embed-mcp-public-path.ts
@@ -1,0 +1,38 @@
+/**
+ * Sets webpack's runtime `publicPath` (`__webpack_require__.p`) so on-demand
+ * chunks (loaded via dynamic `import()` — e.g. the leaflet map renderer and the
+ * echarts renderer) are fetched from the Metabase instance.
+ *
+ * The MCP app runs inside a sandboxed `about:srcdoc` iframe. The initial bundle
+ * scripts load fine because HtmlWebpackPlugin writes them with an absolute,
+ * instance-templated URL. On-demand chunks instead use the runtime `publicPath`,
+ * which is the relative `output.publicPath` ("app/dist/"); that does not resolve
+ * to the instance inside the srcdoc iframe and 404s.
+ *
+ * Unlike the Embedding SDK (which derives its base from `document.currentScript`),
+ * the instance URL is injected synchronously via `window.metabaseConfig`, so we
+ * use it directly — `document.currentScript` is null here because the entry runs
+ * deferred, after the document is parsed.
+ *
+ * This must be imported before any dynamic `import()` can run, so it is the first
+ * import of the bundle entry.
+ */
+
+// Provided by webpack/rspack at build time; the `declare` emits no runtime code,
+// so the assignment below is rewritten to set the runtime's `publicPath`.
+declare let __webpack_public_path__: string;
+
+// @ts-expect-error -- metabaseConfig is only set on the MCP Apps route
+const instanceUrl: string = window.metabaseConfig?.instanceUrl ?? "";
+
+// In hot/dev mode `output.publicPath` is already an absolute localhost URL served
+// by the dev server, so leave it alone — only the relative production path needs
+// to be rewritten to the instance.
+const runtimePathIsAbsolute = /^https?:\/\//.test(__webpack_public_path__);
+
+if (instanceUrl && !runtimePathIsAbsolute) {
+  const base = instanceUrl.endsWith("/") ? instanceUrl : `${instanceUrl}/`;
+  __webpack_public_path__ = `${base}app/dist/`;
+}
+
+export {};

--- a/frontend/src/metabase/app-embed-mcp-public-path.ts
+++ b/frontend/src/metabase/app-embed-mcp-public-path.ts
@@ -22,7 +22,6 @@
 // so the assignment below is rewritten to set the runtime's `publicPath`.
 declare let __webpack_public_path__: string;
 
-// @ts-expect-error -- metabaseConfig is only set on the MCP Apps route
 const instanceUrl: string = window.metabaseConfig?.instanceUrl ?? "";
 
 // In hot/dev mode `output.publicPath` is already an absolute localhost URL served

--- a/frontend/src/metabase/app-embed-mcp-public-path.unit.spec.ts
+++ b/frontend/src/metabase/app-embed-mcp-public-path.unit.spec.ts
@@ -1,0 +1,60 @@
+describe("app-embed-mcp-public-path", () => {
+  const setRuntimePublicPath = (value: string) => {
+    (globalThis as any).__webpack_public_path__ = value;
+  };
+
+  const getRuntimePublicPath = () =>
+    (globalThis as any).__webpack_public_path__;
+
+  const setInstanceUrl = (instanceUrl: string | undefined) => {
+    (window as any).metabaseConfig =
+      instanceUrl === undefined ? undefined : { instanceUrl };
+  };
+
+  const loadModule = () => import("./app-embed-mcp-public-path");
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    delete (window as any).metabaseConfig;
+    delete (globalThis as any).__webpack_public_path__;
+  });
+
+  it("rewrites the relative production publicPath to an absolute instance URL", async () => {
+    setRuntimePublicPath("app/dist/");
+    setInstanceUrl("https://mb.example.com");
+
+    await loadModule();
+
+    expect(getRuntimePublicPath()).toBe("https://mb.example.com/app/dist/");
+  });
+
+  it("does not double the slash when the instance URL already ends with one", async () => {
+    setRuntimePublicPath("app/dist/");
+    setInstanceUrl("https://mb.example.com/");
+
+    await loadModule();
+
+    expect(getRuntimePublicPath()).toBe("https://mb.example.com/app/dist/");
+  });
+
+  it("leaves an already-absolute (hot/dev) publicPath untouched", async () => {
+    setRuntimePublicPath("http://localhost:8080/app/dist/");
+    setInstanceUrl("https://mb.example.com");
+
+    await loadModule();
+
+    expect(getRuntimePublicPath()).toBe("http://localhost:8080/app/dist/");
+  });
+
+  it("does nothing when no instance URL is available", async () => {
+    setRuntimePublicPath("app/dist/");
+    setInstanceUrl(undefined);
+
+    await loadModule();
+
+    expect(getRuntimePublicPath()).toBe("app/dist/");
+  });
+});

--- a/frontend/src/metabase/app-embed-mcp.tsx
+++ b/frontend/src/metabase/app-embed-mcp.tsx
@@ -1,3 +1,7 @@
+// Must run before any dynamic import(): sets webpack's runtime publicPath so
+// on-demand chunks (leaflet, echarts) resolve to the Metabase instance.
+import "./app-embed-mcp-public-path";
+
 import { createRoot } from "react-dom/client";
 
 // Import the embedding SDK vendors side-effects (sets up global CSS vars, etc.)


### PR DESCRIPTION
Closes EMB-1937

## Problem

The MCP embed app (`app-embed-mcp`) runs inside a sandboxed `about:srcdoc` iframe hosted at a third-party origin (e.g. `claudemcpcontent.com`). On-demand chunks loaded via dynamic `import()` (the leaflet map renderer and the echarts renderer) were requested from the **embedder's** origin and 404'd:

```
GET https://<embedder>/app/dist/237.<hash>.js  ->  404
ChunkLoadError: Loading chunk 237 failed.
```

The initial bundle scripts load fine because HtmlWebpackPlugin writes them into the HTML with the per-entry templated, absolute `publicPath` (`{{{instanceUrlRaw}}}/app/dist/`). On-demand chunks don't go through HtmlWebpackPlugin — they use the webpack **runtime** `publicPath`, which is the relative `output.publicPath` (`app/dist/`). Inside the srcdoc iframe that relative path resolves against the embedder origin instead of the Metabase instance, so the chunk requests 404. This is the same class of issue that #75985 fixed for the Embedding SDK, reached a different way.

## Fix

Set webpack's runtime `publicPath` to an absolute instance URL before any dynamic `import()` runs. Unlike the SDK (which derives its base from `document.currentScript`, `null` here because the MCP entry runs deferred), the instance URL is already injected synchronously via `window.metabaseConfig.instanceUrl`, so we use it directly.

- `app-embed-mcp-public-path.ts` (new) — rewrites the relative production `publicPath` to `${instanceUrl}/app/dist/`; leaves an already-absolute (hot/dev) path untouched.
- `app-embed-mcp.tsx` — imports it first, before any code that can trigger a dynamic `import()`.
- `module-boundaries.mjs` — registers the new files in the app entry allow-list.

The other bundles (`app-main`/`app-public`/`app-embed`/`app-embed-sdk`) are served from the Metabase origin itself, so their relative `publicPath` resolves correctly — only `app-embed-mcp` (foreign-origin srcdoc) needed this.