### PR TITLE
Ignore tagged tests in e2e smart runs

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -179,7 +179,7 @@ jobs:
         run: |
           echo "Running tests with specs: $SPEC_PATH"
           node e2e/runner/run_cypress_ci.js e2e \
-          --expose grepTags="${{inputs.tags && format('{0}+-@skip', inputs.tags) || '-@skip'}}" \
+          --expose grepTags="${{inputs.tags && format('{0}+-@skip', inputs.tags) || '-@mongo+-@python+-@OSS+-@skip'}}" \
           --spec "$SPEC_PATH"
         # Trunk Quarantine controls the final state of the run in the CI!
         # Even if this step fails we let it pass, and then `trunk-io/analytics-uploader` determines


### PR DESCRIPTION
Resolves DEV-1840

## Summary

Smart e2e runs (only changed specs) ran their regular chunks with a `-@skip`-only grep, so `@python`/`@mongo`/`@OSS` tests inside a changed spec executed in a chunk without their special environment (e.g. no python-runner) and failed. This aligns the smart-run grep with the full-run exclusion list so those tagged tests are filtered out, matching how they're already handled in non-smart runs.

> [!IMPORTANT]
> Trade-off: this *filters out* the tagged tests rather than running them properly. If a PR changes only a `@python`/`@mongo`/`@OSS` spec, those tests won't execute in that PR — a coverage gap. The smarter fix (detect the changed test and route it to the right environment) is tracked in DEV-2236.
