### PR TITLE
fix(sdk): open SQL editor when Metabot navigates to native hash URL

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
@@ -35,13 +35,10 @@ const metabotResponseWithNavigateTo = `${metabotResponse}
 
 const metabotRetryResponse = `0:"Retry: Here is the [question link](${adHocQuestionPath})"`;
 
-const sqlEditorPath = `/question#${btoa(
-  JSON.stringify({
-    dataset_query: { database: 1, type: "native", native: { query: "" } },
-  }),
-)}`;
-const metabotResponseWithSqlEditor = `0:"Opening the SQL editor for you."
-2:{"type":"navigate_to","version":1,"value":"${sqlEditorPath}"}`;
+// Captured navigate_to event verbatim from a real embedding Metabot response
+// (database id swapped from 2 to 1 to match this env's Sample Database).
+const metabotResponseWithSqlEditor = `0:"I'll direct you to the SQL editor for the Sample Database so you can write a query for the most popular products!"
+2:{"type":"navigate_to","version":1,"value":"/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJ0eXBlIjoibmF0aXZlIiwibmF0aXZlIjp7InF1ZXJ5IjoiIn19fQ=="}`;
 
 describe("scenarios > embedding-sdk > metabot-question", () => {
   const setup = (response: string) => {

--- a/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
@@ -35,6 +35,14 @@ const metabotResponseWithNavigateTo = `${metabotResponse}
 
 const metabotRetryResponse = `0:"Retry: Here is the [question link](${adHocQuestionPath})"`;
 
+const sqlEditorPath = `/question#${btoa(
+  JSON.stringify({
+    dataset_query: { database: 1, type: "native", native: { query: "" } },
+  }),
+)}`;
+const metabotResponseWithSqlEditor = `0:"Opening the SQL editor for you."
+2:{"type":"navigate_to","version":1,"value":"${sqlEditorPath}"}`;
+
 describe("scenarios > embedding-sdk > metabot-question", () => {
   const setup = (response: string) => {
     signInAsAdminAndEnableEmbeddingSdk();
@@ -70,6 +78,17 @@ describe("scenarios > embedding-sdk > metabot-question", () => {
     cy.signOut();
     mockAuthProviderAndJwtSignIn();
   };
+
+  it("should show the SQL editor when Metabot navigates to the SQL editor page", () => {
+    setup(metabotResponseWithSqlEditor);
+
+    mountSdkContent(<MetabotQuestion />);
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("metabot-chat-input").type("Open the SQL editor {enter}");
+      cy.findByTestId("native-query-editor-container").should("be.visible");
+    });
+  });
 
   it("should show drill-through results after drilling from a metabot question", () => {
     setup(metabotResponseWithNavigateTo);

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkAdHocQuestion/SdkAdHocQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkAdHocQuestion/SdkAdHocQuestion.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 
 import type { SdkQuestionProps } from "embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion";
 import { SdkQuestion } from "embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion";
+import type { SdkQuestionId } from "embedding-sdk-bundle/types/question";
 import { deserializeCard, parseHash } from "metabase/common/utils/card";
 import * as Urls from "metabase/urls";
 
@@ -60,17 +61,21 @@ export const SdkAdHocQuestion = ({
     [questionPath],
   );
 
-  // If we cannot extract an entity ID from the slug, assume we are creating a new question.
-  const questionId = Urls.extractEntityId(params.slug) ?? null;
-
-  const { options, deserializedCard } = useMemo(() => {
+  const { options, deserializedCard, questionId } = useMemo(() => {
     const { options, serializedCard } = parseHash(location.hash);
     const deserializedCard = serializedCard
       ? deserializeCard(serializedCard)
       : undefined;
 
-    return { options, deserializedCard };
-  }, [location.hash]);
+    return {
+      options,
+      deserializedCard,
+      questionId: resolveQuestionId(
+        params.slug,
+        deserializedCard as { dataset_query?: { type?: string } } | undefined,
+      ),
+    };
+  }, [location.hash, params.slug]);
 
   return (
     <SdkQuestion
@@ -100,6 +105,25 @@ export const SdkAdHocQuestion = ({
     </SdkQuestion>
   );
 };
+
+/**
+ * Derives the questionId from URL slug and deserialized card.
+ * Returns "new-native" for hash-encoded native cards (e.g. Metabot SQL editor navigation),
+ * a numeric/string ID for saved questions, or null for new notebook questions.
+ */
+export function resolveQuestionId(
+  slug: string | undefined,
+  deserializedCard: { dataset_query?: { type?: string } } | undefined,
+): SdkQuestionId | null {
+  const extractedId = Urls.extractEntityId(slug) ?? null;
+  if (extractedId !== null) {
+    return extractedId;
+  }
+  if (deserializedCard?.dataset_query?.type === "native") {
+    return "new-native";
+  }
+  return null;
+}
 
 /**
  * This generates route parameters based on the provided URL path

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkAdHocQuestion/SdkAdHocQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkAdHocQuestion/SdkAdHocQuestion.tsx
@@ -61,21 +61,19 @@ export const SdkAdHocQuestion = ({
     [questionPath],
   );
 
-  const { options, deserializedCard, questionId } = useMemo(() => {
+  const { options, deserializedCard } = useMemo(() => {
     const { options, serializedCard } = parseHash(location.hash);
     const deserializedCard = serializedCard
       ? deserializeCard(serializedCard)
       : undefined;
 
-    return {
-      options,
-      deserializedCard,
-      questionId: resolveQuestionId(
-        params.slug,
-        deserializedCard as { dataset_query?: { type?: string } } | undefined,
-      ),
-    };
-  }, [location.hash, params.slug]);
+    return { options, deserializedCard };
+  }, [location.hash]);
+
+  const questionId = resolveQuestionId(
+    params.slug,
+    deserializedCard as { dataset_query?: { type?: string } } | undefined,
+  );
 
   return (
     <SdkQuestion

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkAdHocQuestion/SdkAdHocQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkAdHocQuestion/SdkAdHocQuestion.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { getQuestionParameters } from "./SdkAdHocQuestion";
+import { getQuestionParameters, resolveQuestionId } from "./SdkAdHocQuestion";
 
 describe("getQuestionParameters", () => {
   it("should generate proper URL params for ad-hoc question", () => {
@@ -26,5 +26,41 @@ describe("getQuestionParameters", () => {
       },
       params: { slug: "109-days-when-orders-were-added" },
     });
+  });
+});
+
+describe("resolveQuestionId", () => {
+  it("returns 'new-native' for a native card hash with no slug", () => {
+    expect(
+      resolveQuestionId(undefined, {
+        dataset_query: { type: "native" },
+      }),
+    ).toBe("new-native");
+  });
+
+  it("returns null for a structured (MBQL) card hash with no slug", () => {
+    expect(
+      resolveQuestionId(undefined, {
+        dataset_query: { type: "query" },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns numeric ID for a saved question slug", () => {
+    expect(
+      resolveQuestionId("109-days-when-orders-were-added", undefined),
+    ).toBe(109);
+  });
+
+  it("returns null when there is no slug and no deserialized card", () => {
+    expect(resolveQuestionId(undefined, undefined)).toBeNull();
+  });
+
+  it("numeric slug takes precedence over a native card", () => {
+    expect(
+      resolveQuestionId("42-my-question", {
+        dataset_query: { type: "native" },
+      }),
+    ).toBe(42);
   });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76702
Fixes EMB-1958

### Description

`SdkAdHocQuestion` receives `questionPath` from Metabot's `navigate_to` stream event. When Metabot opens the SQL editor, the backend generates `/question#<base64_native_card>` — a hash URL with no path segment after `/question`. `getQuestionParameters` splits on `/` and finds no second segment, so `params.slug` is empty and `questionId` falls back to `null`. With `questionId=null`, `SdkQuestionProvider` sets `isNewQuestion=false`, so the SQL editor never opens.

Fix: after deserializing the card from the URL hash, check if `dataset_query.type === "native"` with no saved ID. If so, return `"new-native"` as `questionId`. This makes `SdkQuestionProvider` set `isNewQuestion=true` and `useNewQuestionEditorSync` open the editor.

The new `resolveQuestionId` export handles the priority logic:
1. Numeric slug → saved question ID (unchanged)
2. No slug + native card hash → `"new-native"` (new)
3. Otherwise → `null`

Dashboard drill-through is unaffected: those paths have numeric IDs or MBQL hashes (`type: "query"`), never native-typed hashes with no slug.

**Note:** This fix opens the SQL editor, but the editor will always have an empty SQL query. The `:embedding_next` Metabot profile lacks `create-sql-query-tool` / `edit-sql-query-tool`, so the Metabot agent can only navigate to the SQL editor with an empty query — it cannot pre-fill SQL like the internal (main app) Metabot profile does. That capability gap is tracked separately in this issue.

### How to verify

1. Open an embedded `<MetabotQuestion />` with a valid Anthropic API key set.
2. Ask Metabot to open the SQL editor (e.g. "Write me a SQL query").
3. Verify the SQL editor panel opens automatically — previously it stayed closed.

### Demo
<img width="2168" height="1261" alt="image" src="https://github.com/user-attachments/assets/35b43190-3647-4d79-869a-385a109eab8c" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)