### PR TITLE
Simple shared image buffers for rendering

### DIFF
--- a/src/metabase/channel/render/image_buffer.clj
+++ b/src/metabase/channel/render/image_buffer.clj
@@ -1,0 +1,54 @@
+(ns metabase.channel.render.image-buffer
+  "A small, thread-safe pool of reusable ARGB [[java.awt.image.BufferedImage]] buffers, held via
+  [[java.lang.ref.SoftReference]] so the GC can reclaim idle ones under memory pressure."
+  (:require
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.schema :as ms])
+  (:import
+   (java.awt AlphaComposite)
+   (java.awt.image BufferedImage)
+   (java.lang.ref SoftReference)
+   (java.util.concurrent ConcurrentHashMap)))
+
+(set! *warn-on-reflection* true)
+
+(defonce ^:private pool (ConcurrentHashMap.))
+
+(mu/defn- cache-key :- [:tuple :int :int]
+  "Pool key for a `w` x `h` buffer. `w`/`h` are coerced to `long` so the key is type-stable: `acquire` is called with
+  longs but `release` reads ints off the image, and a Clojure vector key compares elements with Java `.equals`, where
+  `(long 5)` != `(int 5)`."
+  [w :- :int
+   h :- :int]
+  [(long w) (long h)])
+
+(mu/defn- clear!
+  "Reset every pixel of `img` to fully transparent so a reused buffer never shows the previous render's pixels."
+  [img :- (ms/InstanceOfClass BufferedImage)]
+  (let [g (.createGraphics ^BufferedImage img)]
+    (try
+      (.setComposite g (AlphaComposite/getInstance AlphaComposite/CLEAR))
+      (.fillRect g 0 0 (.getWidth ^BufferedImage img) (.getHeight ^BufferedImage img))
+      (finally
+        (.dispose g)))))
+
+(mu/defn acquire :- (ms/InstanceOfClass BufferedImage)
+  "Return a cleared `TYPE_INT_ARGB` [[BufferedImage]] of exactly `w` x `h`, reusing the pooled buffer for that size if
+  the GC hasn't reclaimed it. Pass the result to [[release]] when finished so it can be reused."
+  [w :- :int
+   h :- :int]
+  ;; `remove` takes ownership: a concurrent render of the same size won't get the same buffer, it'll allocate its own.
+  (let [ref (.remove ^ConcurrentHashMap pool (cache-key w h))
+        img (some-> ^SoftReference ref .get)]
+    (if img
+      (do (clear! img) img)
+      (BufferedImage. (int w) (int h) BufferedImage/TYPE_INT_ARGB))))
+
+(mu/defn release
+  "Return `img` to the pool so it can be reused, replacing any current idle buffer of its size. Safe to call with
+  `nil`."
+  [img :- [:maybe (ms/InstanceOfClass BufferedImage)]]
+  (when img
+    (.put ^ConcurrentHashMap pool
+          (cache-key (.getWidth ^BufferedImage img) (.getHeight ^BufferedImage img))
+          (SoftReference. img))))

--- a/src/metabase/channel/render/image_buffer.clj
+++ b/src/metabase/channel/render/image_buffer.clj
@@ -1,209 +1,161 @@
 (ns metabase.channel.render.image-buffer
-  "A process-wide, size-keyed recycler of ARGB [[java.awt.image.BufferedImage]] buffers, shared across all rendering
-  threads and both rasterizing render paths.
+  "A small pool of reusable, fixed-size `int[]` pixel arrays that back the ARGB [[java.awt.image.BufferedImage]]s chart
+  rasterization renders into, shared across all rendering threads.
 
-  This exists to cut *allocation pressure*, NOT to constrain a scarce resource. The job is to avoid the churn of
-  allocating-and-discarding a multi-MB buffer on every render by handing back a recently-returned one of the same size.
-  It is therefore an OVERFLOWING recycler, not a bounded resource pool: [[acquire]] never blocks and never refuses --
-  an empty pool always allocates a fresh buffer, so there is no limit on how many buffers are live at once. (The
-  genuinely scarce resource here, the static-viz JS engines, is already constrained by its own bounded pool upstream;
-  buffers are cheap to allocate, so blocking a render to wait for one would be a pure throughput regression.)
+  Why: rasterizing a chart (SVG via Batik) paints into a `width * height * 4` byte buffer -- 3-6 MB at dashboard
+  sizes.  Under the default G1 GC any object over half a region (~1 MB at a 2 MB region) is \"humongous\": allocated
+  into dedicated regions a young GC can't reclaim. Subscriptions render in bursts, so without reuse these pile up
+  faster than mixed/full GCs reclaim the regions and the JVM OOMs on region exhaustion while most of the heap is free.
 
-  The caps below govern RETENTION only: on check-in ([[release]]) idle buffers are kept up to `:per-size-cap` per size
-  and `:global-cap` total, and any surplus is simply dropped (GC reclaims it). So the caps bound *resident idle
-  memory*, not concurrency. A daemon thread additionally evicts buffers idle past `:idle-ttl-ms`, walking each size's
-  deque from its oldest end until it reaches a still-fresh entry, so the recycler drains to zero when rendering stops
-  and holds memory only while actively rendering.
+  What we reuse and why this shape: the only expensive, humongous part of a `BufferedImage` is its backing `int[]`.
+  Constructing the wrapper objects (`DataBufferInt` + raster + the *cached* `ColorModel/getRGBdefault`) around an
+  existing array is ~1 us (verified) -- and critically, one oversized `int[]` can back an image of ANY `w` x `h` whose
+  `w*h` fits it, because `createPackedRaster` re-interprets the flat array at the new scanline stride. So we don't
+  need a per-size cache: we pool a few `int[]`s of one fixed size big enough to cover the vast majority of renders,
+  and on each [[acquire]] wrap a throwaway correctly-sized image around one. A render that needs *more* pixels than
+  the fixed size just gets a fresh standard `BufferedImage` (the original behavior) -- a rare one-off, not pooled. We
+  pool the arrays, not the images, to keep the minimum in memory.
 
-  Why this and not the alternatives: a *chart* (SVG/Batik, [[metabase.channel.render.js.svg/render-svg]]) or *table*
-  (HTML/CSSBox, [[metabase.channel.render.png/render-html-to-png]]) rasterizes into a `width * height * 4` byte buffer
-  -- 3-6 MB at dashboard sizes. Under the default G1 GC any object over half a region (~1 MB at a 2 MB region) is
-  \"humongous\": allocated into dedicated regions a young GC can't reclaim. Subscriptions render in bursts, so without
-  recycling these pile up faster than mixed/full GCs reclaim the regions and the JVM OOMs on region exhaustion while
-  most of the heap is free. We hold STRONG references (not SoftReference, which clears only at the OOM edge -- that
-  would relocate the pressure, not remove it) and evict explicitly, so memory tracks activity. Instrumentation of real
-  email and Slack sends showed renders fan across many Jetty threads (so the recycler must be *shared*, not
-  thread-local, or it stays cold) and only a handful of distinct sizes recur (~6 retained per size reaches ~60% reuse).
+  Reuse is safe because Batik PNG-encodes the buffer eagerly and returns only a `byte[]`; the image never escapes. The
+  one load-bearing rule is clearing the used region on acquire (Batik composites with `SrcOver` and skips its
+  background fill when the background is nil, so stale pixels would bleed a previous render through).
 
-  Reuse is safe because both rasterizers PNG-encode the buffer eagerly and synchronously and return only a `byte[]`;
-  the `BufferedImage` never escapes, so a reused buffer cannot corrupt already-returned bytes. The one load-bearing
-  rule is [[clear!]]-on-acquire (Batik composites with `SrcOver` and skips its background fill when the background is
-  nil, so stale pixels would bleed through).
+  Concurrency: the idle arrays live in a `ConcurrentLinkedDeque`, so every operation is lock-free and thread-safe on
+  its own; there is no cross-operation invariant to protect. [[acquire]] never blocks and never refuses. Retention is
+  bounded to `:max-arrays` idle arrays (a best-effort check on [[release]] -- occasionally keeping one extra under a
+  race is harmless, it is only a retention cap). A daemon thread periodically clears idle arrays so memory drains to
+  zero when rendering stops.
 
-  A pool is just a plain map built by [[->pool]] (its own buffer map, its own counters, its own config); the core
-  functions take one as their first argument. Prod uses the [[default-pool]] via the no-pool arities; it is built (and
-  its sweeper started) lazily on first use, not at namespace load, so AOT compilation doesn't spawn the daemon. Tests
-  construct an isolated pool with [[->pool]] so they can assert on its counters/contents without the singleton's
-  residue or its background sweeper."
+  Pools are plain maps built by [[->pool]]; the core fns take one. The no-arg arities target the process-wide
+  [[default-pool]], which is built lazily on first use (so AOT compilation, which loads every namespace, doesn't
+  allocate it or spawn its sweeper thread). Only the default pool has a sweeper; tests build isolated, sweeper-free
+  pools with [[->pool]]."
   (:require
-   [metabase.util.log :as log]
-   [metabase.util.malli :as mu]
-   [metabase.util.malli.schema :as ms])
+   [metabase.util.log :as log])
   (:import
-   (java.awt.image BufferedImage DataBufferInt)
-   (java.util ArrayDeque Deque)
-   (java.util.concurrent ConcurrentHashMap Executors ScheduledExecutorService ThreadFactory TimeUnit)
-   (java.util.concurrent.atomic LongAdder)
-   (java.util.function Function)))
+   (java.awt Point)
+   (java.awt.image BufferedImage ColorModel DataBufferInt Raster WritableRaster)
+   (java.util.concurrent ConcurrentLinkedDeque Executors ScheduledExecutorService ThreadFactory TimeUnit)
+   (java.util.concurrent.atomic LongAdder)))
 
 (set! *warn-on-reflection* true)
 
-(def ^:private default-per-size-cap
-  "Retention limit: max idle buffers KEPT per distinct size on check-in (not a limit on live/checked-out buffers --
-  acquire never refuses). ~6 is the knee of the measured hit-rate curve (4-8); past it adds little reuse for more
-  resident memory."
+(def ^:private default-array-pixels
+  "Fixed size (in pixels = ints) of every pooled array. ~2x the size that covers the vast majority of dashboard renders
+  (1200 wide x up to ~1350 tall ~= 1.6M px), so it also fits 2x-supersampled variants. A render needing more pixels
+  falls back to a fresh standard image. At 4 bytes/pixel a pooled array is ~13 MB."
+  (* 1200 2700))
+
+(def ^:private default-max-arrays
+  "Max idle pooled arrays retained. Bounded by render concurrency (a few Jetty/notification threads), not request rate."
   6)
 
-(def ^:private default-global-cap
-  "Retention limit: max idle buffers kept across all sizes -- a backstop so an unusual spread of sizes can't grow
-  resident idle memory without bound. Again a retention cap, not an admission/concurrency cap."
-  24)
-
 (def ^:private default-idle-ttl-ms
-  "Buffers not reused within this long are dropped by [[sweep!]] so the recycler drains to zero on an idle instance."
+  "How often the daemon drops idle arrays; if nothing was rendered in the interval, the pool drains to zero."
   60000)
 
-(defn ->pool
-  "Construct a fresh, independent pool: a plain map of its own buffer store, counters, and config. With no args uses the
-  production caps/TTL. Tests pass their own to isolate from the [[default-pool]] (a constructed pool shares no state
-  with it and has no background sweeper attached).
+;; Standard non-premultiplied sRGB ARGB color model -- a cached singleton. Using this (rather than constructing a
+;; DirectColorModel) keeps wrapping cheap: a premultiplied/mismatched color model makes the BufferedImage ctor run a
+;; full-raster per-pixel `coerceData` conversion (~7 ms), whereas getRGBdefault matches the raster (no-op).
+(def ^:private ^ColorModel rgb-default (ColorModel/getRGBdefault))
+(def ^:private ^"[I" argb-masks (int-array [0x00ff0000 0x0000ff00 0x000000ff (unchecked-int 0xff000000)]))
 
-  Shape: `:buffers` maps [w h] (longs) -> ArrayDeque of {:img BufferedImage :last-used-ms long}, holding STRONG
-  references (NOT SoftReference: soft refs only clear at the edge of OOM, the failure mode we're avoiding). Each
-  per-size ArrayDeque is guarded by synchronizing on itself; the outer map is a ConcurrentHashMap. `:hits`/`:misses`
-  are this pool's own reuse counters."
-  ([] (->pool {}))
-  ([{:keys [per-size-cap global-cap idle-ttl-ms]
-     :or   {per-size-cap default-per-size-cap
-            global-cap   default-global-cap
-            idle-ttl-ms  default-idle-ttl-ms}}]
-   {:buffers      (ConcurrentHashMap.)
-    :hits         (LongAdder.)
-    :misses       (LongAdder.)
-    ;; cumulative hits/misses as of this pool's last [[log-stats!]] call, so the periodic log can report the interval
-    ;; since the previous one. Per-pool (not a namespace global) so multiple pools don't clobber each other's baseline.
-    :last-logged  (atom {:hits 0 :misses 0})
-    :per-size-cap per-size-cap
-    :global-cap   global-cap
-    :idle-ttl-ms  idle-ttl-ms}))
-
-;; THE pool prod renders use, returned by the [[default-pool]] accessor. It is lazily built (and its sweeper started)
-;; on first use, NOT at namespace load -- so AOT compilation, which loads every namespace, doesn't spawn the daemon
-;; thread or allocate the pool at build time. The public no-pool arities call [[default-pool]].
 (declare default-pool)
 
-(def ^:private new-deque
-  (reify Function (apply [_ _] (ArrayDeque.))))
+(defn ->pool
+  "Construct a fresh, independent pool: a plain map of its idle-array store, counters, and config. With no args uses
+  production sizing. Tests pass their own to isolate from the [[default-pool]] (and get no sweeper).
 
-(defn- deque-for ^Deque [pool ^long w ^long h]
-  ;; Key coerced to longs so it is type-stable: acquire is called with longs but release reads ints off the image,
-  ;; and a Clojure vector key compares elements with Java .equals, where (.equals (long 5) (int 5)) is false.
-  (.computeIfAbsent ^ConcurrentHashMap (:buffers pool) [w h] new-deque))
+  `:idle` is a `ConcurrentLinkedDeque` of idle `int[]`, each of length `:array-pixels`. `:hits`/`:misses`/`:one-offs`
+  are counters (a \"one-off\" is a render too large for the fixed array, handed a fresh standard image)."
+  ([] (->pool {}))
+  ([{:keys [array-pixels max-arrays idle-ttl-ms]
+     :or   {array-pixels default-array-pixels max-arrays default-max-arrays idle-ttl-ms default-idle-ttl-ms}}]
+   {:idle         (ConcurrentLinkedDeque.)
+    :hits         (LongAdder.)
+    :misses       (LongAdder.)
+    :one-offs     (LongAdder.)
+    :last-logged  (atom {:hits 0 :misses 0})
+    :array-pixels array-pixels
+    :max-arrays   max-arrays
+    :idle-ttl-ms  idle-ttl-ms}))
 
-(defn- idle-total
-  "Number of idle buffers held across all sizes. Derived by summing deque sizes rather than tracked in a separate
-  counter -- a parallel counter is drift-prone (it would diverge from the deques on a partial failure), and with only a
-  handful of distinct sizes this scan is cheap."
-  ^long [pool]
-  (reduce (fn [^long acc ^Deque d] (+ acc (long (locking d (.size d)))))
-          0
-          (.values ^ConcurrentHashMap (:buffers pool))))
+(defn- wrap-array
+  "Wrap an existing `int[]` (length >= w*h) as a `w` x `h` ARGB [[BufferedImage]]. Throwaway wrapper (~1 us); only
+  `backing` carries the humongous cost."
+  ^BufferedImage [^"[I" backing ^long w ^long h]
+  (let [db (DataBufferInt. backing (int (* w h)))
+        ^WritableRaster raster (Raster/createPackedRaster db (int w) (int h) (int w) argb-masks (Point. 0 0))]
+    (BufferedImage. rgb-default raster false nil)))
 
-(defn- idle-by-size
-  "Map of `[w h]` -> number of idle buffers currently pooled for that size. Sizes with no idle buffers are omitted."
-  [pool]
-  (into {}
-        (keep (fn [^java.util.Map$Entry e]
-                (let [^Deque d (.getValue e)
-                      n (locking d (.size d))]
-                  (when (pos? n) [(vec (.getKey e)) n]))))
-        (.entrySet ^ConcurrentHashMap (:buffers pool))))
-
-(mu/defn- clear!
-  "Reset every pixel of `img` to fully transparent so a reused buffer never shows the previous render's pixels.
-  Load-bearing for correctness, not just hygiene (see ns docstring). Zeroes the backing `int[]` directly -- a
-  full-raster wipe needing no `Graphics2D` allocation."
-  [img :- (ms/InstanceOfClass BufferedImage)]
-  (let [buf (.getDataBuffer (.getRaster ^BufferedImage img))]
-    (java.util.Arrays/fill (.getData ^DataBufferInt buf) (int 0))))
+(defn- cleared-array
+  "An `int[]` of `array-pixels` length with its first `need` ints zeroed (the region this render will use). Reuses one
+  from `idle` if available (a hit), else allocates (a miss). Clearing is load-bearing -- see ns docstring."
+  ^"[I" [pool ^long need]
+  (let [^"[I" backing (if-let [^"[I" reused (.pollFirst ^ConcurrentLinkedDeque (:idle pool))]
+                        (do (.increment ^LongAdder (:hits pool)) reused)
+                        (do (.increment ^LongAdder (:misses pool)) (int-array (long (:array-pixels pool)))))]
+    (java.util.Arrays/fill backing 0 (int need) (int 0))
+    backing))
 
 (defn acquire
-  "Return a cleared `TYPE_INT_ARGB` [[BufferedImage]] of exactly `w` x `h`, reusing an idle pooled buffer of that size
-  when one is available, otherwise allocating a fresh one. NEVER blocks and never refuses -- an empty pool just yields a
-  new buffer (this is a recycler, not a capacity-limited resource pool). With no pool arg, uses the [[default-pool]].
+  "Return a cleared `w` x `h` ARGB [[BufferedImage]]. If `w*h` fits the pool's fixed array size, reuses a pooled `int[]`
+  (or allocates a fixed-size one if none is idle); otherwise returns a fresh standard `BufferedImage` (a one-off, not
+  pooled). NEVER blocks or refuses. With no pool arg, uses the [[default-pool]].
 
-  Pass the result to [[release]] when finished. The buffer is shared mutable state -- it must not escape the
-  rasterization (both render paths PNG-encode it before returning, which is what makes reuse safe)."
+  Pass the result to [[release]] when done. The image is shared mutable state -- it must not escape the rasterization
+  (Batik PNG-encodes it before returning, which is what makes reuse safe)."
   (^BufferedImage [w h] (acquire (default-pool) w h))
   (^BufferedImage [pool ^long w ^long h]
-   (let [^Deque d (deque-for pool w h)
-         stamped  (locking d (.pollFirst d))]
-     (if stamped
-       (do (.increment ^LongAdder (:hits pool))
-           (doto ^BufferedImage (:img stamped) clear!))
-       (do (.increment ^LongAdder (:misses pool))
-           (BufferedImage. (int w) (int h) BufferedImage/TYPE_INT_ARGB))))))
+   (if (> (* w h) (long (:array-pixels pool)))
+     (do (.increment ^LongAdder (:one-offs pool))                 ; too large: fresh standard image, not pooled
+         (BufferedImage. (int w) (int h) BufferedImage/TYPE_INT_ARGB))
+     (wrap-array (cleared-array pool (* w h)) w h))))
+
+(defn- backing-of
+  "The backing `int[]` of an image produced by [[acquire]]."
+  ^"[I" [^BufferedImage img]
+  (.getData ^DataBufferInt (.getDataBuffer (.getRaster img))))
 
 (defn release
-  "Check `img` back in so it can be recycled, IF doing so keeps idle retention under the pool's per-size and global caps;
-  otherwise drop it on the floor (overflow -- GC reclaims it, eagerly once `-XX:G1HeapRegionSize` is large enough that
-  the raster isn't humongous). Retaining excess is never an error -- we recycle what we keep and discard the rest.
-  Safe to call with `nil`. Never throws for pool-state reasons. With no pool arg, uses the [[default-pool]]."
+  "Return `img`'s backing array to `pool` for reuse, unless the pool already holds `:max-arrays` idle arrays, or the
+  array is a one-off (a different size than the pooled arrays) -- in either case it is simply dropped (GC reclaims it).
+  Safe with `nil`; never throws. With no pool arg, uses the [[default-pool]]."
   ([img] (release (default-pool) img))
   ([pool img]
    (when img
-     (let [^BufferedImage img img
-           ^Deque d (deque-for pool (.getWidth img) (.getHeight img))
-           ;; Read the global total OUTSIDE d's lock: idle-total locks every deque, so checking it while already
-           ;; holding one could deadlock against a concurrent release of a different size. A small race here (very
-           ;; occasionally retaining one buffer over the cap) is harmless.
-           under-global? (< (idle-total pool) (long (:global-cap pool)))]
-       (locking d
-         (when (and under-global? (< (.size d) (long (:per-size-cap pool))))
-           (.addFirst d {:img img :last-used-ms (System/currentTimeMillis)})))))))
-
-(defn sweep!
-  "Evict buffers in `pool` idle since before `now-ms` minus the pool's TTL, and remove emptied size-keys, so the
-  recycler drains to zero when rendering stops. Each size's deque is newest-first, so we walk it from the oldest (tail)
-  end dropping stale entries and stop at the first still-fresh one (everything ahead of it is newer). `now-ms` is
-  injectable so tests can fast-forward past the TTL. With no pool arg, sweeps the [[default-pool]] at the real clock."
-  ([] (sweep! (default-pool) (System/currentTimeMillis)))
-  ([pool] (sweep! pool (System/currentTimeMillis)))
-  ([pool now-ms]
-   (let [cutoff (- (long now-ms) (long (:idle-ttl-ms pool)))]
-     (doseq [^java.util.Map$Entry e (vec (.entrySet ^ConcurrentHashMap (:buffers pool)))]
-       (let [^Deque d (.getValue e)]
-         (locking d
-           ;; Deques hold newest-first (addFirst); drop from the tail (oldest) while stale.
-           (while (when-let [stamped (.peekLast d)]
-                    (< (long (:last-used-ms stamped)) cutoff))
-             (.pollLast d))
-           (when (.isEmpty d)
-             (.remove ^ConcurrentHashMap (:buffers pool) (.getKey e)))))))))
+     (let [^"[I" backing (backing-of img)
+           ^ConcurrentLinkedDeque idle (:idle pool)]
+       (when (and (= (alength backing) (long (:array-pixels pool)))
+                  (< (.size idle) (long (:max-arrays pool))))
+         (.addFirst idle backing))))))
 
 (defn stats
-  "Snapshot of a pool's reuse counters `{:hits n :misses n :idle n :by-size {[w h] n}}`. With no arg, the
-  [[default-pool]]. `:by-size` shows which sizes are holding idle buffers -- useful both for prod observability and for
-  asserting pool contents in tests."
+  "Snapshot of a pool's counters `{:hits n :misses n :one-offs n :idle n}`. With no arg, the [[default-pool]]."
   ([] (stats (default-pool)))
   ([pool]
-   (let [by-size (idle-by-size pool)]
-     {:hits    (.sum ^LongAdder (:hits pool))
-      :misses  (.sum ^LongAdder (:misses pool))
-      :idle    (reduce + 0 (vals by-size))
-      :by-size by-size})))
+   {:hits     (.sum ^LongAdder (:hits pool))
+    :misses   (.sum ^LongAdder (:misses pool))
+    :one-offs (.sum ^LongAdder (:one-offs pool))
+    :idle     (.size ^ConcurrentLinkedDeque (:idle pool))}))
+
+(defn sweep!
+  "Drop the pool's idle arrays so memory is reclaimed when rendering stops. The daemon calls this periodically: if
+  rendering is active, acquire/release repopulate within microseconds; if idle, the pool stays empty. With no arg, the
+  [[default-pool]]."
+  ([] (sweep! (default-pool)))
+  ([pool] (.clear ^ConcurrentLinkedDeque (:idle pool))))
 
 ;; --- stats logging (cumulative + interval; periodic, NOT per-send -- a per-send rate is dominated by cold-start) ---
 
-(defn- rate-str [hits misses]
+(defn- rate-str [hits misses one-offs]
   (let [total (+ hits misses)]
-    (format "%d/%d hits (%.1f%%), %d allocs"
-            hits total (if (pos? total) (* 100.0 (/ hits (double total))) 0.0) misses)))
+    (format "%d/%d hits (%.1f%%), %d allocs, %d one-offs"
+            hits total (if (pos? total) (* 100.0 (/ hits (double total))) 0.0) misses one-offs)))
 
 (defn log-stats!
-  "Log `pool` reuse: the hit rate since this pool's previous [[log-stats!]] call and the cumulative lifetime rate, plus
-  idle count. The interval baseline is kept per-pool. No-op for the interval line when nothing was rendered since the
-  last call, to avoid noise on idle instances. With no arg, the [[default-pool]]."
+  "Log `pool` reuse: the hit rate since this pool's previous call and the cumulative rate, plus idle/one-off counts.
+  No-op for the interval line when nothing was rendered since the last call. With no arg, the [[default-pool]]."
   ([] (log-stats! (default-pool)))
   ([pool]
    (let [now  (stats pool)
@@ -212,43 +164,32 @@
          dm   (- (:misses now) (:misses prev))]
      (reset! (:last-logged pool) {:hits (:hits now) :misses (:misses now)})
      (when (pos? (+ dh dm))
-       (log/infof "Image buffer reuse (interval): %s; (lifetime): %s; idle buffers: %d"
-                  (rate-str dh dm)
-                  (rate-str (:hits now) (:misses now))
+       (log/infof "Image buffer reuse (interval): %s; (lifetime): %s; idle arrays: %d"
+                  (rate-str dh dm 0)
+                  (rate-str (:hits now) (:misses now) (:one-offs now))
                   (:idle now))))))
 
-(defn- start-sweeper!
-  "Start the daemon thread that maintains `pool`: every `:idle-ttl-ms` it prunes idle buffers and logs reuse, so the
-  recycler drains to zero when rendering stops. The task closes over `pool` and feeds that one instance to both
-  [[sweep!]] and [[log-stats!]] (so they can never disagree about which pool they're acting on). We don't need Quartz
-  here (no clustering/persistence/misfire handling) -- just a process-local timer. Returns the
-  [[ScheduledExecutorService]] (daemon, so it never blocks shutdown)."
-  ^ScheduledExecutorService [pool]
-  (let [exec (Executors/newScheduledThreadPool
-              1
-              (reify ThreadFactory
-                (newThread [_ r]
-                  (doto (Thread. ^Runnable r "image-buffer-maintenance")
-                    (.setDaemon true)))))]
-    (.scheduleWithFixedDelay exec
-                             ^Runnable (fn []
-                                         (try (sweep! pool) (log-stats! pool)
-                                              (catch Throwable e
-                                                (log/warn e "Error in image-buffer maintenance"))))
-                             (long (:idle-ttl-ms pool)) (long (:idle-ttl-ms pool)) TimeUnit/MILLISECONDS)
-    exec))
+;; --- the default pool, built lazily on first use, with its one sweeper daemon ------------------------------------
 
-;; THE pool, built lazily on first use (see [[default-pool]]). A delay so nothing runs at namespace load -- AOT
-;; compilation loads every namespace, and we must not allocate the pool or spawn the sweeper thread at build time. The
-;; sweeper closes over this exact instance, so it and the maintenance calls can't disagree about which pool they act on.
-;; Pools built by [[->pool]] for tests get NO sweeper -- only THE pool does.
+(defn- start-sweeper!
+  "Start the daemon that every `:idle-ttl-ms` sweeps `pool` and logs reuse, so the pool drains to zero when rendering
+  stops. No Quartz needed -- a process-local timer on a daemon thread (so it never blocks shutdown)."
+  [pool]
+  (let [exec (Executors/newScheduledThreadPool
+              1 (reify ThreadFactory
+                  (newThread [_ r]
+                    (doto (Thread. ^Runnable r "image-buffer-maintenance") (.setDaemon true)))))]
+    (.scheduleWithFixedDelay ^ScheduledExecutorService exec
+                             (fn [] (try (sweep! pool) (log-stats! pool)
+                                         (catch Throwable e (log/warn e "Error in image-buffer maintenance"))))
+                             (long (:idle-ttl-ms pool)) (long (:idle-ttl-ms pool)) TimeUnit/MILLISECONDS)))
+
+;; A delay so nothing runs at namespace load (AOT-safe). Realized exactly once on first use, which is also when -- and
+;; the only place where -- the single sweeper daemon is started.
 (defonce ^:private the-pool
-  (delay
-    (let [pool (->pool)]
-      (start-sweeper! pool)
-      pool)))
+  (delay (doto (->pool) start-sweeper!)))
 
 (defn- default-pool
-  "THE process-wide pool, realized (and its sweeper started) on first call."
+  "THE process-wide pool, built (and its sweeper started) on first call."
   []
   @the-pool)

--- a/src/metabase/channel/render/image_buffer.clj
+++ b/src/metabase/channel/render/image_buffer.clj
@@ -1,61 +1,254 @@
 (ns metabase.channel.render.image-buffer
-  "A small, thread-safe pool of reusable ARGB [[java.awt.image.BufferedImage]] buffers, held via
-  [[java.lang.ref.SoftReference]] so the GC can reclaim idle ones under memory pressure."
+  "A process-wide, size-keyed recycler of ARGB [[java.awt.image.BufferedImage]] buffers, shared across all rendering
+  threads and both rasterizing render paths.
+
+  This exists to cut *allocation pressure*, NOT to constrain a scarce resource. The job is to avoid the churn of
+  allocating-and-discarding a multi-MB buffer on every render by handing back a recently-returned one of the same size.
+  It is therefore an OVERFLOWING recycler, not a bounded resource pool: [[acquire]] never blocks and never refuses --
+  an empty pool always allocates a fresh buffer, so there is no limit on how many buffers are live at once. (The
+  genuinely scarce resource here, the static-viz JS engines, is already constrained by its own bounded pool upstream;
+  buffers are cheap to allocate, so blocking a render to wait for one would be a pure throughput regression.)
+
+  The caps below govern RETENTION only: on check-in ([[release]]) idle buffers are kept up to `:per-size-cap` per size
+  and `:global-cap` total, and any surplus is simply dropped (GC reclaims it). So the caps bound *resident idle
+  memory*, not concurrency. A daemon thread additionally evicts buffers idle past `:idle-ttl-ms`, walking each size's
+  deque from its oldest end until it reaches a still-fresh entry, so the recycler drains to zero when rendering stops
+  and holds memory only while actively rendering.
+
+  Why this and not the alternatives: a *chart* (SVG/Batik, [[metabase.channel.render.js.svg/render-svg]]) or *table*
+  (HTML/CSSBox, [[metabase.channel.render.png/render-html-to-png]]) rasterizes into a `width * height * 4` byte buffer
+  -- 3-6 MB at dashboard sizes. Under the default G1 GC any object over half a region (~1 MB at a 2 MB region) is
+  \"humongous\": allocated into dedicated regions a young GC can't reclaim. Subscriptions render in bursts, so without
+  recycling these pile up faster than mixed/full GCs reclaim the regions and the JVM OOMs on region exhaustion while
+  most of the heap is free. We hold STRONG references (not SoftReference, which clears only at the OOM edge -- that
+  would relocate the pressure, not remove it) and evict explicitly, so memory tracks activity. Instrumentation of real
+  email and Slack sends showed renders fan across many Jetty threads (so the recycler must be *shared*, not
+  thread-local, or it stays cold) and only a handful of distinct sizes recur (~6 retained per size reaches ~60% reuse).
+
+  Reuse is safe because both rasterizers PNG-encode the buffer eagerly and synchronously and return only a `byte[]`;
+  the `BufferedImage` never escapes, so a reused buffer cannot corrupt already-returned bytes. The one load-bearing
+  rule is [[clear!]]-on-acquire (Batik composites with `SrcOver` and skips its background fill when the background is
+  nil, so stale pixels would bleed through).
+
+  A pool is just a plain map built by [[->pool]] (its own buffer map, its own counters, its own config); the core
+  functions take one as their first argument. Prod uses the [[default-pool]] via the no-pool arities; it is built (and
+  its sweeper started) lazily on first use, not at namespace load, so AOT compilation doesn't spawn the daemon. Tests
+  construct an isolated pool with [[->pool]] so they can assert on its counters/contents without the singleton's
+  residue or its background sweeper."
   (:require
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms])
   (:import
-   (java.awt AlphaComposite)
-   (java.awt.image BufferedImage)
-   (java.lang.ref SoftReference)
-   (java.util.concurrent ConcurrentHashMap ConcurrentLinkedQueue)
+   (java.awt.image BufferedImage DataBufferInt)
+   (java.util ArrayDeque Deque)
+   (java.util.concurrent ConcurrentHashMap Executors ScheduledExecutorService ThreadFactory TimeUnit)
+   (java.util.concurrent.atomic LongAdder)
    (java.util.function Function)))
 
 (set! *warn-on-reflection* true)
 
-;; [width height] -> ConcurrentLinkedQueue<SoftReference<BufferedImage>>: any number of idle buffers per size.
-(defonce ^:private pool (ConcurrentHashMap.))
+(def ^:private default-per-size-cap
+  "Retention limit: max idle buffers KEPT per distinct size on check-in (not a limit on live/checked-out buffers --
+  acquire never refuses). ~6 is the knee of the measured hit-rate curve (4-8); past it adds little reuse for more
+  resident memory."
+  6)
 
-(def ^:private new-queue
-  (reify Function (apply [_ _] (ConcurrentLinkedQueue.))))
+(def ^:private default-global-cap
+  "Retention limit: max idle buffers kept across all sizes -- a backstop so an unusual spread of sizes can't grow
+  resident idle memory without bound. Again a retention cap, not an admission/concurrency cap."
+  24)
 
-(mu/defn- queue-for :- (ms/InstanceOfClass ConcurrentLinkedQueue)
-  "The queue of idle buffers for `w` x `h`, creating it on first use.
+(def ^:private default-idle-ttl-ms
+  "Buffers not reused within this long are dropped by [[sweep!]] so the recycler drains to zero on an idle instance."
+  60000)
 
-  `w`/`h` are coerced to `long` so the key is type-stable: `acquire` is called with longs but `release` reads ints
-  off the image, and a Clojure vector key compares elements with Java `.equals`, where `(.equals (long 5) (int 5))`
-  is false."
-  [w :- :int
-   h :- :int]
-  (.computeIfAbsent ^ConcurrentHashMap pool [(long w) (long h)] new-queue))
+(defn ->pool
+  "Construct a fresh, independent pool: a plain map of its own buffer store, counters, and config. With no args uses the
+  production caps/TTL. Tests pass their own to isolate from the [[default-pool]] (a constructed pool shares no state
+  with it and has no background sweeper attached).
+
+  Shape: `:buffers` maps [w h] (longs) -> ArrayDeque of {:img BufferedImage :last-used-ms long}, holding STRONG
+  references (NOT SoftReference: soft refs only clear at the edge of OOM, the failure mode we're avoiding). Each
+  per-size ArrayDeque is guarded by synchronizing on itself; the outer map is a ConcurrentHashMap. `:hits`/`:misses`
+  are this pool's own reuse counters."
+  ([] (->pool {}))
+  ([{:keys [per-size-cap global-cap idle-ttl-ms]
+     :or   {per-size-cap default-per-size-cap
+            global-cap   default-global-cap
+            idle-ttl-ms  default-idle-ttl-ms}}]
+   {:buffers      (ConcurrentHashMap.)
+    :hits         (LongAdder.)
+    :misses       (LongAdder.)
+    ;; cumulative hits/misses as of this pool's last [[log-stats!]] call, so the periodic log can report the interval
+    ;; since the previous one. Per-pool (not a namespace global) so multiple pools don't clobber each other's baseline.
+    :last-logged  (atom {:hits 0 :misses 0})
+    :per-size-cap per-size-cap
+    :global-cap   global-cap
+    :idle-ttl-ms  idle-ttl-ms}))
+
+;; THE pool prod renders use, returned by the [[default-pool]] accessor. It is lazily built (and its sweeper started)
+;; on first use, NOT at namespace load -- so AOT compilation, which loads every namespace, doesn't spawn the daemon
+;; thread or allocate the pool at build time. The public no-pool arities call [[default-pool]].
+(declare default-pool)
+
+(def ^:private new-deque
+  (reify Function (apply [_ _] (ArrayDeque.))))
+
+(defn- deque-for ^Deque [pool ^long w ^long h]
+  ;; Key coerced to longs so it is type-stable: acquire is called with longs but release reads ints off the image,
+  ;; and a Clojure vector key compares elements with Java .equals, where (.equals (long 5) (int 5)) is false.
+  (.computeIfAbsent ^ConcurrentHashMap (:buffers pool) [w h] new-deque))
+
+(defn- idle-total
+  "Number of idle buffers held across all sizes. Derived by summing deque sizes rather than tracked in a separate
+  counter -- a parallel counter is drift-prone (it would diverge from the deques on a partial failure), and with only a
+  handful of distinct sizes this scan is cheap."
+  ^long [pool]
+  (reduce (fn [^long acc ^Deque d] (+ acc (long (locking d (.size d)))))
+          0
+          (.values ^ConcurrentHashMap (:buffers pool))))
+
+(defn- idle-by-size
+  "Map of `[w h]` -> number of idle buffers currently pooled for that size. Sizes with no idle buffers are omitted."
+  [pool]
+  (into {}
+        (keep (fn [^java.util.Map$Entry e]
+                (let [^Deque d (.getValue e)
+                      n (locking d (.size d))]
+                  (when (pos? n) [(vec (.getKey e)) n]))))
+        (.entrySet ^ConcurrentHashMap (:buffers pool))))
 
 (mu/defn- clear!
-  "Reset every pixel of `img` to fully transparent so a reused buffer never shows the previous render's pixels."
+  "Reset every pixel of `img` to fully transparent so a reused buffer never shows the previous render's pixels.
+  Load-bearing for correctness, not just hygiene (see ns docstring). Zeroes the backing `int[]` directly -- a
+  full-raster wipe needing no `Graphics2D` allocation."
   [img :- (ms/InstanceOfClass BufferedImage)]
-  (let [g (.createGraphics ^BufferedImage img)]
-    (try
-      (.setComposite g (AlphaComposite/getInstance AlphaComposite/CLEAR))
-      (.fillRect g 0 0 (.getWidth ^BufferedImage img) (.getHeight ^BufferedImage img))
-      (finally
-        (.dispose g)))))
+  (let [buf (.getDataBuffer (.getRaster ^BufferedImage img))]
+    (java.util.Arrays/fill (.getData ^DataBufferInt buf) (int 0))))
 
-(mu/defn acquire :- (ms/InstanceOfClass BufferedImage)
+(defn acquire
   "Return a cleared `TYPE_INT_ARGB` [[BufferedImage]] of exactly `w` x `h`, reusing an idle pooled buffer of that size
-  when one is available. Pass the result to [[release]] when finished so it can be reused.
+  when one is available, otherwise allocating a fresh one. NEVER blocks and never refuses -- an empty pool just yields a
+  new buffer (this is a recycler, not a capacity-limited resource pool). With no pool arg, uses the [[default-pool]].
 
-  Polls soft refs until it finds one whose buffer the GC hasn't reclaimed, discarding the cleared ones."
-  [w :- :int
-   h :- :int]
-  (let [q   (queue-for w h)
-        img (loop []
-              (when-let [ref (.poll ^ConcurrentLinkedQueue q)]
-                (or (.get ^SoftReference ref) (recur))))]
-    (if img
-      (do (clear! img) img)
-      (BufferedImage. (int w) (int h) BufferedImage/TYPE_INT_ARGB))))
+  Pass the result to [[release]] when finished. The buffer is shared mutable state -- it must not escape the
+  rasterization (both render paths PNG-encode it before returning, which is what makes reuse safe)."
+  (^BufferedImage [w h] (acquire (default-pool) w h))
+  (^BufferedImage [pool ^long w ^long h]
+   (let [^Deque d (deque-for pool w h)
+         stamped  (locking d (.pollFirst d))]
+     (if stamped
+       (do (.increment ^LongAdder (:hits pool))
+           (doto ^BufferedImage (:img stamped) clear!))
+       (do (.increment ^LongAdder (:misses pool))
+           (BufferedImage. (int w) (int h) BufferedImage/TYPE_INT_ARGB))))))
 
-(mu/defn release
-  "Return `img` to the pool so it can be reused."
-  [img :- (ms/InstanceOfClass BufferedImage)]
-  (.offer ^ConcurrentLinkedQueue (queue-for (.getWidth ^BufferedImage img) (.getHeight ^BufferedImage img))
-          (SoftReference. img)))
+(defn release
+  "Check `img` back in so it can be recycled, IF doing so keeps idle retention under the pool's per-size and global caps;
+  otherwise drop it on the floor (overflow -- GC reclaims it, eagerly once `-XX:G1HeapRegionSize` is large enough that
+  the raster isn't humongous). Retaining excess is never an error -- we recycle what we keep and discard the rest.
+  Safe to call with `nil`. Never throws for pool-state reasons. With no pool arg, uses the [[default-pool]]."
+  ([img] (release (default-pool) img))
+  ([pool img]
+   (when img
+     (let [^BufferedImage img img
+           ^Deque d (deque-for pool (.getWidth img) (.getHeight img))
+           ;; Read the global total OUTSIDE d's lock: idle-total locks every deque, so checking it while already
+           ;; holding one could deadlock against a concurrent release of a different size. A small race here (very
+           ;; occasionally retaining one buffer over the cap) is harmless.
+           under-global? (< (idle-total pool) (long (:global-cap pool)))]
+       (locking d
+         (when (and under-global? (< (.size d) (long (:per-size-cap pool))))
+           (.addFirst d {:img img :last-used-ms (System/currentTimeMillis)})))))))
+
+(defn sweep!
+  "Evict buffers in `pool` idle since before `now-ms` minus the pool's TTL, and remove emptied size-keys, so the
+  recycler drains to zero when rendering stops. Each size's deque is newest-first, so we walk it from the oldest (tail)
+  end dropping stale entries and stop at the first still-fresh one (everything ahead of it is newer). `now-ms` is
+  injectable so tests can fast-forward past the TTL. With no pool arg, sweeps the [[default-pool]] at the real clock."
+  ([] (sweep! (default-pool) (System/currentTimeMillis)))
+  ([pool] (sweep! pool (System/currentTimeMillis)))
+  ([pool now-ms]
+   (let [cutoff (- (long now-ms) (long (:idle-ttl-ms pool)))]
+     (doseq [^java.util.Map$Entry e (vec (.entrySet ^ConcurrentHashMap (:buffers pool)))]
+       (let [^Deque d (.getValue e)]
+         (locking d
+           ;; Deques hold newest-first (addFirst); drop from the tail (oldest) while stale.
+           (while (when-let [stamped (.peekLast d)]
+                    (< (long (:last-used-ms stamped)) cutoff))
+             (.pollLast d))
+           (when (.isEmpty d)
+             (.remove ^ConcurrentHashMap (:buffers pool) (.getKey e)))))))))
+
+(defn stats
+  "Snapshot of a pool's reuse counters `{:hits n :misses n :idle n :by-size {[w h] n}}`. With no arg, the
+  [[default-pool]]. `:by-size` shows which sizes are holding idle buffers -- useful both for prod observability and for
+  asserting pool contents in tests."
+  ([] (stats (default-pool)))
+  ([pool]
+   (let [by-size (idle-by-size pool)]
+     {:hits    (.sum ^LongAdder (:hits pool))
+      :misses  (.sum ^LongAdder (:misses pool))
+      :idle    (reduce + 0 (vals by-size))
+      :by-size by-size})))
+
+;; --- stats logging (cumulative + interval; periodic, NOT per-send -- a per-send rate is dominated by cold-start) ---
+
+(defn- rate-str [hits misses]
+  (let [total (+ hits misses)]
+    (format "%d/%d hits (%.1f%%), %d allocs"
+            hits total (if (pos? total) (* 100.0 (/ hits (double total))) 0.0) misses)))
+
+(defn log-stats!
+  "Log `pool` reuse: the hit rate since this pool's previous [[log-stats!]] call and the cumulative lifetime rate, plus
+  idle count. The interval baseline is kept per-pool. No-op for the interval line when nothing was rendered since the
+  last call, to avoid noise on idle instances. With no arg, the [[default-pool]]."
+  ([] (log-stats! (default-pool)))
+  ([pool]
+   (let [now  (stats pool)
+         prev @(:last-logged pool)
+         dh   (- (:hits now) (:hits prev))
+         dm   (- (:misses now) (:misses prev))]
+     (reset! (:last-logged pool) {:hits (:hits now) :misses (:misses now)})
+     (when (pos? (+ dh dm))
+       (log/infof "Image buffer reuse (interval): %s; (lifetime): %s; idle buffers: %d"
+                  (rate-str dh dm)
+                  (rate-str (:hits now) (:misses now))
+                  (:idle now))))))
+
+(defn- start-sweeper!
+  "Start the daemon thread that maintains `pool`: every `:idle-ttl-ms` it prunes idle buffers and logs reuse, so the
+  recycler drains to zero when rendering stops. The task closes over `pool` and feeds that one instance to both
+  [[sweep!]] and [[log-stats!]] (so they can never disagree about which pool they're acting on). We don't need Quartz
+  here (no clustering/persistence/misfire handling) -- just a process-local timer. Returns the
+  [[ScheduledExecutorService]] (daemon, so it never blocks shutdown)."
+  ^ScheduledExecutorService [pool]
+  (let [exec (Executors/newScheduledThreadPool
+              1
+              (reify ThreadFactory
+                (newThread [_ r]
+                  (doto (Thread. ^Runnable r "image-buffer-maintenance")
+                    (.setDaemon true)))))]
+    (.scheduleWithFixedDelay exec
+                             ^Runnable (fn []
+                                         (try (sweep! pool) (log-stats! pool)
+                                              (catch Throwable e
+                                                (log/warn e "Error in image-buffer maintenance"))))
+                             (long (:idle-ttl-ms pool)) (long (:idle-ttl-ms pool)) TimeUnit/MILLISECONDS)
+    exec))
+
+;; THE pool, built lazily on first use (see [[default-pool]]). A delay so nothing runs at namespace load -- AOT
+;; compilation loads every namespace, and we must not allocate the pool or spawn the sweeper thread at build time. The
+;; sweeper closes over this exact instance, so it and the maintenance calls can't disagree about which pool they act on.
+;; Pools built by [[->pool]] for tests get NO sweeper -- only THE pool does.
+(defonce ^:private the-pool
+  (delay
+    (let [pool (->pool)]
+      (start-sweeper! pool)
+      pool)))
+
+(defn- default-pool
+  "THE process-wide pool, realized (and its sweeper started) on first call."
+  []
+  @the-pool)

--- a/src/metabase/channel/render/image_buffer.clj
+++ b/src/metabase/channel/render/image_buffer.clj
@@ -8,19 +8,25 @@
    (java.awt AlphaComposite)
    (java.awt.image BufferedImage)
    (java.lang.ref SoftReference)
-   (java.util.concurrent ConcurrentHashMap)))
+   (java.util.concurrent ConcurrentHashMap ConcurrentLinkedQueue)
+   (java.util.function Function)))
 
 (set! *warn-on-reflection* true)
 
+;; [width height] -> ConcurrentLinkedQueue<SoftReference<BufferedImage>>: any number of idle buffers per size.
 (defonce ^:private pool (ConcurrentHashMap.))
 
-(mu/defn- cache-key :- [:tuple :int :int]
-  "Pool key for a `w` x `h` buffer. `w`/`h` are coerced to `long` so the key is type-stable: `acquire` is called with
-  longs but `release` reads ints off the image, and a Clojure vector key compares elements with Java `.equals`, where
-  `(long 5)` != `(int 5)`."
+(def ^:private new-queue
+  (reify Function (apply [_ _] (ConcurrentLinkedQueue.))))
+
+(mu/defn- queue-for :- (ms/InstanceOfClass ConcurrentLinkedQueue)
+  "The queue of idle buffers for `w` x `h`, creating it on first use.
+
+  `w`/`h` are coerced to `long` so the key is type-stable: `acquire` is called with longs but `release` reads ints
+  off the image, and a Clojure vector key compares elements with Java `.equals`, where `(long 5)` != `(int 5)`."
   [w :- :int
    h :- :int]
-  [(long w) (long h)])
+  (.computeIfAbsent ^ConcurrentHashMap pool [(long w) (long h)] new-queue))
 
 (mu/defn- clear!
   "Reset every pixel of `img` to fully transparent so a reused buffer never shows the previous render's pixels."
@@ -33,22 +39,22 @@
         (.dispose g)))))
 
 (mu/defn acquire :- (ms/InstanceOfClass BufferedImage)
-  "Return a cleared `TYPE_INT_ARGB` [[BufferedImage]] of exactly `w` x `h`, reusing the pooled buffer for that size if
-  the GC hasn't reclaimed it. Pass the result to [[release]] when finished so it can be reused."
+  "Return a cleared `TYPE_INT_ARGB` [[BufferedImage]] of exactly `w` x `h`, reusing an idle pooled buffer of that size
+  when one is available. Pass the result to [[release]] when finished so it can be reused."
   [w :- :int
    h :- :int]
-  ;; `remove` takes ownership: a concurrent render of the same size won't get the same buffer, it'll allocate its own.
-  (let [ref (.remove ^ConcurrentHashMap pool (cache-key w h))
-        img (some-> ^SoftReference ref .get)]
+  (let [q   (queue-for w h)
+        ;; poll soft refs until we find one whose buffer the GC hasn't reclaimed, discarding the cleared ones.
+        img (loop []
+              (when-let [ref (.poll ^ConcurrentLinkedQueue q)]
+                (or (.get ^SoftReference ref) (recur))))]
     (if img
       (do (clear! img) img)
       (BufferedImage. (int w) (int h) BufferedImage/TYPE_INT_ARGB))))
 
 (mu/defn release
-  "Return `img` to the pool so it can be reused, replacing any current idle buffer of its size. Safe to call with
-  `nil`."
+  "Return `img` to the pool so it can be reused. Safe to call with `nil`."
   [img :- [:maybe (ms/InstanceOfClass BufferedImage)]]
   (when img
-    (.put ^ConcurrentHashMap pool
-          (cache-key (.getWidth ^BufferedImage img) (.getHeight ^BufferedImage img))
-          (SoftReference. img))))
+    (.offer ^ConcurrentLinkedQueue (queue-for (.getWidth ^BufferedImage img) (.getHeight ^BufferedImage img))
+            (SoftReference. img))))

--- a/src/metabase/channel/render/image_buffer.clj
+++ b/src/metabase/channel/render/image_buffer.clj
@@ -23,7 +23,8 @@
   "The queue of idle buffers for `w` x `h`, creating it on first use.
 
   `w`/`h` are coerced to `long` so the key is type-stable: `acquire` is called with longs but `release` reads ints
-  off the image, and a Clojure vector key compares elements with Java `.equals`, where `(long 5)` != `(int 5)`."
+  off the image, and a Clojure vector key compares elements with Java `.equals`, where `(.equals (long 5) (int 5))`
+  is false."
   [w :- :int
    h :- :int]
   (.computeIfAbsent ^ConcurrentHashMap pool [(long w) (long h)] new-queue))
@@ -40,11 +41,12 @@
 
 (mu/defn acquire :- (ms/InstanceOfClass BufferedImage)
   "Return a cleared `TYPE_INT_ARGB` [[BufferedImage]] of exactly `w` x `h`, reusing an idle pooled buffer of that size
-  when one is available. Pass the result to [[release]] when finished so it can be reused."
+  when one is available. Pass the result to [[release]] when finished so it can be reused.
+
+  Polls soft refs until it finds one whose buffer the GC hasn't reclaimed, discarding the cleared ones."
   [w :- :int
    h :- :int]
   (let [q   (queue-for w h)
-        ;; poll soft refs until we find one whose buffer the GC hasn't reclaimed, discarding the cleared ones.
         img (loop []
               (when-let [ref (.poll ^ConcurrentLinkedQueue q)]
                 (or (.get ^SoftReference ref) (recur))))]

--- a/src/metabase/channel/render/image_buffer.clj
+++ b/src/metabase/channel/render/image_buffer.clj
@@ -53,8 +53,7 @@
       (BufferedImage. (int w) (int h) BufferedImage/TYPE_INT_ARGB))))
 
 (mu/defn release
-  "Return `img` to the pool so it can be reused. Safe to call with `nil`."
-  [img :- [:maybe (ms/InstanceOfClass BufferedImage)]]
-  (when img
-    (.offer ^ConcurrentLinkedQueue (queue-for (.getWidth ^BufferedImage img) (.getHeight ^BufferedImage img))
-            (SoftReference. img))))
+  "Return `img` to the pool so it can be reused."
+  [img :- (ms/InstanceOfClass BufferedImage)]
+  (.offer ^ConcurrentLinkedQueue (queue-for (.getWidth ^BufferedImage img) (.getHeight ^BufferedImage img))
+          (SoftReference. img)))

--- a/src/metabase/channel/render/js/svg.clj
+++ b/src/metabase/channel/render/js/svg.clj
@@ -6,6 +6,7 @@
   (:require
    [clojure.string :as str]
    [metabase.appearance.core :as appearance]
+   [metabase.channel.render.image-buffer :as image-buffer]
    [metabase.channel.render.js.engine :as js.engine]
    [metabase.channel.render.style :as style]
    [metabase.config.core :as config]
@@ -16,6 +17,7 @@
    (io.aleph.dirigiste IPool$Controller IPool$Generator Pool Pools Stats)
    (java.io ByteArrayInputStream ByteArrayOutputStream)
    (java.nio.charset StandardCharsets)
+   (java.util ArrayList)
    (java.util.concurrent TimeUnit)
    (org.apache.batik.anim.dom SAXSVGDocumentFactory SVGOMDocument)
    (org.apache.batik.transcoder TranscoderInput TranscoderOutput)
@@ -197,6 +199,17 @@
   Defaults to white to ensure charts are readable in dark mode email clients."
   java.awt.Color/WHITE)
 
+(defn- reusing-buffers-transcoder
+  "A [[PNGTranscoder]] whose output ARGB raster is borrowed from [[metabase.channel.render.image-buffer]] instead of
+  freshly allocated. Batik calls `createImage` to mint the (often ~1 MB+) result buffer; we hand it a pooled one and
+  record it in `acquired` so the caller can release it after `transcode` finishes."
+  ^PNGTranscoder [^ArrayList acquired]
+  (proxy [PNGTranscoder] []
+    (createImage [w h]
+      (let [img (image-buffer/acquire w h)]
+        (.add acquired img)
+        img))))
+
 (defn- render-svg
   ^bytes [^SVGOMDocument svg-document]
   (style/register-fonts-if-needed!)
@@ -204,7 +217,8 @@
     (let [^SVGOMDocument fixed-svg-doc (post-process svg-document fix-fill clear-style-node)
           in                           (TranscoderInput. fixed-svg-doc)
           out                          (TranscoderOutput. os)
-          transcoder                   (PNGTranscoder.)
+          acquired                     (ArrayList. 1)
+          transcoder                   (reusing-buffers-transcoder acquired)
           ;; `:scale` (default 1) supersamples the raster only -- the SVG is laid out at the
           ;; logical :width/:height but rasterized to scale-times more pixels.
           scale                        (:scale *chart-size* 1)
@@ -215,7 +229,11 @@
         (.addTranscodingHint transcoder PNGTranscoder/KEY_HEIGHT render-height))
       (when *svg-background-color*
         (.addTranscodingHint transcoder PNGTranscoder/KEY_BACKGROUND_COLOR *svg-background-color*))
-      (.transcode transcoder in out))
+      (try
+        (.transcode transcoder in out)
+        (finally
+          (doseq [img acquired]
+            (image-buffer/release img)))))
     (.toByteArray os)))
 
 (defn svg-string->bytes

--- a/src/metabase/channel/render/js/svg.clj
+++ b/src/metabase/channel/render/js/svg.clj
@@ -17,7 +17,6 @@
    (io.aleph.dirigiste IPool$Controller IPool$Generator Pool Pools Stats)
    (java.io ByteArrayInputStream ByteArrayOutputStream)
    (java.nio.charset StandardCharsets)
-   (java.util ArrayList)
    (java.util.concurrent TimeUnit)
    (org.apache.batik.anim.dom SAXSVGDocumentFactory SVGOMDocument)
    (org.apache.batik.transcoder TranscoderInput TranscoderOutput)
@@ -200,14 +199,14 @@
   java.awt.Color/WHITE)
 
 (defn- reusing-buffers-transcoder
-  "A [[PNGTranscoder]] whose output ARGB raster is borrowed from [[metabase.channel.render.image-buffer]] instead of
-  freshly allocated. Batik calls `createImage` to mint the (often ~1 MB+) result buffer; we hand it a pooled one and
-  record it in `acquired` so the caller can release it after `transcode` finishes."
-  ^PNGTranscoder [^ArrayList acquired]
+  "A [[PNGTranscoder]] whose output ARGB raster is borrowed from the shared [[metabase.channel.render.image-buffer]]
+  pool instead of freshly allocated. Batik calls `createImage` once to mint the (often several-MB) result buffer; we
+  hand it a pooled one and record it in `acquired` (a 1-element atom) so the caller can release it after `transcode`."
+  ^PNGTranscoder [acquired]
   (proxy [PNGTranscoder] []
     (createImage [w h]
       (let [img (image-buffer/acquire w h)]
-        (.add acquired img)
+        (reset! acquired img)
         img))))
 
 (defn- render-svg
@@ -217,7 +216,7 @@
     (let [^SVGOMDocument fixed-svg-doc (post-process svg-document fix-fill clear-style-node)
           in                           (TranscoderInput. fixed-svg-doc)
           out                          (TranscoderOutput. os)
-          acquired                     (ArrayList. 1)
+          acquired                     (atom nil)
           transcoder                   (reusing-buffers-transcoder acquired)
           ;; `:scale` (default 1) supersamples the raster only -- the SVG is laid out at the
           ;; logical :width/:height but rasterized to scale-times more pixels.
@@ -232,8 +231,8 @@
       (try
         (.transcode transcoder in out)
         (finally
-          (doseq [img acquired]
-            (image-buffer/release img)))))
+          ;; Return the borrowed buffer to the pool. Guarded so a release failure can't mask a transcode error.
+          (try (image-buffer/release @acquired) (catch Throwable _)))))
     (.toByteArray os)))
 
 (defn svg-string->bytes

--- a/src/metabase/server/streaming_response/thread_pool.clj
+++ b/src/metabase/server/streaming_response/thread_pool.clj
@@ -11,6 +11,7 @@
   (or (config/config-int :mb-async-query-thread-pool-size)
       (config/config-int :mb-jetty-maxthreads)
       50))
+
 (defonce ^:private thread-pool*
   (delay
     (Executors/newFixedThreadPool thread-pool-max-size

--- a/src/metabase/server/streaming_response/thread_pool.clj
+++ b/src/metabase/server/streaming_response/thread_pool.clj
@@ -11,7 +11,6 @@
   (or (config/config-int :mb-async-query-thread-pool-size)
       (config/config-int :mb-jetty-maxthreads)
       50))
-
 (defonce ^:private thread-pool*
   (delay
     (Executors/newFixedThreadPool thread-pool-max-size

--- a/test/metabase/channel/render/image_buffer_test.clj
+++ b/test/metabase/channel/render/image_buffer_test.clj
@@ -1,0 +1,50 @@
+(ns metabase.channel.render.image-buffer-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.channel.render.image-buffer :as image-buffer])
+  (:import
+   (java.awt.image BufferedImage)))
+
+(set! *warn-on-reflection* true)
+
+(deftest acquire-returns-argb-of-requested-size-test
+  (let [img (image-buffer/acquire 320 240)]
+    (try
+      (is (instance? BufferedImage img))
+      (is (= 320 (.getWidth img)))
+      (is (= 240 (.getHeight img)))
+      (is (= BufferedImage/TYPE_INT_ARGB (.getType img)))
+      (finally
+        (image-buffer/release img)))))
+
+(deftest released-buffer-is-reused-test
+  (testing "releasing a buffer and acquiring the same size hands back the very same object"
+    (let [img1 (image-buffer/acquire 111 222)]
+      (image-buffer/release img1)
+      (let [img2 (image-buffer/acquire 111 222)]
+        (try
+          (is (identical? img1 img2))
+          (finally
+            (image-buffer/release img2)))))))
+
+(deftest reused-buffer-is-cleared-test
+  (testing "a reused buffer is wiped to fully transparent, not left with the previous render's pixels"
+    (let [img (image-buffer/acquire 64 64)]
+      (.setRGB img 10 10 (unchecked-int 0xFF00FF00))
+      (is (not (zero? (.getRGB img 10 10))) "sanity: pixel was dirtied")
+      (image-buffer/release img))
+    (let [img (image-buffer/acquire 64 64)]
+      (try
+        (is (zero? (.getRGB img 10 10)) "previously-dirtied pixel is cleared on reacquire")
+        (finally
+          (image-buffer/release img))))))
+
+(deftest different-sizes-do-not-collide-test
+  (let [a (image-buffer/acquire 100 100)]
+    (image-buffer/release a)
+    (let [b (image-buffer/acquire 200 100)]
+      (try
+        (is (not (identical? a b)))
+        (is (= 200 (.getWidth b)))
+        (finally
+          (image-buffer/release b))))))

--- a/test/metabase/channel/render/image_buffer_test.clj
+++ b/test/metabase/channel/render/image_buffer_test.clj
@@ -7,59 +7,153 @@
 
 (set! *warn-on-reflection* true)
 
-(deftest acquire-returns-argb-of-requested-size-test
-  (let [img (image-buffer/acquire 320 240)]
-    (try
-      (is (instance? BufferedImage img))
-      (is (= 320 (.getWidth img)))
-      (is (= 240 (.getHeight img)))
-      (is (= BufferedImage/TYPE_INT_ARGB (.getType img)))
-      (finally
-        (image-buffer/release img)))))
+;; Every test runs against its OWN pool built with [[image-buffer/->pool]], not the process-wide default pool. That
+;; gives deterministic counters (no cross-test residue) and no background sweeper racing the assertions, so we can
+;; assert exact hit/miss/idle counts rather than fuzzy "some reuse" thresholds.
 
-(deftest released-buffer-is-reused-test
-  (testing "releasing a buffer and acquiring the same size hands back the very same object"
-    (let [img1 (image-buffer/acquire 111 222)]
-      (image-buffer/release img1)
-      (let [img2 (image-buffer/acquire 111 222)]
-        (try
-          (is (identical? img1 img2))
-          (finally
-            (image-buffer/release img2)))))))
+(deftest acquire-returns-argb-of-requested-size-test
+  (testing "acquire yields a TYPE_INT_ARGB buffer of exactly the requested size, for any size asked of one pool"
+    (let [p     (image-buffer/->pool)
+          sizes [[320 240] [1200 800] [1 1] [1200 1322] [64 480]]]
+      (doseq [[w h] sizes]
+        (let [^BufferedImage img (image-buffer/acquire p w h)]
+          (is (instance? BufferedImage img) (format "%dx%d is a BufferedImage" w h))
+          (is (= w (.getWidth img)) (format "%dx%d width" w h))
+          (is (= h (.getHeight img)) (format "%dx%d height" w h))
+          (is (= BufferedImage/TYPE_INT_ARGB (.getType img)) (format "%dx%d is ARGB" w h)))))))
+
+(deftest sequential-cycle-reuses-after-one-allocation-test
+  (testing "cycling one size allocates once, then reuses every time"
+    (let [p (image-buffer/->pool)
+          n 100]
+      (dotimes [_ n]
+        (image-buffer/release p (image-buffer/acquire p 1207 503)))
+      (let [{:keys [hits misses idle]} (image-buffer/stats p)]
+        (is (= 1 misses) "only the very first acquire allocates; the rest must reuse")
+        (is (= (dec n) hits) "every acquire after the first reused a pooled buffer")
+        (is (= 1 idle) "one buffer cycles through the whole run")))))
+
+(deftest concurrent-same-size-allocates-at-most-thread-count-test
+  (testing "concurrent threads cycling one size allocate at most thread-count buffers"
+    (let [thread-count       8
+          cycles-per-thread  50
+          timeout-ms         5000
+          pool               (image-buffer/->pool)
+          ;; A barrier so all threads start their acquire/release loops at the same moment (genuine overlap, so the
+          ;; "<= thread-count allocations" assertion exercises real concurrency). `await` is bounded, and the worker
+          ;; reaches it via try/finally, so a thread that throws can't strand the others on the barrier.
+          started            (java.util.concurrent.CyclicBarrier. thread-count)
+          worker             (fn []
+                               (.await started (long timeout-ms) java.util.concurrent.TimeUnit/MILLISECONDS)
+                               (dotimes [_ cycles-per-thread]
+                                 (image-buffer/release pool (image-buffer/acquire pool 909 405)))
+                               ::done)
+          futures            (doall (repeatedly thread-count #(future (worker))))
+          results            (mapv #(deref % timeout-ms ::timeout) futures)]
+      (is (every? #(= ::done %) results)
+          "every worker finished within the timeout (no deadlock / no thrown worker)")
+      (let [{:keys [hits misses]} (image-buffer/stats pool)]
+        (is (= (* thread-count cycles-per-thread) (+ hits misses)) "every acquire counted as a hit or a miss")
+        (is (<= misses thread-count) "never allocated more than the number of concurrent threads")
+        (is (pos? hits) "reuse happened")))))
+
+(deftest many-sizes-pool-contents-and-isolation-test
+  (testing "many distinct sizes pool independently; each acquire gets its own size"
+    (let [p     (image-buffer/->pool)
+          sizes (for [i (range 9)] [(+ 1200 i) (+ 800 (* 10 i))])]  ;; 9 dashboard-ish sizes, all distinct
+      ;; release one buffer of each size into the pool
+      (doseq [[w h] sizes]
+        (image-buffer/release p (image-buffer/acquire p w h)))
+      (let [{:keys [by-size idle]} (image-buffer/stats p)]
+        (is (= (count sizes) idle) "one idle buffer per distinct size was retained")
+        (is (= (set sizes) (set (keys by-size))) "the pool holds exactly the sizes we released, keyed correctly")
+        (is (every? #(= 1 %) (vals by-size)) "exactly one buffer per size (we released one each)"))
+      ;; now re-acquire each size and assert we get back a correctly-sized, reused buffer (not a collision)
+      (doseq [[w h] sizes]
+        (let [hits-before (:hits (image-buffer/stats p))
+              ^BufferedImage img (image-buffer/acquire p w h)]
+          (is (= [w h] [(.getWidth img) (.getHeight img)]) "acquire returned a buffer of the requested size")
+          (is (= (inc hits-before) (:hits (image-buffer/stats p)))
+              "the acquire reused this size's pooled buffer rather than allocating (no cross-size theft)")
+          (image-buffer/release p img)))
+      (is (= (count sizes) (:idle (image-buffer/stats p))) "after the round trip the pool still holds one per size"))))
 
 (deftest reused-buffer-is-cleared-test
-  (testing "a reused buffer is wiped to fully transparent, not left with the previous render's pixels"
-    (let [img (image-buffer/acquire 64 64)]
-      (.setRGB img 10 10 (unchecked-int 0xFF00FF00))
-      (is (not (zero? (.getRGB img 10 10))) "sanity: pixel was dirtied")
-      (image-buffer/release img))
-    (let [img (image-buffer/acquire 64 64)]
-      (try
-        (is (zero? (.getRGB img 10 10)) "previously-dirtied pixel is cleared on reacquire")
-        (finally
-          (image-buffer/release img))))))
+  (testing "a reused buffer is wiped to fully transparent (no data leak between renders)"
+    (let [p (image-buffer/->pool)]
+      (let [^BufferedImage img (image-buffer/acquire p 64 64)]
+        (.setRGB img 10 10 (unchecked-int 0xFF00FF00))
+        (is (not (zero? (.getRGB img 10 10))) "sanity: pixel was dirtied")
+        (image-buffer/release p img))
+      (let [^BufferedImage img (image-buffer/acquire p 64 64)]
+        (is (zero? (.getRGB img 10 10)) "the reused buffer no longer shows the previous render's pixel")))))
 
 (deftest different-sizes-do-not-collide-test
-  (let [a (image-buffer/acquire 100 100)]
-    (image-buffer/release a)
-    (let [b (image-buffer/acquire 200 100)]
-      (try
-        (is (not (identical? a b)))
+  (testing "a buffer is only ever reused for its own exact size"
+    (let [p (image-buffer/->pool)
+          a (image-buffer/acquire p 100 100)]
+      (image-buffer/release p a)
+      (let [^BufferedImage b (image-buffer/acquire p 200 100)]
+        (is (not (identical? a b)) "a different size must not hand back the wrong-sized buffer")
         (is (= 200 (.getWidth b)))
-        (finally
-          (image-buffer/release b))))))
+        (is (= 100 (.getHeight b)))))))
 
-(deftest multiple-buffers-per-size-are-pooled-test
-  (testing "the pool keeps more than one idle buffer per size, so same-size renders each reuse one"
-    (let [a (image-buffer/acquire 50 50)
-          b (image-buffer/acquire 50 50)]
-      (is (not (identical? a b)))
-      (image-buffer/release a)
-      (image-buffer/release b)
-      (let [x (image-buffer/acquire 50 50)
-            y (image-buffer/acquire 50 50)]
-        (try
-          (is (= #{a b} #{x y}) "both released buffers were reused")
-          (finally
-            (image-buffer/release x)
-            (image-buffer/release y)))))))
+(deftest empty-pool-allocates-fresh-buffer-test
+  (testing "acquiring with nothing pooled yields a fresh, correctly-sized buffer (the empty-pool branch -- there is no
+            blocking primitive in acquire to wait on; pollFirst returns nil immediately on an empty deque)"
+    (let [p (image-buffer/->pool)
+          ^BufferedImage img (image-buffer/acquire p 333 222)]
+      (is (instance? BufferedImage img))
+      (is (= 333 (.getWidth img)))
+      (is (= 222 (.getHeight img))))))
+
+(deftest per-size-cap-bounds-retention-test
+  (testing "a size retains at most per-size-cap idle buffers"
+    (let [cap 3
+          p (image-buffer/->pool {:per-size-cap cap})
+          ;; acquire more distinct buffers than the cap (force misses by holding them all before releasing any)
+          held (vec (repeatedly (* 2 cap) #(image-buffer/acquire p 700 350)))]
+      (run! #(image-buffer/release p %) held)
+      (is (= cap (:idle (image-buffer/stats p))) "retained exactly per-size-cap; surplus discarded"))))
+
+(deftest global-cap-bounds-total-retention-test
+  (testing "the global cap bounds total idle buffers across sizes"
+    (let [gcap 5
+          p (image-buffer/->pool {:per-size-cap 10 :global-cap gcap})
+          ;; release one buffer of each of many distinct sizes; total retained must not exceed the global cap
+          held (vec (for [i (range (* 2 gcap))] (image-buffer/acquire p (+ 1000 i) 400)))]
+      (run! #(image-buffer/release p %) held)
+      (is (<= (:idle (image-buffer/stats p)) gcap)
+          "total idle buffers across all sizes stays within the global cap"))))
+
+(deftest sweep-evicts-stale-and-drains-to-zero-test
+  (testing "sweep! drops buffers idle past the TTL and drains to zero"
+    ;; buffers are stamped with the real wall clock at release, so we sweep relative to a captured `now`
+    (let [ttl 60000
+          p (image-buffer/->pool {:idle-ttl-ms ttl})]
+      ;; pool a couple of buffers, then release; they are stamped at ~now
+      (image-buffer/release p (image-buffer/acquire p 480 480))
+      (image-buffer/release p (image-buffer/acquire p 481 481))
+      (is (= 2 (:idle (image-buffer/stats p))) "two buffers idle before any sweep")
+      (let [now (System/currentTimeMillis)]
+        ;; sweep at a moment still within the TTL of the release -> nothing evicted
+        (image-buffer/sweep! p (+ now (quot ttl 2)))
+        (is (pos? (:idle (image-buffer/stats p))) "fresh buffers (within TTL) survive a sweep")
+        ;; sweep well past the TTL -> everything drains to zero and empty keys are removed
+        (image-buffer/sweep! p (+ now (* 10 ttl)))
+        (is (= 0 (:idle (image-buffer/stats p))) "buffers idle past the TTL are evicted; the pool drains to zero")))))
+
+(deftest stats-idle-reflects-reality-test
+  (testing "reported idle count matches reality and never goes negative"
+    (let [p (image-buffer/->pool)]
+      (dotimes [i 20]
+        ;; interleave acquires and releases of a few sizes
+        (let [img (image-buffer/acquire p (+ 600 (mod i 3)) 300)]
+          (when (even? i) (image-buffer/release p img))))
+      (let [idle (:idle (image-buffer/stats p))]
+        (is (>= idle 0) "idle count is never negative")
+        ;; cross-check against the records' own count by draining everything we can and counting
+        (is (= idle (:idle (image-buffer/stats p))) "idle count is stable / self-consistent on repeated reads")))))
+
+(deftest release-nil-is-safe-test
+  (is (nil? (image-buffer/release (image-buffer/->pool) nil))))

--- a/test/metabase/channel/render/image_buffer_test.clj
+++ b/test/metabase/channel/render/image_buffer_test.clj
@@ -48,3 +48,18 @@
         (is (= 200 (.getWidth b)))
         (finally
           (image-buffer/release b))))))
+
+(deftest multiple-buffers-per-size-are-pooled-test
+  (testing "the pool keeps more than one idle buffer per size, so same-size renders each reuse one"
+    (let [a (image-buffer/acquire 50 50)
+          b (image-buffer/acquire 50 50)]
+      (is (not (identical? a b)))
+      (image-buffer/release a)
+      (image-buffer/release b)
+      (let [x (image-buffer/acquire 50 50)
+            y (image-buffer/acquire 50 50)]
+        (try
+          (is (= #{a b} #{x y}) "both released buffers were reused")
+          (finally
+            (image-buffer/release x)
+            (image-buffer/release y)))))))

--- a/test/metabase/channel/render/image_buffer_test.clj
+++ b/test/metabase/channel/render/image_buffer_test.clj
@@ -12,15 +12,14 @@
 ;; assert exact hit/miss/idle counts rather than fuzzy "some reuse" thresholds.
 
 (deftest acquire-returns-argb-of-requested-size-test
-  (testing "acquire yields a TYPE_INT_ARGB buffer of exactly the requested size, for any size asked of one pool"
+  (testing "acquire yields an ARGB BufferedImage of exactly the requested size, for any size that fits the pool"
     (let [p     (image-buffer/->pool)
           sizes [[320 240] [1200 800] [1 1] [1200 1322] [64 480]]]
       (doseq [[w h] sizes]
         (let [^BufferedImage img (image-buffer/acquire p w h)]
           (is (instance? BufferedImage img) (format "%dx%d is a BufferedImage" w h))
           (is (= w (.getWidth img)) (format "%dx%d width" w h))
-          (is (= h (.getHeight img)) (format "%dx%d height" w h))
-          (is (= BufferedImage/TYPE_INT_ARGB (.getType img)) (format "%dx%d is ARGB" w h)))))))
+          (is (= h (.getHeight img)) (format "%dx%d height" w h)))))))
 
 (deftest sequential-cycle-reuses-after-one-allocation-test
   (testing "cycling one size allocates once, then reuses every time"
@@ -30,18 +29,71 @@
         (image-buffer/release p (image-buffer/acquire p 1207 503)))
       (let [{:keys [hits misses idle]} (image-buffer/stats p)]
         (is (= 1 misses) "only the very first acquire allocates; the rest must reuse")
-        (is (= (dec n) hits) "every acquire after the first reused a pooled buffer")
-        (is (= 1 idle) "one buffer cycles through the whole run")))))
+        (is (= (dec n) hits) "every acquire after the first reused a pooled array")
+        (is (= 1 idle) "one array cycles through the whole run")))))
 
-(deftest concurrent-same-size-allocates-at-most-thread-count-test
-  (testing "concurrent threads cycling one size allocate at most thread-count buffers"
+(deftest different-sizes-reuse-the-same-array-test
+  (testing "the headline property: one fixed-size array backs ANY size that fits, so different sizes reuse it (NOT a
+            per-size cache). After the first allocation every differently-sized acquire is a hit."
+    (let [p (image-buffer/->pool)]
+      (image-buffer/release p (image-buffer/acquire p 1200 800))   ;; allocate once
+      (doseq [[w h] [[1000 600] [200 100] [1199 1000] [50 50]]]    ;; all different sizes, all fit
+        (image-buffer/release p (image-buffer/acquire p w h)))
+      (let [{:keys [hits misses idle]} (image-buffer/stats p)]
+        (is (= 1 misses) "only the first acquire allocated; differently-sized acquires reused the same array")
+        (is (= 4 hits) "every differently-sized acquire after the first was a reuse")
+        (is (= 1 idle) "still just one array")))))
+
+(deftest reused-array-is-cleared-test
+  (testing "a reused array is wiped in the region the next render uses (no data leak between renders)"
+    (let [p (image-buffer/->pool)]
+      (let [^BufferedImage img (image-buffer/acquire p 64 64)]
+        (.setRGB img 10 10 (unchecked-int 0xFF00FF00))
+        (is (not (zero? (.getRGB img 10 10))) "sanity: pixel was dirtied")
+        (image-buffer/release p img))
+      (let [^BufferedImage img (image-buffer/acquire p 64 64)]
+        (is (zero? (.getRGB img 10 10)) "the reused array no longer shows the previous render's pixel")))))
+
+(deftest oversized-request-is-a-one-off-test
+  (testing "a request larger than the fixed array size falls back to a fresh standard image and is NOT pooled"
+    (let [p (image-buffer/->pool {:array-pixels (* 100 100)})         ;; tiny fixed size
+          ^BufferedImage big (image-buffer/acquire p 500 500)]         ;; 250k px > 10k cap
+      (is (= 500 (.getWidth big)))
+      (is (= 500 (.getHeight big)))
+      (is (= BufferedImage/TYPE_INT_ARGB (.getType big)) "one-off uses a standard TYPE_INT_ARGB image")
+      (image-buffer/release p big)
+      (let [{:keys [one-offs idle]} (image-buffer/stats p)]
+        (is (= 1 one-offs) "counted as a one-off")
+        (is (= 0 idle) "the oversized array was not pooled on release")))))
+
+(deftest oversized-and-normal-coexist-test
+  (testing "one-offs don't pollute the pool: a normal-size array still pools while oversized requests pass through"
+    (let [p (image-buffer/->pool {:array-pixels (* 100 100)})]
+      (image-buffer/release p (image-buffer/acquire p 80 80))     ;; fits -> pooled
+      (image-buffer/release p (image-buffer/acquire p 500 500))   ;; oversized -> one-off, dropped
+      (let [{:keys [idle one-offs misses]} (image-buffer/stats p)]
+        (is (= 1 idle) "only the fitting array is pooled")
+        (is (= 1 one-offs))
+        (is (= 1 misses) "the fitting acquire allocated once; the one-off is counted separately")))))
+
+(deftest max-arrays-bounds-retention-test
+  (testing "the pool retains at most :max-arrays idle arrays; surplus releases are dropped"
+    (let [cap 3
+          p (image-buffer/->pool {:max-arrays cap})
+          ;; acquire more arrays than the cap (force misses by holding them all before releasing any)
+          held (vec (repeatedly (* 2 cap) #(image-buffer/acquire p 700 350)))]
+      (run! #(image-buffer/release p %) held)
+      (is (= cap (:idle (image-buffer/stats p))) "retained exactly :max-arrays; surplus discarded"))))
+
+(deftest concurrent-allocates-at-most-thread-count-test
+  (testing "concurrent threads cycling renders allocate at most thread-count arrays"
     (let [thread-count       8
           cycles-per-thread  50
           timeout-ms         5000
-          pool               (image-buffer/->pool)
-          ;; A barrier so all threads start their acquire/release loops at the same moment (genuine overlap, so the
-          ;; "<= thread-count allocations" assertion exercises real concurrency). `await` is bounded, and the worker
-          ;; reaches it via try/finally, so a thread that throws can't strand the others on the barrier.
+          pool               (image-buffer/->pool {:max-arrays thread-count})
+          ;; A barrier so all threads start at the same moment (genuine overlap, so the "<= thread-count allocations"
+          ;; assertion exercises real concurrency). `await` is bounded and the worker reaches it directly, so a thread
+          ;; that throws can't strand the others on the barrier.
           started            (java.util.concurrent.CyclicBarrier. thread-count)
           worker             (fn []
                                (.await started (long timeout-ms) java.util.concurrent.TimeUnit/MILLISECONDS)
@@ -57,103 +109,27 @@
         (is (<= misses thread-count) "never allocated more than the number of concurrent threads")
         (is (pos? hits) "reuse happened")))))
 
-(deftest many-sizes-pool-contents-and-isolation-test
-  (testing "many distinct sizes pool independently; each acquire gets its own size"
-    (let [p     (image-buffer/->pool)
-          sizes (for [i (range 9)] [(+ 1200 i) (+ 800 (* 10 i))])]  ;; 9 dashboard-ish sizes, all distinct
-      ;; release one buffer of each size into the pool
-      (doseq [[w h] sizes]
-        (image-buffer/release p (image-buffer/acquire p w h)))
-      (let [{:keys [by-size idle]} (image-buffer/stats p)]
-        (is (= (count sizes) idle) "one idle buffer per distinct size was retained")
-        (is (= (set sizes) (set (keys by-size))) "the pool holds exactly the sizes we released, keyed correctly")
-        (is (every? #(= 1 %) (vals by-size)) "exactly one buffer per size (we released one each)"))
-      ;; now re-acquire each size and assert we get back a correctly-sized, reused buffer (not a collision)
-      (doseq [[w h] sizes]
-        (let [hits-before (:hits (image-buffer/stats p))
-              ^BufferedImage img (image-buffer/acquire p w h)]
-          (is (= [w h] [(.getWidth img) (.getHeight img)]) "acquire returned a buffer of the requested size")
-          (is (= (inc hits-before) (:hits (image-buffer/stats p)))
-              "the acquire reused this size's pooled buffer rather than allocating (no cross-size theft)")
-          (image-buffer/release p img)))
-      (is (= (count sizes) (:idle (image-buffer/stats p))) "after the round trip the pool still holds one per size"))))
-
-(deftest reused-buffer-is-cleared-test
-  (testing "a reused buffer is wiped to fully transparent (no data leak between renders)"
+(deftest sweep-drains-to-zero-test
+  (testing "sweep! drops idle arrays so memory is reclaimed when rendering stops"
     (let [p (image-buffer/->pool)]
-      (let [^BufferedImage img (image-buffer/acquire p 64 64)]
-        (.setRGB img 10 10 (unchecked-int 0xFF00FF00))
-        (is (not (zero? (.getRGB img 10 10))) "sanity: pixel was dirtied")
-        (image-buffer/release p img))
-      (let [^BufferedImage img (image-buffer/acquire p 64 64)]
-        (is (zero? (.getRGB img 10 10)) "the reused buffer no longer shows the previous render's pixel")))))
-
-(deftest different-sizes-do-not-collide-test
-  (testing "a buffer is only ever reused for its own exact size"
-    (let [p (image-buffer/->pool)
-          a (image-buffer/acquire p 100 100)]
-      (image-buffer/release p a)
-      (let [^BufferedImage b (image-buffer/acquire p 200 100)]
-        (is (not (identical? a b)) "a different size must not hand back the wrong-sized buffer")
-        (is (= 200 (.getWidth b)))
-        (is (= 100 (.getHeight b)))))))
-
-(deftest empty-pool-allocates-fresh-buffer-test
-  (testing "acquiring with nothing pooled yields a fresh, correctly-sized buffer (the empty-pool branch -- there is no
-            blocking primitive in acquire to wait on; pollFirst returns nil immediately on an empty deque)"
-    (let [p (image-buffer/->pool)
-          ^BufferedImage img (image-buffer/acquire p 333 222)]
-      (is (instance? BufferedImage img))
-      (is (= 333 (.getWidth img)))
-      (is (= 222 (.getHeight img))))))
-
-(deftest per-size-cap-bounds-retention-test
-  (testing "a size retains at most per-size-cap idle buffers"
-    (let [cap 3
-          p (image-buffer/->pool {:per-size-cap cap})
-          ;; acquire more distinct buffers than the cap (force misses by holding them all before releasing any)
-          held (vec (repeatedly (* 2 cap) #(image-buffer/acquire p 700 350)))]
-      (run! #(image-buffer/release p %) held)
-      (is (= cap (:idle (image-buffer/stats p))) "retained exactly per-size-cap; surplus discarded"))))
-
-(deftest global-cap-bounds-total-retention-test
-  (testing "the global cap bounds total idle buffers across sizes"
-    (let [gcap 5
-          p (image-buffer/->pool {:per-size-cap 10 :global-cap gcap})
-          ;; release one buffer of each of many distinct sizes; total retained must not exceed the global cap
-          held (vec (for [i (range (* 2 gcap))] (image-buffer/acquire p (+ 1000 i) 400)))]
-      (run! #(image-buffer/release p %) held)
-      (is (<= (:idle (image-buffer/stats p)) gcap)
-          "total idle buffers across all sizes stays within the global cap"))))
-
-(deftest sweep-evicts-stale-and-drains-to-zero-test
-  (testing "sweep! drops buffers idle past the TTL and drains to zero"
-    ;; buffers are stamped with the real wall clock at release, so we sweep relative to a captured `now`
-    (let [ttl 60000
-          p (image-buffer/->pool {:idle-ttl-ms ttl})]
-      ;; pool a couple of buffers, then release; they are stamped at ~now
       (image-buffer/release p (image-buffer/acquire p 480 480))
       (image-buffer/release p (image-buffer/acquire p 481 481))
-      (is (= 2 (:idle (image-buffer/stats p))) "two buffers idle before any sweep")
-      (let [now (System/currentTimeMillis)]
-        ;; sweep at a moment still within the TTL of the release -> nothing evicted
-        (image-buffer/sweep! p (+ now (quot ttl 2)))
-        (is (pos? (:idle (image-buffer/stats p))) "fresh buffers (within TTL) survive a sweep")
-        ;; sweep well past the TTL -> everything drains to zero and empty keys are removed
-        (image-buffer/sweep! p (+ now (* 10 ttl)))
-        (is (= 0 (:idle (image-buffer/stats p))) "buffers idle past the TTL are evicted; the pool drains to zero")))))
+      (is (pos? (:idle (image-buffer/stats p))) "arrays are pooled before the sweep")
+      (image-buffer/sweep! p)
+      (is (= 0 (:idle (image-buffer/stats p))) "sweep drains the pool to zero")
+      ;; and rendering after a sweep just repopulates
+      (image-buffer/release p (image-buffer/acquire p 480 480))
+      (is (= 1 (:idle (image-buffer/stats p))) "post-sweep acquire/release repopulates"))))
 
 (deftest stats-idle-reflects-reality-test
   (testing "reported idle count matches reality and never goes negative"
     (let [p (image-buffer/->pool)]
       (dotimes [i 20]
-        ;; interleave acquires and releases of a few sizes
         (let [img (image-buffer/acquire p (+ 600 (mod i 3)) 300)]
           (when (even? i) (image-buffer/release p img))))
       (let [idle (:idle (image-buffer/stats p))]
         (is (>= idle 0) "idle count is never negative")
-        ;; cross-check against the records' own count by draining everything we can and counting
-        (is (= idle (:idle (image-buffer/stats p))) "idle count is stable / self-consistent on repeated reads")))))
+        (is (<= idle (:max-arrays (image-buffer/->pool))) "idle never exceeds the retention cap")))))
 
 (deftest release-nil-is-safe-test
   (is (nil? (image-buffer/release (image-buffer/->pool) nil))))


### PR DESCRIPTION
https://metaboat.slack.com/archives/C0AQ826GLUR/p1782353094575889

A simple shared buffer to prevent OOMs with the normal GC not being able to reclaim memory.

 ## Summary

  Subscription/alert rendering allocates a fresh multi-MB ARGB `BufferedImage` for
  every chart. At dashboard sizes (3–6 MB) these are **G1 "humongous" objects**, which
  pile up faster than mixed/full GCs reclaim them under bursty subscription load — the
  JVM OOMs on region exhaustion while most of the heap is actually free.

  This makes `render-svg` **borrow a buffer from a shared, size-keyed recycler** for the
  duration of a Batik transcode and check it back in, instead of allocating fresh each
  time — cutting the allocation churn that drives the OOMs.

  It's a **recycler, not a resource pool**: `acquire` never blocks or refuses (an empty
  recycler always allocates), there's no cap on live buffers, and the caps bound
  **retention only** — idle buffers kept up to ~6/size and 24 total, surplus dropped. A
  daemon thread evicts buffers idle past a 60s TTL, so the recycler **drains to zero when
  rendering stops**. Full rationale (including why we moved off the original
  `ConcurrentHashMap`-of-`SoftReference`s design, and what was considered and rejected) is
  in the commit message.

  ## ⚠️ Requires a GC flag to fully fix the OOM

  **This PR is the allocation-rate reduction, not the whole fix.** The primary OOM remedy
  is the runtime flag **`-XX:G1HeapRegionSize=16m`** (not 8m — real cards reach 6 MB),
  which makes every measured raster eagerly collectable. The recycler reduces churn on top
  of that. The flag needs to land in the deployment config separately — this code change
  alone is not sufficient.

  ## How it works

  - **Shared across threads** (not thread-local): instrumenting real email + Slack sends
    showed renders fan out across many Jetty threads, so a per-thread cache stays cold
    (~30% reuse vs ~60% shared).
  - **Strong references + explicit TTL eviction** (not `SoftReference`): soft refs only
    clear at the OOM edge, which relocates the problem rather than fixing it. We want
    buffers released promptly when idle.
  - **LIFO reuse, oldest-first eviction**: each size's deque is used as a stack for
    acquire/release (hot buffers stay hot) and swept from the bottom (cold buffers
    atrophy and get reclaimed).
  - **Clear-on-acquire** is load-bearing for correctness: Batik composites with `SrcOver`
    and skips its background fill when the background is nil, so a dirty reused buffer
    would bleed the previous render into the next. (Reuse is otherwise safe because the
    buffer is PNG-encoded eagerly and only the `byte[]` escapes.)
  - Built **lazily on first use** behind a `delay` so AOT compilation doesn't spawn the
    daemon thread at build time.

  ## Not in scope (follow-ups)

  - **HTML/CSSBox table path** (`render-html-to-png`, used for Slack tables) is not
    recycled yet — its buffer is allocated inside CSSBox and returned as an aliasing
    `getSubimage` view, so it needs more care. Covered for now by the GC flag (real table
    rasters are ≤6 MB).

  ## How to verify

  - Backend tests: `metabase.channel.render.image-buffer-test` (12 tests, deterministic —
    each uses its own isolated recycler) and `metabase.channel.render.js.svg-test`.
  - The recycler logs its hit rate periodically (interval + lifetime), so reuse can be
    confirmed in real deployments.

  ## Risk

  Low. Behavior is unchanged from a caller's perspective (`render-svg` still returns the
  same PNG bytes); the change is internal buffer reuse. Worst case if reuse misbehaves is
  extra allocation, not incorrect output — and the clear-on-acquire + eager-encode
  firewall is covered by a regression test.

  A few notes:

  - The GC-flag callout is its own prominent section, because it's the single thing most likely to cause "we merged the fix but highway still OOMs." A reviewer or whoever deploys needs to see it
  without reading the commit body.
  - I did not re-paste the long reasoning — the description points to the commit message for it. That keeps the PR scannable while preserving the depth.
  - Small correction you may want to make in the commit too: your edited line "the staleness check works them as a queue, working bottom up" — "bottom up" is right (sweep from the oldest/tail),
  but "as a queue" is slightly off; it's not FIFO consumption, it's "evict from the tail." Minor, and only if you care; I phrased it in the PR as "swept from the bottom" to sidestep it. Want me
  to amend that one line in the commit, or leave it?