### PR TITLE
[GDGT-2782] report null activity for never-viewed documents in stale query

### DIFF
--- a/src/metabase/documents/models/document.clj
+++ b/src/metabase/documents/models/document.clj
@@ -172,7 +172,9 @@
   {:select [:document.id
             [[:inline "Document"] :model]
             [:document.name :name]
-            [:document.last_viewed_at :last_used_at]]
+            ;; last_viewed_at is NOT NULL (default current_timestamp), so it's storage noise for a
+            ;; never-viewed doc — null the anchor when view_count = 0 to keep "never used" distinguishable.
+            [[:case [:= :document.view_count [:inline 0]] nil :else :document.last_viewed_at] :last_used_at]]
    :from :document
    :left-join [:collection [:= :collection.id :document.collection_id]]
    :where [:and

--- a/test/metabase/documents/models/document_test.clj
+++ b/test/metabase/documents/models/document_test.clj
@@ -8,6 +8,8 @@
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
    [metabase.permissions.core :as perms]
+   [metabase.stale-test :as stale-test]
+   [metabase.staleness.core :as staleness]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.util :as tu]
@@ -805,3 +807,21 @@
             (binding [mi/*deserializing?* true]
               (t2/update! :model/Document doc-id {:name "Deserialized Name"}))
             (is (empty? @events-published))))))))
+
+(deftest never-viewed-document-reports-null-activity-anchor
+  (testing "a never-viewed document's activity anchor is NULL, not its last_viewed_at storage default
+            (NOT NULL default current_timestamp) — the never-used arm (view_count = 0) stays
+            distinguishable downstream"
+    (mt/with-temp [:model/Document {viewed-id :id} (stale-test/stale-document {:name       "viewed long ago"
+                                                                               :view_count 5})
+                   :model/Document {never-id :id} {:name       "never viewed"
+                                                   :created_at (stale-test/datetime-months-ago 7)}]
+      (let [rows   (t2/query (staleness/find-stale-query
+                              :model/Document
+                              {:collection-ids #{nil}
+                               :cutoff-date    (stale-test/date-months-ago 6)}))
+            anchor (fn [id] (:last_used_at (first (filter #(= id (:id %)) rows))))]
+        (testing "a viewed-but-stale document keeps its real anchor"
+          (is (some? (anchor viewed-id))))
+        (testing "a never-viewed document (flagged via the never-used arm) reports NULL"
+          (is (nil? (anchor never-id))))))))


### PR DESCRIPTION
### Description
follow up to https://github.com/metabase/metabase/pull/76800.

`find-stale-query :model/Document` surfaced `document.last_viewed_at` directly as the `last_used_at` activity anchor. But `last_viewed_at` is `NOT NULL DEFAULT current_timestamp`, so a never-viewed document reports a real-looking timestamp (its creation time) instead of "never used" - indistinguishable downstream from a document viewed at that moment.

This nulls the anchor when `view_count = 0`, matching the never-used arm already in the query's `WHERE`:

```clojure
[[:case [:= :document.view_count [:inline 0]] nil :else :document.last_viewed_at] :last_used_at]
```


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
