### PR TITLE
fix(parameters): guard against empty filter values in formatted-list and value-string

### DIFF
--- a/src/metabase/parameters/shared.cljc
+++ b/src/metabase/parameters/shared.cljc
@@ -165,6 +165,7 @@
   on the values. The conjunction parameter determines whether to use 'and' or 'or' to join the last two items."
   [values & {:keys [conjunction] :or {conjunction (trs "and")}}]
   (condp = (count values)
+    0 ""
     1 (str (first values))
     2 (trs "{0} {1} {2}" (first values) conjunction (second values))
     (trs "{0}, {1}, {2} {3}"
@@ -212,13 +213,15 @@
   (get parameter :value (:default parameter)))
 
 (defn value-string
-  "Returns the value(s) of a dashboard filter, formatted appropriately."
+  "Returns the value(s) of a dashboard filter, formatted appropriately.
+  Returns nil when the parameter has no value (e.g. its default was removed)."
   [parameter locale]
   (let [tyype  (:type parameter)
         values (param-val-or-default parameter)]
-    (try (formatted-value tyype values locale)
-         (catch #?(:clj Throwable :cljs js/Error) _
-           (formatted-list (u/one-or-many values))))))
+    (when (if (sequential? values) (seq values) (some? values))
+      (try (formatted-value tyype values locale)
+           (catch #?(:clj Throwable :cljs js/Error) _
+             (formatted-list (u/one-or-many values)))))))
 
 (def ^:private template-tag-regex
   "A regex to find template tags in a text card on a dashboard. This should mirror the regex used to find template

--- a/test/metabase/parameters/shared_test.cljc
+++ b/test/metabase/parameters/shared_test.cljc
@@ -412,7 +412,13 @@
              (params/value-string (first parameters) "en"))))
     (testing "If a filter has a single default value, it is formatted appropriately"
       (is (= "Q1, 2021"
-             (params/value-string (second parameters) "en"))))))
+             (params/value-string (second parameters) "en"))))
+    (testing "Returns nil when a filter has no value (nil default — previously removed)"
+      (is (nil? (params/value-string {:name "State" :type "string/=" :default nil} "en"))))
+    (testing "Returns nil when a filter has an empty-vector default (previously set then cleared)"
+      (is (nil? (params/value-string {:name "State" :type "string/=" :default []} "en"))))
+    (testing "Returns nil for string/contains with an empty default vector"
+      (is (nil? (params/value-string {:name "State" :type "string/contains" :default []} "en"))))))
 
 (deftest param-val-or-default-test
   (let [param-val-or-default #'params/param-val-or-default]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/76854

### Description

When a dashboard filter has its default value removed, `param-val-or-default` returns `nil` or `[]` (empty vector). `value-string` passes this directly to `formatted-value`, which (for `string/=` and similar types) dispatches to the `:default` method and calls `formatted-list` with the empty vector.

`formatted-list` had no case for 0 elements — `(condp = 0 ...)` fell through to the default arm and evaluated `(nth [] (- 0 2))` = `(nth [] -2)`, throwing `IndexOutOfBoundsException`. Since the catch clause in `value-string` also calls `formatted-list`, the exception was not caught there either, crashing the entire subscription render.

**Root cause:** `formatted-list` missing a `0` case, causing `IndexOutOfBoundsException` on `(nth [] -2)`.

**Fix:**
1. Added `0 ""` case to `formatted-list` so an empty list renders as an empty string instead of crashing.
2. Added an early `nil` return in `value-string` when `values` is `nil` or an empty sequential — a filter with no value produces no output, which is the correct behaviour (the filter simply isn't shown in the subscription email).

### Changes

| File | Change |
|------|--------|
| `src/metabase/parameters/shared.cljc` | Add `0 ""` case to `formatted-list`; add nil guard in `value-string` for empty/nil values |
| `test/metabase/parameters/shared_test.cljc` | Add tests for nil default, empty-vector default, and empty `string/contains` |

### How to verify

1. Set up a dashboard with a text filter (`string/=`).
2. Give the filter a default value (e.g. `"California"`).
3. Create a dashboard subscription and confirm it sends successfully.
4. Remove the default value from the filter.
5. Send the subscription again — it should now send successfully (previously threw `IndexOutOfBoundsException`).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/77055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parameter display so empty values now show nothing instead of awkward list formatting.
  * Fixed value formatting to return no result when a parameter has no usable default or input.
  * Added coverage for cases where defaults are missing or empty, ensuring more consistent behavior across parameter types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->