### PR TITLE
Granular permissions for workspaces

### DIFF
--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -421,7 +421,15 @@
         (doseq [sql (cond-> [(format "CREATE DATABASE IF NOT EXISTS %s" quoted-db)
                              (format "CREATE USER IF NOT EXISTS %s IDENTIFIED BY '%s'"
                                      quoted-user (:password read-user))
-                             (format "GRANT ALL ON %s.* TO %s" quoted-db quoted-user)]
+                             ;; Least-privilege grant on the workspace's own DB (ClickHouse has no
+                             ;; owner auto-privileges, so grant each verb explicitly):
+                             ;;   SELECT       - read its own tables
+                             ;;   INSERT       - CTAS populate + incremental insert
+                             ;;   CREATE TABLE - transform target
+                             ;;   DROP TABLE   - swap/cleanup
+                             ;; (these four also satisfy the atomic-swap RENAME TABLE.)
+                             (format "GRANT SELECT, INSERT, CREATE TABLE, DROP TABLE ON %s.* TO %s"
+                                     quoted-db quoted-user)]
                       quoted-canonical-db
                       (conj (format "GRANT SHOW DATABASES ON %s.* TO %s"
                                     quoted-canonical-db quoted-user)))]

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -854,11 +854,15 @@
                        (format "ALTER USER %s WITH PASSWORD '%s'" quoted-user (:password read-user))
                        (format "CREATE USER %s WITH PASSWORD '%s'" quoted-user (:password read-user)))]
         (with-open [^Statement stmt (.createStatement ^Connection (:connection t-conn))]
+          ;; Schema-level grant only (Redshift's two schema privileges):
+          ;;   USAGE  - access the schema
+          ;;   CREATE - create tables in it
+          ;; Table DML comes from ownership (the user owns the tables it creates), so we skip
+          ;; `ALTER DEFAULT PRIVILEGES ... GRANT ALL ON TABLES` (that only covers tables created
+          ;; by the admin connection, which never happens on the transform path).
           (doseq [sql [(format "CREATE SCHEMA IF NOT EXISTS %s" quoted-schema)
                        user-sql
-                       (format "GRANT ALL PRIVILEGES ON SCHEMA %s TO %s" quoted-schema quoted-user)
-                       (format "ALTER DEFAULT PRIVILEGES IN SCHEMA %s GRANT ALL ON TABLES TO %s"
-                               quoted-schema quoted-user)]]
+                       (format "GRANT USAGE, CREATE ON SCHEMA %s TO %s" quoted-schema quoted-user)]]
             (.addBatch ^Statement stmt ^String sql))
           (try
             (.executeBatch ^Statement stmt)

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -1182,9 +1182,14 @@
                            escaped-username quoted-user quoted-user)
                    (format "IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '%s') EXEC('CREATE SCHEMA %s')"
                            escaped-schema quoted-schema)
-                   ;; CONTROL ON SCHEMA gives ALTER (needed for creating objects in schema)
-                   (format "GRANT CONTROL ON SCHEMA::%s TO %s" quoted-schema quoted-user)
-                   ;; CREATE TABLE at database level is also required in SQL Server
+                   ;; Least-privilege grant on the workspace's own schema (vs. the old GRANT
+                   ;; CONTROL, dropping EXECUTE, VIEW DEFINITION, REFERENCES, and re-grant rights):
+                   ;;   ALTER  - create/drop/sp_rename objects in the schema
+                   ;;   SELECT, INSERT, UPDATE, DELETE - full DML (SQL Server, unlike Postgres,
+                   ;;            does not confer DML from ALTER/ownership, so grant it explicitly)
+                   (format "GRANT ALTER, SELECT, INSERT, UPDATE, DELETE ON SCHEMA::%s TO %s"
+                           quoted-schema quoted-user)
+                   ;; db-level CREATE TABLE: SELECT INTO (transform materialization) needs it too
                    (format "GRANT CREATE TABLE TO %s" quoted-user)]]
         (jdbc/execute! conn-spec [sql]))
       (catch Throwable t

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -1329,8 +1329,14 @@
           (doseq [sql [;; Create the isolated database
                        (format "CREATE DATABASE IF NOT EXISTS %s" quoted-db)
                        user-sql
-                       ;; Grant all privileges on the isolated database
-                       (format "GRANT ALL PRIVILEGES ON %s.* TO %s@'%%'" quoted-db quoted-user)]]
+                       ;; Least-privilege grant on the workspace's own DB (vs. ALL PRIVILEGES,
+                       ;; dropping GRANT OPTION, CREATE VIEW/ROUTINE, TRIGGER, etc.):
+                       ;;   SELECT, INSERT, UPDATE, DELETE - full DML on its own tables
+                       ;;   CREATE - transform target / CTAS
+                       ;;   DROP   - swap/cleanup
+                       ;;   ALTER  - required (with DROP/CREATE) for RENAME TABLE swaps
+                       (format "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, ALTER ON %s.* TO %s@'%%'"
+                               quoted-db quoted-user)]]
             (.addBatch ^Statement stmt ^String sql))
           (try
             (.executeBatch ^Statement stmt)

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -1572,13 +1572,12 @@
           (doseq [sql [;; PostgreSQL supports IF NOT EXISTS for schemas
                        (format "CREATE SCHEMA IF NOT EXISTS %s" quoted-schema)
                        user-sql
-                       ;; grant schema access (CREATE to create tables, USAGE to access them)
-                       ;; GRANT is idempotent in PostgreSQL
-                       (format "GRANT ALL PRIVILEGES ON SCHEMA %s TO %s" quoted-schema quoted-user)
-                       ;; grant all privileges on future tables created in this schema (by admin)
-                       (format "ALTER DEFAULT PRIVILEGES IN SCHEMA %s GRANT ALL ON TABLES TO %s"
-                               quoted-schema quoted-user)
-                       ;; grant role membership to admin so DROP OWNED BY works during cleanup
+                       ;; Schema-level grant only (Postgres' two schema privileges):
+                       ;;   USAGE  - access the schema
+                       ;;   CREATE - create tables in it
+                       ;; Table DML comes from ownership (the user owns the tables it creates).
+                       (format "GRANT USAGE, CREATE ON SCHEMA %s TO %s" quoted-schema quoted-user)
+                       ;; role membership to admin so DROP OWNED BY works during cleanup
                        (format "GRANT %s TO CURRENT_USER" quoted-user)]]
             (.addBatch ^Statement stmt ^String sql))
           (try


### PR DESCRIPTION
We over-grant permissions for a workspace user, and that causes workspace creation to fail.