### PR TITLE
Fix shift-scroll behavior in the data picker browse all state

### DIFF
--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/components/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/components/EntityPickerModal.tsx
@@ -164,6 +164,13 @@ export function EntityPickerModal({
       w="100vw"
       closeOnEscape={false} // we're doing this manually in useWindowEvent
       yOffset="10dvh"
+      /**
+       * react-remove-scroll (used by Mantine's scroll lock) treats Shift+wheel as a
+       * vertical gesture and preventDefault()s it once the hovered column can't scroll
+       * vertically, which blocks the picker's native horizontal Shift+scroll. This modal
+       * fills the viewport and never scrolls the page, so the lock is unnecessary here. (#66456)
+       */
+      lockScroll={false}
     >
       <Modal.Overlay />
       <Modal.Content


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #66456
Closes https://linear.app/metabase/issue/UXW-2445/shiftscroll-does-not-work-in-the-data-picker

### Description

Allows Shift+wheel over the Browse Data picker columns to scroll the modal horizontally when the columns overflow.
This was observed on Ubuntu + Chrome. You might not be able to reproduce it on a macbook.

### How to verify

1. Go to New notebook question
2. On Data -> Entity Picker -> Browse all -> Our Analytics -> Custom reports (you should have some question in Custom reports for it to appear here).
The horizontal scrollbar should show up.
3. Hold Shift and scroll vertically over the picker columns.
4. The modal should scroll horizontally.

### Demo
https://www.loom.com/share/9c1f160addb44915937cf65ed2de256e

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
