### PR TITLE
add mysql index driver methods

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -35,7 +35,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.memoize :as memoize]
-   [metabase.util.performance :as perf :refer [get-in not-empty some]]
+   [metabase.util.performance :as perf :refer [get-in mapv not-empty some]]
    [next.jdbc :as next.jdbc])
   (:import
    (java.io File)

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -69,6 +69,8 @@
                               :full-join                              false
                               ;; Index sync is turned off across the application as it is not used ATM.
                               :index-info                             false
+                              :index/fetch                            true
+                              :index/standalone-create                true
                               :now                                    true
                               :percentile-aggregations                false
                               :persist-models                         true
@@ -91,8 +93,7 @@
                               :metadata/table-existence-check         true
                               :transforms/python                      true
                               :transforms/table                       true
-                              ;; currently disabled as :describe-indexes is not supported
-                              :transforms/index-ddl                   false
+                              :transforms/index-ddl                   true
                               :describe-default-expr                  true
                               :describe-is-nullable                   true
                               :describe-is-generated                  true
@@ -1440,6 +1441,99 @@
                               nil))
                           (ex-message e)))]
            result))))))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                          Indexes (Index Manager)                                               |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defmethod driver/supported-index-methods :mysql
+  [_driver _database]
+  ;; btree (with a UNIQUE modifier) and fulltext, both standalone. Spatial is niche and InnoDB silently rewrites
+  ;; USING HASH into btree, so neither is offered.
+  (let [name+cols [driver.common/index-name-field driver.common/index-columns-field]]
+    {:btree    {:lifecycle :standalone :fields (conj name+cols driver.common/index-unique-field)}
+     :fulltext {:lifecycle :standalone :fields name+cols}}))
+
+(defn- mysql-index-column-sql
+  "Quote one indexed column; append its `ASC`/`DESC` direction only for btree (fulltext has no per-column order)."
+  [btree? {col-name :name :keys [direction]}]
+  (cond-> (sql.u/quote-name :mysql :field col-name)
+    (and btree? direction) (str " " (u/upper-case-en (name direction)))))
+
+(defn- create-index-sql
+  [schema table {index-name :name, :keys [kind columns unique]}]
+  (let [fulltext? (= kind :fulltext)
+        target    (apply sql.u/quote-name :mysql :table (if (not-empty schema) [schema table] [table]))
+        cols      (str/join ", " (map #(mysql-index-column-sql (not fulltext?) %) columns))]
+    (format "CREATE %sINDEX %s ON %s (%s)"
+            (cond fulltext?            "FULLTEXT "
+                  (and (not fulltext?) unique) "UNIQUE "
+                  :else                "")
+            (sql.u/quote-name :mysql :field index-name)
+            target
+            cols)))
+
+(defn- sql-string-literal
+  "A MySQL `'...'` string literal for the trusted `s` (ANSI-escaping embedded quotes)."
+  [s]
+  (str \' (sql.u/escape-sql s :ansi) \'))
+
+(defmethod driver/compile-create-index :mysql
+  [_driver schema table {index-name :name, :keys [if-not-exists] :as structured}]
+  (let [create (create-index-sql schema table structured)]
+    (if-not if-not-exists
+      [[create]]
+      ;; MySQL has no `CREATE INDEX IF NOT EXISTS`. The transform apply path re-issues creates on full-rebuild runs, so
+      ;; guard with dynamic SQL that skips the create when an index of this name already exists. The schema/table/name
+      ;; are trusted identifiers (already spliced into the DDL), so they're inlined as string literals: the MariaDB
+      ;; driver rejects `?` placeholders inside the `SET @var := (SELECT ...)` subquery. Session variables survive the
+      ;; DDL's implicit commit, and every statement runs via `executeUpdate`, which the `SET`s and
+      ;; `PREPARE`/`EXECUTE`/`DEALLOCATE` all accept.
+      [[(format "SET @mb_idx_exists := (SELECT COUNT(*) FROM information_schema.statistics
+                                        WHERE table_schema = %s AND table_name = %s AND index_name = %s)"
+                (if (not-empty schema) (sql-string-literal schema) "DATABASE()")
+                (sql-string-literal table)
+                (sql-string-literal index-name))]
+       [(format "SET @mb_idx_sql := IF(@mb_idx_exists > 0, 'DO 0', %s)"
+                (sql-string-literal create))]
+       ["PREPARE mb_idx_stmt FROM @mb_idx_sql"]
+       ["EXECUTE mb_idx_stmt"]
+       ["DEALLOCATE PREPARE mb_idx_stmt"]])))
+
+(defn- mysql-index-type->kind
+  [index-type]
+  (case (u/upper-case-en (or index-type ""))
+    "FULLTEXT" :fulltext
+    "SPATIAL"  :spatial
+    :btree))
+
+(defn- mysql-index-rows->index
+  "Collapse the per-column `information_schema.statistics` rows of one index (already ordered by `SEQ_IN_INDEX`) into a
+  normalized `::table-index` map."
+  [rows]
+  (let [{:keys [index_name non_unique index_type]} (first rows)]
+    {:name              index_name
+     :kind              (mysql-index-type->kind index_type)
+     :access-method     (some-> index_type u/lower-case-en)
+     :is-unique         (zero? (long non_unique))
+     :is-primary        (= index_name "PRIMARY")
+     :is-valid          true
+     :key-columns       (mapv :column_name rows)
+     :include-columns   []
+     :partial-predicate nil
+     :definition        nil}))
+
+(defmethod driver/fetch-table-indexes :mysql
+  [_driver database schema table]
+  (->> (jdbc/query
+        (sql-jdbc.conn/db->pooled-connection-spec database)
+        ["SELECT index_name, seq_in_index, column_name, non_unique, index_type
+          FROM information_schema.statistics
+          WHERE table_schema = COALESCE(?, DATABASE()) AND table_name = ?
+          ORDER BY index_name, seq_in_index"
+         (not-empty schema) table])
+       (partition-by :index_name)
+       (mapv mysql-index-rows->index)))
 
 (defmethod driver/llm-sql-dialect-resource :mysql [_]
   "metabot/prompts/dialects/mysql.md")

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -1465,9 +1465,9 @@
         target    (apply sql.u/quote-name :mysql :table (if (not-empty schema) [schema table] [table]))
         cols      (str/join ", " (map #(mysql-index-column-sql (not fulltext?) %) columns))]
     (format "CREATE %sINDEX %s ON %s (%s)"
-            (cond fulltext?            "FULLTEXT "
-                  (and (not fulltext?) unique) "UNIQUE "
-                  :else                "")
+            (cond fulltext? "FULLTEXT "
+                  unique    "UNIQUE "
+                  :else     "")
             (sql.u/quote-name :mysql :field index-name)
             target
             cols)))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -1448,14 +1448,13 @@
 
 (defmethod driver/supported-index-methods :mysql
   [_driver _database]
-  ;; btree (with a UNIQUE modifier) and fulltext, both standalone. Spatial is niche and InnoDB silently rewrites
-  ;; USING HASH into btree, so neither is offered.
+  ;; spatial is niche, and InnoDB silently rewrites USING HASH into btree, so neither is offered.
   (let [name+cols [driver.common/index-name-field driver.common/index-columns-field]]
     {:btree    {:lifecycle :standalone :fields (conj name+cols driver.common/index-unique-field)}
      :fulltext {:lifecycle :standalone :fields name+cols}}))
 
 (defn- mysql-index-column-sql
-  "Quote one indexed column; append its `ASC`/`DESC` direction only for btree (fulltext has no per-column order)."
+  "Quote an indexed column, appending `ASC`/`DESC` only for btree (fulltext has no per-column order)."
   [btree? {col-name :name :keys [direction]}]
   (cond-> (sql.u/quote-name :mysql :field col-name)
     (and btree? direction) (str " " (u/upper-case-en (name direction)))))
@@ -1474,7 +1473,7 @@
             cols)))
 
 (defn- sql-string-literal
-  "A MySQL `'...'` string literal for the trusted `s` (ANSI-escaping embedded quotes)."
+  "A MySQL `'...'` string literal for trusted `s`, escaping embedded quotes."
   [s]
   (str \' (sql.u/escape-sql s :ansi) \'))
 
@@ -1483,12 +1482,9 @@
   (let [create (create-index-sql schema table structured)]
     (if-not if-not-exists
       [[create]]
-      ;; MySQL has no `CREATE INDEX IF NOT EXISTS`. The transform apply path re-issues creates on full-rebuild runs, so
-      ;; guard with dynamic SQL that skips the create when an index of this name already exists. The schema/table/name
-      ;; are trusted identifiers (already spliced into the DDL), so they're inlined as string literals: the MariaDB
-      ;; driver rejects `?` placeholders inside the `SET @var := (SELECT ...)` subquery. Session variables survive the
-      ;; DDL's implicit commit, and every statement runs via `executeUpdate`, which the `SET`s and
-      ;; `PREPARE`/`EXECUTE`/`DEALLOCATE` all accept.
+      ;; MySQL has no `CREATE INDEX IF NOT EXISTS`, and the apply path re-issues creates on full rebuilds, so guard
+      ;; with dynamic SQL that runs the create only when no index of this name exists. Identifiers are inlined as
+      ;; string literals because the MariaDB driver rejects `?` placeholders inside the `SET @var := (SELECT ...)`.
       [[(format "SET @mb_idx_exists := (SELECT COUNT(*) FROM information_schema.statistics
                                         WHERE table_schema = %s AND table_name = %s AND index_name = %s)"
                 (if (not-empty schema) (sql-string-literal schema) "DATABASE()")
@@ -1508,8 +1504,7 @@
     :btree))
 
 (defn- mysql-index-rows->index
-  "Collapse the per-column `information_schema.statistics` rows of one index (already ordered by `SEQ_IN_INDEX`) into a
-  normalized `::table-index` map."
+  "Collapse one index's per-column `information_schema.statistics` rows (ordered by `SEQ_IN_INDEX`) into an index map."
   [rows]
   (let [{:keys [index_name non_unique index_type]} (first rows)]
     {:name              index_name

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -1095,3 +1095,26 @@
               "query should throw rather than completing normally")
           (is (< elapsed 30000)
               (format "query should be cancelled well before SLEEP(60) completes naturally — took %.0f ms" elapsed)))))))
+
+(deftest ^:parallel compile-create-index-test
+  (testing "btree renders with backticks; UNIQUE only when asked, direction only on btree"
+    (is (= [["CREATE INDEX `by_cat` ON `t` (`category`)"]]
+           (driver/compile-create-index :mysql nil "t"
+                                        {:kind :btree :name "by_cat" :columns [{:name "category"}]})))
+    (is (= [["CREATE UNIQUE INDEX `by_cat` ON `s`.`t` (`category` DESC)"]]
+           (driver/compile-create-index :mysql "s" "t"
+                                        {:kind :btree :name "by_cat" :unique true
+                                         :columns [{:name "category" :direction :desc}]}))))
+  (testing "fulltext has no UNIQUE and no per-column direction"
+    (is (= [["CREATE FULLTEXT INDEX `ft_cat` ON `t` (`category`)"]]
+           (driver/compile-create-index :mysql nil "t"
+                                        {:kind :fulltext :name "ft_cat" :unique true
+                                         :columns [{:name "category" :direction :asc}]}))))
+  (testing "MySQL has no CREATE INDEX IF NOT EXISTS, so :if-not-exists guards via dynamic SQL instead"
+    (let [stmts (driver/compile-create-index :mysql nil "t"
+                                             {:kind :btree :name "by_cat" :if-not-exists true
+                                              :columns [{:name "category"}]})]
+      (is (not-any? #(str/includes? (first %) "IF NOT EXISTS") stmts)
+          "no literal IF NOT EXISTS clause")
+      (is (str/includes? (first (last stmts)) "DEALLOCATE PREPARE")
+          "ends by deallocating the prepared guard statement"))))

--- a/test/metabase/transforms/index_test_util.clj
+++ b/test/metabase/transforms/index_test_util.clj
@@ -31,6 +31,17 @@
                  :style   (if (some (comp neg? :sortkey) sort-rows) :interleaved :compound)})
      :distkey (:column_name (first (filter :distkey rows)))}))
 
+(defn- mysql-indexes
+  [database schema table]
+  ;; MySQL has no schema layer, so a transform target's `schema` is nil; fall back to the connection's bound database.
+  (->> (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
+                   [(str "SELECT DISTINCT index_name FROM information_schema.statistics "
+                         "WHERE table_schema = COALESCE(?, DATABASE()) AND table_name = ?")
+                    schema table])
+       (map :index_name)
+       (remove #{"PRIMARY"})
+       set))
+
 (defn- clickhouse-indexes
   [database schema table]
   (let [spec (sql-jdbc.conn/db->pooled-connection-spec database)]
@@ -65,7 +76,13 @@
                                     :columns [{:name "price"}] :granularity 1}]
                 :expected         {:sorting-key  "(category)"
                                    :skip-indexes [{:name "by_price" :type "minmax" :expr "(price)" :granularity 1}]}
-                :physical-indexes clickhouse-indexes}})
+                :physical-indexes clickhouse-indexes}
+   ;; MySQL: standalone btree + fulltext. A TEXT column can't be btree-indexed without a prefix length, so btree
+   ;; goes on `price` (float) while fulltext, which requires a text column, goes on `category`.
+   :mysql      {:indexes          [{:kind :btree :name "by_price" :columns [{:name "price"}]}
+                                   {:kind :fulltext :name "ft_category" :columns [{:name "category"}]}]
+                :expected         #{"by_price" "ft_category"}
+                :physical-indexes mysql-indexes}})
 
 (defn index-test-drivers
   "Drivers that run transforms and declare any index support."
@@ -175,4 +192,23 @@
     {:label "an unsorted table returns []"
      :table "mb_fetch_ch_empty"
      :create ["CREATE TABLE mb_fetch_ch_empty (a Int64) ENGINE = MergeTree ORDER BY ()"]
-     :expected #{}}]})
+     :expected #{}}]
+
+   :mysql
+   [{:label  "btree, unique, composite, fulltext, and the auto PRIMARY KEY index"
+     :table  "mb_fetch_mysql"
+     :create ["CREATE TABLE mb_fetch_mysql (id INT PRIMARY KEY, user_id INT, email VARCHAR(255), a INT, b INT, body TEXT)"
+              "CREATE INDEX fc_btree ON mb_fetch_mysql (user_id)"
+              "CREATE UNIQUE INDEX fc_unique ON mb_fetch_mysql (email)"
+              "CREATE INDEX fc_ab ON mb_fetch_mysql (a, b)"
+              "CREATE FULLTEXT INDEX fc_ft ON mb_fetch_mysql (body)"]
+     ;; the PRIMARY KEY surfaces as a unique btree index named 'PRIMARY'.
+     :expected #{(idx "PRIMARY" :btree "btree" ["id"] :unique true :primary true)
+                 (idx "fc_btree" :btree "btree" ["user_id"])
+                 (idx "fc_unique" :btree "btree" ["email"] :unique true)
+                 (idx "fc_ab" :btree "btree" ["a" "b"])
+                 (idx "fc_ft" :fulltext "fulltext" ["body"])}}
+    {:label "a table with no secondary indexes returns just the primary key"
+     :table "mb_fetch_mysql_empty"
+     :create ["CREATE TABLE mb_fetch_mysql_empty (id INT PRIMARY KEY, a INT)"]
+     :expected #{(idx "PRIMARY" :btree "btree" ["id"] :unique true :primary true)}}]})

--- a/test/metabase/transforms/index_test_util.clj
+++ b/test/metabase/transforms/index_test_util.clj
@@ -33,7 +33,7 @@
 
 (defn- mysql-indexes
   [database schema table]
-  ;; MySQL has no schema layer, so a transform target's `schema` is nil; fall back to the connection's bound database.
+  ;; MySQL has no schemas, so `schema` is nil; fall back to the connection's database.
   (->> (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
                    [(str "SELECT DISTINCT index_name FROM information_schema.statistics "
                          "WHERE table_schema = COALESCE(?, DATABASE()) AND table_name = ?")
@@ -77,8 +77,8 @@
                 :expected         {:sorting-key  "(category)"
                                    :skip-indexes [{:name "by_price" :type "minmax" :expr "(price)" :granularity 1}]}
                 :physical-indexes clickhouse-indexes}
-   ;; MySQL: standalone btree + fulltext. A TEXT column can't be btree-indexed without a prefix length, so btree
-   ;; goes on `price` (float) while fulltext, which requires a text column, goes on `category`.
+   ;; btree goes on `price` because a TEXT column needs a prefix length to be btree-indexed; fulltext needs text,
+   ;; so it goes on `category`.
    :mysql      {:indexes          [{:kind :btree :name "by_price" :columns [{:name "price"}]}
                                    {:kind :fulltext :name "ft_category" :columns [{:name "category"}]}]
                 :expected         #{"by_price" "ft_category"}


### PR DESCRIPTION
- adds the mysql side of the index manager: btree (with unique) and fulltext standalone indexes. spatial skipped (niche), hash too since innodb rewrites `USING HASH` to btree.
- turns on `:index/standalone-create` and `:index/fetch`. existing describe-indexes path is untouched.
- mysql has no `CREATE INDEX IF NOT EXISTS`, so `:if-not-exists` is guarded with a small dynamic-sql block (check information_schema, then PREPARE/EXECUTE only if the name isn't there). schema/table/name get inlined as escaped literals because mariadb rejects `?` placeholders in that subquery.
- tested on local mysql: index-test suite and the enterprise incremental index test pass.

Fixes https://linear.app/metabase/issue/GDGT-2672/add-the-mysql-index-driver-methods
