### PR TITLE
Invalidate transform indexes when target or output schema changes

### DIFF
--- a/src/metabase/indexes/models/table_index.clj
+++ b/src/metabase/indexes/models/table_index.clj
@@ -165,11 +165,10 @@
   re-applies them against the current schema. Skips `:delete-pending` rows so a pending deletion isn't revived."
   [transform-id]
   (when transform-id
-    (let [ids (map :id (select-applicable-for-transform transform-id))]
-      (when (seq ids)
-        (t2/update! :model/TableIndex
-                    {:id [:in ids]}
-                    {:status :update-pending, :error_message nil})))))
+    (when-let [ids (seq (map :id (select-applicable-for-transform transform-id)))]
+      (t2/update! :model/TableIndex
+                  {:id [:in ids]}
+                  {:status :update-pending, :error_message nil}))))
 
 (defn exists-for-transform?
   "True when `transform-id` already has a request for `index-name`."

--- a/src/metabase/indexes/models/table_index.clj
+++ b/src/metabase/indexes/models/table_index.clj
@@ -161,10 +161,8 @@
                  :last_executed_at :%now})))
 
 (defn mark-for-revalidation!
-  "Flip every still-applicable index request for `transform-id` to `:update-pending` and clear stale errors, so a
-  changed target table or output schema gets re-applied and re-validated on the next run. A pending row already forces
-  a full rebuild (see [[metabase.transforms-base.util/full-incremental-run?]]), where an index whose column is gone
-  fails the run. Leaves `:delete-pending` rows alone, so a user's pending deletion isn't revived."
+  "Flip `transform-id`'s applicable index requests to `:update-pending` and clear stale errors, so the next run
+  re-applies them against the current schema. Skips `:delete-pending` rows so a pending deletion isn't revived."
   [transform-id]
   (when transform-id
     (let [ids (map :id (select-applicable-for-transform transform-id))]

--- a/src/metabase/indexes/models/table_index.clj
+++ b/src/metabase/indexes/models/table_index.clj
@@ -160,6 +160,18 @@
                  :error_message    message
                  :last_executed_at :%now})))
 
+(defn invalidate-for-transform!
+  "Flip every still-applicable index request for `transform-id` to `:delete-pending`, so a changed target table or
+  output schema can't apply a stale definition (its columns may no longer exist). The next full rebuild drops the
+  indexes and clears the rows. Updates by id, so it doesn't disturb the transform's incremental checkpoint."
+  [transform-id]
+  (when transform-id
+    (let [ids (map :id (select-applicable-for-transform transform-id))]
+      (when (seq ids)
+        (t2/update! :model/TableIndex
+                    {:id [:in ids]}
+                    {:status :delete-pending, :error_message nil})))))
+
 (defn exists-for-transform?
   "True when `transform-id` already has a request for `index-name`."
   [transform-id index-name]

--- a/src/metabase/indexes/models/table_index.clj
+++ b/src/metabase/indexes/models/table_index.clj
@@ -160,17 +160,18 @@
                  :error_message    message
                  :last_executed_at :%now})))
 
-(defn invalidate-for-transform!
-  "Flip every still-applicable index request for `transform-id` to `:delete-pending`, so a changed target table or
-  output schema can't apply a stale definition (its columns may no longer exist). The next full rebuild drops the
-  indexes and clears the rows. Updates by id, so it doesn't disturb the transform's incremental checkpoint."
+(defn mark-for-revalidation!
+  "Flip every still-applicable index request for `transform-id` to `:update-pending` and clear stale errors, so a
+  changed target table or output schema gets re-applied and re-validated on the next run. A pending row already forces
+  a full rebuild (see [[metabase.transforms-base.util/full-incremental-run?]]), where an index whose column is gone
+  fails the run. Leaves `:delete-pending` rows alone, so a user's pending deletion isn't revived."
   [transform-id]
   (when transform-id
     (let [ids (map :id (select-applicable-for-transform transform-id))]
       (when (seq ids)
         (t2/update! :model/TableIndex
                     {:id [:in ids]}
-                    {:status :delete-pending, :error_message nil})))))
+                    {:status :update-pending, :error_message nil})))))
 
 (defn exists-for-transform?
   "True when `transform-id` already has a request for `index-name`."

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -157,9 +157,8 @@
                           ;; No database existence check added here, unlike for insert.
                           ;; Just allow updates for an invalid target to fail.
                           (transforms-base.i/target-db-id transform))]
-    ;; A retarget or query edit can change the output columns. Mark the managed indexes for revalidation so the next
-    ;; run re-applies them against the new schema (and fails loudly if a column is gone) instead of silently keeping a
-    ;; stale definition.
+    ;; A source or target edit may change the output columns, and we can't cheaply tell, so invalidate conservatively:
+    ;; the next run re-applies the managed indexes against the new schema and fails if a column is gone.
     (when (and target-changed? (not mi/*deserializing?*))
       (table-index/mark-for-revalidation! (:id transform)))
     (cond-> transform

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -157,10 +157,11 @@
                           ;; No database existence check added here, unlike for insert.
                           ;; Just allow updates for an invalid target to fail.
                           (transforms-base.i/target-db-id transform))]
-    ;; A retarget or query edit can change the output columns, leaving managed indexes pointing at columns that no
-    ;; longer exist. Drop them so a stale definition isn't applied on the next run.
+    ;; A retarget or query edit can change the output columns. Mark the managed indexes for revalidation so the next
+    ;; run re-applies them against the new schema (and fails loudly if a column is gone) instead of silently keeping a
+    ;; stale definition.
     (when (and target-changed? (not mi/*deserializing?*))
-      (table-index/invalidate-for-transform! (:id transform)))
+      (table-index/mark-for-revalidation! (:id transform)))
     (cond-> transform
       source
       (assoc :source_type (transforms-base.u/transform-source-type source)

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -157,6 +157,10 @@
                           ;; No database existence check added here, unlike for insert.
                           ;; Just allow updates for an invalid target to fail.
                           (transforms-base.i/target-db-id transform))]
+    ;; A retarget or query edit can change the output columns, leaving managed indexes pointing at columns that no
+    ;; longer exist. Drop them so a stale definition isn't applied on the next run.
+    (when (and target-changed? (not mi/*deserializing?*))
+      (table-index/invalidate-for-transform! (:id transform)))
     (cond-> transform
       source
       (assoc :source_type (transforms-base.u/transform-source-type source)

--- a/test/metabase/indexes/models/table_index_test.clj
+++ b/test/metabase/indexes/models/table_index_test.clj
@@ -89,8 +89,8 @@
       (is (= :failed (t2/select-one-fn :status :model/TableIndex running-id)))
       (is (= "not verified" (t2/select-one-fn :error_message :model/TableIndex update-id))))))
 
-(deftest invalidate-for-transform-test
-  (testing "every applicable request is flipped to :delete-pending, clearing stale errors; delete-pending rows untouched"
+(deftest mark-for-revalidation-test
+  (testing "every applicable request is flipped to :update-pending, clearing stale errors; delete-pending rows untouched"
     (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)
                    :model/TableIndex {create-id :id} {:transform_id transform-id
                                                       :index_name   "create_idx"
@@ -112,14 +112,14 @@
                                                        :status       :delete-pending
                                                        :structured   {:kind :btree :name "deleted_idx"
                                                                       :columns [{:name "d"}]}}]
-      (table-index/invalidate-for-transform! transform-id)
-      (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex create-id)))
-      (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex succeeded-id)))
-      (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex failed-id)))
+      (table-index/mark-for-revalidation! transform-id)
+      (is (= :update-pending (t2/select-one-fn :status :model/TableIndex create-id)))
+      (is (= :update-pending (t2/select-one-fn :status :model/TableIndex succeeded-id)))
+      (is (= :update-pending (t2/select-one-fn :status :model/TableIndex failed-id)))
       (is (nil? (t2/select-one-fn :error_message :model/TableIndex failed-id)) "stale error cleared")
-      (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex deleted-id)))))
+      (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex deleted-id)) "pending deletion not revived")))
   (testing "a nil transform-id is a no-op"
-    (is (nil? (table-index/invalidate-for-transform! nil)))))
+    (is (nil? (table-index/mark-for-revalidation! nil)))))
 
 (deftest select-for-verification-test
   (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)

--- a/test/metabase/indexes/models/table_index_test.clj
+++ b/test/metabase/indexes/models/table_index_test.clj
@@ -89,6 +89,38 @@
       (is (= :failed (t2/select-one-fn :status :model/TableIndex running-id)))
       (is (= "not verified" (t2/select-one-fn :error_message :model/TableIndex update-id))))))
 
+(deftest invalidate-for-transform-test
+  (testing "every applicable request is flipped to :delete-pending, clearing stale errors; delete-pending rows untouched"
+    (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)
+                   :model/TableIndex {create-id :id} {:transform_id transform-id
+                                                      :index_name   "create_idx"
+                                                      :structured   {:kind :btree :name "create_idx"
+                                                                     :columns [{:name "a"}]}}
+                   :model/TableIndex {succeeded-id :id} {:transform_id transform-id
+                                                         :index_name   "succeeded_idx"
+                                                         :status       :succeeded
+                                                         :structured   {:kind :btree :name "succeeded_idx"
+                                                                        :columns [{:name "b"}]}}
+                   :model/TableIndex {failed-id :id} {:transform_id transform-id
+                                                      :index_name   "failed_idx"
+                                                      :status       :failed
+                                                      :error_message "old failure"
+                                                      :structured   {:kind :btree :name "failed_idx"
+                                                                     :columns [{:name "c"}]}}
+                   :model/TableIndex {deleted-id :id} {:transform_id transform-id
+                                                       :index_name   "deleted_idx"
+                                                       :status       :delete-pending
+                                                       :structured   {:kind :btree :name "deleted_idx"
+                                                                      :columns [{:name "d"}]}}]
+      (table-index/invalidate-for-transform! transform-id)
+      (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex create-id)))
+      (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex succeeded-id)))
+      (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex failed-id)))
+      (is (nil? (t2/select-one-fn :error_message :model/TableIndex failed-id)) "stale error cleared")
+      (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex deleted-id)))))
+  (testing "a nil transform-id is a no-op"
+    (is (nil? (table-index/invalidate-for-transform! nil)))))
+
 (deftest select-for-verification-test
   (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)
                  :model/TableIndex {running-id :id} {:transform_id transform-id

--- a/test/metabase/transforms/models/transform_test.clj
+++ b/test/metabase/transforms/models/transform_test.clj
@@ -62,19 +62,19 @@
                   :structured   {:kind :btree :name "by_cat" :columns [{:name "category"}]}}]
     (thunk transform-id index-id)))
 
-(deftest invalidate-indexes-on-schema-change-test
-  (testing "editing the source query (output schema may change) drops the transform's managed indexes"
+(deftest revalidate-indexes-on-schema-change-test
+  (testing "editing the source query (output schema may change) marks the transform's managed indexes for revalidation"
     (temp-transform-with-index!
      (fn [transform-id index-id]
        (t2/update! :model/Transform transform-id
                    {:source {:type "query" :query (query-test-util/make-query :source-table "checkins")}})
-       (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex index-id))))))
-  (testing "retargeting to a different table drops the transform's managed indexes"
+       (is (= :update-pending (t2/select-one-fn :status :model/TableIndex index-id))))))
+  (testing "retargeting to a different table marks the transform's managed indexes for revalidation"
     (temp-transform-with-index!
      (fn [transform-id index-id]
        (t2/update! :model/Transform transform-id
                    {:target {:database (mt/id) :type "table" :schema "public" :name (mt/random-name)}})
-       (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex index-id))))))
+       (is (= :update-pending (t2/select-one-fn :status :model/TableIndex index-id))))))
   (testing "an unrelated edit (renaming the transform) leaves the indexes alone"
     (temp-transform-with-index!
      (fn [transform-id index-id]

--- a/test/metabase/transforms/models/transform_test.clj
+++ b/test/metabase/transforms/models/transform_test.clj
@@ -5,6 +5,7 @@
    [metabase.models.interface :as mi]
    [metabase.test :as mt]
    [metabase.transforms-base.query :as transforms-base.query]
+   [metabase.transforms.query-test-util :as query-test-util]
    [toucan2.core :as t2]))
 
 (deftest source-database-id-set-test
@@ -48,6 +49,37 @@
       (is (nil? (t2/select-one-fn :source_database_id :model/Transform (:id transform))))
       ;; transform itself still exists
       (is (some? (t2/select-one :model/Transform (:id transform)))))))
+
+(defn- temp-transform-with-index! [thunk]
+  (mt/with-temp [:model/Transform {transform-id :id}
+                 {:name   (mt/random-name)
+                  :source {:type "query" :query (query-test-util/make-query :source-table "venues")}
+                  :target {:database (mt/id) :type "table" :schema "public" :name (mt/random-name)}}
+                 :model/TableIndex {index-id :id}
+                 {:transform_id transform-id
+                  :index_name   "by_cat"
+                  :status       :succeeded
+                  :structured   {:kind :btree :name "by_cat" :columns [{:name "category"}]}}]
+    (thunk transform-id index-id)))
+
+(deftest invalidate-indexes-on-schema-change-test
+  (testing "editing the source query (output schema may change) drops the transform's managed indexes"
+    (temp-transform-with-index!
+     (fn [transform-id index-id]
+       (t2/update! :model/Transform transform-id
+                   {:source {:type "query" :query (query-test-util/make-query :source-table "checkins")}})
+       (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex index-id))))))
+  (testing "retargeting to a different table drops the transform's managed indexes"
+    (temp-transform-with-index!
+     (fn [transform-id index-id]
+       (t2/update! :model/Transform transform-id
+                   {:target {:database (mt/id) :type "table" :schema "public" :name (mt/random-name)}})
+       (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex index-id))))))
+  (testing "an unrelated edit (renaming the transform) leaves the indexes alone"
+    (temp-transform-with-index!
+     (fn [transform-id index-id]
+       (t2/update! :model/Transform transform-id {:name "renamed"})
+       (is (= :succeeded (t2/select-one-fn :status :model/TableIndex index-id)))))))
 
 (deftest can-read-write-on-orphaned-transform-test
   (testing "superusers can read/write a transform whose source database has been deleted, data analysts cannot"


### PR DESCRIPTION

Closes https://linear.app/metabase/issue/GDGT-2641/invalidate-transform-indexes-when-the-target-schema-changes
