### PR TITLE
Take existing tables into account when determining already-loaded bigquery

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -1,9 +1,9 @@
 (ns metabase.test.data.bigquery-cloud-sdk
   (:require
+   [clojure.set :as set]
    [clojure.string :as str]
    [java-time.api :as t]
    [medley.core :as m]
-   [metabase.config.core :as config]
    [metabase.driver :as driver]
    [metabase.driver.bigquery-cloud-sdk :as bigquery]
    [metabase.driver.bigquery-cloud-sdk.workspaces :as bigquery.ws]
@@ -67,8 +67,7 @@
         database-name
         ;; releases get their own isolated datasets
         (tx/on-master-or-release-branch?)
-        (str "sha_" (config/current-major-version) "_"
-             (tx/hash-dataset db-def) "_" (normalize-name database-name))
+        (str "sha_rel_" (tx/hash-dataset db-def) "_" (normalize-name database-name))
         :else
         (str "sha__" (tx/hash-dataset db-def) "_" (normalize-name database-name))))
 
@@ -517,9 +516,16 @@
     [(test-dataset-id db-def)])
    ffirst))
 
+(defn- get-existing-tables [dataset-id]
+  (let [sql (format "SELECT table_name FROM %s.%s.INFORMATION_SCHEMA.TABLES"
+                    (project-id) dataset-id)]
+    (set (map first (execute! sql)))))
+
 (defmethod tx/dataset-already-loaded? :bigquery-cloud-sdk
   [_driver db-def]
-  (database-exists?! db-def))
+  (and (database-exists?! db-def)
+       (set/subset? (set (map :table-name (:table-definitions db-def)))
+                    (set (get-existing-tables (test-dataset-id db-def))))))
 
 (defmethod tx/track-dataset :bigquery-cloud-sdk
   [_driver db-def]
@@ -534,11 +540,6 @@
      [(tx/hash-dataset db-def)
       (test-dataset-id db-def)
       (tx/tracking-access-note)])))
-
-(defn- get-existing-tables [dataset-id]
-  (let [sql (format "SELECT table_name FROM %s.%s.INFORMATION_SCHEMA.TABLES"
-                    (project-id) dataset-id)]
-    (set (map first (execute! sql)))))
 
 (defmethod tx/create-db! :bigquery-cloud-sdk
   [driver {:keys [database-name table-definitions options] :as db-def} & _]

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
-   [metabase.config.core :as config]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -56,8 +55,7 @@
         database-name
         ;; releases get their own isolated datasets
         (tx/on-master-or-release-branch?)
-        (str "sha_" (config/current-major-version) "_"
-             (tx/hash-dataset db-def) "_" database-name)
+        (str "sha_rel_" (tx/hash-dataset db-def) "_" database-name)
         :else
         (str "sha__" (tx/hash-dataset db-def) "_" database-name)))
 


### PR DESCRIPTION
We no longer have bigquery tables that constantly think that they need to be recreated, but we have fallen a little too far in the other direction; datasets that get their DB created but fail midway thru will still be treated as loaded.

In snowflake we have a way of checking this down to the individual row counts and counting as not-already-loaded if there's a mismatch. I don't see an efficient way to do this in bigquery, but we can at least check that all the tables exist. If we get a failed partial load that gets all the tables created but fails the rows that will still require manual intervention.

Also stop using (config/current-major-version) when qualifying dataset names; turns out this is not at all reliable in CI. This unfortunately means that we don't actually have cross-major-version isolation; the best we can do is isolate master/release from all other branches, which is still an improvement over what we have now.