### PR TITLE
Add query remarks on MongoDB

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/execute.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/execute.clj
@@ -206,27 +206,8 @@
                []
                (reducible-rows cursor first-row (post-process-row row-col-names))))))
 
-(defn- inject-remark
-  "Insert a MongoDB `{$comment}` aggregation-pipeline stage carrying `remark` into `stages`, giving DBAs visibility
-  into the Metabase query behind each operation (see #9514).
-
-  MongoDB only permits `$documents` as the *first* pipeline stage, so when `stages` opens with `$documents` the
-  comment is placed immediately after it; otherwise it is prepended, mirroring the remark placement used by the
-  SQL drivers. Returns `stages` unchanged when `remark` is nil or blank, so callers may always thread the pipeline
-  through this function."
-  [stages remark]
-  (cond
-    (str/blank? remark)
-    stages
-
-    (contains? (first stages) "$documents")
-    (into [(first stages) {"$comment" remark}] (rest stages))
-
-    :else
-    (into [{"$comment" remark}] (or stages []))))
-
 (defn- include-user-id-and-hash?
-  "Whether the connection `details` request injecting the user id and query hash into queries (the
+  "Whether the connection `details` request attaching the user id and query hash to queries (the
   `:include-user-id-and-hash` detail). Defaults to true when unspecified, matching the toggle honored by the SQL
   and BigQuery drivers; see [[metabase.driver.sql-jdbc.execute/inject-remark]] and #2386."
   [details]
@@ -235,18 +216,21 @@
 (defn execute-reducible-query
   "Process and run a native MongoDB query. This function expects initialized [[mongo.connection/*mongo-client*]].
 
-  When [[include-user-id-and-hash?]] holds for the database's connection details (the default), a `{$comment}`
-  aggregation-pipeline stage carrying the query remark (see [[metabase.query-processor.util/query->remark]] and
-  #9514) is spliced into the pipeline via [[inject-remark]] so DBAs can trace each operation back to its
-  originating Metabase query."
+  When [[include-user-id-and-hash?]] holds for the database's connection details (the default), the query remark
+  (see [[metabase.query-processor.util/query->remark]] and #9514) is attached to the aggregation as its `comment`
+  option (MongoDB 4.4+) via [[com.mongodb.client.AggregateIterable/comment]], so DBAs can trace each operation
+  back to its originating Metabase query.
+
+  `$comment` is a MongoDB *query operator*, not a valid aggregation-pipeline stage — injecting it as a stage is
+  rejected by the server (error 40324) — so the remark is passed as the aggregate command's `comment` option rather
+  than spliced into the pipeline."
   [{{query :query collection-name :collection :as native-query} :native :as outer-query} respond]
   {:pre [(string? collection-name) (fn? respond)]}
   (let [query   (cond-> query
                   (string? query) mongo.qp/parse-query-string)
         database (driver-api/database (driver-api/metadata-provider))
-        query   (cond-> query
-                  (include-user-id-and-hash? (driver.conn/effective-details database))
-                  (inject-remark (driver-api/query->remark :mongo outer-query)))
+        remark   (when (include-user-id-and-hash? (driver.conn/effective-details database))
+                   (driver-api/query->remark :mongo outer-query))
         db-name (mongo.db/db-name database)
         client-database (mongo.util/database mongo.connection/*mongo-client* db-name)]
     (with-open [session ^ClientSession (mongo.util/start-session! mongo.connection/*mongo-client*)]
@@ -259,6 +243,8 @@
                                                       session
                                                       query
                                                       driver.settings/*query-timeout-ms*)]
+        (when remark
+          (.comment ^AggregateIterable aggregate ^String remark))
         (with-open [^MongoCursor cursor (try (.cursor aggregate)
                                              (catch Throwable e
                                                (throw (ex-info (tru "Error executing query: {0}" (ex-message e))

--- a/modules/drivers/mongo/src/metabase/driver/mongo/execute.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/execute.clj
@@ -5,6 +5,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [metabase.driver-api.core :as driver-api]
+   [metabase.driver.connection :as driver.conn]
    [metabase.driver.mongo.connection :as mongo.connection]
    [metabase.driver.mongo.conversion :as mongo.conversion]
    [metabase.driver.mongo.database :as mongo.db]
@@ -205,13 +206,47 @@
                []
                (reducible-rows cursor first-row (post-process-row row-col-names))))))
 
+(defn- inject-remark
+  "Insert a MongoDB `{$comment}` aggregation-pipeline stage carrying `remark` into `stages`, giving DBAs visibility
+  into the Metabase query behind each operation (see #9514).
+
+  MongoDB only permits `$documents` as the *first* pipeline stage, so when `stages` opens with `$documents` the
+  comment is placed immediately after it; otherwise it is prepended, mirroring the remark placement used by the
+  SQL drivers. Returns `stages` unchanged when `remark` is nil or blank, so callers may always thread the pipeline
+  through this function."
+  [stages remark]
+  (cond
+    (str/blank? remark)
+    stages
+
+    (contains? (first stages) "$documents")
+    (into [(first stages) {"$comment" remark}] (rest stages))
+
+    :else
+    (into [{"$comment" remark}] (or stages []))))
+
+(defn- include-user-id-and-hash?
+  "Whether the connection `details` request injecting the user id and query hash into queries (the
+  `:include-user-id-and-hash` detail). Defaults to true when unspecified, matching the toggle honored by the SQL
+  and BigQuery drivers; see [[metabase.driver.sql-jdbc.execute/inject-remark]] and #2386."
+  [details]
+  (get details :include-user-id-and-hash true))
+
 (defn execute-reducible-query
-  "Process and run a native MongoDB query. This function expects initialized [[mongo.connection/*mongo-client*]]."
-  [{{query :query collection-name :collection :as native-query} :native} respond]
+  "Process and run a native MongoDB query. This function expects initialized [[mongo.connection/*mongo-client*]].
+
+  When [[include-user-id-and-hash?]] holds for the database's connection details (the default), a `{$comment}`
+  aggregation-pipeline stage carrying the query remark (see [[metabase.query-processor.util/query->remark]] and
+  #9514) is spliced into the pipeline via [[inject-remark]] so DBAs can trace each operation back to its
+  originating Metabase query."
+  [{{query :query collection-name :collection :as native-query} :native :as outer-query} respond]
   {:pre [(string? collection-name) (fn? respond)]}
-  (let [query  (cond-> query
-                 (string? query) mongo.qp/parse-query-string)
+  (let [query   (cond-> query
+                  (string? query) mongo.qp/parse-query-string)
         database (driver-api/database (driver-api/metadata-provider))
+        query   (cond-> query
+                  (include-user-id-and-hash? (driver.conn/effective-details database))
+                  (inject-remark (driver-api/query->remark :mongo outer-query)))
         db-name (mongo.db/db-name database)
         client-database (mongo.util/database mongo.connection/*mongo-client* db-name)]
     (with-open [session ^ClientSession (mongo.util/start-session! mongo.connection/*mongo-client*)]

--- a/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
@@ -33,16 +33,21 @@
 
 (deftest ^:parallel field-filter-relative-time-native-test
   (mt/test-driver :mongo
-    (let [now (str (java.time.Instant/now))]
+    (let [now (str (java.time.Instant/now))
+          captured-stages (volatile! nil)]
       (binding [mongo.execute/*aggregate*
-                (fn [& _] (make-mongo-aggregate-iterable
-                           [{"_id" 0
-                             "name" "Crowberto"
-                             "alias" "the Brave"}
-                            {"_id" 1
-                             "name" "Rasta"
-                             "last_login" now
-                             "nickname" "Blue"}]))]
+                (fn [& args]
+                  ;; `*aggregate*` is invoked as (db coll session stages timeout-ms); capture the executed
+                  ;; pipeline so we can assert on remark injection below.
+                  (vreset! captured-stages (nth args 3))
+                  (make-mongo-aggregate-iterable
+                   [{"_id" 0
+                     "name" "Crowberto"
+                     "alias" "the Brave"}
+                    {"_id" 1
+                     "name" "Rasta"
+                     "last_login" now
+                     "nickname" "Blue"}]))]
         (testing "Projected and first-row fields are returned"
           (let [query {:database (mt/id)
                        :native
@@ -65,7 +70,29 @@
             (is (= {:rows [[0 "Crowberto" nil "the Brave"]
                            [1 "Rasta"     now nil]]
                     :columns ["_id" "name" "last_login" "alias"]}
-                   (mt/rows+column-names (qp/process-query query))))))))))
+                   (mt/rows+column-names (qp/process-query query))))))
+        (testing "A $comment stage carrying the query remark is prepended to the pipeline (#9514)"
+          ;; The last query above is captured. Its pipeline does not open with `$documents`, so the remark is
+          ;; spliced in front. The remark defaults to "Metabase" because these queries carry no `:info`.
+          (let [stages (some-> (deref captured-stages) vec)]
+            (is (= "$comment" (ffirst stages)))
+            (is (re-find #"^Metabase" (-> stages first (get "$comment"))))))
+        (testing "inject-remark honors the $documents-first rule and is a no-op without a remark (#9514)"
+          (is (= [{"$comment" "r"} {"$match" {}}]
+                 (#'mongo.execute/inject-remark [{"$match" {}}] "r")))
+          (is (= [{"$documents" []} {"$comment" "r"} {"$match" {}}]
+                 (#'mongo.execute/inject-remark [{"$documents" []} {"$match" {}}] "r")))
+          (is (= [{"$match" {}}]
+                 (#'mongo.execute/inject-remark [{"$match" {}}] nil)))
+          (is (= [{"$match" {}}]
+                 (#'mongo.execute/inject-remark [{"$match" {}}] "   ")))
+          (is (= [{"$comment" "r"}]
+                 (#'mongo.execute/inject-remark nil "r"))))
+        (testing "include-user-id-and-hash? defaults to true and honors the detail (#9514)"
+          (is (true? (#'mongo.execute/include-user-id-and-hash? nil)))
+          (is (true? (#'mongo.execute/include-user-id-and-hash? {})))
+          (is (true? (#'mongo.execute/include-user-id-and-hash? {:include-user-id-and-hash true})))
+          (is (false? (#'mongo.execute/include-user-id-and-hash? {:include-user-id-and-hash false}))))))))
 
 (deftest kill-an-in-flight-query-test
   (mt/test-driver

--- a/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/execute_test.clj
@@ -27,19 +27,25 @@
                     (throw (NoSuchElementException. (str "no element at " i))))))
       (close [_]))))
 
-(defn- make-mongo-aggregate-iterable [rows]
-  (reify com.mongodb.client.AggregateIterable
-    (cursor [_] (make-mongo-cursor rows))))
+(defn- make-mongo-aggregate-iterable
+  "Reified [[com.mongodb.client.AggregateIterable]] yielding `rows`. When `comment-vol` is supplied, records any
+  value passed to `.comment` so tests can assert that the query remark is attached to the aggregate command."
+  ([rows] (make-mongo-aggregate-iterable rows nil))
+  ([rows comment-vol]
+   (reify com.mongodb.client.AggregateIterable
+     (cursor [_] (make-mongo-cursor rows))
+     (^com.mongodb.client.AggregateIterable comment [_ ^String c]
+       (some-> comment-vol (vreset! c))
+       nil))))
 
 (deftest ^:parallel field-filter-relative-time-native-test
   (mt/test-driver :mongo
     (let [now (str (java.time.Instant/now))
-          captured-stages (volatile! nil)]
+          captured-comment (volatile! nil)]
       (binding [mongo.execute/*aggregate*
-                (fn [& args]
-                  ;; `*aggregate*` is invoked as (db coll session stages timeout-ms); capture the executed
-                  ;; pipeline so we can assert on remark injection below.
-                  (vreset! captured-stages (nth args 3))
+                (fn [& _args]
+                  ;; `.comment` (set in [[mongo.execute/execute-reducible-query]]) records the query remark into
+                  ;; `captured-comment` via the reified iterable below.
                   (make-mongo-aggregate-iterable
                    [{"_id" 0
                      "name" "Crowberto"
@@ -47,7 +53,8 @@
                     {"_id" 1
                      "name" "Rasta"
                      "last_login" now
-                     "nickname" "Blue"}]))]
+                     "nickname" "Blue"}]
+                   captured-comment))]
         (testing "Projected and first-row fields are returned"
           (let [query {:database (mt/id)
                        :native
@@ -71,23 +78,12 @@
                            [1 "Rasta"     now nil]]
                     :columns ["_id" "name" "last_login" "alias"]}
                    (mt/rows+column-names (qp/process-query query))))))
-        (testing "A $comment stage carrying the query remark is prepended to the pipeline (#9514)"
-          ;; The last query above is captured. Its pipeline does not open with `$documents`, so the remark is
-          ;; spliced in front. The remark defaults to "Metabase" because these queries carry no `:info`.
-          (let [stages (some-> (deref captured-stages) vec)]
-            (is (= "$comment" (ffirst stages)))
-            (is (re-find #"^Metabase" (-> stages first (get "$comment"))))))
-        (testing "inject-remark honors the $documents-first rule and is a no-op without a remark (#9514)"
-          (is (= [{"$comment" "r"} {"$match" {}}]
-                 (#'mongo.execute/inject-remark [{"$match" {}}] "r")))
-          (is (= [{"$documents" []} {"$comment" "r"} {"$match" {}}]
-                 (#'mongo.execute/inject-remark [{"$documents" []} {"$match" {}}] "r")))
-          (is (= [{"$match" {}}]
-                 (#'mongo.execute/inject-remark [{"$match" {}}] nil)))
-          (is (= [{"$match" {}}]
-                 (#'mongo.execute/inject-remark [{"$match" {}}] "   ")))
-          (is (= [{"$comment" "r"}]
-                 (#'mongo.execute/inject-remark nil "r"))))
+        (testing "The query remark is attached as the aggregate `comment` option (#9514)"
+          ;; `query->remark` defaults to "Metabase" because these queries carry no `:info`. Asserting via the
+          ;; `comment` option (rather than a pipeline stage) also confirms the pipeline is not polluted — the
+          ;; row/column assertions above would break if a `$comment` stage were injected, since it is not a
+          ;; valid aggregation stage (see the docstring of [[mongo.execute/execute-reducible-query]]).
+          (is (re-find #"^Metabase" (deref captured-comment))))
         (testing "include-user-id-and-hash? defaults to true and honors the detail (#9514)"
           (is (true? (#'mongo.execute/include-user-id-and-hash? nil)))
           (is (true? (#'mongo.execute/include-user-id-and-hash? {})))


### PR DESCRIPTION
vibe coded PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MongoDB queries now include a Metabase remark on aggregation commands when enabled, helping identify queries in database logs.
  * Added support for toggling whether the remark includes user ID and hash via connection settings.

* **Bug Fixes**
  * Improved Mongo query handling so remarks are attached to the aggregation command directly, without affecting query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->