### PR TITLE
fix: pin opentelemetry-api to 1.62.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -46,6 +46,7 @@
   com.github.steffan-westcott/clj-otel-api  {:mvn/version "0.2.10"}             ; Telemetry library
   com.github.steffan-westcott/clj-otel-exporter-otlp {:mvn/version "0.2.10"}    ; OTLP span exporter (gRPC and HTTP)
   com.github.steffan-westcott/clj-otel-sdk  {:mvn/version "0.2.10"}             ; OpenTelemetry SDK for programmatic configuration
+  io.opentelemetry/opentelemetry-api         {:mvn/version "1.62.0"}             ; pinned: clj-otel-api 0.2.10 pulls 1.54.1 (W3CBaggagePropagator DoS vuln)
   com.github.vertical-blank/sql-formatter   {:mvn/version "2.0.5"}              ; Java SQL formatting library https://github.com/vertical-blank/sql-formatter
   com.google.auth/google-auth-library-credentials {:mvn/version "1.40.0"}       ; dep for BigQuery, Databricks, and Snowflake. Require here rather than letting different dep versions stomp on each other — see #70908
   com.google.code.gson/gson                 {:mvn/version "2.12.1"}             ; dep for BigQuery, Databricks, and Snowflake. Pin here so driver plugin JARs all use the same version — see #73736

--- a/deps.edn
+++ b/deps.edn
@@ -46,7 +46,6 @@
   com.github.steffan-westcott/clj-otel-api  {:mvn/version "0.2.10"}             ; Telemetry library
   com.github.steffan-westcott/clj-otel-exporter-otlp {:mvn/version "0.2.10"}    ; OTLP span exporter (gRPC and HTTP)
   com.github.steffan-westcott/clj-otel-sdk  {:mvn/version "0.2.10"}             ; OpenTelemetry SDK for programmatic configuration
-  io.opentelemetry/opentelemetry-api         {:mvn/version "1.62.0"}             ; pinned: clj-otel-api 0.2.10 pulls 1.54.1 (W3CBaggagePropagator DoS vuln)
   com.github.vertical-blank/sql-formatter   {:mvn/version "2.0.5"}              ; Java SQL formatting library https://github.com/vertical-blank/sql-formatter
   com.google.auth/google-auth-library-credentials {:mvn/version "1.40.0"}       ; dep for BigQuery, Databricks, and Snowflake. Require here rather than letting different dep versions stomp on each other — see #70908
   com.google.code.gson/gson                 {:mvn/version "2.12.1"}             ; dep for BigQuery, Databricks, and Snowflake. Pin here so driver plugin JARs all use the same version — see #73736
@@ -87,6 +86,7 @@
                                              :git/sha "ffc4edc482c057cd9412c62f018a41e9140c618b"
                                              :git/url "https://github.com/eerohele/pp"}
   io.github.metabase/macaw                  {:mvn/version "0.2.36"}             ; Parse native SQL queries
+  io.opentelemetry/opentelemetry-api        {:mvn/version "1.62.0"}             ; pinned: clj-otel-api 0.2.10 pulls 1.54.1 (W3CBaggagePropagator DoS vuln)
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector
   junegunn/grouper                          {:mvn/version "0.1.1"}              ; Batch processing helper
   kixi/stats                                {:mvn/version "0.5.7"               ; Various statistic measures implemented as transducers

--- a/deps.edn
+++ b/deps.edn
@@ -269,7 +269,7 @@
     integrant/integrant          {:mvn/version "1.0.1"}                   ; component lifecycle management
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}                     ; cleaner test output
     io.github.metabase/hawk      {:mvn/version "1.0.13"}                    ; test runner
-    io.opentelemetry/opentelemetry-sdk-testing {:mvn/version "1.54.1"}      ; InMemorySpanExporter for tracing tests; pinned to match the resolved OTel SDK version
+    io.opentelemetry/opentelemetry-sdk-testing {:mvn/version "1.54.1"}      ; InMemorySpanExporter for tracing tests; matches sdk impl (clj-otel-sdk 0.2.10 → 1.54.1); api is separately pinned to 1.62.0
     io.zonky.test/embedded-postgres {:mvn/version "2.2.2"}                  ; In-process postgres for dev and testing
     ;; Native postgres binaries for every OS/arch we're likely to run on in
     ;; dev or CI. Without these Zonky falls back to x86_64 under Rosetta on

--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -24,12 +24,12 @@
   org.apache.arrow/arrow-vector          {:mvn/version "18.3.0"}
   ;; was 1.71.0. bumping to 77
   io.grpc/grpc-netty-shaded              {:mvn/version "1.77.0"}
-  io.opentelemetry/opentelemetry-api     {:mvn/version "1.62.0"}             ; pinned: grpc-netty-shaded pulls 1.54.1 (W3CBaggagePropagator DoS vuln)
+  io.opentelemetry/opentelemetry-api     {:mvn/version "1.62.0"}             ; pinned: google-cloud-bigquery 2.55.3 pulls opentelemetry-api 1.47.0 (W3CBaggagePropagator DoS vuln)
   ;; Netty 4.2.x — latest patched release. grpc-netty-shaded bundles its own
   ;; shaded netty, but these modules are still pulled through arrow-memory-netty
   ;; and must be pinned for security scanning.
-  io.netty/netty-common                  {:mvn/version "4.2.12.Final"}
-  io.netty/netty-buffer                  {:mvn/version "4.2.12.Final"}
+  io.netty/netty-common                  {:mvn/version "4.2.15.Final"}
+  io.netty/netty-buffer                  {:mvn/version "4.2.15.Final"}
   ;; pinned: google-cloud-bigquery pulls 2.18.2 which has resource exhaustion vulns
   com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.2"}
   ;; Need gson ≥ 2.9.0 for JsonWriter.value(float) used in

--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -24,6 +24,7 @@
   org.apache.arrow/arrow-vector          {:mvn/version "18.3.0"}
   ;; was 1.71.0. bumping to 77
   io.grpc/grpc-netty-shaded              {:mvn/version "1.77.0"}
+  io.opentelemetry/opentelemetry-api     {:mvn/version "1.62.0"}             ; pinned: grpc-netty-shaded pulls 1.54.1 (W3CBaggagePropagator DoS vuln)
   ;; Netty 4.2.x — latest patched release. grpc-netty-shaded bundles its own
   ;; shaded netty, but these modules are still pulled through arrow-memory-netty
   ;; and must be pinned for security scanning.

--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -17,6 +17,7 @@
                                                    com.azure/azure-core-http-netty]}
   ;; drop when snowflake update driver to the one without the vulnerabilities
   io.grpc/grpc-netty-shaded         {:mvn/version "1.77.0"}
+  io.opentelemetry/opentelemetry-api {:mvn/version "1.62.0"}             ; pinned: grpc-netty-shaded pulls 1.54.1 (W3CBaggagePropagator DoS vuln)
   ;; pin Bouncy Castle explicitly so the bundled driver JAR uses the patched version
   org.bouncycastle/bcpkix-jdk18on   {:mvn/version "1.84"}
   org.bouncycastle/bcprov-jdk18on   {:mvn/version "1.84"}

--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -17,7 +17,7 @@
                                                    com.azure/azure-core-http-netty]}
   ;; drop when snowflake update driver to the one without the vulnerabilities
   io.grpc/grpc-netty-shaded         {:mvn/version "1.77.0"}
-  io.opentelemetry/opentelemetry-api {:mvn/version "1.62.0"}             ; pinned: grpc-netty-shaded pulls 1.54.1 (W3CBaggagePropagator DoS vuln)
+  io.opentelemetry/opentelemetry-api {:mvn/version "1.62.0"}             ; pinned: pulls vulnerable opentelemetry-api (W3CBaggagePropagator DoS vuln)
   ;; pin Bouncy Castle explicitly so the bundled driver JAR uses the patched version
   org.bouncycastle/bcpkix-jdk18on   {:mvn/version "1.84"}
   org.bouncycastle/bcprov-jdk18on   {:mvn/version "1.84"}


### PR DESCRIPTION
Fixes EMB-1942

fixes:
- https://github.com/metabase/metabase/security/code-scanning/778
- https://github.com/metabase/metabase/security/code-scanning/779
- https://github.com/metabase/metabase/security/code-scanning/780

opentelemetry-api is purely transitive today — pulled via clj-otel-api 0.2.10 (root app) and grpc-netty-shaded 1.77.0 (snowflake + bigquery drivers), resolving to 1.54.1. That version has a W3CBaggagePropagator resource exhaustion CVE (oversized baggage causes unbounded memory allocation re-injected into every outgoing request). Added explicit 1.62.0 pin in deps.edn, modules/drivers/snowflake/deps.edn, and modules/drivers/bigquery-cloud-sdk/deps.edn.