### PR TITLE
BOT-1723 Support OpenAI models

### DIFF
--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
@@ -575,7 +575,7 @@ describe("AIProviderSettingsSection", () => {
     expect(anthropicOption).not.toHaveAttribute("aria-disabled", "true");
   });
 
-  it("shows Coming soon for non-Anthropic providers and disables them", async () => {
+  it("shows OpenAI as selectable in the provider dropdown", async () => {
     await setup({ savedProviderValue: null, isConfigured: false });
 
     await userEvent.click(screen.getByLabelText("Provider"));
@@ -583,14 +583,21 @@ describe("AIProviderSettingsSection", () => {
     const openaiOption = await screen.findByRole("option", {
       name: /OpenAI/,
     });
-    expect(openaiOption).toHaveAttribute("data-combobox-disabled");
+    expect(openaiOption).toBeInTheDocument();
+    expect(openaiOption).not.toHaveAttribute("data-combobox-disabled");
+  });
+
+  it("shows Coming soon for unsupported providers and disables them", async () => {
+    await setup({ savedProviderValue: null, isConfigured: false });
+
+    await userEvent.click(screen.getByLabelText("Provider"));
 
     const openrouterOption = await screen.findByRole("option", {
       name: /OpenRouter/,
     });
     expect(openrouterOption).toHaveAttribute("data-combobox-disabled");
 
-    expect(screen.getAllByText("Coming soon")).toHaveLength(2);
+    expect(screen.getAllByText("Coming soon")).toHaveLength(1);
   });
 
   it("BOT-1429: keeps the form interactive while session-properties refetches in the background", async () => {
@@ -1521,6 +1528,89 @@ describe("AIProviderSettingsSection", () => {
     expect(
       screen.queryByRole("button", { name: "Connect" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("connects to OpenAI by saving the API key and selecting a model", async () => {
+    await setup({
+      savedProviderValue: null,
+      isConfigured: false,
+      apiKeyValues: { openai: null },
+      updateResponse: {
+        value: "openai/gpt-4.1-mini",
+        models: DEFAULT_RESPONSES.openai.models,
+      },
+    });
+
+    await selectProvider("OpenAI");
+    await userEvent.type(screen.getByLabelText("API key"), "sk-openai-test");
+    await userEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory.calls("path:/api/metabot/settings", {
+          method: "PUT",
+        }),
+      ).toHaveLength(1);
+    });
+
+    const connectRequest = fetchMock.callHistory
+      .calls("path:/api/metabot/settings", { method: "PUT" })
+      .at(-1);
+    expect(connectRequest?.options?.body).toBe(
+      JSON.stringify({ provider: "openai", "api-key": "sk-openai-test" }),
+    );
+
+    await screen.findByLabelText("Model");
+    await openModelSelector();
+    await userEvent.click(await screen.findByText("GPT-4.1 mini"));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory.calls("path:/api/metabot/settings", {
+          method: "PUT",
+        }),
+      ).toHaveLength(2);
+    });
+
+    const modelRequest = fetchMock.callHistory
+      .calls("path:/api/metabot/settings", { method: "PUT" })
+      .at(-1);
+    expect(modelRequest?.options?.body).toBe(
+      JSON.stringify({ provider: "openai", model: "gpt-4.1-mini" }),
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Connect" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("disconnects OpenAI by clearing both the provider and API key settings", async () => {
+    await setup({
+      savedProviderValue: "openai/gpt-4.1-mini",
+      isConfigured: true,
+      apiKeyValues: { openai: "**********ey" },
+    });
+
+    await screen.findByText("Connected to OpenAI");
+    await screen.findByLabelText("API key");
+    await confirmDisconnectProvider();
+
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory.called("path:/api/setting", {
+          method: "PUT",
+          body: {
+            "llm-metabot-provider": null,
+            "llm-openai-api-key": null,
+          },
+        }),
+      ).toBe(true);
+    });
+
+    expect(
+      await screen.findByText("Connect to an AI provider"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Provider")).toHaveValue("");
   });
 
   it("disconnects an API-key provider by clearing both the provider and API key settings", async () => {

--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
@@ -89,10 +89,10 @@ const DEFAULT_RESPONSES: Record<MetabotProvider, MetabotSettingsResponse> = {
     ],
   },
   openai: {
-    value: "openai/gpt-4.1-mini",
+    value: "openai/gpt-5.4",
     models: [
-      { id: "gpt-4.1-mini", display_name: "GPT-4.1 mini" },
-      { id: "gpt-4.1", display_name: "GPT-4.1" },
+      { id: "gpt-5.4", display_name: "gpt-5.4" },
+      { id: "gpt-5.4-mini", display_name: "gpt-5.4-mini" },
     ],
   },
   openrouter: {
@@ -1536,7 +1536,7 @@ describe("AIProviderSettingsSection", () => {
       isConfigured: false,
       apiKeyValues: { openai: null },
       updateResponse: {
-        value: "openai/gpt-4.1-mini",
+        value: "openai/gpt-5.4",
         models: DEFAULT_RESPONSES.openai.models,
       },
     });
@@ -1562,7 +1562,7 @@ describe("AIProviderSettingsSection", () => {
 
     await screen.findByLabelText("Model");
     await openModelSelector();
-    await userEvent.click(await screen.findByText("GPT-4.1 mini"));
+    await userEvent.click(await screen.findByText("gpt-5.4"));
 
     await waitFor(() => {
       expect(
@@ -1576,7 +1576,7 @@ describe("AIProviderSettingsSection", () => {
       .calls("path:/api/metabot/settings", { method: "PUT" })
       .at(-1);
     expect(modelRequest?.options?.body).toBe(
-      JSON.stringify({ provider: "openai", model: "gpt-4.1-mini" }),
+      JSON.stringify({ provider: "openai", model: "gpt-5.4" }),
     );
 
     expect(
@@ -1586,7 +1586,7 @@ describe("AIProviderSettingsSection", () => {
 
   it("disconnects OpenAI by clearing both the provider and API key settings", async () => {
     await setup({
-      savedProviderValue: "openai/gpt-4.1-mini",
+      savedProviderValue: "openai/gpt-5.4",
       isConfigured: true,
       apiKeyValues: { openai: "**********ey" },
     });

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/utils.ts
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/utils.ts
@@ -96,7 +96,8 @@ export function isAvailableProvider(provider: MetabotProvider): boolean {
     provider === "anthropic" ||
     provider === "azure" ||
     provider === "bedrock" ||
-    provider === "metabase"
+    provider === "metabase" ||
+    provider === "openai"
   );
 }
 

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -82,10 +82,10 @@
 ;;; -------------------------------------------------- OpenAI ---------------------------------------------------
 
 (defsetting llm-openai-model
-  (deferred-tru "The OpenAI Model (e.g. ''gpt-4'', ''gpt-3.5-turbo'')")
+  (deferred-tru "The OpenAI Model (e.g. ''gpt-5.5'', ''gpt-5.4-mini'')")
   :encryption       :no
   :visibility       :settings-manager
-  :default          "gpt-4.1-mini"
+  :default          "gpt-5.4"
   :export?          false
   :deprecated-name  :ee-openai-model
   :doc              false)

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -395,6 +395,12 @@
     (str/starts-with? id "openai.")    "OpenAI"
     :else                              nil))
 
+(defn- openai-model-group
+  "Group an OpenAI model by version family for the picker."
+  [{:keys [id]}]
+  (when-let [version (second (re-find #"^gpt-(\d+(?:\.\d+)?)" id))]
+    (str "GPT-" version)))
+
 (defn- openrouter-model-group
   [{:keys [display_name id]}]
   (or (some-> display_name
@@ -410,6 +416,7 @@
   (case provider
     "anthropic"  (assoc model :group (anthropic-model-group model))
     "bedrock"    (assoc model :group (bedrock-model-group model))
+    "openai"     (assoc model :group (openai-model-group model))
     "openrouter" (assoc model :group (openrouter-model-group model))
     model))
 
@@ -427,7 +434,7 @@
                            (map normalize-metabase-model models)
                            models)
         decorated-models (map #(decorate-provider-model provider %) models)]
-    (if (contains? #{"anthropic" "bedrock" "openrouter"} provider)
+    (if (contains? #{"anthropic" "bedrock" "openai" "openrouter"} provider)
       (let [grouped-models (group-by :group decorated-models)]
         (->> grouped-models
              keys

--- a/src/metabase/metabot/example_question_generator.clj
+++ b/src/metabase/metabot/example_question_generator.clj
@@ -100,7 +100,7 @@
   "Output-token ceiling for a single generation. The answer itself is tiny, but reasoning models spend output tokens
   reasoning *before* emitting the forced structured_output tool call, so the cap must leave room for that or the call
   returns no tool call.  Non-reasoning providers stop well under this, so the higher ceiling costs them nothing."
-  2048)
+  4096)
 
 (defn- call-llm
   "Make a structured LLM call for example question generation.

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -36,7 +36,7 @@
   "Canonical schema for the opts map passed to every LLM provider adapter.
 
   Required:
-    :model       - Model name string (e.g. \"claude-haiku-4-5\", \"gpt-4.1-mini\")
+    :model       - Model name string (e.g. \"claude-haiku-4-5\", \"gpt-5.4\")
 
   Optional:
     :system      - System prompt string

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -206,7 +206,7 @@
     "gpt-5.4"
     "gpt-5.4-pro"
     "gpt-5.4-mini"
-    "gpt-4.1"})
+    "gpt-5"})
 
 (defn- supported-model?
   "Whether a `/v1/models` catalog entry is one of the [[supported-models]]."

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -206,8 +206,7 @@
     "gpt-5.4"
     "gpt-5.4-pro"
     "gpt-5.4-mini"
-    "gpt-4.1"
-    "gpt-4.1-mini"})
+    "gpt-4.1"})
 
 (defn- supported-model?
   "Whether a `/v1/models` catalog entry is one of the [[supported-models]]."
@@ -261,7 +260,7 @@
 (mu/defn openai-request-body
   "Build the OpenAI Responses API request body for an LLM request."
   [{:keys [model system input tools schema tool_choice temperature max-tokens]
-    :or   {model "gpt-4.1-mini"}} :- core/LLMRequestOpts]
+    :or   {model "gpt-5.4"}} :- core/LLMRequestOpts]
   (let [all-tools (or (when schema
                         ;; Structured output: force a tool call with the given JSON schema
                         [{:type        "function"
@@ -288,7 +287,7 @@
   "Perform a streaming request to OpenAI Responses API.
   `:ai-proxy?` is not supported for OpenAI and throws when true."
   [{:keys [model ai-proxy?] :as opts
-    :or   {model "gpt-4.1-mini"}} :- core/LLMRequestOpts]
+    :or   {model "gpt-5.4"}} :- core/LLMRequestOpts]
   (when ai-proxy?
     (throw (ai-proxy-unsupported-ex)))
   (let [req (openai-request-body opts)]

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -193,30 +193,52 @@
       500 (tru "OpenAI API is not working but not saying why")
       (tru "OpenAI API error (HTTP {0})" status))))
 
+(def ^:private supported-models
+  "OpenAI chat models offered in the Metabot model picker.
+  `list-models` returns the intersection of this set with the account's `/v1/models` catalog."
+  #{"gpt-5.5"
+    "gpt-5.5-pro"
+    "gpt-5.4"
+    "gpt-5.4-pro"
+    "gpt-5.4-mini"
+    "gpt-4.1"
+    "gpt-4.1-mini"})
+
+(defn- supported-model?
+  "Whether a `/v1/models` catalog entry is one of the [[supported-models]]."
+  [{:keys [id]}]
+  (contains? supported-models id))
+
+(defn- list-all-models
+  "Fetch the full OpenAI model catalog (`GET /v1/models`)."
+  [{:keys [credentials ai-proxy?]}]
+  (when (and credentials (str/blank? (:api-key credentials)))
+    (throw (core/missing-api-key-ex "OpenAI")))
+  (try
+    (let [auth (core/resolve-auth "openai" "OpenAI"
+                                  (when-let [k (or (not-empty (:api-key credentials))
+                                                   (not-empty (llm/llm-openai-api-key)))]
+                                    {:url     (llm/llm-openai-api-base-url)
+                                     :headers {"Authorization" (str "Bearer " k)}})
+                                  ai-proxy?)
+          res  (core/request auth {:method  :get
+                                   :url     "/v1/models"
+                                   :as      :json
+                                   :headers {"Content-Type" "application/json"}})]
+      (get-in res [:body :data]))
+    (catch Exception e
+      (core/rethrow-api-error! "openai" openai-error-msg e))))
+
 (defn list-models
-  "List available OpenAI models.
+  "List the OpenAI chat models supported by this adapter (see [[supported-models]]).
   No-arg uses the configured API key. Opts map supports `:credentials` (`{:api-key ...}`) and `:ai-proxy?`."
   ([] (list-models {}))
-  ([{:keys [credentials ai-proxy?]}]
-   (when (and credentials (str/blank? (:api-key credentials)))
-     (throw (core/missing-api-key-ex "OpenAI")))
-   (try
-     (let [auth (core/resolve-auth "openai" "OpenAI"
-                                   (when-let [k (or (not-empty (:api-key credentials))
-                                                    (not-empty (llm/llm-openai-api-key)))]
-                                     {:url     (llm/llm-openai-api-base-url)
-                                      :headers {"Authorization" (str "Bearer " k)}})
-                                   ai-proxy?)
-           res  (core/request auth {:method  :get
-                                    :url     "/v1/models"
-                                    :as      :json
-                                    :headers {"Content-Type" "application/json"}})]
-       {:models (mapv (fn [model]
-                        {:id           (:id model)
-                         :display_name (:id model)})
-                      (reverse (sort-by :created (get-in res [:body :data]))))})
-     (catch Exception e
-       (core/rethrow-api-error! "openai" openai-error-msg e)))))
+  ([opts]
+   {:models (->> (list-all-models opts)
+                 (filter supported-model?)
+                 (sort-by :id)
+                 (mapv (fn [{:keys [id]}]
+                         {:id id :display_name id})))}))
 
 (defn- model-supports-temperature?
   "Whether `model` accepts an explicit `temperature` parameter.

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -181,6 +181,11 @@
      :description doc
      :parameters  (mjs/transform params {:additionalProperties false})}))
 
+(defn- ai-proxy-unsupported-ex []
+  (ex-info (tru "AI proxy is not supported for OpenAI")
+           {:api-error  true
+            :error-code :proxy-unsupported}))
+
 (defn- openai-error-msg
   "Canonical, status-specific OpenAI error message."
   [res]
@@ -210,8 +215,11 @@
   (contains? supported-models id))
 
 (defn- list-all-models
-  "Fetch the full OpenAI model catalog (`GET /v1/models`)."
+  "Fetch the full OpenAI model catalog (`GET /v1/models`).
+  `:ai-proxy?` is not supported for OpenAI and throws when true."
   [{:keys [credentials ai-proxy?]}]
+  (when ai-proxy?
+    (throw (ai-proxy-unsupported-ex)))
   (when (and credentials (str/blank? (:api-key credentials)))
     (throw (core/missing-api-key-ex "OpenAI")))
   (try
@@ -231,7 +239,8 @@
 
 (defn list-models
   "List the OpenAI chat models supported by this adapter (see [[supported-models]]).
-  No-arg uses the configured API key. Opts map supports `:credentials` (`{:api-key ...}`) and `:ai-proxy?`."
+  No-arg uses the configured API key. Opts map supports `:credentials` (`{:api-key ...}`) and `:ai-proxy?`.
+  `:ai-proxy?` is not supported for OpenAI and throws when true."
   ([] (list-models {}))
   ([opts]
    {:models (->> (list-all-models opts)
@@ -276,9 +285,12 @@
       (assoc :temperature temperature))))
 
 (mu/defn openai-raw
-  "Perform a streaming request to OpenAI Responses API."
+  "Perform a streaming request to OpenAI Responses API.
+  `:ai-proxy?` is not supported for OpenAI and throws when true."
   [{:keys [model ai-proxy?] :as opts
     :or   {model "gpt-4.1-mini"}} :- core/LLMRequestOpts]
+  (when ai-proxy?
+    (throw (ai-proxy-unsupported-ex)))
   (let [req (openai-request-body opts)]
     (try
       (let [api-key  (not-empty (llm/llm-openai-api-key))

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -116,7 +116,7 @@
 
 (def ^:private default-openai-llm-metabot-model
   "Default OpenAI model used for Metabot when no explicit model is selected."
-  "gpt-4.1-mini")
+  "gpt-5.4")
 
 (def default-llm-metabot-provider
   "Default provider/model used for Metabot when no explicit model is selected."
@@ -248,7 +248,7 @@
     (validate-direct-provider! value)))
 
 (defsetting llm-metabot-provider
-  (deferred-tru "The AI provider and model for Metabot. Format: provider/model-name, e.g. `anthropic/claude-haiku-4-5`, `openai/gpt-4.1-mini`, `openrouter/anthropic/claude-haiku-4-5`.")
+  (deferred-tru "The AI provider and model for Metabot. Format: provider/model-name, e.g. `anthropic/claude-haiku-4-5`, `openai/gpt-5.4`, `openrouter/anthropic/claude-haiku-4-5`.")
   :type             :string
   :encryption       :no
   :default          default-llm-metabot-provider

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -114,6 +114,10 @@
   "Default Bedrock model used for Metabot when no explicit model is selected."
   "anthropic.claude-opus-4-8")
 
+(def ^:private default-openai-llm-metabot-model
+  "Default OpenAI model used for Metabot when no explicit model is selected."
+  "gpt-4.1-mini")
+
 (def default-llm-metabot-provider
   "Default provider/model used for Metabot when no explicit model is selected."
   (str "anthropic/" default-anthropic-llm-metabot-model))
@@ -125,6 +129,7 @@
   managed `metabase` provider uses the proxied `provider/model` form."
   {"anthropic"                            default-anthropic-llm-metabot-model
    "bedrock"                              default-bedrock-llm-metabot-model
+   "openai"                               default-openai-llm-metabot-model
    provider-util/metabase-provider-prefix default-llm-metabot-provider})
 
 (def default-metabase-llm-metabot-provider

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -394,21 +394,21 @@
       (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn
                                                              ([provider]
                                                               (is (= "openai" provider))
-                                                              {:models [{:id "gpt-4.1-mini"
-                                                                         :display_name "gpt-4.1-mini"}]})
+                                                              {:models [{:id "gpt-5.4"
+                                                                         :display_name "gpt-5.4"}]})
                                                              ([provider {:keys [credentials]}]
                                                               (is (= "openai" provider))
                                                               (is (= {:api-key "sk-fresh"} credentials))
-                                                              {:models [{:id "gpt-4.1-mini"
-                                                                         :display_name "gpt-4.1-mini"}]}))]
-        (is (= {:value  "openai/gpt-4.1-mini"
-                :models [{:id "gpt-4.1-mini"
-                          :display_name "gpt-4.1-mini"
-                          :group "GPT-4.1"}]}
+                                                              {:models [{:id "gpt-5.4"
+                                                                         :display_name "gpt-5.4"}]}))]
+        (is (= {:value  "openai/gpt-5.4"
+                :models [{:id "gpt-5.4"
+                          :display_name "gpt-5.4"
+                          :group "GPT-5.4"}]}
                (mt/user-http-request :crowberto :put 200 "metabot/settings"
                                      {:provider "openai"
                                       :api-key  "sk-fresh"})))
-        (is (= "openai/gpt-4.1-mini"
+        (is (= "openai/gpt-5.4"
                (metabot.settings/llm-metabot-provider)))
         (is (= "sk-fresh"
                (llm.settings/llm-openai-api-key)))))))

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -347,7 +347,7 @@
 
 (deftest settings-put-updates-provider-test
   (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-haiku-4-5"
-                                     llm.settings/llm-openai-api-key      "sk-valid"]
+                                     llm.settings/llm-openai-api-key       "sk-valid"]
     (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn
                                                            ([provider]
                                                             (is (= "openai" provider))
@@ -366,6 +366,31 @@
                                     :model    "gpt-4.1-mini"})))
       (is (= "openai/gpt-4.1-mini"
              (metabot.settings/llm-metabot-provider))))))
+
+(deftest settings-put-connect-openai-defaults-model-test
+  (testing "connecting openai with only an api-key switches to the default openai model"
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-haiku-4-5"
+                                       llm.settings/llm-openai-api-key       nil]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn
+                                                             ([provider]
+                                                              (is (= "openai" provider))
+                                                              {:models [{:id "gpt-4.1-mini"
+                                                                         :display_name "gpt-4.1-mini"}]})
+                                                             ([provider {:keys [credentials]}]
+                                                              (is (= "openai" provider))
+                                                              (is (= {:api-key "sk-fresh"} credentials))
+                                                              {:models [{:id "gpt-4.1-mini"
+                                                                         :display_name "gpt-4.1-mini"}]}))]
+        (is (= {:value  "openai/gpt-4.1-mini"
+                :models [{:id "gpt-4.1-mini"
+                          :display_name "gpt-4.1-mini"}]}
+               (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                     {:provider "openai"
+                                      :api-key  "sk-fresh"})))
+        (is (= "openai/gpt-4.1-mini"
+               (metabot.settings/llm-metabot-provider)))
+        (is (= "sk-fresh"
+               (llm.settings/llm-openai-api-key)))))))
 
 (deftest settings-put-updates-metabase-provider-without-api-key-test
   (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-haiku-4-5"]

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -327,6 +327,25 @@
              (mt/user-http-request :crowberto :get 200 "metabot/settings"
                                    :provider "openrouter"))))))
 
+(deftest settings-get-groups-openai-models-test
+  (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "openai/gpt-5-mini"
+                                     llm.settings/llm-openai-api-key       "sk-valid"]
+    (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [_provider {:keys [credentials]}]
+                                                           (is (= {:api-key "sk-valid"} credentials))
+                                                           {:models [{:id "gpt-5.5"      :display_name "gpt-5.5"}
+                                                                     {:id "gpt-5.5-pro"  :display_name "gpt-5.5-pro"}
+                                                                     {:id "gpt-5.4"      :display_name "gpt-5.4"}
+                                                                     {:id "gpt-5.4-mini" :display_name "gpt-5.4-mini"}
+                                                                     {:id "gpt-4.1-mini" :display_name "gpt-4.1-mini"}]})]
+      (is (= {:value  (metabot.settings/llm-metabot-provider)
+              :models [{:id "gpt-4.1-mini" :display_name "gpt-4.1-mini" :group "GPT-4.1"}
+                       {:id "gpt-5.4"      :display_name "gpt-5.4"      :group "GPT-5.4"}
+                       {:id "gpt-5.4-mini" :display_name "gpt-5.4-mini" :group "GPT-5.4"}
+                       {:id "gpt-5.5"      :display_name "gpt-5.5"      :group "GPT-5.5"}
+                       {:id "gpt-5.5-pro"  :display_name "gpt-5.5-pro"  :group "GPT-5.5"}]}
+             (mt/user-http-request :crowberto :get 200 "metabot/settings"
+                                   :provider "openai"))))))
+
 (deftest settings-get-returns-metabase-models-without-api-key-test
   (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"]
     (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn
@@ -360,7 +379,8 @@
                                                                        :display_name "GPT-4.1 mini"}]}))]
       (is (= {:value  "openai/gpt-4.1-mini"
               :models [{:id "gpt-4.1-mini"
-                        :display_name "GPT-4.1 mini"}]}
+                        :display_name "GPT-4.1 mini"
+                        :group "GPT-4.1"}]}
              (mt/user-http-request :crowberto :put 200 "metabot/settings"
                                    {:provider "openai"
                                     :model    "gpt-4.1-mini"})))
@@ -383,7 +403,8 @@
                                                                          :display_name "gpt-4.1-mini"}]}))]
         (is (= {:value  "openai/gpt-4.1-mini"
                 :models [{:id "gpt-4.1-mini"
-                          :display_name "gpt-4.1-mini"}]}
+                          :display_name "gpt-4.1-mini"
+                          :group "GPT-4.1"}]}
                (mt/user-http-request :crowberto :put 200 "metabot/settings"
                                      {:provider "openai"
                                       :api-key  "sk-fresh"})))

--- a/test/metabase/metabot/self/openai_test.clj
+++ b/test/metabase/metabot/self/openai_test.clj
@@ -255,6 +255,34 @@
              [{:type :tool-output :id "call-1" :error {:message "Tool failed"}}])))))
 
 ;;; ──────────────────────────────────────────────────────────────────
+;;; list-models filtering tests
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest ^:parallel supported-model?-test
+  (testing "whitelisted models are supported"
+    (doseq [id ["gpt-5.5" "gpt-5.4-mini" "gpt-4.1"]]
+      (is (true? (#'openai/supported-model? {:id id})) id)))
+  (testing "non-white-listed models are not supported"
+    (doseq [id ["gpt-4o" "o3" "text-embedding-3-small"]]
+      (is (false? (#'openai/supported-model? {:id id})) id))))
+
+(deftest list-models-filters-catalog-to-whitelist-test
+  (testing "list-models keeps only whitelisted models sorted by id"
+    (mt/with-temporary-setting-values [llm.settings/llm-openai-api-key "sk-test"]
+      (with-redefs [http/request (fn [_]
+                                   {:status 200
+                                    :body   {:data [{:id "gpt-5-mini"             :created 30}
+                                                    {:id "gpt-5.4"                :created 25}
+                                                    {:id "gpt-4.1"                :created 20}
+                                                    {:id "gpt-4o-mini"            :created 18}
+                                                    {:id "o3"                     :created 15}
+                                                    {:id "text-embedding-3-small" :created 8}
+                                                    {:id "whisper-1"              :created 7}]}})]
+        (is (= [{:id "gpt-4.1" :display_name "gpt-4.1"}
+                {:id "gpt-5.4" :display_name "gpt-5.4"}]
+               (:models (openai/list-models))))))))
+
+;;; ──────────────────────────────────────────────────────────────────
 ;;; temperature support tests
 ;;; ──────────────────────────────────────────────────────────────────
 

--- a/test/metabase/metabot/self/openai_test.clj
+++ b/test/metabase/metabot/self/openai_test.clj
@@ -260,10 +260,10 @@
 
 (deftest ^:parallel supported-model?-test
   (testing "whitelisted models are supported"
-    (doseq [id ["gpt-5.5" "gpt-5.4-mini" "gpt-4.1"]]
+    (doseq [id ["gpt-5.5" "gpt-5.4-mini" "gpt-5"]]
       (is (true? (#'openai/supported-model? {:id id})) id)))
   (testing "non-white-listed models are not supported"
-    (doseq [id ["gpt-4.1-mini" "gpt-4o" "o3" "text-embedding-3-small"]]
+    (doseq [id ["gpt-4.1" "gpt-4.1-mini" "gpt-4o" "o3" "text-embedding-3-small"]]
       (is (false? (#'openai/supported-model? {:id id})) id))))
 
 (deftest list-models-filters-catalog-to-whitelist-test
@@ -272,6 +272,7 @@
       (with-redefs [http/request (fn [_]
                                    {:status 200
                                     :body   {:data [{:id "gpt-5-mini"             :created 30}
+                                                    {:id "gpt-5"                  :created 28}
                                                     {:id "gpt-5.4"                :created 25}
                                                     {:id "gpt-4.1"                :created 20}
                                                     {:id "gpt-4.1-mini"           :created 19}
@@ -279,7 +280,7 @@
                                                     {:id "o3"                     :created 15}
                                                     {:id "text-embedding-3-small" :created 8}
                                                     {:id "whisper-1"              :created 7}]}})]
-        (is (= [{:id "gpt-4.1" :display_name "gpt-4.1"}
+        (is (= [{:id "gpt-5" :display_name "gpt-5"}
                 {:id "gpt-5.4" :display_name "gpt-5.4"}]
                (:models (openai/list-models))))))))
 

--- a/test/metabase/metabot/self/openai_test.clj
+++ b/test/metabase/metabot/self/openai_test.clj
@@ -263,7 +263,7 @@
     (doseq [id ["gpt-5.5" "gpt-5.4-mini" "gpt-4.1"]]
       (is (true? (#'openai/supported-model? {:id id})) id)))
   (testing "non-white-listed models are not supported"
-    (doseq [id ["gpt-4o" "o3" "text-embedding-3-small"]]
+    (doseq [id ["gpt-4.1-mini" "gpt-4o" "o3" "text-embedding-3-small"]]
       (is (false? (#'openai/supported-model? {:id id})) id))))
 
 (deftest list-models-filters-catalog-to-whitelist-test
@@ -274,6 +274,7 @@
                                     :body   {:data [{:id "gpt-5-mini"             :created 30}
                                                     {:id "gpt-5.4"                :created 25}
                                                     {:id "gpt-4.1"                :created 20}
+                                                    {:id "gpt-4.1-mini"           :created 19}
                                                     {:id "gpt-4o-mini"            :created 18}
                                                     {:id "o3"                     :created 15}
                                                     {:id "text-embedding-3-small" :created 8}

--- a/test/metabase/metabot/self/openai_test.clj
+++ b/test/metabase/metabot/self/openai_test.clj
@@ -335,17 +335,6 @@
                      :headers {"Authorization" "Bearer sk-ant-byok"}
                      :body    string?}
                     (openai/openai-raw {:input [{:role :user :content "hi"}]})))))
-        (testing "Uses ai proxy when explicitly requested"
-          (mt/with-temporary-setting-values [llm.settings/llm-openai-api-key nil]
-            (with-redefs [self.core/sse-reducible identity
-                          debug/capture-stream    (fn [r _] r)
-                          http/request            (fn [req] {:body req})]
-              (is (=? {:method  :post
-                       :url     "https://proxy.example/openai/v1/responses"
-                       :headers {"x-metabase-instance-token" "proxy-token"}
-                       :body    string?}
-                      (openai/openai-raw {:input [{:role :user :content "hi"}]
-                                          :ai-proxy? true}))))))
         (testing "Does not fall back to ai proxy when BYOK is missing"
           (mt/with-temporary-setting-values [llm.settings/llm-openai-api-key nil]
             (is (thrown-with-msg?
@@ -359,3 +348,27 @@
                  clojure.lang.ExceptionInfo
                  #"No OpenAI API key is set"
                  (openai/openai-raw {:input [{:role :user :content "hi"}]})))))))))
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; AI proxy (unsupported)
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest list-models-ai-proxy-unsupported-test
+  (testing "ai-proxy? throws before credentials are even consulted"
+    (mt/with-temporary-setting-values [llm.settings/llm-openai-api-key nil]
+      (with-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"AI proxy is not supported for OpenAI"
+             (openai/list-models {:ai-proxy? true})))))))
+
+(deftest openai-raw-ai-proxy-unsupported-test
+  (testing "ai-proxy? throws before credentials are even consulted"
+    (mt/with-temporary-setting-values [llm.settings/llm-openai-api-key nil]
+      (with-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"AI proxy is not supported for OpenAI"
+             (openai/openai-raw {:model     "gpt-4.1-mini"
+                                 :input     [{:role :user :content "hi"}]
+                                 :ai-proxy? true})))))))


### PR DESCRIPTION
Closes [BOT-1723: Support OpenAI models](https://linear.app/metabase/issue/BOT-1723/support-openai-models)

### Description

Allow the user to configure openai as a model provider in `/admin/metabot`.

* Add `default-openai-llm-metabot-model` set to gpt-4.1-mini
* Filter openai `list-models` by supported-models. OpenAI's `/v1/models` endpoint returns ~140 models, many of which are not relevant (text embeddings, audio/video models) or else deprecated. Filter this down to a whitelisted set of known supported models.
* Add grouping for openai models in `provider-models-response`
* Throw an exception if callers pass `:ai-proxy true` for openai. Similar to bedrock and azure, supporting this would require some work on the ai-service side, and we already reject non-anthropic in `validate-metabase-managed-provider!`
* FE: enable openai provider in metabot admin UI config

### Demo

<img width="809" height="676" alt="Screenshot 2026-06-24 at 3 36 13 PM" src="https://github.com/user-attachments/assets/bac1dadb-340e-45b0-be73-ded1a7437887" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
