### PR TITLE
Fix SDK theming hover text colors in generated data apps

### DIFF
--- a/skills/create-data-app/SKILL.md
+++ b/skills/create-data-app/SKILL.md
@@ -283,12 +283,18 @@ import type { ComponentType, ReactNode } from "react";
 
 | Field | Purpose | Notes |
 |---|---|---|
-| `colors.brand`, `colors.brand-hover` | Accent for SDK widgets | Use the data app's primary color. |
+| `colors.brand` | Accent for SDK widgets | Use the data app's primary color. |
+| `colors.brand-hover`, `colors.brand-hover-light` | Hover/accent backgrounds for SDK widgets | Use a subtle surface tint that contrasts with hover text. Do not use the same saturated color as `brand`. |
 | `colors.charts` | Chart palette | Array of strings. Use vivid brand-shade colors only; **never pale tints** — palette index 1+ may render labels and pale-on-white is invisible. |
 | `colors.positive` / `colors.negative` | Semantic indicators | |
 | `colors.background`, `colors.background-secondary` | SDK component surface | **MUST match the immediate parent container of the SDK component.** If the chart sits inside a white card, use `"white"`. If it sits on a tinted page, use that tint. |
 | `colors.text-primary`, `text-secondary`, `text-tertiary` | Text on SDK surfaces | **MUST contrast with `background`.** For white bg: use `#1f2937` or similar dark color. The SDK's default `text-primary` resolves to ~white, so leaving it unset on a white surface produces invisible white text. **Always pair `background` and `text-primary` when overriding.** |
 | `fontFamily` | SDK widget typography | |
+
+Hover colors are a contrast pair. If you set `colors.text-hover`, verify it
+contrasts with `colors.brand-hover` / `colors.brand-hover-light` in open menus,
+chart type selectors, and visualization settings dropdowns. For a blue `brand`,
+use a pale hover surface like `#EAF4FF`, not the brand blue itself.
 
 **The theme only styles SDK widgets — never your own UI.** For your page background, headers, card wrappers, etc., use inline `style={{ background: "#f5f5f7" }}` or CSS modules on your own elements.
 

--- a/skills/create-data-app/template/src/theme.ts
+++ b/skills/create-data-app/template/src/theme.ts
@@ -3,7 +3,7 @@ import type { MetabaseTheme } from "@metabase/embedding-sdk-react";
 export const sdkTheme: MetabaseTheme = {
   colors: {
     brand: "#4D96FF",
-    "brand-hover": "#4D96FF",
+    "brand-hover": "#EAF4FF",
     positive: "#4D96FF",
     charts: ["#4D96FF"],
     background: "white",


### PR DESCRIPTION
Fixes EMB-1941

### Description

Generated data apps could inherit unsafe SDK theme hover colors because the starter theme set `brand-hover` to the same saturated blue as `brand`, and the skill guidance described both as primary accent colors.

Since SDK `brand-hover` drives hover/accent backgrounds, this produces low-contrast hover states in chart type selectors and visualization settings dropdowns.

### How to verify

Re-generate the app with a specific color palette and ask it to show the query bar, i.e. no custom layout that removes the query bar.

```
Create a new metabase data app for executives to have an in depth understanding of the franchises. For example, orders, inventory.

Show the query bar from InteractiveQuestion. Do not use custom question layout.
Use a pinkish color palette.

I will use a custom version of the SDK, not 63-data-apps. Use this command to install custom version:

* npm pkg set dependencies.@metabase/embedding-sdk-react="file:../../../metabase/resources/embedding-sdk"
* npm install
```

Then, check these hover states:

- Question visualization selector's hover (chart type selector)
- Question visualization selector's dropdown menu item hover (e.g. hovering on a chart type dropdown)
- Question visualization settings's dropdown menu item hover (e.g. hovering on the column alignment for tables)

### Screenshots

<img width="2362" height="1688" alt="CleanShot 2569-07-06 at 20 58 05@2x" src="https://github.com/user-attachments/assets/d1df1a39-9804-47ee-aa26-b335a12e9f9f" />

<img width="2334" height="1670" alt="CleanShot 2569-07-06 at 20 58 15@2x" src="https://github.com/user-attachments/assets/15717e3c-b0f7-4575-9377-e66e7317e9f7" />
