### PR TITLE
Restore custom-viz dev plugin source between e2e retries

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
@@ -1425,9 +1425,12 @@ describe("admin > custom visualizations", () => {
     before(() => {
       cy.exec(`mkdir -p ${tmpDir}`);
       cy.log("Build the SDK so we can use the repo-local CLI");
-      cy.exec(`cd "${sdkDir}" && bun install && bun run build`, {
-        timeout: TIMEOUT,
-      });
+      cy.exec(
+        `cd "${sdkDir}" && bun install --frozen-lockfile && bun run build`,
+        {
+          timeout: TIMEOUT,
+        },
+      );
 
       // Scaffold the boilerplate plugin using the init CLI command.
       cy.exec(`rm -rf "${projectDir}"`, { timeout: TIMEOUT });

--- a/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
@@ -1420,6 +1420,15 @@ describe("admin > custom visualizations", () => {
       H.activateToken("bleeding-edge");
       H.updateSetting("csp-img-enabled", true);
       H.updateSetting("custom-viz-enabled", true);
+
+      // Start a fresh dev server for every attempt. The test stops the server as
+      // its final assertion, and `before` does not re-run on a Cypress retry or
+      // during burn-in, so the server must be (re)started per test.
+      cy.task<{ pid: number }>("startCustomVizDevServer", {
+        cwd: projectDir,
+      }).then(({ pid }) => {
+        devServerPid = pid;
+      });
     });
 
     before(() => {
@@ -1488,27 +1497,21 @@ describe("admin > custom visualizations", () => {
       cy.readFile(pluginSrcPath).then((src) => {
         pristineSrc = src;
       });
-
-      // Start the plugin dev server and keep it running
-      cy.task<{ pid: number }>("startCustomVizDevServer", {
-        cwd: projectDir,
-      }).then(({ pid }) => {
-        devServerPid = pid;
-      });
     });
 
     afterEach(() => {
+      // Stop the dev server started in beforeEach. Idempotent: the test may have
+      // already stopped it as part of its final assertion.
+      if (devServerPid != null) {
+        cy.task("stopCustomVizDevServer", devServerPid);
+        devServerPid = null;
+      }
+
+      // Revert any in-test edits to the plugin source so a retry starts from the
+      // scaffolded default ("Above threshold") instead of a mutated label.
       if (pristineSrc != null) {
         cy.writeFile(pluginSrcPath, pristineSrc);
       }
-    });
-
-    after(() => {
-      if (devServerPid == null) {
-        return;
-      }
-
-      cy.task("stopCustomVizDevServer", devServerPid);
     });
 
     it("should load a dev-only plugin from a local dev server URL and use it in a question", () => {

--- a/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
@@ -1412,6 +1412,7 @@ describe("admin > custom visualizations", () => {
     const pluginSrcPath = `${projectDir}/src/index.tsx`;
     const QUESTION_NAME = "Custom Viz Dev Mode Question Test";
     let devServerPid: number | null = null;
+    let pristineSrc: string | null = null;
 
     beforeEach(() => {
       H.restore("postgres-writable");
@@ -1478,12 +1479,25 @@ describe("admin > custom visualizations", () => {
 
       // Install dependencies in the tmp plugin folder.
       cy.exec(`cd "${projectDir}" && npm i`, { timeout: TIMEOUT });
+
+      // Capture the pristine plugin source so we can restore it between
+      // attempts — the test mutates this file (hot-reload check)
+      cy.readFile(pluginSrcPath).then((src) => {
+        pristineSrc = src;
+      });
+
       // Start the plugin dev server and keep it running
       cy.task<{ pid: number }>("startCustomVizDevServer", {
         cwd: projectDir,
       }).then(({ pid }) => {
         devServerPid = pid;
       });
+    });
+
+    afterEach(() => {
+      if (pristineSrc != null) {
+        cy.writeFile(pluginSrcPath, pristineSrc);
+      }
     });
 
     after(() => {


### PR DESCRIPTION
Closes [GDGT-2616](https://linear.app/metabase/issue/GDGT-2616)

### Description

Attempt to de-flake the `development mode > should load a dev-only plugin…` custom-viz e2e test. The change is based on a theory, not a confirmed root cause.

The leading failure mode times out waiting for the `"Above threshold"` image while the DOM already shows `"Way above!"` — a label the test itself writes mid-run when verifying hot reload. The likely cause: the test mutates the scaffolded plugin source (`${projectDir}/src/index.tsx`) in place and never reverts it. Since `before` doesn't re-run on a Cypress retry, a retried attempt probably starts from the already-mutated file and fails the opening assertion. This adds an `afterEach` that restores the pristine source (captured once in `before`, after the clean re-scaffold).

Also switches the SDK `bun install` in the `before` hook to `--frozen-lockfile`, on the theory it trims the occasional 120s setup timeout (the second observed failure mode) by skipping lockfile resolution.

### How to verify

Stress-test the `custom-viz.cy.spec.ts` `development mode` spec and confirm the `"Above threshold"` timeout no longer reproduces.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR