### PR TITLE
Better model namespace requiring.

### DIFF
--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -156,13 +156,12 @@
   "Ensure the namespace for given model is loaded. This is a safety mechanism as we are moving to toucan2 and we don't
   need to require the model namespaces in order to use it."
   [x]
-  (when (and (keyword? x)
-             (= (namespace x) "model")
-             ;; Don't try to require if it's already registered as a :metabase/model, since that means it has already
-             ;; been required
-             (not (isa? x :metabase/model)))
-    ;; [[classloader/require]] for thread safety
-    (classloader/require (model->namespace x)))
+  (when (keyword? x)
+    ;; Always require the model's namespace when we know it. It is fast, and there can be race conditions between
+    ;; before side effects like `deftransforms` and `define-before-insert` have run
+    (when-let [nspace (get model->namespace x)]
+      ;; [[classloader/require]] for thread safety
+      (classloader/require nspace)))
   x)
 
 (methodical/defmethod t2.model/resolve-model :around clojure.lang.Symbol

--- a/test/metabase/models/resolution_test.clj
+++ b/test/metabase/models/resolution_test.clj
@@ -57,7 +57,7 @@
         (t2/resolve-model :model/QueryExecution))
       (is (contains? (set @required) 'metabase.queries.models.query-execution)))))
 
-(deftest ^:parallel resolve-model-ignores-unknown-model-keywords-test
+(deftest resolve-model-ignores-unknown-model-keywords-test
   (testing "resolve-model does not attempt to require a namespace for a `model`-namespaced keyword that is not a known model"
     (let [required (atom [])]
       (with-redefs [classloader/require (fn [& args] (swap! required into args))]

--- a/test/metabase/models/resolution_test.clj
+++ b/test/metabase/models/resolution_test.clj
@@ -46,3 +46,21 @@
 (deftest ^:parallel symbol-resolution-test
   (is (= :model/User
          (t2/resolve-model 'User))))
+
+(deftest resolve-model-requires-namespace-even-when-already-derived-test
+  (testing (str "resolve-model must ensure a model's namespace is loaded even when the model is already derived as "
+                ":metabase/model. The derivation is established partway through a model namespace's load (before its "
+                "deftransforms / define-before-insert side effects), so short-circuiting on it let concurrent "
+                "first-access on another thread use the model before its transforms were registered.")
+    (let [required (atom [])]
+      (with-redefs [classloader/require (fn [& args] (swap! required into args))]
+        (t2/resolve-model :model/QueryExecution))
+      (is (contains? (set @required) 'metabase.queries.models.query-execution)))))
+
+(deftest ^:parallel resolve-model-ignores-unknown-model-keywords-test
+  (testing "resolve-model does not attempt to require a namespace for a `model`-namespaced keyword that is not a known model"
+    (let [required (atom [])]
+      (with-redefs [classloader/require (fn [& args] (swap! required into args))]
+        (t2/resolve-model :model/DefinitelyNotARealModel))
+      (is (empty? @required)
+          "should not call classloader/require (which would blow up on a nil namespace) for unknown models"))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74468
### Description

Always classloader/require the model's namespace in `resolve-model` `:before` instead of gating on `isa?`              

Previously,  resolve-model short-circuited requiring a model's namespace whenever `(isa? x :metabase/model)` was already true, treating that derivation as a "fully loaded" marker. But a model namespace runs `(derive <model> :metabase/model)` partway through its load, before its `deftransforms`/ `define-before-insert` side effects register.
                                                                                                                                
This was causing a the first dashboard access to call the invalid SQL `INSERT INTO "query_execution" (..., "context", ...) VALUES (..., "dashboard", ...)` (ERROR: column "dashboard" does not exist) because the first QueryExecution insert happens on the background grouper thread . On first dashboard access it can race the thread loading the model namespace: it sees the derive, skips the require, and uses the model before the :context transform is registered. The raw keyword :dashboard then reaches HoneySQL, which renders keywords as identifiers. 

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
