### PR TITLE
Consolidate unreferenced-entities e2e flake fixes into one guard

### DIFF
--- a/e2e/test/scenarios/dependencies/dependency-unreferenced-list.cy.spec.ts
+++ b/e2e/test/scenarios/dependencies/dependency-unreferenced-list.cy.spec.ts
@@ -8,6 +8,7 @@ import {
 import type {
   CardId,
   CollectionId,
+  DependencyNode,
   FieldId,
   NativeQuerySnippetId,
   SegmentId,
@@ -121,7 +122,7 @@ describe("scenarios > dependencies > unreferenced list", () => {
   describe("analysis", () => {
     it("should show unreferenced entities", () => {
       setupEntities();
-      H.waitForBackfillComplete();
+      waitForUnreferencedAnalysis();
       H.DependencyDiagnostics.visitUnreferencedEntities();
       H.DependencyDiagnostics.list().within(() => {
         ENTITY_NAMES.forEach((name) => {
@@ -132,6 +133,10 @@ describe("scenarios > dependencies > unreferenced list", () => {
 
     it("should not show referenced entities", () => {
       setupEntities({ withReferences: true });
+      // These entities are referenced, so they should never appear in the
+      // unreferenced list — we can't poll for their presence. Wait for the
+      // global backfill so the analysis has run before asserting their absence.
+      H.waitForBackfillComplete();
       H.DependencyDiagnostics.visitUnreferencedEntities();
       H.DependencyDiagnostics.list().within(() => {
         ENTITY_NAMES.forEach((name) => {
@@ -144,7 +149,7 @@ describe("scenarios > dependencies > unreferenced list", () => {
   describe("search", () => {
     it("should search for entities", () => {
       setupEntities();
-      H.waitForBackfillComplete();
+      waitForUnreferencedAnalysis();
       H.DependencyDiagnostics.visitUnreferencedEntities();
       H.DependencyDiagnostics.searchInput().type(
         MODEL_FOR_QUESTION_DATA_SOURCE,
@@ -157,7 +162,7 @@ describe("scenarios > dependencies > unreferenced list", () => {
 
     it("should search for entities with type filters", () => {
       setupEntities();
-      H.waitForBackfillComplete();
+      waitForUnreferencedAnalysis();
       H.DependencyDiagnostics.visitUnreferencedEntities();
       H.DependencyDiagnostics.searchInput().type("tag");
       checkList({
@@ -180,7 +185,7 @@ describe("scenarios > dependencies > unreferenced list", () => {
   describe("filters", () => {
     it("should filter entities by type", () => {
       setupEntities();
-      H.waitForBackfillComplete();
+      waitForUnreferencedAnalysis();
       H.DependencyDiagnostics.visitUnreferencedEntities();
       checkList({ visibleEntities: ENTITY_NAMES });
 
@@ -211,7 +216,7 @@ describe("scenarios > dependencies > unreferenced list", () => {
 
     it("should persist filter changes after page reload", () => {
       setupEntities();
-      H.waitForBackfillComplete();
+      waitForUnreferencedAnalysis();
       H.DependencyDiagnostics.visitUnreferencedEntities();
       checkList({ visibleEntities: MODEL_NAMES });
 
@@ -225,7 +230,7 @@ describe("scenarios > dependencies > unreferenced list", () => {
 
     it("should filter by location", () => {
       setupEntities();
-      H.waitForBackfillComplete();
+      waitForUnreferencedAnalysis();
       H.DependencyDiagnostics.visitUnreferencedEntities();
       checkList({
         visibleEntities: [
@@ -259,7 +264,7 @@ describe("scenarios > dependencies > unreferenced list", () => {
   describe("sorting", () => {
     it("should sort by name", () => {
       setupEntities();
-      H.waitForBackfillComplete();
+      waitForUnreferencedAnalysis();
       H.DependencyDiagnostics.visitUnreferencedEntities();
       H.DependencyDiagnostics.searchInput().type("Model for");
 
@@ -283,7 +288,7 @@ describe("scenarios > dependencies > unreferenced list", () => {
 
     it("should sort by location", () => {
       setupEntities();
-      H.waitForBackfillComplete();
+      waitForUnreferencedAnalysis();
       H.DependencyDiagnostics.visitUnreferencedEntities();
       H.DependencyDiagnostics.searchInput().type("Model for");
 
@@ -302,7 +307,7 @@ describe("scenarios > dependencies > unreferenced list", () => {
 
     it("should persist sorting changes after page reload", () => {
       setupEntities();
-      H.waitForBackfillComplete();
+      waitForUnreferencedAnalysis();
       H.DependencyDiagnostics.visitUnreferencedEntities();
       H.DependencyDiagnostics.searchInput().type("Model for");
 
@@ -318,7 +323,7 @@ describe("scenarios > dependencies > unreferenced list", () => {
   describe("selecting entities", () => {
     it("should show the sidebar for supported entities and trigger snowplow event", () => {
       setupEntities();
-      H.waitForBackfillComplete();
+      waitForUnreferencedAnalysis();
       H.DependencyDiagnostics.visitUnreferencedEntities();
 
       H.DependencyDiagnostics.list().findByText(TABLE_DISPLAY_NAME).click();
@@ -1096,6 +1101,34 @@ function createDashboardWithParameterWithCardSource({
         },
       }),
     ],
+  });
+}
+
+function getNodeName(node: DependencyNode): string | null | undefined {
+  if (node.type === "table") {
+    return node.data.display_name;
+  }
+  return "name" in node.data ? node.data.name : undefined;
+}
+
+// The dependency graph is recomputed asynchronously when entities are created or
+// updated (metabase#71037). `waitForBackfillComplete` only reports the global
+// one-time backfill flag — it does NOT guarantee the entities `setupEntities()`
+// just created have been classified into the unreferenced graph. The list page
+// fires a single query on load, so visiting before that async analysis finishes
+// renders an incomplete list and the `findByText` assertions time out (4000ms).
+//
+// Poll the unreferenced endpoint until every expected entity is present before
+// visiting. Defaults to the full seeded set, which is a superset of what any
+// individual test asserts, so a single arg-free call makes every list test
+// deterministic. The writable-Postgres table reaches the graph via the slower
+// async DB-sync path, so it is covered here too. Mirrors the broken-list spec's
+// `waitForBreakingDependencies` guard.
+function waitForUnreferencedAnalysis(expectedNames: string[] = ENTITY_NAMES) {
+  H.waitForBackfillComplete();
+  H.waitForUnreferencedEntities((nodes) => {
+    const presentNames = new Set(nodes.map(getNodeName));
+    return expectedNames.every((name) => presentNames.has(name));
   });
 }
 


### PR DESCRIPTION
Resolves GHY-3403
Resolves GHY-3072
Resolves GHY-3395
Resolves GHY-3396
Resolves GHY-3392
Resolves GHY-3393
Resolves GHY-3405
Resolves GHY-3761

## Summary

The `dependency-unreferenced-list` e2e flakes were fixed one-by-one across eight PRs, each adding a slightly different ad-hoc wait. Since dependency-graph classification became asynchronous on entity create/update, `waitForBackfillComplete()` (the global one-time flag) doesn't guarantee freshly-seeded entities have surfaced in the unreferenced list, so visiting too early times out `findByText`.

This replaces those scattered waits with one shared `waitForUnreferencedAnalysis()` guard that polls the unreferenced endpoint until every seeded entity (table included) is present, applied uniformly to all presence-asserting tests — including five that share the same race but were never individually patched.

This should supersede the following PRs:

- #76433
- #76432
- #76424
- #76423
- #76422
- #76419
- #76418
- #76417
- #76422

🤖 Generated with [Claude Code](https://claude.com/claude-code)