### PR TITLE
chore(storybook): exclude embedding sdk stories from main app storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -9,8 +9,8 @@ const { CSS_CONFIG } = require("../frontend/build/shared/rspack/css-config");
 
 const mainAppStories = [
   "../frontend/**/*.mdx",
-  "../frontend/**/*.stories.@(js|jsx|ts|tsx)",
-  "../enterprise/frontend/**/*.stories.@(js|jsx|ts|tsx)",
+  "../frontend/*/!(embedding-sdk-bundle|embedding-sdk-shared)/**/*.stories.@(js|jsx|ts|tsx)",
+  "../enterprise/frontend/*/!(embedding-sdk-ee|embedding-sdk-package)/**/*.stories.@(js|jsx|ts|tsx)",
 ];
 
 // Allow filtering to specific story files via env var (used by stress tests)


### PR DESCRIPTION


Closes [EMB-1784: Remove SDK stories from core app Storybook](https://linear.app/metabase/issue/EMB-1784/remove-sdk-stories-from-core-app-storybook)

### Description

We were accidentally showing the stories for the embedding sdk in the core app storybook, but they were not working:
<img width="318" height="806" alt="image" src="https://github.com/user-attachments/assets/52389d81-573d-499f-9af1-c0018158f6d7" />

This PR filters them out

### How to verify
- Run `bun storybook`
- You should not see the embedding sdk stories
