### PR TITLE
add sql server index driver methods

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
@@ -678,13 +678,11 @@
                               (is (some? checkpoint) "Checkpoint should be updated"))))))))))))))))
 
 (defn- incremental-index-test-drivers
-  "Index-supporting drivers exercised by the incremental index test. The general incremental suite excludes
-  redshift/clickhouse/sqlserver, but sqlserver's incremental append (compile-insert) and index DDL are both the
-  standard paths, so the index feature is covered here even though the rest of the suite still skips it."
+  "Index-supporting drivers that also run incremental transforms (effectively postgres today; the incremental suite
+  excludes redshift/clickhouse/sqlserver -- e.g. sqlserver's SELECT INTO preserves the source IDENTITY column, so the
+  append INSERT...SELECT fails without IDENTITY_INSERT)."
   []
-  (let [index-drivers (index-util/index-test-drivers)]
-    (cond-> (into #{} (filter index-drivers) (test-drivers))
-      (contains? index-drivers :sqlserver) (conj :sqlserver))))
+  (into #{} (filter (index-util/index-test-drivers)) (test-drivers)))
 
 (deftest ^:synchronized ^:mb/transforms-python-test declared-indexes-on-incremental-transform-test
   (testing "incremental: the first (full) run creates the target's declared indexes; an append run preserves them"

--- a/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
@@ -678,10 +678,13 @@
                               (is (some? checkpoint) "Checkpoint should be updated"))))))))))))))))
 
 (defn- incremental-index-test-drivers
-  "Index-supporting drivers that also run incremental transforms (effectively postgres today; the incremental suite
-  excludes redshift/clickhouse/sqlserver)."
+  "Index-supporting drivers exercised by the incremental index test. The general incremental suite excludes
+  redshift/clickhouse/sqlserver, but sqlserver's incremental append (compile-insert) and index DDL are both the
+  standard paths, so the index feature is covered here even though the rest of the suite still skips it."
   []
-  (into #{} (filter (index-util/index-test-drivers)) (test-drivers)))
+  (let [index-drivers (index-util/index-test-drivers)]
+    (cond-> (into #{} (filter index-drivers) (test-drivers))
+      (contains? index-drivers :sqlserver) (conj :sqlserver))))
 
 (deftest ^:synchronized ^:mb/transforms-python-test declared-indexes-on-incremental-transform-test
   (testing "incremental: the first (full) run creates the target's declared indexes; an append run preserves them"

--- a/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
@@ -679,8 +679,7 @@
 
 (defn- incremental-index-test-drivers
   "Index-supporting drivers that also run incremental transforms (effectively postgres today; the incremental suite
-  excludes redshift/clickhouse/sqlserver -- e.g. sqlserver's SELECT INTO preserves the source IDENTITY column, so the
-  append INSERT...SELECT fails without IDENTITY_INSERT)."
+  excludes redshift/clickhouse/sqlserver)."
   []
   (into #{} (filter (index-util/index-test-drivers)) (test-drivers)))
 

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.sqlserver
   "Driver for SQLServer databases. Uses the official Microsoft JDBC driver under the hood (pre-0.25.0, used jTDS)."
-  (:refer-clojure :exclude [mapv get-in])
+  (:refer-clojure :exclude [mapv get-in not-empty])
   (:require
    [clojure.java.io :as io]
    [clojure.java.jdbc :as jdbc]
@@ -11,6 +11,7 @@
    [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver-api.core :as driver-api]
+   [metabase.driver.common :as driver.common]
    [metabase.driver.connection :as driver.conn]
    [metabase.driver.sql :as driver.sql]
    [metabase.driver.sql-jdbc :as sql-jdbc]
@@ -35,7 +36,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.match :as match]
    [metabase.util.memoize :as memoize]
-   [metabase.util.performance :as perf :refer [mapv get-in]]
+   [metabase.util.performance :as perf :refer [mapv get-in not-empty]]
    [next.jdbc :as next.jdbc])
   (:import
    (java.sql Connection DatabaseMetaData PreparedStatement ResultSet Time)
@@ -57,6 +58,8 @@
                               :expression-literals                    true
                               ;; Index sync is turned off across the application as it is not used ATM.
                               :index-info                             false
+                              :index/fetch                            true
+                              :index/standalone-create                true
                               :now                                    true
                               :regex                                  false
                               :test/jvm-timezone-setting              false
@@ -1243,6 +1246,94 @@
                        [(format "GRANT SELECT ON SCHEMA::%s TO %s"
                                 (quote-schema schema)
                                 quoted-user)])))))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                          Indexes (Index Manager)                                               |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defmethod driver/supported-index-methods :sqlserver
+  [_driver _database]
+  ;; Both rowstore kinds are B-tree, so both take UNIQUE and per-column ASC/DESC. Columnstore/XML/spatial are niche
+  ;; and left out.
+  (let [fields [driver.common/index-name-field
+                (assoc driver.common/index-columns-field :directions true)
+                driver.common/index-unique-field]]
+    {:nonclustered {:lifecycle :standalone :fields fields}
+     :clustered    {:lifecycle :standalone :fields fields}}))
+
+(defn- index-column-sql
+  "Quote one indexed column, appending its `ASC`/`DESC` direction when set."
+  [{col-name :name :keys [direction]}]
+  (cond-> (quote-field col-name)
+    direction (str " " (u/upper-case-en (name direction)))))
+
+(defn- create-index-sql
+  [schema table {index-name :name, :keys [kind columns unique]}]
+  (let [target (apply sql.u/quote-name :sqlserver :table (if (not-empty schema) [schema table] [table]))
+        cols   (str/join ", " (map index-column-sql columns))]
+    (format "CREATE %s%s INDEX %s ON %s (%s)"
+            (if unique "UNIQUE " "")
+            (if (= kind :clustered) "CLUSTERED" "NONCLUSTERED")
+            (quote-field index-name)
+            target
+            cols)))
+
+(defn- sql-string-literal
+  "A SQL Server `N'...'` string literal for trusted `s`, escaping embedded quotes."
+  [s]
+  (str "N'" (sql.u/escape-sql s :ansi) \'))
+
+(defmethod driver/compile-create-index :sqlserver
+  [_driver schema table {index-name :name, :keys [if-not-exists] :as structured}]
+  (let [create (create-index-sql schema table structured)]
+    (if-not if-not-exists
+      [[create]]
+      ;; SQL Server has no `CREATE INDEX IF NOT EXISTS`, so guard the create with a T-SQL `IF NOT EXISTS (...)` that
+      ;; runs it only when no index of this name exists on the table.
+      (let [target (apply sql.u/quote-name :sqlserver :table (if (not-empty schema) [schema table] [table]))]
+        [[(format "IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = %s AND object_id = OBJECT_ID(%s)) %s"
+                  (sql-string-literal index-name)
+                  (sql-string-literal target)
+                  create)]]))))
+
+(defn- bit->bool
+  "JDBC may hand back a SQL Server `bit` as a Boolean or a 0/1 number; normalize either to a boolean."
+  [v]
+  (if (number? v) (not (zero? v)) (boolean v)))
+
+(defn- index-rows->index
+  "Collapse one index's per-column `sys.index_columns` rows (key columns first, then INCLUDE columns) into an index map."
+  [rows]
+  (let [{:keys [index_name index_type is_unique is_primary is_disabled filter_definition]} (first rows)]
+    {:name              index_name
+     :kind              (if (= index_type "CLUSTERED") :clustered :nonclustered)
+     :access-method     (some-> index_type u/lower-case-en)
+     :is-unique         (bit->bool is_unique)
+     :is-primary        (bit->bool is_primary)
+     :is-valid          (not (bit->bool is_disabled))
+     :key-columns       (->> rows (remove (comp bit->bool :is_included)) (mapv :column_name))
+     :include-columns   (->> rows (filter (comp bit->bool :is_included)) (mapv :column_name))
+     :partial-predicate filter_definition
+     :definition        nil}))
+
+;; Only rowstore clustered (`type` 1) and nonclustered (2) indexes are reported; heaps, columnstore, XML, and spatial
+;; are skipped. A missing table makes `OBJECT_ID` return NULL, so the predicate matches nothing and fetch returns [].
+(defmethod driver/fetch-table-indexes :sqlserver
+  [_driver database schema table]
+  (let [qualified (apply sql.u/quote-name :sqlserver :table (if (not-empty schema) [schema table] [table]))]
+    (->> (jdbc/query
+          (sql-jdbc.conn/db->pooled-connection-spec database)
+          ["SELECT i.name AS index_name, i.type_desc AS index_type, i.is_unique, i.is_primary_key AS is_primary,
+                   i.is_disabled, i.filter_definition, c.name AS column_name,
+                   ic.is_included_column AS is_included, ic.key_ordinal, ic.index_column_id
+            FROM sys.indexes i
+            JOIN sys.index_columns ic ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+            JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+            WHERE i.object_id = OBJECT_ID(?) AND i.type IN (1, 2)
+            ORDER BY i.index_id, ic.is_included_column, ic.key_ordinal, ic.index_column_id"
+           qualified])
+         (partition-by :index_name)
+         (mapv index-rows->index))))
 
 (defmethod driver/llm-sql-dialect-resource :sqlserver [_]
   "metabot/prompts/dialects/sqlserver.md")

--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -982,3 +982,25 @@
                    (lib/expression "diff-minutes" diff-minutes)
                    (qp/process-query)
                    (mt/rows))))))))
+
+(deftest ^:parallel compile-create-index-test
+  (testing "nonclustered renders with double-quoted identifiers; UNIQUE only when asked, ASC/DESC per column"
+    (is (= [["CREATE NONCLUSTERED INDEX \"by_cat\" ON \"t\" (\"category\")"]]
+           (driver/compile-create-index :sqlserver nil "t"
+                                        {:kind :nonclustered :name "by_cat" :columns [{:name "category"}]})))
+    (is (= [["CREATE UNIQUE NONCLUSTERED INDEX \"by_cat\" ON \"dbo\".\"t\" (\"category\" DESC, \"price\" ASC)"]]
+           (driver/compile-create-index :sqlserver "dbo" "t"
+                                        {:kind :nonclustered :name "by_cat" :unique true
+                                         :columns [{:name "category" :direction :desc} {:name "price" :direction :asc}]}))))
+  (testing "clustered renders the CLUSTERED keyword"
+    (is (= [["CREATE CLUSTERED INDEX \"by_cat\" ON \"t\" (\"category\")"]]
+           (driver/compile-create-index :sqlserver nil "t"
+                                        {:kind :clustered :name "by_cat" :columns [{:name "category"}]}))))
+  (testing "SQL Server has no CREATE INDEX IF NOT EXISTS, so :if-not-exists guards via a T-SQL IF NOT EXISTS block"
+    (let [[[stmt]] (driver/compile-create-index :sqlserver "dbo" "t"
+                                                {:kind :nonclustered :name "by_cat" :if-not-exists true
+                                                 :columns [{:name "category"}]})]
+      (is (str/starts-with? stmt "IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'by_cat'")
+          "guards on the index name before creating")
+      (is (str/includes? stmt "CREATE NONCLUSTERED INDEX \"by_cat\"")
+          "still emits the create"))))

--- a/test/metabase/transforms/index_test_util.clj
+++ b/test/metabase/transforms/index_test_util.clj
@@ -87,6 +87,15 @@
              vec))
       [])))
 
+(defn- sqlserver-indexes
+  [database schema table]
+  (->> (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
+                   [(str "SELECT i.name AS index_name FROM sys.indexes i "
+                         "WHERE i.object_id = OBJECT_ID(?) AND i.type IN (1, 2) AND i.name IS NOT NULL")
+                    (format "[%s].[%s]" schema table)])
+       (map :index_name)
+       set))
+
 (def driver-cases
   "Driver -> test case: `:indexes` to declare (every method whose column types `transforms_products` can satisfy; the
   rest, e.g. Postgres gin/gist, live in the driver-level and fetch suites), `:physical-indexes` a
@@ -124,7 +133,14 @@
    ;; Snowflake: a single standalone clustering key, reported unnamed, so we read back just the clustered columns.
    :snowflake  {:indexes          [{:kind :clustering :name "by_category" :columns [{:name "category"}]}]
                 :expected         ["category"]
-                :physical-indexes snowflake-clustering}})
+                :physical-indexes snowflake-clustering}
+   ;; SQL Server: standalone clustered + nonclustered. The clustered key goes on `price` (a heap from SELECT INTO can
+   ;; take one clustered index) since a FLOAT stays under the 900-byte clustered limit; category (VARCHAR(1024)) only
+   ;; fits a nonclustered key (1700-byte limit).
+   :sqlserver  {:indexes          [{:kind :clustered :name "by_price" :columns [{:name "price"}]}
+                                   {:kind :nonclustered :name "by_category" :columns [{:name "category"}]}]
+                :expected         #{"by_price" "by_category"}
+                :physical-indexes sqlserver-indexes}})
 
 (defn index-test-drivers
   "Drivers that run transforms and declare any index support."
@@ -273,4 +289,26 @@
     {:label "a table with no clustering key returns []"
      :table "mb_fetch_sf_empty"
      :create ["CREATE TABLE mb_fetch_sf_empty (a INT, b INT)"]
+     :expected #{}}]
+
+   :sqlserver
+   [{:label  "clustered PK, nonclustered, unique, composite, INCLUDE, and a filtered index"
+     :table  "mb_fetch_ss"
+     ;; a named PK constraint so the clustered index has a deterministic name (the default is PK__mb_fetc__<hash>).
+     :create ["CREATE TABLE mb_fetch_ss (id INT NOT NULL, user_id INT, email NVARCHAR(255), a INT, b INT, CONSTRAINT pk_fetch_ss PRIMARY KEY (id))"
+              "CREATE INDEX fc_nc ON mb_fetch_ss (user_id)"
+              "CREATE UNIQUE INDEX fc_unique ON mb_fetch_ss (email)"
+              "CREATE INDEX fc_ab ON mb_fetch_ss (a, b)"
+              "CREATE INDEX fc_include ON mb_fetch_ss (a) INCLUDE (b, email)"
+              "CREATE INDEX fc_filtered ON mb_fetch_ss (user_id) WHERE user_id IS NOT NULL"]
+     ;; a PRIMARY KEY surfaces as a unique CLUSTERED index; SQL Server normalizes the filter to bracketed parens.
+     :expected #{(idx "pk_fetch_ss" :clustered "clustered" ["id"] :unique true :primary true)
+                 (idx "fc_nc" :nonclustered "nonclustered" ["user_id"])
+                 (idx "fc_unique" :nonclustered "nonclustered" ["email"] :unique true)
+                 (idx "fc_ab" :nonclustered "nonclustered" ["a" "b"])
+                 (idx "fc_include" :nonclustered "nonclustered" ["a"] :include ["b" "email"])
+                 (idx "fc_filtered" :nonclustered "nonclustered" ["user_id"] :partial "([user_id] IS NOT NULL)")}}
+    {:label "a heap with no indexes returns []"
+     :table "mb_fetch_ss_empty"
+     :create ["CREATE TABLE mb_fetch_ss_empty (a INT, b INT)"]
      :expected #{}}]})

--- a/test/metabase/transforms/index_test_util.clj
+++ b/test/metabase/transforms/index_test_util.clj
@@ -134,12 +134,12 @@
    :snowflake  {:indexes          [{:kind :clustering :name "by_category" :columns [{:name "category"}]}]
                 :expected         ["category"]
                 :physical-indexes snowflake-clustering}
-   ;; SQL Server: standalone clustered + nonclustered. The clustered key goes on `price` (a heap from SELECT INTO can
-   ;; take one clustered index) since a FLOAT stays under the 900-byte clustered limit; category (VARCHAR(1024)) only
-   ;; fits a nonclustered key (1700-byte limit).
+   ;; SQL Server: standalone clustered + nonclustered, both on `price` (FLOAT). The CTAS path types the text `category`
+   ;; as VARCHAR(1024), but the Python create-table! path makes it NVARCHAR(MAX), which can't be an index key, so only
+   ;; `price` is indexable through both transform paths.
    :sqlserver  {:indexes          [{:kind :clustered :name "by_price" :columns [{:name "price"}]}
-                                   {:kind :nonclustered :name "by_category" :columns [{:name "category"}]}]
-                :expected         #{"by_price" "by_category"}
+                                   {:kind :nonclustered :name "by_price_nc" :columns [{:name "price"}]}]
+                :expected         #{"by_price" "by_price_nc"}
                 :physical-indexes sqlserver-indexes}})
 
 (defn index-test-drivers


### PR DESCRIPTION
adds index manager support for sql server, following the other drivers. sql server has standalone clustered/nonclustered indexes (CREATE INDEX), so it's the `:index/standalone-create` + `:index/fetch` path, postgres-style.

Fixes https://linear.app/metabase/issue/GDGT-2675/add-the-sql-server-index-driver-methods