### PR TITLE
[GDGT-2728] add find-stale-query logic for Transform model

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2389,6 +2389,7 @@
            run-tracking
            search
            settings
+           staleness
            task
            task-history
            tracing

--- a/src/metabase/transforms/freshness.clj
+++ b/src/metabase/transforms/freshness.clj
@@ -1,6 +1,8 @@
 (ns metabase.transforms.freshness
-  "Decides which transforms pulled into a job's plan only as dependencies are already fresh — no
-  scheduled fire time has passed since their last successful run — and can be skipped."
+  "Schedule-aware freshness checks. Decides which transforms pulled into a job's plan only as
+  dependencies are already fresh — no scheduled fire time has passed since their last successful
+  run — and can be skipped ([[fresh-dep-ids]]); also which transforms are simply between fires of
+  a slow schedule and so should not be treated as inactive ([[schedule-fresh-transform-ids]])."
   (:require
    [java-time.api :as t]
    [metabase.transforms.models.transform-run :as transform-run]
@@ -22,6 +24,24 @@
     (catch Exception e
       (log/warnf e "Ignoring unparseable transform job schedule %s" (pr-str cron))
       false)))
+
+(defn schedule-fresh-transform-ids
+  "Ids of transforms covered by ≥1 active scheduled job where no schedule fire time has elapsed
+  since the transform's most recent run (any status) as of `now`. Such transforms are merely
+  between fires of their schedule — e.g. a six-month cadence whose last run was two months ago —
+  and should not be treated as inactive by recency checks like staleness. Transforms that have
+  never run are never schedule-fresh."
+  [now]
+  (let [schedules-by-id (transform-tag/schedules-for-transforms)
+        last-starts     (transform-run/last-run-start-times (keys schedules-by-id))
+        now-date        (Date/from (t/instant now))]
+    (into #{}
+          (keep (fn [[id schedules]]
+                  (when-let [ran (last-starts id)]
+                    (let [ran-date (Date/from (t/instant ran))]
+                      (when (not-any? #(fired-since? % ran-date now-date) schedules)
+                        id)))))
+          schedules-by-id)))
 
 (defn fresh-dep-ids
   "Subset of `dep-ids` safe to skip as of `now`: a dep that has never succeeded is never fresh; a

--- a/src/metabase/transforms/freshness.clj
+++ b/src/metabase/transforms/freshness.clj
@@ -26,22 +26,22 @@
       false)))
 
 (defn schedule-fresh-transform-ids
-  "IDs of transforms covered by ≥1 active scheduled job where no schedule fire time has elapsed
-  since the transform's most recent run (any status) as of `now`. Such transforms are merely
-  between fires of their schedule - e.g. a six-month cadence whose last run was two months ago -
-  and should not be treated as inactive by recency checks like staleness. Transforms that have
-  never run are never schedule-fresh."
+  "IDs of transforms that are between fires of an active job schedule as of `now`.
+  Covered transforms have ≥1 active scheduled job and no schedule fire time has elapsed since
+  their most recent run (any status) - e.g. a six-month cadence whose last run was two months
+  ago - and should not be treated as inactive by recency checks like staleness. Transforms that
+  have never run are never schedule-fresh."
   [now]
   (let [schedules-by-id (transform-tag/schedules-for-transforms)
         last-starts     (transform-run/last-run-start-times (keys schedules-by-id))
         now-date        (Date/from (t/instant now))]
     (into #{}
-          (keep (fn [[id schedules]]
-                  (when-let [ran (last-starts id)]
-                    (let [ran-date (Date/from (t/instant ran))]
-                      (when (not-any? #(fired-since? % ran-date now-date) schedules)
-                        id)))))
-          schedules-by-id)))
+          (for [[id schedules] schedules-by-id
+                :let  [ran (last-starts id)]
+                :when ran
+                :let  [ran-date (Date/from (t/instant ran))]
+                :when (not-any? #(fired-since? % ran-date now-date) schedules)]
+            id))))
 
 (defn fresh-dep-ids
   "Subset of `dep-ids` safe to skip as of `now`: a dep that has never succeeded is never fresh; a

--- a/src/metabase/transforms/freshness.clj
+++ b/src/metabase/transforms/freshness.clj
@@ -25,6 +25,20 @@
       (log/warnf e "Ignoring unparseable transform job schedule %s" (pr-str cron))
       false)))
 
+(defn- fresh-ids
+  "Subset of `ids` that have a timestamp in `id->last-run` and whose schedules have not fired
+  based on `schedules-by-id` since the `now` timestamp.
+  IDs with no schedules are fresh once they have a timestamp; IDs with no timestamp are never fresh."
+  [now ids schedules-by-id id->last-run]
+  (let [now-date (Date/from (t/instant now))]
+    (into #{}
+          (for [id ids
+                :let  [ran (id->last-run id)]
+                :when ran
+                :let  [ran-date (Date/from (t/instant ran))]
+                :when (not-any? #(fired-since? % ran-date now-date) (schedules-by-id id))]
+            id))))
+
 (defn schedule-fresh-transform-ids
   "IDs of transforms that are between fires of an active job schedule as of `now`.
   Covered transforms have ≥1 active scheduled job and no schedule fire time has elapsed since
@@ -33,15 +47,8 @@
   have never run are never schedule-fresh."
   [now]
   (let [schedules-by-id (transform-schedule/schedules-for-transforms)
-        last-starts     (transform-run/last-run-start-times (keys schedules-by-id))
-        now-date        (Date/from (t/instant now))]
-    (into #{}
-          (for [[id schedules] schedules-by-id
-                :let  [ran (last-starts id)]
-                :when ran
-                :let  [ran-date (Date/from (t/instant ran))]
-                :when (not-any? #(fired-since? % ran-date now-date) schedules)]
-            id))))
+        ids             (keys schedules-by-id)]
+    (fresh-ids now ids schedules-by-id (transform-run/last-run-start-times ids))))
 
 (defn fresh-dep-ids
   "Subset of `dep-ids` safe to skip as of `now`: a dep that has never succeeded is never fresh; a
@@ -49,14 +56,6 @@
   one is fresh once it has succeeded."
   [now dep-ids]
   (when (seq dep-ids)
-    (let [schedules-by-id (transform-schedule/schedules-for-transforms dep-ids)
-          last-success    (transform-run/last-successful-run-times dep-ids)
-          now-date        (Date/from (t/instant now))]
-      (into #{}
-            (keep (fn [id]
-                    (when-let [ran (last-success id)]
-                      (let [ran-date (Date/from (t/instant ran))]
-                        (when (not-any? #(fired-since? % ran-date now-date)
-                                        (schedules-by-id id))
-                          id)))))
-            dep-ids))))
+    (fresh-ids now dep-ids
+               (transform-schedule/schedules-for-transforms dep-ids)
+               (transform-run/last-successful-run-times dep-ids))))

--- a/src/metabase/transforms/freshness.clj
+++ b/src/metabase/transforms/freshness.clj
@@ -26,9 +26,9 @@
       false)))
 
 (defn schedule-fresh-transform-ids
-  "Ids of transforms covered by ≥1 active scheduled job where no schedule fire time has elapsed
+  "IDs of transforms covered by ≥1 active scheduled job where no schedule fire time has elapsed
   since the transform's most recent run (any status) as of `now`. Such transforms are merely
-  between fires of their schedule — e.g. a six-month cadence whose last run was two months ago —
+  between fires of their schedule - e.g. a six-month cadence whose last run was two months ago -
   and should not be treated as inactive by recency checks like staleness. Transforms that have
   never run are never schedule-fresh."
   [now]

--- a/src/metabase/transforms/freshness.clj
+++ b/src/metabase/transforms/freshness.clj
@@ -6,7 +6,7 @@
   (:require
    [java-time.api :as t]
    [metabase.transforms.models.transform-run :as transform-run]
-   [metabase.transforms.models.transform-tag :as transform-tag]
+   [metabase.transforms.models.transform-schedule :as transform-schedule]
    [metabase.util.log :as log])
   (:import
    (java.util Date)
@@ -32,7 +32,7 @@
   ago - and should not be treated as inactive by recency checks like staleness. Transforms that
   have never run are never schedule-fresh."
   [now]
-  (let [schedules-by-id (transform-tag/schedules-for-transforms)
+  (let [schedules-by-id (transform-schedule/schedules-for-transforms)
         last-starts     (transform-run/last-run-start-times (keys schedules-by-id))
         now-date        (Date/from (t/instant now))]
     (into #{}
@@ -49,7 +49,7 @@
   one is fresh once it has succeeded."
   [now dep-ids]
   (when (seq dep-ids)
-    (let [schedules-by-id (transform-tag/schedules-for-transforms dep-ids)
+    (let [schedules-by-id (transform-schedule/schedules-for-transforms dep-ids)
           last-success    (transform-run/last-successful-run-times dep-ids)
           now-date        (Date/from (t/instant now))]
       (into #{}

--- a/src/metabase/transforms/jobs.clj
+++ b/src/metabase/transforms/jobs.clj
@@ -17,7 +17,7 @@
    [metabase.transforms.instrumentation :as transforms.instrumentation]
    [metabase.transforms.models.job-run :as transforms.job-run]
    [metabase.transforms.models.transform-run :as transform-run]
-   [metabase.transforms.models.transform-tag :as transform-tag]
+   [metabase.transforms.models.transform-schedule :as transform-schedule]
    [metabase.transforms.settings :as transforms.settings]
    [metabase.transforms.usage :as transforms.usage]
    [metabase.transforms.util :as transforms.u]
@@ -388,7 +388,7 @@
   (let [tagged    (job-transform-ids job-id)
         plan      (:order (get-plan tagged))
         dep-ids   (into #{} (comp (map :id) (remove tagged)) plan)
-        scheduled (set (keys (transform-tag/schedules-for-transforms dep-ids)))]
+        scheduled (set (keys (transform-schedule/schedules-for-transforms dep-ids)))]
     (map (fn [{:keys [id] :as transform}]
            (cond-> transform
              (contains? dep-ids id) (assoc :dependency true

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -17,6 +17,7 @@
    [metabase.staleness.core :as staleness]
    [metabase.transforms-base.interface :as transforms-base.i]
    [metabase.transforms-base.util :as transforms-base.u]
+   [metabase.transforms.freshness :as freshness]
    [metabase.transforms.models.transform-run :as transform-run]
    [metabase.transforms.util :as transforms.u]
    [metabase.util :as u]
@@ -549,10 +550,7 @@
   ;; merely between scheduled runs — e.g. a six-month cadence with a three-month threshold — not
   ;; stale. Cron math can't run in SQL, so that set is computed here at query-build time and excluded
   ;; below (build-time state reads have precedent in the Card/Dashboard methods' settings checks).
-  ;; `requiring-resolve` because statically requiring the freshness namespace would create a load
-  ;; cycle: freshness → transform-tag → this namespace.
-  (let [schedule-fresh-ids ((requiring-resolve 'metabase.transforms.freshness/schedule-fresh-transform-ids)
-                            (java.time.Instant/now))]
+  (let [schedule-fresh-ids (freshness/schedule-fresh-transform-ids (java.time.Instant/now))]
     {:select    [:transform.id
                  [[:inline "Transform"] :model]
                  [:transform.name :name]

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -537,22 +537,37 @@
 
 (defmethod staleness/find-stale-query :model/Transform
   [_model args]
-  ;; Transform staleness is run-based: there is no `last_used_at` column. A transform is stale when it has
-  ;; never been run, or when its most recent run started on/before the cutoff — regardless of that run's
-  ;; status (a failed run still counts as having been run). "Most recent run" is the row with the greatest
-  ;; `start_time` (the ordering the `:last_run` hydrate uses), captured as a portable grouped MAX(start_time)
-  ;; rather than the window CTE in `transform-run`. `start_time` is NOT NULL, so a NULL aggregate means the
-  ;; transform has no runs at all — i.e. never run.
-  {:select    [:transform.id
-               [[:inline "Transform"] :model]
-               [:transform.name :name]
-               [:latest_run.last_used_at :last_used_at]]
-   :from      :transform
-   :left-join [[{:select   [:transform_id [[:max :start_time] :last_used_at]]
-                 :from     :transform_run
-                 :group-by [:transform_id]}
-                :latest_run]
-               [:= :latest_run.transform_id :transform.id]]
-   :where     [:or
-               [:= :latest_run.last_used_at nil]
-               [:<= :latest_run.last_used_at (:cutoff-date args)]]})
+  ;; Transform staleness is run-based: there is no `last_used_at` column. A transform is stale when
+  ;; (a) it has never been run and was created on/before the cutoff (grace period, so a new transform
+  ;; isn't flagged before anyone has had a chance to run it), or (b) its most recent run started
+  ;; on/before the cutoff — regardless of that run's status (a failed run still counts as having been
+  ;; run). "Most recent run" is the row with the greatest `start_time` (the ordering the `:last_run`
+  ;; hydrate uses), captured as a portable grouped MAX(start_time) rather than the window CTE in
+  ;; `transform-run`. `start_time` is NOT NULL, so a NULL aggregate means the transform has no runs.
+  ;;
+  ;; Exception to (b): a transform whose active job schedules haven't fired since its last run is
+  ;; merely between scheduled runs — e.g. a six-month cadence with a three-month threshold — not
+  ;; stale. Cron math can't run in SQL, so that set is computed here at query-build time and excluded
+  ;; below (build-time state reads have precedent in the Card/Dashboard methods' settings checks).
+  ;; `requiring-resolve` because statically requiring the freshness namespace would create a load
+  ;; cycle: freshness → transform-tag → this namespace.
+  (let [schedule-fresh-ids ((requiring-resolve 'metabase.transforms.freshness/schedule-fresh-transform-ids)
+                            (java.time.Instant/now))]
+    {:select    [:transform.id
+                 [[:inline "Transform"] :model]
+                 [:transform.name :name]
+                 [:latest_run.last_used_at :last_used_at]]
+     :from      :transform
+     :left-join [[{:select   [:transform_id [[:max :start_time] :last_used_at]]
+                   :from     :transform_run
+                   :group-by [:transform_id]}
+                  :latest_run]
+                 [:= :latest_run.transform_id :transform.id]]
+     :where     [:and
+                 [:or
+                  [:and
+                   [:= :latest_run.last_used_at nil]
+                   [:<= :transform.created_at (:cutoff-date args)]]
+                  [:<= :latest_run.last_used_at (:cutoff-date args)]]
+                 (when (seq schedule-fresh-ids)
+                   [:not [:in :transform.id schedule-fresh-ids]])]}))

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -14,6 +14,7 @@
    [metabase.search.core :as search.core]
    [metabase.search.ingestion :as search]
    [metabase.search.spec :as search.spec]
+   [metabase.staleness.core :as staleness]
    [metabase.transforms-base.interface :as transforms-base.i]
    [metabase.transforms-base.util :as transforms-base.u]
    [metabase.transforms.models.transform-run :as transform-run]
@@ -531,3 +532,27 @@
    :search-terms [:name :description]
    :render-terms {:transform-name :name
                   :transform-id   :id}})
+
+;;; ------------------------------------------------- Staleness ------------------------------------------------
+
+(defmethod staleness/find-stale-query :model/Transform
+  [_model args]
+  ;; Transform staleness is run-based: there is no `last_used_at` column. A transform is stale when it has
+  ;; never been run, or when its most recent run started on/before the cutoff — regardless of that run's
+  ;; status (a failed run still counts as having been run). "Most recent run" is the row with the greatest
+  ;; `start_time` (the ordering the `:last_run` hydrate uses), captured as a portable grouped MAX(start_time)
+  ;; rather than the window CTE in `transform-run`. `start_time` is NOT NULL, so a NULL aggregate means the
+  ;; transform has no runs at all — i.e. never run.
+  {:select    [:transform.id
+               [[:inline "Transform"] :model]
+               [:transform.name :name]
+               [:latest_run.last_used_at :last_used_at]]
+   :from      :transform
+   :left-join [[{:select   [:transform_id [[:max :start_time] :last_used_at]]
+                 :from     :transform_run
+                 :group-by [:transform_id]}
+                :latest_run]
+               [:= :latest_run.transform_id :transform.id]]
+   :where     [:or
+               [:= :latest_run.last_used_at nil]
+               [:<= :latest_run.last_used_at (:cutoff-date args)]]})

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -538,18 +538,9 @@
 
 (defmethod staleness/find-stale-query :model/Transform
   [_model args]
-  ;; Transform staleness is run-based: there is no `last_used_at` column. A transform is stale when
-  ;; (a) it has never been run and was created on/before the cutoff (grace period, so a new transform
-  ;; isn't flagged before anyone has had a chance to run it), or (b) its most recent run started
-  ;; on/before the cutoff — regardless of that run's status (a failed run still counts as having been
-  ;; run). The "most recent run" anchor comes from `transform-run/latest-run-start-times-query` (the
-  ;; same definition the schedule-freshness check realizes); `start_time` is NOT NULL, so a NULL
-  ;; aggregate means the transform has no runs.
-  ;;
-  ;; Exception to (b): a transform whose active job schedules haven't fired since its last run is
-  ;; merely between scheduled runs — e.g. a six-month cadence with a three-month threshold — not
-  ;; stale. Cron math can't run in SQL, so that set is computed here at query-build time and excluded
-  ;; below (build-time state reads have precedent in the Card/Dashboard methods' settings checks).
+  ;; Run-based: a transform is stale when it has never run and was created on/before the cutoff,
+  ;; or when its most recent run started on/before the cutoff (failed runs still count). Transforms
+  ;; between fires of a slower-than-threshold schedule are not stale.
   (let [schedule-fresh-ids (freshness/schedule-fresh-transform-ids (java.time.Instant/now))]
     {:select    [:transform.id
                  [[:inline "Transform"] :model]

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -541,9 +541,9 @@
   ;; (a) it has never been run and was created on/before the cutoff (grace period, so a new transform
   ;; isn't flagged before anyone has had a chance to run it), or (b) its most recent run started
   ;; on/before the cutoff — regardless of that run's status (a failed run still counts as having been
-  ;; run). "Most recent run" is the row with the greatest `start_time` (the ordering the `:last_run`
-  ;; hydrate uses), captured as a portable grouped MAX(start_time) rather than the window CTE in
-  ;; `transform-run`. `start_time` is NOT NULL, so a NULL aggregate means the transform has no runs.
+  ;; run). The "most recent run" anchor comes from `transform-run/latest-run-start-times-query` (the
+  ;; same definition the schedule-freshness check realizes); `start_time` is NOT NULL, so a NULL
+  ;; aggregate means the transform has no runs.
   ;;
   ;; Exception to (b): a transform whose active job schedules haven't fired since its last run is
   ;; merely between scheduled runs — e.g. a six-month cadence with a three-month threshold — not
@@ -556,18 +556,15 @@
     {:select    [:transform.id
                  [[:inline "Transform"] :model]
                  [:transform.name :name]
-                 [:latest_run.last_used_at :last_used_at]]
+                 [:latest_run.last_start :last_used_at]]
      :from      :transform
-     :left-join [[{:select   [:transform_id [[:max :start_time] :last_used_at]]
-                   :from     :transform_run
-                   :group-by [:transform_id]}
-                  :latest_run]
+     :left-join [[(transform-run/latest-run-start-times-query) :latest_run]
                  [:= :latest_run.transform_id :transform.id]]
      :where     [:and
                  [:or
                   [:and
-                   [:= :latest_run.last_used_at nil]
+                   [:= :latest_run.last_start nil]
                    [:<= :transform.created_at (:cutoff-date args)]]
-                  [:<= :latest_run.last_used_at (:cutoff-date args)]]
+                  [:<= :latest_run.last_start (:cutoff-date args)]]
                  (when (seq schedule-fresh-ids)
                    [:not [:in :transform.id schedule-fresh-ids]])]}))

--- a/src/metabase/transforms/models/transform_run.clj
+++ b/src/metabase/transforms/models/transform_run.clj
@@ -247,6 +247,16 @@
                                  [:= :status [:inline "succeeded"]]]
                       :group-by [:transform_id]}))))
 
+(defn last-run-start-times
+  "Map each id in `transform-ids` to its most recent run's `start_time`, regardless of run status.
+  Ids with no runs are absent."
+  [transform-ids]
+  (when (seq transform-ids)
+    (t2/select-fn->fn :transform_id :last_start :model/TransformRun
+                      {:select   [:transform_id [[:max :start_time] :last_start]]
+                       :where    [:in :transform_id transform-ids]
+                       :group-by [:transform_id]})))
+
 (defn- paged-runs-join-clause
   "Returns a `:left-join` clause for transform runs sort columns that require joining other tables."
   [{:keys [sort-column]}]

--- a/src/metabase/transforms/models/transform_run.clj
+++ b/src/metabase/transforms/models/transform_run.clj
@@ -247,15 +247,27 @@
                                  [:= :status [:inline "succeeded"]]]
                       :group-by [:transform_id]}))))
 
+(defn latest-run-start-times-query
+  "HoneySQL map selecting each transform's most recent run `start_time` (any status) as
+  `:last_start`, one row per `:transform_id`; optionally restricted to `transform-ids`. The single
+  definition of the \"most recent run\" anchor — embedded as the staleness method's join subquery
+  ([[metabase.staleness.core/find-stale-query]] `:model/Transform`) and realized by
+  [[last-run-start-times]] for the schedule-freshness check, so the two can't drift apart."
+  ([]
+   (latest-run-start-times-query nil))
+  ([transform-ids]
+   (cond-> {:select   [:transform_id [[:max :start_time] :last_start]]
+            :from     [:transform_run]
+            :group-by [:transform_id]}
+     (seq transform-ids) (assoc :where [:in :transform_id transform-ids]))))
+
 (defn last-run-start-times
   "Map each id in `transform-ids` to its most recent run's `start_time`, regardless of run status.
   Ids with no runs are absent."
   [transform-ids]
   (when (seq transform-ids)
     (t2/select-fn->fn :transform_id :last_start :model/TransformRun
-                      {:select   [:transform_id [[:max :start_time] :last_start]]
-                       :where    [:in :transform_id transform-ids]
-                       :group-by [:transform_id]})))
+                      (latest-run-start-times-query transform-ids))))
 
 (defn- paged-runs-join-clause
   "Returns a `:left-join` clause for transform runs sort columns that require joining other tables."

--- a/src/metabase/transforms/models/transform_schedule.clj
+++ b/src/metabase/transforms/models/transform_schedule.clj
@@ -1,0 +1,29 @@
+(ns metabase.transforms.models.transform-schedule
+  "Cron schedules attached to transforms."
+  (:require
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- schedules-by-transform-id
+  [where]
+  (reduce (fn [m {:keys [transform_id schedule]}]
+            (update m transform_id (fnil conj #{}) schedule))
+          {}
+          (t2/select :model/TransformTransformTag
+                     {:select [:ttt.transform_id [:job.schedule :schedule]]
+                      :from   [[:transform_transform_tag :ttt]]
+                      :join   [[:transform_job_transform_tag :jtt] [:= :ttt.tag_id :jtt.tag_id]
+                               [:transform_job :job] [:= :jtt.job_id :job.id]]
+                      :where  where})))
+
+(defn schedules-for-transforms
+  "Map each id in `transform-ids` — or every transform, in the 0-arity — to the cron schedules of the
+  active jobs that run it via shared tags. Ids with no such job are absent."
+  ([]
+   (schedules-by-transform-id [:= :job.active true]))
+  ([transform-ids]
+   (when (seq transform-ids)
+     (schedules-by-transform-id [:and
+                                 [:in :ttt.transform_id transform-ids]
+                                 [:= :job.active true]]))))

--- a/src/metabase/transforms/models/transform_tag.clj
+++ b/src/metabase/transforms/models/transform_tag.clj
@@ -36,22 +36,28 @@
   [_model _instance]
   (api/is-data-analyst?))
 
+(defn- schedules-by-transform-id
+  [where]
+  (reduce (fn [m {:keys [transform_id schedule]}]
+            (update m transform_id (fnil conj #{}) schedule))
+          {}
+          (t2/select :model/TransformTransformTag
+                     {:select [:ttt.transform_id [:job.schedule :schedule]]
+                      :from   [[:transform_transform_tag :ttt]]
+                      :join   [[:transform_job_transform_tag :jtt] [:= :ttt.tag_id :jtt.tag_id]
+                               [:transform_job :job] [:= :jtt.job_id :job.id]]
+                      :where  where})))
+
 (defn schedules-for-transforms
-  "Map each id in `transform-ids` to the cron schedules of the active jobs that run it via shared tags.
-  Ids with no such job are absent."
-  [transform-ids]
-  (when (seq transform-ids)
-    (reduce (fn [m {:keys [transform_id schedule]}]
-              (update m transform_id (fnil conj #{}) schedule))
-            {}
-            (t2/select :model/TransformTransformTag
-                       {:select [:ttt.transform_id [:job.schedule :schedule]]
-                        :from   [[:transform_transform_tag :ttt]]
-                        :join   [[:transform_job_transform_tag :jtt] [:= :ttt.tag_id :jtt.tag_id]
-                                 [:transform_job :job] [:= :jtt.job_id :job.id]]
-                        :where  [:and
+  "Map each id in `transform-ids` — or every transform, in the 0-arity — to the cron schedules of the
+  active jobs that run it via shared tags. Ids with no such job are absent."
+  ([]
+   (schedules-by-transform-id [:= :job.active true]))
+  ([transform-ids]
+   (when (seq transform-ids)
+     (schedules-by-transform-id [:and
                                  [:in :ttt.transform_id transform-ids]
-                                 [:= :job.active true]]}))))
+                                 [:= :job.active true]]))))
 
 (defn tag-name-exists?
   "Check if a tag with the given name already exists"

--- a/src/metabase/transforms/models/transform_tag.clj
+++ b/src/metabase/transforms/models/transform_tag.clj
@@ -36,29 +36,6 @@
   [_model _instance]
   (api/is-data-analyst?))
 
-(defn- schedules-by-transform-id
-  [where]
-  (reduce (fn [m {:keys [transform_id schedule]}]
-            (update m transform_id (fnil conj #{}) schedule))
-          {}
-          (t2/select :model/TransformTransformTag
-                     {:select [:ttt.transform_id [:job.schedule :schedule]]
-                      :from   [[:transform_transform_tag :ttt]]
-                      :join   [[:transform_job_transform_tag :jtt] [:= :ttt.tag_id :jtt.tag_id]
-                               [:transform_job :job] [:= :jtt.job_id :job.id]]
-                      :where  where})))
-
-(defn schedules-for-transforms
-  "Map each id in `transform-ids` — or every transform, in the 0-arity — to the cron schedules of the
-  active jobs that run it via shared tags. Ids with no such job are absent."
-  ([]
-   (schedules-by-transform-id [:= :job.active true]))
-  ([transform-ids]
-   (when (seq transform-ids)
-     (schedules-by-transform-id [:and
-                                 [:in :ttt.transform_id transform-ids]
-                                 [:= :job.active true]]))))
-
 (defn tag-name-exists?
   "Check if a tag with the given name already exists"
   [tag-name]

--- a/test/metabase/transforms/freshness_test.clj
+++ b/test/metabase/transforms/freshness_test.clj
@@ -107,3 +107,76 @@
                                            :is_active    nil
                                            :end_time     (t/minus now (t/minutes 1))})
           (is (= #{} (freshness/fresh-dep-ids now #{(:id t)}))))))))
+
+(defn- insert-run-started-at!
+  "Insert a transform run with explicit `status` and `start-time` — schedule-freshness anchors on
+  the most recent run's start_time, regardless of status."
+  [transform-id status start-time]
+  (t2/insert! :model/TransformRun {:transform_id transform-id
+                                   :run_method   :cron
+                                   :status       status
+                                   :is_active    nil
+                                   :start_time   start-time
+                                   :end_time     start-time}))
+
+(deftest schedule-fresh-transform-ids-test
+  ;; pinned to the same Wednesday at 10:30 (local) as above: the hourly cron last fired at 10:00,
+  ;; the daily one at midnight. Assertions are membership-based because the fn scans every
+  ;; transform in the (shared) test DB, not a caller-supplied id set.
+  (let [now (t/offset-date-time 2025 6 18 10 30)]
+    (testing "with a daily schedule, freshness follows the most recent run's start_time, any status"
+      (mt/with-temp [:model/TransformTag          tag {:name "sf-daily-tag"}
+                     :model/TransformJob          job {:name "sf-daily-job" :schedule daily-cron}
+                     :model/TransformJobTransformTag _ {:job_id (:id job) :tag_id (:id tag) :position 0}
+                     :model/Transform             fresh  {:name "sf-fresh"}
+                     :model/TransformTransformTag _       {:transform_id (:id fresh) :tag_id (:id tag) :position 0}
+                     :model/Transform             stale  {:name "sf-stale"}
+                     :model/TransformTransformTag _       {:transform_id (:id stale) :tag_id (:id tag) :position 0}
+                     :model/Transform             failed {:name "sf-failed-recently"}
+                     :model/TransformTransformTag _       {:transform_id (:id failed) :tag_id (:id tag) :position 0}
+                     :model/Transform             never  {:name "sf-never-run"}
+                     :model/TransformTransformTag _       {:transform_id (:id never) :tag_id (:id tag) :position 0}]
+        ;; 08:30 — after today's midnight fire → fresh; two days ago → two midnights since → not
+        (insert-run-started-at! (:id fresh) :succeeded (t/minus now (t/hours 2)))
+        (insert-run-started-at! (:id stale) :succeeded (t/minus now (t/days 2)))
+        ;; a FAILED run still anchors freshness (unlike fresh-dep-ids, which needs a success)
+        (insert-run-started-at! (:id failed) :failed (t/minus now (t/hours 2)))
+        (let [ids (freshness/schedule-fresh-transform-ids now)]
+          (is (contains? ids (:id fresh)))
+          (is (not (contains? ids (:id stale))))
+          (is (contains? ids (:id failed)))
+          (testing "a transform that has never run is never schedule-fresh"
+            (is (not (contains? ids (:id never))))))
+        (testing "the most recent run governs: a late failed run re-freshens a stale transform"
+          (insert-run-started-at! (:id stale) :failed (t/minus now (t/minutes 30)))
+          (is (contains? (freshness/schedule-fresh-transform-ids now) (:id stale))))))
+    (testing "only transforms covered by an active scheduled job can be schedule-fresh"
+      (mt/with-temp [:model/TransformTag          tag        {:name "sf-inactive-tag"}
+                     :model/TransformJob          job        {:name "sf-inactive-job" :schedule daily-cron :active false}
+                     :model/TransformJobTransformTag _        {:job_id (:id job) :tag_id (:id tag) :position 0}
+                     :model/Transform             inactive   {:name "sf-inactively-scheduled"}
+                     :model/TransformTransformTag _           {:transform_id (:id inactive) :tag_id (:id tag) :position 0}
+                     :model/Transform             unscheduled {:name "sf-unscheduled"}]
+        ;; both ran recently enough to be fresh under the daily cadence — but neither has an
+        ;; active schedule, so neither is schedule-fresh (they're plain recency cases instead)
+        (insert-run-started-at! (:id inactive) :succeeded (t/minus now (t/hours 2)))
+        (insert-run-started-at! (:id unscheduled) :succeeded (t/minus now (t/hours 2)))
+        (let [ids (freshness/schedule-fresh-transform-ids now)]
+          (is (not (contains? ids (:id inactive))))
+          (is (not (contains? ids (:id unscheduled)))))))
+    (testing "with multiple schedules, any one firing since the last run breaks freshness"
+      (mt/with-temp [:model/TransformTag          hourly-tag {:name "sf-hourly-tag"}
+                     :model/TransformTag          daily-tag  {:name "sf-daily-tag-2"}
+                     :model/TransformJob          hourly-job {:name "sf-hourly-job" :schedule hourly-cron}
+                     :model/TransformJob          daily-job  {:name "sf-daily-job-2" :schedule daily-cron}
+                     :model/TransformJobTransformTag _        {:job_id (:id hourly-job) :tag_id (:id hourly-tag) :position 0}
+                     :model/TransformJobTransformTag _        {:job_id (:id daily-job) :tag_id (:id daily-tag) :position 0}
+                     :model/Transform             t          {:name "sf-hourly-and-daily"}
+                     :model/TransformTransformTag _           {:transform_id (:id t) :tag_id (:id hourly-tag) :position 0}
+                     :model/TransformTransformTag _           {:transform_id (:id t) :tag_id (:id daily-tag) :position 1}]
+        (testing "a run 2h ago (08:30): the hourly job has fired since (09:00, 10:00)"
+          (insert-run-started-at! (:id t) :succeeded (t/minus now (t/hours 2)))
+          (is (not (contains? (freshness/schedule-fresh-transform-ids now) (:id t)))))
+        (testing "a run 25m ago (10:05): no schedule has fired since"
+          (insert-run-started-at! (:id t) :succeeded (t/minus now (t/minutes 25)))
+          (is (contains? (freshness/schedule-fresh-transform-ids now) (:id t))))))))

--- a/test/metabase/transforms/models/transform_schedule_test.clj
+++ b/test/metabase/transforms/models/transform_schedule_test.clj
@@ -1,0 +1,21 @@
+(ns metabase.transforms.models.transform-schedule-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.test :as mt]
+   [metabase.transforms.models.transform-schedule :as transform-schedule]))
+
+(deftest schedules-for-transforms-test
+  (testing "returns the schedules of the active jobs that run a transform via shared tags"
+    (mt/with-temp [:model/TransformTag          tag      {}
+                   :model/TransformJob          active   {:schedule "0 0 * * * ? *" :active true}
+                   :model/TransformJob          inactive {:schedule "0 0 0 * * ? *" :active false}
+                   :model/TransformJobTransformTag _      {:job_id (:id active) :tag_id (:id tag) :position 0}
+                   :model/TransformJobTransformTag _      {:job_id (:id inactive) :tag_id (:id tag) :position 1}
+                   :model/Transform             t        {}
+                   :model/TransformTransformTag _         {:transform_id (:id t) :tag_id (:id tag) :position 0}
+                   :model/Transform             untagged {}]
+      (is (= {(:id t) #{"0 0 * * * ? *"}}
+             (transform-schedule/schedules-for-transforms #{(:id t)}))
+          "only the active job's schedule is included")
+      (is (= {} (transform-schedule/schedules-for-transforms #{(:id untagged)}))
+          "a transform with no scheduling job is absent"))))

--- a/test/metabase/transforms/models/transform_test.clj
+++ b/test/metabase/transforms/models/transform_test.clj
@@ -3,6 +3,8 @@
    [clojure.test :refer :all]
    [metabase.events.core :as events]
    [metabase.models.interface :as mi]
+   [metabase.stale-test :as stale-test]
+   [metabase.staleness.core :as staleness]
    [metabase.test :as mt]
    [metabase.transforms-base.query :as transforms-base.query]
    [toucan2.core :as t2]))
@@ -140,3 +142,42 @@
                                     :type     "query"
                                     :query    {:source-table (mt/id :people)}}}})
       (is (nil? (stored-deps id))))))
+
+(defn- insert-run! [transform-id status months-ago]
+  (t2/insert! :model/TransformRun
+              {:transform_id transform-id
+               :status       status
+               :run_method   :cron
+               :start_time   (stale-test/datetime-months-ago months-ago)
+               :end_time     (stale-test/datetime-months-ago months-ago)}))
+
+(deftest find-stale-query-test
+  (testing "a transform is stale when it has never run, or its most recent run started on/before the cutoff"
+    (mt/with-temp [:model/Transform {never-id :id}          {:name "never-run"}
+                   :model/Transform {old-id :id}            {:name "old-run"}
+                   :model/Transform {fresh-id :id}          {:name "fresh-run"}
+                   :model/Transform {recent-failed-id :id}  {:name "recent-failed"}
+                   :model/Transform {old-failed-id :id}     {:name "old-failed"}
+                   :model/Transform {old-then-recent-id :id} {:name "old-then-recent"}]
+      (insert-run! old-id :succeeded 8)
+      (insert-run! fresh-id :succeeded 1)
+      ;; status is irrelevant — only the most recent run's start_time matters
+      (insert-run! recent-failed-id :failed 1)
+      (insert-run! old-failed-id :failed 8)
+      ;; two runs: the most recent (1mo) governs, not the earlier one (8mo)
+      (insert-run! old-then-recent-id :succeeded 8)
+      (insert-run! old-then-recent-id :succeeded 1)
+      (let [stale-ids (set (map :id (t2/query (staleness/find-stale-query
+                                               :model/Transform
+                                               {:collection-ids #{}
+                                                :cutoff-date    (stale-test/date-months-ago 6)}))))]
+        (testing "a transform that has never run is stale"
+          (is (contains? stale-ids never-id)))
+        (testing "a transform whose most recent run started before the cutoff is stale, regardless of status"
+          (is (contains? stale-ids old-id))
+          (is (contains? stale-ids old-failed-id)))
+        (testing "a transform with a recent run is not stale, regardless of status"
+          (is (not (contains? stale-ids fresh-id)))
+          (is (not (contains? stale-ids recent-failed-id))))
+        (testing "the most recent run governs: an old run followed by a recent one is not stale"
+          (is (not (contains? stale-ids old-then-recent-id))))))))

--- a/test/metabase/transforms/models/transform_test.clj
+++ b/test/metabase/transforms/models/transform_test.clj
@@ -9,6 +9,8 @@
    [metabase.transforms-base.query :as transforms-base.query]
    [toucan2.core :as t2]))
 
+(set! *warn-on-reflection* true)
+
 (deftest source-database-id-set-test
   (testing "inserting a transform correctly sets the source-database-id column"
     (mt/with-temp [:model/Transform transform
@@ -152,32 +154,66 @@
                :end_time     (stale-test/datetime-months-ago months-ago)}))
 
 (deftest find-stale-query-test
-  (testing "a transform is stale when it has never run, or its most recent run started on/before the cutoff"
-    (mt/with-temp [:model/Transform {never-id :id}          {:name "never-run"}
-                   :model/Transform {old-id :id}            {:name "old-run"}
-                   :model/Transform {fresh-id :id}          {:name "fresh-run"}
-                   :model/Transform {recent-failed-id :id}  {:name "recent-failed"}
-                   :model/Transform {old-failed-id :id}     {:name "old-failed"}
-                   :model/Transform {old-then-recent-id :id} {:name "old-then-recent"}]
-      (insert-run! old-id :succeeded 8)
-      (insert-run! fresh-id :succeeded 1)
-      ;; status is irrelevant — only the most recent run's start_time matters
-      (insert-run! recent-failed-id :failed 1)
-      (insert-run! old-failed-id :failed 8)
-      ;; two runs: the most recent (1mo) governs, not the earlier one (8mo)
-      (insert-run! old-then-recent-id :succeeded 8)
-      (insert-run! old-then-recent-id :succeeded 1)
-      (let [stale-ids (set (map :id (t2/query (staleness/find-stale-query
-                                               :model/Transform
-                                               {:collection-ids #{}
-                                                :cutoff-date    (stale-test/date-months-ago 6)}))))]
-        (testing "a transform that has never run is stale"
-          (is (contains? stale-ids never-id)))
-        (testing "a transform whose most recent run started before the cutoff is stale, regardless of status"
-          (is (contains? stale-ids old-id))
-          (is (contains? stale-ids old-failed-id)))
-        (testing "a transform with a recent run is not stale, regardless of status"
-          (is (not (contains? stale-ids fresh-id)))
-          (is (not (contains? stale-ids recent-failed-id))))
-        (testing "the most recent run governs: an old run followed by a recent one is not stale"
-          (is (not (contains? stale-ids old-then-recent-id))))))))
+  (testing "a transform is stale when never run past a created_at grace period, or its most recent run predates the cutoff"
+    (let [cutoff-months   6
+          old-months      (+ cutoff-months 2) ; predates the cutoff
+          recent-months   1                   ; within the cutoff
+          ;; fires once a year, ~2 months from now — so its previous fire was ~10 months ago,
+          ;; before the old runs: nothing has fired since them
+          schedule-anchor (-> (java.time.LocalDate/now) (.plusMonths 2) (.withDayOfMonth 15))
+          yearly-cron     (format "0 0 0 15 %d ?" (.getMonthValue schedule-anchor))
+          daily-cron      "0 0 0 * * ?"]
+      (mt/with-temp [:model/Transform {never-new-id :id}       {:name "never-new"}
+                     :model/Transform {never-old-id :id}       {:name "never-old"
+                                                                :created_at (stale-test/datetime-months-ago old-months)}
+                     :model/Transform {old-id :id}             {:name "old-run"}
+                     :model/Transform {fresh-id :id}           {:name "fresh-run"}
+                     :model/Transform {recent-failed-id :id}   {:name "recent-failed"}
+                     :model/Transform {old-failed-id :id}      {:name "old-failed"}
+                     :model/Transform {old-then-recent-id :id} {:name "old-then-recent"}
+                     :model/Transform {on-schedule-id :id}     {:name "on-schedule"}
+                     :model/Transform {missed-schedule-id :id} {:name "missed-schedule"}
+                     :model/Transform {never-scheduled-id :id} {:name "never-run-scheduled"
+                                                                :created_at (stale-test/datetime-months-ago old-months)}
+                     :model/TransformTag {slow-tag-id :id}     {}
+                     :model/TransformTag {fast-tag-id :id}     {}
+                     :model/TransformJob {slow-job-id :id}     {:name "yearly job" :schedule yearly-cron}
+                     :model/TransformJob {fast-job-id :id}     {:name "daily job" :schedule daily-cron}
+                     :model/TransformJobTransformTag _ {:job_id slow-job-id :tag_id slow-tag-id :position 0}
+                     :model/TransformJobTransformTag _ {:job_id fast-job-id :tag_id fast-tag-id :position 0}
+                     :model/TransformTransformTag _ {:transform_id on-schedule-id :tag_id slow-tag-id :position 0}
+                     :model/TransformTransformTag _ {:transform_id missed-schedule-id :tag_id fast-tag-id :position 0}
+                     :model/TransformTransformTag _ {:transform_id never-scheduled-id :tag_id slow-tag-id :position 0}]
+        (insert-run! old-id :succeeded old-months)
+        (insert-run! fresh-id :succeeded recent-months)
+        ;; status is irrelevant — only the most recent run's start_time matters
+        (insert-run! recent-failed-id :failed recent-months)
+        (insert-run! old-failed-id :failed old-months)
+        ;; two runs: the most recent (recent-months) governs, not the earlier one (old-months)
+        (insert-run! old-then-recent-id :succeeded old-months)
+        (insert-run! old-then-recent-id :succeeded recent-months)
+        ;; both scheduled transforms last ran old-months ago; the yearly schedule hasn't fired since
+        ;; (previous fire ~10 months ago), the daily schedule has fired thousands of times since
+        (insert-run! on-schedule-id :succeeded old-months)
+        (insert-run! missed-schedule-id :succeeded old-months)
+        (let [stale-ids (set (map :id (t2/query (staleness/find-stale-query
+                                                 :model/Transform
+                                                 {:collection-ids #{}
+                                                  :cutoff-date    (stale-test/date-months-ago cutoff-months)}))))]
+          (testing "a never-run transform is stale only once its created_at passes the cutoff"
+            (is (contains? stale-ids never-old-id))
+            (is (not (contains? stale-ids never-new-id))))
+          (testing "a transform whose most recent run started before the cutoff is stale, regardless of status"
+            (is (contains? stale-ids old-id))
+            (is (contains? stale-ids old-failed-id)))
+          (testing "a transform with a recent run is not stale, regardless of status"
+            (is (not (contains? stale-ids fresh-id)))
+            (is (not (contains? stale-ids recent-failed-id))))
+          (testing "the most recent run governs: an old run followed by a recent one is not stale"
+            (is (not (contains? stale-ids old-then-recent-id))))
+          (testing "an old run is not stale while a slower-than-threshold schedule has not fired since it"
+            (is (not (contains? stale-ids on-schedule-id))))
+          (testing "an old run is stale when its schedule has fired since it (missed fires)"
+            (is (contains? stale-ids missed-schedule-id)))
+          (testing "the schedule exception does not shield never-run transforms"
+            (is (contains? stale-ids never-scheduled-id))))))))

--- a/test/metabase/transforms/models_test.clj
+++ b/test/metabase/transforms/models_test.clj
@@ -357,22 +357,6 @@
           (let [t (t2/select-one :model/Transform transform-id)]
             (is (= "99" (:last_checkpoint_value t)))))))))
 
-(deftest schedules-for-transforms-test
-  (testing "returns the schedules of the active jobs that run a transform via shared tags"
-    (mt/with-temp [:model/TransformTag          tag      {}
-                   :model/TransformJob          active   {:schedule "0 0 * * * ? *" :active true}
-                   :model/TransformJob          inactive {:schedule "0 0 0 * * ? *" :active false}
-                   :model/TransformJobTransformTag _      {:job_id (:id active) :tag_id (:id tag) :position 0}
-                   :model/TransformJobTransformTag _      {:job_id (:id inactive) :tag_id (:id tag) :position 1}
-                   :model/Transform             t        {}
-                   :model/TransformTransformTag _         {:transform_id (:id t) :tag_id (:id tag) :position 0}
-                   :model/Transform             untagged {}]
-      (is (= {(:id t) #{"0 0 * * * ? *"}}
-             (transform-tag/schedules-for-transforms #{(:id t)}))
-          "only the active job's schedule is included")
-      (is (= {} (transform-tag/schedules-for-transforms #{(:id untagged)}))
-          "a transform with no scheduling job is absent"))))
-
 (deftest start-run-stores-job-run-id-test
   (testing "start-run! stores job_run_id when provided in properties"
     (mt/with-premium-features #{:transforms-basic}


### PR DESCRIPTION
### Description

Transform is considered stale when:
(a) it has never been run and its created_at is earlier than the cutoff date; or
(b) its most recent run started earlier than the **_effective_** cutoff - the stale threshold's cutoff date or, for transform job's most recent **scheduled** fire time, **whichever is earlier**.

This enables instances of this model to be returned in the find-candidates scan of the enterprise/stale module if we include Transforms. 

See https://github.com/metabase/metabase/blob/master/src/metabase/staleness/core.clj. 


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
