### PR TITLE
fix(static-viz): ensure SmartScalar trend colors are explicit in PDF/email export

### DIFF
--- a/frontend/src/metabase/static-viz/components/SmartScalar/SmartScalar.tsx
+++ b/frontend/src/metabase/static-viz/components/SmartScalar/SmartScalar.tsx
@@ -36,6 +36,7 @@ export function SmartScalar({
     root: {
       fontFamily,
       fontSize: "14px",
+      color: getColor("text-primary"),
     },
     value: {
       color: getColor("text-primary"),
@@ -99,10 +100,11 @@ function Comparison({ comparison, renderingContext }: ComparisonProps) {
   const styles: Record<string, CSSProperties> = {
     root: {
       fontSize: "14px",
+      color: getColor("text-primary"),
     },
     icon: {
       fontSize: "14px",
-      color: comparison.changeColor,
+      color: comparison.changeColor || getColor("text-disabled"),
       marginRight: "6px",
     },
     percentChange: {


### PR DESCRIPTION
## Summary

Fixes #77001: Wrong color in Trend chart PDF export

**Root cause:** The static SmartScalar component is rendered inside an `<a>` tag wrapper added by `render-pulse-card` (in `card.clj`). CSSBox — the HTML-to-PNG engine used for PDF export and email subscriptions — applies its user-agent stylesheet, which sets a default link color on `<a>` elements. Child elements that do not set an explicit `color` value inherit this link color (typically blue) rather than the intended dark text color.

Two places in the static SmartScalar had no explicit `color` on their root element:
1. The `SmartScalar` root `<div>` — all contained text defaulted to whatever color was inherited from the `<a>` ancestor.
2. The `Comparison` root `<span>` — same issue.

Additionally, the icon `<span>` used `color: comparison.changeColor` with no fallback. If `changeColor` is `undefined`, React omits the `color` property entirely from the rendered HTML, leaving the element colour-less and at the mercy of inheritance.

**Fix:**
- Set `color: getColor("text-primary")` on both root elements so all text defaults to a neutral dark colour rather than inheriting from the `<a>` ancestor.
- Add `|| getColor("text-disabled")` fallback on the icon `<span>` so the inline colour is always an explicit hex value, never omitted.

## Changes

| File | Change |
|------|--------|
| `frontend/src/metabase/static-viz/components/SmartScalar/SmartScalar.tsx` | Added explicit `color` to SmartScalar root div, Comparison root span, and icon span fallback |

## Testing

- [ ] Existing tests pass
- [ ] Manually reproduce: create a Trend chart with a downward comparison, export dashboard as PDF at dashcard size 6×3, verify arrow is red and no stray badge/UI element appears

Closes #77001

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/77058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated SmartScalar text to use a consistent primary text color.
  * Adjusted comparison icon coloring so it now falls back to a disabled text color when no custom change color is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->