### PR TITLE
Enrich metabot template context once per request

### DIFF
--- a/resources/metabot/prompts/system/embedding-next.selmer
+++ b/resources/metabot/prompts/system/embedding-next.selmer
@@ -53,14 +53,6 @@ In the system, the first day of the week (index 1) is: {{ first_day_of_week }}
 <user_context>
 Here is some information about the user:
 {{ current_user_info|safe }}
-{% if viewing_context %}
-{{ viewing_context|safe }}
-{% endif %}
-</user_context>
-{% elif viewing_context %}
-
-<user_context>
-{{ viewing_context|safe }}
 </user_context>
 {% endif %}
 {% if recent_views %}

--- a/resources/metabot/prompts/system/natural-language-querying-fallback.selmer
+++ b/resources/metabot/prompts/system/natural-language-querying-fallback.selmer
@@ -60,14 +60,6 @@ In the system, the first day of the week (index 1) is: {{ first_day_of_week }}
 <user_context>
 Here is some information about the user:
 {{ current_user_info|safe }}
-{% if viewing_context %}
-{{ viewing_context|safe }}
-{% endif %}
-</user_context>
-{% elif viewing_context %}
-
-<user_context>
-{{ viewing_context|safe }}
 </user_context>
 {% endif %}
 {% if recent_views %}

--- a/resources/metabot/prompts/system/natural-language-querying-only.selmer
+++ b/resources/metabot/prompts/system/natural-language-querying-only.selmer
@@ -60,14 +60,6 @@ In the system, the first day of the week (index 1) is: {{ first_day_of_week }}
 <user_context>
 Here is some information about the user:
 {{ current_user_info|safe }}
-{% if viewing_context %}
-{{ viewing_context|safe }}
-{% endif %}
-</user_context>
-{% elif viewing_context %}
-
-<user_context>
-{{ viewing_context|safe }}
 </user_context>
 {% endif %}
 {% if recent_views %}

--- a/resources/metabot/prompts/system/sql-querying-only.selmer
+++ b/resources/metabot/prompts/system/sql-querying-only.selmer
@@ -373,14 +373,6 @@ In the system, the first day of the week (index 1) is: {{ first_day_of_week }}
 <user_context>
 Here is some information about the user:
 {{ current_user_info|safe }}
-{% if viewing_context %}
-{{ viewing_context|safe }}
-{% endif %}
-</user_context>
-{% elif viewing_context %}
-
-<user_context>
-{{ viewing_context|safe }}
 </user_context>
 {% endif %}
 {% if recent_views %}

--- a/resources/metabot/prompts/system/transform-codegen.selmer
+++ b/resources/metabot/prompts/system/transform-codegen.selmer
@@ -387,14 +387,6 @@ In the system, the first day of the week (index 1) is: {{ first_day_of_week }}
 <user_context>
 Here is some information about the user:
 {{ current_user_info|safe }}
-{% if viewing_context %}
-{{ viewing_context|safe }}
-{% endif %}
-</user_context>
-{% elif viewing_context %}
-
-<user_context>
-{{ viewing_context|safe }}
 </user_context>
 {% endif %}
 {% if recent_views %}

--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -12,6 +12,7 @@
    [metabase.metabot.agent.messages :as messages]
    [metabase.metabot.agent.profiles :as profiles]
    [metabase.metabot.agent.streaming :as streaming]
+   [metabase.metabot.agent.user-context :as user-context]
    [metabase.metabot.provider-util :as provider-util]
    [metabase.metabot.scope :as scope]
    [metabase.metabot.self :as self]
@@ -246,10 +247,10 @@
 
   Builds AISDK parts from memory and passes them to the adapter which converts
   them to its native wire format."
-  [memory context profile tools iteration tracking-opts link-registry-atom]
+  [memory template-context profile tools iteration tracking-opts link-registry-atom]
   (let [model        (:model profile)
-        system-msg   (messages/build-system-message context profile tools)
-        input-parts  (-> (messages/build-message-history context memory)
+        system-msg   (messages/build-system-message template-context profile tools)
+        input-parts  (-> (messages/build-message-history template-context memory)
                          (invert-links @link-registry-atom))
         llm-opts     (cond-> {}
                        (:required-tool-call? profile) (assoc :tool-choice "required"))]
@@ -442,15 +443,18 @@
                                 :tools    (count tools)
                                 :max-iter (:max-iterations profile)
                                 :msgs     (count messages)})
-    {:profile       profile
-     :tools         tools
-     :context       context
-     :memory-atom   memory-atom
-     :tracking-opts (merge {:profile-id profile-id
-                            :request-id (str (random-uuid))
-                            :source     "metabot_agent"
-                            :tag        "agent"}
-                           tracking-opts)}))
+    {:profile          profile
+     :tools            tools
+     ;; Enriched once per request: enrichment formats the viewing context, which fetches
+     ;; entity details for every viewed item — too expensive to redo on every iteration
+     ;; and message build (metabase#76493).
+     :template-context (user-context/enrich-context-for-template context)
+     :memory-atom      memory-atom
+     :tracking-opts    (merge {:profile-id profile-id
+                               :request-id (str (random-uuid))
+                               :source     "metabot_agent"
+                               :tag        "agent"}
+                              tracking-opts)}))
 
 (defn- initial-loop-state
   "Create initial loop state from agent config and reduction context."
@@ -498,14 +502,14 @@
   [{:keys [agent rf result iteration usage-atom] :as loop-state}]
   (with-span :debug {:name      :metabot.agent/loop-step
                      :iteration iteration}
-    (let [{:keys [profile tools context memory-atom tracking-opts]} agent
+    (let [{:keys [profile tools template-context memory-atom tracking-opts]} agent
           max-iter           (:max-iterations profile 10)
           terminal-tools     (set (:terminal-tools profile))
           tracking-opts      (assoc tracking-opts :iteration iteration)
           memory             @memory-atom
           parts-atom         (atom [])
           link-registry-atom (atom (get-in memory [:state :link-registry] {}))
-          llm-call           (call-llm memory context profile tools iteration tracking-opts link-registry-atom)
+          llm-call           (call-llm memory template-context profile tools iteration tracking-opts link-registry-atom)
           xf                 (comp (accumulate-usage-xf usage-atom (:model profile))
                                    (u/tee-xf parts-atom))
           ;; We use `reduce` instead of `transduce` because rf is the outer reducing

--- a/src/metabase/metabot/agent/messages.clj
+++ b/src/metabase/metabot/agent/messages.clj
@@ -8,7 +8,6 @@
   (:require
    [metabase.metabot.agent.memory :as memory]
    [metabase.metabot.agent.prompts :as prompts]
-   [metabase.metabot.agent.user-context :as user-context]
    [metabase.metabot.skills :as skills]
    [metabase.util.json :as json]
    [metabase.util.log :as log]))
@@ -137,21 +136,23 @@
        (filter #(#{:text :tool-input :tool-output} (:type %)))))
 
 (defn- messages-with-injected-context
-  "Returns messages from memory and injects context into the most recent one."
-  [context memory]
+  "Returns messages from memory and injects the template context into the most recent one."
+  [template-context memory]
   (let [all-messages (memory/get-input-messages memory)
         [input-messages [most-recent-message]] (split-at (dec (count all-messages))  all-messages)]
     (if-not (and (= :user (-> most-recent-message :role))
                  (< 0 (count all-messages)))
       all-messages
-      (let [enriched-context (user-context/enrich-context-for-template context)]
-        (conj (vec input-messages)
-              (update most-recent-message :content (partial prompts/inject-context enriched-context)))))))
+      (conj (vec input-messages)
+            (update most-recent-message :content (partial prompts/inject-context template-context))))))
 
 (defn build-message-history
   "Build the conversation history as a flat sequence of AISDK parts.
 
-  Injects the context into the most recent user message.
+  Injects the context into the most recent user message. `template-context` is the
+  pre-enriched template-variable map from `user-context/enrich-context-for-template` —
+  the agent loop computes it once per request (enrichment formats the viewing context,
+  which can be expensive) and shares it between the system message and the history.
 
   Returns a vector of items that are either:
   - `{:role :user, :content \"...\"}` for user messages
@@ -160,8 +161,8 @@
   - `{:type :tool-output, :id ..., :result ...}` for tool results
 
   Each LLM adapter converts this to its own wire format."
-  [context memory]
-  (let [input-messages (messages-with-injected-context context memory)
+  [template-context memory]
+  (let [input-messages (messages-with-injected-context template-context memory)
         steps          (memory/get-steps memory)
         input-parts    (mapcat input-message->parts input-messages)
         step-parts     (mapcat step->parts steps)
@@ -169,7 +170,7 @@
         ;; tool-call/result pair. It is placed after the input messages (so the
         ;; first message is still the user's) and before this turn's steps, which
         ;; keeps it below the system cache breakpoint.
-        preload-parts  (skills/dialect-preload-parts (user-context/extract-sql-dialect context))
+        preload-parts  (skills/dialect-preload-parts (:sql_dialect template-context))
         result         (vec (concat input-parts preload-parts step-parts))]
     (log/info "Building message history"
               {:input-message-count (count input-messages)
@@ -186,14 +187,14 @@
   "Build system message with templated prompt and enriched context.
 
   Parameters:
-  - context: Context map from API (with user_is_viewing, user_recently_viewed, etc.)
+  - template-context: Pre-enriched template-variable map from
+    `user-context/enrich-context-for-template` (computed once per request by the agent loop)
   - profile: Profile map with :prompt-template key
   - tools: Tool registry map (name -> var)
 
   Returns message map with {:role \"system\" :content \"...\"}."
-  [context profile tools]
-  (let [enriched-context (user-context/enrich-context-for-template context)
-        content          (prompts/build-system-message-content
-                          profile enriched-context tools (:capabilities context))]
+  [template-context profile tools]
+  (let [content (prompts/build-system-message-content
+                 profile template-context tools (:capabilities template-context))]
     {:role    "system"
      :content content}))

--- a/src/metabase/metabot/agent/prompts.clj
+++ b/src/metabase/metabot/agent/prompts.clj
@@ -71,8 +71,11 @@
   - :sql-dialect - SQL dialect name
   - :sql-dialect-instructions - Dialect-specific guidance (markdown)
   - :tool-instructions - Vector of tool instruction maps
-  - :viewing-context - Formatted user viewing context
-  - :recent-views - Formatted recent views"
+  - :recent-views - Formatted recent views
+
+  The viewing context is deliberately NOT a system-prompt variable: it is injected into
+  the most recent user message instead (see [[inject-context]]), which keeps the system
+  prompt stable for prompt caching."
   [template context]
   (try
     (selmer/render template context)
@@ -163,8 +166,6 @@
                                      (get context :current-time))
             first-day-of-week    (or (get context :first_day_of_week)
                                      (get context :first-day-of-week "Sunday"))
-            viewing-context      (or (get context :viewing_context)
-                                     (get context :viewing-context))
             recent-views         (or (get context :recent_views)
                                      (get context :recent-views))
             perms                (or scope/*current-user-metabot-permissions*
@@ -187,7 +188,6 @@
                                   ;; load, nudging the model into pointless `load_skill` calls.
                                   :skill_catalog            (not-empty catalog)
                                   :skill_always_on          (mapv :body always-on)
-                                  :viewing_context          viewing-context
                                   :recent_views             recent-views
                                   :has_sql_generation       has-sql?
                                   :has_nlq                  has-nlq?

--- a/src/metabase/metabot/agent/user_context.clj
+++ b/src/metabase/metabot/agent/user_context.clj
@@ -405,17 +405,23 @@
 (defn enrich-context-for-template
   "Enrich context with all necessary variables for system prompt template rendering.
 
+  Formatting the viewing context can be expensive (it fetches entity details for every
+  viewed item), so the agent loop calls this once per request and shares the result
+  between the system message and the message history.
+
   Takes raw context from API and returns map suitable for template rendering:
   - :current_time - Formatted user time string
   - :first_day_of_week - Calendar week start (default 'Sunday')
   - :sql_dialect - SQL dialect name (lowercase)
   - :current_user_info - Formatted current user info and glossary
   - :viewing_context - Formatted viewing context
-  - :recent_views - Formatted recent views"
+  - :recent_views - Formatted recent views
+  - :capabilities - Request capabilities, passed through for prompt/skill gating"
   [context]
   {:current_time (format-current-time context)
    :first_day_of_week (get context :first_day_of_week "Sunday")
    :sql_dialect (extract-sql-dialect context)
    :current_user_info (format-current-user-info context)
    :viewing_context (format-viewing-context context)
-   :recent_views (format-recent-views context)})
+   :recent_views (format-recent-views context)
+   :capabilities (:capabilities context)})

--- a/src/metabase/metabot/context.clj
+++ b/src/metabase/metabot/context.clj
@@ -123,17 +123,30 @@
         (when (lib/native-only-query? normalized-query)
           normalized-query)))))
 
+(defn- table-stub
+  "Reference to a table used by a viewing-context item.
+
+  Excludes columns. [[metabase.metabot.agent.user-context/format-entity]] only reads `:type` and `:id` and calculates
+  column details via [[metabase.metabot.tools.entity-details/get-table-details]], so fetching columns here is wasted
+  work. On large, highly-connected schemas it can contribute to heap exhaustion (metabase#76493).
+  `:name`/`:database_schema`/`:description` are kept for the `format-simple-entity` fallback"
+  [{:keys [id name schema description]}]
+  {:id id
+   :type :table
+   :name name
+   :database_schema schema
+   :description description})
+
 (defn- database-tables-for-context
-  "Get database tables formatted for metabot context. Only includes tables used in the query, formatted for API output.
-   Removes duplicate tables by id while preserving first occurrence order."
+  "Get database tables formatted for metabot context. Only includes tables used in the query.
+  Removes duplicate tables by id while preserving first occurrence order."
   [{:keys [query]}]
   (try
     (if query
-      (let [used-tables (table-utils/used-tables query)
-            tables (table-utils/enhanced-database-tables (:database query)
-                                                         {:priority-tables used-tables
-                                                          :all-tables-limit (count used-tables)})]
-        (m/distinct-by :id tables))
+      (into []
+            (comp (m/distinct-by :id)
+                  (map table-stub))
+            (table-utils/used-tables query))
       [])
     (catch Exception e
       (log/error e "Error getting database tables for context")
@@ -154,10 +167,7 @@
   [{:keys [database-id table-ids]}]
   (try
     (when (and database-id (seq table-ids))
-      (when-let [tables (not-empty (table-utils/used-tables-from-ids database-id table-ids))]
-        (table-utils/enhanced-database-tables database-id
-                                              {:priority-tables tables
-                                               :all-tables-limit (count tables)})))
+      (not-empty (mapv table-stub (table-utils/used-tables-from-ids database-id table-ids))))
     (catch Exception e
       (log/error e "Error getting Python transform tables for context")
       [])))
@@ -179,7 +189,7 @@
         [database-id table-ids]))))
 
 (defn- mbql-source-tables-for-context
-  "Get source tables for an MBQL query, formatted for metabot context (with :type, :display_name, :fields, etc.).
+  "Get source tables for an MBQL query, formatted for metabot context.
 
   Uses a direct table lookup without native-query permission checks. The user is already
   viewing these tables in the notebook editor, so they have at least query-builder access.
@@ -187,16 +197,15 @@
   which is too restrictive for MBQL viewing context enrichment."
   [[database-id table-ids]]
   (try
-    (let [raw-tables (t2/select [:model/Table :id :name :schema]
+    (let [raw-tables (t2/select [:model/Table :id :name :schema :description]
                                 :db_id database-id
                                 :id [:in table-ids]
                                 :active true
-                                :visibility_type nil)
-          tables     (when (seq raw-tables)
-                       (table-utils/enhanced-database-tables database-id
-                                                             {:priority-tables  raw-tables
-                                                              :all-tables-limit (count raw-tables)}))]
-      (m/distinct-by :id tables))
+                                :visibility_type nil)]
+      (into []
+            (comp (m/distinct-by :id)
+                  (map table-stub))
+            raw-tables))
     (catch Exception e
       (log/error e "Error getting MBQL source tables for context")
       nil)))

--- a/src/metabase/metabot/table_utils.clj
+++ b/src/metabase/metabot/table_utils.clj
@@ -3,14 +3,9 @@
   (:require
    [clojure.set :as set]
    [metabase.api.common :as api]
-   [metabase.lib-be.core :as lib-be]
-   [metabase.lib.core :as lib]
-   [metabase.lib.metadata :as lib.metadata]
    [metabase.metabot.query-analyzer :as query-analyzer]
-   [metabase.metabot.tools.util :as metabot.tools.u]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
-   [metabase.util.humanization :as u.humanization]
    [toucan2.core :as t2]
    [toucan2.realize :as t2.realize])
   (:import
@@ -72,58 +67,6 @@
                                              {:data_type database_type}))
                                     fields)}))
            all-tables))))
-
-(defn enhanced-database-tables
-  "Get database tables formatted with the new metabot tools schema format.
-
-  Returns tables with :type, :display_name, :database_id, :database_schema, :fields (with field-id), :metrics.
-  This format is used by metabot context and other modern tools."
-  ([database-id]
-   (enhanced-database-tables database-id nil))
-  ([database-id {:keys [all-tables-limit priority-tables exclude-table-ids]
-                 :or {all-tables-limit max-database-tables
-                      priority-tables []
-                      exclude-table-ids #{}}}]
-   (let [priority-table-ids (set (map :id priority-tables))
-         {table-where-clause :clause table-cte :with} (mi/visible-filter-clause :model/Table
-                                                                                :id
-                                                                                {:user-id       api/*current-user-id*
-                                                                                 :is-superuser? api/*is-superuser?*}
-                                                                                {:perms/view-data      :unrestricted
-                                                                                 :perms/create-queries :query-builder-and-native})
-         ;; Fetch most viewed tables, excluding priority tables and excluded tables
-         fill-tables (t2/select [:model/Table :id :db_id :name :schema :description]
-                                :db_id database-id
-                                :active true
-                                :visibility_type nil
-                                (cond-> {:where    table-where-clause
-                                         :order-by [[:view_count :desc]]
-                                         :limit    all-tables-limit}
-                                  table-cte (assoc :with table-cte)))
-         fill-tables (remove #(or (priority-table-ids (:id %))
-                                  (exclude-table-ids (:id %))) fill-tables)
-         all-tables (concat priority-tables fill-tables)
-         all-tables (take all-tables-limit all-tables)]
-     (lib-be/with-metadata-provider-cache
-       (let [mp (lib-be/application-database-metadata-provider database-id)
-             table-ids (map :id all-tables)
-             _ (lib.metadata/bulk-metadata mp :metadata/table table-ids)
-             engine (:engine (lib.metadata/database mp))]
-         (mapv (fn [{:keys [id name schema description]}]
-                 (let [table-query (lib/query mp (lib.metadata/table mp id))
-                       cols (->> (lib/visible-columns table-query)
-                                 (map #(metabot.tools.u/add-table-reference table-query %)))]
-                   {:id id
-                    :type :table
-                    :name name
-                    :display_name (u.humanization/name->human-readable-name :simple name)
-                    :database_id database-id
-                    :database_engine engine
-                    :database_schema schema
-                    :description description
-                    :fields (mapv #(metabot.tools.u/->result-column table-query %) cols)
-                    :metrics []}))
-               all-tables))))))
 
 (defn get-tables
   "Get information about the tables in a given database.
@@ -198,7 +141,7 @@
         (keep (fn [table]
                 (when (some #(matching-tables? table % {:match-schema? false}) unrecognized-tables)
                   (t2.realize/realize table))))
-        (t2/reducible-select [:model/Table :id :name :schema]
+        (t2/reducible-select [:model/Table :id :name :schema :description]
                              :db_id database-id
                              :active true
                              :visibility_type nil
@@ -215,7 +158,7 @@
   [database-id table-ids]
   (if-not (seq table-ids)
     []
-    (t2/select [:model/Table :id :name :schema]
+    (t2/select [:model/Table :id :name :schema :description]
                :db_id database-id
                :id [:in table-ids]
                :active true

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -656,7 +656,11 @@
                       (let [card    (t2/hydrate (metabot.tools.u/get-card report-id)
                                                 :average_query_time)
                             mp      (lib-be/application-database-metadata-provider (:database_id card))
-                            details (card-details card mp options)]
+                            ;; The select-keys below drops :related_tables and :metrics, so don't compute them. On
+                            ;; wide-FK source tables the related-tables cost can be substantial (metabase#76493).
+                            details (card-details card mp (assoc options
+                                                                 :with-related-tables? false
+                                                                 :with-metrics? false))]
                         (-> details
                             ;; `:query_json` is intentionally part of the slim payload here:
                             ;; it's what `question->xml` renders inside `<metabase_question>`

--- a/test/metabase/metabot/agent/core_test.clj
+++ b/test/metabase/metabot/agent/core_test.clj
@@ -7,6 +7,7 @@
    [metabase.lib.test-metadata :as meta]
    [metabase.metabot.agent.core :as agent]
    [metabase.metabot.agent.memory :as memory]
+   [metabase.metabot.agent.user-context :as user-context]
    [metabase.metabot.persistence :as metabot.persistence]
    [metabase.metabot.self :as self]
    [metabase.metabot.self.openrouter :as openrouter]
@@ -141,6 +142,37 @@
                                     :context    {}})))]
             ;; Should get error message
             (is (some #(= :error (:type %)) result))))))))
+
+(deftest context-enriched-once-per-request-test
+  (testing "viewing-context enrichment runs once per request — not per iteration and not per message build (metabase#76493)"
+    (mt/as-admin
+      (mt/with-temporary-setting-values [llm-metabot-provider test-provider]
+        (let [enrich-calls (atom 0)
+              orig         (mt/original-fn #'user-context/enrich-context-for-template)
+              llm-calls    (atom 0)]
+          (mt/with-dynamic-fn-redefs [user-context/enrich-context-for-template
+                                      (fn [ctx]
+                                        (swap! enrich-calls inc)
+                                        (orig ctx))
+                                      openrouter/openrouter
+                                      (fn [_]
+                                        (if (= 1 (swap! llm-calls inc))
+                                          (mut/mock-llm-response
+                                           [{:type      :tool-input
+                                             :id        "t1"
+                                             :function  "search"
+                                             :arguments {:semantic_queries ["orders"]}}])
+                                          (mut/mock-llm-response
+                                           [{:type :text :text "done"}])))
+                                      metabot-search/search (fn [_] [])]
+            (into [] (agent/run-agent-loop
+                      {:messages   [{:role :user :content "Hi"}]
+                       :state      {}
+                       :profile-id :embedding_next
+                       :context    {}}))
+            (is (= 2 @llm-calls) "sanity check: the loop ran two iterations")
+            (is (= 1 @enrich-calls)
+                "context enrichment (viewing-context formatting) must run exactly once per request")))))))
 
 ;; Note: build-messages-for-llm is now internal to call-llm
 ;; Message building is tested via messages_test.clj

--- a/test/metabase/metabot/agent/messages_test.clj
+++ b/test/metabase/metabot/agent/messages_test.clj
@@ -295,6 +295,59 @@
       (is (=? {:content #(not (str/blank? %))}
               (build-system-message* {} profile {}))))))
 
+;;; ──────────────────────────────────────────────────────────────────
+;;; viewing-context single-injection guarantee (metabase#76493)
+;;; ──────────────────────────────────────────────────────────────────
+
+(def ^:private viewing-ctx-marker "VIEWING-CONTEXT-MARKER-76493")
+
+(defn- marker-count
+  [s]
+  (count (re-seq (re-pattern viewing-ctx-marker) (or s ""))))
+
+(deftest ^:parallel viewing-context-sent-exactly-once-per-template-test
+  (testing "the formatted viewing context appears exactly once across system message + message history"
+    (mt/with-dynamic-fn-redefs [user-context/format-viewing-context (constantly viewing-ctx-marker)]
+      (doseq [template ["internal.selmer"
+                        "embedding-next.selmer"
+                        "sql-querying-only.selmer"
+                        "natural-language-querying-only.selmer"
+                        "natural-language-querying-fallback.selmer"
+                        "transform-codegen.selmer"
+                        "slackbot.selmer"
+                        "document-generate-content.selmer"]]
+        (testing template
+          (let [context          {:user_is_viewing [{:type "dashboard" :id 1 :name "Sales"}]}
+                template-context (user-context/enrich-context-for-template context)
+                profile          {:prompt-template template
+                                  :model           "claude-sonnet-4-5-20250929"}
+                system-msg       (messages/build-system-message template-context profile {})
+                history          (messages/build-message-history
+                                  template-context
+                                  (memory/initialize [{:role :user :content "Hello"}] {}))
+                history-text     (str/join "\n" (keep :content history))]
+            (is (= 0 (marker-count (:content system-msg)))
+                "system prompt must not contain the viewing context")
+            (is (= 1 (marker-count history-text))
+                "message history must contain the viewing context exactly once")
+            (is (= 1 (marker-count (last-user-content history)))
+                "the single occurrence is in the last user message")))))))
+
+(deftest ^:parallel viewing-context-injected-once-per-followup-turn-test
+  (testing "on a multi-turn conversation the viewing context lands only in the most recent user message"
+    (mt/with-dynamic-fn-redefs [user-context/format-viewing-context (constantly viewing-ctx-marker)]
+      (let [template-context (user-context/enrich-context-for-template
+                              {:user_is_viewing [{:type "dashboard" :id 1 :name "Sales"}]})
+            history          (messages/build-message-history
+                              template-context
+                              (memory/initialize [{:role :user :content "First question"}
+                                                  {:role :assistant :content "First answer"}
+                                                  {:role :user :content "Follow-up"}]
+                                                 {}))
+            history-text     (str/join "\n" (keep :content history))]
+        (is (= 1 (marker-count history-text)))
+        (is (= 1 (marker-count (last-user-content history))))))))
+
 (deftest ^:parallel build-system-message-passes-capabilities-test
   (testing "capabilities from the raw API context reach the prompt builder via the enriched template context"
     (let [captured (atom nil)]

--- a/test/metabase/metabot/agent/messages_test.clj
+++ b/test/metabase/metabot/agent/messages_test.clj
@@ -5,6 +5,8 @@
    [metabase.lib.core :as lib]
    [metabase.metabot.agent.memory :as memory]
    [metabase.metabot.agent.messages :as messages]
+   [metabase.metabot.agent.prompts :as prompts]
+   [metabase.metabot.agent.user-context :as user-context]
    [metabase.test :as mt]))
 
 ;;; ──────────────────────────────────────────────────────────────────
@@ -72,6 +74,16 @@
               :content [{:type "tool_result" :tool_use_id "t1" :content "Result 1"}
                         {:type "tool_result" :tool_use_id "t2" :content "Result 2"}]})))))
 
+(defn- build-message-history*
+  "Enrich `context` the way the agent loop does (once per request, in init-agent) and build history."
+  [context memory]
+  (messages/build-message-history (user-context/enrich-context-for-template context) memory))
+
+(defn- build-system-message*
+  "Enrich `context` the way the agent loop does (once per request, in init-agent) and build the system message."
+  [context profile tools]
+  (messages/build-system-message (user-context/enrich-context-for-template context) profile tools))
+
 ;;; ──────────────────────────────────────────────────────────────────
 ;;; build-message-history
 ;;; ──────────────────────────────────────────────────────────────────
@@ -79,7 +91,7 @@
 (deftest ^:parallel build-message-history-test
   (testing "builds history from user messages only"
     (is (=? [{:role :user :content #(str/ends-with? % "Hello")}]
-            (messages/build-message-history
+            (build-message-history*
              {}
              (memory/initialize [{:role :user :content "Hello"}] {}))))))
 
@@ -87,7 +99,7 @@
   (testing "includes assistant text from input"
     (is (=? [{:role :user :content "Hello"}
              {:type :text :text "Hi there"}]
-            (messages/build-message-history
+            (build-message-history*
              {}
              (memory/initialize [{:role :user :content "Hello"}
                                  {:role :assistant :content "Hi there"}] {}))))))
@@ -96,7 +108,7 @@
   (testing "includes step parts from memory"
     (is (=? [{:role :user :content #(str/ends-with? % "Hello")}
              {:type :text :text "Response text"}]
-            (messages/build-message-history
+            (build-message-history*
              {}
              (-> (memory/initialize [{:role :user :content "Hello"}] {})
                  (memory/add-step [{:type :text :text "Response text"}])))))))
@@ -105,7 +117,7 @@
   (testing "includes tool calls from steps"
     (is (=? [{:role :user :content #(str/ends-with? % "Search for revenue")}
              {:type :tool-input :id "t1" :function "search" :arguments {:query "revenue"}}]
-            (messages/build-message-history
+            (build-message-history*
              {}
              (-> (memory/initialize [{:role :user :content "Search for revenue"}] {})
                  (memory/add-step [{:type      :tool-input
@@ -118,7 +130,7 @@
     (is (=? [{:role :user :content #(str/ends-with? % "Search")}
              {:type :tool-input :id "t1" :function "search"}
              {:type :tool-output :id "t1"}]
-            (messages/build-message-history
+            (build-message-history*
              {}
              (-> (memory/initialize [{:role :user :content "Search"}] {})
                  (memory/add-step [{:type :tool-input :id "t1" :function "search" :arguments {:query "test"}}])
@@ -130,7 +142,7 @@
              {:type :tool-input :id "t1"}
              {:type :tool-output :id "t1"}
              {:type :text :text "Found results"}]
-            (messages/build-message-history
+            (build-message-history*
              {}
              (-> (memory/initialize [{:role :user :content "Hello"}] {})
                  (memory/add-step [{:type :tool-input :id "t1" :function "search" :arguments {}}])
@@ -141,7 +153,7 @@
   (testing "filters out non-message parts from steps"
     (is (=? [{:role :user :content #(str/ends-with? % "Hello")}
              {:type :text :text "Response"}]
-            (messages/build-message-history
+            (build-message-history*
              {}
              (-> (memory/initialize [{:role :user :content "Hello"}] {})
                  (memory/add-step [{:type :start :messageId "m1"}
@@ -155,7 +167,7 @@
              {:type :text :text "I'll search for that."}
              {:type :tool-input :id "t1" :function "search"}
              {:type :tool-output :id "t1"}]
-            (messages/build-message-history
+            (build-message-history*
              {}
              (memory/initialize [{:role :user :content "Hello"}
                                  {:role :assistant :content "I'll search for that."}
@@ -175,7 +187,7 @@
 (deftest ^:parallel context-injection-basic-test
   (testing "injects <context> block into the last user message"
     (let [content (last-user-content
-                   (messages/build-message-history
+                   (build-message-history*
                     {}
                     (memory/initialize [{:role :user :content "Hello"}] {})))]
       (is (str/starts-with? content "<context>"))
@@ -185,7 +197,7 @@
 
 (deftest ^:parallel context-injection-skips-non-user-last-message-test
   (testing "does not inject when last message is not :user"
-    (let [parts (messages/build-message-history
+    (let [parts (build-message-history*
                  {}
                  (memory/initialize [{:role :user :content "Hello"}
                                      {:role :assistant :content "Reply"}] {}))]
@@ -193,7 +205,7 @@
 
 (deftest ^:parallel context-injection-targets-last-user-only-test
   (testing "injects into last user message only, not earlier ones"
-    (let [parts (messages/build-message-history
+    (let [parts (build-message-history*
                  {}
                  (memory/initialize [{:role :user :content "First"}
                                      {:role :assistant :content "Reply"}
@@ -205,7 +217,7 @@
 
 (deftest ^:parallel context-injection-does-not-affect-assistant-parts-test
   (testing "context injection does not affect non-user parts"
-    (let [parts (messages/build-message-history
+    (let [parts (build-message-history*
                  {:user_is_viewing [{:type "dashboard" :id 1 :name "Sales"}]}
                  (-> (memory/initialize [{:role :user :content "Hello"}] {})
                      (memory/add-step [{:type :text :text "Response"}])))]
@@ -214,13 +226,13 @@
 (deftest ^:parallel context-injection-first-day-of-week-test
   (testing "includes first_day_of_week from context"
     (let [content (last-user-content
-                   (messages/build-message-history
+                   (build-message-history*
                     {:first_day_of_week "Monday"}
                     (memory/initialize [{:role :user :content "Hi"}] {})))]
       (is (str/includes? content "Monday"))))
   (testing "default first_day_of_week is Sunday"
     (let [content (last-user-content
-                   (messages/build-message-history
+                   (build-message-history*
                     {}
                     (memory/initialize [{:role :user :content "Hi"}] {})))]
       (is (str/includes? content "Sunday")))))
@@ -228,7 +240,7 @@
 (deftest ^:parallel context-injection-viewing-dashboard-test
   (testing "includes viewing context when user is viewing a dashboard"
     (let [content (last-user-content
-                   (messages/build-message-history
+                   (build-message-history*
                     {:user_is_viewing [{:type "dashboard" :id 1 :name "Sales"}]}
                     (memory/initialize [{:role :user :content "Hi"}] {})))]
       (is (str/includes? content "Sales")))))
@@ -256,7 +268,7 @@
                                       :buffers [{:id "qb", :source {:language "sql", :database_id 2}, :cursor {:line 0, :column 0}}],
                                       :id "f4f07783-9276-403f-af5f-b9e7bd96fc88"}]}
           content (last-user-content
-                   (messages/build-message-history
+                   (build-message-history*
                     context
                     (memory/initialize [{:role :user :content "Fix my query"}] {})))]
       (is (str/includes? content "SQL editor"))
@@ -270,15 +282,47 @@
     (let [profile {:prompt-template "internal.selmer"
                    :model           "claude-sonnet-4-5-20250929"}]
       (is (=? {:role "system" :content #"(?s).*Metabot.*"}
-              (messages/build-system-message {} profile {})))))
+              (build-system-message* {} profile {})))))
   (testing "includes viewing context when provided"
     (let [context {:user_is_viewing [{:type "dashboard" :id 1 :name "Sales Dashboard"}]}
           profile {:prompt-template "internal.selmer"
                    :model           "claude-sonnet-4-5-20250929"}]
       (is (=? {:content #(not (str/blank? %))}
-              (messages/build-system-message context profile {})))))
+              (build-system-message* context profile {})))))
   (testing "handles empty context gracefully"
     (let [profile {:prompt-template "internal.selmer"
                    :model           "claude-sonnet-4-5-20250929"}]
       (is (=? {:content #(not (str/blank? %))}
-              (messages/build-system-message {} profile {}))))))
+              (build-system-message* {} profile {}))))))
+
+(deftest ^:parallel build-system-message-passes-capabilities-test
+  (testing "capabilities from the raw API context reach the prompt builder via the enriched template context"
+    (let [captured (atom nil)]
+      (mt/with-dynamic-fn-redefs [prompts/build-system-message-content
+                                  (fn [_profile _ctx _tools capabilities]
+                                    (reset! captured capabilities)
+                                    "content")]
+        (build-system-message* {:capabilities ["frontend:navigate_user_v1"]}
+                               {:prompt-template "internal.selmer"
+                                :model           "claude-sonnet-4-5-20250929"}
+                               {})
+        (is (= ["frontend:navigate_user_v1"] @captured))))))
+
+(deftest ^:parallel dialect-preload-uses-enriched-sql-dialect-test
+  (testing "the dialect skill preload is driven by the enriched :sql_dialect"
+    (let [context {:user_is_viewing [{:type       "native"
+                                      :sql_engine "PostgreSQL"}]}
+          history (build-message-history*
+                   context
+                   (memory/initialize [{:role :user :content "Hi"}] {}))]
+      (is (some #(and (= :tool-input (:type %))
+                      (= "load_skill" (:function %)))
+                history)
+          "a native-SQL viewing context must still produce the dialect skill preload"))))
+
+(deftest ^:parallel dialect-preload-absent-without-sql-context-test
+  (testing "no dialect preload is emitted when the context has no SQL engine"
+    (let [history (build-message-history*
+                   {}
+                   (memory/initialize [{:role :user :content "Hi"}] {}))]
+      (is (not (some #(= "load_skill" (:function %)) history))))))

--- a/test/metabase/metabot/agent/prompts_test.clj
+++ b/test/metabase/metabot/agent/prompts_test.clj
@@ -146,3 +146,41 @@
       (is (some? content))
       (is (not (str/includes? content "Here is some information about the user:")))
       (is (not (str/includes? content "<user><name>Jane Doe</name></user>"))))))
+
+(deftest ^:parallel viewing-context-not-in-system-message-test
+  (testing "no system template renders the viewing context — it is injected into the last user message instead"
+    (doseq [template ["internal.selmer"
+                      "embedding-next.selmer"
+                      "sql-querying-only.selmer"
+                      "natural-language-querying-only.selmer"
+                      "natural-language-querying-fallback.selmer"
+                      "transform-codegen.selmer"
+                      "slackbot.selmer"
+                      "document-generate-content.selmer"]]
+      (testing template
+        (let [profile {:prompt-template template}
+              context {:current_time      "2024-01-15 14:30:00"
+                       :current_user_info "<user><name>Jane Doe</name></user>"
+                       :viewing_context   "VIEWING-CONTEXT-MARKER"}
+              content (prompts/build-system-message-content profile context {} [])]
+          (is (some? content))
+          (is (not (str/includes? content "VIEWING-CONTEXT-MARKER"))))))))
+
+(deftest ^:parallel inject-context-renders-viewing-context-once-test
+  (testing "inject-context prepends the viewing context exactly once"
+    (let [result (prompts/inject-context {:viewing_context "VIEWING-CONTEXT-MARKER"
+                                          :current_time    "2024-01-15 14:30:00"}
+                                         "Hello")]
+      (is (= 1 (count (re-seq #"VIEWING-CONTEXT-MARKER" result))))
+      (is (str/ends-with? result "Hello")))))
+
+(deftest ^:parallel inject-context-with-only-viewing-context-test
+  (testing "injection happens when viewing_context is the only populated key"
+    (let [result (prompts/inject-context {:viewing_context "VIEWING-CONTEXT-MARKER"} "Hello")]
+      (is (str/includes? result "VIEWING-CONTEXT-MARKER"))
+      (is (str/ends-with? result "Hello")))))
+
+(deftest ^:parallel inject-context-skips-blank-viewing-context-test
+  (testing "an empty viewing context (nothing being viewed) does not inject a blank <user_context> block"
+    (let [result (prompts/inject-context {:viewing_context ""} "Hello")]
+      (is (= "Hello" result)))))

--- a/test/metabase/metabot/agent/user_context_test.clj
+++ b/test/metabase/metabot/agent/user_context_test.clj
@@ -313,6 +313,16 @@
       (is (= "" (:viewing_context result)))
       (is (= "" (:recent_views result))))))
 
+(deftest ^:parallel enrich-context-passes-capabilities-through-test
+  (testing "capabilities pass through enrichment so prompt/skill gating still sees them"
+    (is (= ["frontend:navigate_user_v1" "frontend:code_edit_v1"]
+           (:capabilities (user-context/enrich-context-for-template
+                           {:capabilities ["frontend:navigate_user_v1" "frontend:code_edit_v1"]}))))))
+
+(deftest ^:parallel enrich-context-without-capabilities-test
+  (testing "absent capabilities enrich to nil rather than throwing"
+    (is (nil? (:capabilities (user-context/enrich-context-for-template {}))))))
+
 (deftest ^:parallel format-entity-includes-measures-and-segments-test
   (testing "table viewing context includes measures and segments when present"
     (mt/with-dynamic-fn-redefs [entity-details/get-table-details

--- a/test/metabase/metabot/context_test.clj
+++ b/test/metabase/metabot/context_test.clj
@@ -16,82 +16,40 @@
 (def ^:private users-native-query (lib/native-query meta/metadata-provider "SELECT * FROM users"))
 (def ^:private users-mbql-query (lib/query meta/metadata-provider (meta/table-metadata :users)))
 
-(deftest database-tables-for-context-prioritization
-  (let [used [{:id 1 :name "used1"} {:id 2 :name "used2"}]
-        extra [{:id 3 :name "extra1"} {:id 4 :name "extra2"}]
-        all-tables (concat used extra)]
-    (mt/with-dynamic-fn-redefs [table-utils/used-tables (fn [_] used)
-                                table-utils/enhanced-database-tables (fn [_ {:keys [priority-tables all-tables-limit] :or {all-tables-limit 100}}]
-                                                                       (let [priority-ids (set (map :id priority-tables))
-                                                                             non-priority (remove #(priority-ids (:id %)) all-tables)
-                                                                             result (concat priority-tables (take (- all-tables-limit (count priority-tables)) non-priority))]
-                                                                         (take all-tables-limit result)))]
-      (let [result (#'context/database-tables-for-context {:query users-native-query, :all-tables-limit 3})]
-        (is (= used result) "Should only return used tables, in order")
-        (is (= (count used) (count result)) "Should return all used tables")
-        (is (not-any? #(= 3 (:id %)) result) "Should not include extra tables")
-        (is (not-any? #(= 4 (:id %)) result) "Should not include extra tables")
-        (is (= (count (distinct (map :id result))) (count result))))))) ; no duplicates
-
-(deftest database-tables-for-context-used-tables-exceed-limit
-  (let [used (mapv #(hash-map :id % :name (str "used" %)) (range 1 6)) ; 5 used tables
-        extra (mapv #(hash-map :id % :name (str "extra" %)) (range 6 10))
-        all-tables (concat used extra)]
-    (mt/with-dynamic-fn-redefs [table-utils/used-tables (fn [_] used)
-                                table-utils/enhanced-database-tables (fn [_ {:keys [priority-tables all-tables-limit] :or {all-tables-limit 100}}]
-                                                                       (let [priority-ids (set (map :id priority-tables))
-                                                                             non-priority (remove #(priority-ids (:id %)) all-tables)
-                                                                             result (concat priority-tables (take (- all-tables-limit (count priority-tables)) non-priority))]
-                                                                         (take all-tables-limit result)))]
-      (let [result (#'context/database-tables-for-context {:query users-native-query, :all-tables-limit 3})]
-        (is (= used result) "Should return all used tables")
-        (is (= (count used) (count result)) "Should return all used tables")
-        (is (= (count (distinct (map :id result))) (count result))))))) ; no duplicates
+(deftest database-tables-for-context-returns-stubs
+  (testing "Used tables become lightweight stubs — id/type/name/schema/description only, never columns"
+    (let [used [{:id 1 :name "used1" :schema "public" :description "first"}
+                {:id 2 :name "used2" :schema nil :description nil}]]
+      (mt/with-dynamic-fn-redefs [table-utils/used-tables (fn [_] used)]
+        (let [result (#'context/database-tables-for-context {:query users-native-query})]
+          (is (= [{:id 1 :type :table :name "used1" :database_schema "public" :description "first"}
+                  {:id 2 :type :table :name "used2" :database_schema nil :description nil}]
+                 result)
+              "Should return one stub per used table, in order")
+          (is (not-any? #(contains? % :fields) result)
+              "Stubs must not carry columns — the renderer re-fetches details by id"))))))
 
 (deftest database-tables-for-context-no-used-tables
-  (let [extra (mapv #(hash-map :id % :name (str "extra" %)) (range 1 5))]
-    (mt/with-dynamic-fn-redefs [table-utils/used-tables (fn [_] [])
-                                table-utils/enhanced-database-tables (fn [_ opts]
-                                                                       (take (:all-tables-limit opts 100) extra))]
-      (let [result (#'context/database-tables-for-context {:query users-native-query, :all-tables-limit 3})]
-        (is (empty? result) "Should return empty when no used tables")))))
-
-(deftest database-tables-for-context-used-tables-exact-limit
-  (let [used (mapv #(hash-map :id % :name (str "used" %)) (range 1 4)) ; 3 used tables
-        extra (mapv #(hash-map :id % :name (str "extra" %)) (range 4 7))
-        all-tables (concat used extra)]
-    (mt/with-dynamic-fn-redefs [table-utils/used-tables (fn [_] used)
-                                table-utils/enhanced-database-tables (fn [_ {:keys [priority-tables all-tables-limit] :or {all-tables-limit 100}}]
-                                                                       (let [priority-ids (set (map :id priority-tables))
-                                                                             non-priority (remove #(priority-ids (:id %)) all-tables)
-                                                                             result (concat priority-tables (take (- all-tables-limit (count priority-tables)) non-priority))]
-                                                                         (take all-tables-limit result)))]
-      (let [result (#'context/database-tables-for-context {:query users-native-query, :all-tables-limit 3})]
-        (is (= used result) "Should be exactly the used tables, in order")
-        (is (= (count used) (count result)))
-        (is (= (count (distinct (map :id result))) (count result))))))) ; no duplicates
+  (mt/with-dynamic-fn-redefs [table-utils/used-tables (fn [_] [])]
+    (let [result (#'context/database-tables-for-context {:query users-native-query})]
+      (is (empty? result) "Should return empty when no used tables"))))
 
 (deftest database-tables-for-context-exception-handling
-  (testing "Returns empty when table-utils/enhanced-database-tables throws"
-    (mt/with-dynamic-fn-redefs [table-utils/used-tables (fn [_] [{:id 1}])
-                                table-utils/enhanced-database-tables (fn [_ _] (throw (Exception. "boom")))]
+  (testing "Returns empty when table-utils/used-tables throws"
+    (mt/with-dynamic-fn-redefs [table-utils/used-tables (fn [_] (throw (Exception. "boom")))]
       (let [result (#'context/database-tables-for-context {:query users-native-query})]
         (is (empty? result))))))
 
 (deftest database-tables-for-context-nil-used-tables
   (testing "Handles nil used-tables gracefully"
-    (mt/with-dynamic-fn-redefs [table-utils/used-tables (fn [_] nil)
-                                table-utils/enhanced-database-tables (fn [_ opts]
-                                                                       (take (:all-tables-limit opts 100) [{:id 1} {:id 2}]))]
+    (mt/with-dynamic-fn-redefs [table-utils/used-tables (fn [_] nil)]
       (let [result (#'context/database-tables-for-context {:query users-native-query})]
         (is (empty? result) "Should return empty when used-tables is nil")))))
 
 (deftest database-tables-for-context-duplicate-ids
-  (testing "Deduplicates tables returned by database-tables"
-    (let [used [{:id 1}]
-          dup [{:id 1} {:id 1} {:id 2}]]
-      (mt/with-dynamic-fn-redefs [table-utils/used-tables (fn [_] used)
-                                  table-utils/enhanced-database-tables (fn [_ _] dup)]
+  (testing "Deduplicates used tables by id"
+    (let [used [{:id 1 :name "a"} {:id 1 :name "a"} {:id 2 :name "b"}]]
+      (mt/with-dynamic-fn-redefs [table-utils/used-tables (fn [_] used)]
         (let [result (#'context/database-tables-for-context {:query users-native-query})]
           (is (= [1 2] (map :id result)) "Should preserve order and remove duplicates"))))))
 
@@ -152,6 +110,15 @@
               result (#'context/enhance-context-with-schema input)
               used-tables (get-in result [:user_is_viewing 0 :used_tables])]
           (is (= mock-tables used-tables)))))))
+
+(deftest python-transform-tables-for-context-returns-stubs
+  (testing "Python transform used tables are lightweight stubs without columns"
+    (mt/with-dynamic-fn-redefs [table-utils/used-tables-from-ids
+                                (fn [_ _] [{:id 24 :name "orders" :schema "public" :description "orders table"}])]
+      (let [result (#'context/python-transform-tables-for-context {:database-id 2 :table-ids [24]})]
+        (is (= [{:id 24 :type :table :name "orders" :database_schema "public" :description "orders table"}]
+               result))
+        (is (not-any? #(contains? % :fields) result))))))
 
 (deftest enhance-context-with-schema-python-transform-no-source-tables
   (testing "Handles Python transform without source-tables"
@@ -381,7 +348,9 @@
             tables   (get-in result [:user_is_viewing 0 :used_tables])]
         (is (seq tables) "Should have used_tables for MBQL query")
         (is (some #(= table-id (:id %)) tables)
-            (str "Should include source table " table-id " in used_tables"))))))
+            (str "Should include source table " table-id " in used_tables"))
+        (is (not-any? #(contains? % :fields) tables)
+            "used_tables are lightweight stubs — columns are fetched at render time by entity-details")))))
 
 (deftest enhance-context-mbql-viewing-context-rendering-test
   (testing "MBQL adhoc query viewing context includes table name for LLM"

--- a/test/metabase/metabot/table_utils_test.clj
+++ b/test/metabase/metabot/table_utils_test.clj
@@ -215,23 +215,23 @@
                    :model/Table {other-db-table-id :id} {:db_id other-db-id, :name "other_table", :schema "public", :active true, :visibility_type nil}]
       (testing "returns tables with correct structure for valid table-ids"
         (mt/with-current-user (mt/user->id :crowberto)
-          (is (= #{{:id table1-id :name "users" :schema "public"}
-                   {:id table3-id :name "products" :schema "inventory"}}
+          (is (= #{{:id table1-id :name "users" :schema "public" :description nil}
+                   {:id table3-id :name "products" :schema "inventory" :description nil}}
                  (set (table-utils/used-tables-from-ids db-id [table1-id table3-id]))))))
       (testing "handles empty table-ids collection"
         (mt/with-current-user (mt/user->id :crowberto)
           (is (empty? (table-utils/used-tables-from-ids db-id [])))))
       (testing "filters by database-id"
         (mt/with-current-user (mt/user->id :crowberto)
-          (is (= [{:id table1-id :name "users" :schema "public"}]
+          (is (= [{:id table1-id :name "users" :schema "public" :description nil}]
                  (table-utils/used-tables-from-ids db-id [table1-id other-db-table-id])))))
       (testing "filters out inactive tables"
         (mt/with-current-user (mt/user->id :crowberto)
-          (is (= [{:id table1-id :name "users" :schema "public"}]
+          (is (= [{:id table1-id :name "users" :schema "public" :description nil}]
                  (table-utils/used-tables-from-ids db-id [table1-id inactive-id])))))
       (testing "filters out hidden tables"
         (mt/with-current-user (mt/user->id :crowberto)
-          (is (= [{:id table1-id :name "users" :schema "public"}]
+          (is (= [{:id table1-id :name "users" :schema "public" :description nil}]
                  (table-utils/used-tables-from-ids db-id [table1-id hidden-id])))))
       (testing "handles non-existent table-ids"
         (mt/with-current-user (mt/user->id :crowberto)
@@ -240,8 +240,8 @@
       (testing "handles mix of valid and invalid table-ids"
         (mt/with-current-user (mt/user->id :crowberto)
           (let [fake-id 999999]
-            (is (= #{{:id table1-id :name "users" :schema "public"}
-                     {:id table2-id :name "orders" :schema "public"}}
+            (is (= #{{:id table1-id :name "users" :schema "public" :description nil}
+                     {:id table2-id :name "orders" :schema "public" :description nil}}
                    (set (table-utils/used-tables-from-ids db-id [table1-id fake-id table2-id]))))))))))
 
 ;; ======================================
@@ -293,63 +293,6 @@
         (let [tables (table-utils/database-tables db-id)]
           (is (every? #(not= "hidden_table" (:name %)) tables))
           (is (some #(= "visible_table" (:name %)) tables)))))))
-
-(deftest enhanced-database-tables-test
-  (testing "enhanced-database-tables function with new format"
-    (mt/with-temp [:model/Database {db-id :id} {}
-                   :model/Table    {table1-id :id} {:db_id db-id, :name "users", :schema "public", :active true, :visibility_type nil}
-                   :model/Table    {table2-id :id} {:db_id db-id, :name "orders", :schema "public", :active true, :visibility_type nil}
-                   :model/Field    {user-id-field :id} {:table_id table1-id, :name "id", :database_type "INTEGER", :base_type :type/Integer, :semantic_type :type/PK}
-                   :model/Field    {} {:table_id table1-id, :name "name", :database_type "VARCHAR", :base_type :type/Text}
-                   :model/Field    {} {:table_id table2-id, :name "id", :database_type "INTEGER", :base_type :type/Integer, :semantic_type :type/PK}
-                   :model/Field    {} {:table_id table2-id, :name "user_id", :database_type "INTEGER", :base_type :type/Integer, :semantic_type :type/FK, :fk_target_field_id user-id-field}
-                   :model/Field    {} {:table_id table2-id, :name "total", :database_type "DECIMAL", :base_type :type/Decimal}]
-      (testing "returns tables with new enhanced formatting"
-        (mt/with-current-user (mt/user->id :crowberto)
-          (let [tables (table-utils/enhanced-database-tables db-id)]
-            (is (vector? tables))
-            (is (every? #(contains? % :name) tables))
-            (is (every? #(contains? % :database_schema) tables))
-            (is (every? #(contains? % :fields) tables))
-            (is (every? #(contains? % :type) tables))
-            (is (every? #(contains? % :display_name) tables))
-            (is (every? #(= :table (:type %)) tables))
-            (is (every? #(every? (fn [field] (contains? field :field_id)) (:fields %)) tables))
-            (is (every? #(every? (fn [field] (contains? field :name)) (:fields %)) tables))
-            (is (every? #(every? (fn [field] (contains? field :base_type)) (:fields %)) tables))
-            (is (every? #(every? (fn [field] (contains? field :database_type)) (:fields %)) tables))
-            (is (every? #(contains? % :metrics) tables)))))
-      (testing "includes table_reference for implicitly joined fields"
-        (mt/dataset test-data
-          (mt/with-current-user (mt/user->id :crowberto)
-            (let [test-db-id (mt/id)
-                  tables (table-utils/enhanced-database-tables test-db-id)
-                  orders-table (first (filter #(= "ORDERS" (:name %)) tables))
-                  all-fields (:fields orders-table)
-                  user-fields (filter #(= "User" (:table_reference %)) all-fields)
-                  product-fields (filter #(= "Product" (:table_reference %)) all-fields)]
-              (is (some? orders-table) "Expected to find ORDERS table")
-              (is (seq user-fields) "Expected to find fields with table-reference 'User' from implicit join")
-              (is (some #(= "NAME" (:name %)) user-fields) "Expected to find User NAME field from implicit join")
-              (is (seq product-fields) "Expected to find fields with table-reference 'Product' from implicit join")
-              (is (some #(= "TITLE" (:name %)) product-fields) "Expected to find Product TITLE field from implicit join")))))
-      (testing "enhanced format respects all-tables-limit option"
-        (mt/with-current-user (mt/user->id :crowberto)
-          (let [tables (table-utils/enhanced-database-tables db-id {:all-tables-limit 1})]
-            (is (<= (count tables) 1)))))
-      (testing "enhanced format excludes specified table IDs"
-        (mt/with-current-user (mt/user->id :crowberto)
-          (let [all-tables (table-utils/enhanced-database-tables db-id)
-                filtered-tables (table-utils/enhanced-database-tables db-id {:exclude-table-ids #{table1-id}})]
-            (is (< (count filtered-tables) (count all-tables)))
-            (is (not-any? #(= table1-id (:id %)) filtered-tables)))))
-      (testing "enhanced format prioritizes specified tables"
-        (mt/with-current-user (mt/user->id :crowberto)
-          (let [priority-table {:id table2-id :name "orders" :schema "public"}
-                tables (table-utils/enhanced-database-tables db-id {:priority-tables [priority-table]})]
-            (is (seq tables))
-            ;; Priority table should appear first (if it appears at all)
-            (is (= "orders" (-> tables first :name)))))))))
 
 (deftest ^:parallel format-escaped-test
   (are [in out] (= out

--- a/test/metabase/metabot/tools/entity_details_test.clj
+++ b/test/metabase/metabot/tools/entity_details_test.clj
@@ -521,6 +521,46 @@
             (is (map? (:query_json output)))
             (is (= "mbql/query" (get-in output [:query_json "lib/type"])))))))))
 
+(deftest get-report-details-skips-related-tables-test
+  (testing "get-report-details never computes related-tables"
+    (mt/test-driver :h2
+      (mt/with-current-user (mt/user->id :crowberto)
+        (mt/with-temp [:model/Card {card-id :id}
+                       {:database_id   (mt/id)
+                        :type          :question
+                        :name          "Orders question"
+                        :dataset_query (mt/mbql-query orders {:limit 3})}]
+          (let [calls (atom 0)
+                orig  (mt/original-fn #'entity-details/related-tables)]
+            (mt/with-dynamic-fn-redefs [entity-details/related-tables (fn [& args]
+                                                                        (swap! calls inc)
+                                                                        (apply orig args))]
+              (let [output (-> (entity-details/get-report-details {:report-id card-id})
+                               :structured-output)]
+                (is (=? {:id card-id :type :question} output))
+                (is (not (contains? output :related_tables)))
+                (is (= 0 @calls))))))))))
+
+(deftest get-report-details-skips-metrics-test
+  (testing "get-report-details never computes metrics"
+    (mt/test-driver :h2
+      (mt/with-current-user (mt/user->id :crowberto)
+        (mt/with-temp [:model/Card {card-id :id}
+                       {:database_id   (mt/id)
+                        :type          :question
+                        :name          "Orders question"
+                        :dataset_query (mt/mbql-query orders {:limit 3})}]
+          (let [calls (atom 0)
+                orig  (mt/original-fn #'lib/available-metrics)]
+            (mt/with-dynamic-fn-redefs [lib/available-metrics (fn [& args]
+                                                                (swap! calls inc)
+                                                                (apply orig args))]
+              (let [output (-> (entity-details/get-report-details {:report-id card-id})
+                               :structured-output)]
+                (is (=? {:id card-id :type :question} output))
+                (is (not (contains? output :metrics)))
+                (is (= 0 @calls))))))))))
+
 (deftest related-tables-with-fields-capped-test
   (testing (str "FK-related-table *column* expansion is capped at `max-related-tables-with-fields` so a table "
                 "with a very large / highly-connected schema can't fetch and pin an unbounded number of columns "


### PR DESCRIPTION
Closes [BOT-1793: Metabot related-tables and context follow ups](https://linear.app/metabase/issue/BOT-1793/metabot-related-tables-and-context-follow-ups)

### Description

WIP

Enrich metabot template context once per request

`build-system-message` and `build-message-history` each called `user-context/enrich-context-for-template`, and both run on every agent-loop iteration, so the viewing context was formatted twice per LLM call. `init-agent` now enriches the template context once, and passes it to both builders.

Remove viewing_context from system prompt templates

The viewing context is injected into the most recent user message for every profile (`prompts/inject-context` via
`build-message-history`), so templates that also rendered `{{viewing_context}}` in the system prompt sent the whole thing twice per request. internal.selmer had already dropped it, but other templates still included it.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
