### PR TITLE
chore(sdk): clean up old sdk files when starting build-hot

### DIFF
--- a/package.json
+++ b/package.json
@@ -486,7 +486,7 @@
     "ci-frontend": "bun run lint && bun run test",
     "clean-cypress-artifacts": "rm -R -f cypress/",
     "clean-dev:cljs": "rm -rf target/cljs_dev/*",
-    "clean-dev:js": "rm -rf resources/frontend_client/app/dist target/classes/frontend_client/app/dist",
+    "clean-dev:js": "rm -rf resources/frontend_client/app/dist target/classes/frontend_client/app/dist resources/frontend_client/app/embedding-sdk target/classes/frontend_client/app/embedding-sdk",
     "clean-release:cljs": "rm -rf target/cljs_release/*",
     "clean:cljs": "bun install && bun run clean-dev:cljs && bun run clean-release:cljs",
     "cljs-nrepl": "bun install && shadow-cljs node-repl -d cider/cider-nrepl:0.57.0 -d cider/piggieback:0.6.1 -d refactor-nrepl/refactor-nrepl:3.11.0",

--- a/rspack.embedding-sdk-bundle.config.js
+++ b/rspack.embedding-sdk-bundle.config.js
@@ -353,6 +353,31 @@ const config = {
         );
       },
     },
+    // Stop `.hot-update` files for the sdk being written to the disk. HMR doesn't work for the SDK bundle anyway
+    {
+      name: "drop-sdk-hot-update-assets",
+      apply(compiler) {
+        compiler.hooks.compilation.tap(
+          "drop-sdk-hot-update-assets",
+          (compilation) => {
+            compilation.hooks.processAssets.tap(
+              {
+                name: "drop-sdk-hot-update-assets",
+                // Run last, after the HMR plugin has emitted the deltas.
+                stage: rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+              },
+              (assets) => {
+                for (const name of Object.keys(assets)) {
+                  if (name.includes(".hot-update.")) {
+                    compilation.deleteAsset(name);
+                  }
+                }
+              },
+            );
+          },
+        );
+      },
+    },
     shouldAnalyzeBundles &&
       new BundleAnalyzerPlugin({
         analyzerMode: "static",


### PR DESCRIPTION
Closes [EMB-1921: resources/frontend_client/app/embedding-sdk/ gets filled with hot-update.json files that never get cleaned](https://linear.app/metabase/issue/EMB-1921/resourcesfrontend-clientappembedding-sdk-gets-filled-with-hot)

### Description

`clean-dev:js` didn't clean up the sdk bundle files, so the folder kept increasing in files without ever being cleaned unless you manually did so

We were also emitting `.hot-update` files in the wrong folder ` resources/frontend_client/app/embedding-sdk` (outside of `chunks` or `legacy/`).
I added a small plugin that prevents them from being written as they're useless.
There's a way to not save them globally also for the core app that didn't require the plugin (remove `writeToDisk: true`), but we added it for some specific reason 3 years ago and I don't want to risk breaking something 

## How to verify

- check what situation of `resources/frontend_client/app/embedding-sdk` on your machine
- restart `build-hot` from this branch
- edit some sdk file
- see that it should be cleaned up and without the `.hot-update` files (note that the chunks folder will keep growing as we keep creating new chunks with the sha of the content in the name, that's ok)
- verify that core app still works and it writes the hot-update files as before