### PR TITLE
Improve index manager lifecycle states

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1070,6 +1070,7 @@
   indexes
   {:team "Gadget"
    :api  #{metabase.indexes.api
+           metabase.indexes.models.table-index
            metabase.indexes.reconcile}
    :uses #{api
            driver
@@ -2366,6 +2367,7 @@
            database-routing
            driver
            events
+           indexes
            lib
            lib-be
            models

--- a/resources/migrations/063/20260615_metabase_table_indexes.yaml
+++ b/resources/migrations/063/20260615_metabase_table_indexes.yaml
@@ -40,8 +40,8 @@ databaseChangeLog:
               - column:
                   name: status
                   type: varchar(20)
-                  defaultValue: pending
-                  remarks: "Lifecycle status: pending, running, succeeded, failed, or dropped"
+                  defaultValue: create-pending
+                  remarks: "Lifecycle status: create-pending, update-pending, deletion-pending, running, succeeded, or failed"
                   constraints:
                     nullable: false
               - column:

--- a/resources/migrations/063/20260615_metabase_table_indexes.yaml
+++ b/resources/migrations/063/20260615_metabase_table_indexes.yaml
@@ -41,7 +41,7 @@ databaseChangeLog:
                   name: status
                   type: varchar(20)
                   defaultValue: create-pending
-                  remarks: "Lifecycle status: create-pending, update-pending, deletion-pending, running, succeeded, or failed"
+                  remarks: "Lifecycle status: create-pending, update-pending, delete-pending, running, succeeded, or failed"
                   constraints:
                     nullable: false
               - column:

--- a/src/metabase/indexes/api.clj
+++ b/src/metabase/indexes/api.clj
@@ -7,6 +7,7 @@
   (:require
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
+   [metabase.indexes.models.table-index :as table-index]
    [metabase.indexes.reconcile :as reconcile]
    [metabase.indexes.schema :as schema]
    [metabase.util.i18n :refer [tru]]
@@ -24,7 +25,7 @@
    [:index_name ms/NonBlankString]
    ;; The real structured schema (not a bare `:map`) so response coercion doesn't strip its keys.
    [:structured ::schema/index-structured]
-   [:status [:enum :pending :running :succeeded :failed :dropped]]
+   [:status [:enum :create-pending :update-pending :deletion-pending :running :succeeded :failed]]
    [:error_message [:maybe :string]]
    [:created_by [:maybe ms/PositiveInt]]
    [:created_at :any]
@@ -66,7 +67,7 @@
    {:keys [transform-id]} :- [:map [:transform-id ms/PositiveInt]]]
   (let [transform (api/read-check :model/Transform transform-id)
         {:keys [database schema] table-name :name} (:target transform)
-        managed   (t2/select :model/TableIndex :transform_id transform-id {:order-by [[:id :asc]]})
+        managed   (table-index/select-for-transform transform-id)
         warehouse (reconcile/fetch-warehouse-indexes (t2/select-one :model/Database database) schema table-name)]
     {:data (reconcile/merge-indexes managed warehouse)}))
 
@@ -85,9 +86,10 @@
                                          [:transform_id ms/PositiveInt]
                                          [:structured :map]]]
   (api/write-check :model/Transform transform_id)
-  (let [idx-name (reconcile/index-name structured)]
+  (let [structured (schema/keywordize-structured structured)
+        idx-name   (reconcile/index-name structured)]
     ;; (transform_id, index_name) is unique; reject a duplicate cleanly instead of hitting the constraint.
-    (api/check-400 (not (t2/exists? :model/TableIndex :transform_id transform_id :index_name idx-name))
+    (api/check-400 (not (table-index/exists-for-transform? transform_id idx-name))
                    (tru "An index named \"{0}\" already exists for this transform." idx-name))
     (t2/insert-returning-instance! :model/TableIndex
                                    {:transform_id transform_id
@@ -95,24 +97,35 @@
                                     :structured   structured
                                     :created_by   api/*current-user-id*})))
 
+(defn- assert-stable-key!
+  [existing structured]
+  (api/check-400 (= (reconcile/index-name (:structured existing))
+                    (reconcile/index-name structured))
+                 (tru "The index name cannot be changed. Delete and recreate the index instead."))
+  (api/check-400 (= (:kind (:structured existing)) (:kind structured))
+                 (tru "The index type cannot be changed. Delete and recreate the index instead."))
+  (api/check-400 (= (:type (:structured existing)) (:type structured))
+                 (tru "The index type cannot be changed. Delete and recreate the index instead.")))
+
 (api.macros/defendpoint :put "/request/:id" :- RequestIndex
-  "Replace the structured definition of an index request, resetting it to pending."
+  "Replace the structured definition of an index request, marking it update-pending."
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    _query-params
    {:keys [structured]} :- [:map [:structured :map]]]
-  (write-check-owner! (api/check-404 (t2/select-one :model/TableIndex :id id)))
-  ;; toucan2 has no instance-returning update, so re-select; in a tx so we return exactly what we wrote.
-  (t2/with-transaction [_conn]
-    (t2/update! :model/TableIndex id {:structured    structured
-                                      :index_name    (reconcile/index-name structured)
-                                      :status        :pending
-                                      :error_message nil})
-    (t2/select-one :model/TableIndex :id id)))
+  (let [structured (schema/keywordize-structured structured)
+        existing   (api/check-404 (table-index/select-applicable-by-id id))]
+    (write-check-owner! existing)
+    (assert-stable-key! existing structured)
+    ;; toucan2 has no instance-returning update, so re-select; in a tx so we return exactly what we wrote.
+    (t2/with-transaction [_conn]
+      (t2/update! :model/TableIndex id {:structured structured})
+      (t2/select-one :model/TableIndex :id id))))
 
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :delete "/request/:id"
   "Delete an index request."
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
-  (write-check-owner! (api/check-404 (t2/select-one :model/TableIndex :id id)))
-  (t2/delete! :model/TableIndex :id id)
+  (let [existing (api/check-404 (table-index/select-applicable-by-id id))]
+    (write-check-owner! existing)
+    (t2/update! :model/TableIndex id {:status :deletion-pending}))
   api/generic-204-no-content)

--- a/src/metabase/indexes/api.clj
+++ b/src/metabase/indexes/api.clj
@@ -25,7 +25,7 @@
    [:index_name ms/NonBlankString]
    ;; The real structured schema (not a bare `:map`) so response coercion doesn't strip its keys.
    [:structured ::schema/index-structured]
-   [:status [:enum :create-pending :update-pending :deletion-pending :running :succeeded :failed]]
+   [:status [:enum :create-pending :update-pending :delete-pending :running :succeeded :failed]]
    [:error_message [:maybe :string]]
    [:created_by [:maybe ms/PositiveInt]]
    [:created_at :any]
@@ -127,5 +127,5 @@
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
   (let [existing (api/check-404 (table-index/select-applicable-by-id id))]
     (write-check-owner! existing)
-    (t2/update! :model/TableIndex id {:status :deletion-pending}))
+    (t2/update! :model/TableIndex id {:status :delete-pending}))
   api/generic-204-no-content)

--- a/src/metabase/indexes/api.clj
+++ b/src/metabase/indexes/api.clj
@@ -68,7 +68,8 @@
   (let [transform (api/read-check :model/Transform transform-id)
         {:keys [database schema] table-name :name} (:target transform)
         managed   (table-index/select-for-transform transform-id)
-        warehouse (reconcile/fetch-warehouse-indexes (t2/select-one :model/Database database) schema table-name)]
+        warehouse (or (reconcile/fetch-warehouse-indexes (t2/select-one :model/Database database) schema table-name)
+                      [])]
     {:data (reconcile/merge-indexes managed warehouse)}))
 
 (api.macros/defendpoint :get "/request/:id" :- RequestIndex

--- a/src/metabase/indexes/models/table_index.clj
+++ b/src/metabase/indexes/models/table_index.clj
@@ -36,11 +36,11 @@
    :status     (mi/transform-validator mi/transform-keyword (partial mi/assert-enum schema/statuses))})
 
 (def ^:private non-applicable-statuses
-  #{:deletion-pending})
+  #{:delete-pending})
 
 (def pending-statuses
   "Statuses that require a full incremental rebuild before an index request's physical state can be trusted."
-  #{:create-pending :update-pending :deletion-pending :running})
+  #{:create-pending :update-pending :delete-pending :running})
 
 (def ^:private runnable-statuses
   #{:create-pending :update-pending :running :failed})
@@ -112,7 +112,7 @@
   "Rows the current execution can update while verifying indexes.
 
   `index-request-ids` is the applicable request id set hydrated at execution start. Only rows still `:running` are
-  settled; if a request is edited mid-run, its pending status is left for the next rebuild. Deletion-pending rows are
+  settled; if a request is edited mid-run, its pending status is left for the next rebuild. Delete-pending rows are
   also included so a successful full rebuild can remove rows for physical indexes that disappeared."
   [transform-id index-request-ids]
   (concat
@@ -124,7 +124,7 @@
                 {:order-by [[:id :asc]]}))
    (t2/select :model/TableIndex
               :transform_id transform-id
-              :status :deletion-pending
+              :status :delete-pending
               {:order-by [[:id :asc]]})))
 
 (defn select-applicable-by-id

--- a/src/metabase/indexes/models/table_index.clj
+++ b/src/metabase/indexes/models/table_index.clj
@@ -43,7 +43,7 @@
   #{:create-pending :update-pending :deletion-pending :running})
 
 (def ^:private runnable-statuses
-  #{:create-pending :update-pending :failed})
+  #{:create-pending :update-pending :running :failed})
 
 (def ^:private defaults
   {:status :create-pending})
@@ -108,6 +108,25 @@
                      :transform_id transform-id
                      {:order-by [[:index_name :asc]]})))
 
+(defn select-for-verification
+  "Rows the current execution can update while verifying indexes.
+
+  `index-request-ids` is the applicable request id set hydrated at execution start. Only rows still `:running` are
+  settled; if a request is edited mid-run, its pending status is left for the next rebuild. Deletion-pending rows are
+  also included so a successful full rebuild can remove rows for physical indexes that disappeared."
+  [transform-id index-request-ids]
+  (concat
+   (when (seq index-request-ids)
+     (t2/select :model/TableIndex
+                :transform_id transform-id
+                :id [:in index-request-ids]
+                :status :running
+                {:order-by [[:id :asc]]}))
+   (t2/select :model/TableIndex
+              :transform_id transform-id
+              :status :deletion-pending
+              {:order-by [[:id :asc]]})))
+
 (defn select-applicable-by-id
   "Fetch a single applicable index request by id."
   [id]
@@ -123,15 +142,15 @@
            (t2/select :model/TableIndex :transform_id transform-id)))))
 
 (defn mark-runnable-indexes-running!
-  "Mark applicable index requests that this run will apply as running.
+  "Mark hydrated index requests that this run will apply as running.
 
-  Returns the ids marked running so callers can fail rows that verification cannot move to `:succeeded` or `:failed`."
-  [transform-id]
-  (let [ids (t2/select-fn-set :id :model/TableIndex
-                              :transform_id transform-id
-                              :status [:in runnable-statuses])]
-    (doseq [id ids]
-      (t2/update! :model/TableIndex id {:status :running}))
+  Returns the ids so callers can fail rows that verification cannot move to `:succeeded` or `:failed`."
+  [index-request-ids]
+  (let [ids (set index-request-ids)]
+    (when (seq ids)
+      (t2/update! :model/TableIndex
+                  {:id [:in ids] :status [:in runnable-statuses]}
+                  {:status :running}))
     ids))
 
 (defn mark-unverified-running-indexes-failed!

--- a/src/metabase/indexes/models/table_index.clj
+++ b/src/metabase/indexes/models/table_index.clj
@@ -2,12 +2,11 @@
   "The `metabase_table_indexes` model: index/clustering hints for a table.
 
   Every row binds to a transform (`:transform_id`) whose target it indexes, carries a structured index definition
-  (see [[metabase.indexes.schema]]), and tracks a lifecycle `:status` (defaulting to `:pending`). The target table is
+  (see [[metabase.indexes.schema]]), and tracks a lifecycle `:status` (defaulting to `:create-pending`). The target table is
   read off the transform's `:target_table_id`, not mirrored here. The table is named generically so it can hold
   indexes for non-transform tables later too.
 
-  `:structured` and `:status` are validated at the transform layer (on read and write), so every writer is covered.
-  Callers use toucan2 directly; there are no wrapper functions."
+  `:structured` and `:status` are validated at the transform layer (on read and write), so every writer is covered."
   (:require
    [metabase.indexes.schema :as schema]
    [metabase.models.interface :as mi]
@@ -36,15 +35,124 @@
   {:structured transform-structured
    :status     (mi/transform-validator mi/transform-keyword (partial mi/assert-enum schema/statuses))})
 
+(def ^:private non-applicable-statuses
+  #{:deletion-pending})
+
+(def pending-statuses
+  "Statuses that require a full incremental rebuild before an index request's physical state can be trusted."
+  #{:create-pending :update-pending :deletion-pending :running})
+
+(def ^:private runnable-statuses
+  #{:create-pending :update-pending :failed})
+
 (def ^:private defaults
-  {:status :pending})
+  {:status :create-pending})
+
+(defn- reset-incremental-checkpoint!
+  [transform-id]
+  (when (= :table-incremental
+           (some-> (t2/select-one-fn :target :model/Transform :id transform-id)
+                   :type
+                   keyword))
+    ;; Indexes are applied only when a transform recreates its target table. Resetting the checkpoint makes the next
+    ;; incremental run perform that rebuild, matching the existing checkpoint-strategy change behavior.
+    (t2/update! :model/Transform transform-id {:last_checkpoint_value nil})))
+
+(defn- pending-status-for-changes
+  [changes]
+  (cond
+    (contains? changes :structured) :update-pending
+    (contains? pending-statuses (:status changes)) (:status changes)))
+
+(defn- transform-id
+  [idx]
+  (or (:transform_id idx)
+      (:transform_id (t2/original idx))))
 
 (t2/define-before-insert :model/TableIndex
   [req]
   (merge defaults req))
 
+(t2/define-after-insert :model/TableIndex
+  [idx]
+  (reset-incremental-checkpoint! (:transform_id idx))
+  idx)
+
+(t2/define-before-update :model/TableIndex
+  [idx]
+  (let [changes (t2/changes idx)
+        status  (pending-status-for-changes changes)]
+    (when status
+      (reset-incremental-checkpoint! (transform-id idx)))
+    (cond-> idx
+      status (assoc :status status
+                    :error_message nil))))
+
+(defn applicable?
+  "True when an index request should be applied to a transform's target table."
+  [idx]
+  (not (contains? non-applicable-statuses (:status idx))))
+
+(defn select-for-transform
+  "All index request rows for `transform-id`, ordered for the index manager list."
+  [transform-id]
+  (t2/select :model/TableIndex
+             :transform_id transform-id
+             {:order-by [[:id :asc]]}))
+
+(defn select-applicable-for-transform
+  "Rows whose structured definitions should be applied to `transform-id`'s target table."
+  [transform-id]
+  (filter applicable?
+          (t2/select :model/TableIndex
+                     :transform_id transform-id
+                     {:order-by [[:index_name :asc]]})))
+
+(defn select-applicable-by-id
+  "Fetch a single applicable index request by id."
+  [id]
+  (some-> (t2/select-one :model/TableIndex :id id)
+          (as-> idx (when (applicable? idx) idx))))
+
+(defn pending-changes-for-transform?
+  "True when `transform-id` has index changes that require a full rebuild to apply."
+  [transform-id]
+  (boolean
+   (when transform-id
+     (some #(contains? pending-statuses (:status %))
+           (t2/select :model/TableIndex :transform_id transform-id)))))
+
+(defn mark-runnable-indexes-running!
+  "Mark applicable index requests that this run will apply as running.
+
+  Returns the ids marked running so callers can fail rows that verification cannot move to `:succeeded` or `:failed`."
+  [transform-id]
+  (let [ids (t2/select-fn-set :id :model/TableIndex
+                              :transform_id transform-id
+                              :status [:in runnable-statuses])]
+    (doseq [id ids]
+      (t2/update! :model/TableIndex id {:status :running}))
+    ids))
+
+(defn mark-unverified-running-indexes-failed!
+  "Mark rows from [[mark-runnable-indexes-running!]] that are still running as failed."
+  [ids message]
+  (when (seq ids)
+    (t2/update! :model/TableIndex
+                {:id [:in ids] :status :running}
+                {:status           :failed
+                 :error_message    message
+                 :last_executed_at :%now})))
+
+(defn exists-for-transform?
+  "True when `transform-id` already has a request for `index-name`."
+  [transform-id index-name]
+  (t2/exists? :model/TableIndex
+              :transform_id transform-id
+              :index_name index-name))
+
 ;; Inlined into the owning transform's serialization (see the Transform make-spec's `:indexes`). Only the index
-;; definition travels; lifecycle is local, so an imported index starts fresh as `:pending`. `:structured` holds
+;; definition travels; lifecycle is local, so an imported index starts fresh as `:create-pending`. `:structured` holds
 ;; physical column names (no portable refs), so it copies verbatim. `:created_by` is skipped: a nested child's own
 ;; FKs aren't declared in the transform's `dependencies`, so the user may not resolve on import.
 (defmethod serdes/make-spec "TableIndex"

--- a/src/metabase/indexes/models/table_index.clj
+++ b/src/metabase/indexes/models/table_index.clj
@@ -35,9 +35,6 @@
   {:structured transform-structured
    :status     (mi/transform-validator mi/transform-keyword (partial mi/assert-enum schema/statuses))})
 
-(def ^:private non-applicable-statuses
-  #{:delete-pending})
-
 (def pending-statuses
   "Statuses that require a full incremental rebuild before an index request's physical state can be trusted."
   #{:create-pending :update-pending :delete-pending :running})
@@ -91,7 +88,7 @@
 (defn applicable?
   "True when an index request should be applied to a transform's target table."
   [idx]
-  (not (contains? non-applicable-statuses (:status idx))))
+  (not= :delete-pending (:status idx)))
 
 (defn select-for-transform
   "All index request rows for `transform-id`, ordered for the index manager list."

--- a/src/metabase/indexes/reconcile.clj
+++ b/src/metabase/indexes/reconcile.clj
@@ -111,9 +111,10 @@
                               (request-fields row)))]
     (into (vec present) absent)))
 
-(mu/defn fetch-warehouse-indexes :- [:sequential :map]
-  "Physical indexes on `table-name` (`schema`) in `database` via `driver/fetch-table-indexes`. Returns `[]` if the
-  driver can't introspect indexes or the warehouse is unreachable, so callers degrade instead of erroring."
+(mu/defn fetch-warehouse-indexes :- [:maybe [:sequential :map]]
+  "Physical indexes on `table-name` (`schema`) in `database` via `driver/fetch-table-indexes`.
+  Returns `nil` if the driver can't introspect indexes or the warehouse is unreachable, so callers can distinguish
+  fetch failure from a successful empty index list."
   [database   :- :map
    schema     :- [:maybe :string]
    table-name :- :string]
@@ -121,4 +122,4 @@
     (vec (driver/fetch-table-indexes (:engine database) database schema table-name))
     (catch Throwable t
       (log/warnf t "fetch-table-indexes failed for %s.%s" schema table-name)
-      [])))
+      nil)))

--- a/src/metabase/indexes/schema.clj
+++ b/src/metabase/indexes/schema.clj
@@ -79,7 +79,7 @@
 
 (def statuses
   "Valid lifecycle states for a table index request."
-  #{:create-pending :update-pending :deletion-pending :running :succeeded :failed})
+  #{:create-pending :update-pending :delete-pending :running :succeeded :failed})
 
 (defn keywordize-structured
   "Re-keywordize the structured map's enum-valued fields after JSON storage flattened them to strings."

--- a/src/metabase/indexes/schema.clj
+++ b/src/metabase/indexes/schema.clj
@@ -79,7 +79,7 @@
 
 (def statuses
   "Valid lifecycle states for a table index request."
-  #{:pending :running :succeeded :failed :dropped})
+  #{:create-pending :update-pending :deletion-pending :running :succeeded :failed})
 
 (defn keywordize-structured
   "Re-keywordize the structured map's enum-valued fields after JSON storage flattened them to strings."

--- a/src/metabase/transforms/execute.clj
+++ b/src/metabase/transforms/execute.clj
@@ -7,10 +7,19 @@
 
 (set! *warn-on-reflection* true)
 
+(defn- select-transform-index-requests
+  [transform]
+  (vec (table-index/select-applicable-for-transform (:id transform))))
+
 (defn hydrate-transform-indexes
   "Structured index defs for `transform`, read from its managed `TableIndex` rows (ordered by name)."
   [transform]
-  (mapv :structured (table-index/select-applicable-for-transform (:id transform))))
+  (mapv :structured (select-transform-index-requests transform)))
+
+(defn hydrate-transform-index-ids
+  "Applicable index request ids for `transform`, hydrated with the target at execution start."
+  [transform]
+  (mapv :id (select-transform-index-requests transform)))
 
 (defn- resolve-target
   "Apply the workspace target-rewrite hook before dispatch. On a workspaced child
@@ -27,14 +36,15 @@
   identify a target DB), the hook is skipped — workspace rewriting requires a
   known DB id to look up `db-workspace-namespace`.
 
-  Also hydrates the declared indexes onto the target so the base reads them off
-  `(:indexes target)` at every table-creation seam."
+  Also hydrates the declared indexes and their request ids onto the target so the base reads them off
+  `(:indexes target)` and `(:index-request-ids target)` at every table-creation seam."
   [transform]
   (-> (if-let [db-id (transforms-base.i/target-db-id transform)]
         (assoc transform :target
                (transforms.query-impl/resolve-transform-target db-id (:target transform)))
         transform)
-      (assoc-in [:target :indexes] (vec (hydrate-transform-indexes transform)))))
+      (assoc-in [:target :indexes] (vec (hydrate-transform-indexes transform)))
+      (assoc-in [:target :index-request-ids] (vec (hydrate-transform-index-ids transform)))))
 
 (defn execute!
   "Run `transform` and sync its target table.

--- a/src/metabase/transforms/execute.clj
+++ b/src/metabase/transforms/execute.clj
@@ -1,16 +1,16 @@
 (ns metabase.transforms.execute
   (:require
+   [metabase.indexes.models.table-index :as table-index]
    [metabase.transforms-base.interface :as transforms-base.i]
    [metabase.transforms.interface :as transforms.i]
-   [metabase.transforms.query-impl :as transforms.query-impl]
-   [toucan2.core :as t2]))
+   [metabase.transforms.query-impl :as transforms.query-impl]))
 
 (set! *warn-on-reflection* true)
 
 (defn hydrate-transform-indexes
   "Structured index defs for `transform`, read from its managed `TableIndex` rows (ordered by name)."
   [transform]
-  (t2/select-fn-vec :structured :model/TableIndex :transform_id (:id transform) {:order-by [[:index_name :asc]]}))
+  (mapv :structured (table-index/select-applicable-for-transform (:id transform))))
 
 (defn- resolve-target
   "Apply the workspace target-rewrite hook before dispatch. On a workspaced child

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -5,6 +5,7 @@
    [metabase.api.common :as api]
    [metabase.collections.models.collection :as collection]
    [metabase.events.core :as events]
+   [metabase.indexes.models.table-index :as table-index]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.models.interface :as mi]
@@ -375,9 +376,10 @@
   (when (seq transforms)
     (let [transform-ids (into #{} (map u/the-id) transforms)
           idx-mappings  (group-by :transform_id
-                                  (t2/select :model/TableIndex
-                                             :transform_id [:in transform-ids]
-                                             {:order-by [[:index_name :asc]]}))]
+                                  (filter table-index/applicable?
+                                          (t2/select :model/TableIndex
+                                                     :transform_id [:in transform-ids]
+                                                     {:order-by [[:index_name :asc]]})))]
       (for [transform transforms]
         (assoc transform :indexes (get idx-mappings (u/the-id transform) []))))))
 

--- a/src/metabase/transforms/util.clj
+++ b/src/metabase/transforms/util.clj
@@ -13,6 +13,7 @@
    [metabase.driver.settings :as driver.settings]
    [metabase.driver.sql-jdbc :as sql-jdbc]
    [metabase.driver.util :as driver.u]
+   [metabase.indexes.models.table-index :as table-index]
    [metabase.models.interface :as mi]
    [metabase.premium-features.core :as premium-features]
    [metabase.query-processor.pipeline :as qp.pipeline]
@@ -147,6 +148,8 @@
       (try
         (let [source-range-params (transforms-base.u/get-source-range-params transform)
               full-incremental?   (transforms-base.u/full-incremental-run? transform)
+              full-create?        (or (= :table (keyword (:type (:target transform))))
+                                      full-incremental?)
               ;; Efficiency metrics (rows-available / rows-processed) are only meaningful when this run's
               ;; rows-affected count can be trusted. On drivers that declare
               ;; `:transforms/accurate-rows-affected` false, a full-rebuild (CTAS) run reports a bogus
@@ -172,12 +175,22 @@
                                 driver.settings/*query-timeout-ms*   transform-timeout-ms
                                 ;; Match the query timeout so a single slow socket read (or a driver that waits for
                                 ;; the full server-side query) does not get killed before the transform's own deadline.
-                                driver.settings/*network-timeout-ms* (max driver.settings/*network-timeout-ms* transform-timeout-ms)]
+                                driver.settings/*network-timeout-ms* (max driver.settings/*network-timeout-ms*
+                                                                          transform-timeout-ms)]
                         (run-transform! cancel-chan source-range-params)))]
-            ;; Before the watermark/succeed mark, so a failure hits the catch below and fails the run (and a retry
-            ;; stays a full rebuild that re-attempts the index).
-            (transforms-base.u/apply-target-indexes! transform)
-            (transforms-base.u/verify-managed-indexes! transform)
+            (when full-create?
+              ;; Before the watermark/succeed mark, so a failure hits the catch below and fails the run (and a retry
+              ;; stays a full rebuild that re-attempts the index).
+              (let [running-indexes (table-index/mark-runnable-indexes-running! (:id transform))]
+                (try
+                  (transforms-base.u/apply-target-indexes! transform)
+                  (transforms-base.u/verify-managed-indexes! transform)
+                  (table-index/mark-unverified-running-indexes-failed!
+                   running-indexes
+                   "Index status could not be verified after the transform completed.")
+                  (catch Throwable t
+                    (table-index/mark-unverified-running-indexes-failed! running-indexes (ex-message t))
+                    (throw t)))))
             (transforms-base.u/save-watermark! (:id transform) source-range-params)
             (transform-run/succeed-started-run! run-id)
             ;; Narrow try/catch so an emission throw doesn't trigger the outer catch's

--- a/src/metabase/transforms/util.clj
+++ b/src/metabase/transforms/util.clj
@@ -181,7 +181,8 @@
             (when full-create?
               ;; Before the watermark/succeed mark, so a failure hits the catch below and fails the run (and a retry
               ;; stays a full rebuild that re-attempts the index).
-              (let [running-indexes (table-index/mark-runnable-indexes-running! (:id transform))]
+              (let [running-indexes (table-index/mark-runnable-indexes-running!
+                                     (:index-request-ids (:target transform)))]
                 (try
                   (transforms-base.u/apply-target-indexes! transform)
                   (transforms-base.u/verify-managed-indexes! transform)

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -10,6 +10,7 @@
    [metabase.driver :as driver]
    [metabase.driver.sql.normalize :as sql.normalize]
    [metabase.events.core :as events]
+   [metabase.indexes.models.table-index :as table-index]
    [metabase.indexes.reconcile :as reconcile]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
@@ -201,13 +202,13 @@
 
 (defn full-incremental-run?
   "True when an incremental transform should drop-and-recreate the target rather than append.
-  Fires whenever `last_checkpoint_value` is nil — covers the literal first run, and any run after the
-  `:model/Transform` before-update hook clears the watermark on a `checkpoint-filter-field-id`
-  change. Stays true across failed attempts since the predicate only inspects
-  `:last_checkpoint_value`."
-  [{:keys [target last_checkpoint_value]}]
+  Fires whenever `last_checkpoint_value` is nil, or when pending index changes require rebuilding the table to apply
+  physical index state. The pending-status check also covers an in-flight run saving a new checkpoint after an index
+  mutation reset the watermark."
+  [{:keys [id target last_checkpoint_value]}]
   (and (= :table-incremental (keyword (:type target)))
-       (nil? last_checkpoint_value)))
+       (or (nil? last_checkpoint_value)
+           (table-index/pending-changes-for-transform? id))))
 
 (defn- encode-checkpoint-value [v]
   (if (number? v)
@@ -327,7 +328,9 @@
                                "Please select a checkpoint field in the transform settings."))]
         (throw (ex-info msg {:transform-message msg}))))
     (when checkpoint-filter-field-id
-      (let [{:keys [last_checkpoint_value]} transform
+      (let [{:keys [last_checkpoint_value]} (cond-> transform
+                                              (full-incremental-run? transform)
+                                              (assoc :last_checkpoint_value nil))
             db-id             (transforms-base.i/target-db-id transform)
             metadata-provider (lib-be/application-database-metadata-provider db-id)
             column            (lib.metadata/field metadata-provider checkpoint-filter-field-id)
@@ -613,19 +616,34 @@
   (when (full-create-run? transform)
     (when-let [managed (seq (t2/select :model/TableIndex :transform_id (:id transform)))]
       (let [database (t2/select-one :model/Database (transforms-base.i/target-db-id transform))
-            {:keys [schema] table-name :name} (:target transform)]
+            {:keys [schema] table-name :name} (:target transform)
+            deletion-pending (filter #(= :deletion-pending (:status %)) managed)]
         ;; An empty fetch is ambiguous (no indexes vs couldn't introspect -- both degrade to []), so leave statuses
-        ;; untouched rather than mark everything failed; warn so a stuck :pending stays traceable.
+        ;; untouched rather than mark everything failed; warn so a stuck pending state stays traceable.
         (if-let [warehouse-indexes (seq (reconcile/fetch-warehouse-indexes database schema table-name))]
           (let [present-keys (into #{} (map reconcile/match-key) warehouse-indexes)
-                by-present   (group-by #(contains? present-keys (reconcile/managed-match-key %)) managed)]
+                by-outcome   (group-by (fn [row]
+                                         (let [present? (contains? present-keys (reconcile/managed-match-key row))]
+                                           (cond
+                                             (and (table-index/applicable? row) present?) :succeeded
+                                             (table-index/applicable? row)                :failed
+                                             present?                                    :deletion-pending
+                                             :else                                       :delete-row)))
+                                       managed)]
             ;; one update per outcome rather than per row
-            (doseq [[present? rows] by-present]
-              (t2/update! :model/TableIndex :id [:in (map :id rows)]
-                          {:status           (if present? :succeeded :failed)
-                           :last_executed_at :%now})))
-          (log/warnf "verify-managed-indexes!: no indexes read back for %s.%s; leaving %d request(s) unchanged"
-                     schema table-name (count managed)))))))
+            (doseq [[status rows] by-outcome]
+              (if (= :delete-row status)
+                (t2/delete! :model/TableIndex :id [:in (map :id rows)])
+                (t2/update! :model/TableIndex :id [:in (map :id rows)]
+                            {:status           status
+                             :last_executed_at :%now}))))
+          (do
+            ;; The full rebuild succeeded and deletion-pending rows were deliberately excluded from table creation, so the
+            ;; old physical index is gone even when the driver reports no remaining indexes.
+            (when (seq deletion-pending)
+              (t2/delete! :model/TableIndex :id [:in (map :id deletion-pending)]))
+            (log/warnf "verify-managed-indexes!: no indexes read back for %s.%s; leaving %d applicable request(s) unchanged"
+                       schema table-name (- (count managed) (count deletion-pending)))))))))
 
 (defn complete-execution!
   "Post-processing steps after a transform has been executed successfully.

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -621,7 +621,7 @@
       (when-let [managed (seq managed)]
         (let [database (t2/select-one :model/Database (transforms-base.i/target-db-id transform))
               {:keys [schema] table-name :name} (:target transform)
-              deletion-pending (filter #(= :deletion-pending (:status %)) managed)]
+              delete-pending (filter #(= :delete-pending (:status %)) managed)]
           ;; An empty fetch is ambiguous (no indexes vs couldn't introspect -- both degrade to []), so leave statuses
           ;; untouched rather than mark everything failed; warn so a stuck pending state stays traceable.
           (if-let [warehouse-indexes (seq (reconcile/fetch-warehouse-indexes database schema table-name))]
@@ -631,7 +631,7 @@
                                              (cond
                                                (and (table-index/applicable? row) present?) :succeeded
                                                (table-index/applicable? row)                :failed
-                                               present?                                    :deletion-pending
+                                               present?                                    :delete-pending
                                                :else                                       :delete-row)))
                                          managed)]
               ;; one update per outcome rather than per row
@@ -642,12 +642,12 @@
                               {:status           status
                                :last_executed_at :%now}))))
             (do
-              ;; The full rebuild succeeded and deletion-pending rows were deliberately excluded from table creation, so the
+              ;; The full rebuild succeeded and delete-pending rows were deliberately excluded from table creation, so the
               ;; old physical index is gone even when the driver reports no remaining indexes.
-              (when (seq deletion-pending)
-                (t2/delete! :model/TableIndex :id [:in (map :id deletion-pending)]))
+              (when (seq delete-pending)
+                (t2/delete! :model/TableIndex :id [:in (map :id delete-pending)]))
               (log/warnf "verify-managed-indexes!: no indexes read back for %s.%s; leaving %d applicable request(s) unchanged"
-                         schema table-name (- (count managed) (count deletion-pending))))))))))
+                         schema table-name (- (count managed) (count delete-pending))))))))))
 
 (defn complete-execution!
   "Post-processing steps after a transform has been executed successfully.

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -208,6 +208,7 @@
   [{:keys [id target last_checkpoint_value]}]
   (and (= :table-incremental (keyword (:type target)))
        (or (nil? last_checkpoint_value)
+           ;; Protect against an in-flight run writing a new checkpoint after an index mutation cleared it.
            (table-index/pending-changes-for-transform? id))))
 
 (defn- encode-checkpoint-value [v]
@@ -620,11 +621,8 @@
                     (table-index/select-for-transform (:id transform)))]
       (when-let [managed (seq managed)]
         (let [database (t2/select-one :model/Database (transforms-base.i/target-db-id transform))
-              {:keys [schema] table-name :name} (:target transform)
-              delete-pending (filter #(= :delete-pending (:status %)) managed)]
-          ;; An empty fetch is ambiguous (no indexes vs couldn't introspect -- both degrade to []), so leave statuses
-          ;; untouched rather than mark everything failed; warn so a stuck pending state stays traceable.
-          (if-let [warehouse-indexes (seq (reconcile/fetch-warehouse-indexes database schema table-name))]
+              {:keys [schema] table-name :name} (:target transform)]
+          (if-some [warehouse-indexes (reconcile/fetch-warehouse-indexes database schema table-name)]
             (let [present-keys (into #{} (map reconcile/match-key) warehouse-indexes)
                   by-outcome   (group-by (fn [row]
                                            (let [present? (contains? present-keys (reconcile/managed-match-key row))]
@@ -641,13 +639,8 @@
                   (t2/update! :model/TableIndex :id [:in (map :id rows)]
                               {:status           status
                                :last_executed_at :%now}))))
-            (do
-              ;; The full rebuild succeeded and delete-pending rows were deliberately excluded from table creation, so the
-              ;; old physical index is gone even when the driver reports no remaining indexes.
-              (when (seq delete-pending)
-                (t2/delete! :model/TableIndex :id [:in (map :id delete-pending)]))
-              (log/warnf "verify-managed-indexes!: no indexes read back for %s.%s; leaving %d applicable request(s) unchanged"
-                         schema table-name (- (count managed) (count delete-pending))))))))))
+            (log/warnf "verify-managed-indexes!: could not read indexes for %s.%s; leaving %d request(s) unchanged"
+                       schema table-name (count managed))))))))
 
 (defn complete-execution!
   "Post-processing steps after a transform has been executed successfully.

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -614,36 +614,40 @@
   Only runs on full-create runs (same guard as [[apply-target-indexes!]])."
   [transform]
   (when (full-create-run? transform)
-    (when-let [managed (seq (t2/select :model/TableIndex :transform_id (:id transform)))]
-      (let [database (t2/select-one :model/Database (transforms-base.i/target-db-id transform))
-            {:keys [schema] table-name :name} (:target transform)
-            deletion-pending (filter #(= :deletion-pending (:status %)) managed)]
-        ;; An empty fetch is ambiguous (no indexes vs couldn't introspect -- both degrade to []), so leave statuses
-        ;; untouched rather than mark everything failed; warn so a stuck pending state stays traceable.
-        (if-let [warehouse-indexes (seq (reconcile/fetch-warehouse-indexes database schema table-name))]
-          (let [present-keys (into #{} (map reconcile/match-key) warehouse-indexes)
-                by-outcome   (group-by (fn [row]
-                                         (let [present? (contains? present-keys (reconcile/managed-match-key row))]
-                                           (cond
-                                             (and (table-index/applicable? row) present?) :succeeded
-                                             (table-index/applicable? row)                :failed
-                                             present?                                    :deletion-pending
-                                             :else                                       :delete-row)))
-                                       managed)]
-            ;; one update per outcome rather than per row
-            (doseq [[status rows] by-outcome]
-              (if (= :delete-row status)
-                (t2/delete! :model/TableIndex :id [:in (map :id rows)])
-                (t2/update! :model/TableIndex :id [:in (map :id rows)]
-                            {:status           status
-                             :last_executed_at :%now}))))
-          (do
-            ;; The full rebuild succeeded and deletion-pending rows were deliberately excluded from table creation, so the
-            ;; old physical index is gone even when the driver reports no remaining indexes.
-            (when (seq deletion-pending)
-              (t2/delete! :model/TableIndex :id [:in (map :id deletion-pending)]))
-            (log/warnf "verify-managed-indexes!: no indexes read back for %s.%s; leaving %d applicable request(s) unchanged"
-                       schema table-name (- (count managed) (count deletion-pending)))))))))
+    (let [target  (:target transform)
+          managed (if (contains? target :index-request-ids)
+                    (table-index/select-for-verification (:id transform) (:index-request-ids target))
+                    (table-index/select-for-transform (:id transform)))]
+      (when-let [managed (seq managed)]
+        (let [database (t2/select-one :model/Database (transforms-base.i/target-db-id transform))
+              {:keys [schema] table-name :name} (:target transform)
+              deletion-pending (filter #(= :deletion-pending (:status %)) managed)]
+          ;; An empty fetch is ambiguous (no indexes vs couldn't introspect -- both degrade to []), so leave statuses
+          ;; untouched rather than mark everything failed; warn so a stuck pending state stays traceable.
+          (if-let [warehouse-indexes (seq (reconcile/fetch-warehouse-indexes database schema table-name))]
+            (let [present-keys (into #{} (map reconcile/match-key) warehouse-indexes)
+                  by-outcome   (group-by (fn [row]
+                                           (let [present? (contains? present-keys (reconcile/managed-match-key row))]
+                                             (cond
+                                               (and (table-index/applicable? row) present?) :succeeded
+                                               (table-index/applicable? row)                :failed
+                                               present?                                    :deletion-pending
+                                               :else                                       :delete-row)))
+                                         managed)]
+              ;; one update per outcome rather than per row
+              (doseq [[status rows] by-outcome]
+                (if (= :delete-row status)
+                  (t2/delete! :model/TableIndex :id [:in (map :id rows)])
+                  (t2/update! :model/TableIndex :id [:in (map :id rows)]
+                              {:status           status
+                               :last_executed_at :%now}))))
+            (do
+              ;; The full rebuild succeeded and deletion-pending rows were deliberately excluded from table creation, so the
+              ;; old physical index is gone even when the driver reports no remaining indexes.
+              (when (seq deletion-pending)
+                (t2/delete! :model/TableIndex :id [:in (map :id deletion-pending)]))
+              (log/warnf "verify-managed-indexes!: no indexes read back for %s.%s; leaving %d applicable request(s) unchanged"
+                         schema table-name (- (count managed) (count deletion-pending))))))))))
 
 (defn complete-execution!
   "Post-processing steps after a transform has been executed successfully.

--- a/test/metabase/indexes/api_test.clj
+++ b/test/metabase/indexes/api_test.clj
@@ -48,7 +48,7 @@
                                               {:structured (assoc btree :columns [{:name "price"}])})]
             (is (= "update-pending" (:status updated)))
             (is (= "price" (-> updated :structured :columns first :name)))))
-        (testing "DELETE marks it deletion-pending until a rebuild drops the warehouse index"
+        (testing "DELETE marks it delete-pending until a rebuild drops the warehouse index"
           (mt/user-http-request :crowberto :delete 204 (str "indexes/request/" (:id created)))
           (with-redefs [metabase.driver/fetch-table-indexes
                         (fn [& _] [{:name "by_cat" :kind :btree :access-method "btree" :is-unique false
@@ -57,7 +57,7 @@
             (let [{:keys [data]} (mt/user-http-request :crowberto :get 200
                                                        (str "indexes?transform-id=" transform-id))]
               (is (= [(:id created)] (map #(get-in % [:request :id]) data)))
-              (is (= "deletion-pending" (-> data first :request :status)))
+              (is (= "delete-pending" (-> data first :request :status)))
               (is (true? (:present_in_warehouse (first data)))))))))))
 
 (deftest merged-list-test

--- a/test/metabase/indexes/api_test.clj
+++ b/test/metabase/indexes/api_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [metabase.driver]
    [metabase.test :as mt]
+   [metabase.transforms-base.util :as transforms-base.u]
    [metabase.transforms.query-test-util :as query-test-util]
    [toucan2.core :as t2]))
 
@@ -16,14 +17,17 @@
    :source {:type "query" :query (query-test-util/make-query :source-table "venues")}
    :target {:database (mt/id) :type "table" :schema "public" :name (mt/random-name)}})
 
+(defn- temp-incremental-transform-spec []
+  (assoc-in (temp-transform-spec) [:target :type] "table-incremental"))
+
 (def ^:private btree {:kind "btree" :name "by_cat" :columns [{:name "name"}]})
 
 (deftest crud-happy-path-test
   (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)]
-    (testing "POST creates a pending index"
+    (testing "POST creates a create-pending index"
       (let [created (mt/user-http-request :crowberto :post 200 "indexes/request"
                                           {:transform_id transform-id :structured btree})]
-        (is (= "pending" (:status created)))
+        (is (= "create-pending" (:status created)))
         (is (= transform-id (:transform_id created)))
         (is (= "by_cat" (:index_name created)))
         (with-redefs [metabase.driver/fetch-table-indexes (fn [& _] [])]
@@ -42,13 +46,19 @@
         (testing "PUT replaces the structured definition"
           (let [updated (mt/user-http-request :crowberto :put 200 (str "indexes/request/" (:id created))
                                               {:structured (assoc btree :columns [{:name "price"}])})]
+            (is (= "update-pending" (:status updated)))
             (is (= "price" (-> updated :structured :columns first :name)))))
-        (testing "DELETE removes it"
+        (testing "DELETE marks it deletion-pending until a rebuild drops the warehouse index"
           (mt/user-http-request :crowberto :delete 204 (str "indexes/request/" (:id created)))
-          (with-redefs [metabase.driver/fetch-table-indexes (fn [& _] [])]
+          (with-redefs [metabase.driver/fetch-table-indexes
+                        (fn [& _] [{:name "by_cat" :kind :btree :access-method "btree" :is-unique false
+                                    :is-primary false :is-valid true :key-columns ["name"] :include-columns []
+                                    :partial-predicate nil :definition "..."}])]
             (let [{:keys [data]} (mt/user-http-request :crowberto :get 200
                                                        (str "indexes?transform-id=" transform-id))]
-              (is (empty? data)))))))))
+              (is (= [(:id created)] (map #(get-in % [:request :id]) data)))
+              (is (= "deletion-pending" (-> data first :request :status)))
+              (is (true? (:present_in_warehouse (first data)))))))))))
 
 (deftest merged-list-test
   (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)]
@@ -102,6 +112,50 @@
       (is (re-find #"already exists"
                    (mt/user-http-request :crowberto :post 400 "indexes/request"
                                          {:transform_id transform-id :structured btree}))))))
+
+(deftest put-cannot-change-index-key-test
+  (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)]
+    (let [created (mt/user-http-request :crowberto :post 200 "indexes/request"
+                                        {:transform_id transform-id :structured btree})]
+      (testing "name is stable"
+        (is (re-find #"name cannot be changed"
+                     (mt/user-http-request :crowberto :put 400 (str "indexes/request/" (:id created))
+                                           {:structured (assoc btree :name "by_price")}))))
+      (testing "kind is stable"
+        (is (re-find #"type cannot be changed"
+                     (mt/user-http-request :crowberto :put 400 (str "indexes/request/" (:id created))
+                                           {:structured (assoc btree :kind "hash")})))))))
+
+(deftest soft-deleted-index-cannot-be-recreated-test
+  (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)]
+    (let [created (mt/user-http-request :crowberto :post 200 "indexes/request"
+                                        {:transform_id transform-id :structured btree})]
+      (mt/user-http-request :crowberto :delete 204 (str "indexes/request/" (:id created)))
+      (is (re-find #"already exists"
+                   (mt/user-http-request :crowberto :post 400 "indexes/request"
+                                         {:transform_id transform-id :structured btree})))
+      (is (= 1 (count (t2/select :model/TableIndex :transform_id transform-id)))))))
+
+(deftest incremental-mutations-force-next-run-to-rebuild-test
+  (mt/with-temp [:model/Transform {transform-id :id} (assoc (temp-incremental-transform-spec)
+                                                            :last_checkpoint_value "100")]
+    (testing "POST clears the checkpoint so the new index can be applied"
+      (let [created (mt/user-http-request :crowberto :post 200 "indexes/request"
+                                          {:transform_id transform-id :structured btree})]
+        (is (nil? (t2/select-one-fn :last_checkpoint_value :model/Transform transform-id)))
+        (testing "PUT clears the checkpoint so the changed structure can be applied"
+          (t2/update! :model/Transform transform-id {:last_checkpoint_value "200"})
+          (mt/user-http-request :crowberto :put 200 (str "indexes/request/" (:id created))
+                                {:structured (assoc btree :columns [{:name "price"}])})
+          (is (nil? (t2/select-one-fn :last_checkpoint_value :model/Transform transform-id))))
+        (testing "DELETE clears the checkpoint so the old index can be dropped by the rebuild"
+          (t2/update! :model/Transform transform-id {:last_checkpoint_value "300"})
+          (mt/user-http-request :crowberto :delete 204 (str "indexes/request/" (:id created)))
+          (is (nil? (t2/select-one-fn :last_checkpoint_value :model/Transform transform-id))))
+        (testing "pending index status still forces a full rebuild if an in-flight run saves a checkpoint"
+          (t2/update! :model/Transform transform-id {:last_checkpoint_value "400"})
+          (is (#'transforms-base.u/full-incremental-run?
+               (t2/select-one :model/Transform transform-id))))))))
 
 (deftest inline-kind-index-name-test
   (testing "an inline kind with no :name gets its index_name from :kind"

--- a/test/metabase/indexes/models/table_index_test.clj
+++ b/test/metabase/indexes/models/table_index_test.clj
@@ -64,20 +64,47 @@
                                                     :error_message "old failure"
                                                     :structured   {:kind :btree :name "failed_idx"
                                                                    :columns [{:name "c"}]}}
+                 :model/TableIndex {running-id :id} {:transform_id transform-id
+                                                     :index_name   "running_idx"
+                                                     :status       :running
+                                                     :structured   {:kind :btree :name "running_idx"
+                                                                    :columns [{:name "e"}]}}
                  :model/TableIndex {deleted-id :id} {:transform_id transform-id
                                                      :index_name   "deleted_idx"
                                                      :status       :deletion-pending
                                                      :structured   {:kind :btree :name "deleted_idx"
                                                                     :columns [{:name "d"}]}}]
-    (let [ids (table-index/mark-runnable-indexes-running! transform-id)]
-      (is (= #{create-id update-id failed-id} ids))
+    (let [ids (table-index/mark-runnable-indexes-running! [create-id update-id failed-id running-id])]
+      (is (= #{create-id update-id failed-id running-id} ids))
       (is (= :running (t2/select-one-fn :status :model/TableIndex create-id)))
       (is (= :running (t2/select-one-fn :status :model/TableIndex update-id)))
       (is (= :running (t2/select-one-fn :status :model/TableIndex failed-id)))
+      (is (= :running (t2/select-one-fn :status :model/TableIndex running-id)))
       (is (= :deletion-pending (t2/select-one-fn :status :model/TableIndex deleted-id)))
       (t2/update! :model/TableIndex create-id {:status :succeeded})
       (table-index/mark-unverified-running-indexes-failed! ids "not verified")
       (is (= :succeeded (t2/select-one-fn :status :model/TableIndex create-id)))
       (is (= :failed (t2/select-one-fn :status :model/TableIndex update-id)))
       (is (= :failed (t2/select-one-fn :status :model/TableIndex failed-id)))
+      (is (= :failed (t2/select-one-fn :status :model/TableIndex running-id)))
       (is (= "not verified" (t2/select-one-fn :error_message :model/TableIndex update-id))))))
+
+(deftest select-for-verification-test
+  (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)
+                 :model/TableIndex {running-id :id} {:transform_id transform-id
+                                                     :index_name   "running_idx"
+                                                     :status       :running
+                                                     :structured   {:kind :btree :name "running_idx"
+                                                                    :columns [{:name "a"}]}}
+                 :model/TableIndex {pending-id :id} {:transform_id transform-id
+                                                     :index_name   "pending_idx"
+                                                     :status       :update-pending
+                                                     :structured   {:kind :btree :name "pending_idx"
+                                                                    :columns [{:name "b"}]}}
+                 :model/TableIndex {deleted-id :id} {:transform_id transform-id
+                                                     :index_name   "deleted_idx"
+                                                     :status       :deletion-pending
+                                                     :structured   {:kind :btree :name "deleted_idx"
+                                                                    :columns [{:name "c"}]}}]
+    (is (= #{running-id deleted-id}
+           (set (map :id (table-index/select-for-verification transform-id [running-id pending-id])))))))

--- a/test/metabase/indexes/models/table_index_test.clj
+++ b/test/metabase/indexes/models/table_index_test.clj
@@ -71,7 +71,7 @@
                                                                     :columns [{:name "e"}]}}
                  :model/TableIndex {deleted-id :id} {:transform_id transform-id
                                                      :index_name   "deleted_idx"
-                                                     :status       :deletion-pending
+                                                     :status       :delete-pending
                                                      :structured   {:kind :btree :name "deleted_idx"
                                                                     :columns [{:name "d"}]}}]
     (let [ids (table-index/mark-runnable-indexes-running! [create-id update-id failed-id running-id])]
@@ -80,7 +80,7 @@
       (is (= :running (t2/select-one-fn :status :model/TableIndex update-id)))
       (is (= :running (t2/select-one-fn :status :model/TableIndex failed-id)))
       (is (= :running (t2/select-one-fn :status :model/TableIndex running-id)))
-      (is (= :deletion-pending (t2/select-one-fn :status :model/TableIndex deleted-id)))
+      (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex deleted-id)))
       (t2/update! :model/TableIndex create-id {:status :succeeded})
       (table-index/mark-unverified-running-indexes-failed! ids "not verified")
       (is (= :succeeded (t2/select-one-fn :status :model/TableIndex create-id)))
@@ -103,7 +103,7 @@
                                                                     :columns [{:name "b"}]}}
                  :model/TableIndex {deleted-id :id} {:transform_id transform-id
                                                      :index_name   "deleted_idx"
-                                                     :status       :deletion-pending
+                                                     :status       :delete-pending
                                                      :structured   {:kind :btree :name "deleted_idx"
                                                                     :columns [{:name "c"}]}}]
     (is (= #{running-id deleted-id}

--- a/test/metabase/indexes/models/table_index_test.clj
+++ b/test/metabase/indexes/models/table_index_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.indexes.models.table-index-test
   (:require
    [clojure.test :refer :all]
+   [metabase.indexes.models.table-index :as table-index]
    [metabase.test :as mt]
    [metabase.transforms.query-test-util :as query-test-util]
    [toucan2.core :as t2]))
@@ -12,8 +13,8 @@
    :source {:type "query" :query (query-test-util/make-query :source-table "venues")}
    :target {:database (mt/id) :type "table" :schema "public" :name (mt/random-name)}})
 
-(deftest roundtrip-and-status-default-test
-  (testing "structured reads back with keyword-valued fields, and status defaults to :pending"
+(deftest roundtrip-and-defaults-test
+  (testing "structured reads back with keyword-valued fields, and lifecycle defaults are set"
     (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)]
       (let [{:keys [id]} (t2/insert-returning-instance!
                           :model/TableIndex
@@ -21,7 +22,7 @@
                            :index_name   "by_cat"
                            :structured   {:kind :btree :name "by_cat" :columns [{:name "category" :direction :asc}]}})
             back (t2/select-one :model/TableIndex :id id)]
-        (is (= :pending (:status back)) "before-insert defaults status to :pending")
+        (is (= :create-pending (:status back)) "before-insert defaults status to :create-pending")
         (is (= :btree (get-in back [:structured :kind])) "kind re-keywordized on read")
         (is (= :asc (get-in back [:structured :columns 0 :direction])))))))
 
@@ -45,3 +46,38 @@
                         :index_name   "bad-status"
                         :status       :bogus
                         :structured   {:kind :btree :name "x" :columns [{:name "a"}]}}))))))
+
+(deftest running-transition-helpers-test
+  (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)
+                 :model/TableIndex {create-id :id} {:transform_id transform-id
+                                                    :index_name   "create_idx"
+                                                    :structured   {:kind :btree :name "create_idx"
+                                                                   :columns [{:name "a"}]}}
+                 :model/TableIndex {update-id :id} {:transform_id transform-id
+                                                    :index_name   "update_idx"
+                                                    :status       :update-pending
+                                                    :structured   {:kind :btree :name "update_idx"
+                                                                   :columns [{:name "b"}]}}
+                 :model/TableIndex {failed-id :id} {:transform_id transform-id
+                                                    :index_name   "failed_idx"
+                                                    :status       :failed
+                                                    :error_message "old failure"
+                                                    :structured   {:kind :btree :name "failed_idx"
+                                                                   :columns [{:name "c"}]}}
+                 :model/TableIndex {deleted-id :id} {:transform_id transform-id
+                                                     :index_name   "deleted_idx"
+                                                     :status       :deletion-pending
+                                                     :structured   {:kind :btree :name "deleted_idx"
+                                                                    :columns [{:name "d"}]}}]
+    (let [ids (table-index/mark-runnable-indexes-running! transform-id)]
+      (is (= #{create-id update-id failed-id} ids))
+      (is (= :running (t2/select-one-fn :status :model/TableIndex create-id)))
+      (is (= :running (t2/select-one-fn :status :model/TableIndex update-id)))
+      (is (= :running (t2/select-one-fn :status :model/TableIndex failed-id)))
+      (is (= :deletion-pending (t2/select-one-fn :status :model/TableIndex deleted-id)))
+      (t2/update! :model/TableIndex create-id {:status :succeeded})
+      (table-index/mark-unverified-running-indexes-failed! ids "not verified")
+      (is (= :succeeded (t2/select-one-fn :status :model/TableIndex create-id)))
+      (is (= :failed (t2/select-one-fn :status :model/TableIndex update-id)))
+      (is (= :failed (t2/select-one-fn :status :model/TableIndex failed-id)))
+      (is (= "not verified" (t2/select-one-fn :error_message :model/TableIndex update-id))))))

--- a/test/metabase/indexes/reconcile_test.clj
+++ b/test/metabase/indexes/reconcile_test.clj
@@ -7,12 +7,12 @@
 (def ^:private managed-btree
   {:id 1 :transform_id 7 :index_name "by_cat"
    :structured {:kind :btree :name "by_cat" :columns [{:name "name"}] :unique true}
-   :status :pending :error_message nil :created_by 3 :last_executed_at nil})
+   :status :create-pending :error_message nil :created_by 3 :last_executed_at nil})
 
 (def ^:private managed-sortkey
   {:id 2 :transform_id 7 :index_name "sortkey"
    :structured {:kind :sortkey :style :compound :columns [{:name "a"} {:name "b"}]}
-   :status :pending :error_message nil :created_by 3 :last_executed_at nil})
+   :status :create-pending :error_message nil :created_by 3 :last_executed_at nil})
 
 (def ^:private wh-btree
   {:name "by_cat" :kind :btree :access-method "btree" :is-unique true :is-primary false
@@ -25,7 +25,7 @@
 (def ^:private managed-distkey
   {:id 3 :transform_id 7 :index_name "distkey"
    :structured {:kind :distkey :style :key :columns [{:name "category"}]}
-   :status :pending :error_message nil :created_by 3 :last_executed_at nil})
+   :status :create-pending :error_message nil :created_by 3 :last_executed_at nil})
 
 (def ^:private wh-distkey
   {:name nil :kind :distkey :access-method nil :is-unique false :is-primary false
@@ -54,7 +54,7 @@
       (is (= "by_cat" (:name e)))
       (is (true? (:is_unique e)))
       (is (= 1 (-> e :request :id)))
-      (is (= :pending (-> e :request :status)))
+      (is (= :create-pending (-> e :request :status)))
       (is (= (:structured managed-btree) (-> e :request :structured)))))
   (testing "DBA (warehouse-only): observed, unmanaged, no request bookkeeping"
     (let [[e] (reconcile/merge-indexes [] [wh-dba])]
@@ -69,7 +69,7 @@
       (is (false? (:present_in_warehouse e)))
       (is (= "by_cat" (:name e)))
       (is (true? (:is_unique e)))
-      (is (= :pending (-> e :request :status)))))
+      (is (= :create-pending (-> e :request :status)))))
   (testing "a managed inline sortkey matches the warehouse sortkey by kind+columns, listed once as managed"
     (let [merged (reconcile/merge-indexes [managed-sortkey] [wh-sortkey])]
       (is (= 1 (count merged)))

--- a/test/metabase/indexes/reconcile_test.clj
+++ b/test/metabase/indexes/reconcile_test.clj
@@ -93,6 +93,9 @@
     (with-redefs [metabase.driver/fetch-table-indexes (fn [_driver _db _schema _table] [wh-btree])]
       (is (= [wh-btree]
              (reconcile/fetch-warehouse-indexes {:engine :postgres} "public" "t")))))
-  (testing "swallows driver/connection errors and returns []"
+  (testing "preserves a successful empty warehouse response"
+    (with-redefs [metabase.driver/fetch-table-indexes (fn [& _] [])]
+      (is (= [] (reconcile/fetch-warehouse-indexes {:engine :postgres} "public" "t")))))
+  (testing "swallows driver/connection errors and returns nil"
     (with-redefs [metabase.driver/fetch-table-indexes (fn [& _] (throw (ex-info "boom" {})))]
-      (is (= [] (reconcile/fetch-warehouse-indexes {:engine :postgres} "public" "t"))))))
+      (is (nil? (reconcile/fetch-warehouse-indexes {:engine :postgres} "public" "t"))))))

--- a/test/metabase/transforms/index_test.clj
+++ b/test/metabase/transforms/index_test.clj
@@ -206,7 +206,7 @@
                    :model/TableIndex {a-id :id} {:transform_id tid :index_name "a_idx"
                                                  :structured {:kind :btree :name "a_idx" :columns [{:name "y"}]}}
                    :model/TableIndex _ {:transform_id tid :index_name "deleted_idx"
-                                        :status :deletion-pending
+                                        :status :delete-pending
                                         :structured {:kind :btree :name "deleted_idx" :columns [{:name "z"}]}}]
       (is (= ["a_idx" "b_idx"]
              (map :name (transforms.execute/hydrate-transform-indexes {:id tid}))))
@@ -237,7 +237,7 @@
    :is-primary false :is-valid true :key-columns [column] :include-columns []
    :partial-predicate nil :definition "..."})
 
-(deftest ^:synchronized verify-managed-indexes!-removes-deletion-pending-row-when-absent-test
+(deftest ^:synchronized verify-managed-indexes!-removes-delete-pending-row-when-absent-test
   (mt/with-temp [:model/Transform {tid :id} {:name               (mt/random-name)
                                              :source             {:type "query"}
                                              :source_database_id (mt/id)
@@ -245,7 +245,7 @@
                  :model/TableIndex {applicable-id :id} {:transform_id tid :index_name "active_idx"
                                                         :structured {:kind :btree :name "active_idx" :columns [{:name "x"}]}}
                  :model/TableIndex {deleted-id :id} {:transform_id tid :index_name "deleted_idx"
-                                                     :status :deletion-pending
+                                                     :status :delete-pending
                                                      :structured {:kind :btree :name "deleted_idx" :columns [{:name "y"}]}}]
     (with-redefs [driver/fetch-table-indexes (fn [& _] [(warehouse-btree "active_idx" "x")])]
       (transforms-base.u/verify-managed-indexes! (t2/select-one :model/Transform tid))
@@ -279,20 +279,20 @@
       (is (= :succeeded (t2/select-one-fn :status :model/TableIndex hydrated-id)))
       (is (= :create-pending (t2/select-one-fn :status :model/TableIndex concurrent-id))))))
 
-(deftest ^:synchronized verify-managed-indexes!-keeps-deletion-pending-row-when-present-test
+(deftest ^:synchronized verify-managed-indexes!-keeps-delete-pending-row-when-present-test
   (mt/with-temp [:model/Transform {tid :id} {:name               (mt/random-name)
                                              :source             {:type "query"}
                                              :source_database_id (mt/id)
                                              :target             {:database (mt/id) :type "table" :schema "public" :name "t"}}
                  :model/TableIndex {deleted-id :id} {:transform_id tid :index_name "deleted_idx"
-                                                     :status :deletion-pending
+                                                     :status :delete-pending
                                                      :structured {:kind :btree :name "deleted_idx" :columns [{:name "y"}]}}]
     (with-redefs [driver/fetch-table-indexes (fn [& _] [(warehouse-btree "deleted_idx" "y")])]
       (transforms-base.u/verify-managed-indexes! (t2/select-one :model/Transform tid))
-      (is (= :deletion-pending (t2/select-one-fn :status :model/TableIndex deleted-id)))
+      (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex deleted-id)))
       (is (some? (t2/select-one-fn :last_executed_at :model/TableIndex deleted-id))))))
 
-(deftest ^:synchronized verify-managed-indexes!-removes-deletion-pending-absent-rows-test
+(deftest ^:synchronized verify-managed-indexes!-removes-delete-pending-absent-rows-test
   (mt/with-temp [:model/Transform {tid :id} {:name               (mt/random-name)
                                              :source             {:type "query"}
                                              :source_database_id (mt/id)
@@ -300,7 +300,7 @@
                  :model/TableIndex {applicable-id :id} {:transform_id tid :index_name "active_idx"
                                                         :structured {:kind :btree :name "active_idx" :columns [{:name "x"}]}}
                  :model/TableIndex {deleted-id :id} {:transform_id tid :index_name "deleted_idx"
-                                                     :status :deletion-pending
+                                                     :status :delete-pending
                                                      :structured {:kind :btree :name "deleted_idx" :columns [{:name "y"}]}}]
     (with-redefs [driver/fetch-table-indexes (fn [& _] [])]
       (transforms-base.u/verify-managed-indexes! (t2/select-one :model/Transform tid))

--- a/test/metabase/transforms/index_test.clj
+++ b/test/metabase/transforms/index_test.clj
@@ -204,7 +204,10 @@
                    :model/TableIndex _ {:transform_id tid :index_name "b_idx"
                                         :structured {:kind :btree :name "b_idx" :columns [{:name "x"}]}}
                    :model/TableIndex _ {:transform_id tid :index_name "a_idx"
-                                        :structured {:kind :btree :name "a_idx" :columns [{:name "y"}]}}]
+                                        :structured {:kind :btree :name "a_idx" :columns [{:name "y"}]}}
+                   :model/TableIndex _ {:transform_id tid :index_name "deleted_idx"
+                                        :status :deletion-pending
+                                        :structured {:kind :btree :name "deleted_idx" :columns [{:name "z"}]}}]
       (is (= ["a_idx" "b_idx"]
              (map :name (transforms.execute/hydrate-transform-indexes {:id tid})))))))
 
@@ -225,6 +228,63 @@
       (is (= :succeeded (t2/select-one-fn :status :model/TableIndex present-id)))
       (is (= :failed (t2/select-one-fn :status :model/TableIndex missing-id)))
       (is (some? (t2/select-one-fn :last_executed_at :model/TableIndex present-id))))))
+
+(defn- warehouse-btree
+  [name column]
+  {:name name :kind :btree :access-method "btree" :is-unique false
+   :is-primary false :is-valid true :key-columns [column] :include-columns []
+   :partial-predicate nil :definition "..."})
+
+(deftest ^:synchronized verify-managed-indexes!-removes-deletion-pending-row-when-absent-test
+  (mt/with-temp [:model/Transform {tid :id} {:name               (mt/random-name)
+                                             :source             {:type "query"}
+                                             :source_database_id (mt/id)
+                                             :target             {:database (mt/id) :type "table" :schema "public" :name "t"}}
+                 :model/TableIndex {applicable-id :id} {:transform_id tid :index_name "active_idx"
+                                                        :structured {:kind :btree :name "active_idx" :columns [{:name "x"}]}}
+                 :model/TableIndex {deleted-id :id} {:transform_id tid :index_name "deleted_idx"
+                                                     :status :deletion-pending
+                                                     :structured {:kind :btree :name "deleted_idx" :columns [{:name "y"}]}}]
+    (with-redefs [driver/fetch-table-indexes (fn [& _] [(warehouse-btree "active_idx" "x")])]
+      (transforms-base.u/verify-managed-indexes! (t2/select-one :model/Transform tid))
+      (is (= :succeeded (t2/select-one-fn :status :model/TableIndex applicable-id)))
+      (is (not (t2/exists? :model/TableIndex :id deleted-id)))
+      (is (some? (t2/insert-returning-pk! :model/TableIndex
+                                          {:transform_id tid
+                                           :index_name   "deleted_idx"
+                                           :structured   {:kind :btree :name "deleted_idx" :columns [{:name "z"}]}}))))))
+
+(deftest ^:synchronized verify-managed-indexes!-keeps-deletion-pending-row-when-present-test
+  (mt/with-temp [:model/Transform {tid :id} {:name               (mt/random-name)
+                                             :source             {:type "query"}
+                                             :source_database_id (mt/id)
+                                             :target             {:database (mt/id) :type "table" :schema "public" :name "t"}}
+                 :model/TableIndex {deleted-id :id} {:transform_id tid :index_name "deleted_idx"
+                                                     :status :deletion-pending
+                                                     :structured {:kind :btree :name "deleted_idx" :columns [{:name "y"}]}}]
+    (with-redefs [driver/fetch-table-indexes (fn [& _] [(warehouse-btree "deleted_idx" "y")])]
+      (transforms-base.u/verify-managed-indexes! (t2/select-one :model/Transform tid))
+      (is (= :deletion-pending (t2/select-one-fn :status :model/TableIndex deleted-id)))
+      (is (some? (t2/select-one-fn :last_executed_at :model/TableIndex deleted-id))))))
+
+(deftest ^:synchronized verify-managed-indexes!-removes-deletion-pending-absent-rows-test
+  (mt/with-temp [:model/Transform {tid :id} {:name               (mt/random-name)
+                                             :source             {:type "query"}
+                                             :source_database_id (mt/id)
+                                             :target             {:database (mt/id) :type "table" :schema "public" :name "t"}}
+                 :model/TableIndex {applicable-id :id} {:transform_id tid :index_name "active_idx"
+                                                        :structured {:kind :btree :name "active_idx" :columns [{:name "x"}]}}
+                 :model/TableIndex {deleted-id :id} {:transform_id tid :index_name "deleted_idx"
+                                                     :status :deletion-pending
+                                                     :structured {:kind :btree :name "deleted_idx" :columns [{:name "y"}]}}]
+    (with-redefs [driver/fetch-table-indexes (fn [& _] [])]
+      (transforms-base.u/verify-managed-indexes! (t2/select-one :model/Transform tid))
+      (is (= :create-pending (t2/select-one-fn :status :model/TableIndex applicable-id)))
+      (is (not (t2/exists? :model/TableIndex :id deleted-id)))
+      (is (some? (t2/insert-returning-pk! :model/TableIndex
+                                          {:transform_id tid
+                                           :index_name   "deleted_idx"
+                                           :structured   {:kind :btree :name "deleted_idx" :columns [{:name "z"}]}}))))))
 
 (deftest ^:synchronized ddl-failure-marks-row-failed-test
   (mt/with-temp [:model/Transform {tid :id} {:name (mt/random-name)

--- a/test/metabase/transforms/index_test.clj
+++ b/test/metabase/transforms/index_test.clj
@@ -201,15 +201,17 @@
                                                :source             {:type "query"}
                                                :source_database_id (mt/id)
                                                :target             {:database (mt/id) :type "table" :schema "public" :name "t"}}
-                   :model/TableIndex _ {:transform_id tid :index_name "b_idx"
-                                        :structured {:kind :btree :name "b_idx" :columns [{:name "x"}]}}
-                   :model/TableIndex _ {:transform_id tid :index_name "a_idx"
-                                        :structured {:kind :btree :name "a_idx" :columns [{:name "y"}]}}
+                   :model/TableIndex {b-id :id} {:transform_id tid :index_name "b_idx"
+                                                 :structured {:kind :btree :name "b_idx" :columns [{:name "x"}]}}
+                   :model/TableIndex {a-id :id} {:transform_id tid :index_name "a_idx"
+                                                 :structured {:kind :btree :name "a_idx" :columns [{:name "y"}]}}
                    :model/TableIndex _ {:transform_id tid :index_name "deleted_idx"
                                         :status :deletion-pending
                                         :structured {:kind :btree :name "deleted_idx" :columns [{:name "z"}]}}]
       (is (= ["a_idx" "b_idx"]
-             (map :name (transforms.execute/hydrate-transform-indexes {:id tid})))))))
+             (map :name (transforms.execute/hydrate-transform-indexes {:id tid}))))
+      (is (= [a-id b-id]
+             (transforms.execute/hydrate-transform-index-ids {:id tid}))))))
 
 (deftest ^:synchronized verify-managed-indexes!-test
   (mt/with-temp [:model/Transform {tid :id} {:name               (mt/random-name)
@@ -253,6 +255,29 @@
                                           {:transform_id tid
                                            :index_name   "deleted_idx"
                                            :structured   {:kind :btree :name "deleted_idx" :columns [{:name "z"}]}}))))))
+
+(deftest ^:synchronized verify-managed-indexes!-only-verifies-hydrated-indexes-test
+  (mt/with-temp [:model/Transform {tid :id :as transform} {:name               (mt/random-name)
+                                                           :source             {:type "query"}
+                                                           :source_database_id (mt/id)
+                                                           :target             {:database (mt/id)
+                                                                                :type     "table"
+                                                                                :schema   "public"
+                                                                                :name     "t"}}
+                 :model/TableIndex {hydrated-id :id} {:transform_id tid :index_name "hydrated_idx"
+                                                      :status :running
+                                                      :structured {:kind :btree :name "hydrated_idx"
+                                                                   :columns [{:name "x"}]}}
+                 :model/TableIndex {concurrent-id :id} {:transform_id tid :index_name "concurrent_idx"
+                                                        :structured {:kind :btree :name "concurrent_idx"
+                                                                     :columns [{:name "y"}]}}]
+    (with-redefs [driver/fetch-table-indexes (fn [& _] [(warehouse-btree "hydrated_idx" "x")])]
+      (transforms-base.u/verify-managed-indexes!
+       (-> transform
+           (assoc-in [:target :indexes] [{:kind :btree :name "hydrated_idx" :columns [{:name "x"}]}])
+           (assoc-in [:target :index-request-ids] [hydrated-id])))
+      (is (= :succeeded (t2/select-one-fn :status :model/TableIndex hydrated-id)))
+      (is (= :create-pending (t2/select-one-fn :status :model/TableIndex concurrent-id))))))
 
 (deftest ^:synchronized verify-managed-indexes!-keeps-deletion-pending-row-when-present-test
   (mt/with-temp [:model/Transform {tid :id} {:name               (mt/random-name)

--- a/test/metabase/transforms/index_test.clj
+++ b/test/metabase/transforms/index_test.clj
@@ -292,7 +292,7 @@
       (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex deleted-id)))
       (is (some? (t2/select-one-fn :last_executed_at :model/TableIndex deleted-id))))))
 
-(deftest ^:synchronized verify-managed-indexes!-removes-delete-pending-absent-rows-test
+(deftest ^:synchronized verify-managed-indexes!-reconciles-successful-empty-index-list-test
   (mt/with-temp [:model/Transform {tid :id} {:name               (mt/random-name)
                                              :source             {:type "query"}
                                              :source_database_id (mt/id)
@@ -304,12 +304,27 @@
                                                      :structured {:kind :btree :name "deleted_idx" :columns [{:name "y"}]}}]
     (with-redefs [driver/fetch-table-indexes (fn [& _] [])]
       (transforms-base.u/verify-managed-indexes! (t2/select-one :model/Transform tid))
-      (is (= :create-pending (t2/select-one-fn :status :model/TableIndex applicable-id)))
+      (is (= :failed (t2/select-one-fn :status :model/TableIndex applicable-id)))
       (is (not (t2/exists? :model/TableIndex :id deleted-id)))
       (is (some? (t2/insert-returning-pk! :model/TableIndex
                                           {:transform_id tid
                                            :index_name   "deleted_idx"
                                            :structured   {:kind :btree :name "deleted_idx" :columns [{:name "z"}]}}))))))
+
+(deftest ^:synchronized verify-managed-indexes!-leaves-rows-unchanged-when-index-fetch-fails-test
+  (mt/with-temp [:model/Transform {tid :id} {:name               (mt/random-name)
+                                             :source             {:type "query"}
+                                             :source_database_id (mt/id)
+                                             :target             {:database (mt/id) :type "table" :schema "public" :name "t"}}
+                 :model/TableIndex {applicable-id :id} {:transform_id tid :index_name "active_idx"
+                                                        :structured {:kind :btree :name "active_idx" :columns [{:name "x"}]}}
+                 :model/TableIndex {deleted-id :id} {:transform_id tid :index_name "deleted_idx"
+                                                     :status :delete-pending
+                                                     :structured {:kind :btree :name "deleted_idx" :columns [{:name "y"}]}}]
+    (with-redefs [driver/fetch-table-indexes (fn [& _] (throw (ex-info "boom" {})))]
+      (transforms-base.u/verify-managed-indexes! (t2/select-one :model/Transform tid))
+      (is (= :create-pending (t2/select-one-fn :status :model/TableIndex applicable-id)))
+      (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex deleted-id))))))
 
 (deftest ^:synchronized ddl-failure-marks-row-failed-test
   (mt/with-temp [:model/Transform {tid :id} {:name (mt/random-name)


### PR DESCRIPTION
- use status-only managed index lifecycle states: `create-pending`, `update-pending`, `delete-pending`, `running`, `succeeded`, and `failed`
- make DELETE set `delete-pending` so pending deletion remains visible until the next full rebuild removes the physical index
- remove completed deletion rows after verification confirms the warehouse index is gone, freeing the same index name for reuse
- hydrate applicable index request ids onto the execution target so running/verification status updates only settle rows owned by that run
- mark applicable index requests `running` during the index apply/verify phase, and fail any unverified running rows instead of leaving them stuck
- force incremental transforms to rebuild after index create/update/delete so physical indexes are recreated or removed correctly
- fold the lifecycle changes into the existing unlanded table-index migration

Tests:
- `./bin/test-agent :only '[metabase.indexes.api-test metabase.indexes.models.table-index-test metabase.indexes.reconcile-test metabase.transforms.index-test metabase.transforms.util-test]'`