### PR TITLE
Fix time zone offsets for zoned datetimes in CLJS

### DIFF
--- a/src/metabase/util/time/impl.cljs
+++ b/src/metabase/util/time/impl.cljs
@@ -633,10 +633,12 @@
         temporal-formats))
 
 (def ^:private iso-8601-format-strings
-  "Format strings for ISO-8601 output by type and precision."
-  {:offset-date-time {:millis "YYYY-MM-DDTHH:mm:ss.SSS[Z]"
-                      :second "YYYY-MM-DDTHH:mm:ss[Z]"
-                      :minute "YYYY-MM-DDTHH:mm[Z]"}
+  "Format strings for ISO-8601 output by type and precision.
+  `:offset-date-time` omits the trailing zone; [[offset-zone-suffix]] appends the actual offset so the original
+  instant survives a parse/format round-trip (#73972)."
+  {:offset-date-time {:millis "YYYY-MM-DDTHH:mm:ss.SSS"
+                      :second "YYYY-MM-DDTHH:mm:ss"
+                      :minute "YYYY-MM-DDTHH:mm"}
    :local-date-time  {:millis "YYYY-MM-DDTHH:mm:ss.SSS"
                       :second "YYYY-MM-DDTHH:mm:ss"
                       :minute "YYYY-MM-DDTHH:mm"}
@@ -648,6 +650,15 @@
                       :second "HH:mm:ss"
                       :minute "HH:mm"}})
 
+(defn- offset-zone-suffix
+  "ISO-8601 zone suffix for an offset-bearing dayjs value: \"Z\" when it's in UTC, otherwise the numeric offset
+  like \"+08:00\". Using the real offset (instead of a literal \"Z\") keeps the original instant intact when an
+  offset-date-time string is parsed and reformatted, e.g. by [[truncate]]/[[add]] (#73972)."
+  [^dayjs t]
+  (if (.isUTC t)
+    "Z"
+    (.format t "Z")))
+
 (defn- dayjs+type->iso-8601
   "Format a dayjs instance as ISO-8601 string based on its type."
   [[^dayjs t value-type]]
@@ -657,7 +668,8 @@
                             (pos? (.millisecond t)) (:millis formats)
                             (pos? (.second t))      (:second formats)
                             :else                   (:minute formats)))]
-    (.format t format-string)))
+    (cond-> (.format t format-string)
+      (= value-type :offset-date-time) (str (offset-zone-suffix t)))))
 
 (defn- ^dayjs ->dayjs
   "Convert a value to a dayjs instance. Handles strings, js/Date, and dayjs instances."

--- a/test/metabase/util/time_test.cljc
+++ b/test/metabase/util/time_test.cljc
@@ -479,6 +479,22 @@
       (finally
         #?(:cljs (.tz.setDefault dayjs))))))
 
+#?(:cljs
+   (deftest ^:parallel offset-datetime-round-trip-test
+     (testing "truncating/adding an offset-date-time string keeps the original UTC offset, so the instant is
+              preserved on round-trips (e.g. dashcard viz re-rendering) instead of being mislabeled as UTC (#73972)"
+       (are [expected unit] (= expected (shared.ut/truncate "2024-05-13T08:30:45+08:00" unit))
+         "2024-05-13T08:30:45+08:00" :second
+         "2024-05-13T08:30+08:00"    :minute
+         "2024-05-13T08:00+08:00"    :hour
+         "2024-05-13T00:00+08:00"    :day)
+       (testing "negative offsets are preserved too"
+         (is (= "2026-05-06T00:00-07:00" (shared.ut/truncate "2026-05-06T10:00:00-07:00" :day))))
+       (testing "UTC values are still rendered with Z"
+         (is (= "2024-05-13T00:00Z" (shared.ut/truncate "2024-05-13T08:30:00Z" :day))))
+       (testing "add keeps the original offset"
+         (is (= "2024-05-15T08:30+08:00" (shared.ut/add "2024-05-13T08:30:00+08:00" :day 2)))))))
+
 (deftest ^:parallel zulu-add-time-test
   (testing "Time addition in string format works (#53724)"
     #?(:cljs (.tz.setDefault dayjs "Europe/Helsinki"))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73972
Fixes UXW-4040.

### Description

The Moment -> DayJS conversion introduced a subtle gap in the handling
of zoned datetimes between JVM and CLJS, that resulted in wrong times
being rendered in the FE under certain conditions.

This properly emits the time zone offsets so they can be read by DayJS
with the proper time zone.

### How to verify

See UXW-4040's bug; the rendered times will now be correct.

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
