### PR TITLE
Fix sandboxing crashes and update skill file mistakes

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev-entry.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev-entry.tsx
@@ -1,4 +1,7 @@
 import * as React from "react";
+import * as ReactDOM from "react-dom";
+import * as ReactDOMClient from "react-dom/client";
+import * as ReactDOMServer from "react-dom/server";
 import * as ReactJsxDevRuntime from "react/jsx-dev-runtime";
 import * as ReactJsxRuntime from "react/jsx-runtime";
 import * as sdkExports from "@metabase/embedding-sdk-react";
@@ -57,6 +60,9 @@ const sandbox = createDataAppSandbox({
   allowedHosts,
   endowments: {
     React,
+    reactDom: ReactDOM,
+    reactDomClient: ReactDOMClient,
+    reactDomServer: ReactDOMServer,
     reactJsxRuntime: ReactJsxRuntime,
     reactJsxDevRuntime: ReactJsxDevRuntime,
     sdkExports,

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/bundle.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/bundle.ts
@@ -18,6 +18,9 @@ export const DATA_APP_ENTRY = "src/index.tsx";
  */
 export const DATA_APP_GLOBAL_NAMES = {
   react: "React",
+  reactDom: "__react_dom__",
+  reactDomClient: "__react_dom_client__",
+  reactDomServer: "__react_dom_server__",
   reactJsxRuntime: "__react_jsx_runtime__",
   reactJsxDevRuntime: "__react_jsx_dev_runtime__",
   sdk: "__metabase_sdk__",
@@ -30,6 +33,9 @@ export const DATA_APP_FACTORY_GLOBAL = DATA_APP_GLOBAL_NAMES.factory;
 /** Each externalized import mapped to the global the sandbox endows it as. */
 export const DATA_APP_GLOBALS: Record<string, string> = {
   react: DATA_APP_GLOBAL_NAMES.react,
+  "react-dom": DATA_APP_GLOBAL_NAMES.reactDom,
+  "react-dom/client": DATA_APP_GLOBAL_NAMES.reactDomClient,
+  "react-dom/server": DATA_APP_GLOBAL_NAMES.reactDomServer,
   "react/jsx-runtime": DATA_APP_GLOBAL_NAMES.reactJsxRuntime,
   "react/jsx-dev-runtime": DATA_APP_GLOBAL_NAMES.reactJsxDevRuntime,
   "@metabase/embedding-sdk-react": DATA_APP_GLOBAL_NAMES.sdk,

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/bundle.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/bundle.unit.spec.ts
@@ -1,0 +1,20 @@
+import { DATA_APP_EXTERNALS, DATA_APP_GLOBALS } from "./bundle";
+
+describe("data-app bundle externals", () => {
+  it("externalizes React DOM imports to endowed globals", () => {
+    expect(DATA_APP_GLOBALS).toEqual(
+      expect.objectContaining({
+        "react-dom": "__react_dom__",
+        "react-dom/client": "__react_dom_client__",
+        "react-dom/server": "__react_dom_server__",
+      }),
+    );
+    expect(DATA_APP_EXTERNALS).toEqual(
+      expect.arrayContaining([
+        "react-dom",
+        "react-dom/client",
+        "react-dom/server",
+      ]),
+    );
+  });
+});

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/config/define.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/config/define.ts
@@ -1,0 +1,8 @@
+// Libraries such as react-datepicker require a process.NODE_ENV define.
+export function getDataAppDefine(mode: string): Record<string, string> {
+  return {
+    "process.env.NODE_ENV": JSON.stringify(
+      mode === "production" ? "production" : "development",
+    ),
+  };
+}

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/config/define.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/config/define.unit.spec.ts
@@ -1,0 +1,15 @@
+import { getDataAppDefine } from "./define";
+
+describe("getDataAppDefine", () => {
+  it("defines process.env.NODE_ENV for production builds", () => {
+    expect(getDataAppDefine("production")).toEqual({
+      "process.env.NODE_ENV": '"production"',
+    });
+  });
+
+  it("defines process.env.NODE_ENV for development builds", () => {
+    expect(getDataAppDefine("development")).toEqual({
+      "process.env.NODE_ENV": '"development"',
+    });
+  });
+});

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/dev-plugin/plugin.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/dev-plugin/plugin.ts
@@ -12,6 +12,7 @@ import * as dataAppVirtualModules from "build-configs/embedding-sdk/constants/da
 
 import { DATA_APP_BUNDLE_URL, DATA_APP_REBUILT_EVENT } from "../bundle";
 import { dataAppBuildPlugins, dataAppLibBuild } from "../config/build-config";
+import { getDataAppDefine } from "../config/define";
 
 // Virtual modules the dev server provides. The dev server serves a synthetic
 // `index.html` (below) that imports the dev entry; the dev entry imports the
@@ -72,6 +73,7 @@ export function dataAppSandboxDevPlugin(allowedHosts: string[]): Plugin {
       root,
       mode,
       configFile: false,
+      define: getDataAppDefine(mode),
       logLevel: "warn",
       plugins: dataAppBuildPlugins(),
       build: {

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/index.ts
@@ -7,6 +7,7 @@ import {
 } from "vite";
 
 import { dataAppBuildPlugins, dataAppLibBuild } from "./config/build-config";
+import { getDataAppDefine } from "./config/define";
 import { buildConnectSrcCsp, readAllowedHosts } from "./config/dev-connect-src";
 import { dataAppEnvPrefix } from "./config/env-prefix";
 import { findEnvRoot } from "./config/find-env-root";
@@ -37,6 +38,7 @@ function dataAppVitePlugin(): PluginOption[] {
       // win — the bundle Metabase loads always matches what dev runs. `loadEnv`
       // needs the mode, which is only known here in the `config` hook.
       config: (_config: UserConfig, env: ConfigEnv): UserConfig => ({
+        define: getDataAppDefine(env.mode),
         envDir,
         // Dev preview only — keeps `.env.local` secrets out of prod builds. See
         // `dataAppEnvPrefix`.

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.ts
@@ -151,7 +151,6 @@ const isOrderableJavaScriptType = (
   value === "boolean" ||
   value === "Date";
 
-/** @internal */
 export function filter<
   TDimension,
   TOperator extends ValueFilterOperatorForDimension<TDimension>,
@@ -191,7 +190,6 @@ export function filter(
   return { dimension, operator, value };
 }
 
-/** @internal */
 export function breakout<TDimension>(dimension: TDimension): {
   dimension: TDimension;
 };

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/loader.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/loader.ts
@@ -1,5 +1,8 @@
 import * as React from "react";
 import * as ReactJsxRuntime from "react/jsx-runtime";
+import * as ReactDOM from "react-dom";
+import * as ReactDOMClient from "react-dom/client";
+import * as ReactDOMServer from "react-dom/server";
 import { pick } from "underscore";
 
 import * as sdkExports from "embedding-sdk-package";
@@ -112,6 +115,9 @@ export function instantiateDataAppBundle(
     allowedHosts,
     endowments: {
       React,
+      reactDom: ReactDOM,
+      reactDomClient: ReactDOMClient,
+      reactDomServer: ReactDOMServer,
       reactJsxRuntime: ReactJsxRuntime,
       sdkExports,
       dataAppExports,

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox.ts
@@ -44,6 +44,12 @@ export type DataAppFactory = () => {
 export interface DataAppSandboxEndowments {
   /** Endowed as the `React` global the bundle externalizes `react` to. */
   React: unknown;
+  /** Endowed as `__react_dom__` (the `react-dom` external). */
+  reactDom: unknown;
+  /** Endowed as `__react_dom_client__` (the `react-dom/client` external). */
+  reactDomClient: unknown;
+  /** Endowed as `__react_dom_server__` (the `react-dom/server` external). */
+  reactDomServer: unknown;
   /** Endowed as `__react_jsx_runtime__` (the `react/jsx-runtime` external). */
   reactJsxRuntime: unknown;
   /**
@@ -94,6 +100,9 @@ export function createDataAppSandbox({
       // externals (defined by the SDK build) and these endowments can't drift.
       endowments: Object.getOwnPropertyDescriptors({
         [DATA_APP_GLOBAL_NAMES.react]: endowments.React,
+        [DATA_APP_GLOBAL_NAMES.reactDom]: endowments.reactDom,
+        [DATA_APP_GLOBAL_NAMES.reactDomClient]: endowments.reactDomClient,
+        [DATA_APP_GLOBAL_NAMES.reactDomServer]: endowments.reactDomServer,
         [DATA_APP_GLOBAL_NAMES.reactJsxRuntime]: endowments.reactJsxRuntime,
         ...(!!endowments.reactJsxDevRuntime && {
           [DATA_APP_GLOBAL_NAMES.reactJsxDevRuntime]:

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/create-element.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/create-element.ts
@@ -1,0 +1,70 @@
+import {
+  CREATE_ELEMENT,
+  CREATE_ELEMENT_NS,
+} from "metabase/utils/scripts-sandbox/distortions-dom-mutate";
+
+const isStyleTag = (tag: string) => tag.toLowerCase() === "style";
+
+function isStyleQualifiedName(qualifiedName: string) {
+  const localName = qualifiedName.includes(":")
+    ? qualifiedName.slice(qualifiedName.indexOf(":") + 1)
+    : qualifiedName;
+
+  return isStyleTag(localName);
+}
+
+export function makeCreateElementDistortion(
+  value: object,
+  shared: (value: object) => object,
+) {
+  if (value === CREATE_ELEMENT) {
+    const sharedCreateElement = shared(value) as typeof CREATE_ELEMENT;
+
+    return function createElement(
+      this: Document,
+      tag: string,
+      options?: ElementCreationOptions,
+    ) {
+      // Data-app bundles inline imported CSS with
+      // `vite-plugin-css-injected-by-js`, which creates a `<style>` tag at
+      // runtime. Allow only that tag while keeping the shared dangerous-tag
+      // blocklist for `script` and other DOM creation.
+      if (isStyleTag(tag)) {
+        return CREATE_ELEMENT.call(this, tag, options);
+      }
+
+      return sharedCreateElement.call(this, tag, options);
+    };
+  }
+
+  if (value === CREATE_ELEMENT_NS) {
+    const sharedCreateElementNS = shared(value) as typeof CREATE_ELEMENT_NS;
+
+    return function createElementNS(
+      this: Document,
+      namespaceURI: string | null,
+      qualifiedName: string,
+      options?: ElementCreationOptions,
+    ) {
+      if (isStyleQualifiedName(qualifiedName)) {
+        // Same exception as `createElement("style")`, but for namespaced
+        // creation paths.
+        return CREATE_ELEMENT_NS.call(
+          this,
+          namespaceURI,
+          qualifiedName,
+          options as ElementCreationOptions,
+        );
+      }
+
+      return sharedCreateElementNS.call(
+        this,
+        namespaceURI,
+        qualifiedName,
+        options as ElementCreationOptions,
+      );
+    };
+  }
+
+  return null;
+}

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.ts
@@ -1,6 +1,7 @@
 import { makeSandboxDistortionCallback } from "metabase/utils/scripts-sandbox";
 
 import { makeSandboxFetch, makeSandboxXhr } from "./allowed-hosts";
+import { makeCreateElementDistortion } from "./create-element";
 
 /**
  * Data-app Near Membrane distortion callback.
@@ -37,6 +38,12 @@ export function makeDistortionCallback(
   const sandboxXhr = makeSandboxXhr(targetWindow, allowedHosts, label);
 
   return function distortionCallback(value: object): object {
+    const createElementDistortion = makeCreateElementDistortion(value, shared);
+
+    if (createElementDistortion) {
+      return createElementDistortion;
+    }
+
     if (sandboxFetch && value === targetWindow.fetch) {
       return sandboxFetch;
     }

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.unit.spec.ts
@@ -15,6 +15,32 @@ const fakeWindow = () =>
   }) as unknown as Window & typeof globalThis;
 
 describe("makeDistortionCallback", () => {
+  it("allows style elements for bundled CSS injection", () => {
+    const win = fakeWindow();
+    const callback = makeDistortionCallback("sales", win, []);
+    const createElement = callback(
+      Document.prototype.createElement,
+    ) as typeof Document.prototype.createElement;
+
+    expect(() => createElement.call(document, "style")).not.toThrow();
+  });
+
+  it("keeps the shared dangerous-tag blocklist for non-style elements", () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const win = fakeWindow();
+    const callback = makeDistortionCallback("sales", win, []);
+    const createElement = callback(
+      Document.prototype.createElement,
+    ) as typeof Document.prototype.createElement;
+
+    expect(() => createElement.call(document, "script")).toThrow(
+      "[data-app sales] blocked createElement: script",
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
   it("routes window.fetch to the allowlisted wrapper when allowed_hosts is set", async () => {
     const win = fakeWindow();
     const realFetch = jest.fn(() => Promise.resolve(new Response("ok")));

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/resolve-card-prop.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/resolve-card-prop.ts
@@ -1,6 +1,6 @@
 import type { MetabaseCard } from "embedding-sdk-bundle/types/question";
 import { deserializeCardFromQuery } from "metabase/common/utils/card";
-import type { UnsavedCard } from "metabase-types/api";
+import type { DatasetQuery, UnsavedCard } from "metabase-types/api";
 
 export function resolveCardProp(
   input: string | MetabaseCard,
@@ -22,7 +22,7 @@ export function resolveCardProp(
     input.visualization != null || input.displayIsLocked != null;
 
   return {
-    dataset_query: input.query,
+    dataset_query: input.query as DatasetQuery,
     // Public-facing `visualization` maps to the internal card `display`. When
     // omitted, mirror the legacy `query` prop and let query results pick a
     // better unlocked display later.

--- a/frontend/src/metabase/embedding-sdk/types/question.ts
+++ b/frontend/src/metabase/embedding-sdk/types/question.ts
@@ -1,5 +1,4 @@
 import type { VisualizationSettings } from "metabase-types/api/card";
-import type { DatasetQuery } from "metabase-types/api/query";
 import type { CustomVizDisplayType } from "metabase-types/api/visualization";
 
 export interface MetabaseQuestion {
@@ -182,7 +181,7 @@ export type MapVisualizationSettings = Pick<
 >;
 
 interface MetabaseCardBase {
-  query: DatasetQuery;
+  query: unknown | null;
   displayIsLocked?: boolean;
 }
 

--- a/skills/create-data-app/SKILL.md
+++ b/skills/create-data-app/SKILL.md
@@ -235,7 +235,7 @@ Vite bundles everything reachable from `src/index.tsx` into a single `dist/index
 
 ### 3. Import SDK values from the correct SDK entrypoint
 
-The build externalizes `@metabase/embedding-sdk-react` and `@metabase/embedding-sdk-react/data-app` to sandbox globals (`__metabase_sdk__` / `__metabase_data_app__`) in **both** production and `npm run dev` — in dev the sandbox entry endows them from the npm package, so the bundle runs identically in both. Just import from the entrypoints normally:
+The build externalizes React, the JSX runtimes, `@metabase/embedding-sdk-react`, and `@metabase/embedding-sdk-react/data-app` to sandbox globals in **both** production and `npm run dev` — in dev the sandbox entry endows them from the npm package, so the bundle runs identically in both. Just import from the entrypoints normally:
 
 ```tsx
 // ✅ correct
@@ -254,7 +254,7 @@ const { MetabaseProvider, StaticQuestion } = globalThis;
 
 ### 4. Import `react` normally too
 
-The build externalizes `react` (mapped to the `React` global), so a plain `import` resolves to React the same way in both modes — the production host and the dev sandbox both endow it as the `React` global:
+The build externalizes `react` and `react-dom`, so plain imports resolve the same way in both modes — the production host and the dev sandbox both endow them as sandbox globals:
 
 ```tsx
 import { useState, useEffect, useMemo } from "react";
@@ -287,7 +287,7 @@ import type { ComponentType, ReactNode } from "react";
 
 ## Available SDK surface
 
-The bundle imports normally from `@metabase/embedding-sdk-react`. Vite externalizes the package at build time, so production references the host's copies at runtime (`globalThis.__metabase_sdk__`); the Vite dev server resolves to the real npm package directly.
+The bundle imports React hooks/JSX, SDK components from `@metabase/embedding-sdk-react`, and data-app-specific routing/query APIs from `@metabase/embedding-sdk-react/data-app`. `dataAppConfig()` externalizes these packages at build time, so production references the host's copies at runtime (`globalThis.__metabase_sdk__` / `globalThis.__metabase_data_app__` for SDK packages), and the Vite dev sandbox endows the same globals from the installed npm package.
 
 `<MetabaseProvider>` is **not** rendered by the bundle's `App.tsx` — the dev entry and the host wrap it for their respective modes. Bundle author only renders the **content** below.
 
@@ -295,8 +295,8 @@ The bundle imports normally from `@metabase/embedding-sdk-react`. Vite externali
 |---|---|
 | `React` (from `"react"`) | Hooks (`useState`, `useEffect`, etc.), JSX runtime. Externalized to the host's React via `react: "React"`. |
 | `StaticQuestion` | Non-drillable question. Props include `questionId`, `card`, `withChartTypeSelector`, `height`, `width`. |
-| `InteractiveQuestion` | Drillable question. Same props as StaticQuestion plus drill behaviors. Use `card={{ query }}` for ad hoc SDK-rendered questions. Add `visualization` when the request calls for a specific chart type, and add `visualizationSettings` only for explicit setting-level presentation changes; see the `metabase-data-app-semantic-layer` skill for the type guardrails. |
-| `MetabaseCard` | Type-only import from `@metabase/embedding-sdk-react` for ad hoc SDK-rendered cards with `visualization` or `visualizationSettings`; the full contract lives in the `metabase-data-app-semantic-layer` skill. |
+| `InteractiveQuestion` | Drillable question. Same props as StaticQuestion plus drill behaviors. Use `card={{ query }}` for ad hoc SDK-rendered questions. Add `visualization` when the request calls for a specific chart type, and add `visualizationSettings` only for explicit setting-level presentation changes; use skill discovery for schema-backed query and card type guardrails. |
+| `MetabaseCard` | Type-only import from `@metabase/embedding-sdk-react` for ad hoc SDK-rendered cards with `visualization` or `visualizationSettings`; use skill discovery for the full generated-query card contract before authoring data-layer code. |
 | `CreateQuestion`, `MetabotQuestion` | More question variants. |
 | `StaticDashboard`, `InteractiveDashboard`, `EditableDashboard` | Dashboard variants. |
 | `CreateDashboardModal` | Modal for new-dashboard flow. |
@@ -317,13 +317,13 @@ The Near Membrane sandbox throws at runtime on these globals. Use the endowed re
 | **Other `navigator.*` device APIs** — `geolocation`, etc. | Not available. |
 | **Global `document`/`window` listeners** for typing/clipboard events — `keydown`, `keyup`, `keypress`, `beforeinput`, `input`, `paste`, `copy`, `cut`, `before*paste/copy/cut`, `compositionstart/update/end`, `storage` | Attach the listener to your own element, or use the React handler (`onKeyDown`, `onPaste`, …) on the specific input/container. The same listener on a script-owned element still works. |
 
-**Rule of thumb:** if you're about to touch `window.X`, `document.X`, `navigator.X`, `history.X`, or any storage global, stop and pick the endowed replacement above. The endowed surface (React + SDK components + data hooks + `useAction` + DataAppRouter + `copy`) covers every routine need; anything outside it is intentionally unreachable.
+**Rule of thumb:** if you're about to touch `window.X`, `document.X`, `navigator.X`, `history.X`, or any storage global, stop and pick the endowed replacement above. The endowed surface (React + React DOM + SDK components + data hooks + `useAction` + DataAppRouter + `copy`) covers every routine need; anything outside it is intentionally unreachable.
 
 ### When to use SDK charts vs `useMetabaseQuery`
 
 This is a per-rendering decision, not a project-wide one:
 
-- **`useMetabaseQueryObject` + `StaticQuestion` / `InteractiveQuestion`** — default for ordinary dashboard charts: bar, line, area, row, pie, scalar/smartscalar, gauge, progress, pivot, map, sortable table, and other displays Metabase already renders well. Build the semantic query from generated schema objects, then pass it to the SDK component with the `query` prop, for example `<StaticQuestion query={trendQuery} ... />`.
+- **`useMetabaseQueryObject` + `StaticQuestion` / `InteractiveQuestion`** — default for ordinary dashboard charts: bar, line, area, row, pie, scalar/smartscalar, gauge, progress, pivot, map, sortable table, and other displays Metabase already renders well. Build the semantic query from generated schema objects, then pass it to the SDK component with a card object, for example `<StaticQuestion card={{ query: trendQuery }} ... />`.
 - **`useMetabaseQuery`** — use when React genuinely needs row values: extracting KPI numbers, powering custom controls, composing bespoke summary cards, combining multiple queries into one UI element, or rendering a visualization Metabase cannot express.
 
 Generated dashboards should prefer SDK-rendered charts. Do not rebuild normal bar/line/table charts in React just to match app chrome. If you choose `useMetabaseQuery`, keep the row handling typed.
@@ -332,7 +332,7 @@ Generated dashboards should prefer SDK-rendered charts. Do not rebuild normal ba
 
 **Call each schema entry at most once per render tree.** Multiple `useMetabaseQuery` calls on the same `questionId` (or same `tableId` + identical filters/measures/breakouts) mount independent subscriptions, fire duplicate queries, and let consumers disagree mid-load. Lift the call to the highest component that needs the data; pass `data` / `isLoading` / `error` down as props. Different ids — or the same id with different filters / breakouts — are different data sources; call them separately.
 
-(For the hook contract itself — generics, table-vs-metric variants, segments / measures / breakouts, debugging — see the `metabase-data-app-semantic-layer` skill.)
+For the hook contract itself — generics, table sources, segments, measures, breakouts, sorting, and debugging — use skill discovery before authoring schema-backed data-layer code.
 
 ## SDK component sizing
 

--- a/skills/metabase-data-app-semantic-layer/SKILL.md
+++ b/skills/metabase-data-app-semantic-layer/SKILL.md
@@ -21,13 +21,13 @@ Keep the semantic layer and presentation layer separate.
 - Dashboard-level filters should visibly affect every compatible card, table, KPI, and trend. If a filter can only apply to one query, make that scope obvious in the UI; do not show duplicate or no-op date controls.
 - Entity filters, where the stored value is an id/key and the UI shows a label, must use a single searchable combobox. Click/focus must open the option list immediately, before typing. Query options at runtime, search labels, and store the raw value. Never render entity filters as `<select>`; plain selects are only for short closed enums explicitly provided by the user.
 - Do not use native `<input type="date">` for data-app filter bars. Its placeholder and calendar popover are browser-controlled, often show `mm/dd/yyyy`, and cannot be reliably themed. If the repo already has a date picker component or component library, use that. Otherwise install `react-datepicker` for custom date selection.
-- Date bars must include Custom last by default: duration presets, All time, then Custom. Omit Custom only when the user explicitly asks for fixed presets only or no date range control. Date pickers must receive `Date | null`, never `new Date("")` or another invalid date for incomplete ranges.
+- Date bars must include Custom last by default: duration presets, All time, then Custom. Omit Custom only when the user explicitly asks for fixed presets only or no date range control. Date pickers must receive `Date | null`, never `new Date("")` or another invalid date for incomplete ranges; type strict callback parameters explicitly, such as `onChange={(date: Date | null) => ...}`.
 - Never invent aggregation or measure objects such as `{ name: "count" }` or `{ name: "sum", field: ... }`. Measures must come from `schema.tables.*.measures.*`; metrics must come from `schema.metrics.*`.
 - Only render values returned by Metabase or deterministic transforms of returned values. Do not invent KPI values, trends, labels, statuses, ratings, timestamps, rankings, insights, segments, or chart series.
 - Do not custom-render ambiguous business fields such as `margin`, `rate`, `score`, `percent`, `health`, `risk`, or `efficiency`. Do not add `%`, multiply by 100, color-code, or render stars unless semantic-layer units explicitly support it; use an SDK table/chart, omit the field, or ask for curation.
 - Visualization data must come from Metabase through `useMetabaseQuery`, `useMetabaseQueryObject` with `InteractiveQuestion`/`StaticQuestion`, or saved-question SDK components. Do not hardcode chart-ready arrays, sample data, demo values, or schema-shaped mock values.
 - When wrapping an SDK-rendered question in a card or section that already has its own title, pass `title={false}` to the SDK question component to avoid duplicate generated question titles.
-- `useMetabaseQueryObject(...)` returns a `DatasetQuery | null` to pass as `query={...}` to `InteractiveQuestion` or `StaticQuestion`. If TypeScript rejects SDK component props, treat that as a real bug and fix the prop shape instead of working around the error.
+- `useMetabaseQueryObject(...)` returns a query value to pass as `card={{ query }}` to `InteractiveQuestion` or `StaticQuestion`. If TypeScript rejects SDK component props, treat that as a real bug and fix the prop shape instead of working around the error.
 - `useMetabaseQuery().rows` are keyed objects, not tuple arrays. Never read `row[0]` / `row[1]`, and never silence this with `as unknown as [string, number][]`, `DisplayRow`, or another tuple cast. If TypeScript says property `0` does not exist, it is catching a real bug. Use named returned properties, or render the query with an SDK chart via `useMetabaseQueryObject`.
 - Before rendering a field, verify it exists in the generated schema object and is returned by the query. Do not guess column names from business intuition or old mock data.
 - Avoid unsupported freshness or operational claims such as "real-time", "live", "understaffed", or "risk" unless the returned data or curated semantic-layer definition supports them.
@@ -68,7 +68,7 @@ Correlate those representation files with the user's request and offer concrete 
 Warn the user before exporting the whole instance. Including everything is noisy: it bloats context, makes agents more likely to pick irrelevant entities, and weakens the intended boundary between the curated semantic layer and the presentation layer.
 
 The Metabase URL and API key live in the **repo-root** `.env.local` as
-`VITE_MB_URL` and `VITE_MB_API_KEY` (one file per repo, usually two levels up
+`DATA_APP_MB_URL` and `DATA_APP_MB_API_KEY` (one file per repo, usually two levels up
 from the app dir, not in the app dir). The command below `source`s that file so
 the shell substitutes the values straight into `curl` — you never read, extract,
 or handle the credentials yourself.
@@ -76,7 +76,7 @@ or handle the credentials yourself.
 > **Never ask the user to paste the API key into the chat, and never `cat` /
 > `echo` `.env.local`** — it's git-ignored and may hold other secrets, so its
 > contents must stay out of the conversation. `source` it so the shell uses the
-> values without exposing them. If `$VITE_MB_API_KEY` or `$VITE_MB_URL` is empty
+> values without exposing them. If `$DATA_APP_MB_API_KEY` or `$DATA_APP_MB_URL` is empty
 > or still set to the default `mb_replace_me` placeholder after sourcing, ask
 > the user to add real values themselves, then continue.
 
@@ -95,16 +95,16 @@ fi
 (
   source "$ROOT/.env.local" 2>/dev/null
   # Fail early (before curl) if either var is missing or placeholder-only.
-  if [ -z "$VITE_MB_URL" ] || [ "$VITE_MB_URL" = "mb_replace_me" ] ||
-     [ -z "$VITE_MB_API_KEY" ] || [ "$VITE_MB_API_KEY" = "mb_replace_me" ]; then
-    echo "Set real VITE_MB_URL / VITE_MB_API_KEY in repo-root .env.local" >&2
+  if [ -z "$DATA_APP_MB_URL" ] || [ "$DATA_APP_MB_URL" = "mb_replace_me" ] ||
+     [ -z "$DATA_APP_MB_API_KEY" ] || [ "$DATA_APP_MB_API_KEY" = "mb_replace_me" ]; then
+    echo "Set real DATA_APP_MB_URL / DATA_APP_MB_API_KEY in repo-root .env.local" >&2
     exit 1
   fi
   curl \
     -o src/metabase.data.ts \
-    -H "x-api-key: $VITE_MB_API_KEY" \
+    -H "x-api-key: $DATA_APP_MB_API_KEY" \
     -H "Accept: text/typescript" \
-    "$VITE_MB_URL/api/typed-schemas/v1/typescript?includeDataLibrary=true&includeMetricLibrary=true&questionCollections=g-jLnamuHKdezZMthJ-z7"
+    "$DATA_APP_MB_URL/api/typed-schemas/v1/typescript?includeDataLibrary=true&includeMetricLibrary=true&questionCollections=g-jLnamuHKdezZMthJ-z7"
 )
 ```
 

--- a/skills/metabase-data-app-semantic-layer/references/filter-ui-patterns.md
+++ b/skills/metabase-data-app-semantic-layer/references/filter-ui-patterns.md
@@ -1,0 +1,127 @@
+# Filter UI Checklist
+
+Use these patterns when building custom filter bars for data apps.
+
+## Filter Contract
+
+Before writing controls, map each filter to the dashboard. Keep this contract small and concrete:
+
+| Filter | Runtime options query | Raw value | Applies to | Unsupported sections |
+| ------ | --------------------- | --------- | ---------- | -------------------- |
+| Franchise | breakout on franchise id/name | franchise id | orders, revenue, inventory | none |
+| Plan | breakout on plan | plan text | orders | revenue, inventory |
+
+If a filter has unsupported sections, either make it section-scoped or do not render it as a global dashboard filter. Do not show duplicate date controls for the same page unless both visibly affect different labeled sections.
+
+For every rendered card or table, build filters from that semantic object's own generated fields or metric dimensions. Do not reuse a filter array built for a different table or metric.
+
+Before rendering a filter, answer:
+
+- What query provides runtime options?
+- What raw value is stored?
+- Which cards can accept that value?
+- Which cards cannot?
+- Does `All` produce no filter?
+
+## Runtime Categorical Options
+
+Query options from Metabase at runtime with a breakout on the same field or metric dimension used by the filter.
+
+- Run a `useMetabaseQuery` breakout on the same table field or metric dimension used by `filter(...)`, then derive a deduped option list from returned rows.
+- Prefer querying options from the same semantic object used by the charts so the option list stays compatible with the filter.
+- Treat categorical labels as runtime values unless the user explicitly provides a closed enum. Field names in the generated schema are not value lists.
+- Use a searchable picker/combobox for entity filters and long runtime option lists.
+
+For entity filters, keep display labels and raw values separate:
+
+```ts
+type Option = { label: string; value: string };
+
+const franchiseOptions = rows.map((row) => ({
+  label: row.franchise_name ?? row.franchise_id,
+  value: row.franchise_id,
+}));
+```
+
+Use the raw `value` in `filter(...)`. Never filter by display labels when a stable id is available.
+
+Do not render a free-text input that writes directly to an exact id filter. If the filter is searchable, search option labels and store the selected raw value.
+
+## Reset Missing Runtime Values
+
+Runtime option sets can change. If the selected value disappears, reset to `all` so the app does not stay filtered to no rows.
+
+```tsx
+useEffect(() => {
+  if (
+    selectedValue !== "all" &&
+    !options.some((option) => option.value === selectedValue)
+  ) {
+    setSelectedValue("all");
+  }
+}, [options, selectedValue]);
+```
+
+Keep the `All` option selectable even while options are loading, empty, or errored.
+
+## Filter State Rules
+
+- Default every filter to `all` or empty, and run the unfiltered query.
+- Convert `all`, `""`, `null`, and `undefined` to `[]`.
+- Keep `All` options selectable even while runtime option queries are loading, empty, or errored.
+- Do not disable the whole control while loading options; keep `All` enabled and show a loading/empty option for dynamic values.
+- If a selected runtime option disappears from the latest option query, reset that filter to `all` so stale values do not keep filtering the dashboard to no rows.
+- For custom date ranges, apply the filter only when both dates are valid.
+- Never fill half-selected ranges with sentinel dates like `2000-01-01` or `2100-01-01`.
+- Keep one filter array per queried semantic object when charts use different date fields or metric dimensions.
+- Memoize filter arrays so SDK query keys stay stable.
+- For boolean Yes/No/All filters, map both `true` and `false` explicitly; only All maps to no filter.
+
+## Searchable Runtime Filters
+
+Entity filters are filters where the selected value is an id/key but users need a label. They always use one searchable combobox, never a native `<select>` or a search input paired with `<select>`. Plain `<select>` is only for short closed enums explicitly provided by the user.
+
+If no component exists:
+
+- Prefer a small established combobox/listbox dependency for keyboard/focus behavior.
+- Hand-roll only a small picker: input, capped list, mouse selection, Escape/blur close, and clear button.
+
+Minimum behavior:
+
+- Click or focus opens the option list immediately, even before the user types.
+- Search filters labels, not raw ids.
+- The `All` option is always available.
+- Selecting an option stores the raw `value`.
+- The list is capped or scrollable so it cannot stretch the page.
+
+Do not close the list from an `onBlur` handler on the trigger button when the
+popover contains an auto-focused input. Moving focus from the button to the
+input blurs the button and immediately closes the list. If hand-rolling a
+combobox, keep focus inside one wrapper and close only when focus leaves the
+whole wrapper, or close from explicit selection, Escape, and outside clicks.
+
+Style this to match the app. If accessibility, keyboard behavior, or popover positioning becomes non-trivial, prefer a small established combobox component or the app's component library instead of hand-rolling more behavior.
+
+## Date Range Filters
+
+Date ranges should use ISO `YYYY-MM-DD` strings for query values. Never use `type="date"`.
+
+For custom date pickers:
+
+- Include a Custom range option in date preset bars by default. Omit it only when the user explicitly asks for fixed presets only or no date range control. Order presets as durations first, then All time, then Custom last.
+- First check whether the repo already has a date picker component or component library. If it does, use the existing component.
+- If the repo has no existing date picker, install `react-datepicker`. The default data-app template only includes React, React DOM, and the Metabase SDK.
+- Do not install a large UI suite just for one data-app date filter.
+- Import `react-datepicker/dist/react-datepicker.css`, then add small CSS overrides for the app's visual style if needed.
+- Type strict `react-datepicker` callbacks explicitly, for example `onChange={(date: Date | null) => ...}` for single-date pickers.
+- For custom date ranges, use `selectsRange` with local `Date | null` start/end state, but only commit the query range when both dates are selected.
+- If the custom range control should look like the other preset buttons, use `customInput` with a `forwardRef` button, spread react-datepicker's injected props, and call its injected `onClick` so the popover still opens.
+- Convert selected dates to ISO `YYYY-MM-DD` strings with local date getters (`getFullYear`, `getMonth`, `getDate`) rather than `toISOString()`.
+- For date-picker `selected` props, parse saved strings defensively and pass `null` for empty or invalid values. Never pass `new Date("")`.
+- Recent `react-datepicker` packages include their own TypeScript types; do not add `@types/react-datepicker` unless the installed version actually needs it.
+
+Install `react-datepicker` only when the repo does not already have a date picker:
+
+```bash
+npm install react-datepicker
+```


### PR DESCRIPTION
Closes EMB-2043

### Description

Fixes data app sandbox crashes caused by generated apps or third-party libraries that import React DOM or read `process.env.NODE_ENV`. Unblocks the work on metabase-lib.

The current `custom-data-apps-poc` does not work in local run with `npm run dev` because https://github.com/metabase/metabase/pull/76401 clashes with https://github.com/metabase/metabase/pull/76597.

This PR:

- Endows `react-dom`, `react-dom/client`, and `react-dom/server` in the production data app sandbox
- Externalizes the same React DOM modules in the data app template and dev sandbox
- Defines `process.env.NODE_ENV` for data app bundles so libraries can safely read it
- Keeps generated ad-hoc SDK questions on `card={{ query }}` and avoids leaking the opaque `DatasetQuery` type through the public card type.
- Updates the data app skills to use `DATA_APP_*` env vars and avoid stale direct skill cross references.

### How to verify

1. Generate or open a data app that uses custom filtering interfaces, which should trigger `react-datepicker` as per https://github.com/metabase/metabase/pull/76401. You can use this prompt:

```
Create a new metabase data app for executives to have an in depth understanding of the franchises. for example, orders, inventory. make sure to have date filters and other filters.

I will use a custom version of the SDK, not 63-data-apps. Use this command to install custom version:

* npm pkg set dependencies.@metabase/embedding-sdk-react="file:../../../metabase/resources/embedding-sdk"
* npm install
```

2. Run the app locally with `npm run dev`.
3. Confirm the app renders without `process is not defined`, `require is not defined`, or missing React DOM sandbox global errors.
4. Confirm generated SDK questions use `card={{ query }}` and still render.
5. Confirm agents generates the app without type errors due to `DatasetQuery` that it needs to fix

### Screenshots

Local queries works as expected

<img width="2920" height="1798" alt="CleanShot 2569-07-02 at 13 30 21@2x" src="https://github.com/user-attachments/assets/440e4d16-526f-4a91-b928-352cf10f9f37" />

Generation completes

<img width="1958" height="1308" alt="CleanShot 2569-07-02 at 13 29 32@2x" src="https://github.com/user-attachments/assets/f21e6fe5-58f8-4e0e-a459-63c4de922fc7" />
