### PR TITLE
update echarts to 6.1.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -95,7 +95,7 @@
         "detect-package-manager": "^3.0.2",
         "diff": "^5.2.2",
         "dompurify": "^3.4.11",
-        "echarts": "6.0.0",
+        "echarts": "6.1.0",
         "events": "^3.3.0",
         "fast-text-encoding": "^1.0.6",
         "formik": "^2.4.5",
@@ -2921,7 +2921,7 @@
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
-    "echarts": ["echarts@6.0.0", "", { "dependencies": { "tslib": "2.3.0", "zrender": "6.0.0" } }, "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ=="],
+    "echarts": ["echarts@6.1.0", "", { "dependencies": { "tslib": "2.3.0", "zrender": "6.1.0" } }, "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="],
 
@@ -6216,6 +6216,8 @@
     "ecdsa-sig-formatter/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "echarts/tslib": ["tslib@2.3.0", "", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
+
+    "echarts/zrender": ["zrender@6.1.0", "", { "dependencies": { "tslib": "2.3.0" } }, "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ=="],
 
     "elliptic/bn.js": ["bn.js@4.11.9", "", {}, "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="],
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -252,6 +252,9 @@ export const buildNumericDimensionAxis = (
     ...getCommonDimensionAxisOptions(chartLayout, settings, renderingContext),
     type: "value",
     scale: true,
+    // ECharts expands non-band axes to contain bar shapes by default, but we
+    // already pad the domain and size bars to fit
+    containShape: false,
     axisLabel: {
       margin: CHART_STYLE.axisTicksMarginX,
       ...getDimensionTicksDefaultOption(settings, renderingContext),
@@ -286,6 +289,9 @@ export const buildTimeSeriesDimensionAxis = (
   return {
     ...getCommonDimensionAxisOptions(chartLayout, settings, renderingContext),
     type: "time",
+    // ECharts expands non-band axes to contain bar shapes by default, but we
+    // already pad the domain and size bars to fit
+    containShape: false,
     axisLabel: {
       margin:
         CHART_STYLE.axisTicksMarginX +

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "detect-package-manager": "^3.0.2",
     "diff": "^5.2.2",
     "dompurify": "^3.4.11",
-    "echarts": "6.0.0",
+    "echarts": "6.1.0",
     "events": "^3.3.0",
     "fast-text-encoding": "^1.0.6",
     "formik": "^2.4.5",


### PR DESCRIPTION
Routine dependency upgrade of echarts from 6.0.0 to 6.1.0.

Sets `containShape: false` on continuous x-axes to keep the existing chart layout, since we already pad the domain and size bars to fit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart rendering for numeric and time-based x-axes so bars fit more reliably within the available space.
  * Updated the charting library to a newer version for better stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->