### PR TITLE
handle database named permalinks

### DIFF
--- a/frontend/src/metabase/browse/schemas/BrowseSchemas.tsx
+++ b/frontend/src/metabase/browse/schemas/BrowseSchemas.tsx
@@ -121,7 +121,6 @@ export const BrowseSchemas = ({ params }: { params: { slug: string } }) => {
   const dbId = Urls.extractEntityId(params.slug);
 
   if (dbId == null) {
-    // react-router already url-decodes route params, so `slug` is the raw db name here.
     return <DatabaseNameRedirect name={params.slug} />;
   }
 

--- a/frontend/src/metabase/browse/schemas/BrowseSchemas.tsx
+++ b/frontend/src/metabase/browse/schemas/BrowseSchemas.tsx
@@ -1,6 +1,4 @@
 import cx from "classnames";
-import { useEffect } from "react";
-import { replace } from "react-router-redux";
 import { t } from "ttag";
 
 import {
@@ -15,7 +13,6 @@ import { NotFound } from "metabase/common/components/ErrorPages";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { findDatabaseByName } from "metabase/common/utils/database";
 import CS from "metabase/css/core/index.css";
-import { useDispatch } from "metabase/redux";
 import { Flex } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type { DatabaseId } from "metabase-types/api";
@@ -36,13 +33,13 @@ const DatabaseName = ({ id }: { id: DatabaseId | null | undefined }) => {
 
 const BrowseSchemasContainer = ({
   schemas,
+  dbId,
   params,
 }: {
   schemas: Schema[];
+  dbId: DatabaseId;
   params: any;
 }) => {
-  const { slug } = params;
-  const dbId = Urls.extractEntityId(slug);
   return (
     <Flex
       className={S.browseContainer}
@@ -99,29 +96,32 @@ const BrowseSchemasContainer = ({
   );
 };
 
-const DatabaseNameRedirect = ({ name }: { name: string }) => {
-  const dispatch = useDispatch();
+const BrowseSchemasByDatabaseName = ({
+  name,
+  params,
+}: {
+  name: string;
+  params: { slug: string };
+}) => {
   const { data, isLoading } = useListDatabasesQuery();
   const database = findDatabaseByName(data?.data ?? [], name);
 
-  useEffect(() => {
-    if (database) {
-      dispatch(replace(Urls.browseDatabase(database)));
-    }
-  }, [database, dispatch]);
-
-  if (isLoading || database) {
+  if (isLoading) {
     return <LoadingAndErrorWrapper loading />;
   }
 
-  return <NotFound />;
+  if (!database) {
+    return <NotFound />;
+  }
+
+  return <BrowseSchemasForDatabase dbId={database.id} params={params} />;
 };
 
 export const BrowseSchemas = ({ params }: { params: { slug: string } }) => {
   const dbId = Urls.extractEntityId(params.slug);
 
   if (dbId == null) {
-    return <DatabaseNameRedirect name={params.slug} />;
+    return <BrowseSchemasByDatabaseName name={params.slug} params={params} />;
   }
 
   return <BrowseSchemasForDatabase dbId={dbId} params={params} />;
@@ -141,5 +141,8 @@ const BrowseSchemasForDatabase = ({
   }
 
   const schemas: Schema[] = (data ?? []).map((name) => ({ id: name, name }));
-  return <BrowseSchemasContainer schemas={schemas} params={params} />;
+
+  return (
+    <BrowseSchemasContainer schemas={schemas} dbId={dbId} params={params} />
+  );
 };

--- a/frontend/src/metabase/browse/schemas/BrowseSchemas.tsx
+++ b/frontend/src/metabase/browse/schemas/BrowseSchemas.tsx
@@ -103,11 +103,11 @@ const BrowseSchemasByDatabaseName = ({
   name: string;
   params: { slug: string };
 }) => {
-  const { data, isLoading } = useListDatabasesQuery();
+  const { data, isLoading, error } = useListDatabasesQuery();
   const database = findDatabaseByName(data?.data ?? [], name);
 
-  if (isLoading) {
-    return <LoadingAndErrorWrapper loading />;
+  if (isLoading || error) {
+    return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
   }
 
   if (!database) {

--- a/frontend/src/metabase/browse/schemas/BrowseSchemas.tsx
+++ b/frontend/src/metabase/browse/schemas/BrowseSchemas.tsx
@@ -1,16 +1,21 @@
 import cx from "classnames";
+import { useEffect } from "react";
+import { replace } from "react-router-redux";
 import { t } from "ttag";
 
 import {
   skipToken,
   useGetDatabaseQuery,
   useListDatabaseSchemasQuery,
+  useListDatabasesQuery,
 } from "metabase/api";
 import { TableBrowser } from "metabase/browse/tables/TableBrowser";
 import { BrowserCrumbs } from "metabase/common/components/BrowserCrumbs";
 import { NotFound } from "metabase/common/components/ErrorPages";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { findDatabaseByName } from "metabase/common/utils/database";
 import CS from "metabase/css/core/index.css";
+import { useDispatch } from "metabase/redux";
 import { Flex } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type { DatabaseId } from "metabase-types/api";
@@ -94,11 +99,30 @@ const BrowseSchemasContainer = ({
   );
 };
 
+const DatabaseNameRedirect = ({ name }: { name: string }) => {
+  const dispatch = useDispatch();
+  const { data, isLoading } = useListDatabasesQuery();
+  const database = findDatabaseByName(data?.data ?? [], name);
+
+  useEffect(() => {
+    if (database) {
+      dispatch(replace(Urls.browseDatabase(database)));
+    }
+  }, [database, dispatch]);
+
+  if (isLoading || database) {
+    return <LoadingAndErrorWrapper loading />;
+  }
+
+  return <NotFound />;
+};
+
 export const BrowseSchemas = ({ params }: { params: { slug: string } }) => {
   const dbId = Urls.extractEntityId(params.slug);
 
   if (dbId == null) {
-    return <NotFound />;
+    // react-router already url-decodes route params, so `slug` is the raw db name here.
+    return <DatabaseNameRedirect name={params.slug} />;
   }
 
   return <BrowseSchemasForDatabase dbId={dbId} params={params} />;

--- a/frontend/src/metabase/browse/schemas/BrowseSchemas.unit.spec.tsx
+++ b/frontend/src/metabase/browse/schemas/BrowseSchemas.unit.spec.tsx
@@ -1,0 +1,85 @@
+import fetchMock from "fetch-mock";
+import { Route } from "react-router";
+
+import { setupDatabasesEndpoints } from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { Database } from "metabase-types/api";
+import { createMockDatabase } from "metabase-types/api/mocks";
+
+import { BrowseSchemas } from "./BrowseSchemas";
+
+const setup = ({
+  databases,
+  initialRoute,
+}: {
+  databases: Database[];
+  initialRoute: string;
+}) => {
+  setupDatabasesEndpoints(databases);
+  return renderWithProviders(
+    <Route path="/browse/databases/:slug" component={BrowseSchemas} />,
+    { withRouter: true, initialRoute },
+  );
+};
+
+describe("BrowseSchemas name-based permalinks", () => {
+  it("renders the database browse page in place, keeping the name url", async () => {
+    const { history } = setup({
+      databases: [createMockDatabase({ id: 7, name: "Sales" })],
+      initialRoute: "/browse/databases/Sales",
+    });
+
+    expect(await screen.findByTestId("browse-schemas")).toBeInTheDocument();
+    expect(history?.getCurrentLocation().pathname).toBe(
+      "/browse/databases/Sales",
+    );
+  });
+
+  it("resolves to the lowest id when names collide", async () => {
+    setup({
+      databases: [
+        createMockDatabase({ id: 9, name: "Prod" }),
+        createMockDatabase({ id: 4, name: "Prod" }),
+      ],
+      initialRoute: "/browse/databases/Prod",
+    });
+
+    expect(await screen.findByTestId("browse-schemas")).toBeInTheDocument();
+    // the page shows the lowest-id database's schemas
+    expect(
+      fetchMock.callHistory.calls("path:/api/database/4/schemas"),
+    ).toHaveLength(1);
+    expect(
+      fetchMock.callHistory.calls("path:/api/database/9/schemas"),
+    ).toHaveLength(0);
+  });
+
+  it("matches names case-sensitively", async () => {
+    setup({
+      databases: [createMockDatabase({ id: 7, name: "Sales" })],
+      initialRoute: "/browse/databases/sales",
+    });
+
+    expect(await screen.findByLabelText("error page")).toBeInTheDocument();
+  });
+
+  it("shows a not-found page for an unknown name", async () => {
+    setup({
+      databases: [createMockDatabase({ id: 7, name: "Sales" })],
+      initialRoute: "/browse/databases/Unknown",
+    });
+
+    expect(await screen.findByLabelText("error page")).toBeInTheDocument();
+  });
+
+  it("shows an error instead of not-found when the databases request fails", async () => {
+    fetchMock.get("path:/api/database", 500);
+    renderWithProviders(
+      <Route path="/browse/databases/:slug" component={BrowseSchemas} />,
+      { withRouter: true, initialRoute: "/browse/databases/Sales" },
+    );
+
+    expect(await screen.findByText("An error occurred")).toBeInTheDocument();
+    expect(screen.queryByLabelText("error page")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/common/utils/database.ts
+++ b/frontend/src/metabase/common/utils/database.ts
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/v1/metadata/utils/saved-questions";
 import type {
   Card,
   Dashboard,
@@ -117,3 +118,15 @@ export const dashboardUsesRoutingEnabledDatabases = (
 export function hasTableEditingEnabled(database: Pick<Database, "settings">) {
   return Boolean(database.settings?.["database-enable-table-editing"]);
 }
+
+/**
+ * Match a database by exact (case-sensitive) name, ignoring the virtual
+ * "Saved Questions" database; on a name collision the lowest id wins.
+ */
+export const findDatabaseByName = (databases: Database[], name: string) =>
+  databases
+    .filter(
+      (database) =>
+        database.name === name && database.id !== SAVED_QUESTIONS_VIRTUAL_DB_ID,
+    )
+    .sort((a, b) => a.id - b.id)[0];

--- a/frontend/src/metabase/common/utils/database.unit.spec.ts
+++ b/frontend/src/metabase/common/utils/database.unit.spec.ts
@@ -1,7 +1,10 @@
+import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/v1/metadata/utils/saved-questions";
 import type { Card, Dashboard, Database } from "metabase-types/api";
+import { createMockDatabase } from "metabase-types/api/mocks";
 
 import {
   dashboardUsesRoutingEnabledDatabases,
+  findDatabaseByName,
   hasDbRoutingEnabled,
   questionUsesRoutingEnabledDatabase,
 } from "./database";
@@ -91,5 +94,48 @@ describe("database routing utility functions", () => {
         ),
       ).toBe(expected);
     });
+  });
+});
+
+describe("findDatabaseByName", () => {
+  const databases = [
+    createMockDatabase({ id: 1, name: "Sample Database" }),
+    createMockDatabase({ id: 7, name: "Sales" }),
+  ];
+
+  it("finds a database by its exact name", () => {
+    expect(findDatabaseByName(databases, "Sales").id).toBe(databases[1].id);
+  });
+
+  it("matches case-sensitively", () => {
+    expect(findDatabaseByName(databases, "sales")).toBeUndefined();
+    expect(findDatabaseByName(databases, "SALES")).toBeUndefined();
+  });
+
+  it("returns undefined for an unknown name", () => {
+    expect(findDatabaseByName(databases, "Nonexistent")).toBeUndefined();
+  });
+
+  it("returns the database with the lowest id on a name collision", () => {
+    const collisions = [
+      createMockDatabase({ id: 9, name: "Production" }),
+      createMockDatabase({ id: 4, name: "Production" }),
+      createMockDatabase({ id: 12, name: "Production" }),
+    ];
+
+    expect(findDatabaseByName(collisions, "Production").id).toBe(
+      collisions[1].id,
+    );
+  });
+
+  it("never matches the virtual Saved Questions database", () => {
+    const virtualDb = createMockDatabase({
+      id: SAVED_QUESTIONS_VIRTUAL_DB_ID,
+      name: "Saved Questions",
+    });
+
+    expect(
+      findDatabaseByName([...databases, virtualDb], "Saved Questions"),
+    ).toBeUndefined();
   });
 });

--- a/frontend/src/metabase/urls/browse.ts
+++ b/frontend/src/metabase/urls/browse.ts
@@ -29,3 +29,28 @@ export function browseSchema(table: {
     table.schema_name ?? "",
   )}`;
 }
+
+type DatabaseRef = Pick<Database, "id" | "name">;
+
+// A name that starts with a digit is parsed as an id by the router, so fall back
+// to the id for those databases; otherwise use the raw (encoded) name.
+const databaseSegment = (database: DatabaseRef) =>
+  /^\d/.test(database.name)
+    ? `${database.id}`
+    : encodeURIComponent(database.name);
+
+export function permalinkDatabase(database: DatabaseRef) {
+  return `/browse/databases/${databaseSegment(database)}`;
+}
+
+export function permalinkSchema(database: DatabaseRef, schema: string) {
+  return `/browse/databases/${databaseSegment(database)}/schema/${encodeURIComponent(schema)}`;
+}
+
+export function permalinkTable(
+  database: DatabaseRef,
+  { schema, table }: { schema?: string; table: string },
+) {
+  const schemaSegment = schema ? `/schema/${encodeURIComponent(schema)}` : "";
+  return `/browse/databases/${databaseSegment(database)}${schemaSegment}/table/${encodeURIComponent(table)}`;
+}

--- a/frontend/src/metabase/urls/browse.unit.spec.ts
+++ b/frontend/src/metabase/urls/browse.unit.spec.ts
@@ -1,0 +1,35 @@
+import { permalinkDatabase } from "./browse";
+
+describe("permalinkDatabase", () => {
+  it("builds a raw-name URL", () => {
+    expect(permalinkDatabase({ id: 1, name: "sales_db" })).toBe(
+      "/browse/databases/sales_db",
+    );
+  });
+
+  it("URL-encodes spaces and other special characters", () => {
+    expect(permalinkDatabase({ id: 1, name: "Data Warehouse" })).toBe(
+      "/browse/databases/Data%20Warehouse",
+    );
+  });
+
+  it("encodes non-ASCII names raw instead of slugifying them", () => {
+    const name = "Über Aufträge";
+    expect(permalinkDatabase({ id: 1, name })).toBe(
+      `/browse/databases/${encodeURIComponent(name)}`,
+    );
+    // a slugified link ("uber-auftrage") would not resolve back to the row
+    expect(permalinkDatabase({ id: 1, name })).not.toContain("uber-auftrage");
+  });
+
+  it("falls back to the id when the name starts with a digit", () => {
+    // the router parses leading digits as an id, so name resolution can't reach these;
+    // emitting the id keeps the copied link resolvable
+    expect(permalinkDatabase({ id: 7, name: "7-sales" })).toBe(
+      "/browse/databases/7",
+    );
+    expect(permalinkDatabase({ id: 9, name: "2024_metrics" })).toBe(
+      "/browse/databases/9",
+    );
+  });
+});

--- a/frontend/src/metabase/urls/browse.unit.spec.ts
+++ b/frontend/src/metabase/urls/browse.unit.spec.ts
@@ -18,13 +18,9 @@ describe("permalinkDatabase", () => {
     expect(permalinkDatabase({ id: 1, name })).toBe(
       `/browse/databases/${encodeURIComponent(name)}`,
     );
-    // a slugified link ("uber-auftrage") would not resolve back to the row
-    expect(permalinkDatabase({ id: 1, name })).not.toContain("uber-auftrage");
   });
 
   it("falls back to the id when the name starts with a digit", () => {
-    // the router parses leading digits as an id, so name resolution can't reach these;
-    // emitting the id keeps the copied link resolvable
     expect(permalinkDatabase({ id: 7, name: "7-sales" })).toBe(
       "/browse/databases/7",
     );

--- a/frontend/src/metabase/urls/browse.unit.spec.ts
+++ b/frontend/src/metabase/urls/browse.unit.spec.ts
@@ -14,9 +14,8 @@ describe("permalinkDatabase", () => {
   });
 
   it("encodes non-ASCII names raw instead of slugifying them", () => {
-    const name = "Über Aufträge";
-    expect(permalinkDatabase({ id: 1, name })).toBe(
-      `/browse/databases/${encodeURIComponent(name)}`,
+    expect(permalinkDatabase({ id: 1, name: "Über Aufträge" })).toBe(
+      "/browse/databases/%C3%9Cber%20Auftr%C3%A4ge",
     );
   });
 


### PR DESCRIPTION
No copy button yet, to test behavior set the URL manually

https://github.com/user-attachments/assets/dda35f22-043f-4247-a657-1965aef8b978



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database, schema, and table browse links now support cleaner, name-based permalinks.
  * Browse pages can now resolve a database by name when a numeric ID isn’t available, improving navigation from shared links.

* **Bug Fixes**
  * Improved handling for names with spaces, special characters, and non-ASCII text in browse URLs.
  * “Saved Questions” is excluded from name-based database lookup, avoiding incorrect matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->