### PR TITLE
GDGT-2684: Fix Monitor Tools E2E specs

### DIFF
--- a/e2e/support/timings.json
+++ b/e2e/support/timings.json
@@ -133,11 +133,11 @@
       "duration": 2657
     },
     {
-      "spec": "../test/scenarios/admin/tools/help.cy.spec.ts",
+      "spec": "../test/scenarios/admin/help.cy.spec.ts",
       "duration": 13587
     },
     {
-      "spec": "../test/scenarios/admin/tools/tools.cy.spec.ts",
+      "spec": "../test/scenarios/monitor/tools/tools.cy.spec.ts",
       "duration": 47954
     },
     {

--- a/e2e/test/scenarios/admin/help.cy.spec.ts
+++ b/e2e/test/scenarios/admin/help.cy.spec.ts
@@ -2,14 +2,14 @@ import dayjs from "dayjs";
 
 const { H } = cy;
 
-describe("scenarios > admin > tools > help", { tags: "@OSS" }, () => {
+describe("scenarios > admin > help", { tags: "@OSS" }, () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
   });
 
   it("should link `Get help` to help", () => {
-    cy.visit("/admin/tools/help");
+    cy.visit("/admin/help");
 
     // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Metabase Admin");
@@ -24,7 +24,7 @@ describe("scenarios > admin > tools > help", { tags: "@OSS" }, () => {
   });
 });
 
-describe("scenarios > admin > tools > help (EE)", () => {
+describe("scenarios > admin > help (EE)", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
@@ -32,7 +32,7 @@ describe("scenarios > admin > tools > help (EE)", () => {
   });
 
   it("should link `Get Help` to help-premium", () => {
-    cy.visit("/admin/tools/help");
+    cy.visit("/admin/help");
 
     cy.findByTestId("admin-layout-content")
       .findByText("Get help")
@@ -45,7 +45,7 @@ describe("scenarios > admin > tools > help (EE)", () => {
   });
 });
 
-describe("scenarios > admin > tools > help > helping hand", () => {
+describe("scenarios > admin > help > helping hand", () => {
   const executeCreateGrantAccessFlow = (
     durationOption?: "96 hours" | "48 hours" | "24 hours",
     ticket?: string,
@@ -90,7 +90,7 @@ describe("scenarios > admin > tools > help > helping hand", () => {
   });
 
   it("should only display the `Helping hand` section for cloud customers", () => {
-    cy.visit("/admin/tools/help");
+    cy.visit("/admin/help");
     cy.findByRole("heading", { name: "Helping hand" }).should("not.exist");
 
     H.activateToken("pro-self-hosted");
@@ -108,7 +108,7 @@ describe("scenarios > admin > tools > help > helping hand", () => {
 
   it("should allow creating a new access grant", () => {
     H.activateToken("pro-cloud");
-    cy.visit("/admin/tools/help");
+    cy.visit("/admin/help");
 
     cy.findByTestId("access-grant-list-table").should("not.exist");
 
@@ -122,7 +122,7 @@ describe("scenarios > admin > tools > help > helping hand", () => {
 
   it("allow creating an access grant with a ticket number and custom notes", () => {
     H.activateToken("pro-cloud");
-    cy.visit("/admin/tools/help");
+    cy.visit("/admin/help");
 
     executeCreateGrantAccessFlow("48 hours", "TICKET-999", "Custom notes");
 
@@ -138,7 +138,7 @@ describe("scenarios > admin > tools > help > helping hand", () => {
 
   it("should disallow more than one active access grant", () => {
     H.activateToken("pro-cloud");
-    cy.visit("/admin/tools/help");
+    cy.visit("/admin/help");
 
     executeCreateGrantAccessFlow();
 
@@ -151,7 +151,7 @@ describe("scenarios > admin > tools > help > helping hand", () => {
 
   it("can revoke an access grant", () => {
     H.activateToken("pro-cloud");
-    cy.visit("/admin/tools/help");
+    cy.visit("/admin/help");
 
     executeCreateGrantAccessFlow();
     cy.button("Request a helping hand").should("be.disabled");

--- a/e2e/test/scenarios/monitor/tools/tools.cy.spec.ts
+++ b/e2e/test/scenarios/monitor/tools/tools.cy.spec.ts
@@ -79,7 +79,7 @@ describe("issue 14636", () => {
   });
 
   it("pagination should work (metabase#14636)", () => {
-    cy.visit("/admin/tools/tasks/list");
+    cy.visit("/monitor/tasks/list");
     cy.wait("@first");
 
     cy.location("search").should("eq", "");
@@ -115,14 +115,14 @@ describe("issue 14636", () => {
 
     cy.log("pagination should affect browser history");
     cy.go("back");
-    cy.location("pathname").should("eq", "/admin/tools/tasks/list");
+    cy.location("pathname").should("eq", "/monitor/tasks/list");
     cy.location("search").should("eq", "?page=1");
     cy.go("back");
-    cy.location("pathname").should("eq", "/admin/tools/tasks/list");
+    cy.location("pathname").should("eq", "/monitor/tasks/list");
     cy.location("search").should("eq", "");
 
     cy.log("it should respect page query param on page load");
-    cy.visit("/admin/tools/tasks/list?page=1");
+    cy.visit("/monitor/tasks/list?page=1");
     cy.wait("@second");
 
     cy.findByLabelText("pagination")
@@ -131,9 +131,7 @@ describe("issue 14636", () => {
   });
 
   it("filtering should work", () => {
-    cy.visit(
-      "/admin/tools/tasks/list?status=success&task=field+values+scanning",
-    );
+    cy.visit("/monitor/tasks/list?status=success&task=field+values+scanning");
 
     cy.findByPlaceholderText("Filter by task").should(
       "have.value",
@@ -153,10 +151,7 @@ describe("issue 14636", () => {
       "?status=failed&task=field+values+scanning",
     );
     cy.findAllByTestId("task").should("have.length", 0);
-    cy.findByTestId("admin-layout-content").should(
-      "contain.text",
-      "No results",
-    );
+    cy.findByTestId("monitor-main").should("contain.text", "No results");
 
     getFilterByStatus().parent().findByLabelText("Clear").click();
     cy.location("search").should("eq", "?task=field+values+scanning");
@@ -177,19 +172,19 @@ describe("issue 14636", () => {
     cy.findByLabelText("pagination").findByText("1 - 50").should("be.visible");
 
     cy.log("should reset pagination when changing filters");
-    cy.visit("/admin/tools/tasks/list?page=1");
+    cy.visit("/monitor/tasks/list?page=1");
     getFilterByStatus().click();
     H.popover().findByText("Success").click();
     cy.location("search").should("eq", "?status=success");
 
     cy.log("should remove invalid query params");
-    cy.visit("/admin/tools/tasks/list?status=foobar");
+    cy.visit("/monitor/tasks/list?status=foobar");
     cy.location("search").should("eq", "");
     getFilterByStatus().should("have.value", "");
   });
 });
 
-describe("scenarios > admin > tools > tasks", () => {
+describe("scenarios > monitor > tools > tasks", () => {
   const task = createMockTask({
     task_details: {
       useful: {
@@ -219,12 +214,12 @@ describe("scenarios > admin > tools > tasks", () => {
   });
 
   it("shows task details page", () => {
-    cy.visit("/admin/tools/tasks/list");
+    cy.visit("/monitor/tasks/list");
     cy.wait("@getTasks");
 
     cy.findByTestId("tasks-table").findByText("A task").click();
     cy.wait("@getTask");
-    cy.location("pathname").should("eq", `/admin/tools/tasks/list/${task.id}`);
+    cy.location("pathname").should("eq", `/monitor/tasks/list/${task.id}`);
 
     cy.log("task details");
     cy.get(".cm-content").should("be.visible").get(".cm-line").as("lines");
@@ -280,7 +275,7 @@ describe("scenarios > admin > tools > tasks", () => {
       body: taskWithLogs,
     }).as("getTaskWithLogs");
 
-    cy.visit(`/admin/tools/tasks/list/${task.id}`);
+    cy.visit(`/monitor/tasks/list/${task.id}`);
     cy.wait("@getTaskWithLogs");
 
     cy.findByTestId("task-logs").scrollIntoView().should("be.visible");
@@ -300,17 +295,17 @@ describe("scenarios > admin > tools > tasks", () => {
       body: taskWithoutLogs,
     }).as("getTaskWithoutLogs");
 
-    cy.visit(`/admin/tools/tasks/list/${task.id}`);
+    cy.visit(`/monitor/tasks/list/${task.id}`);
     cy.wait("@getTaskWithoutLogs");
 
     cy.findByTestId("task-logs").should("not.exist");
-    cy.findByTestId("admin-layout-content")
+    cy.findByTestId("monitor-main")
       .findByText("There are no captured logs")
       .should("be.visible");
   });
 });
 
-describe("scenarios > admin > tools > logs", () => {
+describe("scenarios > monitor > tools > logs", () => {
   const log1 = {
     timestamp: "2024-01-10T21:21:58.597Z",
     level: "DEBUG",
@@ -334,7 +329,7 @@ describe("scenarios > admin > tools > logs", () => {
     H.restore();
     cy.signInAsAdmin();
 
-    cy.visit("/admin/tools/logs");
+    cy.visit("/monitor/logs");
     cy.wait("@getLogs");
   });
 
@@ -367,8 +362,8 @@ describe("scenarios > admin > tools > logs", () => {
   }
 });
 
-describe("admin > tools > erroring questions ", () => {
-  const TOOLS_ERRORS_URL = "/admin/tools/errors";
+describe("monitor > tools > erroring questions ", () => {
+  const TOOLS_ERRORS_URL = "/monitor/errors";
   // The filter is required but doesn't have a default value set
   const brokenQuestionDetails = {
     name: "Broken SQL",
@@ -420,13 +415,13 @@ describe("admin > tools > erroring questions ", () => {
     });
 
     describe("without broken questions", () => {
-      it('should render the "Tools" tab and navigate to the "Erroring Questions" by clicking on it', () => {
+      it("should render the Monitor nav and navigate to Erroring questions by clicking on it", () => {
         // The sidebar has been taken out, because it looks awkward when there's only one elem on it: put it back in when there's more than one
-        cy.visit("/admin");
+        cy.visit("/monitor");
 
-        cy.get("nav").contains("Tools").click();
-
-        cy.findByRole("link", { name: /Erroring questions/ }).click();
+        cy.findByTestId("monitor-nav")
+          .findByRole("link", { name: /Erroring questions/ })
+          .click();
         cy.location("pathname").should("eq", TOOLS_ERRORS_URL);
 
         cy.log("test no results state");
@@ -491,7 +486,7 @@ describe("admin > tools > erroring questions ", () => {
   });
 });
 
-describe("admin > tools", () => {
+describe("monitor > tools", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
@@ -503,7 +498,7 @@ describe("admin > tools", () => {
       "Enable model persistence in order to have multiple tabs/routes in tools",
     );
     cy.request("POST", "/api/persist/enable");
-    cy.visit("/admin/tools/errors");
+    cy.visit("/monitor/errors");
 
     cy.findByRole("heading", {
       name: "Questions that errored when last run",
@@ -511,16 +506,14 @@ describe("admin > tools", () => {
 
     cy.log("We should be able to switch to the model caching page");
 
-    cy.findByTestId("admin-layout-sidebar")
-      .findByText("Model cache log")
-      .click();
-    cy.location("pathname").should("eq", "/admin/tools/model-caching");
+    cy.findByTestId("monitor-nav").findByText("Model cache log").click();
+    cy.location("pathname").should("eq", "/monitor/model-caching");
 
     cy.log(
       "Once the audit_app feature flag is gone, tools should display an upsell",
     );
     H.deleteToken();
-    cy.visit("/admin/tools/errors");
+    cy.visit("/monitor/errors");
 
     cy.findByRole("heading", {
       name: "Troubleshoot faster",
@@ -529,15 +522,15 @@ describe("admin > tools", () => {
   });
 
   describe("issue 57113", () => {
-    it("should navigate to /admin/tools/tasks/list when clicking Back to Tasks even with no browser history", () => {
-      cy.visit("/admin/tools/tasks/list");
+    it("should navigate to /monitor/tasks/list when clicking Back to Tasks even with no browser history", () => {
+      cy.visit("/monitor/tasks/list");
 
       cy.log("Pick an existing task url");
 
       cy.findAllByTestId("task").should("be.visible").first().click();
 
       cy.location("pathname")
-        .should("match", /\/admin\/tools\/tasks\/list\/[0-9]+$/)
+        .should("match", /\/monitor\/tasks\/list\/[0-9]+$/)
         .then((pathname) => {
           // Clear all history and navigate to the task detail page
           cy.window().then((window) => {
@@ -548,13 +541,13 @@ describe("admin > tools", () => {
 
           cy.visit(pathname);
           cy.findByText("Back to Tasks").click();
-          cy.location("pathname").should("eq", "/admin/tools/tasks/list");
+          cy.location("pathname").should("eq", "/monitor/tasks/list");
         });
     });
   });
 });
 
-describe("scenarios > admin > tools > task runs", () => {
+describe("scenarios > monitor > tools > task runs", () => {
   const taskRun = {
     id: 1,
     run_type: "sync",
@@ -632,21 +625,21 @@ describe("scenarios > admin > tools > task runs", () => {
   });
 
   it("should switch between Tasks and Runs tabs", () => {
-    cy.visit("/admin/tools/tasks/list");
+    cy.visit("/monitor/tasks/list");
 
     cy.findByTestId("tasks-table").should("be.visible");
 
     cy.findByRole("tab", { name: /Runs/i }).click();
-    cy.location("pathname").should("eq", "/admin/tools/tasks/runs");
+    cy.location("pathname").should("eq", "/monitor/tasks/runs");
     cy.findByTestId("task-runs-table").should("be.visible");
 
     cy.findByRole("tab", { name: /Tasks/i }).click();
-    cy.location("pathname").should("eq", "/admin/tools/tasks/list");
+    cy.location("pathname").should("eq", "/monitor/tasks/list");
     cy.findByTestId("tasks-table").should("be.visible");
   });
 
   it("should navigate to task run details and show associated tasks", () => {
-    cy.visit("/admin/tools/tasks/runs");
+    cy.visit("/monitor/tasks/runs");
     cy.wait("@getTaskRuns");
 
     cy.findByTestId("task-runs-table")
@@ -655,12 +648,9 @@ describe("scenarios > admin > tools > task runs", () => {
       .click();
     cy.wait("@getTaskRun");
 
-    cy.location("pathname").should(
-      "eq",
-      `/admin/tools/tasks/runs/${taskRun.id}`,
-    );
+    cy.location("pathname").should("eq", `/monitor/tasks/runs/${taskRun.id}`);
 
-    cy.findByTestId("admin-layout-content").within(() => {
+    cy.findByTestId("monitor-main").within(() => {
       cy.findByText("Run type").should("be.visible");
       cy.findByText("Entity").should("be.visible");
       cy.findByText("Sample Database").should("be.visible");
@@ -671,15 +661,15 @@ describe("scenarios > admin > tools > task runs", () => {
   });
 
   it("should navigate back to runs list from run details", () => {
-    cy.visit(`/admin/tools/tasks/runs/${taskRun.id}`);
+    cy.visit(`/monitor/tasks/runs/${taskRun.id}`);
     cy.wait("@getTaskRun");
 
     cy.findByRole("link", { name: /Back to Runs/i }).click();
-    cy.location("pathname").should("eq", "/admin/tools/tasks/runs");
+    cy.location("pathname").should("eq", "/monitor/tasks/runs");
   });
 
   it("should have clickable entity link in task run details", () => {
-    cy.visit(`/admin/tools/tasks/runs/${taskRun.id}`);
+    cy.visit(`/monitor/tasks/runs/${taskRun.id}`);
     cy.wait("@getTaskRun");
 
     cy.findByRole("link", { name: /Sample Database/i }).click();
@@ -687,7 +677,7 @@ describe("scenarios > admin > tools > task runs", () => {
   });
 
   it("should navigate to task details from task run details", () => {
-    cy.visit(`/admin/tools/tasks/runs/${taskRun.id}`);
+    cy.visit(`/monitor/tasks/runs/${taskRun.id}`);
     cy.wait("@getTaskRun");
 
     cy.findByTestId("task-run-tasks-table")
@@ -697,12 +687,12 @@ describe("scenarios > admin > tools > task runs", () => {
 
     cy.location("pathname").should(
       "eq",
-      `/admin/tools/tasks/list/${taskRunExtended.tasks[0].id}`,
+      `/monitor/tasks/list/${taskRunExtended.tasks[0].id}`,
     );
   });
 });
 
-describe("scenarios > admin > tools > task runs pagination", () => {
+describe("scenarios > monitor > tools > task runs pagination", () => {
   const total = 57;
   const limit = 50;
 
@@ -761,7 +751,7 @@ describe("scenarios > admin > tools > task runs pagination", () => {
   });
 
   it("pagination should work for task runs", () => {
-    cy.visit("/admin/tools/tasks/runs");
+    cy.visit("/monitor/tasks/runs");
     cy.wait("@firstRunsPage");
 
     cy.location("search").should("eq", "");
@@ -788,7 +778,7 @@ describe("scenarios > admin > tools > task runs pagination", () => {
   });
 });
 
-describe("scenarios > admin > tools > task runs filtering", () => {
+describe("scenarios > monitor > tools > task runs filtering", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
@@ -823,7 +813,7 @@ describe("scenarios > admin > tools > task runs filtering", () => {
   });
 
   it("filtering should work for task runs", () => {
-    cy.visit("/admin/tools/tasks/runs");
+    cy.visit("/monitor/tasks/runs");
     cy.wait("@getTaskRuns");
 
     cy.log("Filter by run type");
@@ -858,7 +848,7 @@ describe("scenarios > admin > tools > task runs filtering", () => {
   });
 
   it("entity picker should be disabled/enabled based on run type, started at and entities availability", () => {
-    cy.visit("/admin/tools/tasks/runs");
+    cy.visit("/monitor/tasks/runs");
     cy.wait("@getTaskRuns");
     cy.intercept("GET", "/api/task/runs/entities?*", {
       body: [

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -287,7 +287,7 @@ describe("command palette", () => {
         H.commandPaletteAction("Performance").should("not.exist");
         H.commandPaletteInput().clear();
 
-        // Tools
+        // Monitor tools live outside the Admin command-palette links
         H.commandPaletteInput().clear().type("tool");
         H.commandPaletteAction("Tools").should("not.exist");
         H.commandPaletteInput().clear();
@@ -346,9 +346,9 @@ describe("command palette", () => {
           H.commandPaletteAction("Settings - General").should("exist");
           H.commandPaletteInput().clear();
 
-          // Tools
+          // Monitor tools live outside the Admin command-palette links
           H.commandPaletteInput().clear().type("tool");
-          H.commandPaletteAction("Tools").should("exist");
+          H.commandPaletteAction("Tools").should("not.exist");
           H.commandPaletteInput().clear();
 
           //Database and table metadata
@@ -627,7 +627,7 @@ describe("shortcuts", { tags: ["@actions"] }, () => {
     cy.realPress("5");
     cy.location("pathname").should("contain", "/admin/datamodel");
     cy.realPress("9");
-    cy.location("pathname").should("contain", "/admin/tools");
+    cy.location("pathname").should("contain", "/admin/help");
   });
 
   it("should not navigate to data studio via shortcut for non-admin users", () => {

--- a/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
@@ -126,19 +126,18 @@ describe("scenarios > admin > permissions > application", () => {
 
       it("allows accessing tools for non-admins", () => {
         cy.visit("/");
-        H.goToAdmin();
+        H.getProfileLink().click();
+        H.popover().findByText("Monitor").click();
 
-        cy.log("Tools smoke test");
-        cy.location("pathname").should("eq", "/admin/tools/help");
+        cy.log("Monitor tools smoke test");
+        cy.location("pathname").should("contain", "/monitor/tasks");
         cy.findByRole("heading", {
-          name: "Help",
+          name: "Troubleshooting logs",
         });
 
-        cy.findByTestId("admin-layout-sidebar")
-          .findByText("Erroring questions")
-          .click();
-        cy.location("pathname").should("eq", "/admin/tools/errors");
-        cy.findByTestId("admin-layout-content").findByText(
+        cy.findByTestId("monitor-nav").findByText("Erroring questions").click();
+        cy.location("pathname").should("eq", "/monitor/errors");
+        cy.findByTestId("monitor-main").findByText(
           "Questions that errored when last run",
         );
       });
@@ -152,10 +151,10 @@ describe("scenarios > admin > permissions > application", () => {
 
         H.popover().findByText(adminAppLinkText).should("not.exist");
 
-        cy.visit("/admin/tools/errors");
+        cy.visit("/monitor/errors");
         H.main().findByText("Sorry, you don’t have permission to see that.");
 
-        cy.visit("/admin/tools/help");
+        cy.visit("/monitor");
         H.main().findByText("Sorry, you don’t have permission to see that.");
       });
     });


### PR DESCRIPTION
Closes [GDGT-2730: Move e2e tests of moved pages to new suite(s)](https://linear.app/metabase/issue/GDGT-2730/move-e2e-tests-of-moved-pages-to-new-suites)

## Summary
- Moved Monitor Tools E2E scenarios under `e2e/test/scenarios/monitor/tools`
- Move Help E2E scenario to `e2e/test/scenarios/admin`
- Update stale `/admin/tools/*` pathls and Admin layout selectors to Monitor routes/layout
- Update command palette and application-permissions assertions

## Verification
- CI is green