### PR TITLE
Preserve dashboard table column settings for stale SQL question metadata

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/column.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/column.unit.spec.ts
@@ -7,7 +7,11 @@ import {
   createMockSingleSeries,
 } from "metabase-types/api/mocks";
 
-import { NUMBER_COLUMN_SETTINGS, columnSettings } from "./column";
+import {
+  NUMBER_COLUMN_SETTINGS,
+  columnSettings,
+  tableColumnSettings,
+} from "./column";
 
 registerVisualizations();
 
@@ -146,6 +150,37 @@ describe("column settings", () => {
 
       onChange(options[1].value);
       expect(onChangeSpy).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe("table.columns", () => {
+    it("should filter stale table column settings against current result columns (#76136)", () => {
+      const series: Series = [
+        createMockSingleSeries(
+          {},
+          {
+            data: {
+              cols: [
+                createMockColumn({ name: "ID" }),
+                createMockColumn({ name: "QUANTITY_RENAMED" }),
+              ],
+            },
+          },
+        ),
+      ];
+
+      const computed = getComputedSettings(tableColumnSettings(), series, {
+        "table.columns": [
+          { name: "ID", enabled: true },
+          { name: "QUANTITY", enabled: false },
+          { name: "QUANTITY_RENAMED", enabled: true },
+        ],
+      });
+
+      expect(computed["table.columns"]).toEqual([
+        { name: "ID", enabled: true },
+        { name: "QUANTITY_RENAMED", enabled: true },
+      ]);
     });
   });
 });

--- a/frontend/src/metabase/visualizations/lib/settings/typed-utils.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/typed-utils.ts
@@ -60,9 +60,16 @@ const mergeTableColumns = (
         firstTableColumns.findIndex((col) => col.name === name) === -1,
     )
     .map(({ name }) => name);
+  const shouldRemoveSecondOnlyColumns =
+    addedColumns.length > 0 &&
+    removedColumns.length > 0 &&
+    secondTableColumns.length <= firstTableColumns.length;
 
   return [
-    ...secondTableColumns.filter(({ name }) => !removedColumns.includes(name)),
+    ...secondTableColumns.filter(
+      ({ name }) =>
+        !shouldRemoveSecondOnlyColumns || !removedColumns.includes(name),
+    ),
     ...addedColumns,
   ];
 };

--- a/frontend/src/metabase/visualizations/lib/settings/typed-utils.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/typed-utils.ts
@@ -54,24 +54,8 @@ const mergeTableColumns = (
     ({ name }) =>
       secondTableColumns.findIndex((col) => col.name === name) === -1,
   );
-  const removedColumns = secondTableColumns
-    .filter(
-      ({ name }) =>
-        firstTableColumns.findIndex((col) => col.name === name) === -1,
-    )
-    .map(({ name }) => name);
-  const shouldRemoveSecondOnlyColumns =
-    addedColumns.length > 0 &&
-    removedColumns.length > 0 &&
-    secondTableColumns.length <= firstTableColumns.length;
 
-  return [
-    ...secondTableColumns.filter(
-      ({ name }) =>
-        !shouldRemoveSecondOnlyColumns || !removedColumns.includes(name),
-    ),
-    ...addedColumns,
-  ];
+  return [...secondTableColumns, ...addedColumns];
 };
 
 export const isSettingHiddenOnDashboards = (

--- a/frontend/src/metabase/visualizations/lib/settings/typed-utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/typed-utils.unit.spec.ts
@@ -93,18 +93,22 @@ describe("mergeSettings (metabase#14597)", () => {
       });
     });
 
-    it("should remove replaced columns that don't appear in the first settings", () => {
+    it("should keep replacement columns that only appear in the second settings (#76136)", () => {
       expect(
         mergeSettings(
           {
-            "table.columns": [ID_COLUMN, RENAMED_QUANTITY_COLUMN],
+            "table.columns": [ID_COLUMN, QUANTITY_COLUMN],
           },
           {
-            "table.columns": [ID_COLUMN, QUANTITY_COLUMN],
+            "table.columns": [ID_COLUMN, { ...TAX_COLUMN, enabled: false }],
           },
         ),
       ).toEqual({
-        "table.columns": [ID_COLUMN, RENAMED_QUANTITY_COLUMN],
+        "table.columns": [
+          ID_COLUMN,
+          { ...TAX_COLUMN, enabled: false },
+          QUANTITY_COLUMN,
+        ],
       });
     });
 
@@ -148,7 +152,7 @@ describe("mergeSettings (metabase#14597)", () => {
       });
     });
 
-    it("should preserve second settings order when removing second-only columns", () => {
+    it("should preserve second settings order when columns are replaced", () => {
       expect(
         mergeSettings(
           {
@@ -163,6 +167,7 @@ describe("mergeSettings (metabase#14597)", () => {
         ),
       ).toEqual({
         "table.columns": [
+          QUANTITY_COLUMN,
           { ...ID_COLUMN, enabled: false },
           RENAMED_QUANTITY_COLUMN,
         ],

--- a/frontend/src/metabase/visualizations/lib/settings/typed-utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/typed-utils.unit.spec.ts
@@ -74,7 +74,11 @@ describe("mergeSettings (metabase#14597)", () => {
       name: "DISCOUNT",
     });
 
-    it("should remove columns that don't appear in the first settings", () => {
+    const RENAMED_QUANTITY_COLUMN = createMockTableColumnOrderSetting({
+      name: "QUANTITY_RENAMED",
+    });
+
+    it("should keep added columns that only appear in the second settings (#76136)", () => {
       expect(
         mergeSettings(
           {
@@ -85,7 +89,22 @@ describe("mergeSettings (metabase#14597)", () => {
           },
         ),
       ).toEqual({
-        "table.columns": [ID_COLUMN, QUANTITY_COLUMN],
+        "table.columns": [ID_COLUMN, QUANTITY_COLUMN, TAX_COLUMN],
+      });
+    });
+
+    it("should remove replaced columns that don't appear in the first settings", () => {
+      expect(
+        mergeSettings(
+          {
+            "table.columns": [ID_COLUMN, RENAMED_QUANTITY_COLUMN],
+          },
+          {
+            "table.columns": [ID_COLUMN, QUANTITY_COLUMN],
+          },
+        ),
+      ).toEqual({
+        "table.columns": [ID_COLUMN, RENAMED_QUANTITY_COLUMN],
       });
     });
 
@@ -124,6 +143,28 @@ describe("mergeSettings (metabase#14597)", () => {
           DISCOUNT_COLUMN,
           { ...ID_COLUMN, enabled: false },
           QUANTITY_COLUMN,
+          TAX_COLUMN,
+        ],
+      });
+    });
+
+    it("should preserve second settings order when removing second-only columns", () => {
+      expect(
+        mergeSettings(
+          {
+            "table.columns": [ID_COLUMN, RENAMED_QUANTITY_COLUMN],
+          },
+          {
+            "table.columns": [
+              QUANTITY_COLUMN,
+              { ...ID_COLUMN, enabled: false },
+            ],
+          },
+        ),
+      ).toEqual({
+        "table.columns": [
+          { ...ID_COLUMN, enabled: false },
+          RENAMED_QUANTITY_COLUMN,
         ],
       });
     });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76136
Closes https://linear.app/metabase/issue/UXW-4550/hiding-a-table-column-via-dashboard-card-visualization-options-does

### Description

Fixes dashboard card table column settings when the underlying native SQL question has stale question-level `table.columns` settings after a SQL edit.
Dashboard-only settings for live result columns are now preserved when merging card and dashcard visualization settings.

### How to verify

1. Create a native SQL question:

   ```sql
   SELECT "ID", "TOTAL" FROM "ORDERS" LIMIT 5
   ```

2. Run it.
3. Open question Visualization settings.
4. Hide `TOTAL`.
5. Click Done.
6. Save the question.
7. Edit the SQL to:

   ```sql
   SELECT "ID", "TOTAL", "TAX" FROM "ORDERS" LIMIT 5
   ```

8. Do not run the updated SQL.
9. Save changes to the original question.
10. Add/use that question on a dashboard.
11. Edit dashboard.
12. Open the dashcard Visualization options.
13. Hide `TAX`.
14. Click Done.

`TAX` should remain hidden in the dashboard edit mode and after saving the dashboard.

### Demo
https://www.loom.com/share/743a5259daa24d169d5806334dafc456

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
