### PR TITLE
Gate SDK query builder controls on create-queries permission

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question-permissions.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question-permissions.cy.spec.tsx
@@ -1,0 +1,46 @@
+import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
+
+import { USERS } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing";
+import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
+import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
+
+describe("scenarios > embedding-sdk > sdk-question query builder editing controls permissions (EMB-1963)", () => {
+  beforeEach(() => {
+    signInAsAdminAndEnableEmbeddingSdk();
+  });
+
+  it("hides Filter, Summarize, and the notebook editor toggle when the user lacks create-queries permission on the underlying table", () => {
+    // `readonly` has create-queries: no
+    cy.signOut();
+    mockAuthProviderAndJwtSignIn(USERS.readonly);
+
+    mountSdkContent(<InteractiveQuestion questionId={ORDERS_QUESTION_ID} />);
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("visualization-root").should("be.visible");
+
+      cy.button("Filter").should("not.exist");
+      cy.button("Summarize").should("not.exist");
+      cy.findByTestId("notebook-button").should("not.exist");
+    });
+  });
+
+  it("shows Filter, Summarize, and the notebook editor toggle when the user has create-queries permission on the underlying table", () => {
+    // `readonlynosql` has create-queries: query-builder
+    cy.signOut();
+    mockAuthProviderAndJwtSignIn(USERS.readonlynosql);
+
+    mountSdkContent(<InteractiveQuestion questionId={ORDERS_QUESTION_ID} />);
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("visualization-root").should("be.visible");
+
+      cy.button("Filter").should("be.visible");
+      cy.button("Summarize").should("be.visible");
+      cy.findByTestId("notebook-button").should("be.visible");
+    });
+  });
+});

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/BreakoutDropdown/BreakoutDropdown.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/BreakoutDropdown/BreakoutDropdown.tsx
@@ -9,6 +9,7 @@ import {
 import type { PopoverProps } from "metabase/ui";
 
 import { useSdkQuestionContext } from "../../../context";
+import { shouldRenderQueryBuilderEditingControl } from "../../../utils/should-render-query-builder-editing-control";
 import { ToolbarButton } from "../../util/ToolbarButton";
 import { BreakoutBadgeList } from "../BreakoutBadgeList";
 import { BreakoutPicker } from "../BreakoutPicker";
@@ -103,7 +104,7 @@ export const BreakoutDropdown = (
 ) => {
   const { question } = useSdkQuestionContext();
 
-  if (!question) {
+  if (!shouldRenderQueryBuilderEditingControl(question)) {
     return null;
   }
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/BreakoutDropdown/BreakoutDropdown.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/BreakoutDropdown/BreakoutDropdown.tsx
@@ -104,7 +104,7 @@ export const BreakoutDropdown = (
 ) => {
   const { question } = useSdkQuestionContext();
 
-  if (!shouldRenderQueryBuilderEditingControl(question)) {
+  if (!question || !shouldRenderQueryBuilderEditingControl(question)) {
     return null;
   }
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/EditorButton/EditorButton.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/EditorButton/EditorButton.tsx
@@ -29,17 +29,13 @@ export type EditorButtonProps = {
 
 function shouldShowEditButton({
   question,
-  isActionListVisible,
   isBrandNew = false,
 }: {
   question: Question;
-  isActionListVisible: boolean;
   isBrandNew?: boolean;
 }) {
   const { isEditable } = Lib.queryDisplayInfo(question.query());
-  return (
-    isEditable && isActionListVisible && !question.isArchived() && !isBrandNew
-  );
+  return isEditable && !question.isArchived() && !isBrandNew;
 }
 
 /**
@@ -55,19 +51,18 @@ export const EditorButton = ({
   ...actionIconProps
 }: EditorButtonProps) => {
   const { question } = useSdkQuestionContext();
+
+  if (!question || !shouldShowEditButton({ question })) {
+    return null;
+  }
+
   return (
-    question &&
-    shouldShowEditButton({
-      question,
-      isActionListVisible: true,
-    }) && (
-      <SdkActionIcon
-        tooltip={t`Edit question`}
-        icon="pencil_lines"
-        data-testid="notebook-button"
-        data-active={isOpen}
-        {...actionIconProps}
-      />
-    )
+    <SdkActionIcon
+      tooltip={t`Edit question`}
+      icon="pencil_lines"
+      data-testid="notebook-button"
+      data-active={isOpen}
+      {...actionIconProps}
+    />
   );
 };

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Filter/FilterDropdown/FilterDropdown.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Filter/FilterDropdown/FilterDropdown.tsx
@@ -12,6 +12,7 @@ import { getFilterItems } from "metabase/querying/filters/components/FilterPanel
 import type { PopoverProps } from "metabase/ui";
 
 import { useSdkQuestionContext } from "../../../context";
+import { shouldRenderQueryBuilderEditingControl } from "../../../utils/should-render-query-builder-editing-control";
 import { ToolbarButton } from "../../util/ToolbarButton";
 import { FilterBadgeList } from "../FilterBadgeList";
 import { FilterPicker } from "../FilterPicker/FilterPicker";
@@ -113,7 +114,7 @@ const FilterDropdownInner = ({
 export const FilterDropdown = ({ withColumnItemIcon }: FilterDropdownProps) => {
   const { question } = useSdkQuestionContext();
 
-  if (!question) {
+  if (!question || !shouldRenderQueryBuilderEditingControl(question)) {
     return null;
   }
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/SummarizeDropdown/SummarizeDropdown.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/SummarizeDropdown/SummarizeDropdown.tsx
@@ -9,7 +9,9 @@ import {
 } from "embedding-sdk-bundle/components/private/util/MultiStepPopover";
 import { type PopoverProps, Tooltip } from "metabase/ui";
 
+import { useSdkQuestionContext } from "../../../context";
 import { useStageChangeTooltip } from "../../../hooks/use-stage-change-tooltip";
+import { shouldRenderQueryBuilderEditingControl } from "../../../utils/should-render-query-builder-editing-control";
 import { ToolbarButton } from "../../util/ToolbarButton";
 import { SummarizeBadgeList } from "../SummarizeBadgeList";
 import {
@@ -48,6 +50,12 @@ export const SummarizeDropdown = ({
     useState<SDKAggregationItem>();
 
   const [step, setStep] = useState<MultiStepState<"picker" | "list">>(null);
+
+  const { question } = useSdkQuestionContext();
+
+  if (!shouldRenderQueryBuilderEditingControl(question)) {
+    return null;
+  }
 
   const onSelectBadge = (item?: SDKAggregationItem) => {
     setSelectedAggregationItem(item);

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/util/ToolbarButton/ToolbarButton.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/util/ToolbarButton/ToolbarButton.tsx
@@ -28,7 +28,7 @@ function _ToolbarButton(
         iconUrl ? (
           <img src={iconUrl} alt="" width={16} height={16} />
         ) : icon ? (
-          <Icon name={icon} />
+          <Icon name={icon} aria-hidden />
         ) : undefined
       }
       py="sm"

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/utils/should-render-query-builder-editing-control.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/utils/should-render-query-builder-editing-control.ts
@@ -4,9 +4,9 @@ import type Question from "metabase-lib/v1/Question";
 /**
  * Matches main app's FilterHeaderButton/QuestionSummarizeWidget/QuestionNotebookButton
  * gating. Three of the main app's conditions don't apply to the SDK and are omitted:
- * `queryBuilderMode` (no notebook-mode toggle exposed by the SDK), `isObjectDetail`
- * (the SDK hardcodes `isObjectDetail={false}` in Visualization.tsx), and
- * `isActionListVisible` (governs the legacy static/iframe embed's `action_buttons` option).
+ * - `queryBuilderMode` — no notebook-mode toggle exposed by the SDK
+ * - `isObjectDetail` — the SDK hardcodes `isObjectDetail={false}` in Visualization.tsx
+ * - `isActionListVisible` — governs the legacy static/iframe embed's `action_buttons` option
  */
 export function shouldRenderQueryBuilderEditingControl(
   question: Question | undefined,

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/utils/should-render-query-builder-editing-control.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/utils/should-render-query-builder-editing-control.ts
@@ -1,0 +1,21 @@
+import * as Lib from "metabase-lib";
+import type Question from "metabase-lib/v1/Question";
+
+/**
+ * Matches main app's FilterHeaderButton/QuestionSummarizeWidget/QuestionNotebookButton
+ * gating. Three of the main app's conditions don't apply to the SDK and are omitted:
+ * `queryBuilderMode` (no notebook-mode toggle exposed by the SDK), `isObjectDetail`
+ * (the SDK hardcodes `isObjectDetail={false}` in Visualization.tsx), and
+ * `isActionListVisible` (governs the legacy static/iframe embed's `action_buttons` option).
+ */
+export function shouldRenderQueryBuilderEditingControl(
+  question: Question | undefined,
+): boolean {
+  if (!question) {
+    return false;
+  }
+
+  const { isEditable, isNative } = Lib.queryDisplayInfo(question.query());
+
+  return isEditable && !isNative && !question.isArchived();
+}

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/utils/should-render-query-builder-editing-control.unit.spec.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/utils/should-render-query-builder-editing-control.unit.spec.ts
@@ -1,0 +1,80 @@
+import { createMockMetadata } from "__support__/metadata";
+import * as Lib from "metabase-lib";
+import {
+  DEFAULT_TEST_QUERY,
+  SAMPLE_DATABASE,
+  SAMPLE_METADATA,
+  SAMPLE_PROVIDER,
+} from "metabase-lib/test-helpers";
+import Question from "metabase-lib/v1/Question";
+import {
+  ORDERS_ID,
+  createSampleDatabase,
+} from "metabase-types/api/mocks/presets";
+
+import { shouldRenderQueryBuilderEditingControl } from "./should-render-query-builder-editing-control";
+
+const editableQuery = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
+const EDITABLE_QUESTION = Question.create({
+  metadata: SAMPLE_METADATA,
+}).setQuery(editableQuery);
+
+const ARCHIVED_QUESTION = EDITABLE_QUESTION.setCard({
+  ...EDITABLE_QUESTION.card(),
+  archived: true,
+});
+
+const NATIVE_QUESTION = Question.create({
+  metadata: SAMPLE_METADATA,
+  DEPRECATED_RAW_MBQL_type: "native",
+  DEPRECATED_RAW_MBQL_databaseId: SAMPLE_DATABASE.id,
+});
+
+// Mirrors what the backend does when create-queries permission is missing: `mi/can-read?`
+// on :model/Table requires create-queries, so the Orders table is excluded from metadata
+// entirely, which makes editable-stages? fall through to isEditable: false instead of
+// throwing (see src/metabase/warehouse_schema/models/table.clj).
+const sampleDatabase = createSampleDatabase();
+const databaseWithoutOrders = {
+  ...sampleDatabase,
+  tables: sampleDatabase.tables?.filter((table) => table.id !== ORDERS_ID),
+};
+const METADATA_WITHOUT_ORDERS = createMockMetadata({
+  databases: [databaseWithoutOrders],
+});
+const notEditableQuery = Lib.fromJsQueryAndMetadata(METADATA_WITHOUT_ORDERS, {
+  database: databaseWithoutOrders.id,
+  type: "query",
+  query: { "source-table": ORDERS_ID },
+});
+const NOT_EDITABLE_QUESTION = Question.create({
+  metadata: METADATA_WITHOUT_ORDERS,
+}).setQuery(notEditableQuery);
+
+describe("shouldRenderQueryBuilderEditingControl", () => {
+  it("returns false when there is no question", () => {
+    expect(shouldRenderQueryBuilderEditingControl(undefined)).toBe(false);
+  });
+
+  it("returns true for an editable, non-native, non-archived question", () => {
+    expect(shouldRenderQueryBuilderEditingControl(EDITABLE_QUESTION)).toBe(
+      true,
+    );
+  });
+
+  it("returns false when missing create-queries permission (isEditable: false)", () => {
+    expect(shouldRenderQueryBuilderEditingControl(NOT_EDITABLE_QUESTION)).toBe(
+      false,
+    );
+  });
+
+  it("returns false for a native query, even when editable", () => {
+    expect(shouldRenderQueryBuilderEditingControl(NATIVE_QUESTION)).toBe(false);
+  });
+
+  it("returns false for an archived question", () => {
+    expect(shouldRenderQueryBuilderEditingControl(ARCHIVED_QUESTION)).toBe(
+      false,
+    );
+  });
+});

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/utils/should-render-query-builder-editing-control.unit.spec.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/utils/should-render-query-builder-editing-control.unit.spec.ts
@@ -14,66 +14,71 @@ import {
 
 import { shouldRenderQueryBuilderEditingControl } from "./should-render-query-builder-editing-control";
 
-const editableQuery = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY);
-const EDITABLE_QUESTION = Question.create({
-  metadata: SAMPLE_METADATA,
-}).setQuery(editableQuery);
-
-const ARCHIVED_QUESTION = EDITABLE_QUESTION.setCard({
-  ...EDITABLE_QUESTION.card(),
-  archived: true,
-});
-
-const NATIVE_QUESTION = Question.create({
-  metadata: SAMPLE_METADATA,
-  DEPRECATED_RAW_MBQL_type: "native",
-  DEPRECATED_RAW_MBQL_databaseId: SAMPLE_DATABASE.id,
-});
-
-// Mirrors what the backend does when create-queries permission is missing: `mi/can-read?`
-// on :model/Table requires create-queries, so the Orders table is excluded from metadata
-// entirely, which makes editable-stages? fall through to isEditable: false instead of
-// throwing (see src/metabase/warehouse_schema/models/table.clj).
-const sampleDatabase = createSampleDatabase();
-const databaseWithoutOrders = {
-  ...sampleDatabase,
-  tables: sampleDatabase.tables?.filter((table) => table.id !== ORDERS_ID),
-};
-const METADATA_WITHOUT_ORDERS = createMockMetadata({
-  databases: [databaseWithoutOrders],
-});
-const notEditableQuery = Lib.fromJsQueryAndMetadata(METADATA_WITHOUT_ORDERS, {
-  database: databaseWithoutOrders.id,
-  type: "query",
-  query: { "source-table": ORDERS_ID },
-});
-const NOT_EDITABLE_QUESTION = Question.create({
-  metadata: METADATA_WITHOUT_ORDERS,
-}).setQuery(notEditableQuery);
-
 describe("shouldRenderQueryBuilderEditingControl", () => {
   it("returns false when there is no question", () => {
     expect(shouldRenderQueryBuilderEditingControl(undefined)).toBe(false);
   });
 
   it("returns true for an editable, non-native, non-archived question", () => {
-    expect(shouldRenderQueryBuilderEditingControl(EDITABLE_QUESTION)).toBe(
-      true,
+    const editableQuery = Lib.createTestQuery(
+      SAMPLE_PROVIDER,
+      DEFAULT_TEST_QUERY,
     );
+    const editableQuestion = Question.create({
+      metadata: SAMPLE_METADATA,
+    }).setQuery(editableQuery);
+
+    expect(shouldRenderQueryBuilderEditingControl(editableQuestion)).toBe(true);
   });
 
   it("returns false when missing create-queries permission (isEditable: false)", () => {
-    expect(shouldRenderQueryBuilderEditingControl(NOT_EDITABLE_QUESTION)).toBe(
+    // Mirrors the backend: create a query without create-queries permission.
+    const sampleDatabase = createSampleDatabase();
+    const databaseWithoutOrders = {
+      ...sampleDatabase,
+      tables: sampleDatabase.tables?.filter((table) => table.id !== ORDERS_ID),
+    };
+    const metadataWithoutOrders = createMockMetadata({
+      databases: [databaseWithoutOrders],
+    });
+    const notEditableQuery = Lib.fromJsQueryAndMetadata(metadataWithoutOrders, {
+      database: databaseWithoutOrders.id,
+      type: "query",
+      query: { "source-table": ORDERS_ID },
+    });
+    const notEditableQuestion = Question.create({
+      metadata: metadataWithoutOrders,
+    }).setQuery(notEditableQuery);
+
+    expect(shouldRenderQueryBuilderEditingControl(notEditableQuestion)).toBe(
       false,
     );
   });
 
   it("returns false for a native query, even when editable", () => {
-    expect(shouldRenderQueryBuilderEditingControl(NATIVE_QUESTION)).toBe(false);
+    const nativeQuestion = Question.create({
+      metadata: SAMPLE_METADATA,
+      DEPRECATED_RAW_MBQL_type: "native",
+      DEPRECATED_RAW_MBQL_databaseId: SAMPLE_DATABASE.id,
+    });
+
+    expect(shouldRenderQueryBuilderEditingControl(nativeQuestion)).toBe(false);
   });
 
   it("returns false for an archived question", () => {
-    expect(shouldRenderQueryBuilderEditingControl(ARCHIVED_QUESTION)).toBe(
+    const editableQuery = Lib.createTestQuery(
+      SAMPLE_PROVIDER,
+      DEFAULT_TEST_QUERY,
+    );
+    const editableQuestion = Question.create({
+      metadata: SAMPLE_METADATA,
+    }).setQuery(editableQuery);
+    const archivedQuestion = editableQuestion.setCard({
+      ...editableQuestion.card(),
+      archived: true,
+    });
+
+    expect(shouldRenderQueryBuilderEditingControl(archivedQuestion)).toBe(
       false,
     );
   });


### PR DESCRIPTION
Fixes EMB-1963

### Description

The SDK's Filter, Summarize, and Breakout components lack the logic to disable/hide themselves under certain conditions (e.g. missing `create-queries` permission). This PR brings them up to par with the core app.

### How to verify

1. `bun run build-hot`
2. `CYPRESS_TESTING_TYPE=component bun run test-cypress` and run the E2E test added in this PR (`e2e/test-component/scenarios/embedding-sdk/sdk-question-permissions.cy.spec.tsx`)
3. To confirm the test actually catches a regression: revert this PR's code, or simply patch `shouldRenderQueryBuilderEditingControl`https://github.com/metabase/metabase/blob/5c61fcf3187d787d08de352398a4a53cd977e02a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/utils/should-render-query-builder-editing-control.ts#L11-L21 to return `true` unconditionally — the test should then fail.

### Demo
#### After fix
<img width="1215" height="760" alt="image" src="https://github.com/user-attachments/assets/5f73b64e-86a5-40cf-a9c8-02add1c47915" />


#### Before fix
<img width="1216" height="761" alt="image" src="https://github.com/user-attachments/assets/6bdc85a5-044a-44f0-8fac-afe78729dafb" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)