### PR TITLE
Don't navigate on ad-hoc question chart clicks

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/static-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/static-question.cy.spec.tsx
@@ -6,6 +6,7 @@ import {
   type StaticQuestionProps,
 } from "@metabase/embedding-sdk-react";
 
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { createQuestion, modal, popover } from "e2e/support/helpers";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
@@ -280,5 +281,42 @@ describe("scenarios > embedding-sdk > static-question", () => {
 
       getSdkRoot().button("Alerts").should("be.visible");
     });
+  });
+
+  it.only("should not request /api/card/undefined when clicking a data point on an ad-hoc `query` question", () => {
+    // An ad-hoc question (rendered from `query`) has no saved card id. A static
+    // question must not navigate on a chart click — previously it did, fetching
+    // `GET /api/card/undefined` (the new card's id was `undefined`).
+    cy.intercept("GET", "/api/card/undefined").as("getUndefinedCard");
+
+    mountSdkContent(
+      <StaticQuestion
+        query={{
+          database: SAMPLE_DB_ID,
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"]],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+            ],
+            limit: 5,
+          },
+        }}
+      />,
+    );
+
+    getSdkRoot().within(() => {
+      cy.log("the aggregated query renders a cartesian chart");
+      H.cartesianChartCircle().should("have.length.greaterThan", 0);
+
+      cy.log("clicking a data point must not navigate to a new card");
+      H.cartesianChartCircle().first().click();
+
+      // The chart stays put (retry gives any erroneous navigation time to fire).
+      H.cartesianChartCircle().should("have.length.greaterThan", 0);
+    });
+
+    cy.get("@getUndefinedCard.all").should("have.length", 0);
   });
 });

--- a/e2e/test-component/scenarios/embedding-sdk/static-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/static-question.cy.spec.tsx
@@ -283,7 +283,7 @@ describe("scenarios > embedding-sdk > static-question", () => {
     });
   });
 
-  it.only("should not request /api/card/undefined when clicking a data point on an ad-hoc `query` question", () => {
+  it("should not request /api/card/undefined when clicking a data point on an ad-hoc `query` question", () => {
     // An ad-hoc question (rendered from `query`) has no saved card id. A static
     // question must not navigate on a chart click — previously it did, fetching
     // `GET /api/card/undefined` (the new card's id was `undefined`).

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { match } from "ts-pattern";
 import { t } from "ttag";
 
 import { SdkError } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
@@ -299,14 +300,11 @@ export const SdkQuestionProvider = ({
   //                 (which would load a card by its undefined id → `/card/undefined`).
   //   - undefined → the SDK's internal navigation (the default).
   //   - a handler → run through the drill-through wrapper.
-  let contextNavigateToNewCard: SdkQuestionContextType["navigateToNewCard"];
-  if (userNavigateToNewCard === null) {
-    contextNavigateToNewCard = null;
-  } else if (userNavigateToNewCard === undefined) {
-    contextNavigateToNewCard = navigateToNewCardWithSdkInternalNavigation;
-  } else {
-    contextNavigateToNewCard = navigateToNewCardWithDrillThrough;
-  }
+  const contextNavigateToNewCard: SdkQuestionContextType["navigateToNewCard"] =
+    match(userNavigateToNewCard)
+      .with(null, () => null)
+      .with(undefined, () => navigateToNewCardWithSdkInternalNavigation)
+      .otherwise(() => navigateToNewCardWithDrillThrough);
 
   const questionContext: SdkQuestionContextType = {
     originalId: questionId,

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
@@ -292,20 +292,20 @@ export const SdkQuestionProvider = ({
     [updateQuestion],
   );
 
-  // `navigateToNewCard={null}` explicitly disables navigation (e.g. StaticQuestion
-  // / ad-hoc questions): the viz then won't wire `onChangeCardAndRun`, which would
-  // otherwise try to load a card by its (undefined) id → `/card/undefined`.
-  // `undefined` uses the SDK's internal navigation; a provided handler runs through
-  // the drill-through wrapper.
+  // How the user's `navigateToNewCard` prop maps to the context value:
+  //   - null      → navigation disabled (e.g. StaticQuestion / ad-hoc questions).
+  //                 Passed through as null; `Visualization` turns it into
+  //                 `undefined`, so the chart never wires `onChangeCardAndRun`
+  //                 (which would load a card by its undefined id → `/card/undefined`).
+  //   - undefined → the SDK's internal navigation (the default).
+  //   - a handler → run through the drill-through wrapper.
   let contextNavigateToNewCard: SdkQuestionContextType["navigateToNewCard"];
   if (userNavigateToNewCard === null) {
-    // Passed through as null; `Visualization` turns it into `undefined`, so the
-    // chart never wires `onChangeCardAndRun`.
     contextNavigateToNewCard = null;
-  } else if (userNavigateToNewCard !== undefined) {
-    contextNavigateToNewCard = navigateToNewCardWithDrillThrough;
-  } else {
+  } else if (userNavigateToNewCard === undefined) {
     contextNavigateToNewCard = navigateToNewCardWithSdkInternalNavigation;
+  } else {
+    contextNavigateToNewCard = navigateToNewCardWithDrillThrough;
   }
 
   const questionContext: SdkQuestionContextType = {

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
@@ -292,6 +292,22 @@ export const SdkQuestionProvider = ({
     [updateQuestion],
   );
 
+  // `navigateToNewCard={null}` explicitly disables navigation (e.g. StaticQuestion
+  // / ad-hoc questions): the viz then won't wire `onChangeCardAndRun`, which would
+  // otherwise try to load a card by its (undefined) id → `/card/undefined`.
+  // `undefined` uses the SDK's internal navigation; a provided handler runs through
+  // the drill-through wrapper.
+  let contextNavigateToNewCard: SdkQuestionContextType["navigateToNewCard"];
+  if (userNavigateToNewCard === null) {
+    // Passed through as null; `Visualization` turns it into `undefined`, so the
+    // chart never wires `onChangeCardAndRun`.
+    contextNavigateToNewCard = null;
+  } else if (userNavigateToNewCard !== undefined) {
+    contextNavigateToNewCard = navigateToNewCardWithDrillThrough;
+  } else {
+    contextNavigateToNewCard = navigateToNewCardWithSdkInternalNavigation;
+  }
+
   const questionContext: SdkQuestionContextType = {
     originalId: questionId,
     lastVisibleStageIndex,
@@ -306,10 +322,7 @@ export const SdkQuestionProvider = ({
     updateQuestion,
     updateAndNormalizeQuestion,
     updateParameterValues,
-    navigateToNewCard:
-      userNavigateToNewCard !== undefined
-        ? navigateToNewCardWithDrillThrough
-        : navigateToNewCardWithSdkInternalNavigation,
+    navigateToNewCard: contextNavigateToNewCard,
     plugins,
     question,
     originalQuestion,

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/run-question-on-navigate.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/run-question-on-navigate.ts
@@ -47,10 +47,15 @@ export const runQuestionOnNavigateSdk =
 
     // Fallback when a visualization legend is clicked
     if (cardIsEquivalent(previousCard, nextCard)) {
-      nextCard = await loadCard(
-        { cardId: nextCard.id },
-        { dispatch, getState },
-      );
+      // Reload the canonical card only for saved questions. Ad-hoc questions
+      // (rendered from a `query` prop) have no id — there's nothing to fetch, so
+      // keep the card as-is rather than firing `GET /api/card/undefined`.
+      if (nextCard.id !== null && nextCard.id !== undefined) {
+        nextCard = await loadCard(
+          { cardId: nextCard.id },
+          { dispatch, getState },
+        );
+      }
     } else {
       nextCard = getCardAfterVisualizationClick(nextCard, previousCard);
       onClearQueryResults();


### PR DESCRIPTION
Don't navigate on ad-hoc question chart clicks

<img width="2216" height="506" alt="image" src="https://github.com/user-attachments/assets/43b88dd9-908d-41c3-a326-c593bb0f67fa" />

Clicking a data point on an ad-hoc question (rendered from a `query`/`card`, so it has no saved card id) fired `GET /api/card/undefined`. Static questions shouldn't navigate at all, and the navigation path didn't guard against a missing card id.

Context:
https://metaboat.slack.com/archives/C063Q3F1HPF/p1782833540311049

How to test:
- create a data app that uses StaticQuestion + query prop.
- when you click a viz, it should not trigger `/card/undefined` requests