### PR TITLE
Fix Metabot failure on empty query builder by registering adhoc context

### DIFF
--- a/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.tsx
+++ b/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.tsx
@@ -254,25 +254,26 @@ export const registerQueryBuilderMetabotContextFn = async ({
   const hasDataSource = isNative
     ? Lib.databaseID(query) != null
     : Lib.sourceTableOrCardId(query) != null;
-  if (!hasDataSource) {
-    return {};
-  }
 
-  const queryCtx = {
-    query: question.datasetQuery(),
-    sql_engine: isNative ? Lib.engine(query) : undefined,
-    // Coerce to string to avoid passing objects with circular references
-    // (e.g. Metadata ↔ Database) that would break JSON.stringify in the
-    // streaming request body.
-    error: queryResult?.error?.toString(),
-  };
+  const queryCtx = hasDataSource
+    ? {
+        query: question.datasetQuery(),
+        sql_engine: isNative ? Lib.engine(query) : undefined,
+        // Coerce to string to avoid passing objects with circular references
+        // (e.g. Metadata ↔ Database) that would break JSON.stringify in the
+        // streaming request body.
+        error: queryResult?.error?.toString(),
+      }
+    : {};
 
-  const chart_configs = await getChartConfigs({
-    question,
-    series,
-    visualizationSettings,
-    timelineEvents,
-  });
+  const chart_configs = hasDataSource
+    ? await getChartConfigs({
+        question,
+        series,
+        visualizationSettings,
+        timelineEvents,
+      })
+    : [];
 
   return {
     user_is_viewing: [

--- a/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.unit.spec.tsx
@@ -128,7 +128,7 @@ describe("registerQueryBuilderMetabotContextFn", () => {
     expect(viewing.type).toEqual("adhoc");
   });
 
-  it("should register no context for adhoc questions without a data source", async () => {
+  it("should register an adhoc context for questions without a data source", async () => {
     const question = new Question(
       createAdHocCard({
         dataset_query: { type: "query", database: null, query: {} },
@@ -138,7 +138,10 @@ describe("registerQueryBuilderMetabotContextFn", () => {
     const data = createMockData({ question });
     const result = await registerQueryBuilderMetabotContextFn(data);
 
-    expect(result).toEqual({});
+    expect(getUserIsViewing(result)).toEqual({
+      type: "adhoc",
+      chart_configs: [],
+    });
   });
 
   it("should generate an image for the current question", async () => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

When a user opens the inline Metabot sidebar from a brand-new, empty query builder question (the "Pick your starting data" state, before any table/data source is selected) and asks Metabot to build a query, Metabot fails with the generic error:

> Sorry, I ran into an error. Could you please try that again?

The root cause is that the query-builder context provider returns `{}` for questions without a data source. That was introduced in #75569 to avoid sending invalid empty queries to the backend, but it also strips away all viewing context. Without any `user_is_viewing` item, the agent fails when the user asks it to build a query from scratch.

This change keeps the protection from #75569 (we still omit the empty `query`/`sql_engine`/`error` fields) but now registers an `adhoc` viewing-context item for empty questions:

```js
{ type: "adhoc", chart_configs: [] }
```

That tells the agent the user is in the notebook editor and allows it to search for and select an appropriate data source, then build the requested query.

### How to verify

1. Click **+ New → Question** to open the query builder on a new, empty question.
2. Open the inline Metabot chat panel.
3. Ask Metabot to build a query/table (e.g., "Show me all orders").
4. Metabot should build the query and navigate you to the result instead of returning the generic error.

### Demo

_Removed — no sensible static screenshot captures the agent behavior._

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/76503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

