### PR TITLE
[GDGT-2729] extend find-stale-query multimethod to documents

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -813,6 +813,8 @@
            query-processor
            revisions
            search
+           settings
+           staleness
            util
            view-log}
    :model-exports #{:model/Document}

--- a/enterprise/backend/test/metabase_enterprise/stale/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/stale/impl_test.clj
@@ -9,6 +9,7 @@
    [metabase.stale-test :refer [with-stale-items
                                 stale-dashboard
                                 stale-card
+                                stale-document
                                 date-months-ago
                                 datetime-months-ago]]
    [metabase.test :as mt]
@@ -44,6 +45,91 @@
               :offset         0
               :sort-column    :name
               :sort-direction :asc}))))))
+
+(deftest can-find-stale-documents
+  (mt/with-temp [:model/Document {id :id} (stale-document
+                                           {:name "My Stale Document"
+                                            :collection_id nil})]
+    (let [base {:collection-ids #{nil}
+                :cutoff-date    (date-months-ago 6)
+                :limit          10
+                :offset         0
+                :sort-column    :name
+                :sort-direction :asc}]
+      (testing "a stale document is found when documents are searched"
+        (is (= [{:id id :model :model/Document}]
+               (:rows (stale/find-candidates (assoc base :models #{:model/Document}))))))
+      (testing "documents are not part of the default model set"
+        (is (not-any? #(= (:id %) id)
+                      (:rows (stale/find-candidates base))))))))
+
+(deftest publicly-shared-documents-are-excluded
+  (mt/with-temp [:model/Collection {col-id :id} {}
+                 :model/Document {doc-id1 :id} (stale-document {:name          "A"
+                                                                :collection_id col-id
+                                                                :public_uuid   (str (random-uuid))})
+                 :model/Document {doc-id2 :id} (stale-document {:name          "B"
+                                                                :collection_id col-id})]
+    (let [rows #(:rows (stale/find-candidates {:collection-ids #{col-id}
+                                               :cutoff-date    (date-months-ago 6)
+                                               :limit          10
+                                               :offset         0
+                                               :sort-column    :name
+                                               :sort-direction :asc
+                                               :models         #{:model/Document}}))]
+      (testing "when public sharing is disabled, publicly shared documents are still returned"
+        (mt/with-temporary-setting-values [enable-public-sharing false]
+          (is (= [{:id doc-id1 :model :model/Document}
+                  {:id doc-id2 :model :model/Document}]
+                 (rows)))))
+      (testing "when public sharing is enabled, publicly shared documents are excluded"
+        (mt/with-temporary-setting-values [enable-public-sharing true]
+          (is (= [{:id doc-id2 :model :model/Document}]
+                 (rows))))))))
+
+(deftest never-viewed-documents-created-before-cutoff-are-stale
+  ;; A serdes import restores the old `created_at` but :skip's `last_viewed_at`/`view_count`
+  ;; (make-spec "Document", document.clj), so an imported never-viewed doc has an OLD created_at
+  ;; yet a fresh `last_viewed_at` — only the `view_count = 0 AND created_at <= cutoff` arm catches
+  ;; it; the `last_viewed_at <= cutoff` arm can't.
+  (mt/with-temp [:model/Document {never-viewed-id :id} {:name           "Never viewed, created before cutoff"
+                                                        :collection_id  nil
+                                                        :view_count     0
+                                                        :last_viewed_at (datetime-months-ago 1)
+                                                        :created_at     (datetime-months-ago 7)}
+                 :model/Document {viewed-id :id} {:name           "Viewed recently, created before cutoff"
+                                                  :collection_id  nil
+                                                  :view_count     1
+                                                  :last_viewed_at (datetime-months-ago 1)
+                                                  :created_at     (datetime-months-ago 7)}]
+    (let [ids (into #{}
+                    (map :id)
+                    (:rows (stale/find-candidates
+                            {:collection-ids #{nil}
+                             :cutoff-date    (date-months-ago 6)
+                             :limit          100
+                             :offset         0
+                             :sort-column    :name
+                             :sort-direction :asc
+                             :models         #{:model/Document}})))]
+      (testing "a never-viewed document created before the cutoff is stale despite a recent last_viewed_at"
+        (is (contains? ids never-viewed-id)))
+      (testing "a document viewed after the cutoff is not stale"
+        (is (not (contains? ids viewed-id)))))))
+
+(deftest documents-in-non-standard-collection-types-are-excluded
+  (mt/with-temp [:model/Collection {col-id :id} {:type "instance-analytics"}
+                 :model/Document _ (stale-document {:name "Doc" :collection_id col-id})]
+    (is (= {:rows [] :total 0}
+           (stale/find-candidates
+            {:collection-ids #{col-id}
+             :cutoff-date    (date-months-ago 6)
+             :limit          10
+             :offset         0
+             :sort-column    :name
+             :sort-direction :asc
+             :models         #{:model/Document}}))
+        "should not include documents in non-standard collections")))
 
 (deftest results-can-be-sorted
   (mt/with-temp [:model/Dashboard {id1 :id} {:name "Z"

--- a/src/metabase/documents/models/document.clj
+++ b/src/metabase/documents/models/document.clj
@@ -10,6 +10,8 @@
    [metabase.public-sharing.core :as public-sharing]
    [metabase.search.config :as search.config]
    [metabase.search.spec :as search.spec]
+   [metabase.settings.core :as setting]
+   [metabase.staleness.core :as staleness]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.json :as json]
@@ -162,6 +164,34 @@
                   :collection-position        true
                   :collection-type            :collection.type
                   :archived-directly          true}})
+
+;;; ------------------------------------------------- Staleness ---------------------------------------------------
+
+(defmethod staleness/find-stale-query :model/Document
+  [_model args]
+  {:select [:document.id
+            [[:inline "Document"] :model]
+            [:document.name :name]
+            [:document.last_viewed_at :last_used_at]]
+   :from :document
+   :left-join [:collection [:= :collection.id :document.collection_id]]
+   :where [:and
+           [:= :document.archived false]
+           ;; stale = not viewed since the cutoff, OR never viewed and created before the cutoff.
+           [:or
+            [:<= :document.last_viewed_at (-> args :cutoff-date)]
+            [:and
+             [:= :document.view_count 0]
+             [:<= :document.created_at (-> args :cutoff-date)]]]
+           ;; only regular user collections (type nil), not system collections like
+           ;; `instance-analytics`, `trash`, or the `library` collections.
+           [:= :collection.type nil]
+           (when (setting/get :enable-public-sharing)
+             [:= :document.public_uuid nil])
+           [:or
+            (when (contains? (:collection-ids args) nil)
+              [:is :document.collection_id nil])
+            [:in :document.collection_id (-> args :collection-ids)]]]})
 
 ;;; ---------------------------------------------- Serialization --------------------------------------------------
 

--- a/test/metabase/stale_test.clj
+++ b/test/metabase/stale_test.clj
@@ -28,13 +28,18 @@
   ;; assoc the card with the current time minus 7 months
   (assoc card :last_used_at (datetime-months-ago 7)))
 
+(defn stale-document [document]
+  ;; assoc the document with the current time minus 7 months
+  (assoc document :last_viewed_at (datetime-months-ago 7)))
+
 (defmacro with-stale-items [inputs & body]
   (let [processed-inputs
         (map (fn [[model binding args]]
                (let [column (case model
                               :model/Card :last_used_at
                               :model/Dashboard :last_viewed_at
-                              (throw (ex-info "`with-stale` only works for cards or dashboards." {})))]
+                              :model/Document :last_viewed_at
+                              (throw (ex-info "`with-stale` only works for cards, dashboards, or documents." {})))]
                  [model binding `(assoc ~args ~column (datetime-months-ago 7))]))
              (partition-all 3 inputs))]
     `(mt/with-temp ~(vec (apply concat processed-inputs))


### PR DESCRIPTION
### Description

Document is considered stale when (a) last_viewed_at is within the threshold; or (b) view_count is 0 and created_at is within the threshold

This enables instances of this model to be returned in the find-candidates scan of the enterprise/stale module if we include Document. 

See https://github.com/metabase/metabase/blob/master/src/metabase/staleness/core.clj. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
