### PR TITLE
Remove wrong disabled styles on chart settings Data fields

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.module.css
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.module.css
@@ -29,6 +29,8 @@
 
   &[data-disabled] {
     background-color: var(--mb-color-background_page-primary);
+    color: var(--mb-color-text-primary);
+    cursor: default;
   }
 }
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76201
Refs Closes https://linear.app/metabase/issue/UXW-4559/drag-options-and-remove-buttons-in-data-tab-of-chart-settings-look

Slack thread: https://metaboat.slack.com/archives/C05NXACAG1G/p1782830011854109?thread_ts=1782827268.528599&cid=C05NXACAG1G

### Description

These fields were getting disabled state styles when they shouldn't (text color and pointer).

### How to verify

Open a line-chart question and check its viz settings. X-axis and Y-axis rows shouldn't get disabled-like styles.
This is a regression. To compare this with how it looked like in the past, you can compare it with v0.62.3.

### Demo
Before:
<img width="410" height="462" alt="image" src="https://github.com/user-attachments/assets/6907cecf-b32e-4a92-9027-f22acd76d36c" />

After:
<img width="408" height="453" alt="image" src="https://github.com/user-attachments/assets/06f88631-b29b-4356-aa20-67983919f061" />

v0.62.1 (for reference)
<img width="410" height="462" alt="image" src="https://github.com/user-attachments/assets/283970aa-c293-47f3-b439-aa51bc642403" />
Note: For the `cursor` css prop, I deliberately set it to `default` instead of `pointer`, since clicking the inputs won't do anything.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
