### PR TITLE
fix(viz): always show dot for single-point series in Auto marker mode

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -623,11 +623,13 @@ const buildEChartsLineAreaSeries = (
   labelFormatter: LabelFormatter | undefined,
   renderingContext: RenderingContext,
   xAxisIndex?: number,
+  seriesDotsCount?: number,
 ): LineSeriesOption => {
   const isSymbolVisible = getShowSymbol(
     chartDataDensity,
     chartWidth,
     seriesSettings,
+    seriesDotsCount ?? 2,
   );
 
   const blurOpacity = hasMultipleSeries ? CHART_STYLE.opacity.blur : 1;
@@ -711,6 +713,7 @@ function getShowSymbol(
   chartDataDensity: ComboChartDataDensity,
   chartWidth: number,
   seriesSettings: SeriesSettings,
+  seriesDotsCount: number,
 ): boolean {
   const { totalNumberOfDots } = chartDataDensity;
   const maxNumberOfDots = chartWidth / (2 * CHART_STYLE.symbolSize);
@@ -724,6 +727,12 @@ function getShowSymbol(
   }
 
   if (seriesSettings["line.marker_enabled"] === true) {
+    return true;
+  }
+
+  // A series with a single data point cannot draw a visible line, so always
+  // show its dot in Auto mode regardless of total dot count across all series.
+  if (seriesDotsCount <= 1) {
     return true;
   }
 
@@ -967,7 +976,10 @@ export const buildEChartsSeries = (
 
       switch (seriesSettings.display) {
         case "line":
-        case "area":
+        case "area": {
+          const seriesDotsCount = chartModel.dataset.filter(
+            (datum) => datum[seriesModel.dataKey] != null,
+          ).length;
           return buildEChartsLineAreaSeries(
             seriesModel,
             stackName,
@@ -981,7 +993,9 @@ export const buildEChartsSeries = (
             chartModel.seriesLabelsFormatters?.[seriesModel.dataKey],
             renderingContext,
             panelIndex,
+            seriesDotsCount,
           );
+        }
         case "bar":
           return buildEChartsBarSeries(
             chartModel.transformedDataset,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/76723

### Description

When **Show dots on lines** is set to **Auto**, the decision to render dots is based on whether `totalNumberOfDots` (summed across all line/area series) exceeds the chart width threshold (`chartWidth / (2 × symbolSize)`).

A breakout series with only **one data point** contributes 1 to that global total, but if the overall total exceeds the threshold, dots are hidden for **all** series — including the single-point one. Since the series also can't draw a visible line connecting multiple points, it becomes completely invisible on the chart.

**Root cause** in `getShowSymbol` (`option/series.ts`):

```ts
// Before — uses only global total; single-point series gets hidden with everyone else
return totalNumberOfDots <= maxNumberOfDots;
```

**Fix:** compute the per-series dot count at the `buildEChartsLineAreaSeries` call site and pass it down to `getShowSymbol`. In Auto mode, if a series has **≤ 1 data point**, always show its symbol regardless of global dot density.

```ts
// After — single-point series always shows its dot
if (seriesDotsCount <= 1) {
  return true;
}
return totalNumberOfDots <= maxNumberOfDots;
```

### How to verify

1. Create a question on the Orders table.
2. Add a custom column: `if([Product → Category] != "Widget" OR (year([Created At]) = 2026 AND month([Created At]) = 6), [Total])` — this ensures the Widget category has only a single data point.
3. Summarize: Sum of custom column by Created At: Month and Product Category.
4. Visualize as a line chart with **Show dots on lines = Auto**.
5. **Before fix:** the Widget series is invisible.  
   **After fix:** the single Widget point is visible as a dot.
6. Setting **Show dots on lines = On** produces the same result — confirming parity.

### Checklist

- [x] No new tests required — this is a change to chart rendering options computation; the fix is a targeted guard in a pure function (`getShowSymbol`).

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/77054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symbol visibility for line and area charts in Auto mode, especially when a series has one or no data points.
  * Chart dots now behave more consistently based on the amount of data in each series, reducing cases where markers were unexpectedly hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->