### PR TITLE
Metabot should verify it has the right entity using metadata

### DIFF
--- a/resources/metabot/prompts/shared/prompt_snippets/discovery.selmer
+++ b/resources/metabot/prompts/shared/prompt_snippets/discovery.selmer
@@ -7,6 +7,16 @@ You have two ways to find data, with different strengths:
 
 So: when you can name the scope (a database, schema, or collection), navigate. When the location is unknown, search to get an entry point, then drill into a promising hit with `read_resource` instead of searching the same concept again. When a request spans several distinct concepts, issue one search per concept (fire them in parallel) so one concept's results don't crowd out another's.
 
+## Read a source before you build on it
+
+Finding a candidate table, model, or metric is not the same as confirming it fits. Before you commit a source to a query, read its metadata with `read_resource` — its description, fields, and relationships — and weigh:
+
+- **Caveats in the description** — freshness/ETL lag, retention windows, scope ("last 30 days only", "excludes today", "aggregated nightly"). A source whose caveats conflict with the question — asking for "today" against a table that lags a day — is the wrong source even if its name matches perfectly.
+- **Join keys** — join on the foreign keys the table actually exposes, not on guessed column names.
+- **Whether a simpler source already answers it** — a single table with the right column beats a multi-table join you assemble yourself.
+
+Never pick a source on its name alone. The few seconds to read it is what makes the first query right on the first run.
+
 ## Don't go in circles
 
 If your first search returned several candidates that plausibly match the user's intent, pick the best one and proceed. Re-searching with slightly different wording rarely surfaces something new — it's usually a sign you should commit and move on. Widen the search only when the first call returned zero useful hits.


### PR DESCRIPTION
Refs BOT-1584

Metabot answered "what are the most used models today" by picking a usage table by name and querying it without reading its description, so it only ran into the table's lag and scope limits at runtime (empty results, timeouts, a wrong cross-instance answer) before landing on the right source.

This adds a rule to the shared discovery.selmer snippet: read a candidate table/model/metric's metadata (freshness caveats, retention, scope, FK join keys, whether a simpler source already answers it) before building a query on it, rather than picking by name. It's a shared snippet, so it applies to every profile that exposes read_resource: internal, nlq-only, sql-only, embedding-next.

Prompt-only change, no new tools and no curated_search changes. Slackbot is left out on purpose because its profile doesn't expose read_resource.

Current models already read source metadata before building, so in practice this mostly helps weaker models and messier real instances. The companion benchmark is metabase/ai-benchmarks#10, and a closer repro of the original failure is tracked in BOT-1721.

BOT-1584
