### PR TITLE
Block form submissions in data apps via CSP

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/components/public/debug/DevToolbar/diagnostics.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/debug/DevToolbar/diagnostics.ts
@@ -44,6 +44,20 @@ const formatArg = (arg: unknown): string => {
   }
 };
 
+/**
+ * Format a CSP violation for the toolbar. The dev server mirrors Metabase's
+ * production CSP, so a violation here means the app would be blocked once
+ * sandboxed in Metabase too — e.g. a native `<form action="…">` hitting
+ * `form-action 'none'`, or a `fetch` to a host outside `allowed_hosts`. These
+ * never reach `console.error`, so the toolbar wouldn't see them otherwise.
+ */
+const formatCspViolation = (event: SecurityPolicyViolationEvent): string => {
+  const directive = event.effectiveDirective || event.violatedDirective;
+  const target = event.blockedURI || "inline content";
+
+  return `Content Security Policy (${directive}) blocked ${target}`;
+};
+
 const record = (level: DevDiagnosticLevel, message: string) => {
   // New array reference each time so `useSyncExternalStore` re-renders.
   entries = [...entries, { id: nextId++, time: Date.now(), level, message }];
@@ -92,5 +106,9 @@ export const installDevDiagnostics = (): void => {
 
   window.addEventListener("unhandledrejection", (event) => {
     record("error", `Unhandled rejection: ${formatArg(event.reason)}`);
+  });
+
+  window.addEventListener("securitypolicyviolation", (event) => {
+    record("error", formatCspViolation(event));
   });
 };

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/debug/DevToolbar/diagnostics.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/debug/DevToolbar/diagnostics.unit.spec.ts
@@ -77,6 +77,38 @@ describe("dev diagnostics store", () => {
     expect(last(getDevDiagnostics()).message).toBe("Unhandled rejection: nope");
   });
 
+  it("captures CSP form-action violations (e.g. a blocked native form submit)", () => {
+    const event = new Event("securitypolicyviolation") as Event &
+      Partial<SecurityPolicyViolationEvent>;
+    Object.assign(event, {
+      effectiveDirective: "form-action",
+      violatedDirective: "form-action",
+      blockedURI: "https://example.com/",
+      originalPolicy: "connect-src 'self'; form-action 'none'",
+    });
+    window.dispatchEvent(event);
+
+    expect(last(getDevDiagnostics()).message).toBe(
+      "Content Security Policy (form-action) blocked https://example.com/",
+    );
+  });
+
+  it("formats other CSP violations generically (e.g. connect-src)", () => {
+    const event = new Event("securitypolicyviolation") as Event &
+      Partial<SecurityPolicyViolationEvent>;
+    Object.assign(event, {
+      effectiveDirective: "connect-src",
+      violatedDirective: "connect-src",
+      blockedURI: "https://evil.test/",
+      originalPolicy: "connect-src 'self'; form-action 'none'",
+    });
+    window.dispatchEvent(event);
+
+    expect(last(getDevDiagnostics()).message).toBe(
+      "Content Security Policy (connect-src) blocked https://evil.test/",
+    );
+  });
+
   it("notifies subscribers on record and clear, and stops after unsubscribe", () => {
     const listener = jest.fn();
     const unsubscribe = subscribeDevDiagnostics(listener);

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/config/dev-connect-src.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/config/dev-connect-src.ts
@@ -37,13 +37,22 @@ function toOrigin(url: string | undefined): string | undefined {
 }
 
 /**
- * Dev-server CSP `connect-src` mirroring what Metabase emits for a data app in
- * production: the app may reach its `allowed_hosts` (plus the Metabase instance,
- * for the SDK's own calls) and the Vite dev server / HMR websocket — nothing
- * else. So a `fetch`/XHR a production data app couldn't make is blocked in
- * `npm run dev` too, instead of silently working locally.
+ * Dev-server CSP mirroring what Metabase emits for a data app in production:
+ *
+ *   - `connect-src`: the app may reach its `allowed_hosts` (plus the Metabase
+ *     instance, for the SDK's own calls) and the Vite dev server / HMR websocket
+ *     — nothing else. So a `fetch`/XHR a production data app couldn't make is
+ *     blocked in `npm run dev` too, instead of silently working locally.
+ *   - `form-action`: restricts native `<form action="…">` submits to the app's
+ *     `allowed_hosts` (mirroring `connect-src`); with none declared it is
+ *     `'none'`, blocking every native submit. Client-side `onSubmit` handlers
+ *     still work — they preventDefault, so no submission is ever checked.
+ *   - `frame-src`: the app may embed / navigate to `'self'` and its
+ *     `allowed_hosts` (mirroring production, where declared hosts are added to
+ *     `frame-src`), so an `<iframe>`/navigation a production app couldn't make
+ *     is blocked in `npm run dev` too.
  */
-export function buildConnectSrcCsp(
+export function buildDevCsp(
   allowedHosts: string[],
   metabaseUrl: string | undefined,
 ): string {
@@ -57,5 +66,8 @@ export function buildConnectSrcCsp(
     ...(instanceOrigin ? [instanceOrigin] : []),
     ...allowedHosts,
   ];
-  return `connect-src ${sources.join(" ")}`;
+  const formAction =
+    allowedHosts.length > 0 ? allowedHosts.join(" ") : "'none'";
+  const frameSrc = ["'self'", ...allowedHosts].join(" ");
+  return `connect-src ${sources.join(" ")}; form-action ${formAction}; frame-src ${frameSrc}`;
 }

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/config/dev-connect-src.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/config/dev-connect-src.unit.spec.ts
@@ -1,0 +1,52 @@
+import { buildDevCsp } from "./dev-connect-src";
+
+/** Extract a single directive's value from a CSP header string. */
+function directive(csp: string, name: string): string | undefined {
+  return csp
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part === name || part.startsWith(`${name} `))
+    ?.slice(name.length)
+    .trim();
+}
+
+describe("buildDevCsp", () => {
+  it("blocks native submits and limits framing to 'self' when no allowed_hosts", () => {
+    const csp = buildDevCsp([], undefined);
+
+    expect(directive(csp, "connect-src")).toBe(
+      "'self' ws://localhost:* wss://localhost:* ws://127.0.0.1:* wss://127.0.0.1:*",
+    );
+    expect(directive(csp, "form-action")).toBe("'none'");
+    expect(directive(csp, "frame-src")).toBe("'self'");
+  });
+
+  it("adds allowed_hosts to connect-src, form-action and frame-src", () => {
+    const hosts = ["https://api.example.com", "https://*.trusted.test"];
+    const csp = buildDevCsp(hosts, undefined);
+
+    for (const host of hosts) {
+      expect(directive(csp, "connect-src")).toContain(host);
+    }
+    expect(directive(csp, "form-action")).toBe(hosts.join(" "));
+    expect(directive(csp, "frame-src")).toBe(`'self' ${hosts.join(" ")}`);
+  });
+
+  it("adds the Metabase instance origin to connect-src only, normalized to an origin", () => {
+    const csp = buildDevCsp([], "http://localhost:3000/app?token=secret#x");
+
+    expect(directive(csp, "connect-src")).toContain("http://localhost:3000");
+    // Only the origin — never the path/query/fragment.
+    expect(csp).not.toContain("/app");
+    expect(csp).not.toContain("secret");
+    // The instance origin is for fetch, not for submitting/framing.
+    expect(directive(csp, "form-action")).toBe("'none'");
+    expect(directive(csp, "frame-src")).toBe("'self'");
+  });
+
+  it("ignores an unparseable Metabase URL", () => {
+    const csp = buildDevCsp([], "not a url");
+
+    expect(directive(csp, "connect-src")).not.toContain("not a url");
+  });
+});

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/dev-plugin/plugin.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/dev-plugin/plugin.ts
@@ -217,6 +217,17 @@ export function dataAppSandboxDevPlugin(allowedHosts: string[]): Plugin {
             );
 
             res.statusCode = 200;
+
+            // Apply the configured `server.headers` (our CSP) to this document.
+            const configuredHeaders = server.config.server.headers;
+            if (configuredHeaders) {
+              for (const [name, value] of Object.entries(configuredHeaders)) {
+                if (value != null) {
+                  res.setHeader(name, value);
+                }
+              }
+            }
+
             res.setHeader("Content-Type", "text/html");
             res.end(html);
           } catch (error) {

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/index.ts
@@ -8,7 +8,7 @@ import {
 
 import { dataAppBuildPlugins, dataAppLibBuild } from "./config/build-config";
 import { getDataAppDefine } from "./config/define";
-import { buildConnectSrcCsp, readAllowedHosts } from "./config/dev-connect-src";
+import { buildDevCsp, readAllowedHosts } from "./config/dev-connect-src";
 import { dataAppEnvPrefix } from "./config/env-prefix";
 import { findEnvRoot } from "./config/find-env-root";
 import { dataAppSandboxDevPlugin } from "./dev-plugin/plugin";
@@ -54,7 +54,7 @@ function dataAppVitePlugin(): PluginOption[] {
         server: {
           host: "localhost",
           headers: {
-            "Content-Security-Policy": buildConnectSrcCsp(
+            "Content-Security-Policy": buildDevCsp(
               allowedHosts,
               loadEnv(env.mode, envDir, "").DATA_APP_MB_URL,
             ),

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/AppView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/AppView.tsx
@@ -85,12 +85,20 @@ export function AppView({ params }: AppViewProps) {
 
     const onLoad = () => {
       setIframeLoaded(true);
-      const win = iframeEl.contentWindow;
-      if (!win) {
-        return;
+      // The iframe can navigate cross-origin — a form submitting to an allowed
+      // external host, or the chrome-error page from a blocked navigation — and a
+      // cross-origin `contentWindow` throws on access. Mirroring only works
+      // same-origin, so tear down the old mirror and skip re-attaching if so.
+      try {
+        detach?.();
+        detach = null;
+        const win = iframeEl.contentWindow;
+        if (win) {
+          detach = attachIframeUrlMirror(win, name);
+        }
+      } catch {
+        detach = null;
       }
-      detach?.();
-      detach = attachIframeUrlMirror(win, name);
     };
 
     iframeEl.addEventListener("load", onLoad);
@@ -221,6 +229,13 @@ export function AppView({ params }: AppViewProps) {
         </Box>
       )}
 
+      {/*
+        `allow-forms` is enabled so native form submissions can reach the app's
+        declared `allowed_hosts`. The CSP `form-action` directive (see the data-app
+        CSP in `security.clj` / the dev server) restricts submissions to exactly
+        those hosts — with no `allowed_hosts` it is `'none'` — blocking any other
+        target. Client-side `<form onSubmit>` (preventDefault) is unaffected.
+      */}
       <iframe
         ref={setIframeEl}
         title={meta.display_name}

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/AppView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/AppView.tsx
@@ -18,6 +18,7 @@ import {
 } from "./constants";
 import { attachIframeUrlMirror } from "./lib/attach-iframe-url-mirror";
 import { deriveIframeSrc } from "./lib/derive-iframe-src";
+import { isCrossOriginError } from "./lib/is-cross-origin-error";
 
 interface AppViewProps {
   params: { name: string };
@@ -96,8 +97,13 @@ export function AppView({ params }: AppViewProps) {
         if (win) {
           detach = attachIframeUrlMirror(win, name);
         }
-      } catch {
+      } catch (error) {
         detach = null;
+        // Expected only for a cross-origin frame; rethrow anything else so mirror
+        // bugs surface.
+        if (!isCrossOriginError(error)) {
+          throw error;
+        }
       }
     };
 

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/lib/attach-iframe-url-mirror.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/lib/attach-iframe-url-mirror.ts
@@ -1,5 +1,7 @@
 import { DATA_APP_EMBED_PREFIX } from "../constants";
 
+import { isCrossOriginError } from "./is-cross-origin-error";
+
 /**
  * Mirrors the iframe's URL into the parent's URL bar (no page reload).
  *
@@ -52,11 +54,13 @@ export function attachIframeUrlMirror(
       history.pushState = origPush;
       history.replaceState = origReplace;
       iframeWindow.removeEventListener("popstate", mirror);
-    } catch {
-      // The frame navigated cross-origin (e.g. a form submitting to an external
-      // host, or a blocked navigation's chrome-error page): its window can no
-      // longer be touched, and the patched history/listeners are gone with the
-      // old document anyway.
+    } catch (error) {
+      // Expected only when the frame navigated cross-origin: its window can no
+      // longer be touched, and the patched history/listeners are gone with the old
+      // document anyway. Rethrow anything else so real bugs surface.
+      if (!isCrossOriginError(error)) {
+        throw error;
+      }
     }
   };
 }

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/lib/attach-iframe-url-mirror.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/lib/attach-iframe-url-mirror.ts
@@ -48,8 +48,15 @@ export function attachIframeUrlMirror(
   iframeWindow.addEventListener("popstate", mirror);
 
   return () => {
-    history.pushState = origPush;
-    history.replaceState = origReplace;
-    iframeWindow.removeEventListener("popstate", mirror);
+    try {
+      history.pushState = origPush;
+      history.replaceState = origReplace;
+      iframeWindow.removeEventListener("popstate", mirror);
+    } catch {
+      // The frame navigated cross-origin (e.g. a form submitting to an external
+      // host, or a blocked navigation's chrome-error page): its window can no
+      // longer be touched, and the patched history/listeners are gone with the
+      // old document anyway.
+    }
   };
 }

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/lib/attach-iframe-url-mirror.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/lib/attach-iframe-url-mirror.ts
@@ -3,6 +3,18 @@ import { DATA_APP_EMBED_PREFIX } from "../constants";
 import { isCrossOriginError } from "./is-cross-origin-error";
 
 /**
+ * The `Window` members the URL mirror touches. Narrower than `Window` so a test
+ * can pass a small typed fake without an unsafe cast — a real `Window` satisfies
+ * it.
+ */
+export interface UrlMirrorWindow {
+  readonly location: Pick<Location, "pathname">;
+  history: Pick<History, "pushState" | "replaceState">;
+  addEventListener: (type: "popstate", listener: () => void) => void;
+  removeEventListener: (type: "popstate", listener: () => void) => void;
+}
+
+/**
  * Mirrors the iframe's URL into the parent's URL bar (no page reload).
  *
  * Same-origin frame, so we monkey-patch the iframe's `History` methods
@@ -15,7 +27,7 @@ import { isCrossOriginError } from "./is-cross-origin-error";
  * Returns a cleanup that restores the originals.
  */
 export function attachIframeUrlMirror(
-  iframeWindow: Window,
+  iframeWindow: UrlMirrorWindow,
   parentName: string,
 ): () => void {
   const iframePrefix = `${DATA_APP_EMBED_PREFIX}/${encodeURIComponent(parentName)}`;

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/lib/attach-iframe-url-mirror.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/lib/attach-iframe-url-mirror.unit.spec.ts
@@ -1,23 +1,35 @@
-import { attachIframeUrlMirror } from "./attach-iframe-url-mirror";
+import {
+  type UrlMirrorWindow,
+  attachIframeUrlMirror,
+} from "./attach-iframe-url-mirror";
 
-type FakeIframeWindow = {
+type PopstateArgs = [type: "popstate", listener: () => void];
+
+interface FakeIframeWindow {
   location: { pathname: string };
   history: {
-    pushState: (...args: unknown[]) => void;
-    replaceState: (...args: unknown[]) => void;
+    pushState: jest.Mock<void, unknown[]>;
+    replaceState: jest.Mock<void, unknown[]>;
   };
-  addEventListener: jest.Mock;
-  removeEventListener: jest.Mock;
-};
+  addEventListener: jest.Mock<void, PopstateArgs>;
+  removeEventListener: jest.Mock<void, PopstateArgs>;
+}
 
 function fakeIframeWindow(pathname: string): FakeIframeWindow {
   return {
     location: { pathname },
-    history: { pushState: jest.fn(), replaceState: jest.fn() },
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
+    history: {
+      pushState: jest.fn<void, unknown[]>(),
+      replaceState: jest.fn<void, unknown[]>(),
+    },
+    addEventListener: jest.fn<void, PopstateArgs>(),
+    removeEventListener: jest.fn<void, PopstateArgs>(),
   };
 }
+
+// `FakeIframeWindow` structurally satisfies `UrlMirrorWindow`, so no cast is
+// needed at the call sites below.
+const asMirrorWindow = (iframe: FakeIframeWindow): UrlMirrorWindow => iframe;
 
 describe("attachIframeUrlMirror", () => {
   it("patches the iframe history + popstate on attach and restores them on cleanup", () => {
@@ -25,7 +37,7 @@ describe("attachIframeUrlMirror", () => {
     const origPush = iframe.history.pushState;
     const origReplace = iframe.history.replaceState;
 
-    const detach = attachIframeUrlMirror(iframe as unknown as Window, "sales");
+    const detach = attachIframeUrlMirror(asMirrorWindow(iframe), "sales");
 
     expect(iframe.history.pushState).not.toBe(origPush);
     expect(iframe.history.replaceState).not.toBe(origReplace);
@@ -48,7 +60,7 @@ describe("attachIframeUrlMirror", () => {
     const iframe = fakeIframeWindow("/embed/data-app/sales");
     const replaceSpy = jest.spyOn(window.history, "replaceState");
 
-    attachIframeUrlMirror(iframe as unknown as Window, "sales");
+    attachIframeUrlMirror(asMirrorWindow(iframe), "sales");
 
     // Simulate an in-iframe navigation to a sub-route.
     iframe.location.pathname = "/embed/data-app/sales/orders";
@@ -63,11 +75,11 @@ describe("attachIframeUrlMirror", () => {
 
   it("does not throw on cleanup when the frame has gone cross-origin", () => {
     const iframe = fakeIframeWindow("/embed/data-app/sales");
-    const detach = attachIframeUrlMirror(iframe as unknown as Window, "sales");
+    const detach = attachIframeUrlMirror(asMirrorWindow(iframe), "sales");
 
     // A cross-origin frame throws on any window access (like the chrome-error
     // page after a blocked navigation, or a real external host).
-    iframe.removeEventListener = jest.fn(() => {
+    iframe.removeEventListener = jest.fn<void, PopstateArgs>(() => {
       throw new DOMException("Blocked a frame with origin …", "SecurityError");
     });
 
@@ -76,9 +88,9 @@ describe("attachIframeUrlMirror", () => {
 
   it("rethrows unexpected (non-cross-origin) cleanup errors so real bugs surface", () => {
     const iframe = fakeIframeWindow("/embed/data-app/sales");
-    const detach = attachIframeUrlMirror(iframe as unknown as Window, "sales");
+    const detach = attachIframeUrlMirror(asMirrorWindow(iframe), "sales");
 
-    iframe.removeEventListener = jest.fn(() => {
+    iframe.removeEventListener = jest.fn<void, PopstateArgs>(() => {
       throw new TypeError("boom");
     });
 

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/lib/attach-iframe-url-mirror.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/lib/attach-iframe-url-mirror.unit.spec.ts
@@ -73,4 +73,15 @@ describe("attachIframeUrlMirror", () => {
 
     expect(() => detach()).not.toThrow();
   });
+
+  it("rethrows unexpected (non-cross-origin) cleanup errors so real bugs surface", () => {
+    const iframe = fakeIframeWindow("/embed/data-app/sales");
+    const detach = attachIframeUrlMirror(iframe as unknown as Window, "sales");
+
+    iframe.removeEventListener = jest.fn(() => {
+      throw new TypeError("boom");
+    });
+
+    expect(() => detach()).toThrow("boom");
+  });
 });

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/lib/attach-iframe-url-mirror.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/lib/attach-iframe-url-mirror.unit.spec.ts
@@ -1,0 +1,76 @@
+import { attachIframeUrlMirror } from "./attach-iframe-url-mirror";
+
+type FakeIframeWindow = {
+  location: { pathname: string };
+  history: {
+    pushState: (...args: unknown[]) => void;
+    replaceState: (...args: unknown[]) => void;
+  };
+  addEventListener: jest.Mock;
+  removeEventListener: jest.Mock;
+};
+
+function fakeIframeWindow(pathname: string): FakeIframeWindow {
+  return {
+    location: { pathname },
+    history: { pushState: jest.fn(), replaceState: jest.fn() },
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  };
+}
+
+describe("attachIframeUrlMirror", () => {
+  it("patches the iframe history + popstate on attach and restores them on cleanup", () => {
+    const iframe = fakeIframeWindow("/embed/data-app/sales");
+    const origPush = iframe.history.pushState;
+    const origReplace = iframe.history.replaceState;
+
+    const detach = attachIframeUrlMirror(iframe as unknown as Window, "sales");
+
+    expect(iframe.history.pushState).not.toBe(origPush);
+    expect(iframe.history.replaceState).not.toBe(origReplace);
+    expect(iframe.addEventListener).toHaveBeenCalledWith(
+      "popstate",
+      expect.any(Function),
+    );
+
+    detach();
+
+    expect(iframe.history.pushState).toBe(origPush);
+    expect(iframe.history.replaceState).toBe(origReplace);
+    expect(iframe.removeEventListener).toHaveBeenCalledWith(
+      "popstate",
+      expect.any(Function),
+    );
+  });
+
+  it("mirrors the iframe's sub-path into the parent URL on a patched navigation", () => {
+    const iframe = fakeIframeWindow("/embed/data-app/sales");
+    const replaceSpy = jest.spyOn(window.history, "replaceState");
+
+    attachIframeUrlMirror(iframe as unknown as Window, "sales");
+
+    // Simulate an in-iframe navigation to a sub-route.
+    iframe.location.pathname = "/embed/data-app/sales/orders";
+    iframe.history.pushState({}, "", "/embed/data-app/sales/orders");
+
+    // The parent URL is replaced (not pushed) with the mirrored sub-path.
+    const lastCall = replaceSpy.mock.calls.at(-1);
+    expect(lastCall?.[2]).toContain("/data-app/sales/orders");
+
+    replaceSpy.mockRestore();
+  });
+
+  it("does not throw on cleanup when the frame has gone cross-origin", () => {
+    const iframe = fakeIframeWindow("/embed/data-app/sales");
+    const detach = attachIframeUrlMirror(iframe as unknown as Window, "sales");
+
+    // A cross-origin frame throws on any window access (like the chrome-error
+    // page after a blocked navigation, or a real external host).
+    iframe.removeEventListener = jest.fn(() => {
+      throw new DOMException("Blocked a frame with origin …", "SecurityError");
+    });
+
+    expect(() => detach()).not.toThrow();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/lib/is-cross-origin-error.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/lib/is-cross-origin-error.ts
@@ -1,0 +1,10 @@
+/**
+ * A cross-origin frame throws a `SecurityError` (`DOMException`) on any window
+ * access — reading `contentWindow`, patching its `history`, removing a listener,
+ * etc. That happens expectedly when the data-app iframe navigates to an external
+ * host, or lands on a blocked navigation's `chrome-error` page. Use this to
+ * tolerate that case while letting real bugs surface.
+ */
+export function isCrossOriginError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "SecurityError";
+}

--- a/skills/create-data-app/SKILL.md
+++ b/skills/create-data-app/SKILL.md
@@ -148,6 +148,15 @@ Once the template is in `<repo>/data_apps/<slug>/` (run everything below from th
    and written via `useAction` (the SDK handles auth), never raw `fetch`. Leave
    `allowed_hosts` out entirely when the app only talks to Metabase.
 
+   Native `<form action="…">` submissions and `<iframe src="…">`/navigations obey
+   the **same** allowlist. Prefer a client-side `<form onSubmit>` that
+   `preventDefault`s and writes via `useAction`/`fetch`: a native submit
+   *navigates the sandboxed iframe away* from the app. If you do use one, the
+   target host must be in `allowed_hosts` or it's blocked (`form-action` for
+   submits, `frame-src` for embeds/navigations). A host you navigate to or embed
+   must also permit framing (`X-Frame-Options`/`frame-ancestors`) — many public
+   sites don't.
+
 ## Step 5 — Verify the starter app
 
 At this point the data app exists. Keep this workflow focused on creating the

--- a/skills/create-data-app/template/README.md
+++ b/skills/create-data-app/template/README.md
@@ -75,3 +75,20 @@ The same allowlist is enforced in both places: `npm run dev` applies it via the
 dev server's CSP, and Metabase applies it via the iframe CSP + the membrane
 sandbox. The Metabase instance itself is reached through the SDK (not listed
 here). A call to any other host fails in dev exactly as it will in production.
+
+### Forms and embeds
+
+`allowed_hosts` also governs native `<form action="…">` submissions and
+`<iframe src="…">` / navigations, not just `fetch`.
+
+Prefer a **client-side** form — `<form onSubmit={(e) => { e.preventDefault(); … }}>`
+that writes via the SDK (`useAction`) or `fetch` — over a native
+`<form action="…">`. A native submit **navigates the sandboxed iframe away** from
+your app.
+
+If you do use `<form action="https://…">` (or embed/navigate to a host via an
+`<iframe>`), the target host must be in `allowed_hosts`, or the browser blocks it
+(`form-action` for submits, `frame-src` for embeds). Note a host you embed or
+navigate to must also **allow being framed** (`X-Frame-Options` /
+`frame-ancestors`) — many public sites (e.g. `example.com`) don't, so they can't
+be shown in-frame regardless of `allowed_hosts`.

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -13,6 +13,7 @@
    [metabase.request.core :as request]
    [metabase.server.settings :as server.settings]
    [metabase.settings.core :as setting]
+   [metabase.system.core :as system]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -244,12 +245,14 @@
                                    (str "http://localhost:" cljs-dev-port))
                                  "https://accounts.google.com"]
                   :style-src-attr ["'self'"]
-                  :frame-src    (into (parse-allowed-iframe-hosts (server.settings/allowed-iframe-hosts))
-                                      ;; A data app may embed / navigate its iframe to
-                                      ;; the origins it declares in `allowed_hosts`
-                                      ;; (the same ones it may fetch). Empty for every
-                                      ;; non-data-app document.
-                                      data-app-connect-hosts)
+                  :frame-src    (if (some? data-app-connect-hosts)
+                                  ;; Data-app docs get a per-app framing allowlist:
+                                  ;; only `'self'` and the origins the app declared
+                                  ;; in `allowed_hosts` — NOT the instance-wide iframe
+                                  ;; hosts, so a data app can't frame those unless it
+                                  ;; lists them itself.
+                                  (into ["'self'"] data-app-connect-hosts)
+                                  (parse-allowed-iframe-hosts (server.settings/allowed-iframe-hosts)))
                   :font-src     (into (cond-> always-allowed-resource-hosts
                                         config/is-dev? (conj frontend-address))
                                       (application-font-files->hosts))
@@ -456,6 +459,32 @@
   [request]
   (second (re-matches #"/(?:embed/)?data-app/([^/]+).*" (:uri request))))
 
+(defn- site-origin
+  "This Metabase instance's origin as `{:protocol :domain :port}` (parsed from
+   `site-url`), or nil. Matches the shape [[parse-url]] returns so origins compare
+   with `=`."
+  []
+  (when-let [url (not-empty (system/site-url))]
+    (try
+      (let [^URI uri (URI. ^String url)]
+        (when-let [host (.getHost uri)]
+          {:protocol (.getScheme uri)
+           :domain   host
+           :port     (let [p (.getPort uri)] (when-not (neg? p) (str p)))}))
+      (catch Exception _ nil))))
+
+(defn- drop-instance-origin
+  "Removes any `allowed_hosts` entry that resolves to this Metabase instance's own
+   origin. A native `<form>` submit or frame to the instance would carry the
+   user's session cookies, and the SDK is the only sanctioned way to reach
+   Metabase — so we keep the instance out of the app's `form-action`/`frame-src`/
+   `connect-src` even when an app mistakenly lists it (mirroring the JS fetch/XHR
+   sandbox, which blocks the instance origin regardless)."
+  [hosts]
+  (if-let [self (site-origin)]
+    (remove #(= self (parse-url %)) hosts)
+    hosts))
+
 (defn- add-security-headers* [request response]
   ;; merge is other way around so that handler can override headers
   (let [headers (security-headers
@@ -475,7 +504,7 @@
                  ;; doc) and `frame-src` (both the iframe doc and the top page,
                  ;; whose `frame-src` gates the iframe's own navigations).
                  :data-app-connect-hosts      (when-let [slug (data-app-slug request)]
-                                                (data-app-connect-src-hosts slug)))
+                                                (drop-instance-origin (data-app-connect-src-hosts slug))))
         cors-headers (when (always-allow-cors? request response)
                        {"Access-Control-Allow-Origin" "*"
                         "Access-Control-Allow-Headers" "*"

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -278,9 +278,8 @@
                                     (str "ws://*:" cljs-dev-port))]
                                  ;; Per-app `allowed_hosts` for the data-app iframe document, so its
                                  ;; sandboxed bundle can fetch/XHR the origins the app declared. Added
-                                 ;; separately from `'self'` (which stays for the host-side SDK calls)
-                                 ;; and empty for every non-data-app document.
-                                 data-app-connect-hosts)
+                                 ;; separately from `'self'` (which stays for the host-side SDK calls).
+                                 (when data-app-iframe? data-app-connect-hosts))
                   :manifest-src ["'self'"]
                   :media-src    ["www.metabase.com"]}]
       (format "%s %s; " (name k) (str/join " " vs))))})

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -244,7 +244,12 @@
                                    (str "http://localhost:" cljs-dev-port))
                                  "https://accounts.google.com"]
                   :style-src-attr ["'self'"]
-                  :frame-src    (parse-allowed-iframe-hosts (server.settings/allowed-iframe-hosts))
+                  :frame-src    (into (parse-allowed-iframe-hosts (server.settings/allowed-iframe-hosts))
+                                      ;; A data app may embed / navigate its iframe to
+                                      ;; the origins it declares in `allowed_hosts`
+                                      ;; (the same ones it may fetch). Empty for every
+                                      ;; non-data-app document.
+                                      data-app-connect-hosts)
                   :font-src     (into (cond-> always-allowed-resource-hosts
                                         config/is-dev? (conj frontend-address))
                                       (application-font-files->hosts))
@@ -299,9 +304,20 @@
 
 (defn- content-security-policy-header-with-frame-ancestors
   [frame-ancestors-mode nonce data-app-iframe? data-app-connect-hosts]
-  (update (content-security-policy-header nonce data-app-iframe? data-app-connect-hosts)
-          "Content-Security-Policy"
-          #(format "%s frame-ancestors %s;" % (frame-ancestors-value frame-ancestors-mode))))
+  (cond-> (update (content-security-policy-header nonce data-app-iframe? data-app-connect-hosts)
+                  "Content-Security-Policy"
+                  #(format "%s frame-ancestors %s;" % (frame-ancestors-value frame-ancestors-mode)))
+    ;; Restrict native `<form action="…">` submissions to the app's declared
+    ;; `allowed_hosts` (mirroring `connect-src`); with none declared this is
+    ;; `'none'`, blocking every native submit. `form-action` does not fall back to
+    ;; `default-src`, so it must be set explicitly. Client-side `onSubmit` handlers
+    ;; are unaffected — they `preventDefault`, so no submission is ever checked.
+    data-app-iframe? (update "Content-Security-Policy"
+                             #(str % " form-action "
+                                   (if (seq data-app-connect-hosts)
+                                     (str/join " " data-app-connect-hosts)
+                                     "'none'")
+                                   ";"))))
 
 (defn- x-frame-options-header
   "Legacy `X-Frame-Options` companion to the CSP `frame-ancestors` (for browsers
@@ -433,11 +449,13 @@
   [request]
   (str/starts-with? (:uri request) "/embed/data-app/"))
 
-(defn- data-app-iframe-slug
-  "Slug of the data-app iframe document being served, parsed from
-   `/embed/data-app/<slug>` (and any deeper sub-route), or nil."
+(defn- data-app-slug
+  "Slug of the data-app document being served, parsed from the top-level
+   `/data-app/<slug>` page or the internal `/embed/data-app/<slug>` iframe (and
+   any deeper sub-route), or nil. The top page needs it too: its `frame-src`
+   governs what the iframe below it may navigate to."
   [request]
-  (second (re-matches #"/embed/data-app/([^/]+).*" (:uri request))))
+  (second (re-matches #"/(?:embed/)?data-app/([^/]+).*" (:uri request))))
 
 (defn- add-security-headers* [request response]
   ;; merge is other way around so that handler can override headers
@@ -454,8 +472,10 @@
                                                 :else                                              :none)
                  :allow-cache?                (request/cacheable? request)
                  :data-app-iframe?            (data-app-iframe-request? request)
-                 ;; Per-app `allowed_hosts` → `connect-src` for the data-app iframe document.
-                 :data-app-connect-hosts      (when-let [slug (data-app-iframe-slug request)]
+                 ;; Per-app `allowed_hosts` → `connect-src`/`form-action` (iframe
+                 ;; doc) and `frame-src` (both the iframe doc and the top page,
+                 ;; whose `frame-src` gates the iframe's own navigations).
+                 :data-app-connect-hosts      (when-let [slug (data-app-slug request)]
                                                 (data-app-connect-src-hosts slug)))
         cors-headers (when (always-allow-cors? request response)
                        {"Access-Control-Allow-Origin" "*"

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -159,6 +159,13 @@
     (with-redefs [mw.security/data-app-connect-src-hosts (constantly [])]
       (is (= (csp-directive-for "/embed/data-app/sales" "connect-src")
              (csp-directive-for "/embed/dashboard/abc" "connect-src")))))
+  (testing "the top-level /data-app page keeps a tight connect-src — hosts go to the iframe doc, not here"
+    (with-redefs [mw.security/data-app-connect-src-hosts (constantly ["https://api.example.com"])]
+      (is (not (str/includes? (csp-directive-for "/data-app/sales" "connect-src")
+                              "https://api.example.com")))
+      ;; ...but the top page still gets them in frame-src (it gates the iframe's nav).
+      (is (str/includes? (csp-directive-for "/data-app/sales" "frame-src")
+                         "https://api.example.com"))))
   (testing "non-data-app documents don't get app hosts in connect-src"
     (with-redefs [mw.security/data-app-connect-src-hosts (constantly ["https://api.example.com"])]
       (is (not (str/includes? (csp-directive-for "/embed/dashboard/abc" "connect-src")

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -141,6 +141,10 @@
         (let [frame-src (csp-directive-for uri "frame-src")]
           (is (str/includes? frame-src "'self'") uri)
           (is (str/includes? frame-src "https://example.com") uri)))))
+  (testing "with no allowed_hosts, frame-src stays the base iframe-hosts list (no app hosts added)"
+    (with-redefs [mw.security/data-app-connect-src-hosts (constantly [])]
+      (is (= (csp-directive-for "/embed/data-app/sales" "frame-src")
+             (csp-directive-for "/embed/dashboard/abc" "frame-src")))))
   (testing "non-data-app documents don't get app hosts in frame-src"
     (with-redefs [mw.security/data-app-connect-src-hosts (constantly ["https://example.com"])]
       (is (not (str/includes? (csp-directive-for "/embed/dashboard/abc" "frame-src")
@@ -151,6 +155,10 @@
     (with-redefs [mw.security/data-app-connect-src-hosts (constantly ["https://api.example.com"])]
       (is (str/includes? (csp-directive-for "/embed/data-app/sales" "connect-src")
                          "https://api.example.com"))))
+  (testing "with no allowed_hosts, the iframe connect-src has no app hosts (same as any doc)"
+    (with-redefs [mw.security/data-app-connect-src-hosts (constantly [])]
+      (is (= (csp-directive-for "/embed/data-app/sales" "connect-src")
+             (csp-directive-for "/embed/dashboard/abc" "connect-src")))))
   (testing "non-data-app documents don't get app hosts in connect-src"
     (with-redefs [mw.security/data-app-connect-src-hosts (constantly ["https://api.example.com"])]
       (is (not (str/includes? (csp-directive-for "/embed/dashboard/abc" "connect-src")

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -133,22 +133,45 @@
       (is (nil? (csp-directive-for uri "form-action"))))))
 
 (deftest data-app-frame-src-test
-  (testing "a data app's allowed_hosts are added to frame-src, so it can embed / navigate to them"
-    (with-redefs [mw.security/data-app-connect-src-hosts (constantly ["https://example.com"])]
-      ;; Both the top page and the iframe doc: the top page's `frame-src` gates
-      ;; what the iframe below it may navigate to.
-      (doseq [uri ["/data-app/sales" "/embed/data-app/sales"]]
-        (let [frame-src (csp-directive-for uri "frame-src")]
-          (is (str/includes? frame-src "'self'") uri)
-          (is (str/includes? frame-src "https://example.com") uri)))))
-  (testing "with no allowed_hosts, frame-src stays the base iframe-hosts list (no app hosts added)"
+  (testing "a data app's frame-src is a per-app allowlist: only 'self' + its allowed_hosts"
+    ;; A global iframe host (wikipedia) is configured but must NOT leak into a data
+    ;; app's frame-src — the app can only frame what it declares.
+    (mt/with-temporary-setting-values [allowed-iframe-hosts "https://www.wikipedia.org"]
+      (with-redefs [mw.security/data-app-connect-src-hosts (constantly ["https://example.com"])]
+        ;; Both the top page and the iframe doc: the top page's `frame-src` gates
+        ;; what the iframe below it may navigate to.
+        (doseq [uri ["/data-app/sales" "/embed/data-app/sales"]]
+          (let [frame-src (csp-directive-for uri "frame-src")]
+            (is (str/includes? frame-src "'self'") uri)
+            (is (str/includes? frame-src "https://example.com") uri)
+            (is (not (str/includes? frame-src "wikipedia"))
+                (str uri " must not include the instance-wide iframe hosts")))))))
+  (testing "with no allowed_hosts, a data app can only frame 'self'"
     (with-redefs [mw.security/data-app-connect-src-hosts (constantly [])]
-      (is (= (csp-directive-for "/embed/data-app/sales" "frame-src")
-             (csp-directive-for "/embed/dashboard/abc" "frame-src")))))
-  (testing "non-data-app documents don't get app hosts in frame-src"
-    (with-redefs [mw.security/data-app-connect-src-hosts (constantly ["https://example.com"])]
-      (is (not (str/includes? (csp-directive-for "/embed/dashboard/abc" "frame-src")
-                              "https://example.com"))))))
+      (is (= "frame-src 'self'" (csp-directive-for "/embed/data-app/sales" "frame-src")))))
+  (testing "non-data-app documents keep the instance-wide iframe hosts, not app hosts"
+    (mt/with-temporary-setting-values [allowed-iframe-hosts "https://www.wikipedia.org"]
+      (with-redefs [mw.security/data-app-connect-src-hosts (constantly ["https://example.com"])]
+        (let [frame-src (csp-directive-for "/embed/dashboard/abc" "frame-src")]
+          (is (str/includes? frame-src "wikipedia"))
+          (is (not (str/includes? frame-src "https://example.com"))))))))
+
+(deftest data-app-instance-origin-excluded-test
+  (testing "the Metabase instance origin is dropped from a data app's allowlist even if listed"
+    (mt/with-temporary-setting-values [site-url "https://mymetabase.example"]
+      (with-redefs [mw.security/data-app-connect-src-hosts
+                    (constantly ["https://mymetabase.example" "https://api.allowed.test"])]
+        (let [form-action (csp-directive-for "/embed/data-app/sales" "form-action")
+              frame-src   (csp-directive-for "/embed/data-app/sales" "frame-src")
+              connect-src (csp-directive-for "/embed/data-app/sales" "connect-src")]
+          (testing "the genuinely-external host survives"
+            (is (str/includes? form-action "https://api.allowed.test"))
+            (is (str/includes? frame-src "https://api.allowed.test"))
+            (is (str/includes? connect-src "https://api.allowed.test")))
+          (testing "the instance origin is filtered out (no native form/frame/fetch to Metabase)"
+            (is (not (str/includes? form-action "mymetabase.example")))
+            (is (not (str/includes? frame-src "https://mymetabase.example")))
+            (is (not (str/includes? connect-src "https://mymetabase.example")))))))))
 
 (deftest data-app-connect-src-test
   (testing "a data app's allowed_hosts are added to the iframe document's connect-src"

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -112,6 +112,50 @@
       (is (= "frame-ancestors 'none'" (frame-ancestors-for "/data-app/sales")))
       (is (= "DENY" (get (headers-for-uri "/data-app/sales") "X-Frame-Options"))))))
 
+(defn- csp-directive-for [uri directive]
+  (->> (str/split (get (headers-for-uri uri) "Content-Security-Policy") #"; *")
+       (filter #(str/starts-with? % (str directive " ")))
+       first))
+
+(deftest data-app-form-action-test
+  (testing "with no allowed_hosts, native <form action> submits are blocked (client-side onSubmit still works)"
+    (with-redefs [mw.security/data-app-connect-src-hosts (constantly [])]
+      (is (= "form-action 'none'" (csp-directive-for "/embed/data-app/sales" "form-action")))
+      (is (= "form-action 'none'"
+             (csp-directive-for "/embed/data-app/sales/sub/route" "form-action")))))
+  (testing "form-action mirrors the app's allowed_hosts (like connect-src)"
+    (with-redefs [mw.security/data-app-connect-src-hosts
+                  (constantly ["https://api.example.com" "https://*.trusted.test"])]
+      (is (= "form-action https://api.example.com https://*.trusted.test"
+             (csp-directive-for "/embed/data-app/sales" "form-action")))))
+  (testing "other documents leave form-action unset (falls through to no restriction)"
+    (doseq [uri ["/embed/dashboard/abc" "/public/question/abc" "/data-app/sales"]]
+      (is (nil? (csp-directive-for uri "form-action"))))))
+
+(deftest data-app-frame-src-test
+  (testing "a data app's allowed_hosts are added to frame-src, so it can embed / navigate to them"
+    (with-redefs [mw.security/data-app-connect-src-hosts (constantly ["https://example.com"])]
+      ;; Both the top page and the iframe doc: the top page's `frame-src` gates
+      ;; what the iframe below it may navigate to.
+      (doseq [uri ["/data-app/sales" "/embed/data-app/sales"]]
+        (let [frame-src (csp-directive-for uri "frame-src")]
+          (is (str/includes? frame-src "'self'") uri)
+          (is (str/includes? frame-src "https://example.com") uri)))))
+  (testing "non-data-app documents don't get app hosts in frame-src"
+    (with-redefs [mw.security/data-app-connect-src-hosts (constantly ["https://example.com"])]
+      (is (not (str/includes? (csp-directive-for "/embed/dashboard/abc" "frame-src")
+                              "https://example.com"))))))
+
+(deftest data-app-connect-src-test
+  (testing "a data app's allowed_hosts are added to the iframe document's connect-src"
+    (with-redefs [mw.security/data-app-connect-src-hosts (constantly ["https://api.example.com"])]
+      (is (str/includes? (csp-directive-for "/embed/data-app/sales" "connect-src")
+                         "https://api.example.com"))))
+  (testing "non-data-app documents don't get app hosts in connect-src"
+    (with-redefs [mw.security/data-app-connect-src-hosts (constantly ["https://api.example.com"])]
+      (is (not (str/includes? (csp-directive-for "/embed/dashboard/abc" "connect-src")
+                              "https://api.example.com"))))))
+
 (deftest nonce-test
   (testing "The nonce in the CSP header should match the nonce in the HTML from a index.html request"
     (let [nonceJSON (atom nil)


### PR DESCRIPTION
Restrict data-app `<form>` submissions and framing to `allowed_hosts`
  
A sandboxed data app could POST a native `<form action="https://evil.com">` to any host, this is what the Near-Membrane sandbox can't catch, since React renders forms with the real DOM APIs. 

The restriction is done via CSP.

### What changed
- **`form-action`** (prod + dev): native form submissions are now restricted to the app's `allowed_hosts`; `'none'` when none are declared. Client-side `<form onSubmit>` (with `preventDefault`) is unaffected.
- **Dev CSP delivery fix**: the dev plugin serves a synthetic `index.html` via custom middleware, which Vite doesn't inject `server.headers` into - so the CSP (`connect-src`/`form-action`/`frame-src`) was silently absent in `npm run dev`. The plugin now applies the configured headers to that response.
- **Cross-origin iframe hardening**: navigating the iframe to an external host (or a blocked chrome-error page) made `AppView`'s URL-mirror throw a `SecurityError`; attach/detach are now cross-origin-safe.