### PR TITLE
Redshift: read distkey style correctly so even/all distributions verify

### DIFF
--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -250,10 +250,10 @@
                           :display-name (deferred-tru "Style")
                           :type         :select
                           :required     true
+                          ;; AUTO is Redshift's default and drifts over time, so it can't be reconciled; not offered.
                           :options      [{:name (deferred-tru "Key")  :value "key"}
                                          {:name (deferred-tru "All")  :value "all"}
-                                         {:name (deferred-tru "Even") :value "even"}
-                                         {:name (deferred-tru "Auto") :value "auto"}]}
+                                         {:name (deferred-tru "Even") :value "even"}]}
                          ;; only the :key style takes a column, so this is not required
                          {:name         "columns"
                           :display-name (deferred-tru "Columns")
@@ -286,20 +286,50 @@
     (when (seq clauses)
       (str/join " " clauses))))
 
-;; Redshift has no secondary indexes; the only physical "indexes" are the inline, unnamed sortkey and the distribution
-;; key, so we override the inherited Postgres `pg_index` query. `svv_redshift_columns.sortkey` is the 1-based position
-;; (negative marks the whole key INTERLEAVED); `distkey` is true on the single KEY-distribution column. Blank `schema`
-;; falls back to `current_schema()`.
+(defn- distkey-index
+  "The distkey entry from a table's declared `reldiststyle` (0 EVEN, 1 KEY, 8 ALL) and KEY column; nil for AUTO (9) or
+  anything else, so only an explicitly-distributed table reports one. Keying on the declared style (not the effective
+  one Redshift drifts AUTO tables toward) keeps a default table from reporting a value that changes underneath us."
+  [reldiststyle key-column]
+  (when-let [style (case (long reldiststyle) 0 "even", 1 "key", 8 "all", nil)]
+    (let [key? (= style "key")]
+      {:name              nil
+       :kind              :distkey
+       :access-method     style
+       :is-unique         false
+       :is-primary        false
+       :is-valid          true
+       :key-columns       (if key? [key-column] [])
+       :include-columns   []
+       :partial-predicate nil
+       :definition        (if key?
+                            (format "DISTSTYLE KEY DISTKEY (%s)" key-column)
+                            (format "DISTSTYLE %s" (u/upper-case-en style)))})))
+
+;; Redshift has no secondary indexes; the only physical "indexes" are the inline, unnamed sortkey and the distribution,
+;; so we override the inherited Postgres `pg_index` query. `svv_redshift_columns.sortkey` is the 1-based position
+;; (negative marks the whole key INTERLEAVED); `distkey` is true on the single KEY-distribution column. The declared
+;; distribution style comes from `pg_class_info`, which (unlike `svv_table_info`) reports even for an empty table.
+;; Blank `schema` falls back to `current_schema()`.
 (defmethod driver/fetch-table-indexes :redshift
   [_driver database schema table]
-  (let [rows      (jdbc/query
-                   (sql-jdbc.conn/db->pooled-connection-spec database)
+  (let [spec      (sql-jdbc.conn/db->pooled-connection-spec database)
+        rows      (jdbc/query
+                   spec
                    [(str "SELECT column_name, sortkey, distkey FROM svv_redshift_columns "
                          "WHERE schema_name = COALESCE(?, current_schema()) AND table_name = ? "
                          "ORDER BY abs(sortkey)")
                     (perf/not-empty schema) table])
         sort-rows (filter (comp (complement zero?) :sortkey) rows)
-        dist-row  (perf/some #(when (:distkey %) %) rows)]
+        key-col   (perf/some #(when (:distkey %) (:column_name %)) rows)
+        diststyle (-> (jdbc/query
+                       spec
+                       [(str "SELECT c.reldiststyle AS reldiststyle FROM pg_class_info c "
+                             "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                             "WHERE n.nspname = COALESCE(?, current_schema()) AND c.relname = ?")
+                        (perf/not-empty schema) table])
+                      first :reldiststyle)
+        distkey   (some-> diststyle (distkey-index key-col))]
     (cond-> []
       (seq sort-rows)
       (conj (let [interleaved? (perf/some (comp neg? :sortkey) sort-rows)
@@ -316,17 +346,7 @@
                :definition        (format "%s SORTKEY (%s)"
                                           (if interleaved? "INTERLEAVED" "COMPOUND")
                                           (str/join ", " columns))}))
-      dist-row
-      (conj {:name              nil
-             :kind              :distkey
-             :access-method     nil
-             :is-unique         false
-             :is-primary        false
-             :is-valid          true
-             :key-columns       [(:column_name dist-row)]
-             :include-columns   []
-             :partial-predicate nil
-             :definition        (format "DISTKEY (%s)" (:column_name dist-row))}))))
+      distkey (conj distkey))))
 
 (defmethod driver/compile-transform :redshift
   [driver {:keys [query output-table indexes] :as transform-details}]

--- a/modules/drivers/redshift/test/metabase/driver/redshift/index_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift/index_test.clj
@@ -35,7 +35,7 @@
       (is (= ["columns" "style"] (map :name (get-in methods [:sortkey :fields]))))
       (is (= ["style" "columns"] (map :name (get-in methods [:distkey :fields]))))
       (is (= #{"compound" "interleaved"} (style-options :sortkey)))
-      (is (= #{"key" "all" "even" "auto"} (style-options :distkey))))))
+      (is (= #{"key" "all" "even"} (style-options :distkey))))))
 
 ;;; ------------------------------------------ DDL rendering ------------------------------------------
 
@@ -82,11 +82,6 @@
     :indexes      [{:kind :distkey :style :even}]
     :ctas         "CREATE TABLE \"events\" DISTSTYLE EVEN AS SELECT 1"
     :create-table "CREATE TABLE \"events\" (\"a\" INTEGER, \"b\" INTEGER) DISTSTYLE EVEN"}
-   {:label        "auto distribution renders DISTSTYLE AUTO, no column"
-    :table        :events
-    :indexes      [{:kind :distkey :style :auto}]
-    :ctas         "CREATE TABLE \"events\" DISTSTYLE AUTO AS SELECT 1"
-    :create-table "CREATE TABLE \"events\" (\"a\" INTEGER, \"b\" INTEGER) DISTSTYLE AUTO"}
    {:label        "distkey + sortkey render in Redshift's required order (distribution then sort)"
     :table        :events
     :indexes      [{:kind :distkey :style :key :columns [{:name "a"}]}

--- a/src/metabase/indexes/reconcile.clj
+++ b/src/metabase/indexes/reconcile.clj
@@ -16,20 +16,26 @@
   #{:sortkey :order-by :distkey})
 
 (mr/def ::match-key
-  "Join key for reconciling a managed request with a warehouse index: a `:name` string for named kinds, else a
-  `[kind key-columns]` tuple for unnamed-inline kinds."
-  [:maybe [:or :string [:tuple :keyword [:sequential [:maybe :string]]]]])
+  "Join key for reconciling a managed request with a warehouse index: a `:name` string for named kinds, a
+  `[kind key-columns]` tuple for unnamed-inline kinds, or a `[:distkey style key-columns]` triple for a distkey."
+  [:maybe [:or
+           :string
+           [:tuple :keyword [:sequential [:maybe :string]]]
+           [:tuple [:= :distkey] [:maybe :string] [:sequential [:maybe :string]]]]])
 
 (mu/defn match-key :- ::match-key
-  "Join key for a warehouse index map: `[:kind key-columns]` for unnamed-inline kinds, else its `:name`. Kind
-  qualifiers (e.g. a sortkey's style) are intentionally not part of the key."
-  [{:keys [kind key-columns] nm :name} :- [:map
-                                           [:kind :keyword]
-                                           [:key-columns [:sequential [:maybe :string]]]
-                                           [:name {:optional true} [:maybe :string]]]]
-  (if (contains? unnamed-inline-kinds kind)
-    [kind key-columns]
-    nm))
+  "Join key for a warehouse index map: its `:name` for named kinds, else a tuple for unnamed-inline kinds. Sort/order
+  keys are keyed by their columns; a distkey by its style (`:access-method`) plus column, so the column-less `:even`
+  and `:all` stay distinct. A sortkey's compound/interleaved style is intentionally not part of its key."
+  [{:keys [kind key-columns] am :access-method nm :name} :- [:map
+                                                             [:kind :keyword]
+                                                             [:key-columns [:sequential [:maybe :string]]]
+                                                             [:access-method {:optional true} [:maybe :string]]
+                                                             [:name {:optional true} [:maybe :string]]]]
+  (cond
+    (= kind :distkey)                     [:distkey am key-columns]
+    (contains? unnamed-inline-kinds kind) [kind key-columns]
+    :else                                 nm))
 
 (mu/defn index-name :- :string
   "Physical index name for a structured def: a named kind's `:name`, else its `:kind` as a string (one inline key per
@@ -44,9 +50,13 @@
   [{:keys [index_name structured]} :- [:map
                                        [:index_name [:maybe :string]]
                                        [:structured :map]]]
-  (match-key {:kind        (:kind structured)
-              :name        index_name
-              :key-columns (mapv :name (:columns structured))}))
+  (let [{:keys [kind style columns]} structured
+        ;; only a :key distkey has a meaningful column; :all/:even ignore any stray column the form sent
+        key-columns (if (and (= kind :distkey) (not= style :key)) [] (mapv :name columns))]
+    (match-key {:kind          kind
+                :name          index_name
+                :access-method (some-> style name)
+                :key-columns   key-columns})))
 
 (defn warehouse-key-set
   "Set of [[match-key]]s for the warehouse indexes, to test managed requests against with [[present-in-warehouse?]]."

--- a/src/metabase/indexes/schema.clj
+++ b/src/metabase/indexes/schema.clj
@@ -33,15 +33,15 @@
    [:columns [:vector {:min 1} ::column]]])
 
 (mr/def ::distkey
-  "Redshift distribution, inline. `:columns` holds the single DISTKEY column, required only for the `:key` style;
-  `:all`/`:even`/`:auto` take no column."
+  "Redshift distribution, inline. Only `:key` uses a column (exactly the one DISTKEY column); `:all`/`:even` take none.
+  AUTO is Redshift's default and can't be reconciled against a fixed request, so it isn't offered."
   [:and
    [:map
     [:kind    [:= :distkey]]
-    [:style   [:enum :key :all :even :auto]]
+    [:style   [:enum :key :all :even]]
     [:columns {:optional true} [:vector {:min 1 :max 1} ::column]]]
-   [:fn {:error/message "a :key distkey requires a column"}
-    (fn [{:keys [style columns]}] (or (not= style :key) (seq columns)))]])
+   [:fn {:error/message "a :key distkey requires its one column"}
+    (fn [{:keys [style columns]}] (or (not= style :key) (= 1 (count columns))))]])
 
 (mr/def ::clustering
   "Snowflake (standalone) / BigQuery (inline) clustering. `:name` is required for the standalone form."

--- a/test/metabase/indexes/reconcile_test.clj
+++ b/test/metabase/indexes/reconcile_test.clj
@@ -28,8 +28,17 @@
    :status :pending :error_message nil :created_by 3 :last_executed_at nil})
 
 (def ^:private wh-distkey
-  {:name nil :kind :distkey :access-method nil :is-unique false :is-primary false
+  {:name nil :kind :distkey :access-method "key" :is-unique false :is-primary false
    :is-valid true :key-columns ["category"] :include-columns [] :partial-predicate nil :definition nil})
+
+(def ^:private managed-even-distkey
+  {:id 4 :transform_id 7 :index_name "distkey"
+   :structured {:kind :distkey :style :even}
+   :status :pending :error_message nil :created_by 3 :last_executed_at nil})
+
+(def ^:private wh-even-distkey
+  {:name nil :kind :distkey :access-method "even" :is-unique false :is-primary false
+   :is-valid true :key-columns [] :include-columns [] :partial-predicate nil :definition "DISTSTYLE EVEN"})
 
 (def ^:private wh-dba
   {:name "dba_made" :kind :btree :access-method "btree" :is-unique false :is-primary false
@@ -42,9 +51,17 @@
   (testing "unnamed inline kinds key by kind+columns, so managed and warehouse agree"
     (is (= [:sortkey ["a" "b"]] (reconcile/managed-match-key managed-sortkey)))
     (is (= [:sortkey ["a" "b"]] (reconcile/match-key wh-sortkey))))
-  (testing "a fetched distkey is unnamed-inline too, so it matches its managed request (#76331)"
-    (is (= [:distkey ["category"]] (reconcile/managed-match-key managed-distkey)))
-    (is (= [:distkey ["category"]] (reconcile/match-key wh-distkey)))))
+  (testing "a key distkey is keyed by its style + column, so managed and warehouse agree (#76331)"
+    (is (= [:distkey "key" ["category"]] (reconcile/managed-match-key managed-distkey)))
+    (is (= [:distkey "key" ["category"]] (reconcile/match-key wh-distkey))))
+  (testing "distkey keys are style-aware: column-less even and all don't collapse onto the same key"
+    (is (= [:distkey "even" []] (reconcile/managed-match-key managed-even-distkey)))
+    (is (= [:distkey "even" []] (reconcile/match-key wh-even-distkey)))
+    (is (not= (reconcile/managed-match-key managed-even-distkey)
+              (reconcile/managed-match-key (assoc-in managed-even-distkey [:structured :style] :all))))
+    (testing "a stray column on a non-key request is ignored, so it still matches the column-less warehouse distkey"
+      (is (= [:distkey "even" []]
+             (reconcile/managed-match-key (assoc-in managed-even-distkey [:structured :columns] [{:name "x"}])))))))
 
 (deftest merge-indexes-test
   (testing "managed + present: observed from the warehouse, flagged managed, request carries lifecycle + structured"
@@ -75,11 +92,17 @@
       (is (= 1 (count merged)))
       (is (true? (:metabase_managed (first merged))))
       (is (true? (:present_in_warehouse (first merged))))))
-  (testing "a managed inline distkey matches the warehouse distkey by kind+columns, listed once as managed"
+  (testing "a managed inline distkey matches the warehouse distkey by style+columns, listed once as managed"
     (let [merged (reconcile/merge-indexes [managed-distkey] [wh-distkey])]
       (is (= 1 (count merged)))
       (is (true? (:metabase_managed (first merged))))
       (is (true? (:present_in_warehouse (first merged))))))
+  (testing "a managed even distkey matches an even warehouse distkey, but not an all one"
+    (is (true? (:present_in_warehouse (first (reconcile/merge-indexes [managed-even-distkey] [wh-even-distkey])))))
+    (let [merged  (reconcile/merge-indexes [managed-even-distkey]
+                                           [(assoc wh-even-distkey :access-method "all")])
+          managed (first (filter :metabase_managed merged))]
+      (is (false? (:present_in_warehouse managed)))))
   (testing "mix: a matched managed index, plus a DBA index alongside it"
     (let [merged  (reconcile/merge-indexes [managed-btree] [wh-btree wh-dba])
           by-flag (group-by :metabase_managed merged)]

--- a/test/metabase/indexes/requestable_test.clj
+++ b/test/metabase/indexes/requestable_test.clj
@@ -34,8 +34,7 @@
       {:kind :skip-index :name "s" :columns [{:name "a"}] :type "bloom_filter" :granularity 4}
       {:kind :distkey    :style "key" :columns [{:name "a"}]}
       {:kind :distkey    :style "all"}
-      {:kind :distkey    :style "even"}
-      {:kind :distkey    :style "auto"})))
+      {:kind :distkey    :style "even"})))
 
 (deftest distkey-key-requires-a-column-test
   (testing "a :key distkey without a column is rejected; the column-less styles are fine"

--- a/test/metabase/transforms/index_test_util.clj
+++ b/test/metabase/transforms/index_test_util.clj
@@ -147,9 +147,17 @@
      :table  "mb_fetch_rs_dist"
      :create ["CREATE TABLE mb_fetch_rs_dist (a INT, b INT) DISTSTYLE KEY DISTKEY (a) COMPOUND SORTKEY (b)"]
      :expected #{(idx nil :sortkey nil ["b"])
-                 (idx nil :distkey nil ["a"])}}
-    {:label "a table with no sortkey returns []"
-     :table "mb_fetch_rs_empty"
+                 (idx nil :distkey "key" ["a"])}}
+    {:label  "an EVEN distribution is reported as a column-less distkey, keyed by style"
+     :table  "mb_fetch_rs_even"
+     :create ["CREATE TABLE mb_fetch_rs_even (a INT, b INT) DISTSTYLE EVEN"]
+     :expected #{(idx nil :distkey "even" [])}}
+    {:label  "an ALL distribution is reported as a column-less distkey, distinct from EVEN"
+     :table  "mb_fetch_rs_all"
+     :create ["CREATE TABLE mb_fetch_rs_all (a INT, b INT) DISTSTYLE ALL"]
+     :expected #{(idx nil :distkey "all" [])}}
+    {:label  "a table with no explicit sortkey or distribution (AUTO) returns []"
+     :table  "mb_fetch_rs_empty"
      :create ["CREATE TABLE mb_fetch_rs_empty (a INT, b INT)"]
      :expected #{}}]
 


### PR DESCRIPTION
even/all managed distkeys were always marked failed after a transform run, even though the table got the right distribution. fetch-table-indexes read the distkey from svv_redshift_columns, where the flag is only true on the single column of a DISTSTYLE KEY table, so even/all looked like no distkey and reconcile found no match.

- read the table-level style from pg_class_info.reldiststyle (0 EVEN, 1 KEY, 8 ALL). it's reliable for empty tables, which matters since a CTAS can yield zero rows (svv_table_info skips empty tables).
- match distkeys by style, not columns only. even and all are both column-less, so they used to collapse onto the same key.
- dropped auto from the offered styles. it's keyed 9 on every default table and redshift drifts it between EVEN/KEY/ALL as the table grows, so there's nothing fixed to reconcile against.

stacked on #76595.
