### PR TITLE
Lint: flag eager toucan selects against huge tables (OOM guardrail)

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -72,6 +72,7 @@
   :metabase/no-jsqlparser-imports                            {:level :warning}
   :metabase/prefer-with-dynamic-fn-redefs                    {:level :warning}
   :metabase/toucan-model-ns                                  {:level :warning}
+  :metabase/big-table-eager-select                           {:level :warning}
   :metabase/require-shape-checker                            {:level :warning}
   :metabase/tests-must-live-in-known-modules                 {:level :warning}
   :metabase/validate-defendpoint-route-uses-kebab-case       {:level :warning}
@@ -605,6 +606,13 @@
    metabase.lib.schema.mbql-clause/define-tuple-mbql-clause                                                                  hooks.metabase.lib.schema.mbql-clause/define-mbql-clause
    methodical.core/defmethod                                                                                                 hooks.metabase.toucan.table-name/lint-defmethod
    methodical.macros/defmethod                                                                                               hooks.metabase.toucan.table-name/lint-defmethod
+   toucan2.core/select                                                                                                       hooks.metabase.toucan.big-table-select/lint
+   toucan2.core/select-fn-set                                                                                                hooks.metabase.toucan.big-table-select/lint
+   toucan2.core/select-fn-vec                                                                                                hooks.metabase.toucan.big-table-select/lint
+   toucan2.core/select-fn->fn                                                                                                hooks.metabase.toucan.big-table-select/lint
+   toucan2.core/select-fn->map                                                                                              hooks.metabase.toucan.big-table-select/lint
+   toucan2.core/select-pks-set                                                                                               hooks.metabase.toucan.big-table-select/lint
+   toucan2.core/select-pks-vec                                                                                               hooks.metabase.toucan.big-table-select/lint
    metabase.lib.test-util.macros/$ids                                                                                        hooks.metabase.test.data/$ids
    metabase.lib.test-util.macros/mbql-query                                                                                  hooks.metabase.test.data/mbql-query
    metabase.lib.test-util.macros/mbql-5-query                                                                                hooks.metabase.test.data/mbql-query

--- a/.clj-kondo/src/hooks/metabase/toucan/big_table_select.clj
+++ b/.clj-kondo/src/hooks/metabase/toucan/big_table_select.clj
@@ -1,0 +1,76 @@
+(ns hooks.metabase.toucan.big-table-select
+  "Lint that flags eager, fully-realizing toucan2 selects against tables that
+  can grow to millions/billions of rows (e.g. `:model/DataPermissions`,
+  `:model/Field`, `:model/Table`). Realizing all rows of such a table into a
+  Clojure collection OOMs the JVM. The fix is almost always to push the work
+  into the DB: add `{:select-distinct [...]}` or `{:limit n}`, or use a
+  reducible select that streams.
+
+  A call is considered safe (and not flagged) when its trailing options map
+  contains `:select-distinct`, `:limit`, or `:select` — these bound or
+  project the result set in the database.
+
+  Reducible selects (`select-reducible`, `reducible-query`) are intentionally
+  NOT flagged: they are the streaming escape hatch, not the problem."
+  (:require
+   [clj-kondo.hooks-api :as hooks]))
+
+(def ^:private big-models
+  "Toucan models whose tables can be huge; eager selection OOMs."
+  #{:model/DataPermissions
+    :model/Field
+    :model/Table})
+
+(def ^:private fn->model-arg-index
+  "For each flagged eager-select fn, the 0-based index (among the call's
+  arguments, i.e. children after the fn symbol) at which the model appears."
+  {"select"        0
+   "select-fn-set" 1   ; (f model & conditions)
+   "select-fn-vec" 1
+   "select-fn->fn" 2   ; (k v model & conditions)
+   "select-fn->map" 2
+   "select-pks-set" 0  ; (model & conditions)
+   "select-pks-vec" 0})
+
+(defn- toucan-select-fn?
+  "If `sym` is a flagged toucan2 select fn (as `t2/…` or `toucan2.core/…`),
+  return its bare name, else nil."
+  [sym]
+  (when (symbol? sym)
+    (let [nom (name sym)]
+      (when (and (contains? fn->model-arg-index nom)
+                 (#{"t2" "toucan2.core"} (namespace sym)))
+        nom))))
+
+(defn- bounded-options?
+  "True if any trailing child is an options map literal that bounds/projects
+  the result set in the DB (`:select-distinct`, `:limit`, or `:select`)."
+  [option-nodes]
+  (boolean
+   (some (fn [node]
+           (when (hooks/map-node? node)
+             (let [ks (->> (:children node)
+                           (partition 2)
+                           (map (comp hooks/sexpr first)))]
+               (some #{:select-distinct :limit :select} ks))))
+         option-nodes)))
+
+(defn lint
+  [{:keys [node] :as input}]
+  (let [children (:children node)
+        [fn-sym & args] children
+        fn-name (some-> fn-sym hooks/sexpr toucan-select-fn?)]
+    (when fn-name
+      (let [model-idx (fn->model-arg-index fn-name)
+            model-node (nth args model-idx nil)
+            model (when model-node
+                    (try (hooks/sexpr model-node) (catch Exception _ nil)))]
+        (when (and (contains? big-models model)
+                   (not (bounded-options? (drop (inc model-idx) args))))
+          (hooks/reg-finding!
+           (assoc (meta (or model-node node))
+                  :message (format (str "`t2/%s` against %s realizes the whole table into memory and can OOM. "
+                                        "Add `{:select-distinct [...]}` or `{:limit n}`, or use a reducible select.")
+                                   fn-name model)
+                  :type :metabase/big-table-eager-select))))))
+  input)

--- a/.clj-kondo/test/hooks/metabase/toucan/big_table_select_test.clj
+++ b/.clj-kondo/test/hooks/metabase/toucan/big_table_select_test.clj
@@ -1,0 +1,49 @@
+(ns hooks.metabase.toucan.big-table-select-test
+  (:require
+   [clj-kondo.hooks-api :as hooks]
+   [clj-kondo.impl.utils]
+   [clojure.test :refer :all]
+   [hooks.metabase.toucan.big-table-select :as big-table-select]))
+
+(defn- lint [form]
+  (binding [clj-kondo.impl.utils/*ctx* {:config     {:linters {:metabase/big-table-eager-select {:level :warning}}}
+                                        :ignores    (atom nil)
+                                        :findings   (atom [])
+                                        :namespaces (atom {})}]
+    (big-table-select/lint {:node (hooks/parse-string (pr-str form))})
+    @(:findings clj-kondo.impl.utils/*ctx*)))
+
+(deftest ^:parallel flags-eager-select-against-big-table-test
+  (testing "select-fn-set against a big table is flagged"
+    (is (=? [{:type :metabase/big-table-eager-select}]
+            (lint '(t2/select-fn-set :db_id :model/DataPermissions :group_id 1)))))
+  (testing "select-pks-set (model is first arg) is flagged"
+    (is (=? [{:type :metabase/big-table-eager-select}]
+            (lint '(t2/select-pks-set :model/Field :table_id 1)))))
+  (testing "select-fn->fn (model is third arg) is flagged"
+    (is (=? [{:type :metabase/big-table-eager-select}]
+            (lint '(t2/select-fn->fn :id :name :model/Table)))))
+  (testing "plain select against a big table is flagged"
+    (is (=? [{:type :metabase/big-table-eager-select}]
+            (lint '(t2/select :model/Field :table_id 1)))))
+  (testing "toucan2.core-qualified is also recognized"
+    (is (=? [{:type :metabase/big-table-eager-select}]
+            (lint '(toucan2.core/select-fn-set :db_id :model/DataPermissions))))))
+
+(deftest ^:parallel allows-bounded-selects-test
+  (testing ":select-distinct in options opts out"
+    (is (empty? (lint '(t2/select-fn-set :db_id :model/DataPermissions
+                                         :group_id 1
+                                         {:select-distinct [:db_id]})))))
+  (testing ":limit in options opts out"
+    (is (empty? (lint '(t2/select-fn-set :db_id :model/DataPermissions {:limit 100})))))
+  (testing ":select projection in options opts out"
+    (is (empty? (lint '(t2/select :model/Field {:select [:id] :limit 10}))))))
+
+(deftest ^:parallel ignores-unrelated-calls-test
+  (testing "eager select against a non-big table is fine"
+    (is (empty? (lint '(t2/select-fn-set :id :model/Card :collection_id 1)))))
+  (testing "reducible selects are not flagged (streaming escape hatch)"
+    (is (empty? (lint '(t2/select-reducible :model/Field)))))
+  (testing "non-toucan fns are ignored"
+    (is (empty? (lint '(some.other/select-fn-set :db_id :model/Field))))))


### PR DESCRIPTION
## Why

A raw `t2/select-fn-set :db_id :model/DataPermissions ... :db_id [:in db-ids]` is an instant OOM: `DataPermissions` can have millions/billions of rows, and `select-fn-set` realizes the entire result set into a Clojure collection before deduping. The fix at the call site is to push the work into the DB - `{:select-distinct [:db_id]}` - but nothing stops the next dev or agent from writing the eager form again.

This adds a clj-kondo guardrail that catches the eager form at lint time, before CI.

## Approach

A clj-kondo `:analyze-call` hook on the fully-realizing toucan2 select fns (`select`, `select-fn-set`, `select-fn-vec`, `select-fn->fn`, `select-fn->map`, `select-pks-set`, `select-pks-vec`). It flags a call only when:

1. the model argument is in a small denylist of known-huge tables (`:model/DataPermissions`, `:model/Field`, `:model/Table`), **and**
2. the options map does **not** contain `:select-distinct`, `:limit`, or `:select` (these bound/project the result in the DB).

Model-arg position varies per fn (`select-fn-set` is `(f model & conds)`, `select-pks-set` is `(model & conds)`, `select-fn->fn` is `(k v model & conds)`), so the hook maps each fn to its model-arg index rather than guessing.

Reducible selects (`select-reducible`, `reducible-query`) are intentionally **not** flagged - they stream, so they are the escape hatch, not the problem.

## Scope / what this is not

This is a **guardrail, not the root fix**. The underlying cause is a PG/Redshift JDBC quirk: cursor-based streaming only kicks in when `autoCommit=false`, so with the default these drivers buffer the whole result set in the client. The real fix is to disable autoCommit for non-`:write` selects on those drivers - a separate, larger effort owned by querying-platform. This PR just stops the easy footguns in the meantime.

Adding more huge tables later is a one-line addition to the `big-models` set.

## Verified

- 11 hook unit-test assertions pass (`hooks.metabase.toucan.big-table-select-test`).
- Ran real `clj-kondo` against a probe file: raw `select-fn-set` against `:model/DataPermissions` flagged; the `{:select-distinct ...}` form silent; `:model/Card` (not huge) silent.

Context: [Slack thread](https://metaboat.slack.com) from @alexander.polyankin / @bgrabow.