### PR TITLE
Don't fail builds on linear release issue tracking

### DIFF
--- a/.github/workflows/linear-release-sync.yml
+++ b/.github/workflows/linear-release-sync.yml
@@ -26,6 +26,7 @@ permissions:
 
 jobs:
   sync-linear-release:
+    continue-on-error: true
     if: ${{ github.repository == 'metabase/metabase' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     steps:


### PR DESCRIPTION
There are some release branches failing due to not having the correct functions in the release typescripot code.  I'll handle that along with adding some more backport-pr-tracing logic in a bit, but for now I just want to keep this from failing builds so our release branches can be green again