### PR TITLE
Fix for docs link

### DIFF
--- a/docs/questions/native-editor/writing-sql.md
+++ b/docs/questions/native-editor/writing-sql.md
@@ -138,4 +138,4 @@ See [Caching question policies](../../configuring-metabase/caching.md#question-c
 [sql-gloss]: https://www.metabase.com/glossary/sql
 [troubleshooting-sql]: ../../troubleshooting-guide/sql.md
 [variable-gloss]: https://www.metabase.com/glossary/variable
-[drill-through]: https://www.metabase.com/docs/questions/visualizations/drill-through
+[drill-through]: https://www.metabase.com/docs/latest/questions/visualizations/drill-through


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GRO-594/docs-link-is-missing-latest.

### Description

CI exits on this link in synced product docs (not your CDN code): _site/docs/latest/questions/native-editor/writing-sql.html as /docs/questions/visualizations/drill-through (does not exist).

The page only exists at [/docs/latest/questions/visualizations/drill-through](https://www.metabase.com/docs/latest/questions/visualizations/drill-through).

### How to verify

Describe the steps to verify that the changes are working as expected.

1. The docs will automatically sync with the [docs repo](https://github.com/metabase/docs.metabase.github.io)
2. The build will go through on the [site repo](https://github.com/metabase/metabase.github.io/actions)
