### PR TITLE
Add only published filter to data studio table picker

### DIFF
--- a/frontend/src/metabase-types/api/table.ts
+++ b/frontend/src/metabase-types/api/table.ts
@@ -123,6 +123,7 @@ export interface TableListQuery {
   "owner-email"?: string | null;
   "unused-only"?: boolean | null;
   "orphan-only"?: boolean;
+  "published-only"?: boolean | null;
 }
 
 export interface ForeignKey {

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/FilterPopover.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/FilterPopover.tsx
@@ -16,10 +16,11 @@ import type { FilterState } from "../types";
 
 interface Props {
   filters: FilterState;
+  isLibraryEnabled: boolean;
   onSubmit: (filters: FilterState) => void;
 }
 
-export function FilterPopover({ filters, onSubmit }: Props) {
+export function FilterPopover({ filters, isLibraryEnabled, onSubmit }: Props) {
   const [form, setForm] = useState(filters);
 
   const handleReset = () => {
@@ -30,6 +31,7 @@ export function FilterPopover({ filters, onSubmit }: Props) {
       ownerEmail: null,
       ownerUserId: null,
       unusedOnly: null,
+      publishedOnly: null,
     });
   };
 
@@ -93,6 +95,16 @@ export function FilterPopover({ filters, onSubmit }: Props) {
             setForm((form) => ({ ...form, unusedOnly: e.target.checked }))
           }
         />
+
+        {isLibraryEnabled && (
+          <Checkbox
+            label={t`Published tables only`}
+            checked={form.publishedOnly === true}
+            onChange={(e) =>
+              setForm((form) => ({ ...form, publishedOnly: e.target.checked }))
+            }
+          />
+        )}
 
         <Group justify="space-between" wrap="nowrap">
           <Button flex={1} onClick={handleReset}>{t`Clear filters`}</Button>

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/SearchNew.tsx
@@ -121,6 +121,7 @@ export function SearchNew({
     "owner-email": filters.ownerEmail ?? undefined,
     "orphan-only": filters.ownerUserId === "unknown" ? true : undefined,
     "unused-only": filters.unusedOnly === true ? true : undefined,
+    "published-only": filters.publishedOnly === true ? true : undefined,
   });
   const { data: databases, isLoading: isLoadingDatabases } =
     useListDatabasesQuery();

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/TablePicker.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/TablePicker.tsx
@@ -55,6 +55,7 @@ export function TablePicker({
     ownerEmail: null,
     ownerUserId: null,
     unusedOnly: null,
+    publishedOnly: null,
   });
   const [isOpen, { toggle, close }] = useDisclosure();
   const filtersCount = getFiltersCount(filters);
@@ -133,6 +134,7 @@ export function TablePicker({
           <Popover.Dropdown>
             <FilterPopover
               filters={filters}
+              isLibraryEnabled={isLibraryEnabled}
               onSubmit={(newFilters) => {
                 setFilters(newFilters);
                 close();

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/TablePicker.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/TablePicker.unit.spec.tsx
@@ -1,12 +1,15 @@
 import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
 import { Route } from "react-router";
 
+import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import {
   setupDatabasesEndpoints,
   setupTableSearchEndpoint,
   setupUserKeyValueEndpoints,
   setupUsersEndpoints,
 } from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
 import {
   mockGetBoundingClientRect,
   renderWithProviders,
@@ -14,11 +17,13 @@ import {
   waitFor,
 } from "__support__/ui";
 import { SelectionProvider } from "metabase/data-studio/data-model/pages/DataModel/contexts/SelectionContext";
-import type { Database, User } from "metabase-types/api";
+import { createMockState } from "metabase/redux/store/mocks";
+import type { Database, TokenFeatures, User } from "metabase-types/api";
 import {
   createMockDatabase,
   createMockSchema,
   createMockTable,
+  createMockTokenFeatures,
   createMockUser,
 } from "metabase-types/api/mocks";
 
@@ -147,9 +152,11 @@ const currentUser: User = createMockUser({
 function setup({
   path = {},
   databases = MOCK_DATABASES,
+  tokenFeatures = {},
 }: {
   path?: TreePath;
   databases?: Database[];
+  tokenFeatures?: Partial<TokenFeatures>;
 } = {}) {
   setupDatabasesEndpoints(databases);
   setupTableSearchEndpoint(
@@ -163,6 +170,16 @@ function setup({
     key: "seen-publish-tables-info",
     value: false,
   });
+
+  const state = createMockState({
+    settings: mockSettings({
+      "token-features": createMockTokenFeatures(tokenFeatures),
+    }),
+  });
+
+  if (tokenFeatures.library) {
+    setupEnterpriseOnlyPlugin("library");
+  }
 
   const onChange = jest.fn();
   const setOnUpdateCallback = jest.fn();
@@ -182,7 +199,7 @@ function setup({
         </SelectionProvider>
       )}
     />,
-    { withRouter: true },
+    { withRouter: true, storeInitialState: state },
   );
   return { onChange };
 }
@@ -560,6 +577,46 @@ describe("TablePicker", () => {
       expect(item(QUU)).not.toBeInTheDocument();
       expect(item(QUX)).not.toBeInTheDocument();
       expect(item(GRAULT)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Published tables filter", () => {
+    it("is hidden when the Library is not enabled", async () => {
+      setup();
+      await waitLoading();
+
+      await userEvent.click(screen.getByRole("button", { name: "Filter" }));
+
+      expect(
+        await screen.findByTestId("table-picker-filter"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Published tables only"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("sends published-only=true when enabled, checked, and applied", async () => {
+      setup({ tokenFeatures: { library: true } });
+      await waitLoading();
+
+      // Enter search mode first so the table-search endpoint matches the request
+      await userEvent.type(searchInput(), "o");
+      await waitLoading();
+
+      await userEvent.click(screen.getByRole("button", { name: "Filter" }));
+      await userEvent.click(
+        await screen.findByLabelText("Published tables only"),
+      );
+      await userEvent.click(screen.getByRole("button", { name: "Apply" }));
+      await waitLoading();
+
+      await waitFor(() => {
+        const calls = fetchMock.callHistory.calls("path:/api/table");
+        const lastCall = calls.at(-1);
+        expect(lastCall).toBeDefined();
+        const url = new URL(lastCall!.url);
+        expect(url.searchParams.get("published-only")).toBe("true");
+      });
     });
   });
 });

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/types.ts
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/types.ts
@@ -88,6 +88,7 @@ export interface FilterState {
   ownerEmail: string | null;
   ownerUserId: UserId | "unknown" | null;
   unusedOnly: boolean | null;
+  publishedOnly: boolean | null;
 }
 
 export function isDatabaseNode(node: TreeNode): node is DatabaseNode {

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/utils.ts
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/utils.ts
@@ -135,6 +135,7 @@ export function getFiltersCount(filters: FilterState): number {
     filters.dataLayer != null,
     filters.ownerEmail != null || filters.ownerUserId != null,
     filters.unusedOnly === true,
+    filters.publishedOnly === true,
   ].filter(Boolean).length;
 }
 

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -73,7 +73,7 @@
   - `can-write=true` - filter to only tables the user can edit metadata for"
   [_
    {:keys [term visibility-type data-layer data-source owner-user-id owner-email orphan-only unused-only
-           can-query can-write include-transform-targets]}
+           published-only can-query can-write include-transform-targets]}
    :- [:map
        [:term {:optional true} :string]
        [:visibility-type {:optional true} :string]
@@ -83,6 +83,7 @@
        [:owner-email {:optional true} :string]
        [:orphan-only {:optional true} [:maybe ms/BooleanValue]]
        [:unused-only {:optional true} [:maybe ms/BooleanValue]]
+       [:published-only {:optional true} [:maybe ms/BooleanValue]]
        [:can-query {:optional true} [:maybe ms/BooleanValue]]
        [:can-write {:optional true} [:maybe ms/BooleanValue]]
        [:include-transform-targets {:optional true} [:maybe ms/BooleanValue]]]]
@@ -110,6 +111,7 @@
                      owner-user-id           (conj [:= :owner_user_id   owner-user-id])
                      owner-email             (conj [:= :owner_email     owner-email])
                      orphan-only             (conj [:and [:= :owner_email nil] [:= :owner_user_id nil]])
+                     published-only          (conj [:= :is_published true])
                      (and unused-only (premium-features/has-feature? :dependencies))
                      (conj [:not-exists {:select [:*]
                                          :from   [[:dependency :d]]

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1361,6 +1361,37 @@
                       (map :id)
                       set))))))))
 
+(deftest published-only-filter-test
+  (testing "GET /api/table?published-only=true"
+    (testing "filters tables that are not published"
+      (mt/with-temp [:model/Database {db-id :id} {}
+                     :model/Table {table-1-id :id} {:db_id db-id
+                                                    :name "table_1"
+                                                    :active true
+                                                    :is_published true}
+                     :model/Table {table-2-id :id} {:db_id db-id
+                                                    :name "table_2"
+                                                    :active true
+                                                    :is_published false}]
+        (testing "both tables returned without filter"
+          (is (= #{table-1-id table-2-id}
+                 (->> (mt/user-http-request :crowberto :get 200 "table")
+                      (filter #(= (:db_id %) db-id))
+                      (map :id)
+                      set))))
+        (testing "both tables returned with published-only=false"
+          (is (= #{table-1-id table-2-id}
+                 (->> (mt/user-http-request :crowberto :get 200 "table" :published-only false)
+                      (filter #(= (:db_id %) db-id))
+                      (map :id)
+                      set))))
+        (testing "only table-1 is returned with published-only=true"
+          (is (= #{table-1-id}
+                 (->> (mt/user-http-request :crowberto :get 200 "table" :published-only true)
+                      (filter #(= (:db_id %) db-id))
+                      (map :id)
+                      set))))))))
+
 (deftest no-fks-for-missing-tables-test
   (testing "Check that we don't return foreign keys for missing/inactive tables"
     (mt/with-temp-test-data


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74702
### Description

Adds a "only published tables" option to the table picker, and the `get /table` API. 

### How to verify

1. Go to the data studio table picker
2. Click the filter button and check "Only published tables"
3. Hit apply, and the table should update to only show published tables

### Demo

https://github.com/user-attachments/assets/e6d935ff-ca48-44e1-a83e-dd37e63283b6



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
