### PR TITLE
Link to usage conditions in the theme preview acceptance prompt

### DIFF
--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/EnableEmbeddingPrompt.tsx
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/EnableEmbeddingPrompt.tsx
@@ -1,7 +1,7 @@
-import { t } from "ttag";
+import { jt, t } from "ttag";
 
 import { useUpdateSettingsMutation } from "metabase/api";
-import { Button, Center, Stack, Text } from "metabase/ui";
+import { Anchor, Button, Center, Stack, Text } from "metabase/ui";
 
 interface EnableEmbeddingPromptProps {
   isEnabled: boolean;
@@ -21,9 +21,19 @@ export function EnableEmbeddingPrompt({
     });
   };
 
+  const usageConditionsLink = (
+    <Anchor
+      key="usage-conditions"
+      href="https://metabase.com/license/embedding"
+      target="_blank"
+    >
+      {t`usage conditions`}
+    </Anchor>
+  );
+
   const message = !isEnabled
     ? t`Enable modular embedding to see a live preview of your theme.`
-    : t`Accept the usage conditions to see a live preview of your theme.`;
+    : jt`Accept the ${usageConditionsLink} to see a live preview of your theme.`;
 
   const buttonLabel = !isEnabled
     ? t`Enable modular embedding`

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/EnableEmbeddingPrompt.tsx
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/EnableEmbeddingPrompt.tsx
@@ -1,4 +1,4 @@
-import { jt, t } from "ttag";
+import { c, t } from "ttag";
 
 import { useUpdateSettingsMutation } from "metabase/api";
 import { Anchor, Button, Center, Stack, Text } from "metabase/ui";
@@ -32,8 +32,13 @@ export function EnableEmbeddingPrompt({
   );
 
   const message = !isEnabled
-    ? t`Enable modular embedding to see a live preview of your theme.`
-    : jt`Accept the ${usageConditionsLink} to see a live preview of your theme.`;
+    ? c(
+        "Prompt to enable modular embedding to see a live preview of an embedding theme.",
+      ).t`Enable modular embedding to see a live preview of your theme.`
+    : c(
+        "{0} is a link to the embedding conditions, for users to accept them and see a live preview of their theme.",
+      )
+        .jt`Accept the ${usageConditionsLink} to see a live preview of your theme.`;
 
   const buttonLabel = !isEnabled
     ? t`Enable modular embedding`

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/EnableEmbeddingPrompt.unit.spec.tsx
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/EnableEmbeddingPrompt.unit.spec.tsx
@@ -1,0 +1,54 @@
+import { renderWithProviders, screen } from "__support__/ui";
+
+import { EnableEmbeddingPrompt } from "./EnableEmbeddingPrompt";
+
+const setup = ({
+  isEnabled,
+  isTermsAccepted,
+}: {
+  isEnabled: boolean;
+  isTermsAccepted: boolean;
+}) => {
+  renderWithProviders(
+    <EnableEmbeddingPrompt
+      isEnabled={isEnabled}
+      isTermsAccepted={isTermsAccepted}
+    />,
+  );
+};
+
+describe("EnableEmbeddingPrompt", () => {
+  it("prompts to enable modular embedding when it is disabled", () => {
+    setup({ isEnabled: false, isTermsAccepted: false });
+
+    expect(
+      screen.getByText(
+        "Enable modular embedding to see a live preview of your theme.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Enable modular embedding" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "usage conditions" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("links to the usage conditions when only the terms are pending", () => {
+    setup({ isEnabled: true, isTermsAccepted: false });
+
+    expect(
+      screen.getByText(/to see a live preview of your theme\./),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Accept and continue" }),
+    ).toBeInTheDocument();
+
+    const link = screen.getByRole("link", { name: "usage conditions" });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://metabase.com/license/embedding",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76727
Closes [EMB-1960: Theme acceptance text lacks link to usage terms](https://linear.app/metabase/issue/EMB-1960/theme-acceptance-text-lacks-link-to-usage-terms)

### Description

In Admin > Embedding > Themes, when modular embedding is enabled but the usage
terms haven't been accepted yet, the theme preview asks the user to "Accept the
usage conditions" without explaining what those terms are or linking to them.

This makes "usage conditions" a link to the embedding license
(https://metabase.com/license/embedding), matching the existing pattern in
`EnableGuestEmbedsSection`, which links the same phrase to the same page. The
"Enable modular embedding" variant of the prompt is unchanged — there are no
terms to link there.

### How to verify

1. Start Metabase with `MB_ENABLE_EMBEDDING_SIMPLE=true` (this enables modular
   embedding while leaving the usage terms un-accepted — the only state that
   shows this message; the normal in-app enable flow accepts the terms in the
   same action).
2. Go to `/admin/embedding/themes` and click a theme.
3. In the Theme preview panel, confirm the text reads "Accept the usage
   conditions to see a live preview of your theme." and that "usage conditions"
   is a link opening https://metabase.com/license/embedding in a new tab.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The embedding enablement prompt now includes a clickable “usage conditions” link that opens in a new tab.
  * Updated the enabled-state message to make the next step clearer for users.

* **Tests**
  * Added coverage for the embedding prompt states, including button labels and the new link behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->