### PR TITLE
GDGT-2635 add index editor create update delete

### DIFF
--- a/frontend/src/metabase-types/api/index-manager.ts
+++ b/frontend/src/metabase-types/api/index-manager.ts
@@ -168,4 +168,4 @@ export type IndexMethod = {
   fields: IndexField[];
 };
 
-export type RequestableIndexes = Record<ClassicalIndexKind, IndexMethod>;
+export type RequestableIndexes = Record<string, IndexMethod>;

--- a/frontend/src/metabase-types/api/index-manager.ts
+++ b/frontend/src/metabase-types/api/index-manager.ts
@@ -139,3 +139,33 @@ export type UpdateTableIndexRequest = {
   id: TableIndexRequestId;
   structured: StructuredIndex;
 };
+
+export type IndexFieldType =
+  | "string"
+  | "boolean"
+  | "select"
+  | "integer"
+  | "columns";
+
+export type IndexFieldOption = {
+  name: string;
+  value: string;
+};
+
+export type IndexField = {
+  name: string;
+  "display-name": string;
+  type: IndexFieldType;
+  required?: boolean;
+  directions?: boolean;
+  options?: IndexFieldOption[];
+};
+
+export type IndexMethodLifecycle = "standalone" | "inline";
+
+export type IndexMethod = {
+  lifecycle: IndexMethodLifecycle;
+  fields: IndexField[];
+};
+
+export type RequestableIndexes = Record<ClassicalIndexKind, IndexMethod>;

--- a/frontend/src/metabase-types/api/index-manager.ts
+++ b/frontend/src/metabase-types/api/index-manager.ts
@@ -83,6 +83,8 @@ export type StructuredIndex =
   | OrderByIndex
   | SkipIndex;
 
+export type IndexKind = StructuredIndex["kind"];
+
 export const TABLE_INDEX_REQUEST_STATUSES = [
   "create-pending",
   "update-pending",
@@ -169,4 +171,4 @@ export type IndexMethod = {
   fields: IndexField[];
 };
 
-export type RequestableIndexes = Record<string, IndexMethod>;
+export type RequestableIndexes = Partial<Record<IndexKind, IndexMethod>>;

--- a/frontend/src/metabase-types/api/index-manager.ts
+++ b/frontend/src/metabase-types/api/index-manager.ts
@@ -155,6 +155,7 @@ export type IndexFieldOption = {
 export type IndexField = {
   name: string;
   "display-name": string;
+  description?: string;
   type: IndexFieldType;
   required?: boolean;
   directions?: boolean;

--- a/frontend/src/metabase-types/api/mocks/index-manager.ts
+++ b/frontend/src/metabase-types/api/mocks/index-manager.ts
@@ -1,4 +1,10 @@
-import type { TableIndexEntry, TableIndexRequest } from "metabase-types/api";
+import type {
+  IndexField,
+  IndexMethod,
+  RequestableIndexes,
+  TableIndexEntry,
+  TableIndexRequest,
+} from "metabase-types/api";
 
 export const createMockTableIndexRequest = (
   opts?: Partial<TableIndexRequest>,
@@ -36,4 +42,54 @@ export const createMockTableIndexEntry = (
   access_method: null,
   request: createMockTableIndexRequest(),
   ...opts,
+});
+
+const INDEX_NAME_FIELD: IndexField = {
+  name: "name",
+  "display-name": "Give your index a name",
+  type: "string",
+  required: true,
+};
+
+export const createMockIndexMethod = (
+  opts?: Partial<IndexMethod>,
+): IndexMethod => ({
+  lifecycle: "standalone",
+  fields: [INDEX_NAME_FIELD],
+  ...opts,
+});
+
+export const createMockRequestableIndexes = (): RequestableIndexes => ({
+  btree: createMockIndexMethod({
+    fields: [
+      INDEX_NAME_FIELD,
+      {
+        name: "unique",
+        "display-name": "Enforce uniqueness across rows for indexed columns.",
+        type: "boolean",
+      },
+      {
+        name: "columns",
+        "display-name": "Columns",
+        description:
+          "The column(s) the index will be built on. Usually the ones you filter or join by.",
+        type: "columns",
+        required: true,
+        directions: true,
+      },
+    ],
+  }),
+  gin: createMockIndexMethod({
+    fields: [
+      INDEX_NAME_FIELD,
+      {
+        name: "columns",
+        "display-name": "Columns",
+        description:
+          "The column(s) the index will be built on. Usually the ones you filter or join by.",
+        type: "columns",
+        required: true,
+      },
+    ],
+  }),
 });

--- a/frontend/src/metabase-types/api/mocks/index-manager.ts
+++ b/frontend/src/metabase-types/api/mocks/index-manager.ts
@@ -65,7 +65,8 @@ export const createMockRequestableIndexes = (): RequestableIndexes => ({
       INDEX_NAME_FIELD,
       {
         name: "unique",
-        "display-name": "Enforce uniqueness across rows for indexed columns.",
+        "display-name": "Unique",
+        description: "Enforce uniqueness across rows for indexed columns.",
         type: "boolean",
       },
       {

--- a/frontend/src/metabase-types/api/transform.ts
+++ b/frontend/src/metabase-types/api/transform.ts
@@ -1,6 +1,7 @@
 import type { Collection, CollectionId } from "./collection";
 import type { DatabaseId } from "./database";
 import type { RowValue } from "./dataset";
+import type { RequestableIndexes } from "./index-manager";
 import type { PaginationRequest, PaginationResponse } from "./pagination";
 import type { DatasetQuery, JoinStrategy } from "./query";
 import type { ScheduleDisplayType } from "./settings";
@@ -67,6 +68,7 @@ export type Transform = {
   table?: Table | null;
   last_run?: TransformRun | null;
   creator?: UserInfo;
+  requestable_indexes?: RequestableIndexes | null;
 };
 
 export type SuggestedTransform = Partial<Pick<Transform, "id">> &

--- a/frontend/src/metabase/common/data-studio/components/TitleSection/TitleSection.tsx
+++ b/frontend/src/metabase/common/data-studio/components/TitleSection/TitleSection.tsx
@@ -5,6 +5,7 @@ import { Card, Group, Stack, Text, Title } from "metabase/ui";
 type TitleSectionProps = {
   label: ReactNode;
   description?: ReactNode;
+  actions?: ReactNode;
   children?: ReactNode;
   "data-testid"?: string;
 };
@@ -12,16 +13,18 @@ type TitleSectionProps = {
 export function TitleSection({
   label,
   description,
+  actions,
   children,
   "data-testid": dataTestId,
 }: TitleSectionProps) {
   return (
     <Stack data-testid={dataTestId}>
-      <Group>
+      <Group justify="space-between" wrap="nowrap">
         <Stack flex={1} gap="sm">
           <Title order={4}>{label}</Title>
           {description != null && <Text c="text-secondary">{description}</Text>}
         </Stack>
+        {actions != null && actions}
       </Group>
       <Card p={0} shadow="none" withBorder>
         {children}

--- a/frontend/src/metabase/common/data-studio/components/TitleSection/TitleSection.unit.spec.tsx
+++ b/frontend/src/metabase/common/data-studio/components/TitleSection/TitleSection.unit.spec.tsx
@@ -7,10 +7,15 @@ import { TitleSection } from "./TitleSection";
 type SetupOpts = {
   label?: string;
   children?: ReactNode;
+  actions?: ReactNode;
 };
 
-function setup({ label = "Default Title", children }: SetupOpts = {}) {
-  renderWithProviders(<TitleSection label={label}>{children}</TitleSection>);
+function setup({ label = "Default Title", children, actions }: SetupOpts = {}) {
+  renderWithProviders(
+    <TitleSection label={label} actions={actions}>
+      {children}
+    </TitleSection>,
+  );
 }
 
 describe("TitleSection", () => {
@@ -22,5 +27,13 @@ describe("TitleSection", () => {
 
     expect(screen.getByText(label)).toBeInTheDocument();
     expect(screen.getByText("Title section content")).toBeInTheDocument();
+  });
+
+  it("should render the actions slot", () => {
+    setup({ actions: <button>Create index</button> });
+
+    expect(
+      screen.getByRole("button", { name: "Create index" }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/ColumnsField.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/ColumnsField.tsx
@@ -1,0 +1,147 @@
+import { useField } from "formik";
+import type { ReactNode } from "react";
+import { t } from "ttag";
+
+import {
+  Card,
+  Group,
+  Input,
+  MultiSelect,
+  SegmentedControl,
+  Stack,
+  Text,
+} from "metabase/ui";
+import type { IndexColumn, IndexColumnDirection } from "metabase-types/api";
+
+import type { ColumnOption } from "./types";
+
+type ColumnsFieldProps = {
+  name: string;
+  label?: ReactNode;
+  description?: ReactNode;
+  options: ColumnOption[];
+  supportsDirections: boolean;
+  disabled?: boolean;
+};
+
+export function ColumnsField({
+  name,
+  label,
+  description,
+  options,
+  supportsDirections,
+  disabled,
+}: ColumnsFieldProps) {
+  const [
+    { value: selectedColumns = [] },
+    { error, touched },
+    { setValue, setTouched },
+  ] = useField<IndexColumn[]>(name);
+
+  function handleColumnChange(names: string[]) {
+    setValue(
+      names.map((columnName) => {
+        const existingColumnSelection = selectedColumns.find(
+          (column) => column.name === columnName,
+        );
+        if (existingColumnSelection) {
+          return existingColumnSelection;
+        }
+        return supportsDirections
+          ? { name: columnName, direction: "asc" }
+          : { name: columnName };
+      }),
+    );
+    setTouched(true);
+  }
+
+  function handleDirectionChange(
+    columnName: string,
+    direction: IndexColumnDirection,
+  ) {
+    setValue(
+      selectedColumns.map((column) =>
+        column.name === columnName ? { ...column, direction } : column,
+      ),
+    );
+  }
+
+  return (
+    <Input.Wrapper
+      label={label}
+      description={description}
+      error={touched ? error : null}
+    >
+      <Stack gap="sm" mt="xs">
+        <MultiSelect
+          data={options}
+          value={selectedColumns.map((column) => column.name)}
+          onChange={handleColumnChange}
+          onBlur={() => setTouched(true)}
+          placeholder={t`Select columns`}
+          searchable
+          disabled={disabled}
+        />
+        {supportsDirections && selectedColumns.length > 0 && (
+          <DirectionList
+            columns={selectedColumns}
+            options={options}
+            onChange={handleDirectionChange}
+            disabled={disabled}
+          />
+        )}
+      </Stack>
+    </Input.Wrapper>
+  );
+}
+
+type DirectionListProps = {
+  columns: IndexColumn[];
+  options: ColumnOption[];
+  onChange: (columnName: string, direction: IndexColumnDirection) => void;
+  disabled?: boolean;
+};
+
+function DirectionList({
+  columns,
+  options,
+  onChange,
+  disabled,
+}: DirectionListProps) {
+  return (
+    <Card withBorder shadow="none" p="md">
+      <Stack gap="sm">
+        <Text fw="bold">{t`Sort order for each column to be stored in`}</Text>
+        {columns.map((column) => (
+          <Group key={column.name} justify="space-between" wrap="nowrap">
+            <Text>{getColumnLabel(options, column.name)}</Text>
+            <SegmentedControl
+              value={column.direction}
+              onChange={(direction) =>
+                onChange(column.name, direction as IndexColumnDirection)
+              }
+              data={getDirectionOptions()}
+              disabled={disabled}
+            />
+          </Group>
+        ))}
+      </Stack>
+    </Card>
+  );
+}
+
+function getColumnLabel(columns: ColumnOption[], columnName: string) {
+  return (
+    columns.find((option) => option.value === columnName)?.label ?? columnName
+  );
+}
+
+function getDirectionOptions(): {
+  value: IndexColumnDirection;
+  label: string;
+}[] {
+  return [
+    { value: "asc", label: t`Asc` },
+    { value: "desc", label: t`Desc` },
+  ];
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorForm.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorForm.tsx
@@ -1,11 +1,11 @@
 import { t } from "ttag";
 
 import { Form, FormErrorMessage, FormSubmitButton } from "metabase/forms";
-import { Box, Button, Group, Select, Stack } from "metabase/ui";
+import { Box, Button, Group, Select, Stack, Text } from "metabase/ui";
 import type { IndexField, IndexKind } from "metabase-types/api";
 
 import { IndexFieldInput } from "./IndexFieldInput";
-import { getKindDescription } from "./constants";
+import { getIndexTypeDescription, getKindDescription } from "./constants";
 import type { ColumnOption } from "./types";
 
 type IndexEditorFormProps = {
@@ -48,12 +48,25 @@ export function IndexEditorForm({
 
         <Select
           label={t`Index type`}
-          description={getKindDescription(kind)}
+          description={getIndexTypeDescription()}
           data={kinds}
           value={kind}
           onChange={(value) => value && onKindChange(value)}
           disabled={isEditing}
           allowDeselect={false}
+          renderOption={({ option }) => {
+            const description = getKindDescription(option.value);
+            return (
+              <Stack gap="xs" p="sm">
+                <Text fw="bold">{option.label}</Text>
+                {description && (
+                  <Text size="sm" c="text-secondary">
+                    {description}
+                  </Text>
+                )}
+              </Stack>
+            );
+          }}
         />
 
         {restFields.map((field) => renderField(field))}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorForm.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorForm.tsx
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
-import { Form, FormErrorMessage, FormSubmitButton } from "metabase/forms";
-import { Box, Button, Group, Select, Stack, Text } from "metabase/ui";
+import { Form, FormSubmitButton } from "metabase/forms";
+import { Button, Group, Select, Stack, Text } from "metabase/ui";
 import type { IndexField, IndexKind } from "metabase-types/api";
 
 import { IndexFieldInput } from "./IndexFieldInput";
@@ -72,9 +72,6 @@ export function IndexEditorForm({
         {restFields.map((field) => renderField(field))}
 
         <Group justify="flex-end">
-          <Box flex={1}>
-            <FormErrorMessage />
-          </Box>
           <Button variant="subtle" onClick={onClose}>{t`Cancel`}</Button>
           <FormSubmitButton label={submitLabel} variant="filled" />
         </Group>

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorForm.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorForm.tsx
@@ -1,0 +1,71 @@
+import { t } from "ttag";
+
+import { Form, FormErrorMessage, FormSubmitButton } from "metabase/forms";
+import { Box, Button, Group, Select, Stack } from "metabase/ui";
+import type { IndexField } from "metabase-types/api";
+
+import { IndexFieldInput } from "./IndexFieldInput";
+import { getKindDescription } from "./constants";
+import type { ColumnOption } from "./types";
+
+type IndexEditorFormProps = {
+  kind: string;
+  kinds: string[];
+  fields: IndexField[];
+  columnOptions: ColumnOption[];
+  isEditing: boolean;
+  submitLabel: string;
+  onKindChange: (kind: string) => void;
+  onClose: () => void;
+};
+
+export function IndexEditorForm({
+  kind,
+  kinds,
+  fields,
+  columnOptions,
+  isEditing,
+  submitLabel,
+  onKindChange,
+  onClose,
+}: IndexEditorFormProps) {
+  const [firstField, ...restFields] = fields;
+
+  const renderField = (field: IndexField, autoFocus = false) => (
+    <IndexFieldInput
+      key={field.name}
+      field={field}
+      columnOptions={columnOptions}
+      disabled={isEditing && field.name === "name"}
+      autoFocus={autoFocus}
+    />
+  );
+
+  return (
+    <Form>
+      <Stack gap="lg" mt="sm">
+        {firstField && renderField(firstField, !isEditing)}
+
+        <Select
+          label={t`Index type`}
+          description={getKindDescription(kind)}
+          data={kinds}
+          value={kind}
+          onChange={(value) => value && onKindChange(value)}
+          disabled={isEditing}
+          allowDeselect={false}
+        />
+
+        {restFields.map((field) => renderField(field))}
+
+        <Group justify="flex-end">
+          <Box flex={1}>
+            <FormErrorMessage />
+          </Box>
+          <Button variant="subtle" onClick={onClose}>{t`Cancel`}</Button>
+          <FormSubmitButton label={submitLabel} variant="filled" />
+        </Group>
+      </Stack>
+    </Form>
+  );
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorForm.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorForm.tsx
@@ -2,20 +2,20 @@ import { t } from "ttag";
 
 import { Form, FormErrorMessage, FormSubmitButton } from "metabase/forms";
 import { Box, Button, Group, Select, Stack } from "metabase/ui";
-import type { IndexField } from "metabase-types/api";
+import type { IndexField, IndexKind } from "metabase-types/api";
 
 import { IndexFieldInput } from "./IndexFieldInput";
 import { getKindDescription } from "./constants";
 import type { ColumnOption } from "./types";
 
 type IndexEditorFormProps = {
-  kind: string;
-  kinds: string[];
+  kind: IndexKind;
+  kinds: IndexKind[];
   fields: IndexField[];
   columnOptions: ColumnOption[];
   isEditing: boolean;
   submitLabel: string;
-  onKindChange: (kind: string) => void;
+  onKindChange: (kind: IndexKind) => void;
   onClose: () => void;
 };
 

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorModal.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorModal.tsx
@@ -12,8 +12,10 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { useToast } from "metabase/common/hooks";
 import { FormProvider } from "metabase/forms";
 import { Modal } from "metabase/ui";
+import { getObjectKeys } from "metabase/utils/objects";
 import type {
   IndexField,
+  IndexKind,
   RequestableIndexes,
   Table,
   TableIndexEntry,
@@ -44,10 +46,8 @@ export function IndexEditorModal({
   const isEditing = request != null;
   const tableId = transform.table?.id;
   const requestableIndexes = transform.requestable_indexes;
-  const kinds = transform.requestable_indexes
-    ? Object.keys(transform.requestable_indexes)
-    : [];
-  const [kind, setKind] = useState<string>(
+  const kinds = requestableIndexes ? getObjectKeys(requestableIndexes) : [];
+  const [kind, setKind] = useState<IndexKind>(
     request?.structured.kind ? request?.structured.kind : kinds[0],
   );
 
@@ -122,15 +122,10 @@ export function IndexEditorModal({
 }
 
 function getFields(
-  kind: string,
+  kind: IndexKind,
   requestableIndexes: RequestableIndexes | null | undefined,
-): IndexField[] | never[] {
-  if (!requestableIndexes) {
-    return [];
-  }
-  const fields =
-    kind in requestableIndexes ? requestableIndexes[kind].fields : [];
-  return fields;
+): IndexField[] {
+  return requestableIndexes?.[kind]?.fields ?? [];
 }
 
 function getColumnOptions(table: Table | undefined): ColumnOption[] {

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorModal.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorModal.tsx
@@ -1,0 +1,144 @@
+import { useState } from "react";
+import { t } from "ttag";
+
+import {
+  skipToken,
+  useCreateTableIndexMutation,
+  useGetTableQueryMetadataQuery,
+  useUpdateTableIndexMutation,
+} from "metabase/api";
+import { getErrorMessage } from "metabase/api/utils";
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { useToast } from "metabase/common/hooks";
+import { FormProvider } from "metabase/forms";
+import { Modal } from "metabase/ui";
+import type {
+  IndexField,
+  RequestableIndexes,
+  Table,
+  TableIndexEntry,
+  Transform,
+} from "metabase-types/api";
+
+import { IndexEditorForm } from "./IndexEditorForm";
+import type { ColumnOption } from "./types";
+import {
+  type IndexFormValues,
+  buildInitialValues,
+  buildValidationSchema,
+  toStructured,
+} from "./utils";
+
+type IndexEditorModalProps = {
+  transform: Transform;
+  index?: TableIndexEntry;
+  onClose: () => void;
+};
+
+export function IndexEditorModal({
+  transform,
+  index,
+  onClose,
+}: IndexEditorModalProps) {
+  const request = index?.request;
+  const isEditing = request != null;
+  const tableId = transform.table?.id;
+  const requestableIndexes = transform.requestable_indexes;
+  const kinds = transform.requestable_indexes
+    ? Object.keys(transform.requestable_indexes)
+    : [];
+  const [kind, setKind] = useState<string>(
+    request?.structured.kind ? request?.structured.kind : kinds[0],
+  );
+
+  const {
+    data: table,
+    isLoading,
+    error,
+  } = useGetTableQueryMetadataQuery(
+    tableId != null ? { id: tableId } : skipToken,
+  );
+
+  const columnOptions = getColumnOptions(table);
+  const fields = getFields(kind, requestableIndexes);
+  const initialValues = buildInitialValues(fields, request?.structured);
+  const validationSchema = buildValidationSchema(fields);
+  const [createTableIndex] = useCreateTableIndexMutation();
+  const [updateTableIndex] = useUpdateTableIndexMutation();
+  const [sendToast] = useToast();
+
+  async function handleSubmit(values: IndexFormValues) {
+    const structured = toStructured(kind, fields, values);
+    try {
+      if (isEditing) {
+        await updateTableIndex({ id: request.id, structured }).unwrap();
+        sendToast({ message: t`Index updated` });
+      } else {
+        await createTableIndex({
+          transform_id: transform.id,
+          structured,
+        }).unwrap();
+        sendToast({ message: t`Index created` });
+      }
+      onClose();
+    } catch (submitError) {
+      sendToast({
+        message: getErrorMessage(submitError, t`Failed to save index`),
+        icon: "warning",
+      });
+    }
+  }
+
+  return (
+    <Modal
+      opened
+      title={isEditing ? t`Edit index` : t`Create an index`}
+      padding="xl"
+      onClose={onClose}
+    >
+      {isLoading || error != null ? (
+        <LoadingAndErrorWrapper loading={isLoading} error={error} />
+      ) : (
+        <FormProvider
+          key={kind}
+          initialValues={initialValues}
+          validationSchema={validationSchema}
+          onSubmit={handleSubmit}
+        >
+          <IndexEditorForm
+            kind={kind}
+            kinds={kinds}
+            fields={fields}
+            columnOptions={columnOptions}
+            isEditing={isEditing}
+            submitLabel={isEditing ? t`Update index` : t`Create index`}
+            onKindChange={setKind}
+            onClose={onClose}
+          />
+        </FormProvider>
+      )}
+    </Modal>
+  );
+}
+
+function getFields(
+  kind: string,
+  requestableIndexes: RequestableIndexes | null | undefined,
+): IndexField[] | never[] {
+  if (!requestableIndexes) {
+    return [];
+  }
+  const fields =
+    kind in requestableIndexes ? requestableIndexes[kind].fields : [];
+  return fields;
+}
+
+function getColumnOptions(table: Table | undefined): ColumnOption[] {
+  if (!table?.fields) {
+    return [];
+  }
+  return table.fields.map((field) => ({
+    value: field.name,
+    label: field.display_name ?? field.name,
+  }));
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorModal.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorModal.tsx
@@ -86,6 +86,7 @@ export function IndexEditorModal({
         message: getErrorMessage(submitError, t`Failed to save index`),
         icon: "warning",
       });
+      throw submitError;
     }
   }
 

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorModal.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorModal.unit.spec.tsx
@@ -1,0 +1,178 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { setupTableIndexEndpoints } from "__support__/server-mocks/index-manager";
+import { setupTableQueryMetadataEndpoint } from "__support__/server-mocks/table";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import type { StructuredIndex, TableIndexEntry } from "metabase-types/api";
+import {
+  createMockField,
+  createMockRequestableIndexes,
+  createMockTable,
+  createMockTableIndexEntry,
+  createMockTableIndexRequest,
+  createMockTransform,
+} from "metabase-types/api/mocks";
+
+import { IndexEditorModal } from "./IndexEditorModal";
+
+const TABLE = createMockTable({
+  id: 10,
+  fields: [
+    createMockField({ id: 1, name: "city", display_name: "City name" }),
+    createMockField({ id: 2, name: "country", display_name: "Country" }),
+  ],
+});
+
+function setup({ index }: { index?: TableIndexEntry } = {}) {
+  const transform = createMockTransform({
+    id: 1,
+    table: TABLE,
+    requestable_indexes: createMockRequestableIndexes(),
+  });
+
+  setupTableQueryMetadataEndpoint(TABLE);
+  setupTableIndexEndpoints(
+    transform.id,
+    index?.request != null ? [index.request] : [],
+  );
+
+  const onClose = jest.fn();
+  renderWithProviders(
+    <IndexEditorModal transform={transform} index={index} onClose={onClose} />,
+    { withUndos: true },
+  );
+
+  return { onClose };
+}
+
+describe("IndexEditorModal", () => {
+  it("creates a btree index with directions and unique", async () => {
+    setup();
+
+    await userEvent.type(
+      await screen.findByLabelText("Give your index a name"),
+      "index 1",
+    );
+
+    await userEvent.click(screen.getByPlaceholderText("Select columns"));
+    await userEvent.click(
+      await screen.findByRole("option", { name: "City name" }),
+    );
+    await userEvent.click(
+      await screen.findByRole("option", { name: "Country" }),
+    );
+
+    await userEvent.click(screen.getByRole("switch"));
+
+    await userEvent.click(screen.getByRole("button", { name: "Create index" }));
+
+    const body = await waitForBody("createTableIndex");
+
+    expect(body.transform_id).toBe(1);
+    expect(body.structured).toEqual({
+      kind: "btree",
+      name: "index 1",
+      columns: [
+        { name: "city", direction: "asc" },
+        { name: "country", direction: "asc" },
+      ],
+      unique: true,
+    });
+  });
+
+  it("does not offer directions or a unique switch for gin", async () => {
+    setup();
+
+    await userEvent.click(await screen.findByLabelText("Index type"));
+    await userEvent.click(await screen.findByRole("option", { name: "gin" }));
+
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+
+    await userEvent.type(
+      await screen.findByLabelText("Give your index a name"),
+      "idx_search",
+    );
+    await userEvent.click(screen.getByPlaceholderText("Select columns"));
+    await userEvent.click(
+      await screen.findByRole("option", { name: "City name" }),
+    );
+
+    expect(
+      screen.queryByText("Sort order for each column to be stored in"),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Create index" }));
+
+    const body = await waitForBody("createTableIndex");
+    expect(body.structured).toEqual({
+      kind: "gin",
+      name: "idx_search",
+      columns: [{ name: "city" }],
+    });
+  });
+
+  it("blocks submitting without a required name", async () => {
+    setup();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Create index" }),
+    );
+
+    expect((await screen.findAllByText("required")).length).toBeGreaterThan(0);
+    expect(fetchMock.callHistory.called("createTableIndex")).toBe(false);
+  });
+
+  it("edits an existing index and only sends structured via PUT", async () => {
+    const structured: StructuredIndex = {
+      kind: "btree",
+      name: "idx_existing",
+      columns: [{ name: "city", direction: "asc" }],
+      unique: false,
+    };
+    const index = createMockTableIndexEntry({
+      metabase_managed: true,
+      request: createMockTableIndexRequest({ id: 42, structured }),
+    });
+
+    setup({ index });
+
+    const nameInput = await screen.findByLabelText("Give your index a name");
+    expect(nameInput).toBeDisabled();
+    expect(nameInput).toHaveValue("idx_existing");
+    expect(screen.getByLabelText("Index type")).toBeDisabled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Update index" }));
+
+    const body = await waitForBody("updateTableIndex-42");
+    expect(Object.keys(body)).toEqual(["structured"]);
+    expect(body.structured.name).toBe("idx_existing");
+  });
+
+  it("shows an error toast when the request fails", async () => {
+    setup();
+    fetchMock.modifyRoute("createTableIndex", {
+      response: { status: 400, body: {} },
+    });
+
+    await userEvent.type(
+      await screen.findByLabelText("Give your index a name"),
+      "idx",
+    );
+    await userEvent.click(screen.getByPlaceholderText("Select columns"));
+    await userEvent.click(
+      await screen.findByRole("option", { name: "City name" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Create index" }));
+
+    expect(await screen.findByText("Failed to save index")).toBeInTheDocument();
+  });
+});
+
+async function waitForBody(name: string) {
+  await waitFor(() => {
+    expect(fetchMock.callHistory.called(name)).toBe(true);
+  });
+  const call = fetchMock.callHistory.lastCall(name);
+  return JSON.parse(call?.options?.body as string);
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorModal.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorModal.unit.spec.tsx
@@ -50,6 +50,12 @@ describe("IndexEditorModal", () => {
   it("creates a btree index with directions and unique", async () => {
     setup();
 
+    expect(
+      await screen.findByText(
+        "The data structure used to organize the index. B-tree works well for most lookups, sorting, and range queries.",
+      ),
+    ).toBeInTheDocument();
+
     await userEvent.type(
       await screen.findByLabelText("Give your index a name"),
       "index 1",
@@ -85,7 +91,7 @@ describe("IndexEditorModal", () => {
     setup();
 
     await userEvent.click(await screen.findByLabelText("Index type"));
-    await userEvent.click(await screen.findByRole("option", { name: "gin" }));
+    await userEvent.click(await screen.findByRole("option", { name: /gin/ }));
 
     expect(screen.queryByRole("switch")).not.toBeInTheDocument();
 

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorModal.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorModal.unit.spec.tsx
@@ -172,6 +172,12 @@ describe("IndexEditorModal", () => {
     await userEvent.click(screen.getByRole("button", { name: "Create index" }));
 
     expect(await screen.findByText("Failed to save index")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: "Failed" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Success" }),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexFieldInput.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexFieldInput.tsx
@@ -1,0 +1,81 @@
+import { match } from "ts-pattern";
+
+import {
+  FormNumberInput,
+  FormSelect,
+  FormSwitch,
+  FormTextInput,
+} from "metabase/forms";
+import type { IndexField } from "metabase-types/api";
+
+import { ColumnsField } from "./ColumnsField";
+import { getFieldDescription } from "./constants";
+import type { ColumnOption } from "./types";
+
+type IndexFieldInputProps = {
+  field: IndexField;
+  columnOptions: ColumnOption[];
+  disabled?: boolean;
+  autoFocus?: boolean;
+};
+
+export function IndexFieldInput({
+  field,
+  columnOptions,
+  disabled,
+  autoFocus,
+}: IndexFieldInputProps) {
+  const label = field["display-name"];
+  const description = getFieldDescription(field.name);
+
+  return match(field.type)
+    .with("boolean", () => (
+      <FormSwitch
+        name={field.name}
+        label={label}
+        description={description}
+        disabled={disabled}
+      />
+    ))
+    .with("select", () => (
+      <FormSelect
+        name={field.name}
+        label={label}
+        description={description}
+        data={(field.options ?? []).map((option) => ({
+          value: option.value,
+          label: option.name,
+        }))}
+        disabled={disabled}
+      />
+    ))
+    .with("integer", () => (
+      <FormNumberInput
+        name={field.name}
+        label={label}
+        description={description}
+        disabled={disabled}
+      />
+    ))
+    .with("columns", () => (
+      <ColumnsField
+        name={field.name}
+        label={label}
+        description={description}
+        options={columnOptions}
+        supportsDirections={field.directions ?? false}
+        disabled={disabled}
+      />
+    ))
+    .otherwise(() => (
+      <FormTextInput
+        name={field.name}
+        label={label}
+        description={description}
+        disabled={disabled}
+        autoFocus={autoFocus}
+        data-autofocus={autoFocus}
+        autoComplete="off"
+      />
+    ));
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexFieldInput.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexFieldInput.tsx
@@ -9,7 +9,6 @@ import {
 import type { IndexField } from "metabase-types/api";
 
 import { ColumnsField } from "./ColumnsField";
-import { getFieldDescription } from "./constants";
 import type { ColumnOption } from "./types";
 
 type IndexFieldInputProps = {
@@ -26,7 +25,7 @@ export function IndexFieldInput({
   autoFocus,
 }: IndexFieldInputProps) {
   const label = field["display-name"];
-  const description = getFieldDescription(field.name);
+  const description = field.description;
 
   return match(field.type)
     .with("boolean", () => (

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexFieldInput.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexFieldInput.tsx
@@ -28,14 +28,18 @@ export function IndexFieldInput({
   const description = field.description;
 
   return match(field.type)
-    .with("boolean", () => (
-      <FormSwitch
-        name={field.name}
-        label={label}
-        description={description}
-        disabled={disabled}
-      />
-    ))
+    .with("boolean", () => {
+      // Per design, the unique switch renders its description as the inline label
+      const isUniqueField = field.name === "unique";
+      return (
+        <FormSwitch
+          name={field.name}
+          label={isUniqueField ? (description ?? label) : label}
+          description={isUniqueField ? undefined : description}
+          disabled={disabled}
+        />
+      );
+    })
     .with("select", () => (
       <FormSelect
         name={field.name}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/constants.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/constants.ts
@@ -1,6 +1,8 @@
 import { t } from "ttag";
 
-export function getKindDescription(kind: string): string {
+import type { IndexKind } from "metabase-types/api";
+
+export function getKindDescription(kind: IndexKind): string {
   switch (kind) {
     case "btree":
       return t`The data structure used to organize the index. B-tree works well for most lookups, sorting, and range queries.`;

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/constants.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/constants.ts
@@ -14,12 +14,3 @@ export function getKindDescription(kind: string): string {
       return t`The data structure used to organize the index.`;
   }
 }
-
-export function getFieldDescription(name: string): string | undefined {
-  switch (name) {
-    case "columns":
-      return t`The column(s) the index will be built on. Usually the ones you filter or join by.`;
-    default:
-      return undefined;
-  }
-}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/constants.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/constants.ts
@@ -1,0 +1,25 @@
+import { t } from "ttag";
+
+export function getKindDescription(kind: string): string {
+  switch (kind) {
+    case "btree":
+      return t`The data structure used to organize the index. B-tree works well for most lookups, sorting, and range queries.`;
+    case "gin":
+      return t`For values with multiple components. Best for full-text search, JSONB, and arrays—when you're searching inside a value.`;
+    case "gist":
+      return t`For geometric, spatial, and range data. Best for "nearest neighbor" and overlap queries, like geographic data (PostGIS) or range types.`;
+    case "brin":
+      return t`Tiny and low-overhead. Best for large tables where values correlate with physical row order, like timestamps in an append-only log.`;
+    default:
+      return t`The data structure used to organize the index.`;
+  }
+}
+
+export function getFieldDescription(name: string): string | undefined {
+  switch (name) {
+    case "columns":
+      return t`The column(s) the index will be built on. Usually the ones you filter or join by.`;
+    default:
+      return undefined;
+  }
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/constants.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/constants.ts
@@ -1,11 +1,13 @@
 import { t } from "ttag";
 
-import type { IndexKind } from "metabase-types/api";
+export function getIndexTypeDescription(): string {
+  return t`The data structure used to organize the index. B-tree works well for most lookups, sorting, and range queries.`;
+}
 
-export function getKindDescription(kind: IndexKind): string {
+export function getKindDescription(kind: string): string | null {
   switch (kind) {
     case "btree":
-      return t`The data structure used to organize the index. B-tree works well for most lookups, sorting, and range queries.`;
+      return t`Default. Best for equality and range queries on sortable data; use it for most columns you filter, sort, or join by.`;
     case "gin":
       return t`For values with multiple components. Best for full-text search, JSONB, and arrays—when you're searching inside a value.`;
     case "gist":
@@ -13,6 +15,6 @@ export function getKindDescription(kind: IndexKind): string {
     case "brin":
       return t`Tiny and low-overhead. Best for large tables where values correlate with physical row order, like timestamps in an append-only log.`;
     default:
-      return t`The data structure used to organize the index.`;
+      return null;
   }
 }

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/types.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/types.ts
@@ -1,0 +1,4 @@
+export type ColumnOption = {
+  value: string;
+  label: string;
+};

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.ts
@@ -1,0 +1,95 @@
+import * as Yup from "yup";
+
+import * as Errors from "metabase/utils/errors";
+import type {
+  IndexColumn,
+  IndexField,
+  StructuredIndex,
+} from "metabase-types/api";
+
+export type IndexFormValues = Record<string, unknown>;
+
+function defaultFieldValue(field: IndexField): unknown {
+  switch (field.type) {
+    case "boolean":
+      return false;
+    case "columns":
+      return [];
+    case "integer":
+      return null;
+    case "select":
+      return field.options?.[0]?.value ?? "";
+    default:
+      return "";
+  }
+}
+
+export function buildInitialValues(
+  fields: IndexField[],
+  structured?: StructuredIndex,
+): IndexFormValues {
+  const source = structured as Record<string, unknown> | undefined;
+  return Object.fromEntries(
+    fields.map((field) => [
+      field.name,
+      source?.[field.name] ?? defaultFieldValue(field),
+    ]),
+  );
+}
+
+function getFieldSchema(field: IndexField): Yup.AnySchema {
+  switch (field.type) {
+    case "columns": {
+      const schema = Yup.array().of(
+        Yup.object({
+          name: Yup.string().required(),
+          direction: Yup.string().oneOf(["asc", "desc"]).optional(),
+        }),
+      );
+      return field.required ? schema.min(1, Errors.required) : schema;
+    }
+    case "boolean":
+      return Yup.boolean();
+    case "integer": {
+      const schema = Yup.number().nullable();
+      return field.required ? schema.required(Errors.required) : schema;
+    }
+    default: {
+      const schema = Yup.string();
+      return field.required ? schema.required(Errors.required) : schema;
+    }
+  }
+}
+
+export function buildValidationSchema(fields: IndexField[]) {
+  return Yup.object(
+    Object.fromEntries(
+      fields.map((field) => [field.name, getFieldSchema(field)]),
+    ),
+  );
+}
+
+export function toStructured(
+  kind: string,
+  fields: IndexField[],
+  values: IndexFormValues,
+): StructuredIndex {
+  const structured: Record<string, unknown> = { kind };
+  for (const field of fields) {
+    const value = values[field.name];
+    if (field.type === "columns") {
+      const columns = (value as IndexColumn[] | undefined) ?? [];
+      structured[field.name] = field.directions
+        ? columns.map((column) => ({
+            name: column.name,
+            direction: column.direction ?? "asc",
+          }))
+        : columns.map((column) => ({ name: column.name }));
+    } else {
+      structured[field.name] = value;
+    }
+  }
+  // The body is built dynamically from a backend-driven schema; the concrete
+  // shape always matches one of the StructuredIndex variants for these kinds.
+  return structured as unknown as StructuredIndex;
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.ts
@@ -90,7 +90,5 @@ export function toStructured(
       structured[field.name] = value;
     }
   }
-  // The body is built dynamically from a backend-driven schema; the concrete
-  // shape always matches one of the StructuredIndex variants for these kinds.
-  return structured as unknown as StructuredIndex;
+  return structured as StructuredIndex;
 }

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.ts
@@ -29,7 +29,7 @@ export function buildInitialValues(
   fields: IndexField[],
   structured?: StructuredIndex,
 ): IndexFormValues {
-  const source = structured as Record<string, unknown> | undefined;
+  const source: IndexFormValues | undefined = structured;
   return Object.fromEntries(
     fields.map((field) => [
       field.name,

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.ts
@@ -10,7 +10,7 @@ import type {
 
 export type IndexFormValues = Record<string, unknown>;
 
-function defaultFieldValue(field: IndexField): unknown {
+function defaultFieldValue(field: IndexField) {
   switch (field.type) {
     case "boolean":
       return false;

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.ts
@@ -4,6 +4,7 @@ import * as Errors from "metabase/utils/errors";
 import type {
   IndexColumn,
   IndexField,
+  IndexKind,
   StructuredIndex,
 } from "metabase-types/api";
 
@@ -70,7 +71,7 @@ export function buildValidationSchema(fields: IndexField[]) {
 }
 
 export function toStructured(
-  kind: string,
+  kind: IndexKind,
   fields: IndexField[],
   values: IndexFormValues,
 ): StructuredIndex {

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexPageActions.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexPageActions.tsx
@@ -1,0 +1,35 @@
+import { t } from "ttag";
+
+import { Button, Tooltip } from "metabase/ui";
+
+export function IndexPageActions({
+  readOnly = false,
+  targetTableExists: hasTable,
+  handleCreate,
+  canCreate,
+}: {
+  readOnly: boolean | undefined;
+  targetTableExists: boolean;
+  handleCreate: () => void;
+  canCreate: boolean;
+}) {
+  if (readOnly) {
+    return undefined;
+  }
+
+  const createButton = (
+    <Button variant="filled" disabled={!canCreate} onClick={handleCreate}>
+      {t`Create index`}
+    </Button>
+  );
+
+  const actions = hasTable ? (
+    createButton
+  ) : (
+    <Tooltip label={t`Run the transform before adding indexes`}>
+      {createButton}
+    </Tooltip>
+  );
+
+  return actions;
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexPageActions.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexPageActions.tsx
@@ -14,7 +14,7 @@ export function IndexPageActions({
   canCreate: boolean;
 }) {
   if (readOnly) {
-    return undefined;
+    return null;
   }
 
   const createButton = (

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/IndexRowMenu.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/IndexRowMenu.tsx
@@ -1,7 +1,10 @@
+import type { MouseEvent } from "react";
 import { t } from "ttag";
 
 import { ActionIcon, Icon, Menu } from "metabase/ui";
 import type { TableIndexEntry } from "metabase-types/api";
+
+import { isManagedIndex, isPendingDeletion } from "./utils";
 
 type IndexRowMenuProps = {
   index: TableIndexEntry;
@@ -10,25 +13,29 @@ type IndexRowMenuProps = {
 };
 
 export function IndexRowMenu({ index, onEdit, onDelete }: IndexRowMenuProps) {
-  const isManaged = index.metabase_managed && index.request?.id !== undefined;
-  const isPendingDeletion = index.request?.status === "delete-pending";
-
-  if (!isManaged) {
+  if (!isManagedIndex(index)) {
     return null;
+  }
+
+  const isDisabled = isPendingDeletion(index);
+
+  function handleIconClick(event: MouseEvent) {
+    event.preventDefault();
+    event.stopPropagation();
   }
 
   return (
     <Menu position="bottom-end">
       <Menu.Target>
-        <ActionIcon aria-label={t`Index actions`}>
+        <ActionIcon aria-label={t`Index actions`} onClick={handleIconClick}>
           <Icon name="ellipsis" />
         </ActionIcon>
       </Menu.Target>
-      <Menu.Dropdown>
+      <Menu.Dropdown onClick={(event) => event.stopPropagation()}>
         <Menu.Item
           leftSection={<Icon name="pencil" />}
           onClick={() => onEdit(index)}
-          disabled={isPendingDeletion}
+          disabled={isDisabled}
         >
           {t`Edit`}
         </Menu.Item>
@@ -36,7 +43,7 @@ export function IndexRowMenu({ index, onEdit, onDelete }: IndexRowMenuProps) {
           c="danger"
           leftSection={<Icon name="trash" />}
           onClick={() => onDelete(index)}
-          disabled={isPendingDeletion}
+          disabled={isDisabled}
         >
           {t`Delete`}
         </Menu.Item>

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/IndexRowMenu.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/IndexRowMenu.tsx
@@ -40,7 +40,7 @@ export function IndexRowMenu({ index, onEdit, onDelete }: IndexRowMenuProps) {
           {t`Edit`}
         </Menu.Item>
         <Menu.Item
-          c="danger"
+          c={isDisabled ? undefined : "danger"}
           leftSection={<Icon name="trash" />}
           onClick={() => onDelete(index)}
           disabled={isDisabled}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/IndexRowMenu.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/IndexRowMenu.tsx
@@ -1,0 +1,42 @@
+import { t } from "ttag";
+
+import { ActionIcon, Icon, Menu } from "metabase/ui";
+import type { TableIndexEntry } from "metabase-types/api";
+
+type IndexRowMenuProps = {
+  index: TableIndexEntry;
+  onEdit: (index: TableIndexEntry) => void;
+  onDelete: (index: TableIndexEntry) => void;
+};
+
+export function IndexRowMenu({ index, onEdit, onDelete }: IndexRowMenuProps) {
+  const isManaged = index.metabase_managed && index.request?.id !== undefined;
+  if (!isManaged) {
+    return null;
+  }
+
+  return (
+    <Menu position="bottom-end">
+      <Menu.Target>
+        <ActionIcon aria-label={t`Index actions`}>
+          <Icon name="ellipsis" />
+        </ActionIcon>
+      </Menu.Target>
+      <Menu.Dropdown>
+        <Menu.Item
+          leftSection={<Icon name="pencil" />}
+          onClick={() => onEdit(index)}
+        >
+          {t`Edit`}
+        </Menu.Item>
+        <Menu.Item
+          c="danger"
+          leftSection={<Icon name="trash" />}
+          onClick={() => onDelete(index)}
+        >
+          {t`Delete`}
+        </Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/IndexRowMenu.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/IndexRowMenu.tsx
@@ -11,6 +11,7 @@ type IndexRowMenuProps = {
 
 export function IndexRowMenu({ index, onEdit, onDelete }: IndexRowMenuProps) {
   const isManaged = index.metabase_managed && index.request?.id !== undefined;
+
   if (!isManaged) {
     return null;
   }

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/IndexRowMenu.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/IndexRowMenu.tsx
@@ -11,6 +11,7 @@ type IndexRowMenuProps = {
 
 export function IndexRowMenu({ index, onEdit, onDelete }: IndexRowMenuProps) {
   const isManaged = index.metabase_managed && index.request?.id !== undefined;
+  const isPendingDeletion = index.request?.status === "delete-pending";
 
   if (!isManaged) {
     return null;
@@ -27,6 +28,7 @@ export function IndexRowMenu({ index, onEdit, onDelete }: IndexRowMenuProps) {
         <Menu.Item
           leftSection={<Icon name="pencil" />}
           onClick={() => onEdit(index)}
+          disabled={isPendingDeletion}
         >
           {t`Edit`}
         </Menu.Item>
@@ -34,6 +36,7 @@ export function IndexRowMenu({ index, onEdit, onDelete }: IndexRowMenuProps) {
           c="danger"
           leftSection={<Icon name="trash" />}
           onClick={() => onDelete(index)}
+          disabled={isPendingDeletion}
         >
           {t`Delete`}
         </Menu.Item>

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.tsx
@@ -15,11 +15,19 @@ import { getIndexKey } from "./utils";
 
 type TransformIndexTableProps = {
   indexes: TableIndexEntry[];
+  readOnly?: boolean;
+  onEdit: (index: TableIndexEntry) => void;
+  onDelete: (index: TableIndexEntry) => void;
 };
 
 const DEFAULT_SORTING: SortingState = [{ id: "name", desc: false }];
 
-export function TransformIndexTable({ indexes }: TransformIndexTableProps) {
+export function TransformIndexTable({
+  indexes,
+  readOnly,
+  onEdit,
+  onDelete,
+}: TransformIndexTableProps) {
   const systemTimezone = useSetting("system-timezone");
   const { data: usersResponse } = useListUsersQuery();
   const [sorting, setSorting] = useState<SortingState>(DEFAULT_SORTING);
@@ -48,7 +56,14 @@ export function TransformIndexTable({ indexes }: TransformIndexTableProps) {
     [indexes, usersById],
   );
 
-  const columns = useMemo(() => getColumns(systemTimezone), [systemTimezone]);
+  const columns = useMemo(
+    () =>
+      getColumns({
+        systemTimezone,
+        actions: readOnly ? undefined : { onEdit, onDelete },
+      }),
+    [systemTimezone, readOnly, onEdit, onDelete],
+  );
 
   const treeTableInstance = useTreeTableInstance<IndexRow>({
     data: rows,

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.tsx
@@ -1,5 +1,5 @@
-import type { SortingState } from "@tanstack/react-table";
-import { useMemo, useState } from "react";
+import type { Row, SortingState } from "@tanstack/react-table";
+import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { useListUsersQuery } from "metabase/api";
@@ -11,7 +11,7 @@ import type { TableIndexEntry, UserId } from "metabase-types/api";
 
 import { getColumns } from "./columns";
 import type { IndexRow } from "./types";
-import { getIndexKey } from "./utils";
+import { getIndexKey, isManagedIndex, isPendingDeletion } from "./utils";
 
 type TransformIndexTableProps = {
   indexes: TableIndexEntry[];
@@ -65,6 +65,16 @@ export function TransformIndexTable({
     [systemTimezone, readOnly, onEdit, onDelete],
   );
 
+  const handleRowClick = useCallback(
+    (row: Row<IndexRow>) => {
+      const index = row.original;
+      if (!readOnly && isManagedIndex(index) && !isPendingDeletion(index)) {
+        onEdit(index);
+      }
+    },
+    [readOnly, onEdit],
+  );
+
   const treeTableInstance = useTreeTableInstance<IndexRow>({
     data: rows,
     columns,
@@ -80,6 +90,7 @@ export function TransformIndexTable({
       hierarchical={false}
       emptyState={<ListEmptyState label={t`No indexes yet`} />}
       ariaLabel={t`Transform indexes`}
+      onRowClick={handleRowClick}
     />
   );
 }

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.unit.spec.tsx
@@ -1,3 +1,5 @@
+import userEvent from "@testing-library/user-event";
+
 import { setupUsersEndpoints } from "__support__/server-mocks";
 import {
   mockGetBoundingClientRect,
@@ -17,13 +19,25 @@ import { TransformIndexTable } from "./TransformIndexTable";
 type SetupOpts = {
   indexes?: TableIndexEntry[];
   users?: UserListResult[];
+  readOnly?: boolean;
 };
 
-function setup({ indexes = [], users = [] }: SetupOpts = {}) {
+function setup({ indexes = [], users = [], readOnly = false }: SetupOpts = {}) {
   mockGetBoundingClientRect({ width: 1000, height: 600 });
   setupUsersEndpoints(users);
 
-  renderWithProviders(<TransformIndexTable indexes={indexes} />);
+  const onEdit = jest.fn();
+  const onDelete = jest.fn();
+  renderWithProviders(
+    <TransformIndexTable
+      indexes={indexes}
+      readOnly={readOnly}
+      onEdit={onEdit}
+      onDelete={onDelete}
+    />,
+  );
+
+  return { onEdit, onDelete };
 }
 
 describe("TransformIndexTable", () => {
@@ -134,5 +148,62 @@ describe("TransformIndexTable", () => {
     });
 
     expect(await screen.findByText("Never")).toBeInTheDocument();
+  });
+
+  it("offers edit and delete for a managed index with a request", async () => {
+    const index = createMockTableIndexEntry({
+      metabase_managed: true,
+      request: createMockTableIndexRequest({ id: 5 }),
+    });
+    const { onEdit, onDelete } = setup({ indexes: [index] });
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Index actions" }),
+    );
+    await userEvent.click(await screen.findByText("Edit"));
+    expect(onEdit).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "btree" }),
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Index actions" }),
+    );
+    await userEvent.click(await screen.findByText("Delete"));
+    expect(onDelete).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "btree" }),
+    );
+  });
+
+  it("does not offer a menu for unmanaged indexes", async () => {
+    setup({
+      indexes: [
+        createMockTableIndexEntry({
+          metabase_managed: false,
+          request: undefined,
+        }),
+      ],
+    });
+
+    expect(await screen.findByText("Unmanaged")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Index actions" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render the actions column when read-only", async () => {
+    setup({
+      readOnly: true,
+      indexes: [
+        createMockTableIndexEntry({
+          metabase_managed: true,
+          request: createMockTableIndexRequest({ id: 5 }),
+        }),
+      ],
+    });
+
+    expect(await screen.findByText("Managed")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Index actions" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.unit.spec.tsx
@@ -174,6 +174,56 @@ describe("TransformIndexTable", () => {
     );
   });
 
+  it("opens the editor only when clicking an editable managed index row", async () => {
+    const managed = createMockTableIndexEntry({
+      name: "idx_managed",
+      metabase_managed: true,
+      request: createMockTableIndexRequest({ id: 5 }),
+    });
+    const unmanaged = createMockTableIndexEntry({
+      name: "idx_unmanaged",
+      metabase_managed: false,
+      request: undefined,
+    });
+    const removing = createMockTableIndexEntry({
+      name: "idx_removing",
+      metabase_managed: true,
+      request: createMockTableIndexRequest({ id: 6, status: "delete-pending" }),
+    });
+    const { onEdit } = setup({ indexes: [managed, unmanaged, removing] });
+
+    await userEvent.click(await screen.findByText("idx_unmanaged"));
+    await userEvent.click(screen.getByText("idx_removing"));
+    expect(onEdit).not.toHaveBeenCalled();
+
+    // opening the row menu must not bubble into a row click
+    const managedRow = screen.getByRole("row", { name: /idx_managed/ });
+    await userEvent.click(
+      within(managedRow).getByRole("button", { name: "Index actions" }),
+    );
+    expect(await screen.findByText("Edit")).toBeInTheDocument();
+    expect(onEdit).not.toHaveBeenCalled();
+    await userEvent.keyboard("{Escape}");
+
+    await userEvent.click(screen.getByText("idx_managed"));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(onEdit).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "idx_managed" }),
+    );
+  });
+
+  it("does not open the editor when clicking a row in read-only mode", async () => {
+    const index = createMockTableIndexEntry({
+      name: "idx_readonly",
+      metabase_managed: true,
+      request: createMockTableIndexRequest({ id: 5 }),
+    });
+    const { onEdit } = setup({ indexes: [index], readOnly: true });
+
+    await userEvent.click(await screen.findByText("idx_readonly"));
+    expect(onEdit).not.toHaveBeenCalled();
+  });
+
   it("does not offer a menu for unmanaged indexes", async () => {
     setup({
       indexes: [

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.unit.spec.tsx
@@ -2,7 +2,9 @@ import userEvent from "@testing-library/user-event";
 
 import { setupUsersEndpoints } from "__support__/server-mocks";
 import {
+  getIcon,
   mockGetBoundingClientRect,
+  queryIcon,
   renderWithProviders,
   screen,
   within,
@@ -123,6 +125,40 @@ describe("TransformIndexTable", () => {
 
     expect(await screen.findByText("Pending")).toBeInTheDocument();
     expect(screen.getByText("Removing")).toBeInTheDocument();
+  });
+
+  it("shows an info tooltip for pending statuses", async () => {
+    setup({
+      indexes: [
+        createMockTableIndexEntry({
+          request: createMockTableIndexRequest({ status: "create-pending" }),
+        }),
+      ],
+    });
+
+    expect(await screen.findByText("Pending")).toBeInTheDocument();
+    await userEvent.hover(getIcon("info_outline"));
+    expect(
+      await screen.findByText(
+        "Changes will be applied the next time the transform runs",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the pending info icon for terminal statuses", async () => {
+    setup({
+      indexes: [
+        createMockTableIndexEntry({
+          request: createMockTableIndexRequest({
+            status: "succeeded",
+            error_message: null,
+          }),
+        }),
+      ],
+    });
+
+    expect(await screen.findByText("Succeeded")).toBeInTheDocument();
+    expect(queryIcon("info_outline")).not.toBeInTheDocument();
   });
 
   it("resolves the last modified by user name", async () => {

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/columns.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/columns.tsx
@@ -4,14 +4,27 @@ import { parseTimestampWithTimezone } from "metabase/transforms/utils";
 import type { TreeTableColumnDef } from "metabase/ui";
 import { Ellipsified, Group, Icon, Tooltip } from "metabase/ui";
 import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
+import type { TableIndexEntry } from "metabase-types/api";
 
+import { IndexRowMenu } from "./IndexRowMenu";
 import type { IndexRow } from "./types";
 import { formatStatus, getIndexName } from "./utils";
 
-export function getColumns(
-  systemTimezone: string | undefined,
-): TreeTableColumnDef<IndexRow>[] {
-  return [
+type Actions = {
+  onEdit: (index: TableIndexEntry) => void;
+  onDelete: (index: TableIndexEntry) => void;
+};
+
+type ColumnsProps = {
+  systemTimezone: string | undefined;
+  actions: Actions | undefined;
+};
+
+export function getColumns({
+  systemTimezone,
+  actions,
+}: ColumnsProps): TreeTableColumnDef<IndexRow>[] {
+  const columns: TreeTableColumnDef<IndexRow>[] = [
     {
       id: "name",
       header: t`Name`,
@@ -116,4 +129,22 @@ export function getColumns(
       },
     },
   ];
+
+  if (actions != null) {
+    columns.push({
+      id: "actions",
+      header: "",
+      width: 40,
+      enableSorting: false,
+      cell: ({ row }) => (
+        <IndexRowMenu
+          index={row.original}
+          onEdit={actions.onEdit}
+          onDelete={actions.onDelete}
+        />
+      ),
+    });
+  }
+
+  return columns;
 }

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/columns.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/columns.tsx
@@ -2,13 +2,15 @@ import { t } from "ttag";
 
 import { parseTimestampWithTimezone } from "metabase/transforms/utils";
 import type { TreeTableColumnDef } from "metabase/ui";
-import { Ellipsified, Group, Icon, Tooltip } from "metabase/ui";
+import { Ellipsified, Flex, Group, Icon, Tooltip } from "metabase/ui";
 import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
 import type { TableIndexEntry } from "metabase-types/api";
 
 import { IndexRowMenu } from "./IndexRowMenu";
 import type { IndexRow } from "./types";
 import { formatStatus, getIndexName } from "./utils";
+
+const ACTIONS_COLUMN_WIDTH = 56;
 
 type Actions = {
   onEdit: (index: TableIndexEntry) => void;
@@ -134,14 +136,16 @@ export function getColumns({
     columns.push({
       id: "actions",
       header: "",
-      width: 40,
+      width: ACTIONS_COLUMN_WIDTH,
       enableSorting: false,
       cell: ({ row }) => (
-        <IndexRowMenu
-          index={row.original}
-          onEdit={actions.onEdit}
-          onDelete={actions.onDelete}
-        />
+        <Flex justify="center">
+          <IndexRowMenu
+            index={row.original}
+            onEdit={actions.onEdit}
+            onDelete={actions.onDelete}
+          />
+        </Flex>
       ),
     });
   }

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/columns.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/columns.tsx
@@ -8,7 +8,7 @@ import type { TableIndexEntry } from "metabase-types/api";
 
 import { IndexRowMenu } from "./IndexRowMenu";
 import type { IndexRow } from "./types";
-import { formatStatus, getIndexName } from "./utils";
+import { formatStatus, getIndexName, isPendingStatus } from "./utils";
 
 const ACTIONS_COLUMN_WIDTH = 56;
 
@@ -81,12 +81,20 @@ export function getColumns({
       enableSorting: true,
       accessorFn: (index) => formatStatus(index.request?.status),
       cell: ({ row, getValue }) => {
-        const errorMessage = row.original.request?.error_message;
+        const request = row.original.request;
+        const errorMessage = request?.error_message;
         return (
           <Group gap="sm" wrap="nowrap">
             <Ellipsified>{String(getValue())}</Ellipsified>
             {errorMessage != null && (
               <Tooltip label={errorMessage}>
+                <Icon name="info_outline" c="text-secondary" />
+              </Tooltip>
+            )}
+            {isPendingStatus(request?.status) && (
+              <Tooltip
+                label={t`Changes will be applied the next time the transform runs`}
+              >
                 <Icon name="info_outline" c="text-secondary" />
               </Tooltip>
             )}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/utils.ts
@@ -27,6 +27,16 @@ export function isPendingDeletion(index: TableIndexEntry): boolean {
   return index.request?.status === "delete-pending";
 }
 
+export function isPendingStatus(
+  status: TableIndexRequestStatus | undefined,
+): boolean {
+  return (
+    status === "create-pending" ||
+    status === "update-pending" ||
+    status === "delete-pending"
+  );
+}
+
 export function formatStatus(
   status: TableIndexRequestStatus | undefined,
 ): string {

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/utils.ts
@@ -19,6 +19,14 @@ export function getIndexKey(index: TableIndexEntry, position: number): string {
   return `index-${getIndexName(index)}-${position}`;
 }
 
+export function isManagedIndex(index: TableIndexEntry): boolean {
+  return index.metabase_managed && index.request?.id !== undefined;
+}
+
+export function isPendingDeletion(index: TableIndexEntry): boolean {
+  return index.request?.status === "delete-pending";
+}
+
 export function formatStatus(
   status: TableIndexRequestStatus | undefined,
 ): string {

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
@@ -9,10 +9,10 @@ import {
 } from "metabase/api";
 import { getErrorMessage } from "metabase/api/utils";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
+import { TitleSection } from "metabase/common/data-studio/components/TitleSection";
 import { useToast } from "metabase/common/hooks";
 import { useConfirmation } from "metabase/common/hooks/use-confirmation";
-import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
-import { TitleSection } from "metabase/data-studio/common/components/TitleSection";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
 import { Center } from "metabase/ui";
 import * as Urls from "metabase/urls";

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
@@ -3,10 +3,14 @@ import { t } from "ttag";
 
 import {
   skipToken,
+  useDeleteTableIndexMutation,
   useGetTransformQuery,
   useListTableIndexesQuery,
 } from "metabase/api";
+import { getErrorMessage } from "metabase/api/utils";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { useToast } from "metabase/common/hooks";
+import { useConfirmation } from "metabase/common/hooks/use-confirmation";
 import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
 import { TitleSection } from "metabase/data-studio/common/components/TitleSection";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
@@ -68,6 +72,7 @@ function TransformIndexesContent({
     isLoading,
     error,
   } = useListTableIndexesQuery({ "transform-id": transform.id });
+  const { deleteIndex, confirmationModal } = useDeleteIndex();
   const targetTableExists = transform.table != null;
   const hasRequestableIndexes =
     Object.keys(transform.requestable_indexes ?? {}).length > 0;
@@ -77,6 +82,7 @@ function TransformIndexesContent({
   } | null>(null);
 
   const handleCreate = () => setEditorState({});
+  const handleEdit = (index: TableIndexEntry) => setEditorState({ index });
 
   if (isLoading || !isNullOrUndefined(error)) {
     return (
@@ -102,7 +108,12 @@ function TransformIndexesContent({
         {indexes.length === 0 ? (
           <NoIndexes />
         ) : (
-          <TransformIndexTable indexes={indexes} />
+          <TransformIndexTable
+            indexes={indexes}
+            readOnly={readOnly}
+            onEdit={handleEdit}
+            onDelete={deleteIndex}
+          />
         )}
       </TitleSection>
       {editorState != null && (
@@ -112,6 +123,40 @@ function TransformIndexesContent({
           onClose={() => setEditorState(null)}
         />
       )}
+      {confirmationModal}
     </>
   );
+}
+
+function useDeleteIndex() {
+  const [sendToast] = useToast();
+  const [deleteTableIndex] = useDeleteTableIndexMutation();
+  const { modalContent: confirmationModal, show: showConfirmation } =
+    useConfirmation();
+
+  function deleteIndex(index: TableIndexEntry) {
+    const requestId = index.request?.id;
+    if (requestId == null) {
+      return;
+    }
+    showConfirmation({
+      title: t`Delete this index?`,
+      message: t`This removes the index from the warehouse.`,
+      confirmButtonText: t`Delete`,
+      confirmButtonProps: { color: "danger" },
+      onConfirm: async () => {
+        try {
+          await deleteTableIndex(requestId).unwrap();
+          sendToast({ message: t`Index deleted` });
+        } catch (deleteError) {
+          sendToast({
+            message: getErrorMessage(deleteError, t`Failed to delete index`),
+            icon: "warning",
+          });
+        }
+      },
+    });
+  }
+
+  return { deleteIndex, confirmationModal };
 }

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
@@ -12,10 +12,11 @@ import { useTransformPermissions } from "metabase/transforms/hooks/use-transform
 import { Center } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { isNullOrUndefined } from "metabase/utils/types";
-import type { TransformId } from "metabase-types/api";
+import type { Transform } from "metabase-types/api";
 
 import { TransformHeader } from "../../components/TransformHeader";
 
+import { IndexPageActions } from "./IndexPageActions";
 import { NoIndexes } from "./NoIndexes";
 import { TransformIndexTable } from "./TransformIndexTable";
 
@@ -48,21 +49,27 @@ export function TransformIndexesPage({ params }: TransformIndexesPageProps) {
   return (
     <PageContainer data-testid="transforms-indexes-content">
       <TransformHeader transform={transform} readOnly={readOnly} />
-      <TransformIndexesContent transformId={transform.id} />
+      <TransformIndexesContent transform={transform} readOnly={readOnly} />
     </PageContainer>
   );
 }
 
 function TransformIndexesContent({
-  transformId,
+  transform,
+  readOnly = false,
 }: {
-  transformId: TransformId;
+  transform: Transform;
+  readOnly: boolean | undefined;
 }) {
   const {
     data: indexes = [],
     isLoading,
     error,
-  } = useListTableIndexesQuery({ "transform-id": transformId });
+  } = useListTableIndexesQuery({ "transform-id": transform.id });
+  const targetTableExists = transform.table != null;
+  const hasRequestableIndexes =
+    Object.keys(transform.requestable_indexes ?? {}).length > 0;
+  const canCreate = targetTableExists && hasRequestableIndexes && !readOnly;
 
   if (isLoading || !isNullOrUndefined(error)) {
     return (
@@ -73,7 +80,17 @@ function TransformIndexesContent({
   }
 
   return (
-    <TitleSection label={t`Indexes`}>
+    <TitleSection
+      label={t`Indexes`}
+      actions={
+        <IndexPageActions
+          readOnly={readOnly}
+          targetTableExists={targetTableExists}
+          handleCreate={() => undefined}
+          canCreate={canCreate}
+        />
+      }
+    >
       {indexes.length === 0 ? (
         <NoIndexes />
       ) : (

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { t } from "ttag";
 
 import {
@@ -12,10 +13,11 @@ import { useTransformPermissions } from "metabase/transforms/hooks/use-transform
 import { Center } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { isNullOrUndefined } from "metabase/utils/types";
-import type { Transform } from "metabase-types/api";
+import type { TableIndexEntry, Transform } from "metabase-types/api";
 
 import { TransformHeader } from "../../components/TransformHeader";
 
+import { IndexEditorModal } from "./IndexEditorModal/IndexEditorModal";
 import { IndexPageActions } from "./IndexPageActions";
 import { NoIndexes } from "./NoIndexes";
 import { TransformIndexTable } from "./TransformIndexTable";
@@ -70,6 +72,11 @@ function TransformIndexesContent({
   const hasRequestableIndexes =
     Object.keys(transform.requestable_indexes ?? {}).length > 0;
   const canCreate = targetTableExists && hasRequestableIndexes && !readOnly;
+  const [editorState, setEditorState] = useState<{
+    index?: TableIndexEntry;
+  } | null>(null);
+
+  const handleCreate = () => setEditorState({});
 
   if (isLoading || !isNullOrUndefined(error)) {
     return (
@@ -80,22 +87,31 @@ function TransformIndexesContent({
   }
 
   return (
-    <TitleSection
-      label={t`Indexes`}
-      actions={
-        <IndexPageActions
-          readOnly={readOnly}
-          targetTableExists={targetTableExists}
-          handleCreate={() => undefined}
-          canCreate={canCreate}
+    <>
+      <TitleSection
+        label={t`Indexes`}
+        actions={
+          <IndexPageActions
+            readOnly={readOnly}
+            targetTableExists={targetTableExists}
+            handleCreate={handleCreate}
+            canCreate={canCreate}
+          />
+        }
+      >
+        {indexes.length === 0 ? (
+          <NoIndexes />
+        ) : (
+          <TransformIndexTable indexes={indexes} />
+        )}
+      </TitleSection>
+      {editorState != null && (
+        <IndexEditorModal
+          transform={transform}
+          index={editorState.index}
+          onClose={() => setEditorState(null)}
         />
-      }
-    >
-      {indexes.length === 0 ? (
-        <NoIndexes />
-      ) : (
-        <TransformIndexTable indexes={indexes} />
       )}
-    </TitleSection>
+    </>
   );
 }

--- a/frontend/src/metabase/utils/objects.ts
+++ b/frontend/src/metabase/utils/objects.ts
@@ -5,7 +5,7 @@ export const getObjectEntries = <K extends string, V>(
 };
 
 export const getObjectKeys = <K extends string>(
-  obj: Record<K, unknown>,
+  obj: Partial<Record<K, unknown>>,
 ): K[] => {
   return Object.keys(obj) as K[];
 };

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1574,6 +1574,8 @@
    [:name :string]
    ;; deferred-i18n label (or string)
    [:display-name :any]
+   ;; deferred-i18n user facing description
+   [:description {:optional true} :any]
    [:type [:enum :string :boolean :select :integer :columns]]
    [:required {:optional true} :boolean]
    ;; `:columns` only: whether per-column asc/desc is offered

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -168,7 +168,9 @@
 
 (def index-unique-field
   "Descriptor for the btree unique toggle."
-  {:name "unique" :display-name (deferred-tru "Enforce uniqueness across rows for indexed columns.") :type :boolean})
+  {:name "unique" :display-name (deferred-tru "Unique")
+   :description (deferred-tru "Enforce uniqueness across rows for indexed columns.")
+   :type :boolean})
 
 (def index-granularity-field
   "Descriptor for a ClickHouse skip-index granularity."

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -162,7 +162,9 @@
 (def index-columns-field
   "Descriptor for the indexed columns."
   ;; :directions (per-column asc/desc) is off by default; only btree consumes it, so it opts in.
-  {:name "columns" :display-name (deferred-tru "Columns") :type :columns :required true})
+  {:name "columns" :display-name (deferred-tru "Columns")
+   :description (deferred-tru "The column(s) the index will be built on. Usually the ones you filter or join by.")
+   :type :columns :required true})
 
 (def index-unique-field
   "Descriptor for the btree unique toggle."

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -157,7 +157,7 @@
 
 (def index-name-field
   "Descriptor for the index name."
-  {:name "name" :display-name (deferred-tru "Index name") :type :string :required true})
+  {:name "name" :display-name (deferred-tru "Give your index a name") :type :string :required true})
 
 (def index-columns-field
   "Descriptor for the indexed columns."
@@ -166,7 +166,7 @@
 
 (def index-unique-field
   "Descriptor for the btree unique toggle."
-  {:name "unique" :display-name (deferred-tru "Unique") :type :boolean})
+  {:name "unique" :display-name (deferred-tru "Enforce uniqueness across rows for indexed columns.") :type :boolean})
 
 (def index-granularity-field
   "Descriptor for a ClickHouse skip-index granularity."

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -1456,7 +1456,9 @@
   [_driver _database]
   ;; spatial is niche, and InnoDB silently rewrites USING HASH into btree, so neither is offered.
   (let [name+cols [driver.common/index-name-field driver.common/index-columns-field]]
-    {:btree    {:lifecycle :standalone :fields (conj name+cols driver.common/index-unique-field)}
+    {:btree    {:lifecycle :standalone :fields [driver.common/index-name-field
+                                                driver.common/index-unique-field
+                                                driver.common/index-columns-field]}
      :fulltext {:lifecycle :standalone :fields name+cols}}))
 
 (defn- mysql-index-column-sql

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -1347,8 +1347,8 @@
   (let [name+cols [driver.common/index-name-field driver.common/index-columns-field]]
     ;; btree is the only method where column order direction matters, so it opts into the asc/desc picker.
     {:btree {:lifecycle :standalone :fields [driver.common/index-name-field
-                                             (assoc driver.common/index-columns-field :directions true)
-                                             driver.common/index-unique-field]}
+                                             driver.common/index-unique-field
+                                             (assoc driver.common/index-columns-field :directions true)]}
      :gin   {:lifecycle :standalone :fields name+cols}
      :gist  {:lifecycle :standalone :fields name+cols}
      :brin  {:lifecycle :standalone :fields name+cols}}))

--- a/test/metabase/driver/postgres/index_test.clj
+++ b/test/metabase/driver/postgres/index_test.clj
@@ -23,7 +23,7 @@
       (is (= {:btree :standalone :gin :standalone :gist :standalone :brin :standalone}
              (update-vals methods :lifecycle)))
       (testing "only btree offers the unique toggle"
-        (is (= ["name" "columns" "unique"] (map :name (get-in methods [:btree :fields]))))
+        (is (= ["name" "unique" "columns"] (map :name (get-in methods [:btree :fields]))))
         (is (= ["name" "columns"] (map :name (get-in methods [:gin :fields]))))))))
 
 (deftest default-impls-test


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2635/add-index-editor-create-update-delete

### Description

This PR adds CREATE READ and UPDATE capabilities to index manager. 

The create/edit form is rendered based on schema returned by the BE side (similarly to the create/edit DB form).

This PR is stacked on https://github.com/metabase/metabase/pull/76687

Designs: https://www.figma.com/design/GZmR8Xq9bYvSvMjUJ5dFaB/transform-indexes?node-id=0-1&p=f&t=7hETCVG28CriBKlw-11

[Brief Loom overview](https://www.loom.com/share/d8410a6c2b454fdabdbc89846b95f04a)

### How to verify

1. Connect writable DB.
2. Create transform.
3. Go to Index manager tab
4. Create a new transform index requet using create form
5. Edit existing transform index request using edit form 
6. Delete existing transform index request.
7. (all actions are performed on transform run)


### Demo

<img width="1380" height="1418" alt="image" src="https://github.com/user-attachments/assets/b85bb20d-fe61-4a51-a290-1c51d788a5f9" />

<img width="2158" height="1648" alt="image" src="https://github.com/user-attachments/assets/7c7f8d95-2076-4eee-a0f8-7afa57ae534f" />



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
