### PR TITLE
Mark bigquery as not supporting workspaces yet.

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -991,7 +991,8 @@
                               :transforms/python                true
                               :transforms/table                 true
                               ;; Workspace isolation using service account impersonation
-                              :workspace                        true}]
+                              ;; Tearing down workspaces is not working right currently
+                              :workspace                        false}]
   (defmethod driver/database-supports? [:bigquery-cloud-sdk feature] [_driver _feature _db] supported?))
 
 (defmethod driver/qualified-name-components :bigquery-cloud-sdk

--- a/test/metabase/transforms/execute_test.clj
+++ b/test/metabase/transforms/execute_test.clj
@@ -147,7 +147,8 @@
             (driver/drop-table! driver db-id (:name table-schema))))))))
 
 (deftest transform-schema-created-if-needed-test
-  (mt/test-drivers (mt/normal-driver-select {:+features [:transforms/table :schemas]})
+  (mt/test-drivers (mt/normal-driver-select {:+features [:transforms/table :schemas
+                                                         :test/dynamic-dataset-loading]})
     (mt/dataset transforms-dataset/transforms-test
       (let [schema (str "transform_schema_" (mt/random-name))]
         (try


### PR DESCRIPTION
Also mark transform-schema-created-if-needed-test as requiring dynamic dataset loading feature.