### PR TITLE
Fix Linear Release Sync Again

### DIFF
--- a/.github/workflows/linear-release-sync.yml
+++ b/.github/workflows/linear-release-sync.yml
@@ -51,52 +51,57 @@ jobs:
           INPUT_VERSION: ${{ github.event.inputs.release_version }}
         with:
           script: | # js
-            const R = require('${{ github.workspace }}/release/dist/index.cjs');
+            try {
+              const R = require('${{ github.workspace }}/release/dist/index.cjs');
 
-            const { REF_NAME, CURRENT_VERSION, INPUT_VERSION } = process.env;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
+              const { REF_NAME, CURRENT_VERSION, INPUT_VERSION } = process.env;
+              const owner = context.repo.owner;
+              const repo = context.repo.repo;
 
-            // Manual dispatch override wins.
-            if (INPUT_VERSION) {
-              const releaseVersion = R.getLinearReleaseName(INPUT_VERSION);
-              console.log({ REF_NAME, CURRENT_VERSION, INPUT_VERSION, releaseVersion });
-              core.setOutput('release_version', releaseVersion);
-              core.setOutput('base_ref', '');
-              return;
+              // Manual dispatch override wins.
+              if (INPUT_VERSION) {
+                const releaseVersion = R.getLinearReleaseName(INPUT_VERSION);
+                console.log({ REF_NAME, CURRENT_VERSION, INPUT_VERSION, releaseVersion });
+                core.setOutput('release_version', releaseVersion);
+                core.setOutput('base_ref', '');
+                return;
+              }
+
+              // Branch -> major: release branches encode it; master develops the next major.
+              const major = REF_NAME.startsWith('release-x.')
+                ? R.getMajorVersionNumberFromReleaseBranch(REF_NAME)
+                : String(Number(CURRENT_VERSION) + 1);
+
+              // Last STABLE MINOR shipped on this line (ignore patches + pre-releases),
+              // so the release we record is always the next MINOR (e.g. v0.63.3) and a
+              // patch build (v0.63.2.3) maps to its parent minor rather than its own release.
+              const lastMinorTag = await R.getLastReleaseTag({
+                github, owner, repo,
+                version: `v0.${major}.0`, // only the major is read out of this
+                ignorePatches: true,
+                ignorePreReleases: true,
+              });
+
+              const releaseVersion = lastMinorTag
+                ? R.findNextMinorVersion(lastMinorTag) // v0.63.2 -> v0.63.3
+                : `v0.${major}.0`;                   // .0 not cut yet (done manually)
+              const linearReleaseName = R.getLinearReleaseName(releaseVersion);
+
+              console.log({
+                REF_NAME, CURRENT_VERSION, INPUT_VERSION,
+                major, lastMinorTag, releaseVersion, linearReleaseName,
+              });
+
+              core.setOutput('release_version', linearReleaseName);
+              core.setOutput('base_ref', lastMinorTag ?? '');
+
+              core.info(`Linear release ${linearReleaseName} (baseline: ${lastMinorTag ?? 'none'})`);
+            } catch (err) { // this should never fail a CI check
+              console.error(err);
             }
 
-            // Branch -> major: release branches encode it; master develops the next major.
-            const major = REF_NAME.startsWith('release-x.')
-              ? R.getMajorVersionNumberFromReleaseBranch(REF_NAME)
-              : String(Number(CURRENT_VERSION) + 1);
-
-            // Last STABLE MINOR shipped on this line (ignore patches + pre-releases),
-            // so the release we record is always the next MINOR (e.g. v0.63.3) and a
-            // patch build (v0.63.2.3) maps to its parent minor rather than its own release.
-            const lastMinorTag = await R.getLastReleaseTag({
-              github, owner, repo,
-              version: `v0.${major}.0`, // only the major is read out of this
-              ignorePatches: true,
-              ignorePreReleases: true,
-            });
-
-            const releaseVersion = lastMinorTag
-              ? R.findNextMinorVersion(lastMinorTag) // v0.63.2 -> v0.63.3
-              : `v0.${major}.0`;                   // .0 not cut yet (done manually)
-            const linearReleaseName = R.getLinearReleaseName(releaseVersion);
-
-            console.log({
-              REF_NAME, CURRENT_VERSION, INPUT_VERSION,
-              major, lastMinorTag, releaseVersion, linearReleaseName,
-            });
-
-            core.setOutput('release_version', linearReleaseName);
-            core.setOutput('base_ref', lastMinorTag ?? '');
-
-            core.info(`Linear release ${linearReleaseName} (baseline: ${lastMinorTag ?? 'none'})`);
-
       - name: Sync / update / complete the Linear release
+        if: ${{ steps.ctx.outputs.release_version }}
         uses: linear/linear-release-action@v0
         with:
           access_key: ${{ secrets.LINEAR_RELEASE_ACCESS_KEY }}

--- a/.github/workflows/linear-release-sync.yml
+++ b/.github/workflows/linear-release-sync.yml
@@ -36,12 +36,15 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Build release code from master
+        run: git checkout master
       - name: Build the release scripts
         uses: ./.github/actions/prepare-release-scripts
 
       - name: Derive the in-flight MINOR version + scan baseline (via release/ helpers)
         id: ctx
         uses: actions/github-script@v9
+        continue-on-error: true
         env:
           REF_NAME: ${{ github.ref_name }}
           # master develops the next GA major. cut-release-branch.yml bumps this
@@ -100,6 +103,8 @@ jobs:
               console.error(err);
             }
 
+      - name: Restore branch (for subsequent steps)
+        run: git checkout ${{ github.ref_name }} # restore branch
       - name: Sync / update / complete the Linear release
         if: ${{ steps.ctx.outputs.release_version }}
         uses: linear/linear-release-action@v0


### PR DESCRIPTION
#76889 did not actually do the trick

This adds 3 fixes

1. Build the release code off of master, no matter what branch we're on (as we do elsewhere)
2. Add a big fat try/catch block so we never throw a js error.
3. Adds continue-on-error at the step level, which I think should prevent the job from failing on the js step.