### PR TITLE
Move  only show attachments toggle for email subscriptions

### DIFF
--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -378,7 +378,9 @@ describe("scenarios > dashboard > subscriptions", () => {
         .should("not.be.checked")
         .click({ force: true }); // Input is placed behind the lable due to tooltip in label
       cy.findByLabelText("Questions to attach").click();
-      cy.findByLabelText("Send only attachments").click();
+      cy.findByLabelText("Send only attachments")
+        .should("not.be.checked")
+        .click({ force: true }); // Input is placed behind the lable due to tooltip in label
       cy.findByLabelText("Send only attachments").should("be.checked");
 
       H.sendEmailAndAssert((email) => {

--- a/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/AddEditEmailSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/AddEditEmailSidebar.tsx
@@ -89,22 +89,6 @@ export const AddEditEmailSidebar = ({
     (card) => card.download_perms !== DataPermissionValue.NONE,
   );
 
-  // Whether to attach a server-rendered PDF of the whole dashboard. Stored per-channel in
-  // `details.include_pdf` (the same place as `attachment_only`); the BE reads it on the email path.
-  const includePdf =
-    allowDownload &&
-    pulse.channels.some((channel) => !!channel.details?.include_pdf);
-
-  const handleToggleIncludePdf = (checked: boolean) => {
-    setPulse({
-      ...pulse,
-      channels: pulse.channels.map((channel) => ({
-        ...channel,
-        details: { ...channel.details, include_pdf: checked },
-      })),
-    });
-  };
-
   useEffect(() => {
     if (isEmbeddingSdk()) {
       onChannelPropertyChange("recipients", [currentUser]);
@@ -198,17 +182,6 @@ export const AddEditEmailSidebar = ({
             classNames={{
               body: S.SwitchBody,
             }}
-          />
-          <Switch
-            checked={includePdf}
-            onChange={(e) => handleToggleIncludePdf(e.target.checked)}
-            disabled={!allowDownload}
-            classNames={{
-              body: S.SwitchBody,
-              input: S.SwitchInput,
-            }}
-            label={<Text fw="bold">{t`Attach a PDF of the dashboard`}</Text>}
-            labelPosition="left"
           />
           <EmailAttachmentPicker
             cards={pulse.cards}

--- a/frontend/src/metabase/notifications/EmailAttachmentPicker.tsx
+++ b/frontend/src/metabase/notifications/EmailAttachmentPicker.tsx
@@ -11,7 +11,6 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { ExportSettingsWidget } from "metabase/common/components/ExportSettingsWidget";
-import { Toggle } from "metabase/common/components/Toggle";
 import type { ExportFormat } from "metabase/common/types/export";
 import CS from "metabase/css/core/index.css";
 import type { DraftDashboardSubscription } from "metabase/redux/store";
@@ -251,6 +250,13 @@ export function EmailAttachmentPicker({
   }, [cards, pulse]);
 
   const canAttachFiles = !!allowDownload;
+
+  // Whether to attach a server-rendered PDF of the whole dashboard, stored per-channel in
+  // `details.include_pdf` alongside `attachment_only`. The BE reads it on the email path.
+  const includePdf =
+    canAttachFiles &&
+    pulse.channels.some((channel) => !!channel.details?.include_pdf);
+
   const canConfigurePivoting = cards.some((card) => card.display === "pivot");
   const areAllSelected = cards.length === selectedCardIds.size;
   const areOnlySomeSelected =
@@ -276,18 +282,41 @@ export function EmailAttachmentPicker({
       if (!includeAttachment) {
         const emptySet = new Set<string>();
         setSelectedCardIds(emptySet);
+        // Keep "send only attachments" on if a PDF is still attached; otherwise clear it.
         updatePulseCards(selectedAttachmentType, emptySet, {
           ...exportOptions,
-          isAttachmentOnly: false,
+          isAttachmentOnly: includePdf ? exportOptions.isAttachmentOnly : false,
         });
       }
 
       setIsEnabled(includeAttachment);
-      if (!includeAttachment) {
+      if (!includeAttachment && !includePdf) {
         dispatchExportOptions({ type: "DISABLE_ATTACHMENT_ONLY" });
       }
     },
-    [selectedAttachmentType, updatePulseCards, exportOptions],
+    [selectedAttachmentType, updatePulseCards, exportOptions, includePdf],
+  );
+
+  const onToggleIncludePdf = useCallback(
+    (checked: boolean) => {
+      // When no attachments remain (no PDF and no files), "send only" is meaningless — clear it.
+      const noAttachmentsLeft = !checked && !isEnabled;
+      setPulse({
+        ...pulse,
+        channels: pulse.channels.map((channel) => ({
+          ...channel,
+          details: {
+            ...channel.details,
+            include_pdf: checked,
+            ...(noAttachmentsLeft ? { attachment_only: false } : {}),
+          },
+        })),
+      });
+      if (noAttachmentsLeft) {
+        dispatchExportOptions({ type: "DISABLE_ATTACHMENT_ONLY" });
+      }
+    },
+    [pulse, setPulse, isEnabled],
   );
 
   const setAttachmentType = useCallback(
@@ -380,23 +409,32 @@ export function EmailAttachmentPicker({
     isPivotingEnabled,
   ]);
 
-  const onToggleAttachmentOnly = useCallback(() => {
-    const newOptions = {
-      ...exportOptions,
-      isAttachmentOnly: !isAttachmentOnly,
-    };
-    dispatchExportOptions({ type: "TOGGLE_ATTACHMENT_ONLY" });
-    updatePulseCards(selectedAttachmentType, selectedCardIds, newOptions);
-  }, [
-    selectedAttachmentType,
-    selectedCardIds,
-    updatePulseCards,
-    exportOptions,
-    isAttachmentOnly,
-  ]);
+  const onToggleAttachmentOnly = useCallback(
+    (checked: boolean) => {
+      const newOptions = {
+        ...exportOptions,
+        isAttachmentOnly: checked,
+      };
+      dispatchExportOptions({ type: "TOGGLE_ATTACHMENT_ONLY" });
+      updatePulseCards(selectedAttachmentType, selectedCardIds, newOptions);
+    },
+    [selectedAttachmentType, selectedCardIds, updatePulseCards, exportOptions],
+  );
 
   return (
     <div>
+      <Switch
+        checked={includePdf}
+        onChange={(e) => onToggleIncludePdf(e.target.checked)}
+        disabled={!canAttachFiles}
+        mb="md"
+        classNames={{
+          body: S.AttachmentSwitchBody,
+          input: S.AttachmentSwitchInput,
+        }}
+        label={<Text fw="bold">{t`Attach a PDF of the dashboard`}</Text>}
+        labelPosition="left"
+      />
       <Tooltip label={disabledReason} disabled={!disabledReason}>
         <Box>
           <Switch
@@ -428,9 +466,34 @@ export function EmailAttachmentPicker({
               body: S.AttachmentSwitchBody,
               input: S.AttachmentSwitchInput,
             }}
+            mb="md"
           />
         </Box>
       </Tooltip>
+      {(includePdf || isEnabled) && canAttachFiles && (
+        <Switch
+          label={
+            <Group gap={0}>
+              <Text fw="bold">{t`Send only attachments (no charts)`}</Text>
+              <Icon
+                name="info"
+                c="text-secondary"
+                ml="0.5rem"
+                size={12}
+                tooltip={t`When enabled, only file attachments will be sent (no email content).`}
+              />
+            </Group>
+          }
+          aria-label={t`Send only attachments`}
+          checked={isAttachmentOnly}
+          onChange={(e) => onToggleAttachmentOnly(e.target.checked)}
+          labelPosition="left"
+          classNames={{
+            body: S.AttachmentSwitchBody,
+            input: S.AttachmentSwitchInput,
+          }}
+        />
+      )}
       {isEnabled && canAttachFiles && (
         <div>
           <Box py="1rem">
@@ -489,23 +552,6 @@ export function EmailAttachmentPicker({
               ))}
             </ul>
           </div>
-          <Group justify="space-between" pt="1rem">
-            <Group gap="0">
-              <Text fw="bold">{t`Send only attachments (no charts)`}</Text>
-              <Icon
-                name="info"
-                c="text-secondary"
-                ml="0.5rem"
-                size={12}
-                tooltip={t`When enabled, only file attachments will be sent (no email content).`}
-              />
-            </Group>
-            <Toggle
-              aria-label={t`Send only attachments`}
-              value={isAttachmentOnly}
-              onChange={onToggleAttachmentOnly}
-            />
-          </Group>
         </div>
       )}
     </div>

--- a/frontend/src/metabase/notifications/EmailAttachmentPicker.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/EmailAttachmentPicker.unit.spec.tsx
@@ -12,11 +12,24 @@ function setup({
   pulse = createPulse(),
   allowDownload = true,
   hasAttachments = false,
+  includePdf = false,
+  attachmentOnly = false,
 } = {}) {
   const setPulse = jest.fn();
 
   if (hasAttachments) {
     pulse.cards[0]["include_xls"] = true;
+  }
+
+  if (includePdf || attachmentOnly) {
+    pulse.channels = pulse.channels.map((channel) => ({
+      ...channel,
+      details: {
+        ...channel.details,
+        ...(includePdf ? { include_pdf: true } : {}),
+        ...(attachmentOnly ? { attachment_only: true } : {}),
+      },
+    }));
   }
 
   const state = createMockState({
@@ -282,6 +295,126 @@ describe("EmailAttachmentPicker", () => {
       fireEvent.click(toggleAllCheckbox);
       expect(originalCardCheckbox).not.toBeChecked();
       expect(visualizerCardCheckbox).not.toBeChecked();
+    });
+  });
+
+  describe("PDF attachment", () => {
+    it("should render an unchecked 'Attach a PDF' switch by default", () => {
+      setup();
+      const pdfSwitch = screen.getByRole("switch", {
+        name: /Attach a PDF of the dashboard/,
+      });
+      expect(pdfSwitch).toBeInTheDocument();
+      expect(pdfSwitch).not.toBeChecked();
+    });
+
+    it("should disable the PDF switch when downloads are not allowed", () => {
+      setup({ allowDownload: false });
+      expect(
+        screen.getByRole("switch", { name: /Attach a PDF of the dashboard/ }),
+      ).toBeDisabled();
+    });
+
+    it("should render the PDF switch checked when include_pdf is set", () => {
+      setup({ includePdf: true });
+      expect(
+        screen.getByRole("switch", { name: /Attach a PDF of the dashboard/ }),
+      ).toBeChecked();
+    });
+
+    it("should write include_pdf to every channel when the PDF switch is toggled on", () => {
+      const { setPulse } = setup();
+      fireEvent.click(
+        screen.getByRole("switch", { name: /Attach a PDF of the dashboard/ }),
+      );
+      expect(setPulse).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          channels: expect.arrayContaining([
+            expect.objectContaining({
+              details: expect.objectContaining({ include_pdf: true }),
+            }),
+          ]),
+        }),
+      );
+    });
+  });
+
+  describe("send only attachments toggle", () => {
+    const SEND_ONLY = "Send only attachments";
+
+    it("should be hidden when nothing is attached", () => {
+      setup();
+      expect(
+        screen.queryByRole("switch", { name: SEND_ONLY }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should appear when only a PDF is attached", () => {
+      setup({ includePdf: true });
+      expect(
+        screen.getByRole("switch", { name: SEND_ONLY }),
+      ).toBeInTheDocument();
+    });
+
+    it("should appear when only file attachments are enabled", () => {
+      setup({ hasAttachments: true });
+      expect(
+        screen.getByRole("switch", { name: SEND_ONLY }),
+      ).toBeInTheDocument();
+    });
+
+    it("should reflect the persisted attachment_only value", () => {
+      setup({ includePdf: true, attachmentOnly: true });
+      expect(screen.getByRole("switch", { name: SEND_ONLY })).toBeChecked();
+    });
+
+    it("should write attachment_only when toggled on with only a PDF attached", () => {
+      const { setPulse } = setup({ includePdf: true });
+      fireEvent.click(screen.getByRole("switch", { name: SEND_ONLY }));
+      expect(setPulse).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          channels: expect.arrayContaining([
+            expect.objectContaining({
+              details: expect.objectContaining({
+                include_pdf: true,
+                attachment_only: true,
+              }),
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it("should keep attachment_only when files are disabled but a PDF is still attached", () => {
+      const { setPulse } = setup({
+        hasAttachments: true,
+        includePdf: true,
+        attachmentOnly: true,
+      });
+
+      fireEvent.click(screen.getByLabelText("Attach results"));
+
+      const lastPulse = setPulse.mock.lastCall?.[0];
+      expect(lastPulse.channels[0].details.attachment_only).toBe(true);
+      expect(lastPulse.channels[0].details.include_pdf).toBe(true);
+      expect(
+        lastPulse.cards.every(
+          (card: { include_csv: boolean; include_xls: boolean }) =>
+            !card.include_csv && !card.include_xls,
+        ),
+      ).toBe(true);
+    });
+
+    it("should clear attachment_only when the PDF is disabled and no files are attached", () => {
+      const { setPulse } = setup({ includePdf: true, attachmentOnly: true });
+
+      fireEvent.click(
+        screen.getByRole("switch", { name: /Attach a PDF of the dashboard/ }),
+      );
+
+      const lastPulse = setPulse.mock.lastCall?.[0];
+      expect(lastPulse.channels[0].details.include_pdf).toBe(false);
+      expect(lastPulse.channels[0].details.attachment_only).toBe(false);
     });
   });
 });


### PR DESCRIPTION
### Description

For Email based subscriptions, the "Only Include Attachments" toggle now displays *before* the "Choose your cards" selections, and will display if either "Include CSV / XLSX" or "Include PDF" toggles are displayed. If both of those toggles are disabled, then the value of `attachments_only` is also set to false.

### How to verify
1. Go to a dashboard
2. Menu -> Edit Subscriptions
3. Toggle "Attach PDF"
4. You should see the attachments only toggle
5. Disable "Attach PDF" and toggle "Attach CSV / XLSX". The toggle should re-appear

### Demo

https://github.com/user-attachments/assets/82ec3707-3f40-422a-abf5-7ba59b5cf274

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
