### PR TITLE
GDGT-2713: Update Tasks page styling

### DIFF
--- a/e2e/test/scenarios/monitor/tools/tools.cy.spec.ts
+++ b/e2e/test/scenarios/monitor/tools/tools.cy.spec.ts
@@ -131,6 +131,7 @@ describe("issue 14636", () => {
   });
 
   it("filtering should work", () => {
+    const total = 57;
     cy.visit("/monitor/tasks/list?status=success&task=field+values+scanning");
 
     cy.findByPlaceholderText("Filter by task").should(
@@ -168,11 +169,13 @@ describe("issue 14636", () => {
       .click();
     cy.location("search").should("eq", "");
     cy.wait("@first");
-    cy.findAllByTestId("task").should("have.length", 50);
     cy.findByLabelText("pagination").findByText("1 - 50").should("be.visible");
+    cy.visit("/monitor/tasks/list?page=1");
+    cy.findByLabelText("pagination")
+      .findByText(`51 - ${total}`)
+      .should("be.visible");
 
     cy.log("should reset pagination when changing filters");
-    cy.visit("/monitor/tasks/list?page=1");
     getFilterByStatus().click();
     H.popover().findByText("Success").click();
     cy.location("search").should("eq", "?status=success");

--- a/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/components/DiagnosticsHeader/DiagnosticsHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/components/DiagnosticsHeader/DiagnosticsHeader.tsx
@@ -2,15 +2,15 @@ import { memo } from "react";
 import { t } from "ttag";
 
 import {
-  type PaneHeaderTab,
-  PaneHeaderTabs,
-} from "metabase/common/data-studio/components/PaneHeader";
+  type MonitorHeaderTab,
+  MonitorHeaderTabs,
+} from "metabase/monitor/components/MonitorHeaderTabs";
 import { MonitorHeaderTitle } from "metabase/monitor/components/MonitorHeaderTitle";
 import { Stack } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
 export const DiagnosticsHeader = memo(function DiagnosticsHeader() {
-  const tabs: PaneHeaderTab[] = [
+  const tabs: MonitorHeaderTab[] = [
     {
       label: t`Broken dependencies`,
       to: Urls.brokenDependencies(),
@@ -26,7 +26,7 @@ export const DiagnosticsHeader = memo(function DiagnosticsHeader() {
   return (
     <Stack gap="md">
       <MonitorHeaderTitle>{t`Dependency diagnostics`}</MonitorHeaderTitle>
-      <PaneHeaderTabs tabs={tabs} />
+      <MonitorHeaderTabs tabs={tabs} />
     </Stack>
   );
 });

--- a/frontend/src/metabase-types/api/task.ts
+++ b/frontend/src/metabase-types/api/task.ts
@@ -85,7 +85,7 @@ export interface TaskRun {
   started_at: string;
   ended_at: string | null;
   status: TaskRunStatus;
-  entity_name?: string;
+  entity_name: string | null;
   task_count: number;
   success_count: number;
   failed_count: number;
@@ -98,7 +98,7 @@ export interface TaskRunExtended extends TaskRun {
 export interface RunEntity {
   entity_type: TaskRunEntityType;
   entity_id: number;
-  entity_name?: string;
+  entity_name: string | null;
 }
 
 export type TaskRunStartedAtParam =

--- a/frontend/src/metabase/common/components/LinkTab/LinkTab.tsx
+++ b/frontend/src/metabase/common/components/LinkTab/LinkTab.tsx
@@ -1,0 +1,24 @@
+import type { FC } from "react";
+import { Link } from "react-router";
+
+import { Tabs, type TabsTabProps } from "metabase/ui";
+
+/**
+ * Mantine's `Tabs.Tab` is built with the non-polymorphic `factory`, so
+ * `component`/`to` aren't in its prop types. However it still accepts the
+ * prop and it works as expected, thus type casting.
+ */
+const TabsTabAsLink = Tabs.Tab as FC<
+  TabsTabProps & { component: typeof Link; to: string }
+>;
+
+type LinkTabProps = TabsTabProps & {
+  to: string;
+};
+
+/**
+ * Mantine tab that navigates as a react-router link.
+ */
+export function LinkTab(props: LinkTabProps) {
+  return <TabsTabAsLink {...props} component={Link} />;
+}

--- a/frontend/src/metabase/common/components/LinkTab/LinkTab.tsx
+++ b/frontend/src/metabase/common/components/LinkTab/LinkTab.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
-import { Link } from "react-router";
 
+import { Link } from "metabase/router";
 import { Tabs, type TabsTabProps } from "metabase/ui";
 
 /**

--- a/frontend/src/metabase/common/components/LinkTab/index.ts
+++ b/frontend/src/metabase/common/components/LinkTab/index.ts
@@ -1,0 +1,1 @@
+export * from "./LinkTab";

--- a/frontend/src/metabase/common/data-studio/components/PaneHeader/PaneHeader.tsx
+++ b/frontend/src/metabase/common/data-studio/components/PaneHeader/PaneHeader.tsx
@@ -1,7 +1,8 @@
-import type { FC, ReactNode } from "react";
+import type { ReactNode } from "react";
 import { t } from "ttag";
 
 import { EditableText } from "metabase/common/components/EditableText";
+import { LinkTab } from "metabase/common/components/LinkTab";
 import { UpsellGem } from "metabase/common/components/upsells/components/UpsellGem";
 import { MetabotDataStudioButton } from "metabase/metabot/components/MetabotDataStudioButton";
 import { AppSwitcher } from "metabase/nav/components/AppSwitcher";
@@ -17,7 +18,6 @@ import {
   Stack,
   type StackProps,
   Tabs,
-  type TabsTabProps,
   Tooltip,
 } from "metabase/ui";
 import type { IconName } from "metabase-types/api";
@@ -138,15 +138,6 @@ type PaneHeaderTabsProps = {
   tabs: PaneHeaderTab[];
 };
 
-/**
- * Mantine's `Tabs.Tab` is built with the non-polymorphic `factory`, so
- * `component`/`to` aren't in its prop types. However it still accepts the
- * prop and it works as expected, thus type casting.
- */
-const LinkTab = Tabs.Tab as FC<
-  TabsTabProps & { component: typeof Link; to: string }
->;
-
 function isTabSelected(tab: PaneHeaderTab, pathname: string) {
   const { to, isSelected } = tab;
   return typeof isSelected === "function"
@@ -165,7 +156,6 @@ export function PaneHeaderTabs({ tabs }: PaneHeaderTabsProps) {
           <LinkTab
             key={label}
             value={to}
-            component={Link}
             to={to}
             leftSection={icon != null ? <FixedSizeIcon name={icon} /> : null}
             rightSection={isGated ? <UpsellGem.New size={14} /> : null}

--- a/frontend/src/metabase/common/data-studio/components/PaneHeader/PaneHeader.tsx
+++ b/frontend/src/metabase/common/data-studio/components/PaneHeader/PaneHeader.tsx
@@ -7,7 +7,6 @@ import { UpsellGem } from "metabase/common/components/upsells/components/UpsellG
 import { MetabotDataStudioButton } from "metabase/metabot/components/MetabotDataStudioButton";
 import { AppSwitcher } from "metabase/nav/components/AppSwitcher";
 import { useSelector } from "metabase/redux";
-import { Link } from "metabase/router";
 import { getLocation } from "metabase/selectors/routing";
 import {
   Box,

--- a/frontend/src/metabase/monitor/components/MonitorHeaderTabs/MonitorHeaderTabs.tsx
+++ b/frontend/src/metabase/monitor/components/MonitorHeaderTabs/MonitorHeaderTabs.tsx
@@ -36,7 +36,9 @@ export function MonitorHeaderTabs({ tabs }: MonitorHeaderTabsProps) {
             key={label}
             value={to}
             to={to}
-            leftSection={icon != null ? <FixedSizeIcon name={icon} /> : null}
+            leftSection={
+              icon !== undefined ? <FixedSizeIcon name={icon} /> : null
+            }
             rightSection={isGated ? <UpsellGem.New size={14} /> : null}
           >
             {label}

--- a/frontend/src/metabase/monitor/components/MonitorHeaderTabs/MonitorHeaderTabs.tsx
+++ b/frontend/src/metabase/monitor/components/MonitorHeaderTabs/MonitorHeaderTabs.tsx
@@ -1,0 +1,48 @@
+import { LinkTab } from "metabase/common/components/LinkTab";
+import { UpsellGem } from "metabase/common/components/upsells/components/UpsellGem";
+import { useSelector } from "metabase/redux";
+import { getLocation } from "metabase/selectors/routing";
+import { FixedSizeIcon, Tabs } from "metabase/ui";
+import type { IconName } from "metabase-types/api";
+
+export type MonitorHeaderTab = {
+  label: string;
+  to: string;
+  icon?: IconName;
+  isGated?: boolean;
+  isSelected?: boolean | ((pathname: string) => boolean);
+};
+
+type MonitorHeaderTabsProps = {
+  tabs: MonitorHeaderTab[];
+};
+
+function isTabSelected(tab: MonitorHeaderTab, pathname: string) {
+  const { to, isSelected } = tab;
+  return typeof isSelected === "function"
+    ? isSelected(pathname)
+    : (isSelected ?? to === pathname);
+}
+
+export function MonitorHeaderTabs({ tabs }: MonitorHeaderTabsProps) {
+  const { pathname } = useSelector(getLocation);
+  const activeTab = tabs.find((tab) => isTabSelected(tab, pathname));
+
+  return (
+    <Tabs variant="pills" value={activeTab?.to ?? null}>
+      <Tabs.List>
+        {tabs.map(({ label, to, icon, isGated }) => (
+          <LinkTab
+            key={label}
+            value={to}
+            to={to}
+            leftSection={icon != null ? <FixedSizeIcon name={icon} /> : null}
+            rightSection={isGated ? <UpsellGem.New size={14} /> : null}
+          >
+            {label}
+          </LinkTab>
+        ))}
+      </Tabs.List>
+    </Tabs>
+  );
+}

--- a/frontend/src/metabase/monitor/components/MonitorHeaderTabs/index.ts
+++ b/frontend/src/metabase/monitor/components/MonitorHeaderTabs/index.ts
@@ -1,0 +1,1 @@
+export * from "./MonitorHeaderTabs";

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.tsx
@@ -65,7 +65,7 @@ export const TaskListPage = ({ location }: WithRouterProps) => {
         />
       </Group>
 
-      {error != null ? (
+      {error !== undefined ? (
         <Center flex={1}>
           <DelayedLoadingAndErrorWrapper loading={isLoading} error={error} />
         </Center>

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.tsx
@@ -1,8 +1,9 @@
 import { useListDatabasesQuery, useListTasksQuery } from "metabase/api";
+import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
 import { PaginationControls } from "metabase/common/components/PaginationControls";
 import { useUrlState } from "metabase/common/hooks/use-url-state";
 import type { WithRouterProps } from "metabase/router";
-import { Flex } from "metabase/ui";
+import { Center, Flex, Group } from "metabase/ui";
 
 import { TaskPicker } from "../TaskPicker";
 import { TaskStatusPicker } from "../TaskStatusPicker";
@@ -52,39 +53,47 @@ export const TaskListPage = ({ location }: WithRouterProps) => {
 
   return (
     <TasksTabs>
-      <Flex gap="md" justify="space-between">
-        <Flex gap="md">
-          <TaskPicker
-            value={task}
-            onChange={(task) => patchUrlState({ task, page: 0 })}
-          />
+      <Group gap="md" align="center" wrap="nowrap">
+        <TaskPicker
+          value={task}
+          onChange={(task) => patchUrlState({ task, page: 0 })}
+        />
 
-          <TaskStatusPicker
-            value={status}
-            onChange={(status) => patchUrlState({ status, page: 0 })}
+        <TaskStatusPicker
+          value={status}
+          onChange={(status) => patchUrlState({ status, page: 0 })}
+        />
+      </Group>
+
+      {error != null ? (
+        <Center flex={1}>
+          <DelayedLoadingAndErrorWrapper loading={isLoading} error={error} />
+        </Center>
+      ) : (
+        <TasksTable
+          databases={databases}
+          isLoading={isLoading}
+          sortingOptions={sortingOptions}
+          tasks={tasks}
+          onSortingOptionsChange={(sortingOptions) =>
+            patchUrlState({ ...sortingOptions, page: 0 })
+          }
+        />
+      )}
+
+      {!isLoading && error == null && (
+        <Flex justify="end">
+          <PaginationControls
+            page={page}
+            pageSize={PAGE_SIZE}
+            itemsLength={tasks.length}
+            total={total}
+            showTotal
+            onPreviousPage={() => patchUrlState({ page: page - 1 })}
+            onNextPage={() => patchUrlState({ page: page + 1 })}
           />
         </Flex>
-
-        <PaginationControls
-          onPreviousPage={() => patchUrlState({ page: page - 1 })}
-          onNextPage={() => patchUrlState({ page: page + 1 })}
-          page={page}
-          pageSize={PAGE_SIZE}
-          itemsLength={tasks.length}
-          total={total}
-        />
-      </Flex>
-
-      <TasksTable
-        databases={databases}
-        error={error}
-        isLoading={isLoading}
-        sortingOptions={sortingOptions}
-        tasks={tasks}
-        onSortingOptionsChange={(sortingOptions) =>
-          patchUrlState({ ...sortingOptions, page: 0 })
-        }
-      />
+      )}
     </TasksTabs>
   );
 };

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
@@ -9,6 +9,7 @@ import {
 } from "__support__/server-mocks";
 import {
   act,
+  mockGetBoundingClientRect,
   renderWithProviders,
   screen,
   waitFor,
@@ -42,6 +43,7 @@ const setup = ({
 }: SetupOpts = {}) => {
   setupDatabasesEndpoints([createSampleDatabase()]);
   setupUniqueTasksEndpoint(["task-a", "task-b"]);
+  mockGetBoundingClientRect({ width: 100, height: 100 });
 
   if (error) {
     fetchMock.get("path:/api/task", { status: 500 });
@@ -50,12 +52,19 @@ const setup = ({
   }
 
   return renderWithProviders(
-    <Route path={PATHNAME} component={TaskListPage} />,
+    <Route path={PATHNAME} component={TaskListPage}>
+      <Route path=":taskId" />
+    </Route>,
     {
       initialRoute: `${location.pathname}${location.search}`,
       withRouter: true,
     },
   );
+};
+
+const getLastTaskCallUrl = () => {
+  const calls = fetchMock.callHistory.calls("path:/api/task");
+  return calls[calls.length - 1]?.url;
 };
 
 describe("TaskListPage", () => {
@@ -67,39 +76,33 @@ describe("TaskListPage", () => {
     jest.useRealTimers();
   });
 
-  it("should show loading and empty state", async () => {
+  it("should show empty state", async () => {
     setup();
 
-    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
-    await waitForLoaderToBeRemoved();
-    expect(screen.getByText("No results")).toBeInTheDocument();
+    expect(await screen.findByText("No results")).toBeInTheDocument();
   });
 
-  it("should show loading and results state", async () => {
+  it("should show results state", async () => {
     setup({
       tasksResponse: createMockTasksResponse({ data: [createMockTask()] }),
     });
 
-    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
-    await waitForLoaderToBeRemoved();
+    expect(await screen.findByText("A task")).toBeInTheDocument();
     expect(screen.queryByText("No results")).not.toBeInTheDocument();
-    expect(screen.getByText("A task")).toBeInTheDocument();
   });
 
   it("should show error state", async () => {
     setup({ error: true });
 
-    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
-    await waitForLoaderToBeRemoved();
+    expect(await screen.findByText("An error occurred")).toBeInTheDocument();
     expect(screen.queryByText("No results")).not.toBeInTheDocument();
     expect(screen.queryByText("A task")).not.toBeInTheDocument();
-    expect(screen.getByText("An error occurred")).toBeInTheDocument();
   });
 
   it("should not show pagination controls if there's only 1 page", async () => {
     setup();
 
-    await waitForLoaderToBeRemoved();
+    await screen.findByText("No results");
     expect(
       screen.queryByRole("button", { name: "Previous page" }),
     ).not.toBeInTheDocument();
@@ -126,9 +129,9 @@ describe("TaskListPage", () => {
     ).toEqual([
       "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=desc",
     ]);
-    await waitForLoaderToBeRemoved();
-
-    const previousPage = screen.getByRole("button", { name: "Previous page" });
+    const previousPage = await screen.findByRole("button", {
+      name: "Previous page",
+    });
     const nextPage = screen.getByRole("button", { name: "Next page" });
 
     expect(previousPage).toBeDisabled();
@@ -175,6 +178,25 @@ describe("TaskListPage", () => {
     expect(history?.getCurrentLocation().search).toEqual("");
   });
 
+  it("should show the total results count below the table", async () => {
+    setup({
+      tasksResponse: createMockTasksResponse({
+        data: [createMockTask()],
+        total: 75,
+        limit: 50,
+        offset: 0,
+      }),
+    });
+
+    await screen.findByText("A task");
+
+    const pagination = screen.getByRole("navigation", { name: "pagination" });
+    expect(
+      within(pagination).getByTestId("pagination-total"),
+    ).toHaveTextContent("75");
+    expect(pagination).toHaveTextContent("1 - 1");
+  });
+
   it("should reset pagination on task filter change", async () => {
     const { history } = setup({
       tasksResponse: createMockTasksResponse({
@@ -193,9 +215,9 @@ describe("TaskListPage", () => {
     ).toEqual([
       "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=desc",
     ]);
-    await waitForLoaderToBeRemoved();
-
-    const previousPage = screen.getByRole("button", { name: "Previous page" });
+    const previousPage = await screen.findByRole("button", {
+      name: "Previous page",
+    });
     const nextPage = screen.getByRole("button", { name: "Next page" });
     const taskPicker = screen.getByPlaceholderText("Filter by task");
 
@@ -248,9 +270,9 @@ describe("TaskListPage", () => {
     ).toEqual([
       "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=desc",
     ]);
-    await waitForLoaderToBeRemoved();
-
-    const previousPage = screen.getByRole("button", { name: "Previous page" });
+    const previousPage = await screen.findByRole("button", {
+      name: "Previous page",
+    });
     const nextPage = screen.getByRole("button", { name: "Next page" });
     const taskStatusPicker = screen.getByPlaceholderText("Filter by status");
 
@@ -288,6 +310,7 @@ describe("TaskListPage", () => {
   it("should reset pagination on sorting change", async () => {
     const { history } = setup({
       tasksResponse: createMockTasksResponse({
+        data: [createMockTask()],
         total: 75,
         limit: 50,
         offset: 0,
@@ -303,11 +326,11 @@ describe("TaskListPage", () => {
     ).toEqual([
       "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=desc",
     ]);
-    await waitForLoaderToBeRemoved();
-
-    const previousPage = screen.getByRole("button", { name: "Previous page" });
+    const previousPage = await screen.findByRole("button", {
+      name: "Previous page",
+    });
     const nextPage = screen.getByRole("button", { name: "Next page" });
-    const startedAtHeader = screen.getByRole("button", {
+    const startedAtHeader = screen.getByRole("columnheader", {
       name: /Started at/,
     });
 
@@ -455,7 +478,9 @@ describe("TaskListPage", () => {
   });
 
   it("should allow to sort tasks list", async () => {
-    const { history } = setup();
+    const { history } = setup({
+      tasksResponse: createMockTasksResponse({ data: [createMockTask()] }),
+    });
 
     await waitFor(() => {
       expect(fetchMock.callHistory.calls("path:/api/task")).toHaveLength(1);
@@ -466,15 +491,18 @@ describe("TaskListPage", () => {
     ).toEqual([
       "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=desc",
     ]);
-    await waitForLoaderToBeRemoved();
-
-    const startedAtHeader = screen.getByRole("button", { name: /Started at/ });
-    const endedAtHeader = screen.getByRole("button", { name: /Ended at/ });
-    const durationHeader = screen.getByRole("button", { name: /Duration/ });
+    const startedAtHeader = await screen.findByRole("columnheader", {
+      name: /Started at/,
+    });
 
     expect(startedAtHeader).toBeInTheDocument();
-    expect(endedAtHeader).toBeInTheDocument();
-    expect(durationHeader).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: /Ended at/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: /Duration/ }),
+    ).toBeInTheDocument();
+    expect(startedAtHeader).toHaveAttribute("aria-sort", "descending");
     expect(
       within(startedAtHeader).getByRole("img", { name: "chevrondown icon" }),
     ).toBeInTheDocument();
@@ -482,8 +510,15 @@ describe("TaskListPage", () => {
 
     await userEvent.click(startedAtHeader);
 
+    await waitFor(() => {
+      expect(
+        screen.getByRole("columnheader", { name: /Started at/ }),
+      ).toHaveAttribute("aria-sort", "ascending");
+    });
     expect(
-      within(startedAtHeader).getByRole("img", { name: "chevronup icon" }),
+      within(
+        screen.getByRole("columnheader", { name: /Started at/ }),
+      ).getByRole("img", { name: "chevronup icon" }),
     ).toBeInTheDocument();
     expect(
       fetchMock.callHistory.calls("path:/api/task").map((call) => call.url),
@@ -496,10 +531,20 @@ describe("TaskListPage", () => {
     });
     expect(history?.getCurrentLocation().search).toEqual("?sort_direction=asc");
 
-    await userEvent.click(endedAtHeader);
+    await userEvent.click(
+      screen.getByRole("columnheader", { name: /Ended at/ }),
+    );
 
+    await waitFor(() => {
+      expect(
+        screen.getByRole("columnheader", { name: /Ended at/ }),
+      ).toHaveAttribute("aria-sort", "ascending");
+    });
     expect(
-      within(endedAtHeader).getByRole("img", { name: "chevronup icon" }),
+      within(screen.getByRole("columnheader", { name: /Ended at/ })).getByRole(
+        "img",
+        { name: "chevronup icon" },
+      ),
     ).toBeInTheDocument();
     expect(
       fetchMock.callHistory.calls("path:/api/task").map((call) => call.url),
@@ -515,10 +560,20 @@ describe("TaskListPage", () => {
       "?sort_column=ended_at&sort_direction=asc",
     );
 
-    await userEvent.click(durationHeader);
+    await userEvent.click(
+      screen.getByRole("columnheader", { name: /Duration/ }),
+    );
 
+    await waitFor(() => {
+      expect(
+        screen.getByRole("columnheader", { name: /Duration/ }),
+      ).toHaveAttribute("aria-sort", "ascending");
+    });
     expect(
-      within(durationHeader).getByRole("img", { name: "chevronup icon" }),
+      within(screen.getByRole("columnheader", { name: /Duration/ })).getByRole(
+        "img",
+        { name: "chevronup icon" },
+      ),
     ).toBeInTheDocument();
     expect(
       fetchMock.callHistory.calls("path:/api/task").map((call) => call.url),
@@ -533,6 +588,63 @@ describe("TaskListPage", () => {
     });
     expect(history?.getCurrentLocation().search).toEqual(
       "?sort_column=duration&sort_direction=asc",
+    );
+  });
+
+  it("should toggle sort direction when clicking the active sorted column", async () => {
+    const { history } = setup({
+      tasksResponse: createMockTasksResponse({ data: [createMockTask()] }),
+    });
+
+    const startedAtHeader = await screen.findByRole("columnheader", {
+      name: /Started at/,
+    });
+    expect(startedAtHeader).toHaveAttribute("aria-sort", "descending");
+
+    await userEvent.click(startedAtHeader);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("columnheader", { name: /Started at/ }),
+      ).toHaveAttribute("aria-sort", "ascending");
+    });
+    expect(getLastTaskCallUrl()).toEqual(
+      "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=asc",
+    );
+
+    await userEvent.click(
+      screen.getByRole("columnheader", { name: /Started at/ }),
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByRole("columnheader", { name: /Started at/ }),
+      ).toHaveAttribute("aria-sort", "descending");
+    });
+    expect(
+      within(
+        screen.getByRole("columnheader", { name: /Started at/ }),
+      ).getByRole("img", { name: "chevrondown icon" }),
+    ).toBeInTheDocument();
+    expect(getLastTaskCallUrl()).toEqual(
+      "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=desc",
+    );
+    act(() => {
+      jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
+    });
+    expect(history?.getCurrentLocation().search).toEqual("");
+  });
+
+  it("should navigate to task details when a row is clicked", async () => {
+    const { history } = setup({
+      tasksResponse: createMockTasksResponse({
+        data: [createMockTask({ id: 123 })],
+      }),
+    });
+
+    const row = await screen.findByTestId("task");
+    await userEvent.click(row);
+
+    expect(history?.getCurrentLocation().pathname).toBe(
+      Urls.monitorTaskDetails(123),
     );
   });
 
@@ -558,7 +670,9 @@ describe("TaskListPage", () => {
     const taskPicker = screen.getByPlaceholderText("Filter by task");
 
     expect(taskPicker).toBeInTheDocument();
-    expect(taskPicker).toHaveValue("task-b");
+    await waitFor(() => {
+      expect(taskPicker).toHaveValue("task-b");
+    });
   });
 
   it("accepts status query param", async () => {
@@ -617,9 +731,7 @@ describe("TaskListPage", () => {
       }),
     });
 
-    await waitForLoaderToBeRemoved();
-
-    const row = screen.getByTestId("task");
+    const row = await screen.findByTestId("task");
     const startedAtElement = within(row).getByTestId("started-at");
     const endedAtElement = within(row).getByTestId("ended-at");
     expect(startedAtElement).toHaveTextContent("March 4, 2023, 1:45 AM");
@@ -639,9 +751,7 @@ describe("TaskListPage", () => {
       }),
     });
 
-    await waitForLoaderToBeRemoved();
-
-    const row = screen.getByTestId("task");
+    const row = await screen.findByTestId("task");
     const startedAtElement = within(row).getByTestId("started-at");
     await userEvent.hover(startedAtElement);
 

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TasksTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TasksTable.tsx
@@ -1,16 +1,22 @@
-import cx from "classnames";
+import type { Row, SortingState, Updater } from "@tanstack/react-table";
+import { useCallback, useMemo } from "react";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 import _ from "underscore";
 
 import { DateTime } from "metabase/common/components/DateTime";
-import { SortableColumnHeader } from "metabase/common/components/ItemsTable/BaseItemsTable";
-import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import AdminS from "metabase/css/admin.module.css";
-import CS from "metabase/css/core/index.css";
 import { TaskStatusBadge } from "metabase/monitor/tools/components/TaskStatusBadge";
 import { useDispatch } from "metabase/redux";
-import { Box, Ellipsified, Flex } from "metabase/ui";
+import {
+  Card,
+  Ellipsified,
+  Stack,
+  Text,
+  TreeTable,
+  type TreeTableColumnDef,
+  TreeTableSkeleton,
+  useTreeTableInstance,
+} from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
 import type {
@@ -20,9 +26,10 @@ import type {
   Task,
 } from "metabase-types/api";
 
+const COLUMN_WIDTHS = [0.25, 0.15, 0.12, 0.16, 0.16, 0.1, 0.06];
+
 interface Props {
   databases: Database[];
-  error: unknown;
   isLoading: boolean;
   sortingOptions: SortingOptions<ListTasksSortColumn>;
   tasks: Task[];
@@ -33,129 +40,223 @@ interface Props {
 
 export const TasksTable = ({
   databases,
-  error,
   isLoading,
   sortingOptions,
   tasks,
   onSortingOptionsChange,
 }: Props) => {
-  // index databases by id for lookup
-  const databaseByID: Record<number, Database> = _.indexBy(databases, "id");
-  const showLoadingAndErrorWrapper = isLoading || error != null;
   const dispatch = useDispatch();
 
-  const onClickTask = (task: Task) => {
-    dispatch(push(Urls.monitorTaskDetails(task.id)));
-  };
+  const databaseByID: Record<number, Database> = useMemo(
+    () => _.indexBy(databases, "id"),
+    [databases],
+  );
+
+  const columns = useMemo(() => getColumns(databaseByID), [databaseByID]);
+  const sortingState = useMemo(
+    () => getSortingState(sortingOptions),
+    [sortingOptions],
+  );
+
+  const handleRowActivate = useCallback(
+    (row: Row<Task>) => {
+      dispatch(push(Urls.monitorTaskDetails(row.original.id)));
+    },
+    [dispatch],
+  );
+
+  const handleSortingChange = useCallback(
+    (updater: Updater<SortingState>) => {
+      const newSortingState =
+        typeof updater === "function" ? updater(sortingState) : updater;
+      onSortingOptionsChange(
+        getSortingOptions(newSortingState, sortingOptions),
+      );
+    },
+    [sortingState, sortingOptions, onSortingOptionsChange],
+  );
+
+  const treeTableInstance = useTreeTableInstance<Task>({
+    data: tasks,
+    columns,
+    sorting: sortingState,
+    manualSorting: true,
+    getNodeId: (task) => String(task.id),
+    onRowActivate: handleRowActivate,
+    onSortingChange: handleSortingChange,
+  });
 
   return (
-    <table
-      className={cx(AdminS.ContentTable, CS.mt2)}
-      data-testid="tasks-table"
-    >
-      <thead>
-        <tr>
-          {/* set width to limit CLS when changing sort direction */}
-          <Box component="th" w={300}>{t`Task`}</Box>
-          <th>{t`DB Name`}</th>
-          <th>{t`DB Engine`}</th>
-          <SortableColumnHeader
-            name="started_at"
-            sortingOptions={sortingOptions}
-            onSortingOptionsChange={onSortingOptionsChange}
-          >{t`Started at`}</SortableColumnHeader>
-          <SortableColumnHeader
-            name="ended_at"
-            sortingOptions={sortingOptions}
-            onSortingOptionsChange={onSortingOptionsChange}
-          >{t`Ended at`}</SortableColumnHeader>
-          <SortableColumnHeader
-            name="duration"
-            sortingOptions={sortingOptions}
-            onSortingOptionsChange={onSortingOptionsChange}
-          >{t`Duration (ms)`}</SortableColumnHeader>
-          <th>{t`Status`}</th>
-        </tr>
-      </thead>
-
-      <tbody>
-        {showLoadingAndErrorWrapper && (
-          <tr>
-            <td colSpan={7}>
-              <LoadingAndErrorWrapper loading={isLoading} error={error} />
-            </td>
-          </tr>
-        )}
-
-        {!showLoadingAndErrorWrapper && (
-          <>
-            {tasks.length === 0 && (
-              <tr>
-                <td colSpan={8}>
-                  <Flex
-                    c="text-disabled"
-                    justify="center"
-                  >{t`No results`}</Flex>
-                </td>
-              </tr>
-            )}
-
-            {tasks.map((task: Task) => {
-              const db = task.db_id ? databaseByID[task.db_id] : null;
-              const name = db ? db.name : null;
-              const engine = db ? db.engine : null;
-              // only want unknown if there is a db on the task and we don't have info
-              return (
-                <tr
-                  data-testid="task"
-                  key={task.id}
-                  className={CS.cursorPointer}
-                  onClick={() => onClickTask(task)}
-                >
-                  <td className={CS.textBold}>{task.task}</td>
-                  <td>{task.db_id ? name || t`Unknown name` : null}</td>
-                  <td>{task.db_id ? engine || t`Unknown engine` : null}</td>
-
-                  <td>
-                    <Ellipsified
-                      style={{ maxWidth: 180 }}
-                      alwaysShowTooltip
-                      tooltip={task.started_at}
-                    >
-                      <DateTime
-                        value={task.started_at}
-                        unit="minute"
-                        data-testid="started-at"
-                      />
-                    </Ellipsified>
-                  </td>
-                  <td>
-                    {task.ended_at ? (
-                      <Ellipsified
-                        style={{ maxWidth: 180 }}
-                        alwaysShowTooltip={Boolean(task.ended_at)}
-                        tooltip={task.ended_at}
-                      >
-                        <DateTime
-                          value={task.ended_at}
-                          unit="minute"
-                          data-testid="ended-at"
-                        />
-                      </Ellipsified>
-                    ) : (
-                      EMPTY_CELL_PLACEHOLDER
-                    )}
-                  </td>
-                  <td>{task.duration}</td>
-                  <td>
-                    <TaskStatusBadge task={task} />
-                  </td>
-                </tr>
-              );
-            })}
-          </>
-        )}
-      </tbody>
-    </table>
+    <Card flex="0 1 auto" mih={0} p={0} withBorder data-testid="tasks-table">
+      {isLoading ? (
+        <TreeTableSkeleton columnWidths={COLUMN_WIDTHS} />
+      ) : (
+        <TreeTable
+          instance={treeTableInstance}
+          hierarchical={false}
+          ariaLabel={t`Tasks`}
+          emptyState={
+            <Stack p="xl" align="center">
+              <Text c="text-disabled">{t`No results`}</Text>
+            </Stack>
+          }
+          getRowProps={() => ({ "data-testid": "task" })}
+          onRowClick={handleRowActivate}
+        />
+      )}
+    </Card>
   );
 };
+
+function getColumns(
+  databaseByID: Record<number, Database>,
+): TreeTableColumnDef<Task>[] {
+  return [
+    {
+      id: "task",
+      header: t`Task`,
+      width: "auto",
+      minWidth: 200,
+      maxAutoWidth: 230,
+      enableSorting: false,
+      accessorFn: (task) => task.task,
+      cell: ({ row }) => <Text fw="bold">{row.original.task}</Text>,
+    },
+    {
+      id: "db_name",
+      header: t`DB Name`,
+      width: "auto",
+      minWidth: 120,
+      maxAutoWidth: 240,
+      enableSorting: false,
+      accessorFn: (task) =>
+        task.db_id != null ? (databaseByID[task.db_id]?.name ?? "") : "",
+      cell: ({ row }) => {
+        const { db_id } = row.original;
+        // only want unknown if there is a db on the task and we don't have info
+        if (db_id == null) {
+          return null;
+        }
+        return databaseByID[db_id]?.name || t`Unknown name`;
+      },
+    },
+    {
+      id: "db_engine",
+      header: t`DB Engine`,
+      width: "auto",
+      minWidth: 120,
+      maxAutoWidth: 240,
+      enableSorting: false,
+      accessorFn: (task) =>
+        task.db_id != null ? (databaseByID[task.db_id]?.engine ?? "") : "",
+      cell: ({ row }) => {
+        const { db_id } = row.original;
+        if (db_id == null) {
+          return null;
+        }
+        return databaseByID[db_id]?.engine || t`Unknown engine`;
+      },
+    },
+    {
+      id: "started_at",
+      header: t`Started at`,
+      width: "auto",
+      minWidth: 150,
+      enableSorting: true,
+      sortDescFirst: false,
+      accessorFn: (task) => task.started_at,
+      cell: ({ row }) => (
+        <Ellipsified
+          style={{ maxWidth: 180 }}
+          alwaysShowTooltip
+          tooltip={row.original.started_at}
+        >
+          <DateTime
+            value={row.original.started_at}
+            unit="minute"
+            data-testid="started-at"
+          />
+        </Ellipsified>
+      ),
+    },
+    {
+      id: "ended_at",
+      header: t`Ended at`,
+      width: "auto",
+      minWidth: 150,
+      enableSorting: true,
+      sortDescFirst: false,
+      accessorFn: (task) => task.ended_at,
+      cell: ({ row }) =>
+        row.original.ended_at ? (
+          <Ellipsified
+            style={{ maxWidth: 180 }}
+            alwaysShowTooltip
+            tooltip={row.original.ended_at}
+          >
+            <DateTime
+              value={row.original.ended_at}
+              unit="minute"
+              data-testid="ended-at"
+            />
+          </Ellipsified>
+        ) : (
+          EMPTY_CELL_PLACEHOLDER
+        ),
+    },
+    {
+      id: "duration",
+      header: t`Duration (ms)`,
+      width: "auto",
+      minWidth: 80,
+      maxAutoWidth: 100,
+      enableSorting: true,
+      sortDescFirst: false,
+      accessorFn: (task) => task.duration,
+      cell: ({ row }) => row.original.duration,
+    },
+    {
+      id: "status",
+      header: t`Status`,
+      width: "auto",
+      minWidth: 100,
+      enableSorting: false,
+      accessorFn: (task) => task.status,
+      cell: ({ row }) => <TaskStatusBadge task={row.original} />,
+    },
+  ];
+}
+
+function getSortingState(
+  sortingOptions: SortingOptions<ListTasksSortColumn>,
+): SortingState {
+  return [
+    {
+      id: sortingOptions.sort_column,
+      desc: sortingOptions.sort_direction === "desc",
+    },
+  ];
+}
+
+function getSortingOptions(
+  sortingState: SortingState,
+  currentOptions: SortingOptions<ListTasksSortColumn>,
+): SortingOptions<ListTasksSortColumn> {
+  const [firstSort] = sortingState;
+
+  if (firstSort != null && isSortColumn(firstSort.id)) {
+    return {
+      sort_column: firstSort.id,
+      sort_direction: firstSort.desc ? "desc" : "asc",
+    };
+  }
+
+  return {
+    sort_column: currentOptions.sort_column,
+    sort_direction: currentOptions.sort_direction === "desc" ? "asc" : "desc",
+  };
+}
+
+function isSortColumn(id: string): id is ListTasksSortColumn {
+  return id === "started_at" || id === "ended_at" || id === "duration";
+}

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TasksTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TasksTable.tsx
@@ -130,11 +130,11 @@ function getColumns(
       maxAutoWidth: 240,
       enableSorting: false,
       accessorFn: (task) =>
-        task.db_id != null ? (databaseByID[task.db_id]?.name ?? "") : "",
+        task.db_id !== null ? (databaseByID[task.db_id]?.name ?? "") : "",
       cell: ({ row }) => {
         const { db_id } = row.original;
         // only want unknown if there is a db on the task and we don't have info
-        if (db_id == null) {
+        if (db_id === null) {
           return null;
         }
         return databaseByID[db_id]?.name || t`Unknown name`;
@@ -148,10 +148,10 @@ function getColumns(
       maxAutoWidth: 240,
       enableSorting: false,
       accessorFn: (task) =>
-        task.db_id != null ? (databaseByID[task.db_id]?.engine ?? "") : "",
+        task.db_id !== null ? (databaseByID[task.db_id]?.engine ?? "") : "",
       cell: ({ row }) => {
         const { db_id } = row.original;
-        if (db_id == null) {
+        if (db_id === null) {
           return null;
         }
         return databaseByID[db_id]?.engine || t`Unknown engine`;
@@ -244,7 +244,7 @@ function getSortingOptions(
 ): SortingOptions<ListTasksSortColumn> {
   const [firstSort] = sortingState;
 
-  if (firstSort != null && isSortColumn(firstSort.id)) {
+  if (firstSort !== undefined && isSortColumn(firstSort.id)) {
     return {
       sort_column: firstSort.id,
       sort_direction: firstSort.desc ? "desc" : "asc",

--- a/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.tsx
@@ -85,7 +85,7 @@ export const TaskRunDetailsPage = ({ params }: TaskRunDetailsPageProps) => {
                 to={getEntityUrl(
                   taskRun.entity_type,
                   taskRun.entity_id,
-                  taskRun.entity_name,
+                  taskRun.entity_name ?? undefined,
                 )}
               >
                 {taskRun.entity_name ?? taskRun.entity_id}

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.tsx
@@ -108,7 +108,7 @@ const TaskRunsPageBase = ({ location }: WithRouterProps) => {
         />
       </Group>
 
-      {error != null ? (
+      {error !== undefined ? (
         <Center flex={1}>
           <DelayedLoadingAndErrorWrapper loading={isLoading} error={error} />
         </Center>
@@ -116,7 +116,7 @@ const TaskRunsPageBase = ({ location }: WithRouterProps) => {
         <TaskRunsTable taskRuns={taskRuns} isLoading={isLoading} />
       )}
 
-      {!isLoading && error == null && (
+      {!isLoading && error === undefined && (
         <Flex justify="end">
           <PaginationControls
             page={page}

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.tsx
@@ -1,10 +1,11 @@
 import { t } from "ttag";
 
 import { useListTaskRunsQuery } from "metabase/api";
+import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
 import { PaginationControls } from "metabase/common/components/PaginationControls";
 import { useUrlState } from "metabase/common/hooks/use-url-state";
 import { type WithRouterProps, withRouter } from "metabase/router";
-import { Flex } from "metabase/ui";
+import { Center, Flex, Group } from "metabase/ui";
 
 import { toBackendStartedAt } from "../../utils";
 import { TaskRunTypePicker } from "../RunTypePicker";
@@ -57,68 +58,77 @@ const TaskRunsPageBase = ({ location }: WithRouterProps) => {
 
   return (
     <TasksTabs>
-      <Flex gap="md" justify="space-between">
-        <Flex gap="md">
-          <TaskRunTypePicker
-            value={runType}
-            onChange={(runType) =>
-              patchUrlState({
-                "run-type": runType,
+      <Group gap="md" align="center" wrap="wrap">
+        <TaskRunTypePicker
+          value={runType}
+          onChange={(runType) =>
+            patchUrlState({
+              "run-type": runType,
+              "entity-type": null,
+              "entity-id": null,
+              page: 0,
+            })
+          }
+        />
+
+        <TaskRunDatePicker
+          value={startedAt}
+          includeToday={includeToday}
+          placeholder={t`Filter by started at`}
+          onChange={(nextStartedAt, nextIncludeToday) =>
+            patchUrlState({
+              "started-at": nextStartedAt,
+              "include-today": nextIncludeToday,
+              ...(nextStartedAt !== startedAt && {
                 "entity-type": null,
                 "entity-id": null,
-                page: 0,
-              })
-            }
-          />
+              }),
+              page: 0,
+            })
+          }
+        />
 
-          <TaskRunDatePicker
-            value={startedAt}
-            includeToday={includeToday}
-            placeholder={t`Filter by started at`}
-            onChange={(nextStartedAt, nextIncludeToday) =>
-              patchUrlState({
-                "started-at": nextStartedAt,
-                "include-today": nextIncludeToday,
-                ...(nextStartedAt !== startedAt && {
-                  "entity-type": null,
-                  "entity-id": null,
-                }),
-                page: 0,
-              })
-            }
-          />
+        <TaskRunEntityPicker
+          runType={runType}
+          startedAt={startedAt}
+          includeToday={includeToday}
+          value={entityValue}
+          onChange={(entity) =>
+            patchUrlState({
+              "entity-type": entity?.entityType ?? null,
+              "entity-id": entity?.entityId ?? null,
+              page: 0,
+            })
+          }
+        />
 
-          <TaskRunEntityPicker
-            runType={runType}
-            startedAt={startedAt}
-            includeToday={includeToday}
-            value={entityValue}
-            onChange={(entity) =>
-              patchUrlState({
-                "entity-type": entity?.entityType ?? null,
-                "entity-id": entity?.entityId ?? null,
-                page: 0,
-              })
-            }
-          />
+        <TaskRunStatusPicker
+          value={status}
+          onChange={(status) => patchUrlState({ status, page: 0 })}
+        />
+      </Group>
 
-          <TaskRunStatusPicker
-            value={status}
-            onChange={(status) => patchUrlState({ status, page: 0 })}
+      {error != null ? (
+        <Center flex={1}>
+          <DelayedLoadingAndErrorWrapper loading={isLoading} error={error} />
+        </Center>
+      ) : (
+        <TaskRunsTable taskRuns={taskRuns} isLoading={isLoading} />
+      )}
+
+      {!isLoading && error == null && (
+        <Flex justify="end">
+          <PaginationControls
+            page={page}
+            pageSize={PAGE_SIZE}
+            itemsLength={taskRuns.length}
+            total={total}
+            showTotal
+            onPreviousPage={() => patchUrlState({ page: page - 1 })}
+            onNextPage={() => patchUrlState({ page: page + 1 })}
           />
         </Flex>
-
-        <PaginationControls
-          onPreviousPage={() => patchUrlState({ page: page - 1 })}
-          onNextPage={() => patchUrlState({ page: page + 1 })}
-          page={page}
-          pageSize={PAGE_SIZE}
-          itemsLength={taskRuns.length}
-          total={total}
-        />
-      </Flex>
-
-      <TaskRunsTable taskRuns={taskRuns} isLoading={isLoading} error={error} />
+      )}
     </TasksTabs>
   );
 };

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.unit.spec.tsx
@@ -3,10 +3,12 @@ import fetchMock from "fetch-mock";
 
 import { setupTaskRunsEndpoints } from "__support__/server-mocks";
 import {
+  mockGetBoundingClientRect,
   renderWithProviders,
   screen,
   waitFor,
   waitForLoaderToBeRemoved,
+  within,
 } from "__support__/ui";
 import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
@@ -34,8 +36,12 @@ const setup = ({
     setupTaskRunsEndpoints(taskRunsResponse);
   }
 
+  mockGetBoundingClientRect({ width: 100, height: 100 });
+
   return renderWithProviders(
-    <Route path={PATHNAME} component={TaskRunsPage} />,
+    <Route path={PATHNAME} component={TaskRunsPage}>
+      <Route path=":runId" />
+    </Route>,
     {
       initialRoute,
       withRouter: true,
@@ -71,9 +77,7 @@ describe("TaskRunsPage", () => {
       }),
     });
 
-    await waitForLoaderToBeRemoved();
-
-    const startedAtElement = screen.getByTestId("started-at");
+    const startedAtElement = await screen.findByTestId("started-at");
     const endedAtElement = screen.getByTestId("ended-at");
     expect(startedAtElement).toHaveTextContent("March 4, 2023, 1:45 AM");
     expect(endedAtElement).toHaveTextContent("March 4, 2023, 1:46 AM");
@@ -92,12 +96,43 @@ describe("TaskRunsPage", () => {
       }),
     });
 
-    await waitForLoaderToBeRemoved();
-
-    const startedAtElement = screen.getByTestId("started-at");
+    const startedAtElement = await screen.findByTestId("started-at");
     await userEvent.hover(startedAtElement);
 
     expect(await screen.findByRole("tooltip")).toHaveTextContent(rawTimestamp);
+  });
+
+  it("should show the total results count below the table", async () => {
+    setup({
+      taskRunsResponse: createMockTaskRunsResponse({
+        data: [createMockTaskRun()],
+        total: 75,
+        limit: 50,
+        offset: 0,
+      }),
+    });
+    await waitForLoaderToBeRemoved();
+
+    const pagination = screen.getByRole("navigation", { name: "pagination" });
+    expect(
+      within(pagination).getByTestId("pagination-total"),
+    ).toHaveTextContent("75");
+    expect(pagination).toHaveTextContent("1 - 1");
+  });
+
+  it("should navigate to run details when a row is clicked", async () => {
+    const { history } = setup({
+      taskRunsResponse: createMockTaskRunsResponse({
+        data: [createMockTaskRun({ id: 55 })],
+      }),
+    });
+
+    const row = await screen.findByTestId("task-run");
+    await userEvent.click(row);
+
+    expect(history?.getCurrentLocation().pathname).toBe(
+      Urls.monitorTaskRunDetails(55),
+    );
   });
 
   describe("started-at filter with include-today", () => {

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsTable.tsx
@@ -1,13 +1,20 @@
-import cx from "classnames";
+import type { Row } from "@tanstack/react-table";
+import { useCallback, useMemo } from "react";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 
 import { DateTime } from "metabase/common/components/DateTime";
-import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import AdminS from "metabase/css/admin.module.css";
-import CS from "metabase/css/core/index.css";
 import { useDispatch } from "metabase/redux";
-import { Box, Ellipsified, Flex } from "metabase/ui";
+import {
+  Card,
+  Ellipsified,
+  Stack,
+  Text,
+  TreeTable,
+  type TreeTableColumnDef,
+  TreeTableSkeleton,
+  useTreeTableInstance,
+} from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
 import type { TaskRun } from "metabase-types/api";
@@ -15,115 +22,149 @@ import type { TaskRun } from "metabase-types/api";
 import { formatTaskRunType, renderTaskRunCounters } from "../../utils";
 import { TaskRunStatusBadge } from "../TaskRunStatusBadge";
 
+const COLUMN_WIDTHS = [0.2, 0.2, 0.17, 0.17, 0.13, 0.13];
+
 type TaskRunsTableProps = {
-  error: unknown;
   isLoading: boolean;
   taskRuns: TaskRun[];
 };
 
-export const TaskRunsTable = ({
-  error,
-  isLoading,
-  taskRuns,
-}: TaskRunsTableProps) => {
-  const showLoadingAndErrorWrapper = isLoading || error != null;
+export const TaskRunsTable = ({ isLoading, taskRuns }: TaskRunsTableProps) => {
   const dispatch = useDispatch();
 
-  const onClickTaskRun = (taskRun: TaskRun) => {
-    dispatch(push(Urls.monitorTaskRunDetails(taskRun.id)));
-  };
+  const columns = useMemo(() => getColumns(), []);
+
+  const handleRowActivate = useCallback(
+    (row: Row<TaskRun>) => {
+      dispatch(push(Urls.monitorTaskRunDetails(row.original.id)));
+    },
+    [dispatch],
+  );
+
+  const treeTableInstance = useTreeTableInstance<TaskRun>({
+    data: taskRuns,
+    columns,
+    getNodeId: (taskRun) => String(taskRun.id),
+    onRowActivate: handleRowActivate,
+  });
 
   return (
-    <table
-      className={cx(AdminS.ContentTable, CS.mt2)}
+    <Card
+      flex="0 1 auto"
+      mih={0}
+      p={0}
+      withBorder
       data-testid="task-runs-table"
     >
-      <thead>
-        <tr>
-          <Box component="th" w={200}>{t`Run Type`}</Box>
-          <Box component="th" w={200}>{t`Entity`}</Box>
-          <th>{t`Started at`}</th>
-          <th>{t`Ended at`}</th>
-          <th>{t`Status`}</th>
-          <th>{t`Task Count`}</th>
-        </tr>
-      </thead>
-
-      <tbody>
-        {showLoadingAndErrorWrapper && (
-          <tr>
-            <td colSpan={6}>
-              <LoadingAndErrorWrapper loading={isLoading} error={error} />
-            </td>
-          </tr>
-        )}
-
-        {!showLoadingAndErrorWrapper && (
-          <>
-            {taskRuns.length === 0 && (
-              <tr>
-                <td colSpan={6}>
-                  <Flex
-                    c="text-disabled"
-                    justify="center"
-                  >{t`No results`}</Flex>
-                </td>
-              </tr>
-            )}
-
-            {taskRuns.map((taskRun) => (
-              <tr
-                data-testid="task-run"
-                key={taskRun.id}
-                className={CS.cursorPointer}
-                onClick={() => onClickTaskRun(taskRun)}
-              >
-                <td className={CS.textBold}>
-                  {formatTaskRunType(taskRun.run_type)}
-                </td>
-                <td>
-                  <Ellipsified style={{ maxWidth: 200 }}>
-                    {taskRun.entity_name}
-                  </Ellipsified>
-                </td>
-                <td>
-                  <Ellipsified
-                    style={{ maxWidth: 180 }}
-                    alwaysShowTooltip
-                    tooltip={taskRun.started_at}
-                  >
-                    <DateTime
-                      value={taskRun.started_at}
-                      unit="minute"
-                      data-testid="started-at"
-                    />
-                  </Ellipsified>
-                </td>
-                <td>
-                  {taskRun.ended_at ? (
-                    <Ellipsified
-                      style={{ maxWidth: 180 }}
-                      tooltip={taskRun.ended_at}
-                    >
-                      <DateTime
-                        value={taskRun.ended_at}
-                        unit="minute"
-                        data-testid="ended-at"
-                      />
-                    </Ellipsified>
-                  ) : (
-                    EMPTY_CELL_PLACEHOLDER
-                  )}
-                </td>
-                <td>
-                  <TaskRunStatusBadge taskRun={taskRun} />
-                </td>
-                <td>{renderTaskRunCounters(taskRun)}</td>
-              </tr>
-            ))}
-          </>
-        )}
-      </tbody>
-    </table>
+      {isLoading ? (
+        <TreeTableSkeleton columnWidths={COLUMN_WIDTHS} />
+      ) : (
+        <TreeTable
+          instance={treeTableInstance}
+          hierarchical={false}
+          ariaLabel={t`Task runs`}
+          emptyState={
+            <Stack p="xl" align="center">
+              <Text c="text-disabled">{t`No results`}</Text>
+            </Stack>
+          }
+          getRowProps={() => ({ "data-testid": "task-run" })}
+          onRowClick={handleRowActivate}
+        />
+      )}
+    </Card>
   );
 };
+
+function getColumns(): TreeTableColumnDef<TaskRun>[] {
+  return [
+    {
+      id: "run_type",
+      header: t`Run Type`,
+      width: "auto",
+      minWidth: 150,
+      maxAutoWidth: 240,
+      enableSorting: false,
+      accessorFn: (taskRun) => taskRun.run_type,
+      cell: ({ row }) => (
+        <Text fw="bold">{formatTaskRunType(row.original.run_type)}</Text>
+      ),
+    },
+    {
+      id: "entity",
+      header: t`Entity`,
+      width: "auto",
+      minWidth: 150,
+      maxAutoWidth: 300,
+      enableSorting: false,
+      accessorFn: (taskRun) => taskRun.entity_name ?? "",
+      cell: ({ row }) => (
+        <Ellipsified style={{ maxWidth: 200 }}>
+          {row.original.entity_name}
+        </Ellipsified>
+      ),
+    },
+    {
+      id: "started_at",
+      header: t`Started at`,
+      width: "auto",
+      minWidth: 150,
+      enableSorting: false,
+      accessorFn: (taskRun) => taskRun.started_at,
+      cell: ({ row }) => (
+        <Ellipsified
+          style={{ maxWidth: 180 }}
+          alwaysShowTooltip
+          tooltip={row.original.started_at}
+        >
+          <DateTime
+            value={row.original.started_at}
+            unit="minute"
+            data-testid="started-at"
+          />
+        </Ellipsified>
+      ),
+    },
+    {
+      id: "ended_at",
+      header: t`Ended at`,
+      width: "auto",
+      minWidth: 150,
+      enableSorting: false,
+      accessorFn: (taskRun) => taskRun.ended_at,
+      cell: ({ row }) =>
+        row.original.ended_at ? (
+          <Ellipsified
+            style={{ maxWidth: 180 }}
+            tooltip={row.original.ended_at}
+          >
+            <DateTime
+              value={row.original.ended_at}
+              unit="minute"
+              data-testid="ended-at"
+            />
+          </Ellipsified>
+        ) : (
+          EMPTY_CELL_PLACEHOLDER
+        ),
+    },
+    {
+      id: "status",
+      header: t`Status`,
+      width: "auto",
+      minWidth: 100,
+      enableSorting: false,
+      accessorFn: (taskRun) => taskRun.status,
+      cell: ({ row }) => <TaskRunStatusBadge taskRun={row.original} />,
+    },
+    {
+      id: "task_count",
+      header: t`Task Count`,
+      width: "auto",
+      minWidth: 150,
+      enableSorting: false,
+      accessorFn: (taskRun) => taskRun.task_count,
+      cell: ({ row }) => renderTaskRunCounters(row.original),
+    },
+  ];
+}

--- a/frontend/src/metabase/monitor/tools/components/TasksTabs/TasksTabs.module.css
+++ b/frontend/src/metabase/monitor/tools/components/TasksTabs/TasksTabs.module.css
@@ -1,0 +1,3 @@
+.main {
+  overflow: hidden;
+}

--- a/frontend/src/metabase/monitor/tools/components/TasksTabs/TasksTabs.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TasksTabs/TasksTabs.tsx
@@ -1,62 +1,48 @@
-import { push } from "react-router-redux";
+import type { ReactNode } from "react";
 import { t } from "ttag";
 
-import { SettingsSection } from "metabase/admin/components/SettingsSection";
+import {
+  type MonitorHeaderTab,
+  MonitorHeaderTabs,
+} from "metabase/monitor/components/MonitorHeaderTabs";
 import { MonitorHeaderTitle } from "metabase/monitor/components/MonitorHeaderTitle";
-import { useDispatch } from "metabase/redux";
-import { type WithRouterProps, withRouter } from "metabase/router";
-import { Flex, Icon, Stack, Tabs, Tooltip } from "metabase/ui";
+import { Flex, Icon, Stack, Tooltip } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
-type TabConfig = {
-  value: string;
-  label: string;
+import S from "./TasksTabs.module.css";
+
+type TasksTabsProps = {
+  children: ReactNode;
 };
 
-type TasksTabsProps = WithRouterProps & {
-  children: React.ReactNode;
-};
-
-const TasksTabsBase = ({ children, location }: TasksTabsProps) => {
-  const tabs: TabConfig[] = [
-    { value: Urls.monitorTasksList(), label: t`Tasks` },
-    { value: Urls.monitorTasksRuns(), label: t`Runs` },
+export const TasksTabs = ({ children }: TasksTabsProps) => {
+  const tabs: MonitorHeaderTab[] = [
+    { label: t`Tasks`, to: Urls.monitorTasksList() },
+    { label: t`Runs`, to: Urls.monitorTasksRuns() },
   ];
-  const DEFAULT_TAB = tabs[0].value;
-  const dispatch = useDispatch();
-  const activeTab =
-    tabs.find(({ value }) => value === location.pathname)?.value ?? DEFAULT_TAB;
-
-  const handleTabChange = (value: string | null) => {
-    if (value) {
-      dispatch(push(value));
-    }
-  };
 
   return (
-    <Stack gap="lg">
-      <Flex align="center" gap="xs">
-        <MonitorHeaderTitle>{t`Troubleshooting logs`}</MonitorHeaderTitle>
-        <Tooltip
-          label={t`Trying to get to the bottom of something? This section shows logs of Metabase's background tasks, which can help shed light on what's going on.`}
-        >
-          <Icon name="info" size="1rem" />
-        </Tooltip>
-      </Flex>
-      <SettingsSection>
-        <Tabs value={activeTab} onChange={handleTabChange}>
-          <Tabs.List>
-            {tabs.map((tab) => (
-              <Tabs.Tab key={tab.value} value={tab.value}>
-                {tab.label}
-              </Tabs.Tab>
-            ))}
-          </Tabs.List>
-        </Tabs>
+    <Flex h="100%" wrap="nowrap">
+      <Stack className={S.main} flex={1} gap="md">
+        <Stack gap="md">
+          <Flex align="center" gap="xs">
+            <MonitorHeaderTitle>{t`Troubleshooting logs`}</MonitorHeaderTitle>
+            <Tooltip
+              label={t`Trying to get to the bottom of something? This section shows logs of Metabase's background tasks, which can help shed light on what's going on.`}
+              events={{ hover: true, focus: true, touch: false }}
+            >
+              <Icon
+                name="info"
+                size="1rem"
+                tabIndex={0}
+                aria-label={t`About troubleshooting logs`}
+              />
+            </Tooltip>
+          </Flex>
+          <MonitorHeaderTabs tabs={tabs} />
+        </Stack>
         {children}
-      </SettingsSection>
-    </Stack>
+      </Stack>
+    </Flex>
   );
 };
-
-export const TasksTabs = withRouter(TasksTabsBase);


### PR DESCRIPTION
Closes [GDGT-2713](https://linear.app/metabase/issue/GDGT-2713)

### Description

Restyles the Monitor **Tasks** (both "Tasks" and "Runs" tabs) to match the area views styling (e.g. Dependency Diagnostics).

- Replaced inline table with `metabase/ui` `TreeTable` data-grid + pagination.
- Replaced tabs with restyled navigational pills (extracted to a shared monitor component `MonitorHeaderTabs`).
- Removed vertical scrolling (table has internal scroll).
- Restyled filter dropdowns to match area styling.

### Demo

**Tasks Tab**

<img width="1619" height="964" alt="image" src="https://github.com/user-attachments/assets/47ae39c4-2ae8-4756-a70b-5d98de81d6a1" />

**Runs Tab**

<img width="1626" height="964" alt="image" src="https://github.com/user-attachments/assets/061c7a9f-a150-40b4-9c7e-6a9342859772" />

### How to verify

1. Open `/monitor/tasks/list` — the page should have uniform styling with other Monitor areas (Dependency Diagnostics), no vertical scroll.
2. Filter by task/status, sort by Started at / Ended at / Duration, paginate — state is reflected in the URL, and pagination below the table shows "x – y of N".
3. Click a row (or focus it and press Enter) — navigates to the task details page.
4. Switch to the Runs tab — same look, four filter pickers, no sorting.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR