### PR TITLE
fix(table): render numeric 0/1 DB values as true/false for boolean columns

### DIFF
--- a/frontend/src/metabase/visualizations/lib/formatting/value.tsx
+++ b/frontend/src/metabase/visualizations/lib/formatting/value.tsx
@@ -214,6 +214,10 @@ export function formatValueRaw(
       return options.collapseNewlines ? removeNewLines(value) : value;
     }
     return formatStringFallback(value, options);
+  } else if (typeof value === "number" && isBoolean(column)) {
+    // Databases often return boolean values as 0/1 integers; coerce to
+    // true/false so the cell renders consistently with native JS booleans.
+    return JSON.stringify(Boolean(value));
   } else if (typeof value === "number" && isCoordinate(column)) {
     const range = rangeForValue(value, column);
     if (range && !options.noRange) {

--- a/frontend/src/metabase/visualizations/lib/formatting/value.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/lib/formatting/value.unit.spec.tsx
@@ -527,4 +527,13 @@ describe("formatValue", () => {
       }),
     ).toEqual("7/7/2019");
   });
+
+  it("should format numeric 0/1 from DB as false/true for boolean columns (metabase#76999)", () => {
+    const boolColumn = createMockColumn({ base_type: "type/Boolean" });
+    expect(formatValue(0, { column: boolColumn })).toEqual("false");
+    expect(formatValue(1, { column: boolColumn })).toEqual("true");
+    // native JS booleans should still work
+    expect(formatValue(false, { column: boolColumn })).toEqual("false");
+    expect(formatValue(true, { column: boolColumn })).toEqual("true");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #76999: Boolean columns from databases that return 0/1 integers (PostgreSQL, SQLite, etc.) display as "0"/"1" in table cells instead of "false"/"true".

**Root cause:** `formatValueRaw` checked `typeof value === "boolean"` for boolean columns, but numeric 0/1 values have `typeof value === "number"`. They fell through to the `isNumber(column)` branch (which returns `false` for Boolean type) and then to the catch-all string conversion, rendering as "0" or "1".

**Fix:** Added an explicit branch `typeof value === "number" && isBoolean(column)` before the coordinate/number checks that coerces the integer to a boolean before `JSON.stringify`, producing consistent "false"/"true" output.

## Changes

| File | Change |
|------|--------|
| `frontend/src/metabase/visualizations/lib/formatting/value.tsx` | Added `number && isBoolean` branch before coordinate/number branches |
| `frontend/src/metabase/visualizations/lib/formatting/value.unit.spec.tsx` | Added test covering numeric 0/1 → "false"/"true" and native boolean passthrough |

## Testing

- [ ] New unit test: `formatValue(0, { column: boolColumn })` → `"false"`, `formatValue(1, ...)` → `"true"`
- [ ] Existing native boolean path unchanged: `formatValue(false, ...)` → `"false"`, `formatValue(true, ...)` → `"true"`
- [ ] Manually verified: boolean column with numeric DB values now shows "true"/"false" in table cells

Closes #76999

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/77056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Boolean values now display consistently when sourced from databases that store them as `0` and `1`.
  * Numeric boolean inputs are now shown as `false` and `true` instead of raw numbers, matching the behavior for native boolean values.
* **Tests**
  * Added coverage to confirm boolean formatting works for both numeric database values and standard boolean inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->