### PR TITLE
Use report timezone if breakout field has datetime effective type

### DIFF
--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
@@ -69,13 +69,16 @@
 (defn- in-report-timezone
   [expr]
   (let [report-timezone (get-report-timezone-id-safely)
-        lower           (u/lower-case-en (h2x/database-type expr))
-        db-type         (remove-low-cardinality-and-nullable lower)]
-    (if (and report-timezone (string? db-type) (str/starts-with? db-type "datetime"))
-      (let [timezone (extract-datetime-timezone db-type)]
-        (if (not (= timezone (u/lower-case-en report-timezone)))
-          [:'toTimeZone expr (h2x/literal report-timezone)]
-          expr))
+        db-type (-> (h2x/database-type expr)
+                    remove-low-cardinality-and-nullable)
+        report-tz-db-tz-differ (and (string? db-type)
+                                    (str/starts-with? db-type "datetime")
+                                    (not= (extract-datetime-timezone db-type)
+                                          (u/lower-case-en report-timezone)))
+        no-db-type-dt-eff-type (and (not db-type)
+                                    (isa? (h2x/effective-type expr) :type/DateTime))]
+    (if (and report-timezone (or report-tz-db-tz-differ no-db-type-dt-eff-type))
+      [:'toTimeZone expr (h2x/literal report-timezone)]
       expr)))
 
 (defmethod sql.qp/date [:clickhouse :default]
@@ -429,7 +432,9 @@
 
 (defmethod sql.qp/add-interval-honeysql-form :clickhouse
   [_ dt amount unit]
-  (h2x/+ dt [:raw (format "INTERVAL %d %s" (int amount) (name unit))]))
+  (let [type-info (h2x/type-info dt)]
+    (cond-> (h2x/+ dt [:raw (format "INTERVAL %d %s" (int amount) (name unit))])
+      type-info (h2x/with-type-info type-info))))
 
 (defn- clickhouse-string-fn
   [fn-name field value options]

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_temporal_bucketing_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_temporal_bucketing_test.clj
@@ -3,6 +3,10 @@
                                                             metabase.test.data/run-mbql-query {:namespaces [metabase.driver.clickhouse-temporal-bucketing-test]}}}}}}
   (:require
    [clojure.test :refer :all]
+   [medley.core :as m]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.query-processor.core :as qp]
    [metabase.test :as mt]))
 
 (mt/defdataset temporal_bucketing_db
@@ -177,3 +181,36 @@
                  (mid-year! :quarter-of-year)))
           (is (= [[4]]
                  (end-of-year! :quarter-of-year))))))))
+
+(deftest clickhouse-uses-report-timezone-bucketing-source-query-test
+  (mt/test-driver :clickhouse
+    (mt/with-report-timezone-id! "Europe/London"
+      (let [mp           (mt/metadata-provider)]
+        (mt/with-temp [:model/Card card {:dataset_query (->> (mt/id :orders)
+                                                             (lib.metadata/table mp)
+                                                             (lib/query mp))}]
+          (let [base       (lib/query mp (lib.metadata/card mp (:id card)))
+                created-at (m/find-first #(= {:table-id (mt/id :orders) :name "created_at"}
+                                             (select-keys % [:table-id :name]))
+                                         (lib/breakoutable-columns base))]
+            (are [bucket start-date end-date expected]
+                 (= expected
+                    (-> base
+                        (lib/filter (lib/between created-at start-date end-date))
+                        (lib/aggregate (lib/count))
+                        (lib/breakout (lib/with-temporal-bucket created-at bucket))
+                        (qp/process-query)
+                        (mt/rows)))
+              :day "2016-07-26" "2016-07-31"
+              [["2016-07-26T00:00:00+01:00" 1]
+               ["2016-07-27T00:00:00+01:00" 3]
+               ["2016-07-28T00:00:00+01:00" 2]
+               ["2016-07-29T00:00:00+01:00" 4]
+               ["2016-07-30T00:00:00+01:00" 7]
+               ["2016-07-31T00:00:00+01:00" 3]]
+
+              :week "2016-09-04" "2016-10-01"
+              [["2016-09-04T00:00:00+01:00" 20]
+               ["2016-09-11T00:00:00+01:00" 23]
+               ["2016-09-18T00:00:00+01:00" 18]
+               ["2016-09-25T00:00:00+01:00" 32]])))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/76585

### Description

When determining if we should apply the report timezone to a datetime field, we were only checking if the field database type was a datetime. So if we had a nested question with a datetime field, it wouldn't have the database type and we'd skip applying the report timezone. The fix in this PR is to also check if the field has an effective type of `:type/DateTime`, and apply the report timezone if so. Also makes a fix to include type info when adding the interval for week bucketing. 

### How to verify

See repro steps in original issue. You should get the expected results now.

### Demo

https://www.loom.com/share/5fe45c4377fd4d5f9cd88a3770eac83d

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
