### PR TITLE
Index manager: changes since querying's last review (Do not merge)

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1068,6 +1068,7 @@
   indexes
   {:team "Gadget"
    :api  #{metabase.indexes.api
+           metabase.indexes.models.table-index
            metabase.indexes.reconcile}
    :uses #{api
            driver
@@ -2387,6 +2388,7 @@
            database-routing
            driver
            events
+           indexes
            lib
            lib-be
            models

--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -6,10 +6,36 @@ title: Driver interface changelog
 
 ## Metabase 0.63.0
 
-- Added the `:index/fetch` driver feature flag and the `metabase.driver/fetch-table-indexes` method, for drivers that
-  can read the indexes that physically exist on a table. The method returns them as a vector of normalized index maps;
-  drivers declaring the feature implement it (the default implementation throws). Implemented by Postgres, ClickHouse,
-  and Redshift.
+- Index Manager: drivers can now read and create table indexes, in the broad sense (secondary indexes, sort keys,
+  distribution keys, clustering, etc.). New driver feature flags:
+
+  - `:index/fetch` -- the driver can read the indexes that physically exist on a table. Implemented by Postgres,
+    ClickHouse, and Redshift.
+
+  - `:index/standalone-create` -- the driver can create an index on a transform's target table as a standalone
+    statement after the table is created. Implemented by Postgres.
+
+  - `:index/inline-create` -- the driver inlines an index into the table-creation statement itself (e.g. Redshift
+    `SORTKEY`) rather than creating it afterwards. Such drivers render the index from the `:indexes` key of the
+    transform details when they build the creation statement: in `metabase.driver/compile-transform` (the CTAS for a
+    SQL transform) and/or `metabase.driver/create-table!` (the CREATE TABLE for a Python transform). Implemented by
+    Redshift.
+
+  New driver methods:
+
+  - `metabase.driver/fetch-table-indexes` `[driver database schema table]` -- reads a table's physical indexes,
+    returning them as a vector of normalized index maps. Drivers declaring `:index/fetch` implement it; the default
+    implementation throws.
+
+  - `metabase.driver/supported-index-methods` `[driver database]` -- returns the index methods the driver supports as
+    a map of `index-kind` to a metadata map carrying at least `:lifecycle` (`:standalone` or `:inline`). Defaults to
+    `{}`.
+
+  - `metabase.driver/compile-create-index` `[driver schema table structured]` -- compiles a `:standalone` index into
+    the DDL statement(s) that create it.
+
+  - `metabase.driver/refresh-table-stats!` `[driver database schema table transform-type]` -- refreshes table
+    statistics (e.g. `ANALYZE`) after a transform run. Defaults to a no-op.
 
 - `metabase.driver/describe-table-fks`, deprecated in 0.49.0, has been removed. Please implement
   `metabase.driver/describe-fks` instead. This method is now required for drivers that support
@@ -32,26 +58,6 @@ title: Driver interface changelog
   - The `:describe-fks` driver feature flag has been removed as a feature since it is no longer needed to differentiate
     between the aforementioned FK description methods; you should remove any `metabase.driver/database-supports?`
     implementations for it.
-
-- Added the `:index/standalone-create` driver feature flag, for drivers that can create an index (in the broad
-  sense, including things like clustering or sort keys) on a transform's target table as a standalone statement
-  after the table is created. Postgres supports it.
-
-- Added `metabase.driver/supported-index-methods` `[driver database]`. Returns the index methods the driver supports
-  as a map of `index-kind` to a metadata map carrying at least `:lifecycle` (`:standalone` or `:inline`). Defaults to
-  `{}`.
-
-- Added `metabase.driver/compile-create-index` `[driver schema table structured]`. Compiles a `:standalone` index
-  into the DDL statement(s) that create it.
-
-- Added `metabase.driver/refresh-table-stats!` `[driver database schema table transform-type]`. Refreshes table
-  statistics (e.g. `ANALYZE`) after a transform run. Defaults to a no-op.
-
-- Added the `:index/inline-create` driver feature flag, for drivers that inline an index into the table-creation
-  statement itself (e.g. Redshift `SORTKEY`) rather than creating it afterwards. Such drivers render the index from
-  the `:indexes` key of the transform details when they build the creation statement: in
-  `metabase.driver/compile-transform` (the CTAS for a SQL transform) and/or `metabase.driver/create-table!` (the
-  CREATE TABLE for a Python transform). Redshift supports it.
 
 ## Metabase 0.62.0
 

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/base.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/base.clj
@@ -170,7 +170,7 @@
   (let [db-id   (:id db)
         staging (transforms-base.u/temp-table-name driver (namespace table-name))]
     (transforms-base.u/validate-merge-unique-key! unique-key (mapv :name (:fields metadata)))
-    (create-table-and-insert-data! driver db-id (table-schema staging metadata) data-source)
+    (create-table-and-insert-data! driver db-id (table-schema staging metadata nil) data-source)
     (try
       (let [[sql & params] (sql.qp/format-honeysql driver {:select [:*], :from [staging]})
             select     {:query sql, :params (vec params)}
@@ -203,13 +203,16 @@
         (not table-exists?)
         (do
           (log/info "New table")
-          (create-table-and-insert-data! driver db-id (table-schema table-name metadata) data-source))
+          (create-table-and-insert-data! driver db-id
+                                         (table-schema table-name metadata (:indexes target))
+                                         data-source))
 
         unique-key
         (upsert-with-merge-strategy! driver db table-name metadata data-source unique-key)
 
         :else
-        (insert-data! driver db-id (table-schema table-name metadata) data-source)))))
+        ;; Append into an existing table: no create, so no inline indexes to apply.
+        (insert-data! driver db-id (table-schema table-name metadata nil) data-source)))))
 
 (defmethod transfer-file-to-db :table
   [driver {db-id :id :as db}

--- a/frontend/src/metabase-types/api/icon.ts
+++ b/frontend/src/metabase-types/api/icon.ts
@@ -255,6 +255,7 @@ export type IconName =
   | "tab"
   | "table"
   | "table2"
+  | "table_index"
   | "text_bold"
   | "text_italic"
   | "text_strike"

--- a/frontend/src/metabase-types/api/index-manager.ts
+++ b/frontend/src/metabase-types/api/index-manager.ts
@@ -83,6 +83,8 @@ export type StructuredIndex =
   | OrderByIndex
   | SkipIndex;
 
+export type IndexKind = StructuredIndex["kind"];
+
 export const TABLE_INDEX_REQUEST_STATUSES = [
   "create-pending",
   "update-pending",
@@ -139,3 +141,34 @@ export type UpdateTableIndexRequest = {
   id: TableIndexRequestId;
   structured: StructuredIndex;
 };
+
+export type IndexFieldType =
+  | "string"
+  | "boolean"
+  | "select"
+  | "integer"
+  | "columns";
+
+export type IndexFieldOption = {
+  name: string;
+  value: string;
+};
+
+export type IndexField = {
+  name: string;
+  "display-name": string;
+  description?: string;
+  type: IndexFieldType;
+  required?: boolean;
+  directions?: boolean;
+  options?: IndexFieldOption[];
+};
+
+export type IndexMethodLifecycle = "standalone" | "inline";
+
+export type IndexMethod = {
+  lifecycle: IndexMethodLifecycle;
+  fields: IndexField[];
+};
+
+export type RequestableIndexes = Partial<Record<IndexKind, IndexMethod>>;

--- a/frontend/src/metabase-types/api/index-manager.ts
+++ b/frontend/src/metabase-types/api/index-manager.ts
@@ -84,11 +84,12 @@ export type StructuredIndex =
   | SkipIndex;
 
 export const TABLE_INDEX_REQUEST_STATUSES = [
-  "pending",
+  "create-pending",
+  "update-pending",
+  "delete-pending",
   "running",
   "succeeded",
   "failed",
-  "dropped",
 ] as const;
 export type TableIndexRequestStatus =
   (typeof TABLE_INDEX_REQUEST_STATUSES)[number];

--- a/frontend/src/metabase-types/api/mocks/index-manager.ts
+++ b/frontend/src/metabase-types/api/mocks/index-manager.ts
@@ -11,7 +11,7 @@ export const createMockTableIndexRequest = (
     name: "btree",
     columns: [{ name: "id" }],
   },
-  status: "pending",
+  status: "create-pending",
   error_message: null,
   created_by: 1,
   created_at: "2020-01-01T00:00:00.000Z",

--- a/frontend/src/metabase-types/api/mocks/index-manager.ts
+++ b/frontend/src/metabase-types/api/mocks/index-manager.ts
@@ -1,4 +1,10 @@
-import type { TableIndexEntry, TableIndexRequest } from "metabase-types/api";
+import type {
+  IndexField,
+  IndexMethod,
+  RequestableIndexes,
+  TableIndexEntry,
+  TableIndexRequest,
+} from "metabase-types/api";
 
 export const createMockTableIndexRequest = (
   opts?: Partial<TableIndexRequest>,
@@ -36,4 +42,55 @@ export const createMockTableIndexEntry = (
   access_method: null,
   request: createMockTableIndexRequest(),
   ...opts,
+});
+
+const INDEX_NAME_FIELD: IndexField = {
+  name: "name",
+  "display-name": "Give your index a name",
+  type: "string",
+  required: true,
+};
+
+export const createMockIndexMethod = (
+  opts?: Partial<IndexMethod>,
+): IndexMethod => ({
+  lifecycle: "standalone",
+  fields: [INDEX_NAME_FIELD],
+  ...opts,
+});
+
+export const createMockRequestableIndexes = (): RequestableIndexes => ({
+  btree: createMockIndexMethod({
+    fields: [
+      INDEX_NAME_FIELD,
+      {
+        name: "unique",
+        "display-name": "Unique",
+        description: "Enforce uniqueness across rows for indexed columns.",
+        type: "boolean",
+      },
+      {
+        name: "columns",
+        "display-name": "Columns",
+        description:
+          "The column(s) the index will be built on. Usually the ones you filter or join by.",
+        type: "columns",
+        required: true,
+        directions: true,
+      },
+    ],
+  }),
+  gin: createMockIndexMethod({
+    fields: [
+      INDEX_NAME_FIELD,
+      {
+        name: "columns",
+        "display-name": "Columns",
+        description:
+          "The column(s) the index will be built on. Usually the ones you filter or join by.",
+        type: "columns",
+        required: true,
+      },
+    ],
+  }),
 });

--- a/frontend/src/metabase-types/api/transform.ts
+++ b/frontend/src/metabase-types/api/transform.ts
@@ -1,6 +1,7 @@
 import type { Collection, CollectionId } from "./collection";
 import type { DatabaseId } from "./database";
 import type { RowValue } from "./dataset";
+import type { RequestableIndexes } from "./index-manager";
 import type { PaginationRequest, PaginationResponse } from "./pagination";
 import type { DatasetQuery, JoinStrategy } from "./query";
 import type { ScheduleDisplayType } from "./settings";
@@ -67,6 +68,7 @@ export type Transform = {
   table?: Table | null;
   last_run?: TransformRun | null;
   creator?: UserInfo;
+  requestable_indexes?: RequestableIndexes | null;
 };
 
 export type SuggestedTransform = Partial<Pick<Transform, "id">> &

--- a/frontend/src/metabase/api/index-manager.ts
+++ b/frontend/src/metabase/api/index-manager.ts
@@ -23,7 +23,7 @@ export const indexManagerApi = Api.injectEndpoints({
       {
         query: (params) => ({
           method: "GET",
-          url: "/api/indexes",
+          url: "/api/index",
           params,
         }),
         transformResponse: (response: ListTableIndexesResponse) =>
@@ -34,7 +34,7 @@ export const indexManagerApi = Api.injectEndpoints({
     getTableIndex: builder.query<TableIndexRequest, TableIndexRequestId>({
       query: (id) => ({
         method: "GET",
-        url: `/api/indexes/request/${id}`,
+        url: `/api/index/request/${id}`,
       }),
       providesTags: (index) => (index ? provideTableIndexTags(index) : []),
     }),
@@ -44,7 +44,7 @@ export const indexManagerApi = Api.injectEndpoints({
     >({
       query: (body) => ({
         method: "POST",
-        url: "/api/indexes/request",
+        url: "/api/index/request",
         body,
       }),
       invalidatesTags: (_index, error) =>
@@ -56,7 +56,7 @@ export const indexManagerApi = Api.injectEndpoints({
     >({
       query: ({ id, structured }) => ({
         method: "PUT",
-        url: `/api/indexes/request/${id}`,
+        url: `/api/index/request/${id}`,
         body: { structured },
       }),
       invalidatesTags: (_index, error, { id }) =>
@@ -68,7 +68,7 @@ export const indexManagerApi = Api.injectEndpoints({
     deleteTableIndex: builder.mutation<void, TableIndexRequestId>({
       query: (id) => ({
         method: "DELETE",
-        url: `/api/indexes/request/${id}`,
+        url: `/api/index/request/${id}`,
       }),
       invalidatesTags: (_index, error, id) =>
         invalidateTags(error, [

--- a/frontend/src/metabase/common/data-studio/components/TitleSection/TitleSection.tsx
+++ b/frontend/src/metabase/common/data-studio/components/TitleSection/TitleSection.tsx
@@ -5,6 +5,7 @@ import { Card, Group, Stack, Text, Title } from "metabase/ui";
 type TitleSectionProps = {
   label: ReactNode;
   description?: ReactNode;
+  actions?: ReactNode;
   children?: ReactNode;
   "data-testid"?: string;
 };
@@ -12,16 +13,18 @@ type TitleSectionProps = {
 export function TitleSection({
   label,
   description,
+  actions,
   children,
   "data-testid": dataTestId,
 }: TitleSectionProps) {
   return (
     <Stack data-testid={dataTestId}>
-      <Group>
+      <Group justify="space-between" wrap="nowrap">
         <Stack flex={1} gap="sm">
           <Title order={4}>{label}</Title>
           {description != null && <Text c="text-secondary">{description}</Text>}
         </Stack>
+        {actions != null && actions}
       </Group>
       <Card p={0} shadow="none" withBorder>
         {children}

--- a/frontend/src/metabase/common/data-studio/components/TitleSection/TitleSection.unit.spec.tsx
+++ b/frontend/src/metabase/common/data-studio/components/TitleSection/TitleSection.unit.spec.tsx
@@ -7,10 +7,15 @@ import { TitleSection } from "./TitleSection";
 type SetupOpts = {
   label?: string;
   children?: ReactNode;
+  actions?: ReactNode;
 };
 
-function setup({ label = "Default Title", children }: SetupOpts = {}) {
-  renderWithProviders(<TitleSection label={label}>{children}</TitleSection>);
+function setup({ label = "Default Title", children, actions }: SetupOpts = {}) {
+  renderWithProviders(
+    <TitleSection label={label} actions={actions}>
+      {children}
+    </TitleSection>,
+  );
 }
 
 describe("TitleSection", () => {
@@ -22,5 +27,13 @@ describe("TitleSection", () => {
 
     expect(screen.getByText(label)).toBeInTheDocument();
     expect(screen.getByText("Title section content")).toBeInTheDocument();
+  });
+
+  it("should render the actions slot", () => {
+    setup({ actions: <button>Create index</button> });
+
+    expect(
+      screen.getByRole("button", { name: "Create index" }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/transforms/components/TransformHeader/TransformTabs.tsx
+++ b/frontend/src/metabase/transforms/components/TransformHeader/TransformTabs.tsx
@@ -35,6 +35,10 @@ function getTabs(id: TransformId): PaneHeaderTab[] {
       label: t`Settings`,
       to: Urls.transformSettings(id),
     },
+    {
+      label: t`Indexes`,
+      to: Urls.transformIndexes(id),
+    },
   ];
 
   if (PLUGIN_TRANSFORMS_PYTHON.shouldShowInspectTab) {

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/ColumnsField.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/ColumnsField.tsx
@@ -1,0 +1,147 @@
+import { useField } from "formik";
+import type { ReactNode } from "react";
+import { t } from "ttag";
+
+import {
+  Card,
+  Group,
+  Input,
+  MultiSelect,
+  SegmentedControl,
+  Stack,
+  Text,
+} from "metabase/ui";
+import type { IndexColumn, IndexColumnDirection } from "metabase-types/api";
+
+import type { ColumnOption } from "./types";
+
+type ColumnsFieldProps = {
+  name: string;
+  label?: ReactNode;
+  description?: ReactNode;
+  options: ColumnOption[];
+  supportsDirections: boolean;
+  disabled?: boolean;
+};
+
+export function ColumnsField({
+  name,
+  label,
+  description,
+  options,
+  supportsDirections,
+  disabled,
+}: ColumnsFieldProps) {
+  const [
+    { value: selectedColumns = [] },
+    { error, touched },
+    { setValue, setTouched },
+  ] = useField<IndexColumn[]>(name);
+
+  function handleColumnChange(names: string[]) {
+    setValue(
+      names.map((columnName) => {
+        const existingColumnSelection = selectedColumns.find(
+          (column) => column.name === columnName,
+        );
+        if (existingColumnSelection) {
+          return existingColumnSelection;
+        }
+        return supportsDirections
+          ? { name: columnName, direction: "asc" }
+          : { name: columnName };
+      }),
+    );
+    setTouched(true);
+  }
+
+  function handleDirectionChange(
+    columnName: string,
+    direction: IndexColumnDirection,
+  ) {
+    setValue(
+      selectedColumns.map((column) =>
+        column.name === columnName ? { ...column, direction } : column,
+      ),
+    );
+  }
+
+  return (
+    <Input.Wrapper
+      label={label}
+      description={description}
+      error={touched ? error : null}
+    >
+      <Stack gap="sm" mt="xs">
+        <MultiSelect
+          data={options}
+          value={selectedColumns.map((column) => column.name)}
+          onChange={handleColumnChange}
+          onBlur={() => setTouched(true)}
+          placeholder={t`Select columns`}
+          searchable
+          disabled={disabled}
+        />
+        {supportsDirections && selectedColumns.length > 0 && (
+          <DirectionList
+            columns={selectedColumns}
+            options={options}
+            onChange={handleDirectionChange}
+            disabled={disabled}
+          />
+        )}
+      </Stack>
+    </Input.Wrapper>
+  );
+}
+
+type DirectionListProps = {
+  columns: IndexColumn[];
+  options: ColumnOption[];
+  onChange: (columnName: string, direction: IndexColumnDirection) => void;
+  disabled?: boolean;
+};
+
+function DirectionList({
+  columns,
+  options,
+  onChange,
+  disabled,
+}: DirectionListProps) {
+  return (
+    <Card withBorder shadow="none" p="md">
+      <Stack gap="sm">
+        <Text fw="bold">{t`Sort order for each column to be stored in`}</Text>
+        {columns.map((column) => (
+          <Group key={column.name} justify="space-between" wrap="nowrap">
+            <Text>{getColumnLabel(options, column.name)}</Text>
+            <SegmentedControl
+              value={column.direction}
+              onChange={(direction) =>
+                onChange(column.name, direction as IndexColumnDirection)
+              }
+              data={getDirectionOptions()}
+              disabled={disabled}
+            />
+          </Group>
+        ))}
+      </Stack>
+    </Card>
+  );
+}
+
+function getColumnLabel(columns: ColumnOption[], columnName: string) {
+  return (
+    columns.find((option) => option.value === columnName)?.label ?? columnName
+  );
+}
+
+function getDirectionOptions(): {
+  value: IndexColumnDirection;
+  label: string;
+}[] {
+  return [
+    { value: "asc", label: t`Asc` },
+    { value: "desc", label: t`Desc` },
+  ];
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorForm.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorForm.tsx
@@ -1,0 +1,81 @@
+import { t } from "ttag";
+
+import { Form, FormSubmitButton } from "metabase/forms";
+import { Button, Group, Select, Stack, Text } from "metabase/ui";
+import type { IndexField, IndexKind } from "metabase-types/api";
+
+import { IndexFieldInput } from "./IndexFieldInput";
+import { getIndexTypeDescription, getKindDescription } from "./constants";
+import type { ColumnOption } from "./types";
+
+type IndexEditorFormProps = {
+  kind: IndexKind;
+  kinds: IndexKind[];
+  fields: IndexField[];
+  columnOptions: ColumnOption[];
+  isEditing: boolean;
+  submitLabel: string;
+  onKindChange: (kind: IndexKind) => void;
+  onClose: () => void;
+};
+
+export function IndexEditorForm({
+  kind,
+  kinds,
+  fields,
+  columnOptions,
+  isEditing,
+  submitLabel,
+  onKindChange,
+  onClose,
+}: IndexEditorFormProps) {
+  const [firstField, ...restFields] = fields;
+
+  const renderField = (field: IndexField, autoFocus = false) => (
+    <IndexFieldInput
+      key={field.name}
+      field={field}
+      columnOptions={columnOptions}
+      disabled={isEditing && field.name === "name"}
+      autoFocus={autoFocus}
+    />
+  );
+
+  return (
+    <Form>
+      <Stack gap="lg" mt="sm">
+        {firstField && renderField(firstField, !isEditing)}
+
+        <Select
+          label={t`Index type`}
+          description={getIndexTypeDescription()}
+          data={kinds}
+          value={kind}
+          onChange={(value) => value && onKindChange(value)}
+          disabled={isEditing}
+          allowDeselect={false}
+          renderOption={({ option }) => {
+            const description = getKindDescription(option.value);
+            return (
+              <Stack gap="xs" p="sm">
+                <Text fw="bold">{option.label}</Text>
+                {description && (
+                  <Text size="sm" c="text-secondary">
+                    {description}
+                  </Text>
+                )}
+              </Stack>
+            );
+          }}
+        />
+
+        {restFields.map((field) => renderField(field))}
+
+        <Group justify="flex-end">
+          <Button variant="subtle" onClick={onClose}>{t`Cancel`}</Button>
+          <FormSubmitButton label={submitLabel} variant="filled" />
+        </Group>
+      </Stack>
+    </Form>
+  );
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorModal.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorModal.tsx
@@ -1,0 +1,140 @@
+import { useState } from "react";
+import { t } from "ttag";
+
+import {
+  skipToken,
+  useCreateTableIndexMutation,
+  useGetTableQueryMetadataQuery,
+  useUpdateTableIndexMutation,
+} from "metabase/api";
+import { getErrorMessage } from "metabase/api/utils";
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { useToast } from "metabase/common/hooks";
+import { FormProvider } from "metabase/forms";
+import { Modal } from "metabase/ui";
+import { getObjectKeys } from "metabase/utils/objects";
+import type {
+  IndexField,
+  IndexKind,
+  RequestableIndexes,
+  Table,
+  TableIndexEntry,
+  Transform,
+} from "metabase-types/api";
+
+import { IndexEditorForm } from "./IndexEditorForm";
+import type { ColumnOption } from "./types";
+import {
+  type IndexFormValues,
+  buildInitialValues,
+  buildValidationSchema,
+  toStructured,
+} from "./utils";
+
+type IndexEditorModalProps = {
+  transform: Transform;
+  index?: TableIndexEntry;
+  onClose: () => void;
+};
+
+export function IndexEditorModal({
+  transform,
+  index,
+  onClose,
+}: IndexEditorModalProps) {
+  const request = index?.request;
+  const isEditing = request != null;
+  const tableId = transform.table?.id;
+  const requestableIndexes = transform.requestable_indexes;
+  const kinds = requestableIndexes ? getObjectKeys(requestableIndexes) : [];
+  const [kind, setKind] = useState<IndexKind>(
+    request?.structured.kind ? request?.structured.kind : kinds[0],
+  );
+
+  const {
+    data: table,
+    isLoading,
+    error,
+  } = useGetTableQueryMetadataQuery(
+    tableId != null ? { id: tableId } : skipToken,
+  );
+
+  const columnOptions = getColumnOptions(table);
+  const fields = getFields(kind, requestableIndexes);
+  const initialValues = buildInitialValues(fields, request?.structured);
+  const validationSchema = buildValidationSchema(fields);
+  const [createTableIndex] = useCreateTableIndexMutation();
+  const [updateTableIndex] = useUpdateTableIndexMutation();
+  const [sendToast] = useToast();
+
+  async function handleSubmit(values: IndexFormValues) {
+    const structured = toStructured(kind, fields, values);
+    try {
+      if (isEditing) {
+        await updateTableIndex({ id: request.id, structured }).unwrap();
+        sendToast({ message: t`Index updated` });
+      } else {
+        await createTableIndex({
+          transform_id: transform.id,
+          structured,
+        }).unwrap();
+        sendToast({ message: t`Index created` });
+      }
+      onClose();
+    } catch (submitError) {
+      sendToast({
+        message: getErrorMessage(submitError, t`Failed to save index`),
+        icon: "warning",
+      });
+      throw submitError;
+    }
+  }
+
+  return (
+    <Modal
+      opened
+      title={isEditing ? t`Edit index` : t`Create an index`}
+      padding="xl"
+      onClose={onClose}
+    >
+      {isLoading || error != null ? (
+        <LoadingAndErrorWrapper loading={isLoading} error={error} />
+      ) : (
+        <FormProvider
+          key={kind}
+          initialValues={initialValues}
+          validationSchema={validationSchema}
+          onSubmit={handleSubmit}
+        >
+          <IndexEditorForm
+            kind={kind}
+            kinds={kinds}
+            fields={fields}
+            columnOptions={columnOptions}
+            isEditing={isEditing}
+            submitLabel={isEditing ? t`Update index` : t`Create index`}
+            onKindChange={setKind}
+            onClose={onClose}
+          />
+        </FormProvider>
+      )}
+    </Modal>
+  );
+}
+
+function getFields(
+  kind: IndexKind,
+  requestableIndexes: RequestableIndexes | null | undefined,
+): IndexField[] {
+  return requestableIndexes?.[kind]?.fields ?? [];
+}
+
+function getColumnOptions(table: Table | undefined): ColumnOption[] {
+  if (!table?.fields) {
+    return [];
+  }
+  return table.fields.map((field) => ({
+    value: field.name,
+    label: field.display_name ?? field.name,
+  }));
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorModal.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexEditorModal.unit.spec.tsx
@@ -1,0 +1,190 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { setupTableIndexEndpoints } from "__support__/server-mocks/index-manager";
+import { setupTableQueryMetadataEndpoint } from "__support__/server-mocks/table";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import type { StructuredIndex, TableIndexEntry } from "metabase-types/api";
+import {
+  createMockField,
+  createMockRequestableIndexes,
+  createMockTable,
+  createMockTableIndexEntry,
+  createMockTableIndexRequest,
+  createMockTransform,
+} from "metabase-types/api/mocks";
+
+import { IndexEditorModal } from "./IndexEditorModal";
+
+const TABLE = createMockTable({
+  id: 10,
+  fields: [
+    createMockField({ id: 1, name: "city", display_name: "City name" }),
+    createMockField({ id: 2, name: "country", display_name: "Country" }),
+  ],
+});
+
+function setup({ index }: { index?: TableIndexEntry } = {}) {
+  const transform = createMockTransform({
+    id: 1,
+    table: TABLE,
+    requestable_indexes: createMockRequestableIndexes(),
+  });
+
+  setupTableQueryMetadataEndpoint(TABLE);
+  setupTableIndexEndpoints(
+    transform.id,
+    index?.request != null ? [index.request] : [],
+  );
+
+  const onClose = jest.fn();
+  renderWithProviders(
+    <IndexEditorModal transform={transform} index={index} onClose={onClose} />,
+    { withUndos: true },
+  );
+
+  return { onClose };
+}
+
+describe("IndexEditorModal", () => {
+  it("creates a btree index with directions and unique", async () => {
+    setup();
+
+    expect(
+      await screen.findByText(
+        "The data structure used to organize the index. B-tree works well for most lookups, sorting, and range queries.",
+      ),
+    ).toBeInTheDocument();
+
+    await userEvent.type(
+      await screen.findByLabelText("Give your index a name"),
+      "index 1",
+    );
+
+    await userEvent.click(screen.getByPlaceholderText("Select columns"));
+    await userEvent.click(
+      await screen.findByRole("option", { name: "City name" }),
+    );
+    await userEvent.click(
+      await screen.findByRole("option", { name: "Country" }),
+    );
+
+    await userEvent.click(screen.getByRole("switch"));
+
+    await userEvent.click(screen.getByRole("button", { name: "Create index" }));
+
+    const body = await waitForBody("createTableIndex");
+
+    expect(body.transform_id).toBe(1);
+    expect(body.structured).toEqual({
+      kind: "btree",
+      name: "index 1",
+      columns: [
+        { name: "city", direction: "asc" },
+        { name: "country", direction: "asc" },
+      ],
+      unique: true,
+    });
+  });
+
+  it("does not offer directions or a unique switch for gin", async () => {
+    setup();
+
+    await userEvent.click(await screen.findByLabelText("Index type"));
+    await userEvent.click(await screen.findByRole("option", { name: /gin/ }));
+
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+
+    await userEvent.type(
+      await screen.findByLabelText("Give your index a name"),
+      "idx_search",
+    );
+    await userEvent.click(screen.getByPlaceholderText("Select columns"));
+    await userEvent.click(
+      await screen.findByRole("option", { name: "City name" }),
+    );
+
+    expect(
+      screen.queryByText("Sort order for each column to be stored in"),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Create index" }));
+
+    const body = await waitForBody("createTableIndex");
+    expect(body.structured).toEqual({
+      kind: "gin",
+      name: "idx_search",
+      columns: [{ name: "city" }],
+    });
+  });
+
+  it("blocks submitting without a required name", async () => {
+    setup();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Create index" }),
+    );
+
+    expect((await screen.findAllByText("required")).length).toBeGreaterThan(0);
+    expect(fetchMock.callHistory.called("createTableIndex")).toBe(false);
+  });
+
+  it("edits an existing index and only sends structured via PUT", async () => {
+    const structured: StructuredIndex = {
+      kind: "btree",
+      name: "idx_existing",
+      columns: [{ name: "city", direction: "asc" }],
+      unique: false,
+    };
+    const index = createMockTableIndexEntry({
+      metabase_managed: true,
+      request: createMockTableIndexRequest({ id: 42, structured }),
+    });
+
+    setup({ index });
+
+    const nameInput = await screen.findByLabelText("Give your index a name");
+    expect(nameInput).toBeDisabled();
+    expect(nameInput).toHaveValue("idx_existing");
+    expect(screen.getByLabelText("Index type")).toBeDisabled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Update index" }));
+
+    const body = await waitForBody("updateTableIndex-42");
+    expect(Object.keys(body)).toEqual(["structured"]);
+    expect(body.structured.name).toBe("idx_existing");
+  });
+
+  it("shows an error toast when the request fails", async () => {
+    setup();
+    fetchMock.modifyRoute("createTableIndex", {
+      response: { status: 400, body: {} },
+    });
+
+    await userEvent.type(
+      await screen.findByLabelText("Give your index a name"),
+      "idx",
+    );
+    await userEvent.click(screen.getByPlaceholderText("Select columns"));
+    await userEvent.click(
+      await screen.findByRole("option", { name: "City name" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Create index" }));
+
+    expect(await screen.findByText("Failed to save index")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: "Failed" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Success" }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+async function waitForBody(name: string) {
+  await waitFor(() => {
+    expect(fetchMock.callHistory.called(name)).toBe(true);
+  });
+  const call = fetchMock.callHistory.lastCall(name);
+  return JSON.parse(call?.options?.body as string);
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexFieldInput.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/IndexFieldInput.tsx
@@ -1,0 +1,84 @@
+import { match } from "ts-pattern";
+
+import {
+  FormNumberInput,
+  FormSelect,
+  FormSwitch,
+  FormTextInput,
+} from "metabase/forms";
+import type { IndexField } from "metabase-types/api";
+
+import { ColumnsField } from "./ColumnsField";
+import type { ColumnOption } from "./types";
+
+type IndexFieldInputProps = {
+  field: IndexField;
+  columnOptions: ColumnOption[];
+  disabled?: boolean;
+  autoFocus?: boolean;
+};
+
+export function IndexFieldInput({
+  field,
+  columnOptions,
+  disabled,
+  autoFocus,
+}: IndexFieldInputProps) {
+  const label = field["display-name"];
+  const description = field.description;
+
+  return match(field.type)
+    .with("boolean", () => {
+      // Per design, the unique switch renders its description as the inline label
+      const isUniqueField = field.name === "unique";
+      return (
+        <FormSwitch
+          name={field.name}
+          label={isUniqueField ? (description ?? label) : label}
+          description={isUniqueField ? undefined : description}
+          disabled={disabled}
+        />
+      );
+    })
+    .with("select", () => (
+      <FormSelect
+        name={field.name}
+        label={label}
+        description={description}
+        data={(field.options ?? []).map((option) => ({
+          value: option.value,
+          label: option.name,
+        }))}
+        disabled={disabled}
+      />
+    ))
+    .with("integer", () => (
+      <FormNumberInput
+        name={field.name}
+        label={label}
+        description={description}
+        disabled={disabled}
+      />
+    ))
+    .with("columns", () => (
+      <ColumnsField
+        name={field.name}
+        label={label}
+        description={description}
+        options={columnOptions}
+        supportsDirections={field.directions ?? false}
+        disabled={disabled}
+      />
+    ))
+    .otherwise(() => (
+      <FormTextInput
+        name={field.name}
+        label={label}
+        description={description}
+        disabled={disabled}
+        autoFocus={autoFocus}
+        data-autofocus={autoFocus}
+        autoComplete="off"
+      />
+    ));
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/constants.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/constants.ts
@@ -1,0 +1,20 @@
+import { t } from "ttag";
+
+export function getIndexTypeDescription(): string {
+  return t`The data structure used to organize the index. B-tree works well for most lookups, sorting, and range queries.`;
+}
+
+export function getKindDescription(kind: string): string | null {
+  switch (kind) {
+    case "btree":
+      return t`Default. Best for equality and range queries on sortable data; use it for most columns you filter, sort, or join by.`;
+    case "gin":
+      return t`For values with multiple components. Best for full-text search, JSONB, and arrays—when you're searching inside a value.`;
+    case "gist":
+      return t`For geometric, spatial, and range data. Best for "nearest neighbor" and overlap queries, like geographic data (PostGIS) or range types.`;
+    case "brin":
+      return t`Tiny and low-overhead. Best for large tables where values correlate with physical row order, like timestamps in an append-only log.`;
+    default:
+      return null;
+  }
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/types.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/types.ts
@@ -1,0 +1,4 @@
+export type ColumnOption = {
+  value: string;
+  label: string;
+};

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.ts
@@ -1,0 +1,94 @@
+import * as Yup from "yup";
+
+import * as Errors from "metabase/utils/errors";
+import type {
+  IndexColumn,
+  IndexField,
+  IndexKind,
+  StructuredIndex,
+} from "metabase-types/api";
+
+export type IndexFormValues = Record<string, unknown>;
+
+function defaultFieldValue(field: IndexField) {
+  switch (field.type) {
+    case "boolean":
+      return false;
+    case "columns":
+      return [];
+    case "integer":
+      return null;
+    case "select":
+      return field.options?.[0]?.value ?? "";
+    default:
+      return "";
+  }
+}
+
+export function buildInitialValues(
+  fields: IndexField[],
+  structured?: StructuredIndex,
+): IndexFormValues {
+  const source: IndexFormValues | undefined = structured;
+  return Object.fromEntries(
+    fields.map((field) => [
+      field.name,
+      source?.[field.name] ?? defaultFieldValue(field),
+    ]),
+  );
+}
+
+function getFieldSchema(field: IndexField): Yup.AnySchema {
+  switch (field.type) {
+    case "columns": {
+      const schema = Yup.array().of(
+        Yup.object({
+          name: Yup.string().required(),
+          direction: Yup.string().oneOf(["asc", "desc"]).optional(),
+        }),
+      );
+      return field.required ? schema.min(1, Errors.required) : schema;
+    }
+    case "boolean":
+      return Yup.boolean();
+    case "integer": {
+      const schema = Yup.number().nullable();
+      return field.required ? schema.required(Errors.required) : schema;
+    }
+    default: {
+      const schema = Yup.string();
+      return field.required ? schema.required(Errors.required) : schema;
+    }
+  }
+}
+
+export function buildValidationSchema(fields: IndexField[]) {
+  return Yup.object(
+    Object.fromEntries(
+      fields.map((field) => [field.name, getFieldSchema(field)]),
+    ),
+  );
+}
+
+export function toStructured(
+  kind: IndexKind,
+  fields: IndexField[],
+  values: IndexFormValues,
+): StructuredIndex {
+  const structured: Record<string, unknown> = { kind };
+  for (const field of fields) {
+    const value = values[field.name];
+    if (field.type === "columns") {
+      const columns = (value as IndexColumn[] | undefined) ?? [];
+      structured[field.name] = field.directions
+        ? columns.map((column) => ({
+            name: column.name,
+            direction: column.direction ?? "asc",
+          }))
+        : columns.map((column) => ({ name: column.name }));
+    } else {
+      structured[field.name] = value;
+    }
+  }
+  return structured as StructuredIndex;
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexPageActions.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexPageActions.tsx
@@ -1,0 +1,35 @@
+import { t } from "ttag";
+
+import { Button, Tooltip } from "metabase/ui";
+
+export function IndexPageActions({
+  readOnly = false,
+  targetTableExists: hasTable,
+  handleCreate,
+  canCreate,
+}: {
+  readOnly: boolean | undefined;
+  targetTableExists: boolean;
+  handleCreate: () => void;
+  canCreate: boolean;
+}) {
+  if (readOnly) {
+    return null;
+  }
+
+  const createButton = (
+    <Button variant="filled" disabled={!canCreate} onClick={handleCreate}>
+      {t`Create index`}
+    </Button>
+  );
+
+  const actions = hasTable ? (
+    createButton
+  ) : (
+    <Tooltip label={t`Run the transform before adding indexes`}>
+      {createButton}
+    </Tooltip>
+  );
+
+  return actions;
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/NoIndexes.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/NoIndexes.tsx
@@ -1,0 +1,18 @@
+import { t } from "ttag";
+
+import { Flex, Text } from "metabase/ui";
+
+import TransformIndexesEmpty from "./assets/transform-indexes-empty.svg?component";
+
+export function NoIndexes() {
+  return (
+    <Flex gap="md" direction="column" justify="center" align="center" mih={360}>
+      <TransformIndexesEmpty aria-hidden />
+      <Text
+        c="text-secondary"
+        maw={360}
+        ta="center"
+      >{t`Index the key columns of your transforms to make them faster and more efficient.`}</Text>
+    </Flex>
+  );
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/IndexRowMenu.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/IndexRowMenu.tsx
@@ -1,0 +1,53 @@
+import type { MouseEvent } from "react";
+import { t } from "ttag";
+
+import { ActionIcon, Icon, Menu } from "metabase/ui";
+import type { TableIndexEntry } from "metabase-types/api";
+
+import { isManagedIndex, isPendingDeletion } from "./utils";
+
+type IndexRowMenuProps = {
+  index: TableIndexEntry;
+  onEdit: (index: TableIndexEntry) => void;
+  onDelete: (index: TableIndexEntry) => void;
+};
+
+export function IndexRowMenu({ index, onEdit, onDelete }: IndexRowMenuProps) {
+  if (!isManagedIndex(index)) {
+    return null;
+  }
+
+  const isDisabled = isPendingDeletion(index);
+
+  function handleIconClick(event: MouseEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  return (
+    <Menu position="bottom-end">
+      <Menu.Target>
+        <ActionIcon aria-label={t`Index actions`} onClick={handleIconClick}>
+          <Icon name="ellipsis" />
+        </ActionIcon>
+      </Menu.Target>
+      <Menu.Dropdown onClick={(event) => event.stopPropagation()}>
+        <Menu.Item
+          leftSection={<Icon name="pencil" />}
+          onClick={() => onEdit(index)}
+          disabled={isDisabled}
+        >
+          {t`Edit`}
+        </Menu.Item>
+        <Menu.Item
+          c={isDisabled ? undefined : "danger"}
+          leftSection={<Icon name="trash" />}
+          onClick={() => onDelete(index)}
+          disabled={isDisabled}
+        >
+          {t`Delete`}
+        </Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.tsx
@@ -1,5 +1,5 @@
-import type { SortingState } from "@tanstack/react-table";
-import { useMemo, useState } from "react";
+import type { Row, SortingState } from "@tanstack/react-table";
+import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { useListUsersQuery } from "metabase/api";
@@ -11,15 +11,23 @@ import type { TableIndexEntry, UserId } from "metabase-types/api";
 
 import { getColumns } from "./columns";
 import type { IndexRow } from "./types";
-import { getIndexKey } from "./utils";
+import { getIndexKey, isManagedIndex, isPendingDeletion } from "./utils";
 
 type TransformIndexTableProps = {
   indexes: TableIndexEntry[];
+  readOnly?: boolean;
+  onEdit: (index: TableIndexEntry) => void;
+  onDelete: (index: TableIndexEntry) => void;
 };
 
 const DEFAULT_SORTING: SortingState = [{ id: "name", desc: false }];
 
-export function TransformIndexTable({ indexes }: TransformIndexTableProps) {
+export function TransformIndexTable({
+  indexes,
+  readOnly,
+  onEdit,
+  onDelete,
+}: TransformIndexTableProps) {
   const systemTimezone = useSetting("system-timezone");
   const { data: usersResponse } = useListUsersQuery();
   const [sorting, setSorting] = useState<SortingState>(DEFAULT_SORTING);
@@ -48,7 +56,24 @@ export function TransformIndexTable({ indexes }: TransformIndexTableProps) {
     [indexes, usersById],
   );
 
-  const columns = useMemo(() => getColumns(systemTimezone), [systemTimezone]);
+  const columns = useMemo(
+    () =>
+      getColumns({
+        systemTimezone,
+        actions: readOnly ? undefined : { onEdit, onDelete },
+      }),
+    [systemTimezone, readOnly, onEdit, onDelete],
+  );
+
+  const handleRowClick = useCallback(
+    (row: Row<IndexRow>) => {
+      const index = row.original;
+      if (!readOnly && isManagedIndex(index) && !isPendingDeletion(index)) {
+        onEdit(index);
+      }
+    },
+    [readOnly, onEdit],
+  );
 
   const treeTableInstance = useTreeTableInstance<IndexRow>({
     data: rows,
@@ -65,6 +90,7 @@ export function TransformIndexTable({ indexes }: TransformIndexTableProps) {
       hierarchical={false}
       emptyState={<ListEmptyState label={t`No indexes yet`} />}
       ariaLabel={t`Transform indexes`}
+      onRowClick={handleRowClick}
     />
   );
 }

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.tsx
@@ -1,0 +1,70 @@
+import type { SortingState } from "@tanstack/react-table";
+import { useMemo, useState } from "react";
+import { t } from "ttag";
+
+import { useListUsersQuery } from "metabase/api";
+import { ListEmptyState } from "metabase/common/components/ListEmptyState";
+import { useSetting } from "metabase/common/hooks";
+import { TreeTable, useTreeTableInstance } from "metabase/ui";
+import { isNullOrUndefined } from "metabase/utils/types";
+import type { TableIndexEntry, UserId } from "metabase-types/api";
+
+import { getColumns } from "./columns";
+import type { IndexRow } from "./types";
+import { getIndexKey } from "./utils";
+
+type TransformIndexTableProps = {
+  indexes: TableIndexEntry[];
+};
+
+const DEFAULT_SORTING: SortingState = [{ id: "name", desc: false }];
+
+export function TransformIndexTable({ indexes }: TransformIndexTableProps) {
+  const systemTimezone = useSetting("system-timezone");
+  const { data: usersResponse } = useListUsersQuery();
+  const [sorting, setSorting] = useState<SortingState>(DEFAULT_SORTING);
+
+  const usersById = useMemo(() => {
+    const map = new Map<UserId, string>();
+    for (const user of usersResponse?.data ?? []) {
+      map.set(user.id, user.common_name);
+    }
+    return map;
+  }, [usersResponse]);
+
+  const rows = useMemo<IndexRow[]>(
+    () =>
+      indexes.map((index, position) => {
+        const userId = index.request?.created_by;
+        const modifiedBy = isNullOrUndefined(userId)
+          ? ""
+          : (usersById.get(userId) ?? "");
+        return {
+          ...index,
+          id: getIndexKey(index, position),
+          modifiedBy,
+        };
+      }),
+    [indexes, usersById],
+  );
+
+  const columns = useMemo(() => getColumns(systemTimezone), [systemTimezone]);
+
+  const treeTableInstance = useTreeTableInstance<IndexRow>({
+    data: rows,
+    columns,
+    getNodeId: (row) => row.id,
+    enableSorting: true,
+    sorting,
+    onSortingChange: setSorting,
+  });
+
+  return (
+    <TreeTable
+      instance={treeTableInstance}
+      hierarchical={false}
+      emptyState={<ListEmptyState label={t`No indexes yet`} />}
+      ariaLabel={t`Transform indexes`}
+    />
+  );
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.unit.spec.tsx
@@ -1,6 +1,10 @@
+import userEvent from "@testing-library/user-event";
+
 import { setupUsersEndpoints } from "__support__/server-mocks";
 import {
+  getIcon,
   mockGetBoundingClientRect,
+  queryIcon,
   renderWithProviders,
   screen,
   within,
@@ -17,13 +21,25 @@ import { TransformIndexTable } from "./TransformIndexTable";
 type SetupOpts = {
   indexes?: TableIndexEntry[];
   users?: UserListResult[];
+  readOnly?: boolean;
 };
 
-function setup({ indexes = [], users = [] }: SetupOpts = {}) {
+function setup({ indexes = [], users = [], readOnly = false }: SetupOpts = {}) {
   mockGetBoundingClientRect({ width: 1000, height: 600 });
   setupUsersEndpoints(users);
 
-  renderWithProviders(<TransformIndexTable indexes={indexes} />);
+  const onEdit = jest.fn();
+  const onDelete = jest.fn();
+  renderWithProviders(
+    <TransformIndexTable
+      indexes={indexes}
+      readOnly={readOnly}
+      onEdit={onEdit}
+      onDelete={onDelete}
+    />,
+  );
+
+  return { onEdit, onDelete };
 }
 
 describe("TransformIndexTable", () => {
@@ -111,6 +127,40 @@ describe("TransformIndexTable", () => {
     expect(screen.getByText("Removing")).toBeInTheDocument();
   });
 
+  it("shows an info tooltip for pending statuses", async () => {
+    setup({
+      indexes: [
+        createMockTableIndexEntry({
+          request: createMockTableIndexRequest({ status: "create-pending" }),
+        }),
+      ],
+    });
+
+    expect(await screen.findByText("Pending")).toBeInTheDocument();
+    await userEvent.hover(getIcon("info_outline"));
+    expect(
+      await screen.findByText(
+        "Changes will be applied the next time the transform runs",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the pending info icon for terminal statuses", async () => {
+    setup({
+      indexes: [
+        createMockTableIndexEntry({
+          request: createMockTableIndexRequest({
+            status: "succeeded",
+            error_message: null,
+          }),
+        }),
+      ],
+    });
+
+    expect(await screen.findByText("Succeeded")).toBeInTheDocument();
+    expect(queryIcon("info_outline")).not.toBeInTheDocument();
+  });
+
   it("resolves the last modified by user name", async () => {
     setup({
       users: [createMockUserListResult({ id: 7, common_name: "Ed Winters" })],
@@ -134,5 +184,112 @@ describe("TransformIndexTable", () => {
     });
 
     expect(await screen.findByText("Never")).toBeInTheDocument();
+  });
+
+  it("offers edit and delete for a managed index with a request", async () => {
+    const index = createMockTableIndexEntry({
+      metabase_managed: true,
+      request: createMockTableIndexRequest({ id: 5 }),
+    });
+    const { onEdit, onDelete } = setup({ indexes: [index] });
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Index actions" }),
+    );
+    await userEvent.click(await screen.findByText("Edit"));
+    expect(onEdit).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "btree" }),
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Index actions" }),
+    );
+    await userEvent.click(await screen.findByText("Delete"));
+    expect(onDelete).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "btree" }),
+    );
+  });
+
+  it("opens the editor only when clicking an editable managed index row", async () => {
+    const managed = createMockTableIndexEntry({
+      name: "idx_managed",
+      metabase_managed: true,
+      request: createMockTableIndexRequest({ id: 5 }),
+    });
+    const unmanaged = createMockTableIndexEntry({
+      name: "idx_unmanaged",
+      metabase_managed: false,
+      request: undefined,
+    });
+    const removing = createMockTableIndexEntry({
+      name: "idx_removing",
+      metabase_managed: true,
+      request: createMockTableIndexRequest({ id: 6, status: "delete-pending" }),
+    });
+    const { onEdit } = setup({ indexes: [managed, unmanaged, removing] });
+
+    await userEvent.click(await screen.findByText("idx_unmanaged"));
+    await userEvent.click(screen.getByText("idx_removing"));
+    expect(onEdit).not.toHaveBeenCalled();
+
+    // opening the row menu must not bubble into a row click
+    const managedRow = screen.getByRole("row", { name: /idx_managed/ });
+    await userEvent.click(
+      within(managedRow).getByRole("button", { name: "Index actions" }),
+    );
+    expect(await screen.findByText("Edit")).toBeInTheDocument();
+    expect(onEdit).not.toHaveBeenCalled();
+    await userEvent.keyboard("{Escape}");
+
+    await userEvent.click(screen.getByText("idx_managed"));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(onEdit).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "idx_managed" }),
+    );
+  });
+
+  it("does not open the editor when clicking a row in read-only mode", async () => {
+    const index = createMockTableIndexEntry({
+      name: "idx_readonly",
+      metabase_managed: true,
+      request: createMockTableIndexRequest({ id: 5 }),
+    });
+    const { onEdit } = setup({ indexes: [index], readOnly: true });
+
+    await userEvent.click(await screen.findByText("idx_readonly"));
+    expect(onEdit).not.toHaveBeenCalled();
+  });
+
+  it("does not offer a menu for unmanaged indexes", async () => {
+    setup({
+      indexes: [
+        createMockTableIndexEntry({
+          metabase_managed: false,
+          request: undefined,
+        }),
+      ],
+    });
+
+    expect(await screen.findByText("Unmanaged")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Index actions" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render the actions column when read-only", async () => {
+    setup({
+      readOnly: true,
+      indexes: [
+        createMockTableIndexEntry({
+          metabase_managed: true,
+          request: createMockTableIndexRequest({ id: 5 }),
+        }),
+      ],
+    });
+
+    expect(await screen.findByText("Managed")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Index actions" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/TransformIndexTable.unit.spec.tsx
@@ -1,0 +1,138 @@
+import { setupUsersEndpoints } from "__support__/server-mocks";
+import {
+  mockGetBoundingClientRect,
+  renderWithProviders,
+  screen,
+  within,
+} from "__support__/ui";
+import type { TableIndexEntry, UserListResult } from "metabase-types/api";
+import {
+  createMockTableIndexEntry,
+  createMockTableIndexRequest,
+  createMockUserListResult,
+} from "metabase-types/api/mocks";
+
+import { TransformIndexTable } from "./TransformIndexTable";
+
+type SetupOpts = {
+  indexes?: TableIndexEntry[];
+  users?: UserListResult[];
+};
+
+function setup({ indexes = [], users = [] }: SetupOpts = {}) {
+  mockGetBoundingClientRect({ width: 1000, height: 600 });
+  setupUsersEndpoints(users);
+
+  renderWithProviders(<TransformIndexTable indexes={indexes} />);
+}
+
+describe("TransformIndexTable", () => {
+  it("renders the column headers", async () => {
+    setup({ indexes: [createMockTableIndexEntry()] });
+
+    for (const header of [
+      "Name",
+      "Type",
+      "Columns",
+      "Source",
+      "Status",
+      "Last modified by",
+      "Last run",
+    ]) {
+      expect(await screen.findByText(header)).toBeInTheDocument();
+    }
+  });
+
+  it("renders the index name, type and columns", async () => {
+    setup({
+      indexes: [
+        createMockTableIndexEntry({
+          name: "idx_orders",
+          kind: "gin",
+          key_columns: ["total", "created_at"],
+        }),
+      ],
+    });
+
+    expect(await screen.findByText("idx_orders")).toBeInTheDocument();
+    expect(screen.getByText("gin")).toBeInTheDocument();
+    expect(screen.getByText("total, created_at")).toBeInTheDocument();
+  });
+
+  it("falls back to the index kind when the index has no name", async () => {
+    setup({
+      indexes: [createMockTableIndexEntry({ name: null, kind: "distkey" })],
+    });
+
+    const table = await screen.findByRole("treegrid", {
+      name: "Transform indexes",
+    });
+    // The kind shows in both the Name (fallback) and Type columns.
+    expect(within(table).getAllByText("distkey")).toHaveLength(2);
+  });
+
+  it("labels metabase-managed indexes as 'Managed'", async () => {
+    setup({
+      indexes: [createMockTableIndexEntry({ metabase_managed: true })],
+    });
+
+    expect(await screen.findByText("Managed")).toBeInTheDocument();
+  });
+
+  it("labels non-managed indexes as 'Unmanaged'", async () => {
+    setup({
+      indexes: [createMockTableIndexEntry({ metabase_managed: false })],
+    });
+
+    expect(await screen.findByText("Unmanaged")).toBeInTheDocument();
+  });
+
+  it("formats the request status", async () => {
+    setup({
+      indexes: [
+        createMockTableIndexEntry({
+          name: "idx_pending",
+          request: createMockTableIndexRequest({
+            id: 1,
+            status: "create-pending",
+          }),
+        }),
+        createMockTableIndexEntry({
+          name: "idx_removing",
+          request: createMockTableIndexRequest({
+            id: 2,
+            status: "delete-pending",
+          }),
+        }),
+      ],
+    });
+
+    expect(await screen.findByText("Pending")).toBeInTheDocument();
+    expect(screen.getByText("Removing")).toBeInTheDocument();
+  });
+
+  it("resolves the last modified by user name", async () => {
+    setup({
+      users: [createMockUserListResult({ id: 7, common_name: "Ed Winters" })],
+      indexes: [
+        createMockTableIndexEntry({
+          request: createMockTableIndexRequest({ created_by: 7 }),
+        }),
+      ],
+    });
+
+    expect(await screen.findByText("Ed Winters")).toBeInTheDocument();
+  });
+
+  it("shows 'Never' when the index has not been run", async () => {
+    setup({
+      indexes: [
+        createMockTableIndexEntry({
+          request: createMockTableIndexRequest({ last_executed_at: null }),
+        }),
+      ],
+    });
+
+    expect(await screen.findByText("Never")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/columns.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/columns.tsx
@@ -2,16 +2,31 @@ import { t } from "ttag";
 
 import { parseTimestampWithTimezone } from "metabase/transforms/utils";
 import type { TreeTableColumnDef } from "metabase/ui";
-import { Ellipsified, Group, Icon, Tooltip } from "metabase/ui";
+import { Ellipsified, Flex, Group, Icon, Tooltip } from "metabase/ui";
 import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
+import type { TableIndexEntry } from "metabase-types/api";
 
+import { IndexRowMenu } from "./IndexRowMenu";
 import type { IndexRow } from "./types";
-import { formatStatus, getIndexName } from "./utils";
+import { formatStatus, getIndexName, isPendingStatus } from "./utils";
 
-export function getColumns(
-  systemTimezone: string | undefined,
-): TreeTableColumnDef<IndexRow>[] {
-  return [
+const ACTIONS_COLUMN_WIDTH = 56;
+
+type Actions = {
+  onEdit: (index: TableIndexEntry) => void;
+  onDelete: (index: TableIndexEntry) => void;
+};
+
+type ColumnsProps = {
+  systemTimezone: string | undefined;
+  actions: Actions | undefined;
+};
+
+export function getColumns({
+  systemTimezone,
+  actions,
+}: ColumnsProps): TreeTableColumnDef<IndexRow>[] {
+  const columns: TreeTableColumnDef<IndexRow>[] = [
     {
       id: "name",
       header: t`Name`,
@@ -66,12 +81,20 @@ export function getColumns(
       enableSorting: true,
       accessorFn: (index) => formatStatus(index.request?.status),
       cell: ({ row, getValue }) => {
-        const errorMessage = row.original.request?.error_message;
+        const request = row.original.request;
+        const errorMessage = request?.error_message;
         return (
           <Group gap="sm" wrap="nowrap">
             <Ellipsified>{String(getValue())}</Ellipsified>
             {errorMessage != null && (
               <Tooltip label={errorMessage}>
+                <Icon name="info_outline" c="text-secondary" />
+              </Tooltip>
+            )}
+            {isPendingStatus(request?.status) && (
+              <Tooltip
+                label={t`Changes will be applied the next time the transform runs`}
+              >
                 <Icon name="info_outline" c="text-secondary" />
               </Tooltip>
             )}
@@ -116,4 +139,24 @@ export function getColumns(
       },
     },
   ];
+
+  if (actions != null) {
+    columns.push({
+      id: "actions",
+      header: "",
+      width: ACTIONS_COLUMN_WIDTH,
+      enableSorting: false,
+      cell: ({ row }) => (
+        <Flex justify="center">
+          <IndexRowMenu
+            index={row.original}
+            onEdit={actions.onEdit}
+            onDelete={actions.onDelete}
+          />
+        </Flex>
+      ),
+    });
+  }
+
+  return columns;
 }

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/columns.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/columns.tsx
@@ -1,0 +1,119 @@
+import { t } from "ttag";
+
+import { parseTimestampWithTimezone } from "metabase/transforms/utils";
+import type { TreeTableColumnDef } from "metabase/ui";
+import { Ellipsified, Group, Icon, Tooltip } from "metabase/ui";
+import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
+
+import type { IndexRow } from "./types";
+import { formatStatus, getIndexName } from "./utils";
+
+export function getColumns(
+  systemTimezone: string | undefined,
+): TreeTableColumnDef<IndexRow>[] {
+  return [
+    {
+      id: "name",
+      header: t`Name`,
+      minWidth: "auto",
+      maxAutoWidth: 240,
+      enableSorting: true,
+      accessorFn: (index) => getIndexName(index),
+      cell: ({ getValue }) => (
+        <Group gap="sm" wrap="nowrap">
+          <Icon name="table_index" c="brand" />
+          <Ellipsified>{String(getValue())}</Ellipsified>
+        </Group>
+      ),
+    },
+    {
+      id: "type",
+      header: t`Type`,
+      width: "auto",
+      enableSorting: true,
+      accessorFn: (index) => index.kind,
+      cell: ({ getValue }) => <Ellipsified>{String(getValue())}</Ellipsified>,
+    },
+    {
+      id: "columns",
+      header: t`Columns`,
+      width: "auto",
+      maxAutoWidth: 240,
+      enableSorting: true,
+      accessorFn: (index) => index.key_columns.join(", "),
+      cell: ({ getValue }) => {
+        const value = String(getValue());
+        return value.length > 0 ? (
+          <Ellipsified>{value}</Ellipsified>
+        ) : (
+          EMPTY_CELL_PLACEHOLDER
+        );
+      },
+    },
+    {
+      id: "source",
+      header: t`Source`,
+      width: "auto",
+      enableSorting: true,
+      accessorFn: (index) =>
+        index.metabase_managed ? t`Managed` : t`Unmanaged`,
+      cell: ({ getValue }) => <Ellipsified>{String(getValue())}</Ellipsified>,
+    },
+    {
+      id: "status",
+      header: t`Status`,
+      width: "auto",
+      enableSorting: true,
+      accessorFn: (index) => formatStatus(index.request?.status),
+      cell: ({ row, getValue }) => {
+        const errorMessage = row.original.request?.error_message;
+        return (
+          <Group gap="sm" wrap="nowrap">
+            <Ellipsified>{String(getValue())}</Ellipsified>
+            {errorMessage != null && (
+              <Tooltip label={errorMessage}>
+                <Icon name="info_outline" c="text-secondary" />
+              </Tooltip>
+            )}
+          </Group>
+        );
+      },
+    },
+    {
+      id: "modified-by",
+      header: t`Last modified by`,
+      width: "auto",
+      maxAutoWidth: 200,
+      enableSorting: true,
+      accessorFn: (index) => index.modifiedBy,
+      cell: ({ getValue }) => {
+        const value = String(getValue());
+        return value.length > 0 ? (
+          <Ellipsified>{value}</Ellipsified>
+        ) : (
+          EMPTY_CELL_PLACEHOLDER
+        );
+      },
+    },
+    {
+      id: "last-run",
+      header: t`Last run`,
+      width: "auto",
+      enableSorting: true,
+      accessorFn: (index) => index.request?.last_executed_at ?? null,
+      cell: ({ getValue }) => {
+        const lastExecutedAt = getValue<string | null>();
+        if (lastExecutedAt == null) {
+          return t`Never`;
+        }
+        return (
+          <Ellipsified>
+            {parseTimestampWithTimezone(lastExecutedAt, systemTimezone).format(
+              "lll",
+            )}
+          </Ellipsified>
+        );
+      },
+    },
+  ];
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/index.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/index.ts
@@ -1,0 +1,1 @@
+export * from "./TransformIndexTable";

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/types.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/types.ts
@@ -1,0 +1,8 @@
+import type { TableIndexEntry } from "metabase-types/api";
+
+type IndexRowId = string;
+
+export type IndexRow = TableIndexEntry & {
+  id: IndexRowId;
+  modifiedBy: string;
+};

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/utils.ts
@@ -19,6 +19,24 @@ export function getIndexKey(index: TableIndexEntry, position: number): string {
   return `index-${getIndexName(index)}-${position}`;
 }
 
+export function isManagedIndex(index: TableIndexEntry): boolean {
+  return index.metabase_managed && index.request?.id !== undefined;
+}
+
+export function isPendingDeletion(index: TableIndexEntry): boolean {
+  return index.request?.status === "delete-pending";
+}
+
+export function isPendingStatus(
+  status: TableIndexRequestStatus | undefined,
+): boolean {
+  return (
+    status === "create-pending" ||
+    status === "update-pending" ||
+    status === "delete-pending"
+  );
+}
+
 export function formatStatus(
   status: TableIndexRequestStatus | undefined,
 ): string {

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexTable/utils.ts
@@ -1,0 +1,36 @@
+import { match } from "ts-pattern";
+import { t } from "ttag";
+
+import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
+import type {
+  TableIndexEntry,
+  TableIndexRequestStatus,
+} from "metabase-types/api";
+
+export function getIndexName(index: TableIndexEntry): string {
+  return index.name ?? index.kind;
+}
+
+export function getIndexKey(index: TableIndexEntry, position: number): string {
+  if (index.request?.id !== undefined) {
+    return `request-${index.request.id}`;
+  }
+
+  return `index-${getIndexName(index)}-${position}`;
+}
+
+export function formatStatus(
+  status: TableIndexRequestStatus | undefined,
+): string {
+  if (status === undefined) {
+    return EMPTY_CELL_PLACEHOLDER;
+  }
+
+  return match(status)
+    .with("create-pending", "update-pending", () => t`Pending`)
+    .with("delete-pending", () => t`Removing`)
+    .with("running", () => t`Running`)
+    .with("succeeded", () => t`Succeeded`)
+    .with("failed", () => t`Failed`)
+    .exhaustive();
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
@@ -7,13 +7,17 @@ import {
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
+import { TitleSection } from "metabase/data-studio/common/components/TitleSection";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
-import { Card, Center, Stack, Text } from "metabase/ui";
+import { Center } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { isNullOrUndefined } from "metabase/utils/types";
-import type { TableIndexEntry, TransformId } from "metabase-types/api";
+import type { TransformId } from "metabase-types/api";
 
 import { TransformHeader } from "../../components/TransformHeader";
+
+import { NoIndexes } from "./NoIndexes";
+import { TransformIndexTable } from "./TransformIndexTable";
 
 type TransformIndexesPageProps = {
   params: {
@@ -68,38 +72,13 @@ function TransformIndexesContent({
     );
   }
 
-  if (indexes.length === 0) {
-    return (
-      <Card flex={1} withBorder>
-        <Center h="100%">
-          <Text c="text-secondary">{t`No indexes defined for this transform.`}</Text>
-        </Center>
-      </Card>
-    );
-  }
-
   return (
-    <Card flex={1} withBorder>
-      <Stack gap="md">
-        {indexes.map((index, indexPosition) => (
-          <TransformIndexRow
-            key={index.request?.id ?? index.name ?? indexPosition}
-            index={index}
-          />
-        ))}
-      </Stack>
-    </Card>
-  );
-}
-
-function TransformIndexRow({ index }: { index: TableIndexEntry }) {
-  const status = index.request?.status;
-  return (
-    <Stack gap={0}>
-      <Text fw="bold">{index.name ?? index.kind}</Text>
-      <Text c="text-secondary" size="sm">
-        {status ? `${index.kind} · ${status}` : index.kind}
-      </Text>
-    </Stack>
+    <TitleSection label={t`Indexes`}>
+      {indexes.length === 0 ? (
+        <NoIndexes />
+      ) : (
+        <TransformIndexTable indexes={indexes} />
+      )}
+    </TitleSection>
   );
 }

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
@@ -1,0 +1,105 @@
+import { t } from "ttag";
+
+import {
+  skipToken,
+  useGetTransformQuery,
+  useListTableIndexesQuery,
+} from "metabase/api";
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
+import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
+import { Card, Center, Stack, Text } from "metabase/ui";
+import * as Urls from "metabase/urls";
+import { isNullOrUndefined } from "metabase/utils/types";
+import type { TableIndexEntry, TransformId } from "metabase-types/api";
+
+import { TransformHeader } from "../../components/TransformHeader";
+
+type TransformIndexesPageProps = {
+  params: {
+    transformId?: string;
+  };
+};
+
+export function TransformIndexesPage({ params }: TransformIndexesPageProps) {
+  const transformId = Urls.extractEntityId(params.transformId);
+  const {
+    data: transform,
+    isLoading: isLoadingTransform,
+    error: transformError,
+  } = useGetTransformQuery(transformId ?? skipToken);
+  const { readOnly, isLoadingDatabases, databasesError } =
+    useTransformPermissions({ transform });
+  const isLoading = isLoadingTransform || isLoadingDatabases;
+  const error = transformError || databasesError;
+
+  if (transform === undefined || isLoading || !isNullOrUndefined(error)) {
+    return (
+      <Center h="100%">
+        <LoadingAndErrorWrapper loading={isLoading} error={error} />
+      </Center>
+    );
+  }
+
+  return (
+    <PageContainer data-testid="transforms-indexes-content">
+      <TransformHeader transform={transform} readOnly={readOnly} />
+      <TransformIndexesContent transformId={transform.id} />
+    </PageContainer>
+  );
+}
+
+function TransformIndexesContent({
+  transformId,
+}: {
+  transformId: TransformId;
+}) {
+  const {
+    data: indexes = [],
+    isLoading,
+    error,
+  } = useListTableIndexesQuery({ "transform-id": transformId });
+
+  if (isLoading || !isNullOrUndefined(error)) {
+    return (
+      <Center flex={1}>
+        <LoadingAndErrorWrapper loading={isLoading} error={error} />
+      </Center>
+    );
+  }
+
+  if (indexes.length === 0) {
+    return (
+      <Card flex={1} withBorder>
+        <Center h="100%">
+          <Text c="text-secondary">{t`No indexes defined for this transform.`}</Text>
+        </Center>
+      </Card>
+    );
+  }
+
+  return (
+    <Card flex={1} withBorder>
+      <Stack gap="md">
+        {indexes.map((index, indexPosition) => (
+          <TransformIndexRow
+            key={index.request?.id ?? index.name ?? indexPosition}
+            index={index}
+          />
+        ))}
+      </Stack>
+    </Card>
+  );
+}
+
+function TransformIndexRow({ index }: { index: TableIndexEntry }) {
+  const status = index.request?.status;
+  return (
+    <Stack gap={0}>
+      <Text fw="bold">{index.name ?? index.kind}</Text>
+      <Text c="text-secondary" size="sm">
+        {status ? `${index.kind} · ${status}` : index.kind}
+      </Text>
+    </Stack>
+  );
+}

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.tsx
@@ -1,21 +1,28 @@
+import { useState } from "react";
 import { t } from "ttag";
 
 import {
   skipToken,
+  useDeleteTableIndexMutation,
   useGetTransformQuery,
   useListTableIndexesQuery,
 } from "metabase/api";
+import { getErrorMessage } from "metabase/api/utils";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
-import { TitleSection } from "metabase/data-studio/common/components/TitleSection";
+import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
+import { TitleSection } from "metabase/common/data-studio/components/TitleSection";
+import { useToast } from "metabase/common/hooks";
+import { useConfirmation } from "metabase/common/hooks/use-confirmation";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
 import { Center } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { isNullOrUndefined } from "metabase/utils/types";
-import type { TransformId } from "metabase-types/api";
+import type { TableIndexEntry, Transform } from "metabase-types/api";
 
 import { TransformHeader } from "../../components/TransformHeader";
 
+import { IndexEditorModal } from "./IndexEditorModal/IndexEditorModal";
+import { IndexPageActions } from "./IndexPageActions";
 import { NoIndexes } from "./NoIndexes";
 import { TransformIndexTable } from "./TransformIndexTable";
 
@@ -48,21 +55,34 @@ export function TransformIndexesPage({ params }: TransformIndexesPageProps) {
   return (
     <PageContainer data-testid="transforms-indexes-content">
       <TransformHeader transform={transform} readOnly={readOnly} />
-      <TransformIndexesContent transformId={transform.id} />
+      <TransformIndexesContent transform={transform} readOnly={readOnly} />
     </PageContainer>
   );
 }
 
 function TransformIndexesContent({
-  transformId,
+  transform,
+  readOnly = false,
 }: {
-  transformId: TransformId;
+  transform: Transform;
+  readOnly: boolean | undefined;
 }) {
   const {
     data: indexes = [],
     isLoading,
     error,
-  } = useListTableIndexesQuery({ "transform-id": transformId });
+  } = useListTableIndexesQuery({ "transform-id": transform.id });
+  const { deleteIndex, confirmationModal } = useDeleteIndex();
+  const targetTableExists = transform.table != null;
+  const hasRequestableIndexes =
+    Object.keys(transform.requestable_indexes ?? {}).length > 0;
+  const canCreate = targetTableExists && hasRequestableIndexes && !readOnly;
+  const [editorState, setEditorState] = useState<{
+    index?: TableIndexEntry;
+  } | null>(null);
+
+  const handleCreate = () => setEditorState({});
+  const handleEdit = (index: TableIndexEntry) => setEditorState({ index });
 
   if (isLoading || !isNullOrUndefined(error)) {
     return (
@@ -73,12 +93,70 @@ function TransformIndexesContent({
   }
 
   return (
-    <TitleSection label={t`Indexes`}>
-      {indexes.length === 0 ? (
-        <NoIndexes />
-      ) : (
-        <TransformIndexTable indexes={indexes} />
+    <>
+      <TitleSection
+        label={t`Indexes`}
+        actions={
+          <IndexPageActions
+            readOnly={readOnly}
+            targetTableExists={targetTableExists}
+            handleCreate={handleCreate}
+            canCreate={canCreate}
+          />
+        }
+      >
+        {indexes.length === 0 ? (
+          <NoIndexes />
+        ) : (
+          <TransformIndexTable
+            indexes={indexes}
+            readOnly={readOnly}
+            onEdit={handleEdit}
+            onDelete={deleteIndex}
+          />
+        )}
+      </TitleSection>
+      {editorState != null && (
+        <IndexEditorModal
+          transform={transform}
+          index={editorState.index}
+          onClose={() => setEditorState(null)}
+        />
       )}
-    </TitleSection>
+      {confirmationModal}
+    </>
   );
+}
+
+function useDeleteIndex() {
+  const [sendToast] = useToast();
+  const [deleteTableIndex] = useDeleteTableIndexMutation();
+  const { modalContent: confirmationModal, show: showConfirmation } =
+    useConfirmation();
+
+  function deleteIndex(index: TableIndexEntry) {
+    const requestId = index.request?.id;
+    if (requestId == null) {
+      return;
+    }
+    showConfirmation({
+      title: t`Delete this index?`,
+      message: t`This removes the index from the warehouse.`,
+      confirmButtonText: t`Delete`,
+      confirmButtonProps: { color: "danger" },
+      onConfirm: async () => {
+        try {
+          await deleteTableIndex(requestId).unwrap();
+          sendToast({ message: t`Index deleted` });
+        } catch (deleteError) {
+          sendToast({
+            message: getErrorMessage(deleteError, t`Failed to delete index`),
+            icon: "warning",
+          });
+        }
+      },
+    });
+  }
+
+  return { deleteIndex, confirmationModal };
 }

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.unit.spec.tsx
@@ -1,0 +1,107 @@
+import fetchMock from "fetch-mock";
+import { Route } from "react-router";
+
+import {
+  setupCollectionByIdEndpoint,
+  setupDatabasesEndpoints,
+  setupUserMetabotPermissionsEndpoint,
+} from "__support__/server-mocks";
+import {
+  renderWithProviders,
+  screen,
+  waitForLoaderToBeRemoved,
+} from "__support__/ui";
+import * as Urls from "metabase/urls";
+import type { TableIndexEntry, Transform } from "metabase-types/api";
+import {
+  createMockCollection,
+  createMockDatabase,
+  createMockTableIndexEntry,
+  createMockTableIndexRequest,
+  createMockTransform,
+} from "metabase-types/api/mocks";
+
+import { TransformIndexesPage } from "./TransformIndexesPage";
+
+type SetupOpts = {
+  transform?: Transform;
+  indexes?: TableIndexEntry[];
+};
+
+function setup({
+  transform = createMockTransform({ id: 1, name: "Test Transform" }),
+  indexes = [],
+}: SetupOpts = {}) {
+  setupDatabasesEndpoints([
+    createMockDatabase({ id: 1, transforms_permissions: "write" }),
+  ]);
+  setupCollectionByIdEndpoint({
+    collections: [createMockCollection({ id: "root" })],
+  });
+  setupUserMetabotPermissionsEndpoint();
+
+  fetchMock.get(`path:/api/transform/${transform.id}`, transform);
+  fetchMock.get({
+    url: "path:/api/indexes",
+    query: { "transform-id": transform.id },
+    response: { data: indexes },
+  });
+
+  const initialRoute = Urls.transformIndexes(transform.id);
+  const path = initialRoute.replace(`/${transform.id}/`, "/:transformId/");
+
+  renderWithProviders(<Route path={path} component={TransformIndexesPage} />, {
+    withRouter: true,
+    initialRoute,
+  });
+
+  return { transform };
+}
+
+describe("TransformIndexesPage", () => {
+  it("renders the empty state when there are no indexes", async () => {
+    setup({ indexes: [] });
+    await waitForLoaderToBeRemoved();
+
+    expect(
+      await screen.findByText("No indexes defined for this transform."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the list of indexes", async () => {
+    setup({
+      indexes: [
+        createMockTableIndexEntry({
+          name: "idx_orders_id",
+          kind: "btree",
+          request: createMockTableIndexRequest({ id: 1 }),
+        }),
+        createMockTableIndexEntry({
+          name: "idx_orders_total",
+          kind: "gin",
+          request: createMockTableIndexRequest({ id: 2 }),
+        }),
+      ],
+    });
+    await waitForLoaderToBeRemoved();
+
+    expect(await screen.findByText("idx_orders_id")).toBeInTheDocument();
+    expect(screen.getByText("idx_orders_total")).toBeInTheDocument();
+  });
+
+  it("falls back to the index kind when the index has no name", async () => {
+    setup({
+      indexes: [
+        createMockTableIndexEntry({
+          name: null,
+          kind: "distkey",
+          request: createMockTableIndexRequest({ status: "pending" }),
+        }),
+      ],
+    });
+    await waitForLoaderToBeRemoved();
+
+    expect(await screen.findByText("distkey")).toBeInTheDocument();
+    expect(screen.getByText("distkey · pending")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/TransformIndexesPage.unit.spec.tsx
@@ -5,20 +5,27 @@ import {
   setupCollectionByIdEndpoint,
   setupDatabasesEndpoints,
   setupUserMetabotPermissionsEndpoint,
+  setupUsersEndpoints,
 } from "__support__/server-mocks";
 import {
+  mockGetBoundingClientRect,
   renderWithProviders,
   screen,
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
 import * as Urls from "metabase/urls";
-import type { TableIndexEntry, Transform } from "metabase-types/api";
+import type {
+  TableIndexEntry,
+  Transform,
+  UserListResult,
+} from "metabase-types/api";
 import {
   createMockCollection,
   createMockDatabase,
   createMockTableIndexEntry,
   createMockTableIndexRequest,
   createMockTransform,
+  createMockUserListResult,
 } from "metabase-types/api/mocks";
 
 import { TransformIndexesPage } from "./TransformIndexesPage";
@@ -26,12 +33,15 @@ import { TransformIndexesPage } from "./TransformIndexesPage";
 type SetupOpts = {
   transform?: Transform;
   indexes?: TableIndexEntry[];
+  users?: UserListResult[];
 };
 
 function setup({
   transform = createMockTransform({ id: 1, name: "Test Transform" }),
   indexes = [],
+  users = [],
 }: SetupOpts = {}) {
+  mockGetBoundingClientRect({ width: 1000, height: 600 });
   setupDatabasesEndpoints([
     createMockDatabase({ id: 1, transforms_permissions: "write" }),
   ]);
@@ -39,10 +49,11 @@ function setup({
     collections: [createMockCollection({ id: "root" })],
   });
   setupUserMetabotPermissionsEndpoint();
+  setupUsersEndpoints(users);
 
   fetchMock.get(`path:/api/transform/${transform.id}`, transform);
   fetchMock.get({
-    url: "path:/api/indexes",
+    url: "path:/api/index",
     query: { "transform-id": transform.id },
     response: { data: indexes },
   });
@@ -64,7 +75,9 @@ describe("TransformIndexesPage", () => {
     await waitForLoaderToBeRemoved();
 
     expect(
-      await screen.findByText("No indexes defined for this transform."),
+      await screen.findByText(
+        "Index the key columns of your transforms to make them faster and more efficient.",
+      ),
     ).toBeInTheDocument();
   });
 
@@ -74,11 +87,13 @@ describe("TransformIndexesPage", () => {
         createMockTableIndexEntry({
           name: "idx_orders_id",
           kind: "btree",
+          key_columns: ["id"],
           request: createMockTableIndexRequest({ id: 1 }),
         }),
         createMockTableIndexEntry({
           name: "idx_orders_total",
           kind: "gin",
+          key_columns: ["total"],
           request: createMockTableIndexRequest({ id: 2 }),
         }),
       ],
@@ -89,19 +104,69 @@ describe("TransformIndexesPage", () => {
     expect(screen.getByText("idx_orders_total")).toBeInTheDocument();
   });
 
+  it("renders the index columns, type, source and status", async () => {
+    setup({
+      indexes: [
+        createMockTableIndexEntry({
+          name: "idx_city_country",
+          kind: "btree",
+          metabase_managed: true,
+          key_columns: ["City name", "Country"],
+          request: createMockTableIndexRequest({ status: "create-pending" }),
+        }),
+      ],
+    });
+    await waitForLoaderToBeRemoved();
+
+    expect(await screen.findByText("idx_city_country")).toBeInTheDocument();
+    expect(screen.getByText("btree")).toBeInTheDocument();
+    expect(screen.getByText("City name, Country")).toBeInTheDocument();
+    expect(screen.getByText("Managed")).toBeInTheDocument();
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+  });
+
+  it("resolves the last modified by user name", async () => {
+    setup({
+      users: [createMockUserListResult({ id: 7, common_name: "Maz Ameli" })],
+      indexes: [
+        createMockTableIndexEntry({
+          name: "idx_orders_id",
+          request: createMockTableIndexRequest({ created_by: 7 }),
+        }),
+      ],
+    });
+    await waitForLoaderToBeRemoved();
+
+    expect(await screen.findByText("Maz Ameli")).toBeInTheDocument();
+  });
+
+  it("shows 'Never' when the index has not been run", async () => {
+    setup({
+      indexes: [
+        createMockTableIndexEntry({
+          name: "idx_orders_id",
+          request: createMockTableIndexRequest({ last_executed_at: null }),
+        }),
+      ],
+    });
+    await waitForLoaderToBeRemoved();
+
+    expect(await screen.findByText("Never")).toBeInTheDocument();
+  });
+
   it("falls back to the index kind when the index has no name", async () => {
     setup({
       indexes: [
         createMockTableIndexEntry({
           name: null,
           kind: "distkey",
-          request: createMockTableIndexRequest({ status: "pending" }),
+          request: createMockTableIndexRequest({ status: "create-pending" }),
         }),
       ],
     });
     await waitForLoaderToBeRemoved();
 
-    expect(await screen.findByText("distkey")).toBeInTheDocument();
-    expect(screen.getByText("distkey · pending")).toBeInTheDocument();
+    // The kind appears in both the Name (fallback) and Type columns.
+    expect(await screen.findAllByText("distkey")).toHaveLength(2);
   });
 });

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/assets/transform-indexes-empty.svg
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/assets/transform-indexes-empty.svg
@@ -1,0 +1,7 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="48" cy="48" r="48" fill="#F6F7F8"/>
+<path d="M57 41H47" stroke="#071722" stroke-opacity="0.51" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M57 48H47" stroke="#071722" stroke-opacity="0.51" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M57 55H47" stroke="#071722" stroke-opacity="0.51" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M39 44L43 48L39 52" stroke="#071722" stroke-opacity="0.51" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/index.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/index.ts
@@ -1,0 +1,1 @@
+export * from "./TransformIndexesPage";

--- a/frontend/src/metabase/transforms/routes.tsx
+++ b/frontend/src/metabase/transforms/routes.tsx
@@ -18,6 +18,7 @@ import {
 } from "./pages/NewTransformPage";
 import { RunListPage } from "./pages/RunListPage";
 import { TransformDependenciesPage } from "./pages/TransformDependenciesPage";
+import { TransformIndexesPage } from "./pages/TransformIndexesPage";
 import { TransformListPage } from "./pages/TransformListPage";
 import { TransformQueryPage } from "./pages/TransformQueryPage";
 import { TransformRunPage } from "./pages/TransformRunPage";
@@ -43,6 +44,7 @@ export function getDataStudioTransformRoutes() {
         <Route path=":transformId/edit" component={TransformQueryPage} />
         <Route path=":transformId/run" component={TransformRunPage} />
         <Route path=":transformId/settings" component={TransformSettingsPage} />
+        <Route path=":transformId/indexes" component={TransformIndexesPage} />
         {PLUGIN_TRANSFORMS_PYTHON.getInspectorRoutes()}
         {PLUGIN_DEPENDENCIES.isEnabled && (
           <Route

--- a/frontend/src/metabase/ui/components/icons/Icon/icons/index.ts
+++ b/frontend/src/metabase/ui/components/icons/Icon/icons/index.ts
@@ -514,6 +514,8 @@ import table_component from "./table.svg?component";
 import table_source from "./table.svg?source";
 import table2_component from "./table2.svg?component";
 import table2_source from "./table2.svg?source";
+import table_index_component from "./table_index.svg?component";
+import table_index_source from "./table_index.svg?source";
 import test_tube_component from "./test_tube.svg?component";
 import test_tube_source from "./test_tube.svg?source";
 import text_bold_component from "./text_bold.svg?component";
@@ -1590,6 +1592,10 @@ export const Icons: Record<IconName, { component: React.VFC; source: string }> =
       // for questions with table visualizations
       component: table2_component,
       source: table2_source,
+    },
+    table_index: {
+      component: table_index_component,
+      source: table_index_source,
     },
     text_bold: {
       component: text_bold_component,

--- a/frontend/src/metabase/ui/components/icons/Icon/icons/table_index.svg
+++ b/frontend/src/metabase/ui/components/icons/Icon/icons/table_index.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+<path d="M14.0002 3.33331H7.3335" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.0002 8H7.3335" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.0002 12.6667H7.3335" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2 5.33331L4.66667 7.99998L2 10.6666" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/metabase/urls/transforms.ts
+++ b/frontend/src/metabase/urls/transforms.ts
@@ -71,6 +71,10 @@ export function transformSettings(transformId: TransformId) {
   return `${TRANSFORMS_ROOT_URL}/${transformId}/settings`;
 }
 
+export function transformIndexes(transformId: TransformId) {
+  return `${TRANSFORMS_ROOT_URL}/${transformId}/indexes`;
+}
+
 export function transformDependencies(transformId: TransformId) {
   return `${TRANSFORMS_ROOT_URL}/${transformId}/dependencies`;
 }

--- a/frontend/src/metabase/utils/objects.ts
+++ b/frontend/src/metabase/utils/objects.ts
@@ -5,7 +5,7 @@ export const getObjectEntries = <K extends string, V>(
 };
 
 export const getObjectKeys = <K extends string>(
-  obj: Record<K, unknown>,
+  obj: Partial<Record<K, unknown>>,
 ): K[] => {
   return Object.keys(obj) as K[];
 };

--- a/frontend/test/__support__/server-mocks/index-manager.ts
+++ b/frontend/test/__support__/server-mocks/index-manager.ts
@@ -8,21 +8,21 @@ export function setupTableIndexEndpoints(
   indexRequests: TableIndexRequest[] = [],
 ) {
   fetchMock.get({
-    url: `path:/api/indexes`,
+    url: `path:/api/index`,
     query: { "transform-id": transformId },
     response: { data: indexRequests },
     name: `listTableIndexes-${transformId}`,
   });
 
   indexRequests.forEach((index) => {
-    fetchMock.get(`path:/api/indexes/request/${index.id}`, index, {
+    fetchMock.get(`path:/api/index/request/${index.id}`, index, {
       name: `getTableIndex-${index.id}`,
     });
-    fetchMock.delete(`path:/api/indexes/request/${index.id}`, 204, {
+    fetchMock.delete(`path:/api/index/request/${index.id}`, 204, {
       name: `deleteTableIndex-${index.id}`,
     });
     fetchMock.put(
-      `path:/api/indexes/request/${index.id}`,
+      `path:/api/index/request/${index.id}`,
       async (call) => {
         const lastCall = fetchMock.callHistory.lastCall(call.url);
         return { ...index, ...(await lastCall?.request?.json()) };
@@ -32,7 +32,7 @@ export function setupTableIndexEndpoints(
   });
 
   fetchMock.post(
-    `path:/api/indexes/request`,
+    `path:/api/index/request`,
     async (call) => {
       const lastCall = fetchMock.callHistory.lastCall(call.url);
       return createMockTableIndexRequest(await lastCall?.request?.json());

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -14,6 +14,7 @@
    ;; isolation (`init-workspace-isolation!`, `grant-workspace-read-access!`,
    ;; `check-isolation-permissions`, `destroy-workspace-isolation!`).
    [metabase.driver.bigquery-cloud-sdk.workspaces]
+   [metabase.driver.common :as driver.common]
    [metabase.driver.common.table-rows-sample :as table-rows-sample]
    [metabase.driver.connection :as driver.conn]
    [metabase.driver.settings :as driver.settings]
@@ -46,6 +47,7 @@
     BigQuery$TableOption
     BigQueryException
     BigQueryOptions
+    Clustering
     Dataset
     DatasetId
     Field
@@ -56,6 +58,7 @@
     JobInfo
     QueryJobConfiguration
     Schema
+    StandardTableDefinition
     Table
     TableDefinition$Type
     TableId
@@ -991,6 +994,9 @@
                               :expressions/integer              true
                               :expressions/text                 true
                               :identifiers-with-spaces          true
+                              ;; clustering is the only index-equivalent, inlined as CLUSTER BY (no standalone DDL)
+                              :index/fetch                      true
+                              :index/inline-create              true
                               :metadata/key-constraints         false
                               :metadata/table-existence-check   true
                               :nested-fields                    true
@@ -1103,6 +1109,55 @@
   (sql.u/format-sql-and-fix-params :mysql native-form))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                          Indexes (Index Manager)                                               |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+;; BigQuery has no secondary indexes. Clustering is the index-equivalent, inlined as `CLUSTER BY` into both creation
+;; seams (the CTAS in `compile-transform` and the CREATE TABLE in `create-table!`). It's unnamed, so reconcile matches
+;; it by kind + columns.
+
+(defmethod driver/supported-index-methods :bigquery-cloud-sdk
+  [_driver _database]
+  {:clustering {:lifecycle :inline
+                :fields    [driver.common/index-columns-field]}})
+
+(defn- clustering-clause
+  "Inline `CLUSTER BY col, ...` clause for a table's `indexes`, or nil when there's no clustering."
+  [indexes]
+  (when-let [{:keys [columns]} (some #(when (= :clustering (:kind %)) %) indexes)]
+    (let [cols (str/join ", " (map #(sql.u/quote-name :bigquery-cloud-sdk :field (:name %)) columns))]
+      (format "CLUSTER BY %s" cols))))
+
+(defn- table-clustering-columns
+  "Clustering columns of the BigQuery `table` in `schema`, in clustering order, or nil when the table is absent, isn't a
+  standard table (view/external), or isn't clustered. Reads table metadata directly, no SQL."
+  [database schema table]
+  (when-not (or (str/blank? schema) (str/blank? table))
+    (let [details    (driver.conn/effective-details database)
+          client     (database-details->client details)
+          project-id (bigquery.common/get-project-id details)]
+      (when-let [^Table bq-table (get-table* client project-id schema table)]
+        (let [definition (.getDefinition bq-table)]
+          (when (instance? StandardTableDefinition definition)
+            (when-let [^Clustering clustering (.getClustering ^StandardTableDefinition definition)]
+              (not-empty (vec (.getFields clustering))))))))))
+
+(defmethod driver/fetch-table-indexes :bigquery-cloud-sdk
+  [_driver database schema table]
+  (if-let [cluster-cols (table-clustering-columns database schema table)]
+    [{:name              nil
+      :kind              :clustering
+      :access-method     nil
+      :is-unique         false
+      :is-primary        false
+      :is-valid          true
+      :key-columns       cluster-cols
+      :include-columns   []
+      :partial-predicate nil
+      :definition        (format "CLUSTER BY %s" (str/join ", " cluster-cols))}]
+    []))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                Transforms Support                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
@@ -1113,10 +1168,13 @@
       (qn (name table)))))
 
 (defmethod driver/compile-transform :bigquery-cloud-sdk
-  [_driver {:keys [query output-table]}]
+  [_driver {:keys [query output-table indexes]}]
   (let [{sql-query :query sql-params :params} query
-        table-str (get-table-str output-table)]
-    [(format "CREATE OR REPLACE TABLE %s AS %s" table-str sql-query)
+        table-str (get-table-str output-table)
+        cluster   (clustering-clause indexes)]
+    [(if cluster
+       (format "CREATE OR REPLACE TABLE %s %s AS %s" table-str cluster sql-query)
+       (format "CREATE OR REPLACE TABLE %s AS %s" table-str sql-query))
      sql-params]))
 
 (defmethod driver/compile-insert :bigquery-cloud-sdk
@@ -1132,8 +1190,10 @@
     [(str "DROP TABLE IF EXISTS " table-str)]))
 
 (defmethod driver/create-table! :bigquery-cloud-sdk
-  [driver database-id table-name column-definitions & {:keys [primary-key]}]
-  (let [sql       (#'driver.sql-jdbc/create-table!-sql driver table-name column-definitions :primary-key primary-key)
+  [driver database-id table-name column-definitions & {:keys [primary-key indexes]}]
+  (let [base      (#'driver.sql-jdbc/create-table!-sql driver table-name column-definitions :primary-key primary-key)
+        cluster   (clustering-clause indexes)
+        sql       (if cluster (str base " " cluster) base)
         database  (t2/select-one :model/Database database-id)
         conn-spec (driver/connection-spec driver database)]
     (driver/execute-raw-queries! driver conn-spec [sql])))

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -282,11 +282,9 @@
                              :display-name (deferred-tru "Type")
                              :type         :select
                              :required     true
-                             :options      [{:name (deferred-tru "Min/max")             :value "minmax"}
-                                            {:name (deferred-tru "Set")                 :value "set"}
-                                            {:name (deferred-tru "Bloom filter")        :value "bloom_filter"}
-                                            {:name (deferred-tru "N-gram bloom filter") :value "ngrambf_v1"}
-                                            {:name (deferred-tru "Token bloom filter")  :value "tokenbf_v1"}]}
+                             ;; only arg-free types; set/ngrambf_v1/tokenbf_v1 need params the form can't supply yet
+                             :options      [{:name (deferred-tru "Min/max")      :value "minmax"}
+                                            {:name (deferred-tru "Bloom filter") :value "bloom_filter"}]}
                             driver.common/index-granularity-field]}})
 
 (defn- order-by-columns

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -332,36 +332,13 @@
   [^String s]
   (cond-> s (and (str/starts-with? s "(") (str/ends-with? s ")")) (subs 1 (dec (count s)))))
 
-(defn- split-top-level-commas
-  "Split on commas that aren't nested in parens or inside a `backtick`/'string' span, so neither a function key like
-  `toStartOfInterval(d, INTERVAL 1 DAY)` nor a quoted name like `weird,name` is torn at an inner comma."
-  [^String s]
-  (loop [i 0, depth 0, q nil, start 0, acc []]
-    (if (< i (.length s))
-      (let [c (nth s i)]
-        (cond
-          q                            (recur (inc i) depth (when-not (= c q) q) start acc)
-          (or (= c \`) (= c \'))       (recur (inc i) depth c start acc)
-          (= c \()                     (recur (inc i) (inc depth) q start acc)
-          (= c \))                     (recur (inc i) (dec depth) q start acc)
-          (and (= c \,) (zero? depth)) (recur (inc i) depth q (inc i) (conj acc (subs s start i)))
-          :else                        (recur (inc i) depth q start acc)))
-      (conj acc (subs s start)))))
-
-(defn- unquote-ident
-  "Strip the backticks off a quoted identifier (doubled backticks unescaped), so it matches the bare column name the
-  managed side stores. Leaves bare names and expressions untouched."
-  [^String s]
-  (if (and (> (count s) 1) (str/starts-with? s "`") (str/ends-with? s "`"))
-    (str/replace (subs s 1 (dec (count s))) "``" "`")
-    s))
-
 (defn- expr->columns
   "Best-effort split of a ClickHouse key expression into its top-level columns/expressions. A quoted name like
   `weird,name` becomes a bare element; a real expression like `lower(email)` stays one element."
   [expr]
   (if-let [s (perf/not-empty expr)]
-    (perf/mapv (comp unquote-ident str/trim) (split-top-level-commas (strip-wrapping-parens s)))
+    (perf/mapv #(driver.common/unquote-ident (str/trim %) \`)
+               (driver.common/split-top-level-commas (strip-wrapping-parens s)))
     []))
 
 ;; Named skip-indexes come from `system.data_skipping_indices`; the inline MergeTree sorting key

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse/index_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse/index_test.clj
@@ -33,7 +33,7 @@
       (is (= ["columns"] (map :name (get-in methods [:order-by :fields]))))
       (is (= ["name" "columns" "type" "granularity"]
              (map :name (get-in methods [:skip-index :fields]))))
-      (is (= #{"minmax" "set" "bloom_filter" "ngrambf_v1" "tokenbf_v1"}
+      (is (= #{"minmax" "bloom_filter"}
              (set (map :value (:options type-field))))))))
 
 ;;; --- inline ORDER BY at both creation seams ---
@@ -75,6 +75,11 @@
             ["ALTER TABLE `events` MATERIALIZE INDEX `idx_a`"]]
            (driver/compile-create-index :clickhouse nil "events"
                                         {:name "idx_a" :columns [{:name "a"}] :type :minmax :granularity 4}))))
+  (testing "bloom_filter (the other arg-free advertised type) renders TYPE bloom_filter, no args"
+    (is (= [["ALTER TABLE `events` ADD INDEX `idx_a` (`a`) TYPE bloom_filter GRANULARITY 4"]
+            ["ALTER TABLE `events` MATERIALIZE INDEX `idx_a`"]]
+           (driver/compile-create-index :clickhouse nil "events"
+                                        {:name "idx_a" :columns [{:name "a"}] :type :bloom_filter :granularity 4}))))
   (testing "type args render, schema qualifies, granularity defaults to 1"
     (is (= [["ALTER TABLE `public`.`events` ADD INDEX `idx_ab` (`a`, `b`) TYPE set(100) GRANULARITY 1"]
             ["ALTER TABLE `public`.`events` MATERIALIZE INDEX `idx_ab`"]]

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -250,10 +250,11 @@
                           :display-name (deferred-tru "Style")
                           :type         :select
                           :required     true
+                          ;; AUTO is Redshift's default and drifts over time, so it's not offered as a managed style;
+                          ;; an AUTO table still surfaces its current style as a (non-managed) index.
                           :options      [{:name (deferred-tru "Key")  :value "key"}
                                          {:name (deferred-tru "All")  :value "all"}
-                                         {:name (deferred-tru "Even") :value "even"}
-                                         {:name (deferred-tru "Auto") :value "auto"}]}
+                                         {:name (deferred-tru "Even") :value "even"}]}
                          ;; only the :key style takes a column, so this is not required
                          {:name         "columns"
                           :display-name (deferred-tru "Columns")
@@ -286,20 +287,49 @@
     (when (seq clauses)
       (str/join " " clauses))))
 
-;; Redshift has no secondary indexes; the only physical "indexes" are the inline, unnamed sortkey and the distribution
-;; key, so we override the inherited Postgres `pg_index` query. `svv_redshift_columns.sortkey` is the 1-based position
-;; (negative marks the whole key INTERLEAVED); `distkey` is true on the single KEY-distribution column. Blank `schema`
+(defn- distkey-index
+  "The distkey entry from a table's declared `reldiststyle` (0 EVEN, 1 KEY, 8 ALL) and KEY column; nil for AUTO (9) and
+  anything else. Reads the declared style, not the effective one Redshift drifts AUTO tables toward."
+  [reldiststyle key-column]
+  (when-let [style (case (long reldiststyle) 0 "even", 1 "key", 8 "all", nil)]
+    (let [key? (= style "key")]
+      {:name              nil
+       :kind              :distkey
+       :access-method     style
+       :is-unique         false
+       :is-primary        false
+       :is-valid          true
+       :key-columns       (if key? [key-column] [])
+       :include-columns   []
+       :partial-predicate nil
+       :definition        (if key?
+                            (format "DISTSTYLE KEY DISTKEY (%s)" key-column)
+                            (format "DISTSTYLE %s" (u/upper-case-en style)))})))
+
+;; Redshift has no secondary indexes; the only physical "indexes" are the inline unnamed sortkey and the distribution,
+;; so we override the inherited Postgres `pg_index` query. `svv_redshift_columns.sortkey` is the 1-based position
+;; (negative marks the whole key INTERLEAVED); `distkey` is true on the single KEY column. The declared distribution
+;; style comes from `pg_class_info`, which reports it for empty tables (`svv_table_info` doesn't). Blank `schema`
 ;; falls back to `current_schema()`.
 (defmethod driver/fetch-table-indexes :redshift
   [_driver database schema table]
-  (let [rows      (jdbc/query
-                   (sql-jdbc.conn/db->pooled-connection-spec database)
+  (let [spec      (sql-jdbc.conn/db->pooled-connection-spec database)
+        rows      (jdbc/query
+                   spec
                    [(str "SELECT column_name, sortkey, distkey FROM svv_redshift_columns "
                          "WHERE schema_name = COALESCE(?, current_schema()) AND table_name = ? "
                          "ORDER BY abs(sortkey)")
                     (perf/not-empty schema) table])
         sort-rows (filter (comp (complement zero?) :sortkey) rows)
-        dist-row  (perf/some #(when (:distkey %) %) rows)]
+        key-col   (perf/some #(when (:distkey %) (:column_name %)) rows)
+        diststyle (-> (jdbc/query
+                       spec
+                       [(str "SELECT c.reldiststyle AS reldiststyle FROM pg_class_info c "
+                             "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                             "WHERE n.nspname = COALESCE(?, current_schema()) AND c.relname = ?")
+                        (perf/not-empty schema) table])
+                      first :reldiststyle)
+        distkey   (some-> diststyle (distkey-index key-col))]
     (cond-> []
       (seq sort-rows)
       (conj (let [interleaved? (perf/some (comp neg? :sortkey) sort-rows)
@@ -316,17 +346,7 @@
                :definition        (format "%s SORTKEY (%s)"
                                           (if interleaved? "INTERLEAVED" "COMPOUND")
                                           (str/join ", " columns))}))
-      dist-row
-      (conj {:name              nil
-             :kind              :distkey
-             :access-method     nil
-             :is-unique         false
-             :is-primary        false
-             :is-valid          true
-             :key-columns       [(:column_name dist-row)]
-             :include-columns   []
-             :partial-predicate nil
-             :definition        (format "DISTKEY (%s)" (:column_name dist-row))}))))
+      distkey (conj distkey))))
 
 (defmethod driver/compile-transform :redshift
   [driver {:keys [query output-table indexes] :as transform-details}]

--- a/modules/drivers/redshift/test/metabase/driver/redshift/index_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift/index_test.clj
@@ -35,7 +35,7 @@
       (is (= ["columns" "style"] (map :name (get-in methods [:sortkey :fields]))))
       (is (= ["style" "columns"] (map :name (get-in methods [:distkey :fields]))))
       (is (= #{"compound" "interleaved"} (style-options :sortkey)))
-      (is (= #{"key" "all" "even" "auto"} (style-options :distkey))))))
+      (is (= #{"key" "all" "even"} (style-options :distkey))))))
 
 ;;; ------------------------------------------ DDL rendering ------------------------------------------
 
@@ -77,6 +77,11 @@
     :indexes      [{:kind :distkey :style :all}]
     :ctas         "CREATE TABLE \"events\" DISTSTYLE ALL AS SELECT 1"
     :create-table "CREATE TABLE \"events\" (\"a\" INTEGER, \"b\" INTEGER) DISTSTYLE ALL"}
+   {:label        "even distribution renders DISTSTYLE EVEN, no column"
+    :table        :events
+    :indexes      [{:kind :distkey :style :even}]
+    :ctas         "CREATE TABLE \"events\" DISTSTYLE EVEN AS SELECT 1"
+    :create-table "CREATE TABLE \"events\" (\"a\" INTEGER, \"b\" INTEGER) DISTSTYLE EVEN"}
    {:label        "distkey + sortkey render in Redshift's required order (distribution then sort)"
     :table        :events
     :indexes      [{:kind :distkey :style :key :columns [{:name "a"}]}

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -67,10 +67,13 @@
                               :expressions/float                      true
                               :expressions/date                       true
                               :identifiers-with-spaces                true
+                              :index/fetch                            true
+                              :index/standalone-create                true
                               :split-part                             true
                               :collate                                true
                               :now                                    true
                               :database-routing                       true
+                              :transforms/index-ddl                   true
                               :metadata/table-existence-check         true
                               :regex/lookaheads-and-lookbehinds       false
                               :transforms/accurate-rows-affected      false
@@ -1009,6 +1012,59 @@
                                :dialect (sql.qp/quote-style driver)))]
     (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec db-id)]
       (jdbc/execute! conn sql))))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                          Indexes (Index Manager)                                               |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+;; Snowflake's only physical "index" is the table's single clustering key (`CLUSTER BY`); there are no secondary
+;; indexes, so it's a standalone `:clustering` kind. The `:name` is Metabase-side only: the warehouse keeps clustering
+;; keys unnamed, so fetch reports `:name nil` and reconcile matches by kind + columns.
+
+(defmethod driver/supported-index-methods :snowflake
+  [_driver _database]
+  {:clustering {:lifecycle :standalone
+                :fields    [driver.common/index-name-field driver.common/index-columns-field]}})
+
+(defmethod driver/compile-create-index :snowflake
+  [driver schema table {:keys [columns]}]
+  ;; Re-issuing the same CLUSTER BY is a no-op, so no IF NOT EXISTS needed.
+  (let [target (apply sql.u/quote-name driver :table (if (not-empty schema) [schema table] [table]))
+        cols   (str/join ", " (map #(sql.u/quote-name driver :field (:name %)) columns))]
+    [[(format "ALTER TABLE %s CLUSTER BY (%s)" target cols)]]))
+
+(defn- parse-clustering-key
+  "Parse a Snowflake `CLUSTERING_KEY` string like `LINEAR(category, price)` into its top-level column names/expressions
+  in order. Returns nil for a table with no clustering key."
+  [clustering-key]
+  (when-let [s (not-empty (some-> clustering-key str/trim))]
+    (let [inner (or (second (re-matches #"(?is)\s*LINEAR\s*\((.*)\)\s*" s)) s)]
+      (->> (driver.common/split-top-level-commas inner)
+           (map #(driver.common/unquote-ident (str/trim %) \"))
+           (remove str/blank?)
+           vec))))
+
+;; `CLUSTERING_KEY` lives in the current database's INFORMATION_SCHEMA; a blank schema falls back to `current_schema()`.
+(defmethod driver/fetch-table-indexes :snowflake
+  [_driver database schema table]
+  (let [clustering-key (-> (jdbc/query
+                            (sql-jdbc.conn/db->pooled-connection-spec database)
+                            [(str "SELECT clustering_key FROM information_schema.tables "
+                                  "WHERE table_schema = COALESCE(?, current_schema()) AND table_name = ?")
+                             (not-empty schema) table])
+                           first :clustering_key)]
+    (if-let [columns (not-empty (parse-clustering-key clustering-key))]
+      [{:name              nil
+        :kind              :clustering
+        :access-method     nil
+        :is-unique         false
+        :is-primary        false
+        :is-valid          true
+        :key-columns       columns
+        :include-columns   []
+        :partial-predicate nil
+        :definition        (format "CLUSTER BY (%s)" (str/join ", " columns))}]
+      [])))
 
 (defmethod driver/table-name-length-limit :snowflake
   [_driver]

--- a/resources/migrations/063/20260615_metabase_table_indexes.yaml
+++ b/resources/migrations/063/20260615_metabase_table_indexes.yaml
@@ -40,8 +40,8 @@ databaseChangeLog:
               - column:
                   name: status
                   type: varchar(20)
-                  defaultValue: pending
-                  remarks: "Lifecycle status: pending, running, succeeded, failed, or dropped"
+                  defaultValue: create-pending
+                  remarks: "Lifecycle status: create-pending, update-pending, delete-pending, running, succeeded, or failed"
                   constraints:
                     nullable: false
               - column:

--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -199,7 +199,7 @@
    "/glossary"             (+auth 'metabase.glossary.api)
    "/google"               (+auth metabase.sso.api/google-auth-routes)
    "/health-inspector"     (+auth 'metabase.health-inspector.api)
-   "/indexes"              (+auth 'metabase.indexes.api)
+   "/index"                (+auth 'metabase.indexes.api)
    "/ldap"                 (+auth metabase.sso.api/ldap-routes)
    "/llm"                  (+auth metabase.llm.api/routes)
    "/logger"               (+auth 'metabase.logger.api)

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1574,6 +1574,8 @@
    [:name :string]
    ;; deferred-i18n label (or string)
    [:display-name :any]
+   ;; deferred-i18n user facing description
+   [:description {:optional true} :any]
    [:type [:enum :string :boolean :select :integer :columns]]
    [:required {:optional true} :boolean]
    ;; `:columns` only: whether per-column asc/desc is offered

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -161,7 +161,8 @@
 
 (def index-columns-field
   "Descriptor for the indexed columns."
-  {:name "columns" :display-name (deferred-tru "Columns") :type :columns :directions true :required true})
+  ;; :directions (per-column asc/desc) is off by default; only btree consumes it, so it opts in.
+  {:name "columns" :display-name (deferred-tru "Columns") :type :columns :required true})
 
 (def index-unique-field
   "Descriptor for the btree unique toggle."

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -157,16 +157,20 @@
 
 (def index-name-field
   "Descriptor for the index name."
-  {:name "name" :display-name (deferred-tru "Index name") :type :string :required true})
+  {:name "name" :display-name (deferred-tru "Give your index a name") :type :string :required true})
 
 (def index-columns-field
   "Descriptor for the indexed columns."
   ;; :directions (per-column asc/desc) is off by default; only btree consumes it, so it opts in.
-  {:name "columns" :display-name (deferred-tru "Columns") :type :columns :required true})
+  {:name "columns" :display-name (deferred-tru "Columns")
+   :description (deferred-tru "The column(s) the index will be built on. Usually the ones you filter or join by.")
+   :type :columns :required true})
 
 (def index-unique-field
   "Descriptor for the btree unique toggle."
-  {:name "unique" :display-name (deferred-tru "Unique") :type :boolean})
+  {:name "unique" :display-name (deferred-tru "Unique")
+   :description (deferred-tru "Enforce uniqueness across rows for indexed columns.")
+   :type :boolean})
 
 (def index-granularity-field
   "Descriptor for a ClickHouse skip-index granularity."

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -171,6 +171,34 @@
   "Descriptor for a ClickHouse skip-index granularity."
   {:name "granularity" :display-name (deferred-tru "Granularity") :type :integer})
 
+;; Helpers for parsing a warehouse's stored key/index column list (a `CLUSTER BY`, `ORDER BY`, sorting key, ...) back
+;; into the bare column names the managed side stores.
+
+(defn split-top-level-commas
+  "Split `s` on commas that aren't nested in parens or inside a `` ` ``/`'`/`\"` quote span, so neither a function key
+  like `toStartOfInterval(d, INTERVAL 1 DAY)` nor a quoted name like `\"weird,name\"` is torn at an inner comma."
+  [^String s]
+  (loop [i 0, depth 0, q nil, start 0, acc []]
+    (if (< i (.length s))
+      (let [c (nth s i)]
+        (cond
+          q                               (recur (inc i) depth (when-not (= c q) q) start acc)
+          (or (= c \`) (= c \') (= c \")) (recur (inc i) depth c start acc)
+          (= c \()                        (recur (inc i) (inc depth) q start acc)
+          (= c \))                        (recur (inc i) (dec depth) q start acc)
+          (and (= c \,) (zero? depth))    (recur (inc i) depth q (inc i) (conj acc (subs s start i)))
+          :else                           (recur (inc i) depth q start acc)))
+      (conj acc (subs s start)))))
+
+(defn unquote-ident
+  "Strip a wrapping `quote-char` pair off a quoted identifier (doubled `quote-char` unescaped), so it matches the bare
+  column name the managed side stores. Leaves bare names and expressions untouched."
+  [^String s quote-char]
+  (let [q (str quote-char)]
+    (if (and (> (count s) 1) (str/starts-with? s q) (str/ends-with? s q))
+      (str/replace (subs s 1 (dec (count s))) (str q q) q)
+      s)))
+
 (def advanced-options-start
   "Map representing the start of the advanced option section in a DB connection form. Fields in this section should
   have their visibility controlled using the `visible-if` property."

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -1456,7 +1456,9 @@
   [_driver _database]
   ;; spatial is niche, and InnoDB silently rewrites USING HASH into btree, so neither is offered.
   (let [name+cols [driver.common/index-name-field driver.common/index-columns-field]]
-    {:btree    {:lifecycle :standalone :fields (conj name+cols driver.common/index-unique-field)}
+    {:btree    {:lifecycle :standalone :fields [driver.common/index-name-field
+                                                driver.common/index-unique-field
+                                                driver.common/index-columns-field]}
      :fulltext {:lifecycle :standalone :fields name+cols}}))
 
 (defn- mysql-index-column-sql

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -35,7 +35,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.memoize :as memoize]
-   [metabase.util.performance :as perf :refer [get-in not-empty some]]
+   [metabase.util.performance :as perf :refer [get-in mapv not-empty some]]
    [next.jdbc :as next.jdbc])
   (:import
    (java.io File)
@@ -69,6 +69,8 @@
                               :full-join                              false
                               ;; Index sync is turned off across the application as it is not used ATM.
                               :index-info                             false
+                              :index/fetch                            true
+                              :index/standalone-create                true
                               :now                                    true
                               :percentile-aggregations                false
                               :persist-models                         true
@@ -91,8 +93,7 @@
                               :metadata/table-existence-check         true
                               :transforms/python                      true
                               :transforms/table                       true
-                              ;; currently disabled as :describe-indexes is not supported
-                              :transforms/index-ddl                   false
+                              :transforms/index-ddl                   true
                               :describe-default-expr                  true
                               :describe-is-nullable                   true
                               :describe-is-generated                  true
@@ -1446,6 +1447,94 @@
                               nil))
                           (ex-message e)))]
            result))))))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                          Indexes (Index Manager)                                               |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defmethod driver/supported-index-methods :mysql
+  [_driver _database]
+  ;; spatial is niche, and InnoDB silently rewrites USING HASH into btree, so neither is offered.
+  (let [name+cols [driver.common/index-name-field driver.common/index-columns-field]]
+    {:btree    {:lifecycle :standalone :fields (conj name+cols driver.common/index-unique-field)}
+     :fulltext {:lifecycle :standalone :fields name+cols}}))
+
+(defn- mysql-index-column-sql
+  "Quote an indexed column, appending `ASC`/`DESC` only for btree (fulltext has no per-column order)."
+  [btree? {col-name :name :keys [direction]}]
+  (cond-> (sql.u/quote-name :mysql :field col-name)
+    (and btree? direction) (str " " (u/upper-case-en (name direction)))))
+
+(defn- create-index-sql
+  [schema table {index-name :name, :keys [kind columns unique]}]
+  (let [fulltext? (= kind :fulltext)
+        target    (apply sql.u/quote-name :mysql :table (if (not-empty schema) [schema table] [table]))
+        cols      (str/join ", " (map #(mysql-index-column-sql (not fulltext?) %) columns))]
+    (format "CREATE %sINDEX %s ON %s (%s)"
+            (cond fulltext? "FULLTEXT "
+                  unique    "UNIQUE "
+                  :else     "")
+            (sql.u/quote-name :mysql :field index-name)
+            target
+            cols)))
+
+(defn- sql-string-literal
+  "A MySQL `'...'` string literal for trusted `s`, escaping embedded quotes."
+  [s]
+  (str \' (sql.u/escape-sql s :ansi) \'))
+
+(defmethod driver/compile-create-index :mysql
+  [_driver schema table {index-name :name, :keys [if-not-exists] :as structured}]
+  (let [create (create-index-sql schema table structured)]
+    (if-not if-not-exists
+      [[create]]
+      ;; MySQL has no `CREATE INDEX IF NOT EXISTS`, and the apply path re-issues creates on full rebuilds, so guard
+      ;; with dynamic SQL that runs the create only when no index of this name exists. Identifiers are inlined as
+      ;; string literals because the MariaDB driver rejects `?` placeholders inside the `SET @var := (SELECT ...)`.
+      [[(format "SET @mb_idx_exists := (SELECT COUNT(*) FROM information_schema.statistics
+                                        WHERE table_schema = %s AND table_name = %s AND index_name = %s)"
+                (if (not-empty schema) (sql-string-literal schema) "DATABASE()")
+                (sql-string-literal table)
+                (sql-string-literal index-name))]
+       [(format "SET @mb_idx_sql := IF(@mb_idx_exists > 0, 'DO 0', %s)"
+                (sql-string-literal create))]
+       ["PREPARE mb_idx_stmt FROM @mb_idx_sql"]
+       ["EXECUTE mb_idx_stmt"]
+       ["DEALLOCATE PREPARE mb_idx_stmt"]])))
+
+(defn- mysql-index-type->kind
+  [index-type]
+  (case (u/upper-case-en (or index-type ""))
+    "FULLTEXT" :fulltext
+    "SPATIAL"  :spatial
+    :btree))
+
+(defn- mysql-index-rows->index
+  "Collapse one index's per-column `information_schema.statistics` rows (ordered by `SEQ_IN_INDEX`) into an index map."
+  [rows]
+  (let [{:keys [index_name non_unique index_type]} (first rows)]
+    {:name              index_name
+     :kind              (mysql-index-type->kind index_type)
+     :access-method     (some-> index_type u/lower-case-en)
+     :is-unique         (zero? (long non_unique))
+     :is-primary        (= index_name "PRIMARY")
+     :is-valid          true
+     :key-columns       (mapv :column_name rows)
+     :include-columns   []
+     :partial-predicate nil
+     :definition        nil}))
+
+(defmethod driver/fetch-table-indexes :mysql
+  [_driver database schema table]
+  (->> (jdbc/query
+        (sql-jdbc.conn/db->pooled-connection-spec database)
+        ["SELECT index_name, seq_in_index, column_name, non_unique, index_type
+          FROM information_schema.statistics
+          WHERE table_schema = COALESCE(?, DATABASE()) AND table_name = ?
+          ORDER BY index_name, seq_in_index"
+         (not-empty schema) table])
+       (partition-by :index_name)
+       (mapv mysql-index-rows->index)))
 
 (defmethod driver/llm-sql-dialect-resource :mysql [_]
   "metabot/prompts/dialects/mysql.md")

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -1345,7 +1345,10 @@
   ;; btree is the only method that supports UNIQUE; gin/gist/brin are containment/range methods. The niche methods
   ;; (hash, spgist) and partial/expression indexes are intentionally left out.
   (let [name+cols [driver.common/index-name-field driver.common/index-columns-field]]
-    {:btree {:lifecycle :standalone :fields (conj name+cols driver.common/index-unique-field)}
+    ;; btree is the only method where column order direction matters, so it opts into the asc/desc picker.
+    {:btree {:lifecycle :standalone :fields [driver.common/index-name-field
+                                             (assoc driver.common/index-columns-field :directions true)
+                                             driver.common/index-unique-field]}
      :gin   {:lifecycle :standalone :fields name+cols}
      :gist  {:lifecycle :standalone :fields name+cols}
      :brin  {:lifecycle :standalone :fields name+cols}}))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -1347,8 +1347,8 @@
   (let [name+cols [driver.common/index-name-field driver.common/index-columns-field]]
     ;; btree is the only method where column order direction matters, so it opts into the asc/desc picker.
     {:btree {:lifecycle :standalone :fields [driver.common/index-name-field
-                                             (assoc driver.common/index-columns-field :directions true)
-                                             driver.common/index-unique-field]}
+                                             driver.common/index-unique-field
+                                             (assoc driver.common/index-columns-field :directions true)]}
      :gin   {:lifecycle :standalone :fields name+cols}
      :gist  {:lifecycle :standalone :fields name+cols}
      :brin  {:lifecycle :standalone :fields name+cols}}))

--- a/src/metabase/indexes/api.clj
+++ b/src/metabase/indexes/api.clj
@@ -1,5 +1,5 @@
 (ns metabase.indexes.api
-  "Table-index endpoints, mounted at `/api/indexes`. Two concepts: `GET /` is a transform's merged index reality
+  "Table-index endpoints, mounted at `/api/index`. Two concepts: `GET /` is a transform's merged index reality
   (warehouse indexes plus managed requests); `/request/:id` is CRUD over a single index request. An index
   belongs to a transform's output, so reads require read access to that transform and mutations require write access
   -- the same permission editing the transform itself uses. Validation and the `:status` default live in the model's

--- a/src/metabase/indexes/api.clj
+++ b/src/metabase/indexes/api.clj
@@ -7,6 +7,7 @@
   (:require
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
+   [metabase.indexes.models.table-index :as table-index]
    [metabase.indexes.reconcile :as reconcile]
    [metabase.indexes.schema :as schema]
    [metabase.util.i18n :refer [tru]]
@@ -24,7 +25,7 @@
    [:index_name ms/NonBlankString]
    ;; The real structured schema (not a bare `:map`) so response coercion doesn't strip its keys.
    [:structured ::schema/index-structured]
-   [:status [:enum :pending :running :succeeded :failed :dropped]]
+   [:status [:enum :create-pending :update-pending :delete-pending :running :succeeded :failed]]
    [:error_message [:maybe :string]]
    [:created_by [:maybe ms/PositiveInt]]
    [:created_at :any]
@@ -66,8 +67,9 @@
    {:keys [transform-id]} :- [:map [:transform-id ms/PositiveInt]]]
   (let [transform (api/read-check :model/Transform transform-id)
         {:keys [database schema] table-name :name} (:target transform)
-        managed   (t2/select :model/TableIndex :transform_id transform-id {:order-by [[:id :asc]]})
-        warehouse (reconcile/fetch-warehouse-indexes (t2/select-one :model/Database database) schema table-name)]
+        managed   (table-index/select-for-transform transform-id)
+        warehouse (or (reconcile/fetch-warehouse-indexes (t2/select-one :model/Database database) schema table-name)
+                      [])]
     {:data (reconcile/merge-indexes managed warehouse)}))
 
 (api.macros/defendpoint :get "/request/:id" :- RequestIndex
@@ -85,9 +87,10 @@
                                          [:transform_id ms/PositiveInt]
                                          [:structured :map]]]
   (api/write-check :model/Transform transform_id)
-  (let [idx-name (reconcile/index-name structured)]
+  (let [structured (schema/keywordize-structured structured)
+        idx-name   (reconcile/index-name structured)]
     ;; (transform_id, index_name) is unique; reject a duplicate cleanly instead of hitting the constraint.
-    (api/check-400 (not (t2/exists? :model/TableIndex :transform_id transform_id :index_name idx-name))
+    (api/check-400 (not (table-index/exists-for-transform? transform_id idx-name))
                    (tru "An index named \"{0}\" already exists for this transform." idx-name))
     (t2/insert-returning-instance! :model/TableIndex
                                    {:transform_id transform_id
@@ -95,24 +98,35 @@
                                     :structured   structured
                                     :created_by   api/*current-user-id*})))
 
+(defn- assert-stable-key!
+  [existing structured]
+  (api/check-400 (= (reconcile/index-name (:structured existing))
+                    (reconcile/index-name structured))
+                 (tru "The index name cannot be changed. Delete and recreate the index instead."))
+  (api/check-400 (= (:kind (:structured existing)) (:kind structured))
+                 (tru "The index type cannot be changed. Delete and recreate the index instead."))
+  (api/check-400 (= (:type (:structured existing)) (:type structured))
+                 (tru "The index type cannot be changed. Delete and recreate the index instead.")))
+
 (api.macros/defendpoint :put "/request/:id" :- RequestIndex
-  "Replace the structured definition of an index request, resetting it to pending."
+  "Replace the structured definition of an index request, marking it update-pending."
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    _query-params
    {:keys [structured]} :- [:map [:structured :map]]]
-  (write-check-owner! (api/check-404 (t2/select-one :model/TableIndex :id id)))
-  ;; toucan2 has no instance-returning update, so re-select; in a tx so we return exactly what we wrote.
-  (t2/with-transaction [_conn]
-    (t2/update! :model/TableIndex id {:structured    structured
-                                      :index_name    (reconcile/index-name structured)
-                                      :status        :pending
-                                      :error_message nil})
-    (t2/select-one :model/TableIndex :id id)))
+  (let [structured (schema/keywordize-structured structured)
+        existing   (api/check-404 (table-index/select-applicable-by-id id))]
+    (write-check-owner! existing)
+    (assert-stable-key! existing structured)
+    ;; toucan2 has no instance-returning update, so re-select; in a tx so we return exactly what we wrote.
+    (t2/with-transaction [_conn]
+      (t2/update! :model/TableIndex id {:structured structured})
+      (t2/select-one :model/TableIndex :id id))))
 
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :delete "/request/:id"
   "Delete an index request."
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
-  (write-check-owner! (api/check-404 (t2/select-one :model/TableIndex :id id)))
-  (t2/delete! :model/TableIndex :id id)
+  (let [existing (api/check-404 (table-index/select-applicable-by-id id))]
+    (write-check-owner! existing)
+    (t2/update! :model/TableIndex id {:status :delete-pending}))
   api/generic-204-no-content)

--- a/src/metabase/indexes/models/table_index.clj
+++ b/src/metabase/indexes/models/table_index.clj
@@ -2,12 +2,11 @@
   "The `metabase_table_indexes` model: index/clustering hints for a table.
 
   Every row binds to a transform (`:transform_id`) whose target it indexes, carries a structured index definition
-  (see [[metabase.indexes.schema]]), and tracks a lifecycle `:status` (defaulting to `:pending`). The target table is
+  (see [[metabase.indexes.schema]]), and tracks a lifecycle `:status` (defaulting to `:create-pending`). The target table is
   read off the transform's `:target_table_id`, not mirrored here. The table is named generically so it can hold
   indexes for non-transform tables later too.
 
-  `:structured` and `:status` are validated at the transform layer (on read and write), so every writer is covered.
-  Callers use toucan2 directly; there are no wrapper functions."
+  `:structured` and `:status` are validated at the transform layer (on read and write), so every writer is covered."
   (:require
    [metabase.indexes.schema :as schema]
    [metabase.models.interface :as mi]
@@ -36,15 +35,140 @@
   {:structured transform-structured
    :status     (mi/transform-validator mi/transform-keyword (partial mi/assert-enum schema/statuses))})
 
+(def pending-statuses
+  "Statuses that require a full incremental rebuild before an index request's physical state can be trusted."
+  #{:create-pending :update-pending :delete-pending :running})
+
+(def ^:private runnable-statuses
+  #{:create-pending :update-pending :running :failed})
+
 (def ^:private defaults
-  {:status :pending})
+  {:status :create-pending})
+
+(defn- reset-incremental-checkpoint!
+  [transform-id]
+  (when (= :table-incremental
+           (some-> (t2/select-one-fn :target :model/Transform :id transform-id)
+                   :type
+                   keyword))
+    ;; Indexes are applied only when a transform recreates its target table. Resetting the checkpoint makes the next
+    ;; incremental run perform that rebuild, matching the existing checkpoint-strategy change behavior.
+    (t2/update! :model/Transform transform-id {:last_checkpoint_value nil})))
+
+(defn- pending-status-for-changes
+  [changes]
+  (cond
+    (contains? changes :structured) :update-pending
+    (contains? pending-statuses (:status changes)) (:status changes)))
+
+(defn- transform-id
+  [idx]
+  (or (:transform_id idx)
+      (:transform_id (t2/original idx))))
 
 (t2/define-before-insert :model/TableIndex
   [req]
   (merge defaults req))
 
+(t2/define-after-insert :model/TableIndex
+  [idx]
+  (reset-incremental-checkpoint! (:transform_id idx))
+  idx)
+
+(t2/define-before-update :model/TableIndex
+  [idx]
+  (let [changes (t2/changes idx)
+        status  (pending-status-for-changes changes)]
+    (when status
+      (reset-incremental-checkpoint! (transform-id idx)))
+    (cond-> idx
+      status (assoc :status status
+                    :error_message nil))))
+
+(defn applicable?
+  "True when an index request should be applied to a transform's target table."
+  [idx]
+  (not= :delete-pending (:status idx)))
+
+(defn select-for-transform
+  "All index request rows for `transform-id`, ordered for the index manager list."
+  [transform-id]
+  (t2/select :model/TableIndex
+             :transform_id transform-id
+             {:order-by [[:id :asc]]}))
+
+(defn select-applicable-for-transform
+  "Rows whose structured definitions should be applied to `transform-id`'s target table."
+  [transform-id]
+  (filter applicable?
+          (t2/select :model/TableIndex
+                     :transform_id transform-id
+                     {:order-by [[:index_name :asc]]})))
+
+(defn select-for-verification
+  "Rows the current execution can update while verifying indexes.
+
+  `index-request-ids` is the applicable request id set hydrated at execution start. Only rows still `:running` are
+  settled; if a request is edited mid-run, its pending status is left for the next rebuild. Delete-pending rows are
+  also included so a successful full rebuild can remove rows for physical indexes that disappeared."
+  [transform-id index-request-ids]
+  (concat
+   (when (seq index-request-ids)
+     (t2/select :model/TableIndex
+                :transform_id transform-id
+                :id [:in index-request-ids]
+                :status :running
+                {:order-by [[:id :asc]]}))
+   (t2/select :model/TableIndex
+              :transform_id transform-id
+              :status :delete-pending
+              {:order-by [[:id :asc]]})))
+
+(defn select-applicable-by-id
+  "Fetch a single applicable index request by id."
+  [id]
+  (some-> (t2/select-one :model/TableIndex :id id)
+          (as-> idx (when (applicable? idx) idx))))
+
+(defn pending-changes-for-transform?
+  "True when `transform-id` has index changes that require a full rebuild to apply."
+  [transform-id]
+  (boolean
+   (when transform-id
+     (some #(contains? pending-statuses (:status %))
+           (t2/select :model/TableIndex :transform_id transform-id)))))
+
+(defn mark-runnable-indexes-running!
+  "Mark hydrated index requests that this run will apply as running.
+
+  Returns the ids so callers can fail rows that verification cannot move to `:succeeded` or `:failed`."
+  [index-request-ids]
+  (let [ids (set index-request-ids)]
+    (when (seq ids)
+      (t2/update! :model/TableIndex
+                  {:id [:in ids] :status [:in runnable-statuses]}
+                  {:status :running}))
+    ids))
+
+(defn mark-unverified-running-indexes-failed!
+  "Mark rows from [[mark-runnable-indexes-running!]] that are still running as failed."
+  [ids message]
+  (when (seq ids)
+    (t2/update! :model/TableIndex
+                {:id [:in ids] :status :running}
+                {:status           :failed
+                 :error_message    message
+                 :last_executed_at :%now})))
+
+(defn exists-for-transform?
+  "True when `transform-id` already has a request for `index-name`."
+  [transform-id index-name]
+  (t2/exists? :model/TableIndex
+              :transform_id transform-id
+              :index_name index-name))
+
 ;; Inlined into the owning transform's serialization (see the Transform make-spec's `:indexes`). Only the index
-;; definition travels; lifecycle is local, so an imported index starts fresh as `:pending`. `:structured` holds
+;; definition travels; lifecycle is local, so an imported index starts fresh as `:create-pending`. `:structured` holds
 ;; physical column names (no portable refs), so it copies verbatim. `:created_by` is skipped: a nested child's own
 ;; FKs aren't declared in the transform's `dependencies`, so the user may not resolve on import.
 (defmethod serdes/make-spec "TableIndex"

--- a/src/metabase/indexes/models/table_index.clj
+++ b/src/metabase/indexes/models/table_index.clj
@@ -160,6 +160,16 @@
                  :error_message    message
                  :last_executed_at :%now})))
 
+(defn mark-for-revalidation!
+  "Flip `transform-id`'s applicable index requests to `:update-pending` and clear stale errors, so the next run
+  re-applies them against the current schema. Skips `:delete-pending` rows so a pending deletion isn't revived."
+  [transform-id]
+  (when transform-id
+    (when-let [ids (seq (map :id (select-applicable-for-transform transform-id)))]
+      (t2/update! :model/TableIndex
+                  {:id [:in ids]}
+                  {:status :update-pending, :error_message nil}))))
+
 (defn exists-for-transform?
   "True when `transform-id` already has a request for `index-name`."
   [transform-id index-name]

--- a/src/metabase/indexes/reconcile.clj
+++ b/src/metabase/indexes/reconcile.clj
@@ -13,7 +13,7 @@
 
 (def ^:private unnamed-inline-kinds
   "Index kinds with no physical name (warehouse `:name` is nil); matched by kind + key columns instead."
-  #{:sortkey :order-by :distkey})
+  #{:sortkey :order-by :distkey :clustering})
 
 (mr/def ::match-key
   "Join key for reconciling a managed request with a warehouse index: a `:name` string for named kinds, else a

--- a/src/metabase/indexes/reconcile.clj
+++ b/src/metabase/indexes/reconcile.clj
@@ -16,20 +16,26 @@
   #{:sortkey :order-by :distkey :clustering})
 
 (mr/def ::match-key
-  "Join key for reconciling a managed request with a warehouse index: a `:name` string for named kinds, else a
-  `[kind key-columns]` tuple for unnamed-inline kinds."
-  [:maybe [:or :string [:tuple :keyword [:sequential [:maybe :string]]]]])
+  "Join key for reconciling a managed request with a warehouse index. `:kind` selects how it's matched: `:named` keys
+  by `:name`; an unnamed-inline `:sortkey`/`:order-by` by `:kind` + `:key-columns`; `:distkey` also by `:style`, so the
+  column-less `:even` and `:all` stay distinct."
+  [:map
+   [:kind :keyword]
+   [:name {:optional true} [:maybe :string]]
+   [:style {:optional true} [:maybe :string]]
+   [:key-columns {:optional true} [:sequential [:maybe :string]]]])
 
 (mu/defn match-key :- ::match-key
-  "Join key for a warehouse index map: `[:kind key-columns]` for unnamed-inline kinds, else its `:name`. Kind
-  qualifiers (e.g. a sortkey's style) are intentionally not part of the key."
-  [{:keys [kind key-columns] nm :name} :- [:map
-                                           [:kind :keyword]
-                                           [:key-columns [:sequential [:maybe :string]]]
-                                           [:name {:optional true} [:maybe :string]]]]
-  (if (contains? unnamed-inline-kinds kind)
-    [kind key-columns]
-    nm))
+  "The [[::match-key]] for a warehouse index map (see the schema for how each kind is keyed)."
+  [{:keys [kind key-columns] am :access-method nm :name} :- [:map
+                                                             [:kind :keyword]
+                                                             [:key-columns [:sequential [:maybe :string]]]
+                                                             [:access-method {:optional true} [:maybe :string]]
+                                                             [:name {:optional true} [:maybe :string]]]]
+  (cond
+    (= kind :distkey)                     {:kind :distkey :style am :key-columns key-columns}
+    (contains? unnamed-inline-kinds kind) {:kind kind :key-columns key-columns}
+    :else                                 {:kind :named :name nm}))
 
 (mu/defn index-name :- :string
   "Physical index name for a structured def: a named kind's `:name`, else its `:kind` as a string (one inline key per
@@ -44,9 +50,13 @@
   [{:keys [index_name structured]} :- [:map
                                        [:index_name [:maybe :string]]
                                        [:structured :map]]]
-  (match-key {:kind        (:kind structured)
-              :name        index_name
-              :key-columns (mapv :name (:columns structured))}))
+  (let [{:keys [kind style columns]} structured
+        ;; only a :key distkey has a meaningful column; :all/:even ignore any stray column the form sent
+        key-columns (if (and (= kind :distkey) (not= style :key)) [] (mapv :name columns))]
+    (match-key {:kind          kind
+                :name          index_name
+                :access-method (some-> style name)
+                :key-columns   key-columns})))
 
 (defn warehouse-key-set
   "Set of [[match-key]]s for the warehouse indexes, to test managed requests against with [[present-in-warehouse?]]."

--- a/src/metabase/indexes/reconcile.clj
+++ b/src/metabase/indexes/reconcile.clj
@@ -48,6 +48,16 @@
               :name        index_name
               :key-columns (mapv :name (:columns structured))}))
 
+(defn warehouse-key-set
+  "Set of [[match-key]]s for the warehouse indexes, to test managed requests against with [[present-in-warehouse?]]."
+  [warehouse-maps]
+  (into #{} (map match-key) warehouse-maps))
+
+(defn present-in-warehouse?
+  "Whether managed request `row`'s index is one of `present-keys` (a [[warehouse-key-set]])."
+  [present-keys row]
+  (contains? present-keys (managed-match-key row)))
+
 (defn- observed-fields
   "The observation fields of a warehouse `::table-index` map, snake-cased for the API."
   [wh]
@@ -86,7 +96,7 @@
   [rows           :- [:sequential :map]
    warehouse-maps :- [:sequential :map]]
   (let [by-key       (u/index-by managed-match-key rows)
-        present-keys (into #{} (map match-key) warehouse-maps)
+        present-keys (warehouse-key-set warehouse-maps)
         present      (for [wh warehouse-maps
                            :let [row (get by-key (match-key wh))]]
                        (merge (observed-fields wh)
@@ -94,7 +104,7 @@
                                :present_in_warehouse true}
                               (when row (request-fields row))))
         absent       (for [row   rows
-                           :when (not (contains? present-keys (managed-match-key row)))]
+                           :when (not (present-in-warehouse? present-keys row))]
                        (merge (declared-fields row)
                               {:metabase_managed     true
                                :present_in_warehouse false}

--- a/src/metabase/indexes/reconcile.clj
+++ b/src/metabase/indexes/reconcile.clj
@@ -111,9 +111,10 @@
                               (request-fields row)))]
     (into (vec present) absent)))
 
-(mu/defn fetch-warehouse-indexes :- [:sequential :map]
-  "Physical indexes on `table-name` (`schema`) in `database` via `driver/fetch-table-indexes`. Returns `[]` if the
-  driver can't introspect indexes or the warehouse is unreachable, so callers degrade instead of erroring."
+(mu/defn fetch-warehouse-indexes :- [:maybe [:sequential :map]]
+  "Physical indexes on `table-name` (`schema`) in `database` via `driver/fetch-table-indexes`.
+  Returns `nil` if the driver can't introspect indexes or the warehouse is unreachable, so callers can distinguish
+  fetch failure from a successful empty index list."
   [database   :- :map
    schema     :- [:maybe :string]
    table-name :- :string]
@@ -121,4 +122,4 @@
     (vec (driver/fetch-table-indexes (:engine database) database schema table-name))
     (catch Throwable t
       (log/warnf t "fetch-table-indexes failed for %s.%s" schema table-name)
-      [])))
+      nil)))

--- a/src/metabase/indexes/schema.clj
+++ b/src/metabase/indexes/schema.clj
@@ -79,7 +79,7 @@
 
 (def statuses
   "Valid lifecycle states for a table index request."
-  #{:pending :running :succeeded :failed :dropped})
+  #{:create-pending :update-pending :delete-pending :running :succeeded :failed})
 
 (defn keywordize-structured
   "Re-keywordize the structured map's enum-valued fields after JSON storage flattened them to strings."

--- a/src/metabase/indexes/schema.clj
+++ b/src/metabase/indexes/schema.clj
@@ -33,15 +33,14 @@
    [:columns [:vector {:min 1} ::column]]])
 
 (mr/def ::distkey
-  "Redshift distribution, inline. `:columns` holds the single DISTKEY column, required only for the `:key` style;
-  `:all`/`:even`/`:auto` take no column."
+  "Redshift distribution, inline. Only `:key` uses a column (the one DISTKEY column); `:all`/`:even` take none."
   [:and
    [:map
     [:kind    [:= :distkey]]
-    [:style   [:enum :key :all :even :auto]]
+    [:style   [:enum :key :all :even]]
     [:columns {:optional true} [:vector {:min 1 :max 1} ::column]]]
-   [:fn {:error/message "a :key distkey requires a column"}
-    (fn [{:keys [style columns]}] (or (not= style :key) (seq columns)))]])
+   [:fn {:error/message "a :key distkey requires its one column"}
+    (fn [{:keys [style columns]}] (or (not= style :key) (= 1 (count columns))))]])
 
 (mr/def ::clustering
   "Snowflake (standalone) / BigQuery (inline) clustering. `:name` is required for the standalone form."
@@ -57,13 +56,13 @@
    [:columns [:vector {:min 1} ::column]]])
 
 (mr/def ::skip-index
-  "ClickHouse data-skipping index, standalone."
+  "ClickHouse data-skipping index, standalone. Only arg-free types; the parameterized ones need type-args the form
+  can't supply yet."
   [:map
    [:kind [:= :skip-index]]
    [:name :string]
    [:columns [:vector {:min 1} ::column]]
-   [:type [:enum :minmax :set :bloom_filter :ngrambf_v1 :tokenbf_v1]]
-   [:type-args {:optional true} [:vector :any]]
+   [:type [:enum :minmax :bloom_filter]]
    [:granularity {:optional true} pos-int?]])
 
 (mr/def ::index-structured

--- a/src/metabase/indexes/schema.clj
+++ b/src/metabase/indexes/schema.clj
@@ -39,7 +39,7 @@
    [:map
     [:kind    [:= :distkey]]
     [:style   [:enum :key :all :even :auto]]
-    [:columns {:optional true} [:vector {:min 1} ::column]]]
+    [:columns {:optional true} [:vector {:min 1 :max 1} ::column]]]
    [:fn {:error/message "a :key distkey requires a column"}
     (fn [{:keys [style columns]}] (or (not= style :key) (seq columns)))]])
 

--- a/src/metabase/transforms/execute.clj
+++ b/src/metabase/transforms/execute.clj
@@ -1,16 +1,25 @@
 (ns metabase.transforms.execute
   (:require
+   [metabase.indexes.models.table-index :as table-index]
    [metabase.transforms-base.interface :as transforms-base.i]
    [metabase.transforms.interface :as transforms.i]
-   [metabase.transforms.query-impl :as transforms.query-impl]
-   [toucan2.core :as t2]))
+   [metabase.transforms.query-impl :as transforms.query-impl]))
 
 (set! *warn-on-reflection* true)
+
+(defn- select-transform-index-requests
+  [transform]
+  (vec (table-index/select-applicable-for-transform (:id transform))))
 
 (defn hydrate-transform-indexes
   "Structured index defs for `transform`, read from its managed `TableIndex` rows (ordered by name)."
   [transform]
-  (t2/select-fn-vec :structured :model/TableIndex :transform_id (:id transform) {:order-by [[:index_name :asc]]}))
+  (mapv :structured (select-transform-index-requests transform)))
+
+(defn hydrate-transform-index-ids
+  "Applicable index request ids for `transform`, hydrated with the target at execution start."
+  [transform]
+  (mapv :id (select-transform-index-requests transform)))
 
 (defn- resolve-target
   "Apply the workspace target-rewrite hook before dispatch. On a workspaced child
@@ -27,14 +36,15 @@
   identify a target DB), the hook is skipped — workspace rewriting requires a
   known DB id to look up `db-workspace-namespace`.
 
-  Also hydrates the declared indexes onto the target so the base reads them off
-  `(:indexes target)` at every table-creation seam."
+  Also hydrates the declared indexes and their request ids onto the target so the base reads them off
+  `(:indexes target)` and `(:index-request-ids target)` at every table-creation seam."
   [transform]
   (-> (if-let [db-id (transforms-base.i/target-db-id transform)]
         (assoc transform :target
                (transforms.query-impl/resolve-transform-target db-id (:target transform)))
         transform)
-      (assoc-in [:target :indexes] (vec (hydrate-transform-indexes transform)))))
+      (assoc-in [:target :indexes] (vec (hydrate-transform-indexes transform)))
+      (assoc-in [:target :index-request-ids] (vec (hydrate-transform-index-ids transform)))))
 
 (defn execute!
   "Run `transform` and sync its target table.

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -5,6 +5,7 @@
    [metabase.api.common :as api]
    [metabase.collections.models.collection :as collection]
    [metabase.events.core :as events]
+   [metabase.indexes.models.table-index :as table-index]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.models.interface :as mi]
@@ -401,9 +402,10 @@
   (when (seq transforms)
     (let [transform-ids (into #{} (map u/the-id) transforms)
           idx-mappings  (group-by :transform_id
-                                  (t2/select :model/TableIndex
-                                             :transform_id [:in transform-ids]
-                                             {:order-by [[:index_name :asc]]}))]
+                                  (filter table-index/applicable?
+                                          (t2/select :model/TableIndex
+                                                     :transform_id [:in transform-ids]
+                                                     {:order-by [[:index_name :asc]]})))]
       (for [transform transforms]
         (assoc transform :indexes (get idx-mappings (u/the-id transform) []))))))
 

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -176,6 +176,10 @@
                           ;; No database existence check added here, unlike for insert.
                           ;; Just allow updates for an invalid target to fail.
                           (transforms-base.i/target-db-id transform))]
+    ;; A source or target edit may change the output columns, and we can't cheaply tell, so invalidate conservatively:
+    ;; the next run re-applies the managed indexes against the new schema and fails if a column is gone.
+    (when (and target-changed? (not mi/*deserializing?*))
+      (table-index/mark-for-revalidation! (:id transform)))
     (cond-> transform
       source
       (assoc :source_type (transforms-base.u/transform-source-type source)

--- a/src/metabase/transforms/util.clj
+++ b/src/metabase/transforms/util.clj
@@ -13,6 +13,7 @@
    [metabase.driver.settings :as driver.settings]
    [metabase.driver.sql-jdbc :as sql-jdbc]
    [metabase.driver.util :as driver.u]
+   [metabase.indexes.models.table-index :as table-index]
    [metabase.models.interface :as mi]
    [metabase.premium-features.core :as premium-features]
    [metabase.query-processor.pipeline :as qp.pipeline]
@@ -147,6 +148,8 @@
       (try
         (let [source-range-params (transforms-base.u/get-source-range-params transform)
               full-incremental?   (transforms-base.u/full-incremental-run? transform)
+              full-create?        (or (= :table (keyword (:type (:target transform))))
+                                      full-incremental?)
               ;; Efficiency metrics (rows-available / rows-processed) are only meaningful when this run's
               ;; rows-affected count can be trusted. On drivers that declare
               ;; `:transforms/accurate-rows-affected` false, a full-rebuild (CTAS) run reports a bogus
@@ -172,12 +175,23 @@
                                 driver.settings/*query-timeout-ms*   transform-timeout-ms
                                 ;; Match the query timeout so a single slow socket read (or a driver that waits for
                                 ;; the full server-side query) does not get killed before the transform's own deadline.
-                                driver.settings/*network-timeout-ms* (max driver.settings/*network-timeout-ms* transform-timeout-ms)]
+                                driver.settings/*network-timeout-ms* (max driver.settings/*network-timeout-ms*
+                                                                          transform-timeout-ms)]
                         (run-transform! cancel-chan source-range-params)))]
-            ;; Before the watermark/succeed mark, so a failure hits the catch below and fails the run (and a retry
-            ;; stays a full rebuild that re-attempts the index).
-            (transforms-base.u/apply-target-indexes! transform)
-            (transforms-base.u/verify-managed-indexes! transform)
+            (when full-create?
+              ;; Before the watermark/succeed mark, so a failure hits the catch below and fails the run (and a retry
+              ;; stays a full rebuild that re-attempts the index).
+              (let [running-indexes (table-index/mark-runnable-indexes-running!
+                                     (:index-request-ids (:target transform)))]
+                (try
+                  (transforms-base.u/apply-target-indexes! transform)
+                  (transforms-base.u/verify-managed-indexes! transform)
+                  (table-index/mark-unverified-running-indexes-failed!
+                   running-indexes
+                   "Index status could not be verified after the transform completed.")
+                  (catch Throwable t
+                    (table-index/mark-unverified-running-indexes-failed! running-indexes (ex-message t))
+                    (throw t)))))
             (transforms-base.u/save-watermark! (:id transform) source-range-params)
             (transform-run/succeed-started-run! run-id)
             ;; Narrow try/catch so an emission throw doesn't trigger the outer catch's

--- a/src/metabase/transforms_base/query.clj
+++ b/src/metabase/transforms_base/query.clj
@@ -131,7 +131,8 @@
                              ;; the CTAS table name. See
                              ;; `metabase.driver.sql.query-processor/compile-transform :sql`.
                              :output-db (:db target)
-                             :output-table (transforms-base.u/qualified-table-name driver target)}
+                             :output-table (transforms-base.u/qualified-table-name driver target)
+                             :indexes (:indexes target)}
           opts (transform-opts effective-transform-type transform)
           features (transforms-base.u/required-database-features transform)]
       (when-not (every? (fn [feature] (driver.u/supports? (:engine database) feature database)) features)

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -656,8 +656,8 @@
         ;; An empty fetch is ambiguous (no indexes vs couldn't introspect -- both degrade to []), so leave statuses
         ;; untouched rather than mark everything failed; warn so a stuck :pending stays traceable.
         (if-let [warehouse-indexes (seq (reconcile/fetch-warehouse-indexes database schema table-name))]
-          (let [present-keys (into #{} (map reconcile/match-key) warehouse-indexes)
-                by-present   (group-by #(contains? present-keys (reconcile/managed-match-key %)) managed)]
+          (let [present-keys (reconcile/warehouse-key-set warehouse-indexes)
+                by-present   (group-by #(reconcile/present-in-warehouse? present-keys %) managed)]
             ;; one update per outcome rather than per row
             (doseq [[present? rows] by-present]
               (t2/update! :model/TableIndex :id [:in (map :id rows)]

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -10,6 +10,7 @@
    [metabase.driver :as driver]
    [metabase.driver.sql.normalize :as sql.normalize]
    [metabase.events.core :as events]
+   [metabase.indexes.models.table-index :as table-index]
    [metabase.indexes.reconcile :as reconcile]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
@@ -94,13 +95,13 @@
 
 (defn full-incremental-run?
   "True when an incremental transform should drop-and-recreate the target rather than append.
-  Fires whenever `last_checkpoint_value` is nil — covers the literal first run, and any run after the
-  `:model/Transform` before-update hook clears the watermark on a `checkpoint-filter-field-id`
-  change. Stays true across failed attempts since the predicate only inspects
-  `:last_checkpoint_value`."
-  [transform]
+  Fires when `last_checkpoint_value` is nil (first run, or after the before-update hook clears the watermark on
+  a `checkpoint-filter-field-id` change), or when pending index changes require rebuilding the table to apply
+  physical index state."
+  [{:keys [id] :as transform}]
   (and (incremental-target? transform)
-       (nil? (:last_checkpoint_value transform))))
+       (or (nil? (:last_checkpoint_value transform))
+           (table-index/pending-changes-for-transform? id))))
 
 ;;; ------------------------------------------------- Table Template Tags -------------------------------------------------
 
@@ -344,7 +345,9 @@
                                "Please select a checkpoint field in the transform settings."))]
         (throw (ex-info msg {:transform-message msg}))))
     (when checkpoint-filter-field-id
-      (let [{:keys [last_checkpoint_value]} transform
+      (let [{:keys [last_checkpoint_value]} (cond-> transform
+                                              (full-incremental-run? transform)
+                                              (assoc :last_checkpoint_value nil))
             db-id             (transforms-base.i/target-db-id transform)
             metadata-provider (lib-be/application-database-metadata-provider db-id)
             column            (lib.metadata/field metadata-provider checkpoint-filter-field-id)
@@ -650,21 +653,32 @@
   Only runs on full-create runs (same guard as [[apply-target-indexes!]])."
   [transform]
   (when (full-create-run? transform)
-    (when-let [managed (seq (t2/select :model/TableIndex :transform_id (:id transform)))]
-      (let [database (t2/select-one :model/Database (transforms-base.i/target-db-id transform))
-            {:keys [schema] table-name :name} (:target transform)]
-        ;; An empty fetch is ambiguous (no indexes vs couldn't introspect -- both degrade to []), so leave statuses
-        ;; untouched rather than mark everything failed; warn so a stuck :pending stays traceable.
-        (if-let [warehouse-indexes (seq (reconcile/fetch-warehouse-indexes database schema table-name))]
-          (let [present-keys (reconcile/warehouse-key-set warehouse-indexes)
-                by-present   (group-by #(reconcile/present-in-warehouse? present-keys %) managed)]
-            ;; one update per outcome rather than per row
-            (doseq [[present? rows] by-present]
-              (t2/update! :model/TableIndex :id [:in (map :id rows)]
-                          {:status           (if present? :succeeded :failed)
-                           :last_executed_at :%now})))
-          (log/warnf "verify-managed-indexes!: no indexes read back for %s.%s; leaving %d request(s) unchanged"
-                     schema table-name (count managed)))))))
+    (let [target  (:target transform)
+          managed (if (contains? target :index-request-ids)
+                    (table-index/select-for-verification (:id transform) (:index-request-ids target))
+                    (table-index/select-for-transform (:id transform)))]
+      (when-let [managed (seq managed)]
+        (let [database (t2/select-one :model/Database (transforms-base.i/target-db-id transform))
+              {:keys [schema] table-name :name} (:target transform)]
+          (if-some [warehouse-indexes (reconcile/fetch-warehouse-indexes database schema table-name)]
+            (let [present-keys (into #{} (map reconcile/match-key) warehouse-indexes)
+                  by-outcome   (group-by (fn [row]
+                                           (let [present? (contains? present-keys (reconcile/managed-match-key row))]
+                                             (cond
+                                               (and (table-index/applicable? row) present?) :succeeded
+                                               (table-index/applicable? row)                :failed
+                                               present?                                    :delete-pending
+                                               :else                                       :delete-row)))
+                                         managed)]
+              ;; one update per outcome rather than per row
+              (doseq [[status rows] by-outcome]
+                (if (= :delete-row status)
+                  (t2/delete! :model/TableIndex :id [:in (map :id rows)])
+                  (t2/update! :model/TableIndex :id [:in (map :id rows)]
+                              {:status           status
+                               :last_executed_at :%now}))))
+            (log/warnf "verify-managed-indexes!: could not read indexes for %s.%s; leaving %d request(s) unchanged"
+                       schema table-name (count managed))))))))
 
 (defn complete-execution!
   "Post-processing steps after a transform has been executed successfully.

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -1095,3 +1095,26 @@
               "query should throw rather than completing normally")
           (is (< elapsed 30000)
               (format "query should be cancelled well before SLEEP(60) completes naturally — took %.0f ms" elapsed)))))))
+
+(deftest ^:parallel compile-create-index-test
+  (testing "btree renders with backticks; UNIQUE only when asked, direction only on btree"
+    (is (= [["CREATE INDEX `by_cat` ON `t` (`category`)"]]
+           (driver/compile-create-index :mysql nil "t"
+                                        {:kind :btree :name "by_cat" :columns [{:name "category"}]})))
+    (is (= [["CREATE UNIQUE INDEX `by_cat` ON `s`.`t` (`category` DESC)"]]
+           (driver/compile-create-index :mysql "s" "t"
+                                        {:kind :btree :name "by_cat" :unique true
+                                         :columns [{:name "category" :direction :desc}]}))))
+  (testing "fulltext has no UNIQUE and no per-column direction"
+    (is (= [["CREATE FULLTEXT INDEX `ft_cat` ON `t` (`category`)"]]
+           (driver/compile-create-index :mysql nil "t"
+                                        {:kind :fulltext :name "ft_cat" :unique true
+                                         :columns [{:name "category" :direction :asc}]}))))
+  (testing "MySQL has no CREATE INDEX IF NOT EXISTS, so :if-not-exists guards via dynamic SQL instead"
+    (let [stmts (driver/compile-create-index :mysql nil "t"
+                                             {:kind :btree :name "by_cat" :if-not-exists true
+                                              :columns [{:name "category"}]})]
+      (is (not-any? #(str/includes? (first %) "IF NOT EXISTS") stmts)
+          "no literal IF NOT EXISTS clause")
+      (is (str/includes? (first (last stmts)) "DEALLOCATE PREPARE")
+          "ends by deallocating the prepared guard statement"))))

--- a/test/metabase/driver/postgres/index_test.clj
+++ b/test/metabase/driver/postgres/index_test.clj
@@ -23,7 +23,7 @@
       (is (= {:btree :standalone :gin :standalone :gist :standalone :brin :standalone}
              (update-vals methods :lifecycle)))
       (testing "only btree offers the unique toggle"
-        (is (= ["name" "columns" "unique"] (map :name (get-in methods [:btree :fields]))))
+        (is (= ["name" "unique" "columns"] (map :name (get-in methods [:btree :fields]))))
         (is (= ["name" "columns"] (map :name (get-in methods [:gin :fields]))))))))
 
 (deftest default-impls-test

--- a/test/metabase/indexes/api_test.clj
+++ b/test/metabase/indexes/api_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [metabase.driver]
    [metabase.test :as mt]
+   [metabase.transforms-base.util :as transforms-base.u]
    [metabase.transforms.query-test-util :as query-test-util]
    [toucan2.core :as t2]))
 
@@ -16,14 +17,17 @@
    :source {:type "query" :query (query-test-util/make-query :source-table "venues")}
    :target {:database (mt/id) :type "table" :schema "public" :name (mt/random-name)}})
 
+(defn- temp-incremental-transform-spec []
+  (assoc-in (temp-transform-spec) [:target :type] "table-incremental"))
+
 (def ^:private btree {:kind "btree" :name "by_cat" :columns [{:name "name"}]})
 
 (deftest crud-happy-path-test
   (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)]
-    (testing "POST creates a pending index"
+    (testing "POST creates a create-pending index"
       (let [created (mt/user-http-request :crowberto :post 200 "index/request"
                                           {:transform_id transform-id :structured btree})]
-        (is (= "pending" (:status created)))
+        (is (= "create-pending" (:status created)))
         (is (= transform-id (:transform_id created)))
         (is (= "by_cat" (:index_name created)))
         (with-redefs [metabase.driver/fetch-table-indexes (fn [& _] [])]
@@ -42,13 +46,19 @@
         (testing "PUT replaces the structured definition"
           (let [updated (mt/user-http-request :crowberto :put 200 (str "index/request/" (:id created))
                                               {:structured (assoc btree :columns [{:name "price"}])})]
+            (is (= "update-pending" (:status updated)))
             (is (= "price" (-> updated :structured :columns first :name)))))
-        (testing "DELETE removes it"
+        (testing "DELETE marks it delete-pending until a rebuild drops the warehouse index"
           (mt/user-http-request :crowberto :delete 204 (str "index/request/" (:id created)))
-          (with-redefs [metabase.driver/fetch-table-indexes (fn [& _] [])]
+          (with-redefs [metabase.driver/fetch-table-indexes
+                        (fn [& _] [{:name "by_cat" :kind :btree :access-method "btree" :is-unique false
+                                    :is-primary false :is-valid true :key-columns ["name"] :include-columns []
+                                    :partial-predicate nil :definition "..."}])]
             (let [{:keys [data]} (mt/user-http-request :crowberto :get 200
                                                        (str "index?transform-id=" transform-id))]
-              (is (empty? data)))))))))
+              (is (= [(:id created)] (map #(get-in % [:request :id]) data)))
+              (is (= "delete-pending" (-> data first :request :status)))
+              (is (true? (:present_in_warehouse (first data)))))))))))
 
 (deftest merged-list-test
   (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)]
@@ -102,6 +112,50 @@
       (is (re-find #"already exists"
                    (mt/user-http-request :crowberto :post 400 "index/request"
                                          {:transform_id transform-id :structured btree}))))))
+
+(deftest put-cannot-change-index-key-test
+  (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)]
+    (let [created (mt/user-http-request :crowberto :post 200 "index/request"
+                                        {:transform_id transform-id :structured btree})]
+      (testing "name is stable"
+        (is (re-find #"name cannot be changed"
+                     (mt/user-http-request :crowberto :put 400 (str "index/request/" (:id created))
+                                           {:structured (assoc btree :name "by_price")}))))
+      (testing "kind is stable"
+        (is (re-find #"type cannot be changed"
+                     (mt/user-http-request :crowberto :put 400 (str "index/request/" (:id created))
+                                           {:structured (assoc btree :kind "hash")})))))))
+
+(deftest soft-deleted-index-cannot-be-recreated-test
+  (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)]
+    (let [created (mt/user-http-request :crowberto :post 200 "index/request"
+                                        {:transform_id transform-id :structured btree})]
+      (mt/user-http-request :crowberto :delete 204 (str "index/request/" (:id created)))
+      (is (re-find #"already exists"
+                   (mt/user-http-request :crowberto :post 400 "index/request"
+                                         {:transform_id transform-id :structured btree})))
+      (is (= 1 (count (t2/select :model/TableIndex :transform_id transform-id)))))))
+
+(deftest incremental-mutations-force-next-run-to-rebuild-test
+  (mt/with-temp [:model/Transform {transform-id :id} (assoc (temp-incremental-transform-spec)
+                                                            :last_checkpoint_value "100")]
+    (testing "POST clears the checkpoint so the new index can be applied"
+      (let [created (mt/user-http-request :crowberto :post 200 "index/request"
+                                          {:transform_id transform-id :structured btree})]
+        (is (nil? (t2/select-one-fn :last_checkpoint_value :model/Transform transform-id)))
+        (testing "PUT clears the checkpoint so the changed structure can be applied"
+          (t2/update! :model/Transform transform-id {:last_checkpoint_value "200"})
+          (mt/user-http-request :crowberto :put 200 (str "index/request/" (:id created))
+                                {:structured (assoc btree :columns [{:name "price"}])})
+          (is (nil? (t2/select-one-fn :last_checkpoint_value :model/Transform transform-id))))
+        (testing "DELETE clears the checkpoint so the old index can be dropped by the rebuild"
+          (t2/update! :model/Transform transform-id {:last_checkpoint_value "300"})
+          (mt/user-http-request :crowberto :delete 204 (str "index/request/" (:id created)))
+          (is (nil? (t2/select-one-fn :last_checkpoint_value :model/Transform transform-id))))
+        (testing "pending index status still forces a full rebuild if an in-flight run saves a checkpoint"
+          (t2/update! :model/Transform transform-id {:last_checkpoint_value "400"})
+          (is (#'transforms-base.u/full-incremental-run?
+               (t2/select-one :model/Transform transform-id))))))))
 
 (deftest inline-kind-index-name-test
   (testing "an inline kind with no :name gets its index_name from :kind"

--- a/test/metabase/indexes/api_test.clj
+++ b/test/metabase/indexes/api_test.clj
@@ -21,7 +21,7 @@
 (deftest crud-happy-path-test
   (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)]
     (testing "POST creates a pending index"
-      (let [created (mt/user-http-request :crowberto :post 200 "indexes/request"
+      (let [created (mt/user-http-request :crowberto :post 200 "index/request"
                                           {:transform_id transform-id :structured btree})]
         (is (= "pending" (:status created)))
         (is (= transform-id (:transform_id created)))
@@ -29,30 +29,30 @@
         (with-redefs [metabase.driver/fetch-table-indexes (fn [& _] [])]
           (testing "GET lists it for the transform (managed hint, not yet in the warehouse)"
             (let [{:keys [data]} (mt/user-http-request :crowberto :get 200
-                                                       (str "indexes?transform-id=" transform-id))]
+                                                       (str "index?transform-id=" transform-id))]
               (is (= [(:id created)] (map #(get-in % [:request :id]) data)))
               (is (false? (:present_in_warehouse (first data))))))
           (testing "the listed index carries no mirrored table_id"
             (let [{:keys [data]} (mt/user-http-request :crowberto :get 200
-                                                       (str "indexes?transform-id=" transform-id))]
+                                                       (str "index?transform-id=" transform-id))]
               (is (not (contains? (first data) :table_id))))))
         (testing "GET /request/:id fetches one (status poll)"
           (is (= "by_cat" (:index_name (mt/user-http-request :crowberto :get 200
-                                                             (str "indexes/request/" (:id created)))))))
+                                                             (str "index/request/" (:id created)))))))
         (testing "PUT replaces the structured definition"
-          (let [updated (mt/user-http-request :crowberto :put 200 (str "indexes/request/" (:id created))
+          (let [updated (mt/user-http-request :crowberto :put 200 (str "index/request/" (:id created))
                                               {:structured (assoc btree :columns [{:name "price"}])})]
             (is (= "price" (-> updated :structured :columns first :name)))))
         (testing "DELETE removes it"
-          (mt/user-http-request :crowberto :delete 204 (str "indexes/request/" (:id created)))
+          (mt/user-http-request :crowberto :delete 204 (str "index/request/" (:id created)))
           (with-redefs [metabase.driver/fetch-table-indexes (fn [& _] [])]
             (let [{:keys [data]} (mt/user-http-request :crowberto :get 200
-                                                       (str "indexes?transform-id=" transform-id))]
+                                                       (str "index?transform-id=" transform-id))]
               (is (empty? data)))))))))
 
 (deftest merged-list-test
   (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)]
-    (let [created (mt/user-http-request :crowberto :post 200 "indexes/request"
+    (let [created (mt/user-http-request :crowberto :post 200 "index/request"
                                         {:transform_id transform-id :structured btree})
           ;; one warehouse index matching the managed one by name, plus a DBA-made one
           wh [{:name "by_cat" :kind :btree :access-method "btree" :is-unique false :is-primary false
@@ -61,7 +61,7 @@
                :is-valid true :key-columns ["price"] :include-columns [] :partial-predicate nil :definition "..."}]]
       (with-redefs [metabase.driver/fetch-table-indexes (fn [& _] wh)]
         (let [{:keys [data]} (mt/user-http-request :crowberto :get 200
-                                                   (str "indexes?transform-id=" transform-id))
+                                                   (str "index?transform-id=" transform-id))
               by-name (group-by :name data)]
           (testing "the managed index is observed from the warehouse, flagged managed, request carries its id"
             (let [e (first (get by-name "by_cat"))]
@@ -81,32 +81,32 @@
   (testing "a user without write access to the transform cannot manage its indexes"
     (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)]
       (is (= "You don't have permissions to do that."
-             (mt/user-http-request :rasta :post 403 "indexes/request"
+             (mt/user-http-request :rasta :post 403 "index/request"
                                    {:transform_id transform-id :structured btree}))))))
 
 (deftest list-requires-transform-id-test
   (testing "GET requires transform-id"
     (is (re-find #"transform-id"
-                 (str (mt/user-http-request :crowberto :get 400 "indexes"))))))
+                 (str (mt/user-http-request :crowberto :get 400 "index"))))))
 
 (deftest unknown-transform-404s-test
   (testing "creating an index for a non-existent transform 404s"
-    (mt/user-http-request :crowberto :post 404 "indexes/request"
+    (mt/user-http-request :crowberto :post 404 "index/request"
                           {:transform_id Integer/MAX_VALUE :structured btree})))
 
 (deftest duplicate-index-name-rejected-test
   (testing "you can't create two indexes with the same name on one transform"
     (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)]
-      (mt/user-http-request :crowberto :post 200 "indexes/request"
+      (mt/user-http-request :crowberto :post 200 "index/request"
                             {:transform_id transform-id :structured btree})
       (is (re-find #"already exists"
-                   (mt/user-http-request :crowberto :post 400 "indexes/request"
+                   (mt/user-http-request :crowberto :post 400 "index/request"
                                          {:transform_id transform-id :structured btree}))))))
 
 (deftest inline-kind-index-name-test
   (testing "an inline kind with no :name gets its index_name from :kind"
     (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)]
-      (let [created (mt/user-http-request :crowberto :post 200 "indexes/request"
+      (let [created (mt/user-http-request :crowberto :post 200 "index/request"
                                           {:transform_id transform-id
                                            :structured {:kind "sortkey" :style "compound" :columns [{:name "name"}]}})]
         (is (= "sortkey" (:index_name created)))))))

--- a/test/metabase/indexes/models/table_index_test.clj
+++ b/test/metabase/indexes/models/table_index_test.clj
@@ -89,6 +89,38 @@
       (is (= :failed (t2/select-one-fn :status :model/TableIndex running-id)))
       (is (= "not verified" (t2/select-one-fn :error_message :model/TableIndex update-id))))))
 
+(deftest mark-for-revalidation-test
+  (testing "every applicable request is flipped to :update-pending, clearing stale errors; delete-pending rows untouched"
+    (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)
+                   :model/TableIndex {create-id :id} {:transform_id transform-id
+                                                      :index_name   "create_idx"
+                                                      :structured   {:kind :btree :name "create_idx"
+                                                                     :columns [{:name "a"}]}}
+                   :model/TableIndex {succeeded-id :id} {:transform_id transform-id
+                                                         :index_name   "succeeded_idx"
+                                                         :status       :succeeded
+                                                         :structured   {:kind :btree :name "succeeded_idx"
+                                                                        :columns [{:name "b"}]}}
+                   :model/TableIndex {failed-id :id} {:transform_id transform-id
+                                                      :index_name   "failed_idx"
+                                                      :status       :failed
+                                                      :error_message "old failure"
+                                                      :structured   {:kind :btree :name "failed_idx"
+                                                                     :columns [{:name "c"}]}}
+                   :model/TableIndex {deleted-id :id} {:transform_id transform-id
+                                                       :index_name   "deleted_idx"
+                                                       :status       :delete-pending
+                                                       :structured   {:kind :btree :name "deleted_idx"
+                                                                      :columns [{:name "d"}]}}]
+      (table-index/mark-for-revalidation! transform-id)
+      (is (= :update-pending (t2/select-one-fn :status :model/TableIndex create-id)))
+      (is (= :update-pending (t2/select-one-fn :status :model/TableIndex succeeded-id)))
+      (is (= :update-pending (t2/select-one-fn :status :model/TableIndex failed-id)))
+      (is (nil? (t2/select-one-fn :error_message :model/TableIndex failed-id)) "stale error cleared")
+      (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex deleted-id)) "pending deletion not revived")))
+  (testing "a nil transform-id is a no-op"
+    (is (nil? (table-index/mark-for-revalidation! nil)))))
+
 (deftest select-for-verification-test
   (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)
                  :model/TableIndex {running-id :id} {:transform_id transform-id

--- a/test/metabase/indexes/models/table_index_test.clj
+++ b/test/metabase/indexes/models/table_index_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.indexes.models.table-index-test
   (:require
    [clojure.test :refer :all]
+   [metabase.indexes.models.table-index :as table-index]
    [metabase.test :as mt]
    [metabase.transforms.query-test-util :as query-test-util]
    [toucan2.core :as t2]))
@@ -12,8 +13,8 @@
    :source {:type "query" :query (query-test-util/make-query :source-table "venues")}
    :target {:database (mt/id) :type "table" :schema "public" :name (mt/random-name)}})
 
-(deftest roundtrip-and-status-default-test
-  (testing "structured reads back with keyword-valued fields, and status defaults to :pending"
+(deftest roundtrip-and-defaults-test
+  (testing "structured reads back with keyword-valued fields, and lifecycle defaults are set"
     (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)]
       (let [{:keys [id]} (t2/insert-returning-instance!
                           :model/TableIndex
@@ -21,7 +22,7 @@
                            :index_name   "by_cat"
                            :structured   {:kind :btree :name "by_cat" :columns [{:name "category" :direction :asc}]}})
             back (t2/select-one :model/TableIndex :id id)]
-        (is (= :pending (:status back)) "before-insert defaults status to :pending")
+        (is (= :create-pending (:status back)) "before-insert defaults status to :create-pending")
         (is (= :btree (get-in back [:structured :kind])) "kind re-keywordized on read")
         (is (= :asc (get-in back [:structured :columns 0 :direction])))))))
 
@@ -45,3 +46,65 @@
                         :index_name   "bad-status"
                         :status       :bogus
                         :structured   {:kind :btree :name "x" :columns [{:name "a"}]}}))))))
+
+(deftest running-transition-helpers-test
+  (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)
+                 :model/TableIndex {create-id :id} {:transform_id transform-id
+                                                    :index_name   "create_idx"
+                                                    :structured   {:kind :btree :name "create_idx"
+                                                                   :columns [{:name "a"}]}}
+                 :model/TableIndex {update-id :id} {:transform_id transform-id
+                                                    :index_name   "update_idx"
+                                                    :status       :update-pending
+                                                    :structured   {:kind :btree :name "update_idx"
+                                                                   :columns [{:name "b"}]}}
+                 :model/TableIndex {failed-id :id} {:transform_id transform-id
+                                                    :index_name   "failed_idx"
+                                                    :status       :failed
+                                                    :error_message "old failure"
+                                                    :structured   {:kind :btree :name "failed_idx"
+                                                                   :columns [{:name "c"}]}}
+                 :model/TableIndex {running-id :id} {:transform_id transform-id
+                                                     :index_name   "running_idx"
+                                                     :status       :running
+                                                     :structured   {:kind :btree :name "running_idx"
+                                                                    :columns [{:name "e"}]}}
+                 :model/TableIndex {deleted-id :id} {:transform_id transform-id
+                                                     :index_name   "deleted_idx"
+                                                     :status       :delete-pending
+                                                     :structured   {:kind :btree :name "deleted_idx"
+                                                                    :columns [{:name "d"}]}}]
+    (let [ids (table-index/mark-runnable-indexes-running! [create-id update-id failed-id running-id])]
+      (is (= #{create-id update-id failed-id running-id} ids))
+      (is (= :running (t2/select-one-fn :status :model/TableIndex create-id)))
+      (is (= :running (t2/select-one-fn :status :model/TableIndex update-id)))
+      (is (= :running (t2/select-one-fn :status :model/TableIndex failed-id)))
+      (is (= :running (t2/select-one-fn :status :model/TableIndex running-id)))
+      (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex deleted-id)))
+      (t2/update! :model/TableIndex create-id {:status :succeeded})
+      (table-index/mark-unverified-running-indexes-failed! ids "not verified")
+      (is (= :succeeded (t2/select-one-fn :status :model/TableIndex create-id)))
+      (is (= :failed (t2/select-one-fn :status :model/TableIndex update-id)))
+      (is (= :failed (t2/select-one-fn :status :model/TableIndex failed-id)))
+      (is (= :failed (t2/select-one-fn :status :model/TableIndex running-id)))
+      (is (= "not verified" (t2/select-one-fn :error_message :model/TableIndex update-id))))))
+
+(deftest select-for-verification-test
+  (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)
+                 :model/TableIndex {running-id :id} {:transform_id transform-id
+                                                     :index_name   "running_idx"
+                                                     :status       :running
+                                                     :structured   {:kind :btree :name "running_idx"
+                                                                    :columns [{:name "a"}]}}
+                 :model/TableIndex {pending-id :id} {:transform_id transform-id
+                                                     :index_name   "pending_idx"
+                                                     :status       :update-pending
+                                                     :structured   {:kind :btree :name "pending_idx"
+                                                                    :columns [{:name "b"}]}}
+                 :model/TableIndex {deleted-id :id} {:transform_id transform-id
+                                                     :index_name   "deleted_idx"
+                                                     :status       :delete-pending
+                                                     :structured   {:kind :btree :name "deleted_idx"
+                                                                    :columns [{:name "c"}]}}]
+    (is (= #{running-id deleted-id}
+           (set (map :id (table-index/select-for-verification transform-id [running-id pending-id])))))))

--- a/test/metabase/indexes/reconcile_test.clj
+++ b/test/metabase/indexes/reconcile_test.clj
@@ -28,8 +28,17 @@
    :status :create-pending :error_message nil :created_by 3 :last_executed_at nil})
 
 (def ^:private wh-distkey
-  {:name nil :kind :distkey :access-method nil :is-unique false :is-primary false
+  {:name nil :kind :distkey :access-method "key" :is-unique false :is-primary false
    :is-valid true :key-columns ["category"] :include-columns [] :partial-predicate nil :definition nil})
+
+(def ^:private managed-even-distkey
+  {:id 4 :transform_id 7 :index_name "distkey"
+   :structured {:kind :distkey :style :even}
+   :status :pending :error_message nil :created_by 3 :last_executed_at nil})
+
+(def ^:private wh-even-distkey
+  {:name nil :kind :distkey :access-method "even" :is-unique false :is-primary false
+   :is-valid true :key-columns [] :include-columns [] :partial-predicate nil :definition "DISTSTYLE EVEN"})
 
 (def ^:private wh-dba
   {:name "dba_made" :kind :btree :access-method "btree" :is-unique false :is-primary false
@@ -37,14 +46,22 @@
 
 (deftest match-key-test
   (testing "named kinds key by name; managed and warehouse agree"
-    (is (= "by_cat" (reconcile/managed-match-key managed-btree)))
-    (is (= "by_cat" (reconcile/match-key wh-btree))))
+    (is (= {:kind :named :name "by_cat"} (reconcile/managed-match-key managed-btree)))
+    (is (= {:kind :named :name "by_cat"} (reconcile/match-key wh-btree))))
   (testing "unnamed inline kinds key by kind+columns, so managed and warehouse agree"
-    (is (= [:sortkey ["a" "b"]] (reconcile/managed-match-key managed-sortkey)))
-    (is (= [:sortkey ["a" "b"]] (reconcile/match-key wh-sortkey))))
-  (testing "a fetched distkey is unnamed-inline too, so it matches its managed request (#76331)"
-    (is (= [:distkey ["category"]] (reconcile/managed-match-key managed-distkey)))
-    (is (= [:distkey ["category"]] (reconcile/match-key wh-distkey)))))
+    (is (= {:kind :sortkey :key-columns ["a" "b"]} (reconcile/managed-match-key managed-sortkey)))
+    (is (= {:kind :sortkey :key-columns ["a" "b"]} (reconcile/match-key wh-sortkey))))
+  (testing "a key distkey is keyed by its style + column, so managed and warehouse agree (#76331)"
+    (is (= {:kind :distkey :style "key" :key-columns ["category"]} (reconcile/managed-match-key managed-distkey)))
+    (is (= {:kind :distkey :style "key" :key-columns ["category"]} (reconcile/match-key wh-distkey))))
+  (testing "distkey keys are style-aware: column-less even and all don't collapse onto the same key"
+    (is (= {:kind :distkey :style "even" :key-columns []} (reconcile/managed-match-key managed-even-distkey)))
+    (is (= {:kind :distkey :style "even" :key-columns []} (reconcile/match-key wh-even-distkey)))
+    (is (not= (reconcile/managed-match-key managed-even-distkey)
+              (reconcile/managed-match-key (assoc-in managed-even-distkey [:structured :style] :all))))
+    (testing "a stray column on a non-key request is ignored, so it still matches the column-less warehouse distkey"
+      (is (= {:kind :distkey :style "even" :key-columns []}
+             (reconcile/managed-match-key (assoc-in managed-even-distkey [:structured :columns] [{:name "x"}])))))))
 
 (deftest merge-indexes-test
   (testing "managed + present: observed from the warehouse, flagged managed, request carries lifecycle + structured"
@@ -75,11 +92,17 @@
       (is (= 1 (count merged)))
       (is (true? (:metabase_managed (first merged))))
       (is (true? (:present_in_warehouse (first merged))))))
-  (testing "a managed inline distkey matches the warehouse distkey by kind+columns, listed once as managed"
+  (testing "a managed inline distkey matches the warehouse distkey by style+columns, listed once as managed"
     (let [merged (reconcile/merge-indexes [managed-distkey] [wh-distkey])]
       (is (= 1 (count merged)))
       (is (true? (:metabase_managed (first merged))))
       (is (true? (:present_in_warehouse (first merged))))))
+  (testing "a managed even distkey matches an even warehouse distkey, but not an all one"
+    (is (true? (:present_in_warehouse (first (reconcile/merge-indexes [managed-even-distkey] [wh-even-distkey])))))
+    (let [merged  (reconcile/merge-indexes [managed-even-distkey]
+                                           [(assoc wh-even-distkey :access-method "all")])
+          managed (first (filter :metabase_managed merged))]
+      (is (false? (:present_in_warehouse managed)))))
   (testing "mix: a matched managed index, plus a DBA index alongside it"
     (let [merged  (reconcile/merge-indexes [managed-btree] [wh-btree wh-dba])
           by-flag (group-by :metabase_managed merged)]

--- a/test/metabase/indexes/reconcile_test.clj
+++ b/test/metabase/indexes/reconcile_test.clj
@@ -7,12 +7,12 @@
 (def ^:private managed-btree
   {:id 1 :transform_id 7 :index_name "by_cat"
    :structured {:kind :btree :name "by_cat" :columns [{:name "name"}] :unique true}
-   :status :pending :error_message nil :created_by 3 :last_executed_at nil})
+   :status :create-pending :error_message nil :created_by 3 :last_executed_at nil})
 
 (def ^:private managed-sortkey
   {:id 2 :transform_id 7 :index_name "sortkey"
    :structured {:kind :sortkey :style :compound :columns [{:name "a"} {:name "b"}]}
-   :status :pending :error_message nil :created_by 3 :last_executed_at nil})
+   :status :create-pending :error_message nil :created_by 3 :last_executed_at nil})
 
 (def ^:private wh-btree
   {:name "by_cat" :kind :btree :access-method "btree" :is-unique true :is-primary false
@@ -25,7 +25,7 @@
 (def ^:private managed-distkey
   {:id 3 :transform_id 7 :index_name "distkey"
    :structured {:kind :distkey :style :key :columns [{:name "category"}]}
-   :status :pending :error_message nil :created_by 3 :last_executed_at nil})
+   :status :create-pending :error_message nil :created_by 3 :last_executed_at nil})
 
 (def ^:private wh-distkey
   {:name nil :kind :distkey :access-method nil :is-unique false :is-primary false
@@ -54,7 +54,7 @@
       (is (= "by_cat" (:name e)))
       (is (true? (:is_unique e)))
       (is (= 1 (-> e :request :id)))
-      (is (= :pending (-> e :request :status)))
+      (is (= :create-pending (-> e :request :status)))
       (is (= (:structured managed-btree) (-> e :request :structured)))))
   (testing "DBA (warehouse-only): observed, unmanaged, no request bookkeeping"
     (let [[e] (reconcile/merge-indexes [] [wh-dba])]
@@ -69,7 +69,7 @@
       (is (false? (:present_in_warehouse e)))
       (is (= "by_cat" (:name e)))
       (is (true? (:is_unique e)))
-      (is (= :pending (-> e :request :status)))))
+      (is (= :create-pending (-> e :request :status)))))
   (testing "a managed inline sortkey matches the warehouse sortkey by kind+columns, listed once as managed"
     (let [merged (reconcile/merge-indexes [managed-sortkey] [wh-sortkey])]
       (is (= 1 (count merged)))
@@ -93,6 +93,9 @@
     (with-redefs [metabase.driver/fetch-table-indexes (fn [_driver _db _schema _table] [wh-btree])]
       (is (= [wh-btree]
              (reconcile/fetch-warehouse-indexes {:engine :postgres} "public" "t")))))
-  (testing "swallows driver/connection errors and returns []"
+  (testing "preserves a successful empty warehouse response"
+    (with-redefs [metabase.driver/fetch-table-indexes (fn [& _] [])]
+      (is (= [] (reconcile/fetch-warehouse-indexes {:engine :postgres} "public" "t")))))
+  (testing "swallows driver/connection errors and returns nil"
     (with-redefs [metabase.driver/fetch-table-indexes (fn [& _] (throw (ex-info "boom" {})))]
-      (is (= [] (reconcile/fetch-warehouse-indexes {:engine :postgres} "public" "t"))))))
+      (is (nil? (reconcile/fetch-warehouse-indexes {:engine :postgres} "public" "t"))))))

--- a/test/metabase/indexes/requestable_test.clj
+++ b/test/metabase/indexes/requestable_test.clj
@@ -1,6 +1,6 @@
 (ns metabase.indexes.requestable-test
   "Checks that the form descriptors `driver/supported-index-methods` returns stay in sync with `::index-structured`, the
-  schema `POST /api/indexes/request` validates request bodies against."
+  schema `POST /api/index/request` validates request bodies against."
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]

--- a/test/metabase/indexes/requestable_test.clj
+++ b/test/metabase/indexes/requestable_test.clj
@@ -10,35 +10,11 @@
 
 (comment metabase.driver.postgres/keep-me)
 
-(defn- sample-value
-  "A representative value for a descriptor field, the way the FE would fill the form."
-  [{:keys [type options]}]
-  (case type
-    :string  "idx_sample"
-    :boolean true
-    :integer 1
-    :columns [{:name "a"} {:name "b"}]
-    :select  (-> options first :value)))
-
-(defn- body-from-fields
-  "Assemble a structured index body from ONLY the kind + its descriptor fields, then re-keywordize enum values the way
-  the POST path does."
-  [kind fields]
-  (-> (into {:kind kind} (map (fn [{nm :name :as f}] [(keyword nm) (sample-value f)])) fields)
-      schema/keywordize-structured))
-
 (deftest return-conforms-to-schema-test
   (testing "the supported-index-methods return validates against ::driver/supported-index-methods"
     (is (mr/validate ::driver/supported-index-methods (driver/supported-index-methods :postgres nil)))
     (testing "including the empty default for a driver with no index support"
       (is (mr/validate ::driver/supported-index-methods (driver/supported-index-methods :h2 nil))))))
-
-(deftest postgres-descriptors-match-schema-test
-  (testing "a body built from each advertised kind's descriptors validates against ::index-structured"
-    (doseq [[kind {:keys [fields]}] (driver/supported-index-methods :postgres nil)]
-      (let [body (body-from-fields kind fields)]
-        (is (mr/validate ::schema/index-structured body)
-            (str "descriptor body for " kind " should validate: " (pr-str body)))))))
 
 (deftest postgres-lifecycle-matches-feature-flag-test
   (testing ":standalone <=> :index/standalone-create, :inline <=> :index/inline-create"
@@ -58,8 +34,7 @@
       {:kind :skip-index :name "s" :columns [{:name "a"}] :type "bloom_filter" :granularity 4}
       {:kind :distkey    :style "key" :columns [{:name "a"}]}
       {:kind :distkey    :style "all"}
-      {:kind :distkey    :style "even"}
-      {:kind :distkey    :style "auto"})))
+      {:kind :distkey    :style "even"})))
 
 (deftest distkey-key-requires-a-column-test
   (testing "a :key distkey without a column is rejected; the column-less styles are fine"

--- a/test/metabase/transforms/index_test.clj
+++ b/test/metabase/transforms/index_test.clj
@@ -201,12 +201,17 @@
                                                :source             {:type "query"}
                                                :source_database_id (mt/id)
                                                :target             {:database (mt/id) :type "table" :schema "public" :name "t"}}
-                   :model/TableIndex _ {:transform_id tid :index_name "b_idx"
-                                        :structured {:kind :btree :name "b_idx" :columns [{:name "x"}]}}
-                   :model/TableIndex _ {:transform_id tid :index_name "a_idx"
-                                        :structured {:kind :btree :name "a_idx" :columns [{:name "y"}]}}]
+                   :model/TableIndex {b-id :id} {:transform_id tid :index_name "b_idx"
+                                                 :structured {:kind :btree :name "b_idx" :columns [{:name "x"}]}}
+                   :model/TableIndex {a-id :id} {:transform_id tid :index_name "a_idx"
+                                                 :structured {:kind :btree :name "a_idx" :columns [{:name "y"}]}}
+                   :model/TableIndex _ {:transform_id tid :index_name "deleted_idx"
+                                        :status :delete-pending
+                                        :structured {:kind :btree :name "deleted_idx" :columns [{:name "z"}]}}]
       (is (= ["a_idx" "b_idx"]
-             (map :name (transforms.execute/hydrate-transform-indexes {:id tid})))))))
+             (map :name (transforms.execute/hydrate-transform-indexes {:id tid}))))
+      (is (= [a-id b-id]
+             (transforms.execute/hydrate-transform-index-ids {:id tid}))))))
 
 (deftest ^:synchronized verify-managed-indexes!-test
   (mt/with-temp [:model/Transform {tid :id} {:name               (mt/random-name)
@@ -225,6 +230,101 @@
       (is (= :succeeded (t2/select-one-fn :status :model/TableIndex present-id)))
       (is (= :failed (t2/select-one-fn :status :model/TableIndex missing-id)))
       (is (some? (t2/select-one-fn :last_executed_at :model/TableIndex present-id))))))
+
+(defn- warehouse-btree
+  [name column]
+  {:name name :kind :btree :access-method "btree" :is-unique false
+   :is-primary false :is-valid true :key-columns [column] :include-columns []
+   :partial-predicate nil :definition "..."})
+
+(deftest ^:synchronized verify-managed-indexes!-removes-delete-pending-row-when-absent-test
+  (mt/with-temp [:model/Transform {tid :id} {:name               (mt/random-name)
+                                             :source             {:type "query"}
+                                             :source_database_id (mt/id)
+                                             :target             {:database (mt/id) :type "table" :schema "public" :name "t"}}
+                 :model/TableIndex {applicable-id :id} {:transform_id tid :index_name "active_idx"
+                                                        :structured {:kind :btree :name "active_idx" :columns [{:name "x"}]}}
+                 :model/TableIndex {deleted-id :id} {:transform_id tid :index_name "deleted_idx"
+                                                     :status :delete-pending
+                                                     :structured {:kind :btree :name "deleted_idx" :columns [{:name "y"}]}}]
+    (with-redefs [driver/fetch-table-indexes (fn [& _] [(warehouse-btree "active_idx" "x")])]
+      (transforms-base.u/verify-managed-indexes! (t2/select-one :model/Transform tid))
+      (is (= :succeeded (t2/select-one-fn :status :model/TableIndex applicable-id)))
+      (is (not (t2/exists? :model/TableIndex :id deleted-id)))
+      (is (some? (t2/insert-returning-pk! :model/TableIndex
+                                          {:transform_id tid
+                                           :index_name   "deleted_idx"
+                                           :structured   {:kind :btree :name "deleted_idx" :columns [{:name "z"}]}}))))))
+
+(deftest ^:synchronized verify-managed-indexes!-only-verifies-hydrated-indexes-test
+  (mt/with-temp [:model/Transform {tid :id :as transform} {:name               (mt/random-name)
+                                                           :source             {:type "query"}
+                                                           :source_database_id (mt/id)
+                                                           :target             {:database (mt/id)
+                                                                                :type     "table"
+                                                                                :schema   "public"
+                                                                                :name     "t"}}
+                 :model/TableIndex {hydrated-id :id} {:transform_id tid :index_name "hydrated_idx"
+                                                      :status :running
+                                                      :structured {:kind :btree :name "hydrated_idx"
+                                                                   :columns [{:name "x"}]}}
+                 :model/TableIndex {concurrent-id :id} {:transform_id tid :index_name "concurrent_idx"
+                                                        :structured {:kind :btree :name "concurrent_idx"
+                                                                     :columns [{:name "y"}]}}]
+    (with-redefs [driver/fetch-table-indexes (fn [& _] [(warehouse-btree "hydrated_idx" "x")])]
+      (transforms-base.u/verify-managed-indexes!
+       (-> transform
+           (assoc-in [:target :indexes] [{:kind :btree :name "hydrated_idx" :columns [{:name "x"}]}])
+           (assoc-in [:target :index-request-ids] [hydrated-id])))
+      (is (= :succeeded (t2/select-one-fn :status :model/TableIndex hydrated-id)))
+      (is (= :create-pending (t2/select-one-fn :status :model/TableIndex concurrent-id))))))
+
+(deftest ^:synchronized verify-managed-indexes!-keeps-delete-pending-row-when-present-test
+  (mt/with-temp [:model/Transform {tid :id} {:name               (mt/random-name)
+                                             :source             {:type "query"}
+                                             :source_database_id (mt/id)
+                                             :target             {:database (mt/id) :type "table" :schema "public" :name "t"}}
+                 :model/TableIndex {deleted-id :id} {:transform_id tid :index_name "deleted_idx"
+                                                     :status :delete-pending
+                                                     :structured {:kind :btree :name "deleted_idx" :columns [{:name "y"}]}}]
+    (with-redefs [driver/fetch-table-indexes (fn [& _] [(warehouse-btree "deleted_idx" "y")])]
+      (transforms-base.u/verify-managed-indexes! (t2/select-one :model/Transform tid))
+      (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex deleted-id)))
+      (is (some? (t2/select-one-fn :last_executed_at :model/TableIndex deleted-id))))))
+
+(deftest ^:synchronized verify-managed-indexes!-reconciles-successful-empty-index-list-test
+  (mt/with-temp [:model/Transform {tid :id} {:name               (mt/random-name)
+                                             :source             {:type "query"}
+                                             :source_database_id (mt/id)
+                                             :target             {:database (mt/id) :type "table" :schema "public" :name "t"}}
+                 :model/TableIndex {applicable-id :id} {:transform_id tid :index_name "active_idx"
+                                                        :structured {:kind :btree :name "active_idx" :columns [{:name "x"}]}}
+                 :model/TableIndex {deleted-id :id} {:transform_id tid :index_name "deleted_idx"
+                                                     :status :delete-pending
+                                                     :structured {:kind :btree :name "deleted_idx" :columns [{:name "y"}]}}]
+    (with-redefs [driver/fetch-table-indexes (fn [& _] [])]
+      (transforms-base.u/verify-managed-indexes! (t2/select-one :model/Transform tid))
+      (is (= :failed (t2/select-one-fn :status :model/TableIndex applicable-id)))
+      (is (not (t2/exists? :model/TableIndex :id deleted-id)))
+      (is (some? (t2/insert-returning-pk! :model/TableIndex
+                                          {:transform_id tid
+                                           :index_name   "deleted_idx"
+                                           :structured   {:kind :btree :name "deleted_idx" :columns [{:name "z"}]}}))))))
+
+(deftest ^:synchronized verify-managed-indexes!-leaves-rows-unchanged-when-index-fetch-fails-test
+  (mt/with-temp [:model/Transform {tid :id} {:name               (mt/random-name)
+                                             :source             {:type "query"}
+                                             :source_database_id (mt/id)
+                                             :target             {:database (mt/id) :type "table" :schema "public" :name "t"}}
+                 :model/TableIndex {applicable-id :id} {:transform_id tid :index_name "active_idx"
+                                                        :structured {:kind :btree :name "active_idx" :columns [{:name "x"}]}}
+                 :model/TableIndex {deleted-id :id} {:transform_id tid :index_name "deleted_idx"
+                                                     :status :delete-pending
+                                                     :structured {:kind :btree :name "deleted_idx" :columns [{:name "y"}]}}]
+    (with-redefs [driver/fetch-table-indexes (fn [& _] (throw (ex-info "boom" {})))]
+      (transforms-base.u/verify-managed-indexes! (t2/select-one :model/Transform tid))
+      (is (= :create-pending (t2/select-one-fn :status :model/TableIndex applicable-id)))
+      (is (= :delete-pending (t2/select-one-fn :status :model/TableIndex deleted-id))))))
 
 (deftest ^:synchronized ddl-failure-marks-row-failed-test
   (mt/with-temp [:model/Transform {tid :id} {:name (mt/random-name)

--- a/test/metabase/transforms/index_test.clj
+++ b/test/metabase/transforms/index_test.clj
@@ -97,8 +97,8 @@
               (transforms.tu/wait-for-table table-name 10000)
               (testing "every managed row is verified succeeded"
                 (is (= #{:succeeded} (t2/select-fn-set :status :model/TableIndex :transform_id tid))))
-              (testing "GET /indexes lists them, flagged metabase_managed"
-                (let [{:keys [data]} (mt/user-http-request :crowberto :get 200 (str "indexes?transform-id=" tid))]
+              (testing "GET /index lists them, flagged metabase_managed"
+                (let [{:keys [data]} (mt/user-http-request :crowberto :get 200 (str "index?transform-id=" tid))]
                   (is (= (count indexes) (count (filter :metabase_managed data)))))))))))))
 
 (deftest ^:synchronized declared-index-failure-fails-the-run-test

--- a/test/metabase/transforms/index_test.clj
+++ b/test/metabase/transforms/index_test.clj
@@ -4,12 +4,11 @@
   Per-driver cases and helpers live in [[metabase.transforms.index-test-util]]. Each test stubs
   [[metabase.transforms.execute/hydrate-transform-indexes]] to inject its case."
   (:require
-   [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.driver :as driver]
-   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.test :as mt]
+   [metabase.test.data.sql :as sql.tx]
    [metabase.transforms-base.util :as transforms-base.u]
    [metabase.transforms.execute :as transforms.execute]
    [metabase.transforms.index-test-util :as index-util]
@@ -157,36 +156,53 @@
                        (assoc-in transform [:target :indexes] indexes))
                       (is (= expected (physical-indexes db schema table-name))))))))))))))
 
+(defn- fetch-schema
+  "Schema the fetch-correctness suite creates its table in and passes to fetch-table-indexes. nil for sql-jdbc drivers
+  (the connection default); bigquery has none, so it uses its session dataset and qualifies the DDL with it."
+  [driver]
+  (when-not (isa? driver/hierarchy driver :sql-jdbc)
+    (sql.tx/session-schema driver)))
+
+(defn- run-fetch-ddl!
+  "Run raw fetch-case DDL through execute-raw-queries! (both sql-jdbc and bigquery implement it). Each statement is
+  wrapped as `[sql]` because the seam expects `[sql & params]` vectors, not bare strings."
+  [driver db stmts]
+  (driver/execute-raw-queries! driver (driver/connection-spec driver db) (mapv vector stmts)))
+
 (deftest ^:synchronized fetch-table-indexes-correctness-test
   (testing "fetch-table-indexes reports each driver's popular index kinds in the normalized cross-driver shape"
     ;; The e2e tests above prove indexes Metabase *applies* land on the table; this proves the driver method the
     ;; GET /indexes API consumes reads them back correctly, including catalog shapes the apply path can't produce
-    ;; (e.g. a Postgres gin or partial index). Indexes are created directly; nil schema uses the connection default.
+    ;; (e.g. a Postgres gin or partial index). Tables are created directly from raw DDL.
     (mt/test-drivers (index-util/index-test-drivers)
-      (let [spec  (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
-            cases (index-util/fetch-cases driver/*driver*)]
-        (is (driver/database-supports? driver/*driver* :index/fetch (mt/db))
+      (let [db     (mt/db)
+            schema (fetch-schema driver/*driver*)
+            cases  (index-util/fetch-cases driver/*driver*)]
+        (is (driver/database-supports? driver/*driver* :index/fetch db)
             "a driver that implements fetch-table-indexes declares :index/fetch")
         (is (some? cases) (index-util/missing-case-message driver/*driver*))
         (doseq [{:keys [label table create expected definition-contains]} cases]
           (testing label
-            (jdbc/execute! spec [(str "DROP TABLE IF EXISTS " table)])
-            (try
-              (doseq [stmt create]
-                (jdbc/execute! spec [stmt]))
-              (let [indexes (driver/fetch-table-indexes driver/*driver* (mt/db) nil table)]
-                (is (nil? (mr/explain :metabase.driver/fetch-table-indexes.result indexes))
-                    "result conforms to ::fetch-table-indexes.result")
-                (is (= expected (into #{} (map #(dissoc % :definition)) indexes)))
-                ;; `:definition` is dropped from the equality check above (it's driver-verbatim), so a case that hinges
-                ;; on it (e.g. Redshift INTERLEAVED vs COMPOUND, identical except for this word) asserts it explicitly.
-                (when definition-contains
-                  (is (some #(str/includes? (:definition %) definition-contains) indexes)
-                      (str "an index definition contains " (pr-str definition-contains)))))
-              (finally
-                (jdbc/execute! spec [(str "DROP TABLE IF EXISTS " table)])))))
+            ;; sql-jdbc drivers create in the connection default (schema nil, bare name); bigquery needs the dataset.
+            (let [qualified (if schema (format "`%s`.%s" schema table) table)
+                  drop-sql  (str "DROP TABLE IF EXISTS " qualified)
+                  creates   (cond->> create schema (mapv #(str/replace-first % table qualified)))]
+              (run-fetch-ddl! driver/*driver* db [drop-sql])
+              (try
+                (run-fetch-ddl! driver/*driver* db creates)
+                (let [indexes (driver/fetch-table-indexes driver/*driver* db schema table)]
+                  (is (nil? (mr/explain :metabase.driver/fetch-table-indexes.result indexes))
+                      "result conforms to ::fetch-table-indexes.result")
+                  (is (= expected (into #{} (map #(dissoc % :definition)) indexes)))
+                  ;; `:definition` is dropped from the equality check above (it's driver-verbatim), so a case that hinges
+                  ;; on it (e.g. Redshift INTERLEAVED vs COMPOUND, identical except for this word) asserts it explicitly.
+                  (when definition-contains
+                    (is (some #(str/includes? (:definition %) definition-contains) indexes)
+                        (str "an index definition contains " (pr-str definition-contains)))))
+                (finally
+                  (run-fetch-ddl! driver/*driver* db [drop-sql]))))))
         (testing "a table that does not exist returns [] rather than throwing"
-          (is (= [] (driver/fetch-table-indexes driver/*driver* (mt/db) nil "mb_fetch_does_not_exist"))))))))
+          (is (= [] (driver/fetch-table-indexes driver/*driver* db schema "mb_fetch_does_not_exist"))))))))
 
 (deftest ^:parallel fetch-table-indexes-unsupported-driver-test
   (testing "a driver that can't introspect indexes doesn't declare :index/fetch"

--- a/test/metabase/transforms/index_test_util.clj
+++ b/test/metabase/transforms/index_test_util.clj
@@ -200,15 +200,25 @@
      :table  "mb_fetch_rs_interleaved"
      :create ["CREATE TABLE mb_fetch_rs_interleaved (a INT, b INT) INTERLEAVED SORTKEY (a, b)"]
      ;; same normalized shape as the compound case, so `:definition` is the only signal it's interleaved.
+     ;; interleaved can't use AUTO distribution, so Redshift assigns EVEN; it surfaces as an unmanaged distkey.
      :definition-contains "INTERLEAVED"
-     :expected #{(idx nil :sortkey nil ["a" "b"])}}
+     :expected #{(idx nil :sortkey nil ["a" "b"])
+                 (idx nil :distkey "even" [])}}
     {:label  "a KEY distkey alongside a compound sortkey, both reported as unnamed inline rows"
      :table  "mb_fetch_rs_dist"
      :create ["CREATE TABLE mb_fetch_rs_dist (a INT, b INT) DISTSTYLE KEY DISTKEY (a) COMPOUND SORTKEY (b)"]
      :expected #{(idx nil :sortkey nil ["b"])
-                 (idx nil :distkey nil ["a"])}}
-    {:label "a table with no sortkey returns []"
-     :table "mb_fetch_rs_empty"
+                 (idx nil :distkey "key" ["a"])}}
+    {:label  "an EVEN distribution is reported as a column-less distkey, keyed by style"
+     :table  "mb_fetch_rs_even"
+     :create ["CREATE TABLE mb_fetch_rs_even (a INT, b INT) DISTSTYLE EVEN"]
+     :expected #{(idx nil :distkey "even" [])}}
+    {:label  "an ALL distribution is reported as a column-less distkey, distinct from EVEN"
+     :table  "mb_fetch_rs_all"
+     :create ["CREATE TABLE mb_fetch_rs_all (a INT, b INT) DISTSTYLE ALL"]
+     :expected #{(idx nil :distkey "all" [])}}
+    {:label  "a table with no explicit sortkey or distribution (AUTO) returns []"
+     :table  "mb_fetch_rs_empty"
      :create ["CREATE TABLE mb_fetch_rs_empty (a INT, b INT)"]
      :expected #{}}]
 

--- a/test/metabase/transforms/index_test_util.clj
+++ b/test/metabase/transforms/index_test_util.clj
@@ -4,6 +4,7 @@
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
+   [clojure.string :as str]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.test :as mt]))
 
@@ -42,6 +43,24 @@
                                           schema table])
                         (mapv #(update % :granularity long)))}))
 
+(defn- snowflake-clustering
+  "Read a Snowflake table's clustering key back as an ordered vector of column names, or [] when unclustered.
+  `CLUSTERING_KEY` comes back as a string like `LINEAR(category, price)`."
+  [database schema table]
+  (let [clustering-key (-> (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
+                                       [(str "SELECT clustering_key FROM information_schema.tables "
+                                             "WHERE table_schema = ? AND table_name = ?")
+                                        schema table])
+                           first :clustering_key)]
+    (if-let [s (some-> clustering-key str/trim not-empty)]
+      (let [inner (or (second (re-matches #"(?is)\s*LINEAR\s*\((.*)\)\s*" s)) s)]
+        (->> (str/split inner #",")
+             (map str/trim)
+             (map #(str/replace % #"^\"|\"$" ""))
+             (remove str/blank?)
+             vec))
+      [])))
+
 (def driver-cases
   "Driver -> test case: `:indexes` to declare (every method whose column types `transforms_products` can satisfy; the
   rest, e.g. Postgres gin/gist, live in the driver-level and fetch suites), `:physical-indexes` a
@@ -65,7 +84,11 @@
                                     :columns [{:name "price"}] :granularity 1}]
                 :expected         {:sorting-key  "(category)"
                                    :skip-indexes [{:name "by_price" :type "minmax" :expr "(price)" :granularity 1}]}
-                :physical-indexes clickhouse-indexes}})
+                :physical-indexes clickhouse-indexes}
+   ;; Snowflake: a single standalone clustering key, reported unnamed, so we read back just the clustered columns.
+   :snowflake  {:indexes          [{:kind :clustering :name "by_category" :columns [{:name "category"}]}]
+                :expected         ["category"]
+                :physical-indexes snowflake-clustering}})
 
 (defn index-test-drivers
   "Drivers that run transforms and declare any index support."
@@ -175,4 +198,14 @@
     {:label "an unsorted table returns []"
      :table "mb_fetch_ch_empty"
      :create ["CREATE TABLE mb_fetch_ch_empty (a Int64) ENGINE = MergeTree ORDER BY ()"]
+     :expected #{}}]
+
+   :snowflake
+   [{:label  "the clustering key, unnamed, reconciled by kind + columns"
+     :table  "mb_fetch_sf"
+     :create ["CREATE TABLE mb_fetch_sf (category TEXT, price FLOAT) CLUSTER BY (category)"]
+     :expected #{(idx nil :clustering nil ["category"])}}
+    {:label "a table with no clustering key returns []"
+     :table "mb_fetch_sf_empty"
+     :create ["CREATE TABLE mb_fetch_sf_empty (a INT, b INT)"]
      :expected #{}}]})

--- a/test/metabase/transforms/index_test_util.clj
+++ b/test/metabase/transforms/index_test_util.clj
@@ -32,6 +32,17 @@
                  :style   (if (some (comp neg? :sortkey) sort-rows) :interleaved :compound)})
      :distkey (:column_name (first (filter :distkey rows)))}))
 
+(defn- mysql-indexes
+  [database schema table]
+  ;; MySQL has no schemas, so `schema` is nil; fall back to the connection's database.
+  (->> (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
+                   [(str "SELECT DISTINCT index_name FROM information_schema.statistics "
+                         "WHERE table_schema = COALESCE(?, DATABASE()) AND table_name = ?")
+                    schema table])
+       (map :index_name)
+       (remove #{"PRIMARY"})
+       set))
+
 (defn- clickhouse-indexes
   [database schema table]
   (let [spec (sql-jdbc.conn/db->pooled-connection-spec database)]
@@ -100,6 +111,12 @@
                 :expected         {:sorting-key  "(category)"
                                    :skip-indexes [{:name "by_price" :type "minmax" :expr "(price)" :granularity 1}]}
                 :physical-indexes clickhouse-indexes}
+   ;; btree goes on `price` because a TEXT column needs a prefix length to be btree-indexed; fulltext needs text,
+   ;; so it goes on `category`.
+   :mysql      {:indexes          [{:kind :btree :name "by_price" :columns [{:name "price"}]}
+                                   {:kind :fulltext :name "ft_category" :columns [{:name "category"}]}]
+                :expected         #{"by_price" "ft_category"}
+                :physical-indexes mysql-indexes}
    ;; BigQuery: inline, unnamed clustering (`CLUSTER BY`), its only index-equivalent.
    :bigquery-cloud-sdk {:indexes          [{:kind :clustering :columns [{:name "category"}]}]
                         :expected         ["category"]
@@ -218,6 +235,25 @@
      :table "mb_fetch_ch_empty"
      :create ["CREATE TABLE mb_fetch_ch_empty (a Int64) ENGINE = MergeTree ORDER BY ()"]
      :expected #{}}]
+
+   :mysql
+   [{:label  "btree, unique, composite, fulltext, and the auto PRIMARY KEY index"
+     :table  "mb_fetch_mysql"
+     :create ["CREATE TABLE mb_fetch_mysql (id INT PRIMARY KEY, user_id INT, email VARCHAR(255), a INT, b INT, body TEXT)"
+              "CREATE INDEX fc_btree ON mb_fetch_mysql (user_id)"
+              "CREATE UNIQUE INDEX fc_unique ON mb_fetch_mysql (email)"
+              "CREATE INDEX fc_ab ON mb_fetch_mysql (a, b)"
+              "CREATE FULLTEXT INDEX fc_ft ON mb_fetch_mysql (body)"]
+     ;; the PRIMARY KEY surfaces as a unique btree index named 'PRIMARY'.
+     :expected #{(idx "PRIMARY" :btree "btree" ["id"] :unique true :primary true)
+                 (idx "fc_btree" :btree "btree" ["user_id"])
+                 (idx "fc_unique" :btree "btree" ["email"] :unique true)
+                 (idx "fc_ab" :btree "btree" ["a" "b"])
+                 (idx "fc_ft" :fulltext "fulltext" ["body"])}}
+    {:label "a table with no secondary indexes returns just the primary key"
+     :table "mb_fetch_mysql_empty"
+     :create ["CREATE TABLE mb_fetch_mysql_empty (id INT PRIMARY KEY, a INT)"]
+     :expected #{(idx "PRIMARY" :btree "btree" ["id"] :unique true :primary true)}}]
 
    :bigquery-cloud-sdk
    [{:label  "the inline clustering, unnamed, reconciled by kind + columns"

--- a/test/metabase/transforms/index_test_util.clj
+++ b/test/metabase/transforms/index_test_util.clj
@@ -43,6 +43,21 @@
                                           schema table])
                         (mapv #(update % :granularity long)))}))
 
+(defn- bigquery-clustering
+  "Clustering columns of `table` in dataset `schema`, in clustering order, read from INFORMATION_SCHEMA. BigQuery has no
+  JDBC, so this runs through the QP as a native query rather than `jdbc/query`."
+  [database schema table]
+  (mapv first
+        (mt/rows
+         (mt/process-query
+          {:database (:id database)
+           :type     :native
+           :native   {:query (format (str "SELECT column_name FROM `%s`.INFORMATION_SCHEMA.COLUMNS "
+                                          "WHERE table_name = ? AND clustering_ordinal_position IS NOT NULL "
+                                          "ORDER BY clustering_ordinal_position")
+                                     schema)
+                      :params [table]}}))))
+
 (defn- snowflake-clustering
   "Read a Snowflake table's clustering key back as an ordered vector of column names, or [] when unclustered.
   `CLUSTERING_KEY` comes back as a string like `LINEAR(category, price)`."
@@ -85,6 +100,10 @@
                 :expected         {:sorting-key  "(category)"
                                    :skip-indexes [{:name "by_price" :type "minmax" :expr "(price)" :granularity 1}]}
                 :physical-indexes clickhouse-indexes}
+   ;; BigQuery: inline, unnamed clustering (`CLUSTER BY`), its only index-equivalent.
+   :bigquery-cloud-sdk {:indexes          [{:kind :clustering :columns [{:name "category"}]}]
+                        :expected         ["category"]
+                        :physical-indexes bigquery-clustering}
    ;; Snowflake: a single standalone clustering key, reported unnamed, so we read back just the clustered columns.
    :snowflake  {:indexes          [{:kind :clustering :name "by_category" :columns [{:name "category"}]}]
                 :expected         ["category"]
@@ -198,6 +217,16 @@
     {:label "an unsorted table returns []"
      :table "mb_fetch_ch_empty"
      :create ["CREATE TABLE mb_fetch_ch_empty (a Int64) ENGINE = MergeTree ORDER BY ()"]
+     :expected #{}}]
+
+   :bigquery-cloud-sdk
+   [{:label  "the inline clustering, unnamed, reconciled by kind + columns"
+     :table  "mb_fetch_bq"
+     :create ["CREATE TABLE mb_fetch_bq (category STRING, price FLOAT64) CLUSTER BY category"]
+     :expected #{(idx nil :clustering nil ["category"])}}
+    {:label "a table with no clustering returns []"
+     :table "mb_fetch_bq_empty"
+     :create ["CREATE TABLE mb_fetch_bq_empty (a INT64, b INT64)"]
      :expected #{}}]
 
    :snowflake

--- a/test/metabase/transforms/models/transform_test.clj
+++ b/test/metabase/transforms/models/transform_test.clj
@@ -5,6 +5,7 @@
    [metabase.models.interface :as mi]
    [metabase.test :as mt]
    [metabase.transforms-base.query :as transforms-base.query]
+   [metabase.transforms.query-test-util :as query-test-util]
    [toucan2.core :as t2]))
 
 (deftest source-database-id-set-test
@@ -48,6 +49,37 @@
       (is (nil? (t2/select-one-fn :source_database_id :model/Transform (:id transform))))
       ;; transform itself still exists
       (is (some? (t2/select-one :model/Transform (:id transform)))))))
+
+(defn- temp-transform-with-index! [thunk]
+  (mt/with-temp [:model/Transform {transform-id :id}
+                 {:name   (mt/random-name)
+                  :source {:type "query" :query (query-test-util/make-query :source-table "venues")}
+                  :target {:database (mt/id) :type "table" :schema "public" :name (mt/random-name)}}
+                 :model/TableIndex {index-id :id}
+                 {:transform_id transform-id
+                  :index_name   "by_cat"
+                  :status       :succeeded
+                  :structured   {:kind :btree :name "by_cat" :columns [{:name "category"}]}}]
+    (thunk transform-id index-id)))
+
+(deftest revalidate-indexes-on-schema-change-test
+  (testing "editing the source query (output schema may change) marks the transform's managed indexes for revalidation"
+    (temp-transform-with-index!
+     (fn [transform-id index-id]
+       (t2/update! :model/Transform transform-id
+                   {:source {:type "query" :query (query-test-util/make-query :source-table "checkins")}})
+       (is (= :update-pending (t2/select-one-fn :status :model/TableIndex index-id))))))
+  (testing "retargeting to a different table marks the transform's managed indexes for revalidation"
+    (temp-transform-with-index!
+     (fn [transform-id index-id]
+       (t2/update! :model/Transform transform-id
+                   {:target {:database (mt/id) :type "table" :schema "public" :name (mt/random-name)}})
+       (is (= :update-pending (t2/select-one-fn :status :model/TableIndex index-id))))))
+  (testing "an unrelated edit (renaming the transform) leaves the indexes alone"
+    (temp-transform-with-index!
+     (fn [transform-id index-id]
+       (t2/update! :model/Transform transform-id {:name "renamed"})
+       (is (= :succeeded (t2/select-one-fn :status :model/TableIndex index-id)))))))
 
 (deftest can-read-write-on-orphaned-transform-test
   (testing "superusers can read/write a transform whose source database has been deleted, data analysts cannot"


### PR DESCRIPTION
review-only diff to make re-review easier, don't merge this.

it's the 10 commits added to #75848 since your last review on jun 25 (commit 9b9a7c3), replayed on top of that same reviewed commit brought up to current master. so the diff here is just the new index-manager work, without the ~176 master commits a raw compare would drag in.

the code is identical to the #75848 head (the trees match exactly), this branch just isolates what's new for you. per-commit history, discussion and CI stay on #75848.

## what's new since your review

- **index manager UI** (new `TransformIndexesPage`): an "Indexes" tab on the transform page, a list/table of the transform's indexes with a row menu + empty state, and an index editor modal to create / edit / delete indexes (column picker + form).
- **indexes backend** (`metabase.indexes.*`): request-based CRUD api (`GET /`, `POST` / `PUT` / `DELETE /request/:id`), the `table_index` model with lifecycle states (pending -> running -> verified/failed, plus revalidation), reconcile logic that diffs requested indexes against what's actually in the warehouse, malli schemas, and the `metabase_table_indexes` migration.
- **per-driver index support**: the index driver multimethods themselves were already reviewed (they landed with postgres in #75593), this delta just adds the per-driver *implementations* on top of them. new defmethods for bigquery + snowflake clustering and mysql standard indexes (`supported-index-methods` / `compile-create-index` / `fetch-table-indexes`), plus fixes to the existing redshift (distkey/sortkey) and clickhouse (skip-index) readers and an asc/desc direction option for postgres btree.
- **transforms integration**: thread declared target indexes through the transform run so they're applied on create/CTAS, invalidate a transform's indexes when its target or output schema changes, and `full-incremental-run?` now drop-recreates the table when there are pending index changes.
- **last commit is the merge reconciliation**: integrating that index threading with the incremental-transforms work (#76663) that landed in master after your review.