### PR TITLE
Do not compute related-tables or metrics in get-report-details

### DIFF
--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -656,7 +656,11 @@
                       (let [card    (t2/hydrate (metabot.tools.u/get-card report-id)
                                                 :average_query_time)
                             mp      (lib-be/application-database-metadata-provider (:database_id card))
-                            details (card-details card mp options)]
+                            ;; The select-keys below drops :related_tables and :metrics, so don't compute them. On
+                            ;; wide-FK source tables the related-tables cost can be substantial (metabase#76493).
+                            details (card-details card mp (assoc options
+                                                                 :with-related-tables? false
+                                                                 :with-metrics? false))]
                         (-> details
                             ;; `:query_json` is intentionally part of the slim payload here:
                             ;; it's what `question->xml` renders inside `<metabase_question>`

--- a/test/metabase/metabot/tools/entity_details_test.clj
+++ b/test/metabase/metabot/tools/entity_details_test.clj
@@ -521,6 +521,46 @@
             (is (map? (:query_json output)))
             (is (= "mbql/query" (get-in output [:query_json "lib/type"])))))))))
 
+(deftest get-report-details-skips-related-tables-test
+  (testing "get-report-details never computes related-tables"
+    (mt/test-driver :h2
+      (mt/with-current-user (mt/user->id :crowberto)
+        (mt/with-temp [:model/Card {card-id :id}
+                       {:database_id   (mt/id)
+                        :type          :question
+                        :name          "Orders question"
+                        :dataset_query (mt/mbql-query orders {:limit 3})}]
+          (let [calls (atom 0)
+                orig  (mt/original-fn #'entity-details/related-tables)]
+            (mt/with-dynamic-fn-redefs [entity-details/related-tables (fn [& args]
+                                                                        (swap! calls inc)
+                                                                        (apply orig args))]
+              (let [output (-> (entity-details/get-report-details {:report-id card-id})
+                               :structured-output)]
+                (is (=? {:id card-id :type :question} output))
+                (is (not (contains? output :related_tables)))
+                (is (= 0 @calls))))))))))
+
+(deftest get-report-details-skips-metrics-test
+  (testing "get-report-details never computes metrics"
+    (mt/test-driver :h2
+      (mt/with-current-user (mt/user->id :crowberto)
+        (mt/with-temp [:model/Card {card-id :id}
+                       {:database_id   (mt/id)
+                        :type          :question
+                        :name          "Orders question"
+                        :dataset_query (mt/mbql-query orders {:limit 3})}]
+          (let [calls (atom 0)
+                orig  (mt/original-fn #'lib/available-metrics)]
+            (mt/with-dynamic-fn-redefs [lib/available-metrics (fn [& args]
+                                                                (swap! calls inc)
+                                                                (apply orig args))]
+              (let [output (-> (entity-details/get-report-details {:report-id card-id})
+                               :structured-output)]
+                (is (=? {:id card-id :type :question} output))
+                (is (not (contains? output :metrics)))
+                (is (= 0 @calls))))))))))
+
 (deftest related-tables-with-fields-capped-test
   (testing (str "FK-related-table *column* expansion is capped at `max-related-tables-with-fields` so a table "
                 "with a very large / highly-connected schema can't fetch and pin an unbounded number of columns "


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76493

Closes [BOT-1725: MetaBot context build OOMs on databases with very large table counts](https://linear.app/metabase/issue/BOT-1725/metabot-context-build-ooms-on-databases-with-very-large-table-counts)

### Description

`get-report-details` drops `:related_tables` and `:metrics` via a `select-keys`, so don't ask `card-details` for them.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report/card loading performance by avoiding extra metadata calculations that weren’t needed for the displayed details.
  * Reduced unnecessary overhead when viewing reports tied to tables with many relationships.
  * Added regression coverage to help ensure the lighter-weight payload stays lean going forward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->