### PR TITLE
Preserve map order when deserializing MBQL

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -342,7 +342,8 @@
    honeysql.format        {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}
    honeysql.helpers       {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}
    honeysql.types         {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}
-   honeysql.util          {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}}
+   honeysql.util          {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}
+   jsonista.core          {:message "Use metabase.util.json instead of JSONista directly."}}
 
   :discouraged-tag {p {:message "You can use it, but don't commit it."}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -101,6 +101,7 @@
                                                           org.bouncycastle/bcprov-jdk18on]}
   metabase/throttle                         {:mvn/version "1.0.2"}              ; Tools for throttling access to API endpoints and other code pathways
   methodical/methodical                     {:mvn/version "1.0.127"}            ; drop-in replacements for Clojure multimethods and adds several advanced features
+  metosin/jsonista                          {:mvn/version "1.0.0"}
   metosin/malli                             {:git/url "https://github.com/metabase/malli" ; Data-driven Schemas for Clojure/Script and babashka
                                              :git/sha "b4a2d78647a049870b316753d7aae7fb4ade3ae5"} ; patched to resolve an issue causing OOM
   net.carcdr/oidc-provider                  {:mvn/version "0.6.2"}              ; OAuth/OIDC server abstract implementation

--- a/src/metabase/lib_be/models/transforms.clj
+++ b/src/metabase/lib_be/models/transforms.clj
@@ -8,9 +8,10 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [some empty?]]))
+   [metabase.util.performance :refer [empty? some]]))
 
 (set! *warn-on-reflection* true)
 
@@ -79,7 +80,9 @@
        (log/errorf e "Error normalizing query %s" (pr-str query))
        {}))))
 
-(defn- transform-query-in [query]
+(defn- transform-query-in
+  "Transform MBQL `query` for going in to the app DB (i.e., serialize to JSON)."
+  [query]
   (when-not (map? query)
     (throw (ex-info (format "Query must be a map, got ^%s %s" (.getCanonicalName (class query)) (pr-str query))
                     {:query query, :status-code 400})))
@@ -88,10 +91,22 @@
       lib/prepare-for-serialization
       mi/json-in))
 
-(defn- transform-query-out [s]
+(defn- parse-query-json [s]
+  (letfn [(decode [s]
+            (try
+              (json/decode-with-ordered-maps-no-keywordization s)
+              (catch Throwable e
+                (log/error e "Error parsing JSON")
+                s)))]
+    (cond-> s
+      (string? s) decode)))
+
+(defn- transform-query-out
+  "Transform MBQL `query` for coming out of the app DB (i.e., deserialize from JSON)."
+  [s]
   (when (some? s)
     (try
-      (let [query (mi/json-out-without-keywordization s)]
+      (let [query (parse-query-json s)]
         (assert (map? query)
                 (format "Expected deserialized query to be a map, got ^%s %s" (.getCanonicalName (class query)) (pr-str query)))
         (normalize-query query))

--- a/src/metabase/util/json.clj
+++ b/src/metabase/util/json.clj
@@ -1,13 +1,13 @@
 (ns metabase.util.json
   "Functions for encoding and decoding JSON that abstract away the underlying implementation."
+  #_{:clj-kondo/ignore [:discouraged-namespace]}
   (:require
-   #_{:clj-kondo/ignore [:discouraged-namespace]} [cheshire.core :as cheshire]
+   [cheshire.core :as cheshire]
    [cheshire.factory]
    [cheshire.generate :as json.generate]
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [flatland.ordered.map :as ordered-map]
-   #_{:clj-kondo/ignore [:discouraged-namespace]} [jsonista.core :as jsonista])
+   [flatland.ordered.map :as ordered-map] [jsonista.core :as jsonista])
   (:import
    (com.fasterxml.jackson.core JsonGenerator JsonParser JsonToken)
    (com.fasterxml.jackson.databind DeserializationContext JsonDeserializer ObjectMapper)

--- a/src/metabase/util/json.clj
+++ b/src/metabase/util/json.clj
@@ -6,9 +6,14 @@
    [cheshire.factory]
    [cheshire.generate :as json.generate]
    [clojure.java.io :as io]
-   [clojure.string :as str])
+   [clojure.string :as str]
+   [flatland.ordered.map :as ordered-map]
+   #_{:clj-kondo/ignore [:discouraged-namespace]}
+   [jsonista.core :as jsonista])
   (:import
-   (com.fasterxml.jackson.core JsonGenerator)
+   (com.fasterxml.jackson.core JsonGenerator JsonParser JsonToken)
+   (com.fasterxml.jackson.databind DeserializationContext JsonDeserializer ObjectMapper)
+   (com.fasterxml.jackson.databind.module SimpleModule)
    (java.io InputStream Reader)))
 
 (set! *warn-on-reflection* true)
@@ -124,3 +129,26 @@
       (some-> ctype (str/starts-with? "application/json")) (update res :body decode-with-encoding ctype)
       (string? (:body res))                                res
       :else                                                (update res :body slurp))))
+
+(defn- ordered-map-deserializer [key-fn]
+  (proxy [JsonDeserializer] []
+    (deserialize [^JsonParser p ^DeserializationContext _context]
+      (loop [m (ordered-map/ordered-map)]
+        (if (= (.nextToken p) JsonToken/END_OBJECT)
+          m
+          (let [k (key-fn (.getCurrentName p))]
+            (.nextToken p)
+            (recur (assoc m k (.readValueAs p Object)))))))))
+
+(def ^:private ^ObjectMapper ordered-map-no-keywordization-json-mapper
+  "Create a JSONista mapper that reads maps as `ordered-map`s for use with [[jsonista.core/read-value]]. It is
+  somewhat more performant to create this once and reuse it rather than recreate it every time you read JSON the same
+  way."
+  (jsonista/object-mapper
+   {:modules [(doto (SimpleModule. "ordered-map-deserializer")
+                (.addDeserializer java.util.Map (ordered-map-deserializer identity)))]}))
+
+(defn decode-with-ordered-maps-no-keywordization
+  "Decode `source` while reading maps as `ordered-map`s (i.e., preserving order) without keywordizing keys."
+  [source]
+  (jsonista/read-value source ordered-map-no-keywordization-json-mapper))

--- a/src/metabase/util/json.clj
+++ b/src/metabase/util/json.clj
@@ -1,15 +1,13 @@
 (ns metabase.util.json
   "Functions for encoding and decoding JSON that abstract away the underlying implementation."
   (:require
-   #_{:clj-kondo/ignore [:discouraged-namespace]}
-   [cheshire.core :as cheshire]
+   #_{:clj-kondo/ignore [:discouraged-namespace]} [cheshire.core :as cheshire]
    [cheshire.factory]
    [cheshire.generate :as json.generate]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [flatland.ordered.map :as ordered-map]
-   #_{:clj-kondo/ignore [:discouraged-namespace]}
-   [jsonista.core :as jsonista])
+   #_{:clj-kondo/ignore [:discouraged-namespace]} [jsonista.core :as jsonista])
   (:import
    (com.fasterxml.jackson.core JsonGenerator JsonParser JsonToken)
    (com.fasterxml.jackson.databind DeserializationContext JsonDeserializer ObjectMapper)

--- a/test/metabase/lib_be/models/transforms_test.clj
+++ b/test/metabase/lib_be/models/transforms_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.lib-be.models.transforms-test
   (:require
    [clojure.test :refer :all]
+   [flatland.ordered.map :as ordered-map]
    [metabase.lib-be.core :as lib-be]
    [metabase.util.json :as json]
    [metabase.util.malli :as mu]))
@@ -82,3 +83,39 @@
                                               "widget-type"  "category/="
                                               "default"      nil}}
                           "query" "<<NATIVE QUERY>>"}})))))
+
+(deftest ^:parallel preserve-template-tag-order-test
+  (testing "Should preserve parameter order when deserializing MBQL from JSON (#5136, QUE2-607)"
+    (let [json ((:in lib-be/transform-query)
+                {:lib/type :mbql/query
+                 :stages   [{:lib/type :mbql.stage/native
+                             :template-tags
+                             (into
+                              (ordered-map/ordered-map)
+                              (map (fn [i]
+                                     (let [param-name (format "parameter_%d" i)]
+                                       [param-name
+                                        {:widget-type  :category
+                                         :id           (format "00000000-0000-0000-0000-00000000000%d" i)
+                                         :name         param-name
+                                         :display-name (format "Parameter %d" i)
+                                         :type         :dimension
+                                         :dimension    [:field {} 1]
+                                         :default      nil}])))
+                              (range 10))
+                             :native   "<<NATIVE QUERY>>"}]
+                 :database 2})
+          query ((:out lib-be/transform-query) json)]
+      (is (instance? flatland.ordered.map.OrderedMap
+                     (get-in query [:stages 0 :template-tags])))
+      (is (= ["parameter_0"
+              "parameter_1"
+              "parameter_2"
+              "parameter_3"
+              "parameter_4"
+              "parameter_5"
+              "parameter_6"
+              "parameter_7"
+              "parameter_8"
+              "parameter_9"]
+             (keys (get-in query [:stages 0 :template-tags])))))))


### PR DESCRIPTION
Fixes #5136

The root cause of the issue is that Cheshire + Jackson reads maps to Clojure's usual map types and maps with more than 8 values get converted to hash maps, so to solve the problem I'm reading out MBQL using `ordered-map` for all maps. 

Cheshire was not flexible enough to allow customizing Jackson in this way so I used JSONista for this specific column instead. Both libraries wrap Jackson so this should hopefully not add much overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query JSON now preserves the original order of template tags and similar map fields when transformed.
  * JSON values can now be decoded without automatically converting keys into keywords, improving compatibility with existing payloads.

* **Bug Fixes**
  * Reduced the risk of query data being reordered during save/load or transformation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->