### PR TITLE
Fix BigQuery driver tests on release-x.58.x (backport #72484)

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test/reconciliation_test_util.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test/reconciliation_test_util.clj
@@ -172,9 +172,11 @@
 (defn- temporal-type-reconciliation-expected-value
   [{:keys [field temporal-type expected-value honeysql-filter-fn num-args], :as _test-case}]
   (let [field-literal?      (lib.util.match/match-one field [:field (_ :guard string?) _])
+        mock-field          (get mock-temporal-fields temporal-type)
         expected-identifier (cond-> (-> (h2x/identifier :field "ABC" (name temporal-type))
                                         (vary-meta assoc ::bigquery.qp/do-not-qualify? true))
-                              (not field-literal?) (h2x/with-database-type-info (name temporal-type)))
+                              (not field-literal?) (h2x/with-database-type-info (name temporal-type))
+                              field-literal?       (h2x/with-type-info {:effective-type (:base-type mock-field)}))
         args                (repeat (dec num-args) expected-value)]
     (if (fn? honeysql-filter-fn)
       (honeysql-filter-fn expected-identifier args)

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -357,6 +357,7 @@
 (defonce ^:private deleted-old-datasets?
   (atom false))
 
+#_{:clj-kondo/ignore [:unused-private-var]}
 (defn- delete-old-datasets-if-needed!
   "Call [[delete-old-datasets!]], only if we haven't done so already."
   []
@@ -429,7 +430,11 @@
 (defmethod tx/create-db! :bigquery-cloud-sdk
   [driver {:keys [database-name table-definitions options] :as db-def} & _]
   {:pre [(seq database-name) (sequential? table-definitions)]}
-  (delete-old-datasets-if-needed!)
+  ;; disabling this like on release-x.59.x and up: it deletes any tracked dataset not accessed in
+  ;; the last 2 hours, including datasets that other branches' CI runs are actively using (see
+  ;; #74663 and #76706 for the whole saga). If datasets change, old versions will need to be
+  ;; manually GCed.
+  ;; (delete-old-datasets-if-needed!)
   (let [dataset-id (test-dataset-id db-def)]
     (if (database-exists?! db-def)
       (log/info (u/format-color 'blue "Dataset already exists %s, not loading db" (pr-str dataset-id)))

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -144,6 +144,7 @@
 (defonce ^:private deleted-old-datasets?
   (atom false))
 
+#_{:clj-kondo/ignore [:unused-private-var]}
 (defn- delete-old-datasets-if-needed!
   "Call [[delete-old-datasets!]], only if we haven't done so already."
   []
@@ -164,8 +165,10 @@
   [driver db-def & options]
   ;; qualify the DB name with the unique prefix
   (let [db-def (assoc db-def :database-name (qualified-db-name db-def))]
-    ;; clean up any old datasets that should be deleted
-    (delete-old-datasets-if-needed!)
+    ;; disabling this like on release-x.59.x and up (see #74663): it deletes tracked datasets not
+    ;; accessed in the last 2 days, including datasets other branches' CI runs may be relying on.
+    ;; If datasets change, old versions will need to be manually GCed.
+    ;; (delete-old-datasets-if-needed!)
     ;; Snowflake by default uses America/Los_Angeles timezone. See https://docs.snowflake.com/en/sql-reference/parameters#timezone.
     ;; We expect UTC in tests. Hence fixing [[metabase.query-processor.timezone/database-timezone-id]] (PR #36413)
     ;; produced lot of failures. Following expression addresses that, setting timezone for the test user.


### PR DESCRIPTION
## Summary

Two fixes for `release-x.58.x` driver CI:

### 1. Backport the #72484 test fix (BigQuery job red on the branch)

`driver-tests / BigQuery Driver Tests` fails with 420 assertion failures in `metabase.driver.bigquery-cloud-sdk.query-processor-test/reconcile-temporal-types-test` ([example run](https://github.com/metabase/metabase/actions/runs/28683499465)). The backport of "Fall back on effective-type for time fields" (#75762) changed SQL compilation so field literals are wrapped in `::h2x/typed ... {:effective-type ...}`, but the matching test fix #72484 (`52257c531f9`) was only backported to 59/60/61/62 — never to 58. Cherry-picked here (adapted: 58 has no `match-lite`, kept `match-one`).

Verified locally against BigQuery: 840 assertions, 0 failures.

### 2. Stop this branch's CI from deleting other branches' test datasets

x.58 is the last branch still running `delete-old-datasets-if-needed!` at the start of every driver-test job. The BigQuery version deletes **any tracked dataset not accessed in the last 2 hours** (log message says "two days", SQL says `INTERVAL -2 hour`); Snowflake uses a 2-day window. This is the "rogue process dropping the test-data database" referenced in #76706 — it dropped the shared `sha__..._test_data` dataset mid-run of another branch's BigQuery job today (confirmed by timestamps). Every other release branch already disabled these calls (#74663/#74781/#74780/#74672); this ports the same change to 58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)