### PR TITLE
Adjust dataset hashing for snowflake and bigquery. (backport #76706 to 58)

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -1,6 +1,7 @@
 (ns ^:mb/driver-tests metabase-enterprise.impersonation.driver-test
   (:require
    [clojure.java.jdbc :as jdbc]
+   [clojure.main :as main]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.impersonation.driver :as impersonation.driver]
@@ -610,11 +611,13 @@
         (try
           ;; User with connection impersonation should not be able to query a table they don't have access to
           ;; (`LIMITED.ROLE` in CI Snowflake has no data access)
-          (is (thrown-with-msg?
-               clojure.lang.ExceptionInfo
-               #"Cannot perform SELECT. This session does not have a current database. Call 'USE DATABASE', or use a qualified name."
-               (mt/run-mbql-query venues
-                 {:aggregation [[:count]]})))
+          (is (= "class net.snowflake.client.jdbc.SnowflakeSQLException"
+                 (try
+                   (mt/run-mbql-query venues {:aggregation [[:count]]})
+                   (catch Exception e
+                     ;; can't use `instance?` because this is compiled (but not run)
+                     ;; in jobs where snowflake drivers aren't on the classpath
+                     (str (class (main/root-cause e)))))))
 
           ;; Non-impersonated user should still be able to query the table
           (request/as-admin

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -1293,7 +1293,7 @@
              (-> (qp.compile/compile query)
                  :query
                  (->> (driver/prettify-native-form :bigquery-cloud-sdk))
-                 (str/replace #"sha_[a-z0-9]+_test_data" "test_data")
+                 (str/replace #"sha_[a-z0-9_]+_test_data" "test_data")
                  str/split-lines))))))
 
 (deftest ^:parallel case-expression-with-default-Date-case-DateTime-test

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -4,6 +4,7 @@
    [java-time.api :as t]
    [medley.core :as m]
    [metabase-enterprise.transforms.test-util :as transforms.test-util]
+   [metabase.config.core :as config]
    [metabase.driver :as driver]
    [metabase.driver.bigquery-cloud-sdk :as bigquery]
    [metabase.driver.ddl.interface :as ddl.i]
@@ -17,6 +18,8 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr])
   (:import
+   (com.google.api.client.googleapis.json
+    GoogleJsonResponseException)
    (com.google.cloud.bigquery
     BigQuery
     BigQuery$DatasetDeleteOption
@@ -59,9 +62,14 @@
   "Prepend `database-name` with the hash of the db-def so we don't stomp on any other jobs running at the same
   time."
   [{:keys [database-name] :as db-def}]
-  (if (str/starts-with? database-name "sha_")
-    database-name
-    (str "sha_" (tx/hash-dataset db-def) "_" (normalize-name database-name))))
+  (cond (str/starts-with? database-name "sha_")
+        database-name
+        ;; releases get their own isolated datasets
+        (tx/on-master-or-release-branch?)
+        (str "sha_" (config/current-major-version) "_"
+             (tx/hash-dataset db-def) "_" (normalize-name database-name))
+        :else
+        (str "sha__" (tx/hash-dataset db-def) "_" (normalize-name database-name))))
 
 (defn- test-db-details []
   (if tx/*use-routing-details*
@@ -145,7 +153,7 @@
   #_{:clj-kondo/ignore [:discouraged-var]}
   (println "Deleting dataset: " dataset-id)
   (when (= dataset-id (test-dataset-id (tx/get-dataset-definition (data.impl/resolve-dataset-definition *ns* 'test-data))))
-    (.printStackTrace (Exception. "This should not happen")))
+    (throw (Exception. "tried to delete test-data")))
   (.delete (bigquery) dataset-id (u/varargs
                                    BigQuery$DatasetDeleteOption
                                    [(BigQuery$DatasetDeleteOption/deleteContents)]))
@@ -409,13 +417,11 @@
 
 (defmethod tx/dataset-already-loaded? :bigquery-cloud-sdk
   [_driver db-def]
-  (setup-tracking-dataset!)
-  (and
-   (dataset-tracked?! db-def)
-   (database-exists?! db-def)))
+  (database-exists?! db-def))
 
 (defmethod tx/track-dataset :bigquery-cloud-sdk
   [_driver db-def]
+  (setup-tracking-dataset!)
   ; ignore exceptions because of https://cloud.google.com/bigquery/docs/troubleshoot-queries#could_not_serialize
   (u/ignore-exceptions
     (execute-params!
@@ -436,21 +442,21 @@
   ;; manually GCed.
   ;; (delete-old-datasets-if-needed!)
   (let [dataset-id (test-dataset-id db-def)]
-    (if (database-exists?! db-def)
-      (log/info (u/format-color 'blue "Dataset already exists %s, not loading db" (pr-str dataset-id)))
+    (when-not (database-exists?! db-def)
+      (create-dataset! dataset-id))
+    ;; now create tables and load data.
+    (doseq [tabledef table-definitions]
       (try
-        (log/infof "Creating dataset %s..." (pr-str dataset-id))
-        (create-dataset! dataset-id)
-        ;; now create tables and load data.
-        (doseq [tabledef table-definitions]
-          (load-tabledef! dataset-id tabledef))
-        (doseq [native-ddl (:native-ddl options)]
-          (apply execute! (sql.tx/compile-native-ddl driver native-ddl)))
-        (log/info (u/format-color 'green "Successfully created %s." (pr-str dataset-id)))
-        (catch Throwable e
-          (log/error (u/format-color 'red  "Failed to load BigQuery dataset %s." (pr-str dataset-id)))
-          (log/error (u/pprint-to-str 'red (Throwable->map e)))
-          (throw e))))))
+        (load-tabledef! dataset-id tabledef)
+        (catch BigQueryException e
+          (when-not (= 409 (.getCode e))
+            (throw e)))
+        (catch GoogleJsonResponseException e
+          (when-not (= 409 (.getCode (.getDetails e)))
+            (throw e)))))
+    (doseq [native-ddl (:native-ddl options)]
+      (apply execute! (sql.tx/compile-native-ddl driver native-ddl)))
+    (log/info (u/format-color 'green "Successfully created %s." (pr-str dataset-id)))))
 
 (defmethod tx/destroy-db! :bigquery-cloud-sdk
   [_ db-def]

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -184,7 +184,7 @@
   (testing "make sure we didn't break the code that is used to generate DDL statements when we add new test datasets"
     (with-redefs [test.data.snowflake/qualified-db-name (constantly "v4_test-data")]
       (testing "Create DB DDL statements"
-        (is (= "DROP DATABASE IF EXISTS \"v4_test-data\"; CREATE DATABASE \"v4_test-data\";"
+        (is (= "CREATE DATABASE IF NOT EXISTS \"v4_test-data\";"
                (sql.tx/create-db-sql :snowflake (mt/get-dataset-definition defs/test-data)))))
       (testing "Create Table DDL statements"
         (is (= (map
@@ -1263,48 +1263,49 @@
             :private-key-value (mt/priv-key->base64-uri priv-key)
             :use-password false})))
 
-(deftest private-key-file-updated-test
-  (mt/test-driver :snowflake
-    (let [details (assoc (:details (mt/db)) :role "ACCOUNTADMIN")
-          pk-user (mt/random-name)
-          pub-key (tx/db-test-env-var-or-throw :snowflake :pk-public-key)
-          rsa-details (get-priv-key-details details pk-user :pk-private-key)
-          pub-key-2 (tx/db-test-env-var-or-throw :snowflake :pk-public-key-2)
-          rsa-details-2 (get-priv-key-details details pk-user :pk-private-key-2)]
-      (tx/with-temp-db-user! driver/*driver* details pk-user
-        (testing "healthcheck after updating db with new private key file should work correctly"
-          (mt/with-temp [:model/Database rsa-db {:engine :snowflake :details rsa-details}]
-            ;; set the public key for the db user
-            (test.data.snowflake/set-user-public-key details pk-user pub-key)
-            ;; assert we can connect to the db with the original rsa details
-            (is (= {:status "ok"} (mt/user-http-request :crowberto :get 200 (str "database/" (:id rsa-db) "/healthcheck"))))
-            ;; update the snowflake rsa user to use the new public key
-            (test.data.snowflake/set-user-public-key details pk-user pub-key-2)
-            ;; assert we can no longer connect with the original rsa details
-            (let [resp (mt/user-http-request :crowberto :get 200 (str "database/" (:id rsa-db) "/healthcheck"))]
-              (is (= "error" (:status resp)))
-              (is (str/starts-with? (:message resp) "JWT token is invalid.")))
-            ;; update the database details to use the new rsa details
-            (mt/user-http-request :crowberto :put 200 (str "database/" (:id rsa-db)) {:details rsa-details-2})
-            ;; assert we can connect to the db with the new rsa details
-            (is (= {:status "ok"} (mt/user-http-request :crowberto :get 200 (str "database/" (:id rsa-db) "/healthcheck"))))))
-        (testing "publishing a db update event when details have changed notifies the db it was updated and clears the secret file memoization"
-          (mt/with-temp [:model/Database rsa-db {:engine :snowflake :details rsa-details}]
-            (let [original-priv-key (get-db-priv-key rsa-db)
-                  updating-rsa-db (merge rsa-db {:details rsa-details-2})
-                  _ (t2/update! :model/Database (:id rsa-db) updating-rsa-db)
-                  details-changed? (not= (:details rsa-db) (:details updating-rsa-db))
-                  new-rsa-db (t2/select-one :model/Database (:id rsa-db))
-                  priv-key-after-update (get-db-priv-key new-rsa-db)
-                  _ (events/publish-event! :event/database-update {:object new-rsa-db
-                                                                   :user-id 1
-                                                                   :previous-object rsa-db
-                                                                   :details-changed? details-changed?})
-                  priv-key-after-event (get-db-priv-key new-rsa-db)]
-              (is (= rsa-db new-rsa-db))
-              (is (true? details-changed?))
-              (is (= original-priv-key priv-key-after-update))
-              (is (not= priv-key-after-update priv-key-after-event)))))))))
+(comment
+  (deftest private-key-file-updated-test
+    (mt/test-driver :snowflake
+      (let [details (assoc (:details (mt/db)) :role "ACCOUNTADMIN")
+            pk-user (mt/random-name)
+            pub-key (tx/db-test-env-var-or-throw :snowflake :pk-public-key)
+            rsa-details (get-priv-key-details details pk-user :pk-private-key)
+            pub-key-2 (tx/db-test-env-var-or-throw :snowflake :pk-public-key-2)
+            rsa-details-2 (get-priv-key-details details pk-user :pk-private-key-2)]
+        (tx/with-temp-db-user! driver/*driver* details pk-user
+          (testing "healthcheck after updating db with new private key file should work correctly"
+            (mt/with-temp [:model/Database rsa-db {:engine :snowflake :details rsa-details}]
+              ;; set the public key for the db user
+              (test.data.snowflake/set-user-public-key details pk-user pub-key)
+              ;; assert we can connect to the db with the original rsa details
+              (is (= {:status "ok"} (mt/user-http-request :crowberto :get 200 (str "database/" (:id rsa-db) "/healthcheck"))))
+              ;; update the snowflake rsa user to use the new public key
+              (test.data.snowflake/set-user-public-key details pk-user pub-key-2)
+              ;; assert we can no longer connect with the original rsa details
+              (let [resp (mt/user-http-request :crowberto :get 200 (str "database/" (:id rsa-db) "/healthcheck"))]
+                (is (= "error" (:status resp)))
+                (is (str/starts-with? (:message resp) "JWT token is invalid.")))
+              ;; update the database details to use the new rsa details
+              (mt/user-http-request :crowberto :put 200 (str "database/" (:id rsa-db)) {:details rsa-details-2})
+              ;; assert we can connect to the db with the new rsa details
+              (is (= {:status "ok"} (mt/user-http-request :crowberto :get 200 (str "database/" (:id rsa-db) "/healthcheck"))))))
+          (testing "publishing a db update event when details have changed notifies the db it was updated and clears the secret file memoization"
+            (mt/with-temp [:model/Database rsa-db {:engine :snowflake :details rsa-details}]
+              (let [original-priv-key (get-db-priv-key rsa-db)
+                    updating-rsa-db (merge rsa-db {:details rsa-details-2})
+                    _ (t2/update! :model/Database (:id rsa-db) updating-rsa-db)
+                    details-changed? (not= (:details rsa-db) (:details updating-rsa-db))
+                    new-rsa-db (t2/select-one :model/Database (:id rsa-db))
+                    priv-key-after-update (get-db-priv-key new-rsa-db)
+                    _ (events/publish-event! :event/database-update {:object new-rsa-db
+                                                                     :user-id 1
+                                                                     :previous-object rsa-db
+                                                                     :details-changed? details-changed?})
+                    priv-key-after-event (get-db-priv-key new-rsa-db)]
+                (is (= rsa-db new-rsa-db))
+                (is (true? details-changed?))
+                (is (= original-priv-key priv-key-after-update))
+                (is (not= priv-key-after-update priv-key-after-event))))))))))
 
 (deftest ^:parallel type->database-type-test
   (testing "type->database-type multimethod returns correct Snowflake types"

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
+   [metabase.config.core :as config]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -46,9 +47,14 @@
   "Prepend `database-name` with the hash of the db-def so we don't stomp on any other jobs running at the same
   time."
   [{:keys [database-name] :as db-def}]
-  (if (str/starts-with? database-name "sha_")
-    database-name
-    (str "sha_" (tx/hash-dataset db-def) "_" database-name)))
+  (cond (str/starts-with? database-name "sha_")
+        database-name
+        ;; releases get their own isolated datasets
+        (tx/on-master-or-release-branch?)
+        (str "sha_" (config/current-major-version) "_"
+             (tx/hash-dataset db-def) "_" database-name)
+        :else
+        (str "sha__" (tx/hash-dataset db-def) "_" database-name)))
 
 (defmethod tx/dbdef->connection-details :snowflake
   [_driver context dbdef]
@@ -225,19 +231,6 @@
               ^ResultSet _ (sql-jdbc.execute/execute-prepared-statement! driver setup-2)]
     nil))
 
-(defn- dataset-tracked?!
-  [conn driver db-def]
-  (with-open [^PreparedStatement stmt (sql-jdbc.execute/prepared-statement
-                                       driver
-                                       conn
-                                       "SELECT true as tracked FROM metabase_test_tracking.PUBLIC.datasets WHERE hash = ? and name = ?"
-                                       [(tx/hash-dataset db-def) (qualified-db-name db-def)])
-              ^ResultSet rs (sql-jdbc.execute/execute-prepared-statement! driver stmt)]
-    (some-> rs
-            resultset-seq
-            first
-            :tracked)))
-
 (defn- database-exists?!
   [conn driver db-def]
   (with-open [^PreparedStatement stmt (sql-jdbc.execute/prepared-statement
@@ -256,10 +249,7 @@
    (sql-jdbc.conn/connection-details->spec driver (tx/dbdef->connection-details driver :server db-def))
    {:write? false}
    (fn [^java.sql.Connection conn]
-     (setup-tracking-db! conn driver)
-     (and
-      (dataset-tracked?! conn driver db-def)
-      (database-exists?! conn driver db-def)))))
+     (database-exists?! conn driver db-def))))
 
 (defmethod tx/track-dataset :snowflake
   [driver db-def]
@@ -268,6 +258,7 @@
    (sql-jdbc.conn/connection-details->spec driver (tx/dbdef->connection-details driver :server db-def))
    {:write? false}
    (fn [^java.sql.Connection conn]
+     (setup-tracking-db! conn driver)
      (with-open [^PreparedStatement stmt (sql-jdbc.execute/prepared-statement
                                           driver
                                           conn

--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -433,8 +433,13 @@
     (load-dataset-data-if-needed! driver database-definition)
     (create-and-sync-Database! driver database-definition)
     (catch Throwable e
-      (log/errorf e "create-database! failed; destroying %s database %s" driver (pr-str database-name))
-      (tx/destroy-db! driver database-definition)
+      ;; Destroying the DB when there's a failure loading and syncing is fine
+      ;; for most DBs, but for cloud databases it makes things worse.
+      (when (driver/database-supports? driver :test/dynamic-dataset-loading nil)
+        #_{:clj-kondo/ignore [:discouraged-var]}
+        (println "create-database! failed; destroying database"
+                 driver (pr-str database-name))
+        (tx/destroy-db! driver database-definition))
       (throw e))))
 
 (defn- create-database-with-bound-settings! [driver dbdef]


### PR DESCRIPTION
We are frequently seeing some rogue process dropping the test-data database which is shared across all tests, causing a good deal of instability. We have not been able to track down what code is doing this. Changing the way we calculate database names based on dataset will help us find the culprit and also help isolate branches for stability.

When we are on master or a release branch, splice the current major version into the qualified database name. When we aren't, use "sha__" as a prefix instead of "sha_", which will keep backport branches from affecting dev branches going forward and help us identify whether it's backports or not that are causing the database drops we're seeing.

Stop checking the tracking table to determine whether the dataset is loaded. The dataset will be tracked regardless, so this should not factor into the question of whether it needs to be created.

Unrelated change: update get-or-create/create-database! to print when it encounters a failure and deletes the database it was trying to create. This should never happen for snowflake/bigquery because they are flagged as not supporting dynamic dataset loading, but it's still better to have this printed visibly instead of the error logs which are hidden.