### PR TITLE
Metabot catalog to include all curated entities

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -271,6 +271,10 @@
                             (or (contains? verified-ids id)
                                 (contains? official-cids collection_id)
                                 (contains? library-cids collection_id)))
+        ;; nil (not an always-false pred) when the filter is statically empty — curated-only with no
+        ;; curated content anywhere — so `pick-by-row` returns [] without walking the universe.
+        ;; The `(not curated-only?)` disjunct must stay in BOTH the guard and the pred: without the
+        ;; curated filter a nil pred would wrongly mean "empty catalog" instead of "no card filtering".
         in-metabot-card?  (when (and (or (nil? metabot-cids) (seq metabot-cids))
                                      (or (not curated-only?)
                                          (some seq [verified-ids official-cids library-cids])))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -271,10 +271,10 @@
                             (or (contains? verified-ids id)
                                 (contains? official-cids collection_id)
                                 (contains? library-cids collection_id)))
-        ;; nil (not an always-false pred) when the filter is statically empty — curated-only with no
-        ;; curated content anywhere — so `pick-by-row` returns [] without walking the universe.
-        ;; The `(not curated-only?)` disjunct must stay in BOTH the guard and the pred: without the
-        ;; curated filter a nil pred would wrongly mean "empty catalog" instead of "no card filtering".
+        ;; A nil pred makes `pick-by-row` return [] without walking the universe; used here when the
+        ;; card filter is statically empty (curated-only, but nothing anywhere is curated).
+        ;; The `(not curated-only?)` disjunct must stay in both the guard and the pred — dropping it
+        ;; from the guard would collapse an unfiltered scope into an empty catalog.
         in-metabot-card?  (when (and (or (nil? metabot-cids) (seq metabot-cids))
                                      (or (not curated-only?)
                                          (some seq [verified-ids official-cids library-cids])))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -184,17 +184,17 @@
             (collections/descendant-ids root)))))
 
 (defn- verified-card-id-set
-  "Set of Card ids whose most-recent moderation review is `verified`. Called only when
-   `metabot-scope` requests curated-only filtering — avoids a `moderation_review` join on the
-   universe Card select by pushing the check into a small auxiliary lookup."
+  "Set of Card ids whose most-recent moderation review is `verified`."
   []
+  ;; Called only when `metabot-scope` requests curated-only filtering — avoids a `moderation_review`
+  ;; join on the universe Card select by pushing the check into a small auxiliary lookup.
   (t2/select-fn-set :moderated_item_id :model/ModerationReview
                     :moderated_item_type "card"
                     :most_recent         true
                     :status              "verified"))
 
 (defn- official-collection-id-set
-  "Set of collection ids with `official` authority level — their Cards count as curated."
+  "Set of collection ids with `official` authority level."
   []
   (t2/select-fn-set :id :model/Collection :authority_level "official"))
 
@@ -219,24 +219,21 @@
     []))
 
 (defn- enumerate-catalogs
-  "One-pass enumeration of all three scoring catalogs. Returns
-   `{:library [...] :universe [...] :metabot [...]}` where entity maps are shared *by reference*
-   across catalogs — a Card or Table that appears in more than one catalog is one map in memory,
-   not three.
+  "One-pass enumeration of all three scoring catalogs.
+   Returns `{:library [...] :universe [...] :metabot [...]}` where entity maps are shared *by reference*
+   across catalogs — a Card or Table that appears in more than one catalog is one map in memory, not three.
 
-   An earlier revision fetched the three catalogs separately, which duplicated DB work up to 3×
-   per scoring run — most expensively on [[table-field-counts]] and [[table-measure-names]],
-   each a `GROUP BY` scan over `metabase_field` / `measure`. We now fetch the universe superset
-   once and derive the `:library` and `:metabot` subsets by in-memory filter, which collapses 6
-   DB round-trips + 2 auxiliaries into 4 + up-to-2 and lets the aggregates run once each.
-
-   `metabot-scope` is `{:curated-only? <bool> :collection-id <nil|Long>}` describing how the
-   internal Metabot narrows its retrieval further — it only adds filters, never widens.
-   `:curated-only?` mirrors Metabot search's `use_verified_content` filter: Cards must be
-   verified, in an official collection, or in the Library tree; Tables must satisfy
-   [[curation/curated?]]. The caller owns the scope decision (Metabot row lookup); this
-   namespace does not read settings, premium-feature gates, or Metabot rows directly."
+   `metabot-scope` is `{:curated-only? <bool> :collection-id <nil|Long>}` describing how the internal
+   Metabot narrows its retrieval further — it only adds filters, never widens.
+   `:curated-only?` mirrors Metabot search's `use_verified_content` filter (see [[curation/curated?]]).
+   The caller owns the scope decision (Metabot row lookup); this namespace does not read settings,
+   premium-feature gates, or Metabot rows directly."
   [{:keys [curated-only? collection-id]}]
+  ;; An earlier revision fetched the three catalogs separately, which duplicated DB work up to 3× per
+  ;; scoring run — most expensively on [[table-field-counts]] and [[table-measure-names]], each a
+  ;; `GROUP BY` scan over `metabase_field` / `measure`. We now fetch the universe superset once and
+  ;; derive the `:library` and `:metabot` subsets by in-memory filter, which collapses 6 DB round-trips
+  ;; + 2 auxiliaries into 4 + up-to-2 and lets the aggregates run once each.
   (let [library-cids      (library-collection-ids)
         metabot-cids      (metabot-collection-scope-ids collection-id)
         verified-ids      (when curated-only? (verified-card-id-set))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/complexity.clj
@@ -10,6 +10,7 @@
    [metabase.analytics.core :as analytics]
    [metabase.audit-app.core :as audit]
    [metabase.collections.core :as collections]
+   [metabase.collections.curation :as curation]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
@@ -184,13 +185,18 @@
 
 (defn- verified-card-id-set
   "Set of Card ids whose most-recent moderation review is `verified`. Called only when
-   `metabot-scope` requests verified-only filtering — avoids a `moderation_review` join on the
+   `metabot-scope` requests curated-only filtering — avoids a `moderation_review` join on the
    universe Card select by pushing the check into a small auxiliary lookup."
   []
   (t2/select-fn-set :moderated_item_id :model/ModerationReview
                     :moderated_item_type "card"
                     :most_recent         true
                     :status              "verified"))
+
+(defn- official-collection-id-set
+  "Set of collection ids with `official` authority level — their Cards count as curated."
+  []
+  (t2/select-fn-set :id :model/Collection :authority_level "official"))
 
 (defn- routed-child-database-id-set
   "Set of database ids whose `router_database_id` is non-nil — the routed child databases whose
@@ -224,25 +230,29 @@
    once and derive the `:library` and `:metabot` subsets by in-memory filter, which collapses 6
    DB round-trips + 2 auxiliaries into 4 + up-to-2 and lets the aggregates run once each.
 
-   `metabot-scope` is `{:verified-only? <bool> :collection-id <nil|Long>}` describing how the
-   internal Metabot narrows its Cards further — it only adds filters, never widens. The caller
-   owns the scope decision (premium-feature gate + Metabot row lookup); this namespace does not
-   read settings, premium-feature gates, or Metabot rows directly."
-  [{:keys [verified-only? collection-id]}]
+   `metabot-scope` is `{:curated-only? <bool> :collection-id <nil|Long>}` describing how the
+   internal Metabot narrows its retrieval further — it only adds filters, never widens.
+   `:curated-only?` mirrors Metabot search's `use_verified_content` filter: Cards must be
+   verified, in an official collection, or in the Library tree; Tables must satisfy
+   [[curation/curated?]]. The caller owns the scope decision (Metabot row lookup); this
+   namespace does not read settings, premium-feature gates, or Metabot rows directly."
+  [{:keys [curated-only? collection-id]}]
   (let [library-cids      (library-collection-ids)
         metabot-cids      (metabot-collection-scope-ids collection-id)
-        verified-ids      (when verified-only? (verified-card-id-set))
+        verified-ids      (when curated-only? (verified-card-id-set))
+        official-cids     (when curated-only? (official-collection-id-set))
         routed-db-ids     (routed-child-database-id-set)
-        ;; Extra columns (`:collection_id`, `:is_published`, `:visibility_type`, `:db_id`) are
-        ;; selected purely to drive the in-memory library/metabot derivations below — they're
-        ;; ignored by `->card-entity` / `->table-entity`. `:card_schema` is required by
-        ;; `:model/Card`'s post-select hooks even when we don't otherwise use it.
+        ;; Extra columns (`:collection_id`, `:is_published`, `:visibility_type`, `:db_id`,
+        ;; `:data_layer`, `:data_authority`) are selected purely to drive the in-memory
+        ;; library/metabot derivations below — they're ignored by `->card-entity` /
+        ;; `->table-entity`. `:card_schema` is required by `:model/Card`'s post-select hooks
+        ;; even when we don't otherwise use it.
         universe-cards    (t2/select [:model/Card :id :name :type :collection_id :card_schema]
                                      :type        [:in ["metric" "model"]]
                                      :archived    false
                                      :database_id [:not= audit/audit-db-id])
         universe-tables   (t2/select [:model/Table :id :name :collection_id :is_published
-                                      :visibility_type :db_id]
+                                      :visibility_type :db_id :data_layer :data_authority]
                                      :active true
                                      :db_id  [:not= audit/audit-db-id])
         field-counts      (table-field-counts  (mapv :id universe-tables))
@@ -256,16 +266,28 @@
                             (fn [{:keys [collection_id is_published]}]
                               (and is_published
                                    (contains? library-cids collection_id))))
+        ;; Set-membership mirror of [[curation/curated?]] for Cards (same shape as
+        ;; `metabase.metabot.tools.util/metabot-metrics-and-models-query`): verified, in an
+        ;; official collection, or in the Library tree (≡ `root_collection_type` is a library
+        ;; type, since library-typed collections only exist inside the Library root's tree).
+        curated-card?     (fn [{:keys [id collection_id]}]
+                            (or (contains? verified-ids id)
+                                (contains? official-cids collection_id)
+                                (contains? library-cids collection_id)))
         in-metabot-card?  (when (and (or (nil? metabot-cids) (seq metabot-cids))
-                                     (or (not verified-only?) (seq verified-ids)))
-                            (fn [{:keys [collection_id id]}]
+                                     (or (not curated-only?)
+                                         (some seq [verified-ids official-cids library-cids])))
+                            (fn [{:keys [collection_id] :as card-row}]
                               (and (or (nil? metabot-cids)
                                        (contains? metabot-cids collection_id))
-                                   (or (not verified-only?)
-                                       (contains? verified-ids id)))))
-        in-metabot-table? (fn [{:keys [visibility_type db_id]}]
+                                   (or (not curated-only?)
+                                       (curated-card? card-row)))))
+        in-metabot-table? (fn [{:keys [visibility_type db_id] :as table-row}]
                             (and (nil? visibility_type)
-                                 (not (contains? routed-db-ids db_id))))]
+                                 (not (contains? routed-db-ids db_id))
+                                 (or (not curated-only?)
+                                     (curation/curated? (assoc (select-keys table-row [:is_published :data_layer :data_authority])
+                                                               :model "table")))))]
     {:universe (into card-entities table-entities)
      :library  (into (pick-by-row in-library-card?  universe-cards  card-entities)
                      (pick-by-row in-library-table? universe-tables table-entities))
@@ -572,8 +594,8 @@
     `:text-variant`         — preprocessing variant published into `:meta.text-variant`. Pass nil
                               to omit (the search-index path passes nil because its preprocessing
                               isn't a single named variant).
-    `:metabot-scope`        — `{:verified-only? <bool> :collection-id <nil|Long>}` describing how
-                              the internal Metabot filters Cards.
+    `:metabot-scope`        — `{:curated-only? <bool> :collection-id <nil|Long>}` describing how
+                              the internal Metabot filters its retrieval; see [[enumerate-catalogs]].
     `:emit-snowplow?`       — whether to publish per-score Snowplow events. Defaults true."
   [& {:keys [embedder embedding-model-meta text-variant metabot-scope emit-snowplow?]
       :or {emit-snowplow? true}}]

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/metabot_scope.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/metabot_scope.clj
@@ -5,11 +5,13 @@
    [toucan2.core :as t2]))
 
 (defn internal-metabot-scope
-  "`{:curated-only? <bool> :collection-id <nil|Long>}` matching the filters Metabot search applies.
-  `use_verified_content` means \"verified or curated content only\" (see `metabase.metabot.models.metabot`);
-  no premium-feature gate, mirroring the search index's precomputed `curated` column."
+  "`{:curated-only? <bool> :collection-id <nil|Long>}` matching the filters Metabot search applies."
   []
   (let [entity-id (get-in metabot.config/metabot-config [metabot.config/internal-metabot-id :entity-id])
         metabot   (t2/select-one :model/Metabot :entity_id entity-id)]
+    ;; `use_verified_content` means "verified or curated content only" (see the note in
+    ;; `metabase.metabot.models.metabot`). No premium-feature gate, mirroring the search index's
+    ;; precomputed `curated` column: a curation signal can only be set while its feature is present,
+    ;; so the signals are already feature-correct.
     {:curated-only? (boolean (:use_verified_content metabot))
      :collection-id (:collection_id metabot)}))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/metabot_scope.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/metabot_scope.clj
@@ -2,14 +2,14 @@
   "Resolves the internal Metabot's retrieval scope for the `:metabot` catalog."
   (:require
    [metabase.metabot.config :as metabot.config]
-   [metabase.premium-features.core :as premium-features]
    [toucan2.core :as t2]))
 
 (defn internal-metabot-scope
-  "`{:verified-only? <bool> :collection-id <nil|Long>}` matching what Metabot's Card query would apply."
+  "`{:curated-only? <bool> :collection-id <nil|Long>}` matching the filters Metabot search applies.
+  `use_verified_content` means \"verified or curated content only\" (see `metabase.metabot.models.metabot`);
+  no premium-feature gate, mirroring the search index's precomputed `curated` column."
   []
   (let [entity-id (get-in metabot.config/metabot-config [metabot.config/internal-metabot-id :entity-id])
         metabot   (t2/select-one :model/Metabot :entity_id entity-id)]
-    {:verified-only? (and (boolean (:use_verified_content metabot))
-                          (premium-features/has-feature? :content-verification))
-     :collection-id  (:collection_id metabot)}))
+    {:curated-only? (boolean (:use_verified_content metabot))
+     :collection-id (:collection_id metabot)}))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/representation.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/representation.clj
@@ -18,8 +18,8 @@
   Library membership is derived from `Collection.type = \"library\"` plus the `parent_id` chain.
 
   Caveats vs. the live appdb scorer in [[metabase-enterprise.data-complexity-score.complexity]]:
-    - `:metabot` catalog: requires premium-feature gates and a Metabot config row that aren't in
-      an export. The CLI flags `:metabot` as a universe fallback (see `cli/run-cli`)."
+    - `:metabot` catalog: requires a Metabot config row that isn't in an export. The CLI flags
+      `:metabot` as a universe fallback (see `cli/run-cli`)."
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/api_test.clj
@@ -231,8 +231,8 @@
                   (format "%s :synonym_pairs (%s) can't exceed n*(n-1)/2 for n=%s" catalog syn-pairs n-entities)))))))))
 
 (deftest ^:sequential complexity-endpoint-force-recalculation-metabot-catalog-test
-  (testing ":metabot mirrors :universe when neither content-verification nor use_verified_content is active"
-    ;; Pin both gates explicitly instead of relying on test-env defaults — the reused-verbatim path
+  (testing ":metabot mirrors :universe when use_verified_content is off"
+    ;; Pin the setting explicitly instead of relying on test-env defaults — the unfiltered path
     ;; is only exercised when the scope is empty, and we want this assertion to keep passing even
     ;; if the ambient defaults shift.
     (mt/with-premium-features #{}
@@ -241,23 +241,28 @@
         (mt/with-dynamic-fn-redefs [data-complexity-score/record-score! (fn [& _] nil)]
           (let [resp (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)]
             (is (= (:universe resp) (:metabot resp))))))))
-  (testing ":metabot is scored separately when :content-verification + use_verified_content are both active"
-    ;; Positive path: verified-only filtering restricts Cards to those with an active verified
-    ;; moderation review. We inject a fresh unverified Card so the assertion doesn't depend on
-    ;; ambient test-env content — the `:universe` count includes this Card, `:metabot` excludes it.
-    (mt/with-premium-features #{:content-verification}
+  (testing ":metabot is narrowed to curated content when use_verified_content is on — with no premium-feature gate"
+    ;; Positive path: curated-only filtering restricts Cards and Tables to curated ones. We inject
+    ;; a fresh uncurated Card + Table so the assertion doesn't depend on ambient test-env content —
+    ;; the `:universe` count includes them, `:metabot` excludes them. Premium features are pinned
+    ;; OFF to guard against reintroducing the old :content-verification gate (curated-only
+    ;; filtering mirrors the search index's precomputed `curated` column, which has no runtime gate).
+    (mt/with-premium-features #{}
       (mt/with-temp [:model/Database {db-id :id} {}
                      :model/Card    _           {:database_id db-id
                                                  :type        :model
-                                                 :name        "Unverified Only Card"
-                                                 :archived    false}]
+                                                 :name        "Uncurated Card"
+                                                 :archived    false}
+                     :model/Table   _           {:db_id  db-id
+                                                 :name   "uncurated_table"
+                                                 :active true}]
         (mt/with-temp-vals-in-db :model/Metabot (internal-metabot-id)
                                  {:use_verified_content true :collection_id nil}
           (mt/with-dynamic-fn-redefs [data-complexity-score/record-score! (fn [& _] nil)]
             (let [resp (mt/user-http-request :crowberto :get 200 endpoint :force-recalculation true)]
               (is (< (get-in resp [:metabot  :components :size :components :entity_count :measurement])
                      (get-in resp [:universe :components :size :components :entity_count :measurement]))
-                  ":metabot entity-count must be strictly < :universe when verified-only filters out the injected Card"))))))))
+                  ":metabot entity-count must be strictly < :universe when curated-only filters out the injected uncurated Card/Table"))))))))
 
 (deftest ^:sequential complexity-endpoint-force-recalculation-metabot-collection-scope-test
   (testing ":metabot is scoped to the internal Metabot's collection_id subtree (root + descendants)"
@@ -267,10 +272,10 @@
     ;;   sibling    → holds the out-of-subtree Card
     ;;   empty      → no Cards; baseline scope so we can pin *exact* card-count deltas
     ;;
-    ;; Tables pass through :metabot unfiltered, so ambient table counts cancel when we take
-    ;; differentials against `empty`. That leaves us a clean count of Cards visible under each
-    ;; scope, which lets us assert exact expected counts rather than relative inequalities.
-    ;; Pin premium features off explicitly so `:verified-only?` can't drift in and confound.
+    ;; With use_verified_content off, Tables only get the visibility/routed-DB filter — identical
+    ;; across scopes — so ambient table counts cancel when we take differentials against `empty`.
+    ;; That leaves us a clean count of Cards visible under each scope, which lets us assert exact
+    ;; expected counts rather than relative inequalities.
     (mt/with-premium-features #{}
       (mt/with-temp [:model/Collection {parent-id :id}  {:name "Metabot Scope Parent"
                                                          :location "/"}
@@ -401,22 +406,21 @@
           (is (= 2 @call-count)))))))
 
 (deftest internal-metabot-scope-test
-  (testing ":verified-only? is true only when the premium feature + use_verified_content both apply"
-    (doseq [{:keys [features use-verified? expected-verified?]}
-            [{:features #{}                        :use-verified? false :expected-verified? false}
-             {:features #{}                        :use-verified? true  :expected-verified? false}
-             {:features #{:content-verification}   :use-verified? false :expected-verified? false}
-             {:features #{:content-verification}   :use-verified? true  :expected-verified? true}]]
+  (testing ":curated-only? mirrors use_verified_content regardless of premium features"
+    ;; No feature gate, matching the search index's precomputed `curated` column: a curation signal
+    ;; can only be set while its feature is present, so the signals are already feature-correct.
+    (doseq [features      [#{} #{:content-verification}]
+            use-verified? [false true]]
       (testing (format "features=%s use_verified_content=%s" (pr-str features) use-verified?)
         (mt/with-premium-features features
           (mt/with-temp-vals-in-db :model/Metabot (internal-metabot-id)
                                    {:use_verified_content use-verified? :collection_id nil}
-            (is (= {:verified-only? expected-verified? :collection-id nil}
+            (is (= {:curated-only? use-verified? :collection-id nil}
                    (metabot-scope/internal-metabot-scope))))))))
   (testing ":collection-id is read straight from the internal Metabot row regardless of premium features"
     (mt/with-temp [:model/Collection {coll-id :id} {:name "metabot scope test coll"}]
       (mt/with-premium-features #{}
         (mt/with-temp-vals-in-db :model/Metabot (internal-metabot-id)
                                  {:use_verified_content false :collection_id coll-id}
-          (is (= {:verified-only? false :collection-id coll-id}
+          (is (= {:curated-only? false :collection-id coll-id}
                  (metabot-scope/internal-metabot-scope))))))))

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -373,7 +373,7 @@
          :model/Table {plain-table :id}   {:db_id db-id :active true :name "curated_scope_plain_table"}
          :model/Table {hidden-auth :id}   {:db_id db-id :active true :name "curated_scope_hidden_authoritative"
                                            :visibility_type "hidden" :data_authority :authoritative}]
-        (let [metabot (:metabot (#'complexity/enumerate-catalogs {:curated-only? true}))
+        (let [metabot (:metabot (#'complexity/enumerate-catalogs {:curated-only? true :collection-id nil}))
               in?     (comp boolean (into #{} (map (juxt :kind :id)) metabot) vector)]
           (is (= {:verified-card       true
                   :official-card       true

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -263,7 +263,7 @@
               (format ":error must be a nonblank string when the throwable's message is %s" label)))))))
 
 (deftest ^:sequential complexity-scores-metabot-scope-opt-test
-  (testing ":verified-only? true flows the caller's metabot-scope through to enumerate-catalogs"
+  (testing ":curated-only? true flows the caller's metabot-scope through to enumerate-catalogs"
     (let [captured-scope (atom nil)]
       (mt/with-dynamic-fn-redefs [complexity/enumerate-catalogs
                                   (fn [scope]
@@ -273,12 +273,12 @@
                                      :metabot  [(entity :name "orders")]})]
         (let [{:keys [universe metabot]} (complexity/complexity-scores
                                           :embedder nil
-                                          :metabot-scope {:verified-only? true :collection-id nil})]
-          (is (= {:verified-only? true :collection-id nil} @captured-scope)
+                                          :metabot-scope {:curated-only? true :collection-id nil})]
+          (is (= {:curated-only? true :collection-id nil} @captured-scope)
               "enumerate-catalogs was invoked with the caller's scope")
           (is (= 1.0 (get-in metabot  [:components :size :components :entity-count :measurement])))
           (is (= 2.0 (get-in universe [:components :size :components :entity-count :measurement])))))))
-  (testing ":collection-id alone also flows through to enumerate-catalogs (no verified flag required)"
+  (testing ":collection-id alone also flows through to enumerate-catalogs (no curated flag required)"
     (let [captured-scope (atom nil)]
       (mt/with-dynamic-fn-redefs [complexity/enumerate-catalogs
                                   (fn [scope]
@@ -288,14 +288,14 @@
                                      :metabot  [(entity :name "orders")]})]
         (let [{:keys [metabot]} (complexity/complexity-scores
                                  :embedder nil
-                                 :metabot-scope {:verified-only? false :collection-id 42})]
-          (is (= {:verified-only? false :collection-id 42} @captured-scope))
+                                 :metabot-scope {:curated-only? false :collection-id 42})]
+          (is (= {:curated-only? false :collection-id 42} @captured-scope))
           (is (= 1.0 (get-in metabot [:components :size :components :entity-count :measurement])))))))
   (testing "empty scope (or no :metabot-scope opt) still runs enumerate-catalogs with that scope so metabot's table-visibility filter still narrows the catalog"
     ;; Regression: we used to reuse the :universe score verbatim when scope was empty. That hid the
     ;; fact that Metabot's table visibility (`:visibility_type nil`, non-routed DB) already narrows
     ;; the catalog even before Card scoping kicks in.
-    (doseq [scope [nil {} {:verified-only? false :collection-id nil}]]
+    (doseq [scope [nil {} {:curated-only? false :collection-id nil}]]
       (let [captured-scope (atom ::not-called)]
         (mt/with-dynamic-fn-redefs [complexity/enumerate-catalogs
                                     (fn [s]
@@ -341,6 +341,60 @@
         (testing "tables on a routed database are excluded"
           (is (not (contains? ids routed))
               "tables whose db has router_database_id are filtered out"))))))
+
+(deftest ^:sequential metabot-catalog-curated-scope-test
+  (testing "{:curated-only? true} restricts the :metabot catalog to curated Cards AND Tables,
+           mirroring the `curated` filter Metabot search applies when use_verified_content is on"
+    (collections.tu/with-library [{:keys [metrics]}]
+      (mt/with-temp
+        [:model/Database   {db-id :id}    {:name "Curated Scope DB"}
+         :model/Collection {official :id} {:name "Curated Scope Official" :authority_level "official"}
+         :model/Card {verified-card :id}  {:database_id db-id :type :model :archived false
+                                           :name "curated_scope_verified_card"}
+         :model/ModerationReview _        {:moderated_item_id   verified-card
+                                           :moderated_item_type "card"
+                                           :moderator_id        (mt/user->id :crowberto)
+                                           :status              "verified"
+                                           :most_recent         true}
+         :model/Card {official-card :id}  {:database_id db-id :type :model :archived false
+                                           :collection_id official
+                                           :name "curated_scope_official_card"}
+         :model/Card {library-card :id}   {:database_id db-id :type :metric :archived false
+                                           :collection_id (:id metrics)
+                                           :name "curated_scope_library_card"}
+         :model/Card {plain-card :id}     {:database_id db-id :type :model :archived false
+                                           :name "curated_scope_plain_card"}
+         :model/Table {authoritative :id} {:db_id db-id :active true :name "curated_scope_authoritative"
+                                           :data_authority :authoritative}
+         :model/Table {pub-final :id}     {:db_id db-id :active true :name "curated_scope_published_final"
+                                           :is_published true :data_layer :final}
+         :model/Table {pub-internal :id}  {:db_id db-id :active true :name "curated_scope_published_internal"
+                                           :is_published true :data_layer :internal}
+         :model/Table {plain-table :id}   {:db_id db-id :active true :name "curated_scope_plain_table"}
+         :model/Table {hidden-auth :id}   {:db_id db-id :active true :name "curated_scope_hidden_authoritative"
+                                           :visibility_type "hidden" :data_authority :authoritative}]
+        (let [metabot (:metabot (#'complexity/enumerate-catalogs {:curated-only? true}))
+              in?     (comp boolean (into #{} (map (juxt :kind :id)) metabot) vector)]
+          (is (= {:verified-card       true
+                  :official-card       true
+                  :library-card        true
+                  :plain-card          false
+                  :authoritative-table true
+                  :published-final     true
+                  :published-internal  false
+                  :plain-table         false
+                  :hidden-authoritative false}
+                 {:verified-card        (in? :model  verified-card)
+                  :official-card        (in? :model  official-card)
+                  :library-card         (in? :metric library-card)
+                  :plain-card           (in? :model  plain-card)
+                  :authoritative-table  (in? :table  authoritative)
+                  :published-final      (in? :table  pub-final)
+                  :published-internal   (in? :table  pub-internal)
+                  :plain-table          (in? :table  plain-table)
+                  :hidden-authoritative (in? :table  hidden-auth)})
+              "curated Cards (verified / official / library) and curated Tables (authoritative /
+               published-final) are in; uncurated entities and hidden tables stay out"))))))
 
 (deftest ^:sequential metabot-collection-scope-ids-test
   (testing "nil collection-id returns nil (no Metabot collection scope configured)"

--- a/src/metabase/collections/curation.clj
+++ b/src/metabase/collections/curation.clj
@@ -35,6 +35,8 @@
       engine SQL filter
     - metabase.metabot.tools.util/metabot-metrics-and-models-query — suggested-prompt source filter
     - metabase.metabot.curation/curated-ids — source-of-truth check for recent views
+    - metabase-enterprise.data-complexity-score.complexity/enumerate-catalogs — set-membership mirror
+      for the `:metabot` catalog's Cards (Tables call [[curated?]] directly)
     - metabase-enterprise.semantic-search.db.migration.impl/add-data-authority-and-curated-columns! —
       recomputes the precomputed `curated` column for existing index rows
 


### PR DESCRIPTION
Closes BOT-1728

## Problem

The Data Complexity Score's `:metabot` catalog is meant to model what the internal Metabot can actually surface, but it drifted from Metabot's real retrieval path:

- Cards were filtered by **verified-only**, gated on the `:content-verification` premium feature.
- Tables passed through with only the visibility/routed-DB filter.

Metabot search (`metabase.metabot.tools.search/search`) instead applies `:curated true` to the search context when `use_verified_content` is on, which filters **both Cards and Tables** by the canonical `metabase.collections.curation/curated?` rule via the search index's precomputed `curated` column. So the catalog undercounted curated-but-unverified Cards and overcounted uncurated Tables.

## Fix

Align the `:metabot` catalog with the curated rule:

- `metabot-scope/internal-metabot-scope` now returns `{:curated-only? ... :collection-id ...}`, read straight from `use_verified_content` with **no premium-feature gate** — matching the index column, whose signals are feature-correct by construction (a signal can only be set while its feature is present).
- **Cards**: curated = verified OR official-collection OR Library-tree membership (set-membership mirror of `curated?`, same shape as `metabot-metrics-and-models-query`; registered in `curated?`'s keep-in-sync docstring list).
- **Tables**: `curation/curated?` applied directly (`data_authority = authoritative`, or `is_published` + `data_layer = final`), ANDed with the existing visibility/routed-DB filters.

Collection-id scoping is unchanged. The Snowplow `catalog` enum is untouched (`metabot` stays `metabot`); renaming to `curated` is tracked separately since schema 1-0-0 has shipped and an enum change needs a 1-0-1 bump through the iglu registry.

## Tests

- New `metabot-catalog-curated-scope-test`: full in/out matrix — verified/official/library Cards in, plain Card out; authoritative and published-final Tables in, published-internal / plain / hidden-authoritative Tables out.
- API catalog test now pins premium features **off** with `use_verified_content` on, guarding against reintroducing the feature gate.
- Scope truth-table test rewritten for the ungated `:curated-only?` semantics.
