### PR TITLE
Fix rendering of tenant avatars

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsListing/TenantsListing.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsListing/TenantsListing.tsx
@@ -100,7 +100,7 @@ export const TenantsListing = ({
                 gap="md"
               >
                 <UserAvatar
-                  user={{ first_name: tenant.name }}
+                  user={{ name: tenant.name }}
                   bg={tenantIdToColor(tenant.id)}
                 />
                 <Box component="span" fw={700} c="core-brand">

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsListing/TenantsListing.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsListing/TenantsListing.unit.spec.tsx
@@ -47,6 +47,13 @@ describe("TenantsListing", () => {
     expect(screen.getByText("Acme Corp")).toBeInTheDocument();
   });
 
+  it("renders the tenant's first initial in the avatar, not a question mark", () => {
+    setup([createMockTenant({ id: 11, name: "Acme Corp", slug: "acme-corp" })]);
+
+    expect(screen.getByText("A")).toBeInTheDocument();
+    expect(screen.queryByText("?")).not.toBeInTheDocument();
+  });
+
   it("filters non-Latin tenants by search text", async () => {
     setup([
       createMockTenant({ id: 10, name: "здравей", slug: "zdravey" }),

--- a/frontend/src/metabase/common/components/UserAvatar/UserAvatar.tsx
+++ b/frontend/src/metabase/common/components/UserAvatar/UserAvatar.tsx
@@ -1,8 +1,8 @@
 import {
   type PartialGroup,
+  type PartialTenant,
   type PartialUser,
-  initial,
-  userInitials,
+  prepareInitials,
 } from "metabase/common/utils/user";
 
 import type { AvatarProps } from "./UserAvatar.styled";
@@ -12,14 +12,17 @@ interface UserAvatarProps extends AvatarProps {
   user: PartialUser;
 }
 
-interface GroupProps {
+interface GroupProps extends AvatarProps {
   user: PartialGroup;
 }
 
-export function UserAvatar({ user, ...props }: UserAvatarProps | GroupProps) {
-  return <StyledAvatar {...props}>{userInitials(user) || "?"}</StyledAvatar>;
+interface TenantProps extends AvatarProps {
+  user: PartialTenant;
 }
 
-export function Avatar({ children, ...props }: { children: string }) {
-  return <StyledAvatar {...props}>{initial(children) ?? "?"}</StyledAvatar>;
+export function UserAvatar({
+  user,
+  ...props
+}: UserAvatarProps | GroupProps | TenantProps) {
+  return <StyledAvatar {...props}>{prepareInitials(user) || "?"}</StyledAvatar>;
 }

--- a/frontend/src/metabase/common/components/UserAvatar/index.ts
+++ b/frontend/src/metabase/common/components/UserAvatar/index.ts
@@ -1,1 +1,1 @@
-export { UserAvatar, Avatar } from "./UserAvatar";
+export { UserAvatar } from "./UserAvatar";

--- a/frontend/src/metabase/common/utils/user.ts
+++ b/frontend/src/metabase/common/utils/user.ts
@@ -1,37 +1,24 @@
 import { isEmail } from "metabase/utils/email";
-import type { BaseUser, Group } from "metabase-types/api";
+import type { BaseUser, Group, Tenant } from "metabase-types/api";
 
 export type PartialUser = Partial<
   Pick<BaseUser, "first_name" | "last_name" | "email" | "common_name">
 >;
 export type PartialGroup = Pick<Group, "name">;
 
-const isUser = (user: PartialUser | PartialGroup): user is PartialUser => {
-  return "common_name" in user || "email" in user;
-};
+export type PartialTenant = Pick<Tenant, "name">;
 
-export function userInitials(user: PartialGroup | PartialUser) {
-  const initials = nameInitials(user);
+export type Named = PartialUser | PartialGroup | PartialTenant;
 
-  if (initials) {
-    return initials;
-  } else if (isUser(user)) {
-    return emailInitials(user);
-  }
-
-  return null;
-}
-
-function nameInitials(user: PartialUser | PartialGroup) {
-  if (isUser(user)) {
-    return initial(user.first_name) + initial(user.last_name);
+export function prepareInitials(namedParty: Named): string | null {
+  if (isUser(namedParty)) {
+    return (
+      initial(namedParty.first_name) + initial(namedParty.last_name) ||
+      emailInitials(namedParty)
+    );
   } else {
-    // render group
-    return initial(user.name);
+    return initial(namedParty.name) || null;
   }
-}
-export function initial(name?: string | null) {
-  return name ? name.charAt(0).toUpperCase() : "";
 }
 
 function emailInitials(user: PartialUser) {
@@ -44,4 +31,12 @@ function emailInitials(user: PartialUser) {
   }
 
   return null;
+}
+
+const isUser = (user: PartialUser | PartialGroup): user is PartialUser => {
+  return "common_name" in user || "email" in user;
+};
+
+function initial(name?: string | null) {
+  return name ? name.charAt(0).toUpperCase() : "";
 }

--- a/frontend/src/metabase/common/utils/user.ts
+++ b/frontend/src/metabase/common/utils/user.ts
@@ -1,9 +1,12 @@
 import { isEmail } from "metabase/utils/email";
 import type { BaseUser, Group, Tenant } from "metabase-types/api";
 
+// Requires at least an `email` or `common_name` (mirroring `isUser` below), so
+// name-only objects like a tenant's `{ name }` can't be passed as first_name alone.
 export type PartialUser = Partial<
   Pick<BaseUser, "first_name" | "last_name" | "email" | "common_name">
->;
+> &
+  (Pick<BaseUser, "email"> | Pick<BaseUser, "common_name">);
 export type PartialGroup = Pick<Group, "name">;
 
 export type PartialTenant = Pick<Tenant, "name">;

--- a/frontend/src/metabase/common/utils/user.ts
+++ b/frontend/src/metabase/common/utils/user.ts
@@ -33,7 +33,7 @@ function emailInitials(user: PartialUser) {
   return null;
 }
 
-const isUser = (user: PartialUser | PartialGroup): user is PartialUser => {
+const isUser = (user: Named): user is PartialUser => {
   return "common_name" in user || "email" in user;
 };
 

--- a/frontend/src/metabase/nav/components/AppSwitcher/AppSwitcher.tsx
+++ b/frontend/src/metabase/nav/components/AppSwitcher/AppSwitcher.tsx
@@ -7,7 +7,7 @@ import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { ForwardRefLink } from "metabase/common/components/Link";
 import { trackDataStudioOpened } from "metabase/common/data-studio/analytics";
 import { canAccessDataStudio as canAccessDataStudioSelector } from "metabase/common/data-studio/selectors";
-import { userInitials } from "metabase/common/utils/user";
+import { prepareInitials } from "metabase/common/utils/user";
 import { useDispatch, useSelector } from "metabase/redux";
 import { openDiagnostics } from "metabase/redux/app";
 import { logout } from "metabase/redux/auth";
@@ -177,7 +177,7 @@ export const AppSwitcher = ({ className }: { className?: string }) => {
               bd="1px solid var(--mb-color-border-neutral)"
               data-testid="app-switcher-target"
             >
-              {user ? userInitials(user) : "?"}
+              {user ? prepareInitials(user) : "?"}
             </Avatar>
           )}
         </Menu.Target>
@@ -191,7 +191,7 @@ export const AppSwitcher = ({ className }: { className?: string }) => {
             >
               <Group wrap="nowrap">
                 <Avatar color="core-brand" radius="lg" size={32}>
-                  {user ? userInitials(user) : "?"}
+                  {user ? prepareInitials(user) : "?"}
                 </Avatar>
                 <Stack gap="xs">
                   <Text lh="xs">{user?.first_name}</Text>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/73910

### Description

Use the same approach to rendering tenant avatars as the one used for rendering user group avatars

### Checklist

- [x] Tests have been added/updated to cover changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Tenant avatars in the tenants listing now display the correct initial from the tenant name (no longer a question mark).
  * User/menu initials in the app switcher now render using the same initials logic for consistent display.

* **Tests**
  * Added a unit test to confirm tenant avatar initials render correctly in the tenants listing.

* **Refactor**
  * Unified avatar initials handling across user-like, group, and tenant shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->