### PR TITLE
Copy old sample DB permissions to new sample DB on upgrade

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1939,8 +1939,8 @@
    :model-imports #{:model/Card
                     :model/Dashboard
                     :model/DashboardCard
-                    :model/Database
                     :model/DataPermissions
+                    :model/Database
                     :model/Field
                     :model/Table}}
 

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1931,6 +1931,7 @@
            metabase.sample-data.init}
    :uses #{config
            models
+           permissions
            plugins
            settings
            sync
@@ -1939,6 +1940,7 @@
                     :model/Dashboard
                     :model/DashboardCard
                     :model/Database
+                    :model/DataPermissions
                     :model/Field
                     :model/Table}}
 

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -1068,7 +1068,10 @@
                                     :from   [[(t2/table-name :model/DataPermissions)]]
                                     :where  [:and
                                              [:in :group_id group-ids]
-                                             [:in :perm_type ["perms/create-queries" "perms/download-results"]]]}))
+                                             [:in :perm_type ["perms/create-queries" "perms/download-results"]]
+                                             [:not-in :db_id {:select [:id]
+                                                              :from [(t2/table-name :model/Database)]
+                                                              :where [:= :is_audit true]}]]}))
           ;; Group by (group_id, perm_type) → set of values
           perms-by-grp (when all-perms
                          (reduce (fn [acc {:keys [group_id perm_type perm_value]}]

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -1068,10 +1068,7 @@
                                     :from   [[(t2/table-name :model/DataPermissions)]]
                                     :where  [:and
                                              [:in :group_id group-ids]
-                                             [:in :perm_type ["perms/create-queries" "perms/download-results"]]
-                                             [:not-in :db_id {:select [:id]
-                                                              :from [(t2/table-name :model/Database)]
-                                                              :where [:= :is_audit true]}]]}))
+                                             [:in :perm_type ["perms/create-queries" "perms/download-results"]]]}))
           ;; Group by (group_id, perm_type) → set of values
           perms-by-grp (when all-perms
                          (reduce (fn [acc {:keys [group_id perm_type perm_value]}]

--- a/src/metabase/sample_data/impl.clj
+++ b/src/metabase/sample_data/impl.clj
@@ -165,9 +165,9 @@
                                                       rows))]
                           :when (seq remapped)]
                       [group-id perm-type remapped])]
-    (doseq [[[group-id perm-type] perm-value] db-perms]
+    (doseq [[group-id perm-type perm-value] db-perms]
       (perms/set-database-permission! group-id new-db-id perm-type perm-value))
-    (doseq [[[group-id perm-type] one-table-perms] table-perms]
+    (doseq [[group-id perm-type one-table-perms] table-perms]
       (perms/set-table-permissions! group-id perm-type one-table-perms))))
 
 (defn- replace-sample-database!

--- a/src/metabase/sample_data/impl.clj
+++ b/src/metabase/sample_data/impl.clj
@@ -4,6 +4,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [metabase.config.core :as config]
+   [metabase.permissions.core :as perms]
    [metabase.plugins.core :as plugins]
    [metabase.sample-data.example-content :as example-content]
    [metabase.sync.core :as sync]
@@ -131,6 +132,44 @@
       (when (seq empty-ids)
         (t2/delete! :model/Dashboard :id [:in empty-ids])))))
 
+(defn- capture-permissions-snapshot
+  "Snapshot a database's data-permission rows plus the names of the tables referenced by any table-level
+  rows, so the same access can be re-applied to a replacement database whose tables have new IDs. Must run
+  before the old database (and its cascading permission rows) is deleted."
+  [db-id]
+  (let [permissions (t2/select :model/DataPermissions :db_id db-id)
+        table-ids   (into #{} (keep :table_id) permissions)]
+    {:permissions    permissions
+     :table-id->name (if (seq table-ids)
+                       (t2/select-pk->fn :name :model/Table :id [:in table-ids])
+                       {})}))
+
+(defn- apply-permissions-snapshot!
+  "Re-apply a permission snapshot (see [[capture-permissions-snapshot]]) to the replacement database
+  `new-db-id`, replacing the defaults granted when it was created. Table-level rows are remapped onto the
+  new database's tables by name; since the new tables exist only after the first sync, this must run
+  post-sync. A table-level row whose table has no name match in the new database is dropped."
+  [new-db-id {:keys [permissions table-id->name]}]
+  (let [name->new-table-id (t2/select-fn->pk :name :model/Table :db_id new-db-id)
+        granular?   (fn [rows] (some :table_id rows))
+        permission-groups (group-by (juxt :group_id :perm_type) permissions)
+        db-perms    (for [[[group-id perm-type] rows] permission-groups
+                          :when (not (granular? rows))]
+                      [group-id perm-type (:perm_value (first rows))])
+        table-perms (for [[[group-id perm-type] rows] permission-groups
+                          :when (granular? rows)
+                          :let  [remapped (into {}
+                                                (keep (fn [{:keys [table_id perm_value]}]
+                                                        (when-let [new-table-id (-> table_id table-id->name name->new-table-id)]
+                                                          [new-table-id perm_value]))
+                                                      rows))]
+                          :when (seq remapped)]
+                      [group-id perm-type remapped])]
+    (doseq [[[group-id perm-type] perm-value] db-perms]
+      (perms/set-database-permission! group-id new-db-id perm-type perm-value))
+    (doseq [[[group-id perm-type] one-table-perms] table-perms]
+      (perms/set-table-permissions! group-id perm-type one-table-perms))))
+
 (defn- replace-sample-database!
   "The bundled sample database's engine changed (e.g. H2 -> SQLite on upgrade). The old sample
   Database's tables, fields, and connection details are incompatible with the new engine, so rather
@@ -152,25 +191,34 @@
   ;; doesn't hold the app-DB transaction open.
   (let [new-db-details (when (config/load-sample-content?)
                          (try-to-extract-sample-database! engine))
-        new-db (t2/with-transaction [_conn]
-                 (let [dashboard-ids (sample-database-dashboard-ids (:id old-sample-db))]
-                   (t2/delete! :model/Database (:id old-sample-db))
-                   (delete-emptied-dashboards! dashboard-ids))
-                 (when new-db-details
-                   (first (t2/insert-returning-instances! :model/Database
-                                                          :name sample-database-name
-                                                          :details new-db-details
-                                                          :engine engine
-                                                          :is_sample true))))]
+        {:keys [new-db permissions-snapshot]}
+        (t2/with-transaction [_conn]
+          (let [dashboard-ids (sample-database-dashboard-ids (:id old-sample-db))
+                snapshot      (when new-db-details
+                                (capture-permissions-snapshot (:id old-sample-db)))]
+            (t2/delete! :model/Database (:id old-sample-db))
+            (delete-emptied-dashboards! dashboard-ids)
+            {:permissions-snapshot snapshot
+             :new-db (when new-db-details
+                       (first (t2/insert-returning-instances! :model/Database
+                                                              :name sample-database-name
+                                                              :details new-db-details
+                                                              :engine engine
+                                                              :is_sample true)))}))]
     (when new-db
-      (when (and (try
-                   (sync/sync-database! new-db)
-                   true
-                   (catch Throwable e
-                     (log/error e "Failed to sync the replacement sample database")
-                     false))
-                 (not (config/config-bool :mb-enable-test-endpoints)))
-        (example-content/recreate-example-content! (:id new-db))))))
+      (let [synced? (try
+                      (sync/sync-database! new-db)
+                      true
+                      (catch Throwable e
+                        (log/error e "Failed to sync the replacement sample database")
+                        false))]
+        (when synced?
+          ;; The new database's tables exist now, so the old sample DB's access can be restored (replacing
+          ;; the defaults granted at creation) before the bundled example content is recreated.
+          (when permissions-snapshot
+            (apply-permissions-snapshot! (:id new-db) permissions-snapshot))
+          (when-not (config/config-bool :mb-enable-test-endpoints)
+            (example-content/recreate-example-content! (:id new-db))))))))
 
 (defn update-sample-database-if-needed!
   "Reconcile the existing sample database with the bundled one. When the bundled engine changed

--- a/test/metabase/sample_data/impl_test.clj
+++ b/test/metabase/sample_data/impl_test.clj
@@ -278,16 +278,10 @@
           (#'sample-data/update-sample-database-if-needed! old-sample)))
       (let [db (t2/select-one :model/Database :is_sample true :engine :sqlite)]
         (is (some? db) "the engine swap created a SQLite sample database")
-        (let [orders-id (t2/select-one-pk :model/Table :db_id (u/the-id db) :name "ORDERS")
-              query     {:database (u/the-id db)
-                         :type     :query
-                         :query    {:source-table orders-id, :limit 1}}]
-          (testing "admin (crowberto) can query the sample DB"
-            (is (= "completed"
-                   (:status (mt/user-http-request :crowberto :post 202 "dataset" query)))))
-          (testing "non-admin (rasta, All Users) can query the sample DB"
-            (is (= "completed"
-                   (:status (mt/user-http-request :rasta :post 202 "dataset" query))))))))))
+        (testing "admin (crowberto) has access to the sample DB"
+          (is (= (u/the-id db) (:id (mt/user-http-request :crowberto :get 200 (format "database/%s" (u/the-id db)))))))
+        (testing "non-admin (rasta, All Users) has access to the sample DB"
+          (is (= (u/the-id db) (:id (mt/user-http-request :rasta :get 200 (format "database/%s" (u/the-id db)))))))))))
 
 (deftest sample-database-schedule-sync-test
   (testing "Check that the sample database has scheduled sync jobs, just like a newly created database"

--- a/test/metabase/sample_data/impl_test.clj
+++ b/test/metabase/sample_data/impl_test.clj
@@ -267,22 +267,6 @@
           (testing "the engine swap itself still completed - a new SQLite sample DB exists"
             (is (t2/exists? :model/Database :is_sample true :engine :sqlite))))))))
 
-(deftest sample-database-queryable-by-admin-and-non-admin-test
-  (testing "After the H2->SQLite sample database swap, both admin and non-admin users can query the new sample DB"
-    (mt/with-model-cleanup [:model/Database]
-      ;; Start from a pre-upgrade H2 sample DB and run the real swap, which inserts + syncs the SQLite sample DB
-      ;; via the production code path (so its permissions come from the after-insert default-perms hook, not the
-      ;; with-temp test helper that would otherwise grant full access and mask the real behavior).
-      (mt/with-temp [:model/Database old-sample {:engine :h2, :is_sample true, :details {:db "mem:old-sample"}}]
-        (with-redefs [config/load-sample-content? (constantly true)]
-          (#'sample-data/update-sample-database-if-needed! old-sample)))
-      (let [db (t2/select-one :model/Database :is_sample true :engine :sqlite)]
-        (is (some? db) "the engine swap created a SQLite sample database")
-        (testing "admin (crowberto) has access to the sample DB"
-          (is (= (u/the-id db) (:id (mt/user-http-request :crowberto :get 200 (format "database/%s" (u/the-id db)))))))
-        (testing "non-admin (rasta, All Users) has access to the sample DB"
-          (is (= (u/the-id db) (:id (mt/user-http-request :rasta :get 200 (format "database/%s" (u/the-id db)))))))))))
-
 (deftest sample-database-schedule-sync-test
   (testing "Check that the sample database has scheduled sync jobs, just like a newly created database"
     (mt/with-temp-empty-app-db [_conn :h2]

--- a/test/metabase/sample_data/impl_test.clj
+++ b/test/metabase/sample_data/impl_test.clj
@@ -267,6 +267,28 @@
           (testing "the engine swap itself still completed - a new SQLite sample DB exists"
             (is (t2/exists? :model/Database :is_sample true :engine :sqlite))))))))
 
+(deftest sample-database-queryable-by-admin-and-non-admin-test
+  (testing "After the H2->SQLite sample database swap, both admin and non-admin users can query the new sample DB"
+    (mt/with-model-cleanup [:model/Database]
+      ;; Start from a pre-upgrade H2 sample DB and run the real swap, which inserts + syncs the SQLite sample DB
+      ;; via the production code path (so its permissions come from the after-insert default-perms hook, not the
+      ;; with-temp test helper that would otherwise grant full access and mask the real behavior).
+      (mt/with-temp [:model/Database old-sample {:engine :h2, :is_sample true, :details {:db "mem:old-sample"}}]
+        (with-redefs [config/load-sample-content? (constantly true)]
+          (#'sample-data/update-sample-database-if-needed! old-sample)))
+      (let [db (t2/select-one :model/Database :is_sample true :engine :sqlite)]
+        (is (some? db) "the engine swap created a SQLite sample database")
+        (let [orders-id (t2/select-one-pk :model/Table :db_id (u/the-id db) :name "ORDERS")
+              query     {:database (u/the-id db)
+                         :type     :query
+                         :query    {:source-table orders-id, :limit 1}}]
+          (testing "admin (crowberto) can query the sample DB"
+            (is (= "completed"
+                   (:status (mt/user-http-request :crowberto :post 202 "dataset" query)))))
+          (testing "non-admin (rasta, All Users) can query the sample DB"
+            (is (= "completed"
+                   (:status (mt/user-http-request :rasta :post 202 "dataset" query))))))))))
+
 (deftest sample-database-schedule-sync-test
   (testing "Check that the sample database has scheduled sync jobs, just like a newly created database"
     (mt/with-temp-empty-app-db [_conn :h2]

--- a/test/metabase/sample_data/impl_test.clj
+++ b/test/metabase/sample_data/impl_test.clj
@@ -277,7 +277,8 @@
 
 (deftest sample-database-upgrade-preserves-permissions-test
   (testing "The H2->SQLite sample-database swap re-applies each group's permissions to the new sample DB"
-    (mt/with-model-cleanup [:model/Database]
+    (mt/with-temp-empty-app-db [_conn :h2]
+      (mdb/setup-db! :create-sample-content? false)
       (mt/with-temp [:model/PermissionsGroup custom-group {}
                      :model/Database         old-sample {:engine :h2, :is_sample true, :details {:db "mem:old-sample"}}]
         ;; Put the old sample DB into a distinctive, non-default permission state, so we test that real custom

--- a/test/metabase/sample_data/impl_test.clj
+++ b/test/metabase/sample_data/impl_test.clj
@@ -7,6 +7,7 @@
    [metabase.app-db.core :as mdb]
    [metabase.config.core :as config]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.permissions.core :as perms]
    [metabase.plugins.impl :as plugins]
    [metabase.sample-data.example-content :as example-content]
    [metabase.sample-data.impl :as sample-data]
@@ -266,6 +267,34 @@
             (is (false? @recreate-called?)))
           (testing "the engine swap itself still completed - a new SQLite sample DB exists"
             (is (t2/exists? :model/Database :is_sample true :engine :sqlite))))))))
+
+(defn- db-level-perms
+  "DB-level data-permission rows for `db-id` as a comparable map {[group-id perm-type] perm-value}."
+  [db-id]
+  (into {}
+        (for [{:keys [group_id perm_type perm_value]} (t2/select :model/DataPermissions :db_id db-id :table_id nil)]
+          [[group_id perm_type] perm_value])))
+
+(deftest sample-database-upgrade-preserves-permissions-test
+  (testing "The H2->SQLite sample-database swap re-applies each group's permissions to the new sample DB"
+    (mt/with-model-cleanup [:model/Database]
+      (mt/with-temp [:model/PermissionsGroup custom-group {}
+                     :model/Database         old-sample {:engine :h2, :is_sample true, :details {:db "mem:old-sample"}}]
+        ;; Put the old sample DB into a distinctive, non-default permission state, so we test that real custom
+        ;; permissions carry forward - not just that the defaults happen to line up.
+        (perms/set-database-permission! (perms/all-users-group) (:id old-sample) :perms/create-queries :no)
+        (perms/set-database-permission! custom-group            (:id old-sample) :perms/create-queries :query-builder)
+        (let [expected-perms (db-level-perms (:id old-sample))]
+          (with-redefs [config/load-sample-content? (constantly true)]
+            (#'sample-data/update-sample-database-if-needed! old-sample))
+          (let [new-sample (t2/select-one :model/Database :is_sample true :engine :sqlite)]
+            (is (some? new-sample) "the swap created a SQLite sample database")
+            (testing "every group's db-level permissions match the old sample DB exactly"
+              (is (= expected-perms (db-level-perms (:id new-sample)))))
+            (testing "the custom permission state specifically carried forward"
+              (let [new-perms (db-level-perms (:id new-sample))]
+                (is (= :no            (new-perms [(:id (perms/all-users-group)) :perms/create-queries])))
+                (is (= :query-builder (new-perms [(:id custom-group)            :perms/create-queries])))))))))))
 
 (deftest sample-database-schedule-sync-test
   (testing "Check that the sample database has scheduled sync jobs, just like a newly created database"


### PR DESCRIPTION
### Description

When the sample DB is upgraded from H2 -> SQLite, we delete any records associated with the H2 sample DB and create the SQLite sample DB as a fresh entity. However, there may be permissions configured for the outgoing sample DB that should also be applied to the SQLite sample DB, and the default permissions established by inserting a new DB doesn't necessarily match what the old H2 sample DB had.

This PR snapshots all DataPermissions related to the H2 sample DB and applies them to the new SQLite sample DB.

N.b. The internal metabase stats instance was upgraded to SQLite without this change in place, and this PR's changes will not be retroactively applicable to an instance that has already upgraded, so we will need to manually fix up the data permissions on that instance.