### PR TITLE
fix: bump netty to 4.1.135.Final (athena) and 4.2.15.Final (hive-like)

### DIFF
--- a/modules/drivers/athena/deps.edn
+++ b/modules/drivers/athena/deps.edn
@@ -17,13 +17,13 @@
   ;; Netty — pinned at latest 4.1.x patched release. The Athena JDBC driver's
   ;; async AWS SDK path requires the 4.1 API; 4.2.x is not binary-compatible
   ;; with classes the driver calls. 4.1.133 patches CVE-2026-33870 et al.
-  io.netty/netty-common                       {:mvn/version "4.1.133.Final"}
-  io.netty/netty-handler                      {:mvn/version "4.1.133.Final"}
-  io.netty/netty-transport                    {:mvn/version "4.1.133.Final"}
-  io.netty/netty-buffer                       {:mvn/version "4.1.133.Final"}
-  io.netty/netty-codec                        {:mvn/version "4.1.133.Final"}
-  io.netty/netty-codec-http                   {:mvn/version "4.1.133.Final"}
-  io.netty/netty-codec-http2                  {:mvn/version "4.1.133.Final"}
-  io.netty/netty-resolver                     {:mvn/version "4.1.133.Final"}
-  io.netty/netty-transport-native-unix-common {:mvn/version "4.1.133.Final"}
-  io.netty/netty-transport-native-epoll       {:mvn/version "4.1.133.Final"}}}
+  io.netty/netty-common                       {:mvn/version "4.1.135.Final"}
+  io.netty/netty-handler                      {:mvn/version "4.1.135.Final"}
+  io.netty/netty-transport                    {:mvn/version "4.1.135.Final"}
+  io.netty/netty-buffer                       {:mvn/version "4.1.135.Final"}
+  io.netty/netty-codec                        {:mvn/version "4.1.135.Final"}
+  io.netty/netty-codec-http                   {:mvn/version "4.1.135.Final"}
+  io.netty/netty-codec-http2                  {:mvn/version "4.1.135.Final"}
+  io.netty/netty-resolver                     {:mvn/version "4.1.135.Final"}
+  io.netty/netty-transport-native-unix-common {:mvn/version "4.1.135.Final"}
+  io.netty/netty-transport-native-epoll       {:mvn/version "4.1.135.Final"}}}

--- a/modules/drivers/athena/deps.edn
+++ b/modules/drivers/athena/deps.edn
@@ -16,7 +16,7 @@
 
   ;; Netty — pinned at latest 4.1.x patched release. The Athena JDBC driver's
   ;; async AWS SDK path requires the 4.1 API; 4.2.x is not binary-compatible
-  ;; with classes the driver calls. 4.1.133 patches CVE-2026-33870 et al.
+  ;; with classes the driver calls. 4.1.135 patches CVE-2026-33870 et al.
   io.netty/netty-common                       {:mvn/version "4.1.135.Final"}
   io.netty/netty-handler                      {:mvn/version "4.1.135.Final"}
   io.netty/netty-transport                    {:mvn/version "4.1.135.Final"}

--- a/modules/drivers/hive-like/deps.edn
+++ b/modules/drivers/hive-like/deps.edn
@@ -245,11 +245,11 @@
 
   ;; Netty — pinned explicitly at safe versions for security scanning.
   ;; Driver JARs are scanned individually so these must be declared directly.
-  io.netty/netty-common                              {:mvn/version "4.2.13.Final"}
-  io.netty/netty-handler                             {:mvn/version "4.2.13.Final"}
-  io.netty/netty-transport                           {:mvn/version "4.2.13.Final"}
-  io.netty/netty-buffer                              {:mvn/version "4.2.13.Final"}
-  io.netty/netty-codec                               {:mvn/version "4.2.13.Final"}
-  io.netty/netty-resolver                            {:mvn/version "4.2.13.Final"}
-  io.netty/netty-transport-native-unix-common        {:mvn/version "4.2.13.Final"}
-  io.netty/netty-transport-native-epoll              {:mvn/version "4.2.13.Final"}}}
+  io.netty/netty-common                              {:mvn/version "4.2.15.Final"}
+  io.netty/netty-handler                             {:mvn/version "4.2.15.Final"}
+  io.netty/netty-transport                           {:mvn/version "4.2.15.Final"}
+  io.netty/netty-buffer                              {:mvn/version "4.2.15.Final"}
+  io.netty/netty-codec                               {:mvn/version "4.2.15.Final"}
+  io.netty/netty-resolver                            {:mvn/version "4.2.15.Final"}
+  io.netty/netty-transport-native-unix-common        {:mvn/version "4.2.15.Final"}
+  io.netty/netty-transport-native-epoll              {:mvn/version "4.2.15.Final"}}}


### PR DESCRIPTION
Fixes EMB-1942

fixes:
- https://github.com/metabase/metabase/security/code-scanning/774
- https://github.com/metabase/metabase/security/code-scanning/775
- https://github.com/metabase/metabase/security/code-scanning/776
- https://github.com/metabase/metabase/security/code-scanning/777
- https://github.com/metabase/metabase/security/code-scanning/782
- https://github.com/metabase/metabase/security/code-scanning/784
- https://github.com/metabase/metabase/security/code-scanning/785
- https://github.com/metabase/metabase/security/code-scanning/786
- https://github.com/metabase/metabase/security/code-scanning/771
- https://github.com/metabase/metabase/security/code-scanning/772
- https://github.com/metabase/metabase/security/code-scanning/773
- https://github.com/metabase/metabase/security/code-scanning/787
- https://github.com/metabase/metabase/security/code-scanning/767
- https://github.com/metabase/metabase/security/code-scanning/768
- https://github.com/metabase/metabase/security/code-scanning/769
- https://github.com/metabase/metabase/security/code-scanning/770
- https://github.com/metabase/metabase/security/code-scanning/781
- https://github.com/metabase/metabase/security/code-scanning/788
- https://github.com/metabase/metabase/security/code-scanning/789
- https://github.com/metabase/metabase/security/code-scanning/790

athena: all netty sub-packages 4.1.133.Final → 4.1.135.Final in modules/drivers/athena/deps.edn. Fixes HTTP request smuggling, HTTP/2 DoS, TLS hostname verification bypass, memory leaks.

hive-like: all netty sub-packages 4.2.13.Final → 4.2.15.Final in modules/drivers/hive-like/deps.edn. Same CVE classes. Jar alerts (#767–#770, #781, #788–#790) auto-close on rebuild.