### PR TITLE
Claude Sonnet 5 support

### DIFF
--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -300,16 +300,18 @@
 (defn- model-supports-temperature?
   "Whether `model` accepts an explicit `temperature` parameter.
 
-  Sampling parameters (`temperature`, `top_p`, `top_k`) were removed starting with Claude Opus 4.7.  Strips an
-  optional vendor prefix (e.g. Bedrock's `anthropic.`) before checking."
+  Sampling parameters (`temperature`, `top_p`, `top_k`) were removed starting with Claude Opus 4.7 and Sonnet 5.
+  Strips an optional vendor prefix (e.g. Bedrock's `anthropic.`) before checking."
   [model]
   (let [model (str/replace-first (str model) #"^anthropic\." "")]
     (not (or (str/starts-with? model "claude-fable")
-             (when-let [[_ major minor] (re-find #"^claude-opus-(\d+)(?:-(\d+))?" model)]
+             (when-let [[_ family major minor] (re-find #"^claude-(opus|sonnet)-(\d+)(?:-(\d+))?" model)]
                (let [major (parse-long major)
                      minor (or (some-> minor parse-long) 0)]
-                 (or (> major 4)
-                     (and (= major 4) (>= minor 7)))))))))
+                 (case family
+                   "opus"   (or (> major 4)
+                                (and (= major 4) (>= minor 7)))
+                   "sonnet" (>= major 5))))))))
 
 (mu/defn claude-request-body
   "Build the Anthropic Messages API request body for an LLM request."

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -51,6 +51,12 @@
    :cacheCreationTokens (:cache_creation_input_tokens u 0)
    :cacheReadTokens     (:cache_read_input_tokens u 0)})
 
+(def ^:private translated-chunk-type?
+  "Claude content-block types we translate into AI SDK chunks. Other block types
+  (e.g. `thinking`/`redacted_thinking` from extended or adaptive thinking) are
+  ignored, mirroring the OpenAI adapter's handling of reasoning output."
+  #{:text :tool_use})
+
 (defn claude->aisdk-chunks-xf
   "Translates Claude /v1/messages streaming events into AI SDK v5 protocol chunks.
 
@@ -82,10 +88,14 @@
           ;; usage in the completion arity so we don't lose data entirely.
           last-usage   (volatile! nil)
           close!       (fn [result]
-                         (u/prog1 (rf result (merge {:type (case @current-type
-                                                             :text     :text-end
-                                                             :tool_use :tool-input-available)}
-                                                    @payload))
+                         ;; only emit an end marker for block types we translate; thinking and
+                         ;; other untranslated blocks are ignored.
+                         (u/prog1 (if-let [end-type (case @current-type
+                                                      :text     :text-end
+                                                      :tool_use :tool-input-available
+                                                      nil)]
+                                    (rf result (merge {:type end-type} @payload))
+                                    result)
                            (vreset! current-type nil)
                            (vreset! current-id nil)
                            (vreset! payload {})))]
@@ -121,19 +131,24 @@
                                                           :tool_use {:toolCallId chunk-id
                                                                      :toolName   (:name content_block)}
                                                           nil)))
-                                             (rf (merge (case block-type
-                                                          :text     {:type :text-start}
-                                                          :tool_use {:type :tool-input-start})
-                                                        @payload)))
+                                             (cond->
+                                              (translated-chunk-type? block-type)
+                                               (rf (merge (case block-type
+                                                            :text     {:type :text-start}
+                                                            :tool_use {:type :tool-input-start})
+                                                          @payload))))
 
-             ;; content block delta
-             (= t "content_block_delta") (rf (case (:type delta)
-                                               "text_delta"       {:type  :text-delta
-                                                                   :id    (:id @payload)
-                                                                   :delta (:text delta)}
-                                               "input_json_delta" {:type           :tool-input-delta
-                                                                   :toolCallId     (:toolCallId @payload)
-                                                                   :inputTextDelta (:partial_json delta)}))
+             ;; content block delta — ignore deltas for blocks we don't translate
+             ;; (e.g. thinking_delta / signature_delta from extended thinking)
+             (and (= t "content_block_delta")
+                  (contains? #{"text_delta" "input_json_delta"} (:type delta)))
+             (rf (case (:type delta)
+                   "text_delta"       {:type  :text-delta
+                                       :id    (:id @payload)
+                                       :delta (:text delta)}
+                   "input_json_delta" {:type           :tool-input-delta
+                                       :toolCallId     (:toolCallId @payload)
+                                       :inputTextDelta (:partial_json delta)}))
 
              ;; end of content block
              (= t "content_block_stop") (close!)

--- a/test/metabase/metabot/self/claude_test.clj
+++ b/test/metabase/metabot/self/claude_test.clj
@@ -419,9 +419,11 @@
                    "claude-opus-4-5" "claude-opus-4-6" "claude-opus-4-1"]]
       (is (true? (#'claude/model-supports-temperature? model))
           model)))
-  (testing "sampling parameters were removed starting with Opus 4.7 and on Fable models"
+  (testing "sampling parameters were removed starting with Opus 4.7, Sonnet 5, and on Fable models"
     (doseq [model ["claude-opus-4-7" "claude-opus-4-8" "claude-opus-4-8-20260415"
-                   "claude-opus-5" "claude-opus-5-0" "claude-fable-5"]]
+                   "claude-opus-5" "claude-opus-5-0"
+                   "claude-sonnet-5" "claude-sonnet-5-0" "claude-sonnet-6"
+                   "claude-fable-5"]]
       (is (false? (#'claude/model-supports-temperature? model))
           model))))
 
@@ -440,4 +442,5 @@
       (is (= 0.3 (:temperature (request-body "claude-haiku-4-5")))))
     (testing "temperature is omitted for models that reject sampling parameters"
       (is (not (contains? (request-body "claude-opus-4-8") :temperature)))
+      (is (not (contains? (request-body "claude-sonnet-5") :temperature)))
       (is (not (contains? (request-body "anthropic.claude-opus-4-8") :temperature))))))

--- a/test/metabase/metabot/self/claude_test.clj
+++ b/test/metabase/metabot/self/claude_test.clj
@@ -149,6 +149,46 @@
       (is (= {:cacheCreationTokens 0 :cacheReadTokens 0}
              (select-keys (:usage usage) [:cacheCreationTokens :cacheReadTokens]))))))
 
+(deftest ^:parallel claude-thinking-blocks-ignored-test
+  (testing "thinking content blocks (extended/adaptive thinking, e.g. Claude Sonnet 5) are ignored"
+    (let [events [{:type "message_start"
+                   :message {:id "msg-1" :model "claude-sonnet-5"
+                             :usage {:input_tokens 10 :output_tokens 0}}}
+                  ;; a thinking block arrives before the text
+                  {:type "content_block_start" :index 0 :content_block {:type "thinking"}}
+                  {:type "content_block_delta" :index 0 :delta {:type "thinking_delta" :thinking "let me think"}}
+                  {:type "content_block_delta" :index 0 :delta {:type "signature_delta" :signature "abc"}}
+                  {:type "content_block_stop" :index 0}
+                  {:type "content_block_start" :index 1 :content_block {:type "text" :id "text-1"}}
+                  {:type "content_block_delta" :index 1 :delta {:type "text_delta" :text "hi"}}
+                  {:type "content_block_stop" :index 1}
+                  {:type "message_delta" :delta {:stop_reason "end_turn"}
+                   :usage {:input_tokens 10 :output_tokens 5}}
+                  {:type "message_stop"}]]
+      (testing "no thinking/reasoning chunks are emitted; only text + usage survive"
+        (is (=? [{:type :start} {:type :text-start} {:type :text-delta} {:type :text-end} {:type :usage}]
+                (into []
+                      (comp (claude/claude->aisdk-chunks-xf)
+                            (m/distinct-by :type))
+                      events))))
+      (testing "through the full pipeline produces text + usage"
+        (is (=? [{:type :start} {:type :text :text "hi"} {:type :usage}]
+                (into []
+                      (comp (claude/claude->aisdk-chunks-xf)
+                            (self.core/aisdk-xf))
+                      events))))))
+  (testing "a stream that ends mid-thinking flushes usage without emitting a thinking part"
+    (let [events [{:type "message_start"
+                   :message {:id "msg-2" :model "claude-sonnet-5"
+                             :usage {:input_tokens 10 :output_tokens 0}}}
+                  {:type "content_block_start" :index 0 :content_block {:type "thinking"}}
+                  {:type "content_block_delta" :index 0 :delta {:type "thinking_delta" :thinking "partial"}}]]
+      (is (=? [{:type :start} {:type :usage}]
+              (into []
+                    (comp (claude/claude->aisdk-chunks-xf)
+                          (m/distinct-by :type))
+                    events))))))
+
 ;;; ──────────────────────────────────────────────────────────────────
 ;;; parts->claude-messages tests
 ;;; ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes [BOT-1771: Claude Sonnet 5 support](https://linear.app/metabase/issue/BOT-1771/claude-sonnet-5-support)
Maybe also [BOT-1743: Claude Fable support](https://linear.app/metabase/issue/BOT-1743/claude-fable-support) but needs to be tested to confirm.

### Description

Updates for Claude Sonnet 5 support.

* Update `model-supports-temperature?`. Sonnet 5 does not support `:temperature`. Without this, requests fail with HTTP 400 Bad Request.
* Ignore thinking chunks in `claude->aisdk-chunks-xf`. Sonnet 5 enables adaptive reasoning by default, and `claude->aisdk-chunks-xf` would throw when it encountered them. Similar to changes made for openai and GPT 5.5 / 5.4 in 9f7176302669146d876e27df0a576b973a5a0e39

### Benchmarks (sonnet-5 vs master with sonnet-4-6)

canonical_benchmark with internal profile

<img width="1524" height="391" alt="Screenshot 2026-06-30 at 2 21 51 PM" src="https://github.com/user-attachments/assets/f590ebdc-21cb-424d-9a43-f913bd16462b" />

### Demo

```
INFO metabot.api :: Using native Clojure agent {:profile-id internal, :debug? false}
INFO agent.core :: Starting agent {:profile :internal, :tools 13, :max-iter 10, :msgs 1}
INFO agent.messages :: Building message history {:input-message-count 1, :step-count 0, :preload-parts 0, :total-parts 1}
INFO metabot.self :: Calling LLM {:provider anthropic, :model claude-sonnet-5, :parts 1, :tools 13, :tool-choice nil, :ai-proxy? false}
INFO self.claude :: :metabot.claude/request (1500.462291ms) {:model "claude-sonnet-5", :msg-count 1, :tool-count 13}
INFO metabot.self :: :metabot.agent/call-llm (3265.912875ms) {:provider "anthropic", :model "claude-sonnet-5", :part-count 1, :tool-count 13}
DEBUG agent.core :: Iteration {:n 1, :parts-count 8}
DEBUG agent.core :: Got parts {:count 8, :types [:start :text :text :text :text :text :text :usage]}
INFO agent.core :: Agent loop complete {:iterations 1, :reason :stop}
DEBUG agent.core :: :metabot.agent/loop-step (3530.957ms) {:iteration 1}
INFO agent.core :: :metabot.agent/run-agent-loop (3536.394125ms) {:profile-id :internal, :msg-count 1}
```
### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
