### PR TITLE
Add endpoint for document creation

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -164,6 +164,7 @@
               channel
               collections
               dashboards
+              documents
               events
               lib
               lib-be
@@ -181,6 +182,7 @@
                     :model/Dashboard
                     :model/DashboardCard
                     :model/Database
+                    :model/Document
                     :model/Table
                     :model/User}}
 

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -15,6 +15,8 @@
    [metabase.collections.models.collection :as collection]
    [metabase.dashboards.autoplace :as autoplace]
    [metabase.dashboards.models.dashboard :as dashboard]
+   [metabase.documents.core :as documents]
+   [metabase.documents.prose-mirror :as documents.prose-mirror]
    [metabase.events.core :as events]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
@@ -1353,6 +1355,81 @@
      :parent_id     parent_collection_id
      :location      (:location coll)
      :description   (:description coll)}))
+
+;;; ------------------------------------------------- Create Document ------------------------------------------------
+
+(mr/def ::create-document-request
+  "Request shape for `create_document`. `:content` is Markdown (converted to the document's
+  ProseMirror AST server-side); a paragraph that is exactly `{{card:<id>}}` embeds saved question
+  `<id>` inline."
+  [:map
+   [:name {:tool/description "Title for the document."}
+    [:string {:min 1 :max 254}]]
+   [:content {:tool/description (str "The document body as Markdown. Supports headings, bold/italic, "
+                                     "inline code, links, bulleted and numbered lists, code blocks, "
+                                     "blockquotes, and horizontal rules. To embed an existing saved "
+                                     "question (chart) inline, put it on its own line as {{card:ID}} "
+                                     "where ID is a saved-question id from create_question.")}
+    ms/NonBlankString]
+   [:collection_id {:optional true} [:maybe ms/PositiveInt]]])
+
+(mr/def ::create-document-response
+  [:map
+   [:id              ms/PositiveInt]
+   [:name            ms/NonBlankString]
+   [:url             :string]
+   [:collection_id   [:maybe ms/PositiveInt]]
+   [:collection_path :string]])
+
+(api.macros/defendpoint :post "/v1/document" :- ::create-document-response
+  "Create a new Document — a rich-text page that can embed saved questions (charts) inline.
+
+  The `content` parameter is Markdown and is converted to the document's internal format.
+  Embed an existing saved question by placing `{{card:ID}}` on its own line (create the question
+  first with `create_question`). Each embedded question must be readable by the caller.
+  If `collection_id` is omitted the document is saved to the caller's personal collection.
+  Pass an explicit `null` to save it to the root collection.
+  The response `collection_path` is the saved location."
+  {:scope metabot/agent-document-create
+   :tool  {:name "create_document"
+           :description (str "Create a Document in Metabase: a rich-text report page that can embed "
+                             "saved questions (charts) alongside prose. Pass the body as Markdown in "
+                             "`content`. To embed an existing saved question, create it with "
+                             "create_question, then put {{card:ID}} on its own line in the Markdown. "
+                             "If you omit collection_id it's saved to the user's personal collection; "
+                             "pass an explicit null to save it to the root collection. "
+                             "Report the saved location from the response `collection_path`. "
+                             "Returns the document URL.")}}
+  [_route-params
+   _query-params
+   {:keys [content]
+    document-name :name
+    :as body}
+   :- ::create-document-request]
+  ;; `nil` means the root collection, so only default to the personal collection when the key is
+  ;; absent. `(or ...)` would silently turn an explicit `null` into personal.
+  (let [collection_id (if (contains? body :collection_id)
+                        (:collection_id body)
+                        (personal-collection-id))
+        ;; why do we need this?
+        ast           (documents/markdown->prose-mirror content)
+        ;; Read-check every embedded saved question up front: `create-document!` clones embedded
+        ;; cards into the document (read-checking the ones it finds), but a `{{card:ID}}` pointing
+        ;; at a non-existent or unreadable card would otherwise be silently dropped, leaving a
+        ;; broken embed. Surfacing a 403/404 here is the clearer behaviour.
+        embedded-ids  (documents.prose-mirror/card-ids
+                       {:document     ast
+                        :content_type documents.prose-mirror/prose-mirror-content-type})]
+    (doseq [card-id embedded-ids]
+      (api/read-check :model/Card card-id))
+    (let [doc (documents/create-document! {:name          document-name
+                                           :document      ast
+                                           :collection_id collection_id})]
+      {:id              (:id doc)
+       :name            (:name doc)
+       :url             (frontend-url (channel.urls/document-path (:id doc)))
+       :collection_id   (:collection_id doc)
+       :collection_path (collection-path (:collection_id doc))})))
 
 ;;; ------------------------------------------------- Authentication -------------------------------------------------
 ;;

--- a/src/metabase/agent_api/reference.md
+++ b/src/metabase/agent_api/reference.md
@@ -572,6 +572,39 @@ Response:
 }
 ```
 
+### POST /v1/document
+
+Create a Document - a rich-text report page that can embed saved questions
+(charts) alongside prose. The `content` field is Markdown and is converted to
+the document's internal format server-side. To embed an existing saved question
+inline, place `{{card:<id>}}` on its own line (create the question first with
+POST /v1/question). Each embedded question must be readable by the caller.
+
+If `collection_id` is omitted the document is saved to the caller's personal
+collection; pass an explicit `null` to save it to the root collection.
+
+Request:
+
+```json
+{
+  "name": "Q3 Revenue Analysis",
+  "content": "# Q3 Revenue\n\nRevenue grew **15%** QoQ.\n\n{{card:42}}\n\n## Takeaways\n\n- Widgets led growth\n- AOV trending up",
+  "collection_id": 12
+}
+```
+
+Response:
+
+```json
+{
+  "id": 7,
+  "name": "Q3 Revenue Analysis",
+  "url": "http://localhost:3000/document/7",
+  "collection_id": 12,
+  "collection_path": "Our analytics / Marketing"
+}
+```
+
 ## Typical workflow
 
 1. **Search** - POST /v1/search to find relevant tables, metrics, cards, or dashboards
@@ -584,7 +617,8 @@ Response:
    POST /v2/query to construct and execute in one round-trip with pagination
 5. **Save (optional)** - POST /v1/question to persist the query as a saved
    question; PUT /v1/question/{id} to update one; POST /v1/dashboard to
-   bundle questions into a dashboard; POST /v1/collection to create a
+   bundle questions into a dashboard; POST /v1/document to write a rich-text
+   report that embeds saved questions inline; POST /v1/collection to create a
    collection
 6. **Iterate** - Adjust the query and repeat steps 3-4
 

--- a/src/metabase/channel/urls.clj
+++ b/src/metabase/channel/urls.clj
@@ -33,6 +33,11 @@
   [^Integer id]
   (format "/question/%d" id))
 
+(defn document-path
+  "Relative frontend path for a `Document` with ID, e.g. \"/document/10\"."
+  [^Integer id]
+  (format "/document/%d" id))
+
 (defn dashboard-url
   "Return an appropriate URL for a `Dashboard` with ID.
 

--- a/src/metabase/documents/api/document.clj
+++ b/src/metabase/documents/api/document.clj
@@ -153,15 +153,18 @@
                                                           [:= :archived false]]})
                       :creator :can_write :is_remote_synced)})
 
-;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
-;; use our API + we will need it when we make auto-TypeScript-signature generation happen
-;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
-(api.macros/defendpoint :post "/"
-  "Create a new `Document`."
-  [_route-params
-   _query-params
-   {:keys [name document collection_id collection_position cards]} :- DocumentCreateOptions]
+(defn create-document!
+  "Create a new `Document` and return it hydrated.
+
+  `document` is the ProseMirror AST stored on the document. Runs the collection `create-check`,
+  clones any existing cards embedded in the AST so they belong to the new document, creates any
+  inline `cards` (a negative-id -> card map), rewrites embed ids in the AST to point at the
+  resulting cards, and publishes `:event/document-create`.
+
+  This is the single create path shared by the REST endpoint (`POST /api/document`) and the Agent
+  API `create_document` tool, so both get identical permission and lifecycle behaviour. The
+  current user (`api/*current-user*` / `api/*current-user-id*`) must be bound."
+  [{:keys [name document collection_id collection_position cards]}]
   (api/create-check :model/Document {:collection_id collection_id})
   (let [created-document (t2/with-transaction [_conn]
                            (when collection_position
@@ -193,6 +196,17 @@
                            {:object created-document
                             :user-id api/*current-user-id*})
     created-document))
+
+;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
+;; use our API + we will need it when we make auto-TypeScript-signature generation happen
+;;
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :post "/"
+  "Create a new `Document`."
+  [_route-params
+   _query-params
+   body :- DocumentCreateOptions]
+  (create-document! body))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/src/metabase/documents/core.clj
+++ b/src/metabase/documents/core.clj
@@ -1,13 +1,18 @@
 (ns metabase.documents.core
   (:require
    [metabase.documents.api.document]
+   [metabase.documents.markdown]
    [metabase.documents.recent-views]
    [potemkin :as p]))
 
 (comment
   metabase.documents.api.document/keep-me
+  metabase.documents.markdown/keep-me
   metabase.documents.recent-views/keep-me)
 
 (p/import-vars
  [metabase.documents.api.document
-  get-document])
+  create-document!
+  get-document]
+ [metabase.documents.markdown
+  markdown->prose-mirror])

--- a/src/metabase/documents/markdown.clj
+++ b/src/metabase/documents/markdown.clj
@@ -1,0 +1,127 @@
+(ns metabase.documents.markdown
+  "Convert a Markdown string into a ProseMirror document AST — the shape stored in a
+  `:model/Document`'s `:document` column.
+
+  Documents are normally authored by the front-end TipTap editor, which owns the ProseMirror
+  AST. The Agent API `create_document` tool, however, lets an LLM author a document, and an LLM
+  cannot reliably hand-write ProseMirror JSON. This namespace bridges that gap: the agent sends
+  Markdown and we convert it to the equivalent ProseMirror nodes.
+
+  A paragraph whose entire text is `{{card:<id>}}` is converted to a `cardEmbed` node that embeds
+  the saved question with that id, so an agent can place previously-created charts inline."
+  (:require
+   [clojure.string :as str]
+   [metabase.documents.prose-mirror :as prose-mirror])
+  (:import
+   (com.vladsch.flexmark.ast AutoLink BlockQuote BulletList Code Emphasis FencedCodeBlock
+                             HardLineBreak Heading IndentedCodeBlock Link MailLink OrderedList
+                             Paragraph SoftLineBreak StrongEmphasis Text ThematicBreak)
+   (com.vladsch.flexmark.parser Parser)
+   (com.vladsch.flexmark.util.ast Node)
+   (com.vladsch.flexmark.util.data MutableDataSet)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private parser
+  "A Flexmark parser. Core CommonMark features only — no autolink/strike extensions, matching the
+  subset of nodes we map below."
+  (.build (Parser/builder (MutableDataSet.))))
+
+(def ^:private card-embed-regex
+  "Matches a paragraph that is exactly `{{card:<id>}}` (optionally padded), capturing the id."
+  #"^\{\{\s*card\s*:\s*(\d+)\s*\}\}$")
+
+;;; ------------------------------------------------- Inline nodes --------------------------------------------------
+
+(defn- text-node
+  "A ProseMirror `text` node carrying the accumulated `marks` (a vector, omitted when empty)."
+  [marks ^String s]
+  (cond-> {:type "text" :text s}
+    (seq marks) (assoc :marks marks)))
+
+(declare inline-nodes)
+
+(defn- with-mark
+  "Recurse into `node`'s children with `mark` appended to the active mark set."
+  [^Node node marks mark]
+  (inline-nodes node (conj marks mark)))
+
+(defn- inline-node
+  "Convert one inline Flexmark `node` into a seq of ProseMirror inline nodes, carrying the active
+  `marks`. Unknown inline nodes fall back to recursing their children, so unsupported syntax still
+  contributes its text rather than vanishing."
+  [^Node node marks]
+  (condp instance? node
+    Text           [(text-node marks (str (.getChars node)))]
+    StrongEmphasis (with-mark node marks {:type "bold"})
+    Emphasis       (with-mark node marks {:type "italic"})
+    Code           [(text-node (conj marks {:type "code"}) (str (.getText ^Code node)))]
+    Link           (inline-nodes node (conj marks {:type "link"
+                                                   :attrs (cond-> {:href (str (.getUrl ^Link node))}
+                                                            (not (str/blank? (str (.getTitle ^Link node))))
+                                                            (assoc :title (str (.getTitle ^Link node))))}))
+    AutoLink       (let [url (str (.getUrl ^AutoLink node))]
+                     [(text-node (conj marks {:type "link" :attrs {:href url}}) url)])
+    MailLink       (let [address (str (.getText ^MailLink node))]
+                     [(text-node (conj marks {:type "link" :attrs {:href (str "mailto:" address)}}) address)])
+    SoftLineBreak  [(text-node marks " ")]
+    HardLineBreak  [{:type "hardBreak"}]
+    (seq (mapcat #(inline-node % marks) (.getChildren node)))))
+
+(defn- inline-nodes
+  "Convert the inline children of `node` into a vector of ProseMirror inline nodes."
+  [^Node node marks]
+  (into [] (mapcat #(inline-node % marks)) (.getChildren node)))
+
+;;; ------------------------------------------------- Block nodes ---------------------------------------------------
+
+(declare block-node)
+
+(defn- block-children
+  "Convert the block-level children of `node`, dropping any that map to nil."
+  [^Node node]
+  (into [] (keep block-node) (.getChildren node)))
+
+(defn- code-block-node
+  [^String content ^String info]
+  (cond-> {:type "codeBlock" :content (if (str/blank? content)
+                                        []
+                                        [{:type "text" :text (str/replace content #"\n\z" "")}])}
+    (not (str/blank? info)) (assoc :attrs {:language info})))
+
+(defn- paragraph-node
+  "Convert a paragraph, or — when its whole text is a `{{card:<id>}}` directive — a `cardEmbed`."
+  [^Paragraph node]
+  (if-let [[_ id] (re-matches card-embed-regex (str/trim (str (.getChars node))))]
+    {:type  prose-mirror/card-embed-type
+     :attrs {:id (parse-long id) :name nil}}
+    {:type "paragraph" :content (inline-nodes node [])}))
+
+(defn- block-node
+  "Convert one block-level Flexmark `node` into a ProseMirror block node, or nil to drop it."
+  [^Node node]
+  (condp instance? node
+    Heading           {:type "heading" :attrs {:level (.getLevel ^Heading node)}
+                       :content (inline-nodes node [])}
+    Paragraph         (paragraph-node node)
+    BulletList        {:type "bulletList" :content (block-children node)}
+    OrderedList       {:type "orderedList" :content (block-children node)}
+    FencedCodeBlock   (code-block-node (str (.getContentChars ^FencedCodeBlock node))
+                                       (str (.getInfo ^FencedCodeBlock node)))
+    IndentedCodeBlock (code-block-node (str (.getContentChars ^IndentedCodeBlock node)) "")
+    BlockQuote        {:type "blockquote" :content (block-children node)}
+    ThematicBreak     {:type "horizontalRule"}
+    ;; BulletListItem / OrderedListItem and any other container: a list item wrapping block content.
+    (when (seq (.getChildren node))
+      {:type "listItem" :content (block-children node)})))
+
+(defn markdown->prose-mirror
+  "Convert a Markdown string into a ProseMirror document AST `{:type \"doc\" :content [...]}`.
+
+  Supports headings, paragraphs, bold/italic/inline-code/link marks, bulleted and numbered lists,
+  code blocks, blockquotes, and horizontal rules. A paragraph that is exactly `{{card:<id>}}`
+  becomes a `cardEmbed` node embedding saved question `<id>`."
+  [^String markdown]
+  (let [doc     (.parse parser (or markdown ""))
+        content (into [] (keep block-node) (.getChildren doc))]
+    {:type "doc" :content content}))

--- a/src/metabase/metabot/core.clj
+++ b/src/metabase/metabot/core.clj
@@ -15,6 +15,7 @@
   agent-collection-create
   agent-dashboard-create
   agent-dashboard-update
+  agent-document-create
   agent-query
   agent-query-construct
   agent-query-execute

--- a/test/metabase/agent_api/api_test.clj
+++ b/test/metabase/agent_api/api_test.clj
@@ -911,6 +911,100 @@
   ;; that make end-to-end coverage redundant.
   )
 
+;;; ----------------------------------------------- Create Document Tests ------------------------------------------
+
+(deftest create-document-test
+  (testing "Creates a document from Markdown, defaulting to the caller's personal collection"
+    (mt/with-model-cleanup [:model/Document]
+      (let [personal-id   (:id (collection/user->personal-collection (mt/user->id :rasta)))
+            personal-name (collection/user->personal-collection-name (mt/user->id :rasta) :user)
+            resp          (mt/user-http-request :rasta :post 200 "agent/v1/document"
+                                                {:name    "Agent Report"
+                                                 :content "# Heading\n\nSome **bold** analysis."})]
+        (is (=? {:id              pos?
+                 :name            "Agent Report"
+                 :collection_id   personal-id
+                 :collection_path personal-name}
+                resp))
+        (testing "the Markdown was converted to a ProseMirror AST"
+          (let [doc (t2/select-one :model/Document :id (:id resp))]
+            (is (= "application/json+vnd.prose-mirror" (:content_type doc)))
+            (is (= {:type "doc"
+                    :content [{:type "heading" :attrs {:level 1} :content [{:type "text" :text "Heading"}]}
+                              {:type "paragraph"
+                               :content [{:type "text" :text "Some "}
+                                         {:type "text" :text "bold" :marks [{:type "bold"}]}
+                                         {:type "text" :text " analysis."}]}]}
+                   (:document doc)))))))))
+
+(deftest create-document-explicit-null-collection-test
+  (testing "An explicit null collection_id saves to the root collection, not the personal default"
+    (mt/with-model-cleanup [:model/Document]
+      (let [resp (mt/user-http-request :rasta :post 200 "agent/v1/document"
+                                       {:name          "Agent Root Doc"
+                                        :content       "Body"
+                                        :collection_id nil})]
+        (is (=? {:collection_id   nil
+                 :collection_path "Our analytics"}
+                resp))))))
+
+(deftest create-document-collection-test
+  (testing "Creates a document in a specific collection and reports its path"
+    (mt/with-model-cleanup [:model/Document]
+      (mt/with-temp [:model/Collection {coll-id :id} {:name "Agent Doc Collection"}]
+        (let [resp (mt/user-http-request :rasta :post 200 "agent/v1/document"
+                                         {:name          "Collection Doc"
+                                          :content       "Body"
+                                          :collection_id coll-id})]
+          (is (=? {:collection_id   coll-id
+                   :collection_path "Our analytics / Agent Doc Collection"}
+                  resp))))))
+  (testing "Returns a frontend URL"
+    (mt/with-model-cleanup [:model/Document]
+      (mt/with-temporary-setting-values [site-url "https://mb.example.com"]
+        (let [resp (mt/user-http-request :rasta :post 200 "agent/v1/document"
+                                         {:name "URL Doc" :content "Body"})]
+          (is (= (str "https://mb.example.com/document/" (:id resp)) (:url resp))))))))
+
+(deftest create-document-embedded-card-test
+  (testing "A {{card:ID}} directive embeds the saved question, cloning it into the document"
+    (mt/with-model-cleanup [:model/Document :model/Card]
+      (mt/with-temp [:model/Card {card-id :id} {:name          "Embedded Q"
+                                                :dataset_query (orders-count-query)
+                                                :display       :bar}]
+        (let [resp (mt/user-http-request :rasta :post 200 "agent/v1/document"
+                                         {:name    "Doc With Chart"
+                                          :content (str "# Analysis\n\n{{card:" card-id "}}")})
+              doc  (t2/select-one :model/Document :id (:id resp))
+              embed (->> (get-in doc [:document :content])
+                         (filter #(= "cardEmbed" (:type %)))
+                         first)]
+          (is (some? embed))
+          (testing "the embed points at a card owned by the document (a clone, not the original)"
+            (let [embedded-card-id (get-in embed [:attrs :id])]
+              (is (pos? embedded-card-id))
+              (is (= (:id resp) (t2/select-one-fn :document_id :model/Card :id embedded-card-id))))))))))
+
+(deftest create-document-missing-card-test
+  (testing "Returns 404 when an embedded card id does not exist"
+    (mt/with-model-cleanup [:model/Document]
+      (mt/user-http-request :rasta :post 404 "agent/v1/document"
+                            {:name "Bad Embed" :content "{{card:999999}}"}))))
+
+(deftest create-document-unreadable-card-test
+  (testing "Returns 403 when the caller cannot read an embedded card"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-model-cleanup [:model/Document]
+        (mt/with-temp [:model/Collection {coll-id :id} {:name "Locked Coll"}
+                       :model/Card {card-id :id} {:name          "Locked Q"
+                                                  :collection_id coll-id
+                                                  :dataset_query (orders-count-query)}]
+          (mt/user-http-request :rasta :post 403 "agent/v1/document"
+                                {:name          "Should Fail"
+                                 :content       (str "{{card:" card-id "}}")
+                                 ;; target a collection rasta can write to so the failure is the card read-check
+                                 :collection_id nil}))))))
+
 ;;; ----------------------------------------------- Update Question Tests ------------------------------------------
 
 (deftest update-question-patch-fields-test

--- a/test/metabase/documents/markdown_test.clj
+++ b/test/metabase/documents/markdown_test.clj
@@ -1,0 +1,74 @@
+(ns metabase.documents.markdown-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.documents.markdown :as documents.markdown]))
+
+(defn- content [markdown]
+  (:content (documents.markdown/markdown->prose-mirror markdown)))
+
+(deftest empty-input-test
+  (testing "nil and empty input produce an empty doc"
+    (is (= {:type "doc" :content []} (documents.markdown/markdown->prose-mirror "")))
+    (is (= {:type "doc" :content []} (documents.markdown/markdown->prose-mirror nil)))))
+
+(deftest headings-test
+  (testing "ATX headings carry their level"
+    (is (= [{:type "heading" :attrs {:level 1} :content [{:type "text" :text "Title"}]}
+            {:type "heading" :attrs {:level 2} :content [{:type "text" :text "Sub"}]}]
+           (content "# Title\n\n## Sub")))))
+
+(deftest paragraph-and-marks-test
+  (testing "inline marks: bold, italic, inline code"
+    (is (= [{:type "paragraph"
+             :content [{:type "text" :text "a "}
+                       {:type "text" :text "bold" :marks [{:type "bold"}]}
+                       {:type "text" :text " "}
+                       {:type "text" :text "italic" :marks [{:type "italic"}]}
+                       {:type "text" :text " "}
+                       {:type "text" :text "code" :marks [{:type "code"}]}]}]
+           (content "a **bold** *italic* `code`"))))
+  (testing "links become a link mark carrying the href"
+    (is (= [{:type "paragraph"
+             :content [{:type "text" :text "see "}
+                       {:type "text" :text "here"
+                        :marks [{:type "link" :attrs {:href "https://example.com"}}]}]}]
+           (content "see [here](https://example.com)")))))
+
+(deftest lists-test
+  (testing "bulleted list"
+    (is (= [{:type "bulletList"
+             :content [{:type "listItem" :content [{:type "paragraph" :content [{:type "text" :text "one"}]}]}
+                       {:type "listItem" :content [{:type "paragraph" :content [{:type "text" :text "two"}]}]}]}]
+           (content "- one\n- two"))))
+  (testing "numbered list"
+    (is (= "orderedList" (:type (first (content "1. one\n2. two")))))))
+
+(deftest code-block-test
+  (testing "fenced code block keeps language and literal content"
+    (is (= [{:type "codeBlock" :attrs {:language "sql"}
+             :content [{:type "text" :text "select 1"}]}]
+           (content "```sql\nselect 1\n```")))))
+
+(deftest blockquote-and-rule-test
+  (testing "blockquote wraps paragraphs"
+    (is (= [{:type "blockquote"
+             :content [{:type "paragraph" :content [{:type "text" :text "quoted"}]}]}]
+           (content "> quoted"))))
+  (testing "thematic break becomes a horizontal rule"
+    (is (= [{:type "horizontalRule"}]
+           (content "---")))))
+
+(deftest card-embed-test
+  (testing "a standalone {{card:id}} paragraph becomes a cardEmbed node"
+    (is (= [{:type "cardEmbed" :attrs {:id 42 :name nil}}]
+           (content "{{card:42}}")))
+    (is (= [{:type "cardEmbed" :attrs {:id 7 :name nil}}]
+           (content "{{ card : 7 }}"))))
+  (testing "a cardEmbed can sit between prose blocks"
+    (is (= [{:type "heading" :attrs {:level 1} :content [{:type "text" :text "Report"}]}
+            {:type "cardEmbed" :attrs {:id 9 :name nil}}
+            {:type "paragraph" :content [{:type "text" :text "after"}]}]
+           (content "# Report\n\n{{card:9}}\n\nafter"))))
+  (testing "card directive embedded mid-sentence stays plain text"
+    (is (= [{:type "paragraph" :content [{:type "text" :text "see {{card:1}} here"}]}]
+           (content "see {{card:1}} here")))))

--- a/test/metabase/mcp/tools_test.clj
+++ b/test/metabase/mcp/tools_test.clj
@@ -39,6 +39,25 @@
             (is (empty? unknown)
                 (str label " has keys that don't match any tool name: " (vec unknown)))))))))
 
+(defn- tool-named [scopes tool-name]
+  (some #(when (= tool-name (:name %)) %) (mcp.tools/list-tools scopes)))
+
+(deftest ^:parallel create-document-tool-published-test
+  (testing "create_document is generated from the agent-api endpoint and published as an MCP tool"
+    (let [tool (tool-named #{::api.scope/unrestricted} "create_document")]
+      (is (some? tool) "create_document should be present under the unrestricted scope")
+      (is (re-find #"(?i)markdown" (:description tool))
+          "description should tell the agent it authors in Markdown")
+      (let [props (get-in tool [:inputSchema :properties])]
+        (is (contains? props :name))
+        (is (contains? props :content))
+        (is (contains? props :collection_id)))))
+  (testing "create_document is gated by the agent:document:create scope"
+    (is (some? (tool-named #{"agent:document:create"} "create_document")))
+    (is (some? (tool-named #{"agent:document:*"} "create_document")))
+    (is (nil? (tool-named #{"agent:search"} "create_document"))
+        "a scope set without document:create must not expose create_document")))
+
 (defn- data-node?
   "True if `x` is a value type our published JSON-Schema-shaped tool schemas
    are allowed to contain. Visited via `walk/postwalk`, which traverses every


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #73653
WIP

Closes [BOT-1765: Allow the MCP server to create Documents](https://linear.app/metabase/issue/BOT-1765/allow-the-mcp-server-to-create-documents)

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
