### PR TITLE
fix(sdk-bundle): restore back button after "Edit question" in embedded dashboards

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/EditableDashboard/enterprise.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/EditableDashboard/enterprise.unit.spec.tsx
@@ -129,6 +129,28 @@ describe("EditableDashboard", () => {
     expect(screen.getByText("Test dashboard")).toBeInTheDocument();
   });
 
+  it("should allow to go back to the dashboard after editing a question from the dashcard menu (EMB-2012)", async () => {
+    await setupEnterprise({ dashboardName: "Test dashboard" });
+
+    const dashcard = screen.getAllByTestId("dashcard").at(0);
+    await userEvent.click(within(dashcard!).getByTestId("dashcard-menu"));
+
+    const menu = await screen.findByRole("menu");
+    await userEvent.click(within(menu).getByText("Edit question"));
+
+    // We should be in the question view
+    expect(
+      await screen.findByTestId("query-visualization-root"),
+    ).toBeInTheDocument();
+
+    // The back button should be there, just like when drilling into a question
+    const backButton = await screen.findByLabelText("Back to Test dashboard");
+    await userEvent.click(backButton);
+
+    // We should be back on the dashboard
+    expect(await screen.findByTestId("dashboard-grid")).toBeInTheDocument();
+  });
+
   it("should allow to pass `dataPickerProps.entityTypes` to the query builder", async () => {
     await setupEnterprise({
       dataPickerProps: {

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -438,6 +438,21 @@ const SdkDashboardInner = ({
     ],
   );
 
+  // "Edit question" renders the question via adhocQuestionUrl without going through
+  // onNavigateToNewCardFromDashboard, so push a nav entry here to keep the back button.
+  const onEditQuestionWithNav = useCallback(
+    (question: Parameters<typeof onEditQuestion>[0]) => {
+      sdkNavigation?.push({
+        type: "open-card",
+        virtual: true,
+        name: question.displayName() ?? t`Question`,
+        onPop: () => onNavigateBackToDashboard(),
+      });
+      onEditQuestion(question);
+    },
+    [onEditQuestion, sdkNavigation, onNavigateBackToDashboard],
+  );
+
   if (isLocaleLoading) {
     return (
       <MaybeStyledWrapper
@@ -598,7 +613,7 @@ const SdkDashboardInner = ({
           .with({ finalRenderMode: "dashboard" }, () => (
             <SdkDashboardProvider
               plugins={plugins}
-              onEditQuestion={onEditQuestion}
+              onEditQuestion={onEditQuestionWithNav}
             >
               {children ?? (
                 <MaybeStyledWrapper


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76796
### Description

A customer reported that when embedding `EditableDashboard` with the React embedding SDK (v62), they cannot navigate back to the dashboard after choosing **Edit question** from a dashcard menu. Drilling into a question (clicking the card title) does show a back link, and the full Metabase app shows one in both cases.

**Root cause:** there are two ways to open a question from a dashboard in the SDK:

1. Drilling / clicking into a card goes through `onNavigateToNewCardFromDashboard`, which pushes a virtual entry onto the SDK internal navigation stack.
2. **Edit question** goes through `onEditQuestion`, which only sets `adhocQuestionUrl` and never pushes a nav entry.

`SdkInternalNavigationBackButton` is gated on `canGoBack` (`stack` length > 1), so after **Edit question** the stack still holds only the dashboard entry and the button stays hidden.

**Fix:** wrap `onEditQuestion` in `SdkDashboard` to push a virtual `open-card` entry (mirroring the drill path), so the back button shows and returns to the dashboard.

### How to verify

1. Embed `EditableDashboard` via the React embedding SDK.
2. Open a dashcard menu and click **Edit question**.
3. You now see a **Back to <dashboard>** button; clicking it returns to the dashboard.
4. Regression covered by a unit test in `EditableDashboard/enterprise.unit.spec.tsx` (EMB-2012).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR