### PR TITLE
Make more entities discoverable through mcp search

### DIFF
--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -99,21 +99,30 @@
 ;; - Convert keyword enum values (like :table, :metric) to strings for JSON
 
 (mr/def ::search-result-item
-  "A table, metric, or model returned from search."
+  "A table, model, metric, saved question, dashboard, or collection returned from search.
+   The map is intentionally open: the underlying search enriches results with extra fields
+   (e.g. `:database_name`, `:portable_entity_id`, metric base-table info) that callers may
+   ignore. Only the keys agents commonly rely on are declared here."
   [:map {:encode/api #(update-keys % metabot.u/safe->snake_case_en)}
    [:id :int]
-   [:type [:enum "table" "metric" "model"]]
+   [:type [:enum "table" "metric" "model" "question" "dashboard" "collection"]]
    [:name :string]
    [:display_name {:optional true} [:maybe :string]]
    [:description {:optional true} [:maybe :string]]
    [:database_id {:optional true} [:maybe :int]]
    [:database_schema {:optional true} [:maybe :string]]
    [:verified {:optional true} [:maybe :boolean]]
+   [:official {:optional true} [:maybe :boolean]]
+   ;; Present on questions, dashboards, metrics, and models — the collection the entity lives in.
+   [:collection {:optional true} [:maybe :map]]
+   ;; Present on collection results — the parent location path (e.g. "/12/34/").
+   [:location {:optional true} [:maybe :string]]
    [:updated_at {:optional true} [:maybe :any]]
    [:created_at {:optional true} [:maybe :any]]])
 
 (mr/def ::search-response
-  "Search results containing tables, metrics, and models matching the query."
+  "Search results containing tables, models, metrics, saved questions, dashboards, and
+   collections matching the query."
   [:map {:encode/api #(update-keys % metabot.u/safe->snake_case_en)}
    [:data [:sequential ::search-result-item]]
    [:total_count :int]])
@@ -146,14 +155,15 @@
     :else           v))
 
 (api.macros/defendpoint :post "/v1/search" :- ::search-response
-  "Search for tables, metrics, and models.
+  "Search for tables, models, metrics, saved questions, dashboards, and collections.
 
   Supports both term-based and semantic search queries. Results are ranked using
   Reciprocal Rank Fusion when both query types are provided."
   {:scope metabot/agent-search
    :tool  {:name "search"
-           :title "Search Tables, Metrics, and Models"
-           :description (str "Search for tables, metrics, and models in Metabase. "
+           :title "Search Metabase Content"
+           :description (str "Search for tables, models, metrics, saved questions, dashboards, and collections "
+                             "in Metabase. "
                              "Use term_queries for keyword search or semantic_queries for natural language search. "
                              "Both arguments are arrays of strings, for example term_queries: [\"orders\", \"revenue\"].")
            :annotations {:read-only? true}}}
@@ -171,7 +181,7 @@
   (let [results (metabot-search/search
                  {:term-queries     (or (coerce-query-list term-queries) [])
                   :semantic-queries (or (coerce-query-list semantic-queries) [])
-                  :entity-types     ["table" "metric" "model"]
+                  :entity-types     ["table" "metric" "model" "question" "dashboard" "collection"]
                   :limit            (or (request/limit) 50)})]
     {:data        results
      :total_count (count results)}))

--- a/src/metabase/metabot/tools/search.clj
+++ b/src/metabase/metabot/tools/search.clj
@@ -46,6 +46,12 @@
       "database"
       common-fields
 
+      "collection"
+      ;; A collection has no database/base-table; surface its own curation level and parent location.
+      (-> common-fields
+          (merge {:official official?})
+          (m/assoc-some :location (:location result)))
+
       "table"
       (-> common-fields
           (merge {:name            (:table_name result)

--- a/test/metabase/agent_api/api_test.clj
+++ b/test/metabase/agent_api/api_test.clj
@@ -98,6 +98,22 @@
                   (mt/user-http-request :rasta :post 200 "agent/v1/search"
                                         {:term_queries ["AgentSearchTestTable"]}))))))))
 
+(deftest search-content-types-test
+  (testing "search surfaces saved questions, dashboards, and collections (not just tables/metrics/models)"
+    (binding [search.ingestion/*force-sync* true]
+      (search.tu/with-new-search-if-available-otherwise-legacy
+        (mt/with-temp [:model/Card      _ {:name "AgentSearchAcmeQuestion"}
+                       :model/Dashboard _ {:name "AgentSearchAcmeDashboard"}
+                       :model/Collection _ {:name "AgentSearchAcmeCollection"}]
+          (let [results (->> (mt/user-http-request :rasta :post 200 "agent/v1/search"
+                                                   {:term_queries ["AgentSearchAcme"]})
+                             :data
+                             (map (juxt :name :type))
+                             set)]
+            (is (contains? results ["AgentSearchAcmeQuestion" "question"]))
+            (is (contains? results ["AgentSearchAcmeDashboard" "dashboard"]))
+            (is (contains? results ["AgentSearchAcmeCollection" "collection"]))))))))
+
 (deftest coerce-query-list-test
   (let [coerce #'agent-api.api/coerce-query-list]
     (testing "arrays pass through unchanged"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76316 closes #76317
Closes [BOT-1710: Make cards (saved questions), dashboards, and collections discoverable via MCP `search`](https://linear.app/metabase/issue/BOT-1710/make-cards-saved-questions-dashboards-and-collections-discoverable-via)
Closes [BOT-1711: MCP `search` docs claim it finds cards/dashboards/collections, but it only returns tables/metrics/models](https://linear.app/metabase/issue/BOT-1711/mcp-search-docs-claim-it-finds-cardsdashboardscollections-but-it-only)

