### PR TITLE
fix: move data complexity lower on the stats page

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/ConversationStatsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/ConversationStatsPage.tsx
@@ -263,7 +263,6 @@ export function ConversationStatsPage({ location }: WithRouterProps) {
         mt="sm"
         title={hasDataComplexityFeature ? t`Usage stats` : undefined}
       >
-        <DataComplexitySection />
         <Flex align="center" justify="space-between">
           {hasDataComplexityFeature ? (
             <Title order={3} display="flex" style={{ alignItems: "center" }}>
@@ -372,6 +371,8 @@ export function ConversationStatsPage({ location }: WithRouterProps) {
             h={500}
           />
         </SimpleGrid>
+
+        <DataComplexitySection />
       </SettingsPageWrapper>
     </MetabotAdminLayout>
   );

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.module.css
@@ -1,3 +1,9 @@
+.cardButton {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
 .accordionRoot {
   display: flex;
   flex-direction: column;

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.module.css
@@ -1,9 +1,3 @@
-.cardButton {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-}
-
 .accordionRoot {
   display: flex;
   flex-direction: column;

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.tsx
@@ -74,7 +74,7 @@ function DataComplexityCardSkeleton() {
         <Skeleton h={14} />
       </Box>
       <Stack align="center" gap={0} my="sm">
-        <Skeleton h="4rem" w="30%" />
+        <Skeleton h="3rem" w="30%" />
       </Stack>
     </Card>
   );
@@ -99,22 +99,23 @@ function DataComplexityCard({
     }))
     .with("metabot", () => ({
       title: t`Metabot-visible layer`,
-      subtitle: t`The subset the internal Metabot can surface with its current scope.`,
+      subtitle: t`The subset the internal Metabot can see.`,
     }))
     .exhaustive();
 
   return (
     <Card withBorder shadow="none" p="md">
-      <UnstyledButton onClick={open}>
+      <UnstyledButton onClick={open} className={S.cardButton}>
         <Flex align="center" justify="space-between" gap="sm">
           <Text fw={700}>{title}</Text>
           <Icon name="expand" c="text-disabled" />
         </Flex>
         <Text c="text-secondary">{subtitle}</Text>
         {catalog.score !== null ? (
-          <Stack align="center" gap="sm" my="sm">
+          <Stack align="center" gap="sm" pt="sm" mt="auto" mb="sm">
             <Text
-              size="4rem"
+              size="2.5rem"
+              lh="3rem"
               fw={700}
               c={RATING_TEXT_COLORS[catalog.rating ?? "default"]}
             >
@@ -123,7 +124,7 @@ function DataComplexityCard({
             <Text c="text-secondary">{catalog.rating_label}</Text>
           </Stack>
         ) : (
-          <Stack gap={4} my="sm">
+          <Stack align="center" ta="center" gap={4} pt="sm" mt="auto" mb="sm">
             <Text c="feedback-negative" fw={700}>{t`Score unavailable`}</Text>
             <Text c="text-secondary">{t`Open for component details.`}</Text>
           </Stack>

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/DataComplexityCards.tsx
@@ -105,7 +105,7 @@ function DataComplexityCard({
 
   return (
     <Card withBorder shadow="none" p="md">
-      <UnstyledButton onClick={open} className={S.cardButton}>
+      <Stack component={UnstyledButton} onClick={open} flex={1} gap={0}>
         <Flex align="center" justify="space-between" gap="sm">
           <Text fw={700}>{title}</Text>
           <Icon name="expand" c="text-disabled" />
@@ -129,7 +129,7 @@ function DataComplexityCard({
             <Text c="text-secondary">{t`Open for component details.`}</Text>
           </Stack>
         )}
-      </UnstyledButton>
+      </Stack>
 
       <Modal
         opened={isModalOpen}

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/__snapshots__/DataComplexityCards.unit.spec.tsx.snap
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationStatsPage/__snapshots__/DataComplexityCards.unit.spec.tsx.snap
@@ -109,7 +109,7 @@ exports[`DataComplexityCards renders the data complexity cards 1`] = `
           color="text-primary"
           data-size="md"
         >
-          The subset the internal Metabot can surface with its current scope.
+          The subset the internal Metabot can see.
         </div>
         <div>
           <div


### PR DESCRIPTION
Closes [BOT-1797: Move data complexity lower on the stats page](https://linear.app/metabase/issue/BOT-1797/move-data-complexity-lower-on-the-stats-page)

### Description

Move data complexity lower on the stats page, decrease font size and copy length.

### How to verify

1. Go to Admin settings -> AI.
2. Scroll down to the data complexity section.

### Demo

<img width="1840" height="1120" alt="image" src="https://github.com/user-attachments/assets/627935fd-e9d2-40d6-8c1c-7b2a52c35394" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
