### PR TITLE
fix sql server incremental transforms failing on the append

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms_python/base.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/base.clj
@@ -347,9 +347,15 @@
             start-ms (u/start-timer)]
         (log! message-log (i18n/tru "Executing Python transform"))
         (log/info "Executing Python transform" transform-id "with target" (pr-str target))
-        (let [result (run-python-transform-impl! transform db effective-run-id cancel-chan message-log
-                                                 {:with-stage-timing-fn with-stage-timing-fn
-                                                  :source-range-params  source-range-params})]
+        ;; Establish a resilient-connection context so the SQL Server source read/export can recover a dropped
+        ;; connection mid-run instead of bailing with "not in a resilient context". No-op for drivers that don't
+        ;; need recovery (nothing is opened, so the finally closes nothing).
+        (let [result (driver/do-with-resilient-connection
+                      (:engine db) db
+                      (fn [_driver _db]
+                        (run-python-transform-impl! transform db effective-run-id cancel-chan message-log
+                                                    {:with-stage-timing-fn with-stage-timing-fn
+                                                     :source-range-params  source-range-params})))]
           (log! message-log (i18n/tru "Python execution finished successfully in {0}"
                                       (u.format/format-milliseconds (u/since-ms start-ms))))
           ;; Check cancellation after python

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.sqlserver
   "Driver for SQLServer databases. Uses the official Microsoft JDBC driver under the hood (pre-0.25.0, used jTDS)."
-  (:refer-clojure :exclude [mapv get-in])
+  (:refer-clojure :exclude [mapv get-in some])
   (:require
    [clojure.java.io :as io]
    [clojure.java.jdbc :as jdbc]
@@ -35,7 +35,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.match :as match]
    [metabase.util.memoize :as memoize]
-   [metabase.util.performance :as perf :refer [mapv get-in]]
+   [metabase.util.performance :as perf :refer [mapv get-in some]]
    [next.jdbc :as next.jdbc])
   (:import
    (java.sql Connection DatabaseMetaData PreparedStatement ResultSet Time)
@@ -1113,6 +1113,40 @@
   (let [{sql-query :query sql-params :params} query
         ^String table-name (first (sql.qp/format-honeysql driver (keyword output-table)))]
     [(format "INSERT INTO %s %s" table-name sql-query) sql-params]))
+
+(defn- identity-column?
+  [{:keys [is_identity]}]
+  (if (number? is_identity) (pos? (long is_identity)) (boolean is_identity)))
+
+(defn- target-column-info
+  "Columns of `qualified-table` (in definition order) and whether the table has an IDENTITY column."
+  [database qualified-table]
+  (let [rows (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
+                         ["SELECT name, is_identity FROM sys.columns WHERE object_id = OBJECT_ID(?) ORDER BY column_id"
+                          qualified-table])]
+    {:columns       (mapv :name rows)
+     :has-identity? (boolean (some identity-column? rows))}))
+
+;; The full run's `SELECT ... INTO` inherits the source's IDENTITY column, so a plain `INSERT ... SELECT` append that
+;; carries explicit id values is rejected. When the target has an identity column, insert with an explicit column list
+;; under IDENTITY_INSERT so the source ids are written verbatim; otherwise fall back to the generic append.
+(defmethod driver/run-transform! [:sqlserver :table-incremental]
+  [driver {:keys [conn-spec database output-table query] :as transform-details} _opts]
+  (let [target     (keyword output-table)
+        table-name (first (sql.qp/format-honeysql driver target))]
+    (if-not (driver/table-exists? driver database {:schema (namespace target) :name (name target)})
+      (last (driver/execute-raw-queries! driver conn-spec [(driver/compile-transform driver transform-details)]))
+      (let [{:keys [columns has-identity?]} (target-column-info database table-name)]
+        (if-not has-identity?
+          (last (driver/execute-raw-queries! driver conn-spec [(driver/compile-insert driver transform-details)]))
+          (let [{sql-query :query sql-params :params} query
+                insert (format "INSERT INTO %s (%s) %s"
+                               table-name (str/join ", " (map quote-field columns)) sql-query)
+                ;; SQL Server scopes IDENTITY_INSERT to the batch it runs in, and the JDBC driver runs each statement
+                ;; as its own batch, so ON/INSERT/OFF must be one statement or the insert won't see it on.
+                batch  (format "SET IDENTITY_INSERT %s ON;\n%s;\nSET IDENTITY_INSERT %s OFF;"
+                               table-name insert table-name)]
+            (last (driver/execute-raw-queries! driver conn-spec [[batch sql-params]]))))))))
 
 (defmethod driver/table-exists? :sqlserver
   [driver database {:keys [schema name] :as _table}]


### PR DESCRIPTION
sql server incremental transforms break on the append run. the first (full) run does `SELECT ... INTO`, which on sql server preserves the source's IDENTITY column, so the target ends up with an identity id. the append then does `INSERT INTO target SELECT ...`, supplying explicit id values, and sql server rejects it unless IDENTITY_INSERT is on.

this is generic incremental code, nothing to do with the index manager. sql server was actually built for incremental (the incremental transforms PR added its `compile-insert`), it was just excluded from the test suite, so it shipped broken.

the fix: for the sql server incremental append, if the target has an identity column, insert with an explicit column list wrapped in `SET IDENTITY_INSERT ON/OFF` as a single batch. identity_insert is batch-scoped and the jdbc driver runs each statement as its own batch, so it has to be one statement or the insert won't see it on. plain append when there's no identity column.

stacked on #76793, which turns the incremental suite back on for sql server.