### PR TITLE
feat: show nulls last when ordering temporal fields

### DIFF
--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -1056,6 +1056,16 @@
   (h2x/maybe-cast (sql.qp/integer-dbtype driver)
                   [:round (sql.qp/->float driver value) 0]))
 
+(defmethod sql.qp/order-by-clause :sqlserver
+  [driver direction field-clause]
+  (let [field-hsql (sql.qp/->honeysql driver field-clause)]
+    (if (sql.qp/temporal-field? field-clause)
+      ;; For temporal columns, always put nulls last
+      ;; SQL Server workaround: ORDER BY CASE WHEN col IS NULL THEN 1 ELSE 0 END, col ASC/DESC
+      [[[:case [:= field-hsql nil] [:inline 1] :else [:inline 0]]]
+       [field-hsql direction]]
+      [[field-hsql direction]])))
+
 (defmethod sql-jdbc/impl-query-canceled? :sqlserver [_ e]
   (= (sql-jdbc/get-sql-state e) "HY008"))
 

--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -982,3 +982,19 @@
                    (lib/expression "diff-minutes" diff-minutes)
                    (qp/process-query)
                    (mt/rows))))))))
+
+(deftest ^:parallel order-by-temporal-nulls-last-test
+  (testing "SQL Server order-by-clause uses CASE workaround for temporal columns"
+    (mt/test-driver :sqlserver
+      (qp.store/with-metadata-provider (mt/metadata-provider)
+        (let [temporal-field [:field (mt/id :orders :created_at) {:base-type :type/DateTimeWithTZ}]
+              non-temporal-field [:field (mt/id :orders :id) {:base-type :type/BigInteger}]]
+          (testing "ascending order on temporal field generates two clauses"
+            (let [result (sql.qp/order-by-clause :sqlserver :asc temporal-field)]
+              (is (= 2 (count result)) "Should return two ORDER BY clauses for SQL Server temporal NULLS LAST workaround")))
+          (testing "descending order on temporal field generates two clauses"
+            (let [result (sql.qp/order-by-clause :sqlserver :desc temporal-field)]
+              (is (= 2 (count result)) "Should return two ORDER BY clauses for SQL Server temporal NULLS LAST workaround")))
+          (testing "non-temporal field uses single clause"
+            (let [result (sql.qp/order-by-clause :sqlserver :asc non-temporal-field)]
+              (is (= 1 (count result)) "Non-temporal fields should use standard single ORDER BY clause"))))))))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -7,6 +7,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [honey.sql :as sql]
+   [honey.sql.helpers :as sql.helpers]
    [java-time.api :as t]
    [medley.core :as m]
    [metabase.driver :as driver]
@@ -632,13 +633,25 @@
 (defmethod sql.qp/order-by-clause :mysql
   [driver direction field-clause]
   (let [field-hsql (sql.qp/->honeysql driver field-clause)]
-    ;; (if (sql.qp/temporal-field? field-clause)
-    ;;   ;; For temporal columns, always put nulls last
-    ;;   ;; MySQL workaround: ORDER BY (col IS NULL), col ASC/DESC
-    ;;   [[[:is field-hsql nil]]
-    ;;    [field-hsql direction]]
-    ;;   [[field-hsql direction]])))
-    [[field-hsql direction]]))
+    (if (sql.qp/temporal-field? field-clause)
+      [[[:is field-hsql nil]]
+       [field-hsql direction]]
+      [[field-hsql direction]])))
+
+(defmethod sql.qp/apply-top-level-clause [:mysql :order-by]
+  [driver _ honeysql-form {subclauses :order-by}]
+  (let [has-group-by? (seq (:group-by honeysql-form))
+        order-by-clauses (mapcat (partial sql.qp/->honeysql driver) subclauses)
+        ;; When GROUP BY exists, collect IS NULL expressions from temporal order-by clauses
+        ;; and add them to GROUP BY so MySQL's ONLY_FULL_GROUP_BY accepts them
+        null-check-exprs (when has-group-by?
+                           (keep (fn [[_dir field-clause]]
+                                   (when (sql.qp/temporal-field? field-clause)
+                                     [:is (sql.qp/->honeysql driver field-clause) nil]))
+                                 subclauses))]
+    (cond-> (reduce sql.helpers/order-by honeysql-form order-by-clauses)
+      (seq null-check-exprs)
+      (update :group-by into null-check-exprs))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         metabase.driver.sql-jdbc impls                                         |

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -629,6 +629,17 @@
 (defmethod sql.qp/datetime-diff [:mysql :minute]  [_driver _unit x y] (timestampdiff :minute x y))
 (defmethod sql.qp/datetime-diff [:mysql :second]  [_driver _unit x y] (timestampdiff :second x y))
 
+(defmethod sql.qp/order-by-clause :mysql
+  [driver direction field-clause]
+  (let [field-hsql (sql.qp/->honeysql driver field-clause)]
+    ;; (if (sql.qp/temporal-field? field-clause)
+    ;;   ;; For temporal columns, always put nulls last
+    ;;   ;; MySQL workaround: ORDER BY (col IS NULL), col ASC/DESC
+    ;;   [[[:is field-hsql nil]]
+    ;;    [field-hsql direction]]
+    ;;   [[field-hsql direction]])))
+    [[field-hsql direction]]))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         metabase.driver.sql-jdbc impls                                         |
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -2051,8 +2051,13 @@
 
 (defn temporal-field?
   "Returns true if the field clause represents a temporal (date/time/datetime) column."
-  [[_ _id-or-name options :as _field-clause]]
-  (let [field-type (or (:effective-type options) (:base-type options))]
+  [[_ second-arg third-arg :as _field-clause]]
+  ;; Handle both MBQL5 [:field opts id] and MBQL4 [:field id opts]
+  (let [options (if (and (map? second-arg) (:lib/uuid second-arg))
+                  second-arg   ; MBQL5: opts is second
+                  third-arg)   ; MBQL4: opts is third
+        field-type (when (map? options)
+                     (or (:effective-type options) (:base-type options)))]
     (and field-type (isa? field-type :type/Temporal))))
 
 (defmulti order-by-clause

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -2049,17 +2049,42 @@
 
 ;;; ---------------------------------------------------- order-by ----------------------------------------------------
 
+(defn temporal-field?
+  "Returns true if the field clause represents a temporal (date/time/datetime) column."
+  [[_ _id-or-name options :as _field-clause]]
+  (let [field-type (or (:effective-type options) (:base-type options))]
+    (and field-type (isa? field-type :type/Temporal))))
+
+(defmulti order-by-clause
+  "Converts an order-by subclause to HoneySQL. For temporal columns in descending order,
+   ensures nulls are sorted last. Override for databases that don't support NULLS LAST syntax."
+  {:arglists '([driver direction field-clause])}
+  driver/dispatch-on-initialized-driver
+  :hierarchy #'driver/hierarchy)
+
+(defmethod order-by-clause :sql
+  [driver direction field-clause]
+  (let [field-hsql (->honeysql driver field-clause)]
+    (if (temporal-field? field-clause)
+      ;; For temporal columns, always put nulls last
+      (case direction
+        :asc  [[field-hsql :asc-nulls-last]]
+        :desc [[field-hsql :desc-nulls-last]])
+      ;; For non-temporal columns, use default behavior
+      [[field-hsql direction]])))
+
 (defmethod ->honeysql [:sql :asc]
-  [driver [direction field]]
-  [(->honeysql driver field) direction])
+  [driver [_direction field-clause]]
+  (order-by-clause driver :asc field-clause))
 
 (defmethod ->honeysql [:sql :desc]
-  [driver [direction field]]
-  [(->honeysql driver field) direction])
+  [driver [_direction field-clause]]
+  (order-by-clause driver :desc field-clause))
 
 (defmethod apply-top-level-clause [:sql :order-by]
   [driver _ honeysql-form {subclauses :order-by}]
-  (reduce sql.helpers/order-by honeysql-form (mapv (partial ->honeysql driver) subclauses)))
+  (let [order-by-clauses (mapcat (partial ->honeysql driver) subclauses)]
+    (reduce sql.helpers/order-by honeysql-form order-by-clauses)))
 
 ;;; -------------------------------------------------- limit & page --------------------------------------------------
 

--- a/src/metabase/driver/sqlite.clj
+++ b/src/metabase/driver/sqlite.clj
@@ -591,5 +591,15 @@
   [driver value]
   (sql.qp/->integer-with-round driver value))
 
+(defmethod sql.qp/order-by-clause :sqlite
+  [driver direction field-clause]
+  (let [field-hsql (sql.qp/->honeysql driver field-clause)]
+    (if (sql.qp/temporal-field? field-clause)
+      ;; For temporal columns, always put nulls last
+      ;; SQLite workaround: ORDER BY (col IS NULL), col ASC/DESC
+      [[[:is field-hsql nil]]
+       [field-hsql direction]]
+      [[field-hsql direction]])))
+
 (defmethod driver/llm-sql-dialect-resource :sqlite [_]
   "metabot/prompts/dialects/sqlite.md")

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -1096,18 +1096,18 @@
           (is (< elapsed 30000)
               (format "query should be cancelled well before SLEEP(60) completes naturally — took %.0f ms" elapsed)))))))
 
-;; (deftest ^:parallel order-by-temporal-nulls-last-test
-;;   (testing "MySQL order-by-clause uses IS NULL workaround for temporal columns"
-;;     (mt/test-driver :mysql
-;;       (qp.store/with-metadata-provider (mt/metadata-provider)
-;;         (let [temporal-field [:field (mt/id :orders :created_at) {:base-type :type/DateTimeWithTZ}]
-;;               non-temporal-field [:field (mt/id :orders :id) {:base-type :type/BigInteger}]]
-;;           (testing "ascending order on temporal field generates two clauses"
-;;             (let [result (sql.qp/order-by-clause :mysql :asc temporal-field)]
-;;               (is (= 2 (count result)) "Should return two ORDER BY clauses for MySQL temporal NULLS LAST workaround")))
-;;           (testing "descending order on temporal field generates two clauses"
-;;             (let [result (sql.qp/order-by-clause :mysql :desc temporal-field)]
-;;               (is (= 2 (count result)) "Should return two ORDER BY clauses for MySQL temporal NULLS LAST workaround")))
-;;           (testing "non-temporal field uses single clause"
-;;             (let [result (sql.qp/order-by-clause :mysql :asc non-temporal-field)]
-;;               (is (= 1 (count result)) "Non-temporal fields should use standard single ORDER BY clause"))))))))
+(deftest ^:parallel order-by-temporal-nulls-last-test
+  (testing "MySQL order-by-clause uses IS NULL workaround for temporal columns"
+    (mt/test-driver :mysql
+      (qp.store/with-metadata-provider (mt/metadata-provider)
+        (let [temporal-field [:field (mt/id :orders :created_at) {:base-type :type/DateTimeWithTZ}]
+              non-temporal-field [:field (mt/id :orders :id) {:base-type :type/BigInteger}]]
+          (testing "ascending order on temporal field generates two clauses"
+            (let [result (sql.qp/order-by-clause :mysql :asc temporal-field)]
+              (is (= 2 (count result)) "Should return two ORDER BY clauses for MySQL temporal NULLS LAST workaround")))
+          (testing "descending order on temporal field generates two clauses"
+            (let [result (sql.qp/order-by-clause :mysql :desc temporal-field)]
+              (is (= 2 (count result)) "Should return two ORDER BY clauses for MySQL temporal NULLS LAST workaround")))
+          (testing "non-temporal field uses single clause"
+            (let [result (sql.qp/order-by-clause :mysql :asc non-temporal-field)]
+              (is (= 1 (count result)) "Non-temporal fields should use standard single ORDER BY clause"))))))))

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -1095,3 +1095,19 @@
               "query should throw rather than completing normally")
           (is (< elapsed 30000)
               (format "query should be cancelled well before SLEEP(60) completes naturally — took %.0f ms" elapsed)))))))
+
+;; (deftest ^:parallel order-by-temporal-nulls-last-test
+;;   (testing "MySQL order-by-clause uses IS NULL workaround for temporal columns"
+;;     (mt/test-driver :mysql
+;;       (qp.store/with-metadata-provider (mt/metadata-provider)
+;;         (let [temporal-field [:field (mt/id :orders :created_at) {:base-type :type/DateTimeWithTZ}]
+;;               non-temporal-field [:field (mt/id :orders :id) {:base-type :type/BigInteger}]]
+;;           (testing "ascending order on temporal field generates two clauses"
+;;             (let [result (sql.qp/order-by-clause :mysql :asc temporal-field)]
+;;               (is (= 2 (count result)) "Should return two ORDER BY clauses for MySQL temporal NULLS LAST workaround")))
+;;           (testing "descending order on temporal field generates two clauses"
+;;             (let [result (sql.qp/order-by-clause :mysql :desc temporal-field)]
+;;               (is (= 2 (count result)) "Should return two ORDER BY clauses for MySQL temporal NULLS LAST workaround")))
+;;           (testing "non-temporal field uses single clause"
+;;             (let [result (sql.qp/order-by-clause :mysql :asc non-temporal-field)]
+;;               (is (= 1 (count result)) "Non-temporal fields should use standard single ORDER BY clause"))))))))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1582,7 +1582,7 @@
           (is (= (str "SELECT attempts.date AS date, COUNT(*) AS count "
                       "FROM attempts "
                       "GROUP BY attempts.date "
-                      "ORDER BY attempts.date ASC")
+                      "ORDER BY attempts.date ASC NULLS LAST")
                  (some-> (qp.compile/compile query) :query pretty-sql))))))))
 
 (deftest ^:parallel do-not-cast-to-timestamp-if-column-if-timestamp-tz-or-date-test
@@ -2534,3 +2534,29 @@
                     (mt/db) [(format "SELECT generate_series(1, %d) AS i" n)])]
         (testing "only the first rows are pulled, not all ~2 billion"
           (is (= [1 2 3] (into [] (comp (take 3) (map :i)) result))))))))
+
+(deftest ^:parallel order-by-temporal-nulls-last-test
+  (testing "Temporal columns get NULLS LAST in ORDER BY"
+    (mt/test-driver :postgres
+      (mt/dataset test-data
+        (let [query (mt/mbql-query orders
+                      {:order-by [[:asc $created_at]]
+                       :limit    5})]
+          (is (str/includes?
+               (-> (qp.compile/compile query) :query pretty-sql)
+               "ASC NULLS LAST")))
+        (let [query (mt/mbql-query orders
+                      {:order-by [[:desc $created_at]]
+                       :limit    5})]
+          (is (str/includes?
+               (-> (qp.compile/compile query) :query pretty-sql)
+               "DESC NULLS LAST"))))))
+  (testing "Non-temporal columns do not get NULLS LAST"
+    (mt/test-driver :postgres
+      (mt/dataset test-data
+        (let [query (mt/mbql-query orders
+                      {:order-by [[:asc $id]]
+                       :limit    5})]
+          (is (not (str/includes?
+                    (-> (qp.compile/compile query) :query pretty-sql)
+                    "NULLS LAST"))))))))

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -808,7 +808,7 @@
                                 SUM (CHECKINS.VENUE_ID)                                          AS sum_2]
                      :from     [CHECKINS]
                      :group-by [DATE_TRUNC ("month" CHECKINS.DATE)]
-                     :order-by [DATE_TRUNC ("month" CHECKINS.DATE) ASC]}
+                     :order-by [DATE_TRUNC ("month" CHECKINS.DATE) ASC NULLS LAST]}
                     AS __mb_source]
            :where  [__mb_source.sum > 300]
            :limit  [2]}
@@ -1452,7 +1452,7 @@
                           "    GROUP BY"
                           "      DATE_TRUNC('month', \"PUBLIC\".\"CHECKINS\".\"DATE\")"
                           "    ORDER BY"
-                          "      DATE_TRUNC('month', \"PUBLIC\".\"CHECKINS\".\"DATE\") ASC"
+                          "      DATE_TRUNC('month', \"PUBLIC\".\"CHECKINS\".\"DATE\") ASC NULLS LAST"
                           "  ) AS \"__mb_source\""
                           "GROUP BY"
                           "  \"__mb_source\".\"count\""
@@ -1810,31 +1810,3 @@
   (testing "temporal-field? returns false when no type info available"
     (is (not (sql.qp/temporal-field? [:field 1 {}])))
     (is (not (sql.qp/temporal-field? [:field 1 nil])))))
-
-(deftest ^:parallel order-by-clause-temporal-nulls-last-test
-  (testing "order-by-clause adds NULLS LAST for temporal columns"
-    (driver/with-driver :h2
-      (qp.store/with-metadata-provider meta/metadata-provider
-        (let [temporal-field-clause [:field (meta/id :orders :created-at) {:base-type :type/DateTimeWithTZ}]]
-          (testing "ascending order on temporal field"
-            (let [result (sql.qp/order-by-clause :h2 :asc temporal-field-clause)]
-              (is (= 1 (count result)))
-              (is (= :asc-nulls-last (second (first result))))))
-          (testing "descending order on temporal field"
-            (let [result (sql.qp/order-by-clause :h2 :desc temporal-field-clause)]
-              (is (= 1 (count result)))
-              (is (= :desc-nulls-last (second (first result)))))))))))
-
-(deftest ^:parallel order-by-clause-non-temporal-default-test
-  (testing "order-by-clause uses default ordering for non-temporal columns"
-    (driver/with-driver :h2
-      (qp.store/with-metadata-provider meta/metadata-provider
-        (let [non-temporal-field-clause [:field (meta/id :orders :id) {:base-type :type/BigInteger}]]
-          (testing "ascending order on non-temporal field"
-            (let [result (sql.qp/order-by-clause :h2 :asc non-temporal-field-clause)]
-              (is (= 1 (count result)))
-              (is (= :asc (second (first result))))))
-          (testing "descending order on non-temporal field"
-            (let [result (sql.qp/order-by-clause :h2 :desc non-temporal-field-clause)]
-              (is (= 1 (count result)))
-              (is (= :desc (second (first result)))))))))))

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -1766,7 +1766,7 @@
               "        GROUP BY"
               "          CAST(PUBLIC.ORDERS.CREATED_AT AS date)"
               "        ORDER BY"
-              "          CAST(PUBLIC.ORDERS.CREATED_AT AS date) ASC"
+              "          CAST(PUBLIC.ORDERS.CREATED_AT AS date) ASC NULLS LAST"
               "      ) AS __mb_source"
               "    GROUP BY"
               "      extract("
@@ -1781,10 +1781,60 @@
               "        from"
               "          __mb_source.CREATED_AT"
               "      ) ASC,"
-              "      DATE_TRUNC('month', __mb_source.CREATED_AT) ASC"
+              "      DATE_TRUNC('month', __mb_source.CREATED_AT) ASC NULLS LAST"
               "  ) AS __mb_source"]
              (-> (qp.compile/compile query)
                  :query
                  (->> (driver/prettify-native-form :h2))
                  (str/replace #"\"" "")
                  str/split-lines))))))
+
+(deftest ^:parallel temporal-field?-test
+  (testing "temporal-field? correctly identifies temporal columns by base-type"
+    (is (true? (sql.qp/temporal-field? [:field 1 {:base-type :type/Date}])))
+    (is (true? (sql.qp/temporal-field? [:field 1 {:base-type :type/DateTime}])))
+    (is (true? (sql.qp/temporal-field? [:field 1 {:base-type :type/DateTimeWithTZ}])))
+    (is (true? (sql.qp/temporal-field? [:field 1 {:base-type :type/Time}])))
+    (is (true? (sql.qp/temporal-field? [:field 1 {:base-type :type/TimeWithTZ}]))))
+  (testing "temporal-field? correctly identifies temporal columns by effective-type"
+    (is (true? (sql.qp/temporal-field? [:field 1 {:effective-type :type/Date}])))
+    (is (true? (sql.qp/temporal-field? [:field 1 {:effective-type :type/DateTime}]))))
+  (testing "temporal-field? prefers effective-type over base-type"
+    (is (true? (sql.qp/temporal-field? [:field 1 {:base-type :type/Text :effective-type :type/Date}])))
+    (is (false? (sql.qp/temporal-field? [:field 1 {:base-type :type/Date :effective-type :type/Text}]))))
+  (testing "temporal-field? returns false for non-temporal types"
+    (is (false? (sql.qp/temporal-field? [:field 1 {:base-type :type/Integer}])))
+    (is (false? (sql.qp/temporal-field? [:field 1 {:base-type :type/Text}])))
+    (is (false? (sql.qp/temporal-field? [:field 1 {:base-type :type/Boolean}])))
+    (is (false? (sql.qp/temporal-field? [:field 1 {:base-type :type/Float}]))))
+  (testing "temporal-field? returns false when no type info available"
+    (is (not (sql.qp/temporal-field? [:field 1 {}])))
+    (is (not (sql.qp/temporal-field? [:field 1 nil])))))
+
+(deftest ^:parallel order-by-clause-temporal-nulls-last-test
+  (testing "order-by-clause adds NULLS LAST for temporal columns"
+    (driver/with-driver :h2
+      (qp.store/with-metadata-provider meta/metadata-provider
+        (let [temporal-field-clause [:field (meta/id :orders :created-at) {:base-type :type/DateTimeWithTZ}]]
+          (testing "ascending order on temporal field"
+            (let [result (sql.qp/order-by-clause :h2 :asc temporal-field-clause)]
+              (is (= 1 (count result)))
+              (is (= :asc-nulls-last (second (first result))))))
+          (testing "descending order on temporal field"
+            (let [result (sql.qp/order-by-clause :h2 :desc temporal-field-clause)]
+              (is (= 1 (count result)))
+              (is (= :desc-nulls-last (second (first result)))))))))))
+
+(deftest ^:parallel order-by-clause-non-temporal-default-test
+  (testing "order-by-clause uses default ordering for non-temporal columns"
+    (driver/with-driver :h2
+      (qp.store/with-metadata-provider meta/metadata-provider
+        (let [non-temporal-field-clause [:field (meta/id :orders :id) {:base-type :type/BigInteger}]]
+          (testing "ascending order on non-temporal field"
+            (let [result (sql.qp/order-by-clause :h2 :asc non-temporal-field-clause)]
+              (is (= 1 (count result)))
+              (is (= :asc (second (first result))))))
+          (testing "descending order on non-temporal field"
+            (let [result (sql.qp/order-by-clause :h2 :desc non-temporal-field-clause)]
+              (is (= 1 (count result)))
+              (is (= :desc (second (first result)))))))))))

--- a/test/metabase/driver/sqlite_test.clj
+++ b/test/metabase/driver/sqlite_test.clj
@@ -12,6 +12,7 @@
    [metabase.driver.sql.query-processor-test-util :as sql.qp-test-util]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
@@ -325,3 +326,19 @@
         (testing "so its base/effective type stays temporal (Lib's type wins over the storage affinity)"
           (is (isa? (:base_type col) :type/Temporal))
           (is (isa? (:effective_type col) :type/Temporal)))))))
+
+(deftest ^:parallel order-by-temporal-nulls-last-test
+  (testing "SQLite order-by-clause uses IS NULL workaround for temporal columns"
+    (mt/test-driver :sqlite
+      (qp.store/with-metadata-provider (mt/metadata-provider)
+        (let [temporal-field [:field (mt/id :orders :created_at) {:base-type :type/DateTimeWithTZ}]
+              non-temporal-field [:field (mt/id :orders :id) {:base-type :type/BigInteger}]]
+          (testing "ascending order on temporal field generates two clauses"
+            (let [result (sql.qp/order-by-clause :sqlite :asc temporal-field)]
+              (is (= 2 (count result)) "Should return two ORDER BY clauses for SQLite temporal NULLS LAST workaround")))
+          (testing "descending order on temporal field generates two clauses"
+            (let [result (sql.qp/order-by-clause :sqlite :desc temporal-field)]
+              (is (= 2 (count result)) "Should return two ORDER BY clauses for SQLite temporal NULLS LAST workaround")))
+          (testing "non-temporal field uses single clause"
+            (let [result (sql.qp/order-by-clause :sqlite :asc non-temporal-field)]
+              (is (= 1 (count result)) "Non-temporal fields should use standard single ORDER BY clause"))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/75394

### Description

Ensures null values are consistently sorted last when ordering by temporal (date/time/datetime) columns in table visualizations, regardless of sort direction (ASC or DESC).

Problem: Different databases have inconsistent default null ordering behavior. For example, H2 sorts nulls first in ascending order, while PostgreSQL sorts nulls last. This leads to unpredictable user experience when sorting date columns with null values.

Solution:
- Added temporal-field? helper to identify date/time columns
- Created extensible order-by-clause multimethod that applies NULLS LAST ordering for temporal columns
- Implemented database-specific workarounds for MySQL, SQLite and SQL Server (which don't support NULLS LAST syntax natively)

Note: For MySQL, some modifications for GROUP BY clause have also been made to support ONLY_FULL_GROUP_BY mode. Anytime grouping is done on a temporal column, then one extra clause as 'temporal_column IS NULL' is added such that everything in ORDER BY exists in GROUP BY as well. Output of the query is not affected by this.

### How to verify

1. New Question - Postgres DB
2. Select any table with a temporal column which also contains null values for some rows
4. Sort by the temporal column in ascending order → nulls should appear last
5. Now sort descending → nulls should still appear last
6. Repeat with other DBs like H2, SQLite, MySQL or SQL Server.

### Demo

The following screenshot are from Postgres DB but I have verified this on UI for MySQL, SQLite, SQL Server and ClickHouse as well.
<img width="760" height="325" alt="image" src="https://github.com/user-attachments/assets/f7707481-c8ec-4731-8012-004b9f99588d" />
<img width="326" height="230" alt="image" src="https://github.com/user-attachments/assets/bc225c48-49e6-4b93-b3cf-6858470edc75" />
<img width="764" height="314" alt="image" src="https://github.com/user-attachments/assets/f2d4020a-f9a4-482b-9361-20d19df0eea0" />
<img width="323" height="229" alt="image" src="https://github.com/user-attachments/assets/eb2c6d0a-b390-445e-b7a6-9ad2bf6cca62" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/77046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting for temporal columns across SQL Server, MySQL, SQLite, and Postgres so `NULL` values now appear last in ascending and descending order.
  * Preserved standard sorting behavior for non-temporal fields.
  * Updated nested and source-query ordering cases to match the new sort behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->