### PR TITLE
fix(sdk): controlled parameters prop leaks into drill-through target dashboard

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
@@ -666,6 +666,136 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
     });
   });
 
+  describe("controlled parameters do not leak into drill-through target (EMB-1946)", () => {
+    const DASHBOARD_A_UNRELATED_FILTER: Parameter = createMockActionParameter({
+      id: "dashboard-a-unrelated",
+      name: "City Filter",
+      slug: "city-filter",
+      type: "string/=",
+      sectionId: "string",
+    });
+
+    beforeEach(() => {
+      signInAsAdminAndEnableEmbeddingSdk();
+
+      H.createDashboard({
+        name: "Dashboard B (EMB-1946)",
+        parameters: [DASHBOARD_B_FILTER],
+      }).then(({ body: dashboardB }) => {
+        cy.wrap(dashboardB.id).as("dashboardBId");
+
+        H.createQuestion({
+          name: "Orders for Dashboard B (EMB-1946)",
+          query: { "source-table": ORDERS_ID, limit: 5 },
+        }).then(({ body: questionB }) => {
+          H.addOrUpdateDashboardCard({
+            card_id: questionB.id,
+            dashboard_id: dashboardB.id,
+            card: {
+              row: 0,
+              col: 0,
+              size_x: 24,
+              size_y: 8,
+              parameter_mappings: [
+                {
+                  parameter_id: DASHBOARD_B_FILTER.id,
+                  card_id: questionB.id,
+                  target: ["dimension", ["field", ORDERS.ID, null]],
+                },
+              ],
+            },
+          });
+        });
+      });
+
+      cy.get<number>("@dashboardBId").then((dashboardBId) => {
+        H.createDashboard({
+          name: "Dashboard A (EMB-1946)",
+          parameters: [DASHBOARD_A_UNRELATED_FILTER],
+        }).then(({ body: dashboardA }) => {
+          cy.wrap(dashboardA.id).as("dashboardAId");
+
+          H.createQuestion({
+            name: "Orders for Dashboard A (EMB-1946)",
+            query: { "source-table": ORDERS_ID, limit: 5 },
+          }).then(({ body: questionA }) => {
+            H.addOrUpdateDashboardCard({
+              card_id: questionA.id,
+              dashboard_id: dashboardA.id,
+              card: {
+                row: 0,
+                col: 0,
+                size_x: 24,
+                size_y: 8,
+                visualization_settings: {
+                  column_settings: {
+                    [`["ref",["field",${ORDERS.ID},null]]`]: {
+                      click_behavior: {
+                        type: "link",
+                        linkType: "dashboard",
+                        linkTextTemplate: "Go to Dashboard B",
+                        targetId: dashboardBId,
+                        parameterMapping: {
+                          [DASHBOARD_B_FILTER.id]: {
+                            source: { type: "column", id: "ID", name: "ID" },
+                            target: {
+                              type: "parameter",
+                              id: DASHBOARD_B_FILTER.id,
+                            },
+                            id: DASHBOARD_B_FILTER.id,
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            });
+          });
+        });
+      });
+
+      cy.signOut();
+      mockAuthProviderAndJwtSignIn();
+
+      cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
+      cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+        "dashcardQuery",
+      );
+    });
+
+    it("should not forward root controlled parameters to the drill-through target dashboard", () => {
+      cy.get<number>("@dashboardAId").then((dashboardAId) => {
+        mountSdkContent(
+          <InteractiveDashboard
+            dashboardId={dashboardAId}
+            enableEntityNavigation
+            parameters={{ "city-filter": "new-york" }}
+          />,
+        );
+      });
+
+      cy.wait("@getDashboard");
+      cy.wait("@dashcardQuery");
+
+      getSdkRoot().within(() => {
+        cy.findByText("Dashboard A (EMB-1946)").should("be.visible");
+
+        H.getDashboardCard().findAllByText("Go to Dashboard B").first().click();
+
+        cy.wait("@getDashboard");
+
+        cy.findByText("Dashboard B (EMB-1946)").should("be.visible");
+
+        // The ID filter must show the click-behavior-mapped value from the clicked row,
+        // not be suppressed by the root dashboard's controlled `parameters` prop.
+        // Before the fix, controlled `parameters` overwrites `initialParameters` entirely,
+        // leaving `id-filter` absent and the widget empty.
+        H.filterWidget({ name: "ID Filter" }).should("contain.text", "1");
+      });
+    });
+  });
+
   describe("same-dashboard navigation (EMB-1714)", () => {
     beforeEach(() => {
       signInAsAdminAndEnableEmbeddingSdk();

--- a/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
@@ -666,9 +666,9 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
     });
   });
 
-  describe("controlled parameters do not leak into drill-through target (EMB-1946)", () => {
-    const DASHBOARD_A_UNRELATED_FILTER: Parameter = createMockActionParameter({
-      id: "dashboard-a-unrelated",
+  describe.only("root dashboard controller props do not leak into drill-through target (EMB-1946)", () => {
+    const ORIGIN_DASHBOARD_FILTER: Parameter = createMockActionParameter({
+      id: "origin-dashboard-filter",
       name: "City Filter",
       slug: "city-filter",
       type: "string/=",
@@ -679,18 +679,18 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
       signInAsAdminAndEnableEmbeddingSdk();
 
       H.createDashboard({
-        name: "Dashboard B (EMB-1946)",
+        name: "Target Dashboard (EMB-1946)",
         parameters: [DASHBOARD_B_FILTER],
-      }).then(({ body: dashboardB }) => {
-        cy.wrap(dashboardB.id).as("dashboardBId");
+      }).then(({ body: targetDashboard }) => {
+        cy.wrap(targetDashboard.id).as("targetDashboardId");
 
         H.createQuestion({
-          name: "Orders for Dashboard B (EMB-1946)",
+          name: "Orders for Target Dashboard (EMB-1946)",
           query: { "source-table": ORDERS_ID, limit: 5 },
-        }).then(({ body: questionB }) => {
+        }).then(({ body: targetQuestion }) => {
           H.addOrUpdateDashboardCard({
-            card_id: questionB.id,
-            dashboard_id: dashboardB.id,
+            card_id: targetQuestion.id,
+            dashboard_id: targetDashboard.id,
             card: {
               row: 0,
               col: 0,
@@ -699,7 +699,7 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
               parameter_mappings: [
                 {
                   parameter_id: DASHBOARD_B_FILTER.id,
-                  card_id: questionB.id,
+                  card_id: targetQuestion.id,
                   target: ["dimension", ["field", ORDERS.ID, null]],
                 },
               ],
@@ -708,20 +708,20 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
         });
       });
 
-      cy.get<number>("@dashboardBId").then((dashboardBId) => {
+      cy.get<number>("@targetDashboardId").then((targetDashboardId) => {
         H.createDashboard({
-          name: "Dashboard A (EMB-1946)",
-          parameters: [DASHBOARD_A_UNRELATED_FILTER],
-        }).then(({ body: dashboardA }) => {
-          cy.wrap(dashboardA.id).as("dashboardAId");
+          name: "Origin Dashboard (EMB-1946)",
+          parameters: [ORIGIN_DASHBOARD_FILTER],
+        }).then(({ body: originDashboard }) => {
+          cy.wrap(originDashboard.id).as("originDashboardId");
 
           H.createQuestion({
-            name: "Orders for Dashboard A (EMB-1946)",
+            name: "Orders for Origin Dashboard (EMB-1946)",
             query: { "source-table": ORDERS_ID, limit: 5 },
-          }).then(({ body: questionA }) => {
+          }).then(({ body: originQuestion }) => {
             H.addOrUpdateDashboardCard({
-              card_id: questionA.id,
-              dashboard_id: dashboardA.id,
+              card_id: originQuestion.id,
+              dashboard_id: originDashboard.id,
               card: {
                 row: 0,
                 col: 0,
@@ -733,8 +733,8 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
                       click_behavior: {
                         type: "link",
                         linkType: "dashboard",
-                        linkTextTemplate: "Go to Dashboard B",
-                        targetId: dashboardBId,
+                        linkTextTemplate: "Go to Target Dashboard",
+                        targetId: targetDashboardId,
                         parameterMapping: {
                           [DASHBOARD_B_FILTER.id]: {
                             source: { type: "column", id: "ID", name: "ID" },
@@ -757,38 +757,31 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
 
       cy.signOut();
       mockAuthProviderAndJwtSignIn();
-
-      cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
-      cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-        "dashcardQuery",
-      );
     });
 
     it("should not forward root controlled parameters to the drill-through target dashboard", () => {
-      cy.get<number>("@dashboardAId").then((dashboardAId) => {
+      cy.get<number>("@originDashboardId").then((originDashboardId) => {
         mountSdkContent(
           <InteractiveDashboard
-            dashboardId={dashboardAId}
+            dashboardId={originDashboardId}
             enableEntityNavigation
             parameters={{ "city-filter": "new-york" }}
           />,
         );
       });
 
-      cy.wait("@getDashboard");
-      cy.wait("@dashcardQuery");
-
       getSdkRoot().within(() => {
-        cy.findByText("Dashboard A (EMB-1946)").should("be.visible");
+        cy.findByText("Origin Dashboard (EMB-1946)").should("be.visible");
 
-        H.getDashboardCard().findAllByText("Go to Dashboard B").first().click();
+        H.getDashboardCard()
+          .findAllByText("Go to Target Dashboard")
+          .first()
+          .click();
 
-        cy.wait("@getDashboard");
-
-        cy.findByText("Dashboard B (EMB-1946)").should("be.visible");
+        cy.findByText("Target Dashboard (EMB-1946)").should("be.visible");
 
         // The ID filter must show the click-behavior-mapped value from the clicked row,
-        // not be suppressed by the root dashboard's controlled `parameters` prop.
+        // not be suppressed by the origin dashboard's controlled `parameters` prop.
         // Before the fix, controlled `parameters` overwrites `initialParameters` entirely,
         // leaving `id-filter` absent and the widget empty.
         H.filterWidget({ name: "ID Filter" }).should("contain.text", "1");

--- a/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
@@ -666,7 +666,7 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
     });
   });
 
-  describe.only("root dashboard controller props do not leak into drill-through target (EMB-1946)", () => {
+  describe("root dashboard controller props do not leak into drill-through target (EMB-1946)", () => {
     const ORIGIN_DASHBOARD_FILTER: Parameter = createMockActionParameter({
       id: "origin-dashboard-filter",
       name: "City Filter",

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
@@ -35,6 +35,23 @@ import {
   type SdkInternalNavigationEntry,
 } from "./context";
 
+/**
+ * Strip root-dashboard-specific controller props before forwarding to a
+ * drill-through target. Display props (withDownloads, withTitle, etc.) pass
+ * through unchanged so UI features remain consistent across the stack.
+ *
+ * - parameters / onParametersChange: scoped to the root dashboard the host
+ *   controls. The drill-through target is seeded from click-behavior
+ *   initialParameters instead.
+ */
+function getDrillThroughDashboardProps({
+  parameters: _parameters,
+  onParametersChange: _onParametersChange,
+  ...props
+}: Partial<SdkDashboardInnerProps> = {}): Partial<SdkDashboardInnerProps> {
+  return props;
+}
+
 type Props = {
   children: ReactNode;
   dashboardProps?: Partial<Omit<SdkDashboardInnerProps, "dashboardId">>;
@@ -183,7 +200,7 @@ const SdkInternalNavigationProviderInner = ({
   const content = match({ activeEntry: entryToRender })
     .with({ activeEntry: { type: "dashboard" } }, ({ activeEntry }) => (
       <InteractiveDashboardContent
-        {...dashboardProps}
+        {...getDrillThroughDashboardProps(dashboardProps)}
         dashboardId={activeEntry.id}
         initialParameters={activeEntry.parameters}
         enableEntityNavigation

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
@@ -35,24 +35,16 @@ import {
   type SdkInternalNavigationEntry,
 } from "./context";
 
-/**
- * Strip root-dashboard-specific controller props before forwarding to a
- * drill-through target. Display props (withDownloads, withTitle, etc.) pass
- * through unchanged so UI features remain consistent across the stack.
- *
- * - parameters / onParametersChange: scoped to the root dashboard the host
- *   controls. The drill-through target is seeded from click-behavior
- *   initialParameters instead.
- * - initialParameters: seeds the root dashboard's initial filter state.
- *   The drill-through target always receives its own initialParameters
- *   from the click-behavior stack entry.
- */
+// Strips props that are only meant for the root dashboard before forwarding to a drill-through target.
 function getDrillThroughDashboardProps({
   parameters: _parameters,
   onParametersChange: _onParametersChange,
   initialParameters: _initialParameters,
   ...props
-}: Partial<SdkDashboardInnerProps> = {}): Partial<SdkDashboardInnerProps> {
+}: Partial<SdkDashboardInnerProps> = {}): Omit<
+  SdkDashboardInnerProps,
+  "dashboardId" | "parameters" | "onParametersChange" | "initialParameters"
+> {
   return props;
 }
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider.tsx
@@ -43,10 +43,14 @@ import {
  * - parameters / onParametersChange: scoped to the root dashboard the host
  *   controls. The drill-through target is seeded from click-behavior
  *   initialParameters instead.
+ * - initialParameters: seeds the root dashboard's initial filter state.
+ *   The drill-through target always receives its own initialParameters
+ *   from the click-behavior stack entry.
  */
 function getDrillThroughDashboardProps({
   parameters: _parameters,
   onParametersChange: _onParametersChange,
+  initialParameters: _initialParameters,
   ...props
 }: Partial<SdkDashboardInnerProps> = {}): Partial<SdkDashboardInnerProps> {
   return props;


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76511
Fixes EMB-1946

### Description

When `<InteractiveDashboard>` uses `enableEntityNavigation` with the controlled `parameters` prop, drilling through to another dashboard opens it with empty filters instead of the click-behavior-mapped values.

This happens because `SdkInternalNavigationProvider` forwards the full `dashboardProps` to drill-through targets, including `parameters` and `onParametersChange`. These are controller props scoped to the root dashboard — they were never meant to be inherited by navigated dashboards. `getEffectiveParameterValues` makes `parameters` win over `initialParameters`, so the click-behavior values are silently discarded.

Fix: `getDrillThroughDashboardProps` strips `parameters`, `onParametersChange`, and `initialParameters` before spreading onto the target. Display props (`withDownloads`, `withTitle`, etc.) pass through unchanged.

### How to verify

1. Create two dashboards A and B. On a card in A, add a click behavior: Go to Dashboard B, mapping a clicked column (e.g. ORDERS.ID) to one of B's filters.
2. Render A with controlled parameters and entity navigation:
   ```jsx
   <InteractiveDashboard
     dashboardId={A}
     parameters={{ "some-filter": "some-value" }}
     onParametersChange={handleChange}
     enableEntityNavigation
   />
   ```
3. Click a value on A to drill through to B.
4. B should open with the click-behavior filter value applied, not empty.

### Demo

#### After the fix
<img width="1131" height="710" alt="image" src="https://github.com/user-attachments/assets/4cd4895a-8fc8-48e5-b675-e3f8a22eaf56" />

#### Before the fix (empty parameter value)
<img width="1127" height="705" alt="image" src="https://github.com/user-attachments/assets/c1367fca-5b48-49cd-a76e-e7875808d42c" />


### Stress test

- This PR — ✅ [30/30](https://github.com/metabase/metabase/actions/runs/28433319766)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)