### PR TITLE
improving Pivot table and and object detail PDF renders

### DIFF
--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -680,7 +680,9 @@
   assembly ([[pivot.postprocess/build-pivot-output]] + [[pivot.core]]) and the row/col/measure indices the
   pivot QP already computed in `:pivot-export-options`."
   [card dashcard {:keys [cols pivot-export-options] :as data}]
-  (let [settings (merge (:visualization_settings card) (:visualization_settings dashcard))
+  (let [;; db->norm gives the same settings shape the CSV/xlsx pivot exports pass build-pivot-output: per-column
+        ;; overrides (e.g. a renamed column title) under the normalized ::mb.viz/column-settings key, pivot keys raw.
+        settings (mb.viz/db->norm (merge (:visualization_settings card) (:visualization_settings dashcard)))
         split    (setting-value settings :pivot_table.column_split)
         pg-idx   (pivot.postprocess/pivot-grouping-index (mapv :name cols))]
     (when (and split pivot-export-options pg-idx)

--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -665,11 +665,12 @@
          [:tr
           (map-indexed
            (fn [c cell]
-             (let [header? (zero? r)
-                   label?  (and (pos? r) (zero? c))
-                   bg      (cell-bg cell c)]
+             (let [header?    (zero? r)
+                   first-col? (zero? c)
+                   label?     (and (pos? r) first-col?)
+                   bg         (cell-bg cell c)]
                [(if (or header? label?) :th :td)
-                {:style (style/style (style/pivot-cell-style header? label? bg))}
+                {:style (style/style (style/pivot-cell-style header? label? first-col? bg))}
                 (h (pivot-cell->str cell))]))
            row)])
        rows)]]))

--- a/src/metabase/channel/render/pdf.clj
+++ b/src/metabase/channel/render/pdf.clj
@@ -88,6 +88,12 @@
   their grid cell, preserving aspect ratio."
   #{:line :area :bar :combo :scatter :boxplot :waterfall :sankey :row})
 
+(def ^:private table-like-chart-types
+  "Chart types (from [[render.card/detect-pulse-chart-type]]) that render as a CSSBox HTML table -- the native
+  flat table, an assembled pivot, and the object-detail key/value view. All three take the width-filling,
+  natively-framed table path (see [[draw-table-card!]]) instead of the aspect-fit, centered image path."
+  #{:table :pivot :object})
+
 ;; --------------------------------------------------------------------------------------------
 ;; Page geometry
 ;; --------------------------------------------------------------------------------------------
@@ -788,44 +794,101 @@
           items)))
 
 (defn- restyle-form
-  "Restyle one walked Hiccup form: the `<table>` gets [[table-css]]; header rows get per-cell
-  dividers. Everything else passes through."
-  [form]
+  "Restyle one walked Hiccup form: the `<table>` gets [[table-css]] (fill the frame, drop its own
+  border/radius/margin); with `add-dividers?` header rows also get per-cell dividers. Everything else passes
+  through."
+  [add-dividers? form]
   (cond
     (and (element? form :table) (map? (second form)))
     (append-style form table-css)
 
-    (and (element? form :tr) (header-row? form))
+    (and add-dividers? (element? form :tr) (header-row? form))
     (add-header-dividers form)
 
     :else form))
 
 (defn- restyle-table
-  "Restyle the inner `<table>` to fit the card frame: fill the width, drop its own border/radius/margin
-  (the native frame and per-cell dividers remain), and add header dividers to match the body."
-  [content]
-  (walk/postwalk restyle-form content))
+  "Restyle the inner `<table>` to fill the card frame: `width:100%`, dropping its own border/radius/margin (the
+  native frame and per-cell dividers remain). In the fixed-width clip box this fills the cell when the content
+  is narrower (columns stretch, like the dashboard) and overflows-then-clips when it's wider. `add-dividers?`
+  adds header dividers to match the body (native `:table` only -- pivots and object-detail border their cells)."
+  [content add-dividers?]
+  (walk/postwalk #(restyle-form add-dividers? %) content))
+
+(def ^:private footer-text-css
+  "Font size and color shared by the card footers -- the native table's row-count footer and object-detail's
+  \"Showing 1 of N\" note -- so they match."
+  "font-size:12.5px;color:#696E7B")
+
+(def ^:private footer-pad-px
+  "Horizontal inset (logical px) of footer text from the card frame, shared by the table and object-detail footers."
+  16)
 
 (def ^:private table-footer-css
   "Style of the `N rows` footer row at the bottom of a table image."
   (format (str "height:%1$dpx;line-height:%1$dpx;box-sizing:border-box;"
-               "font-size:12.5px;text-align:right;padding-right:16px;"
-               "color:#696E7B;border-top:1px solid %2$s")
-          table-footer-px table-border-color))
+               "text-align:right;padding-right:%2$dpx;%3$s;border-top:1px solid %4$s")
+          table-footer-px footer-pad-px footer-text-css table-border-color))
+
+(def ^:private object-detail-footer-px
+  "Logical-pixel height reserved for the object-detail \"Showing 1 of N\" note, kept visible below the
+  (possibly clipped) fields rather than hidden by the height clip on a short card."
+  34)
+
+(def ^:private object-detail-footer-css
+  "Style of the object-detail \"Showing 1 of N\" footer box: a fixed-height band inset from the frame, carrying
+  the shared footer font/color so the plain note text inherits it (like the table footer's count)."
+  (format "height:%dpx;overflow:hidden;padding:12px %dpx 0;%s"
+          object-detail-footer-px footer-pad-px footer-text-css))
+
+(defn- object-detail-note
+  "The text of the trailing \"Showing 1 of N\" note in object-detail render content, or nil when the shown
+  record is the only one. Coupled to [[body/render]] `:object`, which appends the note `<div>` after the
+  key/value `<table>` inside a section `<div>`."
+  [content]
+  (some-> (some #(when (element? % :div) %) (drop 2 content)) last))
+
+(defn- card-footer
+  "The pinned footer for a table-like card body, as `{:footer <hiccup-or-nil>, :footer-h <reserved-px>}`: the
+  native `:table` shows its row count and object-detail its \"Showing 1 of N\" `note` text (both inheriting the
+  shared footer style from their box); a pivot has neither."
+  [chart-type note n-rows]
+  (cond
+    (= :table chart-type)
+    {:footer   [:div {:style table-footer-css} (trun "{0} row" "{0} rows" n-rows)]
+     :footer-h table-footer-px}
+
+    note
+    {:footer   [:div {:style object-detail-footer-css} note]
+     :footer-h object-detail-footer-px}
+
+    :else
+    {:footer nil :footer-h 0}))
 
 (defn- table-body-png
-  "Render a table card body to PNG bytes sized to the `px-w` x `px-h` cell (logical pixels):
-  width-filled, height-capped, with a row-count footer, supersampled at [[table-supersample]]x."
-  ^bytes [timezone {:keys [card dashcard result]} px-w px-h]
+  "Render a table-like card body (`:table`, `:pivot`, or `:object`) to PNG bytes sized to the `px-w` x `px-h`
+  cell (logical pixels), supersampled at [[table-supersample]]x. The body is a `width:100%` table inside a
+  fixed-`px-w` clip box, so -- like the dashboard -- its columns stretch to fill when the content is narrower
+  than the cell, and a wider table (e.g. a many-column pivot) overflows and is clipped at the cell edge. (The
+  card frame itself is stroked around the full cell in [[draw-table-card!]], not around this content.)
+
+  A pinned footer (see [[card-footer]]) is kept visible below the (possibly height-clipped) body: the native
+  `:table` gets a row-count footer, and object-detail keeps its \"Showing 1 of N\" note (pulled out of the
+  clipped body so a short card can't hide it). A pivot has neither."
+  ^bytes [timezone {:keys [card dashcard result]} chart-type px-w px-h]
   (let [;; Render directly, not via render-pulse-card: its <p>/.pulse-body margins escape CSSBox's
         ;; height clip and push the image past the cell. body/render gives the bare table.
-        info     (body/render :table :inline timezone card dashcard (:data result))
-        n-rows   (count (get-in result [:data :rows]))
-        clip-css (format "max-height:%dpx;overflow:hidden" (max 0 (- (long px-h) table-footer-px 2)))
+        info     (body/render chart-type :inline timezone card dashcard (:data result))
+        note     (when (= :object chart-type) (object-detail-note (:content info)))
+        ;; the note is body/render's trailing element, so drop it from the clipped body (it's pinned below)
+        body     (cond-> (:content info) note pop)
+        {:keys [footer footer-h]} (card-footer chart-type note (count (get-in result [:data :rows])))
+        max-h    (max 0 (- (long px-h) footer-h 2))
+        clip-css (format "width:%dpx;max-height:%dpx;overflow:hidden" (long px-w) max-h)
         ;; the frame is stroked natively in draw-table-card!, so this wrapper has no border
         content  [:div
-                  [:div {:style clip-css} (restyle-table (:content info))]
-                  [:div {:style table-footer-css} (trun "{0} row" "{0} rows" n-rows)]]]
+                  [:div {:style clip-css} (restyle-table body (= :table chart-type))]
+                  footer]]
     (png/render-html-to-png (assoc info :content content) px-w {:channel.render/scale table-supersample})))
 
 (defn- move-to! [^PDPageContentStream cs x y] (.moveTo cs (float x) (float y)))
@@ -885,16 +948,19 @@
   (px->pt (/ (double px) table-supersample)))
 
 (defn- draw-table-card!
-  "Draw the table card body fitted to `[x, body-top]` x `cell-w` x `body-h`, with the card's outer
-  frame stroked natively around the image."
-  [^PDDocument doc ^PDPageContentStream cs timezone part x body-top cell-w body-h]
+  "Draw a table-like card body (`:table`, `:pivot`, or `:object`) into its `[x, body-top]` x `cell-w` x
+  `body-h` cell. The content image is drawn top-left at its natural size (filled or hugged per type, and
+  clipped to the cell), and the outer frame is stroked natively around the *full allocated cell* -- like the
+  card border on the dashboard -- so the border wraps the whole dashcard rather than shrink-wrapping the
+  content."
+  [^PDDocument doc ^PDPageContentStream cs timezone chart-type part x body-top cell-w body-h]
   (let [img (PDImageXObject/createFromByteArray
-             doc (table-body-png timezone part (pt->px cell-w) (pt->px body-h)) "table")
+             doc (table-body-png timezone part chart-type (pt->px cell-w) (pt->px body-h)) "table")
         ;; image is at table-supersample x logical pixels -> divide back to points
         dw  (supersampled-px->pt (.getWidth img))
         dh  (supersampled-px->pt (.getHeight img))]
     (.drawImage cs img (float x) (float (- body-top dh)) (float dw) (float dh))
-    (stroke-round-rect! cs table-frame-color 0.5 4.0 x body-top dw dh)))
+    (stroke-round-rect! cs table-frame-color 0.5 4.0 x body-top cell-w body-h)))
 
 (def ^:private no-results-image-bytes
   "Raw bytes of the 'no results' sail-boat asset (the same image the email/dashboard empty state uses), read once."
@@ -954,6 +1020,7 @@
   vary from the frontend dashboard and add little in a static export.
 
   Rectangular (ECharts/visx) charts are then rendered to exactly fill the remaining body area (matching the frontend);
+  table-like cards (native table, pivot, object-detail) draw their content top-left and get a native frame around the cell (see [[draw-table-card!]]);
   other types render their body title-less and resized (preserving aspect) to fit into the body area."
   [^PDDocument doc ^PDPageContentStream cs timezone
    {:keys [card dashcard inline-params]
@@ -979,10 +1046,9 @@
         fill?      (or (contains? rectangular-displays display)
                        (and (= :pie display)
                             (>= cell-w body-h)))
-        ;; tables, pivots, and table fallbacks (map/object/unknown) all detect as :table; a result with no
-        ;; rows (e.g. filtered out) detects as :empty regardless of display, and gets the no-results placeholder.
         chart-type (render.card/detect-pulse-chart-type card dashcard data)
-        table?     (= :table chart-type)
+        tabular?   (contains? table-like-chart-types chart-type)
+        ;; a no-row result detects as :empty regardless of display -> no-results placeholder
         empty?     (= :empty chart-type)
         ;; the result was too big to load into memory (see [[draw-too-large!]]); show its message instead of a chart.
         ;; carries no :data, so it would otherwise detect as :empty and show a misleading no-results placeholder.
@@ -1022,8 +1088,8 @@
                       (float x) (float (- body-top body-h))
                       (float cell-w) (float body-h))
 
-          table?
-          (draw-table-card! doc cs timezone part x body-top cell-w body-h)
+          tabular?
+          (draw-table-card! doc cs timezone chart-type part x body-top cell-w body-h)
 
           ;; other types (and charts whose render produced no SVG): title-less body PNG,
           ;; fit preserving aspect

--- a/src/metabase/channel/render/pdf.clj
+++ b/src/metabase/channel/render/pdf.clj
@@ -750,6 +750,15 @@
   via [[table-border-color]]."
   (Color. 0xF0 0xF0 0xF0))
 
+(def ^:private frame-line-w-pt
+  "Stroke width (points) of the native card frame."
+  0.5)
+
+(def ^:private frame-corner-radius-pt
+  "Corner radius (points) of the native card frame -- also used to clip the content image so its square corners
+  don't spill past the rounded frame."
+  4.0)
+
 (def ^:private table-border-color
   "CSS form of [[table-frame-color]] for the in-image footer divider (`border-top` above the `N rows` row)."
   (format "#%06X" (bit-and (.getRGB ^Color table-frame-color) 0xFFFFFF)))
@@ -916,19 +925,16 @@
                (+ ax (* rc dx2)) (+ ay (* rc dy2))
                (+ ax (* r  dx2)) (+ ay (* r  dy2)))))
 
-(defn- stroke-round-rect!
-  "Stroke a rounded-rectangle outline whose top-left is `[x, top-y]` (and is `w` x `h`) with `color`
-  at `line-w` points and corner radius `r` points, then reset to a black hairline. Corners are
-  quarter-circle cubic Béziers (see [[corner-to!]])."
-  [^PDPageContentStream cs ^Color color line-w r x top-y w h]
+(defn- round-rect-path!
+  "Append a rounded-rectangle subpath -- top-left `[x, top-y]`, size `w` x `h`, corner radius `r` points -- to the
+  content stream's current path (quarter-circle cubic Béziers, see [[corner-to!]]). The caller strokes or clips it."
+  [^PDPageContentStream cs r x top-y w h]
   (let [l  x
         t  top-y
         rt (+ l w)
         b  (- t h)
         r  (min r (/ w 2.0) (/ h 2.0))
         c  (* r bezier-circle-kappa)]
-    (.setStrokingColor cs color)
-    (.setLineWidth cs (float line-w))
     (move-to!   cs (+ l r) t)
     (line-to!   cs (- rt r) t)               ; top edge
     (corner-to! cs r c rt t   1  0   0 -1)   ; TR
@@ -937,10 +943,18 @@
     (line-to!   cs (+ l r) b)                ; bottom edge
     (corner-to! cs r c l  b  -1  0   0  1)   ; BL
     (line-to!   cs l (- t r))                ; left edge
-    (corner-to! cs r c l  t   0  1   1  0)   ; TL
-    (.stroke cs)
-    (.setStrokingColor cs Color/BLACK)
-    (.setLineWidth cs (float 1.0))))
+    (corner-to! cs r c l  t   0  1   1  0)))  ; TL
+
+(defn- stroke-round-rect!
+  "Stroke a rounded-rectangle outline whose top-left is `[x, top-y]` (and is `w` x `h`) with `color`
+  at `line-w` points and corner radius `r` points, then reset to a black hairline."
+  [^PDPageContentStream cs ^Color color line-w r x top-y w h]
+  (.setStrokingColor cs color)
+  (.setLineWidth cs (float line-w))
+  (round-rect-path! cs r x top-y w h)
+  (.stroke cs)
+  (.setStrokingColor cs Color/BLACK)
+  (.setLineWidth cs (float 1.0)))
 
 (defn- supersampled-px->pt
   "Points spanned on the page by `px` device pixels of a [[table-supersample]]-rastered image."
@@ -959,8 +973,13 @@
         ;; image is at table-supersample x logical pixels -> divide back to points
         dw  (supersampled-px->pt (.getWidth img))
         dh  (supersampled-px->pt (.getHeight img))]
+    ;; clip the rectangular image to the frame's rounded rect so its square corners can't spill past the arc
+    (.saveGraphicsState cs)
+    (round-rect-path! cs frame-corner-radius-pt x body-top cell-w body-h)
+    (.clip cs)
     (.drawImage cs img (float x) (float (- body-top dh)) (float dw) (float dh))
-    (stroke-round-rect! cs table-frame-color 0.5 4.0 x body-top cell-w body-h)))
+    (.restoreGraphicsState cs)
+    (stroke-round-rect! cs table-frame-color frame-line-w-pt frame-corner-radius-pt x body-top cell-w body-h)))
 
 (def ^:private no-results-image-bytes
   "Raw bytes of the 'no results' sail-boat asset (the same image the email/dashboard empty state uses), read once."

--- a/src/metabase/channel/render/style.clj
+++ b/src/metabase/channel/render/style.clj
@@ -264,22 +264,31 @@
   "Style for the `<table>` element of a rendered `:pivot` table."
   []
   (merge (font-style)
+         ;; CSSBox ignores border-collapse, so for a uniform 1px grid we set border-spacing:0 and draw each line
+         ;; once via per-cell borders (see pivot-cell-style: right+bottom, plus top/left on the first row/column).
          {:border-collapse :collapse
+          :border-spacing  0
           :font-size       (format "%spx" font-size)}))
 
 (defn pivot-cell-style
-  "Style for one cell of a rendered `:pivot` table. `header?`/`label?` select the cell role; `bg`, when
-  non-nil, is the conditional-formatting background color for a value cell."
-  [header? label? bg]
-  (merge {:border      (str "1px solid " color-border)
-          :padding     "5px 10px"
-          :white-space :nowrap}
-         (cond
-           header? {:background  color-pivot-header-bg
-                    :font-weight 700
-                    :text-align  :left}
-           label?  {:background  color-pivot-label-bg
-                    :font-weight 600
-                    :text-align  :left}
-           :else   {:text-align :right})
-         (when bg {:background-color bg})))
+  "Style for one cell of a rendered `:pivot` table. `header?`/`label?` select the cell role; `first-col?` is the
+  leftmost column; `bg`, when non-nil, is the conditional-formatting background color for a value cell. Each cell
+  draws only its right+bottom border (plus top/left on the first row/column) so abutting cells form a uniform 1px
+  grid -- CSSBox renders `border-collapse:collapse` as `separate`, which would otherwise double interior lines."
+  [header? label? first-col? bg]
+  (let [edge (str "1px solid " color-border)]
+    (merge {:border-right  edge
+            :border-bottom edge
+            :padding       "5px 10px"
+            :white-space   :nowrap}
+           (when header?    {:border-top  edge})
+           (when first-col? {:border-left edge})
+           (cond
+             header? {:background  color-pivot-header-bg
+                      :font-weight 700
+                      :text-align  :left}
+             label?  {:background  color-pivot-label-bg
+                      :font-weight 600
+                      :text-align  :left}
+             :else   {:text-align :right})
+           (when bg {:background-color bg}))))

--- a/test/metabase/channel/render/pdf_test.clj
+++ b/test/metabase/channel/render/pdf_test.clj
@@ -657,22 +657,27 @@
         ;; render-table-head splices the header cells into the :tr as a seq, like `for` output.
         table [:table {:style "border: 1px solid #F0F0F0; border-radius: 6px; margin: 16px;"}
                [:thead [:tr {} (list (th "a") (th "b") (th "c"))]]
-               [:tbody [:tr {} [:td {:style "x"} "1"]]]]
-        [_table attrs
-         [_thead
-          [_tr _tr-attrs
-           th-a th-b th-c]]
-         tbody]              (#'pdf/restyle-table table)]
-    (testing "the <table> fills its frame and drops its own border/radius/margin"
-      (is (str/includes? (:style attrs) "width:100%"))
-      (is (str/includes? (:style attrs) "border:none")))
-    (testing "header cells get a divider, except the last"
-      (is (divider? th-a))
-      (is (divider? th-b))
-      (is (not (divider? th-c))))
-    (testing "body rows pass through untouched"
-      (is (= [:tbody [:tr {} [:td {:style "x"} "1"]]]
-             tbody)))))
+               [:tbody [:tr {} [:td {:style "x"} "1"]]]]]
+    (testing "the native :table (add-dividers? true) fills its frame, drops its own border/radius/margin, and gets header dividers"
+      (let [[_table attrs
+             [_thead
+              [_tr _tr-attrs
+               th-a th-b th-c]]
+             tbody] (#'pdf/restyle-table table true)]
+        (is (str/includes? (:style attrs) "width:100%"))
+        (is (str/includes? (:style attrs) "border:none"))
+        (is (divider? th-a))
+        (is (divider? th-b))
+        (is (not (divider? th-c)))
+        (testing "body rows pass through untouched"
+          (is (= [:tbody [:tr {} [:td {:style "x"} "1"]]]
+                 tbody)))))
+    (testing "pivot/object-detail (add-dividers? false) also fill the frame but add no header dividers"
+      (let [restyled (#'pdf/restyle-table table false)
+            attrs    (second restyled)]
+        (is (str/includes? (:style attrs) "width:100%"))
+        (is (str/includes? (:style attrs) "border:none"))
+        (is (not (str/includes? (pr-str restyled) "border-right")))))))
 
 (deftest ^:parallel add-header-dividers-test
   (testing "spliced seqs are flattened and all header cells but the last get the divider"
@@ -687,6 +692,17 @@
               [:th {:style ""} "last"]]]
       (is (= tr (#'pdf/add-header-dividers tr))))))
 
+(def ^:private cell-fill-slack-px
+  "Logical px a width-filling table image may fall short of the cell (CSSBox rounding)."
+  8)
+
+(defn- fills-cell-width?
+  "Whether a table image's device-pixel `width` fills its `px-w` cell at the supersample scale (within
+  [[cell-fill-slack-px]]) without overflowing past it."
+  [width px-w]
+  (let [ss (long @#'pdf/table-supersample)]
+    (<= (* ss (- px-w cell-fill-slack-px)) width (* ss px-w))))
+
 ;; not ^:parallel: exercises the real CSSBox HTML rendering path
 (deftest ^:synchronized table-body-png-sizing-test
   (let [data               {:cols [{:name         "n"
@@ -699,13 +715,66 @@
         px-w               400
         px-h               300
         ss                 (long @#'pdf/table-supersample)
-        ^BufferedImage img (ImageIO/read (io/input-stream (#'pdf/table-body-png nil part px-w px-h)))]
+        ^BufferedImage img (ImageIO/read (io/input-stream (#'pdf/table-body-png nil part :table px-w px-h)))]
     (testing "width fills the cell at the supersampled scale"
-      (is (<= (* ss (- px-w 8))
-              (.getWidth img)
-              (* ss px-w))))
+      (is (fills-cell-width? (.getWidth img) px-w)))
     (testing "height is capped to the cell even though 50 rows don't fit"
       (is (<= 1 (.getHeight img) (* ss px-h))))))
+
+;; not ^:parallel: exercises the real CSSBox HTML rendering path for object-detail through the framed table path
+(deftest ^:synchronized object-detail-body-png-test
+  (testing "an object-detail card renders through the framed table path: width-filled and height-bounded"
+    (let [data               {:cols [{:name "id" :display_name "ID" :base_type :type/Integer}
+                                     {:name "name" :display_name "Name" :base_type :type/Text}]
+                              :rows [[1401 "Carmela"]]}
+          part               {:card     {:name "Most recent subscription"}
+                              :dashcard nil
+                              :result   {:data data}}
+          px-w               400
+          px-h               300
+          ss                 (long @#'pdf/table-supersample)
+          ^BufferedImage img (ImageIO/read (io/input-stream (#'pdf/table-body-png nil part :object px-w px-h)))]
+      (is (fills-cell-width? (.getWidth img) px-w))
+      (is (<= 1 (.getHeight img) (* ss px-h))))))
+
+;; not ^:parallel: exercises the real CSSBox HTML rendering path for the pivot's fill-the-cell framing
+(deftest ^:synchronized pivot-body-png-test
+  (let [px-h      400
+        assembled {:card     {:display                :pivot
+                              :visualization_settings {:pivot_table.column_split {:rows ["R"] :columns ["C"] :values ["m"]}}}
+                   :dashcard nil
+                   :result   {:data {:cols                 [{:name "R" :base_type :type/Text}
+                                                            {:name "C" :base_type :type/Text}
+                                                            {:name "pivot-grouping" :base_type :type/Integer}
+                                                            {:name "m" :base_type :type/Integer}]
+                                     :rows                 [["a" "x" 0 10]
+                                                            ["a" "y" 0 20]
+                                                            ["b" "x" 0 30]
+                                                            ["b" "y" 0 40]]
+                                     :format-rows?         true
+                                     :pivot-export-options {:pivot-rows [0] :pivot-cols [1] :pivot-measures [2]}}}}
+        width     (fn [part px-w] (.getWidth ^BufferedImage
+                                   (ImageIO/read (io/input-stream (#'pdf/table-body-png nil part :pivot px-w px-h)))))]
+    (testing "an assembled pivot fills a roomy cell -- columns stretch to use the space, like the dashboard"
+      (is (fills-cell-width? (width assembled 1000) 1000)))
+    (testing "a pivot wider than the cell is clipped at the cell edge, not rendered past it"
+      (is (fills-cell-width? (width assembled 100) 100)))
+    (testing "a :pivot that can't be assembled falls back to a flat table and also fills the cell (no collapse)"
+      (let [fallback {:card     {:display :pivot}
+                      :dashcard nil
+                      :result   {:data {:cols [{:name "a" :display_name "A" :base_type :type/Text}
+                                               {:name "b" :display_name "B" :base_type :type/Text}]
+                                        :rows [["x" "y"]]}}}]
+        (is (fills-cell-width? (width fallback 1000) 1000))))))
+
+(deftest ^:parallel table-like-chart-types-test
+  (testing "native table, pivot, and object-detail cards all classify into the framed table path"
+    (let [data {:cols [{:name "n" :display_name "N" :base_type :type/Integer}]
+                :rows [[1] [2]]}]
+      (doseq [display [:table :pivot :object]]
+        (is (contains? @#'pdf/table-like-chart-types
+                       (render.card/detect-pulse-chart-type {:display display} nil data))
+            (format "display %s should route through the framed table path" display))))))
 
 ;; not ^:parallel: exercises the real CSSBox/PDFBox rendering path (font loading + the no-results HTML->PNG asset)
 (deftest ^:synchronized no-results-card-render-test


### PR DESCRIPTION
Closes UXW-4518
Closes UXW-4524

### Description

Rotues Pivot Table and Object Detail viz through the same rendering pipeline as the regular table viz. The result should give us pivot tables and object detail visualizations that better fit their dashcards in the PDF, scaling horizontally to fill space if available but clipping when necessary which better matches what is rendered in the browser.

### How to verify
1. Build a dashboard and add some pivot tables + object detail visualizations. Ensure you're varying the sizes
2. Export this as a PDF. This can done by adding a PDF to a subscription and testing
3. Inspect visually

### Demo

[dash71.pdf](https://github.com/user-attachments/files/29513187/dash71.pdf)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
