### PR TITLE
Update c3p0 version

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -54,7 +54,7 @@
   {:mvn/version "2.1.214"}            ; embedded SQL database
   com.ibm.icu/icu4j                         {:mvn/version "78.1"}               ; Used to transliterate Unicode characters into Latin characters
   com.knuddels/jtokkit                      {:mvn/version "1.1.0"}              ; Java tokenizer library for OpenAI models, used for token counting in semantic search
-  com.mchange/c3p0                          {:mvn/version "0.12.0"}             ; DB connection pool
+  com.mchange/c3p0                          {:mvn/version "0.14.1"}             ; DB connection pool
   com.snowplowanalytics/snowplow-java-tracker ^:antq/exclude                    ; 2+ depend on apache httpclient 5.x, but saml and clj-http depend on 4.x
   {:mvn/version "1.0.1"}              ; Snowplow analytics
   com.sun.mail/jakarta.mail                 ^:antq/exclude                      ; 2+ changes imports from javax.mail to jakarta.mail


### PR DESCRIPTION
Update c3p0 version that updates mchange-commons-java version to 0.6.1

As alternative i can only pin mchange-commons-java

Closes https://github.com/metabase/metabase/security/code-scanning/869