### PR TITLE
Don't error when table has a foreign key reference to an inaccessible table

### DIFF
--- a/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.ts
@@ -1,12 +1,14 @@
 const { H } = cy;
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import type {
   ConcreteFieldReference,
   StructuredQuery,
 } from "metabase-types/api";
+import { DataPermission, DataPermissionValue } from "metabase-types/api";
 
-const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+const { ALL_USERS_GROUP } = USER_GROUPS;
+const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 const ORDERS_TOTAL_FIELD: ConcreteFieldReference = [
   "field",
@@ -108,5 +110,40 @@ describe("issue 39221", () => {
 
       cy.get("@siteSettings").should("be.null");
     });
+  });
+});
+
+describe("issue 76710", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.activateToken("pro-self-hosted");
+
+    cy.updatePermissionsGraph({
+      [ALL_USERS_GROUP]: {
+        [SAMPLE_DB_ID]: {
+          [DataPermission.VIEW_DATA]: {
+            PUBLIC: {
+              [ORDERS_ID]: DataPermissionValue.UNRESTRICTED,
+              [PRODUCTS_ID]: DataPermissionValue.BLOCKED,
+            },
+          },
+          [DataPermission.CREATE_QUERIES]: {
+            PUBLIC: {
+              [ORDERS_ID]: DataPermissionValue.QUERY_BUILDER,
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("can view a table whose foreign key targets a table the user can't access (metabase#76710)", () => {
+    cy.intercept("GET", `/api/field/${PRODUCTS.ID}`).as("fkTargetField");
+    cy.signIn("none");
+    cy.visit(`/table/${ORDERS_ID}`);
+    cy.wait("@fkTargetField").its("response.statusCode").should("eq", 403);
+    H.tableInteractive().should("be.visible");
+    H.tableHeaderColumn("Product ID").should("be.visible");
   });
 });

--- a/frontend/src/metabase/redux/tables.ts
+++ b/frontend/src/metabase/redux/tables.ts
@@ -79,7 +79,7 @@ export const fetchTableMetadataAndForeignKeys =
     await dispatch(fetchTableMetadata({ id }, options));
 
     const table = getMetadataUnfiltered(getState()).table(id) as ForeignKeyHost;
-    await Promise.all([
+    await Promise.allSettled([
       ...getTableForeignKeyTableIds(table).map((tableId) =>
         dispatch(fetchTableMetadata({ id: tableId }, options)),
       ),

--- a/frontend/src/metabase/redux/tables.unit.spec.ts
+++ b/frontend/src/metabase/redux/tables.unit.spec.ts
@@ -1,0 +1,50 @@
+import fetchMock from "fetch-mock";
+
+import { getMainStore } from "__support__/entities-store";
+import {
+  setupTableQueryMetadataEndpoint,
+  setupUnauthorizedFieldEndpoint,
+} from "__support__/server-mocks";
+import { getMetadata } from "metabase/selectors/metadata";
+import { createMockField, createMockTable } from "metabase-types/api/mocks";
+
+import { fetchTableMetadataAndForeignKeys } from "./tables";
+
+const TABLE_ID = 1;
+const FK_TARGET_FIELD_ID = 3;
+
+const FK_FIELD = createMockField({
+  id: 1,
+  table_id: TABLE_ID,
+  name: "a",
+  // This field is a foreign key to a table that the user doesn't have access to
+  semantic_type: "type/FK",
+  fk_target_field_id: FK_TARGET_FIELD_ID,
+  target: undefined,
+});
+
+const TABLE_A = createMockTable({
+  id: TABLE_ID,
+  fields: [FK_FIELD],
+});
+
+describe("fetchTableMetadataAndForeignKeys", () => {
+  it("resolves and loads the table even when a foreign key target field is forbidden", async () => {
+    setupTableQueryMetadataEndpoint(TABLE_A);
+    setupUnauthorizedFieldEndpoint(createMockField({ id: FK_TARGET_FIELD_ID }));
+
+    const store = getMainStore();
+
+    // Check there's no permission error
+    await expect(
+      store.dispatch(fetchTableMetadataAndForeignKeys({ id: TABLE_ID })),
+    ).resolves.toBeUndefined();
+
+    expect(
+      fetchMock.callHistory.called(`path:/api/field/${FK_TARGET_FIELD_ID}`),
+    ).toBe(true);
+
+    const table = getMetadata(store.getState()).table(TABLE_ID);
+    expect(table).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/76710

### Description

Use `Promise.allSettled` when getting foreign key metadata so that we don't throw a permission error when viewing a table the user has permission to access. 

### How to verify

See repro steps in original issue. You should be able to access the table now. 

### Demo

https://www.loom.com/share/063b0e991ab64fd1bb86934637a62635

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
