### PR TITLE
Consolidate `basename` into a dedicated module

### DIFF
--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
@@ -31,6 +31,7 @@ import {
   isEmbeddingEajs,
 } from "metabase/embedding-sdk/config";
 import { PLUGIN_API, PLUGIN_EMBEDDING_SDK } from "metabase/plugins";
+import { getBasename, setBasename } from "metabase/utils/basename";
 import registerVisualizations from "metabase/visualizations/register";
 
 const reactSdkEmbedReferrerHandler: OnBeforeRequestHandler = async (
@@ -122,8 +123,8 @@ export const useInitDataInternal = ({
   const sdkPackageVersion = getSdkPackageVersion();
 
   // We have to initialize the API fields before other possible API calls
-  if (api.basename !== authConfig.metabaseInstanceUrl) {
-    api.basename = authConfig.metabaseInstanceUrl;
+  if (getBasename() !== authConfig.metabaseInstanceUrl) {
+    setBasename(authConfig.metabaseInstanceUrl);
   }
 
   setSdkRequestClientHeadersOnce({

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
@@ -31,7 +31,7 @@ import {
   isEmbeddingEajs,
 } from "metabase/embedding-sdk/config";
 import { PLUGIN_API, PLUGIN_EMBEDDING_SDK } from "metabase/plugins";
-import { getBasename, setBasename } from "metabase/utils/basename";
+import { setBasename } from "metabase/utils/basename";
 import registerVisualizations from "metabase/visualizations/register";
 
 const reactSdkEmbedReferrerHandler: OnBeforeRequestHandler = async (
@@ -123,9 +123,7 @@ export const useInitDataInternal = ({
   const sdkPackageVersion = getSdkPackageVersion();
 
   // We have to initialize the API fields before other possible API calls
-  if (getBasename() !== authConfig.metabaseInstanceUrl) {
-    setBasename(authConfig.metabaseInstanceUrl);
-  }
+  setBasename(authConfig.metabaseInstanceUrl);
 
   setSdkRequestClientHeadersOnce({
     name: EMBEDDING_SDK_CONFIG.metabaseClientRequestHeader,

--- a/frontend/src/metabase/api/ai-streaming/requests.unit.spec.ts
+++ b/frontend/src/metabase/api/ai-streaming/requests.unit.spec.ts
@@ -1,6 +1,6 @@
 import fetchMock from "fetch-mock";
 
-import { api } from "metabase/api/client";
+import { setupBasename } from "__support__/basename";
 
 import {
   aiStreamingQuery,
@@ -10,16 +10,9 @@ import { mockStreamedEndpoint } from "./test-utils";
 
 const endpoint = "/some-streamed-endpoint";
 const fakeBasename = "http://example.com";
-const originalBasename = api.basename;
 
 describe("ai requests", () => {
-  beforeAll(() => {
-    api.basename = fakeBasename;
-  });
-
-  afterAll(() => {
-    api.basename = originalBasename;
-  });
+  setupBasename(fakeBasename);
 
   describe("aiStreamingQuery", () => {
     it("should call a request with a baseurl", async () => {

--- a/frontend/src/metabase/api/client/client.ts
+++ b/frontend/src/metabase/api/client/client.ts
@@ -1,6 +1,7 @@
 /* eslint-disable metabase/no-literal-metabase-strings */
 import EventEmitter from "events";
 
+import { getBasename } from "metabase/utils/basename";
 import { getTraceparentHeader } from "metabase/utils/otel";
 import { retry } from "metabase/utils/retry";
 
@@ -28,15 +29,13 @@ import {
 const MAX_RETRIES = 10;
 
 export class ApiClient extends EventEmitter<EventMap> {
-  basename = "";
-
   private buildUrl(
     template: string,
     data: Record<string, unknown>,
     body?: Record<string, unknown>,
   ): URL {
     const relativePath = substituteUrlTags(template, data, body);
-    return new URL(this.basename.concat(relativePath), location.origin);
+    return new URL(getBasename().concat(relativePath), location.origin);
   }
 
   private getClientHeaders(
@@ -111,7 +110,7 @@ export class ApiClient extends EventEmitter<EventMap> {
 
       if (!init.noEvent && (status === 401 || status === 403)) {
         // Strip basename so listeners (app-main.js) see the relative path.
-        this.emit(status, relativeUrl(this.basename, init.url));
+        this.emit(status, relativeUrl(getBasename(), init.url));
       }
 
       if (!ok) {

--- a/frontend/src/metabase/api/client/client.unit.spec.ts
+++ b/frontend/src/metabase/api/client/client.unit.spec.ts
@@ -1,6 +1,8 @@
 import fetchMock from "fetch-mock";
 
+import { setupBasename } from "__support__/basename";
 import { PLUGIN_API, reinitialize } from "metabase/plugins";
+import { setBasename } from "metabase/utils/basename";
 
 import { ApiClient } from "./client";
 
@@ -280,6 +282,8 @@ describe("api", () => {
   describe("status-code event emit", () => {
     let apiInstance: ApiClient;
 
+    setupBasename();
+
     beforeEach(() => {
       apiInstance = new ApiClient();
     });
@@ -304,7 +308,7 @@ describe("api", () => {
     });
 
     it("strips a subpath basename so listeners see the relative path", async () => {
-      apiInstance.basename = "/metabase";
+      setBasename("/metabase");
       fetchMock.get("path:/metabase/api/session", { status: 401 });
       const listener = jest.fn();
       apiInstance.on(401, listener);
@@ -317,7 +321,7 @@ describe("api", () => {
     });
 
     it("emits the relative path when basename is a full URL (SDK case)", async () => {
-      apiInstance.basename = "https://metabase.example.com";
+      setBasename("https://metabase.example.com");
       fetchMock.get("https://metabase.example.com/api/session", {
         status: 401,
       });
@@ -332,7 +336,7 @@ describe("api", () => {
     });
 
     it("strips the subpath when basename is a full URL with a subpath", async () => {
-      apiInstance.basename = "http://localhost/mb";
+      setBasename("http://localhost/mb");
       fetchMock.get("http://localhost/mb/api/session", { status: 401 });
       const listener = jest.fn();
       apiInstance.on(401, listener);

--- a/frontend/src/metabase/api/localization.ts
+++ b/frontend/src/metabase/api/localization.ts
@@ -1,4 +1,4 @@
-import { api } from "metabase/api/client";
+import { getBasename } from "metabase/utils/basename";
 import {
   type LocaleDataWithLanguage,
   setLocalization,
@@ -17,7 +17,7 @@ export async function loadLocalization(
         // which will make the browser do the pre-flight request on the SDK.
         // The backend doesn't seem to support pre-flight request on the static assets, but even
         // if it supported them it's more performant to skip the pre-flight request
-        await fetch(`${api.basename}/app/locales/${locale}.json`).then(
+        await fetch(`${getBasename()}/app/locales/${locale}.json`).then(
           (response) => response.json(),
         )
       : // We don't serve en.json. Instead, use this object to fall back to the literals.

--- a/frontend/src/metabase/app-embed-mcp.tsx
+++ b/frontend/src/metabase/app-embed-mcp.tsx
@@ -7,11 +7,11 @@ import { createRoot } from "react-dom/client";
 // Import the embedding SDK vendors side-effects (sets up global CSS vars, etc.)
 import "metabase/embedding-sdk/vendors-side-effects";
 
-import { api } from "metabase/api/client";
 import { setSessionTokenHeader } from "metabase/embedding/lib/embedding-request-auth";
 import { McpUiAppRoute } from "metabase/embedding/mcp/McpUiAppRoute";
 import { EMBEDDING_SDK_CONFIG } from "metabase/embedding-sdk/config";
 import { PLUGIN_API } from "metabase/plugins";
+import { setBasename } from "metabase/utils/basename";
 
 // Load EE plugins (whitelabeling, etc.) - no-op in OSS
 import "sdk-iframe-embedding-ee-plugins";
@@ -23,11 +23,9 @@ EMBEDDING_SDK_CONFIG.tokenFeatureKey = "embedding_simple";
 
 // Set session token immediately so all SDK API calls include X-Metabase-Session.
 // @ts-expect-error -- this is ONLY set in the MCP Apps route
-const { instanceUrl = "", sessionToken = "" } = window.metabaseConfig ?? {};
+const { instanceUrl, sessionToken = "" } = window.metabaseConfig ?? {};
 
-if (instanceUrl) {
-  api.basename = instanceUrl;
-}
+setBasename(instanceUrl);
 
 if (sessionToken) {
   PLUGIN_API.onBeforeRequestHandlers.setEmbeddingRequestAuthHeaders =

--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -33,7 +33,6 @@ import { syncHistoryWithStore } from "react-router-redux";
 import { initializePlugins } from "ee-plugins";
 import { AppThemeProvider } from "metabase/AppThemeProvider";
 import { createSnowplowTracker } from "metabase/analytics";
-import { api } from "metabase/api/client";
 import { ModifiedBackend } from "metabase/common/components/dnd/ModifiedBackend";
 import registerDashboardVisualizations from "metabase/dashboard/visualizations/register";
 import { initializeInteractiveEmbedding } from "metabase/embedding/interactive-embedding";
@@ -45,6 +44,7 @@ import { getUserId } from "metabase/selectors/user";
 import { GlobalStyles } from "metabase/styled-components/containers/GlobalStyles";
 import { PortalContainer } from "metabase/ui";
 import { EmotionCacheProvider } from "metabase/ui/components/theme/EmotionCacheProvider";
+import { getBasename, setBasename } from "metabase/utils/basename";
 import { captureConsoleErrors } from "metabase/utils/errors";
 import { initMetaplow } from "metabase/utils/metaplow";
 import { initTracing, rotateTraceId } from "metabase/utils/otel";
@@ -56,14 +56,11 @@ import { RouterProvider } from "./router";
 import { getStore } from "./store";
 import { OverlayStackProvider } from "./ui/components/overlays/overlay-stack";
 
-// remove trailing slash
-const BASENAME = window.MetabaseRoot.replace(/\/+$/, "");
-
-api.basename = BASENAME;
+setBasename(window.MetabaseRoot);
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
 const browserHistory = useRouterHistory(createHistory)({
-  basename: BASENAME,
+  basename: getBasename(),
 });
 
 initializePlugins();

--- a/frontend/src/metabase/monitor/tools/components/Help/Help.tsx
+++ b/frontend/src/metabase/monitor/tools/components/Help/Help.tsx
@@ -9,7 +9,6 @@ import {
 } from "metabase/admin/components/SettingsSection";
 import { UpsellBetterSupport } from "metabase/admin/upsells";
 import { useGetBugReportDetailsQuery } from "metabase/api/bug-report";
-import { api } from "metabase/api/client";
 import { CopyButton } from "metabase/common/components/CopyButton";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { useSetting } from "metabase/common/hooks";
@@ -18,6 +17,7 @@ import { PLUGIN_SUPPORT } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import { getIsPaidPlan } from "metabase/selectors/settings";
 import { Box, Code, Group } from "metabase/ui";
+import { getBasename } from "metabase/utils/basename";
 
 import S from "./help.module.css";
 
@@ -29,7 +29,7 @@ function navigatorInfo() {
 // to support Metabase deployments at a subpath.
 function getConnectionPoolDetailsUrl() {
   const path = "/api/bug-reporting/connection-pool-details";
-  return new URL(api.basename + path, location.origin).href;
+  return new URL(getBasename() + path, location.origin).href;
 }
 
 const template = `**Describe the bug**

--- a/frontend/src/metabase/query_builder/actions/url.ts
+++ b/frontend/src/metabase/query_builder/actions/url.ts
@@ -3,9 +3,9 @@ import { parse as parseUrl } from "url";
 import type { LocationDescriptor } from "history";
 import { push, replace } from "react-router-redux";
 
-import { api } from "metabase/api/client";
 import { isEqualCard } from "metabase/common/utils/card";
 import { createThunkAction } from "metabase/redux";
+import { getBasename } from "metabase/utils/basename";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import { isAdHocModelOrMetricQuestion } from "metabase-lib/v1/metadata/utils/models";
@@ -99,7 +99,7 @@ export const updateUrl = createThunkAction(
       // Compare against the basename-aware path so this still works under
       // subpath deployments (e.g. /mb/table/...).
       const isOnTableRoute = window.location.pathname.startsWith(
-        `${api.basename}/table/`,
+        `${getBasename()}/table/`,
       );
       const tableUrl =
         isOnTableRoute && objectId == null && queryBuilderMode === "view"

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -8,7 +8,6 @@ import {
 import { t } from "ttag";
 import _ from "underscore";
 
-import { api } from "metabase/api/client";
 import { datasetApi } from "metabase/api/dataset";
 import { exportFormatPng } from "metabase/common/types/export";
 import { waitUntilNextFramePainted } from "metabase/common/utils/wait-until-next-frame-paints";
@@ -17,6 +16,7 @@ import type { DownloadsState, State } from "metabase/redux/store";
 import { createAsyncThunk } from "metabase/redux/utils";
 import { getTokenFeature } from "metabase/selectors/settings";
 import * as Urls from "metabase/urls";
+import { getBasename } from "metabase/utils/basename";
 import { openSaveDialog } from "metabase/utils/dom";
 import { isWithinIframe } from "metabase/utils/iframe";
 import { isJWT } from "metabase/utils/jwt";
@@ -580,7 +580,7 @@ export function getDatasetDownloadUrl(
   url: string,
   params?: URLSearchParams | string,
 ) {
-  url = url.replace(api.basename, ""); // make url relative if it's not
+  url = url.replace(getBasename(), ""); // make url relative if it's not
   if (params) {
     url += `?${params.toString()}`;
   }

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -580,7 +580,10 @@ export function getDatasetDownloadUrl(
   url: string,
   params?: URLSearchParams | string,
 ) {
-  url = url.replace(getBasename(), ""); // make url relative if it's not
+  const basename = getBasename();
+  if (basename && url.startsWith(basename)) {
+    url = url.slice(basename.length); // make url relative if it's not
+  }
   if (params) {
     url += `?${params.toString()}`;
   }

--- a/frontend/src/metabase/redux/downloads.unit.spec.ts
+++ b/frontend/src/metabase/redux/downloads.unit.spec.ts
@@ -1,4 +1,4 @@
-import { api } from "metabase/api/client";
+import { setupBasename } from "__support__/basename";
 import { mockIsEmbeddingSdk } from "metabase/embedding-sdk/mocks/config-mock";
 import Question from "metabase-lib/v1/Question";
 import type { EntityToken } from "metabase-types/api/entity";
@@ -34,19 +34,12 @@ describe("getDatasetResponse", () => {
     /**
      * We will assert that the result is a relative path without subpath.
      * Because this URL will be pass to `frontend/src/metabase/api/client`
-     * which already takes care of the subpath (api.basename)
+     * which already takes care of the subpath (the basename)
      */
     const origin = "http://localhost";
     const subpath = "/mb";
-    const originalBasename = api.basename;
 
-    beforeEach(() => {
-      api.basename = `${origin}${subpath}`;
-    });
-
-    afterEach(() => {
-      api.basename = originalBasename;
-    });
+    setupBasename(`${origin}${subpath}`);
 
     it("should handle absolute URLs", () => {
       const url = `${origin}${subpath}/embed/question/123.xlsx`;

--- a/frontend/src/metabase/urls/utils.ts
+++ b/frontend/src/metabase/urls/utils.ts
@@ -1,4 +1,4 @@
-import { api } from "metabase/api/client";
+import { getBasename } from "metabase/utils/basename";
 
 export function appendSlug(path: string | number, slug?: string) {
   return slug ? `${path}-${slug}` : String(path);
@@ -32,11 +32,11 @@ export function getEncodedUrlSearchParams(query: Record<string, unknown>) {
 }
 
 export function getSubpathSafeUrl(url: string) {
-  const basename = api.basename;
+  const basename = getBasename();
   const normalizedUrl =
     !basename || !url || url.startsWith("/") ? url : `/${url}`;
 
-  return `${api.basename}${normalizedUrl}`;
+  return `${basename}${normalizedUrl}`;
 }
 
 /**

--- a/frontend/src/metabase/urls/utils.unit.spec.ts
+++ b/frontend/src/metabase/urls/utils.unit.spec.ts
@@ -1,4 +1,5 @@
-import { api } from "metabase/api/client";
+import { setupBasename } from "__support__/basename";
+import { setBasename } from "metabase/utils/basename";
 
 import {
   getSubpathSafeUrl,
@@ -11,17 +12,13 @@ import {
 } from "./utils";
 
 const fakeBasename = "foobar";
-const originalBasename = api.basename;
 
 const mockWindowOpen = jest.spyOn(window, "open").mockImplementation();
 
 describe("utils", () => {
-  beforeEach(() => {
-    api.basename = fakeBasename;
-  });
+  setupBasename(fakeBasename);
 
   afterEach(() => {
-    api.basename = originalBasename;
     mockWindowOpen.mockClear();
   });
 
@@ -38,8 +35,8 @@ describe("utils", () => {
       expect(getSubpathSafeUrl("baz")).toBe(`${fakeBasename}/baz`);
     });
 
-    it("should return original url if `api.basename ` is empty", () => {
-      api.basename = "";
+    it("should return original url if the basename is empty", () => {
+      setBasename("");
 
       expect(getSubpathSafeUrl("baz")).toBe("baz");
     });

--- a/frontend/src/metabase/utils/basename.ts
+++ b/frontend/src/metabase/utils/basename.ts
@@ -4,6 +4,6 @@ export function getBasename() {
   return basename;
 }
 
-export function setBasename(newBasename = "") {
-  basename = newBasename.replace(/\/+$/, "");
+export function setBasename(newBasename?: string | null) {
+  basename = (newBasename ?? "").replace(/\/+$/, "");
 }

--- a/frontend/src/metabase/utils/basename.ts
+++ b/frontend/src/metabase/utils/basename.ts
@@ -1,0 +1,9 @@
+let basename = "";
+
+export function getBasename() {
+  return basename;
+}
+
+export function setBasename(newBasename = "") {
+  basename = newBasename.replace(/\/+$/, "");
+}

--- a/frontend/test/__support__/basename.ts
+++ b/frontend/test/__support__/basename.ts
@@ -1,0 +1,19 @@
+import { getBasename, setBasename } from "metabase/utils/basename";
+
+/**
+ * Set the app basename for the duration of a `describe` block.
+ *
+ * Call inside a `describe` block — it registers beforeEach/afterEach hooks
+ * that apply the given basename and restore the original afterward.
+ */
+export function setupBasename(basename = "") {
+  const originalBasename = getBasename();
+
+  beforeEach(() => {
+    setBasename(basename);
+  });
+
+  afterEach(() => {
+    setBasename(originalBasename);
+  });
+}

--- a/frontend/test/__support__/basename.ts
+++ b/frontend/test/__support__/basename.ts
@@ -7,9 +7,10 @@ import { getBasename, setBasename } from "metabase/utils/basename";
  * that apply the given basename and restore the original afterward.
  */
 export function setupBasename(basename = "") {
-  const originalBasename = getBasename();
+  let originalBasename = "";
 
   beforeEach(() => {
+    originalBasename = getBasename();
     setBasename(basename);
   });
 


### PR DESCRIPTION
Moves the app basename (the subpath / instance URL Metabase is served under) off the `ApiClient` and into a dedicated `metabase/utils/basename` module. The api client should not own app-level routing config, and a bunch of unrelated modules were reaching into `metabase/api/client` just to read `api.basename`.


- **New `metabase/utils/basename` module**: a small `getBasename()` / `setBasename()` holder. It's a zero-import leaf, and `setBasename` normalizes trailing slashes so callers can pass raw env values.
- **`ApiClient` no longer owns `basename`**: `buildUrl` and the 401/403 emit read `getBasename()`. Removing the field also shrinks the client's public surface (no externally-mutable state).
- **Each app shell owns its own environment read** (restores the original init flow, just decoupled from the client):
  - `app.js` → `window.MetabaseRoot`
  - `app-embed-mcp.tsx` → `window.metabaseConfig.instanceUrl`
  - SDK `useInitData` hook → `authConfig.metabaseInstanceUrl`
- **All readers migrated** off `metabase/api/client`: `urls/utils`, `redux/downloads`, `query_builder/actions/url`, `monitor/.../Help`, `api/localization`.
- **New `setupBasename` test helper** (`frontend/test/__support__/basename.ts`) adopted in test.



