### PR TITLE
Support OSI ai_context string shorthand 

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/osi_ai_context_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/osi_ai_context_test.clj
@@ -121,6 +121,17 @@
         (is (=? {:ai_context {:instructions "v2"}}
                 (t2/select-one :model/OsiAiContext :entity_type "card" :entity_local_id card-id)))))))
 
+(deftest string-ai-context-import-coerces-to-instructions-test
+  (testing "an OSI string-shorthand ai_context imports as {:instructions s} — serdes copies it verbatim and
+           the model transform normalizes it on write, so no read path sees a naked string"
+    (mt/with-temp [:model/Card {card-id :id} {}
+                   :model/OsiAiContext _ {:entity_type "metric" :entity_local_id card-id
+                                          :ai_context {:instructions "object form"}}]
+      (let [extracted (assoc (extract-for "card" card-id) :ai_context "just the instructions")]
+        (serdes.load/load-metabase! (ingestion-in-memory [extracted]))
+        (is (=? {:ai_context {:instructions "just the instructions"}}
+                (t2/select-one :model/OsiAiContext :entity_type "card" :entity_local_id card-id)))))))
+
 (deftest disk-round-trip-card-context-test
   (testing "a card-backed ai_context survives a real on-disk store/ingest/load (storage-path handles a non-table parent)"
     (mt/with-temp [:model/Card {card-id :id} {}

--- a/src/metabase/osi/ai_context/api.clj
+++ b/src/metabase/osi/ai_context/api.clj
@@ -6,6 +6,7 @@
    [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as app-db]
    [metabase.entity-retrieval.core :as entity-retrieval]
+   [metabase.osi.models.osi-ai-context :as osi-ai-context]
    [metabase.request.core :as request]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
@@ -33,6 +34,16 @@
    [:instructions {:optional true} [:maybe [:string {:max entity-retrieval/max-instructions-len}]]]
    [:synonyms     {:optional true} [:sequential {:max max-list-len} [:string {:max max-item-len}]]]
    [:examples     {:optional true} [:sequential {:max max-list-len} [:string {:max max-item-len}]]]])
+
+(def ^:private AiContextInput
+  "Accepted write shape for `ai_context` — the OSI `AIContext` oneOf.
+
+  It is either an [[AiContext]] object or the bare-string shorthand. `:decode/api` folds the string into
+  `{:instructions s}` before validation, so:
+
+    - a string is length-capped as the `:instructions` it becomes, and
+    - validation (and every read) only ever sees the object form."
+  (into [:map {:decode/api osi-ai-context/->ai-context}] (rest AiContext)))
 
 (def ^:private Entry
   "An ai_context row as returned on reads. `entity_type` is any string: a row can predate a type's
@@ -96,7 +107,7 @@
   upsert keep two concurrent writers from racing in a duplicate row."
   [{:keys [entity-type entity-local-id]} :- logical-key-route-schema
    _query-params
-   {:keys [ai_context]} :- [:map [:ai_context AiContext]]]
+   {:keys [ai_context]} :- [:map [:ai_context AiContextInput]]]
   (api/check-superuser)
   (api/check-400 (contains? writable-entity-types entity-type)
                  "entity_type must be one of: measure, metric, model, segment, table")

--- a/src/metabase/osi/ai_context/api.clj
+++ b/src/metabase/osi/ai_context/api.clj
@@ -8,6 +8,7 @@
    [metabase.entity-retrieval.core :as entity-retrieval]
    [metabase.osi.models.osi-ai-context :as osi-ai-context]
    [metabase.request.core :as request]
+   [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
@@ -43,7 +44,7 @@
 
     - a string is length-capped as the `:instructions` it becomes, and
     - validation (and every read) only ever sees the object form."
-  (into [:map {:decode/api osi-ai-context/->ai-context}] (rest AiContext)))
+  (mu/with AiContext {:decode/api osi-ai-context/->ai-context}))
 
 (def ^:private Entry
   "An ai_context row as returned on reads. `entity_type` is any string: a row can predate a type's

--- a/src/metabase/osi/models/osi_ai_context.clj
+++ b/src/metabase/osi/models/osi_ai_context.clj
@@ -31,9 +31,23 @@
 ;; The logical (entity_type, entity_local_id) pair is the primary key — no surrogate id.
 (methodical/defmethod t2/primary-keys :model/OsiAiContext [_model] [:entity_type :entity_local_id])
 
+(defn ->ai-context
+  "Coerce the OSI `ai_context` oneOf into the object form we store.
+
+    \"count new signups\"  =>  {:instructions \"count new signups\"}   ; string shorthand
+    {:synonyms [...]}     =>  {:synonyms [...]}                    ; already an object
+    nil                   =>  nil
+
+  Runs ahead of [[mi/json-in]], which would otherwise store the string verbatim as pre-serialized JSON."
+  [ai-context]
+  (if (string? ai-context) {:instructions ai-context} ai-context))
+
 (t2/deftransforms :model/OsiAiContext
-  ;; ai_context is keywordized on read so reconcile reads (:instructions ai_context) etc. directly.
-  {:ai_context mi/transform-json})
+  ;; ai_context is keywordized on read so reconcile reads (:instructions ai_context) etc. directly. On write
+  ;; the string shorthand is migrated to {:instructions s}, so storage is always the object form and every
+  ;; write path (CRUD API, serdes import, direct appdb write) is normalized at this one boundary.
+  {:ai_context {:in  (comp mi/json-in ->ai-context)
+                :out mi/json-out-with-keywordization}})
 
 ;;; Card-backed entities (question/metric/model) store their `entity_type` as the canonical `card`, so one
 ;;; ai_context row survives a type relabel and keys on a stable `(card, entity_local_id)`. The CRUD and tool

--- a/test/metabase/osi/ai_context/api_test.clj
+++ b/test/metabase/osi/ai_context/api_test.clj
@@ -88,11 +88,22 @@
       (is (=? {:entity_type "measure" :entity_local_id 77 :ai_context {:instructions "same"}}
               (mt/user-http-request :crowberto :put 200 "osi/ai-context/measure/77" {:ai_context {:instructions "same"}})))
       (finally (t2/delete! :model/OsiAiContext :entity_type "measure" :entity_local_id 77))))
+  (testing "the OSI string shorthand for ai_context is accepted and migrated to {:instructions s}"
+    (try
+      (is (=? {:entity_type     "table"
+               :entity_local_id 3
+               :ai_context      {:instructions "Use for revenue questions."}}
+              (mt/user-http-request :crowberto :put 200 "osi/ai-context/table/3"
+                                    {:ai_context "Use for revenue questions."})))
+      (finally (t2/delete! :model/OsiAiContext :entity_type "table" :entity_local_id 3))))
   (testing "ai_context is required"
     (mt/user-http-request :crowberto :put 400 "osi/ai-context/table/1" {}))
   (testing "an over-long instructions string is rejected"
     (mt/user-http-request :crowberto :put 400 "osi/ai-context/table/1"
                           {:ai_context {:instructions (apply str (repeat 6000 "x"))}}))
+  (testing "an over-long string shorthand is rejected (capped like instructions, which it becomes)"
+    (mt/user-http-request :crowberto :put 400 "osi/ai-context/table/1"
+                          {:ai_context (apply str (repeat 6000 "x"))}))
   (testing "too many synonyms is rejected"
     (mt/user-http-request :crowberto :put 400 "osi/ai-context/table/1"
                           {:ai_context {:synonyms (mapv str (range 51))}}))

--- a/test/metabase/osi/models/osi_ai_context_test.clj
+++ b/test/metabase/osi/models/osi_ai_context_test.clj
@@ -33,6 +33,12 @@
     (mt/with-temp [:model/OsiAiContext _ (assoc entity :ai_context {:instructions "Just this."})]
       (is (= {:instructions "Just this."} (:ai_context (by-key entity)))))))
 
+(deftest string-ai-context-migrates-to-instructions-test
+  (testing "the OSI string shorthand is migrated to {:instructions s} on write, so storage is always the
+           object form (this covers every write path — the coercion is in the model transform, not the API)"
+    (mt/with-temp [:model/OsiAiContext _ (assoc entity :ai_context "Use for revenue questions.")]
+      (is (= {:instructions "Use for revenue questions."} (:ai_context (by-key entity)))))))
+
 (deftest hooks-nudge-a-targeted-reconcile-test
   (testing "insert, update and delete each nudge the entity's reconcile once — deferred until the txn commits"
     (let [nudges (atom [])


### PR DESCRIPTION
## What

The OSI `AIContext` type is a `oneOf`: either a structured object (`{instructions, synonyms[], examples[]}`) or a **bare string** that is shorthand for the instructions. We only modelled the object form, so a string was:

- **rejected** at the `osi_ai_context` CRUD API, and — worse —
- **copied verbatim** on the serdes / direct-appdb-write paths, where it read back as a naked string that every read path (`(:instructions …)`, `(:synonyms …)`) then silently saw as `nil`.

This PR migrates the string to `{:instructions s}` **at the storage boundary**, so we honour the OSI shorthand instead of dropping it.

## How

- **`osi-ai-context/->ai-context`** runs ahead of `mi/json-in` in the model's `:ai_context` transform `:in`. Every write path (CRUD API, serdes import, direct appdb write) is normalized at this one point, so storage is always the object form and no read path ever sees a naked string.
- The **write API** reuses that same fn via a `:decode/api` property on the body schema, folding a bare string to `{:instructions s}` *before* validation — so the string is length-capped as the `:instructions` it becomes, and both validation and reads only ever see the object form.
  - Using `:decode/api` (coerce-then-validate) rather than an `[:or :string AiContext]` schema is deliberate: a mixed scalar/nested `:or` error path crashes Metabase's error humanizer (`invalid-params-errors` `assoc-in` → `String cannot be cast to Associative`, turning 400s into 500s).

`synonyms`/`examples` are unchanged — they already matched the upstream type (array of strings).

## Tests

- `osi-ai-context-test` — the model transform coerces a bare string (covers serdes / direct writes).
- `osi.ai-context.api-test` — the API accepts the string form and returns the object form; an over-long string is still rejected via the instructions cap.
- `serialization.v2.osi-ai-context-test` — a string-shorthand `ai_context` imports as `{:instructions s}`.

All green locally.