### PR TITLE
[PDFs] Respect the text wrapping settings on tables

### DIFF
--- a/src/metabase/channel/render/pdf.clj
+++ b/src/metabase/channel/render/pdf.clj
@@ -47,6 +47,7 @@
    [metabase.channel.render.pdf.markdown :as md]
    [metabase.channel.render.pdf.typeset :as typeset]
    [metabase.channel.render.png :as png]
+   [metabase.channel.render.table :as table]
    [metabase.channel.render.util :as render.util]
    [metabase.channel.shared :as channel.shared]
    [metabase.dashboards.models.dashboard-card :as dashboard-card]
@@ -919,8 +920,11 @@
   clipped body so a short card can't hide it). A pivot has neither."
   ^bytes [timezone {:keys [card dashcard result]} chart-type px-w px-h]
   (let [;; Render directly, not via render-pulse-card: its <p>/.pulse-body margins escape CSSBox's
-        ;; height clip and push the image past the cell. body/render gives the bare table.
-        info     (body/render chart-type :inline timezone card dashcard (:data result))
+        ;; height clip and push the image past the cell. body/render gives the bare table. Opt out of the email/Slack
+        ;; fixed-width fallback for wrapping columns: CSSBox lays the table out at `px-w` and auto-wraps, so a fixed
+        ;; width would only overflow the page and clip the text (see [[table/*text-wrapping-fallback-width*]]).
+        info     (binding [table/*text-wrapping-fallback-width* nil]
+                   (body/render :table :inline timezone card dashcard (:data result)))
         note     (when (= :object chart-type) (object-detail-note (:content info)))
         ;; the note is body/render's trailing element, so drop it from the clipped body (it's pinned below)
         body     (cond-> (:content info) note pop)

--- a/src/metabase/channel/render/pdf.clj
+++ b/src/metabase/channel/render/pdf.clj
@@ -47,6 +47,7 @@
    [metabase.channel.render.pdf.markdown :as md]
    [metabase.channel.render.pdf.typeset :as typeset]
    [metabase.channel.render.png :as png]
+   [metabase.channel.render.table :as table]
    [metabase.channel.render.util :as render.util]
    [metabase.channel.shared :as channel.shared]
    [metabase.dashboards.models.dashboard-card :as dashboard-card]
@@ -919,8 +920,11 @@
   clipped body so a short card can't hide it). A pivot has neither."
   ^bytes [timezone {:keys [card dashcard result]} chart-type px-w px-h]
   (let [;; Render directly, not via render-pulse-card: its <p>/.pulse-body margins escape CSSBox's
-        ;; height clip and push the image past the cell. body/render gives the bare table.
-        info     (body/render chart-type :inline timezone card dashcard (:data result))
+        ;; height clip and push the image past the cell. body/render gives the bare table. Opt out of the email/Slack
+        ;; fixed-width fallback for wrapping columns: CSSBox lays the table out at `px-w` and auto-wraps, so a fixed
+        ;; width would only overflow the page and clip the text (see [[table/*text-wrapping-fallback-width*]]).
+        info     (binding [table/*text-wrapping-fallback-width* nil]
+                   (body/render chart-type :inline timezone card dashcard (:data result)))
         note     (when (= :object chart-type) (object-detail-note (:content info)))
         ;; the note is body/render's trailing element, so drop it from the clipped body (it's pinned below)
         body     (cond-> (:content info) note pop)

--- a/src/metabase/channel/render/table.clj
+++ b/src/metabase/channel/render/table.clj
@@ -11,6 +11,13 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:dynamic *text-wrapping-fallback-width*
+  "The CSS width given to a text-wrapping column that has no explicit `table.column_widths` entry. Email and Slack
+  clients won't wrap a cell without an explicit width, so this defaults to a wide value. Renderers that lay the table
+  out at a known width and auto-wrap (the PDF, via CSSBox) bind this to `nil`, so a wrapping column sizes to the table
+  and its text wraps within the real column width instead of overflowing the narrower page."
+  "780px")
+
 (defn- bar-th-style []
   (merge
    (style/font-style)
@@ -268,12 +275,16 @@
            ;; text wrapping
            (::mb.viz/text-wrapping col-setting)
            (assoc column-name (merge {:white-space "normal"}
-                                     (if (column-has-width column-widths column-index)
+                                     (cond
+                                       (column-has-width column-widths column-index)
                                        {:min-width (format "%spx" (get-min-width column-widths column-index))}
-                                       ;; Text wrapping enabled but conditions not met, fall back to 780px
-                                       ;; Email clients respond to `min-width`, but slack responds to `width`
-                                       {:max-width "780px !important"
-                                        :width "780px"})))
+
+                                       ;; No explicit width: email clients respond to `min-width`, slack to `width`,
+                                       ;; so fall back to a fixed width. Renderers that auto-wrap bind
+                                       ;; [[*text-wrapping-fallback-width*]] to nil to opt out (no fixed width).
+                                       *text-wrapping-fallback-width*
+                                       {:max-width (str *text-wrapping-fallback-width* " !important")
+                                        :width     *text-wrapping-fallback-width*})))
 
            ;; text alignment
            (::mb.viz/text-align col-setting)

--- a/test/metabase/channel/render/pdf_test.clj
+++ b/test/metabase/channel/render/pdf_test.clj
@@ -11,6 +11,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.api.common :as api]
+   [metabase.channel.render.body :as body]
    [metabase.channel.render.card :as render.card]
    [metabase.channel.render.pdf :as pdf]
    [metabase.channel.render.pdf.font :as font]
@@ -846,6 +847,21 @@
                                                {:name "b" :display_name "B" :base_type :type/Text}]
                                         :rows [["x" "y"]]}}}]
         (is (fills-cell-width? (width fallback 1000) 1000))))))
+
+(deftest ^:synchronized table-body-png-dispatches-on-chart-type-test
+  (testing "table-body-png renders each table-like card with its own renderer, not always the flat table"
+    (let [data     {:cols [{:name "n" :display_name "N" :base_type :type/Integer}]
+                    :rows [[1]]}
+          part     {:card {} :dashcard nil :result {:data data}}
+          rendered (atom [])
+          orig     body/render]
+      (with-redefs [body/render (fn [chart-type & args]
+                                  (swap! rendered conj chart-type)
+                                  (apply orig chart-type args))]
+        (doseq [chart-type [:table :pivot :object]]
+          (#'pdf/table-body-png nil part chart-type 400 300)))
+      ;; :pivot's own renderer degrades to :table internally, hence the trailing :table
+      (is (= [:table :pivot :table :object] @rendered)))))
 
 (deftest ^:parallel table-like-chart-types-test
   (testing "native table, pivot, and object-detail cards all classify into the framed table path"

--- a/test/metabase/channel/render/table_test.clj
+++ b/test/metabase/channel/render/table_test.clj
@@ -318,3 +318,28 @@
                                    :rows (repeat 200 ["I will keep default limits."])}})
                           :content
                           (render.tu/nodes-with-text "I will keep default limits.")))))))))
+
+(deftest ^:parallel text-wrapping-fallback-width-test
+  (testing "a text-wrapping column with no explicit table.column_widths (UXW-4714)"
+    (let [columns    [{:name "desc"}]
+          viz        {::mb.viz/column-settings {{::mb.viz/column-name "desc"} {::mb.viz/text-wrapping true}}}
+          styles-for #(get (table/column->viz-setting-styles columns viz) "desc")]
+      (testing "defaults to a fixed fallback width, so email/Slack clients (which don't auto-wrap) wrap"
+        (let [s (styles-for)]
+          (is (= "normal" (:white-space s)))
+          (is (= "780px" (:width s)))
+          (is (= "780px !important" (:max-width s)))))
+      (testing "binding *text-wrapping-fallback-width* to nil omits the fixed width, so an auto-wrapping renderer (the PDF) sizes the column to the table"
+        (binding [table/*text-wrapping-fallback-width* nil]
+          (let [s (styles-for)]
+            (is (= "normal" (:white-space s)))
+            (is (not (contains? s :width)))
+            (is (not (contains? s :max-width))))))))
+  (testing "an explicit table.column_widths gives min-width and ignores the fallback var entirely"
+    (let [columns [{:name "desc"}]
+          viz     {::mb.viz/column-settings {{::mb.viz/column-name "desc"} {::mb.viz/text-wrapping true}}
+                   :table.column_widths [200]}]
+      (binding [table/*text-wrapping-fallback-width* nil]
+        (let [s (get (table/column->viz-setting-styles columns viz) "desc")]
+          (is (contains? s :min-width))
+          (is (not (contains? s :width))))))))


### PR DESCRIPTION
Fixes UXW-4714.

### Description

The static viz for tables uses a fixed width, but it was too big for the
PDFs, causing tables with long text in columns to lay out badly.

This PR disables the fixed width of `780px` on tables for PDFs, so that
the tables now lay out correctly.

### How to verify

Render a dashboard containing a table where some cells contain long strings.

### Demo

<img width="1102" height="312" alt="Screenshot 2026-07-06 at 10 15 29" src="https://github.com/user-attachments/assets/0ec22cd7-7c24-4eba-9fd5-99440ea3fa01" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table rendering in PDFs so wrapped text now adapts more reliably when column widths aren’t set.
  * Fixed cases where tables could be forced into a fixed width, helping content fit better in exported documents.
  * Preserved custom column widths when they are provided, while keeping wrapped text styling consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


#### PR Dependency Tree


* **PR #77090** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)