### PR TITLE
Ghy 3975 fix dependency analysis on upgrade

### DIFF
--- a/src/metabase/dashboards/models/dashboard_card.clj
+++ b/src/metabase/dashboards/models/dashboard_card.clj
@@ -36,11 +36,10 @@
           :inline_parameters      []}
          dashcard))
 
-;;; Update visualizer dashboard cards in stats to have card id references instead of entity ids
 (t2/define-after-select :model/DashboardCard
   [dashcard]
   (if (contains? dashcard :visualization_settings)
-    (update dashcard :visualization_settings serdes/import-visualizer-settings)
+    (update dashcard :visualization_settings serdes/import-visualizer-settings-lenient)
     dashcard))
 
 (declare series)

--- a/src/metabase/dashboards/models/dashboard_card.clj
+++ b/src/metabase/dashboards/models/dashboard_card.clj
@@ -36,6 +36,7 @@
           :inline_parameters      []}
          dashcard))
 
+;;; Update visualizer dashboard cards in stats to have card id references instead of entity ids
 (t2/define-after-select :model/DashboardCard
   [dashcard]
   (if (contains? dashcard :visualization_settings)

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1789,36 +1789,45 @@
 
 (defn- import-card-dimension-ref
   [s]
-  (if-let [[_ card-id] (and (string? s) (re-matches #"^\$_card:([A-Za-z0-9_\-]{21})_name$" s))]
-    (str "$_card:" (*import-fk* card-id :model/Card) "_name")
-    s))
+  (or (when-let [[_ card-id] (and (string? s) (re-matches #"^\$_card:([A-Za-z0-9_\-]{21})_name$" s))]
+        (when-let [resolved (*import-fk* card-id :model/Card)]
+          (str "$_card:" resolved "_name")))
+      s))
 
 (defn- import-visualizer-source-id
   [source-id]
   (when (string? source-id)
-    (if-let [card-entity-id (second (re-matches #"^card:([A-Za-z0-9_\-]{21})$" source-id))]
-      (str "card:" (*import-fk* card-entity-id :model/Card))
-      source-id)))
+    (or (when-let [card-entity-id (second (re-matches #"^card:([A-Za-z0-9_\-]{21})$" source-id))]
+          (when-let [card-id (*import-fk* card-entity-id :model/Card)]
+            (str "card:" card-id)))
+        source-id)))
 
 (defn import-visualizer-settings
   "Update embedded entity ids to card ids in visualizer dashcard settings"
   [settings]
   (m/update-existing-in
-    settings
-    [:visualization :columnValuesMapping]
-    update-vals
-    (fn [cols]
-      (cond
-        ;; e.g. [{:sourceId "card:..."} ...]
-        (and (coll? cols) (map? (first cols)))
-        (mapv #(update % :sourceId import-visualizer-source-id) cols)
+   settings
+   [:visualization :columnValuesMapping]
+   update-vals
+   (fn [cols]
+     (cond
+       ;; e.g. [{:sourceId "card:..."} ...]
+       (and (coll? cols) (map? (first cols)))
+       (mapv #(update % :sourceId import-visualizer-source-id) cols)
 
-        ;; e.g. ["$_card:<id>_name"] for funnel dimensions
-        (and (coll? cols) (string? (first cols)))
-        (mapv import-card-dimension-ref cols)
+       ;; e.g. ["$_card:<id>_name"] for funnel dimensions
+       (and (coll? cols) (string? (first cols)))
+       (mapv import-card-dimension-ref cols)
 
-                                  :else cols)]
-               [k updated-cols]))))))
+       :else cols))))
+
+(defn import-visualizer-settings-lenient
+  "Like [[import-visualizer-settings]], but resolves card references leniently: a dangling reference is
+  left in its portable entity-id form instead of throwing. For read paths (the DashboardCard after-select
+  hook) where a deleted source Card must render as a broken section rather than break the whole read."
+  [settings]
+  (binding [resolve/*import-resolver* @(requiring-resolve 'metabase.models.serialization.resolve.db/lenient-import-resolver)]
+    (import-visualizer-settings settings)))
 
 (defn import-visualization-settings
   "Given an EDN value as exported by [[export-visualization-settings]], convert its portable `[db schema table field]`

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1823,8 +1823,8 @@
 
 (defn import-visualizer-settings-lenient
   "Like [[import-visualizer-settings]], but resolves card references leniently: a dangling reference is
-  left in its portable entity-id form instead of throwing. For read paths (the DashboardCard after-select
-  hook) where a deleted source Card must render as a broken section rather than break the whole read."
+  left in its portable entity-id form, instead of throwing. Use for paths where a deleted source Card
+  should be treated as a broken section rather than break the whole read."
   [settings]
   (binding [resolve/*import-resolver* @(requiring-resolve 'metabase.models.serialization.resolve.db/lenient-import-resolver)]
     (import-visualizer-settings settings)))

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1804,19 +1804,18 @@
   "Update embedded entity ids to card ids in visualizer dashcard settings"
   [settings]
   (m/update-existing-in
-   settings
-   [:visualization :columnValuesMapping]
-   (fn [mapping]
-     (into {}
-           (for [[k cols] mapping]
-             (let [updated-cols (cond
-                                  ;; e.g. [{:sourceId "card:..."} ...]
-                                  (and (coll? cols) (map? (first cols)))
-                                  (mapv #(update % :sourceId import-visualizer-source-id) cols)
+    settings
+    [:visualization :columnValuesMapping]
+    update-vals
+    (fn [cols]
+      (cond
+        ;; e.g. [{:sourceId "card:..."} ...]
+        (and (coll? cols) (map? (first cols)))
+        (mapv #(update % :sourceId import-visualizer-source-id) cols)
 
-                                  ;; e.g. ["$_card:<id>_name"] for funnel dimensions
-                                  (and (coll? cols) (string? (first cols)))
-                                  (mapv import-card-dimension-ref cols)
+        ;; e.g. ["$_card:<id>_name"] for funnel dimensions
+        (and (coll? cols) (string? (first cols)))
+        (mapv import-card-dimension-ref cols)
 
                                   :else cols)]
                [k updated-cols]))))))

--- a/src/metabase/models/serialization/resolve/db.clj
+++ b/src/metabase/models/serialization/resolve/db.clj
@@ -6,6 +6,7 @@
   (:require
    [metabase.models.serialization :as serdes]
    [metabase.models.serialization.resolve :as resolve]
+   [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import (clojure.lang ExceptionInfo)))
 
@@ -165,7 +166,9 @@
   "A stateless database-backed import resolver that returns nil for an unresolvable FK instead of throwing."
   (reify resolve/SerdesImportResolver
     (resolve/import-fk       [_ eid model]            (try (resolve/import-fk default-import-resolver eid model)
-                                                           (catch ExceptionInfo _ nil)))
+                                                           (catch ExceptionInfo e
+                                                             (log/warn e "Failed to import FK")
+                                                             nil)))
     (resolve/import-fk-keyed [_ portable model field] (resolve/import-fk-keyed default-import-resolver portable model field))
     (resolve/import-user     [_ email]                (resolve/import-user default-import-resolver email))
     (resolve/import-table-fk [_ path]                 (resolve/import-table-fk default-import-resolver path))

--- a/src/metabase/models/serialization/resolve/db.clj
+++ b/src/metabase/models/serialization/resolve/db.clj
@@ -6,7 +6,8 @@
   (:require
    [metabase.models.serialization :as serdes]
    [metabase.models.serialization.resolve :as resolve]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import (clojure.lang ExceptionInfo)))
 
 (set! *warn-on-reflection* true)
 
@@ -145,20 +146,30 @@
 (def default-export-resolver
   "A stateless database-backed export resolver."
   (reify resolve/SerdesExportResolver
-    (export-fk       [_ id model]       (export-fk id model))
-    (export-fk-keyed [_ id model field] (export-fk-keyed id model field))
-    (export-user     [this id]          (export-user this id))
-    (export-table-fk [_ table-id]       (export-table-fk table-id))
-    (export-field-fk [this field-id]    (export-field-fk this field-id))))
+    (resolve/export-fk       [_ id model]       (export-fk id model))
+    (resolve/export-fk-keyed [_ id model field] (export-fk-keyed id model field))
+    (resolve/export-user     [this id]          (export-user this id))
+    (resolve/export-table-fk [_ table-id]       (export-table-fk table-id))
+    (resolve/export-field-fk [this field-id]    (export-field-fk this field-id))))
 
 (def default-import-resolver
   "A stateless database-backed import resolver."
   (reify resolve/SerdesImportResolver
-    (import-fk       [_ eid model]            (import-fk eid model))
-    (import-fk-keyed [_ portable model field] (import-fk-keyed portable model field))
-    (import-user     [this email]             (import-user this email))
-    (import-table-fk [_ path]                (import-table-fk path))
-    (import-field-fk [this path]             (import-field-fk this path))))
+    (resolve/import-fk       [_ eid model]            (import-fk eid model))
+    (resolve/import-fk-keyed [_ portable model field] (import-fk-keyed portable model field))
+    (resolve/import-user     [this email]             (import-user this email))
+    (resolve/import-table-fk [_ path]                 (import-table-fk path))
+    (resolve/import-field-fk [this path]              (import-field-fk this path))))
+
+(def lenient-import-resolver
+  "A stateless database-backed import resolver that returns nil for an unresolvable FK instead of throwing."
+  (reify resolve/SerdesImportResolver
+    (resolve/import-fk       [_ eid model]            (try (resolve/import-fk default-import-resolver eid model)
+                                                           (catch ExceptionInfo _ nil)))
+    (resolve/import-fk-keyed [_ portable model field] (resolve/import-fk-keyed default-import-resolver portable model field))
+    (resolve/import-user     [_ email]                (resolve/import-user default-import-resolver email))
+    (resolve/import-table-fk [_ path]                 (resolve/import-table-fk default-import-resolver path))
+    (resolve/import-field-fk [_ path]                 (resolve/import-field-fk default-import-resolver path))))
 
 (defn cached-export-resolver
   "Returns a database-backed export resolver with memoized lookups."
@@ -169,11 +180,11 @@
         export-table-fk* (memoize export-table-fk)
         export-field-fk* (memoize export-field-fk)]
     (reify resolve/SerdesExportResolver
-      (export-fk       [_ id model]       (export-fk* id model))
-      (export-fk-keyed [_ id model field] (export-fk-keyed* id model field))
-      (export-user     [this id]          (export-user* this id))
-      (export-table-fk [_ table-id]       (export-table-fk* table-id))
-      (export-field-fk [this field-id]    (export-field-fk* this field-id)))))
+      (resolve/export-fk       [_ id model]       (export-fk* id model))
+      (resolve/export-fk-keyed [_ id model field] (export-fk-keyed* id model field))
+      (resolve/export-user     [this id]          (export-user* this id))
+      (resolve/export-table-fk [_ table-id]       (export-table-fk* table-id))
+      (resolve/export-field-fk [this field-id]    (export-field-fk* this field-id)))))
 
 (defn cached-import-resolver
   "Returns a database-backed import resolver with memoized lookups."
@@ -184,8 +195,8 @@
         import-table-fk* (memoize import-table-fk)
         import-field-fk* (memoize import-field-fk)]
     (reify resolve/SerdesImportResolver
-      (import-fk       [_ eid model]            (import-fk* eid model))
-      (import-fk-keyed [_ portable model field] (import-fk-keyed* portable model field))
-      (import-user     [this email]             (import-user* this email))
-      (import-table-fk [_ path]                (import-table-fk* path))
-      (import-field-fk [this path]             (import-field-fk* this path)))))
+      (resolve/import-fk       [_ eid model]            (import-fk* eid model))
+      (resolve/import-fk-keyed [_ portable model field] (import-fk-keyed* portable model field))
+      (resolve/import-user     [this email]             (import-user* this email))
+      (resolve/import-table-fk [_ path]                 (import-table-fk* path))
+      (resolve/import-field-fk [this path]              (import-field-fk* this path)))))

--- a/src/metabase/sample_data/impl.clj
+++ b/src/metabase/sample_data/impl.clj
@@ -115,7 +115,7 @@
   "IDs of Dashboards holding at least one card backed by `database-id`. Captured before the sample
   database is deleted so the dashboards it empties out can be pruned afterward."
   [database-id]
-  (t2/select-fn-set :dashboard_id :model/DashboardCard
+  (t2/select-fn-set :dashboard_id [:model/DashboardCard :dashboard_id]
                     :card_id [:in {:select [:id]
                                    :from   [(t2/table-name :model/Card)]
                                    :where  [:= :database_id database-id]}]))
@@ -126,7 +126,7 @@
   in cards from another database) is left alone."
   [dashboard-ids]
   (when (seq dashboard-ids)
-    (let [non-empty (t2/select-fn-set :dashboard_id :model/DashboardCard :dashboard_id [:in dashboard-ids])
+    (let [non-empty (t2/select-fn-set :dashboard_id [:model/DashboardCard :dashboard_id] :dashboard_id [:in dashboard-ids])
           empty-ids (remove (or non-empty #{}) dashboard-ids)]
       (when (seq empty-ids)
         (t2/delete! :model/Dashboard :id [:in empty-ids])))))

--- a/test/metabase/dashboards/models/dashboard_card_test.clj
+++ b/test/metabase/dashboards/models/dashboard_card_test.clj
@@ -324,3 +324,33 @@
             transformed  (dashboard-card/from-parsed-json deserialized)]
         (is (= dashcard
                transformed))))))
+
+(deftest ^:parallel after-select-tolerates-dangling-visualizer-ref-test
+  (testing "A DashboardCard whose visualizer settings reference a deleted Card is returned unmodified on read,
+           rather than throwing and making the dashcard unloadable."
+    (mt/with-temp [:model/Dashboard     dash {}
+                   :model/Card          card {}
+                   :model/DashboardCard dc   {:dashboard_id (:id dash), :card_id (:id card)}]
+      (let [dangling {:visualization {:columnValuesMapping {:COLUMN_1 [{:sourceId "card:gEnfWx10SmfjiccZpcGrj"}]}}}]
+        ;; Inject the dangling ref via raw SQL so model hooks don't rewrite it on write.
+        (t2/query-one {:update (t2/table-name :model/DashboardCard)
+                       :set    {:visualization_settings (json/encode dangling)}
+                       :where  [:= :id (:id dc)]})
+        (testing "the read does not throw and the unresolved ref is left untouched"
+          (let [loaded (t2/select-one :model/DashboardCard :id (:id dc))]
+            (is (= [{:sourceId "card:gEnfWx10SmfjiccZpcGrj"}]
+                   (get-in loaded [:visualization_settings :visualization :columnValuesMapping :COLUMN_1])))))))))
+
+(deftest ^:parallel after-select-resolves-valid-visualizer-ref-test
+  (testing "A valid visualizer entity-id reference is resolved to a numeric card id on read."
+    (mt/with-temp [:model/Dashboard     dash {}
+                   :model/Card          card {}
+                   :model/Card          src  {}
+                   :model/DashboardCard dc   {:dashboard_id (:id dash), :card_id (:id card)}]
+      (let [viz {:visualization {:columnValuesMapping {:COLUMN_1 [{:sourceId (str "card:" (:entity_id src))}]}}}]
+        (t2/query-one {:update (t2/table-name :model/DashboardCard)
+                       :set    {:visualization_settings (json/encode viz)}
+                       :where  [:= :id (:id dc)]})
+        (let [loaded (t2/select-one :model/DashboardCard :id (:id dc))]
+          (is (= [{:sourceId (str "card:" (:id src))}]
+                 (get-in loaded [:visualization_settings :visualization :columnValuesMapping :COLUMN_1]))))))))

--- a/test/metabase/sample_data/impl_test.clj
+++ b/test/metabase/sample_data/impl_test.clj
@@ -206,9 +206,7 @@
         (is (t2/exists? :model/Collection :id (:id examples)))))))
 
 (deftest replace-sample-database-survives-dangling-visualizer-ref-test
-  (testing "A sample-DB dashcard whose visualizer_settings reference a now-deleted Card must not block the engine
-           swap. Loading such a dashcard fires the DashboardCard after-select hook, which resolves visualizer FK
-           refs and hard-throws on a dangling one; the deletion path must not trip that hook."
+  (testing "The engine swap completes when a sample dashcard has a dangling visualizer ref"
     (mt/with-temp
       [:model/Database  old-sample  {:engine :h2, :is_sample true, :details {:db "mem:old-sample"}}
        :model/Card      sample-card {:database_id (:id old-sample)}

--- a/test/metabase/sample_data/impl_test.clj
+++ b/test/metabase/sample_data/impl_test.clj
@@ -14,6 +14,7 @@
    [metabase.sync.task.sync-databases-test :as task.sync-databases-test]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.warehouse-schema.models.field-values :as field-values]
    [metabase.warehouses-rest.api-test :as api.database-test]
    [toucan2.core :as t2])
@@ -203,6 +204,30 @@
         (is (not (t2/exists? :model/DashboardTab :id (:id tab)))))
       (testing "the Example collection is preserved (the engine swap no longer deletes it)"
         (is (t2/exists? :model/Collection :id (:id examples)))))))
+
+(deftest replace-sample-database-survives-dangling-visualizer-ref-test
+  (testing "A sample-DB dashcard whose visualizer_settings reference a now-deleted Card must not block the engine
+           swap. Loading such a dashcard fires the DashboardCard after-select hook, which resolves visualizer FK
+           refs and hard-throws on a dangling one; the deletion path must not trip that hook."
+    (mt/with-temp
+      [:model/Database  old-sample  {:engine :h2, :is_sample true, :details {:db "mem:old-sample"}}
+       :model/Card      sample-card {:database_id (:id old-sample)}
+       :model/Dashboard sample-dash {}
+       :model/DashboardCard dc {:dashboard_id (:id sample-dash), :card_id (:id sample-card)}]
+      ;; Inject a dangling visualizer ref via raw SQL so the model's hooks don't reject/rewrite it.
+      (t2/query-one {:update (t2/table-name :model/DashboardCard)
+                     :set    {:visualization_settings
+                              (json/encode {:visualization
+                                            {:columnValuesMapping
+                                             {:COLUMN_1 [{:sourceId "card:gEnfWx10SmfjiccZpcGrj"}]}}})}
+                     :where  [:= :id (:id dc)]})
+      (with-redefs [config/load-sample-content? (constantly false)]
+        (testing "the replacement completes instead of throwing on the dangling ref"
+          (is (nil? (#'sample-data/update-sample-database-if-needed! old-sample)))))
+      (testing "the old sample DB and the dashboard emptied by its removal are deleted"
+        (is (not (t2/exists? :model/Database :id (:id old-sample))))
+        (is (not (t2/exists? :model/Card :id (:id sample-card))))
+        (is (not (t2/exists? :model/Dashboard :id (:id sample-dash))))))))
 
 (def ^:private edn-example-collection-entity-id
   "Stable entity id of the bundled Examples collection in sample-content.edn."


### PR DESCRIPTION
Closes [GHY-3975: Crash loop on stats](https://linear.app/metabase/issue/GHY-3975/crash-loop-on-stats)

### Description

In stats we have a dashboard card whose visualizer settings references a card that no longer exists. When a query selects this dashboard card, an `after-select` hook attempts to resolve references in the visualizer settings and throws when it encounters the missing card. The sample DB upgrade process has such a query that selects the problematic dashboard card in stats, so the sample DB upgrade process throws and causes a crash loop.

This PR has two different fixes, each of which would be sufficient to solve this particular instance of the problem.

* When querying for dashboard cards, select only the dashboard_id so we do not also select the visualizer_settings and trigger the fk import that would trip over the dangling reference. (This has a side benefit of being marginally more performant.)
* Change the dashboardcard after-select logic itself to be lenient when encountering dangling refs. A card reference in the visualizer settings that fails to resolve will be left as the original pre-import value rather than blowing up the whole query. This may result in some apparently broken dashboard cards, but that's better than the whole query failing.