### PR TITLE
Sync starburst and presto-jdbc column comments

### DIFF
--- a/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
+++ b/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
@@ -625,11 +625,12 @@
           :name   table-name
           :fields (into
                    #{}
-                   (map-indexed (fn [idx {:keys [column type] :as _col}]
-                                  {:name              column
-                                   :database-type     type
-                                   :base-type         (presto-type->base-type type)
-                                   :database-position idx}))
+                   (map-indexed (fn [idx {:keys [column type comment] :as _col}]
+                                  (cond-> {:name              column
+                                           :database-type     type
+                                           :base-type         (presto-type->base-type type)
+                                           :database-position idx}
+                                    (not (str/blank? comment)) (assoc :field-comment comment))))
                    (jdbc/reducible-query {:connection conn} sql))})))))
 
 ;;; The Presto JDBC driver DOES NOT support the `.getImportedKeys` method so just return `nil` here so the `:sql-jdbc`

--- a/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
+++ b/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
@@ -611,6 +611,14 @@
                          (all-schemas driver conn catalog))]
          {:tables (reduce set/union #{} schemas)})))))
 
+(defn- column->field
+  [database-pos {:keys [column type comment]}]
+  (cond-> {:name              column
+           :database-type     type
+           :base-type         (presto-type->base-type type)
+           :database-position database-pos}
+    (not (str/blank? comment)) (assoc :field-comment comment)))
+
 (defmethod driver/describe-table :presto-jdbc
   [driver database {schema :schema, table-name :name}]
   (let [{:keys [catalog]} (driver.conn/effective-details database)]
@@ -625,12 +633,7 @@
           :name   table-name
           :fields (into
                    #{}
-                   (map-indexed (fn [idx {:keys [column type comment] :as _col}]
-                                  (cond-> {:name              column
-                                           :database-type     type
-                                           :base-type         (presto-type->base-type type)
-                                           :database-position idx}
-                                    (not (str/blank? comment)) (assoc :field-comment comment))))
+                   (map-indexed column->field)
                    (jdbc/reducible-query {:connection conn} sql))})))))
 
 ;;; The Presto JDBC driver DOES NOT support the `.getImportedKeys` method so just return `nil` here so the `:sql-jdbc`

--- a/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
+++ b/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
@@ -287,3 +287,18 @@
 (deftest bytes-to-varbinary-test
   (is (= ["FROM_BASE64(?)" "YSBzdHJpbmc="]
          (sql/format (sql.qp/->honeysql :presto-jdbc (.getBytes "a string"))))))
+
+(deftest column->field-test
+  (testing "no field comment with blank column"
+    (is (= {:name "foo"
+            :database-type "integer"
+            :base-type :type/Integer
+            :database-position 0}
+           (#'presto-jdbc/column->field 0 {:column "foo" :type "integer" :comment ""}))))
+  (testing "field comment included with non-blank column"
+    (is (= {:name "foo"
+            :database-type "integer"
+            :base-type :type/Integer
+            :database-position 0
+            :field-comment "foo comment"}
+           (#'presto-jdbc/column->field 0 {:column "foo" :type "integer" :comment "foo comment"})))))

--- a/modules/drivers/starburst/src/metabase/driver/starburst.clj
+++ b/modules/drivers/starburst/src/metabase/driver/starburst.clj
@@ -484,10 +484,33 @@
     (let [sql (describe-catalog-sql driver catalog)
           rs (sql-jdbc.execute/execute-statement! driver stmt sql)]
       (into []
-            (map (fn [{:keys [schema] :as _full}]
-                   (when-not (contains? excluded-schemas schema)
-                     (describe-schema driver conn catalog schema))))
+            (keep (fn [{:keys [schema] :as _full}]
+                    (when-not (contains? excluded-schemas schema)
+                      (describe-schema driver conn catalog schema))))
             (jdbc/reducible-result-set rs {})))))
+
+(defn- table-comments
+  "Returns a map of `[schema table-name] -> comment` for tables in `catalog`, with an optional `schema` filter."
+  [driver ^Connection conn catalog schema]
+  (if (str/blank? catalog)
+    {}
+    (try
+      (let [sql (str "SELECT schema_name AS schema, table_name AS name, comment
+                      FROM system.metadata.table_comments
+                      WHERE catalog_name = ?"
+                     (when schema " AND schema_name = ?"))]
+        (with-open [^PreparedStatement stmt (.prepareStatement conn sql)]
+          (.setString stmt 1 catalog)
+          (when schema (.setString stmt 2 schema))
+          (let [rs (sql-jdbc.execute/execute-prepared-statement! driver stmt)]
+            (into {}
+                  (keep (fn [{:keys [schema name comment]}]
+                          (when-not (str/blank? comment)
+                            [[schema name] comment])))
+                  (jdbc/reducible-result-set rs {})))))
+      (catch Throwable e
+        (log/debug e "Failed to read table comments from system.metadata.table_comments")
+        {}))))
 
 (defmethod driver/describe-database* :starburst
   [driver database]
@@ -498,9 +521,16 @@
      nil
      (fn [^Connection conn]
        (let [schemas (if schema
-                       #{(describe-schema driver conn catalog schema)}
-                       (all-schemas driver conn catalog))]
-         {:tables (reduce set/union #{} schemas)})))))
+                       [(describe-schema driver conn catalog schema)]
+                       (all-schemas driver conn catalog))
+             tables (reduce set/union #{} schemas)
+             comments (table-comments driver conn catalog schema)]
+         {:tables (into #{}
+                        (map (fn [{:keys [schema name] :as table}]
+                               (let [table-comment (get comments [schema name])]
+                                 (cond-> table
+                                   (not (str/blank? table-comment)) (assoc :description table-comment)))))
+                        tables)})))))
 
 (defmethod driver/describe-table :starburst
   [driver database {schema :schema, table-name :name}]
@@ -517,11 +547,12 @@
             :name   table-name
             :fields (into
                      #{}
-                     (map-indexed (fn [idx {:keys [column type] :as _col}]
-                                    {:name              column
-                                     :database-type     type
-                                     :base-type         (starburst-type->base-type type)
-                                     :database-position idx}))
+                     (map-indexed (fn [idx {:keys [column type comment], :as _col}]
+                                    (cond-> {:name              column
+                                             :database-type     type
+                                             :base-type         (starburst-type->base-type type)
+                                             :database-position idx}
+                                      (not (str/blank? comment)) (assoc :field-comment comment))))
                      (jdbc/reducible-result-set rs {}))}))))))
 
 (defmethod driver/db-default-timezone :starburst

--- a/modules/drivers/starburst/test/metabase/test/data/starburst.clj
+++ b/modules/drivers/starburst/test/metabase/test/data/starburst.clj
@@ -182,3 +182,9 @@
 
 (defmethod sql.tx/generated-column-sql :starburst [_ _] nil)
 (defmethod sql.tx/default-column-sql :starburst [_ _] nil)
+
+(defmethod sql.tx/standalone-column-comment-sql :starburst [& args]
+  (apply sql.tx/standard-standalone-column-comment-sql args))
+
+(defmethod sql.tx/standalone-table-comment-sql :starburst [& args]
+  (apply sql.tx/standard-standalone-table-comment-sql args))

--- a/modules/drivers/starburst/test/metabase/test/data/starburst.clj
+++ b/modules/drivers/starburst/test/metabase/test/data/starburst.clj
@@ -183,8 +183,16 @@
 (defmethod sql.tx/generated-column-sql :starburst [_ _] nil)
 (defmethod sql.tx/default-column-sql :starburst [_ _] nil)
 
-(defmethod sql.tx/standalone-column-comment-sql :starburst [& args]
-  (apply sql.tx/standard-standalone-column-comment-sql args))
+(defmethod sql.tx/standalone-column-comment-sql :starburst
+  [driver {:keys [database-name]} {:keys [table-name]} {:keys [field-name field-comment]}]
+  (when (seq field-comment)
+    (format "COMMENT ON COLUMN %s IS '%s'"
+            (sql.tx/qualify-and-quote driver database-name table-name field-name)
+            field-comment)))
 
-(defmethod sql.tx/standalone-table-comment-sql :starburst [& args]
-  (apply sql.tx/standard-standalone-table-comment-sql args))
+(defmethod sql.tx/standalone-table-comment-sql :starburst
+  [driver {:keys [database-name]} {:keys [table-name table-comment]}]
+  (when (seq table-comment)
+    (format "COMMENT ON TABLE %s IS '%s'"
+            (sql.tx/qualify-and-quote driver database-name table-name)
+            table-comment)))

--- a/test/metabase/sync/sync_metadata/comments_test.clj
+++ b/test/metabase/sync/sync_metadata/comments_test.clj
@@ -23,9 +23,18 @@
      {:field-name "no_comment", :base-type :type/Text}]
     [["foo" "bar"]]]])
 
+(defmethod driver/database-supports? [::driver/driver ::field-comments-sync]
+  [_driver _feature _database]
+  false)
+
+(doseq [driver [:h2 :postgres :starburst]]
+  (defmethod driver/database-supports? [driver ::field-comments-sync]
+    [_driver _feature _database]
+    true))
+
 (deftest ^:parallel basic-field-comments-test
   (testing "test basic field comments sync"
-    (mt/test-drivers #{:h2 :postgres}
+    (mt/test-drivers (mt/normal-driver-select {:+features [::field-comments-sync]})
       (mt/dataset basic-field-comments
         (is (= #{{:name (mt/format-name "id"), :description nil}
                  {:name (mt/format-name "with_comment"), :description "comment"}
@@ -40,7 +49,7 @@
 (deftest comment-should-not-overwrite-custom-description-test
   (testing (str "test changing the description in metabase db so we can check it is not overwritten by comment in "
                 "source db when resyncing")
-    (mt/test-drivers #{:h2 :postgres}
+    (mt/test-drivers (mt/normal-driver-select {:+features [::field-comments-sync]})
       (mt/dataset update-desc
         (mt/with-temp-copy-of-db
           ;; change the description in metabase while the source table comment remains the same
@@ -58,7 +67,7 @@
 
 (deftest sync-comment-on-existing-field-test
   (testing "test adding a comment to the source data that was initially empty, so we can check that the resync picks it up"
-    (mt/test-drivers #{:h2 :postgres}
+    (mt/test-drivers (mt/normal-driver-select {:+features [::field-comments-sync]})
       ;; modify the source DB to add the comment and resync. The easiest way to do this is just destroy the entire DB
       ;; and re-create a modified version. As such, let the SQL JDBC driver know the DB is being "modified" so it can
       ;; destroy its current connection pool
@@ -90,30 +99,46 @@
 (defn- db->tables [db]
   (set (map (partial into {}) (t2/select [:model/Table :name :description] :db_id (u/the-id db)))))
 
+(defmethod driver/database-supports? [::driver/driver ::table-comments-sync]
+  [_driver _feature _database]
+  false)
+
+(doseq [driver [:h2 :postgres :starburst]]
+  (defmethod driver/database-supports? [driver ::table-comments-sync]
+    [_driver _feature _database]
+    true))
+
+(defn- get-table-name [driver table-name]
+  (-> (sql.tx/qualified-name-components driver (str table-name "_db") table-name)
+      last
+      mt/format-name))
+
 (deftest ^:parallel table-comments-test
   (testing "test basic comments on table"
-    (mt/test-drivers #{:h2 :postgres}
+    (mt/test-drivers (mt/normal-driver-select {:+features [::table-comments-sync]})
       (mt/dataset (basic-table "table_with_comment" "table comment")
-        (is (= #{{:name (mt/format-name "table_with_comment"), :description "table comment"}}
+        (is (= #{{:name (get-table-name driver/*driver* "table_with_comment")
+                  :description "table comment"}}
                (db->tables (mt/db))))))))
 
 (deftest dont-overwrite-table-custom-description-test
   (testing (str "test changing the description in metabase on table to check it is not overwritten by comment in "
                 "source db when resyncing")
-    (mt/test-drivers #{:h2 :postgres}
+    (mt/test-drivers (mt/normal-driver-select {:+features [::table-comments-sync]})
       (mt/dataset (basic-table "table_with_updated_desc" "table comment")
         (mt/with-temp-copy-of-db
           ;; change the description in metabase while the source table comment remains the same
           (t2/update! :model/Table {:id (mt/id "table_with_updated_desc")} {:description "updated table description"})
           ;; now sync the DB again, this should NOT overwrite the manually updated description
           (sync-tables/sync-tables-and-database! (mt/db))
-          (is (= #{{:name (mt/format-name "table_with_updated_desc") :description "updated table description"}}
+          (is (= #{{:name (get-table-name driver/*driver* "table_with_updated_desc")
+                    :description "updated table description"}}
                  (db->tables (mt/db)))))))))
 
 (deftest sync-existing-table-comment-test
   (testing "test adding a comment to the source table that was initially empty, so we can check that the resync picks it up"
-    (mt/test-drivers #{:h2 :postgres :redshift}
-      (let [table-name (apply str (take 10 (mt/random-name)))
+    (mt/test-drivers (mt/normal-driver-select {:+features [::table-comments-sync]})
+      (let [table-name (u/lower-case-en (apply str (take 10 (mt/random-name))))
             added-comment (mt/random-name)
             dbdef (basic-table table-name nil)]
         (mt/dataset dbdef
@@ -123,6 +148,7 @@
                            driver/*driver*
                            dbdef
                            (tx/map->TableDefinition {:table-name table-name
-                                                     :table-comment added-comment}))])
+                                                     :table-comment added-comment}))]
+                         {:transaction? false}) ;; trino needs transactions off
           (sync-tables/sync-tables-and-database! (mt/db))
           (is (true? (t2/exists? :model/Table :db_id (mt/id) :description added-comment))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/56022

### Description

Adds support for syncing column and table comments for starburst. 

Adds support for syncing column comments for presto. Presto doesn't provide a straightforward way to get table comments. We'd need to run `show create table` and parse the output. I think it makes sense to leave this as a follow-up for now. 

We were already syncing column comments for athena. Similar to presto, there's not a straightforward way to get table comments. We'd need to do `SHOW TBLPROPERTIES` or use the glue sdk.  I think it makes sense to leave this as a follow-up for now. 

We use a pre-built presto image to test against. It uses a memory connector that doesn't support table or column comments, so there's not a good way to test this in CI. I've verified locally that column syncing works when using a hive connector, and split out a presto `column->field` function to have some light testing for the change. 

### How to verify

1. Set up a starburst database witha table that has comments on the table and the columns
2. Sync the database
3. The table should have table and column descriptions under the admin table metadata section

Repeat the same as above for presto. The column comments should be synced. 

### Demo

https://www.loom.com/share/0c2580eef50f4819a11373ba646eb15e

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
