### PR TITLE
add content diagnostics backend for stale API

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2957,6 +2957,12 @@
    :api  #{}
    :uses #{premium-features}}
 
+  enterprise/content-diagnostics
+  {:team "Gadget"
+   :api  #{metabase-enterprise.content-diagnostics.api
+           metabase-enterprise.content-diagnostics.init}
+   :uses :any} ;; `:any` is broad; enumerate `:uses` once the module's deps settle
+
   enterprise/content-translation
   {:team "UX West"
    :api  #{metabase-enterprise.content-translation.routes}
@@ -3535,7 +3541,10 @@
 
   enterprise/stale
   {:team "UX West"
+   ;; stale.impl/find-candidates is the exported staleness-rule entry point (incl. the instance-wide
+   ;; `:collection-ids :all` arity) reused by Content Diagnostics — one source of truth for the rule.
    :api  #{metabase-enterprise.stale.api
+           metabase-enterprise.stale.impl
            metabase-enterprise.stale.init}
    :uses #{analytics
            api

--- a/enterprise/backend/src/metabase_enterprise/api_routes/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/api_routes/routes.clj
@@ -14,6 +14,7 @@
    [metabase-enterprise.billing.api.routes]
    [metabase-enterprise.cloud-add-ons.api]
    [metabase-enterprise.cloud-proxy.api]
+   [metabase-enterprise.content-diagnostics.api]
    [metabase-enterprise.content-translation.routes]
    [metabase-enterprise.content-verification.api.routes]
    [metabase-enterprise.custom-viz-plugin.api]
@@ -57,6 +58,7 @@
    :attached-dwh               (deferred-tru "Attached DWH")
    :audit-app                  (deferred-tru "Audit app")
    :collection-cleanup         (deferred-tru "Collection Cleanup")
+   :content-diagnostics          (deferred-tru "Content Diagnostics")
    :content-translation        (deferred-tru "Content translation")
    :custom-viz                 (deferred-tru "Custom Visualizations")
    :library                    (deferred-tru "Library")
@@ -106,6 +108,9 @@
    "/ai-controls"                  (premium-handler metabase-enterprise.metabot.api.routes/routes :ai-controls)
    "/audit-app"                    (premium-handler metabase-enterprise.audit-app.api.routes/routes :audit-app)
    "/billing"                      metabase-enterprise.billing.api.routes/routes
+   ;; Content Diagnostics — Dependency-Diagnostics access model: +auth + premium feature gate (not
+   ;; superuser-only).
+   "/content-diagnostics"            (premium-handler metabase-enterprise.content-diagnostics.api/routes :content-diagnostics)
    "/content-translation"          (premium-handler metabase-enterprise.content-translation.routes/routes :content-translation)
    "/custom-viz-plugin"            (premium-handler metabase-enterprise.custom-viz-plugin.api/routes :custom-viz)
    "/cloud-add-ons"                metabase-enterprise.cloud-add-ons.api/routes

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -1,0 +1,96 @@
+(ns metabase-enterprise.content-diagnostics.api
+  "Content Diagnostics API. Mounted under `premium-handler … :content-diagnostics` (feature-gated) — see
+  `api_routes/routes.clj`. Exposes a synchronous **demo-only** `/scan` trigger and a paginated,
+  batch-hydrated latest-per-entity finding list."
+  (:require
+   [metabase-enterprise.content-diagnostics.detect :as detect]
+   [metabase.api.macros :as api.macros]
+   [metabase.api.routes.common :refer [+auth]]
+   [metabase.request.core :as request]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- latest-per-entity-ids
+  "Subquery selecting the id of the most-recent finding for each (entity_type, entity_id, finding_type).
+  Recency = MAX(id): id is a monotonic autoincrement, whereas `scan_id` is a random UUID and cannot be
+  ordered by recency. Portable across every app-db engine (h2/mysql/postgres) — plain MAX + GROUP BY,
+  no `DISTINCT ON`/window functions. Serving latest-per-entity (rather than only the single newest
+  `scan_id`) keeps results coherent under chunk-committed/partial scans: an entity the newest scan
+  hasn't re-written yet still shows its last known finding instead of vanishing."
+  []
+  {:select   [[[:max :id] :id]]
+   :from     [(t2/table-name :model/ContentDiagnosticsFinding)]
+   :group-by [:entity_type :entity_id :finding_type]})
+
+(defn- active-where
+  "Predicate for the served set: the latest finding per entity, excluding any whose latest row was
+  invalidated (`stale = true`). Picking MAX(id) over *all* rows then filtering `stale = false` means an
+  invalidated latest row hides the entity, and an older non-stale row does NOT resurface."
+  []
+  [:and
+   [:= :stale false]
+   [:in :id (latest-per-entity-ids)]])
+
+;;; ------------------------------------------- display hydration ---------------------------------------
+;;; Display fields (entity name + current collection) are hydrated live (always-current), batched per
+;;; entity-type — NOT per row. One `IN`-query per entity-type on the page replaces the old per-row N+1.
+
+(defn- display-fields
+  "{entity-id → {:name … :collection_id …}} for one entity-type's id set, in a single query."
+  [entity-type ids]
+  (when-let [model (detect/entity-type->model entity-type)]
+    (t2/select-pk->fn #(select-keys % [:name :collection_id])
+                      [model :id :name :collection_id]
+                      :id [:in ids])))
+
+(defn- hydrate-display
+  "Add :name + :collection_id to each finding via ≤1 query per entity-type (page-size-independent)."
+  [findings]
+  (let [lookup (into {} (for [[etype rows] (group-by :entity_type findings)]
+                          [etype (display-fields etype (map :entity_id rows))]))]
+    (mapv (fn [{:keys [entity_type entity_id] :as finding}]
+            (let [fields (get-in lookup [entity_type entity_id])]
+              (assoc finding
+                     :name          (:name fields)
+                     :collection_id (:collection_id fields))))
+          findings)))
+
+;;; ------------------------------------------------ endpoints ------------------------------------------
+
+(api.macros/defendpoint :post "/scan"
+  :- [:map
+      [:scan_id          :string]
+      [:finding_count    :int]
+      [:entities_scanned :int]
+      [:duration_ms      :int]]
+  "Run a scan **synchronously** and return its topline. Demo/dev-only — the production trigger is the
+  scheduled Quartz job. Synchronous (calls `detect/scan!` directly, not `trigger-now!`) so it works with
+  the scheduler disabled (`MB_DISABLE_SCHEDULER=true`)."
+  []
+  (detect/scan!))
+
+(api.macros/defendpoint :get "/finding"
+  :- [:map
+      [:data   [:sequential :map]]
+      [:total  :int]
+      [:limit  [:maybe :int]]
+      [:offset [:maybe :int]]]
+  "List active findings — the latest non-invalidated finding per (entity, finding-type) across all scans.
+  Paginated via the standard `limit`/`offset` query params; `total` is the full active count. Display
+  fields (name, collection) are batch-hydrated live."
+  []
+  (let [where (active-where)
+        page  (t2/select :model/ContentDiagnosticsFinding
+                         (cond-> {:where    where
+                                  :order-by [[:finding_type :asc] [:id :asc]]}
+                           (request/limit)  (assoc :limit (request/limit))
+                           (request/offset) (assoc :offset (request/offset))))]
+    {:data   (hydrate-display page)
+     :total  (t2/count :model/ContentDiagnosticsFinding {:where where})
+     :limit  (request/limit)
+     :offset (request/offset)}))
+
+(def ^{:arglists '([request respond raise])} routes
+  "Ring routes for the Content Diagnostics API."
+  (api.macros/ns-handler *ns* +auth))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/detect.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/detect.clj
@@ -1,0 +1,146 @@
+(ns metabase-enterprise.content-diagnostics.detect
+  "Content Diagnostics scan pipeline. A scan runs every registered *checker* instance-wide, writes one
+  `scan_id` batch of findings, and emits o11y signals (duration + outcome + magnitude).
+
+  The `stale` checker reuses the EE stale module's candidate query via its instance-wide
+  (`:collection-ids :all`) arity — one source of truth for the staleness rule, no copy."
+  (:require
+   [clojure.set :as set]
+   [java-time.api :as t]
+   [medley.core :as m]
+   [metabase-enterprise.content-diagnostics.models.finding :as finding]
+   [metabase-enterprise.content-diagnostics.settings :as cd.settings]
+   ;; sanctioned export: find-candidates is the stale module's public staleness-rule entry point
+   ;; (see enterprise/stale :api in .clj-kondo/config/modules/config.edn).
+   [metabase-enterprise.stale.impl :as stale.impl]
+   [metabase.analytics-interface.core :as analytics]
+   [metabase.util :as u]
+   [metabase.util.log :as log]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:const detector-version
+  "Bump when a checker's logic/threshold changes so the next scan supersedes older-version findings."
+  1)
+
+(def entity-type->model
+  "Content Diagnostics entity-types → their Toucan models. Single source of truth: the API's display
+  hydration and the scan's candidate→finding mapping both derive from this (inverse below)."
+  {:card      :model/Card
+   :dashboard :model/Dashboard})
+
+(def ^:private model->entity-type
+  "Inverse of [[entity-type->model]] — `find-candidates` returns `:model` keywords like `:model/Card`."
+  (set/map-invert entity-type->model))
+
+;;; ---------------------------------------------- checkers ----------------------------------------------
+;;; A checker is a 0-arg fn returning a seq of finding maps:
+;;;   {:entity-type <kw> :entity-id <int> :finding-type <kw> :details <map>}
+
+(defn stale-checker
+  "Instance-wide stale Card/Dashboard candidates as finding maps (reuses the EE stale module)."
+  []
+  (let [threshold (cd.settings/content-diagnostics-stale-threshold-days)
+        cutoff    (t/minus (t/local-date) (t/days threshold))
+        {:keys [rows]} (stale.impl/find-candidates
+                        {:collection-ids :all
+                         :cutoff-date    cutoff
+                         :limit          nil
+                         :offset         nil
+                         :sort-column    :name
+                         :sort-direction :asc})]
+    (for [{:keys [id model]} rows
+          :let  [et (model->entity-type model)]
+          :when et]
+      {:entity-type  et
+       :entity-id    id
+       :finding-type :stale
+       :details      {:threshold_days threshold}})))
+
+(def checkers
+  "Ordered checker registry. Each entry **declares** the finding-types it owns and a 0-arg `:run` fn
+  returning finding maps. Declaring the types (rather than inferring them from a scan's output) is what
+  lets post-scan invalidation know its supersession scope even when a scan emits **zero** rows — i.e. an
+  all-clean scan still resolves the previous scan's findings."
+  [{:finding-types #{:stale} :run stale-checker}])
+
+(defn covered-finding-types
+  "The set of finding-types the registered checkers own — the supersession scope for post-scan invalidation."
+  []
+  (into #{} (mapcat :finding-types) checkers))
+
+(defn detect
+  "Run every checker instance-wide and return one realized, de-duplicated vector of finding maps.
+  `m/distinct-by` is a memoized seen-set transducer: it remembers each (entity-type, entity-id,
+  finding-type) tuple and silently drops the second occurrence as it streams through. A checker — or
+  the stale query's one-to-many joins (e.g. a card with several `pulse_card` rows) — can surface the
+  same finding twice; this is the app-layer guarantee that no intra-scan duplicate ever reaches the DB."
+  []
+  (into []
+        (m/distinct-by (juxt :entity-type :entity-id :finding-type))
+        (mapcat (fn [checker] ((:run checker))) checkers)))
+
+;;; ----------------------------------------------- scan ------------------------------------------------
+
+(defn- count-scannable
+  "Size of the candidate universe the checkers swept (non-archived Cards + Dashboards) — the denominator
+  for the findings/entities topline."
+  []
+  (+ (t2/count :model/Card :archived false)
+     (t2/count :model/Dashboard :archived false)))
+
+(def ^:private insert-batch-size
+  "Rows per INSERT. Postgres caps a prepared statement at 65,535 bind parameters; at ~6 columns/row a
+  single all-rows insert overflows past ~10k findings (observed on the stats DB). 1000 keeps us well
+  under (mirrors `mark-stale-batch-size` in the deps module)."
+  1000)
+
+(defn- insert-findings!
+  "Persist findings as independent **chunk-committed** transactions — each chunk is its own transaction,
+  so completed chunks are durable even if a later chunk fails (no single all-rows transaction held open
+  for the whole scan). Chunking also keeps each statement under the bind-parameter cap. This is safe to
+  serve mid-write because the serve layer reads latest-per-entity (`api/active-findings`), so a partial
+  batch degrades gracefully rather than blanking out un-written entities."
+  [scan-id findings]
+  (doseq [chunk (partition-all insert-batch-size findings)]
+    (t2/with-transaction [_conn]
+      (t2/insert! :model/ContentDiagnosticsFinding
+                  (for [{:keys [entity-type entity-id finding-type details]} chunk]
+                    {:scan_id          scan-id
+                     :entity_type      entity-type
+                     :entity_id        entity-id
+                     :finding_type     finding-type
+                     :detector_version detector-version
+                     :details          details})))))
+
+(defn scan!
+  "Run a full scan synchronously: every checker → one `scan_id` batch → persisted. Emits scan o11y
+  (duration histogram, outcome counter, findings/entities gauges). Returns
+  `{:scan_id :finding_count :entities_scanned :duration_ms}`."
+  []
+  (let [timer (u/start-timer)]
+    (try
+      (let [scan-id  (str (random-uuid))
+            findings (detect)
+            entities (count-scannable)]
+        (insert-findings! scan-id findings)
+        ;; write-side resolution: supersede prior-scan findings the new batch didn't re-emit. Runs after
+        ;; the batch commits and only on success — a failed scan leaves prior findings served (last-known).
+        (finding/invalidate-superseded! scan-id (covered-finding-types))
+        (let [duration (u/since-ms timer)]
+          (analytics/observe! :metabase-content-diagnostics/scan-duration-ms {:status "ok"} duration)
+          (analytics/inc!     :metabase-content-diagnostics/scans            {:status "ok"})
+          (analytics/set-gauge! :metabase-content-diagnostics/scan-findings (count findings))
+          (analytics/set-gauge! :metabase-content-diagnostics/scan-entities entities)
+          (log/infof "Content Diagnostics scan %s: %d findings over %d entities in %.0f ms"
+                     scan-id (count findings) entities (double duration))
+          {:scan_id          scan-id
+           :finding_count    (count findings)
+           :entities_scanned entities
+           :duration_ms      (long duration)}))
+      (catch Throwable t
+        (analytics/observe! :metabase-content-diagnostics/scan-duration-ms {:status "error"} (u/since-ms timer))
+        (analytics/inc!     :metabase-content-diagnostics/scans            {:status "error"})
+        (log/error t "Content Diagnostics scan failed")
+        (throw t)))))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/init.clj
@@ -1,0 +1,7 @@
+(ns metabase-enterprise.content-diagnostics.init
+  "Loader for the Content Diagnostics module — pulls in settings, models, and the scan task so their
+  `defsetting` / model registrations / `task/init!` method are registered at startup."
+  (:require
+   [metabase-enterprise.content-diagnostics.models.finding]
+   [metabase-enterprise.content-diagnostics.settings]
+   [metabase-enterprise.content-diagnostics.task]))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/models/finding.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/models/finding.clj
@@ -1,0 +1,44 @@
+(ns metabase-enterprise.content-diagnostics.models.finding
+  "Toucan model for `content_diagnostics_finding` — a detected problem for one entity, from one scan run.
+  Scan-snapshot, latest-wins; `stale` evicts a finding once its entity is fixed (invalidate-on-fix)."
+  (:require
+   [metabase.models.interface :as mi]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(methodical/defmethod t2/table-name :model/ContentDiagnosticsFinding [_model] :content_diagnostics_finding)
+
+(doto :model/ContentDiagnosticsFinding
+  (derive :metabase/model))
+
+(t2/deftransforms :model/ContentDiagnosticsFinding
+  {:entity_type  mi/transform-keyword
+   :finding_type mi/transform-keyword
+   :details      mi/transform-json})
+
+(defn invalidate-finding!
+  "Evict a finding because its entity was fixed/changed (§8A.2 invalidate-on-fix)."
+  [finding-id]
+  (t2/update! :model/ContentDiagnosticsFinding finding-id {:stale true :invalidated_at (mi/now)}))
+
+(defn reactivate-finding!
+  "Reverse an invalidation — used when a fix is undone, so the restored problem reappears."
+  [finding-id]
+  (when finding-id
+    (t2/update! :model/ContentDiagnosticsFinding finding-id {:stale false :invalidated_at nil})))
+
+(defn invalidate-superseded!
+  "Write-side resolution after a scan commits its fresh batch: soft-invalidate (set `stale = true`, stamp
+  `invalidated_at`) every still-active finding of `finding-types` that came from a *prior* scan. Entities
+  the new scan re-flagged keep a newer active row (served via latest-per-entity); entities it no longer
+  flags have only their now-invalidated older rows and so drop out of the served set — this is what makes
+  resolution work once serve switched from latest-scan-only to latest-per-entity. **Soft, not a hard
+  delete** — the invalidated row is kept and flagged, never removed. Filtering on `stale false` keeps it
+  idempotent and preserves the original `invalidated_at` on already-stale rows."
+  [scan-id finding-types]
+  (when (seq finding-types)
+    (t2/update! :model/ContentDiagnosticsFinding
+                {:scan_id      [:not= scan-id]
+                 :finding_type [:in finding-types]
+                 :stale        false}
+                {:stale true :invalidated_at (mi/now)})))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/settings.clj
@@ -1,0 +1,13 @@
+(ns metabase-enterprise.content-diagnostics.settings
+  (:require
+   [metabase.settings.core :refer [defsetting]]
+   [metabase.util.i18n :refer [deferred-tru]]))
+
+(defsetting content-diagnostics-stale-threshold-days
+  (deferred-tru "Content unused beyond this many days is flagged stale by the Content Diagnostics.")
+  :encryption :no
+  :visibility :admin
+  :default    90
+  :type       :positive-integer
+  :export?    false
+  :doc        false)

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/task.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/task.clj
@@ -1,0 +1,45 @@
+(ns metabase-enterprise.content-diagnostics.task
+  "Quartz job for the Content Diagnostics scan. The job is stored durably so it can be triggered on demand
+  as a one-off run rather than scanning inline."
+  (:require
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.schedule.cron :as cron]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [metabase-enterprise.content-diagnostics.detect :as detect]
+   [metabase.task.core :as task])
+  (:import
+   (org.quartz DisallowConcurrentExecution)))
+
+(set! *warn-on-reflection* true)
+
+(def scan-job-key
+  "Quartz key for the Content Diagnostics scan job."
+  (jobs/key "metabase.task.content-diagnostics-scan.job"))
+
+(def ^:private scan-trigger-key
+  (triggers/key "metabase.task.content-diagnostics-scan.trigger"))
+
+(task/defjob ^{DisallowConcurrentExecution true
+               :doc                         "Content Diagnostics — scan for problematic content."}
+  ContentDiagnosticsScan [_ctx]
+  (detect/scan!))
+
+(defn trigger-scan!
+  "Enqueue an immediate one-off run of the scan job (runs on a Quartz worker, not inline)."
+  []
+  (task/trigger-now! scan-job-key))
+
+(defmethod task/init! ::ContentDiagnosticsScan [_]
+  (let [job     (jobs/build
+                 (jobs/of-type ContentDiagnosticsScan)
+                 (jobs/store-durably)
+                 (jobs/with-identity scan-job-key)
+                 (jobs/with-description "Content Diagnostics scan"))
+        trigger (triggers/build
+                 (triggers/with-identity scan-trigger-key)
+                 (triggers/for-job scan-job-key)
+                 (triggers/with-schedule
+                  (cron/schedule
+                   (cron/cron-schedule "0 0 3 * * ? *")
+                   (cron/with-misfire-handling-instruction-fire-and-proceed))))]
+    (task/schedule-task! job trigger)))

--- a/enterprise/backend/src/metabase_enterprise/core/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/core/init.clj
@@ -10,6 +10,7 @@
    [metabase-enterprise.advanced-config.init]
    [metabase-enterprise.audit-app.init]
    [metabase-enterprise.cache.init]
+   [metabase-enterprise.content-diagnostics.init]
    [metabase-enterprise.curated-search.init]
    [metabase-enterprise.custom-viz-plugin.init]
    [metabase-enterprise.data-complexity-score.init]

--- a/enterprise/backend/src/metabase_enterprise/stale/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/stale/impl.clj
@@ -10,7 +10,11 @@
 
 (def ^:private FindStaleContentArgs
   [:map
-   [:collection-ids [:set {:doc "The set of collection IDs to search for stale content."} [:maybe :int]]]
+   ;; Either an explicit set of collection IDs (collection-scoped), or the `:all` sentinel for an
+   ;; instance-wide sweep that omits the collection predicate entirely (used by Content Diagnostics).
+   [:collection-ids [:or
+                     [:= {:doc "Instance-wide sweep — no collection filter."} :all]
+                     [:set {:doc "The set of collection IDs to search for stale content."} [:maybe :int]]]]
    [:cutoff-date [:time/local-date {:doc "The cutoff date for stale content."}]]
    [:limit  [:maybe {:doc "The limit for pagination."} :int]]
    [:offset [:maybe {:doc "The offset for pagination."} :int]]
@@ -52,10 +56,12 @@
              [:= :report_card.enable_embedding false])
            (when (setting/get :enable-public-sharing)
              [:= :report_card.public_uuid nil])
-           [:or
-            (when (contains? (:collection-ids args) nil)
-              [:is :report_card.collection_id nil])
-            [:in :report_card.collection_id (-> args :collection-ids)]]]})
+           ;; instance-wide (`:all`) omits the collection predicate; otherwise scope to the given set.
+           (when-not (= :all (:collection-ids args))
+             [:or
+              (when (contains? (:collection-ids args) nil)
+                [:is :report_card.collection_id nil])
+              [:in :report_card.collection_id (-> args :collection-ids)]])]})
 
 (defmethod find-stale-query :model/Dashboard
   [_model args]
@@ -84,10 +90,12 @@
              [:= :report_dashboard.enable_embedding false])
            (when (setting/get :enable-public-sharing)
              [:= :report_dashboard.public_uuid nil])
-           [:or
-            (when (contains? (:collection-ids args) nil)
-              [:is :report_dashboard.collection_id nil])
-            [:in :report_dashboard.collection_id (-> args :collection-ids)]]]})
+           ;; instance-wide (`:all`) omits the collection predicate; otherwise scope to the given set.
+           (when-not (= :all (:collection-ids args))
+             [:or
+              (when (contains? (:collection-ids args) nil)
+                [:is :report_dashboard.collection_id nil])
+              [:in :report_dashboard.collection_id (-> args :collection-ids)]])]})
 
 (defn- sort-column [column]
   (case column
@@ -139,7 +147,8 @@
   - `:total` (the total count of stale elements that could be found if you iterated through all pages)
   "
   [{:keys [collection-ids] :as args} :- FindStaleContentArgs]
-  (when (contains? collection-ids :root) (throw (ex-info "not implemented." {:collection-ids collection-ids})))
+  (when (and (set? collection-ids) (contains? collection-ids :root))
+    (throw (ex-info "not implemented." {:collection-ids collection-ids})))
   {:rows (into []
                (comp
                 (map #(select-keys % [:id :model]))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -1,0 +1,181 @@
+(ns metabase-enterprise.content-diagnostics.scan-test
+  "The scan pipeline runs the instance-wide `stale` checker, persists a snapshot, and emits
+  o11y signals (duration histogram, outcome counter, findings/entities gauges)."
+  (:require
+   [clojure.set :as set]
+   [clojure.test :refer :all]
+   [java-time.api :as t]
+   [metabase-enterprise.content-diagnostics.detect :as detect]
+   [metabase-enterprise.content-diagnostics.settings :as cd.settings]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(defn- stale-instant []
+  (t/minus (t/offset-date-time) (t/days 365)))
+
+(defn- fresh-instant []
+  (t/offset-date-time))
+
+(deftest scan-detects-stale-and-emits-metrics-test
+  (mt/with-premium-features #{:content-diagnostics}
+    (mt/with-prometheus-system! [_ system]
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (mt/with-temp [:model/Collection {coll-id :id} {}
+                       ;; stale: last activity well past the 90-day threshold
+                       :model/Card      {s1 :id} {:collection_id coll-id :last_used_at (stale-instant)}
+                       :model/Card      {s2 :id} {:collection_id coll-id :last_used_at (stale-instant)}
+                       :model/Card      {s3 :id} {:collection_id coll-id :last_used_at (stale-instant)}
+                       :model/Dashboard {s4 :id} {:collection_id coll-id :last_viewed_at (stale-instant)}
+                       :model/Dashboard {s5 :id} {:collection_id coll-id :last_viewed_at (stale-instant)}
+                       ;; fresh: used just now — must NOT be flagged
+                       :model/Card      {f1 :id} {:collection_id coll-id :last_used_at (fresh-instant)}
+                       :model/Dashboard {f2 :id} {:collection_id coll-id :last_viewed_at (fresh-instant)}]
+          (let [stale-keys #{[:card s1] [:card s2] [:card s3] [:dashboard s4] [:dashboard s5]}
+                fresh-keys #{[:card f1] [:dashboard f2]}
+                result     (detect/scan!)
+                rows       (t2/select :model/ContentDiagnosticsFinding :scan_id (:scan_id result))
+                found-keys (set (map (juxt :entity_type :entity_id) rows))]
+            (testing "scan! returns a topline {scan_id, finding_count, entities_scanned, duration_ms}"
+              (is (string? (:scan_id result)))
+              (is (pos-int? (:finding_count result)))
+              (is (pos-int? (:entities_scanned result)))
+              (is (<= (:finding_count result) (:entities_scanned result)))
+              (is (nat-int? (:duration_ms result))))
+            (testing "every stale temp entity produced a :stale finding; no fresh one did"
+              (is (every? found-keys stale-keys))
+              (is (empty? (set/intersection found-keys fresh-keys))))
+            (testing "persisted findings carry finding_type + detector_version"
+              (let [row (first (filter #(and (= :card (:entity_type %)) (= s1 (:entity_id %))) rows))]
+                (is (= :stale (:finding_type row)))
+                (is (= detect/detector-version (:detector_version row)))
+                ;; derive from the setting, not a literal — a default change must not silently desync
+                (is (= {:threshold_days (cd.settings/content-diagnostics-stale-threshold-days)}
+                       (:details row)))))
+            (testing "duration histogram recorded one ok observation"
+              (is (<= 1 (:count (mt/metric-value system :metabase-content-diagnostics/scan-duration-ms
+                                                 {:status "ok"})))))
+            (testing "outcome counter bumped {status=ok}"
+              (is (pos? (mt/metric-value system :metabase-content-diagnostics/scans {:status "ok"}))))
+            (testing "magnitude gauges match the scan topline"
+              (is (= (double (:finding_count result))
+                     (mt/metric-value system :metabase-content-diagnostics/scan-findings)))
+              (is (= (double (:entities_scanned result))
+                     (mt/metric-value system :metabase-content-diagnostics/scan-entities))))
+            ;; --- record the topline for the run log (println is intentional for human-readable output) ---
+            #_{:clj-kondo/ignore [:discouraged-var]}
+            (let [h (mt/metric-value system :metabase-content-diagnostics/scan-duration-ms {:status "ok"})]
+              (println (str "\n=== Content Diagnostics — stale scan topline ==="
+                            (format "\nfindings:                        %d" (:finding_count result))
+                            (format "\nentities scanned:                %d" (:entities_scanned result))
+                            (format "\nratio:                           %.1f%% of swept entities flagged"
+                                    (* 100.0 (/ (:finding_count result) (double (:entities_scanned result)))))
+                            (format "\nduration (return):               %d ms" (:duration_ms result))
+                            (format "\nduration (prometheus histogram): count=%d sum=%.1f ms"
+                                    (long (:count h)) (double (:sum h)))
+                            "\n===============================================\n")))))))))
+
+(deftest scan-error-path-emits-error-metrics-test
+  (mt/with-premium-features #{:content-diagnostics}
+    (mt/with-prometheus-system! [_ system]
+      (mt/with-dynamic-fn-redefs [detect/detect (fn [] (throw (ex-info "boom" {})))]
+        (is (thrown? Exception (detect/scan!)))
+        (testing "error outcome counter + error duration observation bump"
+          (is (pos? (mt/metric-value system :metabase-content-diagnostics/scans {:status "error"})))
+          (is (<= 1 (:count (mt/metric-value system :metabase-content-diagnostics/scan-duration-ms
+                                             {:status "error"})))))
+        (testing "no ok signal on the error path"
+          (is (zero? (mt/metric-value system :metabase-content-diagnostics/scans {:status "ok"}))))))))
+
+(deftest scan-soft-invalidates-superseded-findings-test
+  (testing "a fresh scan supersedes prior findings it no longer produces — via soft invalidation, not delete"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (mt/with-temp [:model/Collection {coll-id :id} {}
+                       :model/Card {resolved :id} {:collection_id coll-id :last_used_at (stale-instant)}
+                       :model/Card {still :id}    {:collection_id coll-id :last_used_at (stale-instant)}]
+          (detect/scan!)                                            ; scan 1: both stale
+          (t2/update! :model/Card resolved {:last_used_at (fresh-instant)})  ; resolved is now fresh
+          (detect/scan!)                                            ; scan 2: only `still` is stale
+          (let [active (set (map :entity_id (t2/select :model/ContentDiagnosticsFinding
+                                                       :entity_type :card :stale false)))]
+            (testing "the re-flagged card stays active; the resolved one does not"
+              (is (contains? active still))
+              (is (not (contains? active resolved))))
+            (testing "the resolved card's prior finding is soft-invalidated (kept + stale + timestamped), not deleted"
+              (let [rows (t2/select :model/ContentDiagnosticsFinding :entity_type :card :entity_id resolved)]
+                (is (seq rows))                                     ; not hard-deleted — history retained
+                (is (every? :stale rows))
+                (is (every? :invalidated_at rows))))))))))
+
+(deftest serve-latest-per-entity-and-hydration-test
+  (testing "GET /finding serves the latest non-invalidated finding per entity, batch-hydrated"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (mt/with-temp [:model/Collection {coll-id :id} {}
+                       :model/Card {card-id :id} {:collection_id coll-id :name "Quarterly Revenue"}]
+          (let [insert     (fn [scan threshold]
+                             (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                              {:scan_id          scan
+                                                               :entity_type      :card
+                                                               :entity_id        card-id
+                                                               :finding_type     :stale
+                                                               :detector_version 1
+                                                               :details          {:threshold_days threshold}})))
+                old-id     (insert "scan-old" 30)
+                new-id     (insert "scan-new" 90)
+                serve      #(mt/user-http-request :rasta :get 200 "ee/content-diagnostics/finding")
+                served-ids (fn [resp] (set (map :id (:data resp))))]
+            ;; membership assertions (robust to other rows / pagination), not absolute page counts
+            (testing "the latest finding is served, the superseded older one is not — and `total` counts only the latest"
+              (let [resp (serve)
+                    ids  (served-ids resp)]
+                (is (contains? ids new-id))
+                (is (not (contains? ids old-id)))
+                ;; total must exclude the older row even though it is stale=false: it isn't MAX(id) for the entity
+                (is (= 1 (:total resp)))))
+            (testing "the served finding is batch-hydrated with entity name + collection, and details round-trip"
+              (let [row (first (filter #(= new-id (:id %)) (:data (serve))))]
+                (is (= "Quarterly Revenue" (:name row)))
+                (is (= coll-id (:collection_id row)))
+                (is (= 90 (:threshold_days (:details row))))))
+            (testing "invalidating the latest hides the entity AND drops it from total; older row does NOT resurface"
+              (t2/update! :model/ContentDiagnosticsFinding new-id {:stale true})
+              (let [resp (serve)
+                    ids  (served-ids resp)]
+                (is (not (contains? ids new-id)))
+                (is (not (contains? ids old-id)))
+                ;; total excludes the invalidated latest (stale=true), and does not fall back to the older row
+                (is (= 0 (:total resp)))))))))))
+
+(deftest serve-paginates-test
+  (testing "GET /finding honors limit/offset and reports the full active total"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (doseq [eid [970001 970002 970003]]
+          (t2/insert! :model/ContentDiagnosticsFinding
+                      {:scan_id "p" :entity_type :card :entity_id eid
+                       :finding_type :stale :detector_version 1 :details {}}))
+        (let [page (fn [limit offset]
+                     (mt/user-http-request :rasta :get 200 "ee/content-diagnostics/finding"
+                                           :limit limit :offset offset))]
+          (testing "limit caps the page; total reflects the full active set; limit/offset echoed back"
+            (let [r (page 2 0)]
+              (is (= 2 (count (:data r))))
+              (is (= 3 (:total r)))
+              (is (= 2 (:limit r)))
+              (is (= 0 (:offset r)))))
+          (testing "offset advances to the remainder"
+            (is (= 1 (count (:data (page 2 2)))))))))))
+
+(deftest scan-endpoint-is-feature-gated-test
+  (testing "POST /scan runs synchronously for a licensed instance"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [resp (mt/user-http-request :rasta :post 200 "ee/content-diagnostics/scan")]
+          (is (contains? resp :scan_id))
+          (is (contains? resp :finding_count))
+          (is (contains? resp :entities_scanned))
+          (is (contains? resp :duration_ms))))))
+  (testing "without the feature the endpoint is gated (premium-handler)"
+    (mt/with-premium-features #{}
+      (mt/user-http-request :rasta :post 402 "ee/content-diagnostics/scan"))))

--- a/resources/migrations/063/20260616_content_diagnostics.yaml
+++ b/resources/migrations/063/20260616_content_diagnostics.yaml
@@ -1,0 +1,115 @@
+## Content Diagnostics — detected findings snapshot (scan-snapshot, latest-wins).
+## Persisted table: `content_diagnostics_finding`.
+
+databaseChangeLog:
+  - changeSet:
+      id: v63.2026-06-16T00:00:00
+      author: yb
+      comment: Content Diagnostics — content_diagnostics_finding (scan snapshot)
+      changes:
+        - createTable:
+            tableName: content_diagnostics_finding
+            remarks: One detected problem for one entity, from one scan run.
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: scan_id
+                  type: varchar(36)
+                  remarks: Groups all rows from one scan run (UUID). API serves the newest scan.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: entity_type
+                  type: varchar(32)
+                  remarks: Polymorphic — card/dashboard/document/collection/transform. No FK.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: entity_id
+                  type: int
+                  remarks: Polymorphic id of the flagged entity (no FK; paired with entity_type).
+                  constraints:
+                    nullable: false
+              - column:
+                  name: finding_type
+                  type: varchar(32)
+                  remarks: stale/duplicated/empty/crowded/sparse/slow/trash-not-emptied
+                  constraints:
+                    nullable: false
+              - column:
+                  name: detector_version
+                  type: int
+                  defaultValueNumeric: 1
+                  remarks: Detector-logic/threshold version that produced this finding.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: scope_collection_id
+                  type: int
+                  remarks: collection the entity lived in at scan time (filter/sort); no FK
+              - column:
+                  name: details
+                  type: ${text.type}
+                  remarks: JSON evidence — e.g. {threshold_days, last_active_at}
+              - column:
+                  name: detected_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  remarks: When this finding was detected (per-finding freshness signal).
+                  constraints:
+                    nullable: false
+              - column:
+                  name: stale
+                  type: ${boolean.type}
+                  defaultValueBoolean: false
+                  remarks: true = invalidated (entity fixed/changed since scan); evicted from the served set
+                  constraints:
+                    nullable: false
+              - column:
+                  name: invalidated_at
+                  type: ${timestamp_type}
+                  remarks: when invalidated (audit; null = active)
+
+  - changeSet:
+      id: v63.2026-06-16T00:00:01
+      author: yb
+      comment: Content Diagnostics — unique finding per scan (dedup)
+      changes:
+        - addUniqueConstraint:
+            tableName: content_diagnostics_finding
+            columnNames: scan_id, entity_type, entity_id, finding_type
+            constraintName: idx_uniq_cd_finding
+
+  - changeSet:
+      id: v63.2026-06-16T00:00:02
+      author: yb
+      comment: Content Diagnostics — index findings by scan + finding_type
+      changes:
+        - createIndex:
+            tableName: content_diagnostics_finding
+            indexName: idx_cd_finding_scan
+            columns:
+              - column:
+                  name: scan_id
+              - column:
+                  name: finding_type
+
+  - changeSet:
+      id: v63.2026-06-16T00:00:03
+      author: yb
+      comment: Content Diagnostics — index findings by entity
+      changes:
+        - createIndex:
+            tableName: content_diagnostics_finding
+            indexName: idx_cd_finding_entity
+            columns:
+              - column:
+                  name: entity_type
+              - column:
+                  name: entity_id

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -789,7 +789,19 @@
                         :labels [:stage]})
    (prometheus/gauge :metabase-memoize/cache-size
                      {:description "Number of entries currently held in a monitored in-memory memoization cache."
-                      :labels [:cache]})])
+                      :labels [:cache]})
+   ;; content diagnostics scan metrics
+   (prometheus/histogram :metabase-content-diagnostics/scan-duration-ms
+                         {:description "Duration in milliseconds of a Content Diagnostics scan, by outcome."
+                          :labels [:status]
+                          :buckets [100 500 1000 5000 10000 30000 60000 120000 300000 600000]})
+   (prometheus/counter :metabase-content-diagnostics/scans
+                       {:description "Number of Content Diagnostics scans run, by outcome."
+                        :labels [:status]})
+   (prometheus/gauge :metabase-content-diagnostics/scan-findings
+                     {:description "Number of findings produced by the latest successful Content Diagnostics scan."})
+   (prometheus/gauge :metabase-content-diagnostics/scan-entities
+                     {:description "Number of entities swept by the latest successful Content Diagnostics scan."})])
 
 (defn- quartz-collectors
   []

--- a/src/metabase/premium_features/settings.clj
+++ b/src/metabase/premium_features/settings.clj
@@ -239,6 +239,10 @@
   "Should we enable Collection Cleanup?"
   :collection-cleanup)
 
+(define-premium-feature ^{:added "0.59.0"} enable-content-diagnostics?
+  "Should we enable the Content Diagnostics?"
+  :content-diagnostics)
+
 (define-premium-feature ^{:added "0.51.0"} enable-database-auth-providers?
   "Should we enable database auth-providers?"
   :database-auth-providers)
@@ -381,6 +385,7 @@
    :cloud_custom_smtp              (cloud-custom-smtp?)
    :collection_cleanup             (enable-collection-cleanup?)
    :config_text_file               (enable-config-text-file?)
+   :content_diagnostics              (enable-content-diagnostics?)
    :content_translation            (enable-content-translation?)
    :content_verification           (enable-content-verification?)
    :custom-viz                     (enable-custom-viz?)


### PR DESCRIPTION
### Description

Adds finding table, batched scanning logic and the `content-diagnostics/stale` API

### How to verify
  1. Boot the EE backend: clojure -M:dev:dev-start:drivers:drivers-dev:ee:ee-dev, then (dev/start!) in the nREPL.
  2. Enable the new feature — it's brand-new so the standard dev token doesn't grant it. In the nREPL:
  ```
  (let [orig @#'metabase.premium-features.token-check/*token-features*]
    (alter-var-root #'metabase.premium-features.token-check/*token-features*
                    (constantly (fn [] (conj (orig) "content-diagnostics")))))
  ```
  3. Have stale content (scan flags cards/dashboards unused > 90 days). On a fresh DB there's none — age one:
  `(t2/update! :model/Card <id> {:last_used_at #t "2020-01-01T00:00:00Z"})`, or boot against the stats DB which
  already has 13.5k.
  5. Trigger scan via curl -X POST -b
  cookies.txt localhost:3000/api/ee/content-diagnostics/scan or implement a FE button to call that API.


### Demo


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
