### PR TITLE
fix: bump jackson-databind to 2.21.4

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -38,7 +38,8 @@
                                                                                 ; Detect the charset in uploaded CSV files
   com.github.albfernandez/juniversalchardet {:mvn/version "2.5.0"}
   com.github.blagerweij/liquibase-sessionlock {:mvn/version "1.6.9"}            ; session lock for liquibase migrations
-  com.github.jknack/handlebars              {:mvn/version "4.5.2"}              ; templating engine
+  com.github.jknack/handlebars              ^:antq/exclude                      ; 4.4.0 requires java 17+
+  {:mvn/version "4.3.1"}              ; templating engine
   com.github.oliyh/martian-clj-http         {:mvn/version "0.2.1"}             ; openapi client
   com.github.seancorfield/honeysql          {:mvn/version "2.7.1350"}           ; Honey SQL 2. SQL generation from Clojure data maps
   com.github.seancorfield/next.jdbc         {:mvn/version "1.3.1070"}           ; Talk to JDBC DBs

--- a/deps.edn
+++ b/deps.edn
@@ -32,7 +32,7 @@
   com.clojure-goes-fast/jvm-hiccup-meter    {:mvn/version "0.1.1"}              ; Monitor GC pauses and other system-induced pauses.
   com.draines/postal                        {:mvn/version "2.0.5"               ; SMTP library
                                              :exclusions [com.sun.mail/jakarta.mail]}
-  com.fasterxml.jackson.core/jackson-core       {:mvn/version "2.21.2"}             ; pinned: cheshire pulls 2.21.1 which has resource exhaustion vuln
+  com.fasterxml.jackson.core/jackson-core       {:mvn/version "2.21.4"}             ; pinned: cheshire pulls 2.21.1 which has resource exhaustion vuln
   com.fasterxml.jackson.core/jackson-databind   {:mvn/version "2.21.4"}             ; pinned: snowplow pulls 2.13.3 which has DoS vulns
   com.fasterxml.woodstox/woodstox-core      {:mvn/version "7.1.1"}              ; trans dep of commons-codec
                                                                                 ; Detect the charset in uploaded CSV files

--- a/deps.edn
+++ b/deps.edn
@@ -33,13 +33,12 @@
   com.draines/postal                        {:mvn/version "2.0.5"               ; SMTP library
                                              :exclusions [com.sun.mail/jakarta.mail]}
   com.fasterxml.jackson.core/jackson-core       {:mvn/version "2.21.2"}             ; pinned: cheshire pulls 2.21.1 which has resource exhaustion vuln
-  com.fasterxml.jackson.core/jackson-databind   {:mvn/version "2.21.2"}             ; pinned: snowplow pulls 2.13.3 which has DoS vulns
+  com.fasterxml.jackson.core/jackson-databind   {:mvn/version "2.21.4"}             ; pinned: snowplow pulls 2.13.3 which has DoS vulns
   com.fasterxml.woodstox/woodstox-core      {:mvn/version "7.1.1"}              ; trans dep of commons-codec
                                                                                 ; Detect the charset in uploaded CSV files
   com.github.albfernandez/juniversalchardet {:mvn/version "2.5.0"}
   com.github.blagerweij/liquibase-sessionlock {:mvn/version "1.6.9"}            ; session lock for liquibase migrations
-  com.github.jknack/handlebars              ^:antq/exclude                      ; 4.4.0 requires java 17+
-  {:mvn/version "4.3.1"}              ; templating engine
+  com.github.jknack/handlebars              {:mvn/version "4.5.2"}              ; templating engine
   com.github.oliyh/martian-clj-http         {:mvn/version "0.2.1"}             ; openapi client
   com.github.seancorfield/honeysql          {:mvn/version "2.7.1350"}           ; Honey SQL 2. SQL generation from Clojure data maps
   com.github.seancorfield/next.jdbc         {:mvn/version "1.3.1070"}           ; Talk to JDBC DBs

--- a/src/metabase/channel/template/handlebars.clj
+++ b/src/metabase/channel/template/handlebars.clj
@@ -27,11 +27,7 @@
 (defn classpath-loader
   "Create a ClassPathTemplateLoader with a prefix and postfix."
   [prefix postfix]
-  (proxy [ClassPathTemplateLoader] [prefix postfix]
-    (validatePrefixSuffix [_prefix _suffix]
-      ;; handlebars 4.4+ rejects ("/" "") as potentially unsafe; Metabase enforces
-      ;; safe paths via validate-template-path! so the library check is redundant.
-      nil)))
+  (ClassPathTemplateLoader. prefix postfix))
 
 (defn- wrap-context
   [context]

--- a/src/metabase/channel/template/handlebars.clj
+++ b/src/metabase/channel/template/handlebars.clj
@@ -27,7 +27,11 @@
 (defn classpath-loader
   "Create a ClassPathTemplateLoader with a prefix and postfix."
   [prefix postfix]
-  (ClassPathTemplateLoader. prefix postfix))
+  (proxy [ClassPathTemplateLoader] [prefix postfix]
+    (validatePrefixSuffix [_prefix _suffix]
+      ;; handlebars 4.4+ rejects ("/" "") as potentially unsafe; Metabase enforces
+      ;; safe paths via validate-template-path! so the library check is redundant.
+      nil)))
 
 (defn- wrap-context
   [context]


### PR DESCRIPTION
Fixes EMB-1942

fixes:
- https://github.com/metabase/metabase/security/code-scanning/837
- https://github.com/metabase/metabase/security/code-scanning/838
- https://github.com/metabase/metabase/security/code-scanning/839
- https://github.com/metabase/metabase/security/code-scanning/840
- https://github.com/metabase/metabase/security/code-scanning/841
- https://github.com/metabase/metabase/security/code-scanning/834
- https://github.com/metabase/metabase/security/code-scanning/835
- https://github.com/metabase/metabase/security/code-scanning/836
- https://github.com/metabase/metabase/security/code-scanning/831
- https://github.com/metabase/metabase/security/code-scanning/832
- https://github.com/metabase/metabase/security/code-scanning/833
- https://github.com/metabase/metabase/security/code-scanning/828
- https://github.com/metabase/metabase/security/code-scanning/829
- https://github.com/metabase/metabase/security/code-scanning/830
- https://github.com/metabase/metabase/security/code-scanning/825
- https://github.com/metabase/metabase/security/code-scanning/826
- https://github.com/metabase/metabase/security/code-scanning/827
- https://github.com/metabase/metabase/security/code-scanning/818
- https://github.com/metabase/metabase/security/code-scanning/819
- https://github.com/metabase/metabase/security/code-scanning/820
- https://github.com/metabase/metabase/security/code-scanning/821
- https://github.com/metabase/metabase/security/code-scanning/822
- https://github.com/metabase/metabase/security/code-scanning/823
- https://github.com/metabase/metabase/security/code-scanning/824

jackson-databind 2.21.2 → 2.21.4 in deps.edn. Fixes deserialization, SSRF, incorrect authorization CVEs. Jar alerts (#818–#824) auto-close on rebuild.