### PR TITLE
GDGT-2527: Make new treemaps full width by default

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/TreemapChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/TreemapChart/chart-definition.ts
@@ -268,7 +268,7 @@ export const TREEMAP_CHART_DEFINITION: VisualizationDefinition = {
     return t`treemap chart`;
   },
   minSize: { width: 6, height: 4 },
-  defaultSize: { width: 12, height: 8 },
+  defaultSize: { width: 24, height: 8 },
   disableVisualizer: true,
   hasEmptyState: true,
   isSensible: (data: DatasetData) => {


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2527/make-new-treemaps-full-width-by-default

### Description

Very simple change: default size of treemap viz on a dashboard is full width (24 grid units)

### How to verify

Create treemap viz and add it to a dashboard. It should span whole widht 

### Demo
<img width="2498" height="1634" alt="image" src="https://github.com/user-attachments/assets/af6ea108-076c-4526-9606-6ac73d2f8509" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
