### PR TITLE
Fix Snowflake impersonation test on release-x.60.x

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -704,7 +704,8 @@
           ;; (`LIMITED.ROLE` in CI Snowflake has no data access)
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"(?s)SQL compilation error:.*Object.*does not exist or not authorized"
+               ;; I've seen different error messages here, not 100% sure why but the important thing is that this fails
+               #"(?s)(?:SQL compilation error.*(?:(?:operation cannot be performed)|(?:Object.*does not exist or not authorized))|Cannot perform SELECT)"
                (mt/run-mbql-query venues
                  {:aggregation [[:count]]})))
           ;; Non-impersonated user should still be able to query the table


### PR DESCRIPTION
## Summary

`driver-tests / Snowflake Driver Tests` on `release-x.60.x` fails in `metabase-enterprise.impersonation.driver-test/conn-impersonation-test-snowflake` ([example run](https://github.com/metabase/metabase/actions/runs/28735476430)): the test expects `SQL compilation error: ... Object ... does not exist or not authorized` but Snowflake now returns `Cannot perform SELECT. This session does not have a current database.`

The error message depends on Snowflake-side state; master already accepts every observed variant (regex last broadened in #73578 and #71439). This PR ports master's combined regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)