### PR TITLE
add snowflake index driver methods (clustering)

### DIFF
--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -332,36 +332,13 @@
   [^String s]
   (cond-> s (and (str/starts-with? s "(") (str/ends-with? s ")")) (subs 1 (dec (count s)))))
 
-(defn- split-top-level-commas
-  "Split on commas that aren't nested in parens or inside a `backtick`/'string' span, so neither a function key like
-  `toStartOfInterval(d, INTERVAL 1 DAY)` nor a quoted name like `weird,name` is torn at an inner comma."
-  [^String s]
-  (loop [i 0, depth 0, q nil, start 0, acc []]
-    (if (< i (.length s))
-      (let [c (nth s i)]
-        (cond
-          q                            (recur (inc i) depth (when-not (= c q) q) start acc)
-          (or (= c \`) (= c \'))       (recur (inc i) depth c start acc)
-          (= c \()                     (recur (inc i) (inc depth) q start acc)
-          (= c \))                     (recur (inc i) (dec depth) q start acc)
-          (and (= c \,) (zero? depth)) (recur (inc i) depth q (inc i) (conj acc (subs s start i)))
-          :else                        (recur (inc i) depth q start acc)))
-      (conj acc (subs s start)))))
-
-(defn- unquote-ident
-  "Strip the backticks off a quoted identifier (doubled backticks unescaped), so it matches the bare column name the
-  managed side stores. Leaves bare names and expressions untouched."
-  [^String s]
-  (if (and (> (count s) 1) (str/starts-with? s "`") (str/ends-with? s "`"))
-    (str/replace (subs s 1 (dec (count s))) "``" "`")
-    s))
-
 (defn- expr->columns
   "Best-effort split of a ClickHouse key expression into its top-level columns/expressions. A quoted name like
   `weird,name` becomes a bare element; a real expression like `lower(email)` stays one element."
   [expr]
   (if-let [s (perf/not-empty expr)]
-    (perf/mapv (comp unquote-ident str/trim) (split-top-level-commas (strip-wrapping-parens s)))
+    (perf/mapv #(driver.common/unquote-ident (str/trim %) \`)
+               (driver.common/split-top-level-commas (strip-wrapping-parens s)))
     []))
 
 ;; Named skip-indexes come from `system.data_skipping_indices`; the inline MergeTree sorting key

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -67,10 +67,13 @@
                               :expressions/float                      true
                               :expressions/date                       true
                               :identifiers-with-spaces                true
+                              :index/fetch                            true
+                              :index/standalone-create                true
                               :split-part                             true
                               :collate                                true
                               :now                                    true
                               :database-routing                       true
+                              :transforms/index-ddl                   true
                               :metadata/table-existence-check         true
                               :regex/lookaheads-and-lookbehinds       false
                               :transforms/accurate-rows-affected      false
@@ -1009,6 +1012,84 @@
                                :dialect (sql.qp/quote-style driver)))]
     (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec db-id)]
       (jdbc/execute! conn sql))))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                          Indexes (Index Manager)                                               |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+;; Snowflake's only physical "index" is the table's single clustering key (`CLUSTER BY`); there are no secondary
+;; indexes. We model it as a standalone `:clustering` kind whose `:name` is Metabase-side only -- the warehouse keeps
+;; clustering keys unnamed, so `fetch-table-indexes` reports `:name nil` and reconcile matches by kind + columns.
+
+(defmethod driver/supported-index-methods :snowflake
+  [_driver _database]
+  {:clustering {:lifecycle :standalone
+                :fields    [driver.common/index-name-field driver.common/index-columns-field]}})
+
+(defmethod driver/compile-create-index :snowflake
+  [driver schema table {:keys [columns]}]
+  ;; One clustering key per table; re-issuing the same ALTER is harmless, so no IF NOT EXISTS is needed.
+  (let [target (apply sql.u/quote-name driver :table (if (not-empty schema) [schema table] [table]))
+        cols   (str/join ", " (map #(sql.u/quote-name driver :field (:name %)) columns))]
+    [[(format "ALTER TABLE %s CLUSTER BY (%s)" target cols)]]))
+
+(defn- split-top-level-commas
+  "Split on commas not nested inside parens, so an expression clustering key like `TO_DATE(ts), category` keeps its
+  function args intact."
+  [^String s]
+  (loop [i 0, depth 0, start 0, acc []]
+    (if (< i (.length s))
+      (let [c (.charAt s i)]
+        (cond
+          (= c \()                     (recur (inc i) (inc depth) start acc)
+          (= c \))                     (recur (inc i) (dec depth) start acc)
+          (and (= c \,) (zero? depth))  (recur (inc i) depth (inc i) (conj acc (subs s start i)))
+          :else                        (recur (inc i) depth start acc)))
+      (conj acc (subs s start)))))
+
+(defn- unquote-ident
+  "Strip the double-quotes off a quoted identifier (doubled quotes unescaped), matching the bare column name the
+  managed side stores. Leaves bare names and expressions untouched."
+  [^String s]
+  (if (and (> (count s) 1) (str/starts-with? s "\"") (str/ends-with? s "\""))
+    (str/replace (subs s 1 (dec (count s))) "\"\"" "\"")
+    s))
+
+(defn- parse-clustering-key
+  "Parse a Snowflake `CLUSTERING_KEY` string like `LINEAR(category, price)` into its top-level column names/expressions
+  in order. Returns nil for a table with no clustering key."
+  [clustering-key]
+  (when-let [s (not-empty (some-> clustering-key str/trim))]
+    ;; the wrapper is `LINEAR(...)`; drop it down to the inner column list.
+    (let [inner (or (second (re-matches #"(?is)\s*LINEAR\s*\((.*)\)\s*" s)) s)]
+      (->> (split-top-level-commas inner)
+           (map (comp unquote-ident str/trim))
+           (remove str/blank?)
+           vec))))
+
+;; Snowflake clustering keys are unnamed in the catalog, so the single `:clustering` row is emitted with `:name nil`
+;; and reconciled by kind + key columns. `CLUSTERING_KEY` lives in the current database's INFORMATION_SCHEMA; a blank
+;; schema falls back to the connection's `current_schema()`.
+(defmethod driver/fetch-table-indexes :snowflake
+  [_driver database schema table]
+  (let [clustering-key (-> (jdbc/query
+                            (sql-jdbc.conn/db->pooled-connection-spec database)
+                            [(str "SELECT clustering_key FROM information_schema.tables "
+                                  "WHERE table_schema = COALESCE(?, current_schema()) AND table_name = ?")
+                             (not-empty schema) table])
+                           first :clustering_key)]
+    (if-let [columns (not-empty (parse-clustering-key clustering-key))]
+      [{:name              nil
+        :kind              :clustering
+        :access-method     nil
+        :is-unique         false
+        :is-primary        false
+        :is-valid          true
+        :key-columns       columns
+        :include-columns   []
+        :partial-predicate nil
+        :definition        (format "CLUSTER BY (%s)" (str/join ", " columns))}]
+      [])))
 
 (defmethod driver/table-name-length-limit :snowflake
   [_driver]

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -1033,36 +1033,14 @@
         cols   (str/join ", " (map #(sql.u/quote-name driver :field (:name %)) columns))]
     [[(format "ALTER TABLE %s CLUSTER BY (%s)" target cols)]]))
 
-(defn- split-top-level-commas
-  "Split on commas not nested inside parens, so an expression clustering key like `TO_DATE(ts), category` keeps its
-  function args intact."
-  [^String s]
-  (loop [i 0, depth 0, start 0, acc []]
-    (if (< i (.length s))
-      (let [c (.charAt s i)]
-        (cond
-          (= c \()                     (recur (inc i) (inc depth) start acc)
-          (= c \))                     (recur (inc i) (dec depth) start acc)
-          (and (= c \,) (zero? depth))  (recur (inc i) depth (inc i) (conj acc (subs s start i)))
-          :else                        (recur (inc i) depth start acc)))
-      (conj acc (subs s start)))))
-
-(defn- unquote-ident
-  "Strip surrounding double-quotes off a quoted identifier (unescaping doubled quotes); leaves bare names and
-  expressions untouched."
-  [^String s]
-  (if (and (> (count s) 1) (str/starts-with? s "\"") (str/ends-with? s "\""))
-    (str/replace (subs s 1 (dec (count s))) "\"\"" "\"")
-    s))
-
 (defn- parse-clustering-key
   "Parse a Snowflake `CLUSTERING_KEY` string like `LINEAR(category, price)` into its top-level column names/expressions
   in order. Returns nil for a table with no clustering key."
   [clustering-key]
   (when-let [s (not-empty (some-> clustering-key str/trim))]
     (let [inner (or (second (re-matches #"(?is)\s*LINEAR\s*\((.*)\)\s*" s)) s)]
-      (->> (split-top-level-commas inner)
-           (map (comp unquote-ident str/trim))
+      (->> (driver.common/split-top-level-commas inner)
+           (map #(driver.common/unquote-ident (str/trim %) \"))
            (remove str/blank?)
            vec))))
 

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -1018,8 +1018,8 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 ;; Snowflake's only physical "index" is the table's single clustering key (`CLUSTER BY`); there are no secondary
-;; indexes. We model it as a standalone `:clustering` kind whose `:name` is Metabase-side only -- the warehouse keeps
-;; clustering keys unnamed, so `fetch-table-indexes` reports `:name nil` and reconcile matches by kind + columns.
+;; indexes, so it's a standalone `:clustering` kind. The `:name` is Metabase-side only: the warehouse keeps clustering
+;; keys unnamed, so fetch reports `:name nil` and reconcile matches by kind + columns.
 
 (defmethod driver/supported-index-methods :snowflake
   [_driver _database]
@@ -1028,7 +1028,7 @@
 
 (defmethod driver/compile-create-index :snowflake
   [driver schema table {:keys [columns]}]
-  ;; One clustering key per table; re-issuing the same ALTER is harmless, so no IF NOT EXISTS is needed.
+  ;; Re-issuing the same CLUSTER BY is a no-op, so no IF NOT EXISTS needed.
   (let [target (apply sql.u/quote-name driver :table (if (not-empty schema) [schema table] [table]))
         cols   (str/join ", " (map #(sql.u/quote-name driver :field (:name %)) columns))]
     [[(format "ALTER TABLE %s CLUSTER BY (%s)" target cols)]]))
@@ -1048,8 +1048,8 @@
       (conj acc (subs s start)))))
 
 (defn- unquote-ident
-  "Strip the double-quotes off a quoted identifier (doubled quotes unescaped), matching the bare column name the
-  managed side stores. Leaves bare names and expressions untouched."
+  "Strip surrounding double-quotes off a quoted identifier (unescaping doubled quotes); leaves bare names and
+  expressions untouched."
   [^String s]
   (if (and (> (count s) 1) (str/starts-with? s "\"") (str/ends-with? s "\""))
     (str/replace (subs s 1 (dec (count s))) "\"\"" "\"")
@@ -1060,16 +1060,13 @@
   in order. Returns nil for a table with no clustering key."
   [clustering-key]
   (when-let [s (not-empty (some-> clustering-key str/trim))]
-    ;; the wrapper is `LINEAR(...)`; drop it down to the inner column list.
     (let [inner (or (second (re-matches #"(?is)\s*LINEAR\s*\((.*)\)\s*" s)) s)]
       (->> (split-top-level-commas inner)
            (map (comp unquote-ident str/trim))
            (remove str/blank?)
            vec))))
 
-;; Snowflake clustering keys are unnamed in the catalog, so the single `:clustering` row is emitted with `:name nil`
-;; and reconciled by kind + key columns. `CLUSTERING_KEY` lives in the current database's INFORMATION_SCHEMA; a blank
-;; schema falls back to the connection's `current_schema()`.
+;; `CLUSTERING_KEY` lives in the current database's INFORMATION_SCHEMA; a blank schema falls back to `current_schema()`.
 (defmethod driver/fetch-table-indexes :snowflake
   [_driver database schema table]
   (let [clustering-key (-> (jdbc/query

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -171,6 +171,34 @@
   "Descriptor for a ClickHouse skip-index granularity."
   {:name "granularity" :display-name (deferred-tru "Granularity") :type :integer})
 
+;; Helpers for parsing a warehouse's stored key/index column list (a `CLUSTER BY`, `ORDER BY`, sorting key, ...) back
+;; into the bare column names the managed side stores.
+
+(defn split-top-level-commas
+  "Split `s` on commas that aren't nested in parens or inside a `` ` ``/`'`/`\"` quote span, so neither a function key
+  like `toStartOfInterval(d, INTERVAL 1 DAY)` nor a quoted name like `\"weird,name\"` is torn at an inner comma."
+  [^String s]
+  (loop [i 0, depth 0, q nil, start 0, acc []]
+    (if (< i (.length s))
+      (let [c (nth s i)]
+        (cond
+          q                               (recur (inc i) depth (when-not (= c q) q) start acc)
+          (or (= c \`) (= c \') (= c \")) (recur (inc i) depth c start acc)
+          (= c \()                        (recur (inc i) (inc depth) q start acc)
+          (= c \))                        (recur (inc i) (dec depth) q start acc)
+          (and (= c \,) (zero? depth))    (recur (inc i) depth q (inc i) (conj acc (subs s start i)))
+          :else                           (recur (inc i) depth q start acc)))
+      (conj acc (subs s start)))))
+
+(defn unquote-ident
+  "Strip a wrapping `quote-char` pair off a quoted identifier (doubled `quote-char` unescaped), so it matches the bare
+  column name the managed side stores. Leaves bare names and expressions untouched."
+  [^String s quote-char]
+  (let [q (str quote-char)]
+    (if (and (> (count s) 1) (str/starts-with? s q) (str/ends-with? s q))
+      (str/replace (subs s 1 (dec (count s))) (str q q) q)
+      s)))
+
 (def advanced-options-start
   "Map representing the start of the advanced option section in a DB connection form. Fields in this section should
   have their visibility controlled using the `visible-if` property."

--- a/src/metabase/indexes/reconcile.clj
+++ b/src/metabase/indexes/reconcile.clj
@@ -14,7 +14,7 @@
 (def ^:private unnamed-inline-kinds
   "Index kinds with no physical name (warehouse `:name` is nil); matched by kind + key columns instead. `:distkey` is
   excluded until a driver fetches one: it stores a single `:column`, so it can't be column-keyed."
-  #{:sortkey :order-by})
+  #{:sortkey :order-by :clustering})
 
 (mr/def ::match-key
   "Join key for reconciling a managed request with a warehouse index: a `:name` string for named kinds, else a

--- a/test/metabase/transforms/index_test_util.clj
+++ b/test/metabase/transforms/index_test_util.clj
@@ -4,6 +4,7 @@
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
+   [clojure.string :as str]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.test :as mt]))
 
@@ -42,6 +43,24 @@
                                           schema table])
                         (mapv #(update % :granularity long)))}))
 
+(defn- snowflake-clustering
+  "Read a Snowflake table's clustering key back as a vector of column names in order, or [] when unclustered.
+  `CLUSTERING_KEY` is a string like `LINEAR(category, price)`; strip the wrapper and split on top-level commas."
+  [database schema table]
+  (let [clustering-key (-> (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
+                                       [(str "SELECT clustering_key FROM information_schema.tables "
+                                             "WHERE table_schema = ? AND table_name = ?")
+                                        schema table])
+                           first :clustering_key)]
+    (if-let [s (some-> clustering-key str/trim not-empty)]
+      (let [inner (or (second (re-matches #"(?is)\s*LINEAR\s*\((.*)\)\s*" s)) s)]
+        (->> (str/split inner #",")
+             (map str/trim)
+             (map #(str/replace % #"^\"|\"$" ""))
+             (remove str/blank?)
+             vec))
+      [])))
+
 (def driver-cases
   "Driver -> test case: `:indexes` to declare (every method whose column types `transforms_products` can satisfy; the
   rest, e.g. Postgres gin/gist, live in the driver-level and fetch suites), `:physical-indexes` a
@@ -65,7 +84,12 @@
                                     :columns [{:name "price"}] :granularity 1}]
                 :expected         {:sorting-key  "(category)"
                                    :skip-indexes [{:name "by_price" :type "minmax" :expr "(price)" :granularity 1}]}
-                :physical-indexes clickhouse-indexes}})
+                :physical-indexes clickhouse-indexes}
+   ;; Snowflake: a single standalone clustering key (no secondary indexes). The `:name` is Metabase-side only;
+   ;; the warehouse reports it unnamed, so we read back just the clustered columns.
+   :snowflake  {:indexes          [{:kind :clustering :name "by_category" :columns [{:name "category"}]}]
+                :expected         ["category"]
+                :physical-indexes snowflake-clustering}})
 
 (defn index-test-drivers
   "Drivers that run transforms and declare any index support."
@@ -175,4 +199,14 @@
     {:label "an unsorted table returns []"
      :table "mb_fetch_ch_empty"
      :create ["CREATE TABLE mb_fetch_ch_empty (a Int64) ENGINE = MergeTree ORDER BY ()"]
+     :expected #{}}]
+
+   :snowflake
+   [{:label  "the clustering key, unnamed, reconciled by kind + columns"
+     :table  "mb_fetch_sf"
+     :create ["CREATE TABLE mb_fetch_sf (category TEXT, price FLOAT) CLUSTER BY (category)"]
+     :expected #{(idx nil :clustering nil ["category"])}}
+    {:label "a table with no clustering key returns []"
+     :table "mb_fetch_sf_empty"
+     :create ["CREATE TABLE mb_fetch_sf_empty (a INT, b INT)"]
      :expected #{}}]})

--- a/test/metabase/transforms/index_test_util.clj
+++ b/test/metabase/transforms/index_test_util.clj
@@ -44,8 +44,8 @@
                         (mapv #(update % :granularity long)))}))
 
 (defn- snowflake-clustering
-  "Read a Snowflake table's clustering key back as a vector of column names in order, or [] when unclustered.
-  `CLUSTERING_KEY` is a string like `LINEAR(category, price)`; strip the wrapper and split on top-level commas."
+  "Read a Snowflake table's clustering key back as an ordered vector of column names, or [] when unclustered.
+  `CLUSTERING_KEY` comes back as a string like `LINEAR(category, price)`."
   [database schema table]
   (let [clustering-key (-> (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
                                        [(str "SELECT clustering_key FROM information_schema.tables "
@@ -85,8 +85,7 @@
                 :expected         {:sorting-key  "(category)"
                                    :skip-indexes [{:name "by_price" :type "minmax" :expr "(price)" :granularity 1}]}
                 :physical-indexes clickhouse-indexes}
-   ;; Snowflake: a single standalone clustering key (no secondary indexes). The `:name` is Metabase-side only;
-   ;; the warehouse reports it unnamed, so we read back just the clustered columns.
+   ;; Snowflake: a single standalone clustering key, reported unnamed, so we read back just the clustered columns.
    :snowflake  {:indexes          [{:kind :clustering :name "by_category" :columns [{:name "category"}]}]
                 :expected         ["category"]
                 :physical-indexes snowflake-clustering}})


### PR DESCRIPTION
adds snowflake to the index manager. snowflake has no secondary indexes, its only physical "index" is the single clustering key, so this is just `:clustering`, standalone
Fixes https://linear.app/metabase/issue/GDGT-2674/add-the-snowflake-index-driver-methods
