### PR TITLE
Fix MySQL utf8mb3 app DB Library root migration

### DIFF
--- a/resources/migrations/062/20260513_legacy_library_root_entity_ids.yaml
+++ b/resources/migrations/062/20260513_legacy_library_root_entity_ids.yaml
@@ -20,6 +20,23 @@ databaseChangeLog:
         - empty: {}
 
   - changeSet:
+      id: v62.legacy-library-root-entity-id-updated-id-cleanup
+      author: andsalves
+      comment: >-
+        Delete the first updated changeset rows for the Library Data and Library Metrics entity ID backfills. Those
+        changesets were re-id'd after patching their MySQL/MariaDB SQL to avoid hard-coded utf8mb4 collations, @see
+        #76510.
+      changes:
+        - sql:
+            sql: >-
+              DELETE FROM ${databasechangelog.name} WHERE id IN (
+                'v62.2026-05-13T12:00:01-updated',
+                'v62.2026-05-13T12:00:02-updated'
+              ) AND filename = 'migrations/062_update_migrations.yaml';
+      rollback:
+        - empty: {}
+
+  - changeSet:
       id: v62.2026-05-13T11:59:58
       author: andsalves
       comment: Backfill type column value for Library collections
@@ -71,7 +88,7 @@ databaseChangeLog:
         - empty: {}
 
   - changeSet:
-      id: v62.2026-05-13T12:00:01-updated
+      id: v62.2026-05-13T12:00:01-updated-2
       author: andsalves
       comment: Backfill canonical entity_id for legacy Library Data section
       changes:
@@ -106,9 +123,9 @@ databaseChangeLog:
               UPDATE collection
               SET entity_id = 'librarylibrarydatadat'
               WHERE type = 'library-data'
-                AND location IN (
+                AND CAST(location AS BINARY) IN (
                   SELECT loc FROM (
-                    SELECT CONCAT('/', CAST(id AS CHAR), '/') COLLATE utf8mb4_unicode_ci AS loc
+                    SELECT CAST(CONCAT('/', CAST(id AS CHAR), '/') AS BINARY) AS loc
                     FROM collection
                     WHERE type = 'library' AND location = '/'
                   ) lib_loc
@@ -118,8 +135,8 @@ databaseChangeLog:
                     SELECT COUNT(*) AS cnt
                     FROM collection child
                     WHERE child.type = 'library-data'
-                      AND child.location IN (
-                        SELECT CONCAT('/', CAST(lib.id AS CHAR), '/') COLLATE utf8mb4_unicode_ci
+                      AND CAST(child.location AS BINARY) IN (
+                        SELECT CAST(CONCAT('/', CAST(lib.id AS CHAR), '/') AS BINARY)
                         FROM collection lib
                         WHERE lib.type = 'library' AND lib.location = '/'
                       )
@@ -129,7 +146,7 @@ databaseChangeLog:
         - empty: {}
 
   - changeSet:
-      id: v62.2026-05-13T12:00:02-updated
+      id: v62.2026-05-13T12:00:02-updated-2
       author: andsalves
       comment: Backfill canonical entity_id for legacy Library Metrics section
       changes:
@@ -164,9 +181,9 @@ databaseChangeLog:
               UPDATE collection
               SET entity_id = 'librarylibrarymetrics'
               WHERE type = 'library-metrics'
-                AND location IN (
+                AND CAST(location AS BINARY) IN (
                   SELECT loc FROM (
-                    SELECT CONCAT('/', CAST(id AS CHAR), '/') COLLATE utf8mb4_unicode_ci AS loc
+                    SELECT CAST(CONCAT('/', CAST(id AS CHAR), '/') AS BINARY) AS loc
                     FROM collection
                     WHERE type = 'library' AND location = '/'
                   ) lib_loc
@@ -176,8 +193,8 @@ databaseChangeLog:
                     SELECT COUNT(*) AS cnt
                     FROM collection child
                     WHERE child.type = 'library-metrics'
-                      AND child.location IN (
-                        SELECT CONCAT('/', CAST(lib.id AS CHAR), '/') COLLATE utf8mb4_unicode_ci
+                      AND CAST(child.location AS BINARY) IN (
+                        SELECT CAST(CONCAT('/', CAST(lib.id AS CHAR), '/') AS BINARY)
                         FROM collection lib
                         WHERE lib.type = 'library' AND lib.location = '/'
                       )

--- a/test/metabase/app_db/schema_migrations_test.clj
+++ b/test/metabase/app_db/schema_migrations_test.clj
@@ -2893,8 +2893,8 @@
   (str/trim (t2/select-one-fn :entity_id :collection :id collection-id)))
 
 (deftest backfill-legacy-library-root-collection-entity-ids-test
-  (testing "v62.2026-05-13T12:00:00 through v62.2026-05-13T12:00:02-updated: backfill canonical Library root entity IDs"
-    (impl/test-migrations ["v62.2026-05-13T12:00:00" "v62.2026-05-13T12:00:02-updated"] [migrate!]
+  (testing "v62.2026-05-13T12:00:00 through v62.2026-05-13T12:00:02-updated-2: backfill canonical Library root entity IDs"
+    (impl/test-migrations ["v62.2026-05-13T12:00:00" "v62.2026-05-13T12:00:02-updated-2"] [migrate!]
       (let [library-id (insert-legacy-library-collection! {:name      "Library"
                                                            :slug      "library"
                                                            :type      "library"
@@ -2917,9 +2917,42 @@
         (is (= "librarylibrarymetrics"
                (collection-entity-id metrics-id)))))))
 
+(deftest backfill-legacy-library-root-collection-entity-ids-mysql-utf8mb3-test
+  (testing "Library root entity ID backfill handles utf8mb3 MySQL app DB sessions (#76510)"
+    (mt/test-driver :mysql
+      (impl/with-temp-empty-app-db [conn :mysql]
+        (impl/run-migrations-in-range! conn
+                                       [(str "v" "00.00-000") "v62.2026-05-13T12:00:00"]
+                                       {:inclusive-end? false})
+        (jdbc/execute! {:connection conn}
+                       "ALTER TABLE collection CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci")
+        (let [library-id (insert-legacy-library-collection! {:name      "Library"
+                                                             :slug      "library"
+                                                             :type      "library"
+                                                             :entity_id "legacy-library-root"})
+              data-id    (insert-legacy-library-collection! {:name      "Data"
+                                                             :slug      "data"
+                                                             :type      "library-data"
+                                                             :location  (str "/" library-id "/")
+                                                             :entity_id "legacy-library-data"})
+              metrics-id (insert-legacy-library-collection! {:name      "Metrics"
+                                                             :slug      "metrics"
+                                                             :type      "library-metrics"
+                                                             :location  (str "/" library-id "/")
+                                                             :entity_id "legacy-library-metric"})]
+          (jdbc/execute! {:connection conn} "SET NAMES utf8 COLLATE utf8_general_ci")
+          (impl/run-migrations-in-range! conn
+                                         ["v62.2026-05-13T12:00:00" "v62.2026-05-13T12:00:02-updated-2"])
+          (is (= "librarylibrarylibrary"
+                 (collection-entity-id library-id)))
+          (is (= "librarylibrarydatadat"
+                 (collection-entity-id data-id)))
+          (is (= "librarylibrarymetrics"
+                 (collection-entity-id metrics-id))))))))
+
 (deftest backfill-legacy-library-root-collection-entity-ids-test-2
   (testing "ambiguous Library Data direct children are not modified"
-    (impl/test-migrations ["v62.2026-05-13T12:00:00" "v62.2026-05-13T12:00:02-updated"] [migrate!]
+    (impl/test-migrations ["v62.2026-05-13T12:00:00" "v62.2026-05-13T12:00:02-updated-2"] [migrate!]
       (let [library-id        (insert-legacy-library-collection! {:name      "Library"
                                                                   :slug      "library"
                                                                   :type      "library"
@@ -2951,7 +2984,7 @@
 
 (deftest backfill-legacy-library-root-collection-entity-ids-test-3
   (testing "Library Data collections outside Library root do not count as ambiguous"
-    (impl/test-migrations ["v62.2026-05-13T12:00:00" "v62.2026-05-13T12:00:02-updated"] [migrate!]
+    (impl/test-migrations ["v62.2026-05-13T12:00:00" "v62.2026-05-13T12:00:02-updated-2"] [migrate!]
       (let [library-id      (insert-legacy-library-collection! {:name      "Library"
                                                                 :slug      "library"
                                                                 :type      "library"
@@ -2979,7 +3012,7 @@
 
 (deftest backfill-legacy-library-root-collection-entity-ids-test-4
   (testing "pre-existing canonical Library rows with missing types prevent entity_id collisions"
-    (impl/test-migrations ["v62.2026-05-13T11:59:58" "v62.2026-05-13T12:00:02-updated"] [migrate!]
+    (impl/test-migrations ["v62.2026-05-13T11:59:58" "v62.2026-05-13T12:00:02-updated-2"] [migrate!]
       (let [canonical-library-id (insert-legacy-library-collection! {:name      "Pre-existing canonical Library"
                                                                      :slug      "canonical-library"
                                                                      :type      nil


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76510
Closes https://linear.app/metabase/issue/UXW-4605/v0623-and-v0622-doesnt-migrate-successfully-with-mysql-84-revisited

### Description

Fixes the v62 Library Data/Metrics entity ID backfill for MySQL app DBs whose migration connection uses `utf8mb3`. The migration now compares generated collection paths as binary strings instead of forcing an `utf8mb4` collation.

The issue is not directly related to MySQL 8.4 specifically, could be any MySQL using the legacy utf8/utf8mb3 charset.

### How to verify

1. Initialize a MySQL 8.4 test db with docker
```
docker run --rm --name mb-mysql84 \
  -e MYSQL_ROOT_PASSWORD=root \
  -e MYSQL_DATABASE=metabase_repro \
  -p 3316:3306 \
  -d mysql:8.4
```

2. Checkout branch release-x.61.x (fetch and then pull if needed):
```
git checkout release-x.61.x
```

3. Initialize the app DB by running migrations. Set session variables to ensure we simulate a legacy collation state:
```
MB_DB_TYPE=mysql \
MB_DB_CONNECTION_URI='jdbc:mysql://127.0.0.1:3316/metabase_repro?user=root&password=root&sessionVariables=character_set_connection=utf8,collation_connection=utf8_general_ci' \
clojure -M:run migrate up
```
Go grab a coffee.

4. Simulate the customer’s legacy charset state:
```
docker exec mb-mysql84 mysql -uroot -proot metabase_repro \
  -e "ALTER TABLE collection CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;"
```

5. Checkout tag v0.62.3.3 (latest broken version), or master:
```
git checkout v0.62.3.3
```

6. Run migrations again:
```
MB_DB_TYPE=mysql \
MB_DB_CONNECTION_URI='jdbc:mysql://127.0.0.1:3316/metabase_repro?user=root&password=root&sessionVariables=character_set_connection=utf8,collation_connection=utf8_general_ci' \
clojure -M:run migrate up
```
Expected error result:
`COLLATION 'utf8mb4_unicode_ci' is not valid for CHARACTER SET 'utf8mb3'`

7. Checkout this fix branch and run the migrations again:
```
git fetch origin fix/uxw-4605-mysql-utf8mb3-migration && git checkout fix/uxw-4605-mysql-utf8mb3-migration
```
```
MB_DB_TYPE=mysql \
MB_DB_CONNECTION_URI='jdbc:mysql://127.0.0.1:3316/metabase_repro?user=root&password=root&sessionVariables=character_set_connection=utf8,collation_connection=utf8_general_ci' \
clojure -M:run migrate up
```
Expected result with the fix: migrations complete without the collation error.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)