### PR TITLE
Add Linear Release tracking

### DIFF
--- a/.github/workflows/linear-release-sync.yml
+++ b/.github/workflows/linear-release-sync.yml
@@ -1,0 +1,102 @@
+name: Sync Linear Release
+
+on:
+  push:
+    branches:
+      - master
+      - "release-x.**"
+  workflow_dispatch:
+    inputs:
+      command:
+        description: "sync | update | complete"
+        type: choice
+        options: [sync, update, complete]
+        default: sync
+      release_version:
+        description: "Override minor version, e.g. v0.57.8 (else derived from branch)"
+        type: string
+        required: false
+      stage:
+        description: "Target stage (required for 'update'), e.g. rc"
+        type: string
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync-linear-release:
+    if: ${{ github.repository == 'metabase/metabase' }}
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    steps:
+      - name: Check out (full history + tags — linear-release needs a full clone)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Build the release scripts
+        uses: ./.github/actions/prepare-release-scripts
+
+      - name: Derive the in-flight MINOR version + scan baseline (via release/ helpers)
+        id: ctx
+        uses: actions/github-script@v9
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          # master develops the next GA major. cut-release-branch.yml bumps this
+          # org var to the just-cut major, so master == CURRENT_VERSION + 1.
+          # Confirm this matches your conventions before enabling.
+          CURRENT_VERSION: ${{ vars.CURRENT_VERSION }}
+          INPUT_VERSION: ${{ github.event.inputs.release_version }}
+        with:
+          script: | # js
+            const {
+              getMajorVersionNumberFromReleaseBranch,
+              getLastReleaseTag,
+              findNextMinorVersion,
+            } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+            const { REF_NAME, CURRENT_VERSION, INPUT_VERSION } = process.env;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Manual dispatch override wins.
+            if (INPUT_VERSION) {
+              core.setOutput('release_version', INPUT_VERSION);
+              core.setOutput('base_ref', '');
+              return;
+            }
+
+            // Branch -> major: release branches encode it; master develops the next major.
+            const major = REF_NAME.startsWith('release-x.')
+              ? getMajorVersionNumberFromReleaseBranch(REF_NAME)
+              : String(Number(CURRENT_VERSION) + 1);
+
+            // Last STABLE MINOR shipped on this line (ignore patches + pre-releases),
+            // so the release we record is always the next MINOR (e.g. v0.63.3) and a
+            // patch build (v0.63.2.3) maps to its parent minor rather than its own release.
+            const lastMinorTag = await getLastReleaseTag({
+              github, owner, repo,
+              version: `v0.${major}.0`, // only the major is read out of this
+              ignorePatches: true,
+              ignorePreReleases: true,
+            });
+
+            const releaseVersion = lastMinorTag
+              ? findNextMinorVersion(lastMinorTag) // v0.63.2 -> v0.63.3
+              : `v0.${major}.0`;                   // .0 not cut yet (done manually)
+
+            core.setOutput('release_version', releaseVersion);
+            core.setOutput('base_ref', lastMinorTag ?? '');
+            core.info(`Linear release ${releaseVersion} (baseline: ${lastMinorTag ?? 'none'})`);
+
+      - name: Sync / update / complete the Linear release
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASE_ACCESS_KEY }}
+          command: ${{ github.event.inputs.command || 'sync' }}
+          release_version: ${{ steps.ctx.outputs.release_version }}
+          base_ref: ${{ steps.ctx.outputs.base_ref }}
+          stage: ${{ github.event.inputs.stage }}
+          # Linear extracts ENG-ids AND detects PR numbers from the scanned commits,
+          # so a PR that closes no Linear issue is still tracked on the release.

--- a/.github/workflows/linear-release-sync.yml
+++ b/.github/workflows/linear-release-sync.yml
@@ -58,7 +58,9 @@ jobs:
 
             // Manual dispatch override wins.
             if (INPUT_VERSION) {
-              core.setOutput('release_version', INPUT_VERSION);
+              const releaseVersion = R.getLinearReleaseName(INPUT_VERSION);
+              console.log({ REF_NAME, CURRENT_VERSION, INPUT_VERSION, releaseVersion });
+              core.setOutput('release_version', releaseVersion);
               core.setOutput('base_ref', '');
               return;
             }

--- a/.github/workflows/linear-release-sync.yml
+++ b/.github/workflows/linear-release-sync.yml
@@ -83,9 +83,14 @@ jobs:
               : `v0.${major}.0`;                   // .0 not cut yet (done manually)
             const linearReleaseName = R.getLinearReleaseName(releaseVersion);
 
-            core.setOutput('release_version', releaseVersion);
+            console.log({
+              REF_NAME, CURRENT_VERSION, INPUT_VERSION,
+              major, lastMinorTag, releaseVersion, linearReleaseName,
+            });
+
+            core.setOutput('release_version', linearReleaseName);
             core.setOutput('base_ref', lastMinorTag ?? '');
-            core.setOutput('linear_release_name', linearReleaseName);
+
             core.info(`Linear release ${linearReleaseName} (baseline: ${lastMinorTag ?? 'none'})`);
 
       - name: Sync / update / complete the Linear release

--- a/.github/workflows/linear-release-sync.yml
+++ b/.github/workflows/linear-release-sync.yml
@@ -50,11 +50,7 @@ jobs:
           INPUT_VERSION: ${{ github.event.inputs.release_version }}
         with:
           script: | # js
-            const {
-              getMajorVersionNumberFromReleaseBranch,
-              getLastReleaseTag,
-              findNextMinorVersion,
-            } = require('${{ github.workspace }}/release/dist/index.cjs');
+            const R = require('${{ github.workspace }}/release/dist/index.cjs');
 
             const { REF_NAME, CURRENT_VERSION, INPUT_VERSION } = process.env;
             const owner = context.repo.owner;
@@ -69,13 +65,13 @@ jobs:
 
             // Branch -> major: release branches encode it; master develops the next major.
             const major = REF_NAME.startsWith('release-x.')
-              ? getMajorVersionNumberFromReleaseBranch(REF_NAME)
+              ? R.getMajorVersionNumberFromReleaseBranch(REF_NAME)
               : String(Number(CURRENT_VERSION) + 1);
 
             // Last STABLE MINOR shipped on this line (ignore patches + pre-releases),
             // so the release we record is always the next MINOR (e.g. v0.63.3) and a
             // patch build (v0.63.2.3) maps to its parent minor rather than its own release.
-            const lastMinorTag = await getLastReleaseTag({
+            const lastMinorTag = await R.getLastReleaseTag({
               github, owner, repo,
               version: `v0.${major}.0`, // only the major is read out of this
               ignorePatches: true,
@@ -83,12 +79,14 @@ jobs:
             });
 
             const releaseVersion = lastMinorTag
-              ? findNextMinorVersion(lastMinorTag) // v0.63.2 -> v0.63.3
+              ? R.findNextMinorVersion(lastMinorTag) // v0.63.2 -> v0.63.3
               : `v0.${major}.0`;                   // .0 not cut yet (done manually)
+            const linearReleaseName = R.getLinearReleaseName(releaseVersion);
 
             core.setOutput('release_version', releaseVersion);
             core.setOutput('base_ref', lastMinorTag ?? '');
-            core.info(`Linear release ${releaseVersion} (baseline: ${lastMinorTag ?? 'none'})`);
+            core.setOutput('linear_release_name', linearReleaseName);
+            core.info(`Linear release ${linearReleaseName} (baseline: ${lastMinorTag ?? 'none'})`);
 
       - name: Sync / update / complete the Linear release
         uses: linear/linear-release-action@v0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -554,6 +554,53 @@ jobs:
         --distribution-id ${{ vars.AWS_CLOUDFRONT_STATIC_ID }} \
         --paths "/version-info.json" "/version-info-ee.json"
 
+  linear-release-lifecycle:
+    # Advance / finalize the matching Linear release (single "Metabase" pipeline).
+    # Only minors and majors map to a Linear release; patches fold into their minor
+    # and have no release of their own, so we skip them (same gate as the jobs above).
+    # Pre-releases (RC/beta) -> `update` the stage (keep it open); stable -> `complete`.
+    # Requires the LINEAR_RELEASE_ACCESS_KEY secret + the "Metabase" pipeline (see
+    # release/LINEAR_RELEASES.md). The sync side lives in linear-release-sync.yml.
+    if: ${{ needs.check-version.outputs.kind == 'minor' || needs.check-version.outputs.kind == 'major' }}
+    needs: [push-tags, check-version]
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 10
+    continue-on-error: true # don't block the release if Linear fails (we can fix it manually)
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # complete/update target a release by version and do NOT scan commits,
+          # so the default shallow clone is enough (sync, which scans, needs depth 0).
+          sparse-checkout: |
+            release
+            .github
+      - name: Prepare release scripts
+        uses: ./.github/actions/prepare-release-scripts
+      - name: Resolve the Linear MINOR release + lifecycle command
+        id: linear
+        uses: actions/github-script@v9
+        with:
+          script: | # js
+            const R = require('${{ github.workspace }}/release/dist/index.cjs');
+
+            const version = '${{ inputs.version }}';
+            const releaseVersion = R.getLinerReleaseVersion(version);
+
+            const preRelease = R.isPreReleaseVersion(version);
+            core.setOutput('release_version', releaseVersion);
+
+            // if we're doing a beta, we want to update the stage (keep it open) instead of completing it
+            core.setOutput('command', preRelease ? 'update' : 'complete');
+            core.setOutput('stage', preRelease ? 'beta' ; 'Released');
+
+      - name: Advance / complete the Linear release
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASE_ACCESS_KEY }}
+          command: ${{ steps.linear.outputs.command }}
+          release_version: ${{ steps.linear.outputs.release_version }}
+          stage: ${{ steps.linear.outputs.stage }}
+
   publish-complete-message:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     needs: [add-extra-tags]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -584,14 +584,14 @@ jobs:
             const R = require('${{ github.workspace }}/release/dist/index.cjs');
 
             const version = '${{ inputs.version }}';
-            const releaseVersion = R.getLinerReleaseVersion(version);
+            const releaseVersion = R.getLinearReleaseName(version);
 
             const preRelease = R.isPreReleaseVersion(version);
             core.setOutput('release_version', releaseVersion);
 
             // if we're doing a beta, we want to update the stage (keep it open) instead of completing it
             core.setOutput('command', preRelease ? 'update' : 'complete');
-            core.setOutput('stage', preRelease ? 'beta' ; 'Released');
+            core.setOutput('stage', preRelease ? 'beta' : 'Released');
 
       - name: Advance / complete the Linear release
         uses: linear/linear-release-action@v0

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -316,6 +316,28 @@ export const getMilestoneName = (version: string) => {
   return Number(minor) ? `0.${major}.${minor}` : `0.${major}`;
 };
 
+// pre-release: v58.0-beta
+// major: v58.0
+// minor: v58.1
+// patch: v58.1.1
+const getSimpleVersion = (version: string) => {
+  const { major, minor, patch } = getVersionParts(version)
+
+  if (patch) {
+    return `v${major}.${minor}.${patch}`;
+  }
+
+  if (minor) {
+    return `v${major}.${minor}`;
+  }
+
+  return `v${major}.0`;
+}
+
+export const getLinearReleaseName = (version: string) => {
+  return getSimpleVersion(version);
+}
+
 // for auto-setting milestones, we don't ever want to auto-set a patch milestone
 // which we release VERY rarely
 export function ignorePatches(version: string) {


### PR DESCRIPTION
This is the first step in moving us off of github milestones and onto linear releases. This is a non-load-bearing test to see how this works in an ongoing fashion.

The main benefit of linear releases is that a single issue can belong to multiple releases based on multiple backports. It also has some nice automation that can link linear issues, github issues, or just PRs, as appropriate.

- `linear-release-sync` runs on every commit to master or a release branch and adds commits to the appropriate release based on the branch
- new code in `release.yml` closes a release when we cut a release