### PR TITLE
Consolidate metabot usage-auditing e2e flake fixes

### DIFF
--- a/e2e/test/scenarios/metabot/usage-auditing.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/usage-auditing.cy.spec.ts
@@ -43,6 +43,13 @@ const ROBERT_TENANT = {
 };
 const TENANT_CONVERSATIONS_CHART_TITLE = "Tenants with most conversations";
 
+// The usage-stats page only waits for the audit metadata before rendering; each
+// chart then fires its own adhoc /api/dataset query and mounts ECharts. With six
+// charts rendering at once, the [data-testid="chart-container"] mount can blow
+// past Cypress's default 4s under CI CPU contention. Give the container readiness
+// assertion a generous budget rather than racing the render.
+const CHART_RENDER_TIMEOUT = 12000;
+
 const METRIC_CHART_TITLES: Record<UsageStatsMetric, string[]> = {
   conversations: [
     "Conversations by day",
@@ -176,7 +183,9 @@ function getChartCard(title: string): Cypress.Chainable<JQuery<HTMLElement>> {
 
 function assertChartRendered(title: string): void {
   getChartCard(title).within(() => {
-    cy.findByTestId(/^(chart|row-chart)-container$/)
+    cy.findByTestId(/^(chart|row-chart)-container$/, {
+      timeout: CHART_RENDER_TIMEOUT,
+    })
       .should("be.visible")
       .find("svg")
       .should("exist");

--- a/e2e/test/scenarios/metabot/usage-auditing.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/usage-auditing.cy.spec.ts
@@ -225,7 +225,14 @@ function selectGroupFilter(groupName: string): void {
 function selectUserFilter(userName: string, waitAlias = "@dataset"): void {
   H.main().findByTestId("conversation-filters-user-select").realClick();
   H.selectDropdown().findByText(userName).realClick();
-  cy.url().should("include", "user=");
+  // Anchor on the select reflecting the newly chosen user before waiting. A bare
+  // `url includes "user="` check is a no-op after a drill-through (the URL already
+  // carries the drilled user), so it doesn't gate on the filter actually switching
+  // and the conversations request/table can be read mid-transition. Mirrors
+  // selectDateFilter.
+  H.main()
+    .findByTestId("conversation-filters-user-select")
+    .should("have.value", userName);
   cy.wait(waitAlias);
 }
 
@@ -333,16 +340,37 @@ function clickLastTimeseriesChartDot(title: string): void {
 }
 
 function clickRowChartBarForLabel(title: string, label: string): void {
+  // Drill by clicking the bar element itself rather than coordinate-clicking the
+  // container at a fixed offset from the axis label. Two things made the old
+  // `labelRect.right + 30` approach flaky:
+  //   - The page only waits for the audit metadata, so the chart's dataset query
+  //     + ECharts render could still be in flight.
+  //   - Row charts measure their size asynchronously (ExplicitSize, throttled),
+  //     so they first render with zero-width bars before re-laying out at the
+  //     final geometry — and assertChartRendered only proves the <svg> exists,
+  //     it passes in both the unmeasured and measured states.
+  // A pixel coordinate computed in either window lands off the bar: the
+  // drill-through never fires and cy.wait("@conversations") times out, or a
+  // near-miss drills a neighboring group. Instead wait for the measured
+  // (non-zero-width) bar whose vertical band contains the label's midpoint and
+  // realClick it — Cypress re-resolves its center at click time and retries for
+  // actionability, so the click can't miss.
+  assertChartRendered(title);
   getChartCard(title).within(() => {
-    cy.findByTestId("row-chart-container").then(($container) => {
-      cy.findByText(label).then(($label) => {
-        const containerRect = $container[0].getBoundingClientRect();
-        const labelRect = $label[0].getBoundingClientRect();
-        const x = labelRect.right - containerRect.left + 30;
-        const y = labelRect.top - containerRect.top + labelRect.height / 2;
-
-        cy.wrap($container).realClick({ x, y, scrollBehavior: false });
-      });
+    cy.findByText(label).then(([labelEl]) => {
+      cy.get('[aria-roledescription="bar"]')
+        .filter((_index, barEl) => {
+          const labelRect = labelEl.getBoundingClientRect();
+          const labelMidY = labelRect.top + labelRect.height / 2;
+          const barRect = barEl.getBoundingClientRect();
+          return (
+            barRect.width > 0 &&
+            barRect.top <= labelMidY &&
+            labelMidY <= barRect.bottom
+          );
+        })
+        .should("have.length", 1)
+        .realClick({ scrollBehavior: false });
     });
   });
 }

--- a/e2e/test/scenarios/metabot/usage-auditing.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/usage-auditing.cy.spec.ts
@@ -358,7 +358,7 @@ function clickRowChartBarForLabel(title: string, label: string): void {
   assertChartRendered(title);
   getChartCard(title).within(() => {
     cy.findByText(label).then(([labelEl]) => {
-      cy.get('[aria-roledescription="bar"]')
+      cy.findAllByRole("graphics-symbol")
         .filter((_index, barEl) => {
           const labelRect = labelEl.getBoundingClientRect();
           const labelMidY = labelRect.top + labelRect.height / 2;


### PR DESCRIPTION
Resolves [BOT-1620](https://linear.app/metabase/issue/BOT-1620/flaky-test-e2e-tests-scenarios-metabot-usage-auditing-scenarios)
Resolves [BOT-1645](https://linear.app/metabase/issue/BOT-1645/flaky-test-e2e-tests-scenarios-metabot-usage-auditing-scenarios)
Resolves DEV-2230

## Summary

One holistic fix for the flaky `scenarios > metabot > usage auditing` spec, superseding three single-symptom PRs that all touch the same file:

- #76427 — row-chart drill-through (BOT-1620)
- #76428 — groups-chart drill-through (BOT-1645)
- #76489 — chart-render assertion under CI load (DEV-2230)

The row-chart fixes from #76427/#76428 share a root cause, so they're merged into one `clickRowChartBarForLabel` rewrite (anchor on render, click the measured bar aligned with the label instead of a blind pixel offset), plus the `selectUserFilter` anchor fix. #76489's `assertChartRendered` budget is folded in and also hardens the drill helpers that rely on it. See the linked issues for the per-symptom detail.

Stress-tested green (burn-in ×50, throttling on and off) in each superseded PR.