### PR TITLE
fix: hide multi-month date shortcuts on the 30-day retention boundary

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/ConversationFilters.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/ConversationFilters.tsx
@@ -72,7 +72,7 @@ function ConversationDateFilter({
   const data = useMemo(() => {
     const withinRetention = (item: { value: string }) =>
       !retentionCutoff ||
-      !getShortcutStartDate(item.value)?.isBefore(retentionCutoff);
+      getShortcutStartDate(item.value)?.isAfter(retentionCutoff);
 
     return [
       {

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/ConversationFilters.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/ConversationFilters.unit.spec.tsx
@@ -86,6 +86,40 @@ describe("ConversationFilters date dropdown", () => {
     expect(labels).not.toContain("Previous 12 months");
   });
 
+  describe("30-day-minimum boundary days (EMB-2040)", () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it.each([
+      { label: "May 1", frozenDate: "2026-05-01T12:00:00" }, // day after 30-day April
+      { label: "Jul 1", frozenDate: "2026-07-01T12:00:00" }, // day after 30-day June
+      { label: "Oct 1", frozenDate: "2026-10-01T12:00:00" }, // day after 30-day September
+      { label: "Dec 1", frozenDate: "2026-12-01T12:00:00" }, // day after 30-day November
+    ])("hides every multi-month shortcut on $label", async ({ frozenDate }) => {
+      jest.useFakeTimers({
+        advanceTimers: true,
+      });
+      jest.setSystemTime(new Date(frozenDate));
+
+      setup({ retentionDays: 30 });
+      const labels = await getDropdownLabels();
+      expect(labels).toEqual(
+        expect.arrayContaining([
+          "Today",
+          "Yesterday",
+          "Last 7 days",
+          "Last 30 days",
+          "Fixed date range…",
+          "Relative date range…",
+        ]),
+      );
+      expect(labels).not.toContain("Previous month");
+      expect(labels).not.toContain("Previous 3 months");
+      expect(labels).not.toContain("Previous 12 months");
+    });
+  });
+
   it("shows every shortcut when retention is infinite", async () => {
     setup({ retentionDays: null });
     const labels = await getDropdownLabels();


### PR DESCRIPTION
>[!note]
> This unblocks release branches 61 and 62

Fixes EMB-2040

### Description

`ConversationFilters`' date-range dropdown hides shortcuts (Previous month/3 months/12 months) whose start date falls outside the configured AI usage retention window. The boundary check used `!isBefore(retentionCutoff)` (inclusive of the exact cutoff moment), so on the 1st of any month right after a 30-day month (May 1, Jul 1, Oct 1, Dec 1), "Previous month"'s start date landed exactly on the retention cutoff and leaked through as "still within retention" instead of being hidden. Not caught before because the existing unit test ran against the real system clock, so it only failed on those four calendar dates a year — most recently Jul 1, matching this issue's flaky-test report.

Fixed the boundary to a strict `isAfter` check, so a shortcut's start date must be strictly newer than the cutoff to show, closing the equal-boundary case. Added a regression test that freezes the clock to each of the four boundary dates (May/Jul/Oct/Dec 1) so this doesn't depend on what day CI happens to run.

### How to verify

1. `bun run test-unit -- enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationFilters/ConversationFilters.unit.spec.tsx` — 11/11 pass, including the new `30-day-minimum boundary days (EMB-2040)` suite covering May 1 / Jul 1 / Oct 1 / Dec 1.
2. Reverted the fix locally and reran — confirmed exactly 5 tests fail (the 4 new boundary tests + the existing 30-day-minimum test, since today happens to be Jul 1), 6 unrelated tests still pass — verifying the fix is load-bearing.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass stress testing