### PR TITLE
Index manager: fix ClickHouse skip-index and Redshift distkey

### DIFF
--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -282,8 +282,7 @@
                              :display-name (deferred-tru "Type")
                              :type         :select
                              :required     true
-                             ;; only the argument-free types: set/ngrambf_v1/tokenbf_v1 need parameters the request
-                             ;; form can't supply yet.
+                             ;; only arg-free types; set/ngrambf_v1/tokenbf_v1 need params the form can't supply yet
                              :options      [{:name (deferred-tru "Min/max")      :value "minmax"}
                                             {:name (deferred-tru "Bloom filter") :value "bloom_filter"}]}
                             driver.common/index-granularity-field]}})

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -282,11 +282,10 @@
                              :display-name (deferred-tru "Type")
                              :type         :select
                              :required     true
-                             :options      [{:name (deferred-tru "Min/max")             :value "minmax"}
-                                            {:name (deferred-tru "Set")                 :value "set"}
-                                            {:name (deferred-tru "Bloom filter")        :value "bloom_filter"}
-                                            {:name (deferred-tru "N-gram bloom filter") :value "ngrambf_v1"}
-                                            {:name (deferred-tru "Token bloom filter")  :value "tokenbf_v1"}]}
+                             ;; only the argument-free types: set/ngrambf_v1/tokenbf_v1 need parameters the request
+                             ;; form can't supply yet.
+                             :options      [{:name (deferred-tru "Min/max")      :value "minmax"}
+                                            {:name (deferred-tru "Bloom filter") :value "bloom_filter"}]}
                             driver.common/index-granularity-field]}})
 
 (defn- order-by-columns

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse/index_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse/index_test.clj
@@ -13,8 +13,6 @@
    [metabase.driver :as driver]
    [metabase.driver.clickhouse :as clickhouse]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
-   [metabase.indexes.requestable-test :as requestable]
-   [metabase.indexes.schema :as schema]
    [metabase.test :as mt]
    [metabase.util.malli.registry :as mr]))
 
@@ -37,13 +35,6 @@
              (map :name (get-in methods [:skip-index :fields]))))
       (is (= #{"minmax" "bloom_filter"}
              (set (map :value (:options type-field))))))))
-
-(deftest ^:parallel every-advertised-option-is-requestable-test
-  (testing "every value ClickHouse advertises in supported-index-methods builds a schema-valid index request"
-    (doseq [[kind {:keys [fields]}] (driver/supported-index-methods :clickhouse nil)
-            body                    (requestable/advertised-bodies kind fields)]
-      (is (mr/validate ::schema/index-structured body)
-          (str kind " body should validate: " (pr-str body))))))
 
 ;;; --- inline ORDER BY at both creation seams ---
 
@@ -84,6 +75,11 @@
             ["ALTER TABLE `events` MATERIALIZE INDEX `idx_a`"]]
            (driver/compile-create-index :clickhouse nil "events"
                                         {:name "idx_a" :columns [{:name "a"}] :type :minmax :granularity 4}))))
+  (testing "bloom_filter (the other arg-free advertised type) renders TYPE bloom_filter, no args"
+    (is (= [["ALTER TABLE `events` ADD INDEX `idx_a` (`a`) TYPE bloom_filter GRANULARITY 4"]
+            ["ALTER TABLE `events` MATERIALIZE INDEX `idx_a`"]]
+           (driver/compile-create-index :clickhouse nil "events"
+                                        {:name "idx_a" :columns [{:name "a"}] :type :bloom_filter :granularity 4}))))
   (testing "type args render, schema qualifies, granularity defaults to 1"
     (is (= [["ALTER TABLE `public`.`events` ADD INDEX `idx_ab` (`a`, `b`) TYPE set(100) GRANULARITY 1"]
             ["ALTER TABLE `public`.`events` MATERIALIZE INDEX `idx_ab`"]]

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse/index_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse/index_test.clj
@@ -13,6 +13,8 @@
    [metabase.driver :as driver]
    [metabase.driver.clickhouse :as clickhouse]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.indexes.requestable-test :as requestable]
+   [metabase.indexes.schema :as schema]
    [metabase.test :as mt]
    [metabase.util.malli.registry :as mr]))
 
@@ -33,8 +35,15 @@
       (is (= ["columns"] (map :name (get-in methods [:order-by :fields]))))
       (is (= ["name" "columns" "type" "granularity"]
              (map :name (get-in methods [:skip-index :fields]))))
-      (is (= #{"minmax" "set" "bloom_filter" "ngrambf_v1" "tokenbf_v1"}
+      (is (= #{"minmax" "bloom_filter"}
              (set (map :value (:options type-field))))))))
+
+(deftest ^:parallel every-advertised-option-is-requestable-test
+  (testing "every value ClickHouse advertises in supported-index-methods builds a schema-valid index request"
+    (doseq [[kind {:keys [fields]}] (driver/supported-index-methods :clickhouse nil)
+            body                    (requestable/advertised-bodies kind fields)]
+      (is (mr/validate ::schema/index-structured body)
+          (str kind " body should validate: " (pr-str body))))))
 
 ;;; --- inline ORDER BY at both creation seams ---
 

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -250,10 +250,10 @@
                           :display-name (deferred-tru "Style")
                           :type         :select
                           :required     true
+                          ;; AUTO is Redshift's default and drifts over time, so it can't be reconciled; not offered.
                           :options      [{:name (deferred-tru "Key")  :value "key"}
                                          {:name (deferred-tru "All")  :value "all"}
-                                         {:name (deferred-tru "Even") :value "even"}
-                                         {:name (deferred-tru "Auto") :value "auto"}]}
+                                         {:name (deferred-tru "Even") :value "even"}]}
                          ;; only the :key style takes a column, so this is not required
                          {:name         "columns"
                           :display-name (deferred-tru "Columns")
@@ -286,20 +286,50 @@
     (when (seq clauses)
       (str/join " " clauses))))
 
-;; Redshift has no secondary indexes; the only physical "indexes" are the inline, unnamed sortkey and the distribution
-;; key, so we override the inherited Postgres `pg_index` query. `svv_redshift_columns.sortkey` is the 1-based position
-;; (negative marks the whole key INTERLEAVED); `distkey` is true on the single KEY-distribution column. Blank `schema`
-;; falls back to `current_schema()`.
+(defn- distkey-index
+  "The distkey entry from a table's declared `reldiststyle` (0 EVEN, 1 KEY, 8 ALL) and KEY column; nil for AUTO (9) or
+  anything else, so only an explicitly-distributed table reports one. Keying on the declared style (not the effective
+  one Redshift drifts AUTO tables toward) keeps a default table from reporting a value that changes underneath us."
+  [reldiststyle key-column]
+  (when-let [style (case (long reldiststyle) 0 "even", 1 "key", 8 "all", nil)]
+    (let [key? (= style "key")]
+      {:name              nil
+       :kind              :distkey
+       :access-method     style
+       :is-unique         false
+       :is-primary        false
+       :is-valid          true
+       :key-columns       (if key? [key-column] [])
+       :include-columns   []
+       :partial-predicate nil
+       :definition        (if key?
+                            (format "DISTSTYLE KEY DISTKEY (%s)" key-column)
+                            (format "DISTSTYLE %s" (u/upper-case-en style)))})))
+
+;; Redshift has no secondary indexes; the only physical "indexes" are the inline, unnamed sortkey and the distribution,
+;; so we override the inherited Postgres `pg_index` query. `svv_redshift_columns.sortkey` is the 1-based position
+;; (negative marks the whole key INTERLEAVED); `distkey` is true on the single KEY-distribution column. The declared
+;; distribution style comes from `pg_class_info`, which (unlike `svv_table_info`) reports even for an empty table.
+;; Blank `schema` falls back to `current_schema()`.
 (defmethod driver/fetch-table-indexes :redshift
   [_driver database schema table]
-  (let [rows      (jdbc/query
-                   (sql-jdbc.conn/db->pooled-connection-spec database)
+  (let [spec      (sql-jdbc.conn/db->pooled-connection-spec database)
+        rows      (jdbc/query
+                   spec
                    [(str "SELECT column_name, sortkey, distkey FROM svv_redshift_columns "
                          "WHERE schema_name = COALESCE(?, current_schema()) AND table_name = ? "
                          "ORDER BY abs(sortkey)")
                     (perf/not-empty schema) table])
         sort-rows (filter (comp (complement zero?) :sortkey) rows)
-        dist-row  (perf/some #(when (:distkey %) %) rows)]
+        key-col   (perf/some #(when (:distkey %) (:column_name %)) rows)
+        diststyle (-> (jdbc/query
+                       spec
+                       [(str "SELECT c.reldiststyle AS reldiststyle FROM pg_class_info c "
+                             "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                             "WHERE n.nspname = COALESCE(?, current_schema()) AND c.relname = ?")
+                        (perf/not-empty schema) table])
+                      first :reldiststyle)
+        distkey   (some-> diststyle (distkey-index key-col))]
     (cond-> []
       (seq sort-rows)
       (conj (let [interleaved? (perf/some (comp neg? :sortkey) sort-rows)
@@ -316,17 +346,7 @@
                :definition        (format "%s SORTKEY (%s)"
                                           (if interleaved? "INTERLEAVED" "COMPOUND")
                                           (str/join ", " columns))}))
-      dist-row
-      (conj {:name              nil
-             :kind              :distkey
-             :access-method     nil
-             :is-unique         false
-             :is-primary        false
-             :is-valid          true
-             :key-columns       [(:column_name dist-row)]
-             :include-columns   []
-             :partial-predicate nil
-             :definition        (format "DISTKEY (%s)" (:column_name dist-row))}))))
+      distkey (conj distkey))))
 
 (defmethod driver/compile-transform :redshift
   [driver {:keys [query output-table indexes] :as transform-details}]

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -287,9 +287,8 @@
       (str/join " " clauses))))
 
 (defn- distkey-index
-  "The distkey entry from a table's declared `reldiststyle` (0 EVEN, 1 KEY, 8 ALL) and KEY column; nil for AUTO (9) or
-  anything else, so only an explicitly-distributed table reports one. Keying on the declared style (not the effective
-  one Redshift drifts AUTO tables toward) keeps a default table from reporting a value that changes underneath us."
+  "The distkey entry from a table's declared `reldiststyle` (0 EVEN, 1 KEY, 8 ALL) and KEY column; nil for AUTO (9) and
+  anything else. Reads the declared style, not the effective one Redshift drifts AUTO tables toward."
   [reldiststyle key-column]
   (when-let [style (case (long reldiststyle) 0 "even", 1 "key", 8 "all", nil)]
     (let [key? (= style "key")]
@@ -306,11 +305,11 @@
                             (format "DISTSTYLE KEY DISTKEY (%s)" key-column)
                             (format "DISTSTYLE %s" (u/upper-case-en style)))})))
 
-;; Redshift has no secondary indexes; the only physical "indexes" are the inline, unnamed sortkey and the distribution,
+;; Redshift has no secondary indexes; the only physical "indexes" are the inline unnamed sortkey and the distribution,
 ;; so we override the inherited Postgres `pg_index` query. `svv_redshift_columns.sortkey` is the 1-based position
-;; (negative marks the whole key INTERLEAVED); `distkey` is true on the single KEY-distribution column. The declared
-;; distribution style comes from `pg_class_info`, which (unlike `svv_table_info`) reports even for an empty table.
-;; Blank `schema` falls back to `current_schema()`.
+;; (negative marks the whole key INTERLEAVED); `distkey` is true on the single KEY column. The declared distribution
+;; style comes from `pg_class_info`, which reports it for empty tables (`svv_table_info` doesn't). Blank `schema`
+;; falls back to `current_schema()`.
 (defmethod driver/fetch-table-indexes :redshift
   [_driver database schema table]
   (let [spec      (sql-jdbc.conn/db->pooled-connection-spec database)

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -250,7 +250,8 @@
                           :display-name (deferred-tru "Style")
                           :type         :select
                           :required     true
-                          ;; AUTO is Redshift's default and drifts over time, so it can't be reconciled; not offered.
+                          ;; AUTO is Redshift's default and drifts over time, so it's not offered as a managed style;
+                          ;; an AUTO table still surfaces its current style as a (non-managed) index.
                           :options      [{:name (deferred-tru "Key")  :value "key"}
                                          {:name (deferred-tru "All")  :value "all"}
                                          {:name (deferred-tru "Even") :value "even"}]}

--- a/modules/drivers/redshift/test/metabase/driver/redshift/index_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift/index_test.clj
@@ -35,7 +35,7 @@
       (is (= ["columns" "style"] (map :name (get-in methods [:sortkey :fields]))))
       (is (= ["style" "columns"] (map :name (get-in methods [:distkey :fields]))))
       (is (= #{"compound" "interleaved"} (style-options :sortkey)))
-      (is (= #{"key" "all" "even" "auto"} (style-options :distkey))))))
+      (is (= #{"key" "all" "even"} (style-options :distkey))))))
 
 ;;; ------------------------------------------ DDL rendering ------------------------------------------
 
@@ -82,11 +82,6 @@
     :indexes      [{:kind :distkey :style :even}]
     :ctas         "CREATE TABLE \"events\" DISTSTYLE EVEN AS SELECT 1"
     :create-table "CREATE TABLE \"events\" (\"a\" INTEGER, \"b\" INTEGER) DISTSTYLE EVEN"}
-   {:label        "auto distribution renders DISTSTYLE AUTO, no column"
-    :table        :events
-    :indexes      [{:kind :distkey :style :auto}]
-    :ctas         "CREATE TABLE \"events\" DISTSTYLE AUTO AS SELECT 1"
-    :create-table "CREATE TABLE \"events\" (\"a\" INTEGER, \"b\" INTEGER) DISTSTYLE AUTO"}
    {:label        "distkey + sortkey render in Redshift's required order (distribution then sort)"
     :table        :events
     :indexes      [{:kind :distkey :style :key :columns [{:name "a"}]}

--- a/modules/drivers/redshift/test/metabase/driver/redshift/index_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift/index_test.clj
@@ -12,8 +12,6 @@
    [metabase.driver :as driver]
    [metabase.driver.redshift :as redshift]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
-   [metabase.indexes.requestable-test :as requestable]
-   [metabase.indexes.schema :as schema]
    [metabase.test :as mt]
    [metabase.test.data.interface :as tx]
    [metabase.test.data.redshift :as redshift.tx]
@@ -38,13 +36,6 @@
       (is (= ["style" "columns"] (map :name (get-in methods [:distkey :fields]))))
       (is (= #{"compound" "interleaved"} (style-options :sortkey)))
       (is (= #{"key" "all" "even" "auto"} (style-options :distkey))))))
-
-(deftest ^:parallel every-advertised-option-is-requestable-test
-  (testing "every sortkey/distkey style Redshift advertises builds a schema-valid index request"
-    (doseq [[kind {:keys [fields]}] (driver/supported-index-methods :redshift nil)
-            body                    (requestable/advertised-bodies kind fields)]
-      (is (mr/validate ::schema/index-structured body)
-          (str kind " body should validate: " (pr-str body))))))
 
 ;;; ------------------------------------------ DDL rendering ------------------------------------------
 
@@ -86,6 +77,16 @@
     :indexes      [{:kind :distkey :style :all}]
     :ctas         "CREATE TABLE \"events\" DISTSTYLE ALL AS SELECT 1"
     :create-table "CREATE TABLE \"events\" (\"a\" INTEGER, \"b\" INTEGER) DISTSTYLE ALL"}
+   {:label        "even distribution renders DISTSTYLE EVEN, no column"
+    :table        :events
+    :indexes      [{:kind :distkey :style :even}]
+    :ctas         "CREATE TABLE \"events\" DISTSTYLE EVEN AS SELECT 1"
+    :create-table "CREATE TABLE \"events\" (\"a\" INTEGER, \"b\" INTEGER) DISTSTYLE EVEN"}
+   {:label        "auto distribution renders DISTSTYLE AUTO, no column"
+    :table        :events
+    :indexes      [{:kind :distkey :style :auto}]
+    :ctas         "CREATE TABLE \"events\" DISTSTYLE AUTO AS SELECT 1"
+    :create-table "CREATE TABLE \"events\" (\"a\" INTEGER, \"b\" INTEGER) DISTSTYLE AUTO"}
    {:label        "distkey + sortkey render in Redshift's required order (distribution then sort)"
     :table        :events
     :indexes      [{:kind :distkey :style :key :columns [{:name "a"}]}

--- a/modules/drivers/redshift/test/metabase/driver/redshift/index_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift/index_test.clj
@@ -12,6 +12,8 @@
    [metabase.driver :as driver]
    [metabase.driver.redshift :as redshift]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.indexes.requestable-test :as requestable]
+   [metabase.indexes.schema :as schema]
    [metabase.test :as mt]
    [metabase.test.data.interface :as tx]
    [metabase.test.data.redshift :as redshift.tx]
@@ -36,6 +38,13 @@
       (is (= ["style" "columns"] (map :name (get-in methods [:distkey :fields]))))
       (is (= #{"compound" "interleaved"} (style-options :sortkey)))
       (is (= #{"key" "all" "even" "auto"} (style-options :distkey))))))
+
+(deftest ^:parallel every-advertised-option-is-requestable-test
+  (testing "every sortkey/distkey style Redshift advertises builds a schema-valid index request"
+    (doseq [[kind {:keys [fields]}] (driver/supported-index-methods :redshift nil)
+            body                    (requestable/advertised-bodies kind fields)]
+      (is (mr/validate ::schema/index-structured body)
+          (str kind " body should validate: " (pr-str body))))))
 
 ;;; ------------------------------------------ DDL rendering ------------------------------------------
 

--- a/src/metabase/indexes/reconcile.clj
+++ b/src/metabase/indexes/reconcile.clj
@@ -25,8 +25,7 @@
 
 (mu/defn match-key :- ::match-key
   "Join key for a warehouse index map: its `:name` for named kinds, else a tuple for unnamed-inline kinds. Sort/order
-  keys are keyed by their columns; a distkey by its style (`:access-method`) plus column, so the column-less `:even`
-  and `:all` stay distinct. A sortkey's compound/interleaved style is intentionally not part of its key."
+  keys key by columns; a distkey also by style (`:access-method`), so the column-less `:even` and `:all` stay distinct."
   [{:keys [kind key-columns] am :access-method nm :name} :- [:map
                                                              [:kind :keyword]
                                                              [:key-columns [:sequential [:maybe :string]]]

--- a/src/metabase/indexes/reconcile.clj
+++ b/src/metabase/indexes/reconcile.clj
@@ -16,25 +16,26 @@
   #{:sortkey :order-by :distkey})
 
 (mr/def ::match-key
-  "Join key for reconciling a managed request with a warehouse index: a `:name` string for named kinds, a
-  `[kind key-columns]` tuple for unnamed-inline kinds, or a `[:distkey style key-columns]` triple for a distkey."
-  [:maybe [:or
-           :string
-           [:tuple :keyword [:sequential [:maybe :string]]]
-           [:tuple [:= :distkey] [:maybe :string] [:sequential [:maybe :string]]]]])
+  "Join key for reconciling a managed request with a warehouse index. `:kind` selects how it's matched: `:named` keys
+  by `:name`; an unnamed-inline `:sortkey`/`:order-by` by `:kind` + `:key-columns`; `:distkey` also by `:style`, so the
+  column-less `:even` and `:all` stay distinct."
+  [:map
+   [:kind :keyword]
+   [:name {:optional true} [:maybe :string]]
+   [:style {:optional true} [:maybe :string]]
+   [:key-columns {:optional true} [:sequential [:maybe :string]]]])
 
 (mu/defn match-key :- ::match-key
-  "Join key for a warehouse index map: its `:name` for named kinds, else a tuple for unnamed-inline kinds. Sort/order
-  keys key by columns; a distkey also by style (`:access-method`), so the column-less `:even` and `:all` stay distinct."
+  "The [[::match-key]] for a warehouse index map (see the schema for how each kind is keyed)."
   [{:keys [kind key-columns] am :access-method nm :name} :- [:map
                                                              [:kind :keyword]
                                                              [:key-columns [:sequential [:maybe :string]]]
                                                              [:access-method {:optional true} [:maybe :string]]
                                                              [:name {:optional true} [:maybe :string]]]]
   (cond
-    (= kind :distkey)                     [:distkey am key-columns]
-    (contains? unnamed-inline-kinds kind) [kind key-columns]
-    :else                                 nm))
+    (= kind :distkey)                     {:kind :distkey :style am :key-columns key-columns}
+    (contains? unnamed-inline-kinds kind) {:kind kind :key-columns key-columns}
+    :else                                 {:kind :named :name nm}))
 
 (mu/defn index-name :- :string
   "Physical index name for a structured def: a named kind's `:name`, else its `:kind` as a string (one inline key per

--- a/src/metabase/indexes/reconcile.clj
+++ b/src/metabase/indexes/reconcile.clj
@@ -16,20 +16,26 @@
   #{:sortkey :order-by :distkey})
 
 (mr/def ::match-key
-  "Join key for reconciling a managed request with a warehouse index: a `:name` string for named kinds, else a
-  `[kind key-columns]` tuple for unnamed-inline kinds."
-  [:maybe [:or :string [:tuple :keyword [:sequential [:maybe :string]]]]])
+  "Join key for reconciling a managed request with a warehouse index: a `:name` string for named kinds, a
+  `[kind key-columns]` tuple for unnamed-inline kinds, or a `[:distkey style key-columns]` triple for a distkey."
+  [:maybe [:or
+           :string
+           [:tuple :keyword [:sequential [:maybe :string]]]
+           [:tuple [:= :distkey] [:maybe :string] [:sequential [:maybe :string]]]]])
 
 (mu/defn match-key :- ::match-key
-  "Join key for a warehouse index map: `[:kind key-columns]` for unnamed-inline kinds, else its `:name`. Kind
-  qualifiers (e.g. a sortkey's style) are intentionally not part of the key."
-  [{:keys [kind key-columns] nm :name} :- [:map
-                                           [:kind :keyword]
-                                           [:key-columns [:sequential [:maybe :string]]]
-                                           [:name {:optional true} [:maybe :string]]]]
-  (if (contains? unnamed-inline-kinds kind)
-    [kind key-columns]
-    nm))
+  "Join key for a warehouse index map: its `:name` for named kinds, else a tuple for unnamed-inline kinds. Sort/order
+  keys are keyed by their columns; a distkey by its style (`:access-method`) plus column, so the column-less `:even`
+  and `:all` stay distinct. A sortkey's compound/interleaved style is intentionally not part of its key."
+  [{:keys [kind key-columns] am :access-method nm :name} :- [:map
+                                                             [:kind :keyword]
+                                                             [:key-columns [:sequential [:maybe :string]]]
+                                                             [:access-method {:optional true} [:maybe :string]]
+                                                             [:name {:optional true} [:maybe :string]]]]
+  (cond
+    (= kind :distkey)                     [:distkey am key-columns]
+    (contains? unnamed-inline-kinds kind) [kind key-columns]
+    :else                                 nm))
 
 (mu/defn index-name :- :string
   "Physical index name for a structured def: a named kind's `:name`, else its `:kind` as a string (one inline key per
@@ -44,9 +50,13 @@
   [{:keys [index_name structured]} :- [:map
                                        [:index_name [:maybe :string]]
                                        [:structured :map]]]
-  (match-key {:kind        (:kind structured)
-              :name        index_name
-              :key-columns (mapv :name (:columns structured))}))
+  (let [{:keys [kind style columns]} structured
+        ;; only a :key distkey has a meaningful column; :all/:even ignore any stray column the form sent
+        key-columns (if (and (= kind :distkey) (not= style :key)) [] (mapv :name columns))]
+    (match-key {:kind          kind
+                :name          index_name
+                :access-method (some-> style name)
+                :key-columns   key-columns})))
 
 (defn warehouse-key-set
   "Set of [[match-key]]s for the warehouse indexes, to test managed requests against with [[present-in-warehouse?]]."

--- a/src/metabase/indexes/schema.clj
+++ b/src/metabase/indexes/schema.clj
@@ -33,15 +33,15 @@
    [:columns [:vector {:min 1} ::column]]])
 
 (mr/def ::distkey
-  "Redshift distribution, inline. `:columns` holds the single DISTKEY column, required only for the `:key` style;
-  `:all`/`:even`/`:auto` take no column."
+  "Redshift distribution, inline. Only `:key` uses a column (exactly the one DISTKEY column); `:all`/`:even` take none.
+  AUTO is Redshift's default and can't be reconciled against a fixed request, so it isn't offered."
   [:and
    [:map
     [:kind    [:= :distkey]]
-    [:style   [:enum :key :all :even :auto]]
+    [:style   [:enum :key :all :even]]
     [:columns {:optional true} [:vector {:min 1 :max 1} ::column]]]
-   [:fn {:error/message "a :key distkey requires a column"}
-    (fn [{:keys [style columns]}] (or (not= style :key) (seq columns)))]])
+   [:fn {:error/message "a :key distkey requires its one column"}
+    (fn [{:keys [style columns]}] (or (not= style :key) (= 1 (count columns))))]])
 
 (mr/def ::clustering
   "Snowflake (standalone) / BigQuery (inline) clustering. `:name` is required for the standalone form."

--- a/src/metabase/indexes/schema.clj
+++ b/src/metabase/indexes/schema.clj
@@ -33,8 +33,7 @@
    [:columns [:vector {:min 1} ::column]]])
 
 (mr/def ::distkey
-  "Redshift distribution, inline. Only `:key` uses a column (exactly the one DISTKEY column); `:all`/`:even` take none.
-  AUTO is Redshift's default and can't be reconciled against a fixed request, so it isn't offered."
+  "Redshift distribution, inline. Only `:key` uses a column (the one DISTKEY column); `:all`/`:even` take none."
   [:and
    [:map
     [:kind    [:= :distkey]]
@@ -57,8 +56,8 @@
    [:columns [:vector {:min 1} ::column]]])
 
 (mr/def ::skip-index
-  "ClickHouse data-skipping index, standalone. Only the argument-free types are offered; the parameterized ones
-  (set/ngrambf_v1/tokenbf_v1) need type-args the request form can't supply yet."
+  "ClickHouse data-skipping index, standalone. Only arg-free types; the parameterized ones need type-args the form
+  can't supply yet."
   [:map
    [:kind [:= :skip-index]]
    [:name :string]

--- a/src/metabase/indexes/schema.clj
+++ b/src/metabase/indexes/schema.clj
@@ -57,13 +57,13 @@
    [:columns [:vector {:min 1} ::column]]])
 
 (mr/def ::skip-index
-  "ClickHouse data-skipping index, standalone."
+  "ClickHouse data-skipping index, standalone. Only the argument-free types are offered; the parameterized ones
+  (set/ngrambf_v1/tokenbf_v1) need type-args the request form can't supply yet."
   [:map
    [:kind [:= :skip-index]]
    [:name :string]
    [:columns [:vector {:min 1} ::column]]
-   [:type [:enum :minmax :set :bloom_filter :ngrambf_v1 :tokenbf_v1]]
-   [:type-args {:optional true} [:vector :any]]
+   [:type [:enum :minmax :bloom_filter]]
    [:granularity {:optional true} pos-int?]])
 
 (mr/def ::index-structured

--- a/test/metabase/indexes/reconcile_test.clj
+++ b/test/metabase/indexes/reconcile_test.clj
@@ -28,8 +28,17 @@
    :status :pending :error_message nil :created_by 3 :last_executed_at nil})
 
 (def ^:private wh-distkey
-  {:name nil :kind :distkey :access-method nil :is-unique false :is-primary false
+  {:name nil :kind :distkey :access-method "key" :is-unique false :is-primary false
    :is-valid true :key-columns ["category"] :include-columns [] :partial-predicate nil :definition nil})
+
+(def ^:private managed-even-distkey
+  {:id 4 :transform_id 7 :index_name "distkey"
+   :structured {:kind :distkey :style :even}
+   :status :pending :error_message nil :created_by 3 :last_executed_at nil})
+
+(def ^:private wh-even-distkey
+  {:name nil :kind :distkey :access-method "even" :is-unique false :is-primary false
+   :is-valid true :key-columns [] :include-columns [] :partial-predicate nil :definition "DISTSTYLE EVEN"})
 
 (def ^:private wh-dba
   {:name "dba_made" :kind :btree :access-method "btree" :is-unique false :is-primary false
@@ -42,9 +51,17 @@
   (testing "unnamed inline kinds key by kind+columns, so managed and warehouse agree"
     (is (= [:sortkey ["a" "b"]] (reconcile/managed-match-key managed-sortkey)))
     (is (= [:sortkey ["a" "b"]] (reconcile/match-key wh-sortkey))))
-  (testing "a fetched distkey is unnamed-inline too, so it matches its managed request (#76331)"
-    (is (= [:distkey ["category"]] (reconcile/managed-match-key managed-distkey)))
-    (is (= [:distkey ["category"]] (reconcile/match-key wh-distkey)))))
+  (testing "a key distkey is keyed by its style + column, so managed and warehouse agree (#76331)"
+    (is (= [:distkey "key" ["category"]] (reconcile/managed-match-key managed-distkey)))
+    (is (= [:distkey "key" ["category"]] (reconcile/match-key wh-distkey))))
+  (testing "distkey keys are style-aware: column-less even and all don't collapse onto the same key"
+    (is (= [:distkey "even" []] (reconcile/managed-match-key managed-even-distkey)))
+    (is (= [:distkey "even" []] (reconcile/match-key wh-even-distkey)))
+    (is (not= (reconcile/managed-match-key managed-even-distkey)
+              (reconcile/managed-match-key (assoc-in managed-even-distkey [:structured :style] :all))))
+    (testing "a stray column on a non-key request is ignored, so it still matches the column-less warehouse distkey"
+      (is (= [:distkey "even" []]
+             (reconcile/managed-match-key (assoc-in managed-even-distkey [:structured :columns] [{:name "x"}])))))))
 
 (deftest merge-indexes-test
   (testing "managed + present: observed from the warehouse, flagged managed, request carries lifecycle + structured"
@@ -75,11 +92,17 @@
       (is (= 1 (count merged)))
       (is (true? (:metabase_managed (first merged))))
       (is (true? (:present_in_warehouse (first merged))))))
-  (testing "a managed inline distkey matches the warehouse distkey by kind+columns, listed once as managed"
+  (testing "a managed inline distkey matches the warehouse distkey by style+columns, listed once as managed"
     (let [merged (reconcile/merge-indexes [managed-distkey] [wh-distkey])]
       (is (= 1 (count merged)))
       (is (true? (:metabase_managed (first merged))))
       (is (true? (:present_in_warehouse (first merged))))))
+  (testing "a managed even distkey matches an even warehouse distkey, but not an all one"
+    (is (true? (:present_in_warehouse (first (reconcile/merge-indexes [managed-even-distkey] [wh-even-distkey])))))
+    (let [merged  (reconcile/merge-indexes [managed-even-distkey]
+                                           [(assoc wh-even-distkey :access-method "all")])
+          managed (first (filter :metabase_managed merged))]
+      (is (false? (:present_in_warehouse managed)))))
   (testing "mix: a matched managed index, plus a DBA index alongside it"
     (let [merged  (reconcile/merge-indexes [managed-btree] [wh-btree wh-dba])
           by-flag (group-by :metabase_managed merged)]

--- a/test/metabase/indexes/reconcile_test.clj
+++ b/test/metabase/indexes/reconcile_test.clj
@@ -46,21 +46,21 @@
 
 (deftest match-key-test
   (testing "named kinds key by name; managed and warehouse agree"
-    (is (= "by_cat" (reconcile/managed-match-key managed-btree)))
-    (is (= "by_cat" (reconcile/match-key wh-btree))))
+    (is (= {:kind :named :name "by_cat"} (reconcile/managed-match-key managed-btree)))
+    (is (= {:kind :named :name "by_cat"} (reconcile/match-key wh-btree))))
   (testing "unnamed inline kinds key by kind+columns, so managed and warehouse agree"
-    (is (= [:sortkey ["a" "b"]] (reconcile/managed-match-key managed-sortkey)))
-    (is (= [:sortkey ["a" "b"]] (reconcile/match-key wh-sortkey))))
+    (is (= {:kind :sortkey :key-columns ["a" "b"]} (reconcile/managed-match-key managed-sortkey)))
+    (is (= {:kind :sortkey :key-columns ["a" "b"]} (reconcile/match-key wh-sortkey))))
   (testing "a key distkey is keyed by its style + column, so managed and warehouse agree (#76331)"
-    (is (= [:distkey "key" ["category"]] (reconcile/managed-match-key managed-distkey)))
-    (is (= [:distkey "key" ["category"]] (reconcile/match-key wh-distkey))))
+    (is (= {:kind :distkey :style "key" :key-columns ["category"]} (reconcile/managed-match-key managed-distkey)))
+    (is (= {:kind :distkey :style "key" :key-columns ["category"]} (reconcile/match-key wh-distkey))))
   (testing "distkey keys are style-aware: column-less even and all don't collapse onto the same key"
-    (is (= [:distkey "even" []] (reconcile/managed-match-key managed-even-distkey)))
-    (is (= [:distkey "even" []] (reconcile/match-key wh-even-distkey)))
+    (is (= {:kind :distkey :style "even" :key-columns []} (reconcile/managed-match-key managed-even-distkey)))
+    (is (= {:kind :distkey :style "even" :key-columns []} (reconcile/match-key wh-even-distkey)))
     (is (not= (reconcile/managed-match-key managed-even-distkey)
               (reconcile/managed-match-key (assoc-in managed-even-distkey [:structured :style] :all))))
     (testing "a stray column on a non-key request is ignored, so it still matches the column-less warehouse distkey"
-      (is (= [:distkey "even" []]
+      (is (= {:kind :distkey :style "even" :key-columns []}
              (reconcile/managed-match-key (assoc-in managed-even-distkey [:structured :columns] [{:name "x"}])))))))
 
 (deftest merge-indexes-test

--- a/test/metabase/indexes/requestable_test.clj
+++ b/test/metabase/indexes/requestable_test.clj
@@ -10,41 +10,11 @@
 
 (comment metabase.driver.postgres/keep-me)
 
-(defn- sample-value
-  "A representative value for a non-select descriptor field, the way the FE would fill the form. One column suits every
-  kind: kinds that take many allow a single one, and a `:distkey` allows only one."
-  [{:keys [type]}]
-  (case type
-    :string  "idx_sample"
-    :boolean true
-    :integer 1
-    :columns [{:name "a"}]))
-
-(defn advertised-bodies
-  "Every request body the form can build for `kind` from its descriptor `fields`: the cartesian product over each
-  field's candidate values (a `:select` contributes one body per option, so every advertised option is covered),
-  re-keywordized the way the POST path does."
-  [kind fields]
-  (let [field-values (fn [{:keys [type options] :as f}]
-                       (if (= type :select) (map :value options) [(sample-value f)]))
-        combos       (reduce (fn [acc vs] (for [row acc, v vs] (conj row v)))
-                             [[]] (map field-values fields))]
-    (for [combo combos]
-      (schema/keywordize-structured
-       (into {:kind kind} (map vector (map (comp keyword :name) fields) combo))))))
-
 (deftest return-conforms-to-schema-test
   (testing "the supported-index-methods return validates against ::driver/supported-index-methods"
     (is (mr/validate ::driver/supported-index-methods (driver/supported-index-methods :postgres nil)))
     (testing "including the empty default for a driver with no index support"
       (is (mr/validate ::driver/supported-index-methods (driver/supported-index-methods :h2 nil))))))
-
-(deftest postgres-descriptors-match-schema-test
-  (testing "every value Postgres advertises in supported-index-methods builds a body that validates against ::index-structured"
-    (doseq [[kind {:keys [fields]}] (driver/supported-index-methods :postgres nil)
-            body                    (advertised-bodies kind fields)]
-      (is (mr/validate ::schema/index-structured body)
-          (str "descriptor body for " kind " should validate: " (pr-str body))))))
 
 (deftest postgres-lifecycle-matches-feature-flag-test
   (testing ":standalone <=> :index/standalone-create, :inline <=> :index/inline-create"

--- a/test/metabase/indexes/requestable_test.clj
+++ b/test/metabase/indexes/requestable_test.clj
@@ -11,21 +11,27 @@
 (comment metabase.driver.postgres/keep-me)
 
 (defn- sample-value
-  "A representative value for a descriptor field, the way the FE would fill the form."
-  [{:keys [type options]}]
+  "A representative value for a non-select descriptor field, the way the FE would fill the form. One column suits every
+  kind: kinds that take many allow a single one, and a `:distkey` allows only one."
+  [{:keys [type]}]
   (case type
     :string  "idx_sample"
     :boolean true
     :integer 1
-    :columns [{:name "a"} {:name "b"}]
-    :select  (-> options first :value)))
+    :columns [{:name "a"}]))
 
-(defn- body-from-fields
-  "Assemble a structured index body from ONLY the kind + its descriptor fields, then re-keywordize enum values the way
-  the POST path does."
+(defn advertised-bodies
+  "Every request body the form can build for `kind` from its descriptor `fields`: the cartesian product over each
+  field's candidate values (a `:select` contributes one body per option, so every advertised option is covered),
+  re-keywordized the way the POST path does."
   [kind fields]
-  (-> (into {:kind kind} (map (fn [{nm :name :as f}] [(keyword nm) (sample-value f)])) fields)
-      schema/keywordize-structured))
+  (let [field-values (fn [{:keys [type options] :as f}]
+                       (if (= type :select) (map :value options) [(sample-value f)]))
+        combos       (reduce (fn [acc vs] (for [row acc, v vs] (conj row v)))
+                             [[]] (map field-values fields))]
+    (for [combo combos]
+      (schema/keywordize-structured
+       (into {:kind kind} (map vector (map (comp keyword :name) fields) combo))))))
 
 (deftest return-conforms-to-schema-test
   (testing "the supported-index-methods return validates against ::driver/supported-index-methods"
@@ -34,11 +40,11 @@
       (is (mr/validate ::driver/supported-index-methods (driver/supported-index-methods :h2 nil))))))
 
 (deftest postgres-descriptors-match-schema-test
-  (testing "a body built from each advertised kind's descriptors validates against ::index-structured"
-    (doseq [[kind {:keys [fields]}] (driver/supported-index-methods :postgres nil)]
-      (let [body (body-from-fields kind fields)]
-        (is (mr/validate ::schema/index-structured body)
-            (str "descriptor body for " kind " should validate: " (pr-str body)))))))
+  (testing "every value Postgres advertises in supported-index-methods builds a body that validates against ::index-structured"
+    (doseq [[kind {:keys [fields]}] (driver/supported-index-methods :postgres nil)
+            body                    (advertised-bodies kind fields)]
+      (is (mr/validate ::schema/index-structured body)
+          (str "descriptor body for " kind " should validate: " (pr-str body))))))
 
 (deftest postgres-lifecycle-matches-feature-flag-test
   (testing ":standalone <=> :index/standalone-create, :inline <=> :index/inline-create"

--- a/test/metabase/indexes/requestable_test.clj
+++ b/test/metabase/indexes/requestable_test.clj
@@ -34,8 +34,7 @@
       {:kind :skip-index :name "s" :columns [{:name "a"}] :type "bloom_filter" :granularity 4}
       {:kind :distkey    :style "key" :columns [{:name "a"}]}
       {:kind :distkey    :style "all"}
-      {:kind :distkey    :style "even"}
-      {:kind :distkey    :style "auto"})))
+      {:kind :distkey    :style "even"})))
 
 (deftest distkey-key-requires-a-column-test
   (testing "a :key distkey without a column is rejected; the column-less styles are fine"

--- a/test/metabase/transforms/index_test_util.clj
+++ b/test/metabase/transforms/index_test_util.clj
@@ -147,9 +147,17 @@
      :table  "mb_fetch_rs_dist"
      :create ["CREATE TABLE mb_fetch_rs_dist (a INT, b INT) DISTSTYLE KEY DISTKEY (a) COMPOUND SORTKEY (b)"]
      :expected #{(idx nil :sortkey nil ["b"])
-                 (idx nil :distkey nil ["a"])}}
-    {:label "a table with no sortkey returns []"
-     :table "mb_fetch_rs_empty"
+                 (idx nil :distkey "key" ["a"])}}
+    {:label  "an EVEN distribution is reported as a column-less distkey, keyed by style"
+     :table  "mb_fetch_rs_even"
+     :create ["CREATE TABLE mb_fetch_rs_even (a INT, b INT) DISTSTYLE EVEN"]
+     :expected #{(idx nil :distkey "even" [])}}
+    {:label  "an ALL distribution is reported as a column-less distkey, distinct from EVEN"
+     :table  "mb_fetch_rs_all"
+     :create ["CREATE TABLE mb_fetch_rs_all (a INT, b INT) DISTSTYLE ALL"]
+     :expected #{(idx nil :distkey "all" [])}}
+    {:label  "a table with no explicit sortkey or distribution (AUTO) returns []"
+     :table  "mb_fetch_rs_empty"
      :create ["CREATE TABLE mb_fetch_rs_empty (a INT, b INT)"]
      :expected #{}}]
 

--- a/test/metabase/transforms/index_test_util.clj
+++ b/test/metabase/transforms/index_test_util.clj
@@ -141,8 +141,10 @@
      :table  "mb_fetch_rs_interleaved"
      :create ["CREATE TABLE mb_fetch_rs_interleaved (a INT, b INT) INTERLEAVED SORTKEY (a, b)"]
      ;; same normalized shape as the compound case, so `:definition` is the only signal it's interleaved.
+     ;; interleaved can't use AUTO distribution, so Redshift assigns EVEN; it surfaces as an unmanaged distkey.
      :definition-contains "INTERLEAVED"
-     :expected #{(idx nil :sortkey nil ["a" "b"])}}
+     :expected #{(idx nil :sortkey nil ["a" "b"])
+                 (idx nil :distkey "even" [])}}
     {:label  "a KEY distkey alongside a compound sortkey, both reported as unnamed inline rows"
      :table  "mb_fetch_rs_dist"
      :create ["CREATE TABLE mb_fetch_rs_dist (a INT, b INT) DISTSTYLE KEY DISTKEY (a) COMPOUND SORTKEY (b)"]


### PR DESCRIPTION
- clickhouse skip-index: only offer minmax and bloom_filter. the other types (set, ngrambf_v1, tokenbf_v1) need args the form can't supply, so they render bad DDL and fail at apply.
- redshift distkey: even/all were always marked failed after a transform even though the table was fine. we read the distkey from svv_redshift_columns, which only flags KEY tables, so even/all looked like no distkey.
- fix: read the style from pg_class_info.reldiststyle (works on empty CTAS tables) and match by style, not columns (even/all are both column-less and collapsed onto one key).
- dropped auto: redshift drifts it between even/key/all as the table grows, so there's nothing fixed to reconcile against.
- tests: replaced the generative advertised-option schema guards with explicit per-option DDL cases per driver.
