### PR TITLE
Reuse the ci-conductor contract types and utils in e2e reporting

### DIFF
--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -3,6 +3,19 @@ import { dirname } from "node:path";
 
 import fetch from "node-fetch"; // must be node-fetch v2 because it's non-esm
 
+// The canonical wire shape and the numeric-env parser live once in the
+// ci-conductor module (release/ci-conductor), shared by the backend and
+// frontend reporters. e2e reuses them so the report path and the quarantine
+// path can't drift on a test's identity (see contract.ts). The transport stays
+// forked here: e2e posts mid-run from inside Cypress's `after:spec` hook on
+// node-fetch, with screenshots and a dry-run mode — none of which the module's
+// bun-native, post-run transport covers.
+import type {
+  FailedTestsBody,
+  NormalizedTest,
+} from "../../release/ci-conductor/src/contract";
+import { toNumber } from "../../release/ci-conductor/src/util";
+
 // `Cypress` and `CypressCommandLine` are global namespaces provided by the
 // "cypress" types (see e2e/tsconfig.json), so they're referenced without import.
 
@@ -39,34 +52,17 @@ const {
 // resolution and payload shape in CI before sending real data. See DEV-1999.
 const isDryRun = CI_CONDUCTOR_DRY_RUN === "true";
 
-/** Matches the `tests[]` shape consumed by ci-conductor's `ingestFailedTests`. */
-type ConductorTest = {
-  name: string;
-  /** The test's suite path (the joined `describe` titles), formerly `class`. */
-  path?: string;
-  file?: string;
-  duration?: number;
-  /** Raw per-attempt shape from Cypress, e.g. [{state:"failed"},{state:"passed"}]. */
-  attempts?: { state: string }[];
-  /**
-   * "failure" when every attempt failed (broken), "flake" when it failed then
-   * passed on retry, "passed" when every attempt passed. Passes are only
-   * reported on re-runs (run attempt > 1). Derived from `attempts`.
-   */
-  status?: "failure" | "flake" | "passed";
-  /**
-   * Cypress' final `displayError` blob for the test. Null for flaky tests
-   * (Cypress drops it when the final attempt passes); only broken tests carry a
-   * value. Conductor schema isn't final — fields it doesn't store are ignored.
-   */
-  message?: string | null;
-  /**
-   * The test's first failure screenshot as a base64 PNG data URI. ci-conductor
-   * uploads it to S3 and stores the public URL. Attached at send time by
-   * `reportFailedTestsToConductor`; absent when there's no screenshot or it
-   * can't be read. See DEV-2000.
-   */
-  failure_screenshot?: string;
+/**
+ * One reportable e2e test: the shared `NormalizedTest` wire shape (defined once
+ * in the ci-conductor module, so the report path and the quarantine path can't
+ * drift on a test's identity) plus a transient, never-sent `screenshotPath`.
+ *
+ * The Cypress-specific field semantics live at `extractFailedTests`: `message`
+ * is null for flakes (Cypress drops `displayError` once the final attempt
+ * passes), passing tests are only reported on re-runs, and `status` is derived
+ * from `attempts` by `classifyStatus`.
+ */
+type E2ETest = NormalizedTest & {
   /**
    * Transient (never sent on the wire): absolute path to the resolved first
    * failure screenshot, set by `extractFailedTests`. It's read and encoded into
@@ -100,15 +96,6 @@ function classifyStatus(
  */
 function getJobId(): number | null {
   return toNumber(JOB_ID);
-}
-
-/** Parse a numeric env var, treating missing/blank/non-numeric as null. */
-function toNumber(value: string | undefined): number | null {
-  if (value == null || value === "") {
-    return null;
-  }
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
 }
 
 /** Normalize a string to just [a-z0-9] for sanitization-proof matching. */
@@ -214,7 +201,7 @@ function encodeScreenshot(filePath: string): string | undefined {
 export function extractFailedTests(
   spec: Cypress.Spec,
   results: CypressCommandLine.RunResult,
-): ConductorTest[] {
+): E2ETest[] {
   const file = spec?.relative;
 
   // On a re-run we also report passing tests (not just failures) so conductor
@@ -291,7 +278,7 @@ const QUARANTINE_FAILURES_FILE =
  * on retry and passing tests don't gate the build, so they're filtered out.
  * Best-effort and never throws — recording must not break the test run.
  */
-export function recordFailedTestsForQuarantine(tests: ConductorTest[]): void {
+export function recordFailedTestsForQuarantine(tests: E2ETest[]): void {
   try {
     const broken = tests.filter((test) => test.status === "failure");
     if (broken.length === 0) {
@@ -321,7 +308,7 @@ export function recordFailedTestsForQuarantine(tests: ConductorTest[]): void {
  * reporting must not break a test run — so all errors are logged and swallowed.
  */
 export async function reportFailedTestsToConductor(
-  tests: ConductorTest[],
+  tests: E2ETest[],
 ): Promise<void> {
   if (tests.length === 0 || (!CI_CONDUCTOR_BASE_URL && !isDryRun)) {
     return;
@@ -341,7 +328,10 @@ export async function reportFailedTestsToConductor(
       return failure_screenshot ? { ...rest, failure_screenshot } : rest;
     });
 
-    const body = {
+    // Typed against the shared contract so the run-level identity stays in
+    // lockstep with the backend/frontend reporters; `retries` is the one e2e-only
+    // field (Cypress has a retry ceiling; the JUnit producers don't).
+    const body: FailedTestsBody & { retries: number | null } = {
       repo_id: toNumber(REPO_ID),
       run_id: toNumber(GITHUB_RUN_ID),
       attempt: toNumber(GITHUB_RUN_ATTEMPT),


### PR DESCRIPTION
Resolves DEV-2235

Replace e2e's local ConductorTest with the shared NormalizedTest wire shape (plus a transient screenshotPath) and import `toNumber` from the module, so the report path and the quarantine path can't drift on a test's identity. **The transport stays forked**: e2e posts mid-run from Cypress's `after:spec` hook on node-fetch, with screenshots and a dry-run mode the module's post-run transport doesn't cover.

@iethree unfortunately, I think this is as far as we can go with the de-duplication due to the hard-constraint to keep Cypress reporting in-memory, after the spec finished running. That's fine, imo. A bit od duplication is worth having richer and sooner Cypress reports.

> [!IMPORTANT]
> Depends on https://github.com/metabase/metabase/pull/76666