### PR TITLE
run the incremental transform suite against all drivers (coverage probe)

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
@@ -215,7 +215,8 @@
 (set! *warn-on-reflection* true)
 
 (defn- test-drivers []
-  (disj (mt/normal-drivers-with-feature :transforms/table) :redshift :clickhouse :sqlserver))
+  ;; coverage probe: drop the redshift/clickhouse/sqlserver exclusion to see what actually passes in CI.
+  (mt/normal-drivers-with-feature :transforms/table))
 
 (defn- target-table-gen [prefix]
   {:type     :table


### PR DESCRIPTION
our incremental transform tests `disj` redshift, clickhouse and sqlserver, so the whole `incremental-test` namespace never runs them. every deftest is either on `(test-drivers)` (which excluded those three) or hardcoded `#{:postgres}`. so we have zero incremental-transform coverage on those engines here.

this drops the exclusion so CI runs the full `:transforms/table` matrix and we can see what actually passes. not meant to merge as is, it's a coverage probe.

what I expect:
- sqlserver: fails. source is `SELECT *` off transforms_products, whose id pk is `INT IDENTITY(1,1)`, and sqlserver full runs go through `SELECT ... INTO` which preserves the identity. so the append `INSERT ... SELECT` supplies an explicit id and dies without IDENTITY_INSERT. fixing that separately.
- redshift: unknown. it has an identity pk too but goes through CTAS (`CREATE TABLE AS`), which doesn't carry identity, so it might just pass and we can reclaim the coverage.
- clickhouse: unknown. no identity (Int32), but the checkpoint/count assertions may not hold on MergeTree's async merges.
