### PR TITLE
Fix transform table deletion in workspaces

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/workspaces/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/e2e_test.clj
@@ -652,7 +652,14 @@
                                               (str "no app-db Table row should point at a table in the isolation DB " isolation-schema
                                                    " (leaked: " (pr-str (map :name leaked)) ")")))
                                         (is (= [] (filter #(= iso-tbl-schema (:schema %)) (map #(select-keys % [:schema :name]) tables)))
-                                            "no app-db Table row points at the isolation schema")))))))))
+                                            "no app-db Table row points at the isolation schema"))))
+                                  (testing "DELETE /api/transform/:id/table succeeds for the workspace user"
+                                    (let [outcome (try (mt/user-http-request :crowberto :delete 204
+                                                                             (format "transform/%d/table" (:id transform)))
+                                                       ::ok
+                                                       (catch Throwable t [::failed (ex-message t)]))]
+                                      (is (= ::ok outcome)
+                                          (str "deleting the transform output table failed; outcome=" (pr-str outcome))))))))))
                         (finally
                           ;; Clear the `instance-workspace` setting (populated by `apply-workspace-section!`
                           ;; via `initialize!` above) and tear down the WorkspaceDatabase. The

--- a/enterprise/frontend/src/metabase-enterprise/api/workspace-instance.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/workspace-instance.ts
@@ -6,7 +6,7 @@ import type {
 } from "metabase-types/api";
 
 import { EnterpriseApi } from "./api";
-import { invalidateTags, listTag, tag } from "./tags";
+import { invalidateTags, tag } from "./tags";
 
 export const workspaceInstanceApi = EnterpriseApi.injectEndpoints({
   endpoints: (builder) => ({
@@ -25,7 +25,7 @@ export const workspaceInstanceApi = EnterpriseApi.injectEndpoints({
         url: "/api/ee/workspace-instance/current",
       }),
       invalidatesTags: (_, error) =>
-        invalidateTags(error, [tag("workspace"), listTag("workspace")]),
+        invalidateTags(error, [tag("workspace"), tag("table-remapping")]),
     }),
     listTableRemappings: builder.query<TableRemapping[], void>({
       query: () => ({

--- a/enterprise/frontend/src/metabase-enterprise/api/workspace-manager.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/workspace-manager.ts
@@ -67,6 +67,7 @@ export const workspaceManagerApi = EnterpriseApi.injectEndpoints({
 
 export const {
   useListWorkspacesQuery,
+  useLazyListWorkspacesQuery,
   useGetWorkspaceQuery,
   useCreateWorkspaceMutation,
   useUpdateWorkspaceMutation,

--- a/enterprise/frontend/src/metabase-enterprise/workspaces/pages/WorkspaceListPage/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/workspaces/pages/WorkspaceListPage/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -11,7 +11,10 @@ import {
 } from "metabase/forms";
 import { Button, Checkbox, Group, Modal, Stack } from "metabase/ui";
 import * as Errors from "metabase/utils/errors";
-import { useCreateWorkspaceMutation } from "metabase-enterprise/api";
+import {
+  useCreateWorkspaceMutation,
+  useLazyListWorkspacesQuery,
+} from "metabase-enterprise/api";
 import type { Database, Workspace } from "metabase-types/api";
 
 import { trackWorkspaceCreated } from "../../../analytics";
@@ -72,6 +75,7 @@ function NewWorkspaceForm({
   onClose,
 }: NewWorkspaceFormProps) {
   const [createWorkspace] = useCreateWorkspaceMutation();
+  const [fetchWorkspaces] = useLazyListWorkspacesQuery();
 
   const handleSubmit = async ({
     name,
@@ -81,6 +85,7 @@ function NewWorkspaceForm({
       name,
       database_ids: database_ids.map(Number),
     }).unwrap();
+    await fetchWorkspaces();
     trackWorkspaceCreated({ workspaceId: workspace.id });
     onCreate(workspace);
   };

--- a/enterprise/frontend/src/metabase-enterprise/workspaces/pages/WorkspaceListPage/NewWorkspaceModal/NewWorkspaceModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/workspaces/pages/WorkspaceListPage/NewWorkspaceModal/NewWorkspaceModal.unit.spec.tsx
@@ -1,6 +1,9 @@
 import userEvent from "@testing-library/user-event";
 
-import { setupCreateWorkspaceEndpoint } from "__support__/server-mocks";
+import {
+  setupCreateWorkspaceEndpoint,
+  setupListWorkspacesEndpoint,
+} from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import type { Workspace } from "metabase-types/api";
 import {
@@ -25,6 +28,7 @@ function setup({
   const onClose = jest.fn();
 
   setupCreateWorkspaceEndpoint(createdWorkspace);
+  setupListWorkspacesEndpoint([createdWorkspace]);
 
   renderWithProviders(
     <NewWorkspaceModal

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -487,16 +487,38 @@
     ;; TODO this should probably be a function in the sync module
     (t2/update! :model/Table (:id table) {:active false})))
 
+(defn- isolated-drop-target
+  "Resolve `target` to the physical warehouse table to drop.
+
+  On a workspace child the canonical target is backed by an isolation-namespace copy recorded
+  in `table_remapping`; the workspace user can only DROP inside its isolation namespace, so the
+  drop must hit that copy — not the canonical table. Looks the copy up via the general
+  canonical→isolated workspace hook (symmetric with [[canonicalize-target]], which uses the
+  inverse). The isolated namespace lives in `:schema` for schema-based drivers and in `:db` for
+  MySQL; collapse to the single `:schema` slot the driver drop path qualifies on. Off-workspace
+  the hook returns nil and `target` is dropped unchanged."
+  [db-id target]
+  (let [lookup-spec {:db (:db target) :schema (:schema target) :name (:name target)}]
+    (if-let [{:keys [db schema name]} (ws.table-remapping/workspace-remap-schema+name db-id lookup-spec)]
+      (assoc target :schema (or schema db) :name name)
+      target)))
+
 (defn delete-target-table!
-  "Delete the target table of a transform and sync it from the app db."
+  "Drop a transform's output table and deactivate its app-db Table row.
+
+  In workspace-isolation mode the transform writes to an isolation-namespace copy, so the drop
+  resolves the canonical `:target` to that copy (see [[isolated-drop-target]]); dropping the
+  canonical name would fail (the workspace user is read-only there) or hit the wrong table. The
+  app-db Table row that gets deactivated is always the canonical `:target`, since that is what
+  sync surfaces. Off-workspace the two are identical."
   [{:keys [id target], :as transform}]
   (when target
-    (let [target (update target :type keyword)
-          database-id (transforms-base.i/target-db-id transform)]
+    (let [database-id (transforms-base.i/target-db-id transform)]
       (when database-id
         (if-let [{driver :engine :as database} (t2/select-one :model/Database database-id)]
-          (do
-            (driver/drop-transform-target! driver database target)
+          (let [drop-target (->> (update target :type keyword)
+                                 (isolated-drop-target database-id))]
+            (driver/drop-transform-target! driver database drop-target)
             (log/info "Deactivating  target " (pr-str target) "for transform" id)
             (deactivate-table! database target))
           (log/warnf "Skipping drop of transform target %s for transform %d: database %d not found"


### PR DESCRIPTION
Before, it tried to delete the "virtual", i.e. "real" table and failed. Now it correctly deletes the workspace one.