### PR TITLE
Fix perms OOM

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -177,7 +177,8 @@
                                                :perm_type :perms/view-data
                                                :perm_value :blocked
                                                :group_id all-users-group-id
-                                               :db_id [:in db-ids])
+                                               :db_id [:in db-ids]
+                                               {:select-distinct [:db_id]})
           impersonation-db-ids (t2/select-fn-set :db_id :model/ConnectionImpersonation
                                                  :group_id all-users-group-id
                                                  :db_id [:in db-ids])
@@ -203,7 +204,8 @@
     (let [blocked-group-ids   (t2/select-fn-set :group_id :model/DataPermissions
                                                 :perm_type :perms/view-data
                                                 :perm_value :blocked
-                                                :group_id [:in group-ids])
+                                                :group_id [:in group-ids]
+                                                {:select-distinct [:group_id]})
           impersonation-group-ids (t2/select-fn-set :group_id :model/ConnectionImpersonation
                                                     :group_id [:in group-ids])
           sandbox-group-ids   (when (premium-features/enable-sandboxes?)
@@ -225,7 +227,8 @@
                                               :db_id db-id
                                               :perm_type :perms/view-data
                                               :perm_value :blocked
-                                              :group_id [:in group-ids])
+                                              :group_id [:in group-ids]
+                                              {:select-distinct [:group_id]})
           sandbox-group-ids (when (premium-features/enable-sandboxes?)
                               (into #{}
                                     (map :group_id)

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -1019,7 +1019,9 @@
         ;; Regular groups: compute based on All Users group
         (let [au-id    (t2/select-one-pk :model/PermissionsGroup
                                          :magic_group_type "all-internal-users")
-              au-perms (t2/select :model/DataPermissions :group_id au-id)
+              au-perms (t2/select :model/DataPermissions
+                                  {:select-distinct [:db_id :perm_type :perm_value]
+                                   :where [:= :group_id au-id]})
               au-by-db (reduce (fn [acc {:keys [db_id perm_type perm_value]}]
                                  (update-in acc [db_id perm_type] (fnil conj #{}) perm_value))
                                {}


### PR DESCRIPTION
Dedupe `db_id` in the db and not in memory