### PR TITLE
Fix date-dependent test in ConversationFilters date dropdown

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/ConversationFilters.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/ConversationFilters.unit.spec.tsx
@@ -50,6 +50,22 @@ async function getDropdownLabels() {
 }
 
 describe("ConversationFilters date dropdown", () => {
+  // Retention shortcuts are computed relative to the current date, so freeze the
+  // clock to a fixed mid-month date to keep the assertions deterministic. (Without
+  // this, e.g. on the 1st of a month following a 30-day month, the "Previous month"
+  // shortcut's start lands exactly on the retention cutoff and stays visible.)
+  beforeEach(() => {
+    jest.useFakeTimers({
+      advanceTimers: true,
+      now: new Date(2026, 5, 15),
+      doNotFake: ["setTimeout"],
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it("hides shortcuts that go past the configured retention window", async () => {
     setup({ retentionDays: 180 });
     const labels = await getDropdownLabels();


### PR DESCRIPTION
### Description

The "hides every multi-month shortcut when retention is at the 30-day minimum" test in ConversationFilters was date-dependent and failed in CI on certain calendar days (e.g. the 1st of a month preceded by a 30-day month).

The date shortcuts are filtered against a retention cutoff computed from the real current date (`dayjs()`), and neither the component nor the test mocked "now". When today is the 1st of such a month, the "Previous month" shortcut's start lands exactly on the 30-day cutoff (inclusive boundary) and stays visible, breaking `expect(labels).not.toContain("Previous month")`.

Freeze the clock to a fixed mid-month date in the test so the retention math is deterministic.

### How to verify

Run the spec on any date, including the 1st of a month:

```
npx jest enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/ConversationFilters.unit.spec.tsx
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR