### PR TITLE
Fix mcp resources templates list

### DIFF
--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -100,6 +100,9 @@
           (:not-found :scope-denied) (jsonrpc-error id -32602 "Resource not found")
           :ok                        (jsonrpc-response id {:contents (:contents result)}))))))
 
+(defn- handle-resources-templates-list [id _params]
+  (jsonrpc-response id {:resourceTemplates []}))
+
 (defn- handle-ping [id _params]
   (jsonrpc-response id {}))
 
@@ -113,6 +116,7 @@
       "tools/call"                (handle-tools-call id params session-id token-scopes)
       "resources/list"            (handle-resources-list id params token-scopes)
       "resources/read"            (handle-resources-read id params session-id token-scopes)
+      "resources/templates/list"  (handle-resources-templates-list id params)
       "ping"                      (handle-ping id params)
       (if id
         (jsonrpc-error id -32601 (str "Method not found: " method))

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -1351,6 +1351,15 @@
               uris    (set (map :uri (get-in response [:result :resources])))]
           (is (contains? uris scoped-test-uri)))))))
 
+(deftest resources-templates-list-test
+  (testing "resources/templates/list returns an empty list of resource templates"
+    (let [[session-id _] (initialize!)
+          response (mcp-request (jsonrpc-request "resources/templates/list")
+                                {"mcp-session-id" session-id})]
+      (is (= 200 (:status response)))
+      (is (= {:resourceTemplates []}
+             (get-in response [:body :result]))))))
+
 ;;; --------------------------------------------- Scope Filtering ---------------------------------------------------
 
 (deftest tools-list-scope-filtering-test


### PR DESCRIPTION
### Description

Metabase declares the MCP `resources` capability and already implements `resources/list` and `resources/read`, but it did not handle `resources/templates/list`.

`resources/templates/list` is part of [MCP Resources discovery](https://modelcontextprotocol.io/specification/2025-11-25/server/resources#resource-templates) for Resource Templates:

Metabase does not currently expose parameterized resource templates, so this PR returns the protocol-compliant empty response:

```
{
  "resourceTemplates": []
}
```

Before this change, clients performing full MCP resource discovery received a JSON-RPC `-32601 Method not found` error for `resources/templates/list`. This caused strict MCP gateways, such as AWS AgentCore Gateway target validation, to reject the server during discovery even though tools and concrete resources were available.

### How to verify

1. Connect an MCP client to Metabase and complete `initialize`.
2. Call `resources/templates/list` with the active `Mcp-Session-Id`.
3. Verify the response is HTTP 200 and contains:

```
{
  "resourceTemplates": []
}
```

4. Verify existing `resources/list`, `resources/read`, `tools/list`, and `tools/call` behavior is unchanged.

### Demo

N/A. Protocol compatibility fix covered by tests.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/76721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

