### PR TITLE
Migrate underlined Radio usages to Mantine Tabs

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
@@ -4207,7 +4207,7 @@ describe("scenarios > data studio > transforms > permissions", () => {
       "Ensure that transform permissions are visible when instance is hosted and transform feature is present",
     );
 
-    cy.findByRole("radio", { name: "Data" }).click({ force: true });
+    cy.findByRole("tab", { name: "Data" }).click({ force: true });
     cy.findByRole("menuitem", { name: "All Users" }).click();
 
     cy.findByRole("columnheader", { name: /Transforms/ })

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -316,7 +316,7 @@ describe("command palette", () => {
 
         H.saveChangesToPermissions();
 
-        cy.findByRole("radiogroup").findByText("Data").click();
+        cy.findByRole("tab", { name: "Data" }).click();
         cy.findByRole("menuitem", { name: "All Users" }).click();
 
         const TABLE_METADATA_INDEX = 3;

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -88,7 +88,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       H.modal().should("not.exist");
 
       // Switching to data permissions page
-      cy.get("label").contains("Data").click();
+      cy.findByRole("tab", { name: "Data" }).click();
 
       H.modal().within(() => {
         cy.findByText("Discard your changes?");
@@ -102,7 +102,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       cy.url().should("include", "/admin/permissions/collections/root");
 
       // Switching to data permissions page again
-      cy.get("label").contains("Data").click();
+      cy.findByRole("tab", { name: "Data" }).click();
 
       H.modal().button("Discard changes").click();
 

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -288,7 +288,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       H.modal().should("not.exist");
 
       // Switching to collection permissions page
-      cy.get("label").contains("Collection").click();
+      cy.findByRole("tab", { name: "Collections" }).click();
 
       H.modal().within(() => {
         cy.findByText("Discard your changes?");
@@ -302,7 +302,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       cy.url().should("include", "/admin/permissions/data/database");
 
       // Switching to collection permissions page again
-      cy.get("label").contains("Collection").click();
+      cy.findByRole("tab", { name: "Collections" }).click();
 
       H.modal().button("Discard changes").click();
 

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
@@ -754,7 +754,7 @@ describe("UXW-2696", () => {
     H.popover().findByText("Edit Visualization").click();
 
     H.getDocumentSidebar().within(() => {
-      cy.findByRole("radio", { name: /axes/i }).click({ force: true });
+      cy.findByRole("tab", { name: /axes/i }).click({ force: true });
       cy.findByLabelText("Auto y-axis range").should(
         "have.attr",
         "data-checked",
@@ -798,7 +798,7 @@ describe("UXW-2696", () => {
       H.showDashcardVisualizerModalSettings(0, { isVisualizerCard: false });
 
       H.modal().within(() => {
-        cy.findByRole("radio", { name: /axes/i }).click({ force: true });
+        cy.findByRole("tab", { name: /axes/i }).click({ force: true });
         cy.findByLabelText("Auto y-axis range").should(
           "have.attr",
           "data-checked",

--- a/enterprise/frontend/src/metabase-enterprise/replacement/components/SourceReplacementModal/ModalBody/TabPanel/TabPanel.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/replacement/components/SourceReplacementModal/ModalBody/TabPanel/TabPanel.module.css
@@ -1,9 +1,3 @@
 .panel {
   border-bottom: 1px solid var(--mb-color-border-neutral);
 }
-
-.tabs {
-  &:before {
-    display: none;
-  }
-}

--- a/enterprise/frontend/src/metabase-enterprise/replacement/components/SourceReplacementModal/ModalBody/TabPanel/TabPanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/replacement/components/SourceReplacementModal/ModalBody/TabPanel/TabPanel.tsx
@@ -27,8 +27,8 @@ export function TabPanel({
 
   return (
     <Box className={S.panel} px="lg" bg="background_page-primary">
-      <Tabs value={selectedTab} onChange={handleChange}>
-        <Tabs.List className={S.tabs}>
+      <Tabs value={selectedTab} onChange={handleChange} listBorder={false}>
+        <Tabs.List>
           <Tabs.Tab value="column-mappings">{t`Column comparison`}</Tabs.Tab>
           {canReplace && (
             <Tabs.Tab value="dependents">

--- a/enterprise/frontend/src/metabase-enterprise/tenants/containers/TenantsListingApp.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/containers/TenantsListingApp.module.css
@@ -1,5 +1,0 @@
-.tabs {
-  &:before {
-    display: none;
-  }
-}

--- a/enterprise/frontend/src/metabase-enterprise/tenants/containers/TenantsListingApp.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/containers/TenantsListingApp.tsx
@@ -16,8 +16,6 @@ import { EditUserStrategySettingsButton } from "../EditUserStrategySettingsButto
 import { TenantsDocsButton } from "../TenantsDocsButton";
 import { TenantsListing } from "../components/TenantsListing";
 
-import S from "./TenantsListingApp.module.css";
-
 export const TenantsListingApp = ({
   children,
 }: {
@@ -70,8 +68,13 @@ export const TenantsListingApp = ({
       </Group>
 
       {isAdmin && hasDeactivatedTenants && (
-        <Tabs value={status} onChange={handleTabChange} pl="md">
-          <Tabs.List className={S.tabs}>
+        <Tabs
+          value={status}
+          onChange={handleTabChange}
+          pl="md"
+          listBorder={false}
+        >
+          <Tabs.List>
             <Tabs.Tab value={ACTIVE_STATUS.active}>{t`Active`}</Tabs.Tab>
 
             <Tabs.Tab

--- a/frontend/src/metabase/account/app/components/AccountHeader/AccountHeader.tsx
+++ b/frontend/src/metabase/account/app/components/AccountHeader/AccountHeader.tsx
@@ -2,10 +2,9 @@ import type { Path } from "history";
 import { useMemo } from "react";
 import { t } from "ttag";
 
-import { Radio } from "metabase/common/components/Radio";
 import { UserAvatar } from "metabase/common/components/UserAvatar";
 import { PLUGIN_IS_PASSWORD_USER } from "metabase/plugins";
-import { Box, Flex, Title, rem } from "metabase/ui";
+import { Box, Flex, Tabs, Title, rem } from "metabase/ui";
 import { getFullName } from "metabase/utils/user";
 import type { User } from "metabase-types/api";
 
@@ -64,12 +63,19 @@ export const AccountHeader = ({
           {user.email}
         </Title>
       </Flex>
-      <Radio
-        value={path}
-        variant="underlined"
-        options={tabs}
-        onChange={onChangeLocation}
-      />
+      <Tabs
+        listBorder={false}
+        value={path ?? null}
+        onChange={(value) => value && onChangeLocation?.(value)}
+      >
+        <Tabs.List>
+          {tabs.map((tab) => (
+            <Tabs.Tab key={tab.value} value={tab.value}>
+              {tab.name}
+            </Tabs.Tab>
+          ))}
+        </Tabs.List>
+      </Tabs>
     </Flex>
   );
 };

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.module.css
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.module.css
@@ -1,5 +1,0 @@
-.tabs {
-  &:before {
-    display: none;
-  }
-}

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.tsx
@@ -17,8 +17,6 @@ import { SearchFilter } from "../../components/SearchFilter";
 import { ACTIVE_STATUS, type ActiveStatus } from "../../constants";
 import { usePeopleQuery } from "../../hooks/use-people-query";
 
-import S from "./PeopleListingApp.module.css";
-
 const PAGE_SIZE = 25;
 
 const DEFAULT_NO_RESULTS_MESSAGE = () => t`No results found`;
@@ -110,8 +108,13 @@ export function PeopleListingApp({
       </Group>
 
       {isAdmin && hasDeactivatedUsers && (
-        <Tabs value={status} onChange={handleTabChange} pl="md">
-          <Tabs.List className={S.tabs}>
+        <Tabs
+          value={status}
+          onChange={handleTabChange}
+          pl="md"
+          listBorder={false}
+        >
+          <Tabs.List>
             <Tabs.Tab value={ACTIVE_STATUS.active}>{t`Active`}</Tabs.Tab>
             <Tabs.Tab
               value={ACTIVE_STATUS.deactivated}

--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.styled.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.styled.tsx
@@ -32,6 +32,7 @@ export const TabsContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  border-bottom: 1px solid var(--mb-color-border-neutral);
 `;
 
 export const FullHeightContainer = styled.div`

--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.tsx
@@ -18,7 +18,6 @@ import type { PermissionsGraphDiff } from "metabase/admin/permissions/types";
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import { LeaveRouteConfirmModal } from "metabase/common/components/LeaveConfirmModal";
 import { useToggle } from "metabase/common/hooks/use-toggle";
-import CS from "metabase/css/core/index.css";
 import { useDispatch, useSelector } from "metabase/redux";
 import { updateUserSetting } from "metabase/redux/settings";
 import {
@@ -134,7 +133,7 @@ export function PermissionsPageLayout({
           closeButtonText={null}
         />
 
-        <TabsContainer className={CS.borderBottom}>
+        <TabsContainer>
           <PermissionsTabs tab={tab} onChangeTab={navigateToTab} />
           <ToolbarButtonsContainer>
             {helpContent && !isHelpReferenceOpen && (

--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.tsx
@@ -1,13 +1,11 @@
-import cx from "classnames";
 import { t } from "ttag";
 
-import { Radio } from "metabase/common/components/Radio";
 import { useSetting } from "metabase/common/hooks";
-import CS from "metabase/css/core/index.css";
 import {
   PLUGIN_ADMIN_PERMISSIONS_TABS,
   PLUGIN_APPLICATION_PERMISSIONS,
 } from "metabase/plugins";
+import { Box, Tabs } from "metabase/ui";
 
 import type { PermissionsPageTab } from "./PermissionsPageLayout";
 
@@ -27,20 +25,28 @@ export const PermissionsTabs = ({ tab, onChangeTab }: PermissionsTabsProps) => {
           tab.value !== "tenant-specific-collections",
       );
 
+  const tabs = [
+    { name: t`Data`, value: "data" },
+    { name: t`Collections`, value: "collections" },
+    ...adminPermissionsTabs,
+    ...PLUGIN_APPLICATION_PERMISSIONS.tabs,
+  ];
+
   return (
-    <div className={cx(CS.px3, CS.mt1)}>
-      <Radio
-        colorScheme="accent7"
+    <Box mt="sm">
+      <Tabs
+        listBorder={false}
         value={tab}
-        options={[
-          { name: t`Data`, value: "data" },
-          { name: t`Collections`, value: "collections" },
-          ...adminPermissionsTabs,
-          ...PLUGIN_APPLICATION_PERMISSIONS.tabs,
-        ]}
-        onOptionClick={onChangeTab}
-        variant="underlined"
-      />
-    </div>
+        onChange={(value) => value && onChangeTab(value as PermissionsPageTab)}
+      >
+        <Tabs.List pl="xl">
+          {tabs.map((tabOption) => (
+            <Tabs.Tab key={tabOption.value} value={tabOption.value}>
+              {tabOption.name}
+            </Tabs.Tab>
+          ))}
+        </Tabs.List>
+      </Tabs>
+    </Box>
   );
 };

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/common.unit.spec.tsx
@@ -225,7 +225,7 @@ describe("Admin > CollectionPermissionsPage", () => {
     setup();
 
     expect(
-      screen.queryByRole("radio", { name: "Shared collections" }),
+      screen.queryByRole("tab", { name: "Shared collections" }),
     ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/enterprise.unit.spec.tsx
@@ -25,7 +25,7 @@ describe("Admin > CollectionPermissionsPage (enterprise)", () => {
       });
 
       expect(
-        await screen.findByRole("radio", { name: "Shared collections" }),
+        await screen.findByRole("tab", { name: "Shared collections" }),
       ).toBeInTheDocument();
     });
 
@@ -37,7 +37,7 @@ describe("Admin > CollectionPermissionsPage (enterprise)", () => {
       });
 
       expect(
-        screen.queryByRole("radio", { name: "Shared collections" }),
+        screen.queryByRole("tab", { name: "Shared collections" }),
       ).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/metabase/ui/components/navigation/Tabs/Tab.module.css
+++ b/frontend/src/metabase/ui/components/navigation/Tabs/Tab.module.css
@@ -30,8 +30,8 @@
     background-color: var(--mb-color-background_surface-hover);
   }
 
-  &:focus:not([data-css-specificity-hack]) {
-    outline: none;
+  &:focus-visible {
+    outline: 2px solid var(--mb-color-focus);
   }
 
   &:disabled {

--- a/frontend/src/metabase/ui/components/navigation/Tabs/Tab.module.css
+++ b/frontend/src/metabase/ui/components/navigation/Tabs/Tab.module.css
@@ -16,6 +16,10 @@
   }
 }
 
+[data-list-border-hidden] .list::before {
+  border-width: 0;
+}
+
 .tab {
   color: var(--mb-color-text-primary);
   max-width: 100%;

--- a/frontend/src/metabase/ui/components/navigation/Tabs/Tabs.stories.tsx
+++ b/frontend/src/metabase/ui/components/navigation/Tabs/Tabs.stories.tsx
@@ -2,12 +2,16 @@ import { Icon, Tabs, type TabsProps } from "metabase/ui";
 
 const args = {
   orientation: "horizontal",
+  listBorder: true,
 };
 
 const argTypes = {
   orientation: {
     options: ["horizontal", "vertical"],
     control: { type: "inline-radio" },
+  },
+  listBorder: {
+    control: { type: "boolean" },
   },
 };
 
@@ -86,5 +90,13 @@ export const VerticalOrientationIcons = {
   name: "Vertical orientation, icons",
   args: {
     orientation: "vertical",
+  },
+};
+
+export const NoListBorder = {
+  render: DefaultTemplate,
+  name: "Without list border",
+  args: {
+    listBorder: false,
   },
 };

--- a/frontend/src/metabase/ui/components/navigation/Tabs/Tabs.tsx
+++ b/frontend/src/metabase/ui/components/navigation/Tabs/Tabs.tsx
@@ -1,0 +1,31 @@
+import {
+  Tabs as MantineTabs,
+  type TabsProps as MantineTabsProps,
+} from "@mantine/core";
+
+export interface TabsProps extends MantineTabsProps {
+  /**
+   * Whether the tab list renders its own divider line. Only applies to the
+   * default (underlined) variant; ignored for `pills`, `outline`, etc.
+   */
+  listBorder?: boolean;
+}
+
+function TabsRoot({ listBorder = true, variant, ...props }: TabsProps) {
+  const isUnderlinedVariant = variant == null || variant === "default";
+  const hideListBorder = isUnderlinedVariant && !listBorder;
+
+  return (
+    <MantineTabs
+      {...props}
+      variant={variant}
+      data-list-border-hidden={hideListBorder || undefined}
+    />
+  );
+}
+
+export const Tabs = Object.assign(TabsRoot, {
+  List: MantineTabs.List,
+  Tab: MantineTabs.Tab,
+  Panel: MantineTabs.Panel,
+});

--- a/frontend/src/metabase/ui/components/navigation/Tabs/index.ts
+++ b/frontend/src/metabase/ui/components/navigation/Tabs/index.ts
@@ -1,6 +1,6 @@
-export { Tabs } from "@mantine/core";
+export { Tabs } from "./Tabs";
+export type { TabsProps } from "./Tabs";
 export type {
-  TabsProps,
   TabsTabProps,
   TabsListProps,
   TabsPanelProps,

--- a/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.styled.tsx
@@ -1,33 +1,10 @@
 // eslint-disable-next-line no-restricted-imports
 import styled from "@emotion/styled";
 
-import { Radio } from "metabase/common/components/Radio";
-
 export const SectionContainer = styled.div`
   width: 100%;
-
-  ${Radio.RadioGroupVariants.join(", ")} {
-    padding-top: 1rem;
-    padding-inline: 1.5rem;
-    border-bottom: 1px solid var(--mb-color-border-neutral);
-  }
-
-  ${Radio.RadioContainerVariants.join(", ")} {
-    padding-left: 1rem;
-    padding-right: 1rem;
-    padding-block: 0.5rem;
-  }
-
-  ${Radio.RadioLabelVariants.join(", ")} {
-    /* flex-grow: 1; */
-    margin-right: 0;
-    display: flex;
-    justify-content: center;
-
-    &:not(:last-child) {
-      margin-right: 0;
-    }
-  }
+  padding: 1rem 1.5rem 0;
+  border-bottom: 1px solid var(--mb-color-border-neutral);
 `;
 
 export const ChartSettingsListContainer = styled.div`

--- a/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.tsx
@@ -2,9 +2,8 @@ import cx from "classnames";
 import { useCallback, useMemo, useState } from "react";
 import _ from "underscore";
 
-import { Radio } from "metabase/common/components/Radio";
 import CS from "metabase/css/core/index.css";
-import { Stack } from "metabase/ui";
+import { Stack, Tabs } from "metabase/ui";
 import { updateSeriesColor } from "metabase/visualizations/lib/series";
 import {
   getComputedSettings,
@@ -206,15 +205,19 @@ export const BaseChartSettings = ({
       >
         {showSectionPicker && (
           <SectionContainer>
-            <Radio
-              value={chartSettingCurrentSection ?? undefined}
+            <Tabs
+              listBorder={false}
+              value={chartSettingCurrentSection ?? null}
               onChange={handleShowSection}
-              options={orderedSectionNames}
-              optionNameFn={(v) => v}
-              optionValueFn={(v) => v}
-              optionKeyFn={(v) => v}
-              variant="underlined"
-            />
+            >
+              <Tabs.List>
+                {orderedSectionNames.map((sectionName) => (
+                  <Tabs.Tab key={sectionName} value={sectionName}>
+                    {sectionName}
+                  </Tabs.Tab>
+                ))}
+              </Tabs.List>
+            </Tabs>
           </SectionContainer>
         )}
         <ChartSettingsListContainer data-testid="chartsettings-list-container">

--- a/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.unit.spec.tsx
@@ -58,8 +58,14 @@ describe("ChartSettings", () => {
     setup({
       widgets: [widget({ section: "Foo" }), widget({ section: "Bar" })],
     });
-    expect(screen.getByLabelText("Foo")).toBeChecked();
-    expect(screen.getByLabelText("Bar")).not.toBeChecked();
+    expect(screen.getByRole("tab", { name: "Foo" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: "Bar" })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
   });
 
   it("should default to the DEFAULT_TAB_PRIORITY", () => {
@@ -70,8 +76,14 @@ describe("ChartSettings", () => {
       ],
     });
 
-    expect(screen.getByLabelText("Foo")).not.toBeChecked();
-    expect(screen.getByLabelText("Display")).toBeChecked();
+    expect(screen.getByRole("tab", { name: "Foo" })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+    expect(screen.getByRole("tab", { name: "Display" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
   });
 
   it("should be able to switch sections", () => {
@@ -79,11 +91,23 @@ describe("ChartSettings", () => {
       widgets: [widget({ section: "Foo" }), widget({ section: "Bar" })],
     });
 
-    expect(screen.getByLabelText("Foo")).toBeChecked();
-    expect(screen.getByLabelText("Bar")).not.toBeChecked();
+    expect(screen.getByRole("tab", { name: "Foo" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: "Bar" })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
     fireEvent.click(screen.getByText("Bar"));
-    expect(screen.getByLabelText("Foo")).not.toBeChecked();
-    expect(screen.getByLabelText("Bar")).toBeChecked();
+    expect(screen.getByRole("tab", { name: "Foo" })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+    expect(screen.getByRole("tab", { name: "Bar" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
   });
 
   it("should show widget names", () => {
@@ -199,9 +223,18 @@ describe("ChartSettings", () => {
       });
 
       // Data is first in the priority order, so its localized label ("Datos") is the active tab
-      expect(screen.getByLabelText("Datos")).toBeChecked();
-      expect(screen.getByLabelText("Ejes")).not.toBeChecked();
-      expect(screen.getByLabelText("Formato")).not.toBeChecked();
+      expect(screen.getByRole("tab", { name: "Datos" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(screen.getByRole("tab", { name: "Ejes" })).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+      expect(screen.getByRole("tab", { name: "Formato" })).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
     });
 
     it("should put unsectioned widgets into the highest-priority translated section", () => {

--- a/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.unit.spec.tsx
@@ -141,8 +141,8 @@ describe("scalar viz settings", () => {
     renderWithProviders(<QuestionChartSettings series={series} />);
 
     expect(
-      await screen.findByRole("radio", { name: "Formatting" }),
-    ).toBeChecked();
+      await screen.findByRole("tab", { name: "Formatting" }),
+    ).toHaveAttribute("aria-selected", "true");
     expect(await screen.findByText("Field to show")).toBeInTheDocument();
 
     const getFieldSelect = async () =>
@@ -177,8 +177,8 @@ describe("scalar viz settings", () => {
     renderWithProviders(<QuestionChartSettings series={series} />);
 
     expect(
-      await screen.findByRole("radio", { name: "Formatting" }),
-    ).toBeChecked();
+      await screen.findByRole("tab", { name: "Formatting" }),
+    ).toHaveAttribute("aria-selected", "true");
 
     expect(
       screen.queryByTestId("chart-settings-widget-scalar.field"),


### PR DESCRIPTION
Contributes to [GDGT-2588](https://linear.app/metabase/issue/GDGT-2588)

### Description

Second of three PRs retiring the deprecated `metabase/common/components/Radio`. This one covers the `underlined`-variant usages, which were really tab bars, not radios: the **AccountHeader** nav, the admin **PermissionsTabs**, and the **BaseChartSettings** section picker. They now use Mantine `Tabs` from `metabase/ui`, whose default styling already matches the old underlined look (neutral list divider + brand active underline).

`metabase/ui` now exports a **thin `Tabs` wrapper** instead of re-exporting Mantine's directly. It adds one typed prop — `listBorder?: boolean` (default `true`). When `false`, it suppresses the tab list's own divider (default variant only) so the divider can instead be drawn on a parent container. A couple of tab bars already did exactly this with one-off CSS (e.g. `PeopleListingApp`, `TenantsListingApp`), and the legacy underlined radio looked the same way — so the prop matches that look and lets us simplify those existing usages.

The permissions tabs now match the standard Mantine tab bars already used elsewhere in the admin (e.g. the **People** section) rather than the old custom radio styling.

### How to verify

1. **Account header** — open **Account settings** (`/account/profile`): the Profile / Password / Login History / Notifications tab row, centered with a single full-width divider.
2. **Permissions** — **Admin → Permissions** (`/admin/permissions`): Data / Collections / … tabs, left-aligned, full-width divider, help button still at the right.
3. **Viz settings** — open a question → make it a **bar chart** → Visualization settings: the Data / Display / Axes section tabs at the top.
4. **No regressions on existing tabs** — spot-check a few default-variant tab bars (e.g. **Admin → Tools → Tasks**, a question's **info (i) sidebar**): unchanged.

### Demo

<details>
<summary>Account header</summary>

**Before**
<img width="838" height="519" alt="CleanShot 2026-06-25 at 17 58 30" src="https://github.com/user-attachments/assets/79665e5c-a91c-4f7f-9143-020952c01d52" />

**After**
<img width="762" height="555" alt="CleanShot 2026-06-25 at 18 01 16" src="https://github.com/user-attachments/assets/7d85946c-2aca-4f83-90f0-d0deb26ca9b3" />

</details>

<details>
<summary>Permissions tabs</summary>

**Before**
<img width="913" height="470" alt="CleanShot 2026-06-25 at 17 58 56" src="https://github.com/user-attachments/assets/8ef019b3-ec26-42b5-add8-a695e404c470" />

**After — different color, but it matches other tabs already used in admin portal**
<img width="847" height="339" alt="CleanShot 2026-06-25 at 18 01 30" src="https://github.com/user-attachments/assets/003fdef6-2c3f-478b-96b8-b9fc5f230189" />

</details>

<details>
<summary>Visualization settings — section picker</summary>

**Before**
<img width="450" height="298" alt="CleanShot 2026-06-25 at 17 59 21" src="https://github.com/user-attachments/assets/1d2852ce-084c-4217-b201-001d9c521660" />

**After**
<img width="512" height="302" alt="CleanShot 2026-06-25 at 18 01 43" src="https://github.com/user-attachments/assets/2587e754-a702-4400-9355-6c6f5bbf845f" />

</details>

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
