### PR TITLE
Metabot metric math

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1288,7 +1288,9 @@
               legacy-mbql
               lib
               lib-be
+              lib-metric
               llm
+              metrics
               models
               native-query-snippets
               notification
@@ -1333,7 +1335,8 @@
   metrics
   {:team "UX West"
    :api  #{metabase.metrics.api
-           metabase.metrics.core}
+           metabase.metrics.core
+           metabase.metrics.definition}
    :uses #{api
            collections
            lib

--- a/frontend/src/metabase/api/ai-streaming/schemas.ts
+++ b/frontend/src/metabase/api/ai-streaming/schemas.ts
@@ -3,6 +3,7 @@ import * as Yup from "yup";
 import type {
   CardDisplayType,
   DatasetQuery,
+  JsMetricDefinition,
   MetabotCodeEdit,
   MetabotTodoItem,
   SuggestedTransform,
@@ -23,6 +24,7 @@ export const knownDataPartTypes = [
   "generated_entity",
   "adhoc_viz",
   "static_viz",
+  "metric_viz",
 ];
 
 export type AdhocVizValue = {
@@ -34,6 +36,19 @@ export type AdhocVizValue = {
 
 export type StaticVizValue = {
   entity_id: number;
+};
+
+export type MetricVizValue = {
+  // A validated metric definition, ready to POST to /api/metric/dataset. `expression` is kept opaque
+  // (`unknown[]`) rather than the full `JsExpressionRef` tuple union: this value is only forwarded to
+  // the dataset endpoint, and embedding that union in the ts-pattern-matched `KnownDataPart` union
+  // pushes TS's type-instantiation budget over the edge (surfacing as a spurious TS2589 elsewhere).
+  definition: Omit<JsMetricDefinition, "expression"> & {
+    expression: unknown[];
+  };
+  display?: CardDisplayType;
+  title: string;
+  breakout?: { field_id: number; temporal_unit?: string };
 };
 
 export type GeneratedQuery = {
@@ -59,7 +74,8 @@ export type KnownDataPart =
   | { type: "code_edit"; version: 1; value: MetabotCodeEdit }
   | { type: "generated_entity"; version: 1; value: GeneratedEntity }
   | { type: "adhoc_viz"; version: 1; value: AdhocVizValue }
-  | { type: "static_viz"; version: 1; value: StaticVizValue };
+  | { type: "static_viz"; version: 1; value: StaticVizValue }
+  | { type: "metric_viz"; version: 1; value: MetricVizValue };
 
 export const toolCallPartSchema = Yup.object({
   toolCallId: Yup.string().required(),

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataPartMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataPartMessage.tsx
@@ -18,6 +18,7 @@ import { AgentSuggestionMessage } from "./MetabotAgentSuggestionMessage";
 import { AgentTodoListMessage } from "./MetabotAgentTodoMessage";
 import Styles from "./MetabotChat.module.css";
 import { MetabotInlineChart } from "./MetabotInlineChart";
+import { MetabotMetricViz } from "./MetabotMetricViz";
 
 type AgentDataPartMessageProps = {
   message: MetabotAgentDataPartMessage;
@@ -83,6 +84,12 @@ export const AgentDataPartMessage = ({
     .with({ part: { type: "static_viz" } }, ({ part }) =>
       debug ? <DataPartJsonCard type={part.type} value={part.value} /> : null,
     )
+    .with({ part: { type: "metric_viz" } }, ({ part }) => (
+      <Stack gap="md">
+        {debug && <DataPartJsonCard type={part.type} value={part.value} />}
+        <MetabotMetricViz value={part.value} />
+      </Stack>
+    ))
     .exhaustive((msg: unknown) => {
       console.warn("AgentDataPartMessage received an unexpected value:", msg);
       return null;

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -46,6 +46,7 @@ const isUserVisibleDataPart = (part: MetabotDataPart): boolean =>
     .with({ type: "navigate_to" }, () => true)
     .with({ type: "code_edit" }, () => true)
     .with({ type: "generated_entity" }, () => true)
+    .with({ type: "metric_viz" }, () => true)
     .with({ type: "adhoc_viz" }, () => false)
     .with({ type: "static_viz" }, () => false)
     .exhaustive();

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotMetricViz.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotMetricViz.tsx
@@ -1,0 +1,74 @@
+import { useMemo } from "react";
+import { noop } from "underscore";
+
+import { useGetMetricDatasetQuery } from "metabase/api";
+import type { MetricVizValue } from "metabase/api/ai-streaming/schemas";
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { Box, Center, Flex, Text } from "metabase/ui";
+import Visualization from "metabase/visualizations/components/Visualization";
+import { ErrorView } from "metabase/visualizations/components/Visualization/ErrorView";
+import {
+  getDatasetError,
+  getGenericErrorMessage,
+} from "metabase/visualizations/lib/errors";
+import type { Card } from "metabase-types/api";
+
+import S from "./MetabotInlineChart.module.css";
+
+/**
+ * Renders a Metabot metric-math result inline: it posts the validated definition to
+ * /api/metric/dataset (the same engine the metrics viewer uses) and draws the computed
+ * cols/rows. The definition carries no runnable card query, so it renders a synthetic,
+ * read-only card rather than linking out to a question.
+ */
+export function MetabotMetricViz({ value }: { value: MetricVizValue }) {
+  const { definition, display, title } = value;
+
+  const { data: dataset, error } = useGetMetricDatasetQuery({ definition });
+
+  const card: Card = useMemo(
+    () =>
+      ({
+        name: title,
+        display: display ?? "line",
+        visualization_settings: {},
+      }) as Card,
+    [title, display],
+  );
+
+  const rawSeries = useMemo(
+    () => (dataset ? [{ card, data: dataset.data }] : null),
+    [card, dataset],
+  );
+
+  const datasetError = dataset ? getDatasetError(dataset) : undefined;
+  const requestError = error
+    ? { message: getGenericErrorMessage(), icon: "warning" as const }
+    : undefined;
+  const chartError = datasetError ?? requestError;
+
+  return (
+    <Box className={S.container} data-testid="metabot-metric-viz">
+      <Flex className={S.header} align="center" gap="sm">
+        <Text className={S.title} fw="bold" truncate>
+          {title}
+        </Text>
+      </Flex>
+      <Box className={S.viz}>
+        {chartError ? (
+          <Center h="100%" p="md">
+            <ErrorView error={chartError.message} icon={chartError.icon} />
+          </Center>
+        ) : !rawSeries ? (
+          <LoadingAndErrorWrapper loading />
+        ) : (
+          <Visualization
+            rawSeries={rawSeries}
+            isQueryBuilder={false}
+            onChangeCardAndRun={noop}
+          />
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotMetricViz.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotMetricViz.unit.spec.tsx
@@ -1,0 +1,91 @@
+import fetchMock from "fetch-mock";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import type { MetricVizValue } from "metabase/api/ai-streaming/schemas";
+import {
+  createMockColumn,
+  createMockDataset,
+  createMockDatasetData,
+} from "metabase-types/api/mocks";
+
+import { MetabotMetricViz } from "./MetabotMetricViz";
+
+// Visualization pulls in the whole charting stack; stub it so we can unit test the
+// run / render-state logic in isolation.
+jest.mock("metabase/visualizations/components/Visualization", () => ({
+  __esModule: true,
+  default: () => <div data-testid="visualization" />,
+}));
+
+const value: MetricVizValue = {
+  title: "Revenue over headcount",
+  display: "line",
+  definition: {
+    expression: [
+      "/",
+      {},
+      ["metric", { "lib/uuid": "a" }, 1],
+      ["metric", { "lib/uuid": "b" }, 2],
+    ],
+    projections: [],
+  },
+};
+
+function setupDataset({
+  status = 200,
+  dataset = createMockDataset({
+    data: createMockDatasetData({
+      cols: [
+        createMockColumn({ name: "created_at" }),
+        createMockColumn({ name: "ratio" }),
+      ],
+      rows: [["2024-01-01", 1.5]],
+    }),
+  }),
+}: {
+  status?: number;
+  dataset?: unknown;
+} = {}) {
+  fetchMock.post("path:/api/metric/dataset", { status, body: dataset });
+}
+
+function setup(valueOverrides: Partial<MetricVizValue> = {}) {
+  return renderWithProviders(
+    <MetabotMetricViz value={{ ...value, ...valueOverrides }} />,
+  );
+}
+
+describe("MetabotMetricViz", () => {
+  beforeEach(() => {
+    fetchMock.clearHistory();
+  });
+
+  it("posts the definition to /api/metric/dataset and renders the visualization", async () => {
+    setupDataset();
+    setup();
+    expect(screen.getByTestId("metabot-metric-viz")).toBeInTheDocument();
+    expect(await screen.findByTestId("visualization")).toBeInTheDocument();
+    expect(fetchMock.callHistory.called("path:/api/metric/dataset")).toBe(true);
+  });
+
+  it("shows the title", () => {
+    setupDataset();
+    setup();
+    expect(screen.getByText("Revenue over headcount")).toBeInTheDocument();
+  });
+
+  it("does not render the visualization while results are loading", () => {
+    setupDataset();
+    setup();
+    expect(screen.queryByTestId("visualization")).not.toBeInTheDocument();
+  });
+
+  it("shows an error message when the request fails", async () => {
+    setupDataset({ status: 500 });
+    setup();
+    expect(screen.queryByTestId("visualization")).not.toBeInTheDocument();
+    expect(
+      await screen.findByText("There was a problem displaying this chart."),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -458,6 +458,7 @@ export const sendAgentRequest = createAsyncThunk<
                 { type: "generated_entity" },
                 { type: "adhoc_viz" },
                 { type: "static_viz" },
+                { type: "metric_viz" },
                 (part) => {
                   pushDataPart({ type: "data_part", part });
                 },

--- a/resources/metabot/prompts/shared/prompt_snippets/combining-metrics.selmer
+++ b/resources/metabot/prompts/shared/prompt_snippets/combining-metrics.selmer
@@ -1,0 +1,3 @@
+# Relating metrics: one calculation, not many charts
+
+When a request combines two or more **saved metrics** into a single figure or series — a ratio, rate, percentage, difference, variance, or share of a total (e.g. "signups per visit", "budget vs. actual %", "open rate minus bounce rate") — find the metrics involved, then answer with **one `compute_metric_math` calculation** instead of a chart per metric. Load the **compute-metric-math** skill for the formula shape and breakout rules before the first call. Fall back to separate queries only when the metrics genuinely can't be combined this way.

--- a/resources/metabot/prompts/system/natural-language-querying-fallback.selmer
+++ b/resources/metabot/prompts/system/natural-language-querying-fallback.selmer
@@ -14,6 +14,8 @@ You are judged on whether the produced query matches the user's intent against t
 
 {% include "metabot/prompts/shared/prompt_snippets/data-sources.selmer" %}
 
+{% include "metabot/prompts/shared/prompt_snippets/combining-metrics.selmer" %}
+
 # Finding data: search for the right entity, then navigate in
 
 You have two complementary ways to find the data behind a request:

--- a/resources/metabot/prompts/system/natural-language-querying-only.selmer
+++ b/resources/metabot/prompts/system/natural-language-querying-only.selmer
@@ -14,6 +14,8 @@ You are judged on whether the produced query matches the user's intent against t
 
 {% include "metabot/prompts/shared/prompt_snippets/data-sources.selmer" %}
 
+{% include "metabot/prompts/shared/prompt_snippets/combining-metrics.selmer" %}
+
 # Finding data: search for the right entity, then navigate in
 
 You have two complementary ways to find the data behind a request:

--- a/resources/metabot/skills/compute-metric-math.md
+++ b/resources/metabot/skills/compute-metric-math.md
@@ -1,7 +1,7 @@
 ---
 id: compute-metric-math
 title: Metric math — combine metrics with arithmetic
-description: Combining saved metrics/measures with +, -, *, / into one visualization (optionally broken out by a shared dimension) using compute_metric_math — load before building a metric-math formula so you get the expression shape, the breakout rules, and the cross-table limits right.
+description: Combining two or more saved metrics/measures into one visualization — ratios, rates, percentages, differences, variance, share-of-total — with compute_metric_math instead of a separate chart per metric. Load before building a metric-math formula for the expression shape, breakout rules, and limits.
 tools: [compute_metric_math]
 priority: 60
 ---

--- a/resources/metabot/skills/compute-metric-math.md
+++ b/resources/metabot/skills/compute-metric-math.md
@@ -1,0 +1,91 @@
+---
+id: compute-metric-math
+title: Metric math — combine metrics with arithmetic
+description: Combining saved metrics/measures with +, -, *, / into one visualization (optionally broken out by a shared dimension) using compute_metric_math — load before building a metric-math formula so you get the expression shape, the breakout rules, and the cross-table limits right.
+tools: [compute_metric_math]
+priority: 60
+---
+# Metric math
+
+`compute_metric_math` combines **saved metrics and measures** with arithmetic (`+ - * /`) into a single
+visualization — e.g. `Revenue / Headcount`, `(Budget − Spend) / Budget * 100`. It builds a chart the
+**user** sees; it does **not** return the computed numbers to you. Describe what it shows; never invent
+the underlying values.
+
+Use it when the user wants to derive a value by combining **existing** metrics/measures. For a query
+over raw tables/fields, or a per-dimension breakout that metric math can't do (see limits below), use
+`construct_notebook_query` instead.
+
+## Inputs
+
+- **`expression`** — a tree. Each node is one of:
+  - a reference: `{ "type": "metric", "id": 42 }` (or `"measure"`). Optionally `"filter"`: an MBQL
+    filter clause scoped to that reference.
+  - an arithmetic node: `{ "op": "/", "operands": [ <expr>, <expr>, ... ] }`, `op` ∈ `+ - * /`.
+    Nesting sets precedence. Operands may be references, nested nodes, or bare numbers.
+  - a number constant, e.g. `100`.
+  - The whole expression must reference **at least one** metric or measure.
+- **`breakout`** *(optional)* — `{ "field_id": 351, "temporal_unit": "month" }`. Groups the result by a
+  dimension. See the rules below — this is where most failures come from. Omit it for a single scalar.
+- **`display`** *(optional)* — `line` (default), `bar`, `area`, `row`, `table`, or `scalar`.
+- **`title`** — short, human-friendly; shown above the chart.
+
+### Example — budget variance %, by month
+
+```json
+{
+  "title": "Budget variance % by department",
+  "display": "bar",
+  "expression": {
+    "op": "*",
+    "operands": [
+      { "op": "/", "operands": [
+        { "op": "-", "operands": [ {"type":"metric","id":79}, {"type":"metric","id":83} ] },
+        {"type":"metric","id":79} ] },
+      100 ]
+  },
+  "breakout": { "field_id": 351, "temporal_unit": "month" }
+}
+```
+
+## Breakout rules (read before adding a breakout)
+
+**Every metric in the formula must expose the breakout field as one of its own dimensions.** The field
+is matched by its underlying **field id**, so:
+
+1. **Get the field id from the metric's own dimensions** — read `entity_details` for each metric (or the
+   metadata tools) and use a `field_id` listed under *that* metric's queryable dimensions. Do **not** reuse
+   a field id you saw on a different metric.
+2. **Same name ≠ same field.** Two tables can each have a `created_at` or `department_name` column; they
+   are **different fields with different ids**. Picking one table's field id for a metric on another table
+   will fail. The error will name the field's table and the metric that lacks it — read it and pick the
+   right id.
+3. **Cross-table breakouts only work via a conformed dimension** — i.e. the *same physical field* is
+   reachable from every metric (e.g. all metrics join to one shared date or entity table). If the metrics
+   live on different base tables with no shared field, a breakout cannot be resolved.
+
+## Limitations
+
+- **Breakouts need a field shared by every metric.** A breakout resolves to one physical field that must
+  be a dimension on all metrics in the formula. Metrics on **different base tables** can only be broken out
+  by a conformed dimension (the same field reachable from each) — including for time: there is no breaking
+  two metrics on different tables out by each table's own date column. For a cross-table breakout, drop it
+  for a **scalar** result, or use `construct_notebook_query` to build the per-dimension breakout explicitly.
+- **Overlap only.** Results include a bucket only when **every** metric has data for it — non-overlapping
+  dimension values (e.g. months only one metric covers) are dropped.
+- **Missing / divide-by-zero → empty.** A bucket where any operand is missing, or a division by zero,
+  produces no value (a gap), not an error.
+- **Metrics/measures only.** Operands are saved metrics/measures by id — not raw tables, columns, or
+  ad-hoc aggregations. Build those with `construct_notebook_query`.
+
+## Best practices
+
+- **Discover first.** Fetch each metric/measure's id and its dimension `field_id`s via `entity_details`
+  (or metadata tools) before calling — don't guess ids.
+- **Prefer a scalar when a breakout isn't essential.** Scalars work across any tables; add a breakout only
+  when the metrics share the dimension.
+- **On a breakout error**, the message tells you exactly which metric lacks the field and what table the
+  field belongs to. Fix the id, switch to the conformed field, or drop the breakout — don't retry the same
+  id.
+- **Present the result** to the user (the chart is theirs); summarize what it represents without stating
+  specific numbers you don't have.

--- a/src/metabase/lib_metric/core.cljc
+++ b/src/metabase/lib_metric/core.cljc
@@ -78,6 +78,7 @@
     [lib-metric.projection
      add-projection-positions
      default-breakout-dimensions
+     project-breakout-by-field-id
      projectable-dimensions])
    :cljs
    (do

--- a/src/metabase/lib_metric/projection.cljc
+++ b/src/metabase/lib_metric/projection.cljc
@@ -7,6 +7,7 @@
    [metabase.lib-metric.schema :as lib-metric.schema]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
+   [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
@@ -365,3 +366,93 @@
               []
               (filterv #(dimension-has-field-id? breakout-field-ids %)
                        (projectable-dimensions definition)))))))))
+
+;;; -------------------------------------------------- Cross-leaf Breakout --------------------------------------------------
+
+(defn- leaf-dimensions
+  [metadata-provider leaf]
+  (let [leaf-type (lib-metric.definition/expression-leaf-type leaf)
+        leaf-id   (lib-metric.definition/expression-leaf-id leaf)]
+    (case leaf-type
+      :metric  (lib-metric.dimension/dimensions-for-metric metadata-provider leaf-id)
+      :measure (lib-metric.dimension/dimensions-for-measure metadata-provider leaf-id))))
+
+(defn- leaf-entity-name
+  "Human-readable name for a leaf's metric/measure (falls back to \"metric 42\" if unnamed)."
+  [metadata-provider leaf]
+  (let [leaf-type (lib-metric.definition/expression-leaf-type leaf)
+        leaf-id   (lib-metric.definition/expression-leaf-id leaf)
+        mtype     (case leaf-type :metric :metadata/metric :measure :metadata/measure)]
+    (or (:name (first (lib.metadata.protocols/metadatas metadata-provider {:lib/type mtype :id #{leaf-id}})))
+        (str (name leaf-type) " " leaf-id))))
+
+(defn- dimension-tables
+  "Distinct table display-names the dimensions belong to (via each dimension's :group)."
+  [dimensions]
+  (distinct (keep (comp :display-name :group) dimensions)))
+
+(defn- unresolved-breakout-message
+  "Build an actionable error for a breakout `field-id` that isn't a dimension of every leaf.
+  `resolved` is `[{:leaf :dim}]` per leaf (`:dim` nil when unmatched); `example-dim` is any matched
+  dimension, used to name the field and the table it lives on."
+  [metadata-provider field-id example-dim missing]
+  (let [field-desc (if example-dim
+                     (i18n/tru "field {0} (\"{1}\" from table \"{2}\")"
+                               field-id
+                               (:display-name example-dim)
+                               (perf/get-in example-dim [:group :display-name]))
+                     (i18n/tru "field {0}" field-id))
+        offenders  (for [{:keys [leaf dims]} missing]
+                     (i18n/tru "\"{0}\" (its dimensions come from: {1})"
+                               (leaf-entity-name metadata-provider leaf)
+                               (or (perf/not-empty (apply str (interpose ", " (dimension-tables dims))))
+                                   (i18n/tru "no synced dimensions"))))]
+    (str (i18n/tru "Can''t break out by {0}: it isn''t a dimension of {1}."
+                   field-desc
+                   (apply str (interpose "; " offenders)))
+         " "
+         (i18n/tru (str "Every metric in a metric-math formula must have the breakout field among its "
+                        "own dimensions, so all metrics must share that field''s table (e.g. a conformed "
+                        "dimension). Note: a column with the same name on a different table is a different "
+                        "field with a different id — either pick a dimension common to all metrics, or drop "
+                        "the breakout for a scalar result.")))))
+
+(mu/defn project-breakout-by-field-id :- ::lib-metric.schema/metric-definition
+  "Add a breakout on the dimension backed by `field-id` to EVERY leaf of `definition`'s expression.
+
+  `field-id` is the stable cross-leaf key used to match \"the same logical breakout\" across the
+  metrics/measures in a metric-math expression (mirrors the frontend's field-id matching in
+  `dimension-picker.ts`). For each leaf, this finds that leaf's own dimension whose `:sources`
+  reference `field-id`, optionally applies `temporal-unit`, and appends a typed-projection for it.
+
+  Throws a 400 `ex-info` if any leaf has no dimension for `field-id`. The message names the field and
+  its table plus every metric that lacks it and the tables it does cover, so the caller can relay why
+  the (usually cross-table) breakout was rejected."
+  ([definition field-id]
+   (project-breakout-by-field-id definition field-id nil))
+  ([definition    :- ::lib-metric.schema/metric-definition
+    field-id      :- ::lib.schema.id/field
+    temporal-unit :- [:maybe ::lib.schema.temporal-bucketing/unit]]
+   (let [{:keys [expression metadata-provider]} definition
+         field-ids #{field-id}
+         resolved  (perf/mapv (fn [leaf]
+                                (let [dims (leaf-dimensions metadata-provider leaf)]
+                                  {:leaf leaf
+                                   :dims dims
+                                   :dim  (perf/some (fn [d] (when (dimension-has-field-id? field-ids d) d)) dims)}))
+                              (lib-metric.definition/expression-leaves expression))
+         missing   (remove :dim resolved)]
+     (when (seq missing)
+       (throw (ex-info (unresolved-breakout-message metadata-provider field-id (perf/some :dim resolved) missing)
+                       {:status-code 400
+                        :field-id    field-id
+                        :missing     (perf/mapv (fn [{:keys [leaf]}]
+                                                  {:type (lib-metric.definition/expression-leaf-type leaf)
+                                                   :id   (lib-metric.definition/expression-leaf-id leaf)})
+                                                missing)})))
+     (reduce (fn [def* {:keys [leaf dim]}]
+               (let [dim-ref (cond-> (lib-metric.dimension/reference dim)
+                               temporal-unit (with-temporal-bucket temporal-unit))]
+                 (project-for-source def* dim-ref leaf)))
+             definition
+             resolved))))

--- a/src/metabase/metabot/agent/profiles.clj
+++ b/src/metabase/metabot/agent/profiles.clj
@@ -179,6 +179,7 @@
   :tools           [#'tools/retrieve-library-entities-tool
                     #'tools/read-resource-tool
                     #'tools/construct-notebook-query-tool
+                    #'tools/compute-metric-math-tool
                     #'tools/navigate-user-tool
                     #'tools/create-chart-tool
                     #'tools/edit-chart-tool]})
@@ -191,6 +192,7 @@
   :tools           [#'tools/nlq-search-tool
                     #'tools/read-resource-tool
                     #'tools/construct-notebook-query-tool
+                    #'tools/compute-metric-math-tool
                     #'tools/navigate-user-tool
                     #'tools/create-chart-tool
                     #'tools/edit-chart-tool]})

--- a/src/metabase/metabot/agent/streaming.clj
+++ b/src/metabase/metabot/agent/streaming.clj
@@ -21,6 +21,7 @@
 (def generated-entity-type "AI-SDK data type for generated entities." "generated_entity")
 (def adhoc-viz-type "AI-SDK data type for ad-hoc visualizations." "adhoc_viz")
 (def static-viz-type "AI-SDK data type for static visualizations." "static_viz")
+(def metric-viz-type "AI-SDK data type for metric-math visualizations." "metric_viz")
 
 (defn persistable-data-part?
   "True if `part` should be written to MetabotMessage.data. `state` parts are
@@ -134,6 +135,18 @@
   [value]
   {:type :data
    :data-type static-viz-type
+   :version 1
+   :data value})
+
+(defn metric-viz-part
+  "Create a METRIC_VIZ data part for streaming a metric-math visualization.
+  `value` is a map with a validated metric `:definition` (`:expression`/`:filters`/`:projections`,
+  the same shape POST /api/metric/dataset accepts), plus display hints (`:display`, `:title`,
+  and optionally `:breakout`). The frontend renders it by posting the definition to
+  /api/metric/dataset and drawing the result via the metrics-viewer visualization."
+  [value]
+  {:type :data
+   :data-type metric-viz-type
    :version 1
    :data value})
 

--- a/src/metabase/metabot/tools.clj
+++ b/src/metabase/metabot/tools.clj
@@ -18,6 +18,7 @@
    [metabase.metabot.tools.document :as tools.document]
    [metabase.metabot.tools.entity-retrieval :as tools.entity-retrieval]
    [metabase.metabot.tools.metadata :as tools.metadata]
+   [metabase.metabot.tools.metric-math :as tools.metric-math]
    [metabase.metabot.tools.navigation :as tools.navigation]
    [metabase.metabot.tools.resources :as tools.resources]
    [metabase.metabot.tools.search :as tools.search]
@@ -74,6 +75,8 @@
   todo-read-tool]
  [tools.navigation
   navigate-user-tool]
+ [tools.metric-math
+  compute-metric-math-tool]
  [tools.snippets
   list-snippets-tool
   get-snippet-details-tool]

--- a/src/metabase/metabot/tools/metric_math.clj
+++ b/src/metabase/metabot/tools/metric_math.clj
@@ -1,0 +1,189 @@
+(ns metabase.metabot.tools.metric-math
+  "Metabot tool for building a \"metric math\" visualization: an arithmetic formula combining saved
+  metrics/measures (`+ - * /`), optionally broken out by a shared dimension.
+
+  The tool does NOT execute the query. It resolves the LLM's structured expression into an internal
+  metric definition, validates it by compiling a query plan (no execution) and permission-checking
+  every referenced metric/measure, then emits a `metric_viz` data part carrying the validated
+  definition. The frontend renders the result by posting that definition to POST /api/metric/dataset
+  (the same engine the metrics-viewer uses). See [[metabase.metrics.definition]] and
+  [[metabase.lib-metric.projection/project-breakout-by-field-id]]."
+  (:require
+   [metabase.lib-metric.core :as lib-metric]
+   [metabase.metabot.agent.streaming :as streaming]
+   [metabase.metabot.scope :as scope]
+   [metabase.metabot.tmpl :as te]
+   [metabase.metrics.definition :as metrics.definition]
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.log :as log]
+   [metabase.util.malli :as mu]))
+
+(set! *warn-on-reflection* true)
+
+;; Canonical set lives in `metabase.lib-metric.operators/arithmetic-operator-keywords`; kept local here
+;; to avoid depending on a non-API lib-metric namespace. Mirrors the operators in `expression-json-schema`.
+(def ^:private math-operators #{:+ :- :* :/})
+
+;;; ------------------------------------------------ Schema ------------------------------------------------
+
+(def ^:private expression-json-schema
+  "Hand-authored JSON Schema for the recursive `:expression` argument, attached to a deliberately-open
+  malli `:map` via a `:json-schema` override (mirrors `construct_notebook_query`). It only shapes what
+  the LLM sees — validation happens in [[build-expression]]. Recursion is conveyed by prose + a nested
+  example rather than `$ref`, which weaker models handle poorly."
+  {:type        "object"
+   :description (str "A metric-math expression tree. Each node is ONE of:\n"
+                     "1. A metric/measure reference: "
+                     "`{\"type\": \"metric\", \"id\": 42}` (use \"measure\" for measures). "
+                     "Optionally attach a per-reference filter with `\"filter\"` (an MBQL filter clause).\n"
+                     "2. An arithmetic node: `{\"op\": \"/\", \"operands\": [<expr>, <expr>, ...]}` where "
+                     "`op` is one of \"+\", \"-\", \"*\", \"/\" and each operand is itself an expression "
+                     "node (this is how nesting works). Operators follow normal precedence via nesting.\n"
+                     "3. A numeric constant, e.g. `100`.\n"
+                     "The whole expression must reference at least one metric or measure. Example — "
+                     "revenue divided by headcount then scaled: "
+                     "`{\"op\": \"*\", \"operands\": [{\"op\": \"/\", \"operands\": "
+                     "[{\"type\": \"metric\", \"id\": 42}, {\"type\": \"measure\", \"id\": 7}]}, 100]}`.")
+   :properties  {"type"     {:type "string" :enum ["metric" "measure"]}
+                 "id"       {:type "integer"}
+                 "filter"   {:type "object"}
+                 "op"       {:type "string" :enum ["+" "-" "*" "/"]}
+                 ;; items intentionally unconstrained: an operand is itself an expression node
+                 ;; (metric/measure object, arithmetic object, or a bare number).
+                 "operands" {:type "array" :items {}}}})
+
+(def ^:private metric-math-args-schema
+  "Args schema for `compute_metric_math`. `:expression` carries the recursive tree (JSON schema
+  hand-authored above); `:breakout` optionally groups every metric by a shared dimension, referenced
+  by the `field_id` surfaced in metric metadata (the stable key used to match the same logical
+  dimension across metrics)."
+  [:map {:closed true}
+   [:reasoning   {:optional true} [:maybe :string]]
+   [:expression  [:map {:json-schema expression-json-schema}]]
+   [:breakout    {:optional true}
+    [:map {:closed true}
+     [:field_id      pos-int?]
+     [:temporal_unit {:optional true} [:maybe :string]]]]
+   [:display     {:optional true} [:enum "line" "bar" "area" "row" "table" "scalar"]]
+   [:title       :string]])
+
+;;; ------------------------------------------------ Build ------------------------------------------------
+
+(defn- agent-error!
+  "Throw an LLM-facing validation error the tool wrapper relays verbatim."
+  [msg]
+  (throw (ex-info msg {:agent-error? true :status-code 400})))
+
+(defn- build-expression
+  "Recursively convert the LLM's structured expression into the internal AST, stamping a fresh
+  `:lib/uuid` on each leaf occurrence (so the same metric can appear more than once) and collecting
+  per-leaf filters. Returns `{:ast <internal-expr> :filters [<instance-filter> ...]}`.
+  Throws an `:agent-error?` on malformed input."
+  [expr]
+  (cond
+    (number? expr)
+    {:ast expr :filters []}
+
+    (and (map? expr) (contains? expr :op))
+    (let [op       (some-> (:op expr) name keyword)
+          operands (:operands expr)]
+      (when-not (and (contains? math-operators op)
+                     (sequential? operands)
+                     (>= (count operands) 2))
+        (agent-error! (tru "Each arithmetic node needs an \"op\" of +, -, * or / and at least 2 \"operands\".")))
+      (let [children (mapv build-expression operands)]
+        {:ast     (into [op {}] (map :ast) children)
+         :filters (into [] (mapcat :filters) children)}))
+
+    (and (map? expr) (contains? expr :type))
+    (let [type-kw (some-> (:type expr) name keyword)
+          id      (:id expr)]
+      (when-not (and (contains? #{:metric :measure} type-kw) (pos-int? id))
+        (agent-error! (tru "Each reference needs a \"type\" of \"metric\" or \"measure\" and a positive integer \"id\".")))
+      (let [uuid (str (random-uuid))]
+        {:ast     [type-kw {:lib/uuid uuid} id]
+         :filters (if-some [f (:filter expr)]
+                    [{:lib/uuid uuid :filter f}]
+                    [])}))
+
+    :else
+    (agent-error! (tru "Invalid expression node: expected a metric/measure reference, an arithmetic node, or a number."))))
+
+(defn- build-definition
+  "Build and validate an internal metric definition from tool `args`. Returns
+  `{:definition <def> :plan <plan>}`. Throws an `:agent-error?` on invalid LLM input; lets genuine
+  permission (403) errors from [[metrics.definition/from-api-definition]] propagate."
+  [{:keys [expression breakout]}]
+  (let [{:keys [ast filters]} (build-expression expression)]
+    (when (empty? (metrics.definition/collect-expression-leaves ast))
+      (agent-error! (tru "The expression must reference at least one metric or measure.")))
+    ;; Breakout resolution reads each metric's dimensions from the metadata provider, which only sees
+    ;; synced dimensions. Unlike the metrics-viewer (which syncs via GET /metric/:id before sending
+    ;; projections), this tool resolves the breakout itself, so it must sync first — otherwise a
+    ;; never-synced metric exposes zero dimensions and every breakout is wrongly rejected as cross-table.
+    (when breakout
+      (metrics.definition/sync-expression-dimensions! ast))
+    (let [provider (lib-metric/metadata-provider)
+          base     (metrics.definition/from-api-definition provider {:expression ast :filters filters})
+          def*     (if breakout
+                     (lib-metric/project-breakout-by-field-id
+                      base
+                      (:field_id breakout)
+                      (some-> (:temporal_unit breakout) not-empty keyword))
+                     base)
+          plan     (lib-metric/->query-plan def* {:limit 10000})]
+      {:definition def* :plan plan})))
+
+;;; ------------------------------------------------ Tool ------------------------------------------------
+
+(defn- definition->api-shape
+  "Strip the (non-serializable) metadata-provider so the definition can be JSON-encoded and posted
+  straight back to POST /api/metric/dataset by the frontend."
+  [definition]
+  (select-keys definition [:expression :filters :projections]))
+
+(mu/defn ^{:tool-name "compute_metric_math"
+           :scope     scope/agent-notebook-create}
+  compute-metric-math-tool
+  "Combine saved metrics/measures with arithmetic (+, -, *, /) into a single visualization, optionally
+  grouped by a shared dimension. Use the metric/measure ids and dimension field-ids from the metadata
+  tools. Produces a chart the user sees; it does not return the computed numbers to you."
+  [{:keys [breakout display title] :as args} :- metric-math-args-schema]
+  (try
+    (let [{:keys [definition plan]} (build-definition args)
+          api-def   (definition->api-shape definition)
+          display*  (or display "line")
+          instruction-text
+          (te/lines
+           "Your metric-math visualization has been created and shown to the user."
+           ""
+           "Briefly describe what it shows. You do not have the underlying numbers — do not invent them.")]
+      {:output            (str "<result>\n"
+                               (tru "Built a {0} visualization titled \"{1}\"." display* title)
+                               "\n</result>\n"
+                               "<instructions>\n" instruction-text "\n</instructions>")
+       :data-parts        [(streaming/metric-viz-part
+                            (cond-> {:definition api-def
+                                     :display    display*
+                                     :title      title}
+                              breakout (assoc :breakout breakout)))]
+       :structured-output (cond-> {:definition api-def
+                                   :display    display*
+                                   :title      title
+                                   :plan-type  (:plan/type plan)}
+                            breakout (assoc :breakout breakout))
+       :instructions      instruction-text})
+    (catch Exception e
+      (let [{:keys [agent-error? status-code]} (ex-data e)]
+        (cond
+          agent-error?
+          (do (log/debug e "compute_metric_math returned agent-error to the LLM")
+              {:output (ex-message e)})
+          ;; Expected, LLM- or user-actionable conditions: bad input / breakout incompatibility (400),
+          ;; missing permission on a referenced metric (403), or a missing entity (404). Relay cleanly.
+          (contains? #{400 403 404} status-code)
+          (do (log/debug e "compute_metric_math: definition rejected" {:status-code status-code})
+              {:output (ex-message e)})
+          :else
+          (do (log/error e "Failed to compute metric math")
+              {:output (str "Failed to compute metric math: " (or (ex-message e) "Unknown error"))}))))))

--- a/src/metabase/metabot/tools/metric_math.clj
+++ b/src/metabase/metabot/tools/metric_math.clj
@@ -145,9 +145,11 @@
 (mu/defn ^{:tool-name "compute_metric_math"
            :scope     scope/agent-notebook-create}
   compute-metric-math-tool
-  "Combine saved metrics/measures with arithmetic (+, -, *, /) into a single visualization, optionally
-  grouped by a shared dimension. Use the metric/measure ids and dimension field-ids from the metadata
-  tools. Produces a chart the user sees; it does not return the computed numbers to you."
+  "Combine two or more saved metrics/measures with arithmetic (+, -, *, /) into a SINGLE visualization —
+  a ratio, rate, percentage, difference, variance, or share of a total — optionally grouped by a shared
+  dimension. Prefer this over building a separate chart per metric whenever the answer relates metrics to
+  each other. Use the metric/measure ids and dimension field-ids from the metadata tools. Produces a chart
+  the user sees; it does not return the computed numbers to you."
   [{:keys [breakout display title] :as args} :- metric-math-args-schema]
   (try
     (let [{:keys [definition plan]} (build-definition args)

--- a/src/metabase/metrics/api.clj
+++ b/src/metabase/metrics/api.clj
@@ -7,6 +7,7 @@
    [metabase.lib-metric.core :as lib-metric]
    [metabase.lib-metric.schema :as lib-metric.schema]
    [metabase.metrics.core :as metrics]
+   [metabase.metrics.definition :as metrics.definition]
    [metabase.metrics.permissions :as metrics.perms]
    [metabase.query-processor.core :as qp]
    [metabase.query-processor.pipeline :as qp.pipeline]
@@ -105,17 +106,6 @@
 
 ;;; ------------------------------------------------- Expression Helpers --------------------------------------------------
 
-(defn- collect-expression-uuids
-  "Collect all :lib/uuid values from leaf nodes in an expression tree."
-  [expr]
-  (mapv lib-metric/expression-leaf-uuid (lib-metric/expression-leaves expr)))
-
-(defn- collect-expression-leaves
-  "Collect [type id] pairs from leaf nodes in an expression tree."
-  [expr]
-  (mapv (juxt lib-metric/expression-leaf-type lib-metric/expression-leaf-id)
-        (lib-metric/expression-leaves expr)))
-
 (mr/def ::Definition
   "Schema for the definition object within a dataset request.
    Uses expression-based contract for metric math support."
@@ -126,18 +116,18 @@
     [:projections {:optional true} [:maybe ::lib-metric.schema/typed-projections]]]
    [:fn {:error/message "Expression must contain at least one metric or measure"}
     (fn [{:keys [expression]}]
-      (seq (collect-expression-leaves expression)))]
+      (seq (metrics.definition/collect-expression-leaves expression)))]
    [:fn {:error/message "All :lib/uuid values in expression must be unique"}
     (fn [{:keys [expression]}]
-      (let [uuids (collect-expression-uuids expression)]
+      (let [uuids (metrics.definition/collect-expression-uuids expression)]
         (= (count uuids) (count (set uuids)))))]
    [:fn {:error/message "Filter :lib/uuid values must reference UUIDs from expression"}
     (fn [{:keys [expression filters]}]
-      (let [expr-uuids (set (collect-expression-uuids expression))]
+      (let [expr-uuids (set (metrics.definition/collect-expression-uuids expression))]
         (every? #(contains? expr-uuids (:lib/uuid %)) (or filters []))))]
    [:fn {:error/message "Projection :lib/uuid values must reference UUIDs from expression"}
     (fn [{:keys [expression projections]}]
-      (let [expr-uuids (set (collect-expression-uuids expression))]
+      (let [expr-uuids (set (metrics.definition/collect-expression-uuids expression))]
         (every? #(contains? expr-uuids (:lib/uuid %)) (or projections []))))]])
 
 (mr/def ::DatasetRequest
@@ -160,32 +150,6 @@
                 [:cols [:sequential :any]]
                 [:rows [:sequential :any]]]]
    [:row_count ms/IntGreaterThanOrEqualToZero]])
-
-(defn- check-expression-permissions
-  "Collect all metric/measure leaves from the expression and verify query permissions for each."
-  [expression]
-  (doseq [[source-type source-id] (collect-expression-leaves expression)]
-    (case source-type
-      :metric  (api/query-check (t2/select-one :model/Card :id source-id :type "metric"))
-      :measure (api/query-check (t2/select-one :model/Measure :id source-id)))))
-
-(defn- from-api-definition
-  "Create a MetricDefinition from API definition parameters.
-
-   The definition map is passed through directly as the internal MetricDefinition,
-   since the API format and internal format now match.
-
-   Permission checks are performed on all referenced entities in the expression."
-  [provider definition]
-  (let [{:keys [expression filters projections]} definition]
-    ;; Permission check all expression leaves
-    (check-expression-permissions expression)
-    ;; Build MetricDefinition — format matches directly
-    {:lib/type          :metric/definition
-     :expression        expression
-     :filters           (or filters [])
-     :projections       (or projections [])
-     :metadata-provider provider}))
 
 (defn- with-metric-exec-info
   "Attach `:executed-by`/`:context` to a metric-plan MBQL query so that
@@ -231,7 +195,7 @@
   [_route-params
    _query-params
    {:keys [definition]} :- ::DatasetRequest]
-  (let [definition (from-api-definition (lib-metric/metadata-provider) definition)
+  (let [definition (metrics.definition/from-api-definition (lib-metric/metadata-provider) definition)
         plan       (lib-metric/->query-plan definition {:limit 10000})]
     (if (= :leaf (:plan/type plan))
       (qp.streaming/streaming-response [rff :api]
@@ -257,7 +221,7 @@
   [_route-params
    _query-params
    {:keys [definition]} :- ::DatasetRequest]
-  (let [definition (from-api-definition (lib-metric/metadata-provider) definition)
+  (let [definition (metrics.definition/from-api-definition (lib-metric/metadata-provider) definition)
         plan       (lib-metric/->query-plan definition {:limit 100 :values-only true})
         result     (qp/process-query (qp/userland-query (with-metric-exec-info (:plan/mbql plan))))
         col        (first (get-in result [:data :cols]))

--- a/src/metabase/metrics/definition.clj
+++ b/src/metabase/metrics/definition.clj
@@ -1,0 +1,66 @@
+(ns metabase.metrics.definition
+  "Shared helpers for turning an API- or tool-supplied metric definition (an `:expression`
+  plus optional `:filters`/`:projections`) into an internal `::lib-metric.schema/metric-definition`,
+  including query-permission checks over every metric/measure referenced in the expression.
+
+  Used by both the `POST /api/metric/dataset` endpoint ([[metabase.metrics.api]]) and the Metabot
+  metric-math tool ([[metabase.metabot.tools.metric-math]]) so the permission and shaping logic can't
+  drift between them."
+  (:require
+   [metabase.api.common :as api]
+   [metabase.lib-metric.core :as lib-metric]
+   [metabase.metrics.core :as metrics.core]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn collect-expression-uuids
+  "Collect all `:lib/uuid` values from leaf nodes in an expression tree."
+  [expression]
+  (mapv lib-metric/expression-leaf-uuid (lib-metric/expression-leaves expression)))
+
+(defn collect-expression-leaves
+  "Collect `[type id]` pairs from leaf nodes in an expression tree."
+  [expression]
+  (mapv (juxt lib-metric/expression-leaf-type lib-metric/expression-leaf-id)
+        (lib-metric/expression-leaves expression)))
+
+(defn sync-expression-dimensions!
+  "Persist (sync) dimensions for every distinct metric/measure referenced in `expression`.
+
+  Breakout resolution reads a metric's dimensions from the metadata provider, which only sees
+  dimensions that have been synced to the app DB. `GET /api/metric/:id` syncs them as a side effect,
+  so the metrics-viewer flow always has them by the time it POSTs projections; a caller that resolves
+  breakouts itself (e.g. the Metabot metric-math tool) must sync first or a never-synced metric
+  exposes zero dimensions. `sync-dimensions!` only writes when dimensions actually change."
+  [expression]
+  (doseq [[source-type source-id] (distinct (collect-expression-leaves expression))]
+    (metrics.core/sync-dimensions! (case source-type
+                                     :metric  :metadata/metric
+                                     :measure :metadata/measure)
+                                   source-id)))
+
+(defn check-expression-permissions
+  "Collect all metric/measure leaves from `expression` and verify query permissions for each.
+  Throws the standard 403 response (via [[metabase.api.common/query-check]]) if the current user
+  lacks access to any referenced entity."
+  [expression]
+  (doseq [[source-type source-id] (collect-expression-leaves expression)]
+    (case source-type
+      :metric  (api/query-check (t2/select-one :model/Card :id source-id :type "metric"))
+      :measure (api/query-check (t2/select-one :model/Measure :id source-id)))))
+
+(defn from-api-definition
+  "Create an internal MetricDefinition from an API/tool definition map.
+
+  The definition map (`:expression`, optional `:filters`/`:projections`) is passed through directly
+  as the internal MetricDefinition, since the API format and internal format match. Query permissions
+  are checked for every metric/measure referenced in the expression before the definition is returned."
+  [provider definition]
+  (let [{:keys [expression filters projections]} definition]
+    (check-expression-permissions expression)
+    {:lib/type          :metric/definition
+     :expression        expression
+     :filters           (or filters [])
+     :projections       (or projections [])
+     :metadata-provider provider}))

--- a/test/metabase/metabot/agent/profiles_test.clj
+++ b/test/metabase/metabot/agent/profiles_test.clj
@@ -167,11 +167,14 @@
           fallback   (tool-names (profiles/get-profile :nlq-fallback))
           ;; force the curated nlq (no redirect) — get-profile :nlq otherwise falls back when the index can't answer
           curated    (mt/with-dynamic-fn-redefs [entity-retrieval/entity-retrieval-available? (constantly true)]
-                       (tool-names (profiles/get-profile :nlq)))]
-      ;; the fallback profile is embedding_next's discovery surface (general `search`)
-      (is (= fallback embedding))
+                       (tool-names (profiles/get-profile :nlq)))
+          ;; the in-app NLQ pair (:nlq / :nlq-fallback) also carries compute_metric_math (a metrics-viewer
+          ;; visualization builder) that the embedding_next surface intentionally does not.
+          embedding+ (conj embedding "compute_metric_math")]
+      ;; the fallback profile is embedding_next's discovery surface (general `search`) plus metric math
+      (is (= fallback embedding+))
       ;; the curated profile is the same set with retrieve_library_entities in place of `search`
-      (is (= curated (-> embedding (disj "search") (conj "retrieve_library_entities"))))))
+      (is (= curated (-> embedding+ (disj "search") (conj "retrieve_library_entities"))))))
   (binding [scope/*current-user-scope* api-scope/unrestricted]
     (testing "navigate_user is excluded without the capability"
       (let [tools (profiles/get-tools-for-profile :embedding_next [])]

--- a/test/metabase/metabot/tools/metric_math_test.clj
+++ b/test/metabase/metabot/tools/metric_math_test.clj
@@ -1,0 +1,126 @@
+(ns metabase.metabot.tools.metric-math-test
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.metabot.tools.metric-math-test]}}}}}}
+  (:require
+   [clojure.test :refer :all]
+   [metabase.metabot.tools.metric-math :as metric-math]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]))
+
+(use-fixtures :once (fixtures/initialize :db :test-users))
+
+;;; ------------------------------------------------ Pure build-expression ------------------------------------------------
+
+(deftest ^:parallel build-expression-stamps-unique-uuids-test
+  (testing "each leaf occurrence gets its own :lib/uuid so the same metric can appear twice"
+    (let [{:keys [ast filters]} (#'metric-math/build-expression
+                                 {:op "/" :operands [{:type "metric" :id 1}
+                                                     {:type "metric" :id 1}]})
+          [op _opts a b] ast]
+      (is (= :/ op))
+      (is (= [:metric :metric] [(first a) (first b)]))
+      (is (= [1 1] [(nth a 2) (nth b 2)]))
+      (let [ua (get-in a [1 :lib/uuid])
+            ub (get-in b [1 :lib/uuid])]
+        (is (string? ua))
+        (is (string? ub))
+        (is (not= ua ub) "duplicate metric references must get distinct uuids"))
+      (is (= [] filters)))))
+
+(deftest ^:parallel build-expression-nested-and-constant-test
+  (testing "nested arithmetic and bare numeric constants build into the internal AST"
+    (let [{:keys [ast]} (#'metric-math/build-expression
+                         {:op "*" :operands [{:op "/" :operands [{:type "metric" :id 42}
+                                                                 {:type "measure" :id 7}]}
+                                             100]})
+          [op _ inner c] ast]
+      (is (= :* op))
+      (is (= 100 c))
+      (is (= :/ (first inner)))
+      (is (= :measure (first (nth inner 3)))))))
+
+(deftest ^:parallel build-expression-per-leaf-filter-test
+  (testing "a per-reference filter becomes an instance-filter keyed by that leaf's uuid"
+    (let [flt                  [:> {} [:dimension {} "d-uuid"] 3]
+          {:keys [ast filters]} (#'metric-math/build-expression
+                                 {:type "measure" :id 5 :filter flt})
+          uuid                 (get-in ast [1 :lib/uuid])]
+      (is (= [:measure {:lib/uuid uuid} 5] ast))
+      (is (= [{:lib/uuid uuid :filter flt}] filters)))))
+
+(deftest ^:parallel build-expression-rejects-bad-input-test
+  (testing "malformed nodes raise an LLM-facing :agent-error?"
+    (doseq [node [{:op "%" :operands [{:type "metric" :id 1} {:type "metric" :id 2}]} ; bad operator
+                  {:op "+" :operands [{:type "metric" :id 1}]}                        ; too few operands
+                  {:type "widget" :id 1}                                              ; bad type
+                  {:type "metric"}                                                    ; missing id
+                  {:type "metric" :id -3}]]                                           ; non-positive id
+      (let [e (try (#'metric-math/build-expression node) nil (catch Exception e e))]
+        (is (some? e) (str "expected throw for " node))
+        (is (:agent-error? (ex-data e)))))))
+
+(deftest ^:parallel compute-metric-math-rejects-metric-free-expression-test
+  (testing "an expression with no metric/measure leaves is rejected before any query work"
+    (let [result (metric-math/compute-metric-math-tool
+                  {:expression {:op "+" :operands [1 2]} :title "constants only"})]
+      (is (nil? (:data-parts result)))
+      (is (re-find #"at least one metric or measure" (:output result))))))
+
+;;; ------------------------------------------------ Full tool (DB-backed) ------------------------------------------------
+
+(deftest compute-metric-math-builds-metric-viz-part-test
+  (testing "arithmetic over two metrics with a shared breakout yields a validated metric_viz part"
+    ;; Deliberately DO NOT pre-sync the metrics' dimensions: the tool must sync them itself before
+    ;; resolving the breakout. Without that (the original bug), a never-synced metric exposes zero
+    ;; dimensions and the breakout is wrongly rejected.
+    (mt/with-temp [:model/Card metric-a {:name "Metric A" :type :metric
+                                         :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}
+                   :model/Card metric-b {:name "Metric B" :type :metric
+                                         :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
+      (mt/with-test-user :rasta
+        (let [result   (metric-math/compute-metric-math-tool
+                        {:expression {:op "/" :operands [{:type "metric" :id (:id metric-a)}
+                                                         {:type "metric" :id (:id metric-b)}]}
+                         :breakout   {:field_id (mt/id :venues :price)}
+                         :display    "line"
+                         :title      "A over B"})
+              part     (first (:data-parts result))
+              structured (:structured-output result)]
+          (is (= "metric_viz" (:data-type part)) (:output result))
+          (is (= :arithmetic (:plan-type structured)))
+          (testing "definition carries per-leaf projections and no metadata-provider"
+            (let [definition (get-in part [:data :definition])]
+              (is (= 2 (count (:projections definition))))
+              (is (nil? (:metadata-provider definition)))
+              (is (contains? definition :expression)))))))))
+
+(deftest compute-metric-math-incompatible-breakout-test
+  (testing "breaking out by a field absent from one metric returns a clean agent error, not a crash"
+    ;; `users` and `venues` share no FK path, so a users field-id is not a reachable dimension on the
+    ;; venues metric — the cross-leaf breakout must fail with an actionable message rather than crash.
+    (mt/with-temp [:model/Card users-metric  {:name "Users metric" :type :metric
+                                              :dataset_query (mt/mbql-query users {:aggregation [[:count]]})}
+                   :model/Card venues-metric {:name "Venues metric" :type :metric
+                                              :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
+      (mt/with-test-user :rasta
+        (let [result (metric-math/compute-metric-math-tool
+                      {:expression {:op "+" :operands [{:type "metric" :id (:id users-metric)}
+                                                       {:type "metric" :id (:id venues-metric)}]}
+                       :breakout   {:field_id (mt/id :users :name)}
+                       :title      "mismatch"})
+              output (:output result)]
+          (is (nil? (:data-parts result)))
+          (testing "the message names the field, the offending metric, and the cross-table constraint"
+            (is (re-find #"(?i)can.t break out by field" output))
+            (is (re-find #"Venues metric" output))
+            (is (re-find #"(?i)different table" output))))))))
+
+(deftest compute-metric-math-single-leaf-test
+  (testing "a single metric with no breakout validates as a :leaf plan"
+    (mt/with-temp [:model/Card metric {:name "Solo metric" :type :metric
+                                       :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
+      (mt/with-test-user :rasta
+        (let [result     (metric-math/compute-metric-math-tool
+                          {:expression {:type "metric" :id (:id metric)} :title "solo"})
+              structured (:structured-output result)]
+          (is (= "metric_viz" (:data-type (first (:data-parts result)))))
+          (is (= :leaf (:plan-type structured))))))))


### PR DESCRIPTION
## Metric math for Metabot

Adds a Metabot tool, **`compute_metric_math`**, that combines two or more saved **metrics/measures** with arithmetic (`+ - * /`) into a single visualization — ratios, rates, percentages, differences, variance, share-of-total — optionally broken out by a shared dimension. Previously the agent had to build a separate chart per metric and leave the user to combine them by eye.

**Example:** “budget variance % by department” → `(Budget − Spend) / Budget × 100`, grouped by department, rendered as one chart.

### What it does

- **Combines metrics with a formula.** The agent passes a structured expression tree of metric/measure references, arithmetic operators, and constants (with normal precedence via nesting). Each reference can carry its own filter.
- **Optional breakout.** A result can be grouped by a dimension shared across the metrics in the formula (e.g. by month, by category).
- **Renders inline.** The result is shown to the user as a live chart in the conversation, driven by the existing metrics-viewer / `/api/metric/dataset` engine — the tool does not return raw numbers to the model.
- **Validates before rendering.** Builds and compiles the query plan and checks permissions on every referenced metric; on a bad breakout it returns an actionable error (which field, which table, which metric lacks it) instead of a silent failure or a crash.

### How the agent uses it

- Available on the **`:nlq`** and **`:nlq-fallback`** profiles.
- A lazy-loaded **`compute-metric-math` skill** documents the expression shape, breakout/field-id rules, and limitations.
- The nlq system prompt now nudges the agent to answer combined-metric questions (ratios, %, differences, variance, share-of-total) with **one calculation instead of a chart per metric**.

### How it works (for reviewers)

- **Tool:** `metabase.metabot.tools.metric-math` — structured-expression input, per-reference `lib/uuid` stamping, permission + compile-time validation, clean agent-facing errors.
- **Shared definition layer:** promotes `from-api-definition` / permission checks out of the metrics API into `metabase.metrics.definition`, so the tool and `POST /api/metric/dataset` can’t drift.
- **Breakout resolution:** new `lib-metric` helper resolves each metric’s own dimension by underlying field id (the conformed-dimension match), and syncs a metric’s dimensions before resolving — mirroring `GET /metric/:id` — so a never-synced metric no longer reports zero dimensions.
- **Frontend:** new `metric_viz` streaming data-part wired through the schema/dispatch/renderers, plus a `MetabotMetricViz` component that renders the definition via the metrics-viewer visualization.

### Current limitations

- **Breakouts need a field shared by every metric.** Metrics on different base tables can only be broken out by a conformed dimension (the same physical field reachable from each). A cross-table breakout — including by each table’s own date column — isn’t supported; use a scalar result or `construct_notebook_query` for those.
- **Overlap only.** A breakout bucket appears only when every metric has data for it.
- **Missing operand / divide-by-zero → empty bucket** (a gap, not an error).
- **Operands are saved metrics/measures only** — not raw tables, columns, or ad-hoc aggregations.

### Testing

- Unit tests for expression building, breakout resolution, the dimension-sync path, and error messaging.
- Regression coverage for `POST /api/metric/dataset` after the shared-namespace refactor, plus module/profile/tool registration tests.
- Frontend unit tests for the `metric_viz` renderer.