### PR TITLE
fix(funnel): hide series with no value from default tooltip

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -507,7 +507,9 @@ const getSingleSeriesTooltipModel = (
   );
 
   const seriesToShow = chartModel.seriesModels.filter(
-    (series) => series === hoveredSeries || !isBreakoutSeries(series),
+    (series) =>
+      series === hoveredSeries ||
+      (!isBreakoutSeries(series) && datum[series.dataKey] != null),
   );
   const seriesTooltipRows = seriesToShow.map((series) => {
     const isFocused =


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/76933

### Description

In the **Bar-type Funnel** visualization each funnel step is transformed by `funnelToBarTransform` into its own BarChart series, placed at a unique x-axis position matching its dimension value (e.g. "Gizmo", "Widget", …).

When hovering over any bar, `getSingleSeriesTooltipModel` showed **all** non-breakout series — but every step other than the hovered one has `undefined` at that datum position, producing an `(empty)` row in the tooltip for every other step.

**Root cause:** the `seriesToShow` filter did not check whether a series actually has data at the current datum position:

```ts
// Before
const seriesToShow = chartModel.seriesModels.filter(
  (series) => series === hoveredSeries || !isBreakoutSeries(series),
);
```

**Fix:** add a `datum[series.dataKey] != null` guard for non-hovered series so only series with a real value at the hovered datum position are included. The hovered series is always shown unconditionally.

```ts
// After
const seriesToShow = chartModel.seriesModels.filter(
  (series) =>
    series === hoveredSeries ||
    (!isBreakoutSeries(series) && datum[series.dataKey] != null),
);
```

### How to verify

1. Create a question — e.g. Count of Orders grouped by Product Category.
2. Switch the visualization to **Funnel**. In viz settings → Display, set Funnel type to **Bar chart**.
3. Hover over any bar.
4. **Before fix:** tooltip shows all other steps as `(empty)`.  
   **After fix:** tooltip shows only the value of the hovered step.

### Checklist

- [x] No new tests required — the changed function (`getSingleSeriesTooltipModel`) is not covered by existing unit tests and setting up the full CartesianChart model mock is non-trivial for this small guard change. The fix is a one-line predicate guard.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/77053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart tooltips so non-breakout series only appear when they have actual data for the hovered point.
  * Prevented empty or null-value rows from showing up in single-series tooltips, making the tooltip display cleaner and more accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->