### PR TITLE
Allow map tile server host in img-src CSP

### DIFF
--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -361,7 +361,7 @@ Whether to (asynchronously) sync newly created Databases during config-from-file
 - [Exported as](../installation-and-operation/serialization.md): `csp-img-allowed-hosts`.
 - [Configuration file name](./config-file.md): `csp-img-allowed-hosts`
 
-Comma-separated list of hosts that images may load from (e.g. in dashboard text, entity descriptions, and custom visualizations) when `csp-img-enabled` is on. Empty by default, which restricts images to this Metabase instance.
+Comma-separated list of hosts that images may load from (e.g. in dashboard text, entity descriptions, and custom visualizations) when `csp-img-enabled` is on. Empty by default, which restricts images to this Metabase instance and the map tile server used by map visualizations (`map-tile-server-url`, always allowed automatically).
 
 ### `MB_CSP_IMG_ENABLED`
 

--- a/docs/configuring-metabase/settings.md
+++ b/docs/configuring-metabase/settings.md
@@ -89,7 +89,7 @@ See [iframes in dashboards](../dashboards/introduction.md#iframe-cards).
 
 ## Restrict image domains
 
-When on, Metabase restricts the browser's Content Security Policy so images can only load from this Metabase instance or the domains listed in [Allowed domains for images](#allowed-domains-for-images).
+When on, Metabase restricts the browser's Content Security Policy so images can only load from this Metabase instance, the map tile server used by map visualizations, or the domains listed in [Allowed domains for images](#allowed-domains-for-images).
 
 By default, images from any domain are allowed.
 
@@ -97,8 +97,8 @@ You must turn on this setting to enable [Custom visualizations](../questions/vis
 
 ## Allowed domains for images
 
-When the [Restrict image domains](#restrict-image-domains) setting is on, Metabase will only allow images served from this Metabase instance, and any domains listed on this page.
+When the [Restrict image domains](#restrict-image-domains) setting is on, Metabase will only allow images served from this Metabase instance, the map tile server used by map visualizations, and any domains listed on this page.
 
-Leave this input empty to only allow images hosted by your Metabase instance.
+Leave this input empty to allow images hosted by your Metabase instance and the map tile server. The map tile server is always allowed so map visualizations keep working, you don't need to manually add it here.
 
 Add multiple domains separated by a comma. Domains follow the same matching rules as [Allowed domains for iframes in dashboards](#allowed-domains-for-iframes-in-dashboards): listing a domain like `example.com` also allows its subdomains, while listing a subdomain like `images.example.com` allows only that subdomain.

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -104,11 +104,11 @@
   (re-pattern (str "^((?:" url-scheme-pattern "://)?(?:" url-host-pattern ")(?::(?:\\d+|\\*))?)(?:/.*)?$")))
 
 (defn- strip-origin-path
-  "Strips a trailing `/path` from a URL. Used both for admin-entered CORS origin entries and for deriving 
-   the map tile server origin. Origins have no path component by definition (just scheme + host + port), 
-   so a bare trailing slash pasted into an allowlist setting (e.g. `http://localhost:6274/`) shouldn't 
-   silently make that entry fail to parse and drop out of the allowlist. Entries with a real path are 
-   rejected at save time (see the setting's `:setter`); this only needs to normalize bare trailing 
+  "Strips a trailing `/path` from a URL. Used both for admin-entered CORS origin entries and for deriving
+   the map tile server origin. Origins have no path component by definition (just scheme + host + port),
+   so a bare trailing slash pasted into an allowlist setting (e.g. `http://localhost:6274/`) shouldn't
+   silently make that entry fail to parse and drop out of the allowlist. Entries with a real path are
+   rejected at save time (see the setting's `:setter`); this only needs to normalize bare trailing
    slashes and any non-trivial paths saved before that validation existed."
   [url]
   (str/replace url url-authority-pattern "$1"))

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -104,12 +104,12 @@
   (re-pattern (str "^((?:" url-scheme-pattern "://)?(?:" url-host-pattern ")(?::(?:\\d+|\\*))?)(?:/.*)?$")))
 
 (defn- strip-origin-path
-  "Strips a trailing `/path` from an admin-entered CORS origin entry. Origins have no path component by
-   definition (just scheme + host + port), so a bare trailing slash pasted into an allowlist setting
-   (e.g. `http://localhost:6274/`) shouldn't silently make that entry fail to parse and drop out of the
-   allowlist. Entries with a real path are rejected at save time (see the setting's `:setter`); this
-   only needs to normalize bare trailing slashes and any non-trivial paths saved before that validation
-   existed."
+  "Strips a trailing `/path` from a URL. Used both for admin-entered CORS origin entries and for deriving 
+   the map tile server origin. Origins have no path component by definition (just scheme + host + port), 
+   so a bare trailing slash pasted into an allowlist setting (e.g. `http://localhost:6274/`) shouldn't 
+   silently make that entry fail to parse and drop out of the allowlist. Entries with a real path are 
+   rejected at save time (see the setting's `:setter`); this only needs to normalize bare trailing 
+   slashes and any non-trivial paths saved before that validation existed."
   [url]
   (str/replace url url-authority-pattern "$1"))
 

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -99,6 +99,20 @@
   (or (try-parse-url url)
       (do (log/errorf "Invalid URL: %s" url) nil)))
 
+(def ^:private url-authority-pattern
+  ;;                  _________________________________$1_____________________________________
+  (re-pattern (str "^((?:" url-scheme-pattern "://)?(?:" url-host-pattern ")(?::(?:\\d+|\\*))?)(?:/.*)?$")))
+
+(defn- strip-origin-path
+  "Strips a trailing `/path` from an admin-entered CORS origin entry. Origins have no path component by
+   definition (just scheme + host + port), so a bare trailing slash pasted into an allowlist setting
+   (e.g. `http://localhost:6274/`) shouldn't silently make that entry fail to parse and drop out of the
+   allowlist. Entries with a real path are rejected at save time (see the setting's `:setter`); this
+   only needs to normalize bare trailing slashes and any non-trivial paths saved before that validation
+   existed."
+  [url]
+  (str/replace url url-authority-pattern "$1"))
+
 (defn- add-wildcard-entries
   "Adds a wildcard prefix `.*` to the domain part of the given `domain-or-url` string.
 
@@ -191,6 +205,19 @@
        distinct
        vec))
 
+(defn- map-tile-server->hosts
+  "Origin of the configured `map-tile-server-url` (OpenStreetMap or a custom server), so that `img-src`
+  allows map visualizations to load their tiles. The `{s}` subdomain placeholder becomes a `*` wildcard
+  and the `{z}/{x}/{y}` path is dropped; blank or relative templates yield no host."
+  []
+  (let [origin (some-> (setting/get-value-of-type :string :map-tile-server-url)
+                       not-empty
+                       (str/replace "{s}" "*")
+                       strip-origin-path)]
+    (if (and origin (try-parse-url origin))
+      [origin]
+      [])))
+
 (def ^:private frontend-dev-port (or (env/env :mb-frontend-dev-port) "8080"))
 (def ^:private frontend-address (str "http://localhost:" frontend-dev-port))
 (def ^:private cljs-dev-port (or (env/env :mb-cljs-dev-port) "9630"))
@@ -244,7 +271,8 @@
                                         config/is-dev? (conj frontend-address))
                                       (application-font-files->hosts))
                   :img-src      (if (server.settings/csp-img-enabled)
-                                  (cond-> (parse-allowed-resource-hosts (server.settings/csp-img-allowed-hosts))
+                                  (cond-> (into (parse-allowed-resource-hosts (server.settings/csp-img-allowed-hosts))
+                                                (map-tile-server->hosts))
                                     config/is-dev? (conj frontend-address))
                                   (into ["*"] always-allowed-resource-hosts))
                   :connect-src  ["'self'"
@@ -301,20 +329,6 @@
   (or
    (= reference-port "*")
    (= port reference-port)))
-
-(def ^:private url-authority-pattern
-  ;;                  _________________________________$1_____________________________________
-  (re-pattern (str "^((?:" url-scheme-pattern "://)?(?:" url-host-pattern ")(?::(?:\\d+|\\*))?)(?:/.*)?$")))
-
-(defn- strip-origin-path
-  "Strips a trailing `/path` from an admin-entered CORS origin entry. Origins have no path component by
-   definition (just scheme + host + port), so a bare trailing slash pasted into an allowlist setting
-   (e.g. `http://localhost:6274/`) shouldn't silently make that entry fail to parse and drop out of the
-   allowlist. Entries with a real path are rejected at save time (see the setting's `:setter`); this
-   only needs to normalize bare trailing slashes and any non-trivial paths saved before that validation
-   existed."
-  [url]
-  (str/replace url url-authority-pattern "$1"))
 
 (defn parse-approved-origins
   "Parses the space separated string of approved origins"

--- a/src/metabase/server/settings.clj
+++ b/src/metabase/server/settings.clj
@@ -42,7 +42,7 @@ x.com")
   :export?    true)
 
 (defsetting csp-img-allowed-hosts
-  (deferred-tru "Comma-separated list of hosts that images may load from (e.g. in dashboard text, entity descriptions, and custom visualizations) when `csp-img-enabled` is on. Empty by default, which restricts images to this Metabase instance.")
+  (deferred-tru "Comma-separated list of hosts that images may load from (e.g. in dashboard text, entity descriptions, and custom visualizations) when `csp-img-enabled` is on. Empty by default, which restricts images to this Metabase instance and the map tile server used by map visualizations.")
   :encryption :no
   :default    ""
   :audit      :getter

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -573,19 +573,38 @@
     (mt/with-temporary-setting-values [csp-img-enabled false
                                        csp-img-allowed-hosts "example.com"]
       (is (= "img-src * 'self' data:" (csp-directive "img-src")))))
-  (testing "with csp-img-enabled, img-src is restricted to 'self' and data: by default"
+  (testing "with csp-img-enabled, img-src is restricted to 'self', data: and the tile server by default"
     (mt/with-temporary-setting-values [csp-img-enabled true
-                                       csp-img-allowed-hosts ""]
-      (is (= "img-src 'self' data:" (csp-directive "img-src")))))
+                                       csp-img-allowed-hosts ""
+                                       map-tile-server-url "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"]
+      (is (= "img-src 'self' data: https://*.tile.openstreetmap.org" (csp-directive "img-src")))))
   (testing "nil csp-img-allowed-hosts behaves like empty input"
     (mt/with-temporary-setting-values [csp-img-enabled true
-                                       csp-img-allowed-hosts nil]
-      (is (= "img-src 'self' data:" (csp-directive "img-src")))))
+                                       csp-img-allowed-hosts nil
+                                       map-tile-server-url "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"]
+      (is (= "img-src 'self' data: https://*.tile.openstreetmap.org" (csp-directive "img-src")))))
   (testing "csp-img-allowed-hosts widens img-src (with wildcard expansion)"
     (mt/with-temporary-setting-values [csp-img-enabled true
-                                       csp-img-allowed-hosts "example.com, https://cdn.foo.com/"]
-      (is (= "img-src 'self' data: example.com *.example.com https://cdn.foo.com"
+                                       csp-img-allowed-hosts "example.com, https://cdn.foo.com/"
+                                       map-tile-server-url "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"]
+      (is (= "img-src 'self' data: example.com *.example.com https://cdn.foo.com https://*.tile.openstreetmap.org"
              (csp-directive "img-src"))))))
+
+(deftest csp-header-img-src-tile-server-tests
+  (testing "img-src always allows the configured map tile server"
+    (mt/with-temporary-setting-values [csp-img-enabled true
+                                       csp-img-allowed-hosts ""]
+      (testing "{s} subdomain placeholder is replaced with wildcard"
+        (mt/with-temporary-setting-values [map-tile-server-url "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"]
+          (is (= "img-src 'self' data: https://*.tile.openstreetmap.org"
+                 (csp-directive "img-src")))))
+      (testing "custom tile server host and port are allowed; path and query (e.g. api keys) are dropped"
+        (mt/with-temporary-setting-values [map-tile-server-url "https://tiles.example.com:8443/{z}/{x}/{y}.png?apikey=SECRET"]
+          (is (= "img-src 'self' data: https://tiles.example.com:8443"
+                 (csp-directive "img-src")))))
+      (testing "a relative tile template contributes no host"
+        (mt/with-temporary-setting-values [map-tile-server-url "/local/{z}/{x}/{y}.png"]
+          (is (= "img-src 'self' data:" (csp-directive "img-src"))))))))
 
 (deftest csp-header-font-src-tests
   (testing "font-src is restricted to 'self' and data: when no custom fonts are configured"
@@ -621,9 +640,10 @@
         (is (str/includes? (csp-directive "img-src") @#'mw.security/frontend-address))
         (is (str/includes? (csp-directive "font-src") @#'mw.security/frontend-address)))))
   (testing "in prod the dev server origin is not added"
-    (mt/with-temporary-setting-values [csp-img-enabled true]
+    (mt/with-temporary-setting-values [csp-img-enabled true
+                                       map-tile-server-url "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"]
       (with-redefs [config/is-dev? false]
-        (is (= "img-src 'self' data:" (csp-directive "img-src")))
+        (is (= "img-src 'self' data: https://*.tile.openstreetmap.org" (csp-directive "img-src")))
         (is (= "font-src 'self' data:" (csp-directive "font-src")))))))
 
 (deftest ^:parallel parse-allowed-resource-hosts-test


### PR DESCRIPTION
Closes [GDGT-2752](https://linear.app/metabase/issue/GDGT-2752)

### Description

Turning on `Restrict image domains` (`csp-img-enabled`) — which is required for Custom Visualizations — switched the CSP `img-src` from a permissive wildcard to a restricted allowlist that never included the map tile server. As a result, enabling Custom Visualizations silently broke map tiles, and the cause wasn't obvious to admins.

`img-src` now automatically includes the origin of the configured `map-tile-server-url`, covering both the built-in OpenStreetMap default and any custom server. This mirrors how custom font files are already folded into `font-src`. The `{s}` subdomain placeholder becomes a `*` wildcard (`https://{s}.tile.openstreetmap.org/...` → `https://*.tile.openstreetmap.org`).

Only affects the restricted branch — when image domains aren't restricted, `img-src` is still `*` and nothing changes.

### How to verify

1. Enable Custom Visualizations (this forces `Restrict image domains` on).
2. Open a pin map visualization.
3. Tiles should render, and the browser console should show **no** `Refused to load the image … violates … img-src` CSP error.
4. Set a custom `map-tile-server-url` (Admin → Settings → Maps), e.g. `https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png`, and confirm those tiles load too.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR