### PR TITLE
Make openNavigationSidebar self-heal against a pending navbar collapse

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -155,15 +155,32 @@ export function appBar() {
 }
 
 export function openNavigationSidebar() {
-  // The toggle flips the sidebar, so blindly clicking it closes an
-  // already-open sidebar (e.g. right after visiting a dashboard, before it
-  // settles). Only click when it isn't already open so this is idempotent.
+  // Opening the sidebar is racy. The toggle flips the sidebar, so blindly
+  // clicking it closes an already-open one. But a single non-retrying read of
+  // its open state isn't safe either: navigating to a dashboard/question
+  // collapses the navbar, and that collapse can land a beat after the page
+  // content renders. The old code could read a lingering-open navbar, skip the
+  // toggle click, then watch it collapse out from under the assertion below.
+  // Re-check after acting and re-open if it collapsed, so the helper self-heals
+  // regardless of a pending collapse.
+  ensureNavigationSidebarOpen();
+  navigationSidebar().should("be.visible");
+}
+
+function ensureNavigationSidebarOpen(attempt = 0) {
+  const MAX_ATTEMPTS = 5;
   navigationSidebar().then(($nav) => {
     if (!$nav.is(":visible")) {
       appBar().findByTestId("sidebar-toggle").click();
     }
   });
-  navigationSidebar().should("be.visible");
+  // Each Cypress command yields a tick, giving a pending collapse time to
+  // flush; if the navbar closed after our first read, try again.
+  navigationSidebar().then(($nav) => {
+    if (!$nav.is(":visible") && attempt < MAX_ATTEMPTS) {
+      ensureNavigationSidebarOpen(attempt + 1);
+    }
+  });
 }
 
 export function closeNavigationSidebar() {


### PR DESCRIPTION
Resolves DEV-2240

## Summary

Navigating to a dashboard/question collapses the navbar, and that collapse can land a beat after the page content renders. This PR actually hardens the underlying helper which now self-heals.

### Stress-tests

- Throttle ON — https://github.com/metabase/metabase/actions/runs/28262254744 x50 :heavy_check_mark: 
- Throttle OFF — https://github.com/metabase/metabase/actions/runs/28262262430 x50 :heavy_check_mark: 
