### PR TITLE
Bundle-size stats: emit Description column (fixes 422 on upload)

### DIFF
--- a/.github/scripts/bundle-size-stats-prepare.js
+++ b/.github/scripts/bundle-size-stats-prepare.js
@@ -28,7 +28,7 @@ const deltaPercent = (current, base) =>
  * brotliBytes (estimated when no .br shipped), but a cached base point recorded
  * before brotli logging may not, so the delta still falls back to gzip per row.
  */
-function buildStatsRows({ measurements, previous, threshold, date, commit, version }) {
+function buildStatsRows({ measurements, previous, threshold, date, commit, commitMessage, version }) {
   const previousOf = (bundle, kind) => previous.find(row => row.bundle === bundle && row.kind === kind);
 
   let maxServedDeltaPercent = 0;
@@ -51,6 +51,10 @@ function buildStatsRows({ measurements, previous, threshold, date, commit, versi
       "Commit": commit,
       "Bundle": measurement.bundle,
       "Kind": measurement.kind, // "initial" or "total"
+      // The stats table carries a free-text Description column; append-csv
+      // requires every table column to be present. Populate it with the commit
+      // subject so the chart's points are self-describing.
+      "Description": commitMessage,
       "Raw bytes": measurement.rawBytes,
       "Gzip bytes": measurement.gzipBytes,
       "Brotli bytes": measurement.brotliBytes, // as-served (shipped .br, else estimated)
@@ -126,6 +130,7 @@ function main() {
     threshold: Number(env.MIN_DELTA_PERCENT ?? 1),
     date: new Date().toISOString().slice(0, 10), // YYYY-MM-DD
     commit: (env.HEAD_SHA || "").slice(0, 12),
+    commitMessage: (env.COMMIT_MESSAGE || "").split("\n")[0], // subject line only
     version: readVersion(env.VERSION_PROPS),
   });
 

--- a/.github/scripts/bundle-size-stats-prepare.unit.spec.js
+++ b/.github/scripts/bundle-size-stats-prepare.unit.spec.js
@@ -1,6 +1,6 @@
 const { buildStatsRows } = require("./bundle-size-stats-prepare");
 
-const meta = { date: "2026-06-30", commit: "abc123", version: "" };
+const meta = { date: "2026-06-30", commit: "abc123", commitMessage: "Fix the thing (#123)", version: "" };
 const measurement = (over = {}) => ({
   bundle: "embedding-sdk-chunked",
   kind: "total",
@@ -25,6 +25,7 @@ describe("buildStatsRows", () => {
     expect(result.reason).toBe("first point");
     expect(result.rows[0]["Gzip bytes delta"]).toBe("");
     expect(result.rows[0]["Brotli delta %"]).toBe("");
+    expect(result.rows[0]["Description"]).toBe("Fix the thing (#123)");
     expect(result.cacheRows[0]).toEqual({
       bundle: "embedding-sdk-chunked",
       kind: "total",

--- a/.github/workflows/bundle-size-stats.yml
+++ b/.github/workflows/bundle-size-stats.yml
@@ -101,6 +101,9 @@ jobs:
           CACHE_OUT: bundle-size-cache/last.json
           ROWS_OUT: artifacts/upload-rows.json
           VERSION_PROPS: artifacts/version.properties
+          # Passed via env (not interpolated into the shell) so the commit
+          # message can't inject commands; the script keeps only the subject.
+          COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
         run: node ./.github/scripts/bundle-size-stats-prepare.js
       - name: Upload sizes (with deltas) to Stats
         id: upload


### PR DESCRIPTION
## Problem

The `Bundle Size Stats` master workflow fails at the upload step with:

```
422 Unprocessable Entity {"message":"The CSV file is missing columns that are in the table:\n- description"}
```

The stats table (`79702`) has a free-text `description` column that the uploaded CSV never contained. Metabase's `append-csv` (and `replace-csv`) reject any CSV missing a column the table has — `check-schema` in `src/metabase/upload/impl.clj` runs for both actions — so every append 422s.

Dropping the column while keeping history isn't achievable through the upload API (replace re-validates against the existing schema), so the clean, lossless fix is to emit the column.

## Change

- `buildStatsRows` now emits a `Description` column, populated with the head commit's subject line, so the CSV schema matches the table again and the points are self-describing on the chart.
- The workflow passes the commit message via `COMMIT_MESSAGE` env (from the `workflow_run` payload, not interpolated into the shell, so it can't inject commands); the script keeps only the first line.
- Unit spec updated to cover the new column.

No table surgery, no data loss, same `tableId`.
