### PR TITLE
chore: update codeowners file for embedding folders

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,12 +12,26 @@ enterprise/backend/src/metabase_enterprise/dependencies @metabase/graphy
 enterprise/frontend/src/metabase-enterprise/dependencies @metabase/graphy
 
 # @metabase/embedding
-enterprise/frontend/src/embedding-sdk-package @metabase/embedding
-enterprise/frontend/src/embedding-sdk-bundle @metabase/embedding
-enterprise/frontend/src/embedding-sdk-shared @metabase/embedding
+
+frontend/src/metabase/embedding @metabase/embedding
 frontend/src/metabase/embedding-sdk @metabase/embedding
+frontend/src/embedding-sdk-bundle @metabase/embedding
+frontend/src/embedding-sdk-shared @metabase/embedding
 frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion @metabase/embedding
 frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard @metabase/embedding
+
+enterprise/frontend/src/embedding @metabase/embedding
+enterprise/frontend/src/embedding-sdk-ee @metabase/embedding
+enterprise/frontend/src/embedding-sdk-package @metabase/embedding
+
+enterprise/frontend/src/metabase-enterprise/embedding @metabase/embedding
+enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk @metabase/embedding
+enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup @metabase/embedding
+enterprise/frontend/src/metabase-enterprise/embedding-sdk @metabase/embedding
+
+e2e/test-component @metabase/embedding
+e2e/test/scenarios/embedding @metabase/embedding
+e2e/embedding-sdk-host-apps @metabase/embedding
 
 # @metabase/tech-writers
 docs @metabase/tech-writers


### PR DESCRIPTION

Closes [EMB-1929: update embedding codeowners](https://linear.app/metabase/issue/EMB-1929/update-embedding-codeowners)

### Description

The codeowners file was not up to date with our latest changes, this should reflect the current folder structure
