### PR TITLE
GDGT-2747 add index manager e2e tests

### DIFF
--- a/e2e/support/helpers/e2e-data-studio-helpers.ts
+++ b/e2e/support/helpers/e2e-data-studio-helpers.ts
@@ -36,6 +36,7 @@ export const DataStudio = {
     inspectTab: () => DataStudio.Transforms.header().findByText("Inspect"),
     targetTab: () => DataStudio.Transforms.header().findByText("Target"),
     settingsTab: () => DataStudio.Transforms.header().findByText("Settings"),
+    indexesTab: () => DataStudio.Transforms.header().findByText("Indexes"),
     dependenciesTab: () =>
       DataStudio.Transforms.header().findByText("Dependencies"),
     visit: () => {
@@ -50,6 +51,8 @@ export const DataStudio = {
     },
     visitSettingsTab: (transformId: TransformId) =>
       cy.visit(`/data-studio/transforms/${transformId}/settings`),
+    visitIndexes: (transformId: TransformId) =>
+      cy.visit(`/data-studio/transforms/${transformId}/indexes`),
     runButton: () => cy.findAllByTestId("run-button").eq(0),
     pythonResults: () => cy.findByTestId("python-results"),
     enableTransformPage: () => cy.findByTestId("enable-transform-page"),

--- a/e2e/support/helpers/e2e-qa-databases-helpers.js
+++ b/e2e/support/helpers/e2e-qa-databases-helpers.js
@@ -422,11 +422,19 @@ export function waitForSyncToFinish({
   });
 }
 
+/**
+ * @param {object} options
+ * @param {number} [options.dbId]
+ * @param {string} [options.tableName] - wait until this table is synced
+ * @param {string} [options.tableAlias] - alias to `cy.wrap` the synced table as
+ * @param {string[]} [options.tables] - wait until all of these tables are synced
+ * @param {boolean} [options.retrigger] - occasionally re-trigger the schema sync while waiting
+ */
 export function resyncDatabase({
   dbId = 2,
   tableName = "",
-  tableAlias = undefined, // TS was complaining that this was a required param
-  tables,
+  tableAlias = undefined,
+  tables = [],
   retrigger = false,
 }) {
   // must be signed in as admin to sync

--- a/e2e/support/helpers/e2e-qa-databases-helpers.js
+++ b/e2e/support/helpers/e2e-qa-databases-helpers.js
@@ -426,7 +426,7 @@ export function waitForSyncToFinish({
  * @param {object} options
  * @param {number} [options.dbId]
  * @param {string} [options.tableName] - wait until this table is synced
- * @param {string} [options.tableAlias] - alias to `cy.wrap` the synced table as
+ * @param {string} [options.tableAlias]
  * @param {string[]} [options.tables] - wait until all of these tables are synced
  * @param {boolean} [options.retrigger] - occasionally re-trigger the schema sync while waiting
  */

--- a/e2e/test/scenarios/data-studio/transforms/transforms-indexes.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms-indexes.cy.spec.ts
@@ -1,0 +1,207 @@
+import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
+import type { TransformId } from "metabase-types/api";
+
+const { H } = cy;
+
+const SOURCE_TABLE = "Animals";
+const TARGET_SCHEMA = "Schema A";
+
+const INDEX_TABLE_COLUMNS = [
+  "Name",
+  "Type",
+  "Columns",
+  "Source",
+  "Status",
+  "Last modified by",
+  "Last run",
+];
+
+describe("data-studio > transforms > indexes", { tags: ["@external"] }, () => {
+  beforeEach(() => {
+    H.restore("postgres-writable");
+    H.resetTestTable({ type: "postgres", table: "many_schemas" });
+    cy.signInAsAdmin();
+    H.activateToken("pro-self-hosted");
+    H.updateSetting("transforms-enabled", true);
+    H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: SOURCE_TABLE });
+
+    cy.intercept({ method: "GET", pathname: "/api/index" }).as("listIndexes");
+  });
+
+  it("shows the empty state for a transform with no indexes", () => {
+    H.createMbqlTransform({
+      sourceTable: SOURCE_TABLE,
+      targetTable: "indexes_empty_table",
+      targetSchema: TARGET_SCHEMA,
+      name: "Empty indexes transform",
+      visitTransform: true,
+    });
+
+    H.DataStudio.Transforms.indexesTab().click();
+    cy.wait("@listIndexes");
+
+    cy.findByTestId("transforms-indexes-content")
+      .should("contain", "Indexes")
+      .and(
+        "contain",
+        "Index the key columns of your transforms to make them faster and more efficient.",
+      );
+  });
+
+  it("lists managed index requests with pending and removing statuses and sorts by column", () => {
+    H.createMbqlTransform({
+      sourceTable: SOURCE_TABLE,
+      targetTable: "indexes_list_table",
+      targetSchema: TARGET_SCHEMA,
+      name: "Indexes list transform",
+    }).then(({ body: transform }) => {
+      createIndexRequest(transform.id, btreeIndex("idx_animal_name", ["name"]));
+      createIndexRequest(
+        transform.id,
+        btreeIndex("idx_animal_score", ["score", "name"]),
+      ).then(({ body: request }) => {
+        cy.request("DELETE", `/api/index/request/${request.id}`);
+      });
+      H.DataStudio.Transforms.visitIndexes(transform.id);
+    });
+
+    cy.wait("@listIndexes");
+
+    cy.log("all column headers render");
+    indexesTable().within(() => {
+      INDEX_TABLE_COLUMNS.forEach((header) => {
+        cy.findByRole("columnheader", { name: headerName(header) }).should(
+          "be.visible",
+        );
+      });
+    });
+
+    cy.log("pending request row shows all cell values");
+    indexesTable().findAllByRole("row").should("have.length", 2);
+    indexesTable()
+      .findAllByRole("row")
+      .eq(0)
+      .should("contain", "idx_animal_name")
+      .and("contain", "btree")
+      .and("contain", "name")
+      .and("contain", "Managed")
+      .and("contain", "Pending")
+      .and("contain", "Bobby Tables")
+      .and("contain", "Never");
+
+    cy.log("deleted request row shows the Removing status");
+    indexesTable()
+      .findAllByRole("row")
+      .eq(1)
+      .should("contain", "idx_animal_score")
+      .and("contain", "score, name")
+      .and("contain", "Removing");
+
+    cy.log("clicking the Name header toggles the sort direction");
+    indexesTable()
+      .findByRole("columnheader", { name: headerName("Name") })
+      .click();
+    indexesTable()
+      .findByRole("columnheader", { name: headerName("Name") })
+      .should("have.attr", "aria-sort", "descending");
+    indexesTable()
+      .findAllByRole("row")
+      .should("have.length", 2)
+      .eq(0)
+      .should("contain", "idx_animal_score");
+  });
+
+  it("shows a pending index becoming succeeded after a transform run and lists unmanaged warehouse indexes", () => {
+    const targetTable = "indexes_lifecycle_table";
+
+    cy.log("run the transform once so the target table exists");
+    H.createMbqlTransform({
+      sourceTable: SOURCE_TABLE,
+      targetTable,
+      targetSchema: TARGET_SCHEMA,
+      name: "Indexes lifecycle transform",
+    }).then(({ body: transform }) => {
+      H.runTransformAndWaitForSuccess(transform.id);
+      H.DataStudio.Transforms.visitIndexes(transform.id);
+    });
+    cy.wait("@listIndexes");
+
+    cy.log("create an index via the form");
+    cy.findByTestId("transforms-indexes-content")
+      .findByRole("button", { name: "Create index" })
+      .click();
+    H.modal().within(() => {
+      cy.findByLabelText("Give your index a name").type("idx_lifecycle_name");
+      cy.findByPlaceholderText("Select columns").click();
+    });
+    cy.findByRole("option", { name: "Name" }).click();
+    H.modal().within(() => {
+      cy.findByRole("button", { name: "Create index" }).click();
+    });
+    H.undoToast().findByText("Index created").should("be.visible");
+
+    cy.log("the new index request starts out pending and never run");
+    indexesTable()
+      .findAllByRole("row")
+      .should("have.length", 1)
+      .eq(0)
+      .should("contain", "idx_lifecycle_name")
+      .and("contain", "Managed")
+      .and("contain", "Pending")
+      .and("contain", "Never");
+
+    cy.log("run the transform from the run tab");
+    H.DataStudio.Transforms.runTab().click();
+    H.DataStudio.Transforms.runButton().click();
+    H.DataStudio.Transforms.runButton().should("have.text", "Ran successfully");
+
+    cy.log("simulate a DBA-created index directly in the warehouse");
+    H.queryWritableDB(
+      `CREATE INDEX dba_made ON "${TARGET_SCHEMA}"."${targetTable}" (score)`,
+    );
+
+    cy.log("the applied index request shows Succeeded and a last run date");
+    H.DataStudio.Transforms.indexesTab().click();
+    cy.wait("@listIndexes");
+    indexesTable().findAllByRole("row").should("have.length", 2);
+    indexesTable()
+      .findAllByRole("row")
+      .eq(1)
+      .should("contain", "idx_lifecycle_name")
+      .and("contain", "Managed")
+      .and("contain", "Succeeded")
+      .and("not.contain", "Never");
+
+    cy.log("the DBA-created index is listed as unmanaged with no status");
+    indexesTable()
+      .findAllByRole("row")
+      .eq(0)
+      .should("contain", "dba_made")
+      .and("contain", "score")
+      .and("contain", "Unmanaged")
+      .and("contain", "—");
+  });
+});
+
+function btreeIndex(name: string, columns: string[]) {
+  return {
+    kind: "btree",
+    name,
+    columns: columns.map((column) => ({ name: column })),
+  };
+}
+
+function createIndexRequest(transformId: TransformId, structured: object) {
+  return cy.request("POST", "/api/index/request", {
+    transform_id: transformId,
+    structured,
+  });
+}
+
+function indexesTable() {
+  return cy.findByRole("treegrid", { name: "Transform indexes" });
+}
+
+function headerName(label: string) {
+  return new RegExp(`^${label}`);
+}

--- a/e2e/test/scenarios/data-studio/transforms/transforms-indexes.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms-indexes.cy.spec.ts
@@ -28,26 +28,6 @@ describe("data-studio > transforms > indexes", { tags: ["@external"] }, () => {
     cy.intercept({ method: "GET", pathname: "/api/index" }).as("listIndexes");
   });
 
-  it("shows the empty state for a transform with no indexes", () => {
-    H.createMbqlTransform({
-      sourceTable: SOURCE_TABLE,
-      targetTable: "indexes_empty_table",
-      targetSchema: TARGET_SCHEMA,
-      name: "Empty indexes transform",
-      visitTransform: true,
-    });
-
-    H.DataStudio.Transforms.indexesTab().click();
-    cy.wait("@listIndexes");
-
-    cy.findByTestId("transforms-indexes-content")
-      .should("contain", "Indexes")
-      .and(
-        "contain",
-        "Index the key columns of your transforms to make them faster and more efficient.",
-      );
-  });
-
   it("lists managed index requests with pending and removing statuses and sorts by column", () => {
     H.createMbqlTransform({
       sourceTable: SOURCE_TABLE,
@@ -126,10 +106,32 @@ describe("data-studio > transforms > indexes", { tags: ["@external"] }, () => {
     });
     cy.wait("@listIndexes");
 
+    cy.log("the empty state renders for a transform with no indexes");
+    cy.findByTestId("transforms-indexes-content")
+      .should("contain", "Indexes")
+      .and(
+        "contain",
+        "Index the key columns of your transforms to make them faster and more efficient.",
+      );
+
     cy.log("create an index via the form");
     cy.findByTestId("transforms-indexes-content")
       .findByRole("button", { name: "Create index" })
       .click();
+
+    cy.log("form fields render in the backend-defined order, name first");
+    H.modal()
+      .find("label")
+      .should((labels) => {
+        const labelTexts = labels.toArray().map((label) => label.textContent);
+        expect(labelTexts).to.deep.equal([
+          "Give your index a name",
+          "Index type",
+          "Enforce uniqueness across rows for indexed columns.",
+          "Columns",
+        ]);
+      });
+
     H.modal().within(() => {
       cy.findByLabelText("Give your index a name").type("idx_lifecycle_name");
       cy.findByPlaceholderText("Select columns").click();

--- a/e2e/test/scenarios/data-studio/transforms/transforms-indexes.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms-indexes.cy.spec.ts
@@ -24,8 +24,6 @@ describe("data-studio > transforms > indexes", { tags: ["@external"] }, () => {
     H.activateToken("pro-self-hosted");
     H.updateSetting("transforms-enabled", true);
     H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: SOURCE_TABLE });
-
-    cy.intercept({ method: "GET", pathname: "/api/index" }).as("listIndexes");
   });
 
   it("lists managed index requests with pending and removing statuses and sorts by column", () => {
@@ -45,12 +43,10 @@ describe("data-studio > transforms > indexes", { tags: ["@external"] }, () => {
       H.DataStudio.Transforms.visitIndexes(transform.id);
     });
 
-    cy.wait("@listIndexes");
-
     cy.log("all column headers render");
     indexesTable().within(() => {
       INDEX_TABLE_COLUMNS.forEach((header) => {
-        cy.findByRole("columnheader", { name: headerName(header) }).should(
+        cy.findByRole("columnheader", { name: matchHeaderName(header) }).should(
           "be.visible",
         );
       });
@@ -79,10 +75,10 @@ describe("data-studio > transforms > indexes", { tags: ["@external"] }, () => {
 
     cy.log("clicking the Name header toggles the sort direction");
     indexesTable()
-      .findByRole("columnheader", { name: headerName("Name") })
+      .findByRole("columnheader", { name: matchHeaderName("Name") })
       .click();
     indexesTable()
-      .findByRole("columnheader", { name: headerName("Name") })
+      .findByRole("columnheader", { name: matchHeaderName("Name") })
       .should("have.attr", "aria-sort", "descending");
     indexesTable()
       .findAllByRole("row")
@@ -104,7 +100,6 @@ describe("data-studio > transforms > indexes", { tags: ["@external"] }, () => {
       H.runTransformAndWaitForSuccess(transform.id);
       H.DataStudio.Transforms.visitIndexes(transform.id);
     });
-    cy.wait("@listIndexes");
 
     cy.log("the empty state renders for a transform with no indexes");
     cy.findByTestId("transforms-indexes-content")
@@ -164,7 +159,6 @@ describe("data-studio > transforms > indexes", { tags: ["@external"] }, () => {
 
     cy.log("the applied index request shows Succeeded and a last run date");
     H.DataStudio.Transforms.indexesTab().click();
-    cy.wait("@listIndexes");
     indexesTable().findAllByRole("row").should("have.length", 2);
     indexesTable()
       .findAllByRole("row")
@@ -204,6 +198,6 @@ function indexesTable() {
   return cy.findByRole("treegrid", { name: "Transform indexes" });
 }
 
-function headerName(label: string) {
+function matchHeaderName(label: string) {
   return new RegExp(`^${label}`);
 }

--- a/frontend/src/metabase/api/transform.ts
+++ b/frontend/src/metabase/api/transform.ts
@@ -68,6 +68,7 @@ export const transformApi = Api.injectEndpoints({
           tag("table"),
           listTag("table-remapping"),
           listTag("transform-run"),
+          listTag("table-index"),
         ]),
       onQueryStarted: async (id, { dispatch, queryFulfilled }) => {
         const patchResult = dispatch(


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2747/add-index-manager-e2e-tests

### Description

Standard set of e2e tests to cover core of index manager functionality.

### How to verify

### Demo

<img width="2770" height="1378" alt="image" src="https://github.com/user-attachments/assets/592ea21b-4e7d-4743-bc71-73be9bf43d4a" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Indexes** tab to the Data Studio Transforms area, with direct navigation to view transform-related indexes.
  * Added end-to-end coverage for index creation, status changes, sorting, and empty states.

* **Bug Fixes**
  * Improved refresh behavior so transform runs update index-related data more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->