### PR TITLE
[DO NOT MERGE] Semantic Search Improvement Experiments

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -786,6 +786,17 @@
    :api  #{metabase.database-routing.core}
    :uses #{premium-features}}
 
+  describe
+  {:team "Metabot"
+   :api  #{metabase.describe.api}
+   :uses #{api
+           lib
+           lib-be
+           util}
+   :model-imports #{:model/Card
+                    :model/Segment
+                    :model/Measure}}
+
   documents
   {:team "UX West"
    :api  #{metabase.documents.api

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -46,10 +46,13 @@
    (semantic.settings/semantic-search-enabled)))
 
 (defn- with-zero-semantic-distance
-  "Record `:semantic-distance` 0 on `results` that lack it, for a consistent merged-result score breakdown."
+  "Record `:semantic-distance` 0 on `results` that lack it, for a consistent merged-result score breakdown.
+  When `:debug-pipeline?`, also tag each row `:source [\"appdb-fallback\"]` so the eval runner can tell
+  fallback-supplemented rows from pgvector-arm rows (they never entered the hybrid query)."
   [search-ctx results]
   ;; Fallback (appdb/in-place) results never went through vector search, so they carry no semantic distance.
-  (let [entry {:name         :semantic-distance
+  (let [debug? (:debug-pipeline? search-ctx)
+        entry {:name         :semantic-distance
                :score        0
                :weight       (search.config/weight search-ctx :semantic-distance)
                :contribution 0}]
@@ -57,7 +60,8 @@
            (cond-> result
              (and (contains? result :all-scores)
                   (not-any? (comp #{:semantic-distance} :name) (:all-scores result)))
-             (update :all-scores conj entry)))
+             (update :all-scores conj entry)
+             debug? (assoc :source ["appdb-fallback"])))
          results)))
 
 (defenterprise results
@@ -67,12 +71,16 @@
   [search-ctx]
   (tracing/with-span :search "search.semantic.execute" {:search/query-length (count (:search-string search-ctx))}
     (try
-      (let [{:keys [results raw-count]}
+      (let [{:keys [results raw-count pipeline]}
             (semantic.pgvector-api/query (semantic.env/get-pgvector-datasource!)
                                          (semantic.env/get-index-metadata)
                                          search-ctx)
             final-count (count results)
-            threshold (semantic.settings/semantic-search-min-results-threshold)]
+            threshold (semantic.settings/semantic-search-min-results-threshold)
+            ;; The `debug_pipeline` per-stage block rides up as metadata on the results seq (it's read off in
+            ;; metabase.search.impl/search before the transducer consumes the seq). nil pipeline => no-op, so
+            ;; non-debug responses are byte-identical.
+            attach-pipeline (fn [rs pl] (cond-> rs pl (vary-meta assoc :pipeline pl)))]
         (if (or ;; Per-request opt-out: return semantic results unsupplemented regardless of count. Used by
              ;; the eval runner to measure the semantic engine in isolation (the additive appdb fallback
              ;; otherwise contaminates a semantic-only run with keyword hits).
@@ -82,7 +90,7 @@
                   ;; :search-string is nil when using search to populate the list of tables for a given database in
                   ;; the native query editor. Semantic search doesn't support this, so fallback in this case.
                   (not (str/blank? (:search-string search-ctx)))))
-          results
+          (attach-pipeline results pipeline)
           ;; Fallback: semantic search found results but some were filtered out (e.g. due to permission checks), so try to
           ;; supplement with appdb search.
           (let [fallback (fallback-engine)]
@@ -106,8 +114,13 @@
                   fallback-results (take total-limit fallback-results)
                   _                (analytics/observe! :metabase-search/semantic-fallback-results-usage (count fallback-results))
                   combined-results (concat results (with-zero-semantic-distance search-ctx fallback-results))
-                  deduped-results  (m/distinct-by (juxt :model :id) combined-results)]
-              (take total-limit deduped-results)))))
+                  deduped-results  (m/distinct-by (juxt :model :id) combined-results)
+                  ;; Record the fallback provenance in the pipeline block (the appdb rows are not a pgvector
+                  ;; arm/fusion stage -- they only appear in `data`, tagged `appdb-fallback`).
+                  pipeline'        (when pipeline
+                                     (assoc pipeline :fallback {:engine  (str (symbol fallback))
+                                                                :n_added (count fallback-results)}))]
+              (attach-pipeline (take total-limit deduped-results) pipeline')))))
       (catch Exception e
         ;; Per-request opt-out: surface the error instead of masking it with appdb results. A broken vector
         ;; query (e.g. wrong pgvector DB, missing view column) otherwise silently degrades to keyword-only,

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -73,11 +73,15 @@
                                          search-ctx)
             final-count (count results)
             threshold (semantic.settings/semantic-search-min-results-threshold)]
-        (if (or (>= final-count threshold)
-                (and (zero? raw-count)
-                     ;; :search-string is nil when using search to populate the list of tables for a given database in
-                     ;; the native query editor. Semantic search doesn't support this, so fallback in this case.
-                     (not (str/blank? (:search-string search-ctx)))))
+        (if (or ;; Per-request opt-out: return semantic results unsupplemented regardless of count. Used by
+             ;; the eval runner to measure the semantic engine in isolation (the additive appdb fallback
+             ;; otherwise contaminates a semantic-only run with keyword hits).
+             (:disable-fallback? search-ctx)
+             (>= final-count threshold)
+             (and (zero? raw-count)
+                  ;; :search-string is nil when using search to populate the list of tables for a given database in
+                  ;; the native query editor. Semantic search doesn't support this, so fallback in this case.
+                  (not (str/blank? (:search-string search-ctx)))))
           results
           ;; Fallback: semantic search found results but some were filtered out (e.g. due to permission checks), so try to
           ;; supplement with appdb search.
@@ -105,6 +109,11 @@
                   deduped-results  (m/distinct-by (juxt :model :id) combined-results)]
               (take total-limit deduped-results)))))
       (catch Exception e
+        ;; Per-request opt-out: surface the error instead of masking it with appdb results. A broken vector
+        ;; query (e.g. wrong pgvector DB, missing view column) otherwise silently degrades to keyword-only,
+        ;; which has previously made eval runs "succeed" against the wrong engine.
+        (when (:disable-fallback? search-ctx)
+          (throw e))
         (log/error e "Error executing semantic search, falling back to appdb")
         (let [fallback (fallback-engine)]
           (analytics/inc! :metabase-search/semantic-error-fallback {:fallback-engine fallback})

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -12,7 +12,8 @@
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.retry :as retry])
   (:import
    [com.knuddels.jtokkit Encodings]
    [com.knuddels.jtokkit.api Encoding EncodingType]
@@ -361,6 +362,81 @@
 (defmethod pull-model "openai" [_]
   (log/debug "OpenAI provider does not require pulling a model"))
 
+;;;; Voyage provider (direct api.voyageai.com/v1/embeddings)
+
+;; A direct Voyage embeddings client, mirroring the rerank client in
+;; `metabase-enterprise.semantic-search.reranking` (Bearer auth, house exponential-backoff retry). Voyage
+;; handles query/document asymmetry through the `input_type` request field rather than a text prefix, so the
+;; `:type` opt threaded from `query-index` (`:query`) selects it here -- `prefix-search-query` is a no-op for
+;; Voyage models. Used when the `query_embedder=voyage` search param routes the query to this provider so it
+;; shares the active Voyage-embedded table's vector space.
+
+(def ^:private max-voyage-embedding-retries
+  "Retry budget for a rate-limited / transient Voyage embeddings call. Kept small: the query embedding runs
+  synchronously inside a single `/api/search` request, so the cumulative backoff must stay under the client
+  request timeout (cf. the rerank client)."
+  4)
+
+(defn- retryable-voyage-error?
+  "True when a failed Voyage call should be retried: a 429 (rate limit), a 5xx, or a transport-level error
+  (no HTTP status in ex-data). 4xx client errors are not retried."
+  [e]
+  (let [status (:status (ex-data e))]
+    (or (nil? status) (= 429 status) (<= 500 status 599))))
+
+(defn- voyage-input-type
+  "Map the `:type` opt to Voyage's asymmetric-retrieval `input_type`. Queries embed as `\"query\"`, everything
+  else (indexing/default) as `\"document\"`."
+  [type]
+  (if (= :query type) "query" "document"))
+
+(defn- voyage-get-embeddings-batch*
+  "POST a batch of texts to the Voyage embeddings API and return a vector of float-arrays in input order.
+  Voyage returns float lists directly (not base64), so we realize them straight into float-arrays. Records
+  the provider-reported token usage (the billable figure) into analytics + the token-tracking table."
+  [{:keys [model-name vector-dimensions]} texts type record-tokens?]
+  (let [api-key (semantic-settings/ee-voyage-embedding-api-key)]
+    (when (empty? api-key)
+      (throw (ex-info "ee-voyage-embedding-api-key not set" {:provider "voyage"})))
+    (let [url  (str (trim-trailing-slashes (semantic-settings/ee-voyage-embedding-base-url)) "/v1/embeddings")
+          ;; `output_dimension` matches how the document vectors were produced offline (Voyage defaults to
+          ;; float output, as the offline build relied on). `input_type` carries Voyage's query/document
+          ;; asymmetry (the analogue of arctic's `query:` prefix, which is a no-op for Voyage models).
+          body (cond-> {:model      model-name
+                        :input      texts
+                        :input_type (voyage-input-type type)
+                        :truncation true}
+                 vector-dimensions (assoc :output_dimension vector-dimensions))
+          resp (-> (retry/with-retry (assoc (retry/retry-configuration)
+                                            :max-retries max-voyage-embedding-retries
+                                            :retry-if    (fn [_result e]
+                                                           (boolean (and e (retryable-voyage-error? e))))
+                                            :on-retry    (fn [_result e]
+                                                           (log/warn e "Voyage embeddings call failed; retrying")))
+                     (http/post url
+                                {:headers {"Authorization" (str "Bearer " api-key)
+                                           "Content-Type"  "application/json"}
+                                 :body    (json/encode body)}))
+                   :body
+                   (json/decode true))
+          total-tokens (get-in resp [:usage :total_tokens] 0)]
+      (analytics/inc! :metabase-search/semantic-embedding-tokens {:provider "voyage" :model model-name} total-tokens)
+      (when record-tokens?
+        (semantic.models.token-tracking/record-tokens model-name type total-tokens))
+      (log/debug "Voyage embeddings" {:model model-name :documents (count texts) :tokens total-tokens})
+      (mapv (fn [{:keys [embedding]}] (float-array embedding)) (:data resp)))))
+
+(defmethod get-embedding "voyage"
+  [embedding-model text & {:keys [record-tokens? type]}]
+  (first (voyage-get-embeddings-batch* embedding-model [text] type record-tokens?)))
+
+(defmethod get-embeddings-batch "voyage"
+  [embedding-model texts & {:keys [record-tokens? type]}]
+  (voyage-get-embeddings-batch* embedding-model texts type record-tokens?))
+
+(defmethod pull-model "voyage" [_]
+  (log/debug "Voyage provider does not require pulling a model"))
+
 ;;;; Query prefixes for asymmetric retrieval models
 
 (def ^:private model-family-query-prefixes
@@ -396,6 +472,21 @@
   {:provider (semantic-settings/ee-embedding-provider)
    :model-name (semantic-settings/ee-embedding-model)
    :vector-dimensions (semantic-settings/ee-embedding-model-dimensions)})
+
+(defn query-embedder-model
+  "Resolve the embedding-model to use for embedding a *query*, given the `:query-embedder` search-context value
+  (the `query_embedder` API param, keywordized) and the active index's own `embedding-model` (the default).
+
+  `:voyage` returns the Voyage embedding-model built from the `ee-voyage-embedding-*` settings, so the query
+  embeds in the same vector space as a Voyage-embedded index table. `nil` / `:arctic` / `:ai-service` return
+  `index-embedding-model` unchanged -- i.e. today's behavior (embed with whatever the active index declares),
+  so an absent param is byte-identical to baseline."
+  [query-embedder index-embedding-model]
+  (case query-embedder
+    :voyage {:provider          "voyage"
+             :model-name         (semantic-settings/ee-voyage-embedding-model)
+             :vector-dimensions  (semantic-settings/ee-voyage-embedding-model-dimensions)}
+    index-embedding-model))
 
 (defn- calc-token-metrics
   [texts]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -1220,7 +1220,10 @@
                       :score (:total_score row 1.0)
                       :all-scores (scoring/all-scores weights scorers row))]
     (cond-> result
-      rerank?            (assoc :content (:content row))
+      ;; :semantic_distance is the reranker confidence-gate's margin signal; carried under rerank? and stripped
+      ;; before the wire (strip-rerank-carried-keys). Debug attribution uses :cosine_distance below instead.
+      rerank?            (assoc :content (:content row)
+                                :semantic_distance (:semantic_distance row))
       (or debug? rerank?) (assoc :semantic_rank (:semantic_rank row)
                                  :keyword_rank  (:keyword_rank row))
       debug? (assoc :cosine_distance (:semantic_distance row)
@@ -1444,6 +1447,67 @@
                   :rerank_as_scorer  (+ (:score row 0.0) (* w rr))
                   :rerank_fusion     (+ (* w rr) (metadata-boost-contribution row rerank-relevance-scorers)))))
 
+(defn- reblend-rrf
+  "Rank-space fusion for the `:rerank_rrf` blend: final order = RRF of the weighted-score rank and the
+  cross-encoder rank over the pool. `pool-rows` is in weighted (`:total_score`) order so position `i` = weighted
+  rank `i+1`; `order` is the pool indices best-first per the cross-encoder so position = rerank rank; `scores`
+  maps pool position to the raw cross-encoder score. The RRF magnitude `wa/(k+weighted_rank) + wb/(k+rerank_rank)`
+  is kept verbatim on `:fused_score` (for offline re-derivation, §1.4), and the row's `:score` becomes that
+  magnitude lifted by `offset` -- neither axis dominates, and the metadata boosts tip via the weighted-rank arm
+  (they set the `:total_score` that ordered the pool) rather than an uncalibrated additive term. `:rerank_score`
+  keeps the raw cross-encoder score for attribution.
+
+  `:score` lift: the generic layer re-sorts ALL results by `:score` desc after the engine returns
+  (`metabase.search.scoring/top-results` via `impl/search`), and the un-reranked tail keeps its `:total_score`
+  (boost scale, e.g. 100s). A raw RRF magnitude (~0.03 at k=60) is orders of magnitude smaller, so that re-sort
+  would float the whole tail above the reranked pool and bury the winners. `pool-rows` is `:total_score`-desc,
+  so its head is the largest score in the pool and an upper bound on the tail; offsetting every reranked
+  `:score` by it guarantees the pool outranks the tail in the global re-sort while preserving the fused order
+  within the pool. `:score` is stripped before the wire, so the lift affects only sort position."
+  [wa wb k pool-rows order scores]
+  (let [rerank-rank (into {} (map-indexed (fn [pos pool-idx] [pool-idx (inc pos)]) order))
+        n           (count pool-rows)
+        offset      (double (or (:score (first pool-rows)) (:total_score (first pool-rows)) 0.0))]
+    (mapv (fn [pool-idx]
+            (let [wrank (inc pool-idx)
+                  ;; Voyage ranks every pooled doc, so rrank is always present; fall back to the tail rank
+                  ;; defensively if a pool index is ever missing from `order`.
+                  rrank (get rerank-rank pool-idx n)
+                  fused (+ (/ wa (double (+ k wrank)))
+                           (/ wb (double (+ k rrank))))]
+              (assoc (nth pool-rows pool-idx)
+                     :rerank_score (get scores pool-idx 0.0)
+                     :fused_score  fused
+                     :score        (+ offset fused))))
+          (range n))))
+
+(defn- strip-rerank-carried-keys
+  "Drop the keys `legacy-input-with-score` carries only for the rerank step (`:content` + the transient
+  `:semantic_distance` gate signal) so they never reach the wire; under `debug?` keep the arm ranks and
+  `:rerank_score` for attribution (same policy as the reranked block). `serialize` is a blacklist, so any key
+  left on the row rides straight to the wire."
+  [debug? row]
+  (cond-> (dissoc row :content :semantic_distance :fused_score)
+    (not debug?) (dissoc :semantic_rank :keyword_rank :rerank_score)))
+
+(defn- reranker-gate-fires?
+  "True when retrieval is already confident enough that the cross-encoder should be skipped for this query, per
+  the request's `:gate` config read against the head of the weighted-ordered `results`:
+   - `:exact` -- the top result is an exact name match (the weight-independent `:exact` scorer fired); the
+     strongest known-item signal, where reranking only risks demoting the canonical.
+   - `:semantic-margin` -- the rank-1 `:semantic_distance` (cosine) is within the threshold, i.e. the top hit
+     is semantically very close to the query.
+  Skipping spends Voyage tokens only on the uncertain queries the cross-encoder actually helps. Nil/absent
+  `:gate` => never fires => unchanged from today."
+  [search-context results]
+  (boolean
+   (when-let [{:keys [exact semantic-margin]} (:gate (:reranker-config search-context))]
+     (when-let [top (first results)]
+       (or (and exact
+                (some #(and (= :exact (:name %)) (pos? (or (:score %) 0))) (:all-scores top)))
+           (and semantic-margin (:semantic_distance top)
+                (<= (:semantic_distance top) semantic-margin)))))))
+
 (defn- rerank-results
   "Rerank the top-`pool` of `results` with the Voyage cross-encoder and reblend per the request's
   `:reranker-config` `:blend`. Returns `{:results :tokens :pool :model :stage}` where `:results` is the
@@ -1461,8 +1525,9 @@
     {:results results :tokens 0 :pool 0
      :model (or (:model (:reranker-config search-context)) (semantic-settings/ee-reranking-model))
      :stage {:name "rerank:voyage" :candidates []}}
-    (let [{:keys [model pool top-k weight blend]
-           :or   {pool 50 weight 500.0 blend :rerank_then_boost}} (:reranker-config search-context)
+    (let [{:keys [model pool top-k weight blend rrf-weighted rrf-rerank rrf-k]
+           :or   {pool 50 weight 500.0 blend :rerank_then_boost
+                  rrf-weighted 1.0 rrf-rerank 2.0 rrf-k 60}} (:reranker-config search-context)
           ordered          (if (= blend :rerank_fusion)
                              (sort-by (fn [r] (min (or (:semantic_rank r) ##Inf)
                                                    (or (:keyword_rank r) ##Inf)))
@@ -1471,20 +1536,24 @@
           [pool-rows tail] (split-at pool ordered)
           docs             (mapv #(or (:content %) (:name %) "") pool-rows)
           {:keys [order scores tokens]} (reranking/rerank (:search-string search-context) docs {:model model})
-          reranked         (mapv (fn [i] (reblend blend weight (nth pool-rows i) (get scores i 0.0))) order)
+          ;; :rerank_rrf fuses the two ranks over the whole pool (needs both axes at once, so it can't go
+          ;; through the per-row `reblend`); the additive blends reblend each row in cross-encoder order.
+          reranked         (if (= blend :rerank_rrf)
+                             (reblend-rrf rrf-weighted rrf-rerank rrf-k pool-rows order scores)
+                             (mapv (fn [i] (reblend blend weight (nth pool-rows i) (get scores i 0.0))) order))
           merged           (concat (sort-by :score > reranked) tail)
           kept             (cond->> merged top-k (take top-k))
           stage            {:name "rerank:voyage"
                             :candidates (vec (map-indexed (fn [i r]
                                                             {:model (:model r) :id (:id r)
-                                                             :rank  (inc i) :score (:rerank_score r)})
+                                                             :rank  (inc i) :score (:rerank_score r)
+                                                             ;; rrf carries the raw RRF magnitude on :fused_score
+                                                             ;; (:score is offset-lifted for the global re-sort);
+                                                             ;; additive blends have no :fused_score, so their
+                                                             ;; blended :score is the attribution value.
+                                                             :fused_score (or (:fused_score r) (:score r))})
                                                           kept))}
-          ;; Strip the carried internal keys before return. `serialize` is a blacklist, so :content / the arm
-          ;; ranks would otherwise leak; keep them (plus :rerank_score) only under debug? for attribution.
-          cleaned          (mapv (fn [r]
-                                   (cond-> (dissoc r :content)
-                                     (not debug?) (dissoc :semantic_rank :keyword_rank :rerank_score)))
-                                 kept)]
+          cleaned          (mapv (partial strip-rerank-carried-keys debug?) kept)]
       {:results cleaned
        :tokens  (or tokens 0)
        :pool    (count pool-rows)
@@ -1495,7 +1564,11 @@
   "Query the index for documents similar to the search string.
   Returns a map with :results and :raw-count."
   [db index search-context]
-  (let [{:keys [embedding-model]} index
+  (let [;; The query embedder defaults to the active index's own model, but the `query_embedder` API param
+        ;; can override it (e.g. `:voyage` to embed the query via the Voyage API so it shares a
+        ;; Voyage-embedded table's vector space). Absent param => index's model => byte-identical baseline.
+        embedding-model (embedding/query-embedder-model (:query-embedder search-context)
+                                                        (:embedding-model index))
         search-string (:search-string search-context)]
     (if (str/blank? search-string)
       {:results [] :raw-count 0}
@@ -1552,15 +1625,23 @@
             final-results (->> filtered-results
                                (scoring/with-appdb-scores search-context appdb-scorers weights))
             appdb-scores-time-ms (u/since-ms appdb-scores-timer)
+            ;; Reranker confidence gate: when the request configured a `:gate` and the weighted head is already
+            ;; confident, skip the Voyage call entirely -- the weighted order (canonical at rank 1) is returned.
+            gate-fires? (and rerank? (reranker-gate-fires? search-context final-results))
             ;; Rerank after `with-appdb-scores` so the appdb boosts (:bookmarked / :user-recency) are already
             ;; in :all-scores and the D1/D3 re-blend can include every metadata boost.
-            rerank-timer (when rerank? (u/start-timer))
-            reranked (when rerank?
+            rerank-timer (when (and rerank? (not gate-fires?)) (u/start-timer))
+            reranked (when (and rerank? (not gate-fires?))
                        (tracing/with-span :search "search.semantic.rerank"
                          {:search/query-length (count search-string)}
                          (rerank-results search-context debug? final-results)))
-            rerank-time-ms (when rerank? (u/since-ms rerank-timer))
-            out-results (if rerank? (:results reranked) final-results)
+            rerank-time-ms (when rerank-timer (u/since-ms rerank-timer))
+            ;; When the gate fires, `final-results` still carries the rerank-only keys (:content,
+            ;; :semantic_distance) -- strip them so the gated path matches the reranked path on the wire.
+            out-results (cond
+                          reranked    (:results reranked)
+                          gate-fires? (mapv (partial strip-rerank-carried-keys debug?) final-results)
+                          :else       final-results)
             total-time-ms (u/since-ms timer)]
         (log/debug "Semantic search"
                    {:search-string-length (count search-string)
@@ -1583,8 +1664,9 @@
         (analytics/inc! :metabase-search/semantic-search-ms
                         {:embedding-model (:name embedding-model)}
                         total-time-ms)
-        (when rerank?
+        (when reranked
           ;; Reported usage (Voyage `usage.total_tokens`), not a local estimate, per the billable-cost policy.
+          ;; Skipped when the gate fired (no Voyage call, so no tokens to report).
           (analytics/inc! :metabase-search/semantic-rerank-tokens
                           {:model (:model reranked)}
                           (:tokens reranked))
@@ -1594,8 +1676,12 @@
         (cond-> {:results out-results
                  :raw-count (count raw-results)}
           pipeline (assoc :pipeline (cond-> (assoc pipeline :permission_dropped permission-dropped)
-                                      reranked (-> (update :stages conj (:stage reranked))
-                                                   (assoc :rerank (select-keys reranked [:tokens :pool :model]))))))))))
+                                      reranked    (-> (update :stages conj (:stage reranked))
+                                                      (assoc :rerank (select-keys reranked [:tokens :pool :model])))
+                                      ;; Gate fired: emit a marker stage so "gate skipped rerank" is
+                                      ;; distinguishable from "rerank not configured" in the captures.
+                                      gate-fires? (-> (update :stages conj {:name "rerank:voyage" :gated true :candidates []})
+                                                      (assoc :rerank {:gated true})))))))))
 
 (comment
   (def embedding-model (embedding/get-configured-model))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -1071,35 +1071,111 @@
       {:ctes ctes
        :query (dissoc query :with)})))
 
-(defn- hybrid-select
-  "For a given `col-name` return a :coalesce expression to reference it from the outer hybrid search query.
+(defn- hybrid-coalesce-select
+  "For a common-search column, coalesce its value across the present arm `aliases` (e.g. [\"v\" \"t\" \"g\"]).
+  A row can be matched by any single arm, so its display columns are pulled from whichever arm(s) matched.
+  With a single present arm the coalesce degenerates to a bare reference.
 
-   (hybrid-coalesce :model_id) -> [:coalesce :v.model_id :t.model_id]"
-  ([col-name-and-alias]
-   (hybrid-select col-name-and-alias "v." "t."))
-  ([[col-name col-alias] vector-prefix text-prefix]
-   (let [prefix #(keyword (str %1 (name %2)))]
-     [[:coalesce (prefix vector-prefix col-name) (prefix text-prefix col-name)] col-alias])))
+   (hybrid-coalesce-select [\"v\" \"t\"] [:model_id :model_id]) -> [[:coalesce :v.model_id :t.model_id] :model_id]"
+  [aliases [col-name col-alias]]
+  (let [refs (mapv (fn [a] (keyword (str a "." (name col-name)))) aliases)]
+    [(if (= 1 (count refs)) (first refs) (into [:coalesce] refs)) col-alias]))
+
+;; ----------------------------------------------------------------------------
+;; pg_trgm trigram arm (typo tolerance)
+;;
+;; A third retrieval arm alongside semantic + keyword. The keyword arm is pure full-text search, matching
+;; stemmed lexemes *exactly*, so a typo ("Conract") produces a lexeme absent from the index and contributes
+;; nothing. pg_trgm decomposes strings into overlapping 3-grams and scores by overlap, so a one-character
+;; typo perturbs only a few trigrams and "Conract" still scores high against "Contract". This arm filters
+;; `<column> % :q` (the pg_trgm match operator, GIN-accelerated) and ranks by `similarity(<column>, :q)`,
+;; producing a `trigram_rank` that fuses into the existing RRF (see [[scoring/rrf-rank-exp]]) with its own
+;; weight. One-row-per-entity output identical to the other arms, so the hybrid join / scoring / permission
+;; filter / rehydration are unchanged.
+;;
+;; The config arrives per request as `:trigram-config` (see [[metabase.search.config/TrigramConfig]]); absent
+;; -> the two-arm baseline. The target column needs the `pg_trgm` extension + a `GIN (<column> gin_trgm_ops)`
+;; index on the active table (search-eval scripts/manage_index.py set-trgm) or the `%` filter seq-scans.
+
+(defn- resolve-trigram-config
+  "Return the trigram-arm config when the request enables the pg_trgm typo-tolerance arm, else nil
+  (the two-arm semantic+keyword baseline)."
+  [search-context]
+  (:trigram-config search-context))
+
+(defn- trigram-search-query
+  "Build the pg_trgm trigram-similarity arm. Filters `<column> % :q` -- the pg_trgm similarity-threshold match
+  operator, which the `GIN (<column> gin_trgm_ops)` index accelerates -- tightened by an explicit
+  `similarity(<column>, :q) >= :threshold` predicate, and ranks by descending similarity via `row_number()`.
+  Mirrors [[keyword-search-query]]'s filter-then-rank shape over `common-search-columns` so it drops into
+  [[hybrid-search-query]]'s full-join unchanged. The query string is parameterized; `:column` is a
+  schema-validated lower-snake identifier interpolated raw. Requires the `pg_trgm` extension + the GIN index
+  on the active table (search-eval scripts/manage_index.py set-trgm)."
+  [index search-context trigram-config]
+  (let [filters   (search-filters search-context)
+        col       (or (:column trigram-config) "name")
+        threshold (or (:threshold trigram-config) 0.3)
+        limit     (or (:limit trigram-config) (semantic-settings/semantic-search-results-limit))
+        q         (:search-string search-context)
+        sim-expr  [:raw "similarity(" col ", " [:lift q] ")"]
+        match     [:raw col " % " [:lift q]]
+        thresh    [:>= sim-expr [:inline threshold]]
+        where     (cond-> [:and match thresh]
+                    filters (conj filters))]
+    {:select (into common-search-columns
+                   [[[:raw "row_number() OVER (ORDER BY similarity(" col ", " [:lift q] ") DESC)"]
+                     :trigram_rank]])
+     :from [(keyword (:table-name index))]
+     :where where
+     :order-by [[:trigram_rank :asc]]
+     :limit limit}))
 
 (defn- hybrid-search-query
-  "Build a hybrid search query using vector + keyword based searches and reranking with RRF"
+  "Build a hybrid search query fusing the present retrieval arms with RRF. The vector (semantic) arm `v` is the
+  always-present anchor; the keyword arm `t` is present unless the request sets `:disable-keyword?`; the pg_trgm
+  trigram arm `g` is present when the request carries a `:trigram-config`. Each subsequent arm is chained onto
+  the anchor with a FULL JOIN whose left side coalesces the ids of all prior arms, so a row matched by any
+  single arm survives; the display columns coalesce across the present arms and each arm projects its own rank
+  column(s) for the RRF fusion. `:semantic_distance`/`:semantic_view` are vector-only, so they reference `:v.`
+  directly (never coalesced). The two-arm semantic+keyword baseline (no flags) is byte-identical to before, as
+  are the three-arm (+trigram) and the new semantic+trigram / semantic-only combinations."
   [index embedding search-context]
-  (let [semantic-results (semantic-search-query index embedding search-context)
-        keyword-results (keyword-search-query index search-context)
-        full-query {:with [[:vector_results semantic-results]
-                           [:text_results keyword-results]]
-                    ;; `:semantic_view` is vector-only (the keyword arm has no such column), so reference
-                    ;; `:v.` directly rather than coalescing through `common-search-columns`.
-                    :select (into
-                             (mapv hybrid-select common-search-columns)
-                             [[:v.semantic_rank :semantic_rank]
-                              [:v.semantic_distance :semantic_distance]
-                              [:v.semantic_view :semantic_view]
-                              [:t.keyword_rank :keyword_rank]])
-                    :from [[:vector_results :v]]
-                    :full-join [[:text_results :t] [:= :v.id :t.id]]
-                    :limit (semantic-settings/semantic-search-results-limit)}]
-    full-query))
+  (let [disable-keyword? (boolean (:disable-keyword? search-context))
+        trigram-config   (resolve-trigram-config search-context)
+        ;; Present arms in join order. `:rank-cols` are this arm's vector-only rank projections (referenced via
+        ;; the arm alias directly, not coalesced); `mapcat`-ing them preserves the historical column order.
+        arms (cond-> [{:cte :vector_results :alias "v"
+                       :query (semantic-search-query index embedding search-context)
+                       :rank-cols [[:v.semantic_rank :semantic_rank]
+                                   [:v.semantic_distance :semantic_distance]
+                                   [:v.semantic_view :semantic_view]]}]
+               (not disable-keyword?)
+               (conj {:cte :text_results :alias "t"
+                      :query (keyword-search-query index search-context)
+                      :rank-cols [[:t.keyword_rank :keyword_rank]]})
+               trigram-config
+               (conj {:cte :trigram_results :alias "g"
+                      :query (trigram-search-query index search-context trigram-config)
+                      :rank-cols [[:g.trigram_rank :trigram_rank]]}))
+        aliases (mapv :alias arms)
+        anchor  (first arms)
+        ;; FULL JOIN each subsequent arm onto the chain, left side = coalesce of all prior arm ids (a single
+        ;; bare id when only the anchor precedes it). Reproduces the established 3-arm chain: t on v.id, g on
+        ;; coalesce(v.id, t.id).
+        joins (:clauses
+               (reduce (fn [{:keys [prior clauses]} {:keys [cte alias]}]
+                         (let [prior-ids (mapv #(keyword (str % ".id")) prior)
+                               lhs (if (= 1 (count prior-ids)) (first prior-ids) (into [:coalesce] prior-ids))]
+                           {:prior   (conj prior alias)
+                            :clauses (conj clauses [cte (keyword alias)] [:= lhs (keyword (str alias ".id"))])}))
+                       {:prior [(:alias anchor)] :clauses []}
+                       (rest arms)))]
+    (cond-> {:with   (mapv (juxt :cte :query) arms)
+             :select (into (mapv (partial hybrid-coalesce-select aliases) common-search-columns)
+                           (mapcat :rank-cols arms))
+             :from   [[(:cte anchor) (keyword (:alias anchor))]]
+             :limit  (semantic-settings/semantic-search-results-limit)}
+      (seq joins) (assoc :full-join joins))))
 
 (defn- scored-search-query
   "Build a hybrid search query with additional `scorers`"
@@ -1114,8 +1190,19 @@
   (let [hybrid-query (hybrid-search-query index embedding search-context)
         {:keys [ctes query]} (flatten-ctes hybrid-query)
         all-ctes (conj ctes [:hybrid_results query])
+        ;; Each arm's rank column exists in `hybrid_results` only when its arm ran, so track the gates exactly:
+        ;; `:keyword_rank` absent when `:disable-keyword?`, `:trigram_rank` present only when the trigram arm
+        ;; ran. Selecting a column whose CTE wasn't built makes the query throw, so these must match the arm
+        ;; gates in `hybrid-search-query`.
+        disable-keyword? (boolean (:disable-keyword? search-context))
+        trigram? (some? (resolve-trigram-config search-context))
+        select-cols (-> (cond-> [:id :model_id :model :content :verified :legacy_input
+                                 :semantic_rank :semantic_distance]
+                          (not disable-keyword?) (conj :keyword_rank))
+                        (conj :semantic_view)
+                        (cond-> trigram? (conj :trigram_rank)))
         full-query {:with all-ctes
-                    :select [:id :model_id :model :content :verified :legacy_input :semantic_rank :semantic_distance :keyword_rank :semantic_view]
+                    :select select-cols
                     :from [[:hybrid_results :search_index]]
                     :limit (semantic-settings/semantic-search-results-limit)}]
     (scoring/with-scores search-context scorers full-query)))
@@ -1138,9 +1225,11 @@
                                  :keyword_rank  (:keyword_rank row))
       debug? (assoc :cosine_distance (:semantic_distance row)
                     :semantic_view   (:semantic_view row)
+                    :trigram_rank    (:trigram_rank row)
                     :source          (cond-> []
                                        (:semantic_rank row) (conj "semantic")
-                                       (:keyword_rank row)  (conj "keyword"))))))
+                                       (:keyword_rank row)  (conj "keyword")
+                                       (:trigram_rank row)  (conj "trigram"))))))
 
 (defn- decode-legacy-input
   "Decode `row`s `:legacy_input` JSONB PGobject into a Clojure map."
@@ -1172,35 +1261,43 @@
   "Derive the ordered per-stage candidate lists from the full pre-permission `decoded` rows. Each candidate
   is the minimal {:model :id :rank [:distance|:score] [:view]} -- not the full row -- keyed like `data`.
   The arm ranks are the authoritative `row_number()`-assigned ranks; RRF/weighted ranks are positional over
-  the respective score column. Tolerates missing columns (blank-query/no-scoring path yields empty stages)."
-  [decoded]
+  the respective score column. Tolerates missing columns (blank-query/no-scoring path yields empty stages).
+  The `retrieval:keyword` stage is emitted only when `keyword?` (the keyword arm ran -- absent when the request
+  set `disable_keyword`) and the `retrieval:trigram` stage only when `trigram?` (the pg_trgm arm ran), so a
+  baseline debug run is byte-identical to before."
+  [decoded keyword? trigram?]
   (let [rows (mapv (fn [r] (assoc r ::ident (pipeline-ident r))) decoded)]
     {:horizon (semantic-settings/semantic-search-results-limit)
      :stages
-     [{:name "retrieval:semantic"
-       :candidates (->> rows
-                        (filter :semantic_rank)
-                        (sort-by :semantic_rank)
-                        (mapv (fn [r]
-                                (cond-> (assoc (::ident r)
-                                               :rank (:semantic_rank r)
-                                               :distance (:semantic_distance r))
-                                  (some? (:semantic_view r)) (assoc :view (:semantic_view r))))))}
-      {:name "retrieval:keyword"
-       :candidates (->> rows
-                        (filter :keyword_rank)
-                        (sort-by :keyword_rank)
-                        (mapv (fn [r] (assoc (::ident r) :rank (:keyword_rank r)))))}
-      {:name "fusion:rrf"
-       :candidates (->> rows
-                        (sort-by #(or (:rrf %) 0) >)
-                        (map-indexed (fn [i r] (assoc (::ident r) :rank (inc i) :score (:rrf r))))
-                        vec)}
-      {:name "score:weighted"
-       :candidates (->> rows
-                        (sort-by #(or (:total_score %) 0) >)
-                        (map-indexed (fn [i r] (assoc (::ident r) :rank (inc i) :score (:total_score r))))
-                        vec)}]}))
+     (into (cond-> [{:name "retrieval:semantic"
+                     :candidates (->> rows
+                                      (filter :semantic_rank)
+                                      (sort-by :semantic_rank)
+                                      (mapv (fn [r]
+                                              (cond-> (assoc (::ident r)
+                                                             :rank (:semantic_rank r)
+                                                             :distance (:semantic_distance r))
+                                                (some? (:semantic_view r)) (assoc :view (:semantic_view r))))))}]
+             keyword? (conj {:name "retrieval:keyword"
+                             :candidates (->> rows
+                                              (filter :keyword_rank)
+                                              (sort-by :keyword_rank)
+                                              (mapv (fn [r] (assoc (::ident r) :rank (:keyword_rank r)))))})
+             trigram? (conj {:name "retrieval:trigram"
+                             :candidates (->> rows
+                                              (filter :trigram_rank)
+                                              (sort-by :trigram_rank)
+                                              (mapv (fn [r] (assoc (::ident r) :rank (:trigram_rank r)))))}))
+           [{:name "fusion:rrf"
+             :candidates (->> rows
+                              (sort-by #(or (:rrf %) 0) >)
+                              (map-indexed (fn [i r] (assoc (::ident r) :rank (inc i) :score (:rrf r))))
+                              vec)}
+            {:name "score:weighted"
+             :candidates (->> rows
+                              (sort-by #(or (:total_score %) 0) >)
+                              (map-indexed (fn [i r] (assoc (::ident r) :rank (inc i) :score (:total_score r))))
+                              vec)}])}))
 
 (defn- pipeline-permission-dropped
   "Candidates present in the pre-permission `decoded` set but absent from the post-permission/collection
@@ -1421,6 +1518,12 @@
             ;; carry `:content` + arm ranks for the post-SQL rerank step.
             rerank? (boolean (and (:reranker-config search-context)
                                   (semantic-settings/ee-reranking-enabled)))
+            ;; Keyword arm runs unless the request set `:disable-keyword?` (remove the full-text arm entirely
+            ;; to A/B trigram-instead-of-keyword); trigram arm runs iff the request carries a `:trigram-config`
+            ;; (per-request opt-in, like partition/multi-view). Both drive their conditional debug stages; the
+            ;; arms themselves are built inside the SQL (scored-search-query -> hybrid-search-query).
+            keyword? (not (boolean (:disable-keyword? search-context)))
+            trigram? (boolean (resolve-trigram-config search-context))
             query (scored-search-query index embedding search-context scorers)
             reducible (reducible-search-query db query)
             ;; Realize the full candidate rows with their arm ranks / scorer columns intact (the DB hit),
@@ -1432,7 +1535,7 @@
             raw-results (mapv (partial legacy-input-with-score weights (keys scorers) debug? rerank?) decoded)
             db-query-time-ms (u/since-ms db-timer)
 
-            pipeline (when debug? (build-pipeline-stages decoded))
+            pipeline (when debug? (build-pipeline-stages decoded keyword? trigram?))
 
             filter-timer (u/start-timer)
             filtered-results (tracing/with-span :search "search.semantic.permission-filter"

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -804,16 +804,97 @@
   [search-context]
   (some-> (:partition-config search-context) :partitions not-empty))
 
+;; ----------------------------------------------------------------------------
+;; Multi-view embeddings (pooling, fusion v1)
+;;
+;; Each entity carries several embedding columns -- the base `embedding` plus synthetic views
+;; (`embedding_descriptions`, `embedding_attrs`, ...), each embedded from a differently-enriched text.
+;; Instead of one KNN over the single `embedding` column, emit one pure-KNN candidate sub-query per view
+;; column (each capped at the view's `:k`), UNION ALL them, then POOL to one row per entity by keeping the
+;; minimum cosine distance across views (`LEAST` / max-similarity). A single cosine cutoff gates the pooled
+;; distance and `semantic_rank` is recomputed over the survivors. The output is one-row-per-entity with the
+;; same columns the single-KNN path emits, so the keyword arm, RRF, scoring, permission filter, and
+;; rehydration are unchanged -- the same localization guarantee federation has.
+;;
+;; The config arrives per request as `:multi-view-config` (see [[metabase.search.config/MultiViewConfig]]);
+;; absent -> the single global KNN above. The base `embedding` column has a full HNSW (so its candidate CTE
+;; carries no predicate); each synthetic view column has a partial HNSW `WHERE <col> IS NOT NULL`
+;; (search-eval scripts/manage_index.py set-views), and its candidate CTE must emit exactly that predicate
+;; or the planner ignores the index. `:column` is interpolated as a raw SQL identifier; the schema regex
+;; constrains it to the `embedding`/`embedding_<suffix>` shape.
+
+(defn- multi-view-candidate-cte
+  "Build the pure-KNN candidate CTE entry for view `v` (0-indexed `i`). The query embedding is reused; each
+  view runs `ORDER BY <col> <=> q LIMIT k` so the planner uses that column's HNSW index. The base
+  `embedding` column has a full index and gets no predicate; every other (synthetic) column carries
+  `WHERE <col> IS NOT NULL` to match its partial index (unenriched/IE rows are NULL there and never enter
+  the sub-KNN). Returns `{:cand-name <kw> :cte [cand-name <query>]}`."
+  [index embedding-literal i v]
+  (let [col       (:column v)
+        base?     (= col "embedding")
+        k         (or (:k v) (semantic-settings/semantic-search-results-limit))
+        dist-expr [:raw (str col " <=> " embedding-literal)]
+        cand-name (keyword (str "v" i "_candidates"))
+        cand-cols (into common-search-columns [[dist-expr :distance]])]
+    {:cand-name cand-name
+     :cte [cand-name
+           (cond-> {:select   cand-cols
+                    :from     [(keyword (:table-name index))]
+                    :order-by [[dist-expr :asc]]
+                    :limit    k}
+             (not base?) (assoc :where [:raw (str col " IS NOT NULL")]))]}))
+
+(defn- multi-view-semantic-search-query
+  "Build the multi-view semantic vector subquery: one pure-KNN candidate CTE per view column UNION ALL-ed,
+  pooled to one row per entity by minimum cosine distance (`DISTINCT ON (model, model_id) ... ORDER BY
+  distance`), then the request's filters + the cosine cutoff applied and `semantic_rank` recomputed over the
+  survivors (fusion v1). Returns a query with the same output columns as [[hnsw-search-query]] so it drops
+  into the hybrid join unchanged. Filters (including `:models`) run in the outer query -- as in
+  [[hnsw-search-query]] -- so the candidate CTEs stay pure KNN and keep their HNSW index."
+  [index embedding-literal search-context mv-config]
+  (let [filters         (search-filters search-context)
+        cutoff          (or (:max-cosine-distance mv-config)
+                            (:max-cosine-distance search-context)
+                            default-max-cosine-distance)
+        parsed          (map-indexed (partial multi-view-candidate-cte index embedding-literal)
+                                     (:views mv-config))
+        cand-ctes       (mapv :cte parsed)
+        union-col-names (conj (mapv second common-search-columns) :distance)
+        union-q         {:union-all (mapv (fn [{:keys [cand-name]}]
+                                            {:select union-col-names :from [cand-name]})
+                                          parsed)}
+        pooled-q        {:select-distinct-on (into [[:model :model_id]] union-col-names)
+                         :from               [:union_candidates]
+                         :order-by           [[:model :asc] [:model_id :asc] [:distance :asc]]}]
+    {:with     (conj cand-ctes [:union_candidates union-q] [:pooled pooled-q])
+     :select   (into common-search-columns
+                     [[[:raw "row_number() OVER (ORDER BY distance ASC)"] :semantic_rank]
+                      [:distance :semantic_distance]])
+     :from     [:pooled]
+     :where    (let [c [:<= :distance cutoff]]
+                 (if filters (into [:and] [c filters]) c))
+     :order-by [[:semantic_rank :asc]]
+     :limit    (semantic-settings/semantic-search-results-limit)}))
+
+(defn- resolve-multi-view-config
+  "Return the multi-view config to pool over, or nil for the (default) single global KNN path."
+  [search-context]
+  (when (some-> (:multi-view-config search-context) :views not-empty)
+    (:multi-view-config search-context)))
+
 (defn- semantic-search-query
-  "Build the semantic vector subquery. When the request carries a `:partition-config`, emit the
-  federated multi-CTE candidate generation ([[federated-semantic-search-query]]); otherwise dispatch
-  on the resolved [[vector-search-strategy]] -- `:brute-force` (exact, filter-first) or `:hnsw`
-  (approximate, index-backed; the default)."
+  "Build the semantic vector subquery. When the request carries a `:multi-view-config`, pool per-view KNNs
+  ([[multi-view-semantic-search-query]]); when it carries a `:partition-config`, emit the federated
+  multi-CTE candidate generation ([[federated-semantic-search-query]]); otherwise dispatch on the resolved
+  [[vector-search-strategy]] -- `:brute-force` (exact, filter-first) or `:hnsw` (approximate, index-backed;
+  the default)."
   [index embedding search-context]
   (let [filters           (search-filters search-context)
         embedding-literal (format-embedding embedding)
         cutoff            (or (:max-cosine-distance search-context) default-max-cosine-distance)]
-    (or (when-let [partitions (resolve-partition-config search-context)]
+    (or (when-let [mv-config (resolve-multi-view-config search-context)]
+          (multi-view-semantic-search-query index embedding-literal search-context mv-config))
+        (when-let [partitions (resolve-partition-config search-context)]
           (federated-semantic-search-query index embedding-literal search-context partitions))
         (case (vector-search-strategy search-context)
           :brute-force (brute-force-search-query index embedding-literal filters cutoff)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -10,6 +10,7 @@
    [java-time.api :as t]
    ;; TODO: extract schema code to go under db.migration
    [metabase-enterprise.semantic-search.embedding :as embedding]
+   [metabase-enterprise.semantic-search.reranking :as reranking]
    [metabase-enterprise.semantic-search.scoring :as scoring]
    [metabase-enterprise.semantic-search.settings :as semantic-settings]
    [metabase.analytics-interface.core :as analytics]
@@ -640,9 +641,13 @@
                     :order-by [[[:raw (str "embedding <=> " embedding-literal)] :asc]]
                     :limit  (semantic-settings/semantic-search-results-limit)}
         base-query {:with [[:vector_candidates hnsw-query]]
+                    ;; `:semantic_view` (the winning-view attribution tag, see [[multi-view-candidate-cte]])
+                    ;; is NULL here -- the single-KNN path pools no views -- but the column is emitted
+                    ;; unconditionally so [[hybrid-search-query]] can reference it for every strategy.
                     :select (into common-search-columns
                                   [[[:raw "row_number() OVER (ORDER BY distance ASC)"] :semantic_rank]
-                                   [:distance :semantic_distance]])
+                                   [:distance :semantic_distance]
+                                   [[:inline nil] :semantic_view]])
                     :from [:vector_candidates]
                     :where [:<= :distance max-cosine-distance]
                     :order-by [[:semantic_rank :asc]]}]
@@ -666,9 +671,11 @@
                                 :from   [(keyword (:table-name index))]}
                          filters (assoc :where filters))]
     {:with     [[:vector_candidates filtered-query :materialized]]
+     ;; `:semantic_view` is NULL on the single-KNN path; emitted unconditionally for [[hybrid-search-query]].
      :select   (into common-search-columns
                      [[[:raw "row_number() OVER (ORDER BY distance ASC)"] :semantic_rank]
-                      [:distance :semantic_distance]])
+                      [:distance :semantic_distance]
+                      [[:inline nil] :semantic_view]])
      :from     [:vector_candidates]
      :where    [:<= :distance max-cosine-distance]
      :order-by [[:semantic_rank :asc]]
@@ -792,9 +799,12 @@
                                             :from   [filt-name]})
                                          parts)}]
         {:with     (conj all-ctes [:union_candidates union-q])
+         ;; `:semantic_view` is NULL on the federation-only path (no view pooling); emitted unconditionally
+         ;; for [[hybrid-search-query]].
          :select   (into common-search-columns
                          [[[:raw "row_number() OVER (ORDER BY distance ASC)"] :semantic_rank]
-                          [:distance :semantic_distance]])
+                          [:distance :semantic_distance]
+                          [[:inline nil] :semantic_view]])
          :from     [:union_candidates]
          :order-by [[:semantic_rank :asc]]
          :limit    (semantic-settings/semantic-search-results-limit)}))))
@@ -833,9 +843,16 @@
   (let [col       (:column v)
         base?     (= col "embedding")
         k         (or (:k v) (semantic-settings/semantic-search-results-limit))
+        view-label (or (:name v) col)
         dist-expr [:raw (str col " <=> " embedding-literal)]
         cand-name (keyword (str "v" i "_candidates"))
-        cand-cols (into common-search-columns [[dist-expr :distance]])]
+        ;; `:semantic_view` tags each candidate with the view it came from; `:view_idx` (the view's position
+        ;; in the config) breaks pooling ties deterministically so attribution is stable when two views share
+        ;; an identical vector (e.g. a null description ⇒ same distance as base). Lowest index wins the tie.
+        cand-cols (into common-search-columns
+                        [[dist-expr :distance]
+                         [[:inline view-label] :semantic_view]
+                         [[:inline i] :view_idx]])]
     {:cand-name cand-name
      :cte [cand-name
            (cond-> {:select   cand-cols
@@ -859,17 +876,20 @@
         parsed          (map-indexed (partial multi-view-candidate-cte index embedding-literal)
                                      (:views mv-config))
         cand-ctes       (mapv :cte parsed)
-        union-col-names (conj (mapv second common-search-columns) :distance)
+        union-col-names (conj (mapv second common-search-columns) :distance :semantic_view :view_idx)
         union-q         {:union-all (mapv (fn [{:keys [cand-name]}]
                                             {:select union-col-names :from [cand-name]})
                                           parsed)}
+        ;; Pool to one row per entity keeping the minimum distance; the `:view_idx` tiebreaker makes the
+        ;; surviving `:semantic_view` deterministic when views tie on distance (lowest view index wins).
         pooled-q        {:select-distinct-on (into [[:model :model_id]] union-col-names)
                          :from               [:union_candidates]
-                         :order-by           [[:model :asc] [:model_id :asc] [:distance :asc]]}]
+                         :order-by           [[:model :asc] [:model_id :asc] [:distance :asc] [:view_idx :asc]]}]
     {:with     (conj cand-ctes [:union_candidates union-q] [:pooled pooled-q])
      :select   (into common-search-columns
                      [[[:raw "row_number() OVER (ORDER BY distance ASC)"] :semantic_rank]
-                      [:distance :semantic_distance]])
+                      [:distance :semantic_distance]
+                      [:semantic_view :semantic_view]])
      :from     [:pooled]
      :where    (let [c [:<= :distance cutoff]]
                  (if filters (into [:and] [c filters]) c))
@@ -920,16 +940,22 @@
                             config-cutoff
                             (:max-cosine-distance search-context)
                             default-max-cosine-distance)
-            union-cols  (conj (mapv second common-search-columns) :distance)
+            union-cols  (conj (mapv second common-search-columns) :distance :semantic_view :view_idx)
             cand-entries
             (map-indexed
              (fn [j v]
                (let [col        (:column v)
                      base?      (= col "embedding")
                      view-k     (or (:k v) part-k)
+                     view-label (or (:name v) col)
                      dist-expr  [:raw (str col " <=> " embedding-literal)]
                      cand-name  (keyword (str "p" i "_v" j "_candidates"))
-                     cand-cols  (into common-search-columns [[dist-expr :distance]])
+                     ;; See [[multi-view-candidate-cte]]: `:semantic_view` tags the view, `:view_idx` breaks
+                     ;; pooling ties deterministically (lowest view index wins).
+                     cand-cols  (into common-search-columns
+                                      [[dist-expr :distance]
+                                       [[:inline view-label] :semantic_view]
+                                       [[:inline j] :view_idx]])
                      where-pred (if base?
                                   model-pred
                                   [:and model-pred [:raw (str col " IS NOT NULL")]])]
@@ -957,8 +983,8 @@
                                           cand-entries)}
             pooled-q    {:select-distinct-on (into [[:model :model_id]] union-cols)
                          :from               [union-name]
-                         :order-by           [[:model :asc] [:model_id :asc] [:distance :asc]]}
-            filt-q      {:select   (into common-search-columns [[:distance :distance]])
+                         :order-by           [[:model :asc] [:model_id :asc] [:distance :asc] [:view_idx :asc]]}
+            filt-q      {:select   (into common-search-columns [[:distance :distance] [:semantic_view :semantic_view]])
                          :from     [pooled-name]
                          :where    (let [c [:<= :distance cutoff]]
                                      (if non-model-filters (into [:and] [c non-model-filters]) c))
@@ -986,13 +1012,14 @@
     (when (seq parts)
       (let [all-ctes (into [] (mapcat :ctes) parts)
             union-q  {:union-all (mapv (fn [{:keys [filt-name]}]
-                                         {:select (into common-search-columns [[:distance :distance]])
+                                         {:select (into common-search-columns [[:distance :distance] [:semantic_view :semantic_view]])
                                           :from   [filt-name]})
                                        parts)}]
         {:with     (conj all-ctes [:union_candidates union-q])
          :select   (into common-search-columns
                          [[[:raw "row_number() OVER (ORDER BY distance ASC)"] :semantic_rank]
-                          [:distance :semantic_distance]])
+                          [:distance :semantic_distance]
+                          [:semantic_view :semantic_view]])
          :from     [:union_candidates]
          :order-by [[:semantic_rank :asc]]
          :limit    (semantic-settings/semantic-search-results-limit)}))))
@@ -1061,10 +1088,13 @@
         keyword-results (keyword-search-query index search-context)
         full-query {:with [[:vector_results semantic-results]
                            [:text_results keyword-results]]
+                    ;; `:semantic_view` is vector-only (the keyword arm has no such column), so reference
+                    ;; `:v.` directly rather than coalescing through `common-search-columns`.
                     :select (into
                              (mapv hybrid-select common-search-columns)
                              [[:v.semantic_rank :semantic_rank]
                               [:v.semantic_distance :semantic_distance]
+                              [:v.semantic_view :semantic_view]
                               [:t.keyword_rank :keyword_rank]])
                     :from [[:vector_results :v]]
                     :full-join [[:text_results :t] [:= :v.id :t.id]]
@@ -1085,18 +1115,32 @@
         {:keys [ctes query]} (flatten-ctes hybrid-query)
         all-ctes (conj ctes [:hybrid_results query])
         full-query {:with all-ctes
-                    :select [:id :model_id :model :content :verified :legacy_input :semantic_rank :semantic_distance :keyword_rank]
+                    :select [:id :model_id :model :content :verified :legacy_input :semantic_rank :semantic_distance :keyword_rank :semantic_view]
                     :from [[:hybrid_results :search_index]]
                     :limit (semantic-settings/semantic-search-results-limit)}]
     (scoring/with-scores search-context scorers full-query)))
 
 (defn- legacy-input-with-score
   "Extracts the (already-decoded) `:legacy_input` map from `row` and attaches the total score
-  plus per-scorer breakdown."
-  [weights scorers row]
-  (assoc (:legacy_input row)
-         :score (:total_score row 1.0)
-         :all-scores (scoring/all-scores weights scorers row)))
+  plus per-scorer breakdown. When `debug?` (the `debug_pipeline` request flag), also carries the per-row
+  retrieval-attribution fields -- arm ranks, cosine distance, winning view, and a derived `:source` -- onto
+  the result map. When `rerank?`, additionally carries `:content` (the `embeddable_text` block -- the
+  cross-encoder's input) and the arm ranks (the D3 rank-fusion-free pool ordering); the rerank step dissocs
+  them before the return so they never reach the wire. `serialize` (impl.clj) is a blacklist, so any carried
+  key rides straight to the wire unless dropped; with both flags off => result is unchanged from baseline."
+  [weights scorers debug? rerank? row]
+  (let [result (assoc (:legacy_input row)
+                      :score (:total_score row 1.0)
+                      :all-scores (scoring/all-scores weights scorers row))]
+    (cond-> result
+      rerank?            (assoc :content (:content row))
+      (or debug? rerank?) (assoc :semantic_rank (:semantic_rank row)
+                                 :keyword_rank  (:keyword_rank row))
+      debug? (assoc :cosine_distance (:semantic_distance row)
+                    :semantic_view   (:semantic_view row)
+                    :source          (cond-> []
+                                       (:semantic_rank row) (conj "semantic")
+                                       (:keyword_rank row)  (conj "keyword"))))))
 
 (defn- decode-legacy-input
   "Decode `row`s `:legacy_input` JSONB PGobject into a Clojure map."
@@ -1107,6 +1151,66 @@
           (fn [pgo]
             (let [decoded (decode-pgobject pgo)]
               (cond-> decoded (string? decoded) json/decode+kw)))))
+
+;; ----------------------------------------------------------------------------
+;; Per-stage retrieval attribution (the `debug_pipeline` diagnostics)
+;;
+;; The whole hybrid query materializes in one SQL pass; each `decoded` row still carries its arm ranks
+;; (`:semantic_rank`, `:keyword_rank`), `:semantic_distance`, winning `:semantic_view`, the per-scorer columns
+;; (incl. `:rrf`), and `:total_score` -- before `legacy-input-with-score` collapses them. So the four base
+;; stages (semantic arm / keyword arm / RRF fusion / weighted score) are derivable from `decoded` in Clojure
+;; with no extra SQL. Gated behind `:debug-pipeline?`; eval-only.
+
+(defn- pipeline-ident
+  "Stage-candidate identity matching the `data` rows: the collapsed-id (`indexed-entity`-aware) legacy_input
+  model+id. Keyed identically to `data`/qrels so the runner scores stages against the same judgments."
+  [row]
+  (let [li (search/collapse-id (:legacy_input row))]
+    {:model (:model li) :id (:id li)}))
+
+(defn- build-pipeline-stages
+  "Derive the ordered per-stage candidate lists from the full pre-permission `decoded` rows. Each candidate
+  is the minimal {:model :id :rank [:distance|:score] [:view]} -- not the full row -- keyed like `data`.
+  The arm ranks are the authoritative `row_number()`-assigned ranks; RRF/weighted ranks are positional over
+  the respective score column. Tolerates missing columns (blank-query/no-scoring path yields empty stages)."
+  [decoded]
+  (let [rows (mapv (fn [r] (assoc r ::ident (pipeline-ident r))) decoded)]
+    {:horizon (semantic-settings/semantic-search-results-limit)
+     :stages
+     [{:name "retrieval:semantic"
+       :candidates (->> rows
+                        (filter :semantic_rank)
+                        (sort-by :semantic_rank)
+                        (mapv (fn [r]
+                                (cond-> (assoc (::ident r)
+                                               :rank (:semantic_rank r)
+                                               :distance (:semantic_distance r))
+                                  (some? (:semantic_view r)) (assoc :view (:semantic_view r))))))}
+      {:name "retrieval:keyword"
+       :candidates (->> rows
+                        (filter :keyword_rank)
+                        (sort-by :keyword_rank)
+                        (mapv (fn [r] (assoc (::ident r) :rank (:keyword_rank r)))))}
+      {:name "fusion:rrf"
+       :candidates (->> rows
+                        (sort-by #(or (:rrf %) 0) >)
+                        (map-indexed (fn [i r] (assoc (::ident r) :rank (inc i) :score (:rrf r))))
+                        vec)}
+      {:name "score:weighted"
+       :candidates (->> rows
+                        (sort-by #(or (:total_score %) 0) >)
+                        (map-indexed (fn [i r] (assoc (::ident r) :rank (inc i) :score (:total_score r))))
+                        vec)}]}))
+
+(defn- pipeline-permission-dropped
+  "Candidates present in the pre-permission `decoded` set but absent from the post-permission/collection
+  `kept` results, tagged with their `score_rank` (1-based position in `total_score` order)."
+  [decoded kept-results]
+  (let [kept (into #{} (map (juxt :model :id)) kept-results)]
+    (into []
+          (comp (map-indexed (fn [i r] (assoc (pipeline-ident r) :score_rank (inc i))))
+                (remove (fn [c] (contains? kept [(:model c) (:id c)]))))
+          decoded)))
 
 (defn- compute-collection-id-only-search-models
   "Compute search-models whose read perms are determined fully by their collection id."
@@ -1205,6 +1309,91 @@
   [db query]
   (jdbc/plan db (sql-format-quoted query) {:builder-fn jdbc.rs/as-unqualified-lower-maps}))
 
+;; ----------------------------------------------------------------------------
+;; Voyage cross-encoder rerank step (the `reranker_config` request knob)
+;;
+;; A precision-only reorder of the top-N of the (permission-filtered, appdb-boosted) candidate list. RRF +
+;; the SQL pool ordering decide *which* N candidates get reranked (recall); the cross-encoder produces the
+;; relevance ordering over those N. Runs entirely post-SQL in Clojure over rows that already carry
+;; `:all-scores` (each `{:name :score :weight :contribution}`) and `:content`, so the re-blend is pure
+;; arithmetic -- no new SQL, no weight refit. See [[metabase.search.config/RerankerConfig]] /
+;; [[metabase.search.config/rerank-blend-modes]].
+
+(def ^:private rerank-relevance-scorers
+  "Scorers the cross-encoder supersedes as the relevance signal; dropped from the re-blend in the
+  `:rerank_then_boost`/`:rerank_fusion` modes (the rerank score owns the relevance axis instead)."
+  #{:rrf :semantic-distance})
+
+(defn- metadata-boost-contribution
+  "Sum of `:contribution` over a row's `:all-scores`, excluding `drop-set` (the relevance-core scorers). Each
+  `:contribution` is the already-computed `weight*score` for one scorer, so this is the metadata-boost mass
+  that tips the cross-encoder's relevance ordering."
+  [row drop-set]
+  (transduce (comp (remove (comp drop-set :name))
+                   (map #(or (:contribution %) 0.0)))
+             + 0.0 (:all-scores row)))
+
+(defn- reblend
+  "Recompute `:score` for a reranked `row` per `blend`. `rr` is the cross-encoder relevance score in [0,1];
+  `w` is the configured rerank weight. Attaches `:rerank_score` for attribution."
+  [blend w row rr]
+  (assoc row
+         :rerank_score rr
+         :score (case blend
+                  :rerank_only       rr
+                  :rerank_then_boost (+ (* w rr) (metadata-boost-contribution row rerank-relevance-scorers))
+                  ;; D2 keeps the full weighted sum (incl. :rrf) and adds the rerank term -- double-counts
+                  ;; relevance; kept for completeness.
+                  :rerank_as_scorer  (+ (:score row 0.0) (* w rr))
+                  :rerank_fusion     (+ (* w rr) (metadata-boost-contribution row rerank-relevance-scorers)))))
+
+(defn- rerank-results
+  "Rerank the top-`pool` of `results` with the Voyage cross-encoder and reblend per the request's
+  `:reranker-config` `:blend`. Returns `{:results :tokens :pool :model :stage}` where `:results` is the
+  re-sorted result list (one row per entity, `:content`/carried ranks dissoc'd so nothing leaks) and `:stage`
+  is the `rerank:voyage` debug-pipeline stage (built unconditionally; only attached under `debug?`).
+
+  Pool selection: D1/D2 rerank the head of the existing `total_score` order; D3 (`:rerank_fusion`) reranks the
+  head of a rank-fusion-free order (best arm rank), ignoring RRF for *which* N are reranked. The reranked
+  block always sorts above the un-reranked tail (the pool is the precision-ordered head). `:top-k` truncates
+  the final list; left unset it returns the full list, so the min-results fallback stays predictable."
+  [search-context debug? results]
+  (if (empty? results)
+    ;; Nothing to rerank (e.g. everything filtered out). Skip the provider round-trip; Voyage rejects an
+    ;; empty `documents` list anyway.
+    {:results results :tokens 0 :pool 0
+     :model (or (:model (:reranker-config search-context)) (semantic-settings/ee-reranking-model))
+     :stage {:name "rerank:voyage" :candidates []}}
+    (let [{:keys [model pool top-k weight blend]
+           :or   {pool 50 weight 500.0 blend :rerank_then_boost}} (:reranker-config search-context)
+          ordered          (if (= blend :rerank_fusion)
+                             (sort-by (fn [r] (min (or (:semantic_rank r) ##Inf)
+                                                   (or (:keyword_rank r) ##Inf)))
+                                      results)
+                             results)
+          [pool-rows tail] (split-at pool ordered)
+          docs             (mapv #(or (:content %) (:name %) "") pool-rows)
+          {:keys [order scores tokens]} (reranking/rerank (:search-string search-context) docs {:model model})
+          reranked         (mapv (fn [i] (reblend blend weight (nth pool-rows i) (get scores i 0.0))) order)
+          merged           (concat (sort-by :score > reranked) tail)
+          kept             (cond->> merged top-k (take top-k))
+          stage            {:name "rerank:voyage"
+                            :candidates (vec (map-indexed (fn [i r]
+                                                            {:model (:model r) :id (:id r)
+                                                             :rank  (inc i) :score (:rerank_score r)})
+                                                          kept))}
+          ;; Strip the carried internal keys before return. `serialize` is a blacklist, so :content / the arm
+          ;; ranks would otherwise leak; keep them (plus :rerank_score) only under debug? for attribution.
+          cleaned          (mapv (fn [r]
+                                   (cond-> (dissoc r :content)
+                                     (not debug?) (dissoc :semantic_rank :keyword_rank :rerank_score)))
+                                 kept)]
+      {:results cleaned
+       :tokens  (or tokens 0)
+       :pool    (count pool-rows)
+       :model   (or model (semantic-settings/ee-reranking-model))
+       :stage   stage})))
+
 (defn query-index
   "Query the index for documents similar to the search string.
   Returns a map with :results and :raw-count."
@@ -1226,14 +1415,24 @@
             db-timer (u/start-timer)
             weights (search.config/weights search-context)
             scorers (scoring/semantic-scorers (:table-name index) search-context)
+            debug? (boolean (:debug-pipeline? search-context))
+            ;; Rerank runs iff the request carries a `:reranker-config` (the per-request opt-in) AND the global
+            ;; `ee-reranking-enabled` kill switch is on. Computed up front so `legacy-input-with-score` knows to
+            ;; carry `:content` + arm ranks for the post-SQL rerank step.
+            rerank? (boolean (and (:reranker-config search-context)
+                                  (semantic-settings/ee-reranking-enabled)))
             query (scored-search-query index embedding search-context scorers)
-            xform (comp (map decode-legacy-input)
-                        (map (partial legacy-input-with-score weights (keys scorers))))
             reducible (reducible-search-query db query)
-            raw-results (tracing/with-span :search "search.semantic.db-query"
-                          {:search/query-length (count search-string)}
-                          (into [] xform reducible))
+            ;; Realize the full candidate rows with their arm ranks / scorer columns intact (the DB hit),
+            ;; then project to result maps. Splitting the xform keeps `decoded` available for the
+            ;; debug-pipeline stage derivation, which reads columns `legacy-input-with-score` discards.
+            decoded (tracing/with-span :search "search.semantic.db-query"
+                      {:search/query-length (count search-string)}
+                      (into [] (map decode-legacy-input) reducible))
+            raw-results (mapv (partial legacy-input-with-score weights (keys scorers) debug? rerank?) decoded)
             db-query-time-ms (u/since-ms db-timer)
+
+            pipeline (when debug? (build-pipeline-stages decoded))
 
             filter-timer (u/start-timer)
             filtered-results (tracing/with-span :search "search.semantic.permission-filter"
@@ -1243,21 +1442,32 @@
                                     (apply-collection-id-filter search-context)
                                     (mapv search/collapse-id)))
             filter-time-ms (u/since-ms filter-timer)
+            permission-dropped (when debug? (pipeline-permission-dropped decoded filtered-results))
 
             appdb-scorers (scoring/appdb-scorers search-context)
             appdb-scores-timer (u/start-timer)
             final-results (->> filtered-results
                                (scoring/with-appdb-scores search-context appdb-scorers weights))
             appdb-scores-time-ms (u/since-ms appdb-scores-timer)
+            ;; Rerank after `with-appdb-scores` so the appdb boosts (:bookmarked / :user-recency) are already
+            ;; in :all-scores and the D1/D3 re-blend can include every metadata boost.
+            rerank-timer (when rerank? (u/start-timer))
+            reranked (when rerank?
+                       (tracing/with-span :search "search.semantic.rerank"
+                         {:search/query-length (count search-string)}
+                         (rerank-results search-context debug? final-results)))
+            rerank-time-ms (when rerank? (u/since-ms rerank-timer))
+            out-results (if rerank? (:results reranked) final-results)
             total-time-ms (u/since-ms timer)]
         (log/debug "Semantic search"
                    {:search-string-length (count search-string)
                     :raw-results-count (count raw-results)
-                    :final-results-count (count final-results)
+                    :final-results-count (count out-results)
                     :embedding-time-ms embedding-time-ms
                     :db-query-time-ms db-query-time-ms
                     :filter-time-ms filter-time-ms
                     :appdb-scores-time-ms appdb-scores-time-ms
+                    :rerank-time-ms rerank-time-ms
                     :total-time-ms total-time-ms})
         (analytics/inc! :metabase-search/semantic-embedding-ms
                         {:embedding-model (:name embedding-model)}
@@ -1270,10 +1480,19 @@
         (analytics/inc! :metabase-search/semantic-search-ms
                         {:embedding-model (:name embedding-model)}
                         total-time-ms)
+        (when rerank?
+          ;; Reported usage (Voyage `usage.total_tokens`), not a local estimate, per the billable-cost policy.
+          (analytics/inc! :metabase-search/semantic-rerank-tokens
+                          {:model (:model reranked)}
+                          (:tokens reranked))
+          (analytics/inc! :metabase-search/semantic-rerank-ms rerank-time-ms))
         (comment
           (jdbc/execute! db (sql-format-quoted query)))
-        {:results final-results
-         :raw-count (count raw-results)}))))
+        (cond-> {:results out-results
+                 :raw-count (count raw-results)}
+          pipeline (assoc :pipeline (cond-> (assoc pipeline :permission_dropped permission-dropped)
+                                      reranked (-> (update :stages conj (:stage reranked))
+                                                   (assoc :rerank (select-keys reranked [:tokens :pool :model]))))))))))
 
 (comment
   (def embedding-model (embedding/get-configured-model))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -680,16 +680,144 @@
   (or (:vector-search-strategy search-context)
       (semantic-settings/semantic-search-vector-strategy)))
 
+;; ----------------------------------------------------------------------------
+;; Federated / partitioned retrieval (fusion v1)
+;;
+;; Instead of one global KNN over the whole index, emit one candidate sub-query per
+;; partition (a set of model classes), each with its own candidate quota (`:k`),
+;; cosine cutoff, and vector strategy, then UNION ALL them and recompute
+;; `semantic_rank` over the union. Each model-scoped sub-query lets `card`/`dashboard`/
+;; etc. reach the candidate pool regardless of how many `indexed-entity` rows sit
+;; closer in raw cosine distance (the documented crowding problem). The output is
+;; still one-row-per-entity with the same columns the single-KNN path emits, so the
+;; keyword arm, RRF, scoring, permission filter, and rehydration are unchanged.
+;;
+;; The partition map arrives per request as `:partition-config` (see
+;; [[metabase.search.config/PartitionConfig]]); absent → the single global KNN above.
+;; The per-partition model predicate must imply the partial HNSW index predicate built
+;; on the active table (search-eval scripts/manage_index.py) or the planner ignores it.
+
+(defn- sql-string-literal
+  "Quote a string as a SQL literal, doubling embedded single quotes."
+  [s]
+  (str \' (str/replace s "'" "''") \'))
+
+(defn- partition-model-pred
+  "Raw SQL predicate restricting a partition sub-query to its model set. Byte-matches the
+  partial-index predicate emitted by manage_index.py `_model_pred` so the planner uses the
+  partition's partial HNSW index: single model -> `model = '<m>'`; multi ->
+  `model = ANY (ARRAY['a', 'b']::text[])`."
+  [models]
+  (if (= 1 (count models))
+    [:raw (str "model = " (sql-string-literal (first models)))]
+    [:raw (str "model = ANY (ARRAY["
+               (str/join ", " (map sql-string-literal models))
+               "]::text[])")]))
+
+(defn- federated-partition-ctes
+  "Build the candidate + filtered CTE entries for partition `p` (0-indexed `i`).
+  Returns `{:filt-name <kw> :ctes [[cand ...] [filt ...]]}`, or nil when the request's
+  `:models` filter leaves this partition with no models to search.
+
+  HNSW partitions: a pure model-scoped vector scan (matches the partial index) capped at
+  the partition `:k`, with the cosine cutoff + non-model filters applied in the outer
+  `filt` CTE — mirrors [[hnsw-search-query]]. Brute-force partitions: an exact, filter-first
+  MATERIALIZED scan (model predicate + filters), then cutoff + quota — mirrors
+  [[brute-force-search-query]]. Both expose `common-search-columns` + `distance` and contribute
+  at most `:k` rows ordered by distance."
+  [index embedding-literal search-context non-model-filters i p]
+  (let [requested  (:models search-context)
+        eff-models (if (seq requested)
+                     (filterv (set requested) (:models p))
+                     (vec (:models p)))]
+    (when (seq eff-models)
+      (let [model-pred (partition-model-pred eff-models)
+            strategy   (or (:strategy p) (vector-search-strategy search-context))
+            k          (or (:k p) (semantic-settings/semantic-search-results-limit))
+            cutoff     (or (:max-cosine-distance p)
+                           (:max-cosine-distance search-context)
+                           default-max-cosine-distance)
+            dist-expr  [:raw (str "embedding <=> " embedding-literal)]
+            cand-name  (keyword (str "p" i "_candidates"))
+            filt-name  (keyword (str "p" i "_filtered"))
+            cand-cols  (into common-search-columns [[dist-expr :distance]])
+            filt-cols  (into common-search-columns [[:distance :distance]])]
+        {:filt-name filt-name
+         :ctes
+         (case strategy
+           :brute-force
+           [[cand-name
+             (cond-> {:select cand-cols
+                      :from   [(keyword (:table-name index))]
+                      :where  model-pred}
+               non-model-filters (update :where #(into [:and] [% non-model-filters])))
+             :materialized]
+            [filt-name
+             {:select   filt-cols
+              :from     [cand-name]
+              :where    [:<= :distance cutoff]
+              :order-by [[:distance :asc]]
+              :limit    k}]]
+
+           ;; default :hnsw
+           [[cand-name
+             {:select   cand-cols
+              :from     [(keyword (:table-name index))]
+              :where    model-pred
+              :order-by [[dist-expr :asc]]
+              :limit    k}]
+            [filt-name
+             {:select   filt-cols
+              :from     [cand-name]
+              :where    (let [c [:<= :distance cutoff]]
+                          (if non-model-filters (into [:and] [c non-model-filters]) c))
+              :order-by [[:distance :asc]]
+              :limit    k}]])}))))
+
+(defn- federated-semantic-search-query
+  "Build the federated semantic vector subquery: per-partition candidate CTEs UNION ALL-ed,
+  with `semantic_rank` recomputed over the union by raw cosine distance (fusion v1). Returns a
+  query with the same output columns as [[hnsw-search-query]] so it drops into the hybrid join
+  unchanged. Returns nil when no partition matches the request's `:models` filter (caller falls
+  back to the single global KNN)."
+  [index embedding-literal search-context partitions]
+  (let [non-model-filters (search-filters (dissoc search-context :models))
+        parts (keep-indexed
+               (partial federated-partition-ctes index embedding-literal search-context non-model-filters)
+               partitions)]
+    (when (seq parts)
+      (let [all-ctes   (into [] (mapcat :ctes) parts)
+            union-q    {:union-all (mapv (fn [{:keys [filt-name]}]
+                                           {:select (into common-search-columns [[:distance :distance]])
+                                            :from   [filt-name]})
+                                         parts)}]
+        {:with     (conj all-ctes [:union_candidates union-q])
+         :select   (into common-search-columns
+                         [[[:raw "row_number() OVER (ORDER BY distance ASC)"] :semantic_rank]
+                          [:distance :semantic_distance]])
+         :from     [:union_candidates]
+         :order-by [[:semantic_rank :asc]]
+         :limit    (semantic-settings/semantic-search-results-limit)}))))
+
+(defn- resolve-partition-config
+  "Return the partition list to federate over, or nil for the (default) single global KNN path."
+  [search-context]
+  (some-> (:partition-config search-context) :partitions not-empty))
+
 (defn- semantic-search-query
-  "Build the semantic vector subquery, dispatching on the resolved [[vector-search-strategy]].
-  `:brute-force` is exact and filter-first; `:hnsw` (the default) is approximate and index-backed."
+  "Build the semantic vector subquery. When the request carries a `:partition-config`, emit the
+  federated multi-CTE candidate generation ([[federated-semantic-search-query]]); otherwise dispatch
+  on the resolved [[vector-search-strategy]] -- `:brute-force` (exact, filter-first) or `:hnsw`
+  (approximate, index-backed; the default)."
   [index embedding search-context]
   (let [filters           (search-filters search-context)
         embedding-literal (format-embedding embedding)
         cutoff            (or (:max-cosine-distance search-context) default-max-cosine-distance)]
-    (case (vector-search-strategy search-context)
-      :brute-force (brute-force-search-query index embedding-literal filters cutoff)
-      (hnsw-search-query index embedding-literal filters cutoff))))
+    (or (when-let [partitions (resolve-partition-config search-context)]
+          (federated-semantic-search-query index embedding-literal search-context partitions))
+        (case (vector-search-strategy search-context)
+          :brute-force (brute-force-search-query index embedding-literal filters cutoff)
+          (hnsw-search-query index embedding-literal filters cutoff)))))
 
 (defn- flatten-ctes
   "Flatten nested :with clauses into a single top-level :with.

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -620,11 +620,15 @@
      :order-by [[:keyword_rank :asc]]
      :limit (semantic-settings/semantic-search-results-limit)}))
 
-(def ^:private ^:const max-cosine-distance "Cut-off used to filter semantic search results" 0.7)
+(def ^:private ^:const default-max-cosine-distance
+  "Default cut-off used to filter semantic search results, when the request doesn't override it via the
+  `:max-cosine-distance` search-context key (the `max_cosine_distance` API parameter)."
+  0.7)
 
 (defn- hnsw-search-query
-  "Build the semantic vector subquery using the HNSW index, applying `filters` after candidate selection."
-  [index embedding-literal filters]
+  "Build the semantic vector subquery using the HNSW index, applying `filters` after candidate selection.
+  `max-cosine-distance` is the cut-off above which candidates are discarded."
+  [index embedding-literal filters max-cosine-distance]
   ;; The inner `vector_candidates` CTE is a pure vector search (ORDER BY distance LIMIT) so the planner
   ;; uses the HNSW index. The filters only run in the outer query, so this is approximate: when the
   ;; globally-closest rows are dominated by a cluster the filters reject, slightly-further survivors that
@@ -647,8 +651,9 @@
       base-query)))
 
 (defn- brute-force-search-query
-  "Build the semantic vector subquery as an exact, filter-first search over the rows matching `filters`."
-  [index embedding-literal filters]
+  "Build the semantic vector subquery as an exact, filter-first search over the rows matching `filters`.
+  `max-cosine-distance` is the cut-off above which candidates are discarded."
+  [index embedding-literal filters max-cosine-distance]
   ;; The filtered rows and their cosine distance are computed once, inside a MATERIALIZED CTE: that fences
   ;; the planner off the HNSW index (so the scan is exact) and stores the `distance` column, so the outer
   ;; query reads it rather than recomputing it. The cutoff and ranking run in the outer query.
@@ -680,10 +685,11 @@
   `:brute-force` is exact and filter-first; `:hnsw` (the default) is approximate and index-backed."
   [index embedding search-context]
   (let [filters           (search-filters search-context)
-        embedding-literal (format-embedding embedding)]
+        embedding-literal (format-embedding embedding)
+        cutoff            (or (:max-cosine-distance search-context) default-max-cosine-distance)]
     (case (vector-search-strategy search-context)
-      :brute-force (brute-force-search-query index embedding-literal filters)
-      (hnsw-search-query index embedding-literal filters))))
+      :brute-force (brute-force-search-query index embedding-literal filters cutoff)
+      (hnsw-search-query index embedding-literal filters cutoff))))
 
 (defn- flatten-ctes
   "Flatten nested :with clauses into a single top-level :with.

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -882,17 +882,142 @@
   (when (some-> (:multi-view-config search-context) :views not-empty)
     (:multi-view-config search-context)))
 
+;; ----------------------------------------------------------------------------
+;; Composed federated + multi-view (fusion v1)
+;;
+;; The Cartesian product of the two features above: partition by model (federation) AND pool across view
+;; columns within each partition (multi-view). For each partition, emit one model-scoped per-column KNN per
+;; view, UNION the partition's views, pool to one row per entity by minimum cosine distance (`LEAST`), then
+;; apply the partition's cutoff + quota; finally UNION ALL the partitions and recompute `semantic_rank`. Since
+;; partitions are model-disjoint, per-partition pooling equals a global pool but preserves the boundary the
+;; per-partition quota needs. Output columns match [[hnsw-search-query]], so the hybrid join / RRF / scoring /
+;; permission filter / rehydration are unchanged.
+;;
+;; The config arrives per request as `:federated-multi-view-config` (see
+;; [[metabase.search.config/FederatedMultiViewConfig]]). For an HNSW partition, each synthetic view's
+;; candidate CTE emits `WHERE <model-pred> AND <col> IS NOT NULL`, which must byte-match a *composite* partial
+;; HNSW index (search-eval scripts/manage_index.py set-federated-views) or the planner post-filters the model
+;; set (correct, slower, and crowding creeps back). Brute-force partitions need no index.
+
+(defn- federated-multi-view-partition-ctes
+  "Build the CTE entries for partition `p` (0-indexed `i`) of the composed query. For each of the partition's
+  views, emit a model-scoped per-column KNN candidate CTE (HNSW: pure KNN capped at the view `:k`, matching
+  the composite partial index `WHERE <model-pred> AND <col> IS NOT NULL`; brute-force: an exact MATERIALIZED
+  model-scoped scan). UNION the views, pool to one row per entity by minimum cosine distance
+  (`DISTINCT ON (model, model_id)`), then apply the partition cutoff, non-model filters, and quota `:k` in a
+  `filt` CTE. Returns `{:filt-name <kw> :ctes [...]}`, or nil when the request's `:models` filter leaves this
+  partition with no models to search."
+  [index embedding-literal search-context non-model-filters config-cutoff i p]
+  (let [requested  (:models search-context)
+        eff-models (if (seq requested)
+                     (filterv (set requested) (:models p))
+                     (vec (:models p)))]
+    (when (seq eff-models)
+      (let [model-pred  (partition-model-pred eff-models)
+            strategy    (or (:strategy p) (vector-search-strategy search-context))
+            part-k      (or (:k p) (semantic-settings/semantic-search-results-limit))
+            cutoff      (or (:max-cosine-distance p)
+                            config-cutoff
+                            (:max-cosine-distance search-context)
+                            default-max-cosine-distance)
+            union-cols  (conj (mapv second common-search-columns) :distance)
+            cand-entries
+            (map-indexed
+             (fn [j v]
+               (let [col        (:column v)
+                     base?      (= col "embedding")
+                     view-k     (or (:k v) part-k)
+                     dist-expr  [:raw (str col " <=> " embedding-literal)]
+                     cand-name  (keyword (str "p" i "_v" j "_candidates"))
+                     cand-cols  (into common-search-columns [[dist-expr :distance]])
+                     where-pred (if base?
+                                  model-pred
+                                  [:and model-pred [:raw (str col " IS NOT NULL")]])]
+                 {:cand-name cand-name
+                  :cte       (case strategy
+                               :brute-force
+                               [cand-name
+                                {:select cand-cols
+                                 :from   [(keyword (:table-name index))]
+                                 :where  where-pred}
+                                :materialized]
+                               ;; default :hnsw
+                               [cand-name
+                                {:select   cand-cols
+                                 :from     [(keyword (:table-name index))]
+                                 :where    where-pred
+                                 :order-by [[dist-expr :asc]]
+                                 :limit    view-k}])}))
+             (:views p))
+            union-name  (keyword (str "p" i "_union"))
+            pooled-name (keyword (str "p" i "_pooled"))
+            filt-name   (keyword (str "p" i "_filtered"))
+            union-q     {:union-all (mapv (fn [{:keys [cand-name]}]
+                                            {:select union-cols :from [cand-name]})
+                                          cand-entries)}
+            pooled-q    {:select-distinct-on (into [[:model :model_id]] union-cols)
+                         :from               [union-name]
+                         :order-by           [[:model :asc] [:model_id :asc] [:distance :asc]]}
+            filt-q      {:select   (into common-search-columns [[:distance :distance]])
+                         :from     [pooled-name]
+                         :where    (let [c [:<= :distance cutoff]]
+                                     (if non-model-filters (into [:and] [c non-model-filters]) c))
+                         :order-by [[:distance :asc]]
+                         :limit    part-k}]
+        {:filt-name filt-name
+         :ctes      (-> (mapv :cte cand-entries)
+                        (conj [union-name union-q])
+                        (conj [pooled-name pooled-q])
+                        (conj [filt-name filt-q]))}))))
+
+(defn- federated-multi-view-semantic-search-query
+  "Build the composed federated + multi-view semantic vector subquery: per-partition, per-view model-scoped
+  KNNs pooled to one row per entity (`LEAST`) and quota'd, then UNION ALL-ed across partitions with
+  `semantic_rank` recomputed over the union by pooled cosine distance. Returns a query with the same output
+  columns as [[hnsw-search-query]] so it drops into the hybrid join unchanged. Returns nil when no partition
+  matches the request's `:models` filter (caller falls back to the single global KNN)."
+  [index embedding-literal search-context config]
+  (let [non-model-filters (search-filters (dissoc search-context :models))
+        config-cutoff     (:max-cosine-distance config)
+        parts (keep-indexed
+               (partial federated-multi-view-partition-ctes
+                        index embedding-literal search-context non-model-filters config-cutoff)
+               (:partitions config))]
+    (when (seq parts)
+      (let [all-ctes (into [] (mapcat :ctes) parts)
+            union-q  {:union-all (mapv (fn [{:keys [filt-name]}]
+                                         {:select (into common-search-columns [[:distance :distance]])
+                                          :from   [filt-name]})
+                                       parts)}]
+        {:with     (conj all-ctes [:union_candidates union-q])
+         :select   (into common-search-columns
+                         [[[:raw "row_number() OVER (ORDER BY distance ASC)"] :semantic_rank]
+                          [:distance :semantic_distance]])
+         :from     [:union_candidates]
+         :order-by [[:semantic_rank :asc]]
+         :limit    (semantic-settings/semantic-search-results-limit)}))))
+
+(defn- resolve-federated-multi-view-config
+  "Return the composed federated + multi-view config, or nil for the (default) single global KNN path."
+  [search-context]
+  (when (some-> (:federated-multi-view-config search-context) :partitions not-empty)
+    (:federated-multi-view-config search-context)))
+
 (defn- semantic-search-query
-  "Build the semantic vector subquery. When the request carries a `:multi-view-config`, pool per-view KNNs
-  ([[multi-view-semantic-search-query]]); when it carries a `:partition-config`, emit the federated
-  multi-CTE candidate generation ([[federated-semantic-search-query]]); otherwise dispatch on the resolved
-  [[vector-search-strategy]] -- `:brute-force` (exact, filter-first) or `:hnsw` (approximate, index-backed;
-  the default)."
+  "Build the semantic vector subquery. When the request carries a `:federated-multi-view-config`, compose
+  federation and pooling ([[federated-multi-view-semantic-search-query]]); when it carries a
+  `:multi-view-config`, pool per-view KNNs ([[multi-view-semantic-search-query]]); when it carries a
+  `:partition-config`, emit the federated multi-CTE candidate generation
+  ([[federated-semantic-search-query]]); otherwise dispatch on the resolved [[vector-search-strategy]] --
+  `:brute-force` (exact, filter-first) or `:hnsw` (approximate, index-backed; the default). The three
+  experiment configs are mutually exclusive; the composed one wins if more than one is present."
   [index embedding search-context]
   (let [filters           (search-filters search-context)
         embedding-literal (format-embedding embedding)
         cutoff            (or (:max-cosine-distance search-context) default-max-cosine-distance)]
-    (or (when-let [mv-config (resolve-multi-view-config search-context)]
+    (or (when-let [fmv-config (resolve-federated-multi-view-config search-context)]
+          (federated-multi-view-semantic-search-query index embedding-literal search-context fmv-config))
+        (when-let [mv-config (resolve-multi-view-config search-context)]
           (multi-view-semantic-search-query index embedding-literal search-context mv-config))
         (when-let [partitions (resolve-partition-config search-context)]
           (federated-semantic-search-query index embedding-literal search-context partitions))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/reranking.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/reranking.clj
@@ -1,0 +1,78 @@
+(ns metabase-enterprise.semantic-search.reranking
+  "Voyage cross-encoder reranking client for semantic search.
+
+  A single direct-Voyage client (POST api.voyageai.com/v1/rerank, `Authorization: Bearer`), deliberately
+  *without* the provider multimethod of [[metabase-enterprise.semantic-search.embedding]] -- the ai-service
+  proxy `/v1/rerank` route is unverified and out of scope, so this is one fn, not a `dispatch-provider`.
+
+  This is the relevance-ordering (precision) step layered on top of RRF's recall/pool selection: the caller
+  (`query-index`) takes the top-N of the permission-filtered, boost-scored candidate list, hands their
+  `content` here, and reblends the returned per-doc relevance scores. Reranking cannot surface a target the
+  SQL never returned -- it only reorders the pool."
+  (:require
+   [clj-http.client :as http]
+   [metabase-enterprise.semantic-search.settings :as semantic-settings]
+   [metabase.util.json :as json]
+   [metabase.util.log :as log]
+   [metabase.util.retry :as retry]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private voyage-rerank-url "https://api.voyageai.com/v1/rerank")
+
+(def ^:private max-rerank-retries
+  "Retry budget for a rate-limited / transient Voyage call. Deliberately small: the rerank runs
+  synchronously inside a single `/api/search` request, so the cumulative backoff must stay well under
+  the client request timeout. Four retries over the default 500ms-base exponential backoff is ~7.5s of
+  sleeping -- enough to ride out a short 429 burst without blowing the request budget. Sustained
+  rate-limit saturation still surfaces (the last attempt rethrows) rather than blocking indefinitely."
+  4)
+
+(defn- retryable-rerank-error?
+  "True when a failed Voyage rerank call should be retried: a 429 (rate limit), a provider 5xx, or a
+  transport-level error (connection reset / timeout, which carries no HTTP status in its ex-data). Real
+  client errors (400/401/422) carry a 4xx status and are not retried."
+  [e]
+  (let [status (:status (ex-data e))]
+    (or (nil? status)
+        (= 429 status)
+        (<= 500 status 599))))
+
+(defn rerank
+  "Rerank `documents` (a vector of strings) against `query` with the Voyage cross-encoder.
+
+  Returns `{:order [doc-idx ...] :scores {doc-idx relevance-score} :tokens n}` where `:order` is the document
+  indices best-first and `:scores` maps each index to its [0,1] relevance score. `total_tokens` is the
+  provider-reported usage (the billable figure, not a local estimate).
+
+  Options: `:model` (defaults to the `ee-reranking-model` setting) and `:top-k`. `:top-k` is left unset by
+  default so Voyage returns *all* documents reordered -- truncating the final result list is the caller's job
+  (it must keep the count above the min-results threshold so the appdb fallback stays predictable). Throws if
+  the API key is unset."
+  [query documents {:keys [model top-k] :or {model (semantic-settings/ee-reranking-model)}}]
+  (let [api-key (semantic-settings/ee-reranking-api-key)]
+    (when (empty? api-key)
+      (throw (ex-info "ee-reranking-api-key not set" {})))
+    (let [body (cond-> {:model model :query query :documents documents :truncation true}
+                 top-k (assoc :top_k top-k))
+          ;; Retry the provider round-trip on rate-limit (429) / 5xx / transport errors with the house
+          ;; exponential backoff. `:max-retries` is pinned here rather than taken from the global
+          ;; `retry-max-retries` setting (which defaults to 0 in dev, where the eval runs) so the rerank
+          ;; actually retries regardless of environment; the backoff curve + jitter are still operator-tunable.
+          resp (-> (retry/with-retry (assoc (retry/retry-configuration)
+                                            :max-retries max-rerank-retries
+                                            :retry-if    (fn [_result e]
+                                                           (boolean (and e (retryable-rerank-error? e))))
+                                            :on-retry    (fn [_result e]
+                                                           (log/warn e "Voyage rerank call failed; retrying")))
+                     (http/post voyage-rerank-url
+                                {:headers {"Authorization" (str "Bearer " api-key)
+                                           "Content-Type"  "application/json"}
+                                 :body    (json/encode body)}))
+                   :body
+                   (json/decode true))
+          data (:data resp)]
+      (log/debug "Voyage rerank" {:model model :documents (count documents) :tokens (get-in resp [:usage :total_tokens])})
+      {:order  (mapv :index data)
+       :scores (into {} (map (juxt :index :relevance_score)) data)
+       :tokens (get-in resp [:usage :total_tokens] 0)})))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
@@ -59,15 +59,33 @@
                                        (into [:case] cat cases)
                                        1))))
 
-(def ^:private rrf-rank-exp
+(defn- rrf-rank-exp
+  "Reciprocal-rank-fusion expression blending the semantic and keyword arm ranks -- and, when the request
+  carries a `:trigram-config`, the pg_trgm trigram arm rank (the typo-tolerance arm). The per-arm weights
+  default to 0.49 (semantic) / 0.51 (keyword) -- full-text gets a slight edge -- but are overridable
+  per-request via the `:rrf/semantic` / `:rrf/keyword` nested scorer-params (the `weights` API param),
+  so the arm split can be swept without code changes. Both the keyword and trigram terms are conditional and
+  `conj`-ed onto the always-present semantic term: the keyword term is dropped when the request sets
+  `:disable-keyword?` (the arm is absent, so `:keyword_rank` is not a hybrid-query column and referencing it
+  would throw), and the trigram term is added only when the trigram arm is present; its weight comes from the
+  trigram-config `:weight` and defaults small (0.2) so the surface-form arm tips rather than dominates the
+  fusion. With keyword disabled + trigram on the fusion is `0.49*semantic + w*trigram` -- the
+  replace-keyword-with-trigram semantics. Only the ratio matters when an item is in multiple arms; the
+  absolute weights govern how single-arm hits compete."
+  [search-ctx]
   (let [k 60
-        keyword-weight 0.51
-        semantic-weight 0.49]
-    [:+
-     [:* [:cast semantic-weight :float]
-      [:coalesce [:/ 1.0 [:+ k :semantic_rank]] 0]]
-     [:* [:cast keyword-weight :float]
-      [:coalesce [:/ 1.0 [:+ k :keyword_rank]] 0]]]))
+        semantic-weight  (or (search.config/scorer-param search-ctx :rrf :semantic) 0.49)
+        keyword-weight   (or (search.config/scorer-param search-ctx :rrf :keyword) 0.51)
+        disable-keyword? (boolean (:disable-keyword? search-ctx))
+        trigram-cfg      (:trigram-config search-ctx)
+        trigram-weight   (or (:weight trigram-cfg) 0.2)]
+    (cond-> [:+
+             [:* [:cast semantic-weight :float]
+              [:coalesce [:/ 1.0 [:+ k :semantic_rank]] 0]]]
+      (not disable-keyword?) (conj [:* [:cast keyword-weight :float]
+                                    [:coalesce [:/ 1.0 [:+ k :keyword_rank]] 0]])
+      trigram-cfg            (conj [:* [:cast trigram-weight :float]
+                                    [:coalesce [:/ 1.0 [:+ k :trigram_rank]] 0]]))))
 
 (def ^:private cosine-distance-ceiling
   "Largest possible pgvector cosine distance (`<=>`): `1 - cos(theta)` tops out at 2 for opposed vectors."
@@ -89,7 +107,7 @@
     {:model [:inline 1]}
     ;; NOTE: we calculate scores even if the weight is zero, so that it's easy to consider how we could affect any
     ;; given set of results. At some point, we should optimize away the irrelevant scores for any given context.
-    {:rrf        rrf-rank-exp
+    {:rrf        (rrf-rank-exp search-ctx)
      ;; Keyword-only hits have no vector distance, so treat them as maximally distant (score 0).
      :semantic-distance (semantic-distance-score-expr [:coalesce :semantic_distance [:inline cosine-distance-ceiling]])
      :view-count (view-count-expr index-table search.config/view-count-scaling-percentile)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
@@ -77,7 +77,7 @@
   "Map a cosine `distance` (pgvector `<=>`, range [0, 2]) to a [0, 1] score.
   Linear for now: distance 0 scores 1, the maximum distance of 2 scores 0."
   [distance]
-  ;; TODO (Chris 2026-06-02) -- consider rescaling against the retrieval cutoff (index/max-cosine-distance) so the
+  ;; TODO (Chris 2026-06-02) -- consider rescaling against the retrieval cutoff (index/default-max-cosine-distance) so the
   ;; [0, cutoff] band spans the full [0, 1], and/or a non-linear curve. For now keep the raw distance as transparent
   ;; as possible.
   [:- [:inline 1] [:/ distance [:inline cosine-distance-ceiling]]])

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -81,6 +81,39 @@
   :export?    false
   :doc        false)
 
+;; ---------------------------------------------------------------------------
+;; Voyage cross-encoder reranking. A precision-only rerank step over the top-N of the
+;; (permission-filtered, boost-scored) candidate list, gated by both the per-request `reranker_config`
+;; param (the opt-in, see [[metabase.search.config/RerankerConfig]]) and `ee-reranking-enabled` (the global
+;; kill switch). Provider/model/key live here; pool/top_k/weight/blend ride the per-request config.
+
+(defsetting ee-reranking-enabled
+  (deferred-tru
+   (str "Enable the Voyage cross-encoder rerank step in semantic search. Global default-off kill switch; the "
+        "per-request `reranker_config` param also gates it (both must be present for a rerank to run)."))
+  :visibility :internal
+  :encryption :no
+  :default    false
+  :type       :boolean
+  :export?    false
+  :doc        false)
+
+(defsetting ee-reranking-model
+  (deferred-tru "Default Voyage rerank model (e.g. rerank-2.5, rerank-2.5-lite). The per-request `reranker_config` may override it.")
+  :encryption :no
+  :visibility :settings-manager
+  :default    "rerank-2.5"
+  :type       :string
+  :export?    false
+  :doc        false)
+
+(defsetting ee-reranking-api-key
+  (deferred-tru "Voyage API key for the rerank endpoint (direct api.voyageai.com/v1/rerank).")
+  :sensitive? true
+  :visibility :settings-manager
+  :export?    false
+  :doc        false)
+
 (defsetting semantic-search-enabled
   (deferred-tru "Enable the semantic search engine? Intended as a kill switch for the semantic search feature while dogfooding.")
   :visibility :internal

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -8,7 +8,7 @@
 
 (def ^:private valid-embedding-providers
   "The set of valid embedding provider names."
-  #{"ai-service" "openai" "ollama"})
+  #{"ai-service" "openai" "ollama" "voyage"})
 
 (defsetting ee-embedding-provider
   (deferred-tru "The embedding provider to use (`openai`, `ollama`, or `ai-service`)")
@@ -54,6 +54,46 @@
   :type :positive-integer
   :export? false
   :doc false)
+
+;; ---------------------------------------------------------------------------
+;; Voyage embeddings. Used by the `voyage` embedding provider (direct
+;; api.voyageai.com/v1/embeddings, `Authorization: Bearer`), selected per-request via the `query_embedder`
+;; search API param so a search against a Voyage-embedded index table embeds the query in the same vector
+;; space. Distinct from the Voyage rerank settings below (separate endpoint, separate key).
+
+(defsetting ee-voyage-embedding-base-url
+  (deferred-tru "Base URL for the Voyage embeddings API (direct api.voyageai.com).")
+  :encryption :no
+  :visibility :settings-manager
+  :default    "https://api.voyageai.com"
+  :type       :string
+  :export?    false
+  :doc        false)
+
+(defsetting ee-voyage-embedding-api-key
+  (deferred-tru "Voyage API key for the embeddings endpoint (direct api.voyageai.com/v1/embeddings).")
+  :sensitive? true
+  :visibility :settings-manager
+  :export?    false
+  :doc        false)
+
+(defsetting ee-voyage-embedding-model
+  (deferred-tru "Voyage embedding model used when the `query_embedder=voyage` search param is set (e.g. voyage-4-large).")
+  :encryption :no
+  :visibility :settings-manager
+  :default    "voyage-4-large"
+  :type       :string
+  :export?    false
+  :doc        false)
+
+(defsetting ee-voyage-embedding-model-dimensions
+  (deferred-tru "Output dimension requested from the Voyage embedding model; must match the vector column of the Voyage-embedded index table.")
+  :encryption :no
+  :visibility :settings-manager
+  :default    1024
+  :type       :positive-integer
+  :export?    false
+  :doc        false)
 
 (defn openai-api-base-url
   "Get the OpenAI API base url from the existing LLM settings."

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -18,6 +18,7 @@
    [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]
    [metabase.util.json :as json]
+   [metabase.util.retry :as retry]
    [toucan2.core :as t2])
   (:import
    [java.nio ByteBuffer ByteOrder]
@@ -373,3 +374,78 @@
                         (t2/select-one :model/SemanticSearchTokenTracking)]
                     (is (= :query request_type))
                     (is (= 13 total_tokens))))))))))))
+
+;;;; Voyage embedding provider (query_embedder=voyage routing)
+
+(def ^:private voyage-model
+  {:provider "voyage" :model-name "voyage-4-large" :vector-dimensions 1024})
+
+(defn- float-array?* [x] (= (Class/forName "[F") (class x)))
+
+(deftest voyage-get-embedding-parses-floats-and-sends-query-input-type-test
+  (testing "the voyage provider posts the asymmetric query input_type + output_dimension and parses float vectors"
+    (mt/with-temporary-setting-values [ee-voyage-embedding-api-key "voyage-mock-key"]
+      (let [response {:data  [{:embedding [0.1 0.2 0.3]}]
+                      :usage {:total_tokens 7}}
+            captured (atom nil)]
+        (with-redefs [http/post (fn [url opts]
+                                  (reset! captured {:url url :body (json/decode+kw (:body opts))})
+                                  {:body (json/encode response)})]
+          (let [result (embedding/get-embedding voyage-model "revenue dashboard"
+                                                {:type :query :record-tokens? false})]
+            (is (float-array?* result) "returns a float-array, not a base64-decoded buffer")
+            (is (= [(float 0.1) (float 0.2) (float 0.3)] (vec result)))
+            (testing "request body carries model, input, query input_type, output_dimension, truncation"
+              (is (= "voyage-4-large" (get-in @captured [:body :model])))
+              (is (= ["revenue dashboard"] (get-in @captured [:body :input])))
+              (is (= "query" (get-in @captured [:body :input_type])))
+              (is (= 1024 (get-in @captured [:body :output_dimension])))
+              (is (true? (get-in @captured [:body :truncation]))))
+            (testing "hits the configured Voyage embeddings endpoint"
+              (is (= "https://api.voyageai.com/v1/embeddings" (:url @captured))))))))))
+
+(deftest voyage-get-embeddings-batch-uses-document-input-type-test
+  (testing "non-query embedding (indexing/default) sends input_type=document"
+    (mt/with-temporary-setting-values [ee-voyage-embedding-api-key "voyage-mock-key"]
+      (let [captured (atom nil)]
+        (with-redefs [http/post (fn [_url opts]
+                                  (reset! captured (json/decode+kw (:body opts)))
+                                  {:body (json/encode {:data  [{:embedding [0.0]} {:embedding [1.0]}]
+                                                       :usage {:total_tokens 2}})})]
+          (let [result (embedding/get-embeddings-batch voyage-model ["a" "b"] {:record-tokens? false})]
+            (is (= 2 (count result)))
+            (is (every? float-array?* result))
+            (is (= "document" (:input_type @captured)))))))))
+
+(deftest voyage-get-embedding-requires-api-key-test
+  (testing "the voyage provider throws when its key is unset (it must never silently fall through)"
+    (mt/with-temporary-setting-values [ee-voyage-embedding-api-key nil]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"ee-voyage-embedding-api-key not set"
+                            (embedding/get-embedding voyage-model "q" {:type :query}))))))
+
+(deftest voyage-retries-transient-error-test
+  (testing "the voyage provider retries a 429 / 5xx and succeeds once the provider recovers"
+    (mt/with-temporary-setting-values [ee-voyage-embedding-api-key "voyage-mock-key"]
+      (binding [retry/*test-time-config-hook* #(assoc % :initial-interval-millis 1 :max-interval-millis 2 :jitter-factor 0.0)]
+        (let [calls (atom 0)]
+          (with-redefs [http/post (fn [_url _opts]
+                                    (let [n (swap! calls inc)]
+                                      (case n
+                                        1 (throw (ex-info "clj-http: status 429" {:status 429}))
+                                        2 (throw (ex-info "clj-http: status 503" {:status 503}))
+                                        {:body (json/encode {:data [{:embedding [0.5]}] :usage {:total_tokens 1}})})))]
+            (let [result (embedding/get-embedding voyage-model "q" {:type :query :record-tokens? false})]
+              (is (= 3 @calls) "retried the 429 then the 503 before the third attempt succeeded")
+              (is (= [(float 0.5)] (vec result))))))))))
+
+(deftest query-embedder-model-resolution-test
+  (let [index-model {:provider "ai-service" :model-name "Snowflake/snowflake-arctic-embed-l-v2.0" :vector-dimensions 1024}]
+    (testing ":voyage resolves to the Voyage embedding-model from settings (shares the table vector space)"
+      (mt/with-temporary-setting-values [ee-voyage-embedding-model "voyage-4-large"
+                                         ee-voyage-embedding-model-dimensions 1024]
+        (is (= {:provider "voyage" :model-name "voyage-4-large" :vector-dimensions 1024}
+               (embedding/query-embedder-model :voyage index-model)))))
+    (testing "absent / :arctic / :ai-service leave the active index's own embedder unchanged (baseline)"
+      (is (= index-model (embedding/query-embedder-model nil index-model)))
+      (is (= index-model (embedding/query-embedder-model :arctic index-model)))
+      (is (= index-model (embedding/query-embedder-model :ai-service index-model))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -105,6 +105,40 @@
       (mt/with-temporary-setting-values [semantic.settings/semantic-search-vector-strategy strategy]
         (is (= strategy (semantic.settings/semantic-search-vector-strategy)))))))
 
+(defn- multi-view-search-sql+params
+  "Format the private vector subquery for `mv-config` against a stub index, returning the `[sql & params]`
+  vector `sql/format` produces."
+  [mv-config]
+  (let [index {:table-name "idx_tbl"}
+        ctx   {:search-string "pasta" :archived? false :multi-view-config mv-config}]
+    (sql/format (#'semantic.index/semantic-search-query index [0.1 0.2 0.3] ctx) :quoted true)))
+
+(deftest multi-view-semantic-search-query-test
+  (let [mv          {:views [{:column "embedding"              :name "base"         :k 500}
+                             {:column "embedding_descriptions" :name "descriptions" :k 300}
+                             {:column "embedding_attrs"        :name "attributes"   :k 300}]
+                     :max-cosine-distance 0.6
+                     :pool :least}
+        [sql & params] (multi-view-search-sql+params mv)]
+    (testing "one pure-KNN candidate CTE per view column, each an HNSW-triggering ORDER BY <col> <=> q LIMIT"
+      ;; raw distance expressions interpolate the column unquoted; the trailing space avoids matching
+      ;; `embedding_descriptions` when looking for the base `embedding` column
+      (is (re-find #"ORDER BY embedding <=>[^)]*LIMIT" sql))
+      (is (re-find #"ORDER BY embedding_descriptions <=>[^)]*LIMIT" sql))
+      (is (re-find #"ORDER BY embedding_attrs <=>[^)]*LIMIT" sql)))
+    (testing "synthetic view columns carry the partial-index IS NOT NULL predicate; the base column does not"
+      (is (str/includes? sql "embedding_descriptions IS NOT NULL"))
+      (is (str/includes? sql "embedding_attrs IS NOT NULL"))
+      ;; the base column has a full HNSW, so its candidate CTE must stay an unfiltered pure KNN
+      (is (not (re-find #"\bembedding IS NOT NULL" sql))))
+    (testing "candidates are UNION ALL-ed and pooled to one row per entity by minimum distance"
+      (is (str/includes? sql "UNION ALL"))
+      (is (re-find #"DISTINCT ON\s*\(\"model\", \"model_id\"\)" sql)))
+    (testing "the configured cosine cutoff gates the pooled distance"
+      (is (contains? (set params) 0.6)))
+    (testing "multi-view takes precedence over the per-strategy single-KNN path (no global vector_candidates CTE)"
+      (is (not (str/includes? sql "\"vector_candidates\""))))))
+
 (deftest create-index-table!-test
   (mt/with-premium-features #{:semantic-search}
     (with-open [index-ref (semantic.tu/open-temp-index!)]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -180,6 +180,78 @@
     (testing "the composed path takes precedence over the single-KNN path (no global vector_candidates CTE)"
       (is (not (str/includes? sql "\"vector_candidates\""))))))
 
+(deftest semantic-view-attribution-column-test
+  (testing "single-KNN paths emit a NULL semantic_view so the hybrid select can reference it for every strategy"
+    (doseq [strategy [:hnsw :brute-force]]
+      (is (str/includes? (vector-search-sql strategy) "NULL AS \"semantic_view\"")
+          (str strategy " path tags semantic_view NULL"))))
+  (testing "multi-view path tags each candidate with its view label and a deterministic view_idx tiebreaker"
+    (let [mv  {:views [{:column "embedding"       :name "base"       :k 500}
+                       {:column "embedding_attrs" :name "attributes" :k 300}]
+               :max-cosine-distance 0.6 :pool :least}
+          [sql] (multi-view-search-sql+params mv)]
+      (is (str/includes? sql "'base' AS \"semantic_view\""))
+      (is (str/includes? sql "'attributes' AS \"semantic_view\""))
+      ;; the view-index tiebreaker follows distance in the pooled ORDER BY, so ties resolve to the lowest
+      ;; view index deterministically (the base view wins when a synthetic view's vector equals base's)
+      (is (str/includes? sql "\"distance\" ASC, \"view_idx\" ASC")))))
+
+(deftest build-pipeline-stages-test
+  (let [rows [{:model "card"      :legacy_input {:id 1 :model "card"}
+               :semantic_rank 2 :semantic_distance 0.30 :semantic_view "attributes"
+               :keyword_rank 5 :rrf 0.011 :total_score 90.0}
+              {:model "dashboard" :legacy_input {:id 7 :model "dashboard"}
+               :semantic_rank 1 :semantic_distance 0.10 :semantic_view "base"
+               :keyword_rank nil :rrf 0.008 :total_score 120.0}
+              {:model "card"      :legacy_input {:id 9 :model "card"}
+               :semantic_rank nil :semantic_distance nil :semantic_view nil
+               :keyword_rank 1 :rrf 0.009 :total_score 50.0}]
+        {:keys [horizon stages]} (#'semantic.index/build-pipeline-stages rows)
+        by-name (into {} (map (juxt :name :candidates)) stages)]
+    (testing "emits the four base stages in order with the configured horizon"
+      (is (= ["retrieval:semantic" "retrieval:keyword" "fusion:rrf" "score:weighted"]
+             (mapv :name stages)))
+      (is (= (semantic.settings/semantic-search-results-limit) horizon)))
+    (testing "semantic arm: rank-ordered, keyword-only row excluded, carries distance + winning view"
+      (is (= [{:model "dashboard" :id 7 :rank 1 :distance 0.10 :view "base"}
+              {:model "card"      :id 1 :rank 2 :distance 0.30 :view "attributes"}]
+             (by-name "retrieval:semantic"))))
+    (testing "keyword arm: rank-ordered, semantic-only row excluded, no view/distance"
+      (is (= [{:model "card" :id 9 :rank 1}
+              {:model "card" :id 1 :rank 5}]
+             (by-name "retrieval:keyword"))))
+    (testing "weighted stage: positional rank in total_score order, keyed like the data rows"
+      (is (= [{:model "dashboard" :id 7 :rank 1 :score 120.0}
+              {:model "card"      :id 1 :rank 2 :score 90.0}
+              {:model "card"      :id 9 :rank 3 :score 50.0}]
+             (by-name "score:weighted"))))
+    (testing "the blank-query/no-rows path yields empty stages, not an error"
+      (is (= [] (-> (#'semantic.index/build-pipeline-stages []) :stages first :candidates))))))
+
+(deftest legacy-input-with-score-debug-fields-test
+  (let [row {:legacy_input {:id 1 :model "card"} :total_score 5.0 :content "[card]\nname: Q"
+             :semantic_rank 3 :keyword_rank nil :semantic_distance 0.42 :semantic_view "base"}]
+    (testing "debug off, rerank off: no attribution/rerank fields leak onto the wire row (prod payload unchanged)"
+      (let [r (#'semantic.index/legacy-input-with-score {} [] false false row)]
+        (is (not (contains? r :semantic_rank)))
+        (is (not (contains? r :cosine_distance)))
+        (is (not (contains? r :source)))
+        (is (not (contains? r :content)))))
+    (testing "debug on: carries arm ranks, cosine distance, winning view, and derived source"
+      (let [r (#'semantic.index/legacy-input-with-score {} [] true false row)]
+        (is (= 3 (:semantic_rank r)))
+        (is (= 0.42 (:cosine_distance r)))
+        (is (= "base" (:semantic_view r)))
+        (is (= ["semantic"] (:source r)))
+        (is (not (contains? r :content)) "debug alone does not carry :content")))
+    (testing "rerank on: carries :content + arm ranks (the rerank step's inputs) but not debug-only fields"
+      (let [r (#'semantic.index/legacy-input-with-score {} [] false true row)]
+        (is (= "[card]\nname: Q" (:content r)))
+        (is (= 3 (:semantic_rank r)))
+        (is (contains? r :keyword_rank))
+        (is (not (contains? r :cosine_distance)))
+        (is (not (contains? r :source)))))))
+
 (deftest create-index-table!-test
   (mt/with-premium-features #{:semantic-search}
     (with-open [index-ref (semantic.tu/open-temp-index!)]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -139,6 +139,47 @@
     (testing "multi-view takes precedence over the per-strategy single-KNN path (no global vector_candidates CTE)"
       (is (not (str/includes? sql "\"vector_candidates\""))))))
 
+(defn- federated-multi-view-search-sql+params
+  "Format the private vector subquery for `fmv-config` against a stub index, returning the `[sql & params]`
+  vector `sql/format` produces."
+  [fmv-config]
+  (let [index {:table-name "idx_tbl"}
+        ctx   {:search-string "pasta" :archived? false :federated-multi-view-config fmv-config}]
+    (sql/format (#'semantic.index/semantic-search-query index [0.1 0.2 0.3] ctx) :quoted true)))
+
+(deftest federated-multi-view-semantic-search-query-test
+  (let [fmv {:partitions [{:name     "content"
+                           :models   ["card" "dashboard"]
+                           :strategy :hnsw
+                           :k        400
+                           :views    [{:column "embedding"              :name "base"         :k 500}
+                                      {:column "embedding_descriptions" :name "descriptions" :k 300}]}
+                          {:name     "indexed-entity"
+                           :models   ["indexed-entity"]
+                           :strategy :hnsw
+                           :k        100
+                           :views    [{:column "embedding" :name "base"}]}]
+             :max-cosine-distance 0.55
+             :pool   :least
+             :fusion :v1}
+        [sql & params] (federated-multi-view-search-sql+params fmv)]
+    (testing "each (partition, view) is a model-scoped HNSW-triggering ORDER BY <col> <=> q LIMIT"
+      (is (re-find #"ORDER BY embedding <=>[^)]*LIMIT" sql))
+      (is (re-find #"ORDER BY embedding_descriptions <=>[^)]*LIMIT" sql)))
+    (testing "sub-queries carry their partition's model predicate (multi-model ANY-array; single-model =)"
+      (is (str/includes? sql "model = ANY (ARRAY['card', 'dashboard']::text[])"))
+      (is (str/includes? sql "model = 'indexed-entity'")))
+    (testing "synthetic views add the composite-index IS NOT NULL predicate; the base column does not"
+      (is (str/includes? sql "embedding_descriptions IS NOT NULL"))
+      (is (not (re-find #"\bembedding IS NOT NULL" sql))))
+    (testing "views are pooled per entity (UNION ALL + DISTINCT ON) and partitions UNION ALL-ed"
+      (is (str/includes? sql "UNION ALL"))
+      (is (re-find #"DISTINCT ON\s*\(\"model\", \"model_id\"\)" sql)))
+    (testing "the cosine cutoff gates the pooled distance"
+      (is (contains? (set params) 0.55)))
+    (testing "the composed path takes precedence over the single-KNN path (no global vector_candidates CTE)"
+      (is (not (str/includes? sql "\"vector_candidates\""))))))
+
 (deftest create-index-table!-test
   (mt/with-premium-features #{:semantic-search}
     (with-open [index-ref (semantic.tu/open-temp-index!)]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -7,6 +7,7 @@
    [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
    [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.index :as semantic.index]
+   [metabase-enterprise.semantic-search.scoring :as semantic.scoring]
    [metabase-enterprise.semantic-search.settings :as semantic.settings]
    [metabase-enterprise.semantic-search.spec-trace-test-util :as spec-trace]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
@@ -196,6 +197,70 @@
       ;; view index deterministically (the base view wins when a synthetic view's vector equals base's)
       (is (str/includes? sql "\"distance\" ASC, \"view_idx\" ASC")))))
 
+(defn- hybrid-search-sql
+  "Format the private hybrid query for `ctx` against a stub index, returning the SQL string."
+  [ctx]
+  (let [index {:table-name "idx_tbl"}]
+    (first (sql/format (#'semantic.index/hybrid-search-query index [0.1 0.2 0.3]
+                                                             (merge {:search-string "pasta" :archived? false} ctx))
+                       {:quoted true}))))
+
+(deftest hybrid-search-query-arm-combos-test
+  (testing "the present retrieval arms are gated independently; semantic (vector) is always the anchor"
+    (let [trgm {:trigram-config {:column "name" :threshold 0.3 :weight 0.2}}]
+      (testing "baseline semantic+keyword: keyword arm present, trigram arm absent"
+        (let [sql (hybrid-search-sql {})]
+          (is (str/includes? sql "\"text_results\""))
+          (is (str/includes? sql "\"keyword_rank\""))
+          (is (not (str/includes? sql "\"trigram_results\"")))
+          (is (not (str/includes? sql "\"trigram_rank\"")))
+          (is (str/includes? sql "FULL JOIN \"text_results\" AS \"t\" ON \"v\".\"id\" = \"t\".\"id\""))))
+      (testing "semantic+keyword+trigram: all three arms, trigram chained on coalesce(v.id, t.id)"
+        (let [sql (hybrid-search-sql trgm)]
+          (is (str/includes? sql "\"text_results\""))
+          (is (str/includes? sql "\"trigram_results\""))
+          (is (str/includes? sql "\"keyword_rank\""))
+          (is (str/includes? sql "\"trigram_rank\""))
+          (is (str/includes? sql "FULL JOIN \"trigram_results\" AS \"g\" ON COALESCE(\"v\".\"id\", \"t\".\"id\") = \"g\".\"id\""))))
+      (testing "disable_keyword + trigram (replace keyword with trigram): no keyword arm, trigram joins on v.id"
+        (let [sql (hybrid-search-sql (assoc trgm :disable-keyword? true))]
+          (is (not (str/includes? sql "\"text_results\"")))
+          (is (not (str/includes? sql "\"keyword_rank\"")))
+          (is (str/includes? sql "\"trigram_results\""))
+          (is (str/includes? sql "\"trigram_rank\""))
+          (is (str/includes? sql "FULL JOIN \"trigram_results\" AS \"g\" ON \"v\".\"id\" = \"g\".\"id\""))))
+      (testing "disable_keyword only (semantic-only): single vector arm, no FULL JOIN, no coalesced columns"
+        (let [sql (hybrid-search-sql {:disable-keyword? true})]
+          (is (not (str/includes? sql "\"text_results\"")))
+          (is (not (str/includes? sql "\"keyword_rank\"")))
+          (is (not (str/includes? sql "\"trigram_results\"")))
+          (is (not (str/includes? sql "FULL JOIN")))
+          ;; the coalesce degenerates to a bare reference when only the anchor is present
+          (is (not (str/includes? sql "COALESCE(\"v\"")))
+          (is (str/includes? sql "\"v\".\"semantic_rank\" AS \"semantic_rank\"")))))))
+
+(deftest rrf-rank-exp-arm-terms-test
+  (let [rrf      @#'semantic.scoring/rrf-rank-exp
+        refs-col (fn [exp col] (str/includes? (pr-str exp) col))]
+    (testing "baseline blends the semantic + keyword terms"
+      (let [exp (rrf {})]
+        (is (refs-col exp ":semantic_rank"))
+        (is (refs-col exp ":keyword_rank"))
+        (is (not (refs-col exp ":trigram_rank")))))
+    (testing "disable_keyword drops the keyword term (the column is absent and would throw)"
+      (let [exp (rrf {:disable-keyword? true})]
+        (is (refs-col exp ":semantic_rank"))
+        (is (not (refs-col exp ":keyword_rank")))))
+    (testing "disable_keyword + trigram fuses semantic + trigram only -- the replace-keyword-with-trigram blend"
+      (let [exp (rrf {:disable-keyword? true :trigram-config {:weight 0.2}})]
+        (is (refs-col exp ":semantic_rank"))
+        (is (not (refs-col exp ":keyword_rank")))
+        (is (refs-col exp ":trigram_rank"))))
+    (testing "the two-arm baseline expression is unchanged from the hardcoded 0.49/0.51 blend"
+      (is (= [:+ [:* [:cast 0.49 :float] [:coalesce [:/ 1.0 [:+ 60 :semantic_rank]] 0]]
+              [:* [:cast 0.51 :float] [:coalesce [:/ 1.0 [:+ 60 :keyword_rank]] 0]]]
+             (rrf {}))))))
+
 (deftest build-pipeline-stages-test
   (let [rows [{:model "card"      :legacy_input {:id 1 :model "card"}
                :semantic_rank 2 :semantic_distance 0.30 :semantic_view "attributes"
@@ -206,9 +271,9 @@
               {:model "card"      :legacy_input {:id 9 :model "card"}
                :semantic_rank nil :semantic_distance nil :semantic_view nil
                :keyword_rank 1 :rrf 0.009 :total_score 50.0}]
-        {:keys [horizon stages]} (#'semantic.index/build-pipeline-stages rows)
+        {:keys [horizon stages]} (#'semantic.index/build-pipeline-stages rows true false)
         by-name (into {} (map (juxt :name :candidates)) stages)]
-    (testing "emits the four base stages in order with the configured horizon"
+    (testing "emits the four base stages in order with the configured horizon (keyword on, trigram off)"
       (is (= ["retrieval:semantic" "retrieval:keyword" "fusion:rrf" "score:weighted"]
              (mapv :name stages)))
       (is (= (semantic.settings/semantic-search-results-limit) horizon)))
@@ -226,7 +291,25 @@
               {:model "card"      :id 9 :rank 3 :score 50.0}]
              (by-name "score:weighted"))))
     (testing "the blank-query/no-rows path yields empty stages, not an error"
-      (is (= [] (-> (#'semantic.index/build-pipeline-stages []) :stages first :candidates))))))
+      (is (= [] (-> (#'semantic.index/build-pipeline-stages [] true false) :stages first :candidates))))
+    (testing "keyword off (disable_keyword): the retrieval:keyword stage is omitted"
+      (is (= ["retrieval:semantic" "fusion:rrf" "score:weighted"]
+             (mapv :name (:stages (#'semantic.index/build-pipeline-stages rows false false))))))
+    (testing "trigram on: a retrieval:trigram stage is inserted before fusion, rank-ordered over :trigram_rank"
+      (let [trgm-rows (conj rows {:model "card" :legacy_input {:id 11 :model "card"}
+                                  :semantic_rank nil :keyword_rank nil :trigram_rank 1
+                                  :rrf 0.007 :total_score 40.0})
+            stages (:stages (#'semantic.index/build-pipeline-stages trgm-rows true true))
+            by-name (into {} (map (juxt :name :candidates)) stages)]
+        (is (= ["retrieval:semantic" "retrieval:keyword" "retrieval:trigram" "fusion:rrf" "score:weighted"]
+               (mapv :name stages)))
+        (is (= [{:model "card" :id 11 :rank 1}] (by-name "retrieval:trigram")))))
+    (testing "keyword off + trigram on (replace keyword with trigram): semantic + trigram arms, no keyword"
+      (let [trgm-rows (conj rows {:model "card" :legacy_input {:id 11 :model "card"}
+                                  :semantic_rank nil :keyword_rank nil :trigram_rank 1
+                                  :rrf 0.007 :total_score 40.0})]
+        (is (= ["retrieval:semantic" "retrieval:trigram" "fusion:rrf" "score:weighted"]
+               (mapv :name (:stages (#'semantic.index/build-pipeline-stages trgm-rows false true)))))))))
 
 (deftest legacy-input-with-score-debug-fields-test
   (let [row {:legacy_input {:id 1 :model "card"} :total_score 5.0 :content "[card]\nname: Q"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -54,6 +54,30 @@
     (is (= (vector-search-sql (semantic.settings/semantic-search-vector-strategy))
            (vector-search-sql nil)))))
 
+(defn- vector-search-params
+  "Format the private vector subquery for `strategy` with an optional `:max-cosine-distance` `cutoff`,
+  returning the set of HoneySQL parameters the query carries."
+  [strategy cutoff]
+  (let [index     {:table-name "idx_tbl"}
+        ctx       (cond-> {:search-string "pasta" :archived? false}
+                    strategy (assoc :vector-search-strategy strategy)
+                    cutoff   (assoc :max-cosine-distance cutoff))
+        embedding [0.1 0.2 0.3]]
+    (set (rest (sql/format (#'semantic.index/semantic-search-query index embedding ctx) :quoted true)))))
+
+(deftest max-cosine-distance-test
+  (testing "the cosine-distance cut-off is parameterized into the vector subquery"
+    (doseq [strategy [:hnsw :brute-force]]
+      (testing (str "strategy = " strategy)
+        (testing "an explicit :max-cosine-distance overrides the default"
+          (let [params (vector-search-params strategy 0.42)]
+            (is (contains? params 0.42))
+            (is (not (contains? params 0.7)))))
+        (testing "an absent :max-cosine-distance falls back to the 0.7 default"
+          (let [params (vector-search-params strategy nil)]
+            (is (contains? params 0.7))
+            (is (not (contains? params 0.42)))))))))
+
 (defn- flattened-vector-candidates-cte
   "Build the brute-force/hnsw hybrid query, flatten it the way `scored-search-query` does, and return the
   hoisted `:vector_candidates` CTE binding (e.g. `[:vector_candidates <query> :materialized]`)."

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/reranking_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/reranking_test.clj
@@ -4,8 +4,11 @@
    [clojure.test :refer :all]
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.reranking :as reranking]
+   [metabase.search.api :as search.api]
+   [metabase.search.config :as search.config]
    [metabase.test :as mt]
    [metabase.util.json :as json]
+   [metabase.util.malli.registry :as mr]
    [metabase.util.retry :as retry]))
 
 (set! *warn-on-reflection* true)
@@ -99,3 +102,80 @@
     (testing "every mode attaches :rerank_score for attribution"
       (doseq [mode [:rerank_only :rerank_then_boost :rerank_as_scorer :rerank_fusion]]
         (is (= rr (:rerank_score (reblend mode w sample-row rr))))))))
+
+(deftest reblend-rrf-test
+  (testing ":rerank_rrf fuses the weighted rank and the cross-encoder rank in rank space"
+    (let [reblend-rrf #'semantic.index/reblend-rrf
+          ;; pool-rows in weighted (:total_score) order -> position i = weighted rank i+1.
+          pool-rows   [{:id "a"} {:id "b"} {:id "c"}]
+          ;; cross-encoder best-first: pool-idx 2 is rerank rank 1, pool-idx 0 rank 2, pool-idx 1 rank 3.
+          order       [2 0 1]
+          scores      {0 0.4 1 0.1 2 0.9}
+          fused       (reblend-rrf 1.0 2.0 60 pool-rows order scores)
+          by-id       (into {} (map (juxt :id identity)) fused)]
+      (testing ":score = wa/(k+weighted_rank) + wb/(k+rerank_rank)"
+        (is (= (+ (/ 1.0 61) (/ 2.0 62)) (:score (by-id "a")))) ; wrank 1, rrank 2
+        (is (= (+ (/ 1.0 62) (/ 2.0 63)) (:score (by-id "b")))) ; wrank 2, rrank 3
+        (is (= (+ (/ 1.0 63) (/ 2.0 61)) (:score (by-id "c"))))) ; wrank 3, rrank 1
+      (testing "the raw cross-encoder score is kept on :rerank_score for attribution"
+        (is (= 0.4 (:rerank_score (by-id "a"))))
+        (is (= 0.1 (:rerank_score (by-id "b"))))
+        (is (= 0.9 (:rerank_score (by-id "c"))))))))
+
+(deftest rerank-results-rrf-order-test
+  (testing ":rerank_rrf re-sorts the pool by the fused score and keeps the un-reranked tail below"
+    (mt/with-temporary-setting-values [ee-reranking-api-key "voyage-mock-key"]
+      (let [rerank-results #'semantic.index/rerank-results
+            search-context {:search-string "q"
+                            :reranker-config {:blend :rerank_rrf :pool 3
+                                              :rrf-weighted 1.0 :rrf-rerank 2.0 :rrf-k 60}}
+            ;; 4 rows; pool = 3 so "d" is the untouched tail (kept below regardless of its high :score).
+            results        [{:id "a" :model "card" :content "doc-a" :score 100.0}
+                            {:id "b" :model "card" :content "doc-b" :score 99.0}
+                            {:id "c" :model "card" :content "doc-c" :score 98.0}
+                            {:id "d" :model "card" :content "doc-d" :score 97.0}]]
+        (mt/with-dynamic-fn-redefs [reranking/rerank (fn [_q _docs _opts]
+                                                       {:order [2 0 1] :scores {0 0.4 1 0.1 2 0.9} :tokens 5})]
+          (let [{:keys [results pool]} (rerank-results search-context false results)]
+            ;; fused: c (~0.04866) > a (~0.04865) > b (~0.04788); tail d stays last.
+            (is (= ["c" "a" "b" "d"] (mapv :id results)))
+            (is (= 3 pool) "only the top-`pool` rows were reranked")
+            (is (every? #(not (contains? % :content)) results) "carried :content is stripped before return")))))))
+
+(deftest reranker-gate-fires-test
+  (let [gate-fires? #'semantic.index/reranker-gate-fires?
+        exact-head  {:all-scores [{:name :exact :score 1.0} {:name :rrf :score 0.5}]
+                     :semantic_distance 0.30}
+        plain-head  {:all-scores [{:name :exact :score 0.0} {:name :rrf :score 0.5}]
+                     :semantic_distance 0.30}]
+    (testing "no :gate configured => never fires"
+      (is (false? (gate-fires? {:reranker-config {}} [exact-head]))))
+    (testing "empty results => never fires"
+      (is (false? (gate-fires? {:reranker-config {:gate {:exact true}}} []))))
+    (testing ":exact fires only when the weighted head is an exact name match"
+      (is (true?  (gate-fires? {:reranker-config {:gate {:exact true}}} [exact-head])))
+      (is (false? (gate-fires? {:reranker-config {:gate {:exact true}}} [plain-head]))))
+    (testing ":semantic-margin fires only when the rank-1 cosine distance is within the threshold"
+      (is (true?  (gate-fires? {:reranker-config {:gate {:semantic-margin 0.35}}} [plain-head])))
+      (is (false? (gate-fires? {:reranker-config {:gate {:semantic-margin 0.25}}} [plain-head]))))))
+
+(deftest reranker-config-schema-test
+  (testing "RerankerConfig accepts the rerank_rrf fusion knobs and the gate sub-map"
+    (is (mr/validate search.config/RerankerConfig
+                     {:blend :rerank_rrf :pool 100 :rrf-weighted 1.0 :rrf-rerank 2.0 :rrf-k 60
+                      :gate {:exact true :semantic-margin 0.2}}))
+    (is (contains? (set search.config/rerank-blend-modes) :rerank_rrf))
+    (testing "the gate map is closed -- unknown keys are rejected"
+      (is (not (mr/validate search.config/RerankerConfig {:gate {:bogus true}}))))))
+
+(deftest process-reranker-config-test
+  (let [process #'search.api/process-reranker-config]
+    (testing "rrf_* and gate keys are parsed and underscore-normalized to kebab"
+      (is (= {:blend :rerank_rrf :pool 100 :rrf-weighted 1.0 :rrf-rerank 2.0 :rrf-k 60
+              :gate {:exact true :semantic-margin 0.2}}
+             (process (json/encode {:blend "rerank_rrf" :pool 100
+                                    :rrf_weighted 1.0 :rrf_rerank 2.0 :rrf_k 60
+                                    :gate {:exact true :semantic_margin 0.2}})))))
+    (testing "a config without the new keys is unchanged (backward compatible)"
+      (is (= {:blend :rerank_then_boost :pool 50}
+             (process (json/encode {:blend "rerank_then_boost" :pool 50})))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/reranking_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/reranking_test.clj
@@ -1,0 +1,101 @@
+(ns metabase-enterprise.semantic-search.reranking-test
+  (:require
+   [clj-http.client :as http]
+   [clojure.test :refer :all]
+   [metabase-enterprise.semantic-search.index :as semantic.index]
+   [metabase-enterprise.semantic-search.reranking :as reranking]
+   [metabase.test :as mt]
+   [metabase.util.json :as json]
+   [metabase.util.retry :as retry]))
+
+(set! *warn-on-reflection* true)
+
+(deftest rerank-parses-data-and-usage-test
+  (testing "rerank maps the Voyage response into {:order :scores :tokens}, best-first"
+    (mt/with-temporary-setting-values [ee-reranking-api-key "voyage-mock-key"]
+      (let [;; Voyage returns data ordered best-first; index is the position in the input `documents`.
+            response {:data  [{:index 2 :relevance_score 0.9}
+                              {:index 0 :relevance_score 0.4}
+                              {:index 1 :relevance_score 0.1}]
+                      :usage {:total_tokens 123}}
+            captured (atom nil)]
+        (with-redefs [http/post (fn [url opts]
+                                  (reset! captured {:url url :body (json/decode+kw (:body opts))})
+                                  {:body (json/encode response)})]
+          (let [result (reranking/rerank "revenue dashboard" ["doc-a" "doc-b" "doc-c"] {:model "rerank-2.5"})]
+            (is (= [2 0 1] (:order result)) "order is the document indices best-first")
+            (is (= {2 0.9 0 0.4 1 0.1} (:scores result)) "scores map each index to its relevance score")
+            (is (= 123 (:tokens result)) "tokens is the reported usage.total_tokens")
+            (testing "request body carries query/documents/model and truncation"
+              (is (= "revenue dashboard" (get-in @captured [:body :query])))
+              (is (= ["doc-a" "doc-b" "doc-c"] (get-in @captured [:body :documents])))
+              (is (= "rerank-2.5" (get-in @captured [:body :model])))
+              (is (true? (get-in @captured [:body :truncation]))))))))))
+
+(deftest rerank-requires-api-key-test
+  (testing "rerank throws when the Voyage key is unset"
+    (mt/with-temporary-setting-values [ee-reranking-api-key nil]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"ee-reranking-api-key not set"
+                            (reranking/rerank "q" ["d"] {}))))))
+
+(def ^:private fast-backoff-hook
+  "Collapses the retry backoff to ~1ms so retry tests don't sleep the real exponential schedule.
+  (Diehard requires the initial delay be strictly < the max delay.)"
+  #(assoc % :initial-interval-millis 1 :max-interval-millis 2 :jitter-factor 0.0))
+
+(deftest rerank-retries-transient-error-test
+  (testing "rerank retries a 429 / 5xx and succeeds once the provider recovers"
+    (mt/with-temporary-setting-values [ee-reranking-api-key "voyage-mock-key"]
+      (binding [retry/*test-time-config-hook* fast-backoff-hook]
+        (let [response {:data [{:index 0 :relevance_score 0.5}] :usage {:total_tokens 7}}
+              calls    (atom 0)]
+          ;; First attempt 429 (rate limit), second 503 (provider 5xx), third succeeds.
+          (with-redefs [http/post (fn [_url _opts]
+                                    (let [n (swap! calls inc)]
+                                      (case n
+                                        1 (throw (ex-info "clj-http: status 429" {:status 429}))
+                                        2 (throw (ex-info "clj-http: status 503" {:status 503}))
+                                        {:body (json/encode response)})))]
+            (let [result (reranking/rerank "q" ["doc-a"] {:model "rerank-2.5"})]
+              (is (= 3 @calls) "retried the 429 then the 503 before the third attempt succeeded")
+              (is (= [0] (:order result)))
+              (is (= 7 (:tokens result))))))))))
+
+(deftest rerank-does-not-retry-client-error-test
+  (testing "rerank surfaces a non-transient 4xx immediately without retrying"
+    (mt/with-temporary-setting-values [ee-reranking-api-key "voyage-mock-key"]
+      (binding [retry/*test-time-config-hook* fast-backoff-hook]
+        (let [calls (atom 0)]
+          (with-redefs [http/post (fn [_url _opts]
+                                    (swap! calls inc)
+                                    (throw (ex-info "clj-http: status 400" {:status 400})))]
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo #"status 400"
+                                  (reranking/rerank "q" ["doc-a"] {})))
+            (is (= 1 @calls) "a 400 is not retried")))))))
+
+(def ^:private sample-row
+  "A boost-scored result row as it reaches the rerank step: `:score` is the SQL `total_score` (RRF-dominated),
+  `:all-scores` carries each scorer's `:contribution` (= weight*score)."
+  {:score      999.0
+   :all-scores [{:name :rrf               :contribution 500.0}
+                {:name :semantic-distance :contribution 5.0}
+                {:name :pinned            :contribution 2.0}
+                {:name :verified          :contribution 3.0}]})
+
+(deftest reblend-per-mode-test
+  (let [reblend #'semantic.index/reblend
+        w       500.0
+        rr      0.8]
+    (testing ":rerank_only ignores the boosts entirely"
+      (is (= rr (:score (reblend :rerank_only w sample-row rr)))))
+    (testing ":rerank_then_boost = weight*rerank + Σ boosts, dropping :rrf and :semantic-distance"
+      ;; 500*0.8 + (2.0 + 3.0) = 405.0
+      (is (= 405.0 (:score (reblend :rerank_then_boost w sample-row rr)))))
+    (testing ":rerank_fusion blends the same as :rerank_then_boost (differs only in pool selection)"
+      (is (= 405.0 (:score (reblend :rerank_fusion w sample-row rr)))))
+    (testing ":rerank_as_scorer keeps the full weighted sum (incl. :rrf) and adds the rerank term"
+      ;; 999.0 + 500*0.8 = 1399.0
+      (is (= 1399.0 (:score (reblend :rerank_as_scorer w sample-row rr)))))
+    (testing "every mode attaches :rerank_score for attribution"
+      (doseq [mode [:rerank_only :rerank_then_boost :rerank_as_scorer :rerank_fusion]]
+        (is (= rr (:rerank_score (reblend mode w sample-row rr))))))))

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -402,6 +402,11 @@
                         :labels [:embedding-model]})
    (prometheus/counter :metabase-search/semantic-appdb-scores-ms
                        {:description "Total number of ms spent adding appdb-based scores"})
+   (prometheus/counter :metabase-search/semantic-rerank-ms
+                       {:description "Total number of ms spent in the Voyage cross-encoder rerank step"})
+   (prometheus/counter :metabase-search/semantic-rerank-tokens
+                       {:description "Number of tokens consumed by the Voyage rerank model (reported usage)."
+                        :labels [:model]})
    (prometheus/counter :metabase-search/semantic-fallback-triggered
                        {:description "Number of times semantic search triggered fallback to appdb search due to insufficient results"
                         :labels [:fallback-engine]})

--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -23,6 +23,7 @@
    [metabase.config.core :as config]
    [metabase.dashboards-rest.api]
    [metabase.data-studio.api]
+   [metabase.describe.api]
    [metabase.documents.api]
    [metabase.eid-translation.api]
    [metabase.embedding-rest.api]
@@ -90,6 +91,7 @@
          metabase.collections-rest.api/keep-me
          metabase.dashboards-rest.api/keep-me
          metabase.data-studio.api/keep-me
+         metabase.describe.api/keep-me
          metabase.documents.api/keep-me
          metabase.eid-translation.api/keep-me
          metabase.frontend-errors.api/keep-me
@@ -182,6 +184,7 @@
    "/data-studio"          (+auth metabase.data-studio.api/routes)
    "/database"             (+auth 'metabase.warehouses-rest.api)
    "/dataset"              (+auth 'metabase.query-processor.api)
+   "/describe"             (+auth 'metabase.describe.api)
    "/docs"                 (metabase.api.docs/make-routes #'routes)
    "/document"             (+auth metabase.documents.api/routes)
    "/eid-translation"      (+auth 'metabase.eid-translation.api)

--- a/src/metabase/describe/api.clj
+++ b/src/metabase/describe/api.clj
@@ -1,0 +1,102 @@
+(ns metabase.describe.api
+  "`/api/describe/` routes.
+
+  Deterministic (non-LLM) natural-language descriptions derived from an entity's MBQL. Given an entity type and id,
+  returns the Lib `suggested-name` for the whole query plus a per-stage-section breakdown (aggregation, breakout,
+  filters, ...). This is the same describe machinery the UI and the metric-card `:query_description` already use, so
+  output stays consistent with what users see.
+
+  Only MBQL-bearing entity types are supported: cards (questions/models/metrics), segments, and measures. Native
+  queries yield `:native true` with a `nil` `:suggested_name`, which is expected, not an error."
+  (:require
+   [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.core :as lib]
+   [metabase.util.malli.schema :as ms]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private describable-models
+  "Entity types this endpoint can describe. All carry MBQL we can route through Lib."
+  ["card" "segment" "measure"])
+
+(def ^:private described-keys
+  "Stage `top-level-key`s we surface, paired with their JSON-friendly response keys. Order is the order they appear in
+  a query summary."
+  [[:aggregation :aggregation]
+   [:breakout    :breakout]
+   [:filters     :filters]
+   [:order-by    :order_by]
+   [:limit       :limit]
+   [:joins       :joins]])
+
+(def ^:private Sections
+  (into [:map {:closed true}]
+        (for [[_ out-k] described-keys]
+          [out-k [:maybe :string]])))
+
+(def ^:private DescribeResponse
+  [:map
+   [:model          [:enum "card" "segment" "measure"]]
+   [:id             ms/PositiveInt]
+   [:name           [:maybe :string]]
+   ;; Whole-query summary, e.g. "Orders, Sum of Total, Grouped by Category". `nil` for native queries.
+   [:suggested_name [:maybe :string]]
+   [:native         :boolean]
+   [:sections       Sections]])
+
+(defn- describe-key
+  "Describe one stage section of `query`, swallowing the describe machinery's coverage-gap exceptions."
+  [query top-level-key]
+  (try
+    (lib/describe-top-level-key query top-level-key)
+    (catch Throwable _ nil)))
+
+(defn- query-nl
+  "Composite natural-language derivation for a Lib `query`."
+  [query]
+  {:suggested_name (try (lib/suggested-name query) (catch Throwable _ nil))
+   :native         (boolean (try (lib/native? query) (catch Throwable _ false)))
+   :sections       (into {} (for [[k out-k] described-keys]
+                              [out-k (describe-key query k)]))})
+
+(def ^:private empty-nl
+  "Result shape for an entity with no describable query (e.g. a measure/segment with a blank definition)."
+  {:suggested_name nil
+   :native         false
+   :sections       (into {} (for [[_ out-k] described-keys] [out-k nil]))})
+
+(defn- card->query
+  "Build a Lib query for `card`, or `nil` when it has no query to describe. Mirrors the metric-card
+  `:query_description` path in `metabase.queries.models.card`."
+  [card]
+  (when (and (seq (:dataset_query card)) (:database_id card))
+    (-> (lib-be/application-database-metadata-provider (:database_id card))
+        (lib/query (:dataset_query card)))))
+
+(defn- read-entity+query
+  "Read-check the entity (404/403 on failure) and return `[entity lib-query-or-nil]`."
+  [model id]
+  (case model
+    "card"    (let [card (api/read-check :model/Card id)]    [card (card->query card)])
+    ;; Segment/Measure `:definition` is normalized to a full Lib query (with metadata provider) on select, so it can be
+    ;; fed to the describe machinery directly.
+    "segment" (let [seg (api/read-check :model/Segment id)]  [seg (:definition seg)])
+    "measure" (let [m (api/read-check :model/Measure id)]    [m (:definition m)])))
+
+(api.macros/defendpoint :get "/:model/:id" :- DescribeResponse
+  "Return deterministic natural-language data derived from an entity's MBQL.
+
+  `model` is one of `card`, `segment`, `measure`. Returns the whole-query `suggested_name` and a per-section
+  breakdown. Requires read permission on the entity."
+  [{:keys [model id]} :- [:map
+                          [:model (into [:enum] describable-models)]
+                          [:id    ms/PositiveInt]]]
+  (let [[entity query] (read-entity+query model id)]
+    (merge {:model model
+            :id    id
+            :name  (:name entity)}
+           (if query
+             (query-nl query)
+             empty-nl))))

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -108,6 +108,45 @@
         (log/warn "Failed to parse multi_view_config:" (ex-message e))
         nil))))
 
+(defn- process-federated-multi-view-config
+  "Parse the `federated_multi_view_config` JSON query param into the composed config consumed by the semantic
+  engine (see [[metabase.search.config/FederatedMultiViewConfig]]). Returns nil when absent/blank or
+  unparseable. Keywordizes the per-partition `:strategy` and the top-level `:pool`/`:fusion` selectors and
+  normalizes `max_cosine_distance` -> `:max-cosine-distance` at the top, per-partition, and per-view levels,
+  dropping any other keys so the closed schema accepts it.
+
+  Shape: `{\"partitions\": [{\"name\": .., \"models\": [..], \"strategy\": \"hnsw\"|\"brute-force\", \"k\": ..,
+  \"max_cosine_distance\": .., \"views\": [{\"name\": .., \"column\": \"embedding\"|\"embedding_<view>\",
+  \"k\": .., \"max_cosine_distance\": ..}]}], \"max_cosine_distance\": .., \"pool\": \"least\",
+  \"fusion\": \"v1\"}`."
+  [federated-multi-view-config]
+  (when-not (str/blank? federated-multi-view-config)
+    (try
+      (let [{:keys [partitions pool fusion] :as cfg} (json/decode+kw federated-multi-view-config)
+            top-mcd (or (:max-cosine-distance cfg) (:max_cosine_distance cfg))]
+        (cond-> {:partitions
+                 (mapv (fn [p]
+                         (let [p-mcd (or (:max-cosine-distance p) (:max_cosine_distance p))]
+                           (cond-> {:models (:models p)
+                                    :views  (mapv (fn [v]
+                                                    (let [v-mcd (or (:max-cosine-distance v) (:max_cosine_distance v))]
+                                                      (cond-> {:column (:column v)}
+                                                        (:name v)    (assoc :name (:name v))
+                                                        (:k v)       (assoc :k (:k v))
+                                                        (some? v-mcd) (assoc :max-cosine-distance v-mcd))))
+                                                  (:views p))}
+                             (:name p)     (assoc :name (:name p))
+                             (:strategy p) (assoc :strategy (keyword (:strategy p)))
+                             (:k p)        (assoc :k (:k p))
+                             (some? p-mcd) (assoc :max-cosine-distance p-mcd))))
+                       partitions)}
+          (some? top-mcd) (assoc :max-cosine-distance top-mcd)
+          pool            (assoc :pool (keyword pool))
+          fusion          (assoc :fusion (keyword fusion))))
+      (catch Exception e
+        (log/warn "Failed to parse federated_multi_view_config:" (ex-message e))
+        nil))))
+
 (defn- +engine-cookie [handler]
   (open-api/handler-with-open-api-spec
    (fn [request respond raise]
@@ -233,6 +272,7 @@
   - `max_cosine_distance`: for the semantic engine, the cosine-distance cut-off above which vector candidates are discarded (default 0.7); ignored by other engines
   - `partition_config`: for the semantic engine, a JSON object enabling federated/partitioned retrieval (per-partition model set, candidate quota `k`, cosine cutoff, and vector strategy); omit for a single global KNN. Ignored by other engines
   - `multi_view_config`: for the semantic engine, a JSON object enabling multi-view-embedding retrieval (per-view embedding column + candidate quota `k`, pooled by min cosine distance, with a single cosine cutoff); omit for a single global KNN. Ignored by other engines
+  - `federated_multi_view_config`: for the semantic engine, a JSON object composing federated/partitioned retrieval with multi-view embeddings (per-partition model set + quota + cosine cutoff + strategy, each partition pooling its own per-view embedding columns by min cosine distance); omit for a single global KNN. Ignored by other engines
   - `verified`: set to true to search for verified items only (requires Content Management or Official Collections premium feature)
   - `ids`: search for items with those ids, works iff single value passed to `models`
   - `display_type`: search for cards/models with specific display types
@@ -263,6 +303,7 @@
     max-cosine-distance                 :max_cosine_distance
     partition-config                    :partition_config
     multi-view-config                   :multi_view_config
+    federated-multi-view-config         :federated_multi_view_config
     search-native-query                 :search_native_query
     table-db-id                         :table_db_id
     include-metadata                    :include_metadata
@@ -289,6 +330,7 @@
        [:max_cosine_distance                 {:optional true} [:maybe [:double {:min 0.0 :max 2.0}]]]
        [:partition_config                    {:optional true} [:maybe :string]]
        [:multi_view_config                   {:optional true} [:maybe :string]]
+       [:federated_multi_view_config         {:optional true} [:maybe :string]]
        [:search_native_query                 {:optional true} [:maybe :boolean]]
        [:verified                            {:optional true} [:maybe true?]]
        [:ids                                 {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]
@@ -323,6 +365,7 @@
                 :max-cosine-distance                 max-cosine-distance
                 :partition-config                    (process-partition-config partition-config)
                 :multi-view-config                   (process-multi-view-config multi-view-config)
+                :federated-multi-view-config         (process-federated-multi-view-config federated-multi-view-config)
                 :search-native-query                 search-native-query
                 :search-string                       (some-> q str/trim not-empty)
                 :table-db-id                         table-db-id

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -177,6 +177,7 @@
   - `last_edited_by`: search for items last edited by a specific user
   - `search_native_query`: set to true to search the content of native queries
   - `vector_search_strategy`: for the semantic engine, `hnsw` (approximate index search, default) or `brute-force` (exact filter-first search); ignored by other engines
+  - `max_cosine_distance`: for the semantic engine, the cosine-distance cut-off above which vector candidates are discarded (default 0.7); ignored by other engines
   - `verified`: set to true to search for verified items only (requires Content Management or Official Collections premium feature)
   - `ids`: search for items with those ids, works iff single value passed to `models`
   - `display_type`: search for cards/models with specific display types
@@ -204,6 +205,7 @@
     model-ancestors                     :model_ancestors
     search-engine                       :search_engine
     vector-search-strategy              :vector_search_strategy
+    max-cosine-distance                 :max_cosine_distance
     search-native-query                 :search_native_query
     table-db-id                         :table_db_id
     include-metadata                    :include_metadata
@@ -227,6 +229,7 @@
        [:model_ancestors                     {:default false} [:maybe :boolean]]
        [:search_engine                       {:optional true} [:maybe string?]]
        [:vector_search_strategy              {:optional true} [:maybe (into [:enum] (map name) search.config/vector-search-strategies)]]
+       [:max_cosine_distance                 {:optional true} [:maybe [:double {:min 0.0 :max 2.0}]]]
        [:search_native_query                 {:optional true} [:maybe :boolean]]
        [:verified                            {:optional true} [:maybe true?]]
        [:ids                                 {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]
@@ -258,6 +261,7 @@
                 :offset                              (request/offset)
                 :search-engine                       search-engine
                 :vector-search-strategy              vector-search-strategy
+                :max-cosine-distance                 max-cosine-distance
                 :search-native-query                 search-native-query
                 :search-string                       (some-> q str/trim not-empty)
                 :table-db-id                         table-db-id

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -147,6 +147,29 @@
         (log/warn "Failed to parse federated_multi_view_config:" (ex-message e))
         nil))))
 
+(defn- process-reranker-config
+  "Parse the `reranker_config` JSON query param into the map consumed by the semantic engine
+  (see [[metabase.search.config/RerankerConfig]]). Returns nil when absent/blank or unparseable.
+  Keywordizes the `:blend` selector and normalizes `top_k` -> `:top-k`, dropping any other keys so the
+  closed schema accepts it.
+
+  Shape: `{\"model\": .., \"pool\": N, \"top_k\": N, \"weight\": W,
+  \"blend\": \"rerank_only\"|\"rerank_then_boost\"|\"rerank_as_scorer\"|\"rerank_fusion\"}`."
+  [reranker-config]
+  (when-not (str/blank? reranker-config)
+    (try
+      (let [{:keys [model pool weight blend] :as cfg} (json/decode+kw reranker-config)
+            top-k (or (:top-k cfg) (:top_k cfg))]
+        (cond-> {}
+          model         (assoc :model model)
+          pool          (assoc :pool pool)
+          (some? top-k) (assoc :top-k top-k)
+          (some? weight) (assoc :weight (double weight))
+          blend         (assoc :blend (keyword blend))))
+      (catch Exception e
+        (log/warn "Failed to parse reranker_config:" (ex-message e))
+        nil))))
+
 (defn- process-weights
   "Parse the `weights` JSON query param into the per-request scorer-weight overrides consumed by the
   scoring layer (the `:weights` key on the search context; see [[metabase.search.config/weights]]).
@@ -291,8 +314,10 @@
   - `partition_config`: for the semantic engine, a JSON object enabling federated/partitioned retrieval (per-partition model set, candidate quota `k`, cosine cutoff, and vector strategy); omit for a single global KNN. Ignored by other engines
   - `multi_view_config`: for the semantic engine, a JSON object enabling multi-view-embedding retrieval (per-view embedding column + candidate quota `k`, pooled by min cosine distance, with a single cosine cutoff); omit for a single global KNN. Ignored by other engines
   - `federated_multi_view_config`: for the semantic engine, a JSON object composing federated/partitioned retrieval with multi-view embeddings (per-partition model set + quota + cosine cutoff + strategy, each partition pooling its own per-view embedding columns by min cosine distance); omit for a single global KNN. Ignored by other engines
+  - `reranker_config`: for the semantic engine, a JSON object enabling a Voyage cross-encoder rerank step over the top-`pool` of the (permission-filtered, boost-scored) candidate list (`model`, `pool`, `top_k`, `weight`, `blend`); requires the `ee-reranking-enabled` setting + key. A precision-only reorder; omit for no rerank. Ignored by other engines
   - `weights`: a JSON object of per-request scorer-weight overrides (e.g. `{\"rrf\": 1, \"exact\": 0}`); the highest-precedence weight layer, overriding static defaults and the `experimental-search-weight-overrides` setting for this request only. Unknown scorer keys are inert
   - `disable_fallback`: for the semantic engine, set to true to disable the appdb fallback entirely -- the engine returns its own results unsupplemented even when below the min-results threshold, and re-throws (rather than silently falling back) if the vector query errors. Ignored by other engines
+  - `debug_pipeline`: for the semantic engine, set to true to emit per-stage retrieval-attribution diagnostics -- a top-level `pipeline` block (per-stage candidate lists for the semantic arm, keyword arm, RRF fusion, and weighted score, plus `permission_dropped` and `fallback` provenance) and per-row arm/view fields (`source`, `semantic_rank`, `keyword_rank`, `cosine_distance`, `semantic_view`). Eval-only; absent/false leaves the response unchanged. Ignored by other engines
   - `verified`: set to true to search for verified items only (requires Content Management or Official Collections premium feature)
   - `ids`: search for items with those ids, works iff single value passed to `models`
   - `display_type`: search for cards/models with specific display types
@@ -324,8 +349,10 @@
     partition-config                    :partition_config
     multi-view-config                   :multi_view_config
     federated-multi-view-config         :federated_multi_view_config
+    reranker-config                     :reranker_config
     weights                             :weights
     disable-fallback                    :disable_fallback
+    debug-pipeline                      :debug_pipeline
     search-native-query                 :search_native_query
     table-db-id                         :table_db_id
     include-metadata                    :include_metadata
@@ -353,8 +380,10 @@
        [:partition_config                    {:optional true} [:maybe :string]]
        [:multi_view_config                   {:optional true} [:maybe :string]]
        [:federated_multi_view_config         {:optional true} [:maybe :string]]
+       [:reranker_config                     {:optional true} [:maybe :string]]
        [:weights                             {:optional true} [:maybe :string]]
        [:disable_fallback                    {:optional true} [:maybe :boolean]]
+       [:debug_pipeline                      {:optional true} [:maybe :boolean]]
        [:search_native_query                 {:optional true} [:maybe :boolean]]
        [:verified                            {:optional true} [:maybe true?]]
        [:ids                                 {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]
@@ -390,8 +419,10 @@
                 :partition-config                    (process-partition-config partition-config)
                 :multi-view-config                   (process-multi-view-config multi-view-config)
                 :federated-multi-view-config         (process-federated-multi-view-config federated-multi-view-config)
+                :reranker-config                     (process-reranker-config reranker-config)
                 :weights                             (process-weights weights)
                 :disable-fallback?                   disable-fallback
+                :debug-pipeline?                     debug-pipeline
                 :search-native-query                 search-native-query
                 :search-string                       (some-> q str/trim not-empty)
                 :table-db-id                         table-db-id

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -154,18 +154,32 @@
   closed schema accepts it.
 
   Shape: `{\"model\": .., \"pool\": N, \"top_k\": N, \"weight\": W,
-  \"blend\": \"rerank_only\"|\"rerank_then_boost\"|\"rerank_as_scorer\"|\"rerank_fusion\"}`."
+  \"blend\": \"rerank_only\"|\"rerank_then_boost\"|\"rerank_as_scorer\"|\"rerank_fusion\"|\"rerank_rrf\",
+  \"rrf_weighted\": Wa, \"rrf_rerank\": Wb, \"rrf_k\": K, \"gate\": {\"exact\": true, \"semantic_margin\": D}}`."
   [reranker-config]
   (when-not (str/blank? reranker-config)
     (try
-      (let [{:keys [model pool weight blend] :as cfg} (json/decode+kw reranker-config)
-            top-k (or (:top-k cfg) (:top_k cfg))]
+      (let [{:keys [model pool weight blend gate] :as cfg} (json/decode+kw reranker-config)
+            top-k   (or (:top-k cfg)        (:top_k cfg))
+            rrf-wtd (or (:rrf-weighted cfg) (:rrf_weighted cfg))
+            rrf-rrk (or (:rrf-rerank cfg)   (:rrf_rerank cfg))
+            rrf-k   (or (:rrf-k cfg)        (:rrf_k cfg))
+            ;; `:gate` arrives keywordized; normalize the underscore sub-key like `top_k` -> `:top-k`.
+            margin  (when gate (or (:semantic-margin gate) (:semantic_margin gate)))
+            gate*   (when gate
+                      (cond-> {}
+                        (some? (:exact gate)) (assoc :exact (boolean (:exact gate)))
+                        (some? margin)        (assoc :semantic-margin (double margin))))]
         (cond-> {}
-          model         (assoc :model model)
-          pool          (assoc :pool pool)
-          (some? top-k) (assoc :top-k top-k)
+          model          (assoc :model model)
+          pool           (assoc :pool pool)
+          (some? top-k)  (assoc :top-k top-k)
           (some? weight) (assoc :weight (double weight))
-          blend         (assoc :blend (keyword blend))))
+          blend          (assoc :blend (keyword blend))
+          (some? rrf-wtd) (assoc :rrf-weighted (double rrf-wtd))
+          (some? rrf-rrk) (assoc :rrf-rerank   (double rrf-rrk))
+          (some? rrf-k)   (assoc :rrf-k        rrf-k)
+          (seq gate*)     (assoc :gate gate*)))
       (catch Exception e
         (log/warn "Failed to parse reranker_config:" (ex-message e))
         nil))))
@@ -329,6 +343,7 @@
   - `last_edited_by`: search for items last edited by a specific user
   - `search_native_query`: set to true to search the content of native queries
   - `vector_search_strategy`: for the semantic engine, `hnsw` (approximate index search, default) or `brute-force` (exact filter-first search); ignored by other engines
+  - `query_embedder`: for the semantic engine, set to `voyage` to embed the incoming search terms via the Voyage embeddings API (so the query vector shares the active table's Voyage-embedded vector space) instead of the active index's own embedder; the Voyage model/dimensions come from the `ee-voyage-embedding-*` settings. Omit (or `arctic`/`ai-service`) to use the active index's configured embedder. Ignored by other engines
   - `max_cosine_distance`: for the semantic engine, the cosine-distance cut-off above which vector candidates are discarded (default 0.7); ignored by other engines
   - `partition_config`: for the semantic engine, a JSON object enabling federated/partitioned retrieval (per-partition model set, candidate quota `k`, cosine cutoff, and vector strategy); omit for a single global KNN. Ignored by other engines
   - `multi_view_config`: for the semantic engine, a JSON object enabling multi-view-embedding retrieval (per-view embedding column + candidate quota `k`, pooled by min cosine distance, with a single cosine cutoff); omit for a single global KNN. Ignored by other engines
@@ -366,6 +381,7 @@
     model-ancestors                     :model_ancestors
     search-engine                       :search_engine
     vector-search-strategy              :vector_search_strategy
+    query-embedder                      :query_embedder
     max-cosine-distance                 :max_cosine_distance
     partition-config                    :partition_config
     multi-view-config                   :multi_view_config
@@ -399,6 +415,7 @@
        [:model_ancestors                     {:default false} [:maybe :boolean]]
        [:search_engine                       {:optional true} [:maybe string?]]
        [:vector_search_strategy              {:optional true} [:maybe (into [:enum] (map name) search.config/vector-search-strategies)]]
+       [:query_embedder                      {:optional true} [:maybe (into [:enum] (map name) search.config/query-embedders)]]
        [:max_cosine_distance                 {:optional true} [:maybe [:double {:min 0.0 :max 2.0}]]]
        [:partition_config                    {:optional true} [:maybe :string]]
        [:multi_view_config                   {:optional true} [:maybe :string]]
@@ -440,6 +457,7 @@
                 :offset                              (request/offset)
                 :search-engine                       search-engine
                 :vector-search-strategy              vector-search-strategy
+                :query-embedder                      query-embedder
                 :max-cosine-distance                 max-cosine-distance
                 :partition-config                    (process-partition-config partition-config)
                 :multi-view-config                   (process-multi-view-config multi-view-config)

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -170,6 +170,25 @@
         (log/warn "Failed to parse reranker_config:" (ex-message e))
         nil))))
 
+(defn- process-trigram-config
+  "Parse the `trigram_config` JSON query param into the map consumed by the semantic engine
+  (see [[metabase.search.config/TrigramConfig]]). Returns nil when absent/blank or unparseable. Coerces
+  `:threshold`/`:weight` to doubles, dropping any other keys so the closed schema accepts it.
+
+  Shape: `{\"column\": \"name\", \"threshold\": 0.3, \"weight\": 0.2, \"limit\": N}`."
+  [trigram-config]
+  (when-not (str/blank? trigram-config)
+    (try
+      (let [{:keys [column threshold weight limit]} (json/decode+kw trigram-config)]
+        (cond-> {}
+          column            (assoc :column column)
+          (some? threshold) (assoc :threshold (double threshold))
+          (some? weight)    (assoc :weight (double weight))
+          (some? limit)     (assoc :limit limit)))
+      (catch Exception e
+        (log/warn "Failed to parse trigram_config:" (ex-message e))
+        nil))))
+
 (defn- process-weights
   "Parse the `weights` JSON query param into the per-request scorer-weight overrides consumed by the
   scoring layer (the `:weights` key on the search context; see [[metabase.search.config/weights]]).
@@ -315,8 +334,10 @@
   - `multi_view_config`: for the semantic engine, a JSON object enabling multi-view-embedding retrieval (per-view embedding column + candidate quota `k`, pooled by min cosine distance, with a single cosine cutoff); omit for a single global KNN. Ignored by other engines
   - `federated_multi_view_config`: for the semantic engine, a JSON object composing federated/partitioned retrieval with multi-view embeddings (per-partition model set + quota + cosine cutoff + strategy, each partition pooling its own per-view embedding columns by min cosine distance); omit for a single global KNN. Ignored by other engines
   - `reranker_config`: for the semantic engine, a JSON object enabling a Voyage cross-encoder rerank step over the top-`pool` of the (permission-filtered, boost-scored) candidate list (`model`, `pool`, `top_k`, `weight`, `blend`); requires the `ee-reranking-enabled` setting + key. A precision-only reorder; omit for no rerank. Ignored by other engines
+  - `trigram_config`: for the semantic engine, a JSON object enabling a third, pg_trgm trigram-similarity retrieval arm for typo tolerance (`column` [default `name`], `threshold`, `weight`, `limit`), fused into the semantic+keyword RRF; requires a `GIN (<column> gin_trgm_ops)` index + the `pg_trgm` extension on the active index table; omit for the two-arm baseline. Ignored by other engines
   - `weights`: a JSON object of per-request scorer-weight overrides (e.g. `{\"rrf\": 1, \"exact\": 0}`); the highest-precedence weight layer, overriding static defaults and the `experimental-search-weight-overrides` setting for this request only. Unknown scorer keys are inert
   - `disable_fallback`: for the semantic engine, set to true to disable the appdb fallback entirely -- the engine returns its own results unsupplemented even when below the min-results threshold, and re-throws (rather than silently falling back) if the vector query errors. Ignored by other engines
+  - `disable_keyword`: for the semantic engine, set to true to remove the full-text keyword retrieval arm entirely -- no keyword candidates enter the pool and the keyword term is dropped from the RRF fusion (the engine searches on the vector arm, plus the pg_trgm trigram arm when `trigram_config` is set). Pair with `disable_fallback` for a clean measurement (the appdb fallback is itself keyword-based). Ignored by other engines
   - `debug_pipeline`: for the semantic engine, set to true to emit per-stage retrieval-attribution diagnostics -- a top-level `pipeline` block (per-stage candidate lists for the semantic arm, keyword arm, RRF fusion, and weighted score, plus `permission_dropped` and `fallback` provenance) and per-row arm/view fields (`source`, `semantic_rank`, `keyword_rank`, `cosine_distance`, `semantic_view`). Eval-only; absent/false leaves the response unchanged. Ignored by other engines
   - `verified`: set to true to search for verified items only (requires Content Management or Official Collections premium feature)
   - `ids`: search for items with those ids, works iff single value passed to `models`
@@ -350,8 +371,10 @@
     multi-view-config                   :multi_view_config
     federated-multi-view-config         :federated_multi_view_config
     reranker-config                     :reranker_config
+    trigram-config                      :trigram_config
     weights                             :weights
     disable-fallback                    :disable_fallback
+    disable-keyword                     :disable_keyword
     debug-pipeline                      :debug_pipeline
     search-native-query                 :search_native_query
     table-db-id                         :table_db_id
@@ -381,8 +404,10 @@
        [:multi_view_config                   {:optional true} [:maybe :string]]
        [:federated_multi_view_config         {:optional true} [:maybe :string]]
        [:reranker_config                     {:optional true} [:maybe :string]]
+       [:trigram_config                      {:optional true} [:maybe :string]]
        [:weights                             {:optional true} [:maybe :string]]
        [:disable_fallback                    {:optional true} [:maybe :boolean]]
+       [:disable_keyword                     {:optional true} [:maybe :boolean]]
        [:debug_pipeline                      {:optional true} [:maybe :boolean]]
        [:search_native_query                 {:optional true} [:maybe :boolean]]
        [:verified                            {:optional true} [:maybe true?]]
@@ -420,8 +445,10 @@
                 :multi-view-config                   (process-multi-view-config multi-view-config)
                 :federated-multi-view-config         (process-federated-multi-view-config federated-multi-view-config)
                 :reranker-config                     (process-reranker-config reranker-config)
+                :trigram-config                      (process-trigram-config trigram-config)
                 :weights                             (process-weights weights)
                 :disable-fallback?                   disable-fallback
+                :disable-keyword?                    disable-keyword
                 :debug-pipeline?                     debug-pipeline
                 :search-native-query                 search-native-query
                 :search-string                       (some-> q str/trim not-empty)

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -81,6 +81,33 @@
         (log/warn "Failed to parse partition_config:" (ex-message e))
         nil))))
 
+(defn- process-multi-view-config
+  "Parse the `multi_view_config` JSON query param into the view map consumed by the semantic engine
+  (see [[metabase.search.config/MultiViewConfig]]). Returns nil when absent/blank or unparseable.
+  Keywordizes the top-level `:pool` selector and normalizes `max_cosine_distance` -> `:max-cosine-distance`
+  (both top-level and per-view), dropping any other keys so the closed schema accepts it.
+
+  Shape: `{\"views\": [{\"name\": .., \"column\": \"embedding\"|\"embedding_<view>\", \"k\": ..,
+  \"max_cosine_distance\": ..}], \"max_cosine_distance\": .., \"pool\": \"least\"}`."
+  [multi-view-config]
+  (when-not (str/blank? multi-view-config)
+    (try
+      (let [{:keys [views pool] :as cfg} (json/decode+kw multi-view-config)
+            top-mcd (or (:max-cosine-distance cfg) (:max_cosine_distance cfg))]
+        (cond-> {:views
+                 (mapv (fn [v]
+                         (let [mcd (or (:max-cosine-distance v) (:max_cosine_distance v))]
+                           (cond-> {:column (:column v)}
+                             (:name v)   (assoc :name (:name v))
+                             (:k v)      (assoc :k (:k v))
+                             (some? mcd) (assoc :max-cosine-distance mcd))))
+                       views)}
+          (some? top-mcd) (assoc :max-cosine-distance top-mcd)
+          pool            (assoc :pool (keyword pool))))
+      (catch Exception e
+        (log/warn "Failed to parse multi_view_config:" (ex-message e))
+        nil))))
+
 (defn- +engine-cookie [handler]
   (open-api/handler-with-open-api-spec
    (fn [request respond raise]
@@ -205,6 +232,7 @@
   - `vector_search_strategy`: for the semantic engine, `hnsw` (approximate index search, default) or `brute-force` (exact filter-first search); ignored by other engines
   - `max_cosine_distance`: for the semantic engine, the cosine-distance cut-off above which vector candidates are discarded (default 0.7); ignored by other engines
   - `partition_config`: for the semantic engine, a JSON object enabling federated/partitioned retrieval (per-partition model set, candidate quota `k`, cosine cutoff, and vector strategy); omit for a single global KNN. Ignored by other engines
+  - `multi_view_config`: for the semantic engine, a JSON object enabling multi-view-embedding retrieval (per-view embedding column + candidate quota `k`, pooled by min cosine distance, with a single cosine cutoff); omit for a single global KNN. Ignored by other engines
   - `verified`: set to true to search for verified items only (requires Content Management or Official Collections premium feature)
   - `ids`: search for items with those ids, works iff single value passed to `models`
   - `display_type`: search for cards/models with specific display types
@@ -234,6 +262,7 @@
     vector-search-strategy              :vector_search_strategy
     max-cosine-distance                 :max_cosine_distance
     partition-config                    :partition_config
+    multi-view-config                   :multi_view_config
     search-native-query                 :search_native_query
     table-db-id                         :table_db_id
     include-metadata                    :include_metadata
@@ -259,6 +288,7 @@
        [:vector_search_strategy              {:optional true} [:maybe (into [:enum] (map name) search.config/vector-search-strategies)]]
        [:max_cosine_distance                 {:optional true} [:maybe [:double {:min 0.0 :max 2.0}]]]
        [:partition_config                    {:optional true} [:maybe :string]]
+       [:multi_view_config                   {:optional true} [:maybe :string]]
        [:search_native_query                 {:optional true} [:maybe :boolean]]
        [:verified                            {:optional true} [:maybe true?]]
        [:ids                                 {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]
@@ -292,6 +322,7 @@
                 :vector-search-strategy              vector-search-strategy
                 :max-cosine-distance                 max-cosine-distance
                 :partition-config                    (process-partition-config partition-config)
+                :multi-view-config                   (process-multi-view-config multi-view-config)
                 :search-native-query                 search-native-query
                 :search-string                       (some-> q str/trim not-empty)
                 :table-db-id                         table-db-id

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -147,6 +147,24 @@
         (log/warn "Failed to parse federated_multi_view_config:" (ex-message e))
         nil))))
 
+(defn- process-weights
+  "Parse the `weights` JSON query param into the per-request scorer-weight overrides consumed by the
+  scoring layer (the `:weights` key on the search context; see [[metabase.search.config/weights]]).
+  Returns nil when absent/blank or unparseable. Keys are keywordized scorer names and values coerced to
+  doubles; this map is the highest-precedence weight layer, overriding both static defaults and the
+  `experimental-search-weight-overrides` setting for this request only -- nothing global is mutated.
+  Unknown scorer keys are inert (they match no registered scorer column), so no key validation happens
+  here; callers that want a typo to fail validate the key set themselves (e.g. the eval runner's --weights).
+
+  Shape: `{\"rrf\": 1, \"exact\": 0, \"semantic-distance\": 10, ...}`."
+  [weights]
+  (when-not (str/blank? weights)
+    (try
+      (update-vals (json/decode+kw weights) double)
+      (catch Exception e
+        (log/warn "Failed to parse weights:" (ex-message e))
+        nil))))
+
 (defn- +engine-cookie [handler]
   (open-api/handler-with-open-api-spec
    (fn [request respond raise]
@@ -273,6 +291,8 @@
   - `partition_config`: for the semantic engine, a JSON object enabling federated/partitioned retrieval (per-partition model set, candidate quota `k`, cosine cutoff, and vector strategy); omit for a single global KNN. Ignored by other engines
   - `multi_view_config`: for the semantic engine, a JSON object enabling multi-view-embedding retrieval (per-view embedding column + candidate quota `k`, pooled by min cosine distance, with a single cosine cutoff); omit for a single global KNN. Ignored by other engines
   - `federated_multi_view_config`: for the semantic engine, a JSON object composing federated/partitioned retrieval with multi-view embeddings (per-partition model set + quota + cosine cutoff + strategy, each partition pooling its own per-view embedding columns by min cosine distance); omit for a single global KNN. Ignored by other engines
+  - `weights`: a JSON object of per-request scorer-weight overrides (e.g. `{\"rrf\": 1, \"exact\": 0}`); the highest-precedence weight layer, overriding static defaults and the `experimental-search-weight-overrides` setting for this request only. Unknown scorer keys are inert
+  - `disable_fallback`: for the semantic engine, set to true to disable the appdb fallback entirely -- the engine returns its own results unsupplemented even when below the min-results threshold, and re-throws (rather than silently falling back) if the vector query errors. Ignored by other engines
   - `verified`: set to true to search for verified items only (requires Content Management or Official Collections premium feature)
   - `ids`: search for items with those ids, works iff single value passed to `models`
   - `display_type`: search for cards/models with specific display types
@@ -304,6 +324,8 @@
     partition-config                    :partition_config
     multi-view-config                   :multi_view_config
     federated-multi-view-config         :federated_multi_view_config
+    weights                             :weights
+    disable-fallback                    :disable_fallback
     search-native-query                 :search_native_query
     table-db-id                         :table_db_id
     include-metadata                    :include_metadata
@@ -331,6 +353,8 @@
        [:partition_config                    {:optional true} [:maybe :string]]
        [:multi_view_config                   {:optional true} [:maybe :string]]
        [:federated_multi_view_config         {:optional true} [:maybe :string]]
+       [:weights                             {:optional true} [:maybe :string]]
+       [:disable_fallback                    {:optional true} [:maybe :boolean]]
        [:search_native_query                 {:optional true} [:maybe :boolean]]
        [:verified                            {:optional true} [:maybe true?]]
        [:ids                                 {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]
@@ -366,6 +390,8 @@
                 :partition-config                    (process-partition-config partition-config)
                 :multi-view-config                   (process-multi-view-config multi-view-config)
                 :federated-multi-view-config         (process-federated-multi-view-config federated-multi-view-config)
+                :weights                             (process-weights weights)
+                :disable-fallback?                   disable-fallback
                 :search-native-query                 search-native-query
                 :search-string                       (some-> q str/trim not-empty)
                 :table-db-id                         table-db-id

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -55,6 +55,32 @@
         (log/warn "Failed to parse non-temporal dimension IDs:" (ex-message e))
         nil))))
 
+(defn- process-partition-config
+  "Parse the `partition_config` JSON query param into the partition map consumed by the semantic engine
+  (see [[metabase.search.config/PartitionConfig]]). Returns nil when absent/blank or unparseable.
+  Keywordizes the per-partition `:strategy` and the top-level `:fusion` selector and normalizes
+  `max_cosine_distance` -> `:max-cosine-distance`, dropping any other keys so the closed schema accepts it.
+
+  Shape: `{\"partitions\": [{\"name\": .., \"models\": [..], \"strategy\": \"hnsw\"|\"brute-force\",
+  \"k\": .., \"max_cosine_distance\": ..}], \"fusion\": \"v1\"}`."
+  [partition-config]
+  (when-not (str/blank? partition-config)
+    (try
+      (let [{:keys [partitions fusion]} (json/decode+kw partition-config)]
+        (cond-> {:partitions
+                 (mapv (fn [p]
+                         (let [mcd (or (:max-cosine-distance p) (:max_cosine_distance p))]
+                           (cond-> {:models (:models p)}
+                             (:name p)     (assoc :name (:name p))
+                             (:strategy p) (assoc :strategy (keyword (:strategy p)))
+                             (:k p)        (assoc :k (:k p))
+                             (some? mcd)   (assoc :max-cosine-distance mcd))))
+                       partitions)}
+          fusion (assoc :fusion (keyword fusion))))
+      (catch Exception e
+        (log/warn "Failed to parse partition_config:" (ex-message e))
+        nil))))
+
 (defn- +engine-cookie [handler]
   (open-api/handler-with-open-api-spec
    (fn [request respond raise]
@@ -178,6 +204,7 @@
   - `search_native_query`: set to true to search the content of native queries
   - `vector_search_strategy`: for the semantic engine, `hnsw` (approximate index search, default) or `brute-force` (exact filter-first search); ignored by other engines
   - `max_cosine_distance`: for the semantic engine, the cosine-distance cut-off above which vector candidates are discarded (default 0.7); ignored by other engines
+  - `partition_config`: for the semantic engine, a JSON object enabling federated/partitioned retrieval (per-partition model set, candidate quota `k`, cosine cutoff, and vector strategy); omit for a single global KNN. Ignored by other engines
   - `verified`: set to true to search for verified items only (requires Content Management or Official Collections premium feature)
   - `ids`: search for items with those ids, works iff single value passed to `models`
   - `display_type`: search for cards/models with specific display types
@@ -206,6 +233,7 @@
     search-engine                       :search_engine
     vector-search-strategy              :vector_search_strategy
     max-cosine-distance                 :max_cosine_distance
+    partition-config                    :partition_config
     search-native-query                 :search_native_query
     table-db-id                         :table_db_id
     include-metadata                    :include_metadata
@@ -230,6 +258,7 @@
        [:search_engine                       {:optional true} [:maybe string?]]
        [:vector_search_strategy              {:optional true} [:maybe (into [:enum] (map name) search.config/vector-search-strategies)]]
        [:max_cosine_distance                 {:optional true} [:maybe [:double {:min 0.0 :max 2.0}]]]
+       [:partition_config                    {:optional true} [:maybe :string]]
        [:search_native_query                 {:optional true} [:maybe :boolean]]
        [:verified                            {:optional true} [:maybe true?]]
        [:ids                                 {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]
@@ -262,6 +291,7 @@
                 :search-engine                       search-engine
                 :vector-search-strategy              vector-search-strategy
                 :max-cosine-distance                 max-cosine-distance
+                :partition-config                    (process-partition-config partition-config)
                 :search-native-query                 search-native-query
                 :search-string                       (some-> q str/trim not-empty)
                 :table-db-id                         table-db-id

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -361,6 +361,44 @@
    [:max-cosine-distance {:optional true} [:double {:min 0.0 :max 2.0}]]
    [:pool {:optional true} [:enum :least]]])
 
+(def FederatedMultiViewConfig
+  "Schema for the semantic-engine config that *composes* federated retrieval with multi-view embeddings
+  (the `federated_multi_view_config` API param, sent as a JSON object). It is the Cartesian product of
+  [[PartitionConfig]] and [[MultiViewConfig]]: `:partitions` lists per-partition candidate generation
+  (model set, candidate ceiling `:k`, cosine cutoff, vector `:strategy`) exactly as federation does, and
+  each partition additionally carries its own `:views` -- the embedding columns to pool *within* that
+  partition. The backend runs one model-scoped KNN per (partition, view), pools the per-view candidates to
+  one row per entity by minimum cosine distance (`LEAST`), applies the partition's cutoff + quota, then
+  UNION-s across partitions and recomputes `semantic_rank`. An absent param is today's single global KNN.
+
+  Each partition's `:views` MUST include the base `embedding` column (the retrievability floor covering
+  `indexed-entity` and unenriched rows). For a partition whose `:strategy` is `:hnsw`, every synthetic view
+  must be backed by a *composite* partial HNSW index `WHERE <model-pred> AND <col> IS NOT NULL` on the active
+  table (search-eval scripts/manage_index.py set-federated-views) -- the backend emits exactly that predicate
+  so the planner can stay filter-first; without it Postgres falls back to the multi-view index and
+  post-filters the model set (correct, but reintroduces crowding). Brute-force partitions need no index.
+  Model groupings, view columns, and composite indexes form a three-way contract that must stay in sync.
+  Mastered here (rather than in the EE module) so the OSS search API param and the EE query builder share one
+  definition. `:pool` (`:least`) and `:fusion` (`:v1`) select pooling/ranking; only those values are
+  implemented today. Per-view cutoffs are accepted but not honored (a single per-partition cutoff gates)."
+  [:map {:closed true}
+   [:partitions [:sequential
+                 [:map {:closed true}
+                  [:name                {:optional true} :string]
+                  [:models              [:sequential SearchableModel]]
+                  [:strategy            {:optional true} (into [:enum] vector-search-strategies)]
+                  [:k                   {:optional true} pos-int?]
+                  [:max-cosine-distance {:optional true} [:double {:min 0.0 :max 2.0}]]
+                  [:views [:sequential
+                           [:map {:closed true}
+                            [:name                {:optional true} :string]
+                            [:column              [:re #"^embedding(_[a-z0-9_]+)?$"]]
+                            [:k                   {:optional true} pos-int?]
+                            [:max-cosine-distance {:optional true} [:double {:min 0.0 :max 2.0}]]]]]]]]
+   [:max-cosine-distance {:optional true} [:double {:min 0.0 :max 2.0}]]
+   [:pool {:optional true} [:enum :least]]
+   [:fusion {:optional true} [:enum :v1]]])
+
 (def ^:private ui-contexts
   "Search `context` values issued by the frontend, one per UI surface.
   Selects ranking weights ([[static-context-weights]]) and filter defaults ([[filter-defaults-by-context]]).
@@ -461,6 +499,8 @@
    [:partition-config   {:optional true} [:maybe PartitionConfig]]
    ;; Semantic-engine multi-view-embeddings config. When absent, the engine uses a single global KNN.
    [:multi-view-config  {:optional true} [:maybe MultiViewConfig]]
+   ;; Semantic-engine composed federated + multi-view config. When absent, the engine uses a single global KNN.
+   [:federated-multi-view-config {:optional true} [:maybe FederatedMultiViewConfig]]
    [:search-string      {:optional true} [:maybe ms/NonBlankString]]
    [:weights            {:optional true} [:maybe [:map-of :keyword number?]]]
    ;;

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -503,6 +503,9 @@
    [:federated-multi-view-config {:optional true} [:maybe FederatedMultiViewConfig]]
    [:search-string      {:optional true} [:maybe ms/NonBlankString]]
    [:weights            {:optional true} [:maybe [:map-of :keyword number?]]]
+   ;; Semantic-engine: when true, disable the appdb fallback entirely -- return semantic results
+   ;; unsupplemented below the min-results threshold, and re-throw (not fall back) on a vector-query error.
+   [:disable-fallback?  {:optional true} [:maybe :boolean]]
    ;;
    ;; optional
    ;;

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -439,6 +439,33 @@
    [:weight {:optional true} [:double {:min 0.0}]]            ; rerank-score weight in D1/D2/D3 (default 500.0)
    [:blend  {:optional true} (into [:enum] rerank-blend-modes)]]) ; default :rerank_then_boost
 
+(def TrigramConfig
+  "Schema for the semantic-engine pg_trgm typo-tolerance config (the `trigram_config` API param, sent as a
+  JSON object). It adds a *third* retrieval arm to the hybrid query: a trigram-similarity scan over the
+  `:column` text (default `name`), fused into the existing semantic+keyword RRF with its own `:weight`. A
+  single-character typo perturbs only a few of a string's overlapping 3-grams, so a misspelled query
+  ('Conract') still scores high against the canonical name ('Contract') -- which pure full-text search, which
+  matches stemmed lexemes *exactly*, misses entirely. An absent param is today's two-arm hybrid, so
+  absent-param = baseline.
+
+  The `:column` MUST be backed by the `pg_trgm` extension and a `GIN (<column> gin_trgm_ops)` index on the
+  active index table (search-eval scripts/manage_index.py set-trgm): the arm filters `<column> % :q` (the
+  pg_trgm similarity-threshold match operator, which the GIN index accelerates) and orders by
+  `similarity(<column>, :q)`, both of which require the extension; without the index the `%` filter
+  seq-scans. `:column` is interpolated as a raw SQL identifier, so it is constrained to a plain
+  lower-snake identifier shape. `:threshold` tightens the per-request similarity floor via an explicit
+  `similarity(<column>, :q) >= :threshold` predicate (the precision/recall trade) -- note it can only tighten
+  *above* the session `pg_trgm.similarity_threshold` GUC (default 0.3) that governs the `%` pre-filter; to
+  sweep below 0.3, lower that GUC at the DB level. `:weight` is the trigram arm's RRF weight -- start small
+  (default 0.2) so the surface-form arm tips, rather than dominates, the semantic+keyword fusion. `:limit`
+  caps the arm's candidate ceiling. Mastered here (rather than in the EE module) so the OSS search API param
+  and the EE query builder share one definition."
+  [:map {:closed true}
+   [:column    {:optional true} [:re #"^[a-z_][a-z0-9_]*$"]]    ; default "name"
+   [:threshold {:optional true} [:double {:min 0.0 :max 1.0}]]  ; explicit similarity floor (default 0.3)
+   [:weight    {:optional true} [:double {:min 0.0}]]           ; trigram arm RRF weight (default 0.2)
+   [:limit     {:optional true} pos-int?]])                     ; per-arm candidate ceiling (default results-limit)
+
 (def ^:private ui-contexts
   "Search `context` values issued by the frontend, one per UI surface.
   Selects ranking weights ([[static-context-weights]]) and filter defaults ([[filter-defaults-by-context]]).
@@ -543,11 +570,18 @@
    [:federated-multi-view-config {:optional true} [:maybe FederatedMultiViewConfig]]
    ;; Semantic-engine Voyage cross-encoder rerank config. When absent, no rerank step runs (baseline).
    [:reranker-config    {:optional true} [:maybe RerankerConfig]]
+   ;; Semantic-engine pg_trgm trigram (typo-tolerance) arm config. When absent, the hybrid query is the
+   ;; two-arm semantic+keyword baseline.
+   [:trigram-config     {:optional true} [:maybe TrigramConfig]]
    [:search-string      {:optional true} [:maybe ms/NonBlankString]]
    [:weights            {:optional true} [:maybe [:map-of :keyword number?]]]
    ;; Semantic-engine: when true, disable the appdb fallback entirely -- return semantic results
    ;; unsupplemented below the min-results threshold, and re-throw (not fall back) on a vector-query error.
    [:disable-fallback?  {:optional true} [:maybe :boolean]]
+   ;; Semantic-engine: when true, remove the full-text keyword retrieval arm entirely -- no keyword candidates
+   ;; enter the pool and the keyword term is dropped from the RRF fusion (vector arm, plus the pg_trgm trigram
+   ;; arm when `:trigram-config` is set). Pair with `:disable-fallback?` for a clean measurement.
+   [:disable-keyword?   {:optional true} [:maybe :boolean]]
    ;; Semantic-engine: when true, emit per-stage retrieval-attribution diagnostics (the top-level
    ;; `pipeline` block + per-row arm/view fields). Eval-only; absent/false => response is unchanged.
    [:debug-pipeline?    {:optional true} [:maybe :boolean]]

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -332,6 +332,35 @@
                   [:max-cosine-distance {:optional true} [:double {:min 0.0 :max 2.0}]]]]]
    [:fusion {:optional true} [:enum :v1]]])
 
+(def MultiViewConfig
+  "Schema for the semantic-engine multi-view-embeddings config (the `multi_view_config` API param, sent as
+  a JSON object). `:views` lists the embedding columns to pool: each view runs its own per-column KNN with
+  its own candidate ceiling (`:k`), the per-view candidates are UNION-ed, and the per-entity minimum cosine
+  distance across views (`LEAST`, i.e. max-similarity) is kept. A single `:max-cosine-distance` gates the
+  pooled distance; per-view cutoffs are a later (`:v2`) refinement and are not honored today. An absent
+  param is today's single global KNN, so absent-param = baseline.
+
+  The base `embedding` column MUST be one of the views -- it is the only column covering every entity
+  (`indexed-entity` and unenriched rows ride it), so it is the retrievability floor; synthetic views only
+  *add* recall. The view columns MUST exist on the active index table and each synthetic column MUST have a
+  partial HNSW index `WHERE <col> IS NOT NULL` (search-eval scripts/manage_index.py set-views) -- the
+  backend emits exactly that predicate per synthetic view or the planner ignores the index. `:column` is
+  interpolated as a raw SQL identifier, so it is constrained to the `embedding`/`embedding_<suffix>` shape.
+  Mastered here (rather than in the EE module) so the OSS search API param and the EE query builder share
+  one definition. `:pool` selects the cross-view pooling; only `:least` (group-min over the union) is
+  implemented today."
+  [:map {:closed true}
+   [:views [:sequential
+            [:map {:closed true}
+             [:name                {:optional true} :string]
+             [:column              [:re #"^embedding(_[a-z0-9_]+)?$"]]
+             [:k                   {:optional true} pos-int?]
+             ;; Accepted for forward-compat with the eval-side query config; not honored in v1 (a single
+             ;; top-level :max-cosine-distance gates the pooled distance instead).
+             [:max-cosine-distance {:optional true} [:double {:min 0.0 :max 2.0}]]]]]
+   [:max-cosine-distance {:optional true} [:double {:min 0.0 :max 2.0}]]
+   [:pool {:optional true} [:enum :least]]])
+
 (def ^:private ui-contexts
   "Search `context` values issued by the frontend, one per UI surface.
   Selects ranking weights ([[static-context-weights]]) and filter defaults ([[filter-defaults-by-context]]).
@@ -430,6 +459,8 @@
    [:max-cosine-distance {:optional true} [:maybe number?]]
    ;; Semantic-engine federated-retrieval partition config. When absent, the engine uses a single global KNN.
    [:partition-config   {:optional true} [:maybe PartitionConfig]]
+   ;; Semantic-engine multi-view-embeddings config. When absent, the engine uses a single global KNN.
+   [:multi-view-config  {:optional true} [:maybe MultiViewConfig]]
    [:search-string      {:optional true} [:maybe ms/NonBlankString]]
    [:weights            {:optional true} [:maybe [:map-of :keyword number?]]]
    ;;

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -399,6 +399,46 @@
    [:pool {:optional true} [:enum :least]]
    [:fusion {:optional true} [:enum :v1]]])
 
+(def rerank-blend-modes
+  "Valid `:blend` selectors for [[RerankerConfig]], as keywords. Each names how the cross-encoder's
+  per-doc relevance score recombines with the existing scorers in the final sort:
+   - `:rerank_only`       -- final score = the rerank score alone (boosts dropped).
+   - `:rerank_then_boost` -- final score = `weight*rerank + Σ metadata boosts`, dropping the relevance-core
+                             scorers (`:rrf`, `:semantic-distance`) the cross-encoder supersedes. The default
+                             and the smallest faithful change (the boosts tip the learned relevance ordering,
+                             mirroring how `:rrf` dominates today with boosts tipping it).
+   - `:rerank_as_scorer`  -- final score = `existing total_score + weight*rerank` (keeps `:rrf`; double-counts
+                             relevance -- kept for completeness).
+   - `:rerank_fusion`     -- like `:rerank_then_boost`, but the reranked pool is selected rank-fusion-free
+                             (best arm rank) rather than from the RRF-ordered `total_score` list.
+  Mastered here so the OSS API param and the EE rerank step share one definition."
+  [:rerank_only :rerank_then_boost :rerank_as_scorer :rerank_fusion])
+
+(def RerankerConfig
+  "Schema for the semantic-engine Voyage cross-encoder rerank config (the `reranker_config` API param, sent as
+  a JSON object). After the SQL hybrid query, RRF/boost scoring, and the permission filter have produced the
+  candidate list, the top-`:pool` candidates are reranked by the Voyage cross-encoder over their `content`
+  (the `embeddable_text` block), then recombined per `:blend` (see [[rerank-blend-modes]]) and re-sorted. An
+  absent param means no rerank, so absent-param = baseline.
+
+  Rerank is a precision tool, not a recall tool: it only reorders candidates the SQL already returned, so it
+  helps `retrieved-but-buried` targets and cannot surface a target absent from the pool. The global
+  `ee-reranking-enabled` setting is an additional kill switch; this per-request config is the opt-in.
+
+  Provider + API key live in backend settings ([[metabase-enterprise.semantic-search.settings]]), not here --
+  this config carries only the per-request experiment knobs. `:pool` is the candidate count reranked (the
+  cross-encoder cost driver); `:top-k` truncates the final list (keep it >= the min-results threshold, or run
+  the eval with `disable_fallback`, so truncation never spuriously trips the appdb fallback); `:weight` is the
+  rerank-score weight in the `:rerank_then_boost`/`:rerank_as_scorer`/`:rerank_fusion` blends (default mirrors
+  the dominant `:rrf` static weight). Mastered here so the OSS API param and the EE query builder share one
+  definition."
+  [:map {:closed true}
+   [:model  {:optional true} :string]                         ; default = ee-reranking-model setting
+   [:pool   {:optional true} pos-int?]                        ; N candidates reranked (default 50)
+   [:top-k  {:optional true} pos-int?]                        ; results kept after rerank (default = pool)
+   [:weight {:optional true} [:double {:min 0.0}]]            ; rerank-score weight in D1/D2/D3 (default 500.0)
+   [:blend  {:optional true} (into [:enum] rerank-blend-modes)]]) ; default :rerank_then_boost
+
 (def ^:private ui-contexts
   "Search `context` values issued by the frontend, one per UI surface.
   Selects ranking weights ([[static-context-weights]]) and filter defaults ([[filter-defaults-by-context]]).
@@ -501,11 +541,16 @@
    [:multi-view-config  {:optional true} [:maybe MultiViewConfig]]
    ;; Semantic-engine composed federated + multi-view config. When absent, the engine uses a single global KNN.
    [:federated-multi-view-config {:optional true} [:maybe FederatedMultiViewConfig]]
+   ;; Semantic-engine Voyage cross-encoder rerank config. When absent, no rerank step runs (baseline).
+   [:reranker-config    {:optional true} [:maybe RerankerConfig]]
    [:search-string      {:optional true} [:maybe ms/NonBlankString]]
    [:weights            {:optional true} [:maybe [:map-of :keyword number?]]]
    ;; Semantic-engine: when true, disable the appdb fallback entirely -- return semantic results
    ;; unsupplemented below the min-results threshold, and re-throw (not fall back) on a vector-query error.
    [:disable-fallback?  {:optional true} [:maybe :boolean]]
+   ;; Semantic-engine: when true, emit per-stage retrieval-attribution diagnostics (the top-level
+   ;; `pipeline` block + per-row arm/view fields). Eval-only; absent/false => response is unchanged.
+   [:debug-pipeline?    {:optional true} [:maybe :boolean]]
    ;;
    ;; optional
    ;;

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -309,6 +309,15 @@
   separate `case` (with an `:hnsw` default) and must be updated by hand when adding a strategy."
   [:hnsw :brute-force])
 
+(def query-embedders
+  "Valid `query_embedder` API-param values, as keywords. Selects which embedder turns the search string into
+  the query vector for the semantic engine. `:voyage` embeds via the Voyage embeddings API (model/dimensions
+  from the `ee-voyage-embedding-*` settings) so the query shares a Voyage-embedded index table's vector space;
+  `:arctic`/`:ai-service` are explicit no-ops naming the default. Absent param ⇒ the active index's own
+  configured embedder (today's behavior). Mastered here so the OSS search API param and the EE query path
+  ([[metabase-enterprise.semantic-search.index/query-index]]) share one definition."
+  [:voyage :arctic :ai-service])
+
 (def PartitionConfig
   "Schema for the semantic-engine federated-retrieval partition config (the `partition_config`
   API param, sent as a JSON object). `:partitions` lists per-partition candidate generation: each
@@ -411,8 +420,13 @@
                              relevance -- kept for completeness).
    - `:rerank_fusion`     -- like `:rerank_then_boost`, but the reranked pool is selected rank-fusion-free
                              (best arm rank) rather than from the RRF-ordered `total_score` list.
+   - `:rerank_rrf`        -- final order = RRF of the weighted-score rank and the cross-encoder rank over the
+                             pool (`wa/(k+weighted_rank) + wb/(k+rerank_rank)`). Rank-space fusion: neither axis
+                             dominates, and the metadata boosts tip via the weighted-rank arm (they set the
+                             `total_score` that orders the pool) rather than via an uncalibrated additive term.
+                             Tuned by the `:rrf-weighted`/`:rrf-rerank`/`:rrf-k` keys (ignored by other blends).
   Mastered here so the OSS API param and the EE rerank step share one definition."
-  [:rerank_only :rerank_then_boost :rerank_as_scorer :rerank_fusion])
+  [:rerank_only :rerank_then_boost :rerank_as_scorer :rerank_fusion :rerank_rrf])
 
 (def RerankerConfig
   "Schema for the semantic-engine Voyage cross-encoder rerank config (the `reranker_config` API param, sent as
@@ -431,13 +445,29 @@
   the eval with `disable_fallback`, so truncation never spuriously trips the appdb fallback); `:weight` is the
   rerank-score weight in the `:rerank_then_boost`/`:rerank_as_scorer`/`:rerank_fusion` blends (default mirrors
   the dominant `:rrf` static weight). Mastered here so the OSS API param and the EE query builder share one
-  definition."
+  definition.
+
+  The `:rerank_rrf` blend adds three rank-space fusion knobs (ignored by the additive blends): `:rrf-weighted`
+  (`wa`, the weighted-rank arm weight, default 1.0), `:rrf-rerank` (`wb`, the cross-encoder-rank arm weight,
+  default 2.0 -- the best NDCG@10/recall point from the offline sweep; `wa=wb=1.0` was best for MRR, so both
+  are reachable), and `:rrf-k` (the fusion constant, default 60). An optional `:gate` skips the cross-encoder
+  entirely when retrieval is already confident (the head is an exact name match, or the rank-1 cosine distance
+  is within the margin), spending Voyage tokens only on the uncertain queries reranking actually helps."
   [:map {:closed true}
    [:model  {:optional true} :string]                         ; default = ee-reranking-model setting
    [:pool   {:optional true} pos-int?]                        ; N candidates reranked (default 50)
    [:top-k  {:optional true} pos-int?]                        ; results kept after rerank (default = pool)
    [:weight {:optional true} [:double {:min 0.0}]]            ; rerank-score weight in D1/D2/D3 (default 500.0)
-   [:blend  {:optional true} (into [:enum] rerank-blend-modes)]]) ; default :rerank_then_boost
+   [:blend  {:optional true} (into [:enum] rerank-blend-modes)] ; default :rerank_then_boost
+   ;; :rerank_rrf rank-space fusion knobs (ignored by the additive blends)
+   [:rrf-weighted {:optional true} [:double {:min 0.0}]]      ; wa, weighted-rank arm weight (default 1.0)
+   [:rrf-rerank   {:optional true} [:double {:min 0.0}]]      ; wb, rerank-rank arm weight (default 2.0)
+   [:rrf-k        {:optional true} pos-int?]                  ; fusion k (default 60)
+   ;; Confidence gate: skip the cross-encoder when retrieval is already confident.
+   [:gate {:optional true}
+    [:map {:closed true}
+     [:exact           {:optional true} :boolean]             ; skip when the top result is an exact name match
+     [:semantic-margin {:optional true} [:double {:min 0.0}]]]]]) ; skip when rank-1 cosine distance <= this
 
 (def TrigramConfig
   "Schema for the semantic-engine pg_trgm typo-tolerance config (the `trigram_config` API param, sent as a
@@ -560,6 +590,9 @@
    ;; Semantic-engine vector-search strategy (:hnsw or :brute-force). When absent, the engine uses its
    ;; configured default setting.
    [:vector-search-strategy {:optional true} [:maybe keyword?]]
+   ;; Semantic-engine query embedder override. `:voyage` embeds the query via the Voyage API (shares a
+   ;; Voyage-embedded table's vector space); absent/`:arctic`/`:ai-service` ⇒ the active index's own embedder.
+   [:query-embedder     {:optional true} [:maybe (into [:enum] query-embedders)]]
    ;; Semantic-engine cosine-distance cut-off override. When absent, the engine uses its hardcoded default.
    [:max-cosine-distance {:optional true} [:maybe number?]]
    ;; Semantic-engine federated-retrieval partition config. When absent, the engine uses a single global KNN.

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -403,6 +403,8 @@
    ;; Semantic-engine vector-search strategy (:hnsw or :brute-force). When absent, the engine uses its
    ;; configured default setting.
    [:vector-search-strategy {:optional true} [:maybe keyword?]]
+   ;; Semantic-engine cosine-distance cut-off override. When absent, the engine uses its hardcoded default.
+   [:max-cosine-distance {:optional true} [:maybe number?]]
    [:search-string      {:optional true} [:maybe ms/NonBlankString]]
    [:weights            {:optional true} [:maybe [:map-of :keyword number?]]]
    ;;

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -309,6 +309,29 @@
   separate `case` (with an `:hnsw` default) and must be updated by hand when adding a strategy."
   [:hnsw :brute-force])
 
+(def PartitionConfig
+  "Schema for the semantic-engine federated-retrieval partition config (the `partition_config`
+  API param, sent as a JSON object). `:partitions` lists per-partition candidate generation: each
+  partition searches its own `:models` set as one sub-query with its own candidate ceiling (`:k`),
+  cosine cutoff (`:max-cosine-distance`), and vector `:strategy`. An absent param is today's single
+  global KNN, so absent-param = baseline.
+
+  The partition model groupings MUST mirror the partial HNSW indexes built on the active index table
+  (search-eval scripts/manage_index.py) -- the backend emits `model = '<m>'` / `model = ANY (...)`
+  predicates that have to imply the partial-index predicate or the planner ignores it. Mastered here
+  (rather than in the EE module) so the OSS search API param and the EE query builder share one
+  definition. `:fusion` selects the post-union ranking; only `:v1` (union → existing RRF+scoring) is
+  implemented today."
+  [:map {:closed true}
+   [:partitions [:sequential
+                 [:map {:closed true}
+                  [:name                {:optional true} :string]
+                  [:models              [:sequential SearchableModel]]
+                  [:strategy            {:optional true} (into [:enum] vector-search-strategies)]
+                  [:k                   {:optional true} pos-int?]
+                  [:max-cosine-distance {:optional true} [:double {:min 0.0 :max 2.0}]]]]]
+   [:fusion {:optional true} [:enum :v1]]])
+
 (def ^:private ui-contexts
   "Search `context` values issued by the frontend, one per UI surface.
   Selects ranking weights ([[static-context-weights]]) and filter defaults ([[filter-defaults-by-context]]).
@@ -405,6 +428,8 @@
    [:vector-search-strategy {:optional true} [:maybe keyword?]]
    ;; Semantic-engine cosine-distance cut-off override. When absent, the engine uses its hardcoded default.
    [:max-cosine-distance {:optional true} [:maybe number?]]
+   ;; Semantic-engine federated-retrieval partition config. When absent, the engine uses a single global KNN.
+   [:partition-config   {:optional true} [:maybe PartitionConfig]]
    [:search-string      {:optional true} [:maybe ms/NonBlankString]]
    [:weights            {:optional true} [:maybe [:map-of :keyword number?]]]
    ;;

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -266,6 +266,7 @@
    [:search-engine                       {:optional true} [:maybe string?]]
    [:vector-search-strategy              {:optional true} [:maybe string?]]
    [:max-cosine-distance                 {:optional true} [:maybe number?]]
+   [:partition-config                    {:optional true} [:maybe search.config/PartitionConfig]]
    [:search-native-query                 {:optional true} [:maybe boolean?]]
    [:model-ancestors?                    {:optional true} [:maybe boolean?]]
    [:verified                            {:optional true} [:maybe true?]]
@@ -306,6 +307,7 @@
            search-engine
            vector-search-strategy
            max-cosine-distance
+           partition-config
            search-native-query
            search-string
            table-db-id
@@ -351,6 +353,7 @@
                  (some? offset)                              (assoc :offset-int offset)
                  (not (str/blank? vector-search-strategy))    (assoc :vector-search-strategy (keyword vector-search-strategy))
                  (some? max-cosine-distance)                 (assoc :max-cosine-distance max-cosine-distance)
+                 (some? partition-config)                    (assoc :partition-config partition-config)
                  (some? search-native-query)                 (assoc :search-native-query search-native-query)
                  (some? verified)                            (assoc :verified verified)
                  (some? include-dashboard-questions?)        (assoc :include-dashboard-questions? include-dashboard-questions?)

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -270,6 +270,7 @@
    [:multi-view-config                   {:optional true} [:maybe search.config/MultiViewConfig]]
    [:federated-multi-view-config         {:optional true} [:maybe search.config/FederatedMultiViewConfig]]
    [:reranker-config                     {:optional true} [:maybe search.config/RerankerConfig]]
+   [:trigram-config                      {:optional true} [:maybe search.config/TrigramConfig]]
    [:search-native-query                 {:optional true} [:maybe boolean?]]
    [:model-ancestors?                    {:optional true} [:maybe boolean?]]
    [:verified                            {:optional true} [:maybe true?]]
@@ -282,6 +283,7 @@
    [:display-type                        {:optional true} [:maybe [:set ms/NonBlankString]]]
    [:weights                             {:optional true} [:maybe [:map-of :keyword number?]]]
    [:disable-fallback?                   {:optional true} [:maybe :boolean]]
+   [:disable-keyword?                    {:optional true} [:maybe :boolean]]
    [:debug-pipeline?                     {:optional true} [:maybe :boolean]]])
 
 (mu/defn search-context :- SearchContext
@@ -316,6 +318,7 @@
            multi-view-config
            federated-multi-view-config
            reranker-config
+           trigram-config
            search-native-query
            search-string
            table-db-id
@@ -324,6 +327,7 @@
            has-temporal-dim
            weights
            disable-fallback?
+           disable-keyword?
            debug-pipeline?]} :- ::search-context.input]
   ;; for prod where Malli is disabled
   {:pre [(pos-int? current-user-id) (set? current-user-perms)]}
@@ -353,6 +357,7 @@
                         :search-string                       search-string
                         :weights                             weights
                         :disable-fallback?                   (boolean disable-fallback?)
+                        :disable-keyword?                    (boolean disable-keyword?)
                         :debug-pipeline?                     (boolean debug-pipeline?)}
                  (some? collection)                          (assoc :collection collection)
                  (some? created-at)                          (assoc :created-at created-at)
@@ -369,6 +374,7 @@
                  (some? multi-view-config)                   (assoc :multi-view-config multi-view-config)
                  (some? federated-multi-view-config)         (assoc :federated-multi-view-config federated-multi-view-config)
                  (some? reranker-config)                     (assoc :reranker-config reranker-config)
+                 (some? trigram-config)                      (assoc :trigram-config trigram-config)
                  (some? search-native-query)                 (assoc :search-native-query search-native-query)
                  (some? verified)                            (assoc :verified verified)
                  (some? include-dashboard-questions?)        (assoc :include-dashboard-questions? include-dashboard-questions?)

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -267,6 +267,7 @@
    [:vector-search-strategy              {:optional true} [:maybe string?]]
    [:max-cosine-distance                 {:optional true} [:maybe number?]]
    [:partition-config                    {:optional true} [:maybe search.config/PartitionConfig]]
+   [:multi-view-config                   {:optional true} [:maybe search.config/MultiViewConfig]]
    [:search-native-query                 {:optional true} [:maybe boolean?]]
    [:model-ancestors?                    {:optional true} [:maybe boolean?]]
    [:verified                            {:optional true} [:maybe true?]]
@@ -308,6 +309,7 @@
            vector-search-strategy
            max-cosine-distance
            partition-config
+           multi-view-config
            search-native-query
            search-string
            table-db-id
@@ -354,6 +356,7 @@
                  (not (str/blank? vector-search-strategy))    (assoc :vector-search-strategy (keyword vector-search-strategy))
                  (some? max-cosine-distance)                 (assoc :max-cosine-distance max-cosine-distance)
                  (some? partition-config)                    (assoc :partition-config partition-config)
+                 (some? multi-view-config)                   (assoc :multi-view-config multi-view-config)
                  (some? search-native-query)                 (assoc :search-native-query search-native-query)
                  (some? verified)                            (assoc :verified verified)
                  (some? include-dashboard-questions?)        (assoc :include-dashboard-questions? include-dashboard-questions?)

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -279,7 +279,8 @@
    [:non-temporal-dim-ids                {:optional true} [:maybe ms/NonBlankString]]
    [:has-temporal-dim                    {:optional true} [:maybe :boolean]]
    [:display-type                        {:optional true} [:maybe [:set ms/NonBlankString]]]
-   [:weights                             {:optional true} [:maybe [:map-of :keyword number?]]]])
+   [:weights                             {:optional true} [:maybe [:map-of :keyword number?]]]
+   [:disable-fallback?                   {:optional true} [:maybe :boolean]]])
 
 (mu/defn search-context :- SearchContext
   "Create a new search context that you can pass to other functions like [[search]]."
@@ -318,7 +319,8 @@
            verified
            non-temporal-dim-ids
            has-temporal-dim
-           weights]} :- ::search-context.input]
+           weights
+           disable-fallback?]} :- ::search-context.input]
   ;; for prod where Malli is disabled
   {:pre [(pos-int? current-user-id) (set? current-user-perms)]}
   (when (some? verified)
@@ -345,7 +347,8 @@
                         :model-ancestors?                    (boolean model-ancestors?)
                         :search-engine                       engine
                         :search-string                       search-string
-                        :weights                             weights}
+                        :weights                             weights
+                        :disable-fallback?                   (boolean disable-fallback?)}
                  (some? collection)                          (assoc :collection collection)
                  (some? created-at)                          (assoc :created-at created-at)
                  (seq created-by)                            (assoc :created-by created-by)

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -268,6 +268,7 @@
    [:max-cosine-distance                 {:optional true} [:maybe number?]]
    [:partition-config                    {:optional true} [:maybe search.config/PartitionConfig]]
    [:multi-view-config                   {:optional true} [:maybe search.config/MultiViewConfig]]
+   [:federated-multi-view-config         {:optional true} [:maybe search.config/FederatedMultiViewConfig]]
    [:search-native-query                 {:optional true} [:maybe boolean?]]
    [:model-ancestors?                    {:optional true} [:maybe boolean?]]
    [:verified                            {:optional true} [:maybe true?]]
@@ -310,6 +311,7 @@
            max-cosine-distance
            partition-config
            multi-view-config
+           federated-multi-view-config
            search-native-query
            search-string
            table-db-id
@@ -357,6 +359,7 @@
                  (some? max-cosine-distance)                 (assoc :max-cosine-distance max-cosine-distance)
                  (some? partition-config)                    (assoc :partition-config partition-config)
                  (some? multi-view-config)                   (assoc :multi-view-config multi-view-config)
+                 (some? federated-multi-view-config)         (assoc :federated-multi-view-config federated-multi-view-config)
                  (some? search-native-query)                 (assoc :search-native-query search-native-query)
                  (some? verified)                            (assoc :verified verified)
                  (some? include-dashboard-questions?)        (assoc :include-dashboard-questions? include-dashboard-questions?)

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -265,6 +265,7 @@
    [:table-db-id                         {:optional true} [:maybe ms/PositiveInt]]
    [:search-engine                       {:optional true} [:maybe string?]]
    [:vector-search-strategy              {:optional true} [:maybe string?]]
+   [:max-cosine-distance                 {:optional true} [:maybe number?]]
    [:search-native-query                 {:optional true} [:maybe boolean?]]
    [:model-ancestors?                    {:optional true} [:maybe boolean?]]
    [:verified                            {:optional true} [:maybe true?]]
@@ -304,6 +305,7 @@
            offset
            search-engine
            vector-search-strategy
+           max-cosine-distance
            search-native-query
            search-string
            table-db-id
@@ -348,6 +350,7 @@
                  (some? limit)                               (assoc :limit-int limit)
                  (some? offset)                              (assoc :offset-int offset)
                  (not (str/blank? vector-search-strategy))    (assoc :vector-search-strategy (keyword vector-search-strategy))
+                 (some? max-cosine-distance)                 (assoc :max-cosine-distance max-cosine-distance)
                  (some? search-native-query)                 (assoc :search-native-query search-native-query)
                  (some? verified)                            (assoc :verified verified)
                  (some? include-dashboard-questions?)        (assoc :include-dashboard-questions? include-dashboard-questions?)

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -265,6 +265,7 @@
    [:table-db-id                         {:optional true} [:maybe ms/PositiveInt]]
    [:search-engine                       {:optional true} [:maybe string?]]
    [:vector-search-strategy              {:optional true} [:maybe string?]]
+   [:query-embedder                      {:optional true} [:maybe string?]]
    [:max-cosine-distance                 {:optional true} [:maybe number?]]
    [:partition-config                    {:optional true} [:maybe search.config/PartitionConfig]]
    [:multi-view-config                   {:optional true} [:maybe search.config/MultiViewConfig]]
@@ -313,6 +314,7 @@
            offset
            search-engine
            vector-search-strategy
+           query-embedder
            max-cosine-distance
            partition-config
            multi-view-config
@@ -369,6 +371,7 @@
                  (some? limit)                               (assoc :limit-int limit)
                  (some? offset)                              (assoc :offset-int offset)
                  (not (str/blank? vector-search-strategy))    (assoc :vector-search-strategy (keyword vector-search-strategy))
+                 (not (str/blank? query-embedder))           (assoc :query-embedder (keyword query-embedder))
                  (some? max-cosine-distance)                 (assoc :max-cosine-distance max-cosine-distance)
                  (some? partition-config)                    (assoc :partition-config partition-config)
                  (some? multi-view-config)                   (assoc :multi-view-config multi-view-config)

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -269,6 +269,7 @@
    [:partition-config                    {:optional true} [:maybe search.config/PartitionConfig]]
    [:multi-view-config                   {:optional true} [:maybe search.config/MultiViewConfig]]
    [:federated-multi-view-config         {:optional true} [:maybe search.config/FederatedMultiViewConfig]]
+   [:reranker-config                     {:optional true} [:maybe search.config/RerankerConfig]]
    [:search-native-query                 {:optional true} [:maybe boolean?]]
    [:model-ancestors?                    {:optional true} [:maybe boolean?]]
    [:verified                            {:optional true} [:maybe true?]]
@@ -280,7 +281,8 @@
    [:has-temporal-dim                    {:optional true} [:maybe :boolean]]
    [:display-type                        {:optional true} [:maybe [:set ms/NonBlankString]]]
    [:weights                             {:optional true} [:maybe [:map-of :keyword number?]]]
-   [:disable-fallback?                   {:optional true} [:maybe :boolean]]])
+   [:disable-fallback?                   {:optional true} [:maybe :boolean]]
+   [:debug-pipeline?                     {:optional true} [:maybe :boolean]]])
 
 (mu/defn search-context :- SearchContext
   "Create a new search context that you can pass to other functions like [[search]]."
@@ -313,6 +315,7 @@
            partition-config
            multi-view-config
            federated-multi-view-config
+           reranker-config
            search-native-query
            search-string
            table-db-id
@@ -320,7 +323,8 @@
            non-temporal-dim-ids
            has-temporal-dim
            weights
-           disable-fallback?]} :- ::search-context.input]
+           disable-fallback?
+           debug-pipeline?]} :- ::search-context.input]
   ;; for prod where Malli is disabled
   {:pre [(pos-int? current-user-id) (set? current-user-perms)]}
   (when (some? verified)
@@ -348,7 +352,8 @@
                         :search-engine                       engine
                         :search-string                       search-string
                         :weights                             weights
-                        :disable-fallback?                   (boolean disable-fallback?)}
+                        :disable-fallback?                   (boolean disable-fallback?)
+                        :debug-pipeline?                     (boolean debug-pipeline?)}
                  (some? collection)                          (assoc :collection collection)
                  (some? created-at)                          (assoc :created-at created-at)
                  (seq created-by)                            (assoc :created-by created-by)
@@ -363,6 +368,7 @@
                  (some? partition-config)                    (assoc :partition-config partition-config)
                  (some? multi-view-config)                   (assoc :multi-view-config multi-view-config)
                  (some? federated-multi-view-config)         (assoc :federated-multi-view-config federated-multi-view-config)
+                 (some? reranker-config)                     (assoc :reranker-config reranker-config)
                  (some? search-native-query)                 (assoc :search-native-query search-native-query)
                  (some? verified)                            (assoc :verified verified)
                  (some? include-dashboard-questions?)        (assoc :include-dashboard-questions? include-dashboard-questions?)
@@ -473,6 +479,9 @@
                                                :search/query-length (count (:search-string search-ctx))
                                                :search/model-count  (count (:models search-ctx))}
     (let [reducible-results (search.engine/results search-ctx)
+          ;; Per-stage retrieval-attribution diagnostics (semantic engine, `debug_pipeline=true`) ride up as
+          ;; metadata on the realized results seq -- read it here before the transducer consumes the seq.
+          pipeline          (:pipeline (meta reducible-results))
           scoring-ctx       (select-keys search-ctx [:search-engine :search-string :search-native-query])
           xf                (comp
                              (take search.config/*db-max-results*)
@@ -481,4 +490,5 @@
                              (map (partial normalize-result-more search-ctx))
                              (keep #(search.engine/score scoring-ctx %)))
           ranked-results    (scoring/top-results reducible-results search.config/max-filtered-results xf)]
-      (search-results search-ctx search.engine/model-set ranked-results))))
+      (cond-> (search-results search-ctx search.engine/model-set ranked-results)
+        pipeline (assoc :pipeline pipeline)))))

--- a/test/metabase/describe/api_test.clj
+++ b/test/metabase/describe/api_test.clj
@@ -1,0 +1,92 @@
+(ns metabase.describe.api-test
+  "Tests for /api/describe endpoints."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.describe.api-test]}}}}}}
+  (:require
+   [clojure.test :refer :all]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.test :as mt]))
+
+(defn- describe [user model id]
+  (mt/user-http-request user :get 200 (format "describe/%s/%d" (name model) id)))
+
+(defn- sum-measure-definition
+  "An MBQL5 measure definition: Sum of `field-id` over `table-id`."
+  [table-id field-id]
+  (let [mp    (lib-be/application-database-metadata-provider (mt/id))
+        query (lib/query mp (lib.metadata/table mp table-id))]
+    (lib/aggregate query (lib/sum (lib.metadata/field mp field-id)))))
+
+(deftest describe-card-test
+  (testing "GET /api/describe/card/:id"
+    (testing "an MBQL question returns a suggested name and a per-section breakdown"
+      (mt/with-temp [:model/Card {id :id} {:name          "Some name"
+                                           :dataset_query (mt/mbql-query orders
+                                                            {:aggregation [[:sum $total]]
+                                                             :breakout    [$product_id->products.category]
+                                                             :order-by    [[:asc [:aggregation 0]]]})}]
+        (is (=? {:model          "card"
+                 :id             id
+                 :name           "Some name"
+                 :native         false
+                 :suggested_name string?
+                 :sections       {:aggregation "Sum of Total"
+                                  :breakout    "Grouped by Product → Category"
+                                  :filters     nil
+                                  :order_by    string?
+                                  :limit       nil
+                                  ;; the breakout joins Products implicitly, so there is no explicit :joins clause
+                                  :joins       nil}}
+                (describe :crowberto :card id)))))
+    (testing "a native question reports :native true with a nil suggested name"
+      (mt/with-temp [:model/Card {id :id} {:dataset_query (mt/native-query {:query "SELECT 1 AS one"})}]
+        (is (=? {:model          "card"
+                 :native         true
+                 :suggested_name nil
+                 :sections       {:aggregation nil
+                                  :breakout    nil
+                                  :filters     nil
+                                  :order_by    nil
+                                  :limit       nil
+                                  :joins       nil}}
+                (describe :crowberto :card id)))))))
+
+(deftest describe-segment-test
+  (testing "GET /api/describe/segment/:id returns a filter description"
+    (mt/with-temp [:model/Segment {id :id} {:table_id   (mt/id :venues)
+                                            :definition (:query (mt/mbql-query venues
+                                                                  {:filter [:= $price 4]}))}]
+      (is (=? {:model    "segment"
+               :id       id
+               :native   false
+               :sections {:filters     "Filtered by Price is equal to 4"
+                          :aggregation nil}}
+              (describe :crowberto :segment id))))))
+
+(deftest describe-measure-test
+  (testing "GET /api/describe/measure/:id returns an aggregation description"
+    (mt/with-temp [:model/Measure {id :id} {:table_id   (mt/id :venues)
+                                            :definition (sum-measure-definition (mt/id :venues) (mt/id :venues :price))}]
+      (is (=? {:model    "measure"
+               :id       id
+               :native   false
+               :sections {:aggregation "Sum of Price"
+                          :filters     nil}}
+              (describe :crowberto :measure id))))))
+
+(deftest describe-validation-test
+  (testing "an unsupported entity type does not route (the :model enum becomes a path regex)"
+    (mt/user-http-request :crowberto :get 404 "describe/dashboard/1"))
+  (testing "a missing entity returns 404"
+    (mt/user-http-request :crowberto :get 404 "describe/card/999999999")))
+
+(deftest describe-permissions-test
+  (testing "describing a card the caller cannot read returns an error, not the description"
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Card       {id :id}      {:collection_id coll-id
+                                                    :dataset_query (mt/mbql-query orders)}]
+      ;; rasta has no permission on this fresh collection
+      (mt/with-non-admin-groups-no-collection-perms coll-id
+        (is (= "You don't have permissions to do that."
+               (mt/user-http-request :rasta :get 403 (format "describe/card/%d" id))))))))


### PR DESCRIPTION
WIP

Experimental results from using the new v4 search eval test suite ([repo link](https://github.com/metabase/metaslop/tree/tsp-search-eval-metastore/search-eval))
The data environment used to test was:
- hydrated appdb from stats pgdump as of 2026-05-29
- hydrated pgvector semantic db from stats pgdump as of 2026-05-29

## Eval Test Cases - the v4 test suite

The suite is 101 topics / 478 cases authored against our "stats" instance, derived from / inspired by four user personas (bizops-finance, engineering head, enterprise-sales, marketing). See personas [here](https://github.com/metabase/ai-benchmarks/tree/stats-data-selection-suite/benchmarks/suites/stats_data_selection/persona_research)

A topic is one real thing a user wants to find plus a graded relevance set:
```
    grade 3  - the right answer
    grade 2  - a strong alternate
    grade 1  - related / partial
    grade 0  - a "trap", looks relevant but is not right
```

For each topic we have a set of actual search test cases. Each of these are ran and scored against the common relevance set:
```
    exact_name        verbatim title           "Monthly Revenue (Customer)"
    partial_name      partial overlap          "monthly revenue customer"
    alias             alternate phrasing       "per-customer ARR"
    natural_question  a full question          "what's our ARR by customer"
    typo              misspelled               "montly revenue custmer"
```

Lastly, topics can be either "known item" or "informational"
  - `known-item` (n=74) - there is a single right answer
  - `informational` (n=14) - no single answer, the user wants the set of relevant things / is unsure exactly what they're looking for. Only uses `alias` and `natural-question` test case forms

## The experiments

### 1. Federated / partitioned retrieval

Three quarters of the search index is `indexed-entity` rows: individual column values indexed from models. A single global nearest-neighbor search is thus competing against ~95K single value rows and real relevant content gets crowded out (in theory).

Partitioned or federated retrieval uses separate queries for mutually exclusive subsets. The below experiments used this partition approach:
  - dedicated partitions: indexed-entity, card, dataset, table, dashboard, metric, document, collection
  - shared partition for: database, measure, segment, transform, action


### 2. Multiview embeddings

Currently there was a 1:1 map of searchable entity and indexed vector embeddings. So a single search term is expected/hoping to land close enough in vector space to the single indexed embedding of the relevant result. The multiview approach changes this to 1:N whereby we define different ways of textually representing each entity and we index embeddings for all of these. We call these "views", they each get their embedding column in the pgvector db with configured partial HNSW approximate nearest neighbor indexes.

This can be designed any number of different ways. We ran experiments for two primary strategies, one using deterministic construction (all things derived from the appdb / backend helpers), and one using LLM enrichment. Examples:

<details>
<summary>`card:14023` "Monthly Revenue (Customer)" - dataset</summary>

```
deterministic — 3 views

base (column embedding)
dataset
Monthly Revenue (Customer)

descriptions_broad (column embedding_descriptions) — base + the entity's own appdb description
dataset
Monthly Revenue (Customer)
Monthly revenue from our current and past customers. One row per month and customer.
Multiple accounts for a customer are collapsed by selecting the latest account for the
month and the amount/ARR are summed.

details_broad (column embedding_details) — structural render: warehouse location + per-column descriptions (capped, importance-ranked)
dataset
Monthly Revenue (Customer)
dbt_models.Monthly Revenue (Customer) (Analytics Data Warehouse)
ID — Primary key
Customer Name — Name of the customer
Recognized At — The date when the revenue is recognized, which is at the end of the billing period...
Amount — The amount of the revenue being recognized in dollars.
ARR — The annual recurring revenue in dollars. This is basically 12x amount.
Accounts — The number of accounts for the customer in the month
Is Actual — Indicates if the revenue is actual (in the past) or expected (in the future).
... [Plan Name, Purchase Type, Use Case, Deployment, Feature Set, Billing Cycle, Country, ...]
…(+3 more)
(This is a dataset, so details leans on its curated per-column descriptions. For a table this view would instead be dominated by the "used by" downstream consumer names; for a card, by the plain-English describe of what it computes.)

llmv2 — 4 views

base (column embedding) — identical to broadv3's base
dataset
Monthly Revenue (Customer)

instructions_ai (column embedding_instructions) — LLM-written "what is this / how to read it"
dataset
Monthly Revenue (Customer)
What is the monthly revenue and ARR for each customer, and how does it break down by
plan, deployment, purchase type, and other dimensions?
One row per customer per month; ARR and amount are summed across all accounts for the
customer, with the latest account selected for dimensional attributes; includes both
actual (past) and expected (future) revenue.

examples_ai (column embedding_examples) — LLM-generated example questions it can answer (the doc2query alias surface)
Monthly Revenue (Customer)
What is the monthly recurring revenue by customer?
Show me ARR by customer broken down by plan and deployment
Which customers are on self-service vs sold subscriptions?
What is the revenue for cloud vs self-hosted customers?
Show monthly revenue by billing cycle and feature set
Which customers have auto-renewal enabled?
What is the ARR for customers in a specific country?
How much revenue is from embedding use cases vs internal analytics?

synonyms_ai (column embedding_synonyms) — LLM-generated alternative names
Monthly Revenue (Customer)
MRR
ARR
monthly recurring revenue
annual recurring revenue
customer revenue
revenue by customer
customer MRR
customer ARR
```

</details>

<details>
<summary>`card:13007` "Open Bugs by Priority" - MBQL card with no saved description</summary>

```
deterministic — 3 views

base (column embedding)
card
Open Bugs by Priority

descriptions_broad (column embedding_descriptions) — collapses to base because the card has no description
card
Open Bugs by Priority

details_broad (column embedding_details) — the rescue: since it's MBQL, the deterministic describe renders the query into English (suggested-name + aggregation/breakout/filter sections + source table + columns), no LLM
card
Open Scored Issues, Count, Grouped by Priority, Filtered by Type is Bug and Repository is metabase
Count
Grouped by Priority
Filtered by Type is Bug and Repository is metabase
Open Scored Issues
Priority
Count

llmv2 — 4 views

base — identical
card
Open Bugs by Priority

instructions_ai (column embedding_instructions)
card
Open Bugs by Priority
How many open bugs in the Metabase repository are there at each priority level?
Count of open GitHub issues filtered to bug type and the Metabase repository, grouped by priority level.

examples_ai (column embedding_examples)
Open Bugs by Priority
How many open bugs are there by priority?
What is the breakdown of open Metabase bugs by priority level?
How many high priority bugs are currently open?
Show me open bug counts by priority for the Metabase repo
What priority distribution do open bugs have?
How many critical vs low priority bugs are open right now?

synonyms_ai (column embedding_synonyms)
Open Bugs by Priority
bug priority breakdown
open defects by priority
bug queue by severity
```

</details>

<details>
<summary>`table:11471` "stripe.customer" - 108 downstream consumers</summary>

```
deterministic

base and descriptions_broad — both collapse to the bare warehouse name (no description; the schema name is customer)
table
customer

details_broad (column embedding_details) — the showcase. The table's own columns are dry warehouse identifiers, but the used by section is filled from the dependency edge graph: its non-archived downstream consumers, ranked by view_count, rendered name (type).
table
Customer
stripe.customer
Analytics Data Warehouse
columns:
created [CreationTimestamp]
_fivetran_synced (Fivetran Synced)
address_country [Country]
next_invoice_sequence
balance [Category]
... [account_balance, address_*, description, invoice_prefix]
used by:
monthly customers (card)
Trial Conversion Data Project (card)
native sql comparison (card)
Metabot AI – monthly ARR per subscription (card)
Metabot AI Stripe Subscriptions (WIP) (card)
Feb 1st 2023 Enterprise Drill Down (card)
Nested Distinct Enterprise (card)
Metabot AI – quota vs actual usage (card)
Enterprise Sanity Check (card)
Latest Values for Forecast Data Project (card)
Quarterly Trial Conversion Data Project (card)
quarterly customers (card)
... [16 consumers, capped]

llmv2

base — same bare name.

instructions_ai — note the description is written from the consumers (top-down propagation):
table
customer
A single Stripe customer record representing one billing entity (company or individual) in Metabase's Stripe account.
Foundation for subscription, revenue, and billing analyses — used to count active, new, and
churned paying customers over time; compute monthly and annual ARR by plan; measure trial
conversion rates; analyze Metabot AI subscriber quotas and retention; and validate recognized
revenue across reporting models.

examples_ai
customer
how many paying Stripe customers do we have each month
which Stripe customers are delinquent
how do I join Stripe subscriptions to customer billing details
monthly new and churned customer counts from Stripe
trial-to-paid conversion rate by Stripe customer cohort
ARR by Stripe customer and billing plan

synonyms_ai
customer
Stripe customer
billing account
payer
Stripe account
```

</details>


## 3. Reranker model

After retrieval, our candidate pool is decided. Then the objective becomes ordering the results appropriately. Currently we do this via hand rolled weighted scorers whereby we boost things by various degrees based on their attributes. A cross encoder reranker model is an alternate approach and is widely used by production search systems today. We tested using Voyage AI's rerank-2.5 model, both as a naive second step (consuming the already weighted top-100 search results) and via a consolidated rerank w/ RRF approach. Could have spent more time in this area I think theres likely issues with the implementation details here.

## 4. Trigram text search index

Our current keyword retrieval arm completely collapses when there's a typo. The trigram experiment introduced a new keyword text search index using postgres' `pg_trgm` extension which does text search via a 3-gram surface overlap and thus is tolerant to misspellings. I tested this as a 3rd retrieval arm, and as a replacement for the current keyword retrieval arm. In combination with the other techniques it didnt make much of a difference since semantic was doing all the work and we didnt really need either keyword based arm.

### Misc. notes for understanding the table:

  - `00-baseline` - production baseline, ran with ef_search=40
  - `00-baseline-semantic` - also ef_search=40, keyword arm completely disabled
  - everything after 0b was ran with ef_search=500
  - `kwoff` / `kwon` - means keyword arm was OFF entirely, or it was enabled
  - `combo` - means both the partitioned and multiview techniques were used
  - `voyage` - we used Voyage AI's voyage large 4 embedding model entirely (replaced arctic)
  - `llm` vs `llmv2` - llmv2 is the multiview technique described above and was crafted very intentionally. "llm" was a first alternate attempt
  - `reranker` - used naive "bolted on" reranker step
  - `rerank-rrf` - used the fused reranker + scorer RRF approach

### Metrics

  - `N MISS` - complete retrieval miss. For a known-item case, the single answer was not found by any retrieval arm
  - `NDCG@10` - graded ranking quality of the top 10: are the higher-graded entities placed higher
  - `MRR` - mean reciprocal rank: 1 / (rank of the first relevant hit)
  - `SUCCESS@1` / `SUCCESS@10` - fraction of cases with a relevant entity at rank 1 or in the top 10
  - `RECALL@10` - fraction of all a case's relevant entities in the top 10

<img width="995" height="693" alt="Screenshot 2026-06-26 at 8 52 57 AM" src="https://github.com/user-attachments/assets/b3144ebb-6902-46fd-95ae-c3d24a905f57" />

Screenshots taken from the `eval_viewer/` frontend app ([link](https://github.com/metabase/metaslop/tree/tsp-search-eval-metastore/search-eval/eval_viewer))

`00-baseline`
<img width="1393" height="767" alt="image" src="https://github.com/user-attachments/assets/4f9890a9-9fb1-4e70-93b8-c3898ff33ccc" />

`0b-baseline-semantic`
<img width="1393" height="734" alt="image" src="https://github.com/user-attachments/assets/fb434af5-b393-4251-b660-eafeccec1a58" />

`06-combo-determ-reranker_kwoff`
<img width="1390" height="756" alt="image" src="https://github.com/user-attachments/assets/7f8a531e-c88e-4850-a9e4-90800bd7ef8e" />

`08-combo-llmv2-reranker_kwoff`
<img width="1390" height="755" alt="image" src="https://github.com/user-attachments/assets/3e287c8b-4947-4278-b2ec-4e498a52bbf2" />

`00-baseline` vs. `06-combo-determ-reranker_kwoff`
<img width="1390" height="789" alt="image" src="https://github.com/user-attachments/assets/e5c75fa7-c549-4d03-be60-8e8ce4a4ab13" />

