### PR TITLE
Fix the flaky "trash" e2e test

### DIFF
--- a/e2e/test/scenarios/collections/trash.cy.spec.js
+++ b/e2e/test/scenarios/collections/trash.cy.spec.js
@@ -757,7 +757,6 @@ describe("scenarios > collections > trash", () => {
       cy.intercept("GET", `/api/dashboard/${dashboard.id}*`).as("getDashboard");
       H.visitDashboard(dashboard.id);
       cy.wait("@getDashboard");
-      H.openNavigationSidebar();
       assertTrashSelectedInNavigationSidebar();
     });
 
@@ -769,7 +768,6 @@ describe("scenarios > collections > trash", () => {
       );
       H.visitQuestion(question.id);
       cy.wait("@getQuestionResult");
-      H.openNavigationSidebar();
       assertTrashSelectedInNavigationSidebar();
     });
   });
@@ -994,6 +992,10 @@ function assertChecked(name, checked = true) {
 }
 
 function assertTrashSelectedInNavigationSidebar() {
+  // Routes like a dashboard or question collapse the navbar, so ensure it's
+  // open before asserting. openNavigationSidebar is idempotent and self-heals
+  // against a pending collapse, so it's safe to call unconditionally here.
+  H.openNavigationSidebar();
   H.navigationSidebar().within(() => {
     cy.findByText("Trash")
       .parents("li")


### PR DESCRIPTION
Resolves DEV-2243

## Summary

Routes like a dashboard or question collapse the navbar, so the assertion needs it open first. Two of the four call sites opened it manually while the other two relied on the route not collapsing it. Fold the `openNavigationSidebar` into the assertion helper so every call site is covered uniformly, and drop the now redundant standalone calls. 

> [!IMPORTANT]
> `openNavigationSidebar` is idempotent and self-heals against a pending collapse, so calling it unconditionally is safe.


### Stress-tests

- Throttle ON — https://github.com/metabase/metabase/actions/runs/28264169783 x50 :heavy_check_mark: 
- Throttle OFF — https://github.com/metabase/metabase/actions/runs/28264175101 x50 :heavy_check_mark: 
