### PR TITLE
Visualizer: Preserve the `results_timezone` if the source has one

### DIFF
--- a/frontend/src/metabase/visualizer/utils/merge-data.ts
+++ b/frontend/src/metabase/visualizer/utils/merge-data.ts
@@ -90,10 +90,21 @@ export function mergeVisualizerData({
       .flat(),
   );
 
+  // Carry the timezone from the source dataset(s) so time-series charts format datetimes in the query's
+  // report timezone. Without it the cartesian axis falls back to UTC (#73972).
+  const sourceData = referencedColumns
+    .map((ref) => datasets[ref.sourceId])
+    .find(
+      (dataset) =>
+        dataset?.error == null && dataset?.data?.results_timezone != null,
+    )?.data;
+
   return {
     cols: columns,
     rows: _.zip(...unzippedRows),
     insights,
+    results_timezone: sourceData?.results_timezone,
+    requested_timezone: sourceData?.requested_timezone,
     // this is incorrect - `data.cols` are not the same as `data.results_metadata.columns`
     results_metadata: { columns: columns as unknown as Field[] },
   };

--- a/frontend/src/metabase/visualizer/utils/merge-data.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/merge-data.unit.spec.ts
@@ -156,4 +156,38 @@ describe("mergeVisualizerData", () => {
       expect(result.insights).toEqual([]);
     },
   );
+
+  it("should carry the results timezone from the source dataset so charts render in the report timezone (#73972)", () => {
+    const result = mergeVisualizerData({
+      columns: [
+        createMockColumn(StringColumn({ name: "COLUMN_1" })),
+        createMockColumn(NumberColumn({ name: "COLUMN_2" })),
+      ],
+      columnValuesMapping: {
+        COLUMN_1: [
+          { sourceId: "card:1", originalName: "CREATED_AT", name: "COLUMN_1" },
+        ],
+        COLUMN_2: [
+          { sourceId: "card:1", originalName: "count", name: "COLUMN_2" },
+        ],
+      },
+      datasets: {
+        "card:1": createMockDataset({
+          data: {
+            cols: [
+              createMockColumn(StringColumn({ name: "CREATED_AT" })),
+              createMockColumn(NumberColumn({ name: "count" })),
+            ],
+            rows: [["2025-01-01T00:00:00-08:00", 1]],
+            results_timezone: "America/Los_Angeles",
+          },
+        }),
+      },
+      dataSources: [
+        { id: "card:1", sourceId: 1, type: "card", name: "Chart 1" },
+      ],
+    });
+
+    expect(result.results_timezone).toBe("America/Los_Angeles");
+  });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73972
Fixes UXW-4040.

### Description

The timezone being dropped caused it to default to UTC, causing the bug. With the `results_timezone` preserved the correct timezone is used to render the x-axis and tooltip labels, achieving correct results.

### How to verify

1. Create a question with a meaningful `results_timezone`, e.g. one containing Postgres datetimes.
2. Create a card that causes datetimes with timezones to be x-axis labels.
3. Put it in a dashboard.
4. Edit, "Visualize another way" and change something (e.g. the line colour) to make it a Visualizer card.

In the Visualizer, before this change, the datetimes are rendered as if they're always UTC. With this change they render correctly in the `results_timezone`.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
