### PR TITLE
background warming of transform table deps

### DIFF
--- a/src/metabase/transforms/dependency_warming.clj
+++ b/src/metabase/transforms/dependency_warming.clj
@@ -1,0 +1,63 @@
+(ns metabase.transforms.dependency-warming
+  "Background warming of the transform `table_dependencies` cache, so job/plan reads don't pay the
+  cold-cache cost of computing dependencies live."
+  (:require
+   [metabase.events.core :as events]
+   [metabase.task.core :as task]
+   [metabase.transforms-base.ordering :as transforms-base.ordering]
+   [metabase.util.jvm :as u.jvm]
+   [metabase.util.log :as log]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- warmed-deps
+  "`[id raw-deps]` to cache for `transform`, or nil if it's already cached, reads through a
+  card/snippet (whose deps drift independently), or fails to compute."
+  [{:keys [id table_dependencies] :as transform}]
+  (when (and (nil? table_dependencies)
+             (not (transforms-base.ordering/references-card-or-snippet? transform)))
+    (try
+      [id (transforms-base.ordering/stored-or-live-deps transform)]
+      (catch Throwable e
+        (log/warnf e "Failed to warm table-dependencies for transform %s" id)))))
+
+(defn warm-transform-dependencies!
+  "Compute and persist `:table_dependencies` for transform `id`."
+  [id]
+  (when-let [entry (some-> (t2/select-one [:model/Transform :id :source :table_dependencies] id)
+                           warmed-deps)]
+    (transforms-base.ordering/persist-table-dependencies! (conj {} entry))))
+
+(defn warm-all-table-dependencies!
+  "Warm every transform whose `:table_dependencies` is still `nil`. Returns the number warmed."
+  []
+  (let [warmed (into {}
+                     (keep warmed-deps)
+                     (t2/select [:model/Transform :id :source :table_dependencies] :table_dependencies nil))]
+    (transforms-base.ordering/persist-table-dependencies! warmed)
+    (count warmed)))
+
+;; Warm off the request thread on API create/update. Subscribe to the crud-layer events (not the
+;; model-layer ones) so raw inserts and bulk serdes imports don't each spawn a warm.
+(derive ::warm-transform :metabase/event)
+(derive :event/transform-create ::warm-transform)
+(derive :event/transform-update ::warm-transform)
+
+(methodical/defmethod events/publish-event! ::warm-transform
+  [_topic {transform :object}]
+  (when-let [id (:id transform)]
+    (u.jvm/in-virtual-thread*
+     (try
+       (warm-transform-dependencies! id)
+       (catch Throwable e
+         (log/warnf e "Failed to warm table-dependencies for transform %s" id))))))
+
+;; One-shot backfill of pre-existing `nil` rows, in the background so startup isn't blocked.
+(defmethod task/init! ::WarmTransformDependencies [_]
+  (u.jvm/in-virtual-thread*
+   (try
+     (warm-all-table-dependencies!)
+     (catch Throwable e
+       (log/warn e "Failed to warm transform table-dependencies on startup")))))

--- a/src/metabase/transforms/init.clj
+++ b/src/metabase/transforms/init.clj
@@ -1,6 +1,7 @@
 (ns metabase.transforms.init
   (:require
    [metabase.transforms.canceling]
+   [metabase.transforms.dependency-warming]
    [metabase.transforms.jobs]
    [metabase.transforms.models.job-run]
    [metabase.transforms.models.transform]

--- a/test/metabase/transforms/dependency_warming_test.clj
+++ b/test/metabase/transforms/dependency_warming_test.clj
@@ -1,0 +1,52 @@
+(ns ^:mb/driver-tests metabase.transforms.dependency-warming-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.driver :as driver]
+   [metabase.driver.sql :as driver.sql]
+   [metabase.test :as mt]
+   [metabase.transforms.dependency-warming :as dependency-warming]
+   [toucan2.core :as t2]))
+
+(defn- default-schema-or-public []
+  (or (and driver/*driver* (driver.sql/default-schema driver/*driver*)) "public"))
+
+(defn- make-transform [query]
+  (let [name (mt/random-name)]
+    {:source {:type :query :query query}
+     :name   (str "transform_" name)
+     :target {:schema (default-schema-or-public) :name name :type :table}}))
+
+(defn- uncache! [id]
+  (t2/update! (t2/table-name :model/Transform) id {:table_dependencies nil}))
+
+(deftest warm-transform-dependencies-test
+  (mt/test-driver (mt/normal-driver-select {:+parent :sql-jdbc})
+    (mt/with-temp [:model/Transform {id :id} (make-transform {:database (mt/id)
+                                                              :type     "query"
+                                                              :query    {:source-table (mt/id :orders)}})]
+      (uncache! id)
+      (mt/with-metadata-provider (mt/id)
+        (testing "warms a transform whose deps are nil"
+          (dependency-warming/warm-transform-dependencies! id)
+          (is (= [{:table (mt/id :orders)}]
+                 (t2/select-one-fn :table_dependencies :model/Transform id))))
+        (testing "leaves an already-cached transform untouched"
+          (t2/update! (t2/table-name :model/Transform) id {:table_dependencies "[{\"table\":-1}]"})
+          (dependency-warming/warm-transform-dependencies! id)
+          (is (= [{:table -1}]
+                 (t2/select-one-fn :table_dependencies :model/Transform id))))))))
+
+(deftest warm-all-table-dependencies-test
+  (mt/test-driver (mt/normal-driver-select {:+parent :sql-jdbc})
+    (mt/with-temp [:model/Transform {t1 :id} (make-transform {:database (mt/id)
+                                                             :type     "query"
+                                                             :query    {:source-table (mt/id :orders)}})
+                   :model/Transform {t2 :id} (make-transform {:database (mt/id)
+                                                             :type     "query"
+                                                             :query    {:source-table (mt/id :products)}})]
+      (uncache! t1)
+      (uncache! t2)
+      (mt/with-metadata-provider (mt/id)
+        (is (= 2 (dependency-warming/warm-all-table-dependencies!)))
+        (is (= [{:table (mt/id :orders)}] (t2/select-one-fn :table_dependencies :model/Transform t1)))
+        (is (= [{:table (mt/id :products)}] (t2/select-one-fn :table_dependencies :model/Transform t2)))))))

--- a/test/metabase/transforms/dependency_warming_test.clj
+++ b/test/metabase/transforms/dependency_warming_test.clj
@@ -39,11 +39,11 @@
 (deftest warm-all-table-dependencies-test
   (mt/test-driver (mt/normal-driver-select {:+parent :sql-jdbc})
     (mt/with-temp [:model/Transform {t1 :id} (make-transform {:database (mt/id)
-                                                             :type     "query"
-                                                             :query    {:source-table (mt/id :orders)}})
+                                                              :type     "query"
+                                                              :query    {:source-table (mt/id :orders)}})
                    :model/Transform {t2 :id} (make-transform {:database (mt/id)
-                                                             :type     "query"
-                                                             :query    {:source-table (mt/id :products)}})]
+                                                              :type     "query"
+                                                              :query    {:source-table (mt/id :products)}})]
       (uncache! t1)
       (uncache! t2)
       (mt/with-metadata-provider (mt/id)


### PR DESCRIPTION
Closes [GDGT-2757: Transform job page can be very slow to load on a cold cache](https://linear.app/metabase/issue/GDGT-2757/transform-job-page-can-be-very-slow-to-load-on-a-cold-cache)