### PR TITLE
Add ExplicitSize test for measuring a child that renders content after mount

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
@@ -229,37 +229,6 @@ describe("issue 47847", () => {
   });
 });
 
-describe("issue 51926", () => {
-  beforeEach(() => {
-    H.restore();
-    cy.signInAsNormalUser();
-  });
-
-  it("should render pivot table when selecting it from another viz type", () => {
-    H.visitQuestionAdhoc({
-      dataset_query: {
-        type: "query",
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"]],
-          breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "week" }]],
-        },
-        database: SAMPLE_DB_ID,
-      },
-      display: "pivot",
-    });
-
-    H.openVizTypeSidebar();
-    H.leftSidebar().within(() => {
-      cy.findByTestId("Table-button").click();
-      cy.wait(300); // wait for rerender
-      cy.findByTestId("Pivot Table-button").click();
-    });
-
-    cy.findAllByTestId("pivot-table-cell").should("contain", "April 27, 2025"); // expect this to break when we shift years in the Sample Database
-  });
-});
-
 describe("issue 51952", () => {
   beforeEach(() => {
     H.restore();

--- a/frontend/src/metabase/common/components/ExplicitSize/ExplicitSize.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/ExplicitSize/ExplicitSize.unit.spec.tsx
@@ -67,6 +67,29 @@ const SizedComponent = ExplicitSize<{
   height: number | null;
 }>()(Base);
 
+// A child that renders nothing until it has content, mirroring PivotTable,
+// which returns null on its first render (before its data is pivoted) and only
+// later renders a measurable element. See metabase#51926.
+const ConditionalBase = forwardRef<
+  HTMLDivElement,
+  { width: number | null; height: number | null; hasContent: boolean }
+>(function ConditionalBase({ width, height, hasContent }, ref) {
+  if (!hasContent) {
+    return null;
+  }
+  return (
+    <div ref={ref} data-testid="sized">
+      {String(width)}x{String(height)}
+    </div>
+  );
+});
+
+const ConditionalSizedComponent = ExplicitSize<{
+  width: number | null;
+  height: number | null;
+  hasContent: boolean;
+}>()(ConditionalBase);
+
 const createEntry = (
   target: Element,
   inlineSize: number,
@@ -130,5 +153,39 @@ describe("ExplicitSize", () => {
     triggerResize(element, createEntry(element, 400, 868));
 
     expect(screen.getByTestId("sized")).toHaveTextContent("400x868");
+  });
+
+  it("should measure a child that renders content only after mount and pass it non-null dimensions (metabase#51926)", () => {
+    // Regression test for the pivot table rendering blank until resized.
+    // PivotTable returns null on its first render, so there is no element for
+    // ExplicitSize to measure at mount. When it later renders content, the size
+    // must be recalculated even though no resize event ever fires — otherwise
+    // the child stays stuck with null dimensions and never lays out.
+    const { rerender } = render(
+      <ConditionalSizedComponent hasContent={false} />,
+    );
+
+    // Mount: the child renders nothing, so there is nothing to measure.
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(screen.queryByTestId("sized")).not.toBeInTheDocument();
+
+    // The child now renders a measurable element. jsdom reports 0x0 by default,
+    // so stub a real size — there is no resize event to supply one.
+    rerender(<ConditionalSizedComponent hasContent={true} />);
+    const element = screen.getByTestId("sized");
+    jest.spyOn(element, "getBoundingClientRect").mockReturnValue({
+      width: 400,
+      height: 300,
+    } as DOMRect);
+    expect(element).toHaveTextContent("nullxnull");
+
+    // ExplicitSize re-runs measurement on the next tick once content appears.
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByTestId("sized")).toHaveTextContent("400x300");
   });
 });


### PR DESCRIPTION
Resolves DEV-2202

## History

Adds a unit test reproduction for the class of bugs described in #51926 — pivot tables rendered blank until the window was resized.
> [!Note]
> PivotTable returns `null` on its first render (before its data is pivoted), so `ExplicitSize` had no element to measure at mount; once content appeared, the size was never recalculated absent a resize event, leaving the child stuck at `null` dimensions.

#51951 fixed it by re-running measurement in `componentDidUpdate`. That fix shipped with e2e regression test, which is one of the flakiest today. It is currently quarantined. Multiple attempts at fixing it didn't help.

In the meantime `ExplicitSize` also gained `_setElementRef`, which schedules a re-measure when the wrapped element first attaches. It independently covers the same class of bugs — a child that renders nothing at mount and only later renders measurable content.

## Summary

This PR adds a deterministic unit test for that contract directly on `ExplicitSize`.
- It models PivotTable's shape (a non-wrapped child that renders `null`, then content) and asserts the child receives non-null dimensions without any resize event.
- It passes on `master` and fails with `nullxnull` — the blank-pivot symptom — when every measure-on-appear path is removed (the pre-#51951 state), so it genuinely guards the regression regardless of which mechanism (`componentDidUpdate` or `_setElementRef`) is touched.
- Deletes e2e reproduction
