### PR TITLE
Limit metabot related-tables to bound context size

### DIFF
--- a/resources/metabot/prompts/llm_shape.selmer
+++ b/resources/metabot/prompts/llm_shape.selmer
@@ -24,11 +24,11 @@
 <description>{{collection_description}}</description>{% endif %}</collection>
 {% endif %}
 {% if is_related_table %}
-<related-table{% if related_table_id %} id="{{related_table_id}}"{% endif %} name="{{related_table_name}}"{% if related_table_related_by %} related_by="{{related_table_related_by}}"{% endif %}{% if related_table_database_name %} database_name="{{related_table_database_name}}"{% endif %} fully_qualified_name="{{related_table_fqn}}">{% if related_table_fields_xml %}
+<related-table{% if related_table_id %} id="{{related_table_id}}"{% endif %} name="{{related_table_name}}"{% if related_table_related_by_name %} related_by_field_name="{{related_table_related_by_name}}"{% endif %}{% if related_table_related_by_id %} related_by_field_id="{{related_table_related_by_id}}"{% endif %}{% if related_table_database_name %} database_name="{{related_table_database_name}}"{% endif %} fully_qualified_name="{{related_table_fqn}}">{% if related_table_fields_xml %}
 {{related_table_fields_xml|safe}}{% endif %}</related-table>
 {% endif %}
 {% if is_related_table_ref %}
-<related-table-ref{% if related_table_ref_id %} id="{{related_table_ref_id}}"{% endif %} name="{{related_table_ref_name}}"{% if related_table_ref_related_by %} related_by="{{related_table_ref_related_by}}"{% endif %}{% if related_table_ref_description %} description="{{related_table_ref_description}}"{% endif %}/>
+<related-table-ref{% if related_table_ref_id %} id="{{related_table_ref_id}}"{% endif %} name="{{related_table_ref_name}}"{% if related_table_ref_related_by_name %} related_by_field_name="{{related_table_ref_related_by_name}}"{% endif %}{% if related_table_ref_related_by_id %} related_by_field_id="{{related_table_ref_related_by_id}}"{% endif %}{% if related_table_ref_description %} description="{{related_table_ref_description}}"{% endif %}/>
 {% endif %}
 {% if is_related_tables %}{% if related_tables_detailed_xml %}{{related_tables_detailed_xml|safe}}
 {% endif %}{% if related_tables_truncated %}<related-tables-truncated shown="{{related_tables_shown}}"{% if related_tables_total %} total="{{related_tables_total}}"{% endif %}>

--- a/resources/metabot/prompts/llm_shape.selmer
+++ b/resources/metabot/prompts/llm_shape.selmer
@@ -27,6 +27,16 @@
 <related-table{% if related_table_id %} id="{{related_table_id}}"{% endif %} name="{{related_table_name}}"{% if related_table_related_by %} related_by="{{related_table_related_by}}"{% endif %}{% if related_table_database_name %} database_name="{{related_table_database_name}}"{% endif %} fully_qualified_name="{{related_table_fqn}}">{% if related_table_fields_xml %}
 {{related_table_fields_xml|safe}}{% endif %}</related-table>
 {% endif %}
+{% if is_related_table_ref %}
+<related-table-ref{% if related_table_ref_id %} id="{{related_table_ref_id}}"{% endif %} name="{{related_table_ref_name}}"{% if related_table_ref_related_by %} related_by="{{related_table_ref_related_by}}"{% endif %}{% if related_table_ref_description %} description="{{related_table_ref_description}}"{% endif %}/>
+{% endif %}
+{% if is_related_tables %}{% if related_tables_detailed_xml %}{{related_tables_detailed_xml|safe}}
+{% endif %}{% if related_tables_truncated %}<related-tables-truncated shown="{{related_tables_shown}}"{% if related_tables_total %} total="{{related_tables_total}}"{% endif %}>
+Only the related tables above are shown with full column details; this entity has more FK-related tables than are shown here.
+{% if related_tables_refs_xml %}List of related tables:
+{{related_tables_refs_xml|safe}}
+{% endif %}{% if related_tables_refs_truncated %}(This list is itself truncated: {{related_tables_refs_truncated_count}} more related tables exist.)
+{% endif %}</related-tables-truncated>{% endif %}{% endif %}
 {% if is_metric %}
 <metric id="{{metric_id}}", name="{{metric_name}}" is_verified="{{metric_verified}}"{% if metric_database_name %} database_name="{{metric_database_name}}"{% endif %}{% if metric_base_table_fqn %} base_table_fully_qualified_name="{{metric_base_table_fqn}}"{% endif %}{% if metric_portable_entity_id %} portable_entity_id="{{metric_portable_entity_id}}"{% endif %}>
 {% if metric_collection_xml %}

--- a/resources/metabot/prompts/llm_shape.selmer
+++ b/resources/metabot/prompts/llm_shape.selmer
@@ -24,19 +24,18 @@
 <description>{{collection_description}}</description>{% endif %}</collection>
 {% endif %}
 {% if is_related_table %}
-<related-table{% if related_table_id %} id="{{related_table_id}}"{% endif %} name="{{related_table_name}}"{% if related_table_related_by_name %} related_by_field_name="{{related_table_related_by_name}}"{% endif %}{% if related_table_related_by_id %} related_by_field_id="{{related_table_related_by_id}}"{% endif %}{% if related_table_database_name %} database_name="{{related_table_database_name}}"{% endif %} fully_qualified_name="{{related_table_fqn}}">{% if related_table_fields_xml %}
+<related-table{% if related_table_id %} id="{{related_table_id}}"{% endif %} name="{{related_table_name}}"{% if related_table_related_by_name %} related_by_field_name="{{related_table_related_by_name}}"{% endif %}{% if related_table_related_by_id %} related_by_field_id="{{related_table_related_by_id}}"{% endif %}{% if related_table_database_name %} database_name="{{related_table_database_name}}"{% endif %} fully_qualified_name="{{related_table_fqn}}">{% if related_table_description %}
+{{related_table_description}}{% endif %}{% if related_table_fields_xml %}
 {{related_table_fields_xml|safe}}{% endif %}</related-table>
 {% endif %}
-{% if is_related_table_ref %}
-<related-table-ref{% if related_table_ref_id %} id="{{related_table_ref_id}}"{% endif %} name="{{related_table_ref_name}}"{% if related_table_ref_related_by_name %} related_by_field_name="{{related_table_ref_related_by_name}}"{% endif %}{% if related_table_ref_related_by_id %} related_by_field_id="{{related_table_ref_related_by_id}}"{% endif %}{% if related_table_ref_description %} description="{{related_table_ref_description}}"{% endif %}/>
-{% endif %}
-{% if is_related_tables %}{% if related_tables_detailed_xml %}{{related_tables_detailed_xml|safe}}
-{% endif %}{% if related_tables_truncated %}<related-tables-truncated shown="{{related_tables_shown}}"{% if related_tables_total %} total="{{related_tables_total}}"{% endif %}>
-Only the related tables above are shown with full column details; this entity has more FK-related tables than are shown here.
-{% if related_tables_refs_xml %}List of related tables:
-{{related_tables_refs_xml|safe}}
-{% endif %}{% if related_tables_refs_truncated %}(This list is itself truncated: {{related_tables_refs_truncated_count}} more related tables exist.)
-{% endif %}</related-tables-truncated>{% endif %}{% endif %}
+{% if is_related_tables %}{% if related_tables_with_fields_xml %}{{related_tables_with_fields_xml|safe}}
+{% endif %}{% if related_tables_without_fields_xml %}<related-tables-fields-omitted>
+The related tables below are listed without their fields. Look them up separately if you need field details.
+{{related_tables_without_fields_xml|safe}}
+</related-tables-fields-omitted>
+{% endif %}{% if related_tables_truncated %}<related-tables-truncated surfaced="{{related_tables_surfaced}}"{% if related_tables_total %} total="{{related_tables_total}}"{% endif %}>
+This entity has more FK-related tables than the {{related_tables_surfaced}} shown here.
+</related-tables-truncated>{% endif %}{% endif %}
 {% if is_metric %}
 <metric id="{{metric_id}}", name="{{metric_name}}" is_verified="{{metric_verified}}"{% if metric_database_name %} database_name="{{metric_database_name}}"{% endif %}{% if metric_base_table_fqn %} base_table_fully_qualified_name="{{metric_base_table_fqn}}"{% endif %}{% if metric_portable_entity_id %} portable_entity_id="{{metric_portable_entity_id}}"{% endif %}>
 {% if metric_collection_xml %}

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -238,7 +238,7 @@
                      :database_id :database_name :portable_entity_id
                      :base_table_id :base_table_name :base_table_portable_fk]))))
 
-(declare related-tables)
+(declare related-tables related-tables-result)
 
 (def ^:private max-related-tables
   "Maximum number of FK-related tables to expand when building entity context for the LLM.
@@ -248,6 +248,13 @@
   for the request's lifetime, exhausting the heap (metabase#76493). The LLM context window can't usefully
   hold hundreds of related tables anyway, so we cap the fan-out."
   20)
+
+(def ^:private max-related-table-refs
+  "Maximum number of FK-related tables to list by id/name in the truncation roster (see
+  [[related-tables]]). This roster is cheap (ids/names only, no column fetch), so it can be longer than
+  [[max-related-tables]] — it lets the LLM see which related tables exist beyond the detailed ones and
+  look any of them up individually."
+  50)
 
 (defn- table-details
   ([id] (table-details id nil))
@@ -282,8 +289,8 @@
                   (->> (lib/visible-columns table-query -1 {:include-implicitly-joinable? false})
                        field-values-fn
                        (map #(metabot.tools.u/add-table-reference table-query %))))
-           related-tables (when with-related-tables?
-                            (related-tables table-query with-fields? field-values-fn))]
+           related (when with-related-tables?
+                     (related-tables table-query with-fields? field-values-fn))]
        (-> {:id id
             :type :table
             :fields (mapv #(metabot.tools.u/->result-column table-query %) cols)
@@ -299,7 +306,6 @@
             ;; [db-name, schema-or-null, table-name]. LLM uses this as `source-table`.
             :portable_fk (when db-name [db-name (:schema base) (:name base)])}
            (m/assoc-some :description (:description base)
-                         :related_tables related-tables
                          :metrics (when with-metrics?
                                     (not-empty (mapv #(convert-metric % mp options)
                                                      (lib/available-metrics table-query))))
@@ -308,36 +314,70 @@
                                                       (lib/available-measures table-query))))
                          :segments (when with-segments?
                                      (not-empty (mapv #(convert-measure-or-segment % :filters)
-                                                      (lib/available-segments table-query))))))))))
+                                                      (lib/available-segments table-query)))))
+           (merge (related-tables-result related)))))))
 
 (defn related-tables
-  "Constructs a list of tables, optionally including their fields, that are related to the given query via foreign key.
-   Creates separate entries for each FK path when the same table is reachable through multiple foreign keys.
+  "FK-related-table context for `query`. Each distinct FK path (a `[table-id fk-field-id]` pair) is a
+   separate related table, so the same table reachable through multiple foreign keys appears once per FK.
 
-   The number of related tables is capped at [[max-related-tables]] to bound the amount of metadata
-   fetched and formatted for the LLM context — without the cap a highly-connected schema can fetch
-   and pin an unbounded number of columns for the request's lifetime (metabase#76493)."
+   Returns nil when the query has no FK-related tables, otherwise a map:
+
+     :tables  vector of detailed related-table maps (one per FK path), each with its fields, capped at
+              [[max-related-tables]]. This is the expensive part — each entry re-fetches and formats the
+              target table's full column set.
+     :total   total number of FK-related tables before capping.
+     :refs    lightweight roster `{:id :name :related_by}` of related tables, capped at
+              [[max-related-table-refs]] (ids/names only, no column fetch). Lets the LLM see which
+              related tables exist beyond the detailed ones and look any of them up individually.
+
+   Capping bounds the metadata fetched and formatted for the LLM context — without it a highly-connected
+   schema fetches and pins an unbounded number of columns for the request's lifetime (metabase#76493)."
   [query with-fields? field-values-fn]
-  (let [all-main-cols (lib/visible-columns query)
-        fk-cols       (filter :fk-field-id all-main-cols)
-        grouped-fks   (group-by (juxt :table-id :fk-field-id) fk-cols)
-        ;; sort for a deterministic selection when we cap, so the same tables are kept across calls
-        fk-groups     (sort (keys grouped-fks))]
-    (when (seq fk-groups)
-      (when (> (count fk-groups) max-related-tables)
+  (let [fk-groups (->> (lib/visible-columns query)
+                       (filter :fk-field-id)
+                       (group-by (juxt :table-id :fk-field-id))
+                       keys
+                       ;; sort for a deterministic selection when we cap, so the same tables are kept
+                       sort)
+        total     (count fk-groups)]
+    (when (pos? total)
+      (when (> total max-related-tables)
         (log/warnf "Capping MetaBot related-table expansion to %d of %d FK-related tables (metabase#76493)."
-                   max-related-tables (count fk-groups)))
-      (mapv
-       (fn [[table-id fk-field-id]]
-         (let [base-details   (table-details table-id
-                                             {:with-fields?         with-fields?
-                                              :field-values-fn      field-values-fn
-                                              :with-related-tables? false
-                                              :with-metrics?        false})
-               base-table-col (lib.metadata/field query fk-field-id)
-               fk-field-name  (:name base-table-col)]
-           (assoc base-details :related_by fk-field-name)))
-       (take max-related-tables fk-groups)))))
+                   max-related-tables total))
+      {:total  total
+       :tables (mapv
+                (fn [[table-id fk-field-id]]
+                  (-> (table-details table-id
+                                     {:with-fields?         with-fields?
+                                      :field-values-fn      field-values-fn
+                                      :with-related-tables? false
+                                      :with-metrics?        false})
+                      (assoc :related_by (:name (lib.metadata/field query fk-field-id)))))
+                (take max-related-tables fk-groups))
+       :refs   (mapv
+                (fn [[table-id fk-field-id]]
+                  {:id         table-id
+                   ;; table metadata is just the table row (name/schema) — no visible-columns fetch
+                   :name       (:name (lib.metadata/table query table-id))
+                   :related_by (:name (lib.metadata/field query fk-field-id))})
+                (take max-related-table-refs fk-groups))})))
+
+(defn- related-tables-result
+  "Convert the map returned by [[related-tables]] (or nil) into the subset of entity-detail result keys
+   that describe related tables: the detailed `:related_tables` list, plus — when that list was capped —
+   a `:related_tables_truncated` flag, the `:related_tables_total` count, and the `:related_table_refs`
+   roster (with its own `:related_table_refs_truncated` flag) so the LLM knows more related tables exist
+   and can look them up individually."
+  [related]
+  (when-let [{:keys [tables total refs]} related]
+    (let [truncated?      (> total (count tables))
+          refs-truncated? (> total (count refs))]
+      (cond-> {:related_tables tables}
+        truncated?      (assoc :related_tables_truncated true
+                               :related_tables_total     total
+                               :related_table_refs        refs)
+        refs-truncated? (assoc :related_table_refs_truncated true)))))
 
 (defn- card-details
   "Get details for a card."
@@ -373,8 +413,8 @@
          returned-fields (when with-fields?
                            (->> (lib/returned-columns card-query)
                                 field-values-fn))
-         related-tables (when with-related-tables?
-                          (related-tables card-query with-fields? field-values-fn))]
+         related (when with-related-tables?
+                   (related-tables card-query with-fields? field-values-fn))]
      (-> {:id id
           :type card-type
           :fields (mapv #(metabot.tools.u/->result-column card-query %) returned-fields)
@@ -414,7 +454,6 @@
                          metadata-provider
                          (lib/query metadata-provider (lib-be/normalize-query dataset-query))
                          shared.content-store/default-store))
-          :related_tables related-tables
           :metrics (when with-metrics?
                      (not-empty (mapv #(convert-metric % metadata-provider options)
                                       (lib/available-metrics card-query))))
@@ -423,7 +462,8 @@
                                        (lib/available-measures card-query))))
           :segments (when with-segments?
                       (not-empty (mapv #(convert-measure-or-segment % :filters)
-                                       (lib/available-segments card-query)))))))))
+                                       (lib/available-segments card-query)))))
+         (merge (related-tables-result related))))))
 
 (defn cards-details
   "Get the details of metrics or models as specified by `card-type` and `cards`

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -247,7 +247,7 @@
   schema, an unbounded FK fan-out fetches an unbounded number of columns that are cached for the request's lifetime,
   exhausting the heap (metabase#76493). The LLM context window can't usefully hold hundreds of related tables anyway,
   so we limited the number of tables for which we provide column metadata."
-  20)
+  10)
 
 (def ^:private max-related-table-truncated-refs
   "Maximum number of FK-related tables to list by id/name in the truncation list (see [[related-tables]]).

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -371,21 +371,21 @@
       (let [[detail-groups rest-groups] (split-at max-related-tables fk-groups)
             refs-groups (take max-related-table-truncated-refs rest-groups)
             details     (mapv
-                         (fn [[table-id _fk-field-id fk-field-name]]
+                         (fn [[table-id fk-field-id fk-field-name]]
                            (-> (table-details table-id
                                               {:with-fields?         with-fields?
                                                :field-values-fn      field-values-fn
                                                :with-related-tables? false
                                                :with-metrics?        false})
-                               (assoc :related_by fk-field-name)))
+                               (assoc :related_by {:id fk-field-id :name fk-field-name})))
                          detail-groups)
             refs        (mapv
-                         (fn [[table-id _fk-field-id fk-field-name]]
+                         (fn [[table-id fk-field-id fk-field-name]]
                            (let [table (lib.metadata/table query table-id)]
                              {:id          table-id
                               :name        (:name table)
                               :description (:description table)
-                              :related_by  fk-field-name}))
+                              :related_by  {:id fk-field-id :name fk-field-name}}))
                          refs-groups)]
         (cond-> {:related_tables details}
           (> total (count details))

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -323,7 +323,7 @@
   The FK paths that become [[related-tables]]. Each pair means \"`fk-field-id` points at `target-table-id`\", so a
   table reachable through several FKs appears once per FK.
 
-  This deliberately does NOT `:include-implicitly-joinable?` when calling `lib/visibile-columns` to find related
+  This deliberately does NOT `:include-implicitly-joinable?` when calling `lib/visible-columns` to find related
   tables: that fetches and caches the full column set of every FK-target table, even though we only
   expand [[max-related-tables]] of them (metabase#76493). Instead we read the source table's own FK columns and do a
   single bulk lookup of just the target fields (not their sibling columns) to map each FK to its table."

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -318,10 +318,10 @@
            (merge related))))))
 
 (defn- fk-related-table-groups
-  "Sorted, distinct `[target-table-id fk-field-id]` pairs for every direct FK from `query`'s source table.
+  "Sorted `[target-table-id fk-field-id fk-field-name]` tuples for every direct FK from `query`'s source table.
 
-  The FK paths that become [[related-tables]]. Each pair means \"`fk-field-id` points at `target-table-id`\", so a
-  table reachable through several FKs appears once per FK.
+  The FK paths that become [[related-tables]]. Each tuple means \"`fk-field-id` (named `fk-field-name`) points at
+  `target-table-id`\", so a table reachable through several FKs appears once per FK.
 
   This deliberately does NOT `:include-implicitly-joinable?` when calling `lib/visible-columns` to find related
   tables: that fetches and caches the full column set of every FK-target table, even though we only
@@ -334,11 +334,11 @@
         id->target-field   (m/index-by :id (lib.metadata/bulk-metadata
                                             query :metadata/column (into #{} (map :fk-target-field-id) fk-cols)))]
     (->> fk-cols
-         (keep (fn [{fk-field-id :id, :keys [fk-target-field-id]}]
+         (keep (fn [{fk-field-id :id, fk-field-name :name, :keys [fk-target-field-id]}]
                  ;; the target field might not exist; skip self/already-joined tables
                  (when-let [target (id->target-field fk-target-field-id)]
                    (when-not (contains? existing-table-ids (:table-id target))
-                     [(:table-id target) fk-field-id]))))
+                     [(:table-id target) fk-field-id fk-field-name]))))
          distinct
          ;; sort for a deterministic selection when we cap, so the same tables are kept
          sort)))
@@ -371,21 +371,21 @@
       (let [[detail-groups rest-groups] (split-at max-related-tables fk-groups)
             refs-groups (take max-related-table-truncated-refs rest-groups)
             details     (mapv
-                         (fn [[table-id fk-field-id]]
+                         (fn [[table-id _fk-field-id fk-field-name]]
                            (-> (table-details table-id
                                               {:with-fields?         with-fields?
                                                :field-values-fn      field-values-fn
                                                :with-related-tables? false
                                                :with-metrics?        false})
-                               (assoc :related_by (:name (lib.metadata/field query fk-field-id)))))
+                               (assoc :related_by fk-field-name)))
                          detail-groups)
             refs        (mapv
-                         (fn [[table-id fk-field-id]]
+                         (fn [[table-id _fk-field-id fk-field-name]]
                            (let [table (lib.metadata/table query table-id)]
                              {:id          table-id
                               :name        (:name table)
                               :description (:description table)
-                              :related_by  (:name (lib.metadata/field query fk-field-id))}))
+                              :related_by  fk-field-name}))
                          refs-groups)]
         (cond-> {:related_tables details}
           (> total (count details))

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -351,13 +351,16 @@
 
   Returns nil when the query has no FK-related tables, otherwise a map:
 
-    :tables vector of detailed related-table maps (one per FK path), each optionally with its fields, capped at
-            [[max-related-tables]]. This is the expensive part — each entry re-fetches and formats the
-            target table's full column set.
-    :total  total number of FK-related tables before capping.
-    :refs   list of `{:id :name :description :related_by}` of related tables, capped at
-            [[max-related-table-truncated-refs]] (ids/names only, no column fetch). Lets the LLM see
-            which related tables were excluded from `:tables` above."
+    :tables     vector of detailed related-table maps (one per FK path), each optionally with its fields, capped at
+                [[max-related-tables]]. This is the expensive part — each entry re-fetches and formats the
+                target table's full column set.
+    :total      total number of FK-related tables before capping.
+    :refs       list of `{:id :name :description :related_by}` of related tables that were *not* expanded into
+                `:tables`, capped at [[max-related-table-truncated-refs]] (ids/names only, no column fetch). Tables
+                already present in `:tables` are excluded so the roster only surfaces tables the LLM hasn't already
+                seen in full.
+    :refs-total total number of FK-related tables excluded from `:tables` (the population `:refs` is drawn from),
+                before capping."
   [query with-fields? field-values-fn]
   (let [fk-groups (fk-related-table-groups query)
         total     (count fk-groups)]
@@ -365,24 +368,29 @@
       (when (> total max-related-tables)
         (log/infof "Capping metabot related-table expansion to %d of %d FK-related tables."
                    max-related-tables total))
-      {:total  total
-       :tables (mapv
-                (fn [[table-id fk-field-id]]
-                  (-> (table-details table-id
-                                     {:with-fields?         with-fields?
-                                      :field-values-fn      field-values-fn
-                                      :with-related-tables? false
-                                      :with-metrics?        false})
-                      (assoc :related_by (:name (lib.metadata/field query fk-field-id)))))
-                (take max-related-tables fk-groups))
-       :refs   (mapv
-                (fn [[table-id fk-field-id]]
-                  (let [table (lib.metadata/table query table-id)]
-                    {:id          table-id
-                     :name        (:name table)
-                     :description (:description table)
-                     :related_by  (:name (lib.metadata/field query fk-field-id))}))
-                (take max-related-table-truncated-refs fk-groups))})))
+      (let [shown-groups    (take max-related-tables fk-groups)
+            shown-table-ids (into #{} (map first) shown-groups)
+            ;; exclude tables already expanded in :tables so the roster only lists tables not shown in full
+            excluded-groups (remove (comp shown-table-ids first) fk-groups)]
+        {:total      total
+         :tables     (mapv
+                      (fn [[table-id fk-field-id]]
+                        (-> (table-details table-id
+                                           {:with-fields?         with-fields?
+                                            :field-values-fn      field-values-fn
+                                            :with-related-tables? false
+                                            :with-metrics?        false})
+                            (assoc :related_by (:name (lib.metadata/field query fk-field-id)))))
+                      shown-groups)
+         :refs       (mapv
+                      (fn [[table-id fk-field-id]]
+                        (let [table (lib.metadata/table query table-id)]
+                          {:id          table-id
+                           :name        (:name table)
+                           :description (:description table)
+                           :related_by  (:name (lib.metadata/field query fk-field-id))}))
+                      (take max-related-table-truncated-refs excluded-groups))
+         :refs-total (count excluded-groups)}))))
 
 (defn- related-tables-result
   "Convert the map returned by [[related-tables]] into the entity-detail result.
@@ -391,12 +399,13 @@
   - `:related_tables_truncated` (optional) true when `:related_tables` was truncated by [[max-related-tables]]
   - `:related_tables_total` (optional) count of total related tables, before truncation. Only present when truncation
      occurred.
-  - `:related_table_refs` (optional) list of id/name/description. Only present when truncation occurred, so the LLM
-     knows more related tables exist and can look them up individually."
+  - `:related_table_refs` (optional) list of id/name/description for related tables *not* expanded into
+     `:related_tables`. Only present when truncation occurred, so the LLM knows more related tables exist and can
+     look them up individually."
   [related]
-  (when-let [{:keys [tables total refs]} related]
+  (when-let [{:keys [tables total refs refs-total]} related]
     (let [truncated?      (> total (count tables))
-          refs-truncated? (> total (count refs))]
+          refs-truncated? (> refs-total (count refs))]
       (cond-> {:related_tables tables}
         truncated?      (assoc :related_tables_truncated true
                                :related_tables_total     total

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -317,6 +317,32 @@
                                                       (lib/available-segments table-query)))))
            (merge (related-tables-result related)))))))
 
+(defn- fk-related-table-groups
+  "Sorted, distinct `[target-table-id fk-field-id]` pairs for every direct FK from `query`'s source table.
+
+  The FK paths that become [[related-tables]]. Each pair means \"`fk-field-id` points at `target-table-id`\", so a
+  table reachable through several FKs appears once per FK.
+
+  This deliberately does NOT `:include-implicitly-joinable?` when calling `lib/visibile-columns` to find related
+  tables: that fetches and caches the full column set of every FK-target table, even though we only
+  expand [[max-related-tables]] of them (metabase#76493). Instead we read the source table's own FK columns and do a
+  single bulk lookup of just the target fields (not their sibling columns) to map each FK to its table."
+  [query]
+  (let [source-cols        (lib/visible-columns query -1 {:include-implicitly-joinable? false})
+        existing-table-ids (into #{} (keep :table-id) source-cols)
+        fk-cols            (filter (every-pred :fk-target-field-id (comp number? :id)) source-cols)
+        id->target-field   (m/index-by :id (lib.metadata/bulk-metadata
+                                            query :metadata/column (into #{} (map :fk-target-field-id) fk-cols)))]
+    (->> fk-cols
+         (keep (fn [{fk-field-id :id, :keys [fk-target-field-id]}]
+                 ;; the target field might not exist; skip self/already-joined tables
+                 (when-let [target (id->target-field fk-target-field-id)]
+                   (when-not (contains? existing-table-ids (:table-id target))
+                     [(:table-id target) fk-field-id]))))
+         distinct
+         ;; sort for a deterministic selection when we cap, so the same tables are kept
+         sort)))
+
 (defn related-tables
   "FK-related-table context for `query`. Each distinct FK path (a `[table-id fk-field-id]` pair) is a
    separate related table, so the same table reachable through multiple foreign keys appears once per FK.
@@ -329,17 +355,9 @@
      :total   total number of FK-related tables before capping.
      :refs    lightweight list `{:id :name :description :related_by}` of related tables, capped at
               [[max-related-table-truncated-refs]] (ids/names only, no column fetch). Lets the LLM see
-              which related tables exist beyond the detailed ones and look any of them up individually.
-
-   Capping bounds the metadata fetched and formatted for the LLM context — without it a highly-connected
-   schema fetches and pins an unbounded number of columns for the request's lifetime (metabase#76493)."
+              which related tables exist beyond the detailed ones and look any of them up individually."
   [query with-fields? field-values-fn]
-  (let [fk-groups (->> (lib/visible-columns query)
-                       (filter :fk-field-id)
-                       (group-by (juxt :table-id :fk-field-id))
-                       keys
-                       ;; sort for a deterministic selection when we cap, so the same tables are kept
-                       sort)
+  (let [fk-groups (fk-related-table-groups query)
         total     (count fk-groups)]
     (when (pos? total)
       (when (> total max-related-tables)

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -240,6 +240,15 @@
 
 (declare related-tables)
 
+(def ^:private max-related-tables
+  "Maximum number of FK-related tables to expand when building entity context for the LLM.
+
+  Each related table re-fetches and formats its full column set, so on a database with a very large
+  / highly-connected schema an unbounded FK fan-out fetches and pins an unbounded number of columns
+  for the request's lifetime, exhausting the heap (metabase#76493). The LLM context window can't usefully
+  hold hundreds of related tables anyway, so we cap the fan-out."
+  20)
+
 (defn- table-details
   ([id] (table-details id nil))
   ([id {:keys [metadata-provider field-values-fn with-fields? with-related-tables? with-metrics?
@@ -303,14 +312,23 @@
 
 (defn related-tables
   "Constructs a list of tables, optionally including their fields, that are related to the given query via foreign key.
-   Creates separate entries for each FK path when the same table is reachable through multiple foreign keys."
+   Creates separate entries for each FK path when the same table is reachable through multiple foreign keys.
+
+   The number of related tables is capped at [[max-related-tables]] to bound the amount of metadata
+   fetched and formatted for the LLM context — without the cap a highly-connected schema can fetch
+   and pin an unbounded number of columns for the request's lifetime (metabase#76493)."
   [query with-fields? field-values-fn]
   (let [all-main-cols (lib/visible-columns query)
         fk-cols       (filter :fk-field-id all-main-cols)
-        grouped-fks   (group-by (juxt :table-id :fk-field-id) fk-cols)]
-    (when (seq grouped-fks)
+        grouped-fks   (group-by (juxt :table-id :fk-field-id) fk-cols)
+        ;; sort for a deterministic selection when we cap, so the same tables are kept across calls
+        fk-groups     (sort (keys grouped-fks))]
+    (when (seq fk-groups)
+      (when (> (count fk-groups) max-related-tables)
+        (log/warnf "Capping MetaBot related-table expansion to %d of %d FK-related tables (metabase#76493)."
+                   max-related-tables (count fk-groups)))
       (mapv
-       (fn [[[table-id fk-field-id] _]]
+       (fn [[table-id fk-field-id]]
          (let [base-details   (table-details table-id
                                              {:with-fields?         with-fields?
                                               :field-values-fn      field-values-fn
@@ -319,7 +337,7 @@
                base-table-col (lib.metadata/field query fk-field-id)
                fk-field-name  (:name base-table-col)]
            (assoc base-details :related_by fk-field-name)))
-       grouped-fks))))
+       (take max-related-tables fk-groups)))))
 
 (defn- card-details
   "Get details for a card."

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -368,28 +368,29 @@
       (when (> total max-related-tables)
         (log/infof "Capping metabot related-table expansion to %d of %d FK-related tables."
                    max-related-tables total))
-      (let [[included-groups rest-groups] (split-at max-related-tables fk-groups)
-            excluded-groups (take max-related-table-truncated-refs rest-groups)
-            related-tables  (mapv
-                             (fn [[table-id fk-field-id]]
-                               (-> (table-details table-id
-                                                  {:with-fields?         with-fields?
-                                                   :field-values-fn      field-values-fn
-                                                   :with-related-tables? false
-                                                   :with-metrics?        false})
-                                   (assoc :related_by (:name (lib.metadata/field query fk-field-id)))))
-                             included-groups)]
-        (cond-> {:related_tables related-tables}
-          (> total (count related-tables))
+      (let [[detail-groups rest-groups] (split-at max-related-tables fk-groups)
+            refs-groups (take max-related-table-truncated-refs rest-groups)
+            details     (mapv
+                         (fn [[table-id fk-field-id]]
+                           (-> (table-details table-id
+                                              {:with-fields?         with-fields?
+                                               :field-values-fn      field-values-fn
+                                               :with-related-tables? false
+                                               :with-metrics?        false})
+                               (assoc :related_by (:name (lib.metadata/field query fk-field-id)))))
+                         detail-groups)
+            refs        (mapv
+                         (fn [[table-id fk-field-id]]
+                           (let [table (lib.metadata/table query table-id)]
+                             {:id          table-id
+                              :name        (:name table)
+                              :description (:description table)
+                              :related_by  (:name (lib.metadata/field query fk-field-id))}))
+                         refs-groups)]
+        (cond-> {:related_tables details}
+          (> total (count details))
           (assoc :related_tables_total total
-                 :related_table_refs   (mapv
-                                        (fn [[table-id fk-field-id]]
-                                          (let [table (lib.metadata/table query table-id)]
-                                            {:id          table-id
-                                             :name        (:name table)
-                                             :description (:description table)
-                                             :related_by  (:name (lib.metadata/field query fk-field-id))}))
-                                        excluded-groups)))))))
+                 :related_table_refs   refs))))))
 
 (defn- card-details
   "Get details for a card."

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -358,9 +358,7 @@
     :refs       list of `{:id :name :description :related_by}` of related tables that were *not* expanded into
                 `:tables`, capped at [[max-related-table-truncated-refs]] (ids/names only, no column fetch). Tables
                 already present in `:tables` are excluded so the roster only surfaces tables the LLM hasn't already
-                seen in full.
-    :refs-total total number of FK-related tables excluded from `:tables` (the population `:refs` is drawn from),
-                before capping."
+                seen in full."
   [query with-fields? field-values-fn]
   (let [fk-groups (fk-related-table-groups query)
         total     (count fk-groups)]
@@ -389,28 +387,25 @@
                            :name        (:name table)
                            :description (:description table)
                            :related_by  (:name (lib.metadata/field query fk-field-id))}))
-                      (take max-related-table-truncated-refs excluded-groups))
-         :refs-total (count excluded-groups)}))))
+                      (take max-related-table-truncated-refs excluded-groups))}))))
 
 (defn- related-tables-result
   "Convert the map returned by [[related-tables]] into the entity-detail result.
 
   - `:related_tables` list of related tables with full details
-  - `:related_tables_truncated` (optional) true when `:related_tables` was truncated by [[max-related-tables]]
-  - `:related_tables_total` (optional) count of total related tables, before truncation. Only present when truncation
-     occurred.
+  - `:related_tables_total` (optional) count of total related tables, before truncation. Only present when
+     truncation occurred, so callers can infer that `:related_tables` was truncated by comparing it against the
+     length of `:related_tables`.
   - `:related_table_refs` (optional) list of id/name/description for related tables *not* expanded into
      `:related_tables`. Only present when truncation occurred, so the LLM knows more related tables exist and can
-     look them up individually."
+     look them up individually. This list may itself be capped at [[max-related-table-truncated-refs]]; callers
+     infer that by comparing `:related_tables_total` against the lengths of `:related_tables` and
+     `:related_table_refs`."
   [related]
-  (when-let [{:keys [tables total refs refs-total]} related]
-    (let [truncated?      (> total (count tables))
-          refs-truncated? (> refs-total (count refs))]
-      (cond-> {:related_tables tables}
-        truncated?      (assoc :related_tables_truncated true
-                               :related_tables_total     total
-                               :related_table_refs        refs)
-        refs-truncated? (assoc :related_table_refs_truncated true)))))
+  (when-let [{:keys [tables total refs]} related]
+    (cond-> {:related_tables tables}
+      (> total (count tables)) (assoc :related_tables_total total
+                                      :related_table_refs   refs))))
 
 (defn- card-details
   "Get details for a card."

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -240,20 +240,20 @@
 
 (declare ^:private related-tables)
 
-(def ^:private max-related-tables
-  "Maximum number of FK-related tables to expand when building entity context for the LLM.
+(def ^:private max-related-tables-with-fields
+  "Maximum number of related-tables to expand with their full column set.
 
-  Each related table fetches and formats its full column set, so on a database with a very large / highly-connected
-  schema, an unbounded FK fan-out fetches an unbounded number of columns that are cached for the request's lifetime,
-  exhausting the heap (metabase#76493). The LLM context window can't usefully hold hundreds of related tables anyway,
-  so we limited the number of tables for which we provide column metadata."
+  Each expanded table fetches and formats all of its columns. On a highly-connected schema with wide tables, this can
+  exhaust the heap (metabase#76493). We fetch only this many related tables with column metadata; the rest (up
+  to [[max-related-tables]]) are surfaced without columns."
   10)
 
-(def ^:private max-related-table-truncated-refs
-  "Maximum number of FK-related tables to list by id/name in the truncation list (see [[related-tables]]).
+(def ^:private max-related-tables
+  "Maximum number of related-tables to surface at all.
 
-  This list is cheap (ids/names/description only, no column fetch), so it can be longer than
-  [[max-related-tables]].  It lets the LLM see which related tables were excluded."
+  The first [[max-related-tables-with-fields]] of these carry their columns; the remainder are surfaced by identity
+  only (id/name/description/FK/FQN, no column fetch) so the LLM still knows they exist and can look them up
+  individually. Any related-tables beyond this are dropped with a note presented to the LLM in rendering."
   50)
 
 (defn- table-details
@@ -347,50 +347,42 @@
   "Context about tables related to `query` via a foreign key, as the entity-detail result keys callers merge in.
 
   Each distinct FK path (a `[table-id fk-field-id]` pair) is a separate related table, so the same table reachable
-  through multiple foreign keys appears once per FK.
+  through multiple foreign keys appears once per FK. We surface up to [[max-related-tables]] of them; only the
+  first [[max-related-tables-with-fields]] carry their column set to keep memory usage bounded (metabase#76493).
 
   Returns nil when the query has no FK-related tables, otherwise a map:
 
-    :related_tables       vector of detailed related-table maps (one per FK path), each optionally with its fields,
-                          capped at [[max-related-tables]]. This is the expensive part — each entry re-fetches and
-                          formats the target table's full column set.
-    :related_tables_total (optional) total number of FK-related tables before capping. Only present when truncation
-                          occurred, so callers infer that `:related_tables` was truncated by comparing it against
-                          the length of `:related_tables`.
-    :related_table_refs   (optional) list of `{:id :name :description :related_by}` for the FK paths *not* expanded
-                          into `:related_tables` (ids/names only, no column fetch), so the LLM knows more related
-                          tables exist and can look them up individually. This is list is also capped at
-                          [[max-related-table-truncated-refs]]. Only present when truncation occurred."
+    :related_tables                vector of related-table maps with their fields (if `with-fields?`is true). 
+                                   One per FK path, capped at [[max-related-tables-with-fields]].
+    :related_tables_without_fields (optional) the remaining surfaced FK paths, built the same way but without
+                                   columns. Present only when there are more :related_tables than
+                                   [[max-related-tables-with-fields]], capped so the two lists together hold at most
+                                   [[max-related-tables]].
+    :related_tables_total          (optional) total number of related-tables before capping. Present only when
+                                   that total exceeds [[max-related-tables]] (i.e. some were dropped entirely), so
+                                   the LLM knows the surfaced set is truncated."
   [query with-fields? field-values-fn]
   (let [fk-groups (fk-related-table-groups query)
         total     (count fk-groups)]
     (when (pos? total)
-      (when (> total max-related-tables)
-        (log/infof "Capping metabot related-table expansion to %d of %d FK-related tables."
-                   max-related-tables total))
-      (let [[detail-groups rest-groups] (split-at max-related-tables fk-groups)
-            refs-groups (take max-related-table-truncated-refs rest-groups)
-            details     (mapv
-                         (fn [[table-id fk-field-id fk-field-name]]
-                           (-> (table-details table-id
-                                              {:with-fields?         with-fields?
-                                               :field-values-fn      field-values-fn
-                                               :with-related-tables? false
-                                               :with-metrics?        false})
-                               (assoc :related_by {:id fk-field-id :name fk-field-name})))
-                         detail-groups)
-            refs        (mapv
-                         (fn [[table-id fk-field-id fk-field-name]]
-                           (let [table (lib.metadata/table query table-id)]
-                             {:id          table-id
-                              :name        (:name table)
-                              :description (:description table)
-                              :related_by  {:id fk-field-id :name fk-field-name}}))
-                         refs-groups)]
-        (cond-> {:related_tables details}
-          (> total (count details))
-          (assoc :related_tables_total total
-                 :related_table_refs   refs))))))
+      (when (> total max-related-tables-with-fields)
+        (log/infof "Capping metabot related-table column expansion to %d of %d related-tables (capped to %d total)."
+                   max-related-tables-with-fields total max-related-tables))
+      (let [[with-groups without-groups] (split-at max-related-tables-with-fields
+                                                   (take max-related-tables fk-groups))
+            build (fn [include-fields? [table-id fk-field-id fk-field-name]]
+                    (-> (table-details table-id
+                                       {:metadata-provider    query
+                                        :field-values-fn      field-values-fn
+                                        :with-fields?         include-fields?
+                                        :with-related-tables? false
+                                        :with-metrics?        false})
+                        (assoc :related_by {:id fk-field-id :name fk-field-name})))
+            with-fields    (mapv #(build (boolean with-fields?) %) with-groups)
+            without-fields (mapv #(build false %) without-groups)]
+        (cond-> {:related_tables with-fields}
+          (seq without-fields)         (assoc :related_tables_without_fields without-fields)
+          (> total max-related-tables) (assoc :related_tables_total total))))))
 
 (defn- card-details
   "Get details for a card."

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -357,12 +357,10 @@
     :related_tables_total (optional) total number of FK-related tables before capping. Only present when truncation
                           occurred, so callers infer that `:related_tables` was truncated by comparing it against
                           the length of `:related_tables`.
-    :related_table_refs   (optional) list of `{:id :name :description :related_by}` for related tables *not* expanded
+    :related_table_refs   (optional) list of `{:id :name :description :related_by}` for the FK paths *not* expanded
                           into `:related_tables` (ids/names only, no column fetch), so the LLM knows more related
-                          tables exist and can look them up individually. Capped at
-                          [[max-related-table-truncated-refs]]; tables already present in `:related_tables` are
-                          excluded so the roster only surfaces tables the LLM hasn't already seen in full. Only
-                          present when truncation occurred."
+                          tables exist and can look them up individually. This is list is also capped at
+                          [[max-related-table-truncated-refs]]. Only present when truncation occurred."
   [query with-fields? field-values-fn]
   (let [fk-groups (fk-related-table-groups query)
         total     (count fk-groups)]
@@ -370,9 +368,8 @@
       (when (> total max-related-tables)
         (log/infof "Capping metabot related-table expansion to %d of %d FK-related tables."
                    max-related-tables total))
-      (let [included-groups (take max-related-tables fk-groups)
-            included-ids    (into #{} (map first) included-groups)
-            excluded-groups (remove (comp included-ids first) fk-groups)
+      (let [[included-groups rest-groups] (split-at max-related-tables fk-groups)
+            excluded-groups (take max-related-table-truncated-refs rest-groups)
             related-tables  (mapv
                              (fn [[table-id fk-field-id]]
                                (-> (table-details table-id
@@ -392,7 +389,7 @@
                                              :name        (:name table)
                                              :description (:description table)
                                              :related_by  (:name (lib.metadata/field query fk-field-id))}))
-                                        (take max-related-table-truncated-refs excluded-groups))))))))
+                                        excluded-groups)))))))
 
 (defn- card-details
   "Get details for a card."

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -344,13 +344,11 @@
          sort)))
 
 (defn- related-tables
-  "Context about tables related to `query` via a foreign key, as the entity-detail result keys callers merge in.
-
-  Each distinct FK path (a `[table-id fk-field-id]` pair) is a separate related table, so the same table reachable
-  through multiple foreign keys appears once per FK. We surface up to [[max-related-tables]] of them; only the
-  first [[max-related-tables-with-fields]] carry their column set to keep memory usage bounded (metabase#76493).
-
-  Returns nil when the query has no FK-related tables, otherwise a map:
+  "Constructs a list of tables, optionally including their fields, that are related to the given query via foreign key.
+  Creates separate entries for each FK path when the same table is reachable through multiple foreign keys. We surface
+  up to [[max-related-tables]] FK paths; only the first [[max-related-tables-with-fields]] carry their column set to
+  keep memory usage bounded (metabase#76493), even when `with-fields?` is true. Returns nil when the query has no
+  FK-related tables, otherwise a map:
 
     :related_tables                vector of related-table maps, one per FK path. When `with-fields?` is true they
                                    carry their column set and the list is capped at [[max-related-tables-with-fields]];

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -243,17 +243,17 @@
 (def ^:private max-related-tables
   "Maximum number of FK-related tables to expand when building entity context for the LLM.
 
-  Each related table re-fetches and formats its full column set, so on a database with a very large
-  / highly-connected schema an unbounded FK fan-out fetches and pins an unbounded number of columns
-  for the request's lifetime, exhausting the heap (metabase#76493). The LLM context window can't usefully
-  hold hundreds of related tables anyway, so we cap the fan-out."
+  Each related table fetches and formats its full column set, so on a database with a very large / highly-connected
+  schema, an unbounded FK fan-out fetches an unbounded number of columns that are cached for the request's lifetime,
+  exhausting the heap (metabase#76493). The LLM context window can't usefully hold hundreds of related tables anyway,
+  so we limited the number of tables for which we provide column metadata."
   20)
 
-(def ^:private max-related-table-refs
-  "Maximum number of FK-related tables to list by id/name in the truncation roster (see
-  [[related-tables]]). This roster is cheap (ids/names only, no column fetch), so it can be longer than
-  [[max-related-tables]] — it lets the LLM see which related tables exist beyond the detailed ones and
-  look any of them up individually."
+(def ^:private max-related-table-truncated-refs
+  "Maximum number of FK-related tables to list by id/name in the truncation list (see [[related-tables]]).  
+
+  This list is cheap (ids/names/description only, no column fetch), so it can be longer than
+  [[max-related-tables]].  It lets the LLM see which related tables were excluded."
   50)
 
 (defn- table-details
@@ -327,9 +327,9 @@
               [[max-related-tables]]. This is the expensive part — each entry re-fetches and formats the
               target table's full column set.
      :total   total number of FK-related tables before capping.
-     :refs    lightweight roster `{:id :name :related_by}` of related tables, capped at
-              [[max-related-table-refs]] (ids/names only, no column fetch). Lets the LLM see which
-              related tables exist beyond the detailed ones and look any of them up individually.
+     :refs    lightweight list `{:id :name :description :related_by}` of related tables, capped at
+              [[max-related-table-truncated-refs]] (ids/names only, no column fetch). Lets the LLM see
+              which related tables exist beyond the detailed ones and look any of them up individually.
 
    Capping bounds the metadata fetched and formatted for the LLM context — without it a highly-connected
    schema fetches and pins an unbounded number of columns for the request's lifetime (metabase#76493)."
@@ -357,11 +357,13 @@
                 (take max-related-tables fk-groups))
        :refs   (mapv
                 (fn [[table-id fk-field-id]]
-                  {:id         table-id
-                   ;; table metadata is just the table row (name/schema) — no visible-columns fetch
-                   :name       (:name (lib.metadata/table query table-id))
-                   :related_by (:name (lib.metadata/field query fk-field-id))})
-                (take max-related-table-refs fk-groups))})))
+                  ;; table metadata is just the table row (name/schema/description) — no visible-columns fetch
+                  (let [table (lib.metadata/table query table-id)]
+                    {:id          table-id
+                     :name        (:name table)
+                     :description (:description table)
+                     :related_by  (:name (lib.metadata/field query fk-field-id))}))
+                (take max-related-table-truncated-refs fk-groups))})))
 
 (defn- related-tables-result
   "Convert the map returned by [[related-tables]] (or nil) into the subset of entity-detail result keys

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -352,12 +352,15 @@
 
   Returns nil when the query has no FK-related tables, otherwise a map:
 
-    :related_tables                vector of related-table maps with their fields (if `with-fields?`is true). 
-                                   One per FK path, capped at [[max-related-tables-with-fields]].
+    :related_tables                vector of related-table maps, one per FK path. When `with-fields?` is true they
+                                   carry their column set and the list is capped at [[max-related-tables-with-fields]];
+                                   when `with-fields?` is false they carry no columns and the list holds the whole
+                                   surfaced set (capped at [[max-related-tables]]).
     :related_tables_without_fields (optional) the remaining surfaced FK paths, built the same way but without
-                                   columns. Present only when there are more :related_tables than
-                                   [[max-related-tables-with-fields]], capped so the two lists together hold at most
-                                   [[max-related-tables]].
+                                   columns. Present only when `with-fields?` is true and there are more FK paths
+                                   than [[max-related-tables-with-fields]], capped so the two lists together hold at
+                                   most [[max-related-tables]]. Omitted entirely when `with-fields?` is false, since
+                                   without columns there is no distinction between the two lists.
     :related_tables_total          (optional) total number of related-tables before capping. Present only when
                                    that total exceeds [[max-related-tables]] (i.e. some were dropped entirely), so
                                    the LLM knows the surfaced set is truncated."
@@ -365,11 +368,15 @@
   (let [fk-groups (fk-related-table-groups query)
         total     (count fk-groups)]
     (when (pos? total)
-      (when (> total max-related-tables-with-fields)
-        (log/infof "Capping metabot related-table column expansion to %d of %d related-tables (capped to %d total)."
-                   max-related-tables-with-fields total max-related-tables))
-      (let [[with-groups without-groups] (split-at max-related-tables-with-fields
-                                                   (take max-related-tables fk-groups))
+      (when (and with-fields? (> total max-related-tables-with-fields))
+        (log/infof "Capping related-tables column expansion to %d of %d." max-related-tables-with-fields total))
+      (when (> total max-related-tables)
+        (log/infof "Capping related-tables to %d of %d." max-related-tables total))
+      (let [capped (take max-related-tables fk-groups)
+            ;; Only split into a with-fields/without-fields pair when the caller actually asked for columns.
+            [with-groups without-groups] (if with-fields?
+                                           (split-at max-related-tables-with-fields capped)
+                                           [capped nil])
             build (fn [include-fields? [table-id fk-field-id fk-field-name]]
                     (-> (table-details table-id
                                        {:metadata-provider    query
@@ -378,9 +385,9 @@
                                         :with-related-tables? false
                                         :with-metrics?        false})
                         (assoc :related_by {:id fk-field-id :name fk-field-name})))
-            with-fields    (mapv #(build (boolean with-fields?) %) with-groups)
-            without-fields (mapv #(build false %) without-groups)]
-        (cond-> {:related_tables with-fields}
+            maybe-with-fields (mapv #(build (boolean with-fields?) %) with-groups)
+            without-fields    (mapv #(build false %) without-groups)]
+        (cond-> {:related_tables maybe-with-fields}
           (seq without-fields)         (assoc :related_tables_without_fields without-fields)
           (> total max-related-tables) (assoc :related_tables_total total))))))
 

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -238,7 +238,7 @@
                      :database_id :database_name :portable_entity_id
                      :base_table_id :base_table_name :base_table_portable_fk]))))
 
-(declare related-tables)
+(declare ^:private related-tables)
 
 (def ^:private max-related-tables
   "Maximum number of FK-related tables to expand when building entity context for the LLM.
@@ -343,7 +343,7 @@
          ;; sort for a deterministic selection when we cap, so the same tables are kept
          sort)))
 
-(defn related-tables
+(defn- related-tables
   "Context about tables related to `query` via a foreign key, as the entity-detail result keys callers merge in.
 
   Each distinct FK path (a `[table-id fk-field-id]` pair) is a separate related table, so the same table reachable

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -238,7 +238,7 @@
                      :database_id :database_name :portable_entity_id
                      :base_table_id :base_table_name :base_table_portable_fk]))))
 
-(declare related-tables related-tables-result)
+(declare related-tables)
 
 (def ^:private max-related-tables
   "Maximum number of FK-related tables to expand when building entity context for the LLM.
@@ -315,7 +315,7 @@
                          :segments (when with-segments?
                                      (not-empty (mapv #(convert-measure-or-segment % :filters)
                                                       (lib/available-segments table-query)))))
-           (merge (related-tables-result related)))))))
+           (merge related))))))
 
 (defn- fk-related-table-groups
   "Sorted, distinct `[target-table-id fk-field-id]` pairs for every direct FK from `query`'s source table.
@@ -344,21 +344,25 @@
          sort)))
 
 (defn related-tables
-  "Context about tables related to `query` via a foreign key.
+  "Context about tables related to `query` via a foreign key, as the entity-detail result keys callers merge in.
 
   Each distinct FK path (a `[table-id fk-field-id]` pair) is a separate related table, so the same table reachable
   through multiple foreign keys appears once per FK.
 
   Returns nil when the query has no FK-related tables, otherwise a map:
 
-    :tables     vector of detailed related-table maps (one per FK path), each optionally with its fields, capped at
-                [[max-related-tables]]. This is the expensive part — each entry re-fetches and formats the
-                target table's full column set.
-    :total      total number of FK-related tables before capping.
-    :refs       list of `{:id :name :description :related_by}` of related tables that were *not* expanded into
-                `:tables`, capped at [[max-related-table-truncated-refs]] (ids/names only, no column fetch). Tables
-                already present in `:tables` are excluded so the roster only surfaces tables the LLM hasn't already
-                seen in full."
+    :related_tables       vector of detailed related-table maps (one per FK path), each optionally with its fields,
+                          capped at [[max-related-tables]]. This is the expensive part — each entry re-fetches and
+                          formats the target table's full column set.
+    :related_tables_total (optional) total number of FK-related tables before capping. Only present when truncation
+                          occurred, so callers infer that `:related_tables` was truncated by comparing it against
+                          the length of `:related_tables`.
+    :related_table_refs   (optional) list of `{:id :name :description :related_by}` for related tables *not* expanded
+                          into `:related_tables` (ids/names only, no column fetch), so the LLM knows more related
+                          tables exist and can look them up individually. Capped at
+                          [[max-related-table-truncated-refs]]; tables already present in `:related_tables` are
+                          excluded so the roster only surfaces tables the LLM hasn't already seen in full. Only
+                          present when truncation occurred."
   [query with-fields? field-values-fn]
   (let [fk-groups (fk-related-table-groups query)
         total     (count fk-groups)]
@@ -366,46 +370,29 @@
       (when (> total max-related-tables)
         (log/infof "Capping metabot related-table expansion to %d of %d FK-related tables."
                    max-related-tables total))
-      (let [shown-groups    (take max-related-tables fk-groups)
-            shown-table-ids (into #{} (map first) shown-groups)
-            ;; exclude tables already expanded in :tables so the roster only lists tables not shown in full
-            excluded-groups (remove (comp shown-table-ids first) fk-groups)]
-        {:total      total
-         :tables     (mapv
-                      (fn [[table-id fk-field-id]]
-                        (-> (table-details table-id
-                                           {:with-fields?         with-fields?
-                                            :field-values-fn      field-values-fn
-                                            :with-related-tables? false
-                                            :with-metrics?        false})
-                            (assoc :related_by (:name (lib.metadata/field query fk-field-id)))))
-                      shown-groups)
-         :refs       (mapv
-                      (fn [[table-id fk-field-id]]
-                        (let [table (lib.metadata/table query table-id)]
-                          {:id          table-id
-                           :name        (:name table)
-                           :description (:description table)
-                           :related_by  (:name (lib.metadata/field query fk-field-id))}))
-                      (take max-related-table-truncated-refs excluded-groups))}))))
-
-(defn- related-tables-result
-  "Convert the map returned by [[related-tables]] into the entity-detail result.
-
-  - `:related_tables` list of related tables with full details
-  - `:related_tables_total` (optional) count of total related tables, before truncation. Only present when
-     truncation occurred, so callers can infer that `:related_tables` was truncated by comparing it against the
-     length of `:related_tables`.
-  - `:related_table_refs` (optional) list of id/name/description for related tables *not* expanded into
-     `:related_tables`. Only present when truncation occurred, so the LLM knows more related tables exist and can
-     look them up individually. This list may itself be capped at [[max-related-table-truncated-refs]]; callers
-     infer that by comparing `:related_tables_total` against the lengths of `:related_tables` and
-     `:related_table_refs`."
-  [related]
-  (when-let [{:keys [tables total refs]} related]
-    (cond-> {:related_tables tables}
-      (> total (count tables)) (assoc :related_tables_total total
-                                      :related_table_refs   refs))))
+      (let [included-groups (take max-related-tables fk-groups)
+            included-ids    (into #{} (map first) included-groups)
+            excluded-groups (remove (comp included-ids first) fk-groups)
+            related-tables  (mapv
+                             (fn [[table-id fk-field-id]]
+                               (-> (table-details table-id
+                                                  {:with-fields?         with-fields?
+                                                   :field-values-fn      field-values-fn
+                                                   :with-related-tables? false
+                                                   :with-metrics?        false})
+                                   (assoc :related_by (:name (lib.metadata/field query fk-field-id)))))
+                             included-groups)]
+        (cond-> {:related_tables related-tables}
+          (> total (count related-tables))
+          (assoc :related_tables_total total
+                 :related_table_refs   (mapv
+                                        (fn [[table-id fk-field-id]]
+                                          (let [table (lib.metadata/table query table-id)]
+                                            {:id          table-id
+                                             :name        (:name table)
+                                             :description (:description table)
+                                             :related_by  (:name (lib.metadata/field query fk-field-id))}))
+                                        (take max-related-table-truncated-refs excluded-groups))))))))
 
 (defn- card-details
   "Get details for a card."
@@ -491,7 +478,7 @@
           :segments (when with-segments?
                       (not-empty (mapv #(convert-measure-or-segment % :filters)
                                        (lib/available-segments card-query)))))
-         (merge (related-tables-result related))))))
+         (merge related)))))
 
 (defn cards-details
   "Get the details of metrics or models as specified by `card-type` and `cards`

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -250,7 +250,7 @@
   20)
 
 (def ^:private max-related-table-truncated-refs
-  "Maximum number of FK-related tables to list by id/name in the truncation list (see [[related-tables]]).  
+  "Maximum number of FK-related tables to list by id/name in the truncation list (see [[related-tables]]).
 
   This list is cheap (ids/names/description only, no column fetch), so it can be longer than
   [[max-related-tables]].  It lets the LLM see which related tables were excluded."
@@ -344,24 +344,26 @@
          sort)))
 
 (defn related-tables
-  "FK-related-table context for `query`. Each distinct FK path (a `[table-id fk-field-id]` pair) is a
-   separate related table, so the same table reachable through multiple foreign keys appears once per FK.
+  "Context about tables related to `query` via a foreign key.
 
-   Returns nil when the query has no FK-related tables, otherwise a map:
+  Each distinct FK path (a `[table-id fk-field-id]` pair) is a separate related table, so the same table reachable
+  through multiple foreign keys appears once per FK.
 
-     :tables  vector of detailed related-table maps (one per FK path), each with its fields, capped at
-              [[max-related-tables]]. This is the expensive part — each entry re-fetches and formats the
-              target table's full column set.
-     :total   total number of FK-related tables before capping.
-     :refs    lightweight list `{:id :name :description :related_by}` of related tables, capped at
-              [[max-related-table-truncated-refs]] (ids/names only, no column fetch). Lets the LLM see
-              which related tables exist beyond the detailed ones and look any of them up individually."
+  Returns nil when the query has no FK-related tables, otherwise a map:
+
+    :tables vector of detailed related-table maps (one per FK path), each optionally with its fields, capped at
+            [[max-related-tables]]. This is the expensive part — each entry re-fetches and formats the
+            target table's full column set.
+    :total  total number of FK-related tables before capping.
+    :refs   list of `{:id :name :description :related_by}` of related tables, capped at
+            [[max-related-table-truncated-refs]] (ids/names only, no column fetch). Lets the LLM see
+            which related tables were excluded from `:tables` above."
   [query with-fields? field-values-fn]
   (let [fk-groups (fk-related-table-groups query)
         total     (count fk-groups)]
     (when (pos? total)
       (when (> total max-related-tables)
-        (log/warnf "Capping MetaBot related-table expansion to %d of %d FK-related tables (metabase#76493)."
+        (log/infof "Capping metabot related-table expansion to %d of %d FK-related tables."
                    max-related-tables total))
       {:total  total
        :tables (mapv
@@ -375,7 +377,6 @@
                 (take max-related-tables fk-groups))
        :refs   (mapv
                 (fn [[table-id fk-field-id]]
-                  ;; table metadata is just the table row (name/schema/description) — no visible-columns fetch
                   (let [table (lib.metadata/table query table-id)]
                     {:id          table-id
                      :name        (:name table)
@@ -384,11 +385,14 @@
                 (take max-related-table-truncated-refs fk-groups))})))
 
 (defn- related-tables-result
-  "Convert the map returned by [[related-tables]] (or nil) into the subset of entity-detail result keys
-   that describe related tables: the detailed `:related_tables` list, plus — when that list was capped —
-   a `:related_tables_truncated` flag, the `:related_tables_total` count, and the `:related_table_refs`
-   roster (with its own `:related_table_refs_truncated` flag) so the LLM knows more related tables exist
-   and can look them up individually."
+  "Convert the map returned by [[related-tables]] into the entity-detail result.
+
+  - `:related_tables` list of related tables with full details
+  - `:related_tables_truncated` (optional) true when `:related_tables` was truncated by [[max-related-tables]]
+  - `:related_tables_total` (optional) count of total related tables, before truncation. Only present when truncation
+     occurred.
+  - `:related_table_refs` (optional) list of id/name/description. Only present when truncation occurred, so the LLM
+     knows more related tables exist and can look them up individually."
   [related]
   (when-let [{:keys [tables total refs]} related]
     (let [truncated?      (> total (count tables))

--- a/src/metabase/metabot/tools/shared/llm_shape.clj
+++ b/src/metabase/metabot/tools/shared/llm_shape.clj
@@ -274,12 +274,13 @@
   [{:keys [id name related_by database_name fully_qualified_name fields]}]
   (render-llm-template
    :related_table
-   {:related_table_id            (when (some? id) (str id))
-    :related_table_name          name
-    :related_table_related_by    related_by
-    :related_table_database_name database_name
-    :related_table_fqn           fully_qualified_name
-    :related_table_fields_xml    (when (seq fields) (str/join "\n" (map field->xml fields)))}))
+   {:related_table_id              (when (some? id) (str id))
+    :related_table_name            name
+    :related_table_related_by_name (:name related_by)
+    :related_table_related_by_id   (str (:id related_by))
+    :related_table_database_name   database_name
+    :related_table_fqn             fully_qualified_name
+    :related_table_fields_xml      (when (seq fields) (str/join "\n" (map field->xml fields)))}))
 
 (def ^:private max-related-table-ref-description-length
   "Cap on a related-table-ref's description in the truncation list."
@@ -290,11 +291,12 @@
   [{:keys [id name description related_by]}]
   (render-llm-template
    :related_table_ref
-   {:related_table_ref_id          (when (some? id) (str id))
-    :related_table_ref_name        name
-    :related_table_ref_related_by  related_by
-    :related_table_ref_description (when (not-empty description)
-                                     (truncate description max-related-table-ref-description-length))}))
+   {:related_table_ref_id              (when (some? id) (str id))
+    :related_table_ref_name            name
+    :related_table_ref_related_by_name (:name related_by)
+    :related_table_ref_related_by_id   (str (:id related_by))
+    :related_table_ref_description     (when (not-empty description)
+                                         (truncate description max-related-table-ref-description-length))}))
 
 (defn- related-tables->xml
   "Render the related-tables block for a table/model.

--- a/src/metabase/metabot/tools/shared/llm_shape.clj
+++ b/src/metabase/metabot/tools/shared/llm_shape.clj
@@ -284,7 +284,7 @@
   512)
 
 (defn- related-table-ref->xml
-  "One entry in the related-tables truncation roster — a related table the LLM can look up by id."
+  "One entry in the related-tables truncation list."
   [{:keys [id name description related_by]}]
   (str "<related-table-ref"
        (when (some? id) (str " id=\"" id "\""))
@@ -295,13 +295,13 @@
        "/>"))
 
 (defn- related-tables->xml
-  "Render the related-tables block for a table/model: each detailed related table, plus — when the
-   detailed list was capped — a note that more related tables exist and a roster of their ids/names, so
-   the LLM doesn't assume the detailed list is exhaustive and can look any of the others up individually.
+  "Render the related-tables block for a table/model.
 
-   `truncated?`/`total`/`refs`/`refs-truncated?` come from the entity-detail result built by
-   [[metabase.metabot.tools.entity-details/related-tables-result]]. Returns nil when there is nothing to
-   render."
+  Render each detailed related table, plus — when the detailed list was truncated — a note that more related tables
+  exist and a list of their ids/names/description, so the LLM doesn't assume the detailed list is exhaustive and can
+  look any of the others up individually.
+
+  Returns nil when there is nothing to render."
   [related-tables {:keys [truncated? total refs refs-truncated?]}]
   (let [detailed (when (seq related-tables)
                    (str/join "" (map related-table->xml related-tables)))
@@ -311,11 +311,11 @@
                         "Only the related tables above are shown with full column details; this entity "
                         "has more FK-related tables than are shown here.\n"
                         (when (seq refs)
-                          (str "Complete list of related tables (use entity_details by id to fetch the "
-                               "columns of any not detailed above):\n"
+                          (str "List of related tables:\n"
                                (str/join "\n" (map related-table-ref->xml refs)) "\n"))
                         (when refs-truncated?
-                          "(This list is itself truncated — even more related tables exist.)\n")
+                          (format "(This list is itself truncated: %d more related tables exist.)\n"
+                                  (- total (count refs))))
                         "</related-tables-truncated>"))]
     (when (or detailed note)
       (str detailed (when (and detailed note) "\n") note))))

--- a/src/metabase/metabot/tools/shared/llm_shape.clj
+++ b/src/metabase/metabot/tools/shared/llm_shape.clj
@@ -324,7 +324,7 @@
         :related_tables_total                total
         :related_tables_refs_xml             refs-xml
         :related_tables_refs_truncated       refs-truncated?
-        :related_tables_refs_truncated_count (when refs-truncated? (- total (count refs)))}))))
+        :related_tables_refs_truncated_count (when refs-truncated? (- total shown (count refs)))}))))
 
 (defn- dimension-source-table
   "Human-readable `schema.table` for a queryable dimension, derived from its portable FK, plus

--- a/src/metabase/metabot/tools/shared/llm_shape.clj
+++ b/src/metabase/metabot/tools/shared/llm_shape.clj
@@ -140,7 +140,6 @@
    :is_collection (= type :collection)
    :is_related_table (= type :related_table)
    :is_related_tables (= type :related_tables)
-   :is_related_table_ref (= type :related_table_ref)
    :is_metric (= type :metric)
    :is_table (= type :table)
    :is_model (= type :model)
@@ -269,9 +268,14 @@
     :segment_definition         (repr-data->llm-block definition)
     :segment_definition_description definition-description}))
 
+(def ^:private max-related-table-description-length
+  "Cap on a related table's description."
+  512)
+
 (defn- related-table->xml
-  "Format a related table for LLM consumption."
-  [{:keys [id name related_by database_name fully_qualified_name fields]}]
+  "Format a related table for LLM consumption.
+  Used for both :related_tables and :related_tables_without_columns."
+  [{:keys [id name related_by database_name database_schema description fields]}]
   (render-llm-template
    :related_table
    {:related_table_id              (when (some? id) (str id))
@@ -279,54 +283,35 @@
     :related_table_related_by_name (:name related_by)
     :related_table_related_by_id   (str (:id related_by))
     :related_table_database_name   database_name
-    :related_table_fqn             fully_qualified_name
+    :related_table_fqn             (fully-qualified-name database_schema name)
+    :related_table_description     (when (not-empty description)
+                                     (truncate description max-related-table-description-length))
     :related_table_fields_xml      (when (seq fields) (str/join "\n" (map field->xml fields)))}))
-
-(def ^:private max-related-table-ref-description-length
-  "Cap on a related-table-ref's description in the truncation list."
-  512)
-
-(defn- related-table-ref->xml
-  "One entry in the related-tables truncation list."
-  [{:keys [id name description related_by]}]
-  (render-llm-template
-   :related_table_ref
-   {:related_table_ref_id              (when (some? id) (str id))
-    :related_table_ref_name            name
-    :related_table_ref_related_by_name (:name related_by)
-    :related_table_ref_related_by_id   (str (:id related_by))
-    :related_table_ref_description     (when (not-empty description)
-                                         (truncate description max-related-table-ref-description-length))}))
 
 (defn- related-tables->xml
   "Render the related-tables block for a table/model.
 
-  Render each detailed related table, plus — when the detailed list was truncated — a note that more related tables
-  exist and a list of their ids/names/description, so the LLM doesn't assume the detailed list is exhaustive and can
-  look any of the others up individually.
-
-  `total` is the total number of FK-related tables before truncation (nil when nothing was truncated) and `refs` is
-  the (possibly itself truncated) list of related tables not expanded above.
+  `related-tables` carry their fields; `without-fields` do not.  They are rendered as the same `<related-table>`
+  element, but grouped under a note that their columns were omitted, so the LLM can fetch them individually if
+  needed. `total` is the full related-tables count before any cap.  When it exceeds the surfaced set we tell the LLM
+  the list is truncated.
 
   Returns nil when there is nothing to render."
-  [related-tables {:keys [total refs]}]
-  (let [shown           (count related-tables)
-        truncated?      (boolean (and total (> total shown)))
-        refs-truncated? (boolean (and total (> total (+ shown (count refs)))))
-        detailed        (when (seq related-tables)
-                          (str/join "" (map related-table->xml related-tables)))
-        refs-xml        (when (and truncated? (seq refs))
-                          (str/join "\n" (map related-table-ref->xml refs)))]
-    (when (or detailed truncated?)
+  [related-tables without-fields total]
+  (let [with-fields-xml    (when (seq related-tables)
+                             (str/join "" (map related-table->xml related-tables)))
+        without-fields-xml (when (seq without-fields)
+                             (str/join "" (map related-table->xml without-fields)))
+        surfaced           (+ (count related-tables) (count without-fields))
+        truncated?         (boolean (and total (> total surfaced)))]
+    (when (or with-fields-xml without-fields-xml)
       (render-llm-template
        :related_tables
-       {:related_tables_detailed_xml         detailed
-        :related_tables_truncated            truncated?
-        :related_tables_shown                shown
-        :related_tables_total                total
-        :related_tables_refs_xml             refs-xml
-        :related_tables_refs_truncated       refs-truncated?
-        :related_tables_refs_truncated_count (when refs-truncated? (- total shown (count refs)))}))))
+       {:related_tables_with_fields_xml    with-fields-xml
+        :related_tables_without_fields_xml without-fields-xml
+        :related_tables_surfaced           surfaced
+        :related_tables_truncated          truncated?
+        :related_tables_total              total}))))
 
 (defn- dimension-source-table
   "Human-readable `schema.table` for a queryable dimension, derived from its portable FK, plus
@@ -400,7 +385,7 @@
    the representations-format `construct_notebook_query` tool."
   [{:keys [id name database_id database_name database_engine database_schema
            description fields related_tables related_tables_total
-           related_table_refs measures segments]}]
+           related_tables_without_fields measures segments]}]
   (let [fqn (fully-qualified-name database_schema name)]
     (render-llm-template
      :table
@@ -414,8 +399,8 @@
       :table_fields_xml         (when (seq fields)
                                   (str/join "\n" (map field->xml fields)))
       :table_related_tables_xml (related-tables->xml related_tables
-                                                     {:total related_tables_total
-                                                      :refs  related_table_refs})
+                                                     related_tables_without_fields
+                                                     related_tables_total)
       :table_measures_xml       (when (seq measures)
                                   (str/join "\n" (map measure->xml measures)))
       :table_segments_xml       (when (seq segments)
@@ -443,7 +428,7 @@
    representations form used elsewhere. Note: Python uses <metabase-model> tag but closes
    with </model>."
   [{:keys [id name description verified fields database_id database_name database_engine
-           related_tables related_tables_total related_table_refs
+           related_tables related_tables_total related_tables_without_fields
            measures segments portable_entity_id query_json]}]
   (let [fqn (model-fully-qualified-name id name)]
     (render-llm-template
@@ -461,8 +446,8 @@
       :model_fields_xml         (when (seq fields)
                                   (str/join "\n" (map field->xml fields)))
       :model_related_tables_xml (related-tables->xml related_tables
-                                                     {:total related_tables_total
-                                                      :refs  related_table_refs})
+                                                     related_tables_without_fields
+                                                     related_tables_total)
       :model_measures_xml       (when (seq measures)
                                   (str/join "\n" (map measure->xml measures)))
       :model_segments_xml       (when (seq segments)

--- a/src/metabase/metabot/tools/shared/llm_shape.clj
+++ b/src/metabase/metabot/tools/shared/llm_shape.clj
@@ -268,6 +268,41 @@
     :related_table_fqn           fully_qualified_name
     :related_table_fields_xml    (when (seq fields) (str/join "\n" (map field->xml fields)))}))
 
+(defn- related-table-ref->xml
+  "One entry in the related-tables truncation roster — a related table the LLM can look up by id."
+  [{:keys [id name related_by]}]
+  (str "<related-table-ref"
+       (when (some? id) (str " id=\"" id "\""))
+       " name=\"" (escape-xml name) "\""
+       (when related_by (str " related_by=\"" (escape-xml related_by) "\""))
+       "/>"))
+
+(defn- related-tables->xml
+  "Render the related-tables block for a table/model: each detailed related table, plus — when the
+   detailed list was capped — a note that more related tables exist and a roster of their ids/names, so
+   the LLM doesn't assume the detailed list is exhaustive and can look any of the others up individually.
+
+   `truncated?`/`total`/`refs`/`refs-truncated?` come from the entity-detail result built by
+   [[metabase.metabot.tools.entity-details/related-tables-result]]. Returns nil when there is nothing to
+   render."
+  [related-tables {:keys [truncated? total refs refs-truncated?]}]
+  (let [detailed (when (seq related-tables)
+                   (str/join "" (map related-table->xml related-tables)))
+        note     (when truncated?
+                   (str "<related-tables-truncated shown=\"" (count related-tables) "\""
+                        (when total (str " total=\"" total "\"")) ">\n"
+                        "Only the related tables above are shown with full column details; this entity "
+                        "has more FK-related tables than are shown here.\n"
+                        (when (seq refs)
+                          (str "Complete list of related tables (use entity_details by id to fetch the "
+                               "columns of any not detailed above):\n"
+                               (str/join "\n" (map related-table-ref->xml refs)) "\n"))
+                        (when refs-truncated?
+                          "(This list is itself truncated — even more related tables exist.)\n")
+                        "</related-tables-truncated>"))]
+    (when (or detailed note)
+      (str detailed (when (and detailed note) "\n") note))))
+
 (defn- dimension-source-table
   "Human-readable `schema.table` for a queryable dimension, derived from its portable FK, plus
   the join label when the dimension is reached through an FK from the base table."
@@ -339,7 +374,8 @@
    without a separate `entity_details` call — it's the first slot of every portable FK in
    the representations-format `construct_notebook_query` tool."
   [{:keys [id name database_id database_name database_engine database_schema
-           description fields related_tables measures segments]}]
+           description fields related_tables related_tables_truncated related_tables_total
+           related_table_refs related_table_refs_truncated measures segments]}]
   (let [fqn (fully-qualified-name database_schema name)]
     (render-llm-template
      :table
@@ -352,8 +388,11 @@
       :table_description        description
       :table_fields_xml         (when (seq fields)
                                   (str/join "\n" (map field->xml fields)))
-      :table_related_tables_xml (when (seq related_tables)
-                                  (str/join "" (map related-table->xml related_tables)))
+      :table_related_tables_xml (related-tables->xml related_tables
+                                                     {:truncated?      related_tables_truncated
+                                                      :total           related_tables_total
+                                                      :refs            related_table_refs
+                                                      :refs-truncated? related_table_refs_truncated})
       :table_measures_xml       (when (seq measures)
                                   (str/join "\n" (map measure->xml measures)))
       :table_segments_xml       (when (seq segments)
@@ -381,7 +420,8 @@
    representations form used elsewhere. Note: Python uses <metabase-model> tag but closes
    with </model>."
   [{:keys [id name description verified fields database_id database_name database_engine
-           related_tables measures segments portable_entity_id query_json]}]
+           related_tables related_tables_truncated related_tables_total related_table_refs
+           related_table_refs_truncated measures segments portable_entity_id query_json]}]
   (let [fqn (model-fully-qualified-name id name)]
     (render-llm-template
      :model
@@ -397,8 +437,11 @@
       :model_query_json         (repr-data->llm-block query_json)
       :model_fields_xml         (when (seq fields)
                                   (str/join "\n" (map field->xml fields)))
-      :model_related_tables_xml (when (seq related_tables)
-                                  (str/join "\n" (map related-table->xml related_tables)))
+      :model_related_tables_xml (related-tables->xml related_tables
+                                                     {:truncated?      related_tables_truncated
+                                                      :total           related_tables_total
+                                                      :refs            related_table_refs
+                                                      :refs-truncated? related_table_refs_truncated})
       :model_measures_xml       (when (seq measures)
                                   (str/join "\n" (map measure->xml measures)))
       :model_segments_xml       (when (seq segments)

--- a/src/metabase/metabot/tools/shared/llm_shape.clj
+++ b/src/metabase/metabot/tools/shared/llm_shape.clj
@@ -110,6 +110,17 @@
   (when s
     (str/replace s "|" "\\u007c")))
 
+(defn- truncate
+  "Cap `s` at `max-len` characters, appending an ellipsis when truncated.
+  Useful to ensure long free text values (e.g. table descriptions) don't bloat the LLM context.
+  Returns nil for nil input."
+  [s max-len]
+  (when s
+    (let [s (str s)]
+      (if (> (count s) max-len)
+        (str (subs s 0 max-len) "...")
+        s))))
+
 (defn- database-type-or-unknown
   "Return database type or 'unknown' if nil."
   [database-type]
@@ -268,13 +279,19 @@
     :related_table_fqn           fully_qualified_name
     :related_table_fields_xml    (when (seq fields) (str/join "\n" (map field->xml fields)))}))
 
+(def ^:private max-related-table-ref-description-length
+  "Cap on a related-table-ref's description in the truncation list."
+  512)
+
 (defn- related-table-ref->xml
   "One entry in the related-tables truncation roster — a related table the LLM can look up by id."
-  [{:keys [id name related_by]}]
+  [{:keys [id name description related_by]}]
   (str "<related-table-ref"
        (when (some? id) (str " id=\"" id "\""))
        " name=\"" (escape-xml name) "\""
        (when related_by (str " related_by=\"" (escape-xml related_by) "\""))
+       (when (not-empty description)
+         (str " description=\"" (escape-xml (truncate description max-related-table-ref-description-length)) "\""))
        "/>"))
 
 (defn- related-tables->xml

--- a/src/metabase/metabot/tools/shared/llm_shape.clj
+++ b/src/metabase/metabot/tools/shared/llm_shape.clj
@@ -139,6 +139,8 @@
    :is_field (= type :field)
    :is_collection (= type :collection)
    :is_related_table (= type :related_table)
+   :is_related_tables (= type :related_tables)
+   :is_related_table_ref (= type :related_table_ref)
    :is_metric (= type :metric)
    :is_table (= type :table)
    :is_model (= type :model)
@@ -286,13 +288,13 @@
 (defn- related-table-ref->xml
   "One entry in the related-tables truncation list."
   [{:keys [id name description related_by]}]
-  (str "<related-table-ref"
-       (when (some? id) (str " id=\"" id "\""))
-       " name=\"" (escape-xml name) "\""
-       (when related_by (str " related_by=\"" (escape-xml related_by) "\""))
-       (when (not-empty description)
-         (str " description=\"" (escape-xml (truncate description max-related-table-ref-description-length)) "\""))
-       "/>"))
+  (render-llm-template
+   :related_table_ref
+   {:related_table_ref_id          (when (some? id) (str id))
+    :related_table_ref_name        name
+    :related_table_ref_related_by  related_by
+    :related_table_ref_description (when (not-empty description)
+                                     (truncate description max-related-table-ref-description-length))}))
 
 (defn- related-tables->xml
   "Render the related-tables block for a table/model.
@@ -307,24 +309,22 @@
   Returns nil when there is nothing to render."
   [related-tables {:keys [total refs]}]
   (let [shown           (count related-tables)
-        truncated?      (and total (> total shown))
-        refs-truncated? (and total (> total (+ shown (count refs))))
-        detailed (when (seq related-tables)
-                   (str/join "" (map related-table->xml related-tables)))
-        note     (when truncated?
-                   (str "<related-tables-truncated shown=\"" shown "\""
-                        (when total (str " total=\"" total "\"")) ">\n"
-                        "Only the related tables above are shown with full column details; this entity "
-                        "has more FK-related tables than are shown here.\n"
-                        (when (seq refs)
-                          (str "List of related tables:\n"
-                               (str/join "\n" (map related-table-ref->xml refs)) "\n"))
-                        (when refs-truncated?
-                          (format "(This list is itself truncated: %d more related tables exist.)\n"
-                                  (- total (count refs))))
-                        "</related-tables-truncated>"))]
-    (when (or detailed note)
-      (str detailed (when (and detailed note) "\n") note))))
+        truncated?      (boolean (and total (> total shown)))
+        refs-truncated? (boolean (and total (> total (+ shown (count refs)))))
+        detailed        (when (seq related-tables)
+                          (str/join "" (map related-table->xml related-tables)))
+        refs-xml        (when (and truncated? (seq refs))
+                          (str/join "\n" (map related-table-ref->xml refs)))]
+    (when (or detailed truncated?)
+      (render-llm-template
+       :related_tables
+       {:related_tables_detailed_xml         detailed
+        :related_tables_truncated            truncated?
+        :related_tables_shown                shown
+        :related_tables_total                total
+        :related_tables_refs_xml             refs-xml
+        :related_tables_refs_truncated       refs-truncated?
+        :related_tables_refs_truncated_count (when refs-truncated? (- total (count refs)))}))))
 
 (defn- dimension-source-table
   "Human-readable `schema.table` for a queryable dimension, derived from its portable FK, plus

--- a/src/metabase/metabot/tools/shared/llm_shape.clj
+++ b/src/metabase/metabot/tools/shared/llm_shape.clj
@@ -301,12 +301,18 @@
   exist and a list of their ids/names/description, so the LLM doesn't assume the detailed list is exhaustive and can
   look any of the others up individually.
 
+  `total` is the total number of FK-related tables before truncation (nil when nothing was truncated) and `refs` is
+  the (possibly itself truncated) list of related tables not expanded above.
+
   Returns nil when there is nothing to render."
-  [related-tables {:keys [truncated? total refs refs-truncated?]}]
-  (let [detailed (when (seq related-tables)
+  [related-tables {:keys [total refs]}]
+  (let [shown           (count related-tables)
+        truncated?      (and total (> total shown))
+        refs-truncated? (and total (> total (+ shown (count refs))))
+        detailed (when (seq related-tables)
                    (str/join "" (map related-table->xml related-tables)))
         note     (when truncated?
-                   (str "<related-tables-truncated shown=\"" (count related-tables) "\""
+                   (str "<related-tables-truncated shown=\"" shown "\""
                         (when total (str " total=\"" total "\"")) ">\n"
                         "Only the related tables above are shown with full column details; this entity "
                         "has more FK-related tables than are shown here.\n"
@@ -391,8 +397,8 @@
    without a separate `entity_details` call — it's the first slot of every portable FK in
    the representations-format `construct_notebook_query` tool."
   [{:keys [id name database_id database_name database_engine database_schema
-           description fields related_tables related_tables_truncated related_tables_total
-           related_table_refs related_table_refs_truncated measures segments]}]
+           description fields related_tables related_tables_total
+           related_table_refs measures segments]}]
   (let [fqn (fully-qualified-name database_schema name)]
     (render-llm-template
      :table
@@ -406,10 +412,8 @@
       :table_fields_xml         (when (seq fields)
                                   (str/join "\n" (map field->xml fields)))
       :table_related_tables_xml (related-tables->xml related_tables
-                                                     {:truncated?      related_tables_truncated
-                                                      :total           related_tables_total
-                                                      :refs            related_table_refs
-                                                      :refs-truncated? related_table_refs_truncated})
+                                                     {:total related_tables_total
+                                                      :refs  related_table_refs})
       :table_measures_xml       (when (seq measures)
                                   (str/join "\n" (map measure->xml measures)))
       :table_segments_xml       (when (seq segments)
@@ -437,8 +441,8 @@
    representations form used elsewhere. Note: Python uses <metabase-model> tag but closes
    with </model>."
   [{:keys [id name description verified fields database_id database_name database_engine
-           related_tables related_tables_truncated related_tables_total related_table_refs
-           related_table_refs_truncated measures segments portable_entity_id query_json]}]
+           related_tables related_tables_total related_table_refs
+           measures segments portable_entity_id query_json]}]
   (let [fqn (model-fully-qualified-name id name)]
     (render-llm-template
      :model
@@ -455,10 +459,8 @@
       :model_fields_xml         (when (seq fields)
                                   (str/join "\n" (map field->xml fields)))
       :model_related_tables_xml (related-tables->xml related_tables
-                                                     {:truncated?      related_tables_truncated
-                                                      :total           related_tables_total
-                                                      :refs            related_table_refs
-                                                      :refs-truncated? related_table_refs_truncated})
+                                                     {:total related_tables_total
+                                                      :refs  related_table_refs})
       :model_measures_xml       (when (seq measures)
                                   (str/join "\n" (map measure->xml measures)))
       :model_segments_xml       (when (seq segments)

--- a/test/metabase/metabot/tools/entity_details_test.clj
+++ b/test/metabase/metabot/tools/entity_details_test.clj
@@ -562,18 +562,23 @@
                   (is (= 1 (count (:related_tables output))))
                   (is (true? (:related_tables_truncated output)))
                   (is (= 2 (:related_tables_total output)))
-                  (testing "roster lists every related table by id and name, not just the truncated ones"
-                    (is (= 2 (count (:related_table_refs output))))
+                  (testing "roster lists only the related tables excluded from :related_tables, by id and name"
+                    (is (= 1 (count (:related_table_refs output))))
                     (is (every? :id (:related_table_refs output)))
-                    (is (every? :name (:related_table_refs output))))
+                    (is (every? :name (:related_table_refs output)))
+                    (testing "the expanded table is not repeated in the roster"
+                      (let [shown-ids (into #{} (map :id) (:related_tables output))]
+                        (is (not-any? (comp shown-ids :id) (:related_table_refs output))))))
                   (testing "roster itself is not flagged truncated when it fits under its own cap"
                     (is (nil? (:related_table_refs_truncated output)))))))))))))
 
 (deftest related-table-refs-truncation-test
-  (testing "the related-tables list is itself capped at `max-related-table-truncated-refs` and flags truncation"
+  (testing "the related-table roster is itself capped at `max-related-table-truncated-refs` and flags truncation"
     (mt/test-driver :h2
       (mt/with-current-user (mt/user->id :crowberto)
-        (with-redefs-fn {#'entity-details/max-related-tables   1
+        ;; expand zero tables so both of Orders' FK-related tables land in the (excluded) roster, which the cap of
+        ;; 1 then truncates
+        (with-redefs-fn {#'entity-details/max-related-tables   0
                          #'entity-details/max-related-table-truncated-refs 1}
           (fn []
             (let [output (:structured-output

--- a/test/metabase/metabot/tools/entity_details_test.clj
+++ b/test/metabase/metabot/tools/entity_details_test.clj
@@ -520,3 +520,22 @@
                            :structured-output)]
             (is (map? (:query_json output)))
             (is (= "mbql/query" (get-in output [:query_json "lib/type"])))))))))
+
+(deftest related-tables-capped-test
+  (testing (str "FK-related-table expansion is capped at `max-related-tables` so a table with a very "
+                "large / highly-connected schema can't fetch and pin an unbounded number of columns "
+                "during a single MetaBot context build (metabase#76493)")
+    (mt/test-driver :h2
+      (mt/with-current-user (mt/user->id :crowberto)
+        (let [related-count (fn []
+                              (-> (entity-details/get-table-details {:entity-type :table
+                                                                     :entity-id (mt/id :orders)})
+                                  :structured-output
+                                  :related_tables
+                                  count))]
+          (testing "Orders has more than one FK-related table by default (Products + People)"
+            (is (> (related-count) 1)))
+          (testing "with the cap lowered, no more than `max-related-tables` related tables are expanded"
+            (with-redefs-fn {#'entity-details/max-related-tables 1}
+              (fn []
+                (is (= 1 (related-count)))))))))))

--- a/test/metabase/metabot/tools/entity_details_test.clj
+++ b/test/metabase/metabot/tools/entity_details_test.clj
@@ -595,6 +595,36 @@
                         (count (:related_tables_without_fields output))))
                   "total exceeds the surfaced set, signalling tables were dropped"))))))))
 
+(deftest related-tables-without-fields-omitted-when-no-fields-requested-test
+  (testing (str "with `with-fields?` false every related table is column-free, so there is no with/without "
+                "distinction: the whole capped set is surfaced in :related_tables and :related_tables_without_fields "
+                "is omitted, while the :related_tables cap is still enforced")
+    (mt/test-driver :h2
+      (mt/with-current-user (mt/user->id :crowberto)
+        (let [orders-query (let [mp (mt/metadata-provider)]
+                             (lib/query mp (lib.metadata/table mp (mt/id :orders))))
+              related      (fn [] (#'entity-details/related-tables orders-query false identity))]
+          (testing "Orders has more than one FK-related table (Products + People)"
+            (is (> (count (:related_tables (related))) 1)))
+          (testing "lowering the column-expansion cap does NOT spill into a without-fields list"
+            (with-redefs-fn {#'entity-details/max-related-tables-with-fields 1}
+              (fn []
+                (let [output (related)]
+                  (is (> (count (:related_tables output)) 1)
+                      "every surfaced table stays in :related_tables")
+                  (is (every? (comp empty? :fields) (:related_tables output))
+                      "no table carries columns when with-fields? is false")
+                  (is (nil? (:related_tables_without_fields output))
+                      ":related_tables_without_fields is omitted entirely when with-fields? is false")))))
+          (testing "the :related_tables cap still applies (and reports drops) when with-fields? is false"
+            (with-redefs-fn {#'entity-details/max-related-tables 1}
+              (fn []
+                (let [output (related)]
+                  (is (= 1 (count (:related_tables output))))
+                  (is (nil? (:related_tables_without_fields output)))
+                  (is (= 2 (:related_tables_total output))
+                      "tables dropped by the cap are still reported via :related_tables_total"))))))))))
+
 (defn- orders+reviews-join-query
   "A query whose source table is Orders with an explicit join to Reviews.
 

--- a/test/metabase/metabot/tools/entity_details_test.clj
+++ b/test/metabase/metabot/tools/entity_details_test.clj
@@ -542,7 +542,7 @@
                   (is (every? (comp seq :fields) tables)
                       "the surfaced column-bearing table actually carries its fields"))))))))))
 
-(deftest related-tables-without-fields-roster-test
+(deftest related-tables-without-fields-list-test
   (testing (str "FK-related tables beyond the column-expansion cap are still surfaced by identity (no column "
                 "fetch) in :related_tables_without_fields, so the LLM knows they exist and can look them up "
                 "individually (metabase#76493)")
@@ -552,11 +552,11 @@
                         (:structured-output
                          (entity-details/get-table-details {:entity-type :table
                                                             :entity-id (mt/id :orders)})))]
-          (testing "no without-fields roster when every related table fits under the column cap"
+          (testing "no without-fields list when every related table fits under the column cap"
             (let [output (details)]
               (is (nil? (:related_tables_without_fields output)))
               (is (nil? (:related_tables_total output)))))
-          (testing "lowering the column cap moves the remaining tables into the without-fields roster"
+          (testing "lowering the column cap moves the remaining tables into the without-fields list"
             (with-redefs-fn {#'entity-details/max-related-tables-with-fields 1}
               (fn []
                 (let [output      (details)
@@ -564,11 +564,11 @@
                       without     (:related_tables_without_fields output)]
                   (is (= 1 (count with-fields)))
                   (is (= 1 (count without)))
-                  (testing "roster entries carry id/name but no columns"
+                  (testing "list entries carry id/name but no columns"
                     (is (every? :id without))
                     (is (every? :name without))
                     (is (every? (comp empty? :fields) without)))
-                  (testing ":related_tables and the roster are disjoint FK paths"
+                  (testing ":related_tables and the list are disjoint FK paths"
                     (let [shown-paths (into #{} (map (juxt :id :related_by)) with-fields)]
                       (is (not-any? (comp shown-paths (juxt :id :related_by)) without))))
                   (testing "no tables were dropped entirely, so no :related_tables_total"
@@ -587,7 +587,7 @@
                                                              :entity-id (mt/id :orders)}))]
               (is (= 1 (count (:related_tables output))))
               (is (nil? (:related_tables_without_fields output))
-                  "with only one table surfaced and it carrying fields, the without-fields roster is empty")
+                  "with only one table surfaced and it carrying fields, the without-fields list is empty")
               (is (= 2 (:related_tables_total output))
                   ":related_tables_total reports the full FK-related count before the cap")
               (is (> (:related_tables_total output)

--- a/test/metabase/metabot/tools/entity_details_test.clj
+++ b/test/metabase/metabot/tools/entity_details_test.clj
@@ -521,78 +521,79 @@
             (is (map? (:query_json output)))
             (is (= "mbql/query" (get-in output [:query_json "lib/type"])))))))))
 
-(deftest related-tables-capped-test
-  (testing (str "FK-related-table expansion is capped at `max-related-tables` so a table with a very "
-                "large / highly-connected schema can't fetch and pin an unbounded number of columns "
+(deftest related-tables-with-fields-capped-test
+  (testing (str "FK-related-table *column* expansion is capped at `max-related-tables-with-fields` so a table "
+                "with a very large / highly-connected schema can't fetch and pin an unbounded number of columns "
                 "during a single MetaBot context build (metabase#76493)")
     (mt/test-driver :h2
       (mt/with-current-user (mt/user->id :crowberto)
-        (let [related-count (fn []
-                              (-> (entity-details/get-table-details {:entity-type :table
-                                                                     :entity-id (mt/id :orders)})
-                                  :structured-output
-                                  :related_tables
-                                  count))]
+        (let [with-fields-tables (fn []
+                                   (-> (entity-details/get-table-details {:entity-type :table
+                                                                          :entity-id (mt/id :orders)})
+                                       :structured-output
+                                       :related_tables))]
           (testing "Orders has more than one FK-related table by default (Products + People)"
-            (is (> (related-count) 1)))
-          (testing "with the cap lowered, no more than `max-related-tables` related tables are expanded"
-            (with-redefs-fn {#'entity-details/max-related-tables 1}
+            (is (> (count (with-fields-tables)) 1)))
+          (testing "with the cap lowered, no more than `max-related-tables-with-fields` related tables carry columns"
+            (with-redefs-fn {#'entity-details/max-related-tables-with-fields 1}
               (fn []
-                (is (= 1 (related-count)))))))))))
+                (let [tables (with-fields-tables)]
+                  (is (= 1 (count tables)))
+                  (is (every? (comp seq :fields) tables)
+                      "the surfaced column-bearing table actually carries its fields"))))))))))
 
-(deftest related-tables-truncation-tracking-test
-  (testing (str "when the FK-related-table list is capped, the result reports the truncation and a "
-                "lightweight roster of the remaining related tables (id/name) so the LLM knows more exist and "
-                "can look them up individually (metabase#76493)")
+(deftest related-tables-without-fields-roster-test
+  (testing (str "FK-related tables beyond the column-expansion cap are still surfaced by identity (no column "
+                "fetch) in :related_tables_without_fields, so the LLM knows they exist and can look them up "
+                "individually (metabase#76493)")
     (mt/test-driver :h2
       (mt/with-current-user (mt/user->id :crowberto)
         (let [details (fn []
                         (:structured-output
                          (entity-details/get-table-details {:entity-type :table
                                                             :entity-id (mt/id :orders)})))]
-          (testing "no truncation metadata when nothing was capped"
+          (testing "no without-fields roster when every related table fits under the column cap"
             (let [output (details)]
-              ;; truncation is inferred from the absence of :related_tables_total (only present once capped)
-              (is (nil? (:related_tables_total output)))
-              (is (nil? (:related_table_refs output)))))
-          (testing "capping the detailed list reports truncation + a full roster of related tables"
-            (with-redefs-fn {#'entity-details/max-related-tables 1}
+              (is (nil? (:related_tables_without_fields output)))
+              (is (nil? (:related_tables_total output)))))
+          (testing "lowering the column cap moves the remaining tables into the without-fields roster"
+            (with-redefs-fn {#'entity-details/max-related-tables-with-fields 1}
               (fn []
-                (let [output (details)]
-                  (is (= 1 (count (:related_tables output))))
-                  ;; :related_tables_total > (count :related_tables) signals the detailed list was truncated
-                  (is (= 2 (:related_tables_total output)))
-                  (is (> (:related_tables_total output) (count (:related_tables output))))
-                  (testing "roster lists the FK paths not expanded into :related_tables, by id and name"
-                    (is (= 1 (count (:related_table_refs output))))
-                    (is (every? :id (:related_table_refs output)))
-                    (is (every? :name (:related_table_refs output)))
-                    (testing ":related_tables and the roster are disjoint FK paths"
-                      (let [shown-paths (into #{} (map (juxt :id :related_by)) (:related_tables output))]
-                        (is (not-any? (comp shown-paths (juxt :id :related_by))
-                                      (:related_table_refs output))))))
-                  (testing "refs fits under its own cap: total accounts for the shown table plus the full refs list"
-                    (is (= (:related_tables_total output)
-                           (+ (count (:related_tables output))
-                              (count (:related_table_refs output)))))))))))))))
+                (let [output      (details)
+                      with-fields (:related_tables output)
+                      without     (:related_tables_without_fields output)]
+                  (is (= 1 (count with-fields)))
+                  (is (= 1 (count without)))
+                  (testing "roster entries carry id/name but no columns"
+                    (is (every? :id without))
+                    (is (every? :name without))
+                    (is (every? (comp empty? :fields) without)))
+                  (testing ":related_tables and the roster are disjoint FK paths"
+                    (let [shown-paths (into #{} (map (juxt :id :related_by)) with-fields)]
+                      (is (not-any? (comp shown-paths (juxt :id :related_by)) without))))
+                  (testing "no tables were dropped entirely, so no :related_tables_total"
+                    (is (nil? (:related_tables_total output)))))))))))))
 
-(deftest related-table-refs-truncation-test
-  (testing "the related-table roster is itself capped at `max-related-table-truncated-refs` and flags truncation"
+(deftest related-tables-total-truncation-test
+  (testing (str "FK-related tables beyond `max-related-tables` are dropped entirely and the drop is reported via "
+                ":related_tables_total so the LLM knows the surfaced set is itself truncated (metabase#76493)")
     (mt/test-driver :h2
       (mt/with-current-user (mt/user->id :crowberto)
-        ;; expand zero tables so both of Orders' FK-related tables land in the (excluded) roster, which the cap of
-        ;; 1 then truncates
-        (with-redefs-fn {#'entity-details/max-related-tables   0
-                         #'entity-details/max-related-table-truncated-refs 1}
+        ;; surface only one of Orders' two FK-related tables; the other is dropped entirely
+        (with-redefs-fn {#'entity-details/max-related-tables 1}
           (fn []
             (let [output (:structured-output
                           (entity-details/get-table-details {:entity-type :table
                                                              :entity-id (mt/id :orders)}))]
-              (is (= 1 (count (:related_table_refs output))))
-              ;; truncation is inferred: total exceeds the shown tables plus the listed refs
+              (is (= 1 (count (:related_tables output))))
+              (is (nil? (:related_tables_without_fields output))
+                  "with only one table surfaced and it carrying fields, the without-fields roster is empty")
+              (is (= 2 (:related_tables_total output))
+                  ":related_tables_total reports the full FK-related count before the cap")
               (is (> (:related_tables_total output)
                      (+ (count (:related_tables output))
-                        (count (:related_table_refs output))))))))))))
+                        (count (:related_tables_without_fields output))))
+                  "total exceeds the surfaced set, signalling tables were dropped"))))))))
 
 (defn- orders+reviews-join-query
   "A query whose source table is Orders with an explicit join to Reviews.

--- a/test/metabase/metabot/tools/entity_details_test.clj
+++ b/test/metabase/metabot/tools/entity_details_test.clj
@@ -593,3 +593,49 @@
               (is (> (:related_tables_total output)
                      (+ (count (:related_tables output))
                         (count (:related_table_refs output))))))))))))
+
+(defn- orders+reviews-join-query
+  "A query whose source table is Orders with an explicit join to Reviews.
+
+  Both tables carry a `PRODUCT_ID` FK to Products, so `visible-columns` exposes two FK columns with the same name
+  pointing at the same target table and therefore must be distinguished by field id, not name."
+  []
+  (let [mp (mt/metadata-provider)]
+    (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+        (lib/join (lib/join-clause (lib.metadata/table mp (mt/id :reviews))
+                                   [(lib/= (lib.metadata/field mp (mt/id :orders :id))
+                                           (lib.metadata/field mp (mt/id :reviews :id)))])))))
+
+(deftest fk-related-table-groups-distinguishes-same-named-fks-test
+  (testing (str "two distinct FK fields that share a name and point at the same target table stay separate FK paths: "
+                "`fk-related-table-groups` keys distinctness on the FK field id, not its name (so they don't collapse)")
+    (mt/test-driver :h2
+      (mt/with-current-user (mt/user->id :crowberto)
+        (let [groups   (#'entity-details/fk-related-table-groups (orders+reviews-join-query))
+              products (mt/id :products)
+              ;; the two PRODUCT_ID FK paths: orders.PRODUCT_ID and reviews.PRODUCT_ID, both -> products
+              product-paths (filter (fn [[target-table-id _ fk-name]]
+                                      (and (= target-table-id products) (= fk-name "PRODUCT_ID")))
+                                    groups)]
+          (testing "both PRODUCT_ID FKs survive distinct/sort as separate tuples"
+            (is (= 2 (count product-paths))))
+          (testing "they share a name and target table but differ by FK field id"
+            (is (=? #{[products (mt/id :orders :product_id) "PRODUCT_ID"]
+                      [products (mt/id :reviews :product_id) "PRODUCT_ID"]}
+                    (set product-paths)))))))))
+
+(deftest related-tables-related-by-field-id-test
+  (testing (str "`:related_by` carries a `{:id :name}` map so the LLM can disambiguate two related-table entries that "
+                "share a `:related_by` name and target table (e.g. orders.PRODUCT_ID vs reviews.PRODUCT_ID)")
+    (mt/test-driver :h2
+      (mt/with-current-user (mt/user->id :crowberto)
+        (let [output       (#'entity-details/related-tables (orders+reviews-join-query) false identity)
+              products     (mt/id :products)
+              product-rows (filter #(and (= (:id %) products) (= (-> % :related_by :name) "PRODUCT_ID"))
+                                   (:related_tables output))]
+          (testing "every related table's :related_by is a {:id :name} map"
+            (is (every? #(and (-> % :related_by :id) (-> % :related_by :name)) (:related_tables output))))
+          (testing "the two same-named PRODUCT_ID entries are present and distinguished only by :related_by :id"
+            (is (=? #{{:id products :related_by {:id (mt/id :orders :product_id) :name "PRODUCT_ID"}}
+                      {:id products :related_by {:id (mt/id :reviews :product_id) :name "PRODUCT_ID"}}}
+                    (into #{} (map #(select-keys % [:id :related_by])) product-rows)))))))))

--- a/test/metabase/metabot/tools/entity_details_test.clj
+++ b/test/metabase/metabot/tools/entity_details_test.clj
@@ -570,11 +570,11 @@
                     (is (nil? (:related_table_refs_truncated output)))))))))))))
 
 (deftest related-table-refs-truncation-test
-  (testing "the related-tables roster is itself capped at `max-related-table-refs` and flags truncation"
+  (testing "the related-tables list is itself capped at `max-related-table-truncated-refs` and flags truncation"
     (mt/test-driver :h2
       (mt/with-current-user (mt/user->id :crowberto)
         (with-redefs-fn {#'entity-details/max-related-tables   1
-                         #'entity-details/max-related-table-refs 1}
+                         #'entity-details/max-related-table-truncated-refs 1}
           (fn []
             (let [output (:structured-output
                           (entity-details/get-table-details {:entity-type :table

--- a/test/metabase/metabot/tools/entity_details_test.clj
+++ b/test/metabase/metabot/tools/entity_details_test.clj
@@ -542,8 +542,8 @@
 
 (deftest related-tables-truncation-tracking-test
   (testing (str "when the FK-related-table list is capped, the result reports the truncation and a "
-                "lightweight roster of all related tables (id/name) so the LLM knows more exist and can "
-                "look them up individually (metabase#76493)")
+                "lightweight roster of the remaining related tables (id/name) so the LLM knows more exist and "
+                "can look them up individually (metabase#76493)")
     (mt/test-driver :h2
       (mt/with-current-user (mt/user->id :crowberto)
         (let [details (fn []
@@ -563,13 +563,14 @@
                   ;; :related_tables_total > (count :related_tables) signals the detailed list was truncated
                   (is (= 2 (:related_tables_total output)))
                   (is (> (:related_tables_total output) (count (:related_tables output))))
-                  (testing "roster lists only the related tables excluded from :related_tables, by id and name"
+                  (testing "roster lists the FK paths not expanded into :related_tables, by id and name"
                     (is (= 1 (count (:related_table_refs output))))
                     (is (every? :id (:related_table_refs output)))
                     (is (every? :name (:related_table_refs output)))
-                    (testing "the expanded table is not repeated in the roster"
-                      (let [shown-ids (into #{} (map :id) (:related_tables output))]
-                        (is (not-any? (comp shown-ids :id) (:related_table_refs output))))))
+                    (testing ":related_tables and the roster are disjoint FK paths"
+                      (let [shown-paths (into #{} (map (juxt :id :related_by)) (:related_tables output))]
+                        (is (not-any? (comp shown-paths (juxt :id :related_by))
+                                      (:related_table_refs output))))))
                   (testing "refs fits under its own cap: total accounts for the shown table plus the full refs list"
                     (is (= (:related_tables_total output)
                            (+ (count (:related_tables output))

--- a/test/metabase/metabot/tools/entity_details_test.clj
+++ b/test/metabase/metabot/tools/entity_details_test.clj
@@ -539,3 +539,45 @@
             (with-redefs-fn {#'entity-details/max-related-tables 1}
               (fn []
                 (is (= 1 (related-count)))))))))))
+
+(deftest related-tables-truncation-tracking-test
+  (testing (str "when the FK-related-table list is capped, the result reports the truncation and a "
+                "lightweight roster of all related tables (id/name) so the LLM knows more exist and can "
+                "look them up individually (metabase#76493)")
+    (mt/test-driver :h2
+      (mt/with-current-user (mt/user->id :crowberto)
+        (let [details (fn []
+                        (:structured-output
+                         (entity-details/get-table-details {:entity-type :table
+                                                            :entity-id (mt/id :orders)})))]
+          (testing "no truncation metadata when nothing was capped"
+            (let [output (details)]
+              (is (nil? (:related_tables_truncated output)))
+              (is (nil? (:related_tables_total output)))
+              (is (nil? (:related_table_refs output)))))
+          (testing "capping the detailed list reports truncation + a full roster of related tables"
+            (with-redefs-fn {#'entity-details/max-related-tables 1}
+              (fn []
+                (let [output (details)]
+                  (is (= 1 (count (:related_tables output))))
+                  (is (true? (:related_tables_truncated output)))
+                  (is (= 2 (:related_tables_total output)))
+                  (testing "roster lists every related table by id and name, not just the truncated ones"
+                    (is (= 2 (count (:related_table_refs output))))
+                    (is (every? :id (:related_table_refs output)))
+                    (is (every? :name (:related_table_refs output))))
+                  (testing "roster itself is not flagged truncated when it fits under its own cap"
+                    (is (nil? (:related_table_refs_truncated output)))))))))))))
+
+(deftest related-table-refs-truncation-test
+  (testing "the related-tables roster is itself capped at `max-related-table-refs` and flags truncation"
+    (mt/test-driver :h2
+      (mt/with-current-user (mt/user->id :crowberto)
+        (with-redefs-fn {#'entity-details/max-related-tables   1
+                         #'entity-details/max-related-table-refs 1}
+          (fn []
+            (let [output (:structured-output
+                          (entity-details/get-table-details {:entity-type :table
+                                                             :entity-id (mt/id :orders)}))]
+              (is (= 1 (count (:related_table_refs output))))
+              (is (true? (:related_table_refs_truncated output))))))))))

--- a/test/metabase/metabot/tools/entity_details_test.clj
+++ b/test/metabase/metabot/tools/entity_details_test.clj
@@ -552,7 +552,7 @@
                                                             :entity-id (mt/id :orders)})))]
           (testing "no truncation metadata when nothing was capped"
             (let [output (details)]
-              (is (nil? (:related_tables_truncated output)))
+              ;; truncation is inferred from the absence of :related_tables_total (only present once capped)
               (is (nil? (:related_tables_total output)))
               (is (nil? (:related_table_refs output)))))
           (testing "capping the detailed list reports truncation + a full roster of related tables"
@@ -560,8 +560,9 @@
               (fn []
                 (let [output (details)]
                   (is (= 1 (count (:related_tables output))))
-                  (is (true? (:related_tables_truncated output)))
+                  ;; :related_tables_total > (count :related_tables) signals the detailed list was truncated
                   (is (= 2 (:related_tables_total output)))
+                  (is (> (:related_tables_total output) (count (:related_tables output))))
                   (testing "roster lists only the related tables excluded from :related_tables, by id and name"
                     (is (= 1 (count (:related_table_refs output))))
                     (is (every? :id (:related_table_refs output)))
@@ -569,8 +570,10 @@
                     (testing "the expanded table is not repeated in the roster"
                       (let [shown-ids (into #{} (map :id) (:related_tables output))]
                         (is (not-any? (comp shown-ids :id) (:related_table_refs output))))))
-                  (testing "roster itself is not flagged truncated when it fits under its own cap"
-                    (is (nil? (:related_table_refs_truncated output)))))))))))))
+                  (testing "refs fits under its own cap: total accounts for the shown table plus the full refs list"
+                    (is (= (:related_tables_total output)
+                           (+ (count (:related_tables output))
+                              (count (:related_table_refs output)))))))))))))))
 
 (deftest related-table-refs-truncation-test
   (testing "the related-table roster is itself capped at `max-related-table-truncated-refs` and flags truncation"
@@ -585,4 +588,7 @@
                           (entity-details/get-table-details {:entity-type :table
                                                              :entity-id (mt/id :orders)}))]
               (is (= 1 (count (:related_table_refs output))))
-              (is (true? (:related_table_refs_truncated output))))))))))
+              ;; truncation is inferred: total exceeds the shown tables plus the listed refs
+              (is (> (:related_tables_total output)
+                     (+ (count (:related_tables output))
+                        (count (:related_table_refs output))))))))))))

--- a/test/metabase/metabot/tools/shared/llm_shape_test.clj
+++ b/test/metabase/metabot/tools/shared/llm_shape_test.clj
@@ -744,8 +744,7 @@
    :database_schema "public"
    :related_tables [{:id 20 :name "products" :fully_qualified_name "public.products"
                      :related_by "product_id" :fields []}]
-   :related_tables_truncated true
-   :related_tables_total 99
+   :related_tables_total 3
    :related_table_refs [{:id 20 :name "products" :related_by "product_id"}
                         {:id 21 :name "people" :related_by "user_id"}]})
 
@@ -756,7 +755,7 @@
           "the detailed related table is still rendered")
       (is (str/includes? xml "<related-tables-truncated")
           "a truncation marker tells the LLM the list is incomplete")
-      (is (str/includes? xml "total=\"99\""))
+      (is (str/includes? xml "total=\"3\""))
       (is (str/includes? xml "<related-table-ref id=\"20\" name=\"products\" related_by=\"product_id\"/>"))
       (is (str/includes? xml "<related-table-ref id=\"21\" name=\"people\" related_by=\"user_id\"/>")
           "the roster lists every related table by id/name so the LLM can look them up"))))
@@ -784,9 +783,9 @@
           "the description is truncated to the cap before the ellipsis"))))
 
 (deftest ^:parallel table->xml-related-tables-roster-truncation-test
-  (testing "when the roster itself is capped, the note says so"
+  (testing "when the refs is capped, the note says so"
     (let [xml (llm-shape/table->xml (assoc base-table-with-truncated-related
-                                           :related_table_refs_truncated true))]
+                                           :related_tables_total 99))]
       (is (str/includes? xml "itself truncated: 97 more related tables exist")
           "the note reports how many related tables were truncated (total 99 minus the 2 shown)"))))
 

--- a/test/metabase/metabot/tools/shared/llm_shape_test.clj
+++ b/test/metabase/metabot/tools/shared/llm_shape_test.clj
@@ -761,6 +761,28 @@
       (is (str/includes? xml "<related-table-ref id=\"21\" name=\"people\" related_by=\"user_id\"/>")
           "the roster lists every related table by id/name so the LLM can look them up"))))
 
+(deftest ^:parallel table->xml-related-table-ref-description-test
+  (testing "a related-table-ref surfaces the table's description when present, and omits it when absent"
+    (let [xml (llm-shape/table->xml
+               (assoc base-table-with-truncated-related
+                      :related_table_refs [{:id 20 :name "products" :related_by "product_id"
+                                            :description "All the products we sell"}
+                                           {:id 21 :name "people" :related_by "user_id"}]))]
+      (is (str/includes? xml (str "<related-table-ref id=\"20\" name=\"products\" "
+                                  "related_by=\"product_id\" description=\"All the products we sell\"/>")))
+      (is (str/includes? xml "<related-table-ref id=\"21\" name=\"people\" related_by=\"user_id\"/>")
+          "a ref with no description renders no description attribute")))
+  (testing "a long related-table-ref description is capped and gets an ellipsis"
+    (let [long-desc (apply str (repeat 600 "x"))
+          cap-len   @#'llm-shape/max-related-table-ref-description-length
+          xml       (llm-shape/table->xml
+                     (assoc base-table-with-truncated-related
+                            :related_table_refs [{:id 20 :name "products" :related_by "product_id"
+                                                  :description long-desc}]))]
+      (is (str/includes? xml (str "description=\"" (apply str (repeat cap-len "x")) "...\"")))
+      (is (not (str/includes? xml (apply str (repeat (inc cap-len) "x"))))
+          "the description is truncated to the cap before the ellipsis"))))
+
 (deftest ^:parallel table->xml-related-tables-roster-truncation-test
   (testing "when the roster itself is capped, the note says so"
     (let [xml (llm-shape/table->xml (assoc base-table-with-truncated-related

--- a/test/metabase/metabot/tools/shared/llm_shape_test.clj
+++ b/test/metabase/metabot/tools/shared/llm_shape_test.clj
@@ -745,8 +745,8 @@
    :related_tables [{:id 20 :name "products" :fully_qualified_name "public.products"
                      :related_by "product_id" :fields []}]
    :related_tables_total 3
-   :related_table_refs [{:id 20 :name "products" :related_by "product_id"}
-                        {:id 21 :name "people" :related_by "user_id"}]})
+   :related_table_refs [{:id 21 :name "people" :related_by "user_id"}
+                        {:id 22 :name "reviews" :related_by "review_id"}]})
 
 (deftest ^:parallel table->xml-related-tables-truncation-test
   (testing "a capped related-tables list renders a truncation note plus a roster of related-table ids/names"
@@ -756,19 +756,19 @@
       (is (str/includes? xml "<related-tables-truncated")
           "a truncation marker tells the LLM the list is incomplete")
       (is (str/includes? xml "total=\"3\""))
-      (is (str/includes? xml "<related-table-ref id=\"20\" name=\"products\" related_by=\"product_id\"/>"))
-      (is (str/includes? xml "<related-table-ref id=\"21\" name=\"people\" related_by=\"user_id\"/>")
-          "the roster lists every related table by id/name so the LLM can look them up"))))
+      (is (str/includes? xml "<related-table-ref id=\"21\" name=\"people\" related_by=\"user_id\"/>"))
+      (is (str/includes? xml "<related-table-ref id=\"22\" name=\"reviews\" related_by=\"review_id\"/>")
+          "the roster lists every non-expanded related table by id/name so the LLM can look them up"))))
 
 (deftest ^:parallel table->xml-related-table-ref-description-test
   (testing "a related-table-ref surfaces the table's description when present, and omits it when absent"
     (let [xml (llm-shape/table->xml
                (assoc base-table-with-truncated-related
-                      :related_table_refs [{:id 20 :name "products" :related_by "product_id"
-                                            :description "All the products we sell"}
+                      :related_table_refs [{:id 22 :name "reviews" :related_by "review_id"
+                                            :description "All the reviews customers left"}
                                            {:id 21 :name "people" :related_by "user_id"}]))]
-      (is (str/includes? xml (str "<related-table-ref id=\"20\" name=\"products\" "
-                                  "related_by=\"product_id\" description=\"All the products we sell\"/>")))
+      (is (str/includes? xml (str "<related-table-ref id=\"22\" name=\"reviews\" "
+                                  "related_by=\"review_id\" description=\"All the reviews customers left\"/>")))
       (is (str/includes? xml "<related-table-ref id=\"21\" name=\"people\" related_by=\"user_id\"/>")
           "a ref with no description renders no description attribute")))
   (testing "a long related-table-ref description is capped and gets an ellipsis"
@@ -776,7 +776,7 @@
           cap-len   @#'llm-shape/max-related-table-ref-description-length
           xml       (llm-shape/table->xml
                      (assoc base-table-with-truncated-related
-                            :related_table_refs [{:id 20 :name "products" :related_by "product_id"
+                            :related_table_refs [{:id 22 :name "reviews" :related_by "review_id"
                                                   :description long-desc}]))]
       (is (str/includes? xml (str "description=\"" (apply str (repeat cap-len "x")) "...\"")))
       (is (not (str/includes? xml (apply str (repeat (inc cap-len) "x"))))
@@ -786,8 +786,9 @@
   (testing "when the refs is capped, the note says so"
     (let [xml (llm-shape/table->xml (assoc base-table-with-truncated-related
                                            :related_tables_total 99))]
-      (is (str/includes? xml "itself truncated: 97 more related tables exist")
-          "the note reports how many related tables were truncated (total 99 minus the 2 shown)"))))
+      (is (str/includes? xml "itself truncated: 96 more related tables exist")
+          (str "the note reports related tables neither shown in detail nor listed in the roster "
+               "(total 99 minus the 1 shown minus the 2 listed refs)")))))
 
 (deftest ^:parallel table->xml-no-truncation-note-test
   (testing "an un-truncated related-tables list renders no truncation note"

--- a/test/metabase/metabot/tools/shared/llm_shape_test.clj
+++ b/test/metabase/metabot/tools/shared/llm_shape_test.clj
@@ -262,7 +262,7 @@
                  :description "User accounts"
                  :fields [{:name "id" :field_id "f1" :base-type :type/Integer :database_type "INTEGER"}]
                  :related_tables [{:id 20 :name "orders" :fully_qualified_name "public.orders"
-                                   :related_by "user_id" :fields []}]}
+                                   :related_by {:id 91 :name "user_id"} :fields []}]}
           xml (llm-shape/table->xml table)]
       (is (str/starts-with? xml "<table"))
       ;; Python format: id="10", name="users"
@@ -743,10 +743,10 @@
    :database_engine "postgres"
    :database_schema "public"
    :related_tables [{:id 20 :name "products" :fully_qualified_name "public.products"
-                     :related_by "product_id" :fields []}]
+                     :related_by {:id 92 :name "product_id"} :fields []}]
    :related_tables_total 3
-   :related_table_refs [{:id 21 :name "people" :related_by "user_id"}
-                        {:id 22 :name "reviews" :related_by "review_id"}]})
+   :related_table_refs [{:id 21 :name "people" :related_by {:id 91 :name "user_id"}}
+                        {:id 22 :name "reviews" :related_by {:id 93 :name "review_id"}}]})
 
 (deftest ^:parallel table->xml-related-tables-truncation-test
   (testing "a capped related-tables list renders a truncation note plus a roster of related-table ids/names"
@@ -756,27 +756,28 @@
       (is (str/includes? xml "<related-tables-truncated")
           "a truncation marker tells the LLM the list is incomplete")
       (is (str/includes? xml "total=\"3\""))
-      (is (str/includes? xml "<related-table-ref id=\"21\" name=\"people\" related_by=\"user_id\"/>"))
-      (is (str/includes? xml "<related-table-ref id=\"22\" name=\"reviews\" related_by=\"review_id\"/>")
+      (is (str/includes? xml "<related-table-ref id=\"21\" name=\"people\" related_by_field_name=\"user_id\" related_by_field_id=\"91\"/>"))
+      (is (str/includes? xml "<related-table-ref id=\"22\" name=\"reviews\" related_by_field_name=\"review_id\" related_by_field_id=\"93\"/>")
           "the roster lists every non-expanded related table by id/name so the LLM can look them up"))))
 
 (deftest ^:parallel table->xml-related-table-ref-description-test
   (testing "a related-table-ref surfaces the table's description when present, and omits it when absent"
     (let [xml (llm-shape/table->xml
                (assoc base-table-with-truncated-related
-                      :related_table_refs [{:id 22 :name "reviews" :related_by "review_id"
+                      :related_table_refs [{:id 22 :name "reviews" :related_by {:id 93 :name "review_id"}
                                             :description "All the reviews customers left"}
-                                           {:id 21 :name "people" :related_by "user_id"}]))]
+                                           {:id 21 :name "people" :related_by {:id 91 :name "user_id"}}]))]
       (is (str/includes? xml (str "<related-table-ref id=\"22\" name=\"reviews\" "
-                                  "related_by=\"review_id\" description=\"All the reviews customers left\"/>")))
-      (is (str/includes? xml "<related-table-ref id=\"21\" name=\"people\" related_by=\"user_id\"/>")
+                                  "related_by_field_name=\"review_id\" related_by_field_id=\"93\" "
+                                  "description=\"All the reviews customers left\"/>")))
+      (is (str/includes? xml "<related-table-ref id=\"21\" name=\"people\" related_by_field_name=\"user_id\" related_by_field_id=\"91\"/>")
           "a ref with no description renders no description attribute")))
   (testing "a long related-table-ref description is capped and gets an ellipsis"
     (let [long-desc (apply str (repeat 600 "x"))
           cap-len   @#'llm-shape/max-related-table-ref-description-length
           xml       (llm-shape/table->xml
                      (assoc base-table-with-truncated-related
-                            :related_table_refs [{:id 22 :name "reviews" :related_by "review_id"
+                            :related_table_refs [{:id 22 :name "reviews" :related_by {:id 93 :name "review_id"}
                                                   :description long-desc}]))]
       (is (str/includes? xml (str "description=\"" (apply str (repeat cap-len "x")) "...\"")))
       (is (not (str/includes? xml (apply str (repeat (inc cap-len) "x"))))
@@ -796,7 +797,7 @@
                                      :database_schema "public"
                                      :related_tables [{:id 20 :name "products"
                                                        :fully_qualified_name "public.products"
-                                                       :related_by "product_id" :fields []}]})]
+                                                       :related_by {:id 92 :name "product_id"} :fields []}]})]
       (is (str/includes? xml "<related-table id=\"20\""))
       (is (not (str/includes? xml "<related-tables-truncated")))
       (is (not (str/includes? xml "<related-table-ref"))))))
@@ -805,4 +806,26 @@
   (testing "model related-tables truncation renders the same truncation note + roster as tables"
     (let [xml (llm-shape/model->xml (assoc base-table-with-truncated-related :name "orders_model"))]
       (is (str/includes? xml "<related-tables-truncated"))
-      (is (str/includes? xml "<related-table-ref id=\"21\" name=\"people\" related_by=\"user_id\"/>")))))
+      (is (str/includes? xml "<related-table-ref id=\"21\" name=\"people\" related_by_field_name=\"user_id\" related_by_field_id=\"91\"/>")))))
+
+(deftest ^:parallel table->xml-related-by-field-id-test
+  (testing (str "a `{:id :name}` `related_by` renders symmetric `related_by_field_name` + `related_by_field_id` "
+                "attributes so the LLM can tell two related-table entries apart when they share an FK name (two FK "
+                "fields with the same name -> the same table)")
+    (let [xml (llm-shape/table->xml
+               {:id 10 :name "orders" :database_id 1 :database_engine "postgres" :database_schema "public"
+                :related_tables [{:id 20 :name "products" :fully_qualified_name "public.products"
+                                  :related_by {:id 101 :name "product_id"} :fields []}
+                                 {:id 20 :name "products" :fully_qualified_name "public.products"
+                                  :related_by {:id 202 :name "product_id"} :fields []}]
+                :related_tables_total 3
+                :related_table_refs [{:id 21 :name "people" :related_by {:id 303 :name "user_id"}}
+                                     {:id 22 :name "reviews" :related_by {:id 404 :name "review_id"}}]})]
+      (testing "detailed related tables render both the FK field name and id"
+        (is (str/includes? xml "related_by_field_name=\"product_id\" related_by_field_id=\"101\""))
+        (is (str/includes? xml "related_by_field_name=\"product_id\" related_by_field_id=\"202\"")))
+      (testing "roster refs render both the FK field name and id"
+        (is (str/includes? xml
+                           "<related-table-ref id=\"21\" name=\"people\" related_by_field_name=\"user_id\" related_by_field_id=\"303\"/>"))
+        (is (str/includes? xml
+                           "<related-table-ref id=\"22\" name=\"reviews\" related_by_field_name=\"review_id\" related_by_field_id=\"404\"/>"))))))

--- a/test/metabase/metabot/tools/shared/llm_shape_test.clj
+++ b/test/metabase/metabot/tools/shared/llm_shape_test.clj
@@ -261,7 +261,7 @@
                  :database_schema "public"
                  :description "User accounts"
                  :fields [{:name "id" :field_id "f1" :base-type :type/Integer :database_type "INTEGER"}]
-                 :related_tables [{:id 20 :name "orders" :fully_qualified_name "public.orders"
+                 :related_tables [{:id 20 :name "orders" :database_schema "public"
                                    :related_by {:id 91 :name "user_id"} :fields []}]}
           xml (llm-shape/table->xml table)]
       (is (str/starts-with? xml "<table"))
@@ -736,77 +736,95 @@
     (let [result (llm-shape/entity->xml {:type :unknown :data "test"})]
       (is (str/includes? result ":type")))))
 
-(def ^:private base-table-with-truncated-related
+(def ^:private base-table-with-related
+  "Orders with one column-bearing related table, two surfaced without columns, and more dropped entirely
+  (surfaced 3, total 5)."
   {:id 10
    :name "orders"
    :database_id 1
    :database_engine "postgres"
    :database_schema "public"
-   :related_tables [{:id 20 :name "products" :fully_qualified_name "public.products"
+   :related_tables [{:id 20 :name "products" :database_schema "public"
                      :related_by {:id 92 :name "product_id"} :fields []}]
-   :related_tables_total 3
-   :related_table_refs [{:id 21 :name "people" :related_by {:id 91 :name "user_id"}}
-                        {:id 22 :name "reviews" :related_by {:id 93 :name "review_id"}}]})
+   :related_tables_without_fields [{:id 21 :name "people" :database_schema "public"
+                                    :related_by {:id 91 :name "user_id"}}
+                                   {:id 22 :name "reviews" :database_schema "public"
+                                    :related_by {:id 93 :name "review_id"}}]
+   :related_tables_total 5})
 
-(deftest ^:parallel table->xml-related-tables-truncation-test
-  (testing "a capped related-tables list renders a truncation note plus a roster of related-table ids/names"
-    (let [xml (llm-shape/table->xml base-table-with-truncated-related)]
-      (is (str/includes? xml "<related-table id=\"20\"")
-          "the detailed related table is still rendered")
-      (is (str/includes? xml "<related-tables-truncated")
-          "a truncation marker tells the LLM the list is incomplete")
-      (is (str/includes? xml "total=\"3\""))
-      (is (str/includes? xml "<related-table-ref id=\"21\" name=\"people\" related_by_field_name=\"user_id\" related_by_field_id=\"91\"/>"))
-      (is (str/includes? xml "<related-table-ref id=\"22\" name=\"reviews\" related_by_field_name=\"review_id\" related_by_field_id=\"93\"/>")
-          "the roster lists every non-expanded related table by id/name so the LLM can look them up"))))
+(deftest ^:parallel table->xml-related-tables-with-fields-test
+  (testing "a column-bearing related table renders as <related-table> with a derived fully_qualified_name"
+    (let [xml (llm-shape/table->xml base-table-with-related)]
+      (is (str/includes? xml "<related-table id=\"20\" name=\"products\"")
+          "the column-bearing related table is rendered")
+      (is (str/includes? xml "fully_qualified_name=\"public.products\"")
+          "the FQN is derived from the related table's schema + name (not a precomputed key)"))))
 
-(deftest ^:parallel table->xml-related-table-ref-description-test
-  (testing "a related-table-ref surfaces the table's description when present, and omits it when absent"
+(deftest ^:parallel table->xml-related-tables-fields-omitted-test
+  (testing (str "related tables surfaced without fields render under a <related-tables-fields-omitted> note as "
+                "<related-table> elements with FK + FQN but no <field>s, so the LLM can look them up if needed")
+    (let [xml (llm-shape/table->xml base-table-with-related)]
+      (is (str/includes? xml "<related-tables-fields-omitted>")
+          "a note tells the LLM these tables' fields were omitted")
+      (is (str/includes? xml (str "<related-table id=\"21\" name=\"people\" related_by_field_name=\"user_id\" "
+                                  "related_by_field_id=\"91\" fully_qualified_name=\"public.people\"></related-table>"))
+          "an identity-only table renders as <related-table> with FQN and FK but no columns")
+      (is (str/includes? xml (str "<related-table id=\"22\" name=\"reviews\" related_by_field_name=\"review_id\" "
+                                  "related_by_field_id=\"93\" fully_qualified_name=\"public.reviews\"></related-table>"))))))
+
+(deftest ^:parallel table->xml-related-table-description-test
+  (testing "a related table surfaces its description when present, and omits it when absent"
     (let [xml (llm-shape/table->xml
-               (assoc base-table-with-truncated-related
-                      :related_table_refs [{:id 22 :name "reviews" :related_by {:id 93 :name "review_id"}
-                                            :description "All the reviews customers left"}
-                                           {:id 21 :name "people" :related_by {:id 91 :name "user_id"}}]))]
-      (is (str/includes? xml (str "<related-table-ref id=\"22\" name=\"reviews\" "
-                                  "related_by_field_name=\"review_id\" related_by_field_id=\"93\" "
-                                  "description=\"All the reviews customers left\"/>")))
-      (is (str/includes? xml "<related-table-ref id=\"21\" name=\"people\" related_by_field_name=\"user_id\" related_by_field_id=\"91\"/>")
-          "a ref with no description renders no description attribute")))
-  (testing "a long related-table-ref description is capped and gets an ellipsis"
+               (assoc base-table-with-related
+                      :related_tables_without_fields [{:id 22 :name "reviews" :database_schema "public"
+                                                       :related_by {:id 93 :name "review_id"}
+                                                       :description "All the reviews customers left"}
+                                                      {:id 21 :name "people" :database_schema "public"
+                                                       :related_by {:id 91 :name "user_id"}}]))]
+      (is (str/includes? xml "All the reviews customers left")
+          "the description renders inside the <related-table> element")
+      (is (str/includes? xml (str "<related-table id=\"21\" name=\"people\" related_by_field_name=\"user_id\" "
+                                  "related_by_field_id=\"91\" fully_qualified_name=\"public.people\"></related-table>"))
+          "a related table with no description renders no description content")))
+  (testing "a long related-table description is capped and gets an ellipsis"
     (let [long-desc (apply str (repeat 600 "x"))
-          cap-len   @#'llm-shape/max-related-table-ref-description-length
+          cap-len   @#'llm-shape/max-related-table-description-length
           xml       (llm-shape/table->xml
-                     (assoc base-table-with-truncated-related
-                            :related_table_refs [{:id 22 :name "reviews" :related_by {:id 93 :name "review_id"}
-                                                  :description long-desc}]))]
-      (is (str/includes? xml (str "description=\"" (apply str (repeat cap-len "x")) "...\"")))
+                     (assoc base-table-with-related
+                            :related_tables_without_fields [{:id 22 :name "reviews" :database_schema "public"
+                                                             :related_by {:id 93 :name "review_id"}
+                                                             :description long-desc}]))]
+      (is (str/includes? xml (str (apply str (repeat cap-len "x")) "..."))
+          "the description is rendered truncated to the cap with an ellipsis")
       (is (not (str/includes? xml (apply str (repeat (inc cap-len) "x"))))
           "the description is truncated to the cap before the ellipsis"))))
 
-(deftest ^:parallel table->xml-related-tables-roster-truncation-test
-  (testing "when the refs is capped, the note says so"
-    (let [xml (llm-shape/table->xml (assoc base-table-with-truncated-related
-                                           :related_tables_total 99))]
-      (is (str/includes? xml "itself truncated: 96 more related tables exist")
-          (str "the note reports related tables neither shown in detail nor listed in the roster "
-               "(total 99 minus the 1 shown minus the 2 listed refs)")))))
+(deftest ^:parallel table->xml-related-tables-total-truncation-test
+  (testing "when more FK-related tables exist than were surfaced, a <related-tables-truncated> note reports the totals"
+    (let [xml (llm-shape/table->xml base-table-with-related)] ; surfaced 3, total 5
+      (is (str/includes? xml "<related-tables-truncated surfaced=\"3\" total=\"5\">"))
+      (is (str/includes? xml "more FK-related tables than the 3 shown here"))))
+  (testing "no truncation note when every FK-related table was surfaced"
+    (let [xml (llm-shape/table->xml (assoc base-table-with-related :related_tables_total 3))] ; surfaced 3, total 3
+      (is (not (str/includes? xml "<related-tables-truncated"))
+          "surfacing the full set leaves no tables dropped, so no truncation note"))))
 
-(deftest ^:parallel table->xml-no-truncation-note-test
-  (testing "an un-truncated related-tables list renders no truncation note"
+(deftest ^:parallel table->xml-no-related-notes-test
+  (testing "when every related table fits under the caps, neither a fields-omitted nor a truncated note appears"
     (let [xml (llm-shape/table->xml {:id 10 :name "orders" :database_id 1 :database_engine "postgres"
                                      :database_schema "public"
-                                     :related_tables [{:id 20 :name "products"
-                                                       :fully_qualified_name "public.products"
+                                     :related_tables [{:id 20 :name "products" :database_schema "public"
                                                        :related_by {:id 92 :name "product_id"} :fields []}]})]
       (is (str/includes? xml "<related-table id=\"20\""))
-      (is (not (str/includes? xml "<related-tables-truncated")))
-      (is (not (str/includes? xml "<related-table-ref"))))))
+      (is (not (str/includes? xml "<related-tables-fields-omitted")))
+      (is (not (str/includes? xml "<related-tables-truncated"))))))
 
-(deftest ^:parallel model->xml-related-tables-truncation-test
-  (testing "model related-tables truncation renders the same truncation note + roster as tables"
-    (let [xml (llm-shape/model->xml (assoc base-table-with-truncated-related :name "orders_model"))]
-      (is (str/includes? xml "<related-tables-truncated"))
-      (is (str/includes? xml "<related-table-ref id=\"21\" name=\"people\" related_by_field_name=\"user_id\" related_by_field_id=\"91\"/>")))))
+(deftest ^:parallel model->xml-related-tables-test
+  (testing "model related-tables render the same fields-omitted + truncated notes as tables"
+    (let [xml (llm-shape/model->xml (assoc base-table-with-related :name "orders_model"))]
+      (is (str/includes? xml "<related-tables-fields-omitted>"))
+      (is (str/includes? xml "<related-table id=\"21\" name=\"people\""))
+      (is (str/includes? xml "<related-tables-truncated surfaced=\"3\" total=\"5\">")))))
 
 (deftest ^:parallel table->xml-related-by-field-id-test
   (testing (str "a `{:id :name}` `related_by` renders symmetric `related_by_field_name` + `related_by_field_id` "
@@ -814,18 +832,18 @@
                 "fields with the same name -> the same table)")
     (let [xml (llm-shape/table->xml
                {:id 10 :name "orders" :database_id 1 :database_engine "postgres" :database_schema "public"
-                :related_tables [{:id 20 :name "products" :fully_qualified_name "public.products"
+                :related_tables [{:id 20 :name "products" :database_schema "public"
                                   :related_by {:id 101 :name "product_id"} :fields []}
-                                 {:id 20 :name "products" :fully_qualified_name "public.products"
+                                 {:id 20 :name "products" :database_schema "public"
                                   :related_by {:id 202 :name "product_id"} :fields []}]
-                :related_tables_total 3
-                :related_table_refs [{:id 21 :name "people" :related_by {:id 303 :name "user_id"}}
-                                     {:id 22 :name "reviews" :related_by {:id 404 :name "review_id"}}]})]
-      (testing "detailed related tables render both the FK field name and id"
+                :related_tables_without_fields [{:id 21 :name "people" :database_schema "public"
+                                                 :related_by {:id 303 :name "user_id"}}
+                                                {:id 22 :name "reviews" :database_schema "public"
+                                                 :related_by {:id 404 :name "review_id"}}]
+                :related_tables_total 5})]
+      (testing "column-bearing related tables render both the FK field name and id"
         (is (str/includes? xml "related_by_field_name=\"product_id\" related_by_field_id=\"101\""))
         (is (str/includes? xml "related_by_field_name=\"product_id\" related_by_field_id=\"202\"")))
-      (testing "roster refs render both the FK field name and id"
-        (is (str/includes? xml
-                           "<related-table-ref id=\"21\" name=\"people\" related_by_field_name=\"user_id\" related_by_field_id=\"303\"/>"))
-        (is (str/includes? xml
-                           "<related-table-ref id=\"22\" name=\"reviews\" related_by_field_name=\"review_id\" related_by_field_id=\"404\"/>"))))))
+      (testing "identity-only related tables render both the FK field name and id"
+        (is (str/includes? xml "related_by_field_name=\"user_id\" related_by_field_id=\"303\""))
+        (is (str/includes? xml "related_by_field_name=\"review_id\" related_by_field_id=\"404\""))))))

--- a/test/metabase/metabot/tools/shared/llm_shape_test.clj
+++ b/test/metabase/metabot/tools/shared/llm_shape_test.clj
@@ -735,3 +735,51 @@
   (testing "falls back to pr-str for unknown types"
     (let [result (llm-shape/entity->xml {:type :unknown :data "test"})]
       (is (str/includes? result ":type")))))
+
+(def ^:private base-table-with-truncated-related
+  {:id 10
+   :name "orders"
+   :database_id 1
+   :database_engine "postgres"
+   :database_schema "public"
+   :related_tables [{:id 20 :name "products" :fully_qualified_name "public.products"
+                     :related_by "product_id" :fields []}]
+   :related_tables_truncated true
+   :related_tables_total 99
+   :related_table_refs [{:id 20 :name "products" :related_by "product_id"}
+                        {:id 21 :name "people" :related_by "user_id"}]})
+
+(deftest ^:parallel table->xml-related-tables-truncation-test
+  (testing "a capped related-tables list renders a truncation note plus a roster of related-table ids/names"
+    (let [xml (llm-shape/table->xml base-table-with-truncated-related)]
+      (is (str/includes? xml "<related-table id=\"20\"")
+          "the detailed related table is still rendered")
+      (is (str/includes? xml "<related-tables-truncated")
+          "a truncation marker tells the LLM the list is incomplete")
+      (is (str/includes? xml "total=\"99\""))
+      (is (str/includes? xml "<related-table-ref id=\"20\" name=\"products\" related_by=\"product_id\"/>"))
+      (is (str/includes? xml "<related-table-ref id=\"21\" name=\"people\" related_by=\"user_id\"/>")
+          "the roster lists every related table by id/name so the LLM can look them up"))))
+
+(deftest ^:parallel table->xml-related-tables-roster-truncation-test
+  (testing "when the roster itself is capped, the note says so"
+    (let [xml (llm-shape/table->xml (assoc base-table-with-truncated-related
+                                           :related_table_refs_truncated true))]
+      (is (str/includes? xml "itself truncated")))))
+
+(deftest ^:parallel table->xml-no-truncation-note-test
+  (testing "an un-truncated related-tables list renders no truncation note"
+    (let [xml (llm-shape/table->xml {:id 10 :name "orders" :database_id 1 :database_engine "postgres"
+                                     :database_schema "public"
+                                     :related_tables [{:id 20 :name "products"
+                                                       :fully_qualified_name "public.products"
+                                                       :related_by "product_id" :fields []}]})]
+      (is (str/includes? xml "<related-table id=\"20\""))
+      (is (not (str/includes? xml "<related-tables-truncated")))
+      (is (not (str/includes? xml "<related-table-ref"))))))
+
+(deftest ^:parallel model->xml-related-tables-truncation-test
+  (testing "model related-tables truncation renders the same truncation note + roster as tables"
+    (let [xml (llm-shape/model->xml (assoc base-table-with-truncated-related :name "orders_model"))]
+      (is (str/includes? xml "<related-tables-truncated"))
+      (is (str/includes? xml "<related-table-ref id=\"21\" name=\"people\" related_by=\"user_id\"/>")))))

--- a/test/metabase/metabot/tools/shared/llm_shape_test.clj
+++ b/test/metabase/metabot/tools/shared/llm_shape_test.clj
@@ -787,7 +787,8 @@
   (testing "when the roster itself is capped, the note says so"
     (let [xml (llm-shape/table->xml (assoc base-table-with-truncated-related
                                            :related_table_refs_truncated true))]
-      (is (str/includes? xml "itself truncated")))))
+      (is (str/includes? xml "itself truncated: 97 more related tables exist")
+          "the note reports how many related tables were truncated (total 99 minus the 2 shown)"))))
 
 (deftest ^:parallel table->xml-no-truncation-note-test
   (testing "an un-truncated related-tables list renders no truncation note"


### PR DESCRIPTION
relates to #76493
relates to [BOT-1725: MetaBot context build OOMs on databases with very large table counts](https://linear.app/metabase/issue/BOT-1725/metabot-context-build-ooms-on-databases-with-very-large-table-counts)

### Description

Limit metabot FK related-tables to bound context size and memory usage.

When metabot builds the LLM context for a query, it expands the FK-related tables of each used table and fetches and formats that table's full column set. The work and memory for a single used table scales as `(#FK columns) × (target table width) + (source table width)`. Because the whole request runs under one metadata-provider cache, all of that fetched metadata is pinned and cannot be GC'd mid-render, exhausting the JVM heap (metabase#76493).

This PR introduces limits on the `max-related-tables` (50) and `max-related-tables-with-fields` (10) in `metabase.metabot.tools.entity-details/related-tables` and any of it's callers, e.g. `get-table-details`, `get-card-details`, etc. 

- `max-related-tables-with-fields` (10) number of FK-related tables expanded with their full column set.
- `max-related-tables` (50) total number of FK-related tables surfaced (with or without fields).
- `fk-related-table-groups` enumerates FK paths from the source table's own FK columns and does a single bulk lookup of just the target fields, so these can be split into with/without-fields groups. This saves lookup and caching of the full visible-columns set for any paths in the without-fields group.
- Both lists render through the same `<related-table>` element.
  - `:related_tables_without_fields` are grouped under a `<related-tables-fields-omitted>` note. the agent is encouraged to execute a separate tool call to read the field metadata, if needed.
  - a `<related-tables-truncated>` note appears when tables were dropped entirely.
  - fixed an unrelated bug where `<related-table>` always emitted `fully_qualified_name=""`

### Results

Reproduced against a local Postgres warehouse with a highly-connected table with 200 FKs (`hub_200`).

| Metric (for one used table, `hub_200`) | Before fix | After fix |
|---|---|---|
| Columns formatted | 20,411 | 1,221 |
| XML size | 2.03 MB | ~131 KB |
| Format time | ~53 s | ~3 s |
| Heap pinned | ~68 MB | ~4MB |
| Prompt size | ~500K+ tokens | ~56K tokens |
| End-to-end turn | OOMs | Success |

### Benchmarks (reference is master @ c446d690c4b7)
<img width="1539" height="386" alt="Screenshot 2026-06-29 at 4 31 49 PM" src="https://github.com/user-attachments/assets/73bad7c2-1ae4-4ee6-847a-733386f73d61" />

### Follow-ups

This PR bounds the number of related-tables fetched and presented in the context when viewing a saved question or executing the `read_resource` tool, but there are other similar paths that can contribute to OOM on very large tables . These will be investigated / addressed in follow up PRs

- similar fix for `metabase.metabot.table-utils/enhanced-database-tables` which is used by metabot to populate the context for native queries
- bounding the number of fields per table
- potentially using a bounded metadata provider cache, or else disabling or clearing the cache between tables

### How to verify

1. Create a table with a large number of foreign keys
2. Create and save a new notebook question based on that table
3. While viewing the saved question, open the metabot chat sidebar and ask it a question like "What can you tell me about this saved question?"
4. No OOM (e.g. when running in docker with limited ~3GB RAM)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
