### PR TITLE
Add tables and snippets to useSetCollection

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/components/TableHeader/TableMoreMenu/TableMoreMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/components/TableHeader/TableMoreMenu/TableMoreMenu.tsx
@@ -2,9 +2,10 @@ import { useState } from "react";
 import { push } from "react-router-redux";
 import { c, t } from "ttag";
 
-import { collectionApi, useUpdateTableMutation } from "metabase/api";
+import { collectionApi } from "metabase/api";
 import { ForwardRefLink } from "metabase/common/components/Link";
 import { CollectionPickerModal } from "metabase/common/components/Pickers";
+import { useSetCollection } from "metabase/common/hooks/use-set-collection";
 import { PLUGIN_LIBRARY, PLUGIN_REMOTE_SYNC } from "metabase/plugins";
 import { useDispatch, useSelector } from "metabase/redux";
 import { ActionIcon, Box, FixedSizeIcon, Icon, Menu } from "metabase/ui";
@@ -23,7 +24,7 @@ export type TableMoreMenuProps = {
 export function TableMoreMenu({ table, onMoved }: TableMoreMenuProps) {
   const dispatch = useDispatch();
   const [modalType, setModalType] = useState<TableModalType>();
-  const [updateTable] = useUpdateTableMutation();
+  const setCollection = useSetCollection();
   const remoteSyncReadOnly = useSelector(
     PLUGIN_REMOTE_SYNC.getIsRemoteSyncReadOnly,
   );
@@ -37,10 +38,11 @@ export function TableMoreMenu({ table, onMoved }: TableMoreMenuProps) {
 
   const handleMove = async (newCollection: { id: CollectionId }) => {
     const sourceCollectionId = table.collection_id;
-    await updateTable({
-      id: table.id,
-      collection_id: newCollection.id,
-    }).unwrap();
+    await setCollection(
+      { model: "table", id: table.id },
+      { id: newCollection.id },
+      { notify: false },
+    );
     dispatch(
       collectionApi.util.invalidateTags([
         { type: "collection", id: `${sourceCollectionId}-items` },

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/MoveSnippetModal/MoveSnippetModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/MoveSnippetModal/MoveSnippetModal.tsx
@@ -1,41 +1,41 @@
 import { useState } from "react";
 import { t } from "ttag";
 
-import { useUpdateSnippetMutation } from "metabase/api";
 import { getErrorMessage } from "metabase/api/utils";
 import { useToast } from "metabase/common/hooks";
+import { useSetCollection } from "metabase/common/hooks/use-set-collection";
 import type { MoveSnippetModalProps } from "metabase/plugins";
 import type { CollectionId } from "metabase-types/api";
 
 import { SnippetCollectionPickerModal } from "../SnippetCollectionPickerModal";
 
 export function MoveSnippetModal({ snippet, onClose }: MoveSnippetModalProps) {
-  const [updateSnippet] = useUpdateSnippetMutation();
+  const setCollection = useSetCollection();
   const [sendToast] = useToast();
   const [isMoving, setIsMoving] = useState(false);
 
   const handleMove = async (collectionId: CollectionId | null) => {
     setIsMoving(true);
 
-    const { error } = await updateSnippet({
-      id: snippet.id,
-      collection_id: collectionId,
-    });
-
-    if (error) {
-      sendToast({
-        message: getErrorMessage(error, t`Failed to move snippet`),
-        icon: "warning",
-      });
-    } else {
+    try {
+      await setCollection(
+        { model: "snippet", id: snippet.id },
+        { id: collectionId ?? "root" },
+        { notify: false },
+      );
       sendToast({
         message: t`Snippet moved`,
         icon: "check",
       });
       onClose();
+    } catch (error) {
+      sendToast({
+        message: getErrorMessage(error, t`Failed to move snippet`),
+        icon: "warning",
+      });
+    } finally {
+      setIsMoving(false);
     }
-
-    setIsMoving(false);
   };
 
   return (

--- a/frontend/src/metabase/common/hooks/use-set-collection.ts
+++ b/frontend/src/metabase/common/hooks/use-set-collection.ts
@@ -8,11 +8,15 @@ import {
   collectionApi,
   dashboardApi,
   documentApi,
+  snippetApi,
+  tableApi,
   timelineApi,
   useUpdateCardMutation,
   useUpdateCollectionMutation,
   useUpdateDashboardMutation,
   useUpdateDocumentMutation,
+  useUpdateSnippetMutation,
+  useUpdateTableMutation,
   useUpdateTimelineMutation,
 } from "metabase/api";
 import {
@@ -32,6 +36,8 @@ import type {
   Dashboard,
   DashboardId,
   Document,
+  NativeQuerySnippet,
+  Table,
   Timeline,
 } from "metabase-types/api";
 
@@ -51,7 +57,9 @@ export type MovableItem =
   | Movable<"dashboard", Dashboard>
   | Movable<"collection", Collection>
   | Movable<"snippet-collection", Collection>
+  | Movable<"snippet", NativeQuerySnippet>
   | Movable<"document", Document>
+  | Movable<"table", Table>
   | Movable<"timeline", Timeline, "name">;
 
 export type MovableModel = MovableItem["model"];
@@ -63,7 +71,9 @@ const MOVABLE_MODELS = new Set<MovableModel>([
   "dashboard",
   "collection",
   "snippet-collection",
+  "snippet",
   "document",
+  "table",
   "timeline",
 ]);
 
@@ -85,7 +95,9 @@ const LABELS = {
   dashboard: () => t`dashboard`,
   collection: () => t`collection`,
   "snippet-collection": () => t`folder`,
+  snippet: () => t`snippet`,
   document: () => t`document`,
+  table: () => t`table`,
   timeline: () => t`timeline`,
 } as const satisfies Record<MovableModel, () => string>;
 
@@ -107,6 +119,8 @@ export function useSetCollection() {
   const [updateDashboard] = useUpdateDashboardMutation();
   const [updateCollection] = useUpdateCollectionMutation();
   const [updateDocument] = useUpdateDocumentMutation();
+  const [updateSnippet] = useUpdateSnippetMutation();
+  const [updateTable] = useUpdateTableMutation();
   const [updateTimeline] = useUpdateTimelineMutation();
 
   const setCollection = useCallback(
@@ -174,6 +188,28 @@ export function useSetCollection() {
             parent_id: canonicalCollectionId(destination.id),
           }).unwrap();
         })
+        .with({ model: "snippet" }, ({ id }) => {
+          if (!isCollectionDestination(destination)) {
+            throw new Error("Cannot move a snippet into a dashboard");
+          }
+          return updateSnippet({
+            id,
+            collection_id: canonicalCollectionId(destination.id),
+            archived,
+          }).unwrap();
+        })
+        .with({ model: "table" }, ({ id }) => {
+          if (!isCollectionDestination(destination)) {
+            throw new Error("Cannot move a table into a dashboard");
+          }
+          if (archived) {
+            throw new Error("Cannot move a table to the trash");
+          }
+          return updateTable({
+            id,
+            collection_id: canonicalCollectionId(destination.id),
+          }).unwrap();
+        })
         .with({ model: "timeline" }, ({ id, name }) => {
           if (!isCollectionDestination(destination)) {
             throw new Error("Cannot move a timeline into a dashboard");
@@ -192,6 +228,8 @@ export function useSetCollection() {
       updateDashboard,
       updateCollection,
       updateDocument,
+      updateSnippet,
+      updateTable,
       updateTimeline,
     ],
   );
@@ -253,6 +291,27 @@ export function useSetCollection() {
               });
           },
         )
+        .with({ model: "snippet" }, async ({ id }) => {
+          const snippet = await dispatch(
+            snippetApi.endpoints.getSnippet.initiate(id),
+          ).unwrap();
+          return () =>
+            updateSnippet({
+              id,
+              collection_id: snippet.collection_id,
+              archived: snippet.archived,
+            });
+        })
+        .with({ model: "table" }, async ({ id }) => {
+          const table = await dispatch(
+            tableApi.endpoints.getTable.initiate({ id }),
+          ).unwrap();
+          return () =>
+            updateTable({
+              id,
+              collection_id: table.collection_id,
+            });
+        })
         .with({ model: "timeline" }, async ({ id }) => {
           const timeline = await dispatch(
             timelineApi.endpoints.getTimeline.initiate({ id }),
@@ -272,6 +331,8 @@ export function useSetCollection() {
       updateDashboard,
       updateCollection,
       updateDocument,
+      updateSnippet,
+      updateTable,
       updateTimeline,
     ],
   );

--- a/frontend/src/metabase/common/hooks/use-set-collection.ts
+++ b/frontend/src/metabase/common/hooks/use-set-collection.ts
@@ -73,7 +73,6 @@ const MOVABLE_MODELS = new Set<MovableModel>([
   "snippet-collection",
   "snippet",
   "document",
-  "table",
   "timeline",
 ]);
 


### PR DESCRIPTION
### Description

Adds Tables and Snippets to the useSetCollection hook. Main motivation is so that we can easily support bulk moving in the library without duplicating a bunch of what is already here, but realistically these things belong (or can exist inside) collections, so it makes sense to add them.

One part that I want the reviewer to think about: Tables in collections, and being able to move snippets into anything other than a default collection, are both enterprise features. I don't *think* we need to gate this functionality behind the plugin system. As far as I can tell, In the API Today: 

- Tables have no EE gating at all when setting a collection, but if you were to use the API to set a collection_id on a table I don't think it would have an impact on the app, but in OSS we don't actually have a `{:type "library-data"}` check, which is awkward
- Snippets are effectively gated through snippet permissions. so the BE wouldn't let you move them anyways

If we want to though, we could update this to go through the Plugin system as well. In theory, only enterprise code should be attempting the above, but guard rails may be the safer approach.

### How to verify

Shouldn't be a change to the app, aside from moving tables now generating an undo toast

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
