### PR TITLE
Drop metabase_version from serialization (GHY-4013)

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3488,7 +3488,6 @@
            app-db
            appearance
            collections
-           config
            events
            lib
            logger

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -8,7 +8,6 @@
    [metabase-enterprise.serialization.v2.backfill-ids :as serdes.backfill]
    [metabase-enterprise.serialization.v2.models :as serdes.models]
    [metabase.collections.models.collection :as collection]
-   [metabase.config.core :as config]
    [metabase.models.serialization :as serdes]
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -220,22 +219,11 @@
                    ;; extract all non-content entities like data model and settings if necessary
                    (eduction (map #(serdes/extract-all % opts)) cat (remove (set serdes.models/content) models))])))))
 
-(defn- needs-version?
-  "True for extracted entities that should carry a `:metabase_version` stamp."
-  [entity]
-  (and (not (instance? Exception entity))
-       (not= "Setting" (-> entity :serdes/meta last :model))))
-
-(defn- stamp-version [entity]
-  (if (needs-version? entity)
-    (assoc entity :metabase_version config/mb-version-string)
-    entity))
-
 (defn extract
   "Returns a reducible stream of entities to serialize"
   [opts]
   (serdes.backfill/backfill-ids!)
-  (eduction (map stamp-version) (extract-subtrees opts)))
+  (extract-subtrees opts))
 
 (comment
   (def nodes (let [colls (mapv vector (repeat "Collection") (collection-set-for-user nil))]

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -9,7 +9,6 @@
    [metabase-enterprise.serialization.v2.models :as serdes.models]
    [metabase.app-db.core :as mdb]
    [metabase.app-db.transient-error :as transient-error]
-   [metabase.config.core :as config]
    [metabase.models.serialization :as serdes]
    [metabase.search.core :as search]
    [metabase.util :as u]
@@ -48,10 +47,6 @@
    "Document"  #{:document}
    "Card"      #{:dashboard_id :document_id :parameters}})
 
-(def ^:private ^:dynamic *warned-version-mismatch*
-  "Used to avoid double-logging on version mismatches. Warns if nil or set to true"
-  nil)
-
 (defn- keys-to-strip [ingested]
   (let [model (-> ingested :serdes/meta last :model)]
     (or (model->circular-dependency-keys model)
@@ -65,22 +60,21 @@
   If [[load-one]] throws because it can't find that entity in the filesystem, check if it's already loaded in
   our database."
   [ctx deps]
-  (binding [*warned-version-mismatch* (if (nil? *warned-version-mismatch*) (atom false) *warned-version-mismatch*)]
-    (if (empty? deps)
-      ctx
-      (letfn [(loader [ctx dep]
-                (try
-                  (load-one! ctx dep)
-                  (catch Exception e
-                    (cond
-                      ;; It was missing, but we found it locally, so just return the context.
-                      (and (= (:error (ex-data e)) ::not-found)
-                           (serdes/load-find-local dep))
-                      ctx
+  (if (empty? deps)
+    ctx
+    (letfn [(loader [ctx dep]
+              (try
+                (load-one! ctx dep)
+                (catch Exception e
+                  (cond
+                    ;; It was missing, but we found it locally, so just return the context.
+                    (and (= (:error (ex-data e)) ::not-found)
+                         (serdes/load-find-local dep))
+                    ctx
 
-                      :else
-                      (throw e)))))]
-        (reduce loader ctx deps)))))
+                    :else
+                    (throw e)))))]
+      (reduce loader ctx deps))))
 
 (defn- safe-local-id
   "Looks up the local primary key for `path`, swallowing any exception from the DB lookup.
@@ -119,23 +113,6 @@
   (when (valid-model-name-for-load? model-name)
     (let [model (t2.model/resolve-model (symbol model-name))]
       (serdes.backfill/has-entity-id? model))))
-
-(defn- warn-if-version-mismatch
-  "Checks if the version in the exported entity differs from the current Metabase version.
-  Logs a warning if there is a mismatch. Entities without a `:metabase_version` (eg. Settings,
-  which are bundled into settings.yaml without per-entity metadata) are skipped."
-  [ingested path]
-  (when (and (or (nil? *warned-version-mismatch*) (not @*warned-version-mismatch*))
-             (:metabase_version ingested))
-    (let [current-version  config/mb-version-string
-          exported-version (:metabase_version ingested)]
-      (when (not= exported-version current-version)
-        (log/warnf "Version mismatch loading %s: exported with: %s, current version: %s"
-                   path
-                   exported-version
-                   current-version)
-        (when (not (nil? *warned-version-mismatch*))
-          (reset! *warned-version-mismatch* true))))))
 
 (defn- load-one!
   "Loads a single entity, specified by its `:serdes/meta` abstract path, into the appdb, doing some bookkeeping to
@@ -212,7 +189,6 @@
                                                                             :level     (count expanding)}))
               local-or-nil       (when-not require-new-entity (serdes/load-find-local rebuilt-path))]
           (try
-            (warn-if-version-mismatch ingested path)
             (with-retries 3 200
               (fn []
                 (t2/with-transaction [_tx]
@@ -255,41 +231,40 @@
                 :or   {backfill?         true
                        continue-on-error false
                        reindex?          true}}]
-  (binding [*warned-version-mismatch* (atom false)]
-    (u/prog1
-      ;; Each entity is loaded in its own transaction (inside load-one!), so a deadlock or transient
-      ;; failure on one entity doesn't abort the entire import. See #74412.
-      (do
-        (when backfill?
-          (t2/with-transaction [_tx]
-            (serdes.backfill/backfill-ids!)))
-        ;; We proceed in the arbitrary order of ingest-list, deserializing all the files. Their declared
-        ;; dependencies guide the import, and make sure all containers are imported before contents, etc.
-        (let [contents      (serdes.ingest/ingest-list ingestion)
-              ingest-errors (serdes.ingest/ingest-errors ingestion)
-              ctx           (cond-> (new-context ingestion)
-                              (seq ingest-errors) (update :errors into ingest-errors))]
-          (when (and (seq ingest-errors) (not continue-on-error))
-            (let [file-names (mapv #(or (:file (ex-data %)) (ex-message %)) ingest-errors)]
-              (throw (ex-info (format "Failed to read %d file(s) during ingestion: %s"
-                                      (count ingest-errors)
-                                      (str/join ", " file-names))
-                              {:ingest-errors ingest-errors
-                               :files         file-names}
-                              (first ingest-errors)))))
-          (log/infof "Starting deserialization, total %s documents" (count contents))
-          (reduce (fn [ctx item]
-                    (try
-                      (load-one! ctx item)
-                      (catch Exception e
-                        (when-not continue-on-error
-                          (throw e))
-                        ;; eschew big and scary stacktrace
-                        (log/warnf (u/strip-error e "Skipping deserialization error"))
-                        (update ctx :errors conj e))))
-                  ctx
-                  contents)))
-      (when reindex?
-        ;; Reindex after all entities are loaded. Individual entity commits may have produced stale
-        ;; search index entries; this ensures the index reflects the final state.
-        (search/reindex!)))))
+  (u/prog1
+    ;; Each entity is loaded in its own transaction (inside load-one!), so a deadlock or transient
+    ;; failure on one entity doesn't abort the entire import. See #74412.
+    (do
+      (when backfill?
+        (t2/with-transaction [_tx]
+          (serdes.backfill/backfill-ids!)))
+      ;; We proceed in the arbitrary order of ingest-list, deserializing all the files. Their declared
+      ;; dependencies guide the import, and make sure all containers are imported before contents, etc.
+      (let [contents      (serdes.ingest/ingest-list ingestion)
+            ingest-errors (serdes.ingest/ingest-errors ingestion)
+            ctx           (cond-> (new-context ingestion)
+                            (seq ingest-errors) (update :errors into ingest-errors))]
+        (when (and (seq ingest-errors) (not continue-on-error))
+          (let [file-names (mapv #(or (:file (ex-data %)) (ex-message %)) ingest-errors)]
+            (throw (ex-info (format "Failed to read %d file(s) during ingestion: %s"
+                                    (count ingest-errors)
+                                    (str/join ", " file-names))
+                            {:ingest-errors ingest-errors
+                             :files         file-names}
+                            (first ingest-errors)))))
+        (log/infof "Starting deserialization, total %s documents" (count contents))
+        (reduce (fn [ctx item]
+                  (try
+                    (load-one! ctx item)
+                    (catch Exception e
+                      (when-not continue-on-error
+                        (throw e))
+                      ;; eschew big and scary stacktrace
+                      (log/warnf (u/strip-error e "Skipping deserialization error"))
+                      (update ctx :errors conj e))))
+                ctx
+                contents)))
+    (when reindex?
+      ;; Reindex after all entities are loaded. Individual entity commits may have produced stale
+      ;; search index entries; this ensures the index reflects the final state.
+      (search/reindex!))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj
@@ -99,7 +99,6 @@ serdes/meta:
   model: Card
 archived_directly: false
 dashboard_id: null
-metabase_version: v1.54.4-SNAPSHOT (c6780bb)
 source_card_id: null
 type: %s
 document_id: null

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -107,8 +107,7 @@
 (defn- clean-entity
   "Removes any comparison-confounding fields, like `:created_at`."
   [entity]
-  (dissoc entity :created_at :result_metadata :metadata_sync_schedule :cache_field_values_schedule
-          :metabase_version))
+  (dissoc entity :created_at :result_metadata :metadata_sync_schedule :cache_field_values_schedule))
 
 #_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest e2e-storage-ingestion-test

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -12,7 +12,6 @@
    [metabase-enterprise.serialization.v2.round-trip-test :as round-trip-test]
    [metabase.actions.models :as action]
    [metabase.audit-app.core :as audit]
-   [metabase.config.core :as config]
    [metabase.core.core :as mbc]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
@@ -2840,19 +2839,14 @@
         (is (= #{light-eid dark-eid}
                (ids-by-model "EmbeddingTheme" (extract/extract {}))))))))
 
-(deftest stamp-metabase-version-test
-  (testing "extract stamps :metabase_version on entities (so load can detect version mismatches)"
+(deftest no-metabase-version-stamp-test
+  (testing "extract does not stamp :metabase_version on entities (GHY-4013: it caused spurious remote-sync diffs)"
     (mt/with-empty-h2-app-db!
       (ts/with-temp-dpc [:model/Collection {coll-id :id} {:name "My Collection"}
                          :model/Card       _             {:name "My Card" :collection_id coll-id}]
         (let [extracted (into [] (extract/extract {}))
               by-model  (group-by (comp :model last :serdes/meta) extracted)]
-          (testing "Collections and Cards get the current Metabase version"
-            (doseq [m ["Collection" "Card"]
-                    entity (get by-model m)]
-              (is (= config/mb-version-string (:metabase_version entity))
-                  (str m " should be stamped with the current version"))))
-          (testing "Settings are not stamped — settings.yaml only persists :key and :value"
-            (doseq [setting (get by-model "Setting")]
-              (is (not (contains? setting :metabase_version))
-                  "Setting should not be stamped"))))))))
+          (doseq [m      ["Collection" "Card"]
+                  entity (get by-model m)]
+            (is (not (contains? entity :metabase_version))
+                (str m " should not carry a :metabase_version"))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -19,7 +19,6 @@
    [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.json :as json]
-   [metabase.util.log.capture :as log.capture]
    [metabase.warehouses.models.database :as models.database]
    [toucan2.core :as t2]))
 
@@ -1994,32 +1993,6 @@
       (testing "absent :entity_id also works"
         (serdes.load/load-metabase! (ingestion-in-memory [(dissoc coll-ser :entity_id)]))
         (is (= 4 (coll-count)))))))
-
-(deftest warn-if-version-mismatch-test
-  (ts/with-dbs [source-db dest-db dest-db2 dest-db3]
-    (ts/with-db source-db
-      (mt/with-temp [:model/Collection _ {:name "col-1"}]
-        (let [extract (into [] (serdes.extract/extract {:no-settings true}))]
-          (ts/with-db dest-db
-            (testing "logs a warning when version in serdes/meta differs from current version"
-              (let [old-version-extract (map #(assoc % :metabase_version "v1.0.0 (oldcommit)") extract)]
-                (log.capture/with-log-messages-for-level [messages [metabase-enterprise.serialization.v2.load :warn]]
-                  (serdes.load/load-metabase! (ingestion-in-memory old-version-extract))
-                  (is (some #(str/includes? % "Version mismatch loading") (messages)))
-                  (is (= 1 (count (filter #(str/includes? % "Version mismatch loading") (messages))))
-                      "Should log a version mismatch warning only once per load")))))
-          (ts/with-db dest-db2
-            (testing "No warnings when version in serdes/meta matches current version"
-              (log.capture/with-log-messages-for-level [messages [metabase-enterprise.serialization.v2.load :warn]]
-                (serdes.load/load-metabase! (ingestion-in-memory extract))
-                (is (= 0 (count (filter #(str/includes? % "Version mismatch loading") (messages))))))))
-          (ts/with-db dest-db3
-            (testing "No warnings when entities have no :metabase_version (eg. legacy exports or Settings)"
-              (let [no-version-extract (map #(dissoc % :metabase_version) extract)]
-                (log.capture/with-log-messages-for-level [messages [metabase-enterprise.serialization.v2.load :warn]]
-                  (serdes.load/load-metabase! (ingestion-in-memory no-version-extract))
-                  (is (= 0 (count (filter #(str/includes? % "Version mismatch loading") (messages))))
-                      "Missing :metabase_version should be treated as unknown, not as a mismatch"))))))))))
 
 (deftest import-published-table-with-existing-database-test
   (testing "Importing a published table works when database already exists on target"

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/round_trip_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/round_trip_test.clj
@@ -54,6 +54,8 @@
   ;; Is worth considering when adding entries here, whether they shouldn't just be skipped in extraction.
   #{:cache_field_values_schedule
     :metadata_sync_schedule
+    ;; instance-specific build version, no longer serialized (GHY-4013). Legacy baseline fixtures still
+    ;; carry it, which exercises that such exports still import cleanly now that it's skipped.
     :metabase_version
     ;; result_metadata is non-deterministic for dashboard/document cards because the Card before-update hook
     ;; re-computes it without :verified-result-metadata? set. Fixing this properly requires making serdes

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/storage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/storage_test.clj
@@ -42,11 +42,11 @@
           (testing "the Collections properly exported"
             (let [yaml-parent (-> (yaml/from-file (io/file dump-dir "collections" "main"
                                                            "some_collection.yaml"))
-                                  (dissoc :serdes/meta :metabase_version)
+                                  (dissoc :serdes/meta)
                                   (update :created_at t/offset-date-time))
                   yaml-child  (-> (yaml/from-file (io/file dump-dir "collections" "main"
                                                            "some_collection" "child_collection.yaml"))
-                                  (dissoc :serdes/meta :metabase_version)
+                                  (dissoc :serdes/meta)
                                   (update :created_at t/offset-date-time))]
               (is (= (-> (into {} (t2/select-one :model/Collection :id (:id parent)))
                          (dissoc :id :location)
@@ -142,7 +142,6 @@
                                                 "databases"  "my_company_data"
                                                 "tables"     "customers"
                                                 "fields"     "company__SLASH__organization_website.yaml"))
-                       (dissoc :metabase_version)
                        (update :visibility_type keyword)
                        (update :base_type       keyword))))))))))
 

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1366,9 +1366,12 @@
 (defmethod serdes/make-spec "Card"
   [_model-name _opts]
   {:copy [:archived :archived_directly :collection_position :collection_preview :description :display
-          :embedding_params :enable_embedding :embedding_type :entity_id :metabase_version :public_uuid :type :name
+          :embedding_params :enable_embedding :embedding_type :entity_id :public_uuid :type :name
           :card_schema]
-   :skip [;; cache invalidation is instance-specific
+   :skip [;; instance-specific build version; serializing it produces spurious remote-sync diffs, and the
+          ;; serialized representation is versioned by :card_schema instead
+          :metabase_version
+          ;; cache invalidation is instance-specific
           :cache_invalidated_at
           ;; those are instance-specific analytic columns
           :view_count :last_used_at :initially_published_at


### PR DESCRIPTION
Closes ghy-4013

## Summary

A generic remote-sync problem: pulling from `main` could leave unexpected uncommitted changes. The cause is `metabase_version` — serialization stamped every non-Setting entity (and carried it on the Card column) with the instance build version on extract. Since that value differs between instances (e.g. `v1.63.0-SNAPSHOT (5183ebb)` vs `vUNKNOWN (008bf29)`), every export diverged, producing spurious diffs.

Compatibility of the serialized format is now governed by the versioned representation spec (`:card_schema` + `upgrade-card-schema-to`), not the product version, so the per-entity `metabase_version` stamp no longer carries useful information. This drops it from serialization.

## Changes

- **`extract.clj`** — remove the `metabase_version` stamp applied to extracted entities.
- **`card.clj`** — move `:metabase_version` from the Card serdes `:copy` list to `:skip` (the DB column is unchanged; it's just no longer serialized).
- **`load.clj`** — remove the now-dead version-mismatch warning machinery (the warning could only ever fire on the field we no longer write).
- **Tests** — regression guard that extract no longer stamps the field; drop the obsolete warning test; remove now-redundant ignore/`dissoc` entries. Legacy baseline fixtures still carry the field, which exercises that older exports import cleanly now that it's skipped.

## Note

The `report_card.metabase_version` column is intentionally left in place and still populated; only serialization changed.

## Testing

Serdes round-trip, storage, extract, and e2e suites pass. Remaining failures in the touched modules (`validation.clj:35`, "Tables can only be added to 'Data' collections") are pre-existing and reproduce on the base branch.