### PR TITLE
Make Snowflake data loaded checks look at row count.

### DIFF
--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -405,20 +405,24 @@
               ^ResultSet rs (sql-jdbc.execute/execute-prepared-statement! driver stmt)]
     (some-> rs resultset-seq first)))
 
-(defn- dataset-rows-ok? [conn {:keys [table-definitions] :as dataset}]
+(defn- dataset-rows-ok?! [conn {:keys [table-definitions] :as dataset}]
   ;; sometimes for unknown reasons we get datasets double- or triple-inserted
   ;; and we have not been able to determine why. if a dataset has too many rows,
   ;; treat it as if it hasn't been loaded and force it to be reloaded.
-  (let [table-names (set (map :table-name table-definitions))
-        db-tables (->> (jdbc/query conn (format "SHOW TABLES IN DATABASE \"%s\""
-                                                (qualified-db-name dataset)))
-                       ;; there are some other tables of unknown source in there
-                       ;; like "g_inspector_ji_f9f65557_e249_4543_ab34_9e"
-                       (filter #(table-names (:name %))))
-        db-row-counts (zipmap (map :name db-tables) (map :rows db-tables))
-        dataset-row-counts (zipmap (map :table-name table-definitions)
-                                   (map (comp count :rows) table-definitions))]
-    (= db-row-counts dataset-row-counts)))
+  (with-open [^PreparedStatement stmt (sql-jdbc.execute/prepared-statement
+                                       :snowflake conn
+                                       (format "SHOW TABLES IN DATABASE \"%s\""
+                                               (qualified-db-name dataset)) [])
+              ^ResultSet rs (sql-jdbc.execute/execute-prepared-statement! :snowflake stmt)]
+    (let [table-names (set (map :table-name table-definitions))
+          db-tables (->> (resultset-seq rs)
+                         ;; there are some other tables of unknown source in there
+                         ;; like "g_inspector_ji_f9f65557_e249_4543_ab34_9e"
+                         (filter #(table-names (:name %))))
+          db-row-counts (zipmap (map :name db-tables) (map :rows db-tables))
+          dataset-row-counts (zipmap (map :table-name table-definitions)
+                                     (map (comp count :rows) table-definitions))]
+      (= db-row-counts dataset-row-counts))))
 
 (defmethod tx/dataset-already-loaded? :snowflake
   [driver db-def]
@@ -432,7 +436,7 @@
      (and
       (dataset-tracked?! conn driver db-def)
       (database-exists?! conn driver db-def)
-      (dataset-rows-ok? conn db-def)))))
+      (dataset-rows-ok?! conn db-def)))))
 
 (defmethod tx/track-dataset :snowflake
   [driver db-def]

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -92,7 +92,7 @@
 (defmethod sql.tx/create-db-sql :snowflake
   [driver dbdef]
   (let [db (sql.tx/qualify-and-quote driver (qualified-db-name dbdef))]
-    (format "CREATE DATABASE IF NOT EXISTS %s;" db)))
+    (format "DROP DATABASE IF EXISTS %s; CREATE DATABASE %s;" db db)))
 
 (defn- no-db-connection-spec
   "Connection spec for connecting to our Snowflake instance without specifying a DB."
@@ -333,6 +333,8 @@
 
 (defmethod tx/destroy-db! :snowflake
   [_driver dbdef]
+  (when (= "test-data" (:database-name dbdef))
+    (throw (Exception. "tried to delete test-data dataset.")))
   (let [database-name (qualified-db-name dbdef)
         sql           (format "DROP DATABASE \"%s\";" database-name)]
     (log/infof "[Snowflake] %s" sql)
@@ -403,6 +405,21 @@
               ^ResultSet rs (sql-jdbc.execute/execute-prepared-statement! driver stmt)]
     (some-> rs resultset-seq first)))
 
+(defn- dataset-rows-ok? [conn {:keys [table-definitions] :as dataset}]
+  ;; sometimes for unknown reasons we get datasets double- or triple-inserted
+  ;; and we have not been able to determine why. if a dataset has too many rows,
+  ;; treat it as if it hasn't been loaded and force it to be reloaded.
+  (let [table-names (set (map :table-name table-definitions))
+        db-tables (->> (jdbc/query conn (format "SHOW TABLES IN DATABASE \"%s\""
+                                                (qualified-db-name dataset)))
+                       ;; there are some other tables of unknown source in there
+                       ;; like "g_inspector_ji_f9f65557_e249_4543_ab34_9e"
+                       (filter #(table-names (:name %))))
+        db-row-counts (zipmap (map :name db-tables) (map :rows db-tables))
+        dataset-row-counts (zipmap (map :table-name table-definitions)
+                                   (map (comp count :rows) table-definitions))]
+    (= db-row-counts dataset-row-counts)))
+
 (defmethod tx/dataset-already-loaded? :snowflake
   [driver db-def]
   ;; check and see if ANY tables are loaded for the current catalog
@@ -414,7 +431,8 @@
      (setup-tracking-db! conn driver)
      (and
       (dataset-tracked?! conn driver db-def)
-      (database-exists?! conn driver db-def)))))
+      (database-exists?! conn driver db-def)
+      (dataset-rows-ok? conn db-def)))))
 
 (defmethod tx/track-dataset :snowflake
   [driver db-def]

--- a/test/metabase/lib_be/metadata/jvm_test.clj
+++ b/test/metabase/lib_be/metadata/jvm_test.clj
@@ -299,7 +299,7 @@
       (is (not (:field-ref metadata))
           "Legacy keys like :field_ref/:field-ref should have been removed"))))
 
-(deftest ^:parallel database-local-settings-test
+(deftest database-local-settings-test
   (testing "JVM metadata provider should return database-local Settings"
     (let [global-value (setting/get :unaggregated-query-row-limit)
           local-value  (inc (or global-value 0))]


### PR DESCRIPTION
We have some unidentified process that destroys the test-data dataset and causes failures such as this:

https://github.com/metabase/metabase/actions/runs/28206004397/job/83561786972#step:5:381

Sometimes the database exists but the tables have double or triple the expected number of rows.

First change: refuse to destroy the test-data database. This should just never happen. If this ends up throwing, it should allow us to identify where the deletions are coming from. (Unless the culprit is someone calling DROP DATABASE directly.) Of course, we really should be blocking *all* deletions of static datasets, but this is by far the most commonly-used, and we don't have a good predicate for identifying static datasets anyway.

Second change: don't consider a dataset loaded if it's been double-loaded or triple-loaded. Previously we would just look at whether the dataset's database existed and ignore the tables inside it, but now we'll be able to see when it's been double-loaded and treat this the same as if it had not been created at all.

Third change: when creating a database, ensure it gets dropped first before creating. Without this, the previous change would just cause the datasets to get loaded increasingly many times. This actually reverts a change made previously in #74464, but we have a lot more data now about what's happening, and making create-db into a no-op when it already exists has turned out to be counterproductive because of the double-loading issue.

Fourth change: [unrelated] mark database-local-settings-test as no longer parallel. This fails in CI sometimes with `clojure.lang.ExceptionInfo: Error rolling back after previous error: (conn=362) Deadlock found when trying to get lock; try restarting transaction` indicating it is better off not run in parallel.