### PR TITLE
Fix bundle-size extract: drop non-existent embedding-sdk.js pattern

### DIFF
--- a/.github/actions/sdk-bundle-size-check/action.yml
+++ b/.github/actions/sdk-bundle-size-check/action.yml
@@ -73,7 +73,6 @@ runs:
             "frontend_client/app/dist/*" \
             "frontend_client/app/embed.js" \
             "frontend_client/app/embedding-sdk/*" \
-            "frontend_client/app/embedding-sdk.js" \
             -d "$2/resources" >/dev/null || true
         }
 

--- a/.github/workflows/bundle-size-stats.yml
+++ b/.github/workflows/bundle-size-stats.yml
@@ -45,7 +45,6 @@ jobs:
             "frontend_client/app/dist/*" \
             "frontend_client/app/embed.js" \
             "frontend_client/app/embedding-sdk/*" \
-            "frontend_client/app/embedding-sdk.js" \
             -d resources
           unzip -o -j "temp/uberjar/metabase.jar" version.properties -d artifacts
       - name: Download bundle stats and SDK package artifacts


### PR DESCRIPTION
The `Bundle Size Stats` workflow started failing on master after #76409, e.g. https://github.com/metabase/metabase/actions/runs/28563614398 — the "Extract front-end bundles from uberjar" step exits with code 11.

`unzip` returns exit code 11 ("no matching files were found") when a requested pattern matches nothing, and under `bash -e` that fails the step. The offending pattern is `frontend_client/app/embedding-sdk.js`, which was added in #76409 for a legacy fallback. That top-level sibling file does not exist in current uberjars: the legacy SDK lives at `embedding-sdk/legacy/embedding-sdk.js` (already covered by the `embedding-sdk/*` pattern), so unzip logs `caution: filename not matched` and returns 11.

## Fix

Remove the dead `embedding-sdk.js` pattern from both extract lists:
- `.github/workflows/bundle-size-stats.yml` (this is the one that failed; its unzip has no `|| true`)
- `.github/actions/sdk-bundle-size-check/action.yml` (guarded by `|| true`, so it did not fail, but the pattern is equally dead)

