### PR TITLE
Add dep-cruiser for creating module graph

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -1,0 +1,32 @@
+// dependency-cruiser config for the actual frontend import graph (what's
+// imported, vs the *allowed* edges in module-boundaries.mjs). Consumed by
+// .github/scripts/create-test-plan.ts.
+//
+//   bunx depcruise frontend/src enterprise/frontend/src \
+//     --config .dependency-cruiser.cjs --output-type json > dependency-graph.json
+
+/** @type {import('dependency-cruiser').IConfiguration} */
+module.exports = {
+  options: {
+    // Keep only edges between our own source files (drops node_modules etc.),
+    // which keeps the JSON small.
+    includeOnly: "^(frontend/src|enterprise/frontend/src)/",
+
+    doNotFollow: { path: "node_modules" },
+
+    // Resolve the `"*": ["./frontend/src/*", ...]` aliases so bare imports like
+    // `metabase/lib/foo` map back to a real file.
+    tsConfig: { fileName: "tsconfig.json" },
+
+    // Keep type-only imports: a type-only dependent still breaks on a type change.
+    tsPreCompilationDeps: true,
+
+    moduleSystems: ["es6", "cjs", "tsd"],
+
+    enhancedResolveOptions: {
+      exportsFields: ["exports"],
+      conditionNames: ["import", "require", "node", "default", "types"],
+      extensions: [".js", ".jsx", ".ts", ".tsx", ".json"],
+    },
+  },
+};

--- a/.github/actions/create-test-plan/action.yml
+++ b/.github/actions/create-test-plan/action.yml
@@ -1,0 +1,66 @@
+name: Create test plan
+description: Cruise the frontend import graph and compute the affected-tests plan.
+
+inputs:
+  changed-files:
+    description: All changed files (CSV).
+    required: true
+  fe-changed-files:
+    description: Changed frontend_sources files (CSV).
+    required: true
+  be-changed-files:
+    description: Changed backend_sources files (CSV).
+    required: true
+  unit-infra-touched:
+    description: Whether FE unit infra changed.
+    required: true
+  loki-infra-touched:
+    description: Whether Loki infra changed.
+    required: true
+  shared-sources-touched:
+    description: Whether cljc/cljs/package.json changed.
+    required: true
+
+outputs:
+  stats:
+    description: FE Affected Tests stats row (JSON).
+    value: ${{ steps.compute.outputs.stats }}
+  fe_unit_specs_to_run:
+    description: Unit specs to run (JSON array).
+    value: ${{ steps.compute.outputs.fe_unit_specs_to_run }}
+  loki_stories_to_run:
+    description: Loki stories to run (JSON array).
+    value: ${{ steps.compute.outputs.loki_stories_to_run }}
+  e2e_specs_to_run:
+    description: E2E specs to run (JSON array).
+    value: ${{ steps.compute.outputs.e2e_specs_to_run }}
+
+runs:
+  using: composite
+  steps:
+    - name: Prepare Node + Bun
+      uses: ./.github/actions/prepare-node-bun
+    - name: Create test plan
+      id: compute
+      shell: bash
+      env:
+        CHANGED_FILES: ${{ inputs.changed-files }}
+        FE_CHANGED_FILES: ${{ inputs.fe-changed-files }}
+        BE_CHANGED_FILES: ${{ inputs.be-changed-files }}
+        UNIT_INFRA_TOUCHED: ${{ inputs.unit-infra-touched }}
+        LOKI_INFRA_TOUCHED: ${{ inputs.loki-infra-touched }}
+        SHARED_SOURCES_TOUCHED: ${{ inputs.shared-sources-touched }}
+        DEP_GRAPH_JSON: dependency-graph.json
+      run: |
+        # on failure create-test-plan falls back to the rules graph.
+        bun install --frozen-lockfile || true
+        bunx depcruise frontend/src enterprise/frontend/src \
+          --config .dependency-cruiser.cjs \
+          --output-type json > dependency-graph.json || true
+
+        OUTPUT=$(bun .github/scripts/create-test-plan.ts)
+        echo "$OUTPUT" | jq '.stats'
+        echo "stats=$(echo "$OUTPUT" | jq -c '.stats')" >> "$GITHUB_OUTPUT"
+        echo "fe_unit_specs_to_run=$(echo "$OUTPUT" | jq -c '.fe_unit_specs_to_run')" >> "$GITHUB_OUTPUT"
+        echo "loki_stories_to_run=$(echo "$OUTPUT" | jq -c '.loki_stories_to_run')" >> "$GITHUB_OUTPUT"
+        echo "e2e_specs_to_run=$(echo "$OUTPUT" | jq -c '.e2e_specs_to_run')" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/affected-modules.ts
+++ b/.github/scripts/affected-modules.ts
@@ -8,7 +8,7 @@ export type FileDependency = { source: string; dependencies: string[] };
 /**
  * Compiles a glob pattern to an anchored RegExp.
  */
-export function globToRegex(glob: string): RegExp {
+function globToRegex(glob: string): RegExp {
   const escapeSegment = (seg: string) =>
     seg.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, "[^/]*");
   const body = glob.split("**").map(escapeSegment).join(".*");
@@ -88,7 +88,7 @@ export function buildFileGraph(
   return { nodes: buildNodes(elements), fileDependents };
 }
 
-// Changed files plus every file that transitively imports them.
+/** Changed files plus every file that transitively imports them. */
 export function getAffectedFiles(
   fileGraph: FileGraph,
   changedFiles: string[],
@@ -107,26 +107,86 @@ export function getAffectedFiles(
   return affected;
 }
 
-/** Get affected files then collapse them to their modules. */
-export function getAffectedModulesFromFiles(
-  fileGraph: FileGraph,
-  changedFiles: string[],
-): Set<string> {
-  const affectedFiles = getAffectedFiles(fileGraph, changedFiles);
-  const modules = new Set<string>();
-  for (const file of affectedFiles) {
-    const module = mapFileToModule(fileGraph.nodes, file);
-    if (module) {
-      modules.add(module);
-    }
-  }
-  return modules;
-}
-
 export type ModuleGraph = {
   nodes: ModuleNode[];
+  /**
+   * dependents.get(M) is every module affected when M changes — the full
+   * transitive closure, so getAffectedModules only needs a single hop.
+   */
   dependents: Map<string, Set<string>>;
 };
+
+/** Expands a direct-dependents map into its transitive closure. */
+function transitiveClosure(
+  direct: Map<string, Set<string>>,
+): Map<string, Set<string>> {
+  const closure = new Map<string, Set<string>>();
+  for (const start of direct.keys()) {
+    const reached = new Set<string>();
+    const queue = [...(direct.get(start) ?? [])];
+    while (queue.length > 0) {
+      const node = queue.shift()!;
+      if (reached.has(node)) {
+        continue;
+      }
+      reached.add(node);
+      for (const next of direct.get(node) ?? []) {
+        queue.push(next);
+      }
+    }
+    reached.delete(start);
+    closure.set(start, reached);
+  }
+  return closure;
+}
+
+/**
+ * Builds a module graph from the actual import graph. Reachability is computed
+ * per module at the file level and then collapsed to modules.
+ */
+export function buildUsageModuleGraph(
+  elements: ModuleDef[],
+  fileDependencies: FileDependency[],
+): ModuleGraph {
+  const nodes = buildNodes(elements);
+  const fileGraph = buildFileGraph(elements, fileDependencies);
+
+  const filesByModule = new Map<string, string[]>();
+  const allFiles = new Set<string>();
+  for (const { source, dependencies } of fileDependencies) {
+    allFiles.add(source);
+    for (const target of dependencies) {
+      allFiles.add(target);
+    }
+  }
+  for (const file of allFiles) {
+    const module = mapFileToModule(nodes, file);
+    if (module) {
+      const files = filesByModule.get(module);
+      if (files) {
+        files.push(file);
+      } else {
+        filesByModule.set(module, [file]);
+      }
+    }
+  }
+
+  const dependents = new Map<string, Set<string>>(
+    elements.map((el) => [el.type, new Set()]),
+  );
+  for (const [module, files] of filesByModule) {
+    const affected = new Set<string>();
+    for (const file of getAffectedFiles(fileGraph, files)) {
+      const owner = mapFileToModule(nodes, file);
+      if (owner && owner !== module) {
+        affected.add(owner);
+      }
+    }
+    dependents.set(module, affected);
+  }
+
+  return { nodes, dependents };
+}
 
 export function buildModuleGraph(
   elements: ModuleDef[],
@@ -146,9 +206,7 @@ export function buildModuleGraph(
     return allTypes.includes(pattern) ? [pattern] : [];
   }
 
-  // dependents.get(M) is the set of modules that depend on M
-  // i.e. modules that are affected when M changes
-  const dependents = new Map<string, Set<string>>(
+  const directDependents = new Map<string, Set<string>>(
     allTypes.map((type) => [type, new Set()]),
   );
   for (const rule of rules) {
@@ -157,13 +215,13 @@ export function buildModuleGraph(
     for (const target of allowTypes) {
       for (const importer of fromTypes) {
         if (importer !== target) {
-          dependents.get(target)?.add(importer);
+          directDependents.get(target)?.add(importer);
         }
       }
     }
   }
 
-  return { nodes, dependents };
+  return { nodes, dependents: transitiveClosure(directDependents) };
 }
 
 /**
@@ -173,16 +231,10 @@ export function getAffectedModules(
   moduleGraph: ModuleGraph,
   changedFiles: string[],
 ): Set<string> {
-  const direct = getChangedModules(moduleGraph.nodes, changedFiles);
-  const affected = new Set(direct);
-  const queue = [...direct];
-  while (queue.length > 0) {
-    const module = queue.shift()!;
+  const affected = getChangedModules(moduleGraph.nodes, changedFiles);
+  for (const module of [...affected]) {
     for (const dep of moduleGraph.dependents.get(module) ?? []) {
-      if (!affected.has(dep)) {
-        affected.add(dep);
-        queue.push(dep);
-      }
+      affected.add(dep);
     }
   }
   return affected;

--- a/.github/scripts/affected-modules.ts
+++ b/.github/scripts/affected-modules.ts
@@ -1,12 +1,9 @@
 export type ModuleDef = { type: string; pattern: string };
 export type Rule = { from: string[]; allow: string[] };
 
-type ModuleNode = { type: string; regex: RegExp };
+export type ModuleNode = { type: string; regex: RegExp };
 
-export type ModuleGraph = {
-  nodes: ModuleNode[];
-  dependents: Map<string, Set<string>>;
-};
+export type FileDependency = { source: string; dependencies: string[] };
 
 /**
  * Compiles a glob pattern to an anchored RegExp.
@@ -18,15 +15,124 @@ export function globToRegex(glob: string): RegExp {
   return new RegExp(`^${body}$`);
 }
 
+/** First match wins, so element order matters for nested patterns. */
+export function buildNodes(elements: ModuleDef[]): ModuleNode[] {
+  return elements.map((el) => ({
+    type: el.type,
+    regex: globToRegex(el.pattern),
+  }));
+}
+
+export function mapFileToModule(
+  nodes: ModuleNode[],
+  path: string,
+): string | null {
+  for (const node of nodes) {
+    if (node.regex.test(path)) {
+      return node.type;
+    }
+  }
+  return null;
+}
+
+export function getChangedModules(
+  nodes: ModuleNode[],
+  changedFiles: string[],
+): Set<string> {
+  const direct = new Set<string>();
+  for (const file of changedFiles) {
+    const module = mapFileToModule(nodes, file);
+    if (module) {
+      direct.add(module);
+    }
+  }
+  return direct;
+}
+
+export type FileGraph = {
+  nodes: ModuleNode[];
+  fileDependents: Map<string, Set<string>>;
+};
+
+/** Drops unresolvable imports (e.g. ambient types) that point at no real file. */
+export function parseCruiseModules(
+  modules: Array<{
+    source: string;
+    dependencies?: Array<{ resolved: string; couldNotResolve?: boolean }>;
+  }>,
+): FileDependency[] {
+  return modules.map((module) => ({
+    source: module.source,
+    dependencies: (module.dependencies ?? [])
+      .filter((dep) => !dep.couldNotResolve)
+      .map((dep) => dep.resolved),
+  }));
+}
+
+/** Inverts the import edges into the `fileDependents` reverse graph. */
+export function buildFileGraph(
+  elements: ModuleDef[],
+  fileDependencies: FileDependency[],
+): FileGraph {
+  const fileDependents = new Map<string, Set<string>>();
+  for (const { source, dependencies } of fileDependencies) {
+    for (const target of dependencies) {
+      let importers = fileDependents.get(target);
+      if (!importers) {
+        importers = new Set();
+        fileDependents.set(target, importers);
+      }
+      importers.add(source);
+    }
+  }
+  return { nodes: buildNodes(elements), fileDependents };
+}
+
+// Changed files plus every file that transitively imports them.
+export function getAffectedFiles(
+  fileGraph: FileGraph,
+  changedFiles: string[],
+): Set<string> {
+  const affected = new Set(changedFiles);
+  const queue = [...changedFiles];
+  while (queue.length > 0) {
+    const file = queue.shift()!;
+    for (const importer of fileGraph.fileDependents.get(file) ?? []) {
+      if (!affected.has(importer)) {
+        affected.add(importer);
+        queue.push(importer);
+      }
+    }
+  }
+  return affected;
+}
+
+/** Get affected files then collapse them to their modules. */
+export function getAffectedModulesFromFiles(
+  fileGraph: FileGraph,
+  changedFiles: string[],
+): Set<string> {
+  const affectedFiles = getAffectedFiles(fileGraph, changedFiles);
+  const modules = new Set<string>();
+  for (const file of affectedFiles) {
+    const module = mapFileToModule(fileGraph.nodes, file);
+    if (module) {
+      modules.add(module);
+    }
+  }
+  return modules;
+}
+
+export type ModuleGraph = {
+  nodes: ModuleNode[];
+  dependents: Map<string, Set<string>>;
+};
+
 export function buildModuleGraph(
   elements: ModuleDef[],
   rules: Rule[],
 ): ModuleGraph {
-  const nodes = elements.map((el) => ({
-    type: el.type,
-    regex: globToRegex(el.pattern),
-  }));
-
+  const nodes = buildNodes(elements);
   const allTypes = elements.map((e) => e.type);
 
   function expandPattern(pattern: string): string[] {
@@ -61,46 +167,13 @@ export function buildModuleGraph(
 }
 
 /**
- * Returns the module type that owns the given file.
- * First match wins, so element ordering matters for nested patterns.
- */
-export function mapFileToModule(
-  moduleGraph: ModuleGraph,
-  path: string,
-): string | null {
-  for (const el of moduleGraph.nodes) {
-    if (el.regex.test(path)) {
-      return el.type;
-    }
-  }
-  return null;
-}
-
-/**
- * Returns the set of module types containing any of the changed files.
- */
-export function getChangedModules(
-  moduleGraph: ModuleGraph,
-  changedFiles: string[],
-): Set<string> {
-  const direct = new Set<string>();
-  for (const file of changedFiles) {
-    const module = mapFileToModule(moduleGraph, file);
-    if (module) {
-      direct.add(module);
-    }
-  }
-  return direct;
-}
-
-/**
  * Returns the changed modules and all modules that directly or indirectly depend on them
  */
 export function getAffectedModules(
   moduleGraph: ModuleGraph,
   changedFiles: string[],
 ): Set<string> {
-  const direct = getChangedModules(moduleGraph, changedFiles);
+  const direct = getChangedModules(moduleGraph.nodes, changedFiles);
   const affected = new Set(direct);
   const queue = [...direct];
   while (queue.length > 0) {

--- a/.github/scripts/affected-modules.unit.spec.ts
+++ b/.github/scripts/affected-modules.unit.spec.ts
@@ -1,8 +1,13 @@
 import {
+  buildFileGraph,
   buildModuleGraph,
+  buildNodes,
+  getAffectedFiles,
   getAffectedModules,
+  getAffectedModulesFromFiles,
   getChangedModules,
   mapFileToModule,
+  parseCruiseModules,
 } from "./affected-modules";
 
 const ELEMENTS = [
@@ -31,6 +36,7 @@ const RULES = [
   { from: ["app/*"], allow: ["lib/*", "feature/*", "app/*"] },
 ];
 
+const nodes = buildNodes(ELEMENTS);
 const graph = buildModuleGraph(ELEMENTS, RULES);
 
 describe("affected modules", () => {
@@ -49,19 +55,19 @@ describe("affected modules", () => {
       ["external/lib/foo.ts", "feature/external"],
       ["src/embed.tsx", "app/main"],
     ])("should map %s to %s", (path, expected) => {
-      expect(mapFileToModule(graph, path)).toBe(expected);
+      expect(mapFileToModule(nodes, path)).toBe(expected);
     });
 
     it("should return null for files outside any pattern", () => {
-      expect(mapFileToModule(graph, "docs/foo.md")).toBe(null);
-      expect(mapFileToModule(graph, "README.md")).toBe(null);
-      expect(mapFileToModule(graph, "external/notlib/foo.ts")).toBe(null);
+      expect(mapFileToModule(nodes, "docs/foo.md")).toBe(null);
+      expect(mapFileToModule(nodes, "README.md")).toBe(null);
+      expect(mapFileToModule(nodes, "external/notlib/foo.ts")).toBe(null);
     });
   });
 
   describe("getChangedModules", () => {
     it("should return the unique set of modules whose files changed", () => {
-      const result = getChangedModules(graph, [
+      const result = getChangedModules(nodes, [
         "src/utils/colors.ts",
         "src/foo/x.ts",
         "src/foo/y.ts",
@@ -71,11 +77,83 @@ describe("affected modules", () => {
     });
 
     it("should return an empty set when no file maps to a module", () => {
-      expect(getChangedModules(graph, ["docs/foo.md"]).size).toBe(0);
+      expect(getChangedModules(nodes, ["docs/foo.md"]).size).toBe(0);
     });
   });
 
-  describe("getAffectedModules", () => {
+  describe("parseCruiseModules", () => {
+    it("should flatten to source + resolved-paths and drop unresolved deps", () => {
+      expect(
+        parseCruiseModules([
+          {
+            source: "src/foo/foo.tsx",
+            dependencies: [
+              { resolved: "src/utils/colors.ts" },
+              { resolved: "ambient/types", couldNotResolve: true },
+            ],
+          },
+          { source: "src/bar/bar.tsx" }, // no dependencies key
+        ]),
+      ).toEqual([
+        { source: "src/foo/foo.tsx", dependencies: ["src/utils/colors.ts"] },
+        { source: "src/bar/bar.tsx", dependencies: [] },
+      ]);
+    });
+  });
+
+  // Hub-merging scenario: app/main contains BOTH an entry point (app.js) that
+  // imports feature/foo AND a widely-imported file (embed.tsx) that feature/bar
+  // imports. A module-level graph would manufacture feature/foo -> app/main ->
+  // feature/bar; walking files first does not, because nothing imports app.js.
+  const FILE_DEPS = [
+    { source: "src/app.js", dependencies: ["src/foo/foo.tsx"] },
+    { source: "src/bar/bar.tsx", dependencies: ["src/embed.tsx"] },
+    { source: "src/foo/foo.tsx", dependencies: ["src/utils/colors.ts"] },
+  ];
+  const fileGraph = buildFileGraph(ELEMENTS, FILE_DEPS);
+
+  describe("getAffectedFiles", () => {
+    it("should return the changed file and everything that imports it", () => {
+      expect(
+        [...getAffectedFiles(fileGraph, ["src/utils/colors.ts"])].sort(),
+      ).toEqual(["src/app.js", "src/foo/foo.tsx", "src/utils/colors.ts"]);
+    });
+
+    it("should include a changed file with no importers (itself only)", () => {
+      // Nothing imports the app.js entry point.
+      expect([...getAffectedFiles(fileGraph, ["src/app.js"])]).toEqual([
+        "src/app.js",
+      ]);
+    });
+  });
+
+  describe("getAffectedModulesFromFiles", () => {
+    it("should expand affected files to their owning modules", () => {
+      expect(
+        [
+          ...getAffectedModulesFromFiles(fileGraph, ["src/utils/colors.ts"]),
+        ].sort(),
+      ).toEqual(["app/main", "feature/foo", "lib/utils"]);
+    });
+
+    it("should NOT pull in feature/bar via the app/main hub", () => {
+      // The bug a module-level graph has: feature/bar imports embed.tsx (app/main)
+      // and app.js (app/main) imports feature/foo, but those are different files.
+      const affected = getAffectedModulesFromFiles(fileGraph, [
+        "src/foo/foo.tsx",
+      ]);
+      expect([...affected].sort()).toEqual(["app/main", "feature/foo"]);
+      expect(affected.has("feature/bar")).toBe(false);
+    });
+
+    it("should return empty when no file maps to a module", () => {
+      expect(getAffectedModulesFromFiles(fileGraph, ["docs/foo.md"]).size).toBe(
+        0,
+      );
+    });
+  });
+
+  describe("getAffectedModules (rules-graph fallback)", () => {
     it("should affect feature/super and app/main but not feature/bar when feature/foo changes", () => {
       const result = getAffectedModules(graph, ["src/foo/x.ts"]);
       expect([...result].sort()).toEqual([

--- a/.github/scripts/affected-modules.unit.spec.ts
+++ b/.github/scripts/affected-modules.unit.spec.ts
@@ -2,9 +2,9 @@ import {
   buildFileGraph,
   buildModuleGraph,
   buildNodes,
+  buildUsageModuleGraph,
   getAffectedFiles,
   getAffectedModules,
-  getAffectedModulesFromFiles,
   getChangedModules,
   mapFileToModule,
   parseCruiseModules,
@@ -101,10 +101,6 @@ describe("affected modules", () => {
     });
   });
 
-  // Hub-merging scenario: app/main contains BOTH an entry point (app.js) that
-  // imports feature/foo AND a widely-imported file (embed.tsx) that feature/bar
-  // imports. A module-level graph would manufacture feature/foo -> app/main ->
-  // feature/bar; walking files first does not, because nothing imports app.js.
   const FILE_DEPS = [
     { source: "src/app.js", dependencies: ["src/foo/foo.tsx"] },
     { source: "src/bar/bar.tsx", dependencies: ["src/embed.tsx"] },
@@ -127,33 +123,35 @@ describe("affected modules", () => {
     });
   });
 
-  describe("getAffectedModulesFromFiles", () => {
-    it("should expand affected files to their owning modules", () => {
+  describe("buildUsageModuleGraph + getAffectedModules", () => {
+    const usageGraph = buildUsageModuleGraph(ELEMENTS, FILE_DEPS);
+
+    it("should expand a changed module to its file-level affected modules", () => {
       expect(
-        [
-          ...getAffectedModulesFromFiles(fileGraph, ["src/utils/colors.ts"]),
-        ].sort(),
+        [...getAffectedModules(usageGraph, ["src/utils/colors.ts"])].sort(),
       ).toEqual(["app/main", "feature/foo", "lib/utils"]);
     });
 
     it("should NOT pull in feature/bar via the app/main hub", () => {
-      // The bug a module-level graph has: feature/bar imports embed.tsx (app/main)
-      // and app.js (app/main) imports feature/foo, but those are different files.
-      const affected = getAffectedModulesFromFiles(fileGraph, [
-        "src/foo/foo.tsx",
-      ]);
+      const affected = getAffectedModules(usageGraph, ["src/foo/foo.tsx"]);
       expect([...affected].sort()).toEqual(["app/main", "feature/foo"]);
       expect(affected.has("feature/bar")).toBe(false);
     });
 
+    it("should treat the whole changed module as changed", () => {
+      // app.js itself has no importers, but app/main also owns embed.tsx, which
+      // feature/bar imports so changing any app/main file flags feature/bar.
+      expect(
+        [...getAffectedModules(usageGraph, ["src/app.js"])].sort(),
+      ).toEqual(["app/main", "feature/bar"]);
+    });
+
     it("should return empty when no file maps to a module", () => {
-      expect(getAffectedModulesFromFiles(fileGraph, ["docs/foo.md"]).size).toBe(
-        0,
-      );
+      expect(getAffectedModules(usageGraph, ["docs/foo.md"]).size).toBe(0);
     });
   });
 
-  describe("getAffectedModules (rules-graph fallback)", () => {
+  describe("getAffectedModules (rules graph)", () => {
     it("should affect feature/super and app/main but not feature/bar when feature/foo changes", () => {
       const result = getAffectedModules(graph, ["src/foo/x.ts"]);
       expect([...result].sort()).toEqual([

--- a/.github/scripts/affected-tests.ts
+++ b/.github/scripts/affected-tests.ts
@@ -1,36 +1,34 @@
-// Per-suite affected-tests logic: combines module-affected closure with
-// per-suite "infra-touched" booleans (computed by dorny/paths-filter against
-// the `frontend_unit_infra` / `frontend_loki_infra` anchors in file-paths.yaml).
-// When infra files change, the whole suite runs in full.
-
+// Builds the affected-tests plan from raw inputs: computes the rules and usage
+// affected-module sets and selects, per suite, which specs to run under each.
 import {
+  type FileDependency,
   type ModuleDef,
-  type ModuleGraph,
+  type ModuleNode,
   type Rule,
+  buildFileGraph,
   buildModuleGraph,
+  buildNodes,
   getAffectedModules,
+  getAffectedModulesFromFiles,
   getChangedModules,
   mapFileToModule,
 } from "./affected-modules";
 
-export type TestSuiteDef = {
-  statsPrefix: string;
-  runAllTests?: boolean;
-};
-
 export type TestPlanStats = {
-  modules_changed: number;
-  modules_affected: number;
-  modules_affected_list: string[];
-  fe_unit_specs_total: number;
-  fe_unit_specs_run: number;
-  fe_unit_specs_skipped: number;
-  loki_stories_total: number;
-  loki_stories_run: number;
-  loki_stories_skipped: number;
-  e2e_specs_total: number;
-  e2e_specs_run: number;
-  e2e_specs_skipped: number;
+  fe_files_changed: number;
+  be_files_changed: number;
+  fe_modules_changed: number;
+  fe_modules_affected_rules: number;
+  fe_modules_affected_usage: number;
+  unit_specs_all: number;
+  unit_specs_to_run_rules: number;
+  unit_specs_to_run_usage: number;
+  loki_stories_all: number;
+  loki_stories_to_run_rules: number;
+  loki_stories_to_run_usage: number;
+  e2e_specs_all: number;
+  e2e_specs_to_run_rules: number;
+  e2e_specs_to_run_usage: number;
 };
 
 export type TestPlan = {
@@ -40,101 +38,94 @@ export type TestPlan = {
   e2e_specs_to_run: string[];
 };
 
-export const TEST_SUITES = {
-  unit: {
-    statsPrefix: "fe_unit_specs",
-  },
-  loki: {
-    statsPrefix: "loki_stories",
-  },
-  e2e: {
-    statsPrefix: "e2e_specs",
-    // We don't map changed files to e2e tests yet, so for now just run them all
-    runAllTests: true,
-  },
-} satisfies Record<string, TestSuiteDef>;
-
-export function createTestPlan({
-  elements,
-  rules,
-  testSuites,
-  changedFiles,
-  testFilesBySuite,
-  infraTouchedBySuite,
-}: {
+export type CreateTestPlanInput = {
   elements: ModuleDef[];
   rules: Rule[];
-  testSuites: Record<string, TestSuiteDef>;
   changedFiles: string[];
-  testFilesBySuite: Record<string, string[]>;
-  infraTouchedBySuite: Record<string, boolean>;
-}): TestPlan {
-  const moduleGraph = buildModuleGraph(elements, rules);
+  // Parsed dependency-cruiser edges, or null to fall back to the rules graph.
+  fileDependencies: FileDependency[] | null;
+  testFilesBySuite: { unit: string[]; loki: string[]; e2e: string[] };
+  unitInfraTouched: boolean;
+  lokiInfraTouched: boolean;
+  sharedSourcesTouched: boolean;
+  feFilesChanged: number;
+  beFilesChanged: number;
+};
 
-  const changedModules = getChangedModules(moduleGraph, changedFiles);
-  const modulesAffected = getAffectedModules(moduleGraph, changedFiles);
-  const modulesAffectedList = [...modulesAffected].sort();
-
-  const specsToRun: Record<string, string[]> = {};
-  const stats: Record<string, number | string[]> = {
-    modules_changed: changedModules.size,
-    modules_affected: modulesAffected.size,
-    modules_affected_list: modulesAffectedList,
-  };
-
-  for (const [name, testSuite] of Object.entries(testSuites)) {
-    const files = testFilesBySuite[name] ?? [];
-    const tests = createTestPlanForSuite(
-      moduleGraph,
-      testSuite,
-      infraTouchedBySuite[name] ?? false,
-      changedFiles,
-      files,
-    );
-    specsToRun[name] = tests;
-    stats[`${testSuite.statsPrefix}_total`] = files.length;
-    stats[`${testSuite.statsPrefix}_run`] = tests.length;
-    stats[`${testSuite.statsPrefix}_skipped`] = files.length - tests.length;
-  }
-
-  return {
-    stats: stats as TestPlanStats,
-    fe_unit_specs_to_run: specsToRun.unit ?? [],
-    loki_stories_to_run: specsToRun.loki ?? [],
-    e2e_specs_to_run: specsToRun.e2e ?? [],
-  };
-}
-
-/**
- * Computes the test plan for one test suite
- *
- * Runs the full suite when `runAllTests` is set or `infraTouched` is true,
- * otherwise runs the tests based on affected-modules.
- */
-export function createTestPlanForSuite(
-  moduleGraph: ModuleGraph,
-  testSuite: TestSuiteDef,
-  infraTouched: boolean,
-  changedFiles: string[],
-  allTestFiles: string[],
-): string[] {
-  if (testSuite.runAllTests || infraTouched) {
-    return allTestFiles;
-  }
-  const affected = getAffectedModules(moduleGraph, changedFiles);
-  return filterAffectedTests(moduleGraph, affected, allTestFiles);
-}
-
-/**
- * Filters the test-file list down to tests whose owning module is affected.
- */
+// Tests whose owning module is affected.
 export function filterAffectedTests(
-  moduleGraph: ModuleGraph,
+  nodes: ModuleNode[],
   affected: Set<string>,
   testFiles: string[],
 ): string[] {
   return testFiles.filter((file) => {
-    const module = mapFileToModule(moduleGraph, file);
+    const module = mapFileToModule(nodes, file);
     return module !== null && affected.has(module);
   });
+}
+
+export function createTestPlan({
+  elements,
+  rules,
+  changedFiles,
+  fileDependencies,
+  testFilesBySuite,
+  unitInfraTouched,
+  lokiInfraTouched,
+  sharedSourcesTouched,
+  feFilesChanged,
+  beFilesChanged,
+}: CreateTestPlanInput): TestPlan {
+  const nodes = buildNodes(elements);
+  const changedModules = getChangedModules(nodes, changedFiles);
+
+  const rulesAffected = getAffectedModules(
+    buildModuleGraph(elements, rules),
+    changedFiles,
+  );
+  const usageAffected = fileDependencies
+    ? getAffectedModulesFromFiles(
+        buildFileGraph(elements, fileDependencies),
+        changedFiles,
+      )
+    : rulesAffected;
+
+  // cljc/cljs compile into the FE bundle, so they force a full run that module
+  // selection can't narrow — same effect as a suite's own infra changing.
+  const unitForceAll = unitInfraTouched || sharedSourcesTouched;
+  const lokiForceAll = lokiInfraTouched || sharedSourcesTouched;
+
+  const select = (forceAll: boolean, affected: Set<string>, files: string[]) =>
+    forceAll ? files : filterAffectedTests(nodes, affected, files);
+
+  const { unit, loki, e2e } = testFilesBySuite;
+  const unitRules = select(unitForceAll, rulesAffected, unit);
+  const unitUsage = select(unitForceAll, usageAffected, unit);
+  const lokiRules = select(lokiForceAll, rulesAffected, loki);
+  const lokiUsage = select(lokiForceAll, usageAffected, loki);
+  // No e2e-spec -> module mapping exists yet, so e2e always runs in full.
+  const e2eRules = e2e;
+  const e2eUsage = e2e;
+
+  return {
+    stats: {
+      fe_files_changed: feFilesChanged,
+      be_files_changed: beFilesChanged,
+      fe_modules_changed: changedModules.size,
+      fe_modules_affected_rules: rulesAffected.size,
+      fe_modules_affected_usage: usageAffected.size,
+      unit_specs_all: unit.length,
+      unit_specs_to_run_rules: unitRules.length,
+      unit_specs_to_run_usage: unitUsage.length,
+      loki_stories_all: loki.length,
+      loki_stories_to_run_rules: lokiRules.length,
+      loki_stories_to_run_usage: lokiUsage.length,
+      e2e_specs_all: e2e.length,
+      e2e_specs_to_run_rules: e2eRules.length,
+      e2e_specs_to_run_usage: e2eUsage.length,
+    },
+    fe_unit_specs_to_run: unitUsage,
+    loki_stories_to_run: lokiUsage,
+    e2e_specs_to_run: e2eUsage,
+  };
 }

--- a/.github/scripts/affected-tests.ts
+++ b/.github/scripts/affected-tests.ts
@@ -5,11 +5,9 @@ import {
   type ModuleDef,
   type ModuleNode,
   type Rule,
-  buildFileGraph,
   buildModuleGraph,
-  buildNodes,
+  buildUsageModuleGraph,
   getAffectedModules,
-  getAffectedModulesFromFiles,
   getChangedModules,
   mapFileToModule,
 } from "./affected-modules";
@@ -76,19 +74,15 @@ export function createTestPlan({
   feFilesChanged,
   beFilesChanged,
 }: CreateTestPlanInput): TestPlan {
-  const nodes = buildNodes(elements);
-  const changedModules = getChangedModules(nodes, changedFiles);
+  const rulesGraph = buildModuleGraph(elements, rules);
+  const usageGraph = fileDependencies
+    ? buildUsageModuleGraph(elements, fileDependencies)
+    : rulesGraph;
 
-  const rulesAffected = getAffectedModules(
-    buildModuleGraph(elements, rules),
-    changedFiles,
-  );
-  const usageAffected = fileDependencies
-    ? getAffectedModulesFromFiles(
-        buildFileGraph(elements, fileDependencies),
-        changedFiles,
-      )
-    : rulesAffected;
+  const nodes = rulesGraph.nodes;
+  const changedModules = getChangedModules(nodes, changedFiles);
+  const rulesAffected = getAffectedModules(rulesGraph, changedFiles);
+  const usageAffected = getAffectedModules(usageGraph, changedFiles);
 
   // cljc/cljs compile into the FE bundle, so they force a full run that module
   // selection can't narrow — same effect as a suite's own infra changing.

--- a/.github/scripts/affected-tests.unit.spec.ts
+++ b/.github/scripts/affected-tests.unit.spec.ts
@@ -1,9 +1,5 @@
-import { buildModuleGraph } from "./affected-modules";
-import {
-  createTestPlan,
-  createTestPlanForSuite,
-  filterAffectedTests,
-} from "./affected-tests";
+import { buildNodes } from "./affected-modules";
+import { createTestPlan, filterAffectedTests } from "./affected-tests";
 
 const ELEMENTS = [
   { type: "lib/utils", pattern: "src/utils/**" },
@@ -18,12 +14,6 @@ const RULES = [
   { from: ["feature/*"], allow: ["lib/*"] },
 ];
 
-const TEST_SUITE_DEFS = {
-  unit: { statsPrefix: "fe_unit_specs" },
-  loki: { statsPrefix: "loki_stories" },
-  e2e: { statsPrefix: "e2e_specs", runAllTests: true },
-};
-
 const UNIT_FILES = [
   "src/foo/foo.unit.spec.ts",
   "src/foo/bar.unit.spec.ts",
@@ -33,158 +23,110 @@ const UNIT_FILES = [
 const LOKI_FILES = ["src/foo/Foo.stories.tsx", "src/bar/Bar.stories.tsx"];
 const E2E_FILES = ["e2e/test/scenarios/a.cy.spec.ts"];
 
-const moduleGraph = buildModuleGraph(ELEMENTS, RULES);
+const baseInput = {
+  elements: ELEMENTS,
+  rules: RULES,
+  fileDependencies: null,
+  testFilesBySuite: { unit: UNIT_FILES, loki: LOKI_FILES, e2e: E2E_FILES },
+  unitInfraTouched: false,
+  lokiInfraTouched: false,
+  sharedSourcesTouched: false,
+  feFilesChanged: 0,
+  beFilesChanged: 0,
+};
 
-describe("affected tests", () => {
-  describe("createTestPlanForSuite", () => {
-    it("should run all tests when infra is touched", () => {
-      const result = createTestPlanForSuite(
-        moduleGraph,
-        TEST_SUITE_DEFS.unit,
-        true, // infraTouched
-        ["src/foo/x.ts"],
-        UNIT_FILES,
-      );
-      expect(result).toEqual(UNIT_FILES);
-    });
+describe("createTestPlan", () => {
+  it("runs only specs in affected modules (rules graph)", () => {
+    const plan = createTestPlan({ ...baseInput, changedFiles: ["src/foo/x.ts"] });
 
-    it("should fall back to affected-tests filtering when infra not touched", () => {
-      const result = createTestPlanForSuite(
-        moduleGraph,
-        TEST_SUITE_DEFS.unit,
-        false, // infraTouched
-        ["src/foo/x.ts"],
-        UNIT_FILES,
-      );
-      expect(result.sort()).toEqual([
-        "src/foo/bar.unit.spec.ts",
-        "src/foo/foo.unit.spec.ts",
-      ]);
-    });
-
-    it("should return nothing when infra not touched and no file maps to a module", () => {
-      const result = createTestPlanForSuite(
-        moduleGraph,
-        TEST_SUITE_DEFS.unit,
-        false,
-        ["docs/foo.md"],
-        UNIT_FILES,
-      );
-      expect(result).toEqual([]);
-    });
-
-    it("should run all tests for runAllTests suites regardless of inputs", () => {
-      expect(
-        createTestPlanForSuite(
-          moduleGraph,
-          TEST_SUITE_DEFS.e2e,
-          false,
-          ["docs/foo.md"],
-          E2E_FILES,
-        ),
-      ).toEqual(E2E_FILES);
-      expect(
-        createTestPlanForSuite(
-          moduleGraph,
-          TEST_SUITE_DEFS.e2e,
-          false,
-          ["src/foo/x.ts"],
-          E2E_FILES,
-        ),
-      ).toEqual(E2E_FILES);
-    });
+    expect(plan.stats.fe_modules_changed).toBe(1);
+    expect(plan.stats.fe_modules_affected_rules).toBe(1);
+    expect(plan.fe_unit_specs_to_run.sort()).toEqual([
+      "src/foo/bar.unit.spec.ts",
+      "src/foo/foo.unit.spec.ts",
+    ]);
+    expect(plan.stats.unit_specs_to_run_rules).toBe(2);
+    expect(plan.stats.loki_stories_to_run_rules).toBe(1);
+    // With no file deps, usage falls back to rules.
+    expect(plan.stats.unit_specs_to_run_usage).toBe(2);
   });
 
-  describe("createTestPlan", () => {
-    it("should return run lists and stats together", () => {
-      const result = createTestPlan({
-        elements: ELEMENTS,
-        rules: RULES,
-        testSuites: TEST_SUITE_DEFS,
-        changedFiles: ["src/foo/x.ts"],
-        testFilesBySuite: {
-          unit: UNIT_FILES,
-          loki: LOKI_FILES,
-          e2e: E2E_FILES,
-        },
-        infraTouchedBySuite: { unit: false, loki: false, e2e: false },
-      });
-
-      expect(result.fe_unit_specs_to_run.sort()).toEqual([
-        "src/foo/bar.unit.spec.ts",
-        "src/foo/foo.unit.spec.ts",
-      ]);
-      expect(result.loki_stories_to_run).toEqual(["src/foo/Foo.stories.tsx"]);
-      expect(result.e2e_specs_to_run).toEqual(E2E_FILES);
-
-      expect(result.stats).toEqual({
-        modules_changed: 1,
-        modules_affected: 1,
-        modules_affected_list: ["feature/foo"],
-        fe_unit_specs_total: 4,
-        fe_unit_specs_run: 2,
-        fe_unit_specs_skipped: 2,
-        loki_stories_total: 2,
-        loki_stories_run: 1,
-        loki_stories_skipped: 1,
-        e2e_specs_total: 1,
-        e2e_specs_run: 1,
-        e2e_specs_skipped: 0,
-      });
+  it("narrows further with the usage graph than the rules graph", () => {
+    const plan = createTestPlan({
+      ...baseInput,
+      changedFiles: ["src/utils/colors.ts"],
+      // Only feature/foo actually imports lib/utils.
+      fileDependencies: [
+        { source: "src/foo/foo.tsx", dependencies: ["src/utils/colors.ts"] },
+      ],
     });
 
-    it("should run all unit specs when unit infra is touched", () => {
-      const result = createTestPlan({
-        elements: ELEMENTS,
-        rules: RULES,
-        testSuites: TEST_SUITE_DEFS,
-        changedFiles: ["docs/foo.md"],
-        testFilesBySuite: {
-          unit: UNIT_FILES,
-          loki: LOKI_FILES,
-          e2e: E2E_FILES,
-        },
-        infraTouchedBySuite: { unit: true, loki: false, e2e: false },
-      });
-      expect(result.stats.fe_unit_specs_run).toBe(UNIT_FILES.length);
-      expect(result.stats.fe_unit_specs_skipped).toBe(0);
-      // Only the unit suite was triggered.
-      expect(result.stats.loki_stories_run).toBe(0);
-    });
-
-    it("should not run anything when no infra is touched and no modules affected", () => {
-      const result = createTestPlan({
-        elements: ELEMENTS,
-        rules: RULES,
-        testSuites: TEST_SUITE_DEFS,
-        changedFiles: ["docs/foo.md"],
-        testFilesBySuite: {
-          unit: UNIT_FILES,
-          loki: LOKI_FILES,
-          e2e: E2E_FILES,
-        },
-        infraTouchedBySuite: { unit: false, loki: false, e2e: false },
-      });
-      expect(result.stats.fe_unit_specs_run).toBe(0);
-      expect(result.stats.loki_stories_run).toBe(0);
-      // e2e is runAllTests, so it still reports run = total.
-      expect(result.stats.e2e_specs_run).toBe(E2E_FILES.length);
-    });
+    // Rules allow both features to import lib/utils, so both are "affected".
+    expect(plan.stats.fe_modules_affected_rules).toBe(3);
+    // Usage sees only feature/foo + lib/utils.
+    expect(plan.stats.fe_modules_affected_usage).toBe(2);
+    expect(plan.stats.unit_specs_to_run_rules).toBe(4);
+    expect(plan.stats.unit_specs_to_run_usage).toBe(3);
   });
 
-  describe("filterAffectedTests", () => {
-    it("should keep only tests inside affected modules", () => {
-      const affected = new Set(["feature/foo", "lib/utils"]);
-      const tests = [
-        "src/foo/foo.unit.spec.ts",
-        "src/utils/colors.unit.spec.ts",
-        "src/bar/bar.unit.spec.ts",
-        "docs/unrelated.unit.spec.ts",
-      ];
-      expect(filterAffectedTests(moduleGraph, affected, tests)).toEqual([
-        "src/foo/foo.unit.spec.ts",
-        "src/utils/colors.unit.spec.ts",
-      ]);
+  it("forces a full FE run on a shared-sources (cljc) change with no affected modules", () => {
+    const plan = createTestPlan({
+      ...baseInput,
+      changedFiles: ["docs/readme.md"],
+      sharedSourcesTouched: true,
     });
+
+    expect(plan.stats.fe_modules_affected_rules).toBe(0);
+    expect(plan.stats.unit_specs_to_run_rules).toBe(UNIT_FILES.length);
+    expect(plan.stats.unit_specs_to_run_usage).toBe(UNIT_FILES.length);
+    expect(plan.stats.loki_stories_to_run_rules).toBe(LOKI_FILES.length);
+  });
+
+  it("forces only the suite whose infra changed", () => {
+    const plan = createTestPlan({
+      ...baseInput,
+      changedFiles: ["docs/readme.md"],
+      unitInfraTouched: true,
+    });
+
+    expect(plan.stats.unit_specs_to_run_rules).toBe(UNIT_FILES.length);
+    expect(plan.stats.loki_stories_to_run_rules).toBe(0);
+  });
+
+  it("always runs the full e2e suite", () => {
+    const plan = createTestPlan({ ...baseInput, changedFiles: ["src/foo/x.ts"] });
+
+    expect(plan.stats.e2e_specs_to_run_rules).toBe(E2E_FILES.length);
+    expect(plan.stats.e2e_specs_to_run_usage).toBe(E2E_FILES.length);
+    expect(plan.e2e_specs_to_run).toEqual(E2E_FILES);
+  });
+
+  it("passes the FE/BE file counts through to stats", () => {
+    const plan = createTestPlan({
+      ...baseInput,
+      changedFiles: [],
+      feFilesChanged: 5,
+      beFilesChanged: 3,
+    });
+
+    expect(plan.stats.fe_files_changed).toBe(5);
+    expect(plan.stats.be_files_changed).toBe(3);
+  });
+});
+
+describe("filterAffectedTests", () => {
+  it("keeps only tests inside affected modules", () => {
+    const nodes = buildNodes(ELEMENTS);
+    const affected = new Set(["feature/foo", "lib/utils"]);
+    const tests = [
+      "src/foo/foo.unit.spec.ts",
+      "src/utils/colors.unit.spec.ts",
+      "src/bar/bar.unit.spec.ts",
+      "docs/unrelated.unit.spec.ts",
+    ];
+    expect(filterAffectedTests(nodes, affected, tests)).toEqual([
+      "src/foo/foo.unit.spec.ts",
+      "src/utils/colors.unit.spec.ts",
+    ]);
   });
 });

--- a/.github/scripts/create-test-plan.ts
+++ b/.github/scripts/create-test-plan.ts
@@ -1,10 +1,13 @@
-// Changed files come from dorny/paths-filter's `all_changed_files` output
+// I/O entrypoint: gather inputs (env vars, the cruise graph, the test-file
+// lists) and hand them to createTestPlan, which does the computing.
 
 import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 
 import { elements, rules } from "../../frontend/lint/module-boundaries.mjs";
 
-import { TEST_SUITES, createTestPlan } from "./affected-tests";
+import { type FileDependency, parseCruiseModules } from "./affected-modules";
+import { createTestPlan } from "./affected-tests";
 
 const UNIT_GLOBS = [
   "frontend/src/**/*.unit.spec.js",
@@ -42,26 +45,50 @@ function listFiles(globs: string[]): string[] {
     .filter(Boolean);
 }
 
-const changedFiles = (process.env.CHANGED_FILES ?? "")
-  .split(",")
-  .map((s) => s.trim())
-  .filter(Boolean);
+// dorny outputs comma-separated lists; CHANGED_FILES is `all_changed_files`.
+const csvToList = (csv: string | undefined) =>
+  (csv ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+// Reads the dependency-cruiser graph (DEP_GRAPH_JSON). Null falls back to the
+// rules graph, so a missing or unparseable file never breaks the plan.
+function readFileDependencies(): FileDependency[] | null {
+  const path = process.env.DEP_GRAPH_JSON;
+  if (path && existsSync(path)) {
+    try {
+      const { modules } = JSON.parse(readFileSync(path, "utf8"));
+      process.stderr.write(`Using usage graph from ${path}.\n`);
+      return parseCruiseModules(modules);
+    } catch (error) {
+      process.stderr.write(
+        `Failed to read ${path}; falling back to rules graph: ${error}\n`,
+      );
+    }
+  } else {
+    process.stderr.write(
+      "No DEP_GRAPH_JSON found; falling back to rules graph.\n",
+    );
+  }
+  return null;
+}
 
 const testPlan = createTestPlan({
   elements,
   rules,
-  testSuites: TEST_SUITES,
-  changedFiles,
+  changedFiles: csvToList(process.env.CHANGED_FILES),
+  fileDependencies: readFileDependencies(),
   testFilesBySuite: {
     unit: listFiles(UNIT_GLOBS),
     loki: listFiles(STORY_GLOBS),
     e2e: listFiles(E2E_GLOBS),
   },
-  infraTouchedBySuite: {
-    unit: process.env.UNIT_INFRA_TOUCHED === "true",
-    loki: process.env.LOKI_INFRA_TOUCHED === "true",
-    e2e: false,
-  },
+  unitInfraTouched: process.env.UNIT_INFRA_TOUCHED === "true",
+  lokiInfraTouched: process.env.LOKI_INFRA_TOUCHED === "true",
+  sharedSourcesTouched: process.env.SHARED_SOURCES_TOUCHED === "true",
+  feFilesChanged: csvToList(process.env.FE_CHANGED_FILES).length,
+  beFilesChanged: csvToList(process.env.BE_CHANGED_FILES).length,
 });
 
 process.stdout.write(JSON.stringify(testPlan) + "\n");

--- a/.github/scripts/module-usage.ts
+++ b/.github/scripts/module-usage.ts
@@ -1,0 +1,123 @@
+// Builds module-level "usage" maps: for each module, the set of modules that
+// depend on it, both directly and indirectly
+//
+// Both are computed at the FILE level off the real dependency-cruiser import
+// graph, then collapsed to module granularity at the very end.
+//
+//   bunx depcruise frontend/src enterprise/frontend/src \
+//     --config .dependency-cruiser.cjs --output-type json > dependency-graph.json
+//   DEP_GRAPH_JSON=dependency-graph.json \
+//   OUT_JSON=usage.json OUT_DIRECT_JSON=usage-direct.json \
+//     bun .github/scripts/module-usage.ts
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+import { elements } from "../../frontend/lint/module-boundaries.mjs";
+
+import {
+  buildFileGraph,
+  getAffectedFiles,
+  mapFileToModule,
+  parseCruiseModules,
+} from "./affected-modules";
+
+const depGraphPath = process.env.DEP_GRAPH_JSON ?? "dependency-graph.json";
+const { modules } = JSON.parse(readFileSync(depGraphPath, "utf8"));
+
+const fileDependencies = parseCruiseModules(modules);
+const fileGraph = buildFileGraph(elements, fileDependencies);
+
+// Group every known source file by its owning module. We seed from the cruise
+// output's `source` files plus everything that appears as a dependency target,
+// so files imported but never importing are still covered.
+const filesByModule = new Map<string, string[]>();
+const allFiles = new Set<string>();
+for (const { source, dependencies } of fileDependencies) {
+  allFiles.add(source);
+  for (const dep of dependencies) {
+    allFiles.add(dep);
+  }
+}
+for (const file of allFiles) {
+  const module = mapFileToModule(fileGraph.nodes, file);
+  if (!module) {
+    continue;
+  }
+  const list = filesByModule.get(module);
+  if (list) {
+    list.push(file);
+  } else {
+    filesByModule.set(module, [file]);
+  }
+}
+
+// Ensure every module appears as a key, even those nothing depends on.
+const emptyDependents = (): Record<string, Set<string>> => {
+  const map: Record<string, Set<string>> = {};
+  for (const module of filesByModule.keys()) {
+    map[module] = new Set();
+  }
+  return map;
+};
+
+// DIRECT usage: module B directly depends on module A if any file in B imports
+// any file in A — a single edge in the import graph, collapsed to modules.
+const directDependents = emptyDependents();
+for (const { source, dependencies } of fileDependencies) {
+  const importer = mapFileToModule(fileGraph.nodes, source);
+  if (!importer) {
+    continue;
+  }
+  for (const target of dependencies) {
+    const owner = mapFileToModule(fileGraph.nodes, target);
+    if (owner && owner !== importer) {
+      directDependents[owner].add(importer);
+    }
+  }
+}
+
+// TRANSITIVE usage: for each module, take all its files, walk the file-level
+// reverse graph to get every file that transitively imports them, collapse to
+// modules, and drop the module itself.
+const transitiveDependents = emptyDependents();
+for (const [module, files] of filesByModule) {
+  const affectedFiles = getAffectedFiles(fileGraph, files);
+  for (const file of affectedFiles) {
+    const owner = mapFileToModule(fileGraph.nodes, file);
+    if (owner && owner !== module) {
+      transitiveDependents[module].add(owner);
+    }
+  }
+}
+
+// Stable, sorted output for clean diffs.
+const toSorted = (
+  map: Record<string, Set<string>>,
+): Record<string, string[]> => {
+  const sorted: Record<string, string[]> = {};
+  for (const module of Object.keys(map).sort()) {
+    sorted[module] = [...map[module]].sort();
+  }
+  return sorted;
+};
+
+const writeOut = (
+  map: Record<string, Set<string>>,
+  outVar: string,
+  label: string,
+) => {
+  const sorted = toSorted(map);
+  const json = JSON.stringify(sorted, null, 2) + "\n";
+  const outPath = process.env[outVar];
+  if (outPath) {
+    writeFileSync(outPath, json);
+    process.stderr.write(
+      `Wrote ${Object.keys(sorted).length} modules (${label}) to ${outPath}.\n`,
+    );
+  } else {
+    process.stdout.write(json);
+  }
+};
+
+writeOut(transitiveDependents, "OUT_JSON", "transitive");
+writeOut(directDependents, "OUT_DIRECT_JSON", "direct");

--- a/.github/scripts/upload-affected-tests-stats.js
+++ b/.github/scripts/upload-affected-tests-stats.js
@@ -1,19 +1,19 @@
 // Appends the test-plan stats row produced by create-test-plan.ts to the
 // "FE Affected Tests" table on stats.metabase.com.
-// Reads STATS_JSON, PR_NUMBER, HEAD_SHA, BASE_SHA, API_KEY from env.
+// Reads STATS_JSON, TRIGGERED_BY, PR_NUMBER, HEAD_SHA, BASE_SHA, API_KEY from env.
 
 const { uploadCsvToMb } = require("./csv-to-mb.js");
 
 // "FE Affected Tests" uploaded table on stats.metabase.com.
-const TABLE_ID = 79730;
+const TABLE_ID = 79841;
 
 const s = JSON.parse(process.env.STATS_JSON);
 console.log("stats", s);
 
 const row = {
   Date: new Date().toISOString(),
-  // "pr_update" or "merge_to_master".
-  Trigger: process.env.TRIGGER,
+  // "pr_update" or "merge_to_master". ("Trigger" is a reserved SQL word.)
+  "Triggered By": process.env.TRIGGERED_BY,
   PR: Number(process.env.PR_NUMBER),
   "Head SHA": process.env.HEAD_SHA,
   "Base SHA": process.env.BASE_SHA,

--- a/.github/scripts/upload-affected-tests-stats.js
+++ b/.github/scripts/upload-affected-tests-stats.js
@@ -1,34 +1,39 @@
-// This script is used in .github/workflows/run-tests.yml.
-// It uploads the test-plan stats row produced by create-test-plan.js to
-// the stats.metabase.com tracking table.
+// Appends the test-plan stats row produced by create-test-plan.ts to the
+// "FE Affected Tests" table on stats.metabase.com.
 // Reads STATS_JSON, PR_NUMBER, HEAD_SHA, BASE_SHA, API_KEY from env.
 
 const { uploadCsvToMb } = require("./csv-to-mb.js");
 
-const stats = JSON.parse(process.env.STATS_JSON);
-console.log("stats", stats);
+// "FE Affected Tests" uploaded table on stats.metabase.com.
+const TABLE_ID = 79730;
+
+const s = JSON.parse(process.env.STATS_JSON);
+console.log("stats", s);
 
 const row = {
   Date: new Date().toISOString(),
   PR: Number(process.env.PR_NUMBER),
   "Head SHA": process.env.HEAD_SHA,
   "Base SHA": process.env.BASE_SHA,
-  "Modules changed": stats.modules_changed,
-  "Modules affected": stats.modules_affected,
-  "FE Unit specs total": stats.fe_unit_specs_total,
-  "FE Unit specs run": stats.fe_unit_specs_run,
-  "FE Unit specs skipped": stats.fe_unit_specs_skipped,
-  "Loki stories total": stats.loki_stories_total,
-  "Loki stories run": stats.loki_stories_run,
-  "Loki stories skipped": stats.loki_stories_skipped,
-  "E2E specs total": stats.e2e_specs_total,
-  "E2E specs run": stats.e2e_specs_run,
-  "E2E specs skipped": stats.e2e_specs_skipped,
+  "FE Files Changed": s.fe_files_changed,
+  "BE Files Changed": s.be_files_changed,
+  "FE Modules Changed": s.fe_modules_changed,
+  "FE Modules Affected (Rules)": s.fe_modules_affected_rules,
+  "FE Modules Affected (Usage)": s.fe_modules_affected_usage,
+  "Unit Specs All": s.unit_specs_all,
+  "Unit Specs To Run (Rules)": s.unit_specs_to_run_rules,
+  "Unit Specs To Run (Usage)": s.unit_specs_to_run_usage,
+  "Loki Stories All": s.loki_stories_all,
+  "Loki Stories To Run (Rules)": s.loki_stories_to_run_rules,
+  "Loki Stories To Run (Usage)": s.loki_stories_to_run_usage,
+  "E2E Specs All": s.e2e_specs_all,
+  "E2E Specs To Run (Rules)": s.e2e_specs_to_run_rules,
+  "E2E Specs To Run (Usage)": s.e2e_specs_to_run_usage,
 };
 
 uploadCsvToMb({
   baseUrl: "https://stats.metabase.com",
-  tableId: 77008, // "Affected Tests Stats" table on stats.metabase.com
+  tableId: TABLE_ID,
   jsonData: [row],
   mode: "append",
 })

--- a/.github/scripts/upload-affected-tests-stats.js
+++ b/.github/scripts/upload-affected-tests-stats.js
@@ -12,6 +12,8 @@ console.log("stats", s);
 
 const row = {
   Date: new Date().toISOString(),
+  // "pr_update" or "merge_to_master".
+  Trigger: process.env.TRIGGER,
   PR: Number(process.env.PR_NUMBER),
   "Head SHA": process.env.HEAD_SHA,
   "Base SHA": process.env.BASE_SHA,

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -44,7 +44,6 @@ jobs:
       e2e_specs_to_run: ${{ steps.compute.outputs.e2e_specs_to_run }}
     steps:
       - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - name: Test which files changed
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
@@ -56,17 +55,14 @@ jobs:
       - name: Create test plan
         id: compute
         if: ${{ github.event_name == 'pull_request' }}
-        env:
-          CHANGED_FILES: ${{ steps.changes.outputs.all_changed_files }}
-          UNIT_INFRA_TOUCHED: ${{ steps.changes.outputs.frontend_unit_infra }}
-          LOKI_INFRA_TOUCHED: ${{ steps.changes.outputs.frontend_loki_infra }}
-        run: |
-          OUTPUT=$(bun .github/scripts/create-test-plan.ts)
-          echo "$OUTPUT" | jq '.stats'
-          echo "stats=$(echo "$OUTPUT" | jq -c '.stats')" >> $GITHUB_OUTPUT
-          echo "fe_unit_specs_to_run=$(echo "$OUTPUT" | jq -c '.fe_unit_specs_to_run')" >> $GITHUB_OUTPUT
-          echo "loki_stories_to_run=$(echo "$OUTPUT" | jq -c '.loki_stories_to_run')" >> $GITHUB_OUTPUT
-          echo "e2e_specs_to_run=$(echo "$OUTPUT" | jq -c '.e2e_specs_to_run')" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/create-test-plan
+        with:
+          changed-files: ${{ steps.changes.outputs.all_changed_files }}
+          fe-changed-files: ${{ steps.changes.outputs.frontend_sources_files }}
+          be-changed-files: ${{ steps.changes.outputs.backend_sources_files }}
+          unit-infra-touched: ${{ steps.changes.outputs.frontend_unit_infra }}
+          loki-infra-touched: ${{ steps.changes.outputs.frontend_loki_infra }}
+          shared-sources-touched: ${{ steps.changes.outputs.shared_sources }}
 
   upload-affected-tests-stats:
     needs: create-test-plan
@@ -222,16 +218,16 @@ jobs:
       analytics_dev_mode: true
 
   pr-env-stats-dump:
-      needs: [uberjar]
-      if: |
-        !cancelled() &&
-        contains(github.event.pull_request.labels.*.name, 'PR-Env-Stats-Dump')
-      uses: ./.github/workflows/pr-env.yml
-      secrets: inherit
-      with:
-        self_hosting: false
-        analytics_dev_mode: false
-        stats_dump: true
+    needs: [uberjar]
+    if: |
+      !cancelled() &&
+      contains(github.event.pull_request.labels.*.name, 'PR-Env-Stats-Dump')
+    uses: ./.github/workflows/pr-env.yml
+    secrets: inherit
+    with:
+      self_hosting: false
+      analytics_dev_mode: false
+      stats_dump: true
 
   containerize:
     needs: [uberjar]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -54,7 +54,7 @@ jobs:
           filters: .github/file-paths.yaml
       - name: Create test plan
         id: compute
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master') }}
         uses: ./.github/actions/create-test-plan
         with:
           changed-files: ${{ steps.changes.outputs.all_changed_files }}
@@ -67,7 +67,7 @@ jobs:
   upload-affected-tests-stats:
     needs: create-test-plan
     # Only land rows for the upstream repo so forks don't pollute the table.
-    if: ${{ !cancelled() && needs.create-test-plan.result == 'success' && github.event.pull_request.head.repo.full_name == 'metabase/metabase' }}
+    if: ${{ !cancelled() && needs.create-test-plan.result == 'success' && (github.event.pull_request.head.repo.full_name == 'metabase/metabase' || (github.event_name == 'push' && github.repository == 'metabase/metabase')) }}
     # Stats upload is best-effort — a failure here shouldn't fail the PR run.
     continue-on-error: true
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
@@ -75,11 +75,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Upload affected tests stats
+        # On push (merge to master) there is no PR context, so fall back to the
+        # commit SHAs and a 0 PR number.
         env:
           STATS_JSON: ${{ needs.create-test-plan.outputs.stats }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          TRIGGER: ${{ github.event_name == 'pull_request' && 'pr_update' || 'merge_to_master' }}
+          PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || 0 }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           API_KEY: ${{ secrets.STATS_API_KEY }}
         run: node .github/scripts/upload-affected-tests-stats.js
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -79,7 +79,7 @@ jobs:
         # commit SHAs and a 0 PR number.
         env:
           STATS_JSON: ${{ needs.create-test-plan.outputs.stats }}
-          TRIGGER: ${{ github.event_name == 'pull_request' && 'pr_update' || 'merge_to_master' }}
+          TRIGGERED_BY: ${{ github.event_name == 'pull_request' && 'pr_update' || 'merge_to_master' }}
           PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || 0 }}
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}

--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,6 @@ __pycache__/
 .claude/scheduled_tasks.lock
 .playwright-mcp
 .ci_reports/
+
+# dependency-cruiser output
+dependency-graph.json

--- a/bun.lock
+++ b/bun.lock
@@ -296,6 +296,7 @@
         "cypress-real-events": "^1.15.0",
         "cypress-split": "^1.24.31",
         "cypress-terminal-report": "^7.3.3",
+        "dependency-cruiser": "^17.4.3",
         "dnd-core": "^16.0.1",
         "esbuild": "^0.25.0",
         "eslint": "^9.17.0",
@@ -2165,13 +2166,17 @@
 
     "accepts": ["accepts@1.3.7", "", { "dependencies": { "mime-types": "~2.1.24", "negotiator": "0.6.2" } }, "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA=="],
 
-    "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-import-phases": ["acorn-import-phases@1.0.4", "", { "peerDependencies": { "acorn": "^8.14.0" } }, "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", {}, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
-    "acorn-walk": ["acorn-walk@8.3.2", "", {}, "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A=="],
+    "acorn-jsx-walk": ["acorn-jsx-walk@2.0.0", "", {}, "sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA=="],
+
+    "acorn-loose": ["acorn-loose@8.5.2", "", { "dependencies": { "acorn": "^8.15.0" } }, "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A=="],
+
+    "acorn-walk": ["acorn-walk@8.3.5", "", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -2819,6 +2824,8 @@
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
+    "dependency-cruiser": ["dependency-cruiser@17.4.3", "", { "dependencies": { "acorn": "8.16.0", "acorn-jsx": "5.3.2", "acorn-jsx-walk": "2.0.0", "acorn-loose": "8.5.2", "acorn-walk": "8.3.5", "commander": "14.0.3", "enhanced-resolve": "5.22.1", "ignore": "7.0.5", "interpret": "3.1.1", "is-installed-globally": "1.0.0", "json5": "2.2.3", "picomatch": "4.0.4", "prompts": "2.4.2", "rechoir": "0.8.0", "safe-regex": "2.1.1", "semver": "7.8.1", "tsconfig-paths-webpack-plugin": "4.2.0", "watskeburt": "5.0.3" }, "bin": { "depcruise": "bin/dependency-cruise.mjs", "depcruise-fmt": "bin/depcruise-fmt.mjs", "dependency-cruise": "bin/dependency-cruise.mjs", "depcruise-baseline": "bin/depcruise-baseline.mjs", "dependency-cruiser": "bin/dependency-cruise.mjs", "depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.mjs" } }, "sha512-L4GLuAvmXevWnPCIaFfOz6eD92c+yY+pDgVqgufrLDnW3xYA799CSZQlly2r2N13nhAlnZY6VzY7Rx5pHNvk2w=="],
+
     "dependency-tree": ["dependency-tree@11.4.3", "", { "dependencies": { "commander": "^12.1.0", "filing-cabinet": "^5.3.0", "precinct": "^12.3.1", "typescript": "^5.9.3" }, "bin": { "dependency-tree": "bin/cli.js" } }, "sha512-Y2gzOJ2Rb2X7MN6pT9llWpXxl5J5s5/11CBpJ5b85DjEqZH7jv3T9RO6HRV/PI/3MDmaKn/g7uoYdYmSb9vLlw=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
@@ -2931,7 +2938,7 @@
 
     "endent": ["endent@2.1.0", "", { "dependencies": { "dedent": "^0.7.0", "fast-json-parse": "^1.0.3", "objectorarray": "^1.0.5" } }, "sha512-r8VyPX7XL8U01Xgnb1CjZ3XV+z90cXIJ9JPE/R9SEC9vpw2P6CfsRPJmp20DppC5N7ZAMCmjYkJIa744Iyg96w=="],
 
-    "enhanced-resolve": ["enhanced-resolve@0.9.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "memory-fs": "^0.2.0", "tapable": "^0.1.8" } }, "sha512-kxpoMgrdtkXZ5h0SeraBS1iRntpTpQ3R8ussdb38+UAFnMGX5DDyJXePm+OCHOcoXvHDw7mc2erbJBpDnl7TPw=="],
+    "enhanced-resolve": ["enhanced-resolve@5.22.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
@@ -3255,6 +3262,8 @@
 
     "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
 
+    "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
+
     "global-dirs": ["global-dirs@3.0.1", "", { "dependencies": { "ini": "2.0.0" } }, "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA=="],
 
     "global-modules": ["global-modules@2.0.0", "", { "dependencies": { "global-prefix": "^3.0.0" } }, "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A=="],
@@ -3411,7 +3420,7 @@
 
     "iframe-resizer": ["iframe-resizer@4.3.11", "", {}, "sha512-5QtnsmfH11GDsuC7Gxd/eNzojudX3346Gb0E+Ku8ln8AtfSq+cWCZtnhCrthrtE7f1CI2/kwHkZ9G4sFYzHP7A=="],
 
-    "ignore": ["ignore@5.3.1", "", {}, "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw=="],
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "image-size": ["image-size@0.5.5", "", { "bin": { "image-size": "bin/image-size.js" } }, "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ=="],
 
@@ -3459,7 +3468,7 @@
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
-    "interpret": ["interpret@1.4.0", "", {}, "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="],
+    "interpret": ["interpret@3.1.1", "", {}, "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ=="],
 
     "invariant": ["invariant@2.2.4", "", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA=="],
 
@@ -3756,6 +3765,8 @@
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
     "klaw-sync": ["klaw-sync@6.0.0", "", { "dependencies": { "graceful-fs": "^4.1.11" } }, "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ=="],
+
+    "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "knex": ["knex@2.4.2", "", { "dependencies": { "colorette": "2.0.19", "commander": "^9.1.0", "debug": "4.3.4", "escalade": "^3.1.1", "esm": "^3.2.25", "get-package-type": "^0.1.0", "getopts": "2.3.0", "interpret": "^2.2.0", "lodash": "^4.17.21", "pg-connection-string": "2.5.0", "rechoir": "^0.8.0", "resolve-from": "^5.0.0", "tarn": "^3.0.2", "tildify": "2.0.0" }, "bin": { "knex": "bin/cli.js" } }, "sha512-tMI1M7a+xwHhPxjbl/H9K1kHX+VncEYcvCx5K00M16bWvpYPKAZd6QrCu68PtHAdIZNQPWZn0GVhqVBEthGWCg=="],
 
@@ -4473,6 +4484,8 @@
 
     "promise-loader": ["promise-loader@1.0.0", "", {}, "sha1-b8fIUpwf38SXvvX+dEi7Ya+VRsw="],
 
+    "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
+
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "property-expr": ["property-expr@2.0.5", "", {}, "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="],
@@ -4693,6 +4706,8 @@
 
     "regenerator-runtime": ["regenerator-runtime@0.14.0", "", {}, "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="],
 
+    "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
+
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
 
     "regexparam": ["regexparam@3.0.0", "", {}, "sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q=="],
@@ -4803,6 +4818,8 @@
 
     "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
 
+    "safe-regex": ["safe-regex@2.1.1", "", { "dependencies": { "regexp-tree": "~0.1.1" } }, "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A=="],
+
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
@@ -4910,6 +4927,8 @@
     "simple-websocket": ["simple-websocket@9.1.0", "", { "dependencies": { "debug": "^4.3.1", "queue-microtask": "^1.2.2", "randombytes": "^2.1.0", "readable-stream": "^3.6.0", "ws": "^7.4.2" } }, "sha512-8MJPnjRN6A8UCp1I+H/dSFyjwJhp6wta4hsVRhjf8w9qBHRzxYt14RaOcjvQnhD1N4yKOddEjflwMnQM4VtXjQ=="],
 
     "sirv": ["sirv@2.0.4", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "slash": ["slash@2.0.0", "", {}, "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="],
 
@@ -5205,6 +5224,8 @@
 
     "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
 
+    "tsconfig-paths-webpack-plugin": ["tsconfig-paths-webpack-plugin@4.2.0", "", { "dependencies": { "chalk": "^4.1.0", "enhanced-resolve": "^5.7.0", "tapable": "^2.2.1", "tsconfig-paths": "^4.1.2" } }, "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA=="],
+
     "tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "tsx": ["tsx@4.19.3", "", { "dependencies": { "esbuild": "~0.25.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ=="],
@@ -5372,6 +5393,8 @@
     "warning": ["warning@3.0.0", "", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w="],
 
     "watchpack": ["watchpack@2.5.1", "", { "dependencies": { "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.1.2" } }, "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg=="],
+
+    "watskeburt": ["watskeburt@5.0.3", "", { "bin": { "watskeburt": "dist/run-cli.js" } }, "sha512-g9CXukMjazlJJVQ3OHzXsnG25KFYgSgKMIyoJrD8ggr0DbS9UNF7OzIqWmmKKBMedkxj3T01uqEaGnn+y7QhMA=="],
 
     "wbuf": ["wbuf@1.7.3", "", { "dependencies": { "minimalistic-assert": "^1.0.0" } }, "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA=="],
 
@@ -5587,7 +5610,7 @@
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
-    "@eslint/eslintrc/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+    "@eslint/eslintrc/ignore": ["ignore@5.3.1", "", {}, "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw=="],
 
     "@eslint/eslintrc/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
@@ -5872,8 +5895,6 @@
     "@types/redux-auth-wrapper/@types/history": ["@types/history@4.7.11", "", {}, "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA=="],
 
     "@types/serve-index/@types/express": ["@types/express@4.17.13", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^4.17.18", "@types/qs": "*", "@types/serve-static": "*" } }, "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA=="],
-
-    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.60.0", "", { "dependencies": { "@typescript-eslint/types": "8.60.0", "@typescript-eslint/visitor-keys": "8.60.0" } }, "sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw=="],
 
@@ -6163,6 +6184,14 @@
 
     "del/slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 
+    "dependency-cruiser/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "dependency-cruiser/is-installed-globally": ["is-installed-globally@1.0.0", "", { "dependencies": { "global-directory": "^4.0.1", "is-path-inside": "^4.0.0" } }, "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ=="],
+
+    "dependency-cruiser/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "dependency-cruiser/semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+
     "dependency-tree/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "detect-package-manager/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
@@ -6189,9 +6218,7 @@
 
     "endent/dedent": ["dedent@0.7.0", "", {}, "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="],
 
-    "enhanced-resolve/graceful-fs": ["graceful-fs@4.2.4", "", {}, "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="],
-
-    "enhanced-resolve/tapable": ["tapable@0.1.10", "", {}, "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q="],
+    "enhanced-resolve/tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
     "es-abstract/es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -6231,11 +6258,17 @@
 
     "eslint/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
+    "eslint/ignore": ["ignore@5.3.1", "", {}, "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw=="],
+
     "eslint/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "eslint-import-context/get-tsconfig": ["get-tsconfig@4.13.1", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w=="],
 
     "eslint-import-resolver-node/resolve": ["resolve@1.22.8", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw=="],
+
+    "eslint-import-resolver-webpack/enhanced-resolve": ["enhanced-resolve@0.9.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "memory-fs": "^0.2.0", "tapable": "^0.1.8" } }, "sha512-kxpoMgrdtkXZ5h0SeraBS1iRntpTpQ3R8ussdb38+UAFnMGX5DDyJXePm+OCHOcoXvHDw7mc2erbJBpDnl7TPw=="],
+
+    "eslint-import-resolver-webpack/interpret": ["interpret@1.4.0", "", {}, "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="],
 
     "eslint-import-resolver-webpack/is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
 
@@ -6258,6 +6291,8 @@
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
 
     "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "espree/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "espree/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
@@ -6299,6 +6334,8 @@
 
     "find-cypress-specs/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
+    "find-test-names/acorn-walk": ["acorn-walk@8.3.2", "", {}, "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A=="],
+
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "fork-ts-checker-webpack-plugin/chokidar": ["chokidar@3.5.3", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw=="],
@@ -6330,6 +6367,8 @@
     "giget/consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
     "glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "global-directory/ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
 
     "global-prefix/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
@@ -6953,8 +6992,6 @@
 
     "stylelint/file-entry-cache": ["file-entry-cache@10.1.4", "", { "dependencies": { "flat-cache": "^6.1.13" } }, "sha512-5XRUFc0WTtUbjfGzEwXc42tiGxQHBmtbUG1h9L2apu4SulCGN3Hqm//9D6FAolf8MYNL7f/YlJl9vy08pj5JuA=="],
 
-    "stylelint/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
     "stylelint/meow": ["meow@13.2.0", "", {}, "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="],
 
     "stylelint-scss/known-css-properties": ["known-css-properties@0.36.0", "", {}, "sha512-A+9jP+IUmuQsNdsLdcg6Yt7voiMF/D4K83ew0OpJtpu+l34ef7LaohWV0Rc6KNvzw6ZDizkqfyB5JznZnzuKQA=="],
@@ -7002,6 +7039,8 @@
     "to-buffer/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "transliteration/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "tsconfig-paths-webpack-plugin/tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
     "ttag/dedent": ["dedent@0.7.0", "", {}, "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="],
 
@@ -7075,6 +7114,8 @@
 
     "webpack/@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
+    "webpack/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+
     "webpack/browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
     "webpack/enhanced-resolve": ["enhanced-resolve@5.19.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg=="],
@@ -7086,6 +7127,8 @@
     "webpack/tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
     "webpack-bundle-analyzer/acorn": ["acorn@8.11.3", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg=="],
+
+    "webpack-bundle-analyzer/acorn-walk": ["acorn-walk@8.3.2", "", {}, "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A=="],
 
     "webpack-bundle-analyzer/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
@@ -7100,8 +7143,6 @@
     "webpack-cli/fastest-levenshtein": ["fastest-levenshtein@1.0.12", "", {}, "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow=="],
 
     "webpack-cli/import-local": ["import-local@3.0.2", "", { "dependencies": { "pkg-dir": "^4.2.0", "resolve-cwd": "^3.0.0" }, "bin": { "import-local-fixture": "fixtures/cli.js" } }, "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA=="],
-
-    "webpack-cli/interpret": ["interpret@3.1.1", "", {}, "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ=="],
 
     "webpack-dev-middleware/colorette": ["colorette@2.0.16", "", {}, "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g=="],
 
@@ -7260,6 +7301,8 @@
     "@jridgewell/source-map/@jridgewell/trace-mapping/@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.0.7", "", {}, "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA=="],
 
     "@jridgewell/source-map/@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.4.13", "", {}, "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="],
+
+    "@loki/core/shelljs/interpret": ["interpret@1.4.0", "", {}, "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="],
 
     "@loki/core/shelljs/rechoir": ["rechoir@0.6.2", "", { "dependencies": { "resolve": "^1.1.6" } }, "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw=="],
 
@@ -7597,6 +7640,8 @@
 
     "define-properties/has-property-descriptors/get-intrinsic": ["get-intrinsic@1.2.4", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2", "has-proto": "^1.0.1", "has-symbols": "^1.0.3", "hasown": "^2.0.0" } }, "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ=="],
 
+    "dependency-cruiser/is-installed-globally/is-path-inside": ["is-path-inside@4.0.0", "", {}, "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA=="],
+
     "detect-package-manager/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
     "detect-package-manager/execa/human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
@@ -7632,6 +7677,10 @@
     "es-get-iterator/is-string/has-tostringtag": ["has-tostringtag@1.0.0", "", { "dependencies": { "has-symbols": "^1.0.2" } }, "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ=="],
 
     "es-get-iterator/stop-iteration-iterator/internal-slot": ["internal-slot@1.0.7", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.0", "side-channel": "^1.0.4" } }, "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g=="],
+
+    "eslint-import-resolver-webpack/enhanced-resolve/graceful-fs": ["graceful-fs@4.2.4", "", {}, "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="],
+
+    "eslint-import-resolver-webpack/enhanced-resolve/tapable": ["tapable@0.1.10", "", {}, "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q="],
 
     "eslint-import-resolver-webpack/resolve/is-core-module": ["is-core-module@2.13.1", "", { "dependencies": { "hasown": "^2.0.0" } }, "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw=="],
 
@@ -8202,8 +8251,6 @@
     "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.60.0", "", { "dependencies": { "@typescript-eslint/types": "8.60.0", "@typescript-eslint/typescript-estree": "8.60.0", "@typescript-eslint/utils": "8.60.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg=="],
 
     "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.60.0", "", { "dependencies": { "@typescript-eslint/types": "8.60.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg=="],
-
-    "typescript-eslint/@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "typescript-eslint/@typescript-eslint/eslint-plugin/ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 

--- a/package.json
+++ b/package.json
@@ -305,6 +305,7 @@
     "cypress-real-events": "^1.15.0",
     "cypress-split": "^1.24.31",
     "cypress-terminal-report": "^7.3.3",
+    "dependency-cruiser": "^17.4.3",
     "dnd-core": "^16.0.1",
     "esbuild": "^0.25.0",
     "eslint": "^9.17.0",


### PR DESCRIPTION
dependency-cruiser searches the true import graph. Previously, we were using just the module boundary rules to construct the graph, but this assumes that any edge that is _allowed_ between two modules _actually exists_, so it overestimates module connectivity.

For stats, we track both the rules and the usage versions. https://stats.metabase.com/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoyNiwicXVlcnkiOnsic291cmNlLXRhYmxlIjo3OTg0MX0sInR5cGUiOiJxdWVyeSJ9LCJkaXNwbGF5IjoidGFibGUiLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=