### PR TITLE
Make read resource return dashcards for items

### DIFF
--- a/resources/metabot/skills/read-resource.md
+++ b/resources/metabot/skills/read-resource.md
@@ -140,14 +140,14 @@ You can request multiple resources in one call by providing a list of URIs (max 
 ## Dashboard resources
 
 - `metabase://dashboard/{id}` — dashboard details
-- `metabase://dashboard/{id}/items` — cards on the dashboard (each rendered as a `metabase://question/{id}` URI you can drill into)
+- `metabase://dashboard/{id}/items` — all of the dashboard's dashcards in grid reading order (top-to-bottom, left-to-right). Each item is a dashcard: a card's slot on this dashboard, identified by `dashcard_id` — the id dashboard-editing tools use to reference it. `card_type` says what the slot holds. For saved cards (`question`/`model`/`metric`) the item carries the underlying card's `card_id`, `name`, and a `uri` you can drill into for details — or `restricted` when you can't read that card. For `text`/`heading` the content is the item body; `link` carries its URL; `iframe` and `action` appear by type only. A question placed twice on a dashboard appears as two dashcards with distinct `dashcard_id`s but the same `card_id`.
 
 **Examples:**
 - Want to understand what a dashboard contains before recommending it? → `metabase://dashboard/158`
 - User asks "what's on this dashboard?" → `metabase://dashboard/158/items`
 
 **Best Practices:**
-- Treat dashboards as containers — when search returns a dashboard hit (`is_container="true"`), use `/items` to list its cards instead of re-searching for the same concept.
+- Treat dashboards as containers — when search returns a dashboard hit (`is_container="true"`), use `/items` to list its contents instead of re-searching for the same concept.
 - Fetch dashboard details to confirm it contains the information the user is looking for before recommending it.
 - Prefer verified dashboards when they match the user's request.
 

--- a/src/metabase/metabot/tools/resources.clj
+++ b/src/metabase/metabot/tools/resources.clj
@@ -56,7 +56,10 @@
   - metabase://transform/{id}/sources - tables/databases this transform reads from
   - metabase://transform/{id}/target - table this transform writes to
   - metabase://dashboard/{id} - dashboard details
-  - metabase://dashboard/{id}/items - cards on the dashboard"
+  - metabase://dashboard/{id}/items - all of the dashboard's dashcards, one item per dashcard
+    with its dashcard_id; card_type says what the slot holds (question/model/metric with the
+    underlying card's card_id + uri, text/heading with the text as the item body, link/iframe/
+    action, or restricted when the underlying card isn't readable)"
   (:require
    [clojure.string :as str]
    [metabase.activity-feed.core :as activity-feed]
@@ -569,22 +572,58 @@
       {:structured-output (assoc dashboard :result-type :entity)}
       {:status-code 404 :output (:output result)})))
 
-(defn- fetch-dashboard-items [id-str query-params]
+(defn- virtual-display
+  "The virtual-card display of a cardless dashcard (\"text\", \"heading\", \"link\", \"iframe\")
+  as a string, or nil for question dashcards. `name` tolerates both the string the JSON
+  round-trip produces and a keyword from an in-process write."
+  [dashcard]
+  (some-> (get-in dashcard [:visualization_settings :virtual_card :display]) name))
+
+(defn- present-dashcard
+  "One list item per dashcard (a card's slot on the dashboard). Every dashcard is returned —
+  layout operations (remove/move/edit) need each slot to be addressable by `:dashcard_id`
+  even when its content can't be shown. `:card_type` says what the slot holds:
+
+  - question / model / metric — a saved card, flattened in: its id under `:card_id`, plus
+    `:name`, `:description`, and a `:uri` to drill into. Becomes `restricted` (no card
+    details) when the current user can't read the underlying card.
+  - text / heading — virtual content living on the dashcard itself; the text rides in
+    `:description` (the item body).
+  - link / iframe / action — other virtual dashcard types; links carry their URL."
+  [{dashcard-id :id :keys [card card_id action_id visualization_settings] :as dashcard}]
+  (let [base {:type "dashcard" :dashcard_id dashcard-id}]
+    (cond
+      card_id
+      (if (and card (mi/can-read? card))
+        (let [{card-type :type :as presented} (present-card card)]
+          (-> presented
+              (dissoc :id)
+              (merge base)
+              (assoc :card_type card-type
+                     :card_id   card_id)))
+        (assoc base :card_type "restricted"))
+
+      action_id
+      (assoc base :card_type "action")
+
+      :else
+      (let [display (or (virtual-display dashcard) "unknown")]
+        (cond-> (assoc base :card_type display)
+          (#{"text" "heading"} display) (assoc :description (:text visualization_settings))
+          (= "link" display)            (assoc :description (get-in visualization_settings [:link :url])))))))
+
+(defn- fetch-dashboard-items
+  "The dashboard's dashcards in grid reading order (top-to-bottom, left-to-right), with each
+  dashcard's underlying Card hydrated and presented per [[present-dashcard]]."
+  [id-str query-params]
   (let [dashboard-id (parse-long id-str)
         _            (api/read-check :model/Dashboard dashboard-id)
-        cards        (->> (t2/select [:model/Card :id :name :type :description :card_schema
-                                      :collection_id :database_id :table_id]
-                                     {:where    [:and
-                                                 [:= :archived false]
-                                                 [:exists {:select 1
-                                                           :from   [[:report_dashboardcard :dc]]
-                                                           :where  [:and
-                                                                    [:= :dc.card_id :report_card.id]
-                                                                    [:= :dc.dashboard_id dashboard-id]]}]]
-                                      :order-by [[:%lower.name :asc]]})
-                          (filter mi/can-read?)
-                          (mapv present-card))]
-    (list-result :dashboard-items cards query-params)))
+        items        (-> (t2/select :model/DashboardCard
+                                    :dashboard_id dashboard-id
+                                    {:order-by [[:row :asc] [:col :asc]]})
+                         (t2/hydrate :card)
+                         (->> (mapv present-dashcard)))]
+    (list-result :dashboard-items items query-params)))
 
 ;; ----- Dispatch -----
 

--- a/src/metabase/metabot/tools/shared/llm_shape.clj
+++ b/src/metabase/metabot/tools/shared/llm_shape.clj
@@ -859,7 +859,7 @@
 
 (def ^:private item-attr-keys
   "Attributes rendered as XML attrs on each <item> element. Order matters for stable output."
-  [:type :id :name :uri :database_id :collection_id :table_id
+  [:type :id :dashcard_id :card_type :card_id :name :uri :database_id :collection_id :table_id
    :schema :display_name :authority_level :is_personal :path :location
    :engine :timestamp])
 

--- a/test/metabase/metabot/tools/resources_test.clj
+++ b/test/metabase/metabot/tools/resources_test.clj
@@ -414,14 +414,72 @@
               (is (not (str/includes? output "HIDDEN-TBL"))
                   "unreadable table must not appear in the database tables list"))))))))
 
+(deftest read-dashboard-items-dashcards-test
+  (testing "metabase://dashboard/{id}/items returns one item per dashcard, with dashcard_id"
+    (mt/with-current-user (mt/user->id :crowberto)
+      (mt/with-temp [:model/Dashboard     {dash-id :id}    {}
+                     :model/Card          {card-id :id}    {:name "DASH-QUESTION"}
+                     :model/DashboardCard {heading-dc :id} {:dashboard_id dash-id
+                                                            :row 0 :col 0 :size_x 24 :size_y 1
+                                                            :visualization_settings
+                                                            {:virtual_card {:display "heading"}
+                                                             :text         "Q3 RESULTS"}}
+                     :model/DashboardCard {text-dc :id}    {:dashboard_id dash-id
+                                                            :row 1 :col 0 :size_x 12 :size_y 3
+                                                            :visualization_settings
+                                                            {:virtual_card {:display "text"}
+                                                             :text         "NARRATIVE-BODY"}}
+                     :model/DashboardCard {q-dc :id}       {:dashboard_id dash-id :card_id card-id
+                                                            :row 4 :col 0 :size_x 12 :size_y 6}
+                     ;; Other virtual types are returned too, so their slot stays addressable.
+                     :model/DashboardCard {link-dc :id}    {:dashboard_id dash-id
+                                                            :row 1 :col 12 :size_x 8 :size_y 1
+                                                            :visualization_settings
+                                                            {:virtual_card {:display "link"}
+                                                             :link         {:url "https://link-card.example.com"}}}]
+        (let [{:keys [resources output]} (read-resource/read-resource
+                                          {:uris [(str "metabase://dashboard/" dash-id "/items")]})
+              items (get-in (first resources) [:content :structured-output :items])]
+          ;; Grid reading order: heading (row 0), text then link (row 1), question (row 4).
+          (is (=? [{:type "dashcard" :dashcard_id heading-dc :card_type "heading"
+                    :description "Q3 RESULTS"}
+                   {:type "dashcard" :dashcard_id text-dc :card_type "text"
+                    :description "NARRATIVE-BODY"}
+                   {:type "dashcard" :dashcard_id link-dc :card_type "link"
+                    :description "https://link-card.example.com"}
+                   {:type "dashcard" :dashcard_id q-dc :card_type "question" :card_id card-id
+                    :name "DASH-QUESTION" :uri (str "metabase://question/" card-id)}]
+                  items))
+          (is (= 4 (count items)))
+          ;; dashcard_id, the card pointer, and text content must survive into the LLM-facing XML.
+          (is (str/includes? output (str "dashcard_id=\"" text-dc "\"")))
+          (is (str/includes? output (str "dashcard_id=\"" q-dc "\" card_type=\"question\" card_id=\"" card-id "\"")))
+          (is (str/includes? output "NARRATIVE-BODY"))
+          (is (str/includes? output "link-card.example.com")))))))
+
+(deftest read-dashboard-items-duplicate-card-test
+  (testing "a card appearing twice on a dashboard yields two items with distinct dashcard_ids"
+    (mt/with-current-user (mt/user->id :crowberto)
+      (mt/with-temp [:model/Dashboard     {dash-id :id} {}
+                     :model/Card          {card-id :id} {:name "TWICE-ON-DASH"}
+                     :model/DashboardCard {dc1 :id}     {:dashboard_id dash-id :card_id card-id
+                                                         :row 0 :col 0 :size_x 12 :size_y 6}
+                     :model/DashboardCard {dc2 :id}     {:dashboard_id dash-id :card_id card-id
+                                                         :row 0 :col 12 :size_x 12 :size_y 6}]
+        (let [{:keys [resources]} (read-resource/read-resource
+                                   {:uris [(str "metabase://dashboard/" dash-id "/items")]})
+              items (get-in (first resources) [:content :structured-output :items])]
+          (is (= [[card-id dc1] [card-id dc2]]
+                 (map (juxt :card_id :dashcard_id) items))))))))
+
 (deftest list-filters-dashboard-items-by-can-read-test
-  (testing "metabase://dashboard/{id}/items hides cards the user can't read"
+  (testing "metabase://dashboard/{id}/items presents unreadable cards as restricted dashcards"
     (mt/with-current-user (mt/user->id :crowberto)
       (mt/with-temp [:model/Dashboard     {dash-id :id}      {}
                      :model/Card          {visible-card :id} {:name "VISIBLE-DASHCARD"}
                      :model/Card          {hidden-card :id}  {:name "HIDDEN-DASHCARD"}
                      :model/DashboardCard _                  {:dashboard_id dash-id :card_id visible-card}
-                     :model/DashboardCard _                  {:dashboard_id dash-id :card_id hidden-card}]
+                     :model/DashboardCard {hidden-dc :id}    {:dashboard_id dash-id :card_id hidden-card}]
         (let [orig mi/can-read?]
           (with-redefs [mi/can-read? (fn
                                        ([instance]
@@ -433,8 +491,10 @@
             (let [{:keys [output]} (read-resource/read-resource
                                     {:uris [(str "metabase://dashboard/" dash-id "/items")]})]
               (is (str/includes? output "VISIBLE-DASHCARD"))
+              ;; The slot stays addressable, but no card details leak.
+              (is (str/includes? output (str "dashcard_id=\"" hidden-dc "\" card_type=\"restricted\"")))
               (is (not (str/includes? output "HIDDEN-DASHCARD"))
-                  "unreadable card must not appear in dashboard items"))))))))
+                  "unreadable card's details must not appear in dashboard items"))))))))
 
 (deftest read-transform-target-authorization-test
   (testing "fetch-transform-target gates the target table by mi/can-read?"


### PR DESCRIPTION
Prerequisite for successful completion of [BOT-1764: Allow MCP server to create text cards](https://linear.app/metabase/issue/BOT-1764/allow-mcp-server-to-create-text-cards) and [GHY-3650: Allow the MCP server to create headings on dashboards](https://linear.app/metabase/issue/GHY-3650/allow-the-mcp-server-to-create-headings-on-dashboards)

WIP

### Description

The `metabase://dashboard/{id}/items` of `read_resource` returns cards, not the dashcards. Agent API PUT /dashboard/:id can edit dashcards and hints use of that read_resource form to get dashboard id. That is incorrect.

To address linked issues not only create but also update should be implemented. Hence we need the dashcard references working first.

### How to verify

WIP

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
