### PR TITLE
Fix crash when editing column settings in the embedding SDK

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question-native.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question-native.cy.spec.tsx
@@ -141,6 +141,41 @@ describe("scenarios > embedding-sdk > interactive-question > native", () => {
     });
   });
 
+  describe("editing column settings", () => {
+    beforeEach(() => {
+      setup({
+        question: {
+          name: "Orders native question",
+          native: { query: "SELECT * FROM ORDERS" },
+        },
+      });
+    });
+
+    it("edits a column title without crashing (metabase#76455)", () => {
+      mountInteractiveQuestion({});
+
+      cy.wait("@cardQuery");
+
+      getSdkRoot().within(() => {
+        cy.findByText("TAX").should("be.visible");
+
+        H.openVizSettingsSidebar();
+        cy.findByTestId("chartsettings-sidebar")
+          .findByTestId("TAX-settings-button")
+          .click();
+      });
+
+      getSdkRoot().findByLabelText("Column title").clear().type("Renamed tax");
+
+      getSdkRoot().within(() => {
+        // Editing the column title used to throw a full-screen "Unexpected
+        // Application Error!" and leave the title unchanged (metabase#76455).
+        cy.findByText("Unexpected Application Error!").should("not.exist");
+        cy.findAllByText("Renamed tax").should("have.length.at.least", 1);
+      });
+    });
+  });
+
   describe("editable parameters for a native question", () => {
     beforeEach(() => {
       setup({

--- a/frontend/src/metabase/embedding-sdk/lib/links.ts
+++ b/frontend/src/metabase/embedding-sdk/lib/links.ts
@@ -36,7 +36,7 @@ function mapColumnSettings(
 
   const entries = Object.entries(columnSettings);
   const hasInternal = entries.some(([, settings]) =>
-    isInternalLinkClickBehavior(settings.click_behavior),
+    isInternalLinkClickBehavior(settings?.click_behavior),
   );
 
   if (!hasInternal) {
@@ -45,7 +45,7 @@ function mapColumnSettings(
 
   return Object.fromEntries(
     entries.map(([key, settings]) => {
-      if (!isInternalLinkClickBehavior(settings.click_behavior)) {
+      if (!isInternalLinkClickBehavior(settings?.click_behavior)) {
         return [key, settings];
       }
 

--- a/frontend/src/metabase/embedding-sdk/lib/links.unit.spec.ts
+++ b/frontend/src/metabase/embedding-sdk/lib/links.unit.spec.ts
@@ -1,3 +1,5 @@
+import type { VisualizationSettings } from "metabase-types/api";
+
 import { removeInternalClickBehaviors } from "./links";
 
 describe("removeInternalClickBehaviors", () => {
@@ -53,5 +55,27 @@ describe("removeInternalClickBehaviors", () => {
         "type": "link",
       }
     `);
+  });
+
+  it("does not crash on undefined column settings entries (EMB-1940)", () => {
+    const settings = {
+      column_settings: {
+        // columns without stored settings can end up as `undefined` entries
+        '["name","TOTAL"]': undefined,
+        '["name","SUBTOTAL"]': {
+          click_behavior: {
+            type: "link",
+            linkType: "dashboard",
+            targetId: 1,
+          },
+        },
+      },
+    } as unknown as VisualizationSettings;
+
+    const result = removeInternalClickBehaviors(settings);
+
+    expect(
+      result.column_settings?.['["name","SUBTOTAL"]'].click_behavior,
+    ).toBeUndefined();
   });
 });

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.jsx
@@ -66,7 +66,9 @@ export const chartSettingNestedSettings =
               objectSettings,
               changedSettings,
             );
-          } else {
+          } else if (objectSettings != null) {
+            // Objects without stored settings must not be added as `undefined`
+            // entries, which would corrupt the settings map (EMB-1940).
             newSettings[currentKey] = objectSettings;
           }
           return newSettings;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.unit.spec.tsx
@@ -1,0 +1,61 @@
+import userEvent from "@testing-library/user-event";
+
+import { render, screen } from "__support__/ui";
+
+import { chartSettingNestedSettings } from "./ChartSettingNestedSettings";
+
+type TestObject = { name: string };
+
+const getObjectKey = (object: TestObject) =>
+  JSON.stringify(["name", object.name]);
+
+const getObjectSettings = (
+  settings: Record<string, unknown> | undefined,
+  object: TestObject,
+) => settings?.[getObjectKey(object)];
+
+const ComposedComponent = ({ object, onChangeObjectSettings }: any) => (
+  <button
+    onClick={() =>
+      onChangeObjectSettings(object, { column_title: "New title" })
+    }
+  >
+    change
+  </button>
+);
+
+const WrappedComponent = chartSettingNestedSettings({
+  getObjectKey,
+  getObjectSettings,
+  getSettingsWidgetsForObject: () => [],
+})(ComposedComponent);
+
+describe("chartSettingNestedSettings", () => {
+  it("does not write undefined entries for objects without stored settings (EMB-1940)", async () => {
+    const onChange = jest.fn();
+    const objects: TestObject[] = [{ name: "A" }, { name: "B" }];
+
+    render(
+      <WrappedComponent
+        series={[]}
+        objects={objects}
+        // only object B has stored settings
+        value={{ '["name","B"]': { column_title: "Old title" } }}
+        initialKey={getObjectKey(objects[1])}
+        onChange={onChange}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "change" }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const newSettings = onChange.mock.calls[0][0];
+
+    // object A (no stored settings) must not appear as an undefined entry
+    expect(newSettings).not.toHaveProperty('["name","A"]');
+    expect(Object.values(newSettings)).not.toContain(undefined);
+    expect(newSettings).toEqual({
+      '["name","B"]': { column_title: "New title" },
+    });
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76455
Closes [EMB-1940: Fatal error when editing the column title of a native SQL-based question rendered by the Modular Embedding SDK for React](https://linear.app/metabase/issue/EMB-1940/fatal-error-when-editing-the-column-title-of-a-native-sql-based)

### Description

Editing a column's settings (e.g. its title) on a question rendered by the Modular Embedding SDK threw a full-screen "Unexpected Application Error!" (`Cannot read properties of undefined (reading 'click_behavior')`), and the change was lost.

Root cause: when a per-column setting changes, `ChartSettingNestedSettings` rebuilds the entire `column_settings` map by iterating over every column. Columns without stored settings were written as `undefined` entries, producing a map like `{ '["name","A"]': undefined, ... }`. In the embedding SDK, `removeInternalClickBehaviors` then iterates those entries and reads `settings.click_behavior`, crashing on the `undefined` value.

Fix:
- `ChartSettingNestedSettings`: don't write `undefined` entries for columns that have no stored settings.
- `links.ts`: defensively guard against `undefined` column-settings entries in `mapColumnSettings`.

### How to verify

1. Render a native SQL question with the Modular Embedding SDK for React.
2. Open the visualization settings (gear) → Columns → edit a column's title.
3. The title updates without any error appearing.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR