### PR TITLE
[pdf] Remove branding for white-labeling customers

### DIFF
--- a/src/metabase/channel/render/pdf.clj
+++ b/src/metabase/channel/render/pdf.clj
@@ -52,6 +52,7 @@
    [metabase.dashboards.models.dashboard-card :as dashboard-card]
    [metabase.notification.payload.core :as notification.payload]
    [metabase.parameters.shared :as shared.params]
+   [metabase.premium-features.core :as premium-features]
    [metabase.request.core :as request]
    [metabase.system.core :as system]
    [metabase.util.i18n :refer [tru trun]]
@@ -1168,6 +1169,12 @@
     (.setNonStrokingColor cs Color/BLACK)
     (* vw scale)))
 
+(defn- include-branding?
+  "Whether the 'Made with Metabase' badge should be drawn. Branding in exports is included only for
+  instances that lack the `:whitelabel` feature -- i.e. OSS instances. Pro/EE instances get no badge."
+  []
+  (not (premium-features/enable-whitelabeling?)))
+
 (defn- draw-brand-badge!
   "Draw the 'Made with [logo] Metabase' badge, right-aligned to `right`, with the logo's top at
   `logo-top` (placed in the page's top common/margin band). The 'Made with' prefix is localized to the
@@ -1193,9 +1200,11 @@
   [^PDPageContentStream cs page-height content-w {:keys [dashboard-title tab-title param-table]}]
   (let [bold (font/face :bold)
         top  (- page-height common/margin)
-        ;; "Made with Metabase" badge, vector-drawn in the empty top common/margin band, right-aligned
-        _    (draw-brand-badge! cs (+ common/margin content-w)
-                                (common/v-center page-height common/margin brand-logo-pt))
+        ;; "Made with Metabase" badge, vector-drawn in the empty top common/margin band, right-aligned.
+        ;; Only OSS instances get the badge; Pro/EE (whitelabel feature) render no branding.
+        _    (when (include-branding?)
+               (draw-brand-badge! cs (+ common/margin content-w)
+                                  (common/v-center page-height common/margin brand-logo-pt)))
         ;; order: dashboard title, then the dashboard-wide parameter table, then the tab title
         y1   (if dashboard-title
                (do (draw-line! cs bold common/dashboard-title-pt

--- a/test/metabase/channel/render/pdf_test.clj
+++ b/test/metabase/channel/render/pdf_test.clj
@@ -18,6 +18,7 @@
    [metabase.channel.shared :as channel.shared]
    [metabase.notification.payload.temp-storage :as temp-storage]
    [metabase.notification.settings :as notification.settings]
+   [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]
    [metabase.util.memoize :as memo])
   (:import
@@ -108,6 +109,31 @@
           (let [baos (ByteArrayOutputStream.)]
             (.save doc baos)
             (is (pos? (count (.toByteArray baos))))))))))
+
+(deftest ^:synchronized include-branding?-test
+  (testing "the 'Made with Metabase' badge is included only for OSS instances (no :whitelabel feature)"
+    (with-redefs [premium-features/enable-whitelabeling? (constantly false)]
+      (is (true? (#'pdf/include-branding?)) "OSS: branding included"))
+    (with-redefs [premium-features/enable-whitelabeling? (constantly true)]
+      (is (false? (#'pdf/include-branding?)) "Pro/EE (whitelabel): no branding"))))
+
+;; not ^:parallel: exercises the real PDFBox content-stream + font registry, which the deftest linter treats as
+;; side-effecting
+(deftest ^:synchronized header-branding-gated-on-whitelabel-test
+  (testing "draw-header! draws the branding badge only when the instance lacks the :whitelabel feature"
+    (doseq [[whitelabel? expected-badge?] [[false true] [true false]]]
+      (let [badge-drawn? (atom false)]
+        (with-redefs [premium-features/enable-whitelabeling? (constantly whitelabel?)
+                      pdf/draw-brand-badge!                  (fn [& _] (reset! badge-drawn? true))]
+          (with-open [doc (PDDocument.)]
+            (binding [font/*fonts*     (#'font/load-fonts! doc)
+                      pdf/*link-rects* (atom [])]
+              (let [page (PDPage. PDRectangle/A4)]
+                (.addPage doc page)
+                (with-open [cs (PDPageContentStream. doc page)]
+                  (#'pdf/draw-header! cs 841.89 500.0 {:dashboard-title "Dash"}))))))
+        (is (= expected-badge? @badge-drawn?)
+            (str "whitelabel=" whitelabel? " => badge " (if expected-badge? "drawn" "skipped")))))))
 
 (defn- last-non-stroking-color
   "The operands of the last non-stroking colour operator (`r g b sc`) in a page's content stream, as a vector of


### PR DESCRIPTION
Fixes UXW-4575.

### Description

The "Made with Metabase" branding is skipped for customers with
white-labeling enabled.

### How to verify

Generate a PDF on an EE instance, and observe that the branding is gone.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
