### PR TITLE
Remove SDK question query prop for data apps use cases

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/static-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/static-question.cy.spec.tsx
@@ -283,24 +283,26 @@ describe("scenarios > embedding-sdk > static-question", () => {
     });
   });
 
-  it("should not request /api/card/undefined when clicking a data point on an ad-hoc `query` question", () => {
-    // An ad-hoc question (rendered from `query`) has no saved card id. A static
-    // question must not navigate on a chart click — previously it did, fetching
+  it("should not request /api/card/undefined when clicking a data point on a query-only ad-hoc card", () => {
+    // A query-only ad-hoc card has no saved card id. A static question must not
+    // navigate on a chart click — previously it did, fetching
     // `GET /api/card/undefined` (the new card's id was `undefined`).
     cy.intercept("GET", "/api/card/undefined").as("getUndefinedCard");
 
     mountSdkContent(
       <StaticQuestion
-        query={{
-          database: SAMPLE_DB_ID,
-          type: "query",
+        card={{
           query: {
-            "source-table": ORDERS_ID,
-            aggregation: [["count"]],
-            breakout: [
-              ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
-            ],
-            limit: 5,
+            database: SAMPLE_DB_ID,
+            type: "query",
+            query: {
+              "source-table": ORDERS_ID,
+              aggregation: [["count"]],
+              breakout: [
+                ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+              ],
+              limit: 5,
+            },
           },
         }}
       />,

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.schema.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.schema.ts
@@ -2,12 +2,9 @@ import * as Yup from "yup";
 
 import type { FunctionSchema } from "embedding-sdk-bundle/types/schema";
 
-import type { InteractiveQuestionInternalProps } from "./InteractiveQuestion";
-
-// Typed against the internal shape so runtime validation accepts both the
-// public object `query` prop and the internal string `query` prop used by the
-// `useMetabot` hook.
-const propsSchema: Yup.SchemaOf<InteractiveQuestionInternalProps> = Yup.object({
+// Typed against the internal shape so runtime validation accepts the internal
+// string `query` prop used by the `useMetabot` hook.
+const propsSchema: Yup.ObjectSchema<any> = Yup.object({
   children: Yup.mixed().optional(),
   className: Yup.mixed().optional(),
   componentPlugins: Yup.object({
@@ -44,7 +41,7 @@ const propsSchema: Yup.SchemaOf<InteractiveQuestionInternalProps> = Yup.object({
   }),
   token: Yup.mixed().optional(),
   card: Yup.mixed().optional(),
-  query: Yup.mixed().optional(),
+  query: Yup.string().optional(),
   style: Yup.mixed().optional(),
   targetCollection: Yup.mixed().optional(),
   initialCollection: Yup.mixed().optional(),

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.tsx
@@ -55,8 +55,6 @@ export type InteractiveQuestionBaseProps = Omit<
  * @interface
  * @expand
  * @category InteractiveQuestion
- * @notExported SdkQuestionQuery
- * @notExported StructuredDatasetQuery
  */
 export type InteractiveQuestionProps = InteractiveQuestionBaseProps &
   SdkQuestionEntityPublicProps;

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -209,7 +209,7 @@ describe("InteractiveQuestion", () => {
     ).toBeVisible();
   });
 
-  it("should render an ad hoc question from a dataset query object", async () => {
+  it("should render an ad hoc question from a query-only card object", async () => {
     const { state } = setupSdkState();
 
     setupNotificationChannelsEndpoints({ email: { configured: false } });
@@ -230,11 +230,13 @@ describe("InteractiveQuestion", () => {
 
     renderWithSDKProviders(
       <InteractiveQuestion
-        query={{
-          type: "query",
-          database: TEST_DB.id,
-          query: { "source-table": TEST_TABLE.id },
-          parameters: [],
+        card={{
+          query: {
+            type: "query",
+            database: TEST_DB.id,
+            query: { "source-table": TEST_TABLE.id },
+            parameters: [],
+          },
         }}
       />,
       {

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.schema.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.schema.ts
@@ -2,12 +2,9 @@ import * as Yup from "yup";
 
 import type { FunctionSchema } from "embedding-sdk-bundle/types/schema";
 
-import type { StaticQuestionInternalProps } from "./StaticQuestion";
-
-// Typed against the internal shape so runtime validation accepts both the
-// public object `query` prop and the internal string `query` prop used by the
-// `useMetabot` hook.
-const propsSchema: Yup.SchemaOf<StaticQuestionInternalProps> = Yup.object({
+// Typed against the internal shape so runtime validation accepts the internal
+// string `query` prop used by the `useMetabot` hook.
+const propsSchema: Yup.ObjectSchema<any> = Yup.object({
   children: Yup.mixed().optional(),
   className: Yup.mixed().optional(),
   height: Yup.mixed().optional(),
@@ -23,7 +20,7 @@ const propsSchema: Yup.SchemaOf<StaticQuestionInternalProps> = Yup.object({
   }),
   token: Yup.mixed().optional(),
   card: Yup.mixed().optional(),
-  query: Yup.mixed().optional(),
+  query: Yup.string().optional(),
   style: Yup.mixed().optional(),
   title: Yup.mixed().optional(),
   width: Yup.mixed().optional(),

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
@@ -69,8 +69,6 @@ type StaticQuestionBaseProps = PropsWithChildren<
  * @interface
  * @expand
  * @category StaticQuestion
- * @notExported SdkQuestionQuery
- * @notExported StructuredDatasetQuery
  */
 export type StaticQuestionProps = StaticQuestionBaseProps &
   SdkQuestionEntityPublicProps;

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question-query.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question-query.ts
@@ -1,21 +1,12 @@
-import type { SdkQuestionEntityInternalProps } from "embedding-sdk-bundle/types/question";
 import { deserializeCardFromQuery } from "metabase/common/utils/card";
 import type { UnsavedCard } from "metabase-types/api";
 
 export function getCardFromSdkQuestionQuery(
-  query: SdkQuestionEntityInternalProps["query"] | undefined,
+  query: string | undefined,
 ): UnsavedCard | undefined {
   if (!query) {
     return undefined;
   }
 
-  if (typeof query === "string") {
-    return deserializeCardFromQuery(query);
-  }
-
-  return {
-    dataset_query: query,
-    display: "table",
-    visualization_settings: {},
-  };
+  return deserializeCardFromQuery(query);
 }

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/resolve-card-prop.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/resolve-card-prop.ts
@@ -24,8 +24,7 @@ export function resolveCardProp(
   return {
     dataset_query: input.query as DatasetQuery,
     // Public-facing `visualization` maps to the internal card `display`. When
-    // omitted, mirror the legacy `query` prop and let query results pick a
-    // better unlocked display later.
+    // omitted, let query results pick a better unlocked display later.
     display: input.visualization ?? "table",
     ...(shouldSetDisplayLock
       ? {

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/run-question-on-navigate.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/run-question-on-navigate.ts
@@ -48,8 +48,8 @@ export const runQuestionOnNavigateSdk =
     // Fallback when a visualization legend is clicked
     if (cardIsEquivalent(previousCard, nextCard)) {
       // Reload the canonical card only for saved questions. Ad-hoc questions
-      // (rendered from a `query` prop) have no id — there's nothing to fetch, so
-      // keep the card as-is rather than firing `GET /api/card/undefined`.
+      // have no id, so keep the card as-is rather than firing
+      // `GET /api/card/undefined`.
       if (nextCard.id !== null && nextCard.id !== undefined) {
         nextCard = await loadCard(
           { cardId: nextCard.id },

--- a/frontend/src/embedding-sdk-bundle/types/question.ts
+++ b/frontend/src/embedding-sdk-bundle/types/question.ts
@@ -5,12 +5,7 @@ import type { MetabaseCard } from "metabase/embedding-sdk/types/question";
 import type { QueryParams } from "metabase/query_builder/actions";
 import type { ObjectId } from "metabase/visualizations/components/ObjectDetail/types";
 import type InternalQuestion from "metabase-lib/v1/Question";
-import type {
-  Card,
-  ParameterValuesMap,
-  StructuredDatasetQuery,
-  UnsavedCard,
-} from "metabase-types/api";
+import type { Card, ParameterValuesMap, UnsavedCard } from "metabase-types/api";
 
 import type { SdkDashboardId } from "./dashboard";
 import type { SdkEntityId, SdkEntityToken } from "./entity";
@@ -44,17 +39,6 @@ export type SdkQuestionId =
   | "new-native" // Create new native SQL question
   | SdkEntityId; // Entity ID string (e.g., "abc123def456")
 
-/**
- * A table-backed ad hoc question query.
- *
- * @notExported StructuredDatasetQuery
- */
-export type SdkQuestionQuery = StructuredDatasetQuery;
-
-/**
- * @notExported SdkQuestionQuery
- * @notExported StructuredDatasetQuery
- */
 export type SdkQuestionEntityPublicProps =
   | {
       /**
@@ -94,15 +78,6 @@ export type SdkQuestionEntityPublicProps =
        */
       card: string | MetabaseCard;
       query?: never;
-    }
-  | {
-      questionId?: never;
-      token?: never;
-      card?: never;
-      /**
-       * A table-backed ad hoc query created with `createMetabaseQuery`.
-       */
-      query: SdkQuestionQuery;
     };
 
 /**


### PR DESCRIPTION
Closes EMB-2047

### Description

Removes the public SDK question `query` prop for data apps in favor of the `card={{ query }}` prop, where `card` takes a `MetabaseCard`.

The public question entity props now only accept `questionId`, `token`, or `card`; `query` remains available only on the internal question components as a string path for `useMetabot`.

Runtime validation now only accepts string `query` values for that internal Metabot path, and the ad hoc question test now verifies the public query-only card shape.

### How to verify

1. Confirm `InteractiveQuestion` and `StaticQuestion` public types accept `card={{ query }}` but not `query={{ ... }}`.
2. Confirm Metabot chart messages still render. Should already be verified thru the e2e tests for Metabot.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

