### PR TITLE
Add mage sort-modules-config task + wire into kondo lint

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -23,6 +23,8 @@ jobs:
         uses: ./.github/actions/prepare-backend
       - name: Run clj-kondo
         run: ./bin/mage kondo
+      - name: Check modules config is sorted
+        run: ./bin/mage sort-modules-config --check
 
   be-linter-eastwood:
     if: ${{ !inputs.skip }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -23,8 +23,6 @@ jobs:
         uses: ./.github/actions/prepare-backend
       - name: Run clj-kondo
         run: ./bin/mage kondo
-      - name: Check modules config is sorted
-        run: ./bin/mage sort-modules-config --check
 
   be-linter-eastwood:
     if: ${{ !inputs.skip }}

--- a/bb.edn
+++ b/bb.edn
@@ -95,6 +95,14 @@
                                       :description "Files or directories to fix unused requires in"}]]
    :task (task! (fix/fix-files parsed))}
 
+  sort-modules-config
+  {:doc "Sort .clj-kondo/config/modules/config.edn (module order + :model-imports/:model-exports sets)"
+   :examples [["./bin/mage sort-modules-config" "Sort the modules Kondo config in place"]
+              ["./bin/mage sort-modules-config --check" "Fail (exit 1) if the config is not sorted; make no changes"]]
+   :options [["-c" "--check" "Check only: exit non-zero if the config is not sorted"]]
+   :requires [[mage.sort-modules-config :as sort-modules-config]]
+   :task (task! (sort-modules-config/sort-config parsed))}
+
   check
   {:doc "Checks whether we can compile all source files (and finds circular dependencies)"
    :examples [["./bin/mage check"]]

--- a/bb.edn
+++ b/bb.edn
@@ -97,9 +97,7 @@
 
   sort-modules-config
   {:doc "Sort .clj-kondo/config/modules/config.edn (module order + :model-imports/:model-exports sets)"
-   :examples [["./bin/mage sort-modules-config" "Sort the modules Kondo config in place"]
-              ["./bin/mage sort-modules-config --check" "Fail (exit 1) if the config is not sorted; make no changes"]]
-   :options [["-c" "--check" "Check only: exit non-zero if the config is not sorted"]]
+   :examples [["./bin/mage sort-modules-config" "Sort the modules Kondo config in place"]]
    :requires [[mage.sort-modules-config :as sort-modules-config]]
    :task (task! (sort-modules-config/sort-config parsed))}
 

--- a/mage/src/mage/sort_modules_config.clj
+++ b/mage/src/mage/sort_modules_config.clj
@@ -97,28 +97,15 @@
   [content]
   (n/string (sort-root (r.parser/parse-string-all content))))
 
-(defn- sorted-content
-  []
-  (let [path    (str u/project-root-directory "/" config-path)
-        content (slurp path)]
-    [path content (sort-string content)]))
-
 (defn sort-config
-  "CLI entry point. Sorts the modules config file in place.
-
-  With `--check`, makes no changes: exits 1 if the file is not already sorted, 0 otherwise. Use
-  this in CI so an unsorted config fails the lint step instead of the slower backend test suite."
-  [{:keys [options] :as _parsed}]
-  (let [[path content sorted] (sorted-content)
-        sorted? (= content sorted)]
-    (if (:check options)
-      (if sorted?
-        (println (c/green "Modules config is sorted."))
-        (do (println (c/red (str config-path " is not sorted. Run: ./bin/mage sort-modules-config")))
-            (u/exit 1)))
-      (do
-        (println (c/cyan (str "Sorting " config-path "...")))
-        (if sorted?
-          (println (c/green "Modules config already sorted."))
-          (do (spit path sorted)
-              (println (c/green "Sorted modules config."))))))))
+  "CLI entry point. Sorts the modules config file in place. Run this when
+  `metabase.core.modules-test` complains the config is not sorted."
+  [_parsed]
+  (println (c/cyan (str "Sorting " config-path "...")))
+  (let [path    (str u/project-root-directory "/" config-path)
+        content (slurp path)
+        sorted  (sort-string content)]
+    (if (= content sorted)
+      (println (c/green "Modules config already sorted."))
+      (do (spit path sorted)
+          (println (c/green "Sorted modules config."))))))

--- a/mage/src/mage/sort_modules_config.clj
+++ b/mage/src/mage/sort_modules_config.clj
@@ -1,0 +1,124 @@
+(ns mage.sort-modules-config
+  "Sort the modules Kondo config (.clj-kondo/config/modules/config.edn) so it never trips
+  the sortedness assertions in [[metabase.core.modules-test]]:
+
+  - modules are ordered by name, with `enterprise/` modules last
+  - each module's `:model-imports` and `:model-exports` sets are sorted
+
+  Sorting is done in place: existing whitespace/comment nodes stay put and only the values are
+  reordered into their sorted slots, so the file's formatting is preserved."
+  (:require
+   [clojure.string :as str]
+   [mage.color :as c]
+   [mage.util :as u]
+   [rewrite-clj.node :as n]
+   [rewrite-clj.parser :as r.parser]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private config-path ".clj-kondo/config/modules/config.edn")
+
+(defn- module-sort-key
+  "Same ordering the test uses: enterprise/ modules sort last, then alphabetical."
+  [module-name]
+  [(if (str/starts-with? (str module-name) "enterprise/") 1 0)
+   (str module-name)])
+
+(defn- reorder-values
+  "Reorder the value (sexpr-able) children of `node` into `sorted-values`, leaving whitespace and
+  comment nodes in their original positions. `sorted-values` must contain exactly the node's
+  current value children, just in the desired order."
+  [node sorted-values]
+  (let [slots (atom sorted-values)]
+    (n/replace-children
+     node
+     (mapv (fn [child]
+             (if (n/sexpr-able? child)
+               (let [v (first @slots)]
+                 (swap! slots rest)
+                 v)
+               child))
+           (n/children node)))))
+
+(defn- sort-set-node
+  "Sort a `#{...}` set node's elements, preserving formatting."
+  [set-node]
+  (reorder-values set-node (sort-by n/sexpr (filter n/sexpr-able? (n/children set-node)))))
+
+(defn- sort-model-sets
+  "Walk a module's config map node; sort any `:model-imports`/`:model-exports` set value."
+  [config-node]
+  (let [vals (vec (filter n/sexpr-able? (n/children config-node)))
+        sort? #{:model-imports :model-exports}
+        vals' (vec (map-indexed
+                    (fn [i node]
+                      ;; value of a key follows it: sort the node after a matching keyword
+                      (if (and (pos? i)
+                               (n/keyword-node? (nth vals (dec i)))
+                               (sort? (n/sexpr (nth vals (dec i))))
+                               (= :set (n/tag node)))
+                        (sort-set-node node)
+                        node))
+                    vals))]
+    (reorder-values config-node vals')))
+
+(defn- sort-modules-map
+  "Sort the modules map node: sort key/value pairs by module name (enterprise last) and sort each
+  module's model sets."
+  [map-node]
+  (let [vals    (vec (filter n/sexpr-able? (n/children map-node)))
+        pairs   (partition 2 vals)
+        sorted  (->> pairs
+                     (sort-by (fn [[k _]] (module-sort-key (n/sexpr k))))
+                     (mapcat (fn [[k v]] [k (sort-model-sets v)]))
+                     vec)]
+    (reorder-values map-node sorted)))
+
+(defn- sort-root
+  "Sort the modules config in the parsed top-level forms node."
+  [forms-node]
+  (n/replace-children
+   forms-node
+   (mapv (fn [node]
+           (if (= :map (n/tag node))
+             ;; the single top-level {:metabase/modules {...}} map
+             (n/replace-children
+              node
+              (mapv (fn [child]
+                      (if (= :map (n/tag child))
+                        (sort-modules-map child)
+                        child))
+                    (n/children node)))
+             node))
+         (n/children forms-node))))
+
+(defn sort-string
+  "Sort the modules config given as a string; return the sorted string. Pure; used in tests."
+  [content]
+  (n/string (sort-root (r.parser/parse-string-all content))))
+
+(defn- sorted-content
+  []
+  (let [path    (str u/project-root-directory "/" config-path)
+        content (slurp path)]
+    [path content (sort-string content)]))
+
+(defn sort-config
+  "CLI entry point. Sorts the modules config file in place.
+
+  With `--check`, makes no changes: exits 1 if the file is not already sorted, 0 otherwise. Use
+  this in CI so an unsorted config fails the lint step instead of the slower backend test suite."
+  [{:keys [options] :as _parsed}]
+  (let [[path content sorted] (sorted-content)
+        sorted? (= content sorted)]
+    (if (:check options)
+      (if sorted?
+        (println (c/green "Modules config is sorted."))
+        (do (println (c/red (str config-path " is not sorted. Run: ./bin/mage sort-modules-config")))
+            (u/exit 1)))
+      (do
+        (println (c/cyan (str "Sorting " config-path "...")))
+        (if sorted?
+          (println (c/green "Modules config already sorted."))
+          (do (spit path sorted)
+              (println (c/green "Sorted modules config."))))))))

--- a/mage/test/mage/core_test.clj
+++ b/mage/test/mage/core_test.clj
@@ -14,6 +14,7 @@
    [mage.fix-unused-requires-test]
    [mage.merge-yaml-migrations-test :as merge-yaml-migrations-test]
    [mage.modules-test]
+   [mage.sort-modules-config-test]
    [mage.token-scan-test]
    [mage.util :as u]
    [mage.util-test]))
@@ -24,6 +25,7 @@
   mage.fix-unused-requires-test/keep-me
   mage.util-test/keep-me
   mage.modules-test/keep-me
+  mage.sort-modules-config-test/keep-me
   merge-yaml-migrations-test/keep-me
   token-scan-test/keep-me)
 

--- a/mage/test/mage/sort_modules_config_test.clj
+++ b/mage/test/mage/sort_modules_config_test.clj
@@ -1,0 +1,46 @@
+(ns mage.sort-modules-config-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [mage.sort-modules-config :as sort-modules-config]))
+
+(def keep-me "Ensures this namespace is loaded by mage.core-test" :loaded)
+
+(def ^:private unsorted
+  "{:metabase/modules
+ {zebra
+  {:team \"A\"
+   :model-imports #{:model/Table
+                    :model/Card
+                    :model/Database}}
+
+  enterprise/aardvark
+  {:team \"B\"
+   :model-exports #{:model/Foo :model/Bar}}
+
+  apple
+  {:team \"C\"
+   :model-imports :bypass}}}
+")
+
+(def ^:private sorted
+  "{:metabase/modules
+ {apple
+  {:team \"C\"
+   :model-imports :bypass}
+
+  zebra
+  {:team \"A\"
+   :model-imports #{:model/Card
+                    :model/Database
+                    :model/Table}}
+
+  enterprise/aardvark
+  {:team \"B\"
+   :model-exports #{:model/Bar :model/Foo}}}}
+")
+
+(deftest sort-string-test
+  (testing "sorts module order (enterprise last) and :model-imports/:model-exports sets, leaving :bypass alone"
+    (is (= sorted (sort-modules-config/sort-string unsorted))))
+  (testing "idempotent"
+    (is (= sorted (sort-modules-config/sort-string sorted)))))


### PR DESCRIPTION
## Why

`metabase.core.modules-test` asserts that `.clj-kondo/config/modules/config.edn` is sorted three ways:

- modules ordered by name (`enterprise/` modules last)
- each module's `:model-imports` set sorted
- each module's `:model-exports` set sorted

When someone hand-edits the config and slips an entry out of order, the only signal is a failure deep in the backend test suite (slow), and the only fix is to re-sort by hand:

```
FAIL in metabase.core.modules-test/model-imports-sorted-test
Module :model-imports should be sorted
'sample-data' module :model-imports
expected: (... :model/DataPermissions :model/Database ...)
  actual: (... :model/Database :model/DataPermissions ...)
```

## What

A `mage` task, modeled on `fix-unused-requires`:

```
./bin/mage sort-modules-config          # fix the config in place
./bin/mage sort-modules-config --check  # exit 1 if not sorted, no changes
```

The fixer sorts in place via `rewrite-clj` at the node level: it reorders only the value nodes into their sorted slots and leaves every whitespace/comment node where it was, so the file's formatting (and the big header comment) is byte-for-byte preserved. It uses the same comparator the test uses (enterprise last), so fixer and test never disagree.

The `--check` mode is wired into the existing `be-linter-clj-kondo` job (next to `./bin/mage kondo`), so an unsorted config fails fast in lint instead of in backend tests.

## Validation

- Ran the fixer on the current (already-sorted) config -> zero diff, idempotent.
- Mangled `:model-imports` / module order, ran the fixer -> file restored byte-identical to the original.
- `--check` exits 1 on a mangled file, 0 on the sorted file.
- Mage unit test (`sort_modules_config_test.clj`) covers module reordering, set sorting, `:bypass` passthrough, idempotency.
- `metabase.core.modules-test` still green (4034 assertions).
