### PR TITLE
Dont quarantine drivers on master or release branches

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -373,9 +373,9 @@
                         ["1"    "Global skip (no backend changes)"        "SKIP" "workflow skip (no backend changes)"]
                         ["2"    "Driver is :h2 or :postgres"              "RUN"  "H2/Postgres always run"]
                         ["3"    "ci:run-all-drivers or ci:run-DRIVER"     "RUN"  "ci:run-all-drivers or ci:run-DRIVER label"]
-                        ["4"    "Configured status = skip"                "SKIP" "driver is quarantined"]
+                        ["4"    "Configured status = skip (PR branches)" "SKIP" "driver is quarantined"]
                         ["4(a)" "...and has break-quarantine-X label"     "RUN"  "anti-quarantine label present"]
-                        ["5"    "On master or release branch"             "RUN"  "master/release branch"]
+                        ["5"    "On master or release branch"             "RUN"  "master/release branch (quarantine ignored)"]
                         ["6"    "Cloud driver + ci:all-cloud-drivers"     "RUN"  "ci:all-cloud-drivers label"]
                         ["7"
                          "Cloud driver + its files changed"
@@ -391,6 +391,8 @@
                         ["12"   "Self-hosted driver, not affected"        "SKIP" "driver module not affected"]]))
         "\nThis table decides only WHETHER a driver runs. A driver's configured status then\n"
         "applies to that decision (see 'Driver Status' below) and never overrides it.\n"
+        "\nNote: the remote quarantine list (status = skip) is ignored entirely on master and\n"
+        "release-* branches -- every driver runs and gates there (Priority 4 is bypassed).\n"
         "\n\n## Labels of Interest\n\n"
         "These PR labels influence driver test decisions:\n\n"
         "  ci:run-all-drivers        Force-run ALL drivers (overrides quarantine)\n"

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -363,6 +363,20 @@
   [statuses]
   (into #{} (keep (fn [[driver status]] (when (= status :skip) driver))) statuses))
 
+(defn- effective-quarantined-drivers
+  "Set of `:skip` (quarantined) drivers to actually enforce for this run.
+
+   The quarantine list is fetched on the fly from a remote file (ci-test-config.json, see
+   [[driver-statuses]]) and can change at any time. We intentionally IGNORE it on `master` and
+   `release-*` branches: there, every driver must run and gate, so a stray remote quarantine entry
+   can't silently disable a driver's tests (nor raise a quarantine-conflict, which would fail a push
+   demanding a PR-only break-quarantine label). On PR/feature branches the quarantine is honored,
+   subject to the break-quarantine-<driver> label."
+  [statuses is-master-or-release]
+  (if is-master-or-release
+    #{}
+    (skip-drivers statuses)))
+
 (defn- parse-bool
   "Parse a string boolean from CLI args. Returns true for 'true', false otherwise."
   [s]
@@ -422,7 +436,9 @@
                "ci:run-all-drivers label"
                (str (run-driver-label driver) " label"))}
 
-    ;; Priority 4: Quarantined drivers (respected even on master/release)
+    ;; Priority 4: Quarantined drivers — skipped unless a break-quarantine-<driver> label is present.
+    ;; On master/release this set is empty (see [[effective-quarantined-drivers]]), so quarantine is
+    ;; ignored there and we fall through to Priority 5.
     (contains? quarantined-drivers driver)
     (do
       (when verbose?
@@ -492,17 +508,21 @@
   [{:keys [options] :as _parsed}]
   (let [github-output-only? (some? (:github-output-only options))
         git-ref (get options :git-ref "master")
+        is-master-or-release (parse-bool (:is-master-or-release options))
         ;; Detect file changes for ALL drivers via git diff
         particular-driver-changed? (drivers-with-file-changes git-ref)
         ctx {:git-ref git-ref
-             :is-master-or-release (parse-bool (:is-master-or-release options))
+             :is-master-or-release is-master-or-release
              :pr-labels (parse-labels (:pr-labels options))
              :skip (parse-bool (:skip options))
              :particular-driver-changed? particular-driver-changed?
              :verbose? (not github-output-only?)}
         statuses (driver-statuses)
         ;; `:skip` drivers are quarantined (not run); `:info`/`:required` drivers run normally.
-        quarantined (skip-drivers statuses)
+        ;; On master/release we drop the remote quarantine list entirely (see
+        ;; [[effective-quarantined-drivers]]) so every driver runs and gates, and no
+        ;; quarantine-conflict is raised.
+        quarantined (effective-quarantined-drivers statuses is-master-or-release)
         updated-files (u/updated-files git-ref)
         updated (updated-files->updated-modules updated-files)
         driver-affected? (driver-deps-affected? updated)

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -19,7 +19,7 @@
          opts))
 
 ;;; =============================================================================
-;;; Priority 4: Quarantine (respected even on master/release)
+;;; Priority 4: Quarantine (respected on PR branches, ignored on master/release)
 ;;; =============================================================================
 
 (deftest quarantined-driver-skips
@@ -42,22 +42,34 @@
       (is (true? (:should-run result)))
       (is (re-find #"break-quarantine-mysql" (:reason result))))))
 
-(deftest quarantine-respected-on-master
-  (testing "Quarantined driver is skipped even on master/release"
-    (let [result (mage.modules/driver-decision :mysql
+(deftest effective-quarantine-ignored-on-master-and-release
+  (testing "the remote quarantine list is dropped on master/release, but honored on PR branches"
+    (let [statuses {:databricks :skip :snowflake :info}]
+      (is (= #{} (#'mage.modules/effective-quarantined-drivers statuses true))
+          "master/release: nothing is quarantined")
+      (is (= #{:databricks} (#'mage.modules/effective-quarantined-drivers statuses false))
+          "PR/feature branch: :skip drivers remain quarantined"))))
+
+(deftest quarantined-driver-runs-on-master
+  (testing "a driver quarantined in the remote config still runs (and gates) on master/release"
+    ;; Production clears the quarantine set on master/release via effective-quarantined-drivers,
+    ;; so the decision falls through Priority 4 to Priority 5.
+    (let [quarantined (#'mage.modules/effective-quarantined-drivers {:mysql :skip} true)
+          result (mage.modules/driver-decision :mysql
                                                (make-ctx {:is-master-or-release true})
                                                true ; driver-deps-affected?
-                                               #{:mysql} ; quarantined
+                                               quarantined
                                                #{})] ; updated
-      (is (false? (:should-run result)))
-      (is (= "driver is quarantined" (:reason result))))))
+      (is (true? (:should-run result)))
+      (is (= "master/release branch" (:reason result))))))
 
 (deftest quarantine-config-names-are-translated
   (testing "Config names from ci-test-config.json are translated to internal driver keywords via driver-directory->drivers"
     (testing "directory names are translated to internal keywords"
-      ;; bigquery-cloud-sdk -> :bigquery (via driver-directory->drivers mapping)
+      ;; bigquery-cloud-sdk -> :bigquery (via driver-directory->drivers mapping).
+      ;; Use a PR/feature branch here, since quarantine is ignored on master/release.
       (let [result (mage.modules/driver-decision :bigquery
-                                                 (make-ctx {:is-master-or-release true})
+                                                 (make-ctx {:is-master-or-release false})
                                                  false
                                                  #{:bigquery} ; as if translated from "bigquery-cloud-sdk"
                                                  #{})]


### PR DESCRIPTION
We need to stop sweeping failing drivers tests under the rug. 

This ignores driver quarantines on master or release branches.

> [!warning]
> This will block all releases until bigquery, snowflake, and databricks drivers are fixed