### PR TITLE
GRO-536 replace ad hoc metaplow functions with @metabase/track alpha

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
         "@mantine/core": "8.3.18",
         "@mantine/dates": "8.3.18",
         "@mantine/hooks": "8.3.18",
+        "@metabase/track": "^1.0.0-alpha.1",
         "@modelcontextprotocol/ext-apps": "^1.3.2",
         "@popperjs/core": "^2.11.8",
         "@react-oauth/google": "^0.11.1",
@@ -1198,6 +1199,8 @@
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
 
     "@mdx-js/react": ["@mdx-js/react@3.1.0", "", { "dependencies": { "@types/mdx": "^2.0.0" } }, "sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ=="],
+
+    "@metabase/track": ["@metabase/track@1.0.0-alpha.1", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-LPpoNCyBoqUX1TNAdHQMswJETC6bPs7YNpKQp17n5+mCpeDcbP40o+V1DulVsOSWIbwg/RWX770d1s4ec7kPlw=="],
 
     "@microsoft/api-extractor": ["@microsoft/api-extractor@7.58.7", "", { "dependencies": { "@microsoft/api-extractor-model": "7.33.8", "@microsoft/tsdoc": "~0.16.0", "@microsoft/tsdoc-config": "~0.18.1", "@rushstack/node-core-library": "5.23.1", "@rushstack/rig-package": "0.7.3", "@rushstack/terminal": "0.24.0", "@rushstack/ts-command-line": "5.3.9", "diff": "~8.0.2", "minimatch": "10.2.3", "resolve": "~1.22.1", "semver": "~7.7.4", "source-map": "~0.6.1", "typescript": "5.9.3" }, "bin": { "api-extractor": "bin/api-extractor" } }, "sha512-yK6OycD46gIzLRpj6ueVUWPk1ACSpkN1LBo05gY1qPTylbWyUCanXfH7+VgkI5LJrJoRSQR5F04XuCffCXLOBw=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -5,5 +5,4 @@ timeout = 600000
 
 # Only install package versions published at least 3 days ago
 minimumReleaseAge = 259200
-minimumReleaseAgeExcludes = ["@metabase/track"]
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -5,4 +5,5 @@ timeout = 600000
 
 # Only install package versions published at least 3 days ago
 minimumReleaseAge = 259200
+minimumReleaseAgeExcludes = ["@metabase/track"]
 

--- a/frontend/src/embedding-sdk-bundle/analytics/tracker.ts
+++ b/frontend/src/embedding-sdk-bundle/analytics/tracker.ts
@@ -13,6 +13,7 @@ import type { SdkStore } from "embedding-sdk-bundle/store/types";
 import type { MetabaseAuthConfig } from "embedding-sdk-bundle/types/auth-config";
 import { getSdkPackageVersion } from "embedding-sdk-shared/lib/get-build-info";
 import { isEmbeddingEajs } from "metabase/embedding-sdk/config";
+import { initMetaplow } from "metabase/utils/metaplow";
 
 export function deriveAuthMethod(
   authConfig: MetabaseAuthConfig,
@@ -40,6 +41,12 @@ export function useInitSdkTracker(
     if (isEmbeddingEajs() || !isTrackingEnabled) {
       return;
     }
+    initMetaplow({
+      // Via frontend/src/embedding-sdk-bundle/analytics/snowplow.ts
+      // Omits userId — unlike the main-app tracker, SDK component usage is tracked at instance granularity;
+      // the analytics-uuid already identifies the account.
+      getUserId: () => undefined,
+    });
 
     const authMethod = deriveAuthMethod(authConfig);
     const wasJustInitialized = initSdkTracker({

--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -72,10 +72,7 @@ function _init(reducers, getRoutes, callback) {
 
   createSnowplowTracker(() => getUserId(store.getState()));
   initMetaplow({
-    beforeSend: (_type, payload) => ({
-      ...payload,
-      data: { ...payload.data, user_id: getUserId(store.getState()) },
-    }),
+    getUserId: () => getUserId(store.getState()),
   });
 
   // Initialize distributed tracing if enabled via MB_TRACING_ENABLED.

--- a/frontend/src/metabase/utils/metaplow.ts
+++ b/frontend/src/metabase/utils/metaplow.ts
@@ -51,8 +51,8 @@ export function initMetaplow(config: MetaplowConfig): void {
             ? getSanitizedUrl(payload.url)
             : "",
         id: Settings.get("analytics-uuid") ?? "",
-        referrer: "", // TODO: Is unsetting this still needed?
-        title: "", // TODO: Is unsetting this still needed?
+        referrer: "",
+        title: "",
         hostname: anonymizedHostname,
         data: {
           ...(payload.data as Record<string, unknown> | undefined),

--- a/frontend/src/metabase/utils/metaplow.ts
+++ b/frontend/src/metabase/utils/metaplow.ts
@@ -1,4 +1,5 @@
 import { init, track } from "@metabase/track";
+import { isObject } from "underscore";
 
 import Settings from "metabase/utils/settings";
 
@@ -16,7 +17,7 @@ const getSanitizedUrl = (url: string) => {
 };
 
 interface MetaplowConfig {
-  getUserId: () => string;
+  getUserId: () => number | undefined;
 }
 
 export function initMetaplow(config: MetaplowConfig): void {
@@ -24,12 +25,25 @@ export function initMetaplow(config: MetaplowConfig): void {
   if (!metaplowUrl) {
     return;
   }
+  const hostUrl = metaplowUrl.replace(/\/send$/, "");
 
   init({
     website: METAPLOW_WEBSITE_ID,
-    hostUrl: metaplowUrl,
+    hostUrl,
     tag: "metabase-instance",
-    beforeSend: (_type, payload) => {
+    beforeSend: (type, originalPayload) => {
+      let payload = originalPayload as Record<string, unknown>;
+
+      // Replace default pageview behavior with our own custom pageview tracking
+      const isAutoPageView = type === "event" && !payload.name;
+      if (isAutoPageView) {
+        return;
+      }
+      if (payload.name === "pageview" && isObject(payload.data)) {
+        payload = { ...payload, url: payload.data.url };
+        delete (payload.data as Record<string, unknown>).url;
+      }
+
       return {
         ...payload,
         url:
@@ -37,8 +51,13 @@ export function initMetaplow(config: MetaplowConfig): void {
             ? getSanitizedUrl(payload.url)
             : "",
         id: Settings.get("analytics-uuid") ?? "",
+        referrer: "", // TODO: Is unsetting this still needed?
+        title: "", // TODO: Is unsetting this still needed?
         hostname: anonymizedHostname,
-        user_id: config.getUserId(),
+        data: {
+          ...(payload.data as Record<string, unknown> | undefined),
+          user_id: config.getUserId(),
+        },
       };
     },
   });
@@ -47,10 +66,10 @@ export function initMetaplow(config: MetaplowConfig): void {
 export function trackMetaplowEvent(
   name: string,
   data: Record<string, unknown> = {},
-): void {
-  track(name, data);
+) {
+  return track(name, data);
 }
 
-export function trackMetaplowPageView() {
-  track("pageview");
+export function trackMetaplowPageView(url: string) {
+  return track("pageview", { url });
 }

--- a/frontend/src/metabase/utils/metaplow.ts
+++ b/frontend/src/metabase/utils/metaplow.ts
@@ -1,22 +1,10 @@
+import { init, track } from "@metabase/track";
+
 import Settings from "metabase/utils/settings";
 
 const METAPLOW_WEBSITE_ID = "23eefa30-4c4f-490e-aa4f-084cd23b1561";
 const anonymizedHostname = "anonymous.metabase.com";
 const anonymizedOrigin = `http://${anonymizedHostname}`;
-
-type MetaplowPayload = {
-  website: string;
-  url: string;
-  id: string;
-  referrer: string;
-  title: string;
-  hostname: string;
-  screen: string;
-  language: string;
-  tag: string;
-  name: string;
-  data?: Record<string, unknown>;
-};
 
 const getSanitizedUrl = (url: string) => {
   const parsed = new URL(url, window.location.origin);
@@ -27,72 +15,42 @@ const getSanitizedUrl = (url: string) => {
   return anonymizedOrigin + pathWithoutSlug;
 };
 
-function getBasePayload(url: string): Omit<MetaplowPayload, "name" | "data"> {
-  return {
-    website: METAPLOW_WEBSITE_ID,
-    url: getSanitizedUrl(url),
-    id: Settings.get("analytics-uuid") ?? "",
-    referrer: "",
-    title: "",
-    hostname: anonymizedHostname,
-    screen: `${window.screen.width}x${window.screen.height}`,
-    language: navigator.language,
-    tag: "metabase-instance",
-  };
+interface MetaplowConfig {
+  getUserId: () => string;
 }
 
-async function send(payload: MetaplowPayload): Promise<unknown> {
+export function initMetaplow(config: MetaplowConfig): void {
   const metaplowUrl = Settings.get("metaplow-url");
   if (!metaplowUrl) {
     return;
   }
 
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-
-  return fetch(metaplowUrl, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({ type: "event", payload }),
+  init({
+    website: METAPLOW_WEBSITE_ID,
+    hostUrl: metaplowUrl,
+    tag: "metabase-instance",
+    beforeSend: (_type, payload) => {
+      return {
+        ...payload,
+        url:
+          "url" in payload && typeof payload.url === "string"
+            ? getSanitizedUrl(payload.url)
+            : "",
+        id: Settings.get("analytics-uuid") ?? "",
+        hostname: anonymizedHostname,
+        user_id: config.getUserId(),
+      };
+    },
   });
-}
-
-interface MetaplowConfig {
-  beforeSend: (
-    type: string,
-    payload: MetaplowPayload,
-  ) => MetaplowPayload | void;
-}
-
-let _config: MetaplowConfig = {
-  beforeSend: (_type, payload) => payload,
-};
-
-export function initMetaplow(config: Partial<MetaplowConfig>): void {
-  _config = { ..._config, ...config };
 }
 
 export function trackMetaplowEvent(
-  name: MetaplowPayload["name"],
-  data: MetaplowPayload["data"] = {},
+  name: string,
+  data: Record<string, unknown> = {},
 ): void {
-  const payload = _config.beforeSend("event", {
-    ...getBasePayload(window.location.href),
-    name,
-    data,
-  });
-  if (payload) {
-    send(payload).catch(() => undefined);
-  }
+  track(name, data);
 }
 
-export function trackMetaplowPageView(url: string) {
-  const payload = _config.beforeSend("event", {
-    ...getBasePayload(url),
-    name: "pageview",
-  });
-  if (payload) {
-    send(payload).catch(() => undefined);
-  }
+export function trackMetaplowPageView() {
+  track("pageview");
 }

--- a/frontend/src/metabase/utils/metaplow.unit.spec.ts
+++ b/frontend/src/metabase/utils/metaplow.unit.spec.ts
@@ -1,3 +1,5 @@
+import { reset } from "@metabase/track";
+
 import Settings from "metabase/utils/settings";
 
 import {
@@ -9,6 +11,11 @@ import {
 const METAPLOW_URL = "https://metaplow.example.com/api/send";
 const METAPLOW_WEBSITE_ID = "23eefa30-4c4f-490e-aa4f-084cd23b1561";
 const ANON_ORIGIN = "http://anonymous.metabase.com";
+
+const setup = async ({ userId }: { userId?: number } = {}) => {
+  initMetaplow({ getUserId: () => userId });
+  await Promise.resolve();
+};
 
 describe("metaplow", () => {
   let fetchSpy: jest.SpyInstance;
@@ -23,6 +30,7 @@ describe("metaplow", () => {
   afterEach(() => {
     fetchSpy.mockRestore();
     Settings.set("metaplow-url", null);
+    reset();
   });
 
   const getSentPayload = () => {
@@ -37,44 +45,29 @@ describe("metaplow", () => {
   };
 
   describe("initMetaplow", () => {
-    describe("beforeSend", () => {
-      afterEach(() => {
-        initMetaplow({ beforeSend: (_type, payload) => payload });
-      });
+    describe("getUserId", () => {
+      it("injects the user_id into the event data", async () => {
+        initMetaplow({ getUserId: () => 123 });
 
-      it("can modify the payload before it's sent", () => {
-        initMetaplow({
-          beforeSend: (_type, payload) => ({
-            ...payload,
-            data: { ...payload.data, user_id: 123 },
-          }),
-        });
-
-        trackMetaplowEvent("button_clicked");
+        await trackMetaplowEvent("button_clicked");
 
         const { payload } = getSentPayload();
         expect(payload.data.user_id).toBe(123);
-      });
-
-      it("suppresses the fetch call when a falsy value is returned", () => {
-        initMetaplow({ beforeSend: () => undefined });
-
-        trackMetaplowEvent("button_clicked");
-
-        expect(fetchSpy).not.toHaveBeenCalled();
       });
     });
   });
 
   describe("trackMetaplowEvent", () => {
-    it("does not call fetch when metaplow-url is not set", () => {
+    it("does not call fetch when metaplow-url is not set", async () => {
       Settings.set("metaplow-url", null);
-      trackMetaplowEvent("button_clicked");
+      await setup();
+      await trackMetaplowEvent("button_clicked");
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
-    it("sends an event with the given name and default empty data", () => {
-      trackMetaplowEvent("button_clicked");
+    it("sends an event with the given name and default empty data", async () => {
+      await setup();
+      await trackMetaplowEvent("button_clicked");
 
       const body = getSentPayload();
       expect(body.type).toBe("event");
@@ -91,15 +84,17 @@ describe("metaplow", () => {
       );
     });
 
-    it("forwards the data payload", () => {
-      trackMetaplowEvent("button_clicked", { foo: "bar", count: 3 });
+    it("forwards the data payload", async () => {
+      await setup();
+      await trackMetaplowEvent("button_clicked", { foo: "bar", count: 3 });
 
       const { payload } = getSentPayload();
       expect(payload.data).toEqual({ foo: "bar", count: 3 });
     });
 
-    it("includes screen and language from the browser", () => {
-      trackMetaplowEvent("button_clicked");
+    it("includes screen and language from the browser", async () => {
+      await setup();
+      await trackMetaplowEvent("button_clicked");
 
       const { payload } = getSentPayload();
       expect(payload.screen).toBe(
@@ -108,8 +103,9 @@ describe("metaplow", () => {
       expect(payload.language).toBe(navigator.language);
     });
 
-    it("uses an anonymized hostname in the url", () => {
-      trackMetaplowEvent("button_clicked");
+    it("uses an anonymized hostname in the url", async () => {
+      await setup();
+      await trackMetaplowEvent("button_clicked");
 
       const { payload } = getSentPayload();
       expect(payload.url.startsWith(ANON_ORIGIN)).toBe(true);
@@ -119,11 +115,13 @@ describe("metaplow", () => {
   describe("trackMetaplowPageView", () => {
     it("does not call fetch when metaplow-url is not set", async () => {
       Settings.set("metaplow-url", null);
+      await setup();
       await trackMetaplowPageView("/question/42-my-question");
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
     it('sends an event with name "pageview"', async () => {
+      await setup();
       await trackMetaplowPageView("/dashboard/1");
 
       const { payload } = getSentPayload();
@@ -132,6 +130,7 @@ describe("metaplow", () => {
     });
 
     it("strips slugs from /:id-slug paths", async () => {
+      await setup();
       await trackMetaplowPageView("/question/42-my-favorite-question");
 
       const { payload } = getSentPayload();
@@ -139,6 +138,7 @@ describe("metaplow", () => {
     });
 
     it("anonymizes absolute URLs by replacing the origin", async () => {
+      await setup();
       await trackMetaplowPageView(
         "https://my-company.metabaseapp.com/collection/5-secrets",
       );
@@ -148,6 +148,7 @@ describe("metaplow", () => {
     });
 
     it("preserves paths without a numeric slug prefix", async () => {
+      await setup();
       await trackMetaplowPageView("/admin/settings/general");
 
       const { payload } = getSentPayload();

--- a/jest.esm-packages.js
+++ b/jest.esm-packages.js
@@ -5,6 +5,7 @@
  * This list is used by both jest.config.js and jest.tz.unit.conf.js
  */
 const esmPackages = [
+  "@metabase\\+track",
   "bail",
   "ccount",
   "character-entities.*",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@mantine/core": "8.3.18",
     "@mantine/dates": "8.3.18",
     "@mantine/hooks": "8.3.18",
+    "@metabase/track": "^1.0.0-alpha.1",
     "@modelcontextprotocol/ext-apps": "^1.3.2",
     "@popperjs/core": "^2.11.8",
     "@react-oauth/google": "^0.11.1",


### PR DESCRIPTION
Closes [GRO-536](https://linear.app/metabase/issue/GRO-536/js-sdk-update-checkout-store-internal-tools-and-metabase-app-to-use)

### Description

Replaces ad hoc metaplow functions with now-live @metabase/track alpha.1 npm package.

### How to verify

I've found a good way to test is to use the mb-track mock server and compare the event logs on master vs this branch.

1. Run `bun mock-server.ts` in the [metabase-track repo](https://github.com/metabase/metabase-track).
2. In this repo, start on `master`.
3. Similar to https://github.com/metabase/metabase/pull/72380, start your instance with MB_METAPLOW_URL but point it at the mock server: e.g. `MB_METAPLOW_URL="http://localhost:9000/send" bun run dev-ee`
4. Mess around with the app to trigger analytics events.
5. Navigate to http://localhost:9000 and grab the json.
6. Switch to this branch, restart the mock server (to clear the event log), and repeat steps 3-5.
7. Compare the before-and-after event logs using something like https://json-diff.com/

There should be effectively no difference between the before and after logs.

ℹ️ Might also be good to send at least one event on this branch using the same env value as production just to make sure that still works: `MB_METAPLOW_URL="https://product-analytics-ingestion.metabase.com/api/send"`

### Demo

**Before-and-after logs: clicking around the app (same data)**
<img width="1024" height="576" alt="Screenshot 2026-06-30 at 10 56 06 AM" src="https://github.com/user-attachments/assets/3623d5cf-21dc-4f3d-a89d-3c6a6cd55ef1" />


**Before-and-after logs: loading an embedded dashboard (same data)**
<img width="2048" height="949" alt="Screenshot 2026-06-30 at 10 45 08 AM" src="https://github.com/user-attachments/assets/374fd761-917b-4162-ac05-a08c0c3eb46b" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [n/a] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated analytics tracking to use the new tracking integration for app and SDK events.
  * Improved pageview and event reporting with cleaner identifier handling and URL sanitization.

* **Bug Fixes**
  * Fixed event initialization so tracking data is set up more consistently before events are sent.
  * Preserved anonymized host and path handling for tracked URLs.

* **Tests**
  * Expanded tracking tests to cover the updated initialization and event payload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->