### PR TITLE
Fix flaky usage-auditing e2e: anchor seed today in instance timezone

### DIFF
--- a/src/metabase/testing_api/api.clj
+++ b/src/metabase/testing_api/api.clj
@@ -366,14 +366,20 @@
   ([user-id second-user-id]
    (seed-usage-auditing-data! user-id second-user-id nil nil))
   ([user-id second-user-id tenant-id second-tenant-id]
-   ;; Anchor "today" at noon UTC, not the current instant. The seeded "today"
-   ;; conversations are timestamped a few minutes/hours before this reference;
-   ;; with a wall-clock instant they slip into the previous UTC day when the
-   ;; test runs shortly after midnight. That desyncs them from the reported
-   ;; :date (the UTC calendar day) and makes the "Conversations by day" chart's
-   ;; last dot drill to the wrong day. Noon keeps every "today" event firmly
-   ;; inside the current UTC day regardless of run time.
-   (let [today          (-> (t/offset-date-time (t/zone-offset "+00"))
+   ;; Anchor "today" at noon in the instance's own timezone (the JVM default
+   ;; zone), not UTC. The charts resolve relative date filters (past7days~,
+   ;; Yesterday, the per-day buckets) through the query processor, which falls
+   ;; back to the system timezone when no report/database timezone is set, so the
+   ;; app's notion of "today" follows the JVM zone. Anchoring the seed in UTC
+   ;; desyncs the two whenever that zone is behind UTC: e2e CI runs the instance
+   ;; (and browser) in US/Pacific, so a UTC-noon "today" lands on the app's
+   ;; *next* calendar day for ~7-8 hours after UTC midnight. That dropped the
+   ;; seeded "today" rows out of the window and made the "Conversations by day"
+   ;; drill report the wrong date. Noon in the JVM zone keeps every "today" event
+   ;; firmly inside the app's current day regardless of run time. Truncating to
+   ;; days and adding 12h (rather than a wall-clock instant) also keeps the
+   ;; neighbouring days clear of their own midnight boundaries.
+   (let [today          (-> (t/zoned-date-time)
                             (t/truncate-to :days)
                             (t/plus (t/hours 12)))
          yesterday      (t/minus today (t/days 1))


### PR DESCRIPTION
## Problem

`e2e/test/scenarios/metabot/usage-auditing.cy.spec.ts` is flaky on `master` (seen in CI for #76409, where it failed unrelated to that PR's changes). Five tests fail together for a ~7-8 hour window after UTC midnight, e.g.:

- `expected '?date=2026-06-28' to include 'date=2026-06-29'` (conversations-by-day drill)
- `Unable to find an element with the text: Slackbot` (tenant list / tenant drill / per-profile details)
- `Expected not to find content: 'Embedding' ... but continuously found it` (Yesterday filter)

## Root cause

The seed endpoint (`/api/testing/metabot/seed-usage-auditing`) anchored "today" at **noon UTC**. The usage-stats charts resolve their relative date filters (`past7days~`, `Yesterday`, the per-day buckets, and the drill dates) through the query processor, which falls back to the **system timezone** when no report/database timezone is set.

e2e CI runs the instance and the browser in **US/Pacific** (`TZ: US/Pacific` in `e2e-test.yml`, "to make Node match the instance tz"). When CI runs shortly after UTC midnight (e.g. 02:30 UTC = 19:30 PDT the previous day), the app's "today" is still the previous calendar day while the seed's UTC-noon "today" lands on the app's *next* day. The seeded "today" rows fall outside the chart window and the day-chart drill reports the wrong date.

## Fix

Anchor the seed's "today" at noon in the **JVM default timezone** (`t/zoned-date-time` instead of `t/offset-date-time` at `+00`), so the seed and the query processor agree on which calendar day is "today" regardless of run time. Noon keeps every seeded event clear of its own day's midnight boundaries.

One-line change plus an updated comment explaining the timezone coupling.

[Stress test](https://github.com/metabase/metabase/actions/runs/28361056055)