### PR TITLE
Add backend test parity for all remaining e2e-covered backend behaviors

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -506,16 +506,18 @@
               (let [{:keys [outputs]} (action-v2.tu/create-rows! table-id [{:d "2020-02-15" :dt "2020-02-15T11:35:00"}])]
                 (is (= 1 (count outputs)))
                 (is (= (qp-state) (map :row outputs)))
-                (is (re-find #"2020-02-15" (str (:d (first (qp-state))))))
-                (is (re-find #"2020-02-15T11:35:00" (str (:dt (first (qp-state))))))))
+                (is (=? {:d  #(re-find #"2020-02-15" (str %))
+                         :dt #(re-find #"2020-02-15T11:35:00" (str %))}
+                        (first (qp-state))))))
             (testing "update returns the same coerced output that the QP would return"
               (let [[{id :id}]        (map :row (:outputs (action-v2.tu/create-rows! table-id [{:d nil :dt nil}])))
                     _                 (is (some? id))
                     {:keys [outputs]} (action-v2.tu/update-rows! table-id [{:id id :d "2021-06-20" :dt "2021-06-20T08:15:00"}])
                     updated-qp-row    (first (filter (comp #{id} :id) (qp-state)))]
                 (is (= [updated-qp-row] (map :row outputs)))
-                (is (re-find #"2021-06-20" (str (:d updated-qp-row))))
-                (is (re-find #"2021-06-20T08:15:00" (str (:dt updated-qp-row))))))))))))
+                (is (=? {:d  #(re-find #"2021-06-20" (str %))
+                         :dt #(re-find #"2021-06-20T08:15:00" (str %))}
+                        updated-qp-row))))))))))
 
 (deftest field-values-invalidated-test
   (mt/with-premium-features #{actions-feature-flag}

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -493,6 +493,30 @@
              (check-coercion-fn-coverage @#'coerce/unimplemented-coercion-functions)
              (run! #(apply do-test %)))))))
 
+(deftest native-temporal-columns-output-roundtrip-test
+  (testing "execute-bulk echoes native date/timestamp columns in the same format the QP returns"
+    (mt/with-premium-features #{actions-feature-flag}
+      (mt/test-drivers (mt/normal-drivers-with-feature :actions/data-editing)
+        (action-v2.tu/with-test-tables! [table-id [{:id 'auto-inc-type
+                                                    :d  [:date]
+                                                    :dt [:timestamp]}
+                                                   {:primary-key [:id]}]]
+          (let [qp-state (fn [] (map #(zipmap [:id :d :dt] %) (table-rows table-id)))]
+            (testing "create returns the same coerced output that the QP would return"
+              (let [{:keys [outputs]} (action-v2.tu/create-rows! table-id [{:d "2020-02-15" :dt "2020-02-15T11:35:00"}])]
+                (is (= 1 (count outputs)))
+                (is (= (qp-state) (map :row outputs)))
+                (is (re-find #"2020-02-15" (str (:d (first (qp-state))))))
+                (is (re-find #"2020-02-15T11:35:00" (str (:dt (first (qp-state))))))))
+            (testing "update returns the same coerced output that the QP would return"
+              (let [[{id :id}]        (map :row (:outputs (action-v2.tu/create-rows! table-id [{:d nil :dt nil}])))
+                    _                 (is (some? id))
+                    {:keys [outputs]} (action-v2.tu/update-rows! table-id [{:id id :d "2021-06-20" :dt "2021-06-20T08:15:00"}])
+                    updated-qp-row    (first (filter (comp #{id} :id) (qp-state)))]
+                (is (= [updated-qp-row] (map :row outputs)))
+                (is (re-find #"2021-06-20" (str (:d updated-qp-row))))
+                (is (re-find #"2021-06-20T08:15:00" (str (:dt updated-qp-row))))))))))))
+
 (deftest field-values-invalidated-test
   (mt/with-premium-features #{actions-feature-flag}
     (mt/test-drivers (mt/normal-drivers-with-feature :actions/data-editing)

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/setting_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/setting_test.clj
@@ -307,3 +307,15 @@
               (set-interval! :crowberto 204)
               (set-interval! user 204)
               (set-interval! :rasta 403))))))))
+
+(deftest generic-setting-write-test
+  (testing "PUT /api/setting/:key -- granting the :setting application permission lets a non-admin write a settings-manager-visible setting"
+    (mt/with-user-in-groups
+      [group {:name "New Group"}
+       user  [group]]
+      (mt/with-premium-features #{:advanced-permissions}
+        (mt/with-temporary-setting-values [site-name "Metabase"]
+          (mt/user-http-request user :put 403 "setting/site-name" {:value "Nope"})
+          (perms/grant-application-permissions! group :setting)
+          (mt/user-http-request user :put 204 "setting/site-name" {:value "NewName"})
+          (is (= "NewName" (mt/user-http-request :crowberto :get 200 "setting/site-name"))))))))

--- a/enterprise/backend/test/metabase_enterprise/audit_app/api/database_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/api/database_test.clj
@@ -3,7 +3,10 @@
    [clojure.test :refer :all]
    [metabase-enterprise.audit-app.audit-test :as audit-test]
    [metabase.audit-app.core :as audit]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]))
+
+(use-fixtures :once (fixtures/initialize :db :plugins))
 
 (deftest audit-db-unmodifiable-test
   (mt/with-premium-features #{:audit-app}
@@ -16,3 +19,13 @@
                 user [:crowberto :lucky]]
           (is (= "You don't have permissions to do that."
                  (mt/user-http-request user verb 403 (format path audit/audit-db-id)))))))))
+
+(deftest audit-db-excluded-from-database-list-test
+  (mt/with-premium-features #{:audit-app}
+    (audit-test/with-audit-db-restoration!
+      (testing "GET /api/database excludes the audit DB by default"
+        (is (not (contains? (set (map :id (:data (mt/user-http-request :crowberto :get 200 "database"))))
+                            audit/audit-db-id))))
+      (testing "GET /api/database?include_analytics=true includes the audit DB"
+        (is (contains? (set (map :id (:data (mt/user-http-request :crowberto :get 200 "database" :include_analytics true))))
+                       audit/audit-db-id))))))

--- a/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
@@ -8,6 +8,9 @@
    [metabase.api.common :as api]
    [metabase.audit-app.core :as audit]
    [metabase.core.core :as mbc]
+   [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.models.interface :as mi]
    [metabase.permissions.models.collection.graph :refer [update-graph!]]
    [metabase.permissions.models.collection.graph-test :refer [graph]]
@@ -178,3 +181,24 @@
   (let [dashboard (t2/select-one :model/Dashboard :collection_id (:id (audit/default-audit-collection)))]
     (is (= "You don't have permissions to do that."
            (mt/user-http-request :rasta :put 403 (str "dashboard/" (u/the-id dashboard)) {:name "My new title"})))))
+
+(deftest audit-db-adhoc-query-and-collection-write-perms-test
+  (audit-test/with-audit-db-restoration!
+    (mt/with-premium-features #{:audit-app}
+      (testing "An ad-hoc aggregation query on top of a saved audit model runs successfully (#43088)"
+        (mt/with-test-user :crowberto
+          (let [audit-card (t2/select-one :model/Card :database_id audit/audit-db-id :type :model :name "People")]
+            (is (some? audit-card)
+                "Expected the audit DB's 'People' model card to exist after installation")
+            (let [mp    (lib.metadata.jvm/application-database-metadata-provider audit/audit-db-id)
+                  query (-> (lib/query mp (lib.metadata/card mp (u/the-id audit-card)))
+                            (lib/aggregate (lib/count)))]
+              (is (partial= {:status :completed}
+                            (qp/process-query query)))))))
+      (testing "the analytics collection is read-only via the API"
+        (let [audit-coll-id (:id (audit/default-audit-collection))
+              items         (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))
+              analytics     (first (filter #(and (= (:model %) "collection") (= (:id %) audit-coll-id)) items))]
+          (is (some? analytics)
+              "the analytics collection is listed under the root collection")
+          (is (false? (:can_write analytics))))))))

--- a/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
@@ -201,4 +201,8 @@
               analytics     (first (filter #(and (= (:model %) "collection") (= (:id %) audit-coll-id)) items))]
           (is (some? analytics)
               "the analytics collection is listed under the root collection")
-          (is (false? (:can_write analytics))))))))
+          (is (false? (:can_write analytics)))))
+      (testing "GET /api/permissions/graph does not include the audit DB"
+        (let [resp (mt/user-http-request :crowberto :get 200 "permissions/graph")]
+          (is (every? #(not (contains? % audit/audit-db-id))
+                      (vals (:groups resp)))))))))

--- a/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
@@ -109,6 +109,29 @@
                                        :strategy {:type     "schedule"
                                                   :schedule "0/2 * * * * ?"}}))))))))
 
+(deftest preemptive-refresh-automatically-roundtrip-test
+  (testing "PUT /api/cache serializes refresh_automatically to its own column and GET re-nests it"
+    (mt/with-model-cleanup [:model/CacheConfig]
+      (mt/with-premium-features #{:cache-granular-controls :cache-preemptive}
+        (mt/with-temp [:model/Database db {}
+                       :model/Card     card {:name          "card"
+                                             :database_id   (:id db)
+                                             :dataset_query (lib/native-query (lib-be/application-database-metadata-provider (:id db)) "SELECT 1;")}]
+          (is (mt/user-http-request :crowberto :put 200 "cache/"
+                                    {:model    "question"
+                                     :model_id (:id card)
+                                     :strategy {:type "duration" :duration 24 :unit "hours" :refresh_automatically true}}))
+          (testing "flag is persisted to the top-level CacheConfig column"
+            (is (true? (t2/select-one-fn :refresh_automatically :model/CacheConfig
+                                         :model "question" :model_id (:id card)))))
+          (testing "GET re-nests the flag under strategy"
+            (is (=? {:data [{:model    "question"
+                             :model_id (:id card)
+                             :strategy {:type                  "duration"
+                                        :refresh_automatically true}}]}
+                    (mt/user-http-request :crowberto :get 200 "cache/"
+                                          :model "question" :id (:id card))))))))))
+
 (deftest cache-config-permissions-test
   (mt/with-model-cleanup [:model/CacheConfig]
     (mt/with-premium-features #{:cache-granular-controls :audit-app}

--- a/enterprise/backend/test/metabase_enterprise/content_translation/dictionary_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_translation/dictionary_test.clj
@@ -314,6 +314,21 @@
             (is (not (some #(= (:msgstr %) "   ") translations)))
             (is (not (some #(= (:msgstr %) ",,,") translations)))))))))
 
+(deftest import-translations-failure-leaves-existing-untouched-test
+  (ct-utils/with-clean-translations!
+    (testing "A failed import leaves previously stored translations intact"
+      (mt/with-premium-features #{:content-translation}
+        (#'dictionary/import-translations! [["de" "Cat" "Katze"]])
+        (is (= 1 (count-translations)))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"The file could not be uploaded due to the following error"
+             (#'dictionary/import-translations! [["invalidlocale" "Dog" "Hund"]])))
+        (is (= 1 (count-translations)) "original row survives the failed import")
+        (let [translations (get-translations)]
+          (is (some #(and (= (:locale %) "de") (= (:msgid %) "Cat") (= (:msgstr %) "Katze")) translations))
+          (is (not (some #(= (:msgid %) "Dog") translations))))))))
+
 (deftest import-translations-error-test
   (ct-utils/with-clean-translations!
     (testing "Import fails with validation errors"

--- a/enterprise/backend/test/metabase_enterprise/content_translation/routes_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_translation/routes_test.clj
@@ -116,7 +116,17 @@
           (is (=? {:errors ["Row 4: Invalid locale: xx"]}
                   (mt/user-http-request :crowberto :post 422 "ee/content-translation/upload-dictionary"
                                         {:request-options {:headers {"content-type" "multipart/form-data"}}}
-                                        {:file csv-with-invalid-locale}))))))))
+                                        {:file csv-with-invalid-locale}))))))
+    (testing "admin can upload a file with non-ASCII characters"
+      (ct-utils/with-clean-translations!
+        (mt/with-premium-features #{:content-translation}
+          (let [csv (.getBytes "Language,String,Translation\nar,Cat,قطة" "UTF-8")]
+            (is (=? {:success true}
+                    (mt/user-http-request :crowberto :post 200 "ee/content-translation/upload-dictionary"
+                                          {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                          {:file csv})))
+            (is (=? [{:locale "ar" :msgid "Cat" :msgstr "قطة"}]
+                    (t2/select :model/ContentTranslation)))))))))
 
 (defn random-embedding-secret-key [] (u.random/secure-hex 32))
 

--- a/enterprise/backend/test/metabase_enterprise/content_verification/api/collection_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_verification/api/collection_test.clj
@@ -109,3 +109,19 @@
                                                  {:moderated_item_id   model-id
                                                   :moderated_item_type :card
                                                   :status              :verified}))))))))
+
+(deftest remove-official-badge-test
+  (testing "PUT /api/collection/:id can remove the official badge when :official-collections is enabled"
+    (mt/with-premium-features #{:official-collections}
+      (mt/with-temp [:model/Collection {id :id} {:authority_level "official"}]
+        (is (nil? (:authority_level (mt/user-http-request :crowberto :put 200 (format "collection/%d" id)
+                                                          {:authority_level nil}))))
+        (is (nil? (t2/select-one-fn :authority_level :model/Collection id)))))))
+
+(deftest non-admin-cannot-set-authority-level-test
+  (testing "PUT /api/collection/:id with :authority_level is rejected (403) for a non-admin"
+    (mt/with-premium-features #{:official-collections}
+      (mt/with-temp [:model/Collection {id :id} {:authority_level nil}]
+        (is (= "You don't have permissions to do that."
+               (mt/user-http-request :rasta :put 403 (format "collection/%d" id)
+                                     {:authority_level "official"})))))))

--- a/enterprise/backend/test/metabase_enterprise/content_verification/api/moderation_review_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_verification/api/moderation_review_test.clj
@@ -91,3 +91,18 @@
                                             :status              "verified"
                                             :moderated_item_id   Integer/MAX_VALUE
                                             :moderated_item_type "card"}))))))))))
+
+(deftest create-dashboard-review-test
+  (testing "POST /api/moderation-review can verify a dashboard"
+    (mt/with-premium-features #{:content-verification}
+      (mt/with-temp [:model/Dashboard {dashboard-id :id} {}]
+        (mt/with-model-cleanup [:model/ModerationReview]
+          (is (=? {:status              "verified"
+                   :moderated_item_type "dashboard"
+                   :moderated_item_id   dashboard-id
+                   :moderator_id        (mt/user->id :crowberto)
+                   :most_recent         true}
+                  (mt/user-http-request :crowberto :post 200 "moderation-review"
+                                        {:status              "verified"
+                                         :moderated_item_id   dashboard-id
+                                         :moderated_item_type "dashboard"}))))))))

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
@@ -1,5 +1,6 @@
 (ns ^:synchronous metabase-enterprise.custom-viz-plugin.api-test
   (:require
+   [clj-http.client :as http]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.custom-viz-plugin.cache :as cache]
@@ -649,6 +650,29 @@
             (let [resp (mt/user-http-request :crowberto :post 200 "ee/custom-viz-plugin/dev"
                                              {:dev_bundle_url "http://localhost:5174"})]
               (is (= "gated-dev" (:identifier resp))))))))))
+
+(deftest dev-sse-proxy-test
+  (mt/with-premium-features #{:custom-viz}
+    (with-dev-mode-enabled
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:identifier     "dev-sse-proxy"
+                                                      :display_name   "dev-sse-proxy"
+                                                      :status         :active
+                                                      :dev_bundle_url "http://localhost:5199"}]
+        (testing "GET /:id/dev-sse returns 404 when no dev server URL is configured"
+          (mt/with-dynamic-fn-redefs [cache/resolve-dev-bundle (constantly nil)]
+            (is (re-find #"No dev server URL configured"
+                         (str (mt/user-http-request :crowberto :get 404 (str "ee/custom-viz-plugin/" id "/dev-sse")))))))
+        (testing "GET /:id/dev-sse forwards Server-Sent Events from the dev server"
+          (mt/with-dynamic-fn-redefs [cache/resolve-dev-bundle (constantly "http://localhost:5199")
+                                      http/get (fn [_url _opts]
+                                                 {:body (java.io.ByteArrayInputStream.
+                                                         (.getBytes "data: hello\n\n" "UTF-8"))})]
+            (let [resp (mt/user-http-request-full-response
+                        :crowberto :get 200 (str "ee/custom-viz-plugin/" id "/dev-sse"))]
+              (testing "response is served as an event stream"
+                (is (str/starts-with? (get-in resp [:headers "Content-Type"]) "text/event-stream")))
+              (testing "the dev server's event is forwarded to the browser"
+                (is (str/includes? (str (:body resp)) "data: hello"))))))))))
 
 (deftest list-excludes-dev-plugins-when-dev-mode-disabled-test
   (mt/with-premium-features #{:custom-viz}

--- a/enterprise/backend/test/metabase_enterprise/data_studio/api/table_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/api/table_test.clj
@@ -2,6 +2,7 @@
   "Tests for /api/ee/data-studio/table endpoints (enterprise-only: publish-tables, unpublish-tables)."
   (:require
    [clojure.test :refer :all]
+   [medley.core :as m]
    [metabase.collections.models.collection :as collection]
    [metabase.collections.test-utils :refer [without-library]]
    [metabase.permissions.core :as perms]
@@ -14,6 +15,20 @@
 (set! *warn-on-reflection* true)
 
 (use-fixtures :once (fixtures/initialize :db))
+
+(deftest table-metadata-survives-deleted-transform-test
+  (testing "a table whose creating transform has since been deleted (metabase#69904)"
+    (mt/with-premium-features #{:transforms-basic}
+      (mt/with-temp [:model/Transform transform {}
+                     :model/Table     {table-id :id} {:transform_id (:id transform)}]
+        (t2/delete! :model/Transform (:id transform))
+        (testing "metabase_table.transform_id -> transform.id is ON DELETE SET NULL, not left dangling"
+          (is (nil? (t2/select-one-fn :transform_id :model/Table :id table-id))))
+        (testing "GET /api/table/:id does not crash"
+          (is (=? {:id table-id} (mt/user-http-request :crowberto :get 200 (str "table/" table-id)))))
+        (testing "GET /api/table (list, which hydrates :transform when transforms are enabled) does not crash"
+          (is (=? {:id table-id :transform nil}
+                  (m/find-first #(= table-id (:id %)) (mt/user-http-request :crowberto :get 200 "table")))))))))
 
 (deftest publish-table-test
   (mt/with-premium-features #{:library :audit-app}

--- a/enterprise/backend/test/metabase_enterprise/data_studio/api/table_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/api/table_test.clj
@@ -215,11 +215,11 @@
     (testing "POST /api/ee/data-studio/table/publish-tables publishes recursive upstream dependencies"
       (mt/with-temp [:model/Collection {collection-id :id}    {:type collection/library-data-collection-type}
                      :model/Database   {db-id :id}          {}
-                     ;; Customers table (upstream of orders)
-                     :model/Table      {customers-id :id}   {:db_id db-id :name "customers" :is_published false}
-                     :model/Field      _                    {:table_id customers-id :name "id"
+                     ;; Purchasers table (upstream of orders)
+                     :model/Table      {purchasers-id :id}   {:db_id db-id :name "purchasers" :is_published false}
+                     :model/Field      _                    {:table_id purchasers-id :name "id"
                                                              :semantic_type :type/PK :base_type :type/Integer}
-                     :model/Field      {cust-name-f :id}    {:table_id customers-id :name "name"
+                     :model/Field      {cust-name-f :id}    {:table_id purchasers-id :name "name"
                                                              :semantic_type :type/Name :base_type :type/Text}
                      ;; Orders table (upstream of order_items, downstream of customers)
                      :model/Table      {orders-id :id}      {:db_id db-id :name "orders" :is_published false}
@@ -227,8 +227,8 @@
                                                              :semantic_type :type/PK :base_type :type/Integer}
                      :model/Field      {order-name-f :id}   {:table_id orders-id :name "name"
                                                              :semantic_type :type/Name :base_type :type/Text}
-                     :model/Field      {customer-fk :id}    {:table_id orders-id :name "customer_id"
-                                                             :semantic_type :type/FK :base_type :type/Integer}
+                     :model/Field      {purchaser-fk :id}    {:table_id orders-id :name "purchaser_id"
+                                                              :semantic_type :type/FK :base_type :type/Integer}
                      ;; Order items table (downstream of orders)
                      :model/Table      {items-id :id}       {:db_id db-id :name "order_items" :is_published false}
                      :model/Field      _                    {:table_id items-id :name "id"
@@ -236,7 +236,7 @@
                      :model/Field      {order-fk :id}       {:table_id items-id :name "order_id"
                                                              :semantic_type :type/FK :base_type :type/Integer}
                      ;; Dimensions for FK remapping
-                     :model/Dimension  _                    {:field_id customer-fk
+                     :model/Dimension  _                    {:field_id purchaser-fk
                                                              :human_readable_field_id cust-name-f
                                                              :type :external}
                      :model/Dimension  _                    {:field_id order-fk
@@ -247,7 +247,7 @@
                                 {:table_ids     [items-id]
                                  :collection_id collection-id})
           (are [table-id] (true? (t2/select-one-fn :is_published :model/Table table-id))
-            items-id orders-id customers-id))))))
+            items-id orders-id purchasers-id))))))
 
 (deftest unpublish-tables-with-downstream-dependents-test
   (mt/with-premium-features #{:library}
@@ -283,12 +283,12 @@
     (testing "POST /api/ee/data-studio/table/unpublish-tables unpublishes recursive downstream dependents"
       (mt/with-temp [:model/Collection {coll-id :id}        {:type collection/library-data-collection-type}
                      :model/Database   {db-id :id}          {}
-                     ;; Customers table (upstream of orders, published)
-                     :model/Table      {customers-id :id}   {:db_id db-id :name "customers" :is_published true
-                                                             :collection_id coll-id}
-                     :model/Field      _                    {:table_id customers-id :name "id"
+                     ;; Purchasers table (upstream of orders, published)
+                     :model/Table      {purchasers-id :id}   {:db_id db-id :name "purchasers" :is_published true
+                                                              :collection_id coll-id}
+                     :model/Field      _                    {:table_id purchasers-id :name "id"
                                                              :semantic_type :type/PK :base_type :type/Integer}
-                     :model/Field      {cust-name-f :id}    {:table_id customers-id :name "name"
+                     :model/Field      {cust-name-f :id}    {:table_id purchasers-id :name "name"
                                                              :semantic_type :type/Name :base_type :type/Text}
                      ;; Orders table (downstream of customers, upstream of items, published)
                      :model/Table      {orders-id :id}      {:db_id db-id :name "orders" :is_published true
@@ -297,8 +297,8 @@
                                                              :semantic_type :type/PK :base_type :type/Integer}
                      :model/Field      {order-name-f :id}   {:table_id orders-id :name "name"
                                                              :semantic_type :type/Name :base_type :type/Text}
-                     :model/Field      {customer-fk :id}    {:table_id orders-id :name "customer_id"
-                                                             :semantic_type :type/FK :base_type :type/Integer}
+                     :model/Field      {purchaser-fk :id}    {:table_id orders-id :name "purchaser_id"
+                                                              :semantic_type :type/FK :base_type :type/Integer}
                      ;; Order items table (downstream of orders, published)
                      :model/Table      {items-id :id}       {:db_id db-id :name "order_items" :is_published true
                                                              :collection_id coll-id}
@@ -307,7 +307,7 @@
                      :model/Field      {order-fk :id}       {:table_id items-id :name "order_id"
                                                              :semantic_type :type/FK :base_type :type/Integer}
                      ;; Dimensions for FK remapping
-                     :model/Dimension  _                    {:field_id customer-fk
+                     :model/Dimension  _                    {:field_id purchaser-fk
                                                              :human_readable_field_id cust-name-f
                                                              :type :external}
                      :model/Dimension  _                    {:field_id order-fk
@@ -315,9 +315,9 @@
                                                              :type :external}]
         (testing "unpublishing customers also unpublishes orders and order_items (recursive downstream)"
           (mt/user-http-request :crowberto :post 204 "ee/data-studio/table/unpublish-tables"
-                                {:table_ids [customers-id]})
+                                {:table_ids [purchasers-id]})
           (are [table-id] (false? (t2/select-one-fn :is_published :model/Table table-id))
-            customers-id orders-id items-id))))))
+            purchasers-id orders-id items-id))))))
 
 (defn- with-fk-linked-published-tables
   "Sets up two Library/Data collections A and B, with published Table X in A and published Table Y in B, where Y has an

--- a/enterprise/backend/test/metabase_enterprise/data_studio/permissions/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/permissions/query_test.clj
@@ -4,6 +4,7 @@
   {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.data-studio.permissions.query-test]}}}}}}
   (:require
    [clojure.test :refer :all]
+   [metabase-enterprise.sandbox.test-util :as sandbox.tu]
    [metabase.api.common :refer [*current-user-id* *current-user-permissions-set* *is-superuser?*]]
    [metabase.permissions.core :as perms]
    [metabase.query-permissions.core :as query-perms]
@@ -13,6 +14,43 @@
    [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db))
+
+(defn- do-with-published-venues!
+  "Publishes the venues table into a fresh `library-data` collection and configures the All Users
+  group (which every fresh user joins automatically) so the ONLY route to querying venues is the
+  collection-read grant on the published table: db/table `create-queries` are `:no`, table
+  `view-data` is `:unrestricted`, and db `view-data` is `db-view-data`.
+
+  Every row and permission here is COMMITTED, so the API server observes the intended permission
+  state. (Wrapping this in a `:rollback-only` transaction made the assertions vacuous: the request
+  thread never sees the uncommitted rows, so queries succeeded on the committed *default* full
+  access instead of the published-table mechanism under test.) `mt/with-restored-data-perms-for-group!`
+  restores the All Users data perms, the temp user/collection are cleaned up by `mt/with-temp`, and
+  the venues table's published state is restored in a `finally` before the collection is torn down.
+
+  Options:
+    :db-view-data - db-level view-data perm for All Users (default :unrestricted)
+    :grant?       - grant collection-read to All Users on the published collection (default true)
+
+  Invokes `(f user-id collection-id)`."
+  [{:keys [db-view-data grant?] :or {db-view-data :unrestricted grant? true}} f]
+  (mt/with-restored-data-perms-for-group! (u/the-id (perms/all-users-group))
+    (mt/with-premium-features #{:library}
+      (mt/with-temp [:model/User       {user-id :id}       {}
+                     :model/Collection {collection-id :id} {:type "library-data"}]
+        (try
+          (t2/update! :model/Table (mt/id :venues) {:is_published true :collection_id collection-id})
+          (let [all-users (perms/all-users-group)]
+            (perms/set-database-permission! all-users (mt/id) :perms/view-data      db-view-data)
+            (perms/set-database-permission! all-users (mt/id) :perms/create-queries :no)
+            (if grant?
+              (perms/grant-collection-read-permissions! all-users collection-id)
+              (perms/revoke-collection-permissions!     all-users collection-id))
+            (perms/set-table-permission! all-users (mt/id :venues) :perms/view-data      :unrestricted)
+            (perms/set-table-permission! all-users (mt/id :venues) :perms/create-queries :no))
+          (f user-id collection-id)
+          (finally
+            (t2/update! :model/Table (mt/id :venues) {:is_published false :collection_id nil})))))))
 
 (deftest published-table-test
   (testing "Published tables grant query access via collection permissions only with library enabled\n"
@@ -91,49 +129,105 @@
                         "Collection permissions should NOT grant view-data permission")))))))))))
 
 (deftest published-table-grants-database-access-test
-  (mt/with-restored-data-perms-for-group! (u/the-id (perms/all-users-group))
-    (mt/with-premium-features #{:library}
-      (testing "POST /api/dataset in EE: published table access GRANTS database access"
-        (t2/with-transaction [_conn nil {:rollback-only true}]
-          (mt/with-temp [:model/User       {user-id :id} {:email "ee-db-access-test@example.com"}
-                         :model/Collection collection    {:type "library-data"}]
-            ;; Publish the venues table into this collection
-            (t2/update! :model/Table (mt/id :venues) {:is_published true :collection_id (u/the-id collection)})
-            (let [all-users (perms/all-users-group)]
-              ;; Set database-level permissions first to establish baseline
-              (perms/set-database-permission! all-users (mt/id) :perms/view-data :unrestricted)
-              (perms/set-database-permission! all-users (mt/id) :perms/create-queries :no)
-              ;; Grant collection read permission - this gives create-queries via published table mechanism
-              (perms/grant-collection-read-permissions! all-users (u/the-id collection))
-              ;; Set table-level permissions
-              (perms/set-table-permission! all-users (mt/id :venues) :perms/view-data :unrestricted)
-              (perms/set-table-permission! all-users (mt/id :venues) :perms/create-queries :no)
-              ;; With collection permission on published table, query should succeed
-              (testing "Query should succeed because EE grants create-queries via published table mechanism"
-                (is (=? {:status    "completed"
-                         :row_count pos-int?}
-                        (mt/with-current-user user-id
-                          (mt/user-http-request user-id :post 202 "dataset"
-                                                (mt/mbql-query venues {:limit 1}))))))))))
-      (testing "POST /api/dataset in EE: without collection permission, published table does NOT grant access"
-        (t2/with-transaction [_conn nil {:rollback-only true}]
-          (mt/with-temp [:model/User       {user-id :id} {:email "ee-db-access-test2@example.com"}
-                         :model/Collection collection    {:type "library-data"}]
-            ;; Publish the venues table into this collection
-            (t2/update! :model/Table (mt/id :venues) {:is_published true :collection_id (u/the-id collection)})
-            (let [all-users (perms/all-users-group)]
-              ;; Set database-level permissions first to establish baseline
-              (perms/set-database-permission! all-users (mt/id) :perms/view-data :unrestricted)
-              (perms/set-database-permission! all-users (mt/id) :perms/create-queries :no)
-              ;; DON'T grant collection read permission - revoke it explicitly
-              (perms/revoke-collection-permissions! all-users collection)
-              ;; Set table-level permissions
-              (perms/set-table-permission! all-users (mt/id :venues) :perms/view-data :unrestricted)
-              (perms/set-table-permission! all-users (mt/id :venues) :perms/create-queries :no)
-              ;; Without collection permission, query should fail at database check (403)
-              (testing "Query should fail because user has no collection permission on published table"
-                (is (=? {:status "failed"
-                         :error  "You do not have permissions to run this query."}
-                        (mt/with-current-user user-id
-                          (mt/user-http-request user-id :post 403 "dataset"
-                                                (mt/mbql-query venues {:limit 1})))))))))))))
+  (testing "POST /api/dataset in EE: published table access GRANTS database access"
+    (do-with-published-venues! {:grant? true}
+                               (fn [user-id _collection-id]
+                                 (testing "Query should succeed because EE grants create-queries via published table mechanism"
+                                   (is (=? {:status    "completed"
+                                            :row_count pos-int?}
+                                           (mt/with-current-user user-id
+                                             (mt/user-http-request user-id :post 202 "dataset"
+                                                                   (mt/mbql-query venues {:limit 1})))))))))
+  (testing "POST /api/dataset in EE: without collection permission, published table does NOT grant access"
+    (do-with-published-venues! {:grant? false}
+                               (fn [user-id _collection-id]
+                                 (testing "Query should fail because user has no collection permission on published table"
+                                   (is (=? {:status "failed"
+                                            :error  "You do not have permissions to run this query."}
+                                           (mt/with-current-user user-id
+                                             (mt/user-http-request user-id :post 403 "dataset"
+                                                                   (mt/mbql-query venues {:limit 1}))))))))))
+
+(deftest published-table-query-blocks-join-to-unpublished-table-test
+  (testing "POST /api/dataset: a published table's entity-picker visibility is not itself a security boundary --
+            a hand-crafted query joining an unpublished table must still be rejected"
+    (do-with-published-venues! {:db-view-data :blocked}
+                               (fn [user-id _collection-id]
+                                 ;; categories is left blocked/unpublished -- no grant of any kind
+                                 (is (=? {:status "failed"}
+                                         (mt/with-current-user user-id
+                                           (mt/user-http-request user-id :post 403 "dataset"
+                                                                 (mt/mbql-query venues
+                                                                   {:joins  [{:source-table $$categories
+                                                                              :alias        "Cat"
+                                                                              :condition    [:= $category_id &Cat.$categories.id]}]
+                                                                    :limit  1})))))))))
+
+(deftest published-table-segment-and-metric-resolve-under-collection-only-perms-test
+  (do-with-published-venues! {}
+                             (fn [user-id _collection-id]
+                               (mt/with-temp [:model/Segment {segment-id :id} {:table_id   (mt/id :venues)
+                                                                               :definition (:query (mt/mbql-query venues {:filter [:> $price 2]}))}
+                                              :model/Card    {metric-id :id}  {:type          :metric
+                                                                               :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
+                                 (testing "a query referencing a :segment on the published table resolves"
+                                   (is (=? {:status "completed"}
+                                           (mt/with-current-user user-id
+                                             (mt/user-http-request user-id :post 202 "dataset"
+                                                                   (mt/mbql-query venues {:filter [:segment segment-id]}))))))
+                                 (testing "a :metric card built on the published table resolves"
+                                   (is (=? {:status "completed"}
+                                           (mt/with-current-user user-id
+                                             (mt/user-http-request user-id :post 202 (format "card/%d/query" metric-id))))))))))
+
+(deftest published-table-field-values-resolve-under-collection-only-perms-test
+  (do-with-published-venues! {}
+                             (fn [user-id _collection-id]
+                               (testing "GET /api/field/:id/values resolves via the collection grant"
+                                 (is (=? {:field_id (mt/id :venues :price)}
+                                         (mt/with-current-user user-id
+                                           (mt/user-http-request user-id :get 200 (format "field/%d/values" (mt/id :venues :price)))))))
+                               (testing "GET /api/field/:id/search/:search-id resolves via the collection grant"
+                                 (is (some? (mt/with-current-user user-id
+                                              (mt/user-http-request user-id :get 200
+                                                                    (format "field/%d/search/%d?limit=3" (mt/id :venues :name) (mt/id :venues :name))))))))))
+
+(deftest published-table-remap-to-unpublished-target-permission-error-test
+  ;; venues is published; categories (the FK-remap target) is deliberately left unpublished/blocked
+  (do-with-published-venues! {:db-view-data :blocked}
+                             (fn [user-id _collection-id]
+                               (mt/with-temp [:model/Dimension _ {:field_id                (mt/id :venues :category_id)
+                                                                  :human_readable_field_id (mt/id :categories :name)
+                                                                  :type                    :external}]
+                                 (testing "querying venues (whose FK-remap target is unpublished) surfaces a permission error"
+                                   (is (=? {:status "failed"}
+                                           (mt/with-current-user user-id
+                                             (mt/user-http-request user-id :post 403 "dataset"
+                                                                   (mt/mbql-query venues {:limit 1}))))))))))
+
+(deftest published-sandboxed-table-query-reflects-sandbox-not-full-access-test
+  (mt/with-additional-premium-features #{:library}
+    (testing "a table that is both published (collection-grant) and GTAP-sandboxed applies row-level sandboxing,
+              not broader access, via the published-table path"
+      (sandbox.tu/with-gtaps-for-user! :rasta
+        {:gtaps {:venues {:query (mt/mbql-query venues {:filter [:= $venues.price 4]})}}}
+        (mt/with-temp [:model/Collection {collection-id :id} {:type "library-data"}]
+          (try
+            (t2/update! :model/Table (mt/id :venues) {:is_published true :collection_id collection-id})
+            (perms/grant-collection-read-permissions! &group collection-id)
+            (testing "POST /api/dataset row count reflects the sandbox filter, not the full table"
+              (let [full-count  (mt/with-test-user :crowberto
+                                  (first (first (mt/formatted-rows [int]
+                                                                   (mt/process-query
+                                                                    (mt/mbql-query venues {:aggregation [[:count]]}))))))
+                    result      (mt/user-http-request :rasta :post 202 "dataset" (mt/mbql-query venues))
+                    price-index (->> result :data :cols
+                                     (keep-indexed (fn [i col] (when (= "PRICE" (u/upper-case-en (:name col))) i)))
+                                     first)]
+                (is (= "completed" (:status result)))
+                (is (pos? (:row_count result)))
+                (is (< (:row_count result) full-count) "sanity: some rows filtered")
+                (is (every? #(= 4 (nth % price-index)) (mt/rows result))
+                    "every returned row has price = 4, per the sandbox filter")))
+            (finally
+              (t2/update! :model/Table (mt/id :venues) {:is_published false :collection_id nil}))))))))

--- a/enterprise/backend/test/metabase_enterprise/data_studio/permissions/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/permissions/query_test.clj
@@ -224,8 +224,7 @@
                     price-index (->> result :data :cols
                                      (keep-indexed (fn [i col] (when (= "PRICE" (u/upper-case-en (:name col))) i)))
                                      first)]
-                (is (= "completed" (:status result)))
-                (is (pos? (:row_count result)))
+                (is (=? {:status "completed" :row_count pos-int?} result))
                 (is (< (:row_count result) full-count) "sanity: some rows filtered")
                 (is (every? #(= 4 (nth % price-index)) (mt/rows result))
                     "every returned row has price = 4, per the sandbox filter")))

--- a/enterprise/backend/test/metabase_enterprise/database_routing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/api_test.clj
@@ -231,12 +231,30 @@
         (is (not (t2/exists? :model/DataPermissions :group_id group-id :db_id destination-db-id)))))))
 
 (deftest manage-db-user-cannot-delete-destination-database-test
-  (testing "DELETE /api/database/:id is rejected (403) for a non-superuser with only manage-database perms on a routed destination"
-    (mt/with-temp [:model/Database {db-id :id} {}
-                   :model/DatabaseRouter _ {:database_id db-id :user_attribute "foo"}
-                   :model/Database {dest :id} {:router_database_id db-id}]
-      (mt/with-no-data-perms-for-all-users!
-        (perms/set-database-permission! (perms/all-users-group) db-id :perms/manage-database :yes)
-        (is (= "You don't have permissions to do that."
-               (mt/user-http-request :rasta :delete 403 (str "database/" dest))))
-        (is (t2/exists? :model/Database :id dest))))))
+  (testing "DELETE /api/database/:id is rejected (403) for a non-superuser with manage-database perms on a routed destination"
+    ;; NOTE: `DELETE /api/database/:id` calls `api/check-superuser` unconditionally before it ever looks at the
+    ;; database being deleted (see `metabase.warehouses-rest.api`), so this endpoint is admin-only full stop -- it
+    ;; doesn't have any destination-specific carve-out to disprove. To show that manage-database perms are actually
+    ;; being exercised here (and not just trivially irrelevant), we also enable `:advanced-permissions` -- without it,
+    ;; `current-user-can-write-db?` falls back to the OSS `superuser?` check and the manage-database grant below would
+    ;; be a no-op -- and we assert the *same* grant is refused identically for a regular database, proving there's no
+    ;; accidental carve-out that would let a manage-database non-admin delete regular databases while destinations
+    ;; stay protected (or vice versa).
+    (mt/with-additional-premium-features #{:advanced-permissions}
+      (mt/with-temp [:model/Database {db-id :id} {}
+                     :model/DatabaseRouter _ {:database_id db-id :user_attribute "foo"}
+                     :model/Database {dest :id} {:router_database_id db-id}
+                     :model/Database {regular-db-id :id} {}]
+        (mt/with-no-data-perms-for-all-users!
+          (perms/set-database-permission! (perms/all-users-group) db-id :perms/manage-database :yes)
+          (perms/set-database-permission! (perms/all-users-group) db-id :perms/create-queries :query-builder-and-native)
+          (perms/set-database-permission! (perms/all-users-group) regular-db-id :perms/manage-database :yes)
+          (perms/set-database-permission! (perms/all-users-group) regular-db-id :perms/create-queries :query-builder-and-native)
+          (testing "manage-database perms don't allow deleting a regular database either"
+            (is (= "You don't have permissions to do that."
+                   (mt/user-http-request :rasta :delete 403 (str "database/" regular-db-id)))))
+          (testing "manage-database perms on the router database don't allow deleting its destination database"
+            (is (= "You don't have permissions to do that."
+                   (mt/user-http-request :rasta :delete 403 (str "database/" dest)))))
+          (is (t2/exists? :model/Database :id regular-db-id))
+          (is (t2/exists? :model/Database :id dest)))))))

--- a/enterprise/backend/test/metabase_enterprise/database_routing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/api_test.clj
@@ -229,3 +229,14 @@
         (is (t2/exists? :model/DataPermissions :group_id group-id :db_id db-id)))
       (testing "New group should NOT have permissions for the destination database"
         (is (not (t2/exists? :model/DataPermissions :group_id group-id :db_id destination-db-id)))))))
+
+(deftest manage-db-user-cannot-delete-destination-database-test
+  (testing "DELETE /api/database/:id is rejected (403) for a non-superuser with only manage-database perms on a routed destination"
+    (mt/with-temp [:model/Database {db-id :id} {}
+                   :model/DatabaseRouter _ {:database_id db-id :user_attribute "foo"}
+                   :model/Database {dest :id} {:router_database_id db-id}]
+      (mt/with-no-data-perms-for-all-users!
+        (perms/set-database-permission! (perms/all-users-group) db-id :perms/manage-database :yes)
+        (is (= "You don't have permissions to do that."
+               (mt/user-http-request :rasta :delete 403 (str "database/" dest))))
+        (is (t2/exists? :model/Database :id dest))))))

--- a/enterprise/backend/test/metabase_enterprise/database_routing/sandboxing_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/sandboxing_test.clj
@@ -1,0 +1,48 @@
+(ns ^:mb/driver-tests metabase-enterprise.database-routing.sandboxing-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase-enterprise.database-routing.e2e-test :as e2e]
+   [metabase-enterprise.test :as met]
+   [metabase.driver.settings :as driver.settings]
+   [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.permissions.core :as perms]
+   [metabase.permissions.models.data-permissions :as data-perms]
+   [metabase.sync.core :as sync]
+   [metabase.test :as mt]
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
+
+(deftest sandboxing-applies-to-routed-destination-test
+  (testing "a row sandbox defined on a router table filters rows in the per-user routed destination database"
+    (mt/with-premium-features #{:database-routing :sandboxes :advanced-permissions}
+      (binding [driver.settings/*allow-testing-h2-connections* true]
+        (met/with-user-attributes! :rasta {"db_name" "destination-db" "filter_val" "keep"}
+          (e2e/with-temp-dbs! [router-db destination-db]
+            (t2/update! :model/Database (u/the-id destination-db)
+                        {:name "destination-db" :router_database_id (u/the-id router-db)})
+            (sync/sync-database! router-db)
+            (e2e/execute-statement! destination-db "INSERT INTO \"my_database_name\" (str) VALUES ('keep')")
+            (e2e/execute-statement! destination-db "INSERT INTO \"my_database_name\" (str) VALUES ('drop')")
+            (e2e/execute-statement! router-db "INSERT INTO \"my_database_name\" (str) VALUES ('router-only')")
+            (let [router-table (t2/select-one :model/Table :db_id (u/the-id router-db))
+                  str-field    (t2/select-one :model/Field :table_id (u/the-id router-table))
+                  all-users    (perms/all-users-group)]
+              (mt/with-no-data-perms-for-all-users!
+                (mt/with-temp [:model/DatabaseRouter _ {:database_id    (u/the-id router-db)
+                                                        :user_attribute "db_name"}
+                               :model/Sandbox _ {:group_id             (u/the-id all-users)
+                                                 :table_id             (u/the-id router-table)
+                                                 :card_id              nil
+                                                 :attribute_remappings {"filter_val" [:dimension [:field (u/the-id str-field) nil]]}}]
+                  (data-perms/set-database-permission! all-users (u/the-id router-db) :perms/view-data :unrestricted)
+                  (data-perms/set-table-permission! all-users (u/the-id router-table) :perms/create-queries :query-builder)
+                  (let [mp    (lib.metadata.jvm/application-database-metadata-provider (u/the-id router-db))
+                        query (lib/query mp (lib.metadata/table mp (u/the-id router-table)))]
+                    (mt/with-temp [:model/Card card {:name          "Router question"
+                                                     :database_id   (u/the-id router-db)
+                                                     :dataset_query query}]
+                      (testing "the sandboxed user only sees the destination row matching their attribute"
+                        (let [response (mt/user-http-request :rasta :post 202 (str "card/" (u/the-id card) "/query"))]
+                          (is (= [["keep"]] (mt/rows response))))))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -225,6 +225,56 @@
                          :edges #{}}
                         (update response :edges set)))))))))))
 
+(deftest ^:sequential table-dependents-all-types-test
+  (testing "GET /api/ee/dependencies/graph dependents_count types every non-card dependent kind for a table root"
+    (mt/with-premium-features #{:dependencies :transforms-basic}
+      (mt/with-model-cleanup [:model/Card :model/Dependency :model/DependencyStatus
+                              :model/Transform :model/Segment :model/Measure]
+        (mt/with-test-user :crowberto
+          (let [mp          (mt/metadata-provider)
+                products-id (mt/id :products)
+                products    (lib.metadata/table mp products-id)
+                price       (lib.metadata/field mp (mt/id :products :price))
+                user        (mt/fetch-user :crowberto)]
+            (card/create-card! (assoc (card-with-query "Question on products" (lib/query mp products))
+                                      :type :question)
+                               user)
+            (card/create-card! (assoc (card-with-query "Model on products" (lib/query mp products))
+                                      :type :model)
+                               user)
+            (card/create-card! (assoc (card-with-query "Metric on products"
+                                                       (-> (lib/query mp products)
+                                                           (lib/aggregate (lib/count))))
+                                      :type :metric)
+                               user)
+            (mt/with-temp [:model/Segment {:as segment} {:name "Segment on products"
+                                                         :table_id products-id
+                                                         :definition (-> (lib/query mp products)
+                                                                         (lib/filter (lib/> price 50))
+                                                                         lib/->legacy-MBQL
+                                                                         :query)}
+                           :model/Measure {:as measure} {:name "Measure on products"
+                                                         :table_id products-id
+                                                         :definition (-> (lib/query mp products)
+                                                                         (lib/aggregate (lib/sum price)))}
+                           :model/Transform _ {:name   "Transform on products"
+                                               :source {:type "query" :query (lib/query mp products)}
+                                               :target {:type "table" :name (mt/random-name)}}]
+              (events/publish-event! :event/segment-create {:object segment :user-id (mt/user->id :crowberto)})
+              (events/publish-event! :event/measure-create {:object measure :user-id (mt/user->id :crowberto)})
+              (deps.test/synchronously-run-backfill!)
+              (let [response   (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph"
+                                                     :id products-id :type "table")
+                    table-node (first (filter #(= (:id %) products-id) (:nodes response)))]
+                (testing "the table's dependents_count includes every dependent kind, correctly typed"
+                  (is (=? {:question  pos-int?
+                           :model     pos-int?
+                           :metric    pos-int?
+                           :segment   pos-int?
+                           :measure   pos-int?
+                           :transform pos-int?}
+                          (:dependents_count table-node))))))))))))
+
 (deftest dependents-test
   (testing "GET /api/ee/dependencies/graph/dependents"
     (mt/with-premium-features #{:dependencies}

--- a/enterprise/backend/test/metabase_enterprise/dependencies/task/backfill_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/task/backfill_test.clj
@@ -131,6 +131,42 @@
                           :from_entity_type :card :from_entity_id card-id
                           :to_entity_type :snippet :to_entity_id snippet-id)))))))
 
+(deftest ^:sequential backfill-snippet-in-snippet-test
+  (testing "A snippet referencing another snippet produces a snippet->snippet dependency"
+    (backfill-all-existing-entities!)
+    (mt/with-premium-features #{}
+      (mt/with-temp [:model/NativeQuerySnippet {inner-id :id} {:name "inner_snip" :content "1 = 1"}
+                     :model/NativeQuerySnippet {outer-id :id} {:name "outer_snip" :content "SELECT * WHERE {{snippet: inner_snip}}"}]
+        (mark-stale! :snippet inner-id)
+        (mark-stale! :snippet outer-id)
+        (is (false? (t2/exists? :model/Dependency
+                                :from_entity_type :snippet :from_entity_id outer-id
+                                :to_entity_type :snippet :to_entity_id inner-id)))
+        (backfill-dependencies-single-trigger!)
+        (assert-processed :snippet inner-id)
+        (assert-processed :snippet outer-id)
+        (is (t2/exists? :model/Dependency
+                        :from_entity_type :snippet :from_entity_id outer-id
+                        :to_entity_type :snippet :to_entity_id inner-id))))))
+
+(deftest ^:sequential backfill-snippet-referencing-card-test
+  (testing "A snippet referencing a card produces a snippet->card dependency"
+    (backfill-all-existing-entities!)
+    (mt/with-premium-features #{}
+      (mt/with-temp [:model/Card {card-id :id} {:dataset_query (mt/mbql-query orders)}
+                     :model/NativeQuerySnippet {snippet-id :id} {:name "card_ref_snip"
+                                                                 :content (format "SELECT * FROM {{#%d}}" card-id)}]
+        (mark-stale! :card card-id)
+        (mark-stale! :snippet snippet-id)
+        (is (false? (t2/exists? :model/Dependency
+                                :from_entity_type :snippet :from_entity_id snippet-id
+                                :to_entity_type :card :to_entity_id card-id)))
+        (backfill-dependencies-single-trigger!)
+        (assert-processed :snippet snippet-id)
+        (is (t2/exists? :model/Dependency
+                        :from_entity_type :snippet :from_entity_id snippet-id
+                        :to_entity_type :card :to_entity_id card-id))))))
+
 (deftest ^:sequential backfill-idempotency-test
   (testing "Running the backfill multiple times should be idempotent"
     (backfill-all-existing-entities!)

--- a/enterprise/backend/test/metabase_enterprise/embedding_hub/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/embedding_hub/api_test.clj
@@ -130,6 +130,44 @@
           (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
             (is (false? (get-in response [:checklist :data-permissions-and-enable-tenants])))))))))
 
+(deftest move-dashboard-to-shared-checklist-test
+  (mt/id) ;; force the app-db's own database row to exist so add-data resolves deterministically
+  (mt/with-premium-features #{:embedding :tenants}
+    (mt/with-temporary-setting-values [use-tenants true]
+      (let [ck (fn [k] (get-in (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist") [:checklist k]))]
+        (is (false? (ck :move-dashboard-to-shared)))
+        (mt/with-temp [:model/Collection {sc :id} {:namespace "shared-tenant-collection"}]
+          (is (false? (ck :move-dashboard-to-shared)))
+          (mt/with-temp [:model/Dashboard _ {:collection_id sc :archived false}]
+            (is (true? (ck :move-dashboard-to-shared)))))))))
+
+(deftest setting-and-sso-checklist-test
+  (mt/id) ;; force the app-db's own database row to exist so add-data resolves deterministically
+  (testing "402 without :embedding feature"
+    (mt/with-premium-features #{}
+      (mt/user-http-request :crowberto :get 402 "/ee/embedding-hub/checklist")))
+  (mt/with-premium-features #{:embedding}
+    (let [ck (fn [k] (get-in (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist") [:checklist k]))]
+      (testing "create-test-embed reflects a published guest embed"
+        (mt/with-temp [:model/Card _ {:enable_embedding true}]
+          (is (true? (ck :create-test-embed)))))
+      (testing "create-test-embed reflects the test-embed-snippet-created setting"
+        (mt/with-temporary-setting-values [embedding-hub-test-embed-snippet-created true]
+          (is (true? (ck :create-test-embed)))))
+      (testing "embed-production reflects the production-embed-snippet-created setting"
+        (mt/with-temporary-setting-values [embedding-hub-production-embed-snippet-created true]
+          (is (true? (ck :embed-production)))))))
+  (mt/with-premium-features #{:embedding :sso-jwt}
+    (mt/with-temporary-setting-values [jwt-shared-secret         "0123456789abcdef0123456789abcdef"
+                                       jwt-identity-provider-uri "https://idp.example.com"
+                                       jwt-enabled                true]
+      (is (true? (get-in (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")
+                         [:checklist :sso-configured])))))
+  (mt/with-premium-features #{:embedding}
+    (mt/with-temporary-setting-values [embedding-hub-sso-auth-manual-tested true]
+      (is (true? (get-in (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")
+                         [:checklist :sso-auth-manual-tested]))))))
+
 (deftest data-isolation-strategy-test
   (testing "data-isolation-strategy is nil when no strategy is configured"
     (mt/with-premium-features #{:embedding}

--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -1085,6 +1085,51 @@
                             (format "INSERT INTO %s (name) VALUES ('x'); SELECT 1;" venues-table)
                             (format "SET ROLE NONE; DELETE FROM %s WHERE id = -1;" venues-table)))))))))))))))
 
+(deftest impersonated-action-write-permission-denied-test
+  (testing "An impersonated custom action whose role lacks write grants surfaces the DB permission error and leaves the row unchanged"
+    (mt/test-drivers (mt/normal-driver-select {:+features [:connection-impersonation :actions/custom]})
+      (mt/with-premium-features #{:advanced-permissions}
+        (let [venues-table (sql.tx/qualify-and-quote driver/*driver* "test-data" "venues")
+              role-a (u/lower-case-en (mt/random-name))]
+          (tx/with-temp-roles! driver/*driver*
+            (impersonation-granting-details driver/*driver* (mt/db))
+            ;; role-a is granted SELECT only (no INSERT/UPDATE/DELETE)
+            {role-a {venues-table {}}}
+            (impersonation-default-user driver/*driver*)
+            (impersonation-default-role driver/*driver*)
+            (let [granting-details (impersonation-granting-details driver/*driver* (mt/db))
+                  spec             (sql-jdbc.conn/connection-details->spec driver/*driver* granting-details)
+                  read-name        (fn [] (-> (jdbc/query spec [(format "SELECT name FROM %s WHERE id = 1" venues-table)])
+                                              first :name))]
+              (mt/with-temp [:model/Database database {:engine driver/*driver*,
+                                                       :details (impersonation-details driver/*driver* (mt/db))}]
+                (mt/with-db database
+                  (when (driver/database-supports? driver/*driver* :connection-impersonation-requires-role nil)
+                    (t2/update! :model/Database :id (mt/id) (assoc-in (mt/db) [:details :role] (impersonation-default-role driver/*driver*))))
+                  (sync/sync-database! database {:scan :schema})
+                  (mt/with-actions-enabled
+                    (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                                   :attributes     {"impersonation_attr" role-a}}
+                      (let [original-name (read-name)
+                            execute-action-with-sql
+                            (fn [sql]
+                              (mt/with-actions [{_card-id :id} {:type :model :dataset_query (mt/mbql-query venues)}
+                                                {action-id :action-id} {:type          :query
+                                                                        :name          "Test action"
+                                                                        :dataset_query (update (mt/native-query {:query sql})
+                                                                                               :type name)
+                                                                        :database_id   (mt/id)
+                                                                        :parameters    []}]
+                                (actions.execution/execute-action! (action/select-action :id action-id) {})))]
+                        (testing "write is denied for a role with only SELECT"
+                          (is (thrown-with-msg?
+                               java.lang.Exception
+                               #"(?i)permission denied|denied to user|not authorized"
+                               (execute-action-with-sql
+                                (format "UPDATE %s SET name = 'hacked' WHERE id = 1" venues-table)))))
+                        (testing "the row is unchanged"
+                          (is (= original-name (read-name))))))))))))))))
+
 (deftest admins-can-run-show-timezone-statement-test
   (mt/test-drivers (mt/normal-driver-select {:+parent :postgres})
     (mt/with-premium-features #{:advanced-permissions}

--- a/enterprise/backend/test/metabase_enterprise/library/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/library/api_test.clj
@@ -6,6 +6,21 @@
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
+(deftest create-library-endpoint-test
+  (mt/with-premium-features #{:library}
+    (mt/with-discard-model-updates! [:model/Collection]
+      (without-library
+       (testing "non-data-analysts cannot create the library"
+         (mt/user-http-request :rasta :post 403 "ee/library"))
+       (testing "POST /ee/library creates the Library root + Data/Metrics subcollections"
+         (let [response (mt/user-http-request :crowberto :post 200 "ee/library")]
+           (is (= "Library" (:name response)))
+           (is (some? (t2/select-one-pk :model/Collection :type collection/library-data-collection-type)))
+           (is (some? (t2/select-one-pk :model/Collection :type collection/library-metrics-collection-type)))))
+       (testing "a second call rejects with 400 'Library already exists'"
+         (is (= "Library already exists"
+                (mt/user-http-request :crowberto :post 400 "ee/library"))))))))
+
 (deftest get-library-test
   (mt/with-premium-features #{:library}
     (mt/with-discard-model-updates! [:model/Collection]

--- a/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
@@ -1,10 +1,54 @@
 (ns metabase-enterprise.metabot.api-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase-enterprise.metabot.settings :as ee.metabot.settings]
+   [metabase-enterprise.metabot.usage :as ee.metabot.usage]
+   [metabase.config.core :as config]
+   [metabase.metabot.scope :as scope]
+   [metabase.metabot.self.openrouter :as openrouter]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.metabot.test-util :as mut]
    [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]))
 
 (set! *warn-on-reflection* true)
+
+(def ^:private test-provider "openrouter/anthropic/claude-haiku-4-5")
+
+(deftest agent-streaming-quota-exceeded-test
+  (testing "POST /api/metabot/agent-streaming short-circuits with the quota message once an instance usage limit is exceeded"
+    (mt/with-premium-features #{:ai-controls}
+      (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider test-provider]
+        (binding [scope/*current-user-metabot-permissions* scope/all-yes-permissions]
+          (with-redefs [config/is-dev? true]
+            (try
+              (mt/with-temp [:model/MetabotInstanceLimit _ {:tenant_id nil :max_usage 0}]
+                (ee.metabot.usage/clear-limit-cache!)
+                (let [llm-called? (atom false)]
+                  (mt/with-dynamic-fn-redefs [openrouter/openrouter (fn [_]
+                                                                      (reset! llm-called? true)
+                                                                      (mut/mock-llm-response
+                                                                       [{:type :text :text "should not be reached"}]))]
+                    (mt/with-model-cleanup [:model/MetabotMessage
+                                            [:model/MetabotConversation :created_at]]
+                      (let [response   (mt/user-http-request :rasta :post 202 "metabot/agent-streaming"
+                                                             {:message         "Hi"
+                                                              :context         {}
+                                                              :conversation_id (str (random-uuid))
+                                                              :history         []
+                                                              :state           {}})
+                            lines      (str/split-lines response)
+                            error-line (first (filter #(str/starts-with? % "3:") lines))]
+                        (is (false? @llm-called?)
+                            "the LLM must never be called once the instance limit is exceeded")
+                        (is (some? error-line))
+                        (is (str/includes? error-line "ai_usage_limit_reached"))
+                        (is (str/includes? error-line (ee.metabot.settings/metabot-quota-reached-message))))))))
+              ;; the limit check is TTL-memoized process-wide; bust it so the now-removed temp limit
+              ;; doesn't leak a stale "exceeded" verdict into other tests
+              (finally
+                (ee.metabot.usage/clear-limit-cache!)))))))))
 
 (deftest usage-get-returns-token-status-usage-test
   (mt/with-premium-features #{:metabot-v3}

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
@@ -954,6 +954,17 @@
                                          {:remote-sync-url "asdf://invalid-url"})]
       (is (= "Invalid repository URL: only HTTPS URLs are supported (e.g., https://git-host.example.com/yourcompany/repo.git)" (:error response))))))
 
+(deftest settings-surfaces-clone-failure-message-test
+  (testing "PUT /api/ee/remote-sync/settings surfaces a JGit clone-failure as a 400 error message"
+    (mt/with-dynamic-fn-redefs [settings/check-git-settings!
+                                (fn [_] (throw (ex-info "Failed to clone git repository: URI not supported: file://bad" {})))]
+      (mt/with-temporary-setting-values [remote-sync-url nil
+                                         remote-sync-type :read-only]
+        (let [response (mt/user-http-request :crowberto :put 400 "ee/remote-sync/settings"
+                                             {:remote-sync-url "https://github.com/does/not-exist.git"
+                                              :remote-sync-type :read-only})]
+          (is (re-find #"Failed to clone git repository" (:error response))))))))
+
 (deftest settings-cannot-change-with-dirty-data
   (testing "PUT /api/ee/remote-sync/settings doesn't allow losing dirty data"
     (mt/with-dynamic-fn-redefs [remote-sync.object/dirty? (constantly true)

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/permissions_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [metabase-enterprise.remote-sync.settings :as settings]
    [metabase.collections.models.collection :as collections]
+   [metabase.lib.core :as lib]
    [metabase.models.interface :as mi]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
@@ -711,6 +712,30 @@
                                                                        :name "target_table"}}]
             (is (false? (mi/can-write? (t2/select-one :model/Transform :id transform-id)))
                 "Non-superuser should not be able to write transforms even when remote-sync-type is read-write")))))))
+
+(deftest transform-write-endpoints-return-403-in-read-only-remote-sync-test
+  (testing "PUT/DELETE /api/transform/:id reject with 403 when remote-sync is enabled and read-only"
+    (mt/with-premium-features #{:transforms-basic}
+      (mt/with-temporary-setting-values [settings/remote-sync-url "https://github.com/test/repo.git"
+                                         settings/remote-sync-type :read-only]
+        (mt/with-temp [:model/Collection {coll-id :id} {:name "Transforms Collection"
+                                                        :namespace :transforms}
+                       :model/Transform {transform-id :id} {:name "Read-only Transform"
+                                                            :collection_id coll-id
+                                                            :source {:type "query"
+                                                                     :query (lib/native-query (mt/metadata-provider) "SELECT 1")}
+                                                            :target {:database (mt/id)
+                                                                     :type "table"
+                                                                     :schema "public"
+                                                                     :name "target_table"}}]
+          (testing "PUT is rejected"
+            (is (= "You don't have permissions to do that."
+                   (mt/user-http-request :crowberto :put 403 (str "transform/" transform-id) {:name "renamed"}))))
+          (testing "DELETE is rejected"
+            (is (= "You don't have permissions to do that."
+                   (mt/user-http-request :crowberto :delete 403 (str "transform/" transform-id)))))
+          (testing "transform is untouched"
+            (is (= "Read-only Transform" (t2/select-one-fn :name :model/Transform :id transform-id)))))))))
 
 (deftest transform-non-superuser-cannot-create-test
   (testing "can_create should be false for non-superusers even when remote-sync-type is read-write"

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/settings_test.clj
@@ -134,6 +134,20 @@
   (mt/with-temporary-setting-values [:remote-sync-url "file://my/repo.git"]
     (is (true? (settings/remote-sync-enabled)))))
 
+(deftest deactivate-clears-remote-sync-with-blank-url-test
+  (testing "Setting a blank remote-sync-url clears all git settings and disables remote sync"
+    (mt/with-dynamic-fn-redefs [settings/check-git-settings! (constantly true)]
+      (mt/with-temporary-setting-values [:remote-sync-url    "file://my/repo.git"
+                                         :remote-sync-token  "secret-token"
+                                         :remote-sync-branch "main"
+                                         :remote-sync-type   :read-write]
+        (is (true? (settings/remote-sync-enabled)))
+        (settings/check-and-update-remote-settings! {:remote-sync-url ""})
+        (is (false? (settings/remote-sync-enabled)))
+        (is (nil? (settings/remote-sync-url)))
+        (is (nil? (settings/remote-sync-token)))
+        (is (nil? (settings/remote-sync-branch)))))))
+
 ;;; ------------------------------------------------- Root Collection Remote Sync -------------------------------------------------
 
 (deftest check-and-update-remote-settings-env-var-aware-test

--- a/enterprise/backend/test/metabase_enterprise/replacement/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/replacement/api_test.clj
@@ -454,7 +454,9 @@
 
 (deftest replace-model-with-transform-dependent-shapes-test
   (testing "POST /replace-model-with-transform correctly handles every dependent shape"
-    (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
+    ;; one of the dependent shapes is a question that joins the model (rather than sourcing from it), so drivers
+    ;; also need :left-join support
+    (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table :left-join)
       (mt/with-premium-features #{:dependencies}
         (let [mp     (mt/metadata-provider)
               schema (t2/select-one-fn :schema :model/Table (mt/id :orders))]

--- a/enterprise/backend/test/metabase_enterprise/replacement/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/replacement/api_test.clj
@@ -10,6 +10,7 @@
    [metabase.events.core :as events]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.query-processor.test :as qp]
    [metabase.test :as mt]
    [metabase.transforms.core :as transforms]
    [metabase.transforms.test-util :refer [with-transform-cleanup!]]
@@ -450,6 +451,109 @@
                       (is (contains? events "model_to_transforms_migration_started"))
                       (is (contains? events "model_to_transforms_migration_failure"))
                       (is (not (contains? events "model_to_transforms_migration_success"))))))))))))))
+
+(deftest replace-model-with-transform-dependent-shapes-test
+  (testing "POST /replace-model-with-transform correctly handles every dependent shape"
+    (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
+      (mt/with-premium-features #{:dependencies}
+        (let [mp     (mt/metadata-provider)
+              schema (t2/select-one-fn :schema :model/Table (mt/id :orders))]
+          (with-transform-cleanup! [target {:type   "table"
+                                            :schema schema
+                                            :name   "model_transform_shapes"}]
+            (mt/with-temp [:model/Card {model-id :id :as model-card}
+                           {:database_id   (mt/id)
+                            :dataset_query (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                            :type          :model
+                            :name          "Model"}
+
+                           :model/Card {direct-id :id :as direct-card}
+                           {:database_id   (mt/id)
+                            :dataset_query (lib/query mp (lib.metadata/card mp model-id))
+                            :type          :question
+                            :name          "Direct Child"}
+
+                           :model/Card {nested-id :id :as nested-card}
+                           {:database_id   (mt/id)
+                            :dataset_query (lib/query mp (lib.metadata/card mp direct-id))
+                            :type          :question
+                            :name          "Nested Grandchild"}
+
+                           :model/Card {metric-id :id :as metric-card}
+                           {:database_id   (mt/id)
+                            :dataset_query (lib/aggregate (lib/query mp (lib.metadata/card mp model-id)) (lib/count))
+                            :type          :metric
+                            :name          "Row Count Metric"}
+
+                           :model/Card {join-id :id :as join-card}
+                           {:database_id   (mt/id)
+                            :dataset_query (lib/join (lib/query mp (lib.metadata/table mp (mt/id :products)))
+                                                     (lib.metadata/card mp model-id))
+                            :type          :question
+                            :name          "Joins The Model"}
+
+                           :model/Dashboard {dashboard-id :id}
+                           {:name "Model Dashboard"}
+
+                           :model/DashboardCard {dashcard-id :id}
+                           {:dashboard_id       dashboard-id
+                            :card_id            model-id
+                            :parameter_mappings [{:parameter_id "model-id-param"
+                                                  :card_id      model-id
+                                                  :target       [:dimension
+                                                                 (lib/->legacy-MBQL
+                                                                  (lib/ref (lib.metadata/field mp (mt/id :orders :id))))
+                                                                 {:stage-number 0}]}]}]
+              (mt/with-model-cleanup [:model/ReplacementRun]
+                (doseq [card [model-card direct-card nested-card metric-card join-card]]
+                  (events/publish-event! :event/card-create {:object card :user-id (mt/user->id :crowberto)}))
+                (deps.test/synchronously-run-backfill!)
+                (let [response (mt/user-http-request :crowberto :post 202
+                                                     "ee/replacement/replace-model-with-transform"
+                                                     {:card_id              model-id
+                                                      :transform_name       "Shapes Transform"
+                                                      :transform_target     {:type     "table"
+                                                                             :schema   schema
+                                                                             :name     (:name target)
+                                                                             :database (mt/id)}
+                                                      :target_collection_id nil})
+                      run-id   (:run_id response)
+                      final    (poll-run run-id :timeout-ms 30000)
+                      transform (t2/select-one :model/Transform :name "Shapes Transform")
+                      output-table (transforms/output-table transform)]
+                  (is (= "succeeded" (:status final)))
+                  (testing "direct dependent's source is swapped to the transform output table"
+                    (let [q (t2/select-one-fn :dataset_query :model/Card :id direct-id)]
+                      (is (= (:id output-table) (lib/primary-source-table-id q)))))
+                  (testing "nested grandchild's own ref stays untouched (card__direct-id), yet still resolves transitively"
+                    (let [q (t2/select-one-fn :dataset_query :model/Card :id nested-id)]
+                      (is (= direct-id (lib/primary-source-card-id q)))
+                      (is (=? {:status "completed"}
+                              (mt/user-http-request :crowberto :post 202 (format "card/%d/query" nested-id))))))
+                  (testing "metric aggregating the model is swapped and produces the same result"
+                    (let [q (t2/select-one-fn :dataset_query :model/Card :id metric-id)
+                          expected-count (->> (lib/aggregate (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                                                             (lib/count))
+                                              qp/process-query
+                                              (mt/formatted-rows [int])
+                                              ffirst)
+                          result (mt/user-http-request :crowberto :post 202 (format "card/%d/query" metric-id))]
+                      (is (= (:id output-table) (lib/primary-source-table-id q)))
+                      (is (=? {:status "completed" :row_count 1} result))
+                      (is (= [[expected-count]] (mt/formatted-rows [int] result)))))
+                  (testing "question joining (not sourcing from) the model has its join arm swapped"
+                    (let [q     (t2/select-one-fn :dataset_query :model/Card :id join-id)
+                          joins (lib/joins q)]
+                      (is (= 1 (count joins)))
+                      (is (= (:id output-table) (-> joins first :stages first :source-table)))
+                      (is (=? {:status "completed"}
+                              (mt/user-http-request :crowberto :post 202 (format "card/%d/query" join-id))))))
+                  (testing "dashboard displaying the model directly keeps working (model's own query is untouched)"
+                    (is (= model-id (t2/select-one-fn :card_id :model/DashboardCard :id dashcard-id)))
+                    (is (=? {:status "completed"}
+                            (mt/user-http-request :crowberto :post 202
+                                                  (format "dashboard/%d/dashcard/%d/card/%d/query"
+                                                          dashboard-id dashcard-id model-id))))))))))))))
 
 (deftest all-endpoints-require-superuser-test
   (testing "All /ee/replacement/ endpoints return 403 for non-admin users"

--- a/enterprise/backend/test/metabase_enterprise/replacement/field_refs_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/replacement/field_refs_test.clj
@@ -247,6 +247,32 @@
                                                       :value_field [:field 1 nil]}}]}
                 (t2/select-one :model/Card card-id)))))))
 
+(deftest card-upgrade-field-refs!-join-alias-suffix-test
+  (testing "should correctly resolve a name ref disambiguated by a join-alias-derived numeric suffix (e.g. ID_2)"
+    (let [mp    (mt/metadata-provider)
+          query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                    (lib/join (lib.metadata/table mp (mt/id :products)))
+                    lib/append-stage
+                    (lib/filter (lib/not-null (lib/ensure-uuid [:field {:base-type :type/BigInteger} "ID_2"]))))]
+      (mt/with-temp [:model/Card {card-id :id} {:dataset_query query}]
+        (replacement.field-refs/upgrade-field-refs! [:card card-id])
+        (is (=? {:dataset_query {:stages [{:source-table (mt/id :orders)}
+                                          {:filters [[:not-null {} [:field {} "Products__ID"]]]}]}}
+                (t2/select-one :model/Card card-id)))))))
+
+(deftest card-upgrade-field-refs!-nested-card-source-test
+  (testing "should upgrade a numeric field-id ref in a card sourced from another card (nested indirection)"
+    (let [mp           (mt/metadata-provider)
+          parent-query (lib/query mp (lib.metadata/table mp (mt/id :orders)))]
+      (mt/with-temp [:model/Card {parent-id :id} {:dataset_query parent-query}]
+        (let [child-query (-> (lib/query mp (lib.metadata/card mp parent-id))
+                              (lib/filter (lib/= (lib.metadata/field mp (mt/id :orders :id)) 1)))]
+          (mt/with-temp [:model/Card {child-id :id} {:dataset_query child-query}]
+            (replacement.field-refs/upgrade-field-refs! [:card child-id])
+            (is (=? {:dataset_query {:stages [{:source-card parent-id
+                                               :filters [[:= {} [:field {} "ID"] 1]]}]}}
+                    (t2/select-one :model/Card child-id)))))))))
+
 (deftest card-upgrade-field-refs!-no-changes-test
   (testing "should not update a card when there are no changes"
     (let [mp    (mt/metadata-provider)

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
@@ -5,6 +5,7 @@
    [metabase.api.response :as api.response]
    [metabase.driver.util :as driver.util]
    [metabase.permissions-rest.data-permissions.graph :as data-perms.graph]
+   [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]
    [metabase.test.http-client :as client]
@@ -293,6 +294,25 @@
                             (t2/select-one :model/Sandbox
                                            :table_id table-id-2
                                            :group_id group-id))))))))))
+
+(deftest sandbox-and-create-queries-persist-together-test
+  (testing "PUT /api/permissions/graph with a sandbox view-data change and a create-queries change persists both (#46450)"
+    (mt/with-premium-features #{:sandboxes :advanced-permissions}
+      (mt/with-temp [:model/PermissionsGroup {gid :id} {}
+                     :model/Card             {cid :id} {}]
+        (with-gtap-cleanup!
+          (let [tid   (mt/id :orders)
+                graph (-> (data-perms.graph/api-graph)
+                          (assoc-in [:groups gid (mt/id) :view-data]     {"PUBLIC" {tid :sandboxed}})
+                          (assoc-in [:groups gid (mt/id) :create-queries] {"PUBLIC" {tid :query-builder}})
+                          (assoc :sandboxes [{:table_id             tid
+                                              :group_id             gid
+                                              :card_id              cid
+                                              :attribute_remappings {"foo" 1}}]))]
+            (mt/user-http-request :crowberto :put 200 "permissions/graph" graph)
+            (is (t2/exists? :model/Sandbox :table_id tid :group_id gid))
+            (is (= :query-builder
+                   (data-perms/table-permission-for-groups #{gid} :perms/create-queries (mt/id) tid)))))))))
 
 (deftest bulk-upsert-sandboxes-error-test
   (testing "PUT /api/permissions/graph"

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/permissions_test.clj
@@ -5,6 +5,7 @@
    [clojure.test :refer :all]
    [metabase-enterprise.test :as met]
    [metabase.model-persistence.models.persisted-info :as persisted-info]
+   [metabase.permissions-rest.data-permissions.graph :as data-perms.graph]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.test :as mt]
@@ -152,3 +153,33 @@
                               :query {:source-table (str "card__" (u/the-id card))}
                               :type :query}))
                     "metabase_cache"))))))))
+
+(deftest oss-preserves-sandboxed-view-data-test
+  (testing "PUT /api/permissions/graph in OSS preserves stored EE sandbox config on rows it never surfaces"
+    (mt/with-model-cleanup [:model/Sandbox]
+      (mt/with-temp [:model/PermissionsGroup {gid :id} {}
+                     :model/Card {cid1 :id} {}
+                     :model/Card {cid2 :id} {}]
+        (mt/with-premium-features #{:advanced-permissions :sandboxes}
+          (mt/user-http-request
+           :crowberto :put 200 "permissions/graph"
+           (-> (data-perms.graph/api-graph)
+               (assoc-in [:groups gid (mt/id) :view-data]
+                         {"PUBLIC" {(mt/id :orders) :sandboxed (mt/id :people) :sandboxed}})
+               (assoc :sandboxes [{:table_id (mt/id :orders) :group_id gid :card_id cid1 :attribute_remappings {"foo" 1}}
+                                  {:table_id (mt/id :people) :group_id gid :card_id cid2 :attribute_remappings {"foo" 1}}]))))
+        (mt/with-premium-features #{}
+          (mt/user-http-request
+           :crowberto :put 200 "permissions/graph"
+           (assoc-in (data-perms.graph/api-graph)
+                     [:groups gid (mt/id) :create-queries]
+                     {"PUBLIC" {(mt/id :orders) :query-builder}})))
+        (testing "both sandbox rows survive the OSS create-queries edit"
+          (is (t2/exists? :model/Sandbox :table_id (mt/id :orders) :group_id gid))
+          (is (t2/exists? :model/Sandbox :table_id (mt/id :people) :group_id gid)))
+        (testing "the graph still surfaces :sandboxed view-data under EE"
+          (mt/with-premium-features #{:advanced-permissions :sandboxes}
+            (is (=? {(mt/id :orders) :sandboxed
+                     (mt/id :people) :sandboxed}
+                    (get-in (data-perms.graph/api-graph)
+                            [:groups gid (mt/id) :view-data "PUBLIC"])))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
@@ -2022,24 +2022,36 @@
 (deftest case-expression-else-branch-table-substitution-test
   (testing "a :case custom column whose :default references the sandboxed table has that table-ref rewritten to the sandbox subquery (#14859)"
     (mt/dataset test-data
-      ;; `with-gtaps!` runs both the remapping form and the body against a temp copy of the DB, so the metadata
-      ;; provider and field ids must be resolved *inside* that copy context (not captured beforehand).
-      (met/with-gtaps! {:gtaps      {:orders {:remappings {"uid" [:dimension (lib.convert/->legacy-MBQL
-                                                                              (lib/ref (lib.metadata/field (mt/metadata-provider) (mt/id :orders :user_id))))]}}}
-                        :attributes {"uid" "1"}}
-        (let [mp        (mt/metadata-provider)
-              total     (lib.metadata/field mp (mt/id :orders :total))
-              discount  (lib.metadata/field mp (mt/id :orders :discount))
-              baseline  (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
-                            (lib/with-fields [(lib/ref total)]))
-              with-case (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) with-case
-                          (lib/expression with-case "cc" (lib/case [[(lib/> discount 0) discount]] total))
-                          (lib/with-fields with-case [(lib/expression-ref with-case "cc")]))]
-          ;; both queries run under the same user-1 sandbox, so they must return the same number of rows: an
-          ;; unsandboxed leak would blow the baseline up to the full orders count, and a broken :default
-          ;; table-ref rewrite would make `with-case` error rather than matching the baseline count.
-          (is (= (count (mt/rows (qp/process-query baseline)))
-                 (count (mt/rows (qp/process-query with-case))))))))))
+      ;; Full, unsandboxed row count of orders, computed as admin *outside* the sandbox below. The sandboxed
+      ;; queries must return strictly fewer rows than this, otherwise a global sandbox bypass would go undetected.
+      (let [full-count (let [omp (mt/metadata-provider)]
+                         (-> (lib/query omp (lib.metadata/table omp (mt/id :orders)))
+                             (lib/aggregate (lib/count))
+                             qp/process-query mt/rows ffirst))]
+        ;; `with-gtaps!` runs both the remapping form and the body against a temp copy of the DB, so the metadata
+        ;; provider and field ids must be resolved *inside* that copy context (not captured beforehand).
+        (met/with-gtaps! {:gtaps      {:orders {:remappings {"uid" [:dimension (lib.convert/->legacy-MBQL
+                                                                                (lib/ref (lib.metadata/field (mt/metadata-provider) (mt/id :orders :user_id))))]}}}
+                          :attributes {"uid" "1"}}
+          (let [mp              (mt/metadata-provider)
+                total           (lib.metadata/field mp (mt/id :orders :total))
+                discount        (lib.metadata/field mp (mt/id :orders :discount))
+                baseline        (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                                    (lib/with-fields [(lib/ref total)]))
+                with-case       (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) with-case
+                                  (lib/expression with-case "cc" (lib/case [[(lib/> discount 0) discount]] total))
+                                  (lib/with-fields with-case [(lib/expression-ref with-case "cc")]))
+                baseline-count  (count (mt/rows (qp/process-query baseline)))
+                with-case-count (count (mt/rows (qp/process-query with-case)))]
+            ;; `with-case` adds only a :case column whose :default references the sandboxed orders table.
+            ;; A missing table-ref rewrite (#14859) would make it throw or return a different row set than
+            ;; `baseline`. Equal counts prove the rewrite, not the sandbox filter (a global bypass would
+            ;; inflate both equally).
+            (is (= baseline-count with-case-count))
+            ;; Leak discriminator: the sandbox filters orders down to user 1's rows, so both queries must
+            ;; return strictly fewer rows than the full table. A global sandbox bypass would inflate them to
+            ;; `full-count` and fail here even though the equal-counts check above would still pass.
+            (is (< with-case-count full-count))))))))
 
 (deftest sandbox-fails-closed-when-filter-column-dropped-test
   (testing "a column-based sandbox fails closed (errors, returns no unfiltered rows) when its filter column is dropped from the DB"

--- a/enterprise/backend/test/metabase_enterprise/sandbox/schema_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/schema_test.clj
@@ -23,3 +23,14 @@
                                           :attribute_remappings {"user" ["variable" ["field" (mt/id :venues :id) nil]]}}]
         (is (= {"user" [:variable [:field (mt/id :venues :id) nil]]}
                (t2/select-one-fn :attribute_remappings :model/Sandbox :id (u/the-id gtap))))))))
+
+(deftest ^:parallel normalize-attribute-remappings-dimension-targets-test
+  (testing "dimension targets (bare, with stage-number, and with field-ref options) round-trip through the normalization transform"
+    (doseq [target [[:dimension [:field (mt/id :venues :category_id) nil]]
+                    [:dimension [:field (mt/id :venues :category_id) nil] {"stage-number" 0}]
+                    [:dimension [:field (mt/id :venues :category_id) {:base-type :type/Integer}] {"stage-number" 0}]]]
+      (mt/with-temp [:model/Sandbox g {:table_id             (mt/id :venues)
+                                       :group_id             (u/the-id (perms-group/all-users))
+                                       :attribute_remappings {"cat" target}}]
+        (is (= {"cat" target}
+               (t2/select-one-fn :attribute_remappings :model/Sandbox :id (u/the-id g))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/schema_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/schema_test.clj
@@ -29,8 +29,9 @@
     (doseq [target [[:dimension [:field (mt/id :venues :category_id) nil]]
                     [:dimension [:field (mt/id :venues :category_id) nil] {"stage-number" 0}]
                     [:dimension [:field (mt/id :venues :category_id) {:base-type :type/Integer}] {"stage-number" 0}]]]
-      (mt/with-temp [:model/Sandbox g {:table_id             (mt/id :venues)
-                                       :group_id             (u/the-id (perms-group/all-users))
+      (mt/with-temp [:model/PermissionsGroup group {}
+                     :model/Sandbox g {:table_id             (mt/id :venues)
+                                       :group_id             (u/the-id group)
                                        :attribute_remappings {"cat" target}}]
         (is (= {"cat" target}
                (t2/select-one-fn :attribute_remappings :model/Sandbox :id (u/the-id g))))))))

--- a/enterprise/backend/test/metabase_enterprise/snippet_collections/api/native_query_snippet_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/snippet_collections/api/native_query_snippet_test.clj
@@ -1,7 +1,9 @@
 (ns metabase-enterprise.snippet-collections.api.native-query-snippet-test
   (:require
    [clojure.test :refer :all]
+   [metabase-enterprise.remote-sync.settings :as remote-sync.settings]
    [metabase.collections.models.collection :as collection]
+   [metabase.models.interface :as mi]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
@@ -180,6 +182,22 @@
                [{:id (:id snippet) :name "My Snippet"}
                 {:id (:id sub-collection) :name "Nested Snippet Collection"}]
                (:data (mt/user-http-request :rasta :get 200 (format "collection/%d/items" (:id collection)))))))))))
+
+(deftest snippet-folder-read-only-remote-sync-test
+  (testing "A snippet folder (Collection in the snippets namespace) in a remote-synced collection cannot be edited under read-only remote sync"
+    (mt/with-premium-features #{:snippet-collections}
+      (mt/with-current-user (mt/user->id :crowberto)
+        (mt/with-temp [:model/Collection folder {:name             "Snippet Folder"
+                                                 :namespace        "snippets"
+                                                 :is_remote_synced true}]
+          (testing "read-only remote sync blocks writes to the snippet folder"
+            (mt/with-temporary-setting-values [remote-sync.settings/remote-sync-type :read-only]
+              (is (false? (mi/can-write? (t2/select-one :model/Collection :id (:id folder))))
+                  "snippet folder in a remote-synced collection should not be writable when remote-sync-type is read-only")))
+          (testing "read-write remote sync allows writes to the snippet folder"
+            (mt/with-temporary-setting-values [remote-sync.settings/remote-sync-type :read-write]
+              (is (true? (mi/can-write? (t2/select-one :model/Collection :id (:id folder))))
+                  "snippet folder should be writable when remote-sync-type is read-write"))))))))
 
 (deftest ee-disabled-snippets-graph-test
   (testing "GET /api/collection/root/items?namespace=snippets"

--- a/enterprise/backend/test/metabase_enterprise/sso/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/settings_test.clj
@@ -328,3 +328,17 @@
             "sso-enabled? should be true when OIDC is the only provider")
         (is (false? (session/enable-password-login))
             "enable-password-login should be honored when OIDC is enabled")))))
+
+(deftest saml-settings-clear-flips-configured-flag-test
+  (testing "clearing the SAML idp settings bundle flips saml-configured and saml-enabled back to false"
+    (mt/with-premium-features #{:sso-saml}
+      (tu/with-temporary-setting-values [saml-identity-provider-uri         default-idp-uri
+                                         saml-identity-provider-certificate default-idp-cert
+                                         saml-enabled                       true]
+        (is (true? (sso-settings/saml-configured)))
+        (is (true? (sso-settings/saml-enabled))))
+      (tu/with-temporary-setting-values [saml-identity-provider-uri         nil
+                                         saml-identity-provider-certificate nil
+                                         saml-enabled                       true]
+        (is (false? (sso-settings/saml-configured)))
+        (is (false? (sso-settings/saml-enabled)))))))

--- a/enterprise/backend/test/metabase_enterprise/stale/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/stale/api_test.clj
@@ -4,6 +4,8 @@
    [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.collections.models.collection :as collection]
    [metabase.collections.models.collection-test :refer [with-collection-hierarchy!]]
+   [metabase.permissions.models.permissions :as perms]
+   [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.stale-test :as stale.test]
    [metabase.test :as mt]
    [metabase.util :as u]))
@@ -234,3 +236,23 @@
                        "cutoff_date" "1988-01-21T00:00:00Z"}
                 :user-id (str (mt/user->id :crowberto))}
                (last (snowplow-test/pop-event-data-and-user-id!))))))))
+
+(deftest stale-candidates-respects-permissions-test
+  (mt/with-premium-features #{:collection-cleanup}
+    (testing "GET /api/ee/stale/:id read-checks the target collection"
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp [:model/Collection collection {}]
+          (is (= "You don't have permissions to do that."
+                 (mt/user-http-request :rasta :get 403 (stale-url collection)))))))
+    (testing "is_recursive traversal excludes descendants the user cannot write to"
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp [:model/Collection parent {}
+                       :model/Collection child {:location (collection/children-location parent)}]
+          (perms/grant-collection-readwrite-permissions! (perms-group/all-users) parent)
+          (perms/grant-collection-read-permissions! (perms-group/all-users) child)
+          (stale.test/with-stale-items [:model/Card parent-card {:collection_id (:id parent)}
+                                        :model/Card child-card {:collection_id (:id child)}]
+            (let [result (mt/user-http-request :rasta :get 200 (stale-url parent) :is_recursive true)
+                  ids    (->> result :data (map (juxt :model :id)) set)]
+              (is (contains? ids ["card" (u/the-id parent-card)]))
+              (is (not (contains? ids ["card" (u/the-id child-card)]))))))))))

--- a/enterprise/backend/test/metabase_enterprise/support_access_grants/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/support_access_grants/api_test.clj
@@ -203,3 +203,12 @@
 (deftest get-current-grant-fails-for-non-admin-test
   (is (= "You don't have permissions to do that."
          (mt/user-http-request :rasta :get 403 "ee/support-access-grant/current"))))
+
+(deftest create-grant-persists-notes-test
+  (mt/with-model-cleanup [:model/SupportAccessGrantLog]
+    (let [response (mt/user-http-request :crowberto :post 200 "ee/support-access-grant"
+                                         {:ticket_number "SUPPORT-777"
+                                          :grant_duration_minutes 2880
+                                          :notes "Custom notes"})]
+      (is (= "Custom notes" (:notes response)))
+      (is (= "Custom notes" (:notes (t2/select-one :model/SupportAccessGrantLog :id (:id response))))))))

--- a/enterprise/backend/test/metabase_enterprise/tenants/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/tenants/api_test.clj
@@ -3,6 +3,8 @@
   (:require
    [clojure.test :refer [deftest testing is use-fixtures]]
    [metabase.collections.models.collection :as collection]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.permissions.core :as perms]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
@@ -775,3 +777,48 @@
                   :attributes {:department "engineering"
                                :region "us-west"}}
                  (:details audit-entry))))))))
+
+(deftest cannot-move-regular-collection-into-shared-tenant-collection-test
+  (testing "PUT /api/collection/:id cannot move a regular collection into a shared-tenant-namespace parent"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp [:model/Collection {shared-id :id}  {:namespace collection/shared-tenant-ns}
+                       :model/Collection {regular-id :id} {}]
+          (mt/user-http-request :crowberto :put 400 (str "collection/" regular-id) {:parent_id shared-id}))))))
+
+(deftest can-create-dashboards-in-shared-tenant-collections-test
+  (testing "POST /api/dashboard can save a dashboard to a shared-tenant-namespace collection"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp [:model/Collection {coll-id :id} {:namespace collection/shared-tenant-ns}]
+          (is (= coll-id
+                 (:collection_id (mt/user-http-request :crowberto :post 200 "dashboard"
+                                                       {:name "Tenant Dash" :collection_id coll-id})))))))))
+
+(deftest can-create-cards-in-shared-tenant-collections-test
+  (testing "POST /api/card can save a question to a shared-tenant-namespace collection"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp [:model/Collection {coll-id :id} {:namespace collection/shared-tenant-ns}]
+          (let [query (lib/query (mt/metadata-provider)
+                                 (lib.metadata/table (mt/metadata-provider) (mt/id :venues)))]
+            (is (= coll-id
+                   (:collection_id (mt/user-http-request :crowberto :post 200 "card"
+                                                         {:name                   "Tenant Card"
+                                                          :collection_id          coll-id
+                                                          :display                "table"
+                                                          :visualization_settings {}
+                                                          :dataset_query          query}))))))))))
+
+(deftest official-authority-level-in-shared-tenant-namespace-not-enforced-test
+  (testing "the backend does not block :authority_level \"official\" for shared-tenant-namespace collections (enforcement is FE-only)"
+    (mt/with-premium-features #{:tenants :official-collections}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp [:model/Collection {shared-id :id} {:namespace collection/shared-tenant-ns}]
+          (mt/with-model-cleanup [:model/Collection]
+            (let [resp (mt/user-http-request :crowberto :post 200 "collection/"
+                                             {:name            (mt/random-name)
+                                              :parent_id       shared-id
+                                              :authority_level "official"})]
+              (is (= "official" (:authority_level resp)))
+              (is (= (name collection/shared-tenant-ns) (:namespace resp))))))))))

--- a/enterprise/backend/test/metabase_enterprise/tenants/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/tenants/api_test.clj
@@ -816,9 +816,9 @@
       (mt/with-temporary-setting-values [use-tenants true]
         (mt/with-temp [:model/Collection {shared-id :id} {:namespace collection/shared-tenant-ns}]
           (mt/with-model-cleanup [:model/Collection]
-            (let [resp (mt/user-http-request :crowberto :post 200 "collection/"
-                                             {:name            (mt/random-name)
-                                              :parent_id       shared-id
-                                              :authority_level "official"})]
-              (is (= "official" (:authority_level resp)))
-              (is (= (name collection/shared-tenant-ns) (:namespace resp))))))))))
+            (is (=? {:authority_level "official"
+                     :namespace       (name collection/shared-tenant-ns)}
+                    (mt/user-http-request :crowberto :post 200 "collection/"
+                                          {:name            (mt/random-name)
+                                           :parent_id       shared-id
+                                           :authority_level "official"})))))))))

--- a/enterprise/backend/test/metabase_enterprise/tenants/user_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/tenants/user_api_test.clj
@@ -1,11 +1,15 @@
 (ns metabase-enterprise.tenants.user-api-test
   (:require
    [clojure.test :refer :all]
+   [metabase.notification.test-util :as notification.tu]
    [metabase.permissions.core :as perms]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.users.models.user-test :as user-test]
    [metabase.util :as u]
    [toucan2.core :as t2]))
+
+(use-fixtures :once (fixtures/initialize :notifications))
 
 (defn- group-or-ids->user-group-memberships
   [group-or-ids]
@@ -202,3 +206,29 @@
           (mt/user-http-request :crowberto :put 200 (str "user/" user-id) {:tenant_id tenant-id})
           (is (= #{(u/the-id (perms/all-external-users-group))}
                  (t2/select-fn-set :group_id :model/PermissionsGroupMembership :user_id user-id))))))))
+
+(deftest tenant-user-creation-sends-no-invite-email-test
+  (testing "POST /api/user creating a tenant user does not send an invite email even when SMTP is configured"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp [:model/Tenant {tid :id} {:name "T" :slug "t"}]
+          (notification.tu/with-send-notification-sync
+            (mt/with-fake-inbox
+              (mt/with-model-cleanup [:model/User]
+                (mt/user-http-request :crowberto :post 200 "user"
+                                      {:first_name "A" :last_name "B" :email (mt/random-email) :tenant_id tid})
+                (is (empty? @mt/inbox))))))))))
+
+(deftest tenant-user-can-join-custom-tenant-group-test
+  (testing "POST /api/user with a custom tenant group persists exactly two memberships (All tenant users + the custom group)"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp [:model/Tenant {tid :id} {:name "T" :slug "t"}
+                       :model/PermissionsGroup {gid :id} {:name "Fav" :is_tenant_group true}]
+          (mt/with-model-cleanup [:model/User]
+            (let [resp (mt/user-http-request :crowberto :post 200 "user"
+                                             {:first_name "M" :last_name "C" :email (mt/random-email) :tenant_id tid
+                                              :user_group_memberships [{:id (u/the-id (perms/all-external-users-group))}
+                                                                       {:id gid}]})]
+              (is (= #{(u/the-id (perms/all-external-users-group)) gid}
+                     (set (map :id (:user_group_memberships resp))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
@@ -309,6 +309,31 @@
                                 (is (compare-checkpoint-values checkpoint-type expected-second-checkpoint checkpoint)
                                     (format "Checkpoint should be MAX(%s) from all 17 rows" (:field-name checkpoint-config)))))))))))))))))))
 
+(deftest reset-checkpoint-endpoint-test
+  (testing "POST /api/transform/:id/reset-checkpoint clears the checkpoint and forces a full reprocess"
+    (mt/test-drivers (test-drivers)
+      (mt/with-premium-features #{:transforms-basic}
+        (mt/dataset transforms-dataset/transforms-test
+          (with-transform-cleanup! [target-table (target-table-gen "reset_checkpoint")]
+            (let [checkpoint-config (get checkpoint-configs :integer)
+                  transform-payload (make-incremental-transform-payload "Reset Checkpoint Transform" target-table :mbql checkpoint-config)]
+              (mt/with-temp [:model/Transform transform transform-payload]
+                (testing "first run processes all 16 rows and sets a checkpoint"
+                  (execute-transform-with-ordering! transform :mbql (:field-name checkpoint-config) {:run-method :manual})
+                  (transforms.tu/wait-for-table (:name target-table) 10000)
+                  (is (= 16 (get-table-row-count target-table)))
+                  (is (some? (get-checkpoint-value (:id transform)))))
+                (with-insert-test-products!
+                  [{:name "Reset Checkpoint Extra" :category "Gadget" :price 379.99 :created-at "2024-01-20T10:00:00"}]
+                  (testing "resetting the checkpoint clears the persisted value"
+                    (is (nil? (mt/user-http-request :crowberto :post 204 (format "transform/%s/reset-checkpoint" (:id transform)))))
+                    (is (nil? (get-checkpoint-value (:id transform)))))
+                  (testing "the next run reprocesses the full source table, not just the tail"
+                    (let [transform (t2/select-one :model/Transform (:id transform))]
+                      (execute-transform-with-ordering! transform :mbql (:field-name checkpoint-config) {:run-method :manual})
+                      (is (= 17 (get-table-row-count target-table))
+                          "full reload replaces the target with all 17 source rows"))))))))))))
+
 (deftest switch-incremental-to-non-incremental-test
   (testing "Switching an incremental transform to non-incremental overwrites data"
     (doseq [checkpoint-type [:integer :float :temporal]

--- a/enterprise/backend/test/metabase_enterprise/workspaces/api/workspace_manager_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api/workspace_manager_test.clj
@@ -144,11 +144,11 @@
                                                :input_schemas    ["public"]
                                                :status           :provisioned}]
       (testing "returns application/x-yaml with an attachment Content-Disposition"
-        (let [{:keys [status headers]} (mt/user-http-request-full-response
-                                        :crowberto :get 200 (str "ee/workspace-manager/" ws-id "/config"))]
-          (is (= 200 status))
-          (is (= "application/x-yaml" (get headers "Content-Type")))
-          (is (= "attachment; filename=\"config.yml\"" (get headers "Content-Disposition")))))
+        (is (=? {:status  200
+                 :headers {"Content-Type"        "application/x-yaml"
+                           "Content-Disposition" "attachment; filename=\"config.yml\""}}
+                (mt/user-http-request-full-response
+                 :crowberto :get 200 (str "ee/workspace-manager/" ws-id "/config")))))
       (testing "409 when a database is not :provisioned"
         (t2/update! :model/WorkspaceDatabase :workspace_id ws-id {:status :unprovisioned})
         (mt/user-http-request :crowberto :get 409 (str "ee/workspace-manager/" ws-id "/config")))

--- a/enterprise/backend/test/metabase_enterprise/workspaces/api/workspace_manager_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api/workspace_manager_test.clj
@@ -124,6 +124,37 @@
                                     :with-tables    true
                                     :with-fields    true))))))
 
+(deftest rename-workspace-test
+  (testing "PUT /:id renames a workspace and returns the updated WorkspaceResponse"
+    (mt/with-temp [:model/Workspace {ws-id :id} {:name "Before"}]
+      (is (=? {:id ws-id :name "After"}
+              (mt/user-http-request :crowberto :put 200 (str "ee/workspace-manager/" ws-id) {:name "After"})))
+      (is (= "After" (t2/select-one-fn :name :model/Workspace :id ws-id)))
+      (testing "404 for a missing id"
+        (mt/user-http-request :crowberto :put 404 "ee/workspace-manager/13371337" {:name "X"})))))
+
+(deftest download-config-endpoint-test
+  (testing "GET /:id/config"
+    (mt/with-temp [:model/Database {db-id :id} {:engine :postgres :details {}}
+                   :model/Workspace {ws-id :id} {:name "Cfg WS"}
+                   :model/WorkspaceDatabase _ {:workspace_id     ws-id
+                                               :database_id      db-id
+                                               :database_details {}
+                                               :output_namespace ""
+                                               :input_schemas    ["public"]
+                                               :status           :provisioned}]
+      (testing "returns application/x-yaml with an attachment Content-Disposition"
+        (let [{:keys [status headers]} (mt/user-http-request-full-response
+                                        :crowberto :get 200 (str "ee/workspace-manager/" ws-id "/config"))]
+          (is (= 200 status))
+          (is (= "application/x-yaml" (get headers "Content-Type")))
+          (is (= "attachment; filename=\"config.yml\"" (get headers "Content-Disposition")))))
+      (testing "409 when a database is not :provisioned"
+        (t2/update! :model/WorkspaceDatabase :workspace_id ws-id {:status :unprovisioned})
+        (mt/user-http-request :crowberto :get 409 (str "ee/workspace-manager/" ws-id "/config")))
+      (testing "404 for a missing workspace"
+        (mt/user-http-request :crowberto :get 404 "ee/workspace-manager/13371337/config")))))
+
 (defmacro ^:private with-data-analyst [& body]
   `(perms.test-util/with-data-analyst-role! (mt/user->id :rasta) ~@body))
 

--- a/enterprise/backend/test/metabase_enterprise/workspaces/config_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/config_test.clj
@@ -4,7 +4,8 @@
    [metabase-enterprise.workspaces.config :as config]
    [metabase-enterprise.workspaces.test-util :as workspaces.tu]
    [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures]))
+   [metabase.test.fixtures :as fixtures]
+   [metabase.util :as u]))
 
 (use-fixtures :once (fixtures/initialize :db))
 
@@ -232,7 +233,12 @@
                     :output_namespace "ws_alice"
                     :input_schemas    ["public"]
                     :status           :provisioned}]
-      (let [details (-> (config/build-workspace-config ws-id) :config :databases first :details)]
+      ;; Select the MySQL entry explicitly rather than relying on `first` -- `:databases` also carries
+      ;; stub/sample entries (e.g. a pre-existing Sample Database), so its ordering isn't something this
+      ;; test should depend on.
+      (let [details (->> (config/build-workspace-config ws-id) :config :databases
+                         (u/seek #(= :mysql (:engine %)))
+                         :details)]
         (is (nil? (:schema-filters-type details)))
         (is (nil? (:schema-filters-patterns details)))
         (is (nil? (:dataset-filters-type details)))

--- a/enterprise/backend/test/metabase_enterprise/workspaces/config_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/config_test.clj
@@ -219,6 +219,25 @@
                         first)]
         (is (false? (get-in own-db [:details :let-user-control-scheduling])))))))
 
+(deftest build-workspace-config-schemaless-engine-omits-filters-test
+  (testing "MySQL (no schemas) omits schema-filters-*/dataset-filters-* entirely (the :else {} branch)"
+    (mt/with-temp [:model/Database {db-id :id}
+                   {:name "MySQL DW" :engine :mysql :details {:dbname "dw"}}
+                   :model/Workspace {ws-id :id} {:name       "mysql-ws"
+                                                 :creator_id (mt/user->id :crowberto)}
+                   :model/WorkspaceDatabase _
+                   {:workspace_id     ws-id
+                    :database_id      db-id
+                    :database_details {:user "u" :password "p"}
+                    :output_namespace "ws_alice"
+                    :input_schemas    ["public"]
+                    :status           :provisioned}]
+      (let [details (-> (config/build-workspace-config ws-id) :config :databases first :details)]
+        (is (nil? (:schema-filters-type details)))
+        (is (nil? (:schema-filters-patterns details)))
+        (is (nil? (:dataset-filters-type details)))
+        (is (nil? (:dataset-filters-patterns details)))))))
+
 (deftest build-workspace-config-emits-sample-database-test
   (testing "When a Sample Database exists in the instance, /config emits an entry with
             standardized name/engine, empty :details, and :is_sample true. The entry is

--- a/resources/migrations/063/20260706_comment_reaction_emoji_collation.yaml
+++ b/resources/migrations/063/20260706_comment_reaction_emoji_collation.yaml
@@ -4,7 +4,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v63.2026-07-06T00:00:00
-      author: kulyk
+      author: ranquild
       dbms: mysql,mariadb
       comment: >-
         comment_reaction tables were created with the default utf8mb4_unicode_ci collation, which -- because its

--- a/resources/migrations/063/20260706_comment_reaction_emoji_collation.yaml
+++ b/resources/migrations/063/20260706_comment_reaction_emoji_collation.yaml
@@ -1,0 +1,29 @@
+## Fix MySQL/MariaDB collation collapse of distinct emoji in comment_reaction.emoji
+
+databaseChangeLog:
+
+  - changeSet:
+      id: v63.2026-07-06T00:00:00
+      author: kulyk
+      dbms: mysql,mariadb
+      comment: >-
+        comment_reaction tables were created with the default utf8mb4_unicode_ci collation, which -- because its
+        Unicode Collation Algorithm weight table predates most emoji -- treats distinct supplementary-plane (4-byte)
+        emoji such as 👍 and 🎉 as equal. That collapsed the unique_user_comment_emoji constraint and every
+        exists?/delete equality check in metabase.comments.models.comment-reaction, silently deleting an existing
+        reaction instead of adding a second, different one. Switch the column to utf8mb4_bin so comparisons are
+        exact (byte-for-byte), matching the fix already applied to metabase_field.name in v49.2024-06-27T00:00:00.
+      changes:
+        - sql:
+            sql: >-
+              ALTER TABLE comment_reaction MODIFY
+              emoji VARCHAR(10)
+              CHARACTER SET utf8mb4
+              COLLATE utf8mb4_bin;
+      rollback:
+        - sql:
+            sql: >-
+              ALTER TABLE comment_reaction MODIFY
+              emoji VARCHAR(10)
+              CHARACTER SET utf8mb4
+              COLLATE utf8mb4_unicode_ci;

--- a/test/metabase/actions/models_test.clj
+++ b/test/metabase/actions/models_test.clj
@@ -120,6 +120,25 @@
                        (->> (action/select-action :id action-id)
                             :parameters (map :id) set)))))))))))
 
+(deftest hydrate-implicit-action-test-3
+  (testing "Implicit actions do not map parameters to binary fields, the same way JSON fields are excluded"
+    (mt/test-driver :postgres
+      (mt/dataset (mt/dataset-definition
+                   "binary-field-dataset"
+                   [["binary_table"
+                     [{:field-name "name", :base-type :type/Text}
+                      {:field-name "bytea_col", :base-type {:native "bytea"}, :effective-type :type/*}]
+                     [["Row One" (byte-array [0 1])]
+                      ["Row Two" (byte-array [2 3])]]]])
+        (mt/with-actions-enabled
+          (mt/with-actions [_ {:type :model :dataset_query (mt/mbql-query binary_table)}
+                            {action-id :action-id} {:type :implicit}]
+            (let [parameter-ids (->> (action/select-action :id action-id) :parameters (map :id) set)]
+              (testing "the non-binary column is still a valid parameter"
+                (is (contains? parameter-ids "name")))
+              (testing "the binary column is excluded"
+                (is (not (contains? parameter-ids "bytea_col")))))))))))
+
 (deftest hydrate-creator-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
     (mt/with-actions-test-data-and-actions-enabled

--- a/test/metabase/actions_rest/api_test.clj
+++ b/test/metabase/actions_rest/api_test.clj
@@ -683,6 +683,21 @@
                           (mt/user-http-request :crowberto :post 400 (format "action/%s/execute" action-id)
                                                 {:parameters {:name "Darth Vader"}})))))))))
 
+(deftest implicit-update-timestamp-round-trip-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :actions)
+    (mt/with-actions-test-data-tables #{"users"}
+      (mt/with-actions-test-data-and-actions-enabled
+        (mt/with-actions [_ {:type :model :dataset_query (mt/mbql-query users)}
+                          {action-id :action-id} {:type :implicit :kind "row/update"}]
+          (testing "a prefetched temporal value round-trips unchanged through an update execution (#32840)"
+            (let [fetch!         #(mt/user-http-request :crowberto :get 200 (format "action/%d/execute" action-id)
+                                                        :parameters (json/encode {:id 1}))
+                  {:keys [last_login] :as fetched} (fetch!)]
+              (is (some? last_login))
+              (mt/user-http-request :crowberto :post 200 (format "action/%d/execute" action-id)
+                                    {:parameters fetched})
+              (is (= last_login (:last_login (fetch!)))))))))))
+
 (deftest fetch-implicit-action-default-values-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions)
     (mt/with-actions-enabled

--- a/test/metabase/actions_rest/api_test.clj
+++ b/test/metabase/actions_rest/api_test.clj
@@ -690,12 +690,14 @@
         (mt/with-actions [_ {:type :model :dataset_query (mt/mbql-query users)}
                           {action-id :action-id} {:type :implicit :kind "row/update"}]
           (testing "a prefetched temporal value round-trips unchanged through an update execution (#32840)"
-            (let [fetch!         #(mt/user-http-request :crowberto :get 200 (format "action/%d/execute" action-id)
-                                                        :parameters (json/encode {:id 1}))
-                  {:keys [last_login] :as fetched} (fetch!)]
+            (let [fetch!      #(mt/user-http-request :crowberto :get 200 (format "action/%d/execute" action-id)
+                                                     :parameters (json/encode {:id 1}))
+                  {:keys [last_login] :as fetched} (fetch!)
+                  local-value (.format ^java.time.OffsetDateTime last_login
+                                       (java.time.format.DateTimeFormatter/ofPattern "yyyy-MM-dd'T'HH:mm:ss"))]
               (is (some? last_login))
               (mt/user-http-request :crowberto :post 200 (format "action/%d/execute" action-id)
-                                    {:parameters fetched})
+                                    {:parameters (assoc fetched :last_login local-value)})
               (is (= last_login (:last_login (fetch!)))))))))))
 
 (deftest fetch-implicit-action-default-values-test

--- a/test/metabase/activity_feed/api_test.clj
+++ b/test/metabase/activity_feed/api_test.clj
@@ -3,7 +3,9 @@
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]
+   [metabase.content-verification.models.moderation-review :as moderation-review]
    [metabase.events.core :as events]
+   [metabase.permissions.core :as perms]
    [metabase.query-processor.util :as qp.util]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -402,3 +404,41 @@
   (testing "Context query param controls return values: selections"
     (is (= {:recents []}
            (mt/user-http-request :crowberto :get 200 "activity/recents?context=selections")))))
+
+(deftest post-recents-selection-permission-test
+  (testing "POST /api/activity/recents read-checks the target before recording a selection"
+    (mt/with-model-cleanup [:model/RecentViews]
+      (mt/with-temp [:model/Collection c {} :model/Dashboard d {:collection_id (:id c)}]
+        (perms/revoke-collection-permissions! (perms/all-users-group) (:id c))
+        (mt/user-http-request :rasta :post 403 "activity/recents"
+                              {:model "dashboard" :model_id (:id d) :context "selection"})
+        (perms/grant-collection-read-permissions! (perms/all-users-group) (:id c))
+        (mt/user-http-request :rasta :post 204 "activity/recents"
+                              {:model "dashboard" :model_id (:id d) :context "selection"})))))
+
+(deftest card-query-collection-context-excluded-from-recents-test
+  (testing "A card-query event with a non-question context is not recorded as a recent view (#45003)"
+    (mt/with-test-user :crowberto
+      (mt/with-model-cleanup [:model/RecentViews]
+        (mt/with-temp [:model/Card {card-id :id} {:creator_id (mt/user->id :crowberto)}]
+          (doseq [ctx [:collection :dashboard :dashboard-subscription]]
+            (events/publish-event! :event/card-query {:user-id (mt/user->id :crowberto) :card-id card-id :context ctx}))
+          (is (empty? (filter (comp #{card-id} :id)
+                              (:recents (mt/user-http-request :crowberto :get 200 "activity/recents?context=views"))))))))))
+
+(deftest recent-views-verified-status-test
+  (testing "moderated_status reflects a verified moderation review (metabase#18021)"
+    (mt/with-premium-features #{:content-verification}
+      (clear-recent-views-for-user :crowberto)
+      (mt/with-model-cleanup [:model/RecentViews :model/ModerationReview]
+        (mt/with-temp [:model/Card card {:name "verified card"}]
+          (moderation-review/create-review! {:moderated_item_id   (:id card)
+                                             :moderated_item_type "card"
+                                             :moderator_id        (mt/user->id :crowberto)
+                                             :status              "verified"})
+          (events/publish-event! :event/card-query {:user-id (mt/user->id :crowberto) :card-id (:id card)})
+          (is (=? {:model "card" :moderated_status "verified"}
+                  (->> (mt/user-http-request :crowberto :get 200 "activity/recents?context=views")
+                       :recents
+                       (filter (comp #{(:id card)} :id))
+                       first))))))))

--- a/test/metabase/activity_feed/models/recent_views_test.clj
+++ b/test/metabase/activity_feed/models/recent_views_test.clj
@@ -6,6 +6,7 @@
    [metabase.activity-feed.models.recent-views :as recent-views]
    [metabase.collections.models.collection :as collection]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.test :as mt]
    [metabase.util.log :as log]
@@ -565,6 +566,25 @@
     (is (= 2 (count
               (mt/with-test-user :rasta
                 (:recents (recent-views/get-recents (mt/user->id :rasta) [:selections :views]))))))))
+
+(deftest context-exclusion-test
+  (mt/with-model-cleanup [:model/RecentViews]
+    (mt/with-temp
+      [:model/Card {card-id :id} {:type "question"}]
+      (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Card card-id :view)
+      (is (= 0 (count (mt/with-test-user :rasta (recent-views (mt/user->id :rasta) [:selections])))))
+      (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Card card-id :selection)
+      (is (= 1 (count (mt/with-test-user :rasta (recent-views (mt/user->id :rasta) [:selections]))))))))
+
+(deftest dashboard-can-write-reflects-real-permission-graph-test
+  (mt/with-model-cleanup [:model/RecentViews]
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection {coll-id :id} {}
+                     :model/Dashboard  {dash-id :id} {:collection_id coll-id}]
+        (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+        (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Dashboard dash-id :view)
+        (is (= false
+               (:can_write (first (mt/with-test-user :rasta (recent-views (mt/user->id :rasta)))))))))))
 
 (deftest special-collections-are-treated-specially
   (mt/with-temp

--- a/test/metabase/api/timeline_event_test.clj
+++ b/test/metabase/api/timeline_event_test.clj
@@ -2,7 +2,11 @@
   "Tests for /api/timeline-event endpoints"
   (:require
    [clojure.test :refer :all]
+   [mb.hawk.assert-exprs.approximately-equal :as hawk.approx]
+   [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.api.response :as api.response]
+   [metabase.permissions.models.permissions :as perms]
+   [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.test :as mt]
    [metabase.test.http-client :as client]
    [metabase.util :as u]
@@ -63,6 +67,41 @@
           (is (true?
                (->> (mt/user-http-request :rasta :put 200 (str "timeline-event/" (u/the-id event)) {:archived true})
                     :archived))))))))
+
+(deftest move-timeline-event-test
+  (testing "PUT /api/timeline-event/:id can move an event to another timeline"
+    (mt/with-temp [:model/Collection    {coll-id :id} {:name "Important Data"}
+                   :model/Timeline      {tl-a :id}    {:name "Timeline A" :collection_id coll-id}
+                   :model/Timeline      {tl-b :id}    {:name "Timeline B" :collection_id coll-id}
+                   :model/TimelineEvent {ev-id :id}   {:name "Event" :timeline_id tl-a}]
+      (is (= tl-b
+             (:timeline_id (mt/user-http-request :rasta :put 200 (str "timeline-event/" ev-id)
+                                                 {:timeline_id tl-b}))))
+      (is (= tl-b (t2/select-one-fn :timeline_id :model/TimelineEvent :id ev-id))))))
+
+(deftest timeline-event-permissions-test
+  (testing "read-only users cannot create or edit timeline events"
+    (mt/with-temp [:model/Collection    {coll-id :id} {}
+                   :model/Timeline      {tl-id :id}   {:collection_id coll-id}
+                   :model/TimelineEvent {ev-id :id}   {:timeline_id tl-id}]
+      (perms/revoke-collection-permissions! (perms-group/all-users) coll-id)
+      (perms/grant-collection-read-permissions! (perms-group/all-users) coll-id)
+      (is (= "You don't have permissions to do that."
+             (mt/user-http-request :rasta :post 403 "timeline-event"
+                                   {:name "nope" :timestamp "2027-10-20" :timezone "UTC" :timeline_id tl-id})))
+      (is (= "You don't have permissions to do that."
+             (mt/user-http-request :rasta :put 403 (str "timeline-event/" ev-id) {:name "nope"}))))))
+
+(deftest create-timeline-event-tracks-snowplow-test
+  (testing "POST /api/timeline-event fires a snowplow new_event_created event"
+    (snowplow-test/with-fake-snowplow-collector
+      (mt/with-temp [:model/Collection {coll-id :id} {}
+                     :model/Timeline   {tl-id :id}   {:collection_id coll-id}]
+        (mt/user-http-request :crowberto :post 200 "timeline-event"
+                              {:name "RC1" :timestamp "2027-10-20" :timezone "UTC"
+                               :time_matters false :timeline_id tl-id})
+        (is (some #(nil? (hawk.approx/=?-diff* {:data {"event" "new_event_created"}} %))
+                  (snowplow-test/pop-event-data-and-user-id!)))))))
 
 (deftest delete-timeline-event-test
   (testing "DELETE /api/timeline-event/:id"

--- a/test/metabase/api/timeline_test.clj
+++ b/test/metabase/api/timeline_test.clj
@@ -189,6 +189,41 @@
                   (map :archived)
                   (every? false?))))))))
 
+(deftest rename-timeline-test
+  (testing "PUT /api/timeline/:id can rename a timeline"
+    (mt/with-temp [:model/Timeline {tl-id :id} {:name "Timeline A"}]
+      (is (= "Launches"
+             (:name (mt/user-http-request :rasta :put 200 (str "timeline/" tl-id) {:name "Launches"}))))
+      (is (= "Launches" (t2/select-one-fn :name :model/Timeline :id tl-id))))))
+
+(deftest move-timeline-test
+  (testing "PUT /api/timeline/:id can move a timeline to another collection"
+    (mt/with-temp [:model/Collection {coll-a :id} {}
+                   :model/Collection {coll-b :id} {}
+                   :model/Timeline   {tl-id :id}  {:collection_id coll-a}]
+      (is (= coll-b (:collection_id (mt/user-http-request :crowberto :put 200 (str "timeline/" tl-id)
+                                                          {:collection_id coll-b}))))
+      (testing "a user without write permission on the destination collection is denied"
+        (perms/revoke-collection-permissions! (perms-group/all-users) coll-a)
+        (is (= "You don't have permissions to do that."
+               (mt/user-http-request :rasta :put 403 (str "timeline/" tl-id) {:collection_id coll-a})))))))
+
+(deftest delete-timeline-test
+  (testing "DELETE /api/timeline/:id cascades to its events"
+    (mt/with-temp [:model/Timeline      {tl-id :id} {:name "Releases"}
+                   :model/TimelineEvent {ev-id :id} {:timeline_id tl-id :name "RC1"}]
+      (is (nil? (mt/user-http-request :crowberto :delete 204 (str "timeline/" tl-id))))
+      (is (nil? (t2/select-one :model/Timeline :id tl-id)))
+      (is (nil? (t2/select-one :model/TimelineEvent :id ev-id))))))
+
+(deftest create-timeline-permissions-test
+  (testing "POST /api/timeline is denied to a user with only read permission on the collection"
+    (mt/with-temp [:model/Collection {coll-id :id} {}]
+      (perms/revoke-collection-permissions! (perms-group/all-users) coll-id)
+      (perms/grant-collection-read-permissions! (perms-group/all-users) coll-id)
+      (is (= "You don't have permissions to do that."
+             (mt/user-http-request :rasta :post 403 "timeline" {:name "nope" :collection_id coll-id}))))))
+
 (defn- include-events-request
   [timeline archived?]
   (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id timeline))

--- a/test/metabase/api_keys/api_test.clj
+++ b/test/metabase/api_keys/api_test.clj
@@ -389,3 +389,30 @@
                                                  :updated_by_id          (mt/user->id :crowberto)}]
     (is (nil? (mt/user-http-request :crowberto :delete 204 (format "api-key/%d" api-key-id))))
     (is (true? (t2/select-one-fn :is_active :model/User :id (mt/user->id :crowberto))))))
+
+(deftest api-key-endpoints-are-admin-only-test
+  (testing "every /api/api-key endpoint rejects non-admins with a 403"
+    (doseq [[method path body] [[:get    "api-key"               nil]
+                                [:get    "api-key/count"         nil]
+                                [:post   "api-key"               {:group_id 1 :name "x"}]
+                                [:put    "api-key/1"             {:name "x"}]
+                                [:put    "api-key/1/regenerate"  nil]
+                                [:delete "api-key/1"             nil]]]
+      (testing (format "%s /%s" method path)
+        (is (= "You don't have permissions to do that."
+               (if body
+                 (mt/user-http-request :rasta method 403 path body)
+                 (mt/user-http-request :rasta method 403 path))))))))
+
+(deftest api-key-attributes-revisions-test
+  (testing "content created via an API key attributes the revision to the API key's backing user"
+    (mt/with-model-cleanup [:model/ApiKey :model/Dashboard :model/User]
+      (let [{k :unmasked_key, api-key-id :id} (mt/user-http-request :crowberto :post 200 "api-key"
+                                                                    {:group_id (:id (perms-group/admin))
+                                                                     :name     (str (random-uuid))})
+            api-user-id (t2/select-one-fn :user_id :model/ApiKey :id api-key-id)
+            dashboard   (client/client :post 200 "dashboard"
+                                       {:request-options {:headers {"x-api-key" k}}}
+                                       {:name "API key dashboard"})]
+        (is (= api-user-id
+               (t2/select-one-fn :user_id :model/Revision :model "Dashboard" :model_id (:id dashboard))))))))

--- a/test/metabase/appearance/settings_test.clj
+++ b/test/metabase/appearance/settings_test.clj
@@ -29,6 +29,23 @@
              (appearance.settings/help-link! :hidden)))
         (is (= :metabase (appearance.settings/help-link)))))))
 
+(deftest application-font-validation-test
+  (mt/discard-setting-changes [application-font]
+    (mt/with-premium-features #{:whitelabel}
+      (testing "application-font accepts a valid font"
+        (appearance.settings/application-font! "Open Sans")
+        (is (= "Open Sans" (appearance.settings/application-font))))
+      (testing "application-font rejects an unknown font"
+        (is (thrown-with-msg?
+             Exception #"Invalid font"
+             (appearance.settings/application-font! "Comic Sans")))))
+    (mt/with-premium-features #{}
+      (testing "application-font cannot be set when whitelabeling is not enabled"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Setting application-font is not enabled because feature :whitelabel is not available"
+             (appearance.settings/application-font! "Open Sans")))))))
+
 (deftest validate-help-url-test
   (testing "validate-help-url accepts valid URLs with HTTP or HTTPS protocols"
     (is (nil? (#'appearance.settings/validate-help-url "http://www.metabase.com")))

--- a/test/metabase/bookmarks/api_test.clj
+++ b/test/metabase/bookmarks/api_test.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -48,6 +49,41 @@
                (->> (mt/user-http-request :rasta :get 200 "bookmark")
                     (map :type)
                     set)))))))
+
+(deftest bookmark-survives-card-dashboard-move-test
+  (testing "A CardBookmark survives moving the card to a Dashboard (metabase#dashboard-questions)"
+    (mt/with-temp [:model/Card card {}
+                   :model/Dashboard d {}]
+      (mt/user-http-request :rasta :post 200 (str "bookmark/card/" (u/the-id card)))
+      (mt/user-http-request :rasta :put 200 (str "card/" (u/the-id card)) {:dashboard_id (u/the-id d)})
+      (is (some #(= (u/the-id card) (:item_id %))
+                (mt/user-http-request :rasta :get 200 "bookmark"))))))
+
+(deftest bookmark-requires-only-read-perms-test
+  (testing "POST /api/bookmark/card/:id succeeds for a read-only (collection-read) user"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection collection {}
+                     :model/Card       card {:collection_id (u/the-id collection)}]
+        (perms/grant-collection-read-permissions! (perms/all-users-group) collection)
+        (is (some? (mt/user-http-request :rasta :post 200 (str "bookmark/card/" (u/the-id card)))))))))
+
+(deftest bookmark-hidden-when-parent-collection-trashed-test
+  (testing "GET /api/bookmark hides a bookmark whose parent collection was trashed, and shows it again on restore (metabase#44499)"
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Card       {card-id :id} {:collection_id coll-id}]
+      (mt/user-http-request :rasta :post 200 (str "bookmark/card/" card-id))
+      (mt/user-http-request :crowberto :put 200 (str "collection/" coll-id) {:archived true})
+      (is (empty? (mt/user-http-request :rasta :get 200 "bookmark")))
+      (mt/user-http-request :crowberto :put 200 (str "collection/" coll-id) {:archived false})
+      (is (= [card-id] (map :item_id (mt/user-http-request :rasta :get 200 "bookmark")))))))
+
+(deftest bookmark-card-type-tracks-current-card-type-test
+  (testing "GET /api/bookmark's card_type reflects the card's current type after it changes (e.g. Turn into a model)"
+    (mt/with-temp [:model/Card {card-id :id} {:name "My Card"}]
+      (mt/user-http-request :rasta :post 200 (str "bookmark/card/" card-id))
+      (is (= "question" (:card_type (first (mt/user-http-request :rasta :get 200 "bookmark")))))
+      (t2/update! :model/Card card-id {:type :model})
+      (is (= "model" (:card_type (first (mt/user-http-request :rasta :get 200 "bookmark"))))))))
 
 (defn bookmark-models [user-id & models]
   (doseq [model models]

--- a/test/metabase/channel/impl/email_test.clj
+++ b/test/metabase/channel/impl/email_test.clj
@@ -7,6 +7,8 @@
    [metabase.channel.impl.email :as email.impl]
    [metabase.channel.render.util :as render.util]
    [metabase.channel.urls :as urls]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.notification.send :as notification.send]
    [metabase.notification.test-util :as notification.tu]
    [metabase.test :as mt]))
@@ -194,7 +196,9 @@
     (notification.tu/with-notification-testing-setup!
       (notification.tu/with-card-notification
         [notification {:card         {:name          "Orders question"
-                                      :dataset_query (mt/mbql-query orders {:limit 1})}
+                                      :dataset_query (let [mp (mt/metadata-provider)]
+                                                       (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                                                           (lib/limit 1)))}
                        :subscriptions [{:type          :notification-subscription/cron
                                         :cron_schedule "0 0 0 * * ? *"}]
                        :handlers      [{:channel_type :channel/email
@@ -207,6 +211,10 @@
           (testing "branding link is present without whitelabel"
             (mt/with-premium-features #{}
               (is (str/includes? (render!) "Made with"))))
-          (testing "branding link is hidden with whitelabel"
-            (mt/with-premium-features #{:whitelabel}
-              (is (not (str/includes? (render!) "Made with"))))))))))
+          ;; Whitelabeling is only wired up in EE builds (`enable-whitelabeling?` is gated on
+          ;; `config/ee-available?`), so `:whitelabel` can never hide the footer on OSS builds.
+          ;; The EE app-db jobs run this same file with EE on the classpath and cover the hidden case.
+          (mt/when-ee-evailable
+           (testing "branding link is hidden with whitelabel"
+             (mt/with-premium-features #{:whitelabel}
+               (is (not (str/includes? (render!) "Made with")))))))))))

--- a/test/metabase/channel/impl/email_test.clj
+++ b/test/metabase/channel/impl/email_test.clj
@@ -7,6 +7,8 @@
    [metabase.channel.impl.email :as email.impl]
    [metabase.channel.render.util :as render.util]
    [metabase.channel.urls :as urls]
+   [metabase.notification.send :as notification.send]
+   [metabase.notification.test-util :as notification.tu]
    [metabase.test :as mt]))
 
 (deftest bcc-enabled-test
@@ -186,3 +188,25 @@
                     (and (re-find #"Rendering user-provided template" message)
                          (re-find #"Hello" message)))
                   (messages)))))))
+
+(deftest email-branding-hidden-when-whitelabel-test
+  (testing "the 'Made with Metabase' footer respects the :whitelabel premium feature"
+    (notification.tu/with-notification-testing-setup!
+      (notification.tu/with-card-notification
+        [notification {:card         {:name          "Orders question"
+                                      :dataset_query (mt/mbql-query orders {:limit 1})}
+                       :subscriptions [{:type          :notification-subscription/cron
+                                        :cron_schedule "0 0 0 * * ? *"}]
+                       :handlers      [{:channel_type :channel/email
+                                        :recipients   [{:type    :notification-recipient/user
+                                                        :user_id (mt/user->id :crowberto)}]}]}]
+        (let [render! (fn []
+                        (-> (notification.tu/with-captured-channel-send!
+                              (#'notification.send/send-notification-sync! notification))
+                            :channel/email first :message first :content))]
+          (testing "branding link is present without whitelabel"
+            (mt/with-premium-features #{}
+              (is (str/includes? (render!) "Made with"))))
+          (testing "branding link is hidden with whitelabel"
+            (mt/with-premium-features #{:whitelabel}
+              (is (not (str/includes? (render!) "Made with"))))))))))

--- a/test/metabase/channel/render/card_test.clj
+++ b/test/metabase/channel/render/card_test.clj
@@ -482,6 +482,18 @@
               expected-href         (format "https://mb.com/dashboard/%d#scrollTo=%d" (:dashboard_id dc1) (:id dc1))]
           (is (every? #(= % expected-href) (match/match-many rendered-card-content {:href href} href))))))))
 
+(deftest dashcard-title-override-wins-over-card-name-test
+  (testing "a dashcard's card.title override wins over the underlying card's own name in rendered emails (#18344)"
+    (mt/with-temp [:model/Card card {:name "Orders" :dataset_query (mt/mbql-query orders {:limit 1})}
+                   :model/Dashboard dashboard {}
+                   :model/DashboardCard dc {:dashboard_id (:id dashboard) :card_id (:id card)
+                                            :visualization_settings {:card.title "OrdersFoo"}}]
+      (let [rendered (:content (channel.render/render-pulse-card :inline "UTC" card dc
+                                                                 (qp/process-query (:dataset_query card))
+                                                                 {:channel.render/include-title? true}))]
+        (is (match/match-one rendered [:a _ "OrdersFoo"] true))
+        (is (not (match/match-one rendered [:a _ "Orders"] true)))))))
+
 (deftest render-card-with-abbreviated-dates-test
   (testing "Static-viz should render without error when date formatting is abbreviated (metabase#27020)"
     (mt/with-temporary-setting-values [custom-formatting {:type/Temporal {:date_style "MMMM D, YYYY"}}]

--- a/test/metabase/channel/render/maps_test.clj
+++ b/test/metabase/channel/render/maps_test.clj
@@ -2,8 +2,11 @@
   (:require
    [clj-http.fake :as fake]
    [clojure.test :refer :all]
+   [metabase.channel.render.body :as body]
    [metabase.channel.render.maps :as maps]
-   [metabase.pulse.render.test-util :as render.tu])
+   [metabase.pulse.render.test-util :as render.tu]
+   [metabase.test :as mt]
+   [metabase.util.match :as match])
   (:import
    (java.awt Color)
    (java.io ByteArrayInputStream)
@@ -49,6 +52,15 @@
                                :metric  9}]
                              (assoc test-sizing-opts
                                     :tile-url "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"))))))
+
+(deftest render-region-map-test
+  (mt/id) ;; force the app-db test dataset to exist; the render pipeline queries it for timeline annotations
+  (testing "A region (choropleth) map card renders to an image, not a leaked-data table"
+    (let [card {:display :map :visualization_settings {"map.type" "region" "map.region" "us_states"}}
+          data {:cols [{:name "STATE" :base_type :type/Text} {:name "METRIC" :base_type :type/Number}]
+                :rows [["CA" 99999] ["NY" 11111]]}
+          rendered (body/render :region_map :inline "UTC" card nil data)]
+      (is (match/match-one (:content rendered) [:img _] true)))))
 
 (deftest ^:parallel pin-marker-icon-loads-test
   (testing "the teardrop pin marker icon is present on the classpath (markers pin type depends on it)"

--- a/test/metabase/collections_rest/api_test.clj
+++ b/test/metabase/collections_rest/api_test.clj
@@ -1136,6 +1136,18 @@
                       :data
                       (map (juxt :model :name))))))))))
 
+(deftest collection-items-order-by-model-with-subcollection-test
+  (testing "GET /api/collection/:id/items"
+    (testing "Results ordered by model include sub-collections, not just cards/dashboards/pulses"
+      (mt/with-temp [:model/Collection parent {:name "Parent"}
+                     :model/Collection _ {:name "AA Sub" :location (collection/children-location parent)}
+                     :model/Card       _ {:name "ZZ" :collection_id (u/the-id parent)}
+                     :model/Dashboard  _ {:name "ZZ" :collection_id (u/the-id parent)}]
+        (is (= "collection"
+               (-> (mt/user-http-request :rasta :get 200
+                                         (str "collection/" (u/the-id parent) "/items?sort_column=model&sort_direction=desc"))
+                   :data first :model)))))))
+
 (deftest collection-items-include-latest-revision-test
   (testing "GET /api/collection/:id/items"
     (testing "Results have the lastest revision timestamp"
@@ -1721,6 +1733,13 @@
               :can_delete          false}
              (with-some-children-of-collection! nil
                (mt/user-http-request :crowberto :get 200 "collection/root")))))))
+
+(deftest fetch-root-collection-permissions-test
+  (testing "GET /api/collection/root"
+    (testing "403s (not silently filters) for a user without root read perms"
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (is (= "You don't have permissions to do that."
+               (mt/user-http-request :rasta :get 403 "collection/root")))))))
 
 (defn results-matching [collection-items parameters]
   (-> collection-items
@@ -2696,6 +2715,17 @@
                             (update :id integer?)
                             (update :entity_id string?)))))))))
 
+(deftest create-child-collection-of-other-users-personal-collection-test
+  (testing "POST /api/collection"
+    (testing "an admin can create a sub-collection inside another user's personal collection, a non-admin cannot"
+      (mt/with-model-cleanup [:model/Collection]
+        (let [lucky-collection (collection/user->personal-collection (mt/user->id :lucky))]
+          (is (=? {:name "Foo"} (mt/user-http-request :crowberto :post 200 "collection"
+                                                      {:name "Foo" :parent_id (u/the-id lucky-collection)})))
+          (is (= "You don't have permissions to do that."
+                 (mt/user-http-request :rasta :post 403 "collection"
+                                       {:name "Bar" :parent_id (u/the-id lucky-collection)}))))))))
+
 (deftest create-collection-different-namespace-test
   (testing "POST /api/collection"
     (testing "\nShould be able to create a Collection in a different namespace"
@@ -2831,6 +2861,16 @@
                  (mt/user-http-request :rasta :put 403 (str "collection/" (u/the-id collection))
                                        {:name "My Beautiful Collection"}))))))))
 
+(deftest set-authority-level-after-move-out-of-personal-collection-test
+  (testing "PUT /api/collection/:id allows setting authority_level after moving out of a personal-collection subtree (metabase#30235)"
+    (mt/with-premium-features #{:official-collections}
+      (mt/with-temp [:model/Collection sub {:location (collection/children-location
+                                                       (collection/user->personal-collection (mt/user->id :crowberto)))}]
+        (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id sub)) {:parent_id nil})
+        (is (= "official"
+               (:authority_level (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id sub))
+                                                       {:authority_level "official"}))))))))
+
 (deftest archive-collection-test
   (testing "PUT /api/collection/:id"
     (testing "Archiving a collection should delete any alerts associated with questions in the collection"
@@ -2891,6 +2931,13 @@
           ;; This should succeed because C is archived and excluded from permission checks
           (is (some? (mt/user-http-request :rasta :put 200 (str "collection/" (u/the-id collection-a))
                                            {:archived true}))))))))
+
+(deftest archive-collection-inside-own-personal-collection-test
+  (testing "PUT /api/collection/:id can archive a collection nested inside the caller's own personal collection (metabase#15343)"
+    (mt/with-temp [:model/Collection child {:location (collection/children-location
+                                                       (collection/user->personal-collection (mt/user->id :rasta)))}]
+      (is (=? {:archived true}
+              (mt/user-http-request :rasta :put 200 (str "collection/" (u/the-id child)) {:archived true}))))))
 
 (deftest move-collection-test
   (testing "PUT /api/collection/:id"
@@ -2974,6 +3021,15 @@
           ;; This should succeed because C is archived and excluded from permission checks
           (is (some? (mt/user-http-request :rasta :put 200 (str "collection/" (u/the-id collection-a))
                                            {:parent_id (u/the-id collection-d)}))))))))
+
+(deftest move-collection-into-own-descendant-rejected-test
+  (testing "PUT /api/collection/:id rejects moving a collection into its own descendant, without actually moving it"
+    ;; Pinning current (dubious) behavior: this returns a 500 today; a 4xx status would be the correct response.
+    (with-collection-hierarchy! [a b]
+      (let [location-before (t2/select-one-fn :location :model/Collection :id (u/the-id a))]
+        (mt/user-http-request :crowberto :put 500 (str "collection/" (u/the-id a)) {:parent_id (u/the-id b)})
+        (is (= location-before
+               (t2/select-one-fn :location :model/Collection :id (u/the-id a))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                            GET /api/collection/graph and PUT /api/collection/graph                             |
@@ -3232,6 +3288,18 @@
                                               (format "collection/%d/items" (collection/trash-collection-id)))
                   ids   (set (map :id (filter #(= model-name (:model %)) (:data items))))]
               (is (contains? ids item-id)))))))))
+
+(deftest can-write-false-for-view-only-user-on-trashed-item-test
+  (testing "GET /api/collection/<trash-id>/items reflects can_write:false for a trashed item whose source collection only grants read access"
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Dashboard  {dash-id :id} {:collection_id coll-id}]
+      (perms/revoke-collection-permissions! (perms/all-users-group) coll-id)
+      (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+      (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id) {:archived true})
+      (is (empty? (->> (mt/user-http-request :rasta :get 200
+                                             (format "collection/%d/items" (collection/trash-collection-id)))
+                       :data
+                       (filter #(= dash-id (:id %)))))))))
 
 (deftest skip-graph-skips-graph-on-graph-PUT
   (is (malli= [:map [:revision :int] [:groups :map]]

--- a/test/metabase/collections_rest/api_test.clj
+++ b/test/metabase/collections_rest/api_test.clj
@@ -3290,16 +3290,24 @@
               (is (contains? ids item-id)))))))))
 
 (deftest can-write-false-for-view-only-user-on-trashed-item-test
-  (testing "GET /api/collection/<trash-id>/items reflects can_write:false for a trashed item whose source collection only grants read access"
-    (mt/with-temp [:model/Collection {coll-id :id} {}
-                   :model/Dashboard  {dash-id :id} {:collection_id coll-id}]
-      (perms/revoke-collection-permissions! (perms/all-users-group) coll-id)
-      (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
-      (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id) {:archived true})
+  (mt/with-temp [:model/Collection {coll-id :id} {}
+                 :model/Dashboard  {dash-id :id} {:collection_id coll-id}]
+    (perms/revoke-collection-permissions! (perms/all-users-group) coll-id)
+    (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+    (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id) {:archived true})
+    (testing "GET /api/collection/<trash-id>/items does not list the item for a view-only user"
+      ;; Browsing the trash listing requires *write* access to the item's original collection (see
+      ;; `:permission-level (if archived? :write :read)` in `collections-rest.api/collection-children*`), so a
+      ;; view-only user won't see it there at all.
       (is (empty? (->> (mt/user-http-request :rasta :get 200
                                              (format "collection/%d/items" (collection/trash-collection-id)))
                        :data
-                       (filter #(= dash-id (:id %)))))))))
+                       (filter #(= dash-id (:id %)))))))
+    (testing "GET /api/dashboard/:id reflects can_write:false for the trashed item"
+      ;; Unlike the trash listing, fetching the item directly only requires *read* access, so a view-only user can
+      ;; still load it -- and the response should honestly report that they can't write it.
+      (is (=? {:id dash-id :can_write false}
+              (mt/user-http-request :rasta :get 200 (str "dashboard/" dash-id)))))))
 
 (deftest skip-graph-skips-graph-on-graph-PUT
   (is (malli= [:map [:revision :int] [:groups :map]]

--- a/test/metabase/comments/api_test.clj
+++ b/test/metabase/comments/api_test.clj
@@ -345,6 +345,10 @@
                                       :target_id doc-id)))))))
 
 (deftest multiple-emoji-reactions-test
+  ;; Relies on comment_reaction.emoji using an exact (not linguistic) collation on MySQL/MariaDB -- see
+  ;; migration v63.2026-07-06T00:00:00. Under the table's original utf8mb4_unicode_ci collation, distinct
+  ;; supplementary-plane emoji like 👍 and 🎉 compared as equal, so the second POST below looked like a
+  ;; toggle-off of the first reaction instead of a new one.
   (testing "POST /api/comment/:comment-id/reaction supports multiple distinct emoji on the same comment"
     (mt/with-temp [:model/Document {doc-id :id}     {}
                    :model/Comment  {comment-id :id} {:target_id doc-id}]

--- a/test/metabase/comments/api_test.clj
+++ b/test/metabase/comments/api_test.clj
@@ -227,6 +227,70 @@
                 (mt/user-http-request :rasta :put 200 (str "comment/" comment-id)
                                       {:is_resolved true})))))))
 
+(deftest update-delete-non-creator-non-admin-test
+  (testing "PUT/DELETE /api/comment/:comment-id - a user with document access who isn't the creator or an admin cannot edit or delete another user's comment"
+    (mt/with-temp [:model/Document {doc-id :id} {}
+                   :model/Comment  {c-id :id}   {:target_id doc-id :creator_id (mt/user->id :rasta)}]
+      (is (= "You don't have permissions to do that."
+             (mt/user-http-request :lucky :put 403 (str "comment/" c-id) {:content {:text "hi"}})))
+      (is (= "You don't have permissions to do that."
+             (mt/user-http-request :lucky :delete 403 (str "comment/" c-id)))))))
+
+(deftest unresolve-comment-test
+  (testing "PUT /api/comment/:comment-id can flip is_resolved back off after being set"
+    (mt/with-temp [:model/Document {doc-id :id}     {}
+                   :model/Comment  {comment-id :id} {:target_id doc-id}]
+      (mt/user-http-request :rasta :put 200 (str "comment/" comment-id) {:is_resolved true})
+      (is (=? {:is_resolved false}
+              (mt/user-http-request :rasta :put 200 (str "comment/" comment-id) {:is_resolved false}))))))
+
+(deftest resolve-reply-comment-test
+  (testing "PUT /api/comment/:comment-id allows resolving a non-root reply comment (no server-side root-only restriction)"
+    (mt/with-temp [:model/Document {doc-id :id} {}
+                   :model/Comment  {root :id}   {:target_id doc-id}
+                   :model/Comment  {reply :id}  {:target_id doc-id :parent_comment_id root}]
+      (is (=? {:is_resolved true}
+              (mt/user-http-request :rasta :put 200 (str "comment/" reply) {:is_resolved true}))))))
+
+(deftest resolve-deleted-comment-test
+  (testing "PUT /api/comment/:comment-id can set is_resolved on a comment whose content has been soft-deleted"
+    (mt/with-temp [:model/Document {doc-id :id}     {}
+                   :model/Comment  {comment-id :id} {:target_id doc-id}]
+      (mt/user-http-request :rasta :delete 204 (str "comment/" comment-id))
+      (is (=? {:is_resolved true}
+              (mt/user-http-request :rasta :put 200 (str "comment/" comment-id) {:is_resolved true}))))))
+
+(deftest resolve-other-users-thread-test
+  (testing "PUT /api/comment/:comment-id - any user with document write access can resolve a thread they didn't create"
+    (mt/with-temp [:model/Document {doc-id :id} {:creator_id (mt/user->id :crowberto)}
+                   :model/Comment  {c-id :id}   {:target_id doc-id :creator_id (mt/user->id :crowberto)}]
+      (is (=? {:is_resolved true}
+              (mt/user-http-request :rasta :put 200 (str "comment/" c-id) {:is_resolved true}))))))
+
+(deftest reply-to-resolved-comment-test
+  (testing "POST /api/comment/ allows replying to a resolved parent thread (no server-side restriction)"
+    (mt/with-temp [:model/Document {doc-id :id} {}
+                   :model/Comment  {root :id}   {:target_id doc-id}]
+      (mt/with-model-cleanup [:model/Comment]
+        (mt/user-http-request :rasta :put 200 (str "comment/" root) {:is_resolved true})
+        (is (=? {:parent_comment_id root}
+                (mt/user-http-request :rasta :post 200 "comment/"
+                                      {:target_type       "document"
+                                       :target_id         doc-id
+                                       :parent_comment_id root
+                                       :content           (tiptap [:p "reply"])})))))))
+
+(deftest deleted-comment-without-replies-omitted-test
+  (testing "a deleted comment with no replies is omitted entirely from GET"
+    (mt/with-temp [:model/Document {doc-id :id} {}
+                   :model/Comment  {c1 :id}     {:target_id doc-id}
+                   :model/Comment  {c2 :id}     {:target_id doc-id}]
+      (mt/user-http-request :rasta :delete 204 (str "comment/" c1))
+      (is (=? {:comments [{:id c2}]}
+              (mt/user-http-request :rasta :get 200 "comment/"
+                                    :target_type "document"
+                                    :target_id doc-id))))))
+
 (deftest delete-comment-test
   (testing "DELETE /api/comment/:comment-id"
     (mt/with-temp [:model/Document {doc-id :id} {}
@@ -280,6 +344,46 @@
                                       :target_type "document"
                                       :target_id doc-id)))))))
 
+(deftest multiple-emoji-reactions-test
+  (testing "POST /api/comment/:comment-id/reaction supports multiple distinct emoji on the same comment"
+    (mt/with-temp [:model/Document {doc-id :id}     {}
+                   :model/Comment  {comment-id :id} {:target_id doc-id}]
+      (mt/with-model-cleanup [:model/CommentReaction]
+        (mt/user-http-request :rasta :post 200 (str "comment/" comment-id "/reaction") {:emoji "👍"})
+        (mt/user-http-request :rasta :post 200 (str "comment/" comment-id "/reaction") {:emoji "🎉"})
+        (let [{:keys [comments]} (mt/user-http-request :rasta :get 200 "comment/"
+                                                       :target_type "document" :target_id doc-id)
+              reactions          (->> comments (filter #(= comment-id (:id %))) first :reactions
+                                      (map #(select-keys % [:emoji :count])) set)]
+          (is (= #{{:emoji "👍" :count 1} {:emoji "🎉" :count 1}} reactions)))))))
+
+(deftest multi-user-reaction-aggregation-test
+  (testing "reactions from different users on the same emoji aggregate, and one user removing theirs doesn't affect the other's"
+    (mt/with-temp [:model/Document {doc-id :id}     {}
+                   :model/Comment  {comment-id :id} {:target_id doc-id}]
+      (mt/with-model-cleanup [:model/CommentReaction]
+        (mt/user-http-request :rasta :post 200 (str "comment/" comment-id "/reaction") {:emoji "👍"})
+        (mt/user-http-request :crowberto :post 200 (str "comment/" comment-id "/reaction") {:emoji "👍"})
+        (is (=? {:comments [{:id        comment-id
+                             :reactions [{:emoji "👍" :count 2}]}]}
+                (mt/user-http-request :rasta :get 200 "comment/"
+                                      :target_type "document"
+                                      :target_id doc-id)))
+        (mt/user-http-request :crowberto :post 200 (str "comment/" comment-id "/reaction") {:emoji "👍"})
+        (is (=? {:comments [{:id        comment-id
+                             :reactions [{:emoji "👍" :count 1 :users [{:id (mt/user->id :rasta)}]}]}]}
+                (mt/user-http-request :rasta :get 200 "comment/"
+                                      :target_type "document"
+                                      :target_id doc-id)))))))
+
+(deftest cannot-react-to-deleted-comment-test
+  (testing "POST /api/comment/:comment-id/reaction 400s on a soft-deleted comment"
+    (mt/with-temp [:model/Document {doc-id :id}     {}
+                   :model/Comment  {comment-id :id} {:target_id doc-id}]
+      (mt/user-http-request :rasta :delete 204 (str "comment/" comment-id))
+      (is (= "Cannot react to deleted comments"
+             (mt/user-http-request :rasta :post 400 (str "comment/" comment-id "/reaction") {:emoji "👍"}))))))
+
 (deftest comments-permissions-test
   (testing "Comment permissions - users without document access cannot read or write comments"
     (mt/with-non-admin-groups-no-root-collection-perms
@@ -310,6 +414,30 @@
             (is (= "You don't have permissions to do that."
                    (mt/user-http-request :lucky :post 403 (str "comment/" restricted-comment-id "/reaction")
                                          {:emoji "👍"})))))))))
+
+(deftest mention-notification-content-test
+  (testing "@mention notifications pin heading text and comment link, not just the subject"
+    (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+      (mt/with-temp [:model/Document {doc-id :id} {:name       "Mentions Doc"
+                                                   :creator_id (mt/user->id :lucky)}]
+        (mt/with-model-cleanup [:model/Comment :model/Notification]
+          (mt/with-fake-inbox
+            (notification.seed/seed-notification!)
+            (let [created  (mt/user-http-request :rasta :post 200 "comment/"
+                                                 {:target_type "document"
+                                                  :target_id   doc-id
+                                                  :content     (tiptap
+                                                                [:smartLink {:model    "user"
+                                                                             :entityId (mt/user->id :crowberto)}])})
+                  expected [{:subject "Comment on Mentions Doc"
+                             :body    [{:content (relaxed-re
+                                                  (str (:common_name (mt/fetch-user :rasta)) " left a comment on a document")
+                                                  (format "http://localhost:\\d+/document/%s#comment-%s"
+                                                          doc-id
+                                                          (:id created)))}]}]]
+              (is (=? {(:email (mt/fetch-user :lucky))     expected
+                       (:email (mt/fetch-user :crowberto)) expected}
+                      (first (swap-vals! mt/inbox empty)))))))))))
 
 (deftest mention-entities-test
   (testing "We can get users to mention"

--- a/test/metabase/dashboards/models/dashboard_card_test.clj
+++ b/test/metabase/dashboards/models/dashboard_card_test.clj
@@ -325,6 +325,21 @@
         (is (= dashcard
                transformed))))))
 
+(deftest ^:parallel visualizer-settings-no-extra-keys-test
+  (testing "visualization_settings.visualization.settings persists exactly as written (VIZ-905)"
+    (mt/with-temp [:model/Dashboard     dash {}
+                   :model/Card          card {}
+                   :model/DashboardCard dashcard {:dashboard_id (:id dash)
+                                                  :card_id      (:id card)
+                                                  :visualization_settings
+                                                  {:visualization {:display              "line"
+                                                                   :columnValuesMapping  {}
+                                                                   :settings             {"graph.dimensions" ["A"]
+                                                                                          "graph.metrics"    ["B"]}}}}]
+      (is (= {:graph.dimensions ["A"] :graph.metrics ["B"]}
+             (-> (t2/select-one :model/DashboardCard :id (:id dashcard))
+                 :visualization_settings :visualization :settings))))))
+
 (deftest ^:parallel after-select-tolerates-dangling-visualizer-ref-test
   (testing "A DashboardCard whose visualizer settings reference a deleted Card is returned unmodified on read,
            rather than throwing and making the dashcard unloadable."

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -42,6 +42,7 @@
    [metabase.query-processor.pivot.test-util :as api.pivots]
    [metabase.query-processor.streaming.test-util :as streaming.test-util]
    [metabase.query-processor.test :as qp]
+   [metabase.query-processor.test-util :as qp.test-util]
    [metabase.revisions.models.revision :as revision]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -139,6 +140,14 @@
 
 (defmacro ^:private with-dashboards-in-writeable-collection! [dashboards-or-ids & body]
   `(do-with-dashboards-in-a-collection! perms/grant-collection-readwrite-permissions! ~dashboards-or-ids (fn [] ~@body)))
+
+(defn- implicit-fk-column-ref
+  "The legacy `[:field id {:source-field fk-id}]` ref for the column with `target-field-id`, as reached implicitly via
+  an FK from `from-table-key` (e.g. `products.category` reached via `orders.product_id`)."
+  [mp from-table-key target-field-id]
+  (let [query (lib/query mp (lib.metadata/table mp (mt/id from-table-key)))
+        col   (m/find-first #(= (:id %) target-field-id) (lib/filterable-columns query))]
+    (lib.convert/->legacy-MBQL (lib/ref col))))
 
 (defn do-with-simple-dashboard-with-tabs
   [f]
@@ -5692,3 +5701,671 @@
                               {:parameters [{:id "_DASH_PRODUCT_ID_" :value "1"}]})
         (is (some? (t2/select-one-fn :result_metadata :model/Card :id card-id))
             "result_metadata should be persisted when native dashcard runs with default parameter values")))))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                    Additional parameter/permission coverage                                     |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(deftest dashboard-chain-filter-search-missing-data-perms-test
+  (testing "GET /api/dashboard/:id/params/:param-key/search/:query"
+    (testing "missing data perms should not affect search endpoint when users have collection access (#8472)"
+      (mt/with-temp-copy-of-db
+        (with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
+          (mt/with-no-data-perms-for-all-users!
+            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
+            (data-perms/set-table-permission! (perms-group/all-users) (mt/id :venues) :perms/create-queries :no)
+            (is (= {:values [["African"]] :has_more_values false}
+                   (mt/user-http-request :rasta :get 200
+                                         (chain-filter-search-url (:id dashboard) (:category-name param-keys) "afr"))))))))))
+
+(deftest add-card-parameter-mapping-fk-target-permissions-test
+  (testing "PUT /api/dashboard/:id checks perms on the *joined* table for an FK-qualified dimension target"
+    (let [mp (mt/metadata-provider)]
+      (mt/with-no-data-perms-for-all-users!
+        (mt/with-temp [:model/Dashboard {dash-id :id} {:parameters [{:id "_ID_" :type :id :name "ID" :slug "id"}]}
+                       :model/Card {card-id :id} {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :orders)))}]
+          (let [mapping [{:parameter_id "_ID_"
+                          :target       [:dimension (implicit-fk-column-ref mp :orders (mt/id :products :id))]}]
+                put!    (fn [status]
+                          (mt/user-http-request :rasta :put status (format "dashboard/%d" dash-id)
+                                                {:dashcards [{:id -1 :card_id card-id :row 0 :col 0 :size_x 4 :size_y 4
+                                                              :parameter_mappings mapping}]
+                                                 :tabs      []}))]
+            (is (=? {:message #"(?i).*data permissions.*PRODUCTS.*"} (put! 403)))
+            (data-perms/set-table-permission! (perms-group/all-users) (mt/id :products) :perms/view-data :unrestricted)
+            (data-perms/set-table-permission! (perms-group/all-users) (mt/id :products) :perms/create-queries :query-builder)
+            (is (=? [{:parameter_mappings [{:parameter_id "_ID_"
+                                            :target ["dimension" ["field" (mt/id :products :id)
+                                                                  {:source-field (mt/id :orders :product_id)}]]}]}]
+                    (:dashcards (put! 200))))))))))
+
+(deftest required-parameter-without-default-test
+  (testing "PUT /api/dashboard/:id currently accepts a :required parameter with no :default (FE-only enforced)"
+    (mt/with-temp [:model/Dashboard {dashboard-id :id} {}]
+      (with-dashboards-in-writeable-collection! [dashboard-id]
+        (is (=? {:parameters [{:required true}]}
+                (mt/user-http-request :rasta :put 200 (str "dashboard/" dashboard-id)
+                                      {:parameters [{:name "Month" :slug "month" :id "a" :type :date/month-year :required true}]})))))))
+
+(deftest remove-one-parameter-mapping-across-multiple-dashcards-test
+  (testing "PUT /api/dashboard/:id selectively removes one parameter_id's mappings from multiple dashcards while preserving another"
+    (let [mp         (mt/metadata-provider)
+          p1-target  [:dimension (lib.convert/->legacy-MBQL (lib/ref (lib.metadata/field mp (mt/id :venues :name))))]
+          p2-target  [:dimension (lib.convert/->legacy-MBQL (lib/ref (lib.metadata/field mp (mt/id :venues :price))))]]
+      (mt/with-temp [:model/Dashboard {dash-id :id} {:parameters [{:id "p1" :type :string/= :name "P1" :slug "p1"}
+                                                                  {:id "p2" :type :string/= :name "P2" :slug "p2"}]}
+                     :model/Card c1 {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :venues)))}
+                     :model/Card c2 {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :venues)))}
+                     :model/DashboardCard {dc1 :id} {:dashboard_id dash-id :card_id (:id c1)
+                                                     :parameter_mappings [{:parameter_id "p1" :card_id (:id c1) :target p1-target}
+                                                                          {:parameter_id "p2" :card_id (:id c1) :target p2-target}]}
+                     :model/DashboardCard {dc2 :id} {:dashboard_id dash-id :card_id (:id c2)
+                                                     :parameter_mappings [{:parameter_id "p1" :card_id (:id c2) :target p1-target}
+                                                                          {:parameter_id "p2" :card_id (:id c2) :target p2-target}]}]
+        (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id)
+                              {:dashcards [(assoc (dashboard-card/retrieve-dashboard-card dc1) :id dc1
+                                                  :parameter_mappings [{:parameter_id "p2" :card_id (:id c1) :target p2-target}])
+                                           (assoc (dashboard-card/retrieve-dashboard-card dc2) :id dc2
+                                                  :parameter_mappings [{:parameter_id "p2" :card_id (:id c2) :target p2-target}])]
+                               :tabs []})
+        (is (every? #(= 1 (count %)) (t2/select-fn-vec :parameter_mappings :model/DashboardCard :dashboard_id dash-id)))))))
+
+(deftest param-search-no-field-ids-test
+  (testing "GET .../params/:param-key/search/:query for field-ref-only (nested-native) params currently returns the same unfiltered set as /values"
+    (let [mp (mt/metadata-provider)]
+      (mt/with-temp [:model/Card {native-id :id} (qp.test-util/card-with-source-metadata-for-query
+                                                  (lib/native-query mp "select * from people"))
+                     :model/Card {final-id :id} {:dataset_query (lib/query mp (lib.metadata/card mp native-id))}
+                     :model/Dashboard {dashboard-id :id}
+                     {:parameters [{:name "User Source" :slug "user_source" :id "_US_" :type :string/=}]}
+                     :model/DashboardCard _ {:dashboard_id dashboard-id :card_id final-id
+                                             :parameter_mappings [{:card_id final-id :parameter_id "_US_"
+                                                                   :target [:dimension [:field "SOURCE" {:base-type :type/Text}]]}]}]
+        (is (= {:values [["Affiliate"] ["Facebook"] ["Google"] ["Organic"] ["Twitter"]] :has_more_values false}
+               (mt/user-http-request :rasta :get 200
+                                     (str "dashboard/" dashboard-id "/params/_US_/search/Goog"))))))))
+
+(deftest add-card-parameter-mapping-nested-name-ref-permissions-test
+  (testing "PUT /api/dashboard/:id with a mapping targeting a nested/native card's field-name ref is exempt from data-permission checks"
+    (let [mp (mt/metadata-provider)]
+      (mt/with-no-data-perms-for-all-users!
+        (mt/with-temp [:model/Dashboard {dash-id :id} {}
+                       :model/Card {native-id :id} {:dataset_query (lib/native-query mp "select * from people")}
+                       :model/Card {final-id :id} {:dataset_query (lib/query mp (lib.metadata/card mp native-id))}]
+          (is (=? {:dashcards [{:card_id final-id}]}
+                  (mt/user-http-request :rasta :put 200 (format "dashboard/%d" dash-id)
+                                        {:dashcards [{:id -1 :card_id final-id :row 0 :col 0 :size_x 4 :size_y 4
+                                                      :parameter_mappings [{:card_id final-id :parameter_id "abc"
+                                                                            :target [:dimension [:field "SOURCE" {:base-type :type/Text}]]}]}]
+                                         :tabs []}))))))))
+
+(deftest number-static-list-mixed-shape-values-and-search-test
+  (mt/with-temp [:model/Dashboard {id :id}
+                 {:parameters [{:name "Number" :slug "number" :id "_NUM_" :type :number/=
+                                :values_source_type "static-list"
+                                :values_source_config {:values [["10" "Ten"] ["20" "Twenty"] "30"]}}]}]
+    (testing "GET /api/dashboard/:id/params/:param-key/values handles a static-list source with mixed labeled/bare entries"
+      (is (= {:values [["10" "Ten"] ["20" "Twenty"] ["30"]] :has_more_values false}
+             (mt/user-http-request :rasta :get 200 (chain-filter-values-url id "_NUM_")))))
+    (testing "GET /api/dashboard/:id/params/:param-key/search/:query matches both labeled and unlabeled static-list entries"
+      (is (= {:values [["10" "Ten"] ["20" "Twenty"]] :has_more_values false}
+             (mt/user-http-request :rasta :get 200 (chain-filter-search-url id "_NUM_" "t")))))))
+
+(deftest numeric-card-source-values-and-search-test
+  (testing "GET /api/dashboard/:id/params/:param-key/values and /search/:query for a numeric card-source parameter"
+    (let [mp (mt/metadata-provider)]
+      (mt/with-temp [:model/Card {source-id :id} {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :orders)))}
+                     :model/Dashboard {id :id}
+                     {:parameters [{:name "Number" :slug "number" :id "_NUM_" :type :number/<=
+                                    :values_source_type "card"
+                                    :values_source_config
+                                    {:card_id     source-id
+                                     :value_field (lib.convert/->legacy-MBQL (lib/ref (lib.metadata/field mp (mt/id :orders :id))))}}]}]
+        (let [values (:values (mt/user-http-request :rasta :get 200 (format "dashboard/%d/params/_NUM_/values" id)))]
+          (is (seq values))
+          (is (every? #(= 1 (count %)) values)))
+        (let [values (:values (mt/user-http-request :rasta :get 200 (format "dashboard/%d/params/_NUM_/search/225" id)))]
+          (is (seq values))
+          (is (every? (fn [[v]] (str/includes? (str v) "225")) values)
+              "every result actually matches the search query")
+          (is (not-any? #{[5]} values)
+              "an unrelated id that doesn't contain the search query is excluded"))))))
+
+(deftest param-value-remapping-internal-remap-test
+  (testing "GET /api/dashboard/:id/params/:param-key/remapping works for human-readable-values (internal) remaps"
+    (chain-filter-test/with-human-readable-values-remapping!
+      (with-chain-filter-fixtures [{:keys [dashboard]}]
+        (is (= [40 "Japanese"]
+               (mt/user-http-request :rasta :get 200
+                                     (format "dashboard/%d/params/_CATEGORY_ID_/remapping?value=40" (:id dashboard)))))))))
+
+(deftest card-source-param-with-label-field-values-endpoint-test
+  (testing "GET /api/dashboard/:id/params/:key/values returns [value label] pairs for a card-source param with label_field"
+    (let [mp (mt/metadata-provider)]
+      (mt/with-temp [:model/Card native-card (qp.test-util/card-with-source-metadata-for-query
+                                              (lib/native-query mp "select id, name from venues limit 5"))
+                     :model/Dashboard dashboard
+                     {:parameters [{:id "abc" :name "abc" :slug "abc" :type "category"
+                                    :values_source_type "card"
+                                    :values_source_config {:card_id     (:id native-card)
+                                                           :value_field [:field "ID" {:base-type :type/Integer}]
+                                                           :label_field [:field "NAME" {:base-type :type/Text}]}}]}]
+        (let [{:keys [values]} (mt/user-http-request :rasta :get 200
+                                                     (format "dashboard/%d/params/abc/values" (:id dashboard)))]
+          (is (seq values))
+          (is (every? (fn [[value label]] (and (int? value) (string? label))) values)))))))
+
+(deftest chain-filter-template-tags-search-test
+  (testing "GET /api/dashboard/:id/params/:param-key/search/:query works for a native template-tag dimension param"
+    (with-chain-filter-fixtures [{:keys [dashboard]}]
+      (mt/let-url [url (chain-filter-search-url dashboard "_name_" "am")]
+        (is (= {:values [["American"] ["Latin American"] ["Ramen"]] :has_more_values false}
+               (chain-filter-test/take-n-values 3 (mt/user-http-request :rasta :get 200 url))))))))
+
+(deftest can-filter-on-multi-database-params-test
+  (testing "GET /api/dashboard/:id/params/:param-key/values merges/dedupes results across databases (#68998)"
+    (let [orig-db-id             (mt/id)
+          orig-category-field-id (mt/id :products :category)
+          mp-orig                (lib.metadata.jvm/application-database-metadata-provider orig-db-id)
+          card-a-query           (lib/query mp-orig (lib.metadata/table mp-orig (mt/id :products)))
+          card-a-target          [:dimension (lib.convert/->legacy-MBQL (lib/ref (lib.metadata/field mp-orig orig-category-field-id)))]]
+      (mt/with-temp-copy-of-db
+        (let [other-db-id              (mt/id)
+              other-category-field-id  (mt/id :products :category)
+              mp-other                 (lib.metadata.jvm/application-database-metadata-provider other-db-id)
+              card-b-query             (lib/query mp-other (lib.metadata/table mp-other (mt/id :products)))
+              card-b-target            [:dimension (lib.convert/->legacy-MBQL (lib/ref (lib.metadata/field mp-other other-category-field-id)))]]
+          (mt/with-temp
+            [:model/Dashboard dashboard {:parameters [{:name "Category" :slug "category" :id "_CAT_" :type "category"}]}
+             :model/Card card-a {:database_id orig-db-id :dataset_query card-a-query}
+             :model/Card card-b {:database_id other-db-id :dataset_query card-b-query}
+             :model/DashboardCard _ {:dashboard_id (:id dashboard) :card_id (:id card-a)
+                                     :parameter_mappings [{:parameter_id "_CAT_" :card_id (:id card-a) :target card-a-target}]}
+             :model/DashboardCard _ {:dashboard_id (:id dashboard) :card_id (:id card-b)
+                                     :parameter_mappings [{:parameter_id "_CAT_" :card_id (:id card-b) :target card-b-target}]}]
+            (is (= #{"Doohickey" "Gadget" "Gizmo" "Widget"}
+                   (into #{} (map first) (:values (mt/user-http-request :rasta :get 200
+                                                                        (chain-filter-values-url (:id dashboard) "_CAT_"))))))))))))
+
+(deftest ^:parallel legacy-location-city-parameter-search-test
+  (testing "GET /api/dashboard/:id/params/:param-key/search/:query works for the legacy location/city parameter type"
+    (let [mp (mt/metadata-provider)]
+      (mt/with-temp [:model/Dashboard {dashboard-id :id} {:parameters [{:name "City" :slug "city" :id "_CITY_" :type "location/city"}]}
+                     :model/Card {card-id :id} {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :people)))}
+                     :model/DashboardCard {} {:dashboard_id dashboard-id :card_id card-id
+                                              :parameter_mappings [{:parameter_id "_CITY_" :card_id card-id
+                                                                    :target [:dimension (lib.convert/->legacy-MBQL (lib/ref (lib.metadata/field mp (mt/id :people :city))))]}]}]
+        (is (=? {:values [["Flagstaff"]]}
+                (mt/user-http-request :rasta :get 200 (chain-filter-search-url dashboard-id "_CITY_" "Flag"))))))))
+
+(deftest chain-filter-search-unions-values-across-multiple-mapped-fields-test
+  (testing "GET /api/dashboard/:id/params/:param-key/search/:query unions results across every mapped field, even with disjoint value domains"
+    (let [mp             (mt/metadata-provider)
+          people-target  [:dimension (lib.convert/->legacy-MBQL (lib/ref (lib.metadata/field mp (mt/id :people :name))))]
+          products-target [:dimension (lib.convert/->legacy-MBQL (lib/ref (lib.metadata/field mp (mt/id :products :category))))]]
+      (mt/with-temp [:model/Dashboard dashboard {:parameters [{:id "abc" :type :string/= :name "abc" :slug "abc"}]}
+                     :model/Card people-card {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :people)))}
+                     :model/Card products-card {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :products)))}
+                     :model/DashboardCard _ {:dashboard_id (:id dashboard) :card_id (:id people-card)
+                                             :parameter_mappings [{:parameter_id "abc" :card_id (:id people-card) :target people-target}]}
+                     :model/DashboardCard _ {:dashboard_id (:id dashboard) :card_id (:id products-card)
+                                             :parameter_mappings [{:parameter_id "abc" :card_id (:id products-card) :target products-target}]}]
+        (let [{:keys [values]} (mt/user-http-request :rasta :get 200
+                                                     (format "dashboard/%d/params/abc/search/Ga" (:id dashboard)))]
+          (is (some #(= % ["Gadget"]) values)))))))
+
+(deftest stale-parameter-mapping-target-is-silently-ignored-test
+  (testing "a stale parameter_mappings target (from a query edit) is silently ignored, not erroring"
+    (let [mp       (mt/metadata-provider)
+          cat-tag  (-> (lib/native-query mp "select count(*) from products where {{cat}}")
+                       (lib/with-template-tags {"cat" {:id "_CAT_TAG_" :name "cat" :display-name "Cat" :type :dimension
+                                                       :dimension (lib/ref (lib.metadata/field mp (mt/id :products :category)))
+                                                       :widget-type :string/=}}))]
+      (mt/with-temp [:model/Card card {:dataset_query cat-tag}
+                     :model/Dashboard dashboard {:parameters [{:id "p" :type :string/= :name "p" :slug "p"}]}
+                     :model/DashboardCard dashcard {:dashboard_id (:id dashboard) :card_id (:id card)
+                                                    :parameter_mappings [{:parameter_id "p" :card_id (:id card)
+                                                                          :target [:dimension [:template-tag "cat"]]}]}]
+        (mt/user-http-request :rasta :put 200 (str "card/" (:id card))
+                              {:dataset_query (lib/->legacy-MBQL (lib/native-query mp "select 1"))})
+        (is (= [[1]] (mt/rows (mt/user-http-request :rasta :post 202
+                                                    (format "dashboard/%d/dashcard/%d/card/%d/query" (:id dashboard) (:id dashcard) (:id card))
+                                                    {:parameters [{:id "p" :type :string/= :value ["Gadget"]}]}))))))))
+
+(deftest put-dashboard-does-not-clean-orphaned-parameter-mappings-test
+  (testing "PUT /api/dashboard/:id removing a parameter does not prune dashcard parameter_mappings that reference it (#17933)"
+    (let [mp (mt/metadata-provider)]
+      (mt/with-temp [:model/Dashboard dashboard {:parameters [{:id "p" :type :string/= :name "p" :slug "p"}]}
+                     :model/Card card {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :orders)))}
+                     :model/DashboardCard dashcard {:dashboard_id (:id dashboard) :card_id (:id card)
+                                                    :parameter_mappings [{:parameter_id "p" :card_id (:id card)
+                                                                          :target [:dimension (lib.convert/->legacy-MBQL (lib/ref (lib.metadata/field mp (mt/id :orders :total))))]}]}]
+        (mt/user-http-request :crowberto :put 200 (str "dashboard/" (:id dashboard)) {:parameters []})
+        (is (seq (t2/select-one-fn :parameter_mappings :model/DashboardCard :id (:id dashcard)))
+            "backend does not clean up dashcard parameter_mappings that reference a removed parameter_id")))))
+
+(deftest values-endpoint-does-not-gate-by-operator-type-test
+  (testing "GET /api/dashboard/:id/params/:param-key/values has no operator-type gating"
+    (with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
+      (mt/user-http-request :rasta :put 200 (str "dashboard/" (:id dashboard))
+                            {:parameters (mapv (fn [p] (cond-> p (= (:id p) (:category-name param-keys)) (assoc :type :string/starts-with)))
+                                               (:parameters dashboard))})
+      (is (seq (:values (mt/user-http-request :rasta :get 200
+                                              (chain-filter-values-url (:id dashboard) (:category-name param-keys)))))))))
+
+(deftest temporal-unit-param-rejects-invalid-unit-in-allowlist-test
+  (testing "PUT /api/dashboard/:id rejects a temporal_units allow-list containing a non-unit string"
+    (mt/with-temp [:model/Dashboard {dashboard-id :id} {}]
+      (mt/user-http-request :crowberto :put 400 (str "dashboard/" dashboard-id)
+                            {:parameters [{:id "p" :type :temporal-unit :name "p" :slug "p" :temporal_units ["not-a-real-unit"]}]}))))
+
+(deftest temporal-unit-param-mapping-to-text-template-tag-not-rejected-test
+  (testing "PUT /api/dashboard/:id accepts a temporal-unit param mapped onto a non-dimension (text) template tag"
+    (let [mp       (mt/metadata-provider)
+          native-q (-> (lib/native-query mp "select count(*) from products where category = {{cat}}")
+                       (lib/with-template-tags {"cat" {:id "_CAT_TAG_" :name "cat" :display-name "Cat" :type :text}}))]
+      (mt/with-temp [:model/Card {card-id :id} {:dataset_query native-q}
+                     :model/Dashboard {dashboard-id :id} {:parameters [{:id "p" :type :temporal-unit :name "p" :slug "p"}]}
+                     :model/DashboardCard {dashcard-id :id} {:dashboard_id dashboard-id :card_id card-id}]
+        (is (=? [{:parameter_id "p"}]
+                (:parameter_mappings
+                 (first (:dashcards
+                         (mt/user-http-request :crowberto :put 200 (format "dashboard/%d" dashboard-id)
+                                               {:dashcards [{:id dashcard-id :card_id card-id :row 0 :col 0 :size_x 4 :size_y 4
+                                                             :parameter_mappings [{:parameter_id "p" :card_id card-id
+                                                                                   :target [:dimension [:template-tag "cat"]]}]}]
+                                                :tabs []}))))))))))
+
+(deftest dashboard-mixed-permission-dashcards-query-isolation-test
+  (testing "GET /api/dashboard/:id redacts an unreadable dashcard; querying it 403s while a sibling dashcard still succeeds"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (let [mp (mt/metadata-provider)]
+        (mt/with-temp [:model/Collection {accessible-coll-id :id} {}
+                       :model/Collection {restricted-coll-id :id} {}
+                       :model/Card {ok-card-id :id} {:collection_id accessible-coll-id
+                                                     :dataset_query (lib/query mp (lib.metadata/table mp (mt/id :venues)))}
+                       :model/Card {bad-card-id :id} {:collection_id restricted-coll-id
+                                                      :dataset_query (lib/query mp (lib.metadata/table mp (mt/id :venues)))}
+                       :model/Dashboard {dashboard-id :id} {:collection_id accessible-coll-id}
+                       :model/DashboardCard {ok-dc-id :id} {:dashboard_id dashboard-id :card_id ok-card-id}
+                       :model/DashboardCard {bad-dc-id :id} {:dashboard_id dashboard-id :card_id bad-card-id}]
+          (perms/grant-collection-readwrite-permissions! (perms-group/all-users) accessible-coll-id)
+          (let [dashcards (:dashcards (mt/user-http-request :rasta :get 200 (str "dashboard/" dashboard-id)))
+                bad-dc    (m/find-first #(= (:id %) bad-dc-id) dashcards)]
+            (is (=? {:id bad-card-id} (:card bad-dc)))
+            (is (not (contains? (:card bad-dc) :dataset_query))))
+          (mt/user-http-request :rasta :post 202 (dashboard-card-query-url dashboard-id ok-card-id ok-dc-id))
+          (mt/user-http-request :rasta :post 403 (dashboard-card-query-url dashboard-id bad-card-id bad-dc-id)))))))
+
+(deftest update-dashboard-creates-revision-test
+  (testing "PUT /api/dashboard/:id updating name/description creates a Revision row"
+    (mt/with-temp [:model/Dashboard {dashboard-id :id} {:name "Test Dashboard"}]
+      (with-dashboards-in-writeable-collection! [dashboard-id]
+        (let [before (t2/count :model/Revision :model_id dashboard-id :model "Dashboard")]
+          (mt/user-http-request :rasta :put 200 (str "dashboard/" dashboard-id) {:name "Updated Name"})
+          (is (= (inc before) (t2/count :model/Revision :model_id dashboard-id :model "Dashboard"))))))))
+
+(deftest archive-unarchive-round-trip-preserves-collection-id-test
+  (testing "PUT /api/dashboard/:id archived true/false round trip preserves the real collection_id"
+    (mt/with-temp [:model/Collection {collection-id :id} {}
+                   :model/Dashboard {dashboard-id :id} {:collection_id collection-id}]
+      (is (=? {:archived true :archived_directly true}
+              (mt/user-http-request :crowberto :put 200 (str "dashboard/" dashboard-id) {:archived true})))
+      (is (= collection-id (t2/select-one-fn :collection_id :model/Dashboard :id dashboard-id)))
+      (mt/user-http-request :crowberto :put 200 (str "dashboard/" dashboard-id) {:archived false})
+      (is (false? (t2/select-one-fn :archived :model/Dashboard :id dashboard-id)))
+      (is (= collection-id (t2/select-one-fn :collection_id :model/Dashboard :id dashboard-id))))))
+
+(deftest copy-dashboard-permission-model-test
+  (testing "POST /api/dashboard/:id/copy needs only read-on-source + create-on-destination"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection {src-id :id} {}
+                     :model/Dashboard {dash-id :id} {:collection_id src-id}
+                     :model/Collection {dest-id :id} {}]
+        (perms/grant-collection-read-permissions! (perms-group/all-users) src-id)
+        (testing "read-only on source + create on personal collection succeeds"
+          (let [personal-id (u/the-id (collection/user->personal-collection (mt/user->id :rasta)))]
+            (is (= personal-id
+                   (:collection_id (mt/user-http-request :rasta :post 200 (str "dashboard/" dash-id "/copy")
+                                                         {:collection_id personal-id}))))))
+        (testing "no create perms on destination collection is rejected"
+          (mt/user-http-request :rasta :post 403 (str "dashboard/" dash-id "/copy") {:collection_id dest-id}))))))
+
+(deftest dq-not-archived-while-other-dashcard-remains-test
+  (testing "PUT /api/dashboard/:id removing one of two dashcards for the same Dashboard Question does not archive it"
+    (mt/with-temp [:model/Dashboard d {}
+                   :model/Card dq {:dashboard_id (:id d)}
+                   :model/DashboardCard _dc1 {:dashboard_id (:id d) :card_id (:id dq)}
+                   :model/DashboardCard dc2 {:dashboard_id (:id d) :card_id (:id dq)}]
+      (mt/user-http-request :crowberto :put 200 (str "dashboard/" (:id d)) {:dashcards [dc2] :tabs []})
+      (is (false? (t2/select-one-fn :archived :model/Card (:id dq))))
+      (mt/user-http-request :crowberto :put 200 (str "dashboard/" (:id d)) {:dashcards [] :tabs []})
+      (is (true? (t2/select-one-fn :archived :model/Card (:id dq)))))))
+
+(deftest removing-one-dq-does-not-affect-sibling-dq-test
+  (testing "PUT /api/dashboard/:id removing one Dashboard Question's dashcard leaves an unrelated Dashboard Question untouched"
+    (mt/with-temp [:model/Dashboard d {}
+                   :model/Card dq-a {:dashboard_id (:id d)} :model/Card dq-b {:dashboard_id (:id d)}
+                   :model/DashboardCard _dc-a {:dashboard_id (:id d) :card_id (:id dq-a)}
+                   :model/DashboardCard dc-b {:dashboard_id (:id d) :card_id (:id dq-b)}]
+      (mt/user-http-request :crowberto :put 200 (str "dashboard/" (:id d)) {:dashcards [dc-b] :tabs []})
+      (is (true? (t2/select-one-fn :archived :model/Card (:id dq-a))))
+      (is (false? (t2/select-one-fn :archived :model/Card (:id dq-b)))))))
+
+(deftest create-dashboard-blank-name-test
+  (testing "POST /api/dashboard with a whitespace-only name is rejected (#63176)"
+    (is (contains? (:errors (mt/user-http-request :rasta :post 400 "dashboard" {:name " "}))
+                   :name))))
+
+(deftest move-dashcard-between-tabs-without-card-read-perms-test
+  (testing "PUT /api/dashboard/:id moving a dashcard between tabs needs only dashboard write, not card read"
+    (mt/with-temp [:model/Collection {no-access-id :id} {}
+                   :model/Card {card-id :id} {:collection_id no-access-id}
+                   :model/Dashboard {dash-id :id} {}
+                   :model/DashboardTab {t1-id :id} {:dashboard_id dash-id :name "Tab 1" :position 0}
+                   :model/DashboardTab {t2-id :id} {:dashboard_id dash-id :name "Tab 2" :position 1}
+                   :model/DashboardCard {dc-id :id} {:dashboard_id dash-id :card_id card-id :dashboard_tab_id t1-id}]
+      (with-dashboards-in-writeable-collection! [dash-id]
+        (is (=? [{:dashboard_tab_id t2-id}]
+                (:dashcards
+                 (mt/user-http-request :rasta :put 200 (str "dashboard/" dash-id)
+                                       {:tabs [{:id t1-id :name "Tab 1"} {:id t2-id :name "Tab 2"}]
+                                        :dashcards [{:id dc-id :dashboard_tab_id t2-id :card_id card-id :row 0 :col 0 :size_x 4 :size_y 4}]}))))))))
+
+(deftest add-text-tag-parameter-mapping-test
+  (testing "PUT /api/dashboard/:id creates a virtual dashcard with a :text-tag parameter mapping (#11927)"
+    (mt/with-temp [:model/Dashboard {dash-id :id} {:parameters [{:id "_a" :slug "a" :name "a" :type :string/contains}]}]
+      (is (=? [{:parameter_mappings [{:target ["text-tag" "foo"]}]}]
+              (:dashcards
+               (mt/user-http-request :rasta :put 200 (str "dashboard/" dash-id)
+                                     {:tabs [] :dashcards [{:id -1 :row 0 :col 0 :size_x 4 :size_y 4 :card_id nil
+                                                            :visualization_settings {:virtual_card {:display "text"} :text "{{foo}}"}
+                                                            :parameter_mappings [{:parameter_id "_a" :target [:text-tag "foo"]}]}]})))))))
+
+(deftest update-text-tag-mapping-shared-across-dashcards-test
+  (testing "PUT /api/dashboard/:id updates an existing :text-tag mapping shared by two virtual dashcards"
+    (mt/with-temp [:model/Dashboard {dash-id :id} {:parameters [{:id "_a" :slug "a" :name "a" :type :string/contains}]}]
+      (let [mk       (fn [id] {:id id :row 0 :col 0 :size_x 4 :size_y 4 :card_id nil
+                               :visualization_settings {:virtual_card {:display "text"} :text "{{foo}}"}
+                               :parameter_mappings [{:parameter_id "_a" :target [:text-tag "foo"]}]})
+            resp     (mt/user-http-request :rasta :put 200 (str "dashboard/" dash-id) {:tabs [] :dashcards [(mk -1) (mk -2)]})
+            updated  (mt/user-http-request :rasta :put 200 (str "dashboard/" dash-id)
+                                           {:tabs [] :dashcards (mapv #(assoc % :parameter_mappings [{:parameter_id "_a" :target [:text-tag "bar"]}])
+                                                                      (:dashcards resp))})]
+        (is (every? #(= [{:parameter_id "_a" :target ["text-tag" "bar"]}] (:parameter_mappings %))
+                    (:dashcards updated)))))))
+
+(deftest update-cards-parameter-mapping-joined-field-test
+  (testing "PUT /api/dashboard/:id persists parameter_mappings targeting a joined (source-field) column"
+    (let [mp (mt/metadata-provider)]
+      (mt/with-temp [:model/Dashboard {dash-id :id} {}
+                     :model/Card {card-id :id} {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :orders)))}
+                     :model/DashboardCard {dc-id :id} {:dashboard_id dash-id :card_id card-id}]
+        (let [target [:dimension (implicit-fk-column-ref mp :orders (mt/id :products :category))]]
+          (mt/user-http-request :crowberto :put 200 (format "dashboard/%d" dash-id)
+                                {:dashcards [{:id dc-id :card_id card-id :size_x 4 :size_y 4 :row 0 :col 0
+                                              :parameter_mappings [{:parameter_id "abc" :card_id card-id :target target}]}]
+                                 :tabs []})
+          (is (=? [{:target target}]
+                  (t2/select-one-fn :parameter_mappings :model/DashboardCard :id dc-id))))))))
+
+(deftest swap-dashcard-card-id-requires-no-card-permission-test
+  (testing "PUT /api/dashboard/:id swapping a dashcard's card_id needs no data/read perms on the new card"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (let [mp (mt/metadata-provider)]
+        (mt/with-temp [:model/Collection {coll-id :id} {}
+                       :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                       :model/Card {c1-id :id} {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :venues)))}
+                       :model/Card {c2-id :id} {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :venues)))}
+                       :model/DashboardCard {dc-id :id} {:dashboard_id dash-id :card_id c1-id}]
+          (perms/grant-collection-readwrite-permissions! (perms-group/all-users) coll-id)
+          (mt/with-no-data-perms-for-all-users!
+            (is (=? [{:card_id c2-id}]
+                    (:dashcards (mt/user-http-request :rasta :put 200 (format "dashboard/%d" dash-id)
+                                                      {:dashcards [{:id dc-id :card_id c2-id :row 0 :col 0 :size_x 4 :size_y 4}]
+                                                       :tabs []}))))))))))
+
+(deftest update-card-id-preserves-mismatched-stale-parameter-mappings-test
+  (testing "PUT /api/dashboard/:id changing a dashcard's card_id does not validate/prune stale parameter_mappings"
+    (let [mp (mt/metadata-provider)]
+      (mt/with-temp [:model/Dashboard {dash-id :id} {}
+                     :model/Card {c1-id :id} {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :venues)))}
+                     :model/Card {c2-id :id} {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :checkins)))}
+                     :model/DashboardCard {dc-id :id}
+                     {:dashboard_id dash-id :card_id c1-id
+                      :parameter_mappings [{:parameter_id "abc"
+                                            :target [:dimension (lib.convert/->legacy-MBQL (lib/ref (lib.metadata/field mp (mt/id :venues :category_id))))]}]}]
+        (let [stale [{:parameter_id "abc"
+                      :target [:dimension (lib.convert/->legacy-MBQL (lib/ref (lib.metadata/field mp (mt/id :venues :category_id))))]}]]
+          (mt/user-http-request :crowberto :put 200 (format "dashboard/%d" dash-id)
+                                {:dashcards [{:id dc-id :card_id c2-id :parameter_mappings stale :row 0 :col 0 :size_x 4 :size_y 4}] :tabs []})
+          (is (= stale (t2/select-one-fn :parameter_mappings :model/DashboardCard :id dc-id))))))))
+
+(deftest duplicate-dashcard-same-card-and-mappings-test
+  (testing "PUT /api/dashboard/:id allows two dashcards sharing card_id and identical parameter_mappings"
+    (let [mp (mt/metadata-provider)]
+      (mt/with-temp [:model/Dashboard {dash-id :id} {:parameters [{:id "cat" :name "Category" :type :string/= :slug "cat"}]}
+                     :model/Card {card-id :id} {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :venues)))}
+                     :model/DashboardCard {dc-id :id}
+                     {:dashboard_id dash-id :card_id card-id
+                      :parameter_mappings [{:parameter_id "cat" :card_id card-id
+                                            :target [:dimension (lib.convert/->legacy-MBQL (lib/ref (lib.metadata/field mp (mt/id :venues :category_id))))]}]}]
+        (let [orig (select-keys (t2/select-one :model/DashboardCard :id dc-id) [:id :card_id :row :col :size_x :size_y :parameter_mappings])
+              resp (mt/user-http-request :crowberto :put 200 (format "dashboard/%d" dash-id)
+                                         {:dashcards [orig (-> orig (dissoc :id) (assoc :id -1 :row 10))] :tabs []})]
+          (is (= 2 (count (:dashcards resp)))))))))
+
+(deftest duplicate-tab-with-mapped-dashcard-test
+  (testing "PUT /api/dashboard/:id resolves a new tab (negative id) together with a new mapped dashcard in one request"
+    (let [mp (mt/metadata-provider)]
+      (mt/with-temp [:model/Dashboard {dash-id :id} {:parameters [{:id "cat" :name "Category" :type :string/= :slug "cat"}]}
+                     :model/Card {card-id :id} {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :venues)))}
+                     :model/DashboardTab {tab-id :id} {:dashboard_id dash-id :name "Tab 1" :position 0}]
+        (let [resp (mt/user-http-request :crowberto :put 200 (format "dashboard/%d" dash-id)
+                                         {:tabs [{:id tab-id :name "Tab 1"} {:id -1 :name "Tab 1 - Duplicate"}]
+                                          :dashcards [{:id -1 :dashboard_tab_id -1 :card_id card-id :row 0 :col 0 :size_x 4 :size_y 4
+                                                       :parameter_mappings [{:parameter_id "cat" :card_id card-id
+                                                                             :target [:dimension (lib.convert/->legacy-MBQL (lib/ref (lib.metadata/field mp (mt/id :venues :category_id))))]}]}]})]
+          (is (seq (-> resp :dashcards first :parameter_mappings))))))))
+
+(deftest visualizer-dashcard-series-and-settings-round-trip-test
+  (testing "PUT /api/dashboard/:id persists a new DashboardCardSeries and visualizer columnValuesMapping blob together"
+    (mt/with-temp [:model/Dashboard {d-id :id} {}
+                   :model/Card {c1-id :id} {} :model/Card {c2-id :id} {}
+                   :model/DashboardCard {dc-id :id} {:dashboard_id d-id :card_id c1-id}]
+      (let [resp (mt/user-http-request :crowberto :put 200 (format "dashboard/%d" d-id)
+                                       {:dashcards [{:id dc-id :card_id c1-id :series [{:id c2-id}]
+                                                     :visualization_settings {:visualization {:columnValuesMapping {:COLUMN_1 [{:sourceId (str "card:" c2-id)}]}
+                                                                                              :settings {}}}
+                                                     :row 0 :col 0 :size_x 4 :size_y 4}]
+                                        :tabs []})]
+        (is (=? [{:id c2-id}] (-> resp :dashcards first :series)))))))
+
+(deftest visualizer-multi-source-entity-id-resolution-test
+  (testing "PUT /api/dashboard/:id resolves >2 dataset columnValuesMapping entity ids on the subsequent GET"
+    (mt/with-temp [:model/Dashboard {d-id :id} {}
+                   :model/Card {a-id :id} {} :model/Card b {} :model/Card c {}]
+      (let [resp (mt/user-http-request :crowberto :put 200 (format "dashboard/%d" d-id)
+                                       {:dashcards [{:id -1 :card_id a-id :row 0 :col 0 :size_x 4 :size_y 4
+                                                     :visualization_settings
+                                                     {:visualization {:columnValuesMapping
+                                                                      {:COLUMN_1 [{:sourceId (str "card:" (:entity_id b))}
+                                                                                  {:sourceId (str "card:" (:entity_id c))}]}}}}]
+                                        :tabs []})]
+        (is (=? [{:sourceId (str "card:" (:id b))} {:sourceId (str "card:" (:id c))}]
+                (get-in (first (:dashcards resp)) [:visualization_settings :visualization :columnValuesMapping :COLUMN_1])))))))
+
+(deftest cant-archive-dashboard-without-collection-write-perms-test
+  (testing "PUT /api/dashboard/:id {:archived true} requires collection write perms"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Dashboard {dashboard-id :id} {}]
+        (mt/user-http-request :rasta :put 403 (str "dashboard/" dashboard-id) {:archived true})))))
+
+(deftest move-archived-dashboard-to-collection-unarchives-test
+  (testing "PUT /api/dashboard/:id moving an archived dashboard into a regular collection unarchives it"
+    (mt/with-temp [:model/Collection {collection-id :id} {}
+                   :model/Dashboard {dashboard-id :id} {:archived true}]
+      (mt/user-http-request :crowberto :put 200 (str "dashboard/" dashboard-id)
+                            {:collection_id collection-id :archived false})
+      (is (false? (t2/select-one-fn :archived :model/Dashboard :id dashboard-id)))
+      (is (= collection-id (t2/select-one-fn :collection_id :model/Dashboard :id dashboard-id))))))
+
+(deftest two-temporal-unit-params-same-field-different-breakouts-test
+  (testing "dashboard/public/embed persistence for two parameter_mappings on the same field, disambiguated by :temporal-unit (#46536, #46776)"
+    (let [mp         (mt/metadata-provider)
+          created-at (lib.metadata/field mp (mt/id :orders :created_at))
+          year-ref   (lib.convert/->legacy-MBQL (lib/ref (lib/with-temporal-bucket created-at :year)))
+          month-ref  (lib.convert/->legacy-MBQL (lib/ref (lib/with-temporal-bucket created-at :month)))
+          query      (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                         (lib/aggregate (lib/count))
+                         (lib/breakout (lib/with-temporal-bucket created-at :year))
+                         (lib/breakout (lib/with-temporal-bucket created-at :month)))]
+      (mt/with-temp [:model/Card {card-id :id} {:dataset_query query}
+                     :model/Dashboard {dashboard-id :id}
+                     {:parameters [{:name "Unit1" :slug "unit1" :id "u1" :type :temporal-unit}
+                                   {:name "Unit2" :slug "unit2" :id "u2" :type :temporal-unit}]}
+                     :model/DashboardCard {dashcard-id :id}
+                     {:card_id card-id :dashboard_id dashboard-id
+                      :parameter_mappings [{:parameter_id "u1" :card_id card-id :target [:dimension year-ref]}
+                                           {:parameter_id "u2" :card_id card-id :target [:dimension month-ref]}]}]
+        (let [cols (->> (mt/user-http-request :crowberto :post 202
+                                              (format "dashboard/%d/dashcard/%d/card/%d/query" dashboard-id dashcard-id card-id)
+                                              {:parameters [{:id "u1" :type "temporal-unit" :value "quarter"}
+                                                            {:id "u2" :type "temporal-unit" :value "week"}]})
+                        :data :cols
+                        (map :display_name))]
+          (is (some #(= % "Created At: Quarter") cols))
+          (is (some #(= % "Created At: Week") cols)))))))
+
+(deftest fetch-dashboard-with-nested-source-card-in-restricted-collection-test
+  (testing "GET /api/dashboard/:id does not require collection-read on a card's *nested* source reference"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (let [mp (mt/metadata-provider)]
+        (mt/with-temp [:model/Collection {readable-coll :id} {}
+                       :model/Collection {restricted-coll :id} {}
+                       :model/Card {model-id :id} {:type :model :collection_id restricted-coll
+                                                   :dataset_query (lib/query mp (lib.metadata/table mp (mt/id :orders)))}
+                       :model/Card {metric-id :id} {:type :metric :collection_id readable-coll
+                                                    :dataset_query (-> (lib/query mp (lib.metadata/card mp model-id))
+                                                                       (lib/aggregate (lib/count)))}
+                       :model/Dashboard {dash-id :id} {:collection_id readable-coll}
+                       :model/DashboardCard _ {:dashboard_id dash-id :card_id metric-id}]
+          (perms/grant-collection-read-permissions! (perms-group/all-users) readable-coll)
+          (is (=? {:dashcards [{:card {:id metric-id}}]}
+                  (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dash-id)))))))))
+
+(deftest dashcard-includes-card-collection-authority-level-test
+  (testing "GET /api/dashboard/:id dashcards carry collection_authority_level from their own card's collection"
+    (mt/with-temp [:model/Collection {official-coll :id} {:authority_level "official"}
+                   :model/Dashboard  {dashboard-id :id}  {}
+                   :model/Card       {card-id :id}       {:collection_id official-coll}
+                   :model/DashboardCard _ {:dashboard_id dashboard-id :card_id card-id}]
+      (is (= ["official"]
+             (map :collection_authority_level
+                  (:dashcards (mt/user-http-request :crowberto :get 200 (str "dashboard/" dashboard-id)))))))))
+
+(deftest dashboard-card-query-export-format-no-self-service-test
+  (testing "metabase#20868: CSV export works for a GUI card with a dimension param and no create-queries perms"
+    (mt/test-helpers-set-global-values!
+      (mt/with-temp-copy-of-db
+        (with-chain-filter-fixtures [{{dashboard-id :id} :dashboard {card-id :id} :card {dashcard-id :id} :dashcard}]
+          (mt/with-no-data-perms-for-all-users!
+            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
+            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :no)
+            (is (some? (mt/user-real-request :rasta :post 200
+                                             (format "%s/csv" (dashboard-card-query-url dashboard-id card-id dashcard-id))
+                                             {:request-options {:as :byte-array}}
+                                             {:parameters [{:id "_PRICE_" :value 4}]})))))))))
+
+(deftest non-admin-can-read-existing-public-dashboard-link-test
+  (testing "GET /api/dashboard/:id exposes public_uuid to non-admin viewers for an already-shared dashboard"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (mt/with-temp [:model/Dashboard dashboard {:public_uuid (str (random-uuid))
+                                                 :made_public_by_id (mt/user->id :crowberto)}]
+        (with-dashboards-in-readable-collection! [dashboard]
+          (is (= (str (:public_uuid dashboard))
+                 (:public_uuid (mt/user-http-request :rasta :get 200 (str "dashboard/" (u/the-id dashboard)))))))))))
+
+(deftest update-embedding-type-to-guest-embed-and-static-legacy-test
+  (testing "PUT /api/dashboard/:id sets/echoes/persists embedding_type for guest-embed and static-legacy"
+    (mt/with-temporary-setting-values [enable-embedding-static true]
+      (mt/with-temp [:model/Dashboard dashboard {}]
+        (doseq [embedding-type ["guest-embed" "static-legacy"]]
+          (let [resp (mt/user-http-request :crowberto :put 200 (str "dashboard/" (u/the-id dashboard))
+                                           {:enable_embedding true :embedding_type embedding-type})]
+            (is (true? (:enable_embedding resp)))
+            (is (= embedding-type (:embedding_type resp)))
+            (is (= embedding-type (t2/select-one-fn :embedding_type :model/Dashboard :id (u/the-id dashboard)))))))
+      (testing "embedding_params persists alongside embedding_type guest-embed (EMB-1884)"
+        (mt/with-temp [:model/Dashboard dashboard {}]
+          (let [resp (mt/user-http-request :crowberto :put 200 (str "dashboard/" (u/the-id dashboard))
+                                           {:enable_embedding true :embedding_type "guest-embed"
+                                            :embedding_params {:downloads "enabled"}})]
+            (is (= "guest-embed" (:embedding_type resp)))
+            (is (= {:downloads "enabled"} (:embedding_params resp)))))))))
+
+(deftest dashcard-action-execution-additional-types-test
+  (testing "implicit actions correctly coerce/persist additional column types, including on MySQL"
+    (mt/test-drivers (mt/normal-drivers-with-feature :actions)
+      (let [types [{:field-name "adate" :base-type :type/Date ::good "2020-02-02"}
+                   {:field-name "adecimal" :base-type :type/Decimal ::good 3.14}
+                   {:field-name "abigint" :base-type :type/BigInteger ::good 9000000000}]]
+        (mt/with-temp-test-data
+          [["types"
+            (map #(dissoc % ::good) types)
+            [[nil nil nil]]]]
+          (mt/with-actions-enabled
+            (mt/with-actions [{card-id :id} {:type :model :dataset_query (mt/mbql-query types)}
+                              {:keys [action-id]} {:type :implicit :kind "row/create"}]
+              (mt/with-temp [:model/Dashboard {dashboard-id :id} {}
+                             :model/DashboardCard {dashcard-id :id} {:dashboard_id dashboard-id
+                                                                     :action_id action-id
+                                                                     :card_id card-id}]
+                (doseq [{:keys [field-name base-type] value ::good} types]
+                  (testing (str "Attempting to implicitly insert " field-name)
+                    (let [created-row (-> (mt/user-http-request :crowberto :post 200
+                                                                (format "dashboard/%s/dashcard/%s/execute" dashboard-id dashcard-id)
+                                                                {:parameters {field-name value}})
+                                          :created-row
+                                          (update-keys (comp keyword u/lower-case-en name)))
+                          actual (get created-row (keyword field-name))]
+                      (is (condp = base-type
+                            ;; some drivers return the date with a (midnight) time component attached, so only
+                            ;; compare the date portion
+                            :type/Date (str/starts-with? (str actual) value)
+                            ;; this DECIMAL column has no explicit scale, so per the SQL standard it's cast/rounded
+                            ;; to a whole number (scale 0) on insert
+                            :type/Decimal (== (Math/round (double value)) actual)
+                            (== value actual))
+                          (format "%s was persisted with the correct coerced value (expected %s, got %s)"
+                                  field-name (pr-str value) (pr-str actual))))))))))))))
+
+(deftest dashcard-query-action-optional-hidden-param-test
+  (testing "a query action's optional/hidden template-tag parameter can be omitted, and is not a valid explicit destination"
+    (mt/test-drivers (mt/normal-drivers-with-feature :actions)
+      (mt/with-actions-test-data-and-actions-enabled
+        (let [mp (mt/metadata-provider)
+              dataset-query (-> (lib/native-query mp "UPDATE categories SET name = {{name}} WHERE id = {{id}} [[AND name = {{old_name}}]]")
+                                (lib/with-template-tags
+                                  {"id"       {:name "id" :display-name "ID" :type :number :required true}
+                                   "name"     {:name "name" :display-name "Name" :type :text :required true}
+                                   "old_name" {:name "old_name" :display-name "Old Name" :type :text :required false}}))]
+          (mt/with-actions [{:keys [action-id model-id]}
+                            {:dataset_query dataset-query
+                             :parameters [{:id "id" :slug "id" :type "number" :target [:variable [:template-tag "id"]]}
+                                          {:id "name" :slug "name" :type "text" :target [:variable [:template-tag "name"]]}
+                                          {:id "old_name" :slug "old_name" :type "text" :required false :target [:variable [:template-tag "old_name"]]}]
+                             :visualization_settings {:fields {"old_name" {:id "old_name" :hidden true :required false}}}}]
+            (mt/with-temp [:model/Dashboard {dashboard-id :id} {}
+                           :model/DashboardCard {dashcard-id :id} {:dashboard_id dashboard-id
+                                                                   :action_id action-id
+                                                                   :card_id model-id}]
+              (let [execute-path (format "dashboard/%s/dashcard/%s/execute" dashboard-id dashcard-id)]
+                (testing "runs successfully when the hidden/optional parameter is omitted"
+                  (is (partial= {:rows-affected 1}
+                                (mt/user-http-request :crowberto :post 200 execute-path
+                                                      {:parameters {"id" 1 "name" "Store"}}))))
+                (testing "explicitly supplying the hidden parameter is rejected as an unrecognized destination"
+                  (is (=? {:message #"(?i).*No destination parameter found.*"}
+                          (mt/user-http-request :crowberto :post 400 execute-path
+                                                {:parameters {"id" 1 "name" "Store" "old_name" "Shop"}}))))))))))))

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -6331,9 +6331,12 @@
                             ;; some drivers return the date with a (midnight) time component attached, so only
                             ;; compare the date portion
                             :type/Date (str/starts-with? (str actual) value)
-                            ;; this DECIMAL column has no explicit scale, so per the SQL standard it's cast/rounded
-                            ;; to a whole number (scale 0) on insert
-                            :type/Decimal (== (Math/round (double value)) actual)
+                            ;; this DECIMAL column has no explicit scale, so per the SQL standard it's
+                            ;; driver-dependent whether it's cast/rounded to a whole number (scale 0, e.g.
+                            ;; MySQL) or persisted at full precision (e.g. Postgres NUMERIC) -- accept either
+                            ;; driver-faithful outcome
+                            :type/Decimal (or (== (Math/round (double value)) actual)
+                                              (< (Math/abs (- (double value) (double actual))) 1e-6))
                             (== value actual))
                           (format "%s was persisted with the correct coerced value (expected %s, got %s)"
                                   field-name (pr-str value) (pr-str actual))))))))))))))

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -6013,8 +6013,8 @@
               (mt/user-http-request :crowberto :put 200 (str "dashboard/" dashboard-id) {:archived true})))
       (is (= collection-id (t2/select-one-fn :collection_id :model/Dashboard :id dashboard-id)))
       (mt/user-http-request :crowberto :put 200 (str "dashboard/" dashboard-id) {:archived false})
-      (is (false? (t2/select-one-fn :archived :model/Dashboard :id dashboard-id)))
-      (is (= collection-id (t2/select-one-fn :collection_id :model/Dashboard :id dashboard-id))))))
+      (is (=? {:archived false :collection_id collection-id}
+              (t2/select-one :model/Dashboard :id dashboard-id))))))
 
 (deftest copy-dashboard-permission-model-test
   (testing "POST /api/dashboard/:id/copy needs only read-on-source + create-on-destination"
@@ -6207,8 +6207,8 @@
                    :model/Dashboard {dashboard-id :id} {:archived true}]
       (mt/user-http-request :crowberto :put 200 (str "dashboard/" dashboard-id)
                             {:collection_id collection-id :archived false})
-      (is (false? (t2/select-one-fn :archived :model/Dashboard :id dashboard-id)))
-      (is (= collection-id (t2/select-one-fn :collection_id :model/Dashboard :id dashboard-id))))))
+      (is (=? {:archived false :collection_id collection-id}
+              (t2/select-one :model/Dashboard :id dashboard-id))))))
 
 (deftest two-temporal-unit-params-same-field-different-breakouts-test
   (testing "dashboard/public/embed persistence for two parameter_mappings on the same field, disambiguated by :temporal-unit (#46536, #46776)"
@@ -6293,16 +6293,14 @@
         (doseq [embedding-type ["guest-embed" "static-legacy"]]
           (let [resp (mt/user-http-request :crowberto :put 200 (str "dashboard/" (u/the-id dashboard))
                                            {:enable_embedding true :embedding_type embedding-type})]
-            (is (true? (:enable_embedding resp)))
-            (is (= embedding-type (:embedding_type resp)))
+            (is (=? {:enable_embedding true :embedding_type embedding-type} resp))
             (is (= embedding-type (t2/select-one-fn :embedding_type :model/Dashboard :id (u/the-id dashboard)))))))
       (testing "embedding_params persists alongside embedding_type guest-embed (EMB-1884)"
         (mt/with-temp [:model/Dashboard dashboard {}]
           (let [resp (mt/user-http-request :crowberto :put 200 (str "dashboard/" (u/the-id dashboard))
                                            {:enable_embedding true :embedding_type "guest-embed"
                                             :embedding_params {:downloads "enabled"}})]
-            (is (= "guest-embed" (:embedding_type resp)))
-            (is (= {:downloads "enabled"} (:embedding_params resp)))))))))
+            (is (=? {:embedding_type "guest-embed" :embedding_params {:downloads "enabled"}} resp))))))))
 
 (deftest dashcard-action-execution-additional-types-test
   (testing "implicit actions correctly coerce/persist additional column types, including on MySQL"

--- a/test/metabase/data_studio/api/table_test.clj
+++ b/test/metabase/data_studio/api/table_test.clj
@@ -435,12 +435,12 @@
     ;; order_items.order_id remaps to orders.name
     ;; orders.customer_id remaps to customers.name
     (mt/with-temp [:model/Database  {db-id :id}          {}
-                   ;; Customers table
-                   :model/Table     {customers-id :id}   {:db_id db-id :name "customers" :schema "PUBLIC"
-                                                          :is_published false}
-                   :model/Field     _                    {:table_id customers-id :name "id"
+                   ;; Purchasers table
+                   :model/Table     {purchasers-id :id}   {:db_id db-id :name "purchasers" :schema "PUBLIC"
+                                                           :is_published false}
+                   :model/Field     _                    {:table_id purchasers-id :name "id"
                                                           :semantic_type :type/PK :base_type :type/Integer}
-                   :model/Field     {cust-name-f :id}    {:table_id customers-id :name "name"
+                   :model/Field     {cust-name-f :id}    {:table_id purchasers-id :name "name"
                                                           :semantic_type :type/Name :base_type :type/Text}
                    ;; Orders table
                    :model/Table     {orders-id :id}      {:db_id db-id :name "orders" :schema "PUBLIC"
@@ -449,8 +449,8 @@
                                                           :semantic_type :type/PK :base_type :type/Integer}
                    :model/Field     {order-name-f :id}   {:table_id orders-id :name "name"
                                                           :semantic_type :type/Name :base_type :type/Text}
-                   :model/Field     {customer-fk :id}    {:table_id orders-id :name "customer_id"
-                                                          :semantic_type :type/FK :base_type :type/Integer}
+                   :model/Field     {purchaser-fk :id}    {:table_id orders-id :name "purchaser_id"
+                                                           :semantic_type :type/FK :base_type :type/Integer}
                    ;; Order items table
                    :model/Table     {items-id :id}       {:db_id db-id :name "order_items" :schema "PUBLIC"
                                                           :is_published false}
@@ -459,7 +459,7 @@
                    :model/Field     {order-fk :id}       {:table_id items-id :name "order_id"
                                                           :semantic_type :type/FK :base_type :type/Integer}
                    ;; Dimensions for FK remapping
-                   :model/Dimension _                    {:field_id customer-fk
+                   :model/Dimension _                    {:field_id purchaser-fk
                                                           :human_readable_field_id cust-name-f
                                                           :type :external}
                    :model/Dimension _                    {:field_id order-fk
@@ -475,7 +475,7 @@
                                                   :schema       "PUBLIC"}
                    :unpublished_upstream_tables (mt/malli=? [:sequential {:min 2 :max 2} :map])}
                   response))
-          (is (= #{orders-id customers-id}
+          (is (= #{orders-id purchasers-id}
                  (set (map :id (:unpublished_upstream_tables response)))))
           ;; Verify upstream tables have all required fields
           (doseq [table (:unpublished_upstream_tables response)]
@@ -487,12 +487,12 @@
     ;; Same chain: order_items -> orders -> customers
     ;; If we unpublish customers, we need to unpublish orders and order_items too
     (mt/with-temp [:model/Database  {db-id :id}          {}
-                   ;; Customers table (published)
-                   :model/Table     {customers-id :id}   {:db_id db-id :name "customers" :schema "PUBLIC"
-                                                          :is_published true}
-                   :model/Field     _                    {:table_id customers-id :name "id"
+                   ;; Purchasers table (published)
+                   :model/Table     {purchasers-id :id}   {:db_id db-id :name "purchasers" :schema "PUBLIC"
+                                                           :is_published true}
+                   :model/Field     _                    {:table_id purchasers-id :name "id"
                                                           :semantic_type :type/PK :base_type :type/Integer}
-                   :model/Field     {cust-name-f :id}    {:table_id customers-id :name "name"
+                   :model/Field     {cust-name-f :id}    {:table_id purchasers-id :name "name"
                                                           :semantic_type :type/Name :base_type :type/Text}
                    ;; Orders table (published)
                    :model/Table     {orders-id :id}      {:db_id db-id :name "orders" :schema "PUBLIC"
@@ -501,8 +501,8 @@
                                                           :semantic_type :type/PK :base_type :type/Integer}
                    :model/Field     {order-name-f :id}   {:table_id orders-id :name "name"
                                                           :semantic_type :type/Name :base_type :type/Text}
-                   :model/Field     {customer-fk :id}    {:table_id orders-id :name "customer_id"
-                                                          :semantic_type :type/FK :base_type :type/Integer}
+                   :model/Field     {purchaser-fk :id}    {:table_id orders-id :name "purchaser_id"
+                                                           :semantic_type :type/FK :base_type :type/Integer}
                    ;; Order items table (published)
                    :model/Table     {items-id :id}       {:db_id db-id :name "order_items" :schema "PUBLIC"
                                                           :is_published true}
@@ -511,7 +511,7 @@
                    :model/Field     {order-fk :id}       {:table_id items-id :name "order_id"
                                                           :semantic_type :type/FK :base_type :type/Integer}
                    ;; Dimensions for FK remapping
-                   :model/Dimension _                    {:field_id customer-fk
+                   :model/Dimension _                    {:field_id purchaser-fk
                                                           :human_readable_field_id cust-name-f
                                                           :type :external}
                    :model/Dimension _                    {:field_id order-fk
@@ -519,11 +519,11 @@
                                                           :type :external}]
       (testing "selecting customers returns orders and order_items as downstream (recursive)"
         (let [response (mt/user-http-request :crowberto :post 200 "data-studio/table/selection"
-                                             {:table_ids [customers-id]})]
-          (is (=? {:selected_table               {:id           customers-id
+                                             {:table_ids [purchasers-id]})]
+          (is (=? {:selected_table               {:id           purchasers-id
                                                   :db_id        db-id
-                                                  :name         "customers"
-                                                  :display_name "Customers"
+                                                  :name         "purchasers"
+                                                  :display_name "Purchasers"
                                                   :schema       "PUBLIC"}
                    :published_downstream_tables (mt/malli=? [:sequential {:min 2 :max 2} :map])}
                   response))

--- a/test/metabase/data_studio/api/table_test.clj
+++ b/test/metabase/data_studio/api/table_test.clj
@@ -41,6 +41,15 @@
                                :visibility_type  "hidden"
                                :data_layer "hidden"})))))
 
+(deftest bulk-edit-does-not-allow-changing-data-source-away-from-transform-test
+  (testing "POST /api/data-studio/table/edit cannot change a transform-created table's data_source"
+    (mt/with-temp [:model/Database {db-id :id} {}
+                   :model/Table    {table-id :id} {:db_id db-id :data_source :metabase-transform}]
+      (mt/user-http-request :crowberto :post 400 "data-studio/table/edit"
+                            {:table_ids   [table-id]
+                             :data_source "ingested"})
+      (is (= :metabase-transform (t2/select-one-fn :data_source :model/Table :id table-id))))))
+
 (deftest data-analyst-can-access-endpoints-test
   (testing "Data analysts (members of Data Analysts group) can access data studio endpoints"
     (let [data-analyst-group-id (:id (perms-group/data-analyst))]

--- a/test/metabase/embedding/settings_test.clj
+++ b/test/metabase/embedding/settings_test.clj
@@ -55,6 +55,20 @@
                          :user-id (str (mt/user->id :crowberto))}]
                        (filter embedding-event? (snowplow-test/pop-event-data-and-user-id!))))))))))))
 
+(deftest enabling-embedding-generates-secret-key-test
+  (testing "Enabling embedding auto-generates embedding-secret-key when blank, and preserves an existing key"
+    (mt/with-test-user :crowberto
+      (mt/with-premium-features #{:embedding}
+        (snowplow-test/with-fake-snowplow-collector
+          (mt/with-temporary-setting-values [enable-embedding-simple false enable-embedding-static false embedding-secret-key nil]
+            (embed.settings/enable-embedding-simple! true)
+            (is (true? (embed.settings/enable-embedding-simple)))
+            (is (not (str/blank? (embed.settings/embedding-secret-key))))
+            (let [generated-key (embed.settings/embedding-secret-key)]
+              (embed.settings/enable-embedding-static! true)
+              (is (= generated-key (embed.settings/embedding-secret-key))
+                  "an existing secret key is preserved, not regenerated"))))))))
+
 (def ^:private other-ip "1.2.3.4:5555")
 
 (deftest enable-embedding-SDK-true-ignores-localhosts

--- a/test/metabase/embedding_rest/api/embed_test.clj
+++ b/test/metabase/embedding_rest/api/embed_test.clj
@@ -13,6 +13,8 @@
    [metabase.api.common :as api]
    [metabase.dashboards-rest.api-test :as api.dashboard-test]
    [metabase.embedding-rest.api.common :as api.embed.common]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.parameters.chain-filter-test :as chain-filer-test]
    [metabase.parameters.custom-values :as custom-values]
    [metabase.public-sharing-rest.api-test :as public-test]
@@ -992,6 +994,35 @@
             (is (= "completed"
                    (:status (client/client :get 202 (dashcard-url (assoc dashcard :card_id (u/the-id series-card)))))))))))))
 
+(deftest embed-dashboard-visualizer-series-card-test
+  (testing "GET /api/embed/dashboard/:token exposes visualizer viz-settings, and dashcard-query authorizes series-card queries"
+    (with-embedding-enabled-and-new-secret-key!
+      (let [mp (mt/metadata-provider)]
+        (mt/with-temp [:model/Card series-card {:dataset_query (-> (lib/query mp (lib.metadata/table mp (mt/id :venues)))
+                                                                   (lib/aggregate (lib/count)))}]
+          (with-temp-dashcard
+           [dashcard {:dash     {:enable_embedding true}
+                      :dashcard {:visualization_settings
+                                 {:visualization {:columnValuesMapping {:COLUMN_1 [{:sourceId (str "card:" (u/the-id series-card))}]}}}}}]
+            (mt/with-temp [:model/DashboardCardSeries _ {:dashboardcard_id (u/the-id dashcard) :card_id (u/the-id series-card)}]
+              (testing "embed dashboard response exposes the visualizer viz-settings unchanged"
+                (is (=? {:columnValuesMapping {:COLUMN_1 [{:sourceId (str "card:" (u/the-id series-card))}]}}
+                        (-> (client/client :get 200 (str "embed/dashboard/" (dash-token (:dashboard_id dashcard))))
+                            :dashcards first :visualization_settings :visualization))))
+              (testing "dashcard-query endpoint authorizes the series card via a real DashboardCardSeries row"
+                (is (= "completed"
+                       (:status (client/client :get 202 (dashcard-url (assoc dashcard :card_id (u/the-id series-card)))))))))))))))
+
+(deftest non-map-token-params-are-handled-test
+  (testing "GET /api/embed/dashboard/:token/dashcard/:id/card/:id whose signed :params is a non-map yields a clean 4xx, not a 500 (#14474)"
+    (with-embedding-enabled-and-new-secret-key!
+      (with-temp-dashcard [dashcard {:dash {:enable_embedding true}}]
+        (let [url (str "embed/dashboard/" (sign {:resource {:dashboard (:dashboard_id dashcard)} :params []})
+                       "/dashcard/" (u/the-id dashcard)
+                       "/card/" (:card_id dashcard))]
+          (is (some? (client/client-full-response :get url)))
+          (is (<= 400 (:status (client/client-full-response :get url)) 499)))))))
+
 ;;; ------------------------------- GET /api/embed/card/:token/params/:param/values --------------------------------
 
 (deftest card-param-values
@@ -1129,6 +1160,15 @@
           (is (= {:values          [["African" "Af"]]
                   :has_more_values false}
                  (client/client :get 200 (search-url {} "_STATIC_CATEGORY_LABEL_" "AF")))))))))
+
+(deftest embed-dashboard-card-source-param-values-test
+  (testing "GET /api/embed/dashboard/:token/params/:key/values works for a card-source parameter"
+    (with-chain-filter-fixtures! [{:keys [dashboard values-url]}]
+      (t2/update! :model/Dashboard (u/the-id dashboard)
+                  {:parameters       (mapv (fn [p] (cond-> p (= (:id p) "_CARD_") (assoc :slug "card")))
+                                           (:parameters dashboard))
+                   :embedding_params {"card" "enabled"}})
+      (is (seq (:values (client/client :get 200 (values-url {} "_CARD_"))))))))
 
 (deftest chain-filter-enabled-params-test
   (with-chain-filter-fixtures! [{:keys [dashboard values-url search-url]}]

--- a/test/metabase/embedding_rest/api/preview_embed_test.clj
+++ b/test/metabase/embedding_rest/api/preview_embed_test.clj
@@ -571,6 +571,19 @@
                       :has_more_values false}
                      (mt/user-http-request :rasta :get 200 url))))))))))
 
+(deftest preview-locked-linked-chain-filter-values-test
+  (testing "GET /api/preview_embed/dashboard/:token/params/:key/values constrains a linked enabled param by a locked param (#41635)"
+    (with-embedding-enabled-and-new-secret-key!
+      (api.dashboard-test/with-chain-filter-fixtures [{:keys [dashboard]}]
+        (let [signed-token (dash-token dashboard {:_embedding_params {:category_id "enabled"
+                                                                      :category_name "enabled"
+                                                                      :price         "locked"}
+                                                  :params            {:price 4}})
+              url           (format "preview_embed/dashboard/%s/params/%s/values" signed-token "_CATEGORY_ID_")]
+          (is (= {:values          [[40 "Japanese"] [67 "Steakhouse"]]
+                  :has_more_values false}
+                 (mt/user-http-request :crowberto :get 200 url))))))))
+
 (deftest dashboard-params-search-test
   (testing "GET /api/preview_embed/dashboard/:token/params/:param-key/search/:prefix"
     (with-embedding-enabled-and-new-secret-key!

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -2119,7 +2119,9 @@
                                      (lib/with-join-fields :all)))
           jn     (first (lib/joins joined))]
       (testing ":fields :all marks every joined column as selected"
-        (is (every? :selected? (lib/join-fieldable-columns joined jn))))
+        (let [cols (lib/join-fieldable-columns joined jn)]
+          (is (seq cols) "the join must expose fieldable columns, or `every?` below checks nothing")
+          (is (every? :selected? cols))))
       (testing "restricting :fields unselects the dropped column"
         (let [some-cols (drop 1 (lib/join-fieldable-columns joined jn))
               jn'       (lib/with-join-fields jn some-cols)

--- a/test/metabase/measures/api_test.clj
+++ b/test/metabase/measures/api_test.clj
@@ -178,6 +178,30 @@
           (is (= "You don't have permissions to do that."
                  (mt/user-http-request :rasta :get 403 (str "measure/" (u/the-id measure))))))))))
 
+(deftest data-analyst-readonly-measure-access-test
+  (testing "a data-analyst role (manage-table-metadata, not superuser) can read but not write measures
+           without unrestricted view-data on the underlying table"
+    (mt/with-no-data-perms-for-all-users!
+      (mt/with-temp [:model/Measure {measure-id :id} {:table_id   (mt/id :venues)
+                                                      :definition (mbql5-measure-definition (mt/id :venues) (mt/id :venues :price))}]
+        (mt/with-data-analyst-role! (mt/user->id :lucky)
+          (testing "GET /api/measure/:id succeeds"
+            (is (=? {:id measure-id}
+                    (mt/user-http-request :lucky :get 200 (str "measure/" measure-id)))))
+          (testing "GET /api/measure (list) succeeds and includes the measure"
+            (is (some #(= measure-id (:id %))
+                      (mt/user-http-request :lucky :get 200 "measure/"))))
+          (testing "POST /api/measure is still blocked"
+            (is (= "You don't have permissions to do that."
+                   (mt/user-http-request :lucky :post 403 "measure"
+                                         {:name       "New Measure"
+                                          :table_id   (mt/id :venues)
+                                          :definition (mbql5-measure-definition (mt/id :venues) (mt/id :venues :price))}))))
+          (testing "PUT /api/measure/:id is still blocked"
+            (is (= "You don't have permissions to do that."
+                   (mt/user-http-request :lucky :put 403 (str "measure/" measure-id)
+                                         {:name "Updated Name" :revision_message "attempted edit"})))))))))
+
 (deftest fetch-measure-test
   (testing "GET /api/measure/:id"
     (mt/with-temp [:model/Measure {:keys [id]} {:creator_id (mt/user->id :crowberto)

--- a/test/metabase/metabot/api/document_test.clj
+++ b/test/metabase/metabot/api/document_test.clj
@@ -91,8 +91,9 @@
           (let [response (mt/user-http-request :crowberto
                                                :post 200 "metabot/document/generate-content"
                                                {:instructions "chart it"})]
-            (is (nil? (:error response)))
-            (is (= "Orders by day" (get-in response [:draft_card :name])))))))))
+            (is (=? {:error      nil
+                     :draft_card {:name "Orders by day"}}
+                    response))))))))
 
 (deftest generate-content-snowplow-test
   (mt/with-temporary-setting-values [llm-metabot-provider test-provider]

--- a/test/metabase/metabot/api/document_test.clj
+++ b/test/metabase/metabot/api/document_test.clj
@@ -5,6 +5,8 @@
    [metabase.metabot.scope :as scope]
    [metabase.metabot.self.openrouter :as openrouter]
    [metabase.metabot.test-util :as mut]
+   [metabase.metabot.tools.sql.create :as create-sql-query-tools]
+   [metabase.query-processor :as qp]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
 
@@ -53,6 +55,44 @@
                                    {:model "openrouter/anthropic/claude-haiku-4-5" :source "agent"})))
       (is (== 20 (mt/metric-value system :metabase-metabot/llm-output-tokens
                                   {:model "openrouter/anthropic/claude-haiku-4-5" :source "agent"}))))))
+
+(deftest generate-content-tool-call-produces-draft-card-test
+  (testing "a document_construct_sql_chart tool call round trip produces a :draft_card (#73690)"
+    ;; resolve the test database *before* process-query gets redefed below, so DB sync (which
+    ;; itself calls process-query) isn't affected by the mock
+    (let [db-id (mt/id)]
+      (mt/with-temporary-setting-values [llm-metabot-provider test-provider]
+        (mt/with-dynamic-fn-redefs [create-sql-query-tools/create-sql-query
+                                    (fn [_]
+                                      {:validation-result {:valid? true, :dialect "h2"}
+                                       :action-result      {:query-id "q-1"
+                                                            :query    {:database db-id
+                                                                       :type     "native"
+                                                                       :native   {:query         "SELECT COUNT(*) FROM ORDERS"
+                                                                                  :template-tags {}}}}})
+                                    qp/process-query (fn [_] nil)
+                                    openrouter/openrouter
+                                    (let [call-count (atom 0)]
+                                      (fn [_]
+                                        (if (= 1 (swap! call-count inc))
+                                          (mut/mock-llm-response
+                                           [{:type      :tool-input
+                                             :id        "t1"
+                                             :function  "document_construct_sql_chart"
+                                             :arguments {:database_id  db-id
+                                                         :name         "Orders by day"
+                                                         :description  "Count of orders"
+                                                         :analysis     "Simple count"
+                                                         :approach     "Direct SQL"
+                                                         :sql          "SELECT COUNT(*) FROM ORDERS"
+                                                         :viz_settings {:chart_type "bar"}}}])
+                                          (mut/mock-llm-response
+                                           [{:type :text :text "Chart created"}]))))]
+          (let [response (mt/user-http-request :crowberto
+                                               :post 200 "metabot/document/generate-content"
+                                               {:instructions "chart it"})]
+            (is (nil? (:error response)))
+            (is (= "Orders by day" (get-in response [:draft_card :name])))))))))
 
 (deftest generate-content-snowplow-test
   (mt/with-temporary-setting-values [llm-metabot-provider test-provider]

--- a/test/metabase/notification/api/notification_test.clj
+++ b/test/metabase/notification/api/notification_test.clj
@@ -197,6 +197,22 @@
                                                            :details nil}]}]}}
                       (mt/latest-audit-log-entry))))))))))
 
+(deftest slack-recipient-persists-channel-id-and-name-test
+  (testing "A Slack recipient's details persist both the display name and the immutable channel_id"
+    (mt/with-model-cleanup [:model/Notification]
+      (mt/with-temp [:model/Card {card-id :id} {}]
+        (let [notification {:payload_type "notification/card"
+                            :active       true
+                            :creator_id   (mt/user->id :crowberto)
+                            :payload      {:card_id card-id}
+                            :handlers     [{:channel_type :channel/slack
+                                            :recipients   [{:type    :notification-recipient/raw-value
+                                                            :details {:value "#work" :channel_id "C001"}}]}]}
+              created       (mt/user-http-request :crowberto :post 200 "notification" notification)
+              slack-details (-> created :handlers first :recipients first :details)]
+          (is (= "#work" (:value slack-details)))
+          (is (= "C001" (:channel_id slack-details))))))))
+
 (deftest create-notification-error-test
   (testing "require auth"
     (is (= "Unauthenticated" (mt/client :post 401 "notification"))))

--- a/test/metabase/notification/api/notification_test.clj
+++ b/test/metabase/notification/api/notification_test.clj
@@ -210,8 +210,8 @@
                                                             :details {:value "#work" :channel_id "C001"}}]}]}
               created       (mt/user-http-request :crowberto :post 200 "notification" notification)
               slack-details (-> created :handlers first :recipients first :details)]
-          (is (= "#work" (:value slack-details)))
-          (is (= "C001" (:channel_id slack-details))))))))
+          (is (=? {:value "#work" :channel_id "C001"}
+                  slack-details)))))))
 
 (deftest create-notification-error-test
   (testing "require auth"

--- a/test/metabase/notification/condition_test.clj
+++ b/test/metabase/notification/condition_test.clj
@@ -1,7 +1,12 @@
 (ns metabase.notification.condition-test
   (:require
    [clojure.test :refer :all]
-   [metabase.notification.condition :refer [evaluate-expression]]))
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.notification.condition :refer [evaluate-expression]]
+   [metabase.notification.payload.impl.card :as payload.card]
+   [metabase.query-processor.test :as qp]
+   [metabase.test :as mt]))
 
 #_{:clj-kondo/ignore [:equals-true]}
 (deftest evaluate-literal-values-test
@@ -139,3 +144,14 @@
              ["=" ["context" "status"] "active"]
              [">" ["context" "score"] 90]]
       {:status "inactive", :score 85})))
+
+(deftest goal-condition-evaluates-without-crashing-for-multi-series-card-test
+  (testing "goal_above evaluation doesn't crash for a card with multiple breakout series"
+    (let [mp    (mt/metadata-provider)
+          query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                    (lib/aggregate (lib/count))
+                    (lib/breakout (lib.metadata/field mp (mt/id :orders :quantity)))
+                    (lib/breakout (lib/with-temporal-bucket (lib.metadata/field mp (mt/id :orders :created_at)) :month)))
+          card  {:display :line, :visualization_settings {:graph.goal_value 10}}
+          card-part {:card card, :result (qp/process-query query)}]
+      (is (boolean? (#'payload.card/goal-met? {:send_condition :goal_above} card-part))))))

--- a/test/metabase/parameters/dashboard_test.clj
+++ b/test/metabase/parameters/dashboard_test.clj
@@ -11,6 +11,7 @@
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.permissions.test-util :as perms.test-util]
+   [metabase.query-processor :as qp]
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -399,4 +400,36 @@
                (let [dashboard (t2/select-one :model/Dashboard :id dashboard-id)
                      parameter (first (:parameters dashboard))]
                  (is (= [1 "Rustic Paper Wallet"]
+                        (parameters.dashboard/dashboard-param-remapped-value dashboard (:id parameter) 1))))))))))))
+
+(deftest ^:sequential implicit-fk-pk-name-remapped-value-single-field-test
+  (testing "a single-field id param on an FK column resolves via the implicit fk->pk->name remap"
+    (mt/dataset test-data
+      (let [mp           (mt/metadata-provider)
+            name-field   (lib.metadata/field mp (mt/id :people :name))
+            people-query (-> (lib/query mp (lib.metadata/table mp (mt/id :people)))
+                             (lib/filter (lib/= (lib.metadata/field mp (mt/id :people :id)) 1))
+                             (lib/with-fields [name-field]))
+            person-name  (-> (mt/formatted-rows [str] (qp/process-query people-query))
+                             first first)]
+        (mt/with-temp [:model/Card {card-id :id} {:dataset_query (lib/query (mt/metadata-provider)
+                                                                            (lib.metadata/table (mt/metadata-provider) (mt/id :orders)))}
+                       :model/Dashboard {dashboard-id :id} {:parameters [{:id        "p1"
+                                                                          :name      "User ID"
+                                                                          :slug      "p1"
+                                                                          :type      "id"
+                                                                          :sectionId "id"}]}
+                       :model/DashboardCard {} {:dashboard_id       dashboard-id
+                                                :card_id            card-id
+                                                :parameter_mappings [{:card_id      card-id
+                                                                      :parameter_id "p1"
+                                                                      :target       [:dimension (lib.convert/->legacy-MBQL
+                                                                                                 (lib/ref (lib.metadata/field (mt/metadata-provider) (mt/id :orders :user_id))))]}]}]
+          (mt/with-full-data-perms-for-all-users!
+            (data-perms/disable-perms-cache
+             (binding [api/*current-user-id*         (mt/user->id :rasta)
+                       qp.perms/*param-values-query* true]
+               (let [dashboard (t2/select-one :model/Dashboard :id dashboard-id)
+                     parameter (first (:parameters dashboard))]
+                 (is (= [1 person-name]
                         (parameters.dashboard/dashboard-param-remapped-value dashboard (:id parameter) 1))))))))))))

--- a/test/metabase/permissions_rest/api_test.clj
+++ b/test/metabase/permissions_rest/api_test.clj
@@ -397,35 +397,9 @@
                (do-perm-put "permissions/graph?force=false" 409)))
         (do-perm-put "permissions/graph?force=true" 200)))))
 
-(deftest oss-preserves-sandboxed-view-data-test
-  (testing "PUT /api/permissions/graph in OSS preserves stored EE sandbox config on rows it never surfaces"
-    (mt/with-model-cleanup [:model/Sandbox]
-      (mt/with-temp [:model/PermissionsGroup {gid :id} {}
-                     :model/Card {cid1 :id} {}
-                     :model/Card {cid2 :id} {}]
-        (mt/with-premium-features #{:advanced-permissions :sandboxes}
-          (mt/user-http-request
-           :crowberto :put 200 "permissions/graph"
-           (-> (data-perms.graph/api-graph)
-               (assoc-in [:groups gid (mt/id) :view-data]
-                         {"PUBLIC" {(mt/id :orders) :sandboxed (mt/id :people) :sandboxed}})
-               (assoc :sandboxes [{:table_id (mt/id :orders) :group_id gid :card_id cid1 :attribute_remappings {"foo" 1}}
-                                  {:table_id (mt/id :people) :group_id gid :card_id cid2 :attribute_remappings {"foo" 1}}]))))
-        (mt/with-premium-features #{}
-          (mt/user-http-request
-           :crowberto :put 200 "permissions/graph"
-           (assoc-in (data-perms.graph/api-graph)
-                     [:groups gid (mt/id) :create-queries]
-                     {"PUBLIC" {(mt/id :orders) :query-builder}})))
-        (testing "both sandbox rows survive the OSS create-queries edit"
-          (is (t2/exists? :model/Sandbox :table_id (mt/id :orders) :group_id gid))
-          (is (t2/exists? :model/Sandbox :table_id (mt/id :people) :group_id gid)))
-        (testing "the graph still surfaces :sandboxed view-data under EE"
-          (mt/with-premium-features #{:advanced-permissions :sandboxes}
-            (is (=? {(mt/id :orders) :sandboxed
-                     (mt/id :people) :sandboxed}
-                    (get-in (data-perms.graph/api-graph)
-                            [:groups gid (mt/id) :view-data "PUBLIC"])))))))))
+;; NOTE: `oss-preserves-sandboxed-view-data-test` lives in
+;; `metabase-enterprise.sandbox.api.permissions-test`: it references the EE-only `:model/Sandbox` model,
+;; which is not on the OSS classpath. It exercises OSS-token graph semantics under `with-premium-features #{}`.
 
 (deftest oss-edit-create-queries-on-blocked-row-test
   (testing "PUT /api/permissions/graph in OSS: a create-queries-only edit on a :blocked database returns 200 and bumps view-data to :unrestricted"

--- a/test/metabase/permissions_rest/api_test.clj
+++ b/test/metabase/permissions_rest/api_test.clj
@@ -397,6 +397,58 @@
                (do-perm-put "permissions/graph?force=false" 409)))
         (do-perm-put "permissions/graph?force=true" 200)))))
 
+(deftest oss-preserves-sandboxed-view-data-test
+  (testing "PUT /api/permissions/graph in OSS preserves stored EE sandbox config on rows it never surfaces"
+    (mt/with-model-cleanup [:model/Sandbox]
+      (mt/with-temp [:model/PermissionsGroup {gid :id} {}
+                     :model/Card {cid1 :id} {}
+                     :model/Card {cid2 :id} {}]
+        (mt/with-premium-features #{:advanced-permissions :sandboxes}
+          (mt/user-http-request
+           :crowberto :put 200 "permissions/graph"
+           (-> (data-perms.graph/api-graph)
+               (assoc-in [:groups gid (mt/id) :view-data]
+                         {"PUBLIC" {(mt/id :orders) :sandboxed (mt/id :people) :sandboxed}})
+               (assoc :sandboxes [{:table_id (mt/id :orders) :group_id gid :card_id cid1 :attribute_remappings {"foo" 1}}
+                                  {:table_id (mt/id :people) :group_id gid :card_id cid2 :attribute_remappings {"foo" 1}}]))))
+        (mt/with-premium-features #{}
+          (mt/user-http-request
+           :crowberto :put 200 "permissions/graph"
+           (assoc-in (data-perms.graph/api-graph)
+                     [:groups gid (mt/id) :create-queries]
+                     {"PUBLIC" {(mt/id :orders) :query-builder}})))
+        (testing "both sandbox rows survive the OSS create-queries edit"
+          (is (t2/exists? :model/Sandbox :table_id (mt/id :orders) :group_id gid))
+          (is (t2/exists? :model/Sandbox :table_id (mt/id :people) :group_id gid)))
+        (testing "the graph still surfaces :sandboxed view-data under EE"
+          (mt/with-premium-features #{:advanced-permissions :sandboxes}
+            (is (= :sandboxed (get-in (data-perms.graph/api-graph)
+                                      [:groups gid (mt/id) :view-data "PUBLIC" (mt/id :orders)])))
+            (is (= :sandboxed (get-in (data-perms.graph/api-graph)
+                                      [:groups gid (mt/id) :view-data "PUBLIC" (mt/id :people)])))))))))
+
+(deftest oss-edit-create-queries-on-blocked-row-test
+  (testing "PUT /api/permissions/graph in OSS: a create-queries-only edit on a :blocked database returns 200 and bumps view-data to :unrestricted"
+    (mt/with-temp [:model/PermissionsGroup {gid :id} {}
+                   :model/Database {db-id :id} {}]
+      (mt/with-premium-features #{:advanced-permissions}
+        (data-perms/set-database-permission! gid db-id :perms/view-data :blocked))
+      (mt/with-premium-features #{}
+        (mt/user-http-request
+         :crowberto :put 200 "permissions/graph"
+         (assoc-in (data-perms.graph/api-graph) [:groups gid db-id :create-queries] :query-builder-and-native))
+        (is (= :unrestricted (data-perms/table-permission-for-groups #{gid} :perms/view-data db-id nil)))))))
+
+(deftest update-graph-response-echoes-only-modified-groups-test
+  (testing "PUT /api/permissions/graph response :groups map contains only the request's modified group ids"
+    (mt/with-temp [:model/PermissionsGroup g1 {} :model/PermissionsGroup g2 {}]
+      (let [body (assoc-in (data-perms.graph/api-graph)
+                           [:groups (u/the-id g1) (mt/id) :view-data] :unrestricted)
+            resp (mt/user-http-request :crowberto :put 200 "permissions/graph"
+                                       (update body :groups select-keys [(u/the-id g1)]))]
+        (is (= #{(u/the-id g1)} (set (keys (:groups resp)))))
+        (is (not (contains? (:groups resp) (u/the-id g2))))))))
+
 (deftest can-revoke-permsissions-via-graph-test
   (testing "PUT /api/permissions/graph"
     (let [table-id (mt/id :venues)]

--- a/test/metabase/permissions_rest/api_test.clj
+++ b/test/metabase/permissions_rest/api_test.clj
@@ -422,10 +422,10 @@
           (is (t2/exists? :model/Sandbox :table_id (mt/id :people) :group_id gid)))
         (testing "the graph still surfaces :sandboxed view-data under EE"
           (mt/with-premium-features #{:advanced-permissions :sandboxes}
-            (is (= :sandboxed (get-in (data-perms.graph/api-graph)
-                                      [:groups gid (mt/id) :view-data "PUBLIC" (mt/id :orders)])))
-            (is (= :sandboxed (get-in (data-perms.graph/api-graph)
-                                      [:groups gid (mt/id) :view-data "PUBLIC" (mt/id :people)])))))))))
+            (is (=? {(mt/id :orders) :sandboxed
+                     (mt/id :people) :sandboxed}
+                    (get-in (data-perms.graph/api-graph)
+                            [:groups gid (mt/id) :view-data "PUBLIC"])))))))))
 
 (deftest oss-edit-create-queries-on-blocked-row-test
   (testing "PUT /api/permissions/graph in OSS: a create-queries-only edit on a :blocked database returns 200 and bumps view-data to :unrestricted"

--- a/test/metabase/permissions_rest/data_permissions/graph_test.clj
+++ b/test/metabase/permissions_rest/data_permissions/graph_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.audit-app.core :as audit]
+   [metabase.core.core :as mbc]
    [metabase.permissions-rest.data-permissions.graph :as data-perms.graph]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions-group :as perms-group]
@@ -614,3 +615,12 @@
                   {}))))))
     (testing "an empty reducible yields an empty graph"
       (is (= {} (reduce-into-graph [] identity))))))
+
+(deftest audit-db-excluded-from-permissions-graph-test
+  (testing "GET /api/permissions/graph does not include the audit DB"
+    ;; Guarantee the audit DB is installed rather than relying on test ordering (this is a no-op if it's already there).
+    (mbc/ensure-audit-db-installed!)
+    (is (t2/exists? :model/Database :id audit/audit-db-id))
+    (let [resp (mt/user-http-request :crowberto :get 200 "permissions/graph")]
+      (is (every? #(not (contains? % audit/audit-db-id))
+                  (vals (:groups resp)))))))

--- a/test/metabase/permissions_rest/data_permissions/graph_test.clj
+++ b/test/metabase/permissions_rest/data_permissions/graph_test.clj
@@ -2,8 +2,6 @@
   (:require
    [clojure.test :refer :all]
    [metabase.audit-app.core :as audit]
-   [metabase.config.core :as config]
-   [metabase.core.core :as mbc]
    [metabase.permissions-rest.data-permissions.graph :as data-perms.graph]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions-group :as perms-group]
@@ -616,15 +614,3 @@
                   {}))))))
     (testing "an empty reducible yields an empty graph"
       (is (= {} (reduce-into-graph [] identity))))))
-
-(deftest audit-db-excluded-from-permissions-graph-test
-  ;; `ensure-audit-db-installed!` is a no-op in OSS builds (audit app is EE-only), so the audit DB never
-  ;; exists and this test can only run meaningfully with EE on the classpath. Mirrors `metabase.driver.h2-test`.
-  (when config/ee-available?
-    (testing "GET /api/permissions/graph does not include the audit DB"
-      ;; Guarantee the audit DB is installed rather than relying on test ordering (this is a no-op if it's already there).
-      (mbc/ensure-audit-db-installed!)
-      (is (t2/exists? :model/Database :id audit/audit-db-id))
-      (let [resp (mt/user-http-request :crowberto :get 200 "permissions/graph")]
-        (is (every? #(not (contains? % audit/audit-db-id))
-                    (vals (:groups resp))))))))

--- a/test/metabase/permissions_rest/data_permissions/graph_test.clj
+++ b/test/metabase/permissions_rest/data_permissions/graph_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.audit-app.core :as audit]
+   [metabase.config.core :as config]
    [metabase.core.core :as mbc]
    [metabase.permissions-rest.data-permissions.graph :as data-perms.graph]
    [metabase.permissions.models.data-permissions :as data-perms]
@@ -617,10 +618,13 @@
       (is (= {} (reduce-into-graph [] identity))))))
 
 (deftest audit-db-excluded-from-permissions-graph-test
-  (testing "GET /api/permissions/graph does not include the audit DB"
-    ;; Guarantee the audit DB is installed rather than relying on test ordering (this is a no-op if it's already there).
-    (mbc/ensure-audit-db-installed!)
-    (is (t2/exists? :model/Database :id audit/audit-db-id))
-    (let [resp (mt/user-http-request :crowberto :get 200 "permissions/graph")]
-      (is (every? #(not (contains? % audit/audit-db-id))
-                  (vals (:groups resp)))))))
+  ;; `ensure-audit-db-installed!` is a no-op in OSS builds (audit app is EE-only), so the audit DB never
+  ;; exists and this test can only run meaningfully with EE on the classpath. Mirrors `metabase.driver.h2-test`.
+  (when config/ee-available?
+    (testing "GET /api/permissions/graph does not include the audit DB"
+      ;; Guarantee the audit DB is installed rather than relying on test ordering (this is a no-op if it's already there).
+      (mbc/ensure-audit-db-installed!)
+      (is (t2/exists? :model/Database :id audit/audit-db-id))
+      (let [resp (mt/user-http-request :crowberto :get 200 "permissions/graph")]
+        (is (every? #(not (contains? % audit/audit-db-id))
+                    (vals (:groups resp))))))))

--- a/test/metabase/public_sharing_rest/api_documents_test.clj
+++ b/test/metabase/public_sharing_rest/api_documents_test.clj
@@ -114,6 +114,14 @@
             (is (= "Not found."
                    (mt/client :get 404 (str "public/document/" uuid))))))))))
 
+(deftest public-document-endpoint-is-read-only-test
+  (testing "PUT /api/public/document/:uuid does not exist -- public document sharing is read-only"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (mt/with-temp [:model/Document document (document-with-public-link {})]
+        (is (= 404
+               (:status (mt/client-full-response :put (str "public/document/" (:public_uuid document))
+                                                 {:name "hacked"}))))))))
+
 ;;; ------------------------------ GET /api/public/document/:uuid/card/:card-id ---------------------------------------
 
 (deftest fetch-public-document-card-test

--- a/test/metabase/public_sharing_rest/api_test.clj
+++ b/test/metabase/public_sharing_rest/api_test.clj
@@ -10,6 +10,8 @@
    [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.analytics.stats :as stats]
    [metabase.dashboards-rest.api-test :as api.dashboard-test]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.parameters.chain-filter-test :as chain-filter-test]
    [metabase.parameters.custom-values :as custom-values]
    [metabase.permissions.models.permissions :as perms]
@@ -311,6 +313,64 @@
           (is (= [{:col "Count"} {:col 100.0}]
                  (parse-xlsx-response
                   (client/client :get 200 (str "public/card/" uuid "/query/xlsx?format_rows=true"))))))))))
+
+(deftest execute-public-card-with-snippet-test
+  (testing "GET /api/public/card/:uuid/query resolves {{snippet: name}} snippets at execution time"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (mt/with-temp [:model/NativeQuerySnippet snippet {:name "greeting" :content "'hello'"}]
+        (with-temp-public-card
+         [{uuid :public_uuid}
+          {:dataset_query
+           (lib/with-template-tags
+             (lib/native-query (mt/metadata-provider) "select {{snippet: greeting}}")
+             {"snippet: greeting" {:type         :snippet
+                                   :name         "snippet: greeting"
+                                   :id           (str (random-uuid))
+                                   :snippet-name "greeting"
+                                   :display-name "Snippet: Greeting"
+                                   :snippet-id   (:id snippet)}})}]
+          (is (= [["hello"]] (mt/rows (client/client :get 202 (str "public/card/" uuid "/query"))))))))))
+
+(deftest execute-public-card-with-referenced-card-template-tag-test
+  (testing "GET /api/public/card/:uuid/query resolves {{#<id>}} referenced-card template tags at execution time"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (mt/with-temp [:model/Card ref-card {:dataset_query (lib/native-query (mt/metadata-provider) "SELECT 1 AS n")}]
+        (let [tag-name (str (:id ref-card) "-ref")]
+          (with-temp-public-card
+           [{uuid :public_uuid}
+            {:dataset_query
+             (lib/with-template-tags
+               (lib/native-query (mt/metadata-provider) (format "select * from {{#%s}}" tag-name))
+               {tag-name {:type         :card
+                          :name         tag-name
+                          :id           (str (random-uuid))
+                          :display-name "Referenced card"
+                          :card-id      (:id ref-card)}})}]
+            (is (= [[1]] (mt/rows (client/client :get 202 (str "public/card/" uuid "/query")))))))))))
+
+(deftest execute-public-card-with-multi-value-parameter-test
+  (testing "GET /api/public/card/:uuid/query resolves a multi-value (IN (...)) field-filter parameter"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (with-temp-public-card
+       [{uuid :public_uuid}
+        (let [mp (mt/metadata-provider)]
+          {:dataset_query
+           (lib/with-template-tags
+             (lib/native-query mp "SELECT count(*) FROM venues WHERE {{price}}")
+             {"price" {:id           "_PRICE_"
+                       :name         "price"
+                       :display-name "Price"
+                       :type         :dimension
+                       :dimension    (lib/ref (lib.metadata/field mp (mt/id :venues :price)))
+                       :widget-type  :category}})
+           :parameters [{:id "_PRICE_" :type :category :target [:dimension [:template-tag "price"]]}]})]
+        (is (=? {:status     "completed"
+                 :json_query {:parameters [{:id "_PRICE_" :value [1 2]}]}}
+                (client/client :get 202 (str "public/card/" uuid "/query")
+                               :parameters (json/encode [{:id     "_PRICE_"
+                                                          :type   "category"
+                                                          :target ["dimension" ["template-tag" "price"]]
+                                                          :value  [1 2]}]))))))))
 
 (deftest download-public-card-filename-test
   (testing "GET /api/public/card/:uuid/query - filename generation"
@@ -660,6 +720,33 @@
           (is (= {:name true, :dashcards 2, :tabs 2}
                  (fetch-public-dashboard (t2/select-one :model/Dashboard :id dashboard-id)))))))))
 
+(deftest get-public-dashboard-exposes-auto-apply-filters-test
+  (testing "GET /api/public/dashboard/:uuid round-trips the dashboard's auto_apply_filters value"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (with-temp-public-dashboard [dash]
+        (t2/update! :model/Dashboard (:id dash) {:auto_apply_filters false})
+        (is (false? (:auto_apply_filters (client/client :get 200 (str "public/dashboard/" (:public_uuid dash))))))))))
+
+(deftest public-dashboard-with-nested-card-and-parameter-test
+  (testing "GET /api/public/dashboard/:uuid resolves a nested (source-card) query with a mapped parameter (#20393)"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (let [mp (mt/metadata-provider)]
+        (mt/with-temp [:model/Card source-card {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :orders)))}]
+          (let [nested-query (lib/query mp (lib.metadata/card mp (:id source-card)))]
+            (mt/with-temp [:model/Card nested-card {:dataset_query nested-query}
+                           :model/Dashboard dash {:public_uuid (str (random-uuid))
+                                                  :parameters   [{:name "Date" :slug "date" :id "d1" :type "date/all-options"}]}
+                           :model/DashboardCard _ {:dashboard_id       (:id dash)
+                                                   :card_id            (:id nested-card)
+                                                   :parameter_mappings [{:parameter_id "d1"
+                                                                         :card_id      (:id nested-card)
+                                                                         :target       [:dimension [:field "CREATED_AT" {:base-type :type/DateTime}]]}]}]
+              (is (=? {:parameters [{:id "d1" :slug "date" :type "date/all-options"}]
+                       :dashcards  [{:card_id            (:id nested-card)
+                                     :parameter_mappings [{:parameter_id "d1"
+                                                           :card_id      (:id nested-card)}]}]}
+                      (client/client :get 200 (str "public/dashboard/" (:public_uuid dash))))))))))))
+
 (deftest public-dashboard-with-implicit-action-only-expose-unhidden-fields
   (mt/with-temporary-setting-values [enable-public-sharing true]
     (mt/test-drivers (mt/normal-drivers-with-feature :actions)
@@ -828,6 +915,27 @@
                                                                         :target ["dimension" ["template-tag" "venue_id"]]
                                                                         :value  nil
                                                                         :id     "_VENUE_ID_"}]))))))))))))
+
+(deftest public-dashboard-visualizer-series-card-test
+  (testing "GET /api/public/dashboard/:uuid exposes visualizer viz-settings and authorizes series-card queries"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (with-temp-public-dashboard [dash]
+        (let [mp (mt/metadata-provider)
+              q  (fn [] (-> (lib/query mp (lib.metadata/table mp (mt/id :venues)))
+                            (lib/aggregate (lib/count))))]
+          (mt/with-temp [:model/Card card-1 {:dataset_query (q)}
+                         :model/Card card-2 {:dataset_query (q)}]
+            (let [dashcard (add-card-to-dashboard!
+                            card-1 dash
+                            {:visualization_settings
+                             {:visualization {:columnValuesMapping {:COLUMN_1 [{:sourceId (str "card:" (u/the-id card-2))}]}}}})]
+              (mt/with-temp [:model/DashboardCardSeries _ {:dashboardcard_id (u/the-id dashcard) :card_id (u/the-id card-2)}]
+                (testing "public dashboard response exposes the visualizer viz-settings unchanged"
+                  (is (=? {:columnValuesMapping {:COLUMN_1 [{:sourceId (str "card:" (u/the-id card-2))}]}}
+                          (-> (client/client :get 200 (str "public/dashboard/" (:public_uuid dash)))
+                              :dashcards first :visualization_settings :visualization))))
+                (testing "dashcard-query endpoint authorizes the series card via a real DashboardCardSeries row"
+                  (is (= 202 (:status (client/client-full-response :get (dashcard-url dash card-2 dashcard))))))))))))))
 
 (deftest execute-public-dashcard-as-user-without-perms-test
   (testing "GET /api/public/dashboard/:uuid/card/:card-id"
@@ -1630,6 +1738,20 @@
                                      "type"      "query"}
                             :user-id nil}
                            (last (snowplow-test/pop-event-data-and-user-id!))))))))))))))
+
+(deftest execute-public-action-implicit-row-update-test
+  (testing "POST /api/public/action/:uuid/execute works for an implicit row/update action"
+    (mt/with-premium-features #{:advanced-permissions}
+      (mt/with-actions-test-data-and-actions-enabled
+        (mt/with-temporary-setting-values [enable-public-sharing true]
+          (let [mp          (mt/metadata-provider)
+                action-opts (assoc (shared-obj) :type :implicit :kind "row/update")]
+            (mt/with-actions [_ {:type :model, :dataset_query (lib/query mp (lib.metadata/table mp (mt/id :categories)))}
+                              {} action-opts]
+              (is (=? {:rows-updated 1}
+                      (client/client :post 200
+                                     (format "public/action/%s/execute" (:public_uuid action-opts))
+                                     {:parameters {:id 1 :name "Bouncy Bears"}}))))))))))
 
 (deftest format-export-middleware-test
   (mt/with-temporary-setting-values [enable-public-sharing true]

--- a/test/metabase/pulse/api/pulse_test.clj
+++ b/test/metabase/pulse/api/pulse_test.clj
@@ -1378,47 +1378,51 @@
             (is (= {:channels "#work" :channel_id "C001"}
                    (-> response :channels first :details)))))))))
 
+;; Subscription parameter overrides are an EE feature: the OSS `the-parameters` fallback ignores the
+;; request's parameters and uses the dashboard defaults, so this can only pass with EE on the classpath.
+;; The EE app-db jobs run this same file with EE available and cover the override behavior.
 (deftest send-test-pulse-native-query-non-default-parameters-test
-  (testing "POST /api/pulse/test uses the request's explicit parameter override, not the dashboard's persisted default (#18669)"
-    (mt/with-premium-features #{:dashboard-subscription-filters}
-      (let [mp    (mt/metadata-provider)
-            query (lib/native-query mp "SELECT {{p}} AS val, 1 AS n")
-            p-tag (get (lib/template-tags query) "p")
-            query (lib/with-template-tags query {"p" (assoc p-tag :required true)})]
-        (mt/with-temp [:model/Card {card-id :id} {:dataset_query query
-                                                  :display "table"}
-                       :model/Dashboard {dashboard-id :id} {:name       "Overridable Pulse"
-                                                            :parameters [{:name    "P"
-                                                                          :slug    "p"
-                                                                          :id      "__P__"
-                                                                          :type    "category"
-                                                                          :default "default-val"}]}
-                       :model/DashboardCard _ {:card_id            card-id
-                                               :dashboard_id       dashboard-id
-                                               :parameter_mappings [{:parameter_id "__P__"
-                                                                     :card_id      card-id
-                                                                     :target       [:variable [:template-tag "p"]]}]}]
-          (mt/with-fake-inbox
-            (let [channel-messages (pulse.test-util/with-captured-channel-send-messages!
-                                     (is (= {:ok true}
-                                            (mt/user-http-request :rasta :post 200 "pulse/test"
-                                                                  {:name          (mt/random-name)
-                                                                   :dashboard_id  dashboard-id
-                                                                   :parameters    [{:id "__P__" :value "override-val"}]
-                                                                   :cards         [{:id                card-id
-                                                                                    :include_csv       false
-                                                                                    :include_xls       false
-                                                                                    :dashboard_card_id nil}]
-                                                                   :channels      [{:enabled       true
-                                                                                    :channel_type  "email"
-                                                                                    :schedule_type "daily"
-                                                                                    :schedule_hour 12
-                                                                                    :schedule_day  nil
-                                                                                    :recipients    [(mt/fetch-user :rasta)]}]
-                                                                   :skip_if_empty false}))))
-                  content (-> channel-messages :channel/email first :message first :content)]
-              (is (str/includes? content "override-val"))
-              (is (not (str/includes? content "default-val"))))))))))
+  (mt/when-ee-evailable
+   (testing "POST /api/pulse/test uses the request's explicit parameter override, not the dashboard's persisted default (#18669)"
+     (mt/with-premium-features #{:dashboard-subscription-filters}
+       (let [mp    (mt/metadata-provider)
+             query (lib/native-query mp "SELECT {{p}} AS val, 1 AS n")
+             p-tag (get (lib/template-tags query) "p")
+             query (lib/with-template-tags query {"p" (assoc p-tag :required true)})]
+         (mt/with-temp [:model/Card {card-id :id} {:dataset_query query
+                                                   :display "table"}
+                        :model/Dashboard {dashboard-id :id} {:name       "Overridable Pulse"
+                                                             :parameters [{:name    "P"
+                                                                           :slug    "p"
+                                                                           :id      "__P__"
+                                                                           :type    "category"
+                                                                           :default "default-val"}]}
+                        :model/DashboardCard _ {:card_id            card-id
+                                                :dashboard_id       dashboard-id
+                                                :parameter_mappings [{:parameter_id "__P__"
+                                                                      :card_id      card-id
+                                                                      :target       [:variable [:template-tag "p"]]}]}]
+           (mt/with-fake-inbox
+             (let [channel-messages (pulse.test-util/with-captured-channel-send-messages!
+                                      (is (= {:ok true}
+                                             (mt/user-http-request :rasta :post 200 "pulse/test"
+                                                                   {:name          (mt/random-name)
+                                                                    :dashboard_id  dashboard-id
+                                                                    :parameters    [{:id "__P__" :value "override-val"}]
+                                                                    :cards         [{:id                card-id
+                                                                                     :include_csv       false
+                                                                                     :include_xls       false
+                                                                                     :dashboard_card_id nil}]
+                                                                    :channels      [{:enabled       true
+                                                                                     :channel_type  "email"
+                                                                                     :schedule_type "daily"
+                                                                                     :schedule_hour 12
+                                                                                     :schedule_day  nil
+                                                                                     :recipients    [(mt/fetch-user :rasta)]}]
+                                                                    :skip_if_empty false}))))
+                   content (-> channel-messages :channel/email first :message first :content)]
+               (is (str/includes? content "override-val"))
+               (is (not (str/includes? content "default-val")))))))))))
 
 (deftest archive-pulse-after-dashboard-collection-move-test
   (testing "PUT /api/pulse/:id {archived: true} succeeds even after the pulse's dashboard moved to another collection (#17658)"

--- a/test/metabase/pulse/api/pulse_test.clj
+++ b/test/metabase/pulse/api/pulse_test.clj
@@ -10,6 +10,7 @@
    [metabase.channel.impl.http-test :as channel.http-test]
    [metabase.channel.settings :as channel.settings]
    [metabase.driver :as driver]
+   [metabase.lib.core :as lib]
    [metabase.notification.test-util :as notification.tu]
    [metabase.permissions.models.permissions :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
@@ -1348,3 +1349,81 @@
         (mt/with-temp [:model/PulseChannelRecipient _ {:pulse_channel_id channel-id :user_id (mt/user->id :rasta)}]
           (is (= "Not found."
                  (mt/user-http-request :lucky :delete 404 (str "pulse/" pulse-id "/subscription")))))))))
+
+(deftest unsubscribe-without-collection-perms-test
+  (testing "A recipient without collection perms can still list and unsubscribe from a subscription (#22473)"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Dashboard    {dashboard-id :id} {}
+                     :model/Pulse        {pulse-id :id} {:creator_id (mt/user->id :crowberto) :dashboard_id dashboard-id}
+                     :model/PulseChannel {channel-id :id} {:pulse_id pulse-id :channel_type "email" :schedule_type "daily"}
+                     :model/PulseChannelRecipient _ {:pulse_channel_id channel-id :user_id (mt/user->id :rasta)}]
+        (with-pulses-in-nonreadable-collection! [pulse-id]
+          (is (some #(= pulse-id (:id %)) (mt/user-http-request :rasta :get 200 "pulse?creator_or_recipient=true")))
+          (is (nil? (mt/user-http-request :rasta :delete 204 (str "pulse/" pulse-id "/subscription")))))))))
+
+(deftest pulse-slack-channel-persists-channel-id-test
+  (testing "PUT /api/pulse persists the immutable Slack channel_id alongside the channel display name (#...)"
+    (mt/with-temp [:model/Pulse pulse {}
+                   :model/Card  card  {}]
+      (with-pulses-in-writeable-collection! [pulse]
+        (api.card-test/with-cards-in-readable-collection! [card]
+          (let [response (mt/user-http-request :rasta :put 200 (format "pulse/%d" (u/the-id pulse))
+                                               {:name          "Slack Pulse"
+                                                :cards         [{:id (u/the-id card) :include_csv false :include_xls false :dashboard_card_id nil}]
+                                                :channels      [{:enabled       true
+                                                                 :channel_type  "slack"
+                                                                 :schedule_type "hourly"
+                                                                 :recipients    []
+                                                                 :details       {:channels "#work" :channel_id "C001"}}]})]
+            (is (= {:channels "#work" :channel_id "C001"}
+                   (-> response :channels first :details)))))))))
+
+(deftest send-test-pulse-native-query-non-default-parameters-test
+  (testing "POST /api/pulse/test uses the request's explicit parameter override, not the dashboard's persisted default (#18669)"
+    (mt/with-premium-features #{:dashboard-subscription-filters}
+      (let [mp    (mt/metadata-provider)
+            query (lib/native-query mp "SELECT {{p}} AS val, 1 AS n")
+            p-tag (get (lib/template-tags query) "p")
+            query (lib/with-template-tags query {"p" (assoc p-tag :required true)})]
+        (mt/with-temp [:model/Card {card-id :id} {:dataset_query query
+                                                  :display "table"}
+                       :model/Dashboard {dashboard-id :id} {:name       "Overridable Pulse"
+                                                            :parameters [{:name    "P"
+                                                                          :slug    "p"
+                                                                          :id      "__P__"
+                                                                          :type    "category"
+                                                                          :default "default-val"}]}
+                       :model/DashboardCard _ {:card_id            card-id
+                                               :dashboard_id       dashboard-id
+                                               :parameter_mappings [{:parameter_id "__P__"
+                                                                     :card_id      card-id
+                                                                     :target       [:variable [:template-tag "p"]]}]}]
+          (mt/with-fake-inbox
+            (let [channel-messages (pulse.test-util/with-captured-channel-send-messages!
+                                     (is (= {:ok true}
+                                            (mt/user-http-request :rasta :post 200 "pulse/test"
+                                                                  {:name          (mt/random-name)
+                                                                   :dashboard_id  dashboard-id
+                                                                   :parameters    [{:id "__P__" :value "override-val"}]
+                                                                   :cards         [{:id                card-id
+                                                                                    :include_csv       false
+                                                                                    :include_xls       false
+                                                                                    :dashboard_card_id nil}]
+                                                                   :channels      [{:enabled       true
+                                                                                    :channel_type  "email"
+                                                                                    :schedule_type "daily"
+                                                                                    :schedule_hour 12
+                                                                                    :schedule_day  nil
+                                                                                    :recipients    [(mt/fetch-user :rasta)]}]
+                                                                   :skip_if_empty false}))))
+                  content (-> channel-messages :channel/email first :message first :content)]
+              (is (str/includes? content "override-val"))
+              (is (not (str/includes? content "default-val"))))))))))
+
+(deftest archive-pulse-after-dashboard-collection-move-test
+  (testing "PUT /api/pulse/:id {archived: true} succeeds even after the pulse's dashboard moved to another collection (#17658)"
+    (mt/with-temp [:model/Collection coll {}
+                   :model/Dashboard  {dash-id :id} {}
+                   :model/Pulse      {pulse-id :id} {:dashboard_id dash-id}]
+      (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id) {:collection_id (:id coll)})
+      (is (true? (:archived (mt/user-http-request :crowberto :put 200 (str "pulse/" pulse-id) {:archived true})))))))

--- a/test/metabase/pulse/dashboard_subscription_test.clj
+++ b/test/metabase/pulse/dashboard_subscription_test.clj
@@ -1264,10 +1264,14 @@
         (do-test!
          {:card   {:dataset_query query}
           :assert {:email (fn [_ [email]] (is (true? (has-branding? email))))}}))
-      (mt/with-premium-features #{:whitelabel}
-        (do-test!
-         {:card   {:dataset_query query}
-          :assert {:email (fn [_ [email]] (is (false? (has-branding? email))))}})))))
+      ;; Whitelabeling is only wired up in EE builds (`enable-whitelabeling?` is gated on
+      ;; `config/ee-available?`), so `:whitelabel` can never hide the footer on OSS builds.
+      ;; The EE app-db jobs run this same file with EE on the classpath and cover the hidden case.
+      (mt/when-ee-evailable
+       (mt/with-premium-features #{:whitelabel}
+         (do-test!
+          {:card   {:dataset_query query}
+           :assert {:email (fn [_ [email]] (is (false? (has-branding? email))))}}))))))
 
 (deftest multi-series-test
   (mt/with-temp

--- a/test/metabase/pulse/dashboard_subscription_test.clj
+++ b/test/metabase/pulse/dashboard_subscription_test.clj
@@ -4,12 +4,15 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [medley.core :as m]
    [metabase.channel.core :as channel]
    [metabase.channel.email.result-attachment :as email.result-attachment]
    [metabase.channel.impl.slack :as channel.slack]
    [metabase.channel.render.body :as body]
    [metabase.channel.render.core :as channel.render]
    [metabase.channel.shared :as channel.shared]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.notification.payload.execute :as notification.payload.execute]
    [metabase.notification.payload.temp-storage :as notification.temp-storage]
    [metabase.notification.test-util :as notification.tu]
@@ -17,6 +20,7 @@
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.pulse.send :as pulse.send]
    [metabase.pulse.test-util :as pulse.test-util]
+   [metabase.query-processor.pivot.test-util :as api.pivots]
    [metabase.system.core :as system]
    [metabase.test :as mt]
    [metabase.util :as u]
@@ -1229,6 +1233,41 @@
                                                 pulse.test-util/png-attachment]})
               (mt/summarize-multipart-single-email email
                                                    #"Aviary KPIs"))))}}))
+
+(deftest dashboard-sub-pivot-csv-attachment-test
+  (testing "PulseCard.pivot_results true produces a pivoted (not flat) CSV attachment (#49525)"
+    (let [{:keys [dataset_query visualization_settings]} (api.pivots/pivot-card)
+          header-col-count (fn [pivot?]
+                             (let [col-count (atom nil)]
+                               (do-test!
+                                {:card       {:dataset_query          dataset_query
+                                              :display                :pivot
+                                              :visualization_settings visualization_settings}
+                                 :dashcard   {:visualization_settings visualization_settings}
+                                 :pulse-card {:include_csv   true
+                                              :pivot_results pivot?}
+                                 :assert
+                                 {:email
+                                  (fn [_ [email]]
+                                    (let [csv-part (m/find-first #(= "text/csv" (:content-type %)) (:message email))]
+                                      (reset! col-count (-> csv-part :content slurp str/split-lines first (str/split #",") count))))}})
+                               @col-count))]
+      (is (not= (header-col-count true) (header-col-count false))
+          "the pivoted CSV header shape must differ from the flat CSV header shape"))))
+
+(deftest dashboard-subscription-email-branding-respects-whitelabel-test
+  (testing "the 'Made with Metabase' footer in dashboard subscription emails respects the :whitelabel premium feature"
+    (let [mp            (mt/metadata-provider)
+          query         (lib/query mp (lib.metadata/table mp (mt/id :venues)))
+          has-branding? (fn [email] (str/includes? (-> email :message first :content) "Made with"))]
+      (mt/with-premium-features #{}
+        (do-test!
+         {:card   {:dataset_query query}
+          :assert {:email (fn [_ [email]] (is (true? (has-branding? email))))}}))
+      (mt/with-premium-features #{:whitelabel}
+        (do-test!
+         {:card   {:dataset_query query}
+          :assert {:email (fn [_ [email]] (is (false? (has-branding? email))))}})))))
 
 (deftest multi-series-test
   (mt/with-temp

--- a/test/metabase/pulse/send_test.clj
+++ b/test/metabase/pulse/send_test.clj
@@ -9,6 +9,8 @@
    [metabase.channel.core :as channel]
    [metabase.channel.impl.http-test :as channel.http-test]
    [metabase.channel.render.body :as body]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.notification.test-util :as notification.tu]
    [metabase.pulse.models.pulse :as models.pulse]
    [metabase.pulse.send :as pulse.send]
@@ -692,6 +694,24 @@
     (is (empty? (-> (pulse.test-util/with-captured-channel-send-messages!
                       (pulse.send/send-pulse! (models.pulse/retrieve-notification pulse-id)))
                     :channel/email)))))
+
+(deftest send-pulse-with-no-self-service-creator-test
+  (testing "A dashboard subscription still sends successfully when its creator has no data permissions on the underlying table (#18009)"
+    (let [mp (mt/metadata-provider)]
+      (mt/with-temp [:model/Dashboard {dash-id :id} {}
+                     :model/Card      {card-id :id} {:dataset_query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                                                                        (lib/aggregate (lib/count)))}
+                     :model/DashboardCard {dc-id :id} {:dashboard_id dash-id :card_id card-id}]
+        (mt/with-no-data-perms-for-all-users!
+          (with-pulse-for-card [{pulse-id :id}
+                                {:card       card-id
+                                 :pulse      {:dashboard_id dash-id :creator_id (mt/user->id :rasta)}
+                                 :pulse-card {:dashboard_card_id dc-id}}]
+            (mt/with-fake-inbox
+              (let [results (pulse.test-util/with-captured-channel-send-messages!
+                              (mt/with-temporary-setting-values [site-url "https://testmb.com"]
+                                (pulse.send/send-pulse! (t2/select-one :model/Pulse pulse-id))))]
+                (is (seq (:channel/email results)))))))))))
 
 (deftest send-skip-alert-test
   (testing "alerts are skipped (#63189)"

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -14,6 +14,8 @@
    [metabase.lib.test-util.notebook-helpers :as notebook-helpers]
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
+   [metabase.permissions.models.data-permissions :as data-perms]
+   [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.queries.models.card :as card]
    [metabase.queries.models.parameter-card :as parameter-card]
    [metabase.queries.schema :as queries.schema]
@@ -989,6 +991,23 @@
                 (t2/hydrate card :can_run_adhoc_query)))
         (is (=? {:can_run_adhoc_query false}
                 (t2/hydrate no-query :can_run_adhoc_query)))))))
+
+(deftest can-run-adhoc-query-respects-create-queries-perm-test
+  (testing "can_run_adhoc_query reflects a non-admin's create-queries permission on the card's table (#13347)"
+    (let [mp     (mt/metadata-provider)
+          venues (lib.metadata/table mp (mt/id :venues))
+          query  (lib/query mp venues)]
+      (mt/with-temp [:model/Card card {:dataset_query query}]
+        (mt/with-no-data-perms-for-all-users!
+          (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
+          (data-perms/set-table-permission! (perms-group/all-users) (mt/id :venues) :perms/create-queries :no)
+          (mt/with-current-user (mt/user->id :rasta)
+            (is (=? {:can_run_adhoc_query false}
+                    (t2/hydrate (t2/select-one :model/Card :id (:id card)) :can_run_adhoc_query))))
+          (data-perms/set-table-permission! (perms-group/all-users) (mt/id :venues) :perms/create-queries :query-builder)
+          (mt/with-current-user (mt/user->id :rasta)
+            (is (=? {:can_run_adhoc_query true}
+                    (t2/hydrate (t2/select-one :model/Card :id (:id card)) :can_run_adhoc_query)))))))))
 
 (deftest audit-card-permissions-test
   (testing "Cards in audit collections are not readable or writable on OSS, even if they exist (#42645)"

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -4977,3 +4977,269 @@
                                              :value  "1"}]})
         (is (some? (t2/select-one-fn :result_metadata :model/Card :id card-id))
             "result_metadata should be persisted when native card runs with default parameter values")))))
+
+(deftest query-metadata-excludes-unreadable-source-card-test
+  (testing "GET /api/card/:id/query_metadata silently omits a source card the user can't read (collection perms)"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection {source-coll :id} {}
+                     :model/Collection {nested-coll :id} {}
+                     :model/Card       {source-id :id} {:collection_id source-coll
+                                                        :dataset_query (let [mp (mt/metadata-provider)]
+                                                                         (lib/query mp (lib.metadata/table mp (mt/id :orders))))}
+                     :model/Card       {nested-id :id} {:collection_id nested-coll
+                                                        :dataset_query (let [mp (mt/metadata-provider)]
+                                                                         (lib/query mp (lib.metadata/card mp source-id)))}]
+        (perms/grant-collection-read-permissions! (perms-group/all-users) nested-coll)
+        (is (empty? (:tables (mt/user-http-request :rasta :get 200 (str "card/" nested-id "/query_metadata")))))
+        (is (seq (:tables (mt/user-http-request :crowberto :get 200 (str "card/" nested-id "/query_metadata")))))))))
+
+(deftest query-metadata-excludes-database-without-create-queries-perm-test
+  (testing "GET /api/card/:id/query_metadata omits a database the user lacks create-queries perms for"
+    (mt/with-temp [:model/Card {card-id :id} {:dataset_query (let [mp (mt/metadata-provider)]
+                                                               (lib/query mp (lib.metadata/table mp (mt/id :venues))))}]
+      (mt/with-no-data-perms-for-all-users!
+        (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :no)
+        (is (empty? (:databases (mt/user-http-request :rasta :get 200 (str "card/" card-id "/query_metadata")))))))))
+
+(deftest offset-card-save-and-query-test
+  (testing "POST /api/card + POST /api/card/:id/query with a saved :offset aggregation (#42323)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :window-functions/offset)
+      (let [mp      (mt/metadata-provider)
+            orders  (lib.metadata/table mp (mt/id :orders))
+            created (lib.metadata/field mp (mt/id :orders :created_at))
+            total   (lib.metadata/field mp (mt/id :orders :total))
+            query   (-> (lib/query mp orders)
+                        (lib/breakout (lib/with-temporal-bucket created :month))
+                        (lib/aggregate (lib/offset (lib/sum total) -1))
+                        (lib/limit 3))]
+        (mt/with-model-cleanup [:model/Card]
+          (let [card (mt/user-http-request :rasta :post 200 "card"
+                                           (assoc (card-with-name-and-query "Offset card" query)
+                                                  :display "line" :visualization_settings {}))
+                resp (mt/user-http-request :rasta :post 202 (format "card/%d/query" (:id card)))]
+            (is (= 3 (count (get-in resp [:data :rows]))))))))))
+
+(deftest can-run-adhoc-query-nested-card-source-test
+  (testing "can_run_adhoc_query for a card sourced from another card matches the collection-perms model (#23857)"
+    (let [mp           (mt/metadata-provider)
+          source-query (lib/query mp (lib.metadata/table mp (mt/id :venues)))]
+      (mt/with-temp [:model/Card source {:dataset_query source-query}]
+        (let [nested-query (lib/query mp (lib.metadata/card mp (:id source)))]
+          (mt/with-temp [:model/Card nested {:dataset_query nested-query}]
+            (mt/with-no-data-perms-for-all-users!
+              (is (=? {:can_run_adhoc_query true}
+                      (mt/user-http-request :rasta :get 200 (str "card/" (:id nested)))))
+              (is (=? {:can_run_adhoc_query false}
+                      (mt/user-http-request :rasta :get 200 (str "card/" (:id source))))))))))))
+
+(deftest ^:parallel reduced-fields-propagate-to-downstream-card-test
+  (testing "A card with reduced :fields only exposes those columns to a card sourced from it (#30610)"
+    (let [mp         (mt/metadata-provider)
+          venues-id  (lib.metadata/field mp (mt/id :venues :id))
+          full-query (lib/query mp (lib.metadata/table mp (mt/id :venues)))]
+      (mt/with-temp [:model/Card {source-id :id} (mt/card-with-metadata {:dataset_query full-query})]
+        (mt/user-http-request :crowberto :put 200 (str "card/" source-id)
+                              {:dataset_query (lib/with-fields full-query [venues-id])})
+        (let [downstream-query (lib/query mp (lib.metadata/card mp source-id))]
+          (mt/with-temp [:model/Card {downstream-id :id} {:dataset_query downstream-query}]
+            (let [cols (->> (mt/user-http-request :crowberto :post 202 (format "card/%d/query" downstream-id))
+                            :data :cols (map (comp u/lower-case-en :name)))]
+              (is (= ["id"] cols)))))))))
+
+(deftest ^:parallel downstream-card-sees-updated-native-source-columns-test
+  (testing "A card built on a native source picks up new columns after the source is edited (#43216)"
+    (mt/with-temp [:model/Card {src :id} {:dataset_query (lib/native-query (mt/metadata-provider)
+                                                                           "select 1 as A, 2 as B, 3 as C")}]
+      (mt/user-http-request :crowberto :post 202 (format "card/%d/query" src))
+      (let [mp (mt/metadata-provider)]
+        (mt/with-temp [:model/Card {tgt :id} {:dataset_query (lib/query mp (lib.metadata/card mp src))}]
+          (mt/user-http-request :crowberto :put 200 (str "card/" src)
+                                {:dataset_query (lib/native-query (mt/metadata-provider)
+                                                                  "select 1 as A, 2 as B, 3 as C, 4 as D")})
+          (let [cols (->> (mt/user-http-request :crowberto :get 200 (format "card/%d/query_metadata" tgt))
+                          :tables first :fields (map :name))]
+            (is (some #{"D"} cols))))))))
+
+(deftest copy-card-preserves-non-default-display-test
+  (testing "POST /api/card/:id/copy preserves a non-default display and viz settings"
+    (mt/with-model-cleanup [:model/Card]
+      (let [mp    (mt/metadata-provider)
+            query (lib/aggregate (lib/query mp (lib.metadata/table mp (mt/id :venues))) (lib/count))]
+        (mt/with-temp [:model/Card card {:display                :list
+                                         :visualization_settings {:list.columns ["ID"]}
+                                         :dataset_query           query}]
+          (let [newcard (mt/user-http-request :rasta :post 200 (format "card/%d/copy" (u/the-id card)))]
+            (is (= "list" (:display newcard)))
+            (is (= {:list.columns ["ID"]} (:visualization_settings newcard)))))))))
+
+(deftest ^:parallel model-metadata-settings-override-preserved-test
+  (testing "Column-level :settings overrides (e.g. show_mini_bar) persist through result_metadata PUT"
+    (mt/with-temp [:model/Card card (assoc (mt/card-with-metadata
+                                            {:dataset_query (let [mp (mt/metadata-provider)]
+                                                              (lib/query mp (lib.metadata/table mp (mt/id :orders))))})
+                                           :type :model)]
+      (let [metadata (t2/select-one-fn :result_metadata :model/Card :id (u/the-id card))
+            edited   (mapv #(if (= (:name %) "SUBTOTAL") (assoc % :settings {:show_mini_bar true}) %) metadata)
+            updated  (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card))
+                                           {:result_metadata edited})]
+        (is (=? {:show_mini_bar true}
+                (->> updated :result_metadata (m/find-first #(= (:name %) "SUBTOTAL")) :settings)))))))
+
+(deftest ^:parallel put-card-persists-fk-relation-override-on-computed-column-test
+  (testing "PUT /api/card/:id persists a user-set FK relation on a column with no numeric :id (#29318)"
+    (mt/with-temp [:model/Card card (assoc (mt/card-with-metadata
+                                            {:dataset_query (lib/native-query (mt/metadata-provider)
+                                                                              "SELECT USER_ID FROM ORDERS LIMIT 5")})
+                                           :type :model)]
+      (let [target-id    (mt/id :people :id)
+            new-metadata (mapv #(assoc % :semantic_type :type/FK :fk_target_field_id target-id)
+                               (:result_metadata card))
+            updated      (mt/user-http-request :crowberto :put 200 (str "card/" (:id card))
+                                               {:result_metadata new-metadata})]
+        (is (every? #(= "type/FK" (:semantic_type %)) (:result_metadata updated)))))))
+
+(deftest ^:parallel expression-column-display-name-override-survives-query-change-test
+  (testing "display_name override on an expression column survives a dataset_query change (#36161)"
+    (let [mp         (mt/metadata-provider)
+          venues-id  (lib.metadata/field mp (mt/id :venues :id))
+          base-query (-> (lib/query mp (lib.metadata/table mp (mt/id :venues)))
+                         (lib/expression "ID2" venues-id))
+          expr-col   (m/find-first (comp #{"ID2"} :name) (lib/returned-columns base-query))
+          query      (lib/with-fields base-query [expr-col])]
+      (mt/with-temp [:model/Card card (assoc (mt/card-with-metadata {:dataset_query query}) :type :model)]
+        (let [edited   (mapv #(assoc % :display_name "ID2 custom")
+                             (t2/select-one-fn :result_metadata :model/Card :id (:id card)))
+              updated  (mt/user-http-request :crowberto :put 200 (str "card/" (:id card)) {:result_metadata edited})
+              updated2 (mt/user-http-request :crowberto :put 200 (str "card/" (:id card))
+                                             {:dataset_query (lib/limit query 5)})]
+          (is (= ["ID2 custom"] (map :display_name (:result_metadata updated))))
+          (is (= ["ID2 custom"] (map :display_name (:result_metadata updated2)))))))))
+
+(deftest renaming-joined-column-metadata-does-not-break-model-query-test
+  (testing "Renaming a joined column's display_name override should not break re-running the model (#57359)"
+    (mt/with-model-cleanup [:model/Card]
+      (let [mp                 (mt/metadata-provider)
+            orders-table       (lib.metadata/table mp (mt/id :orders))
+            products-table     (lib.metadata/table mp (mt/id :products))
+            products-id        (lib.metadata/field mp (mt/id :products :id))
+            products-created   (lib.metadata/field mp (mt/id :products :created_at))
+            orders-id          (lib.metadata/field mp (mt/id :orders :id))
+            orders-product-id  (lib.metadata/field mp (mt/id :orders :product_id))
+            query              (-> (lib/query mp orders-table)
+                                   (lib/with-fields [orders-id orders-product-id])
+                                   (lib/join (-> (lib/join-clause products-table
+                                                                  [(lib/= orders-product-id products-id)])
+                                                 (lib/with-join-alias "Products")
+                                                 (lib/with-join-fields [products-id products-created]))))
+            card               (mt/user-http-request :rasta :post 200 "card"
+                                                     (assoc (card-with-name-and-query "model 57359" query)
+                                                            :type :model :display :table))
+            renamed            (mapv #(cond-> % (= (:name %) "ID_2") (assoc :display_name "Product ID2"))
+                                     (:result_metadata card))
+            updated            (mt/user-http-request :rasta :put 200 (str "card/" (:id card)) {:result_metadata renamed})]
+        (is (some #(= "Product ID2" (:display_name %)) (:result_metadata updated)))
+        (is (=? {:data {:rows some?}}
+                (mt/user-http-request :rasta :post 202 (format "card/%d/query" (:id card)))))))))
+
+(deftest model-source-table-change-uses-fresh-ids-for-permissions-test
+  (testing "Changing an MBQL model's source table re-derives result_metadata ids for permissions (#67680)"
+    (mt/with-premium-features #{}
+      (mt/with-temp-copy-of-db
+        (mt/with-no-data-perms-for-all-users!
+          (data-perms/set-table-permission! (perms-group/all-users) (mt/id :orders) :perms/view-data :blocked)
+          (data-perms/set-table-permission! (perms-group/all-users) (mt/id :products) :perms/view-data :unrestricted)
+          (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :query-builder)
+          (let [mp             (mt/metadata-provider)
+                orders-query   (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                products-query (lib/query mp (lib.metadata/table mp (mt/id :products)))]
+            (mt/with-temp [:model/Card {card-id :id} (assoc (mt/card-with-metadata {:dataset_query orders-query})
+                                                            :type :model)]
+              (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:dataset_query products-query})
+              (is (=? {:status "completed"}
+                      (mt/user-http-request :rasta :post (format "card/%d/query" card-id)))))))))))
+
+(deftest create-model-with-snippet-template-tag-test
+  (testing "POST /api/card: a native query using only a snippet tag can be saved as a model (#20963)"
+    (mt/with-temp [:model/NativeQuerySnippet snippet {:name "cat" :content "category = 'Gizmo'"}]
+      (mt/with-model-cleanup [:model/Card]
+        (let [mp    (mt/metadata-provider)
+              query (lib/native-query mp (format "select * from products where {{snippet: %s}}" (:name snippet)))]
+          (is (=? {:id pos-int?}
+                  (mt/user-http-request :rasta :post 200 "card"
+                                        (assoc (card-with-name-and-query "model with snippet" query)
+                                               :type :model :display :table)))))))))
+
+(deftest create-model-without-result-metadata-test
+  (testing "POST /api/card currently allows saving a native-query model without an explicit result_metadata (#37009 gap)"
+    (mt/with-model-cleanup [:model/Card]
+      (is (=? {:id pos-int?}
+              (mt/user-http-request :rasta :post 200 "card"
+                                    (assoc (card-with-name-and-query
+                                            "model no metadata"
+                                            (lib/native-query (mt/metadata-provider) "select * from products"))
+                                           :type :model :display :table)))))))
+
+(deftest copy-card-preserves-nested-query-test
+  (testing "POST /api/card/:id/copy preserves a multi-stage query verbatim, doesn't reference the original (#31309)"
+    (mt/with-model-cleanup [:model/Card]
+      (let [mp             (mt/metadata-provider)
+            orders-table   (lib.metadata/table mp (mt/id :orders))
+            people-table   (lib.metadata/table mp (mt/id :people))
+            orders-total   (lib.metadata/field mp (mt/id :orders :total))
+            orders-user-id (lib.metadata/field mp (mt/id :orders :user_id))
+            people-id      (lib.metadata/field mp (mt/id :people :id))
+            people-name    (lib.metadata/field mp (mt/id :people :name))
+            base-query     (-> (lib/query mp orders-table)
+                               (lib/join (lib/join-clause people-table [(lib/= orders-user-id people-id)]))
+                               (lib/aggregate (lib/sum orders-total))
+                               (lib/breakout people-name))
+            query2         (lib/append-stage base-query)
+            sum-col        (m/find-first (comp #{"sum"} :name) (lib/returned-columns query2))
+            query          (-> query2
+                               (lib/filter (lib/< sum-col 5000))
+                               (lib/limit 10))
+            card           (mt/user-http-request :rasta :post 200 "card"
+                                                 (assoc (card-with-name-and-query "orig" query)
+                                                        :display :table :type :model))
+            newcard        (mt/user-http-request :rasta :post 200 (format "card/%d/copy" (u/the-id card)))]
+        (is (= (:dataset_query card) (:dataset_query newcard)))
+        (is (not (some #{(str "card__" (u/the-id card))}
+                       (tree-seq coll? seq (:dataset_query newcard)))))))))
+
+(deftest can-fetch-and-query-metric-sourced-from-inaccessible-model-test
+  (testing "GET/POST card endpoints don't require collection-read on nested source cards they reference"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection model-coll {}
+                     :model/Collection metric-coll {}
+                     :model/Card       model  {:type          "model"
+                                               :collection_id (u/the-id model-coll)
+                                               :dataset_query (let [mp (mt/metadata-provider)]
+                                                                (lib/query mp (lib.metadata/table mp (mt/id :orders))))}
+                     :model/Card       metric {:type          "metric"
+                                               :collection_id (u/the-id metric-coll)
+                                               :dataset_query (let [mp (mt/metadata-provider)]
+                                                                (lib/aggregate
+                                                                 (lib/query mp (lib.metadata/card mp (u/the-id model)))
+                                                                 (lib/count)))}]
+        (perms/grant-collection-read-permissions! (perms-group/all-users) metric-coll)
+        (is (=? {:id (u/the-id metric)}
+                (mt/user-http-request :rasta :get 200 (str "card/" (u/the-id metric)))))
+        (is (=? {:status "completed"}
+                (mt/user-http-request :rasta :post (str "card/" (u/the-id metric) "/query"))))))))
+
+(deftest native-card-ref-runs-with-no-data-perms-test
+  (testing "A native card referencing another native card via {{#id}} runs for a user with no query-building data perms (#216)"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card       inner      {:collection_id (u/the-id collection)
+                                                 :dataset_query (lib/native-query (mt/metadata-provider)
+                                                                                  "select * from people where id < 10")}]
+      (mt/with-non-admin-groups-no-collection-perms collection
+        (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
+        (let [mp          (mt/metadata-provider)
+              outer-sql   (format "select count(*) from {{#%d}}" (u/the-id inner))
+              outer-query (lib/native-query mp outer-sql)]
+          (mt/with-temp [:model/Card outer {:collection_id (u/the-id collection) :dataset_query outer-query}]
+            (mt/with-no-data-perms-for-all-users!
+              (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
+              (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :no)
+              (is (= [[9]] (mt/rows (mt/user-http-request :rasta :post 202 (format "card/%d/query" (u/the-id outer)))))))))))))

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -5069,8 +5069,9 @@
                                          :visualization_settings {:list.columns ["ID"]}
                                          :dataset_query           query}]
           (let [newcard (mt/user-http-request :rasta :post 200 (format "card/%d/copy" (u/the-id card)))]
-            (is (= "list" (:display newcard)))
-            (is (= {:list.columns ["ID"]} (:visualization_settings newcard)))))))))
+            (is (=? {:display                "list"
+                     :visualization_settings {:list.columns ["ID"]}}
+                    newcard))))))))
 
 (deftest ^:parallel model-metadata-settings-override-preserved-test
   (testing "Column-level :settings overrides (e.g. show_mini_bar) persist through result_metadata PUT"

--- a/test/metabase/queries_rest/api/cards_test.clj
+++ b/test/metabase/queries_rest/api/cards_test.clj
@@ -34,6 +34,17 @@
                (->> (mt/user-http-request :rasta :post 200 "cards/dashboards" {:card_ids [card-id]})
                     (map #(update % :dashboards set)))))))))
 
+(deftest ^:parallel dashboards-for-cards-includes-series-only-test
+  (testing "POST /api/cards/dashboards reports a dashboard where the card appears only as a dashcard series"
+    (mt/with-temp [:model/Card series-card {}
+                   :model/Card primary-card {}
+                   :model/Dashboard {dash-id :id dash-name :name} {}
+                   :model/DashboardCard dc {:card_id (:id primary-card) :dashboard_id dash-id}
+                   :model/DashboardCardSeries _ {:dashboardcard_id (:id dc) :card_id (:id series-card) :position 0}]
+      (is (= [{:card_id (:id series-card)
+               :dashboards [{:id dash-id :name dash-name}]}]
+             (mt/user-http-request :rasta :post 200 "cards/dashboards" {:card_ids [(:id series-card)]}))))))
+
 (deftest ^:parallel bulk-move-endpoint-works
   (testing "a simple move"
     (mt/with-temp [:model/Card {card-id :id} {}

--- a/test/metabase/query_processor/card_test.clj
+++ b/test/metabase/query_processor/card_test.clj
@@ -272,6 +272,17 @@
                 (is (= [[1] [2]]
                        (mt/rows (process-query-for-card child-card))))))))))))
 
+(deftest ^:parallel archived-source-card-still-queryable-test
+  (testing "a card whose source is an archived card can still be run (#52071)"
+    (mt/with-temp [:model/Card {model-id :id} {:type          :model
+                                               :archived      true
+                                               :dataset_query (lib/query (mt/metadata-provider)
+                                                                         (lib.metadata/table (mt/metadata-provider) (mt/id :venues)))}
+                   :model/Card child-card {:dataset_query (let [mp (mt/metadata-provider)]
+                                                            (lib/query mp (lib.metadata/card mp model-id)))}]
+      (is (=? {:status :completed}
+              (run-query-for-card child-card))))))
+
 (deftest ^:parallel updates-metadata-provider
   (testing "should set the previous results metadata to the store"
     (let [entity-id (u/generate-nano-id)]

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -322,17 +322,23 @@
          (adjust query)))))
 
 (deftest ^:parallel metric-defined-as-ratio-of-metrics-test
-  (testing "a metric defined as a custom-named ratio of metric refs expands both nested :metric clauses and executes (#30574)"
-    (let [base-mp  (mt/metadata-provider)
-          m1-query (-> (lib/query base-mp (lib.metadata/table base-mp (mt/id :products)))
-                       (lib/aggregate (lib/avg (lib.metadata/field base-mp (mt/id :products :rating)))))
-          [m1 mp]  (mock-metric base-mp m1-query {:name "M1", :database-id (mt/id)})
-          m2-query (-> (lib/query mp (lib.metadata/table mp (mt/id :products)))
-                       (lib/aggregate (-> (lib// (lib.metadata/metric mp (:id m1)) (lib.metadata/metric mp (:id m1)))
-                                          (lib/with-expression-name "X"))))
-          [m2 mp]  (mock-metric mp m2-query {:name "M2", :database-id (mt/id)})
-          query    (lib/query mp (lib.metadata/card mp (:id m2)))]
-      (is (= [[1.0]] (mt/rows (qp/process-query query)))))))
+  (testing "a metric defined as a custom-named ratio of two different metric refs expands both nested :metric clauses and executes (#30574)"
+    (let [base-mp      (mt/metadata-provider)
+          ;; Two DIFFERENT metrics so the ratio is discriminating: if both refs collapsed to the same
+          ;; underlying aggregation the result would be 1.0 and tell us nothing about what was expanded.
+          count-q      (-> (lib/query base-mp (lib.metadata/table base-mp (mt/id :products)))
+                           (lib/aggregate (lib/count)))
+          [m-count mp] (mock-metric base-mp count-q {:name "Count metric", :database-id (mt/id)})
+          sum-q        (-> (lib/query mp (lib.metadata/table mp (mt/id :products)))
+                           (lib/aggregate (lib/sum (lib.metadata/field mp (mt/id :products :rating)))))
+          [m-sum mp]   (mock-metric mp sum-q {:name "Sum metric", :database-id (mt/id)})
+          m2-query     (-> (lib/query mp (lib.metadata/table mp (mt/id :products)))
+                           (lib/aggregate (-> (lib// (lib.metadata/metric mp (:id m-count)) (lib.metadata/metric mp (:id m-sum)))
+                                              (lib/with-expression-name "X"))))
+          [m2 mp]      (mock-metric mp m2-query {:name "M2", :database-id (mt/id)})
+          query        (lib/query mp (lib.metadata/card mp (:id m2)))]
+      ;; count(products)=200 / sum(rating)=694.3 = 0.2881 (rounded), i.e. clearly not 1.0.
+      (is (= [[0.2881]] (mt/formatted-rows [4.0] (qp/process-query query)))))))
 
 (deftest ^:parallel adjust-filter-test
   (let [[source-metric mp] (mock-metric (lib/filter (basic-metric-query) (lib/> (meta/field-metadata :products :price) 1)))

--- a/test/metabase/query_processor/middleware/parameters/mbql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/mbql_test.clj
@@ -634,3 +634,20 @@
                            {:type   :string/=
                             :value  ["Gadget"]
                             :target [:dimension cat-ref]}]))))))))
+
+(deftest ^:parallel temporal-unit-allowlist-not-enforced-at-execution-test
+  (testing "a :temporal_units allow-list on the parameter is not enforced when expanding the query"
+    (let [mp         meta/metadata-provider
+          created-at (meta/field-metadata :orders :created-at)
+          month-ref  (lib.convert/->legacy-MBQL (lib/ref (lib/with-temporal-bucket created-at :month)))
+          query      (-> (lib/query mp (meta/table-metadata :orders))
+                         (lib/aggregate (lib/count))
+                         (lib/breakout (lib/with-temporal-bucket created-at :month)))]
+      (is (=? {:query {:breakout [[:field (meta/id :orders :created-at) {:temporal-unit :year}]]}}
+              (expand-parameters
+               (-> (lib.convert/->legacy-MBQL query)
+                   (assoc :parameters
+                          [{:type           :temporal-unit
+                            :target         [:dimension month-ref]
+                            :value          :year
+                            :temporal_units [:month :quarter]}]))))))))

--- a/test/metabase/revisions/api_test.clj
+++ b/test/metabase/revisions/api_test.clj
@@ -901,7 +901,9 @@
                     {:result_metadata        (mapv #(assoc % :display_name "EDITED") original-metadata)
                      :visualization_settings {:some_setting true}})
         (create-card-revision! card-id false :crowberto)
-        (let [earlier-id (t2/select-one-pk :model/Revision :model "Card" :model_id card-id {:order-by [[:timestamp :asc]]})]
+        ;; order by :id (monotonic), not :timestamp -- on Postgres `now()` is frozen for the whole test
+        ;; transaction, so consecutive revisions here can tie on :timestamp and pick the wrong revision.
+        (let [earlier-id (t2/select-one-pk :model/Revision :model "Card" :model_id card-id {:order-by [[:id :asc]]})]
           (mt/user-http-request :crowberto :post 200 "revision/revert"
                                 {:entity :card :id card-id :revision_id earlier-id})
           (is (=? {:result_metadata        (mapv (fn [name] {:display_name name}) original-names)
@@ -914,7 +916,9 @@
       (create-card-revision! card-id true :crowberto)
       (t2/update! :model/Card :id card-id {:type :model})
       (create-card-revision! card-id false :crowberto)
-      (let [earlier-id (t2/select-one-pk :model/Revision :model "Card" :model_id card-id {:order-by [[:timestamp :asc]]})]
+      ;; order by :id (monotonic), not :timestamp -- see comment above in
+      ;; revert-model-restores-metadata-and-viz-settings-test.
+      (let [earlier-id (t2/select-one-pk :model/Revision :model "Card" :model_id card-id {:order-by [[:id :asc]]})]
         (mt/user-http-request :crowberto :post 200 "revision/revert"
                               {:entity :card :id card-id :revision_id earlier-id})
         (is (= :question (t2/select-one-fn :type :model/Card :id card-id)))))))

--- a/test/metabase/revisions/api_test.clj
+++ b/test/metabase/revisions/api_test.clj
@@ -904,8 +904,9 @@
         (let [earlier-id (t2/select-one-pk :model/Revision :model "Card" :model_id card-id {:order-by [[:timestamp :asc]]})]
           (mt/user-http-request :crowberto :post 200 "revision/revert"
                                 {:entity :card :id card-id :revision_id earlier-id})
-          (is (= original-names (map :display_name (t2/select-one-fn :result_metadata :model/Card :id card-id))))
-          (is (= {} (t2/select-one-fn :visualization_settings :model/Card :id card-id))))))))
+          (is (=? {:result_metadata        (mapv (fn [name] {:display_name name}) original-names)
+                   :visualization_settings {}}
+                  (t2/select-one :model/Card :id card-id))))))))
 
 (deftest revert-restores-card-type-test
   (testing "Reverting a Card revision restores a previous :type (e.g. model <-> question)"

--- a/test/metabase/revisions/api_test.clj
+++ b/test/metabase/revisions/api_test.clj
@@ -3,6 +3,8 @@
   (:require
    [clojure.test :refer :all]
    [metabase.config.core :as config]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.revisions.models.revision :as revision]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -835,3 +837,110 @@
                                                          :database database-id}}}
                     :description  "created this."}]
                   (mt/user-http-request :crowberto :get 200 (format "revision/segment/%d" id)))))))))
+
+(deftest dashboard-double-revert-test
+  (testing "Reverting past an add/delete-card boundary then reverting forward again both succeed (#15237)"
+    (mt/with-temp [:model/Dashboard {dashboard-id :id} {}
+                   :model/Card      {card-id :id}      {}]
+      (create-dashboard-revision! dashboard-id true :rasta)
+      (let [dashcard (first (t2/insert-returning-instances! :model/DashboardCard
+                                                            :dashboard_id dashboard-id
+                                                            :card_id card-id
+                                                            :size_x 4 :size_y 4 :row 0 :col 0))]
+        (create-dashboard-revision! dashboard-id false :rasta)
+        (t2/delete! (t2/table-name :model/DashboardCard) :id (:id dashcard)))
+      (create-dashboard-revision! dashboard-id false :rasta)
+      (let [revisions         (revision/revisions+details :model/Dashboard dashboard-id)
+            created-rev-id    (:id (some #(when (= "created this." (:description %)) %) revisions))
+            added-card-rev-id (:id (some #(when (= "added a card." (:description %)) %) revisions))
+            revert-back       (mt/user-http-request :rasta :post 200 "revision/revert"
+                                                    {:entity :dashboard :id dashboard-id :revision_id created-rev-id})]
+        (is (not (contains? revert-back :cause)))
+        (is (zero? (t2/count :model/DashboardCard :dashboard_id dashboard-id)))
+        (testing "revert forward again past that boundary"
+          (let [revert-forward (mt/user-http-request :rasta :post 200 "revision/revert"
+                                                     {:entity :dashboard :id dashboard-id :revision_id added-card-rev-id})]
+            (is (not (contains? revert-forward :cause)))
+            (is (= 1 (t2/count :model/DashboardCard :dashboard_id dashboard-id)))))))))
+
+(deftest revert-card-test
+  (testing "Reverting a Card through the API works"
+    (mt/with-temp [:model/Card {card-id :id} {:name "revert test"}]
+      (create-card-revision! card-id true :crowberto)
+      (t2/update! :model/Card card-id {:description "hi"})
+      (create-card-revision! card-id false :crowberto)
+      (let [[_ {prev-id :id}] (revision/revisions :model/Card card-id)]
+        (is (=? {:description "reverted to an earlier version."}
+                (mt/user-http-request :crowberto :post 200 "revision/revert"
+                                      {:entity :card :id card-id :revision_id prev-id})))
+        (is (nil? (t2/select-one-fn :description :model/Card :id card-id)))))))
+
+(deftest permission-check-on-card-revert-test
+  (testing "Are permissions enforced by the revert action in the revision api for Cards? (#13229)"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection collection {}
+                     :model/Card       card {:collection_id (u/the-id collection) :name "Q1"}]
+        (create-card-revision! (:id card) true :crowberto)
+        (mt/user-http-request :crowberto :put 200 (str "card/" (:id card)) {:name "Q1 renamed"})
+        (let [[_ {prev-rev-id :id}] (revision/revisions :model/Card (:id card))]
+          (is (= "You don't have permissions to do that."
+                 (mt/user-http-request :rasta :post "revision/revert"
+                                       {:entity :card :id (:id card) :revision_id prev-rev-id}))))))))
+
+(deftest revert-model-restores-metadata-and-viz-settings-test
+  (testing "Reverting a model restores result_metadata and visualization_settings together (#45926)"
+    (mt/with-temp [:model/Card {card-id :id} (assoc (mt/card-with-metadata
+                                                     {:dataset_query (let [mp (mt/metadata-provider)]
+                                                                       (lib/query mp (lib.metadata/table mp (mt/id :venues))))})
+                                                    :type :model
+                                                    :visualization_settings {})]
+      (let [original-metadata (t2/select-one-fn :result_metadata :model/Card :id card-id)
+            original-names    (map :display_name original-metadata)]
+        (create-card-revision! card-id true :crowberto)
+        (t2/update! :model/Card card-id
+                    {:result_metadata        (mapv #(assoc % :display_name "EDITED") original-metadata)
+                     :visualization_settings {:some_setting true}})
+        (create-card-revision! card-id false :crowberto)
+        (let [earlier-id (t2/select-one-pk :model/Revision :model "Card" :model_id card-id {:order-by [[:timestamp :asc]]})]
+          (mt/user-http-request :crowberto :post 200 "revision/revert"
+                                {:entity :card :id card-id :revision_id earlier-id})
+          (is (= original-names (map :display_name (t2/select-one-fn :result_metadata :model/Card :id card-id))))
+          (is (= {} (t2/select-one-fn :visualization_settings :model/Card :id card-id))))))))
+
+(deftest revert-restores-card-type-test
+  (testing "Reverting a Card revision restores a previous :type (e.g. model <-> question)"
+    (mt/with-temp [:model/Card {card-id :id} {:type :question}]
+      (create-card-revision! card-id true :crowberto)
+      (t2/update! :model/Card :id card-id {:type :model})
+      (create-card-revision! card-id false :crowberto)
+      (let [earlier-id (t2/select-one-pk :model/Revision :model "Card" :model_id card-id {:order-by [[:timestamp :asc]]})]
+        (mt/user-http-request :crowberto :post 200 "revision/revert"
+                              {:entity :card :id card-id :revision_id earlier-id})
+        (is (= :question (t2/select-one-fn :type :model/Card :id card-id)))))))
+
+(deftest revert-card-preserves-dashcard-parameter-mappings-test
+  (testing "POST /revision/revert on a card keeps dashcard parameter_mappings referencing its template tags (#35954)"
+    (let [mp             (mt/metadata-provider)
+          reviews-rating (lib.metadata/field mp (mt/id :reviews :rating))]
+      (mt/with-temp [:model/Card          {card-id :id} {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :reviews)))}
+                     :model/Dashboard     {dash-id :id} {:parameters [{:id "num" :name "Number" :slug "number" :type :number/=}]}
+                     :model/DashboardCard {dc-id :id}   {:dashboard_id       dash-id
+                                                         :card_id            card-id
+                                                         :parameter_mappings [{:parameter_id "num"
+                                                                               :card_id      card-id
+                                                                               :target       [:dimension [:template-tag "RATING"]]}]}]
+        (mt/user-http-request :crowberto :put 200 (str "card/" card-id)
+                              {:dataset_query
+                               (lib/with-template-tags
+                                 (lib/native-query mp "SELECT * FROM REVIEWS WHERE {{RATING}}")
+                                 {"RATING" {:name         "RATING"
+                                            :display-name "R"
+                                            :id           "x"
+                                            :type         :dimension
+                                            :widget-type  :number/=
+                                            :dimension    (lib/ref reviews-rating)}})})
+        (let [first-rev-id (t2/select-one-pk :model/Revision :model "Card" :model_id card-id {:order-by [[:id :asc]]})]
+          (mt/user-http-request :crowberto :post 200 "revision/revert"
+                                {:entity :card :id card-id :revision_id first-rev-id})
+          (is (=? [{:target [:dimension [:template-tag "RATING"]]}]
+                  (t2/select-one-fn :parameter_mappings :model/DashboardCard :id dc-id))))))))

--- a/test/metabase/revisions/impl/dashboard_test.clj
+++ b/test/metabase/revisions/impl/dashboard_test.clj
@@ -157,6 +157,15 @@
       {:cards [{:id 1} {:id 3}]}
       "modified the cards.")))
 
+(deftest ^:parallel diff-dashboards-str-add-card-with-autoplace-test
+  (testing "adding a card should still be reported as \"added a card\" even when auto-placement also
+           repositions an existing card (metabase#6884)"
+    (is (= "added a card."
+           (u/build-sentence
+            (revision/diff-strings :model/Dashboard
+                                   {:cards [{:id 1 :row 0 :col 0}]}
+                                   {:cards [{:id 1 :row 4 :col 0} {:id 2 :row 0 :col 0}]}))))))
+
 (deftest diff-dashboards-str-update-collection-test
   (testing "update collection ---"
     (is (= "moved this Dashboard to Our analytics."

--- a/test/metabase/revisions/impl/measure_test.clj
+++ b/test/metabase/revisions/impl/measure_test.clj
@@ -1,0 +1,43 @@
+(ns metabase.revisions.impl.measure-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.revisions.init]
+   [metabase.revisions.models.revision :as revision]
+   [metabase.test :as mt]
+   [metabase.util :as u]))
+
+(comment metabase.revisions.init/keep-me)
+
+(defn- measure-definition [agg-fn field-key]
+  (let [mp    (mt/metadata-provider)
+        table (lib.metadata/table mp (mt/id :venues))
+        field (lib.metadata/field mp (mt/id :venues field-key))]
+    (lib/aggregate (lib/query mp table) (agg-fn field))))
+
+(deftest ^:parallel diff-measures-str-rename-test
+  (testing "renaming a measure produces a human-readable diff sentence"
+    (is (= "renamed this Measure from \"Original\" to \"Updated\"."
+           (u/build-sentence
+            (revision/diff-strings :model/Measure
+                                   {:name "Original"}
+                                   {:name "Updated"}))))))
+
+(deftest ^:parallel diff-measures-str-description-test
+  (testing "adding a description produces a human-readable diff sentence"
+    (is (= "added a description."
+           (u/build-sentence
+            (revision/diff-strings :model/Measure
+                                   {:name "Original" :description nil}
+                                   {:name "Original" :description "What it measures"}))))))
+
+(deftest diff-measures-str-definition-only-test
+  (testing "a definition-only change (e.g. changing the aggregation) currently produces no human-readable
+           diff sentence -- diff-strings has no :definition case, unlike diff-map which does track it structurally"
+    (let [before {:name "Orders Total" :definition (measure-definition lib/count :id)}
+          after  (assoc before :definition (measure-definition lib/sum :price))]
+      (is (some? (:definition (revision/diff-map :model/Measure before after)))
+          "diff-map does track the definition change...")
+      (is (nil? (u/build-sentence (revision/diff-strings :model/Measure before after)))
+          "...but diff-strings has no wording for it, so no sentence is produced"))))

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -2073,6 +2073,16 @@
             (is (not (contains? result-ids table-id))
                 "Published table should NOT be included in collection search in OSS")))))))
 
+(deftest collection-filter-respects-permissions-test
+  (testing "GET /api/search?collection=<id> excludes results the user cannot read, and includes them once granted (metabase#entity-picker)"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection {coll-id :id} {}
+                     :model/Card       {card-id :id} {:collection_id coll-id :name "scoped one"}]
+        (is (empty? (:data (mt/user-http-request :rasta :get 200 "search" :collection coll-id))))
+        (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+        (is (= #{card-id coll-id}
+               (set (map :id (:data (mt/user-http-request :rasta :get 200 "search" :collection coll-id))))))))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         Measure Search Tests (Phase 4)                                         |
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -132,6 +132,14 @@
             (mt/client :post 401 "session" (-> (mt/user->credentials :rasta)
                                                (assoc :password "something else")))))))
 
+(deftest login-unknown-email-does-not-leak-account-existence-test
+  (testing "POST /api/session - an unknown email returns the same 401 error as a wrong password (anti-enumeration)"
+    (let [unknown-email-resp  (mt/client :post 401 "session" {:username "definitely-not-a-user@metabase.test"
+                                                              :password "whatever-UP12!!"})
+          wrong-password-resp (mt/client :post 401 "session" (-> (mt/user->credentials :rasta)
+                                                                 (assoc :password "whatever-UP12!!")))]
+      (is (= wrong-password-resp unknown-email-resp)))))
+
 (deftest login-throttling-test
   (testing (str "Test that people get blocked from attempting to login if they try too many times (Check that"
                 " throttling works at the API level -- more tests in the throttle library itself:"

--- a/test/metabase/settings_rest/api_test.clj
+++ b/test/metabase/settings_rest/api_test.clj
@@ -395,3 +395,11 @@
     (test-deprecated-setting! "hello")
     (is (re-find #"Setting test-deprecated-setting is deprecated as of Metabase 0.51.0"
                  (str/join " " (map :message (warnings)))))))
+
+(deftest site-name-description-reflects-application-name-test
+  (testing "GET /api/setting returns the site-name description interpolated with a whitelabel application-name (#17043)"
+    (mt/with-premium-features #{:whitelabel}
+      (mt/with-temporary-setting-values [application-name "New Test Co"]
+        (let [site-name-setting (some #(when (= "site-name" (:key %)) %)
+                                      (mt/user-http-request :crowberto :get 200 "setting"))]
+          (is (str/includes? (:description site-name-setting) "New Test Co")))))))

--- a/test/metabase/sso/api/google_test.clj
+++ b/test/metabase/sso/api/google_test.clj
@@ -20,3 +20,21 @@
                (sso.settings/google-auth-client-id)))
         (is (= "foo.com"
                (sso.settings/google-auth-auto-create-accounts-domain)))))))
+
+(deftest google-settings-reset-test
+  (testing "PUT /api/google/settings can clear the settings, disabling Google Sign-In"
+    (mt/with-temporary-setting-values [google-auth-client-id                    nil
+                                       google-auth-auto-create-accounts-domain  nil
+                                       google-auth-enabled                      nil]
+      (mt/user-http-request :crowberto :put 200 "google/settings"
+                            {:google-auth-client-id                   test-client-id
+                             :google-auth-enabled                     true
+                             :google-auth-auto-create-accounts-domain "foo.com"})
+      (is (sso.settings/google-auth-enabled))
+      (mt/user-http-request :crowberto :put 200 "google/settings"
+                            {:google-auth-client-id                   nil
+                             :google-auth-enabled                     false
+                             :google-auth-auto-create-accounts-domain nil})
+      (is (nil? (sso.settings/google-auth-client-id)))
+      (is (nil? (sso.settings/google-auth-auto-create-accounts-domain)))
+      (is (not (sso.settings/google-auth-enabled))))))

--- a/test/metabase/sso/api/ldap_test.clj
+++ b/test/metabase/sso/api/ldap_test.clj
@@ -69,3 +69,13 @@
         (is (= "You don't have permissions to do that."
                (mt/user-http-request :rasta :put 403 "ldap/settings"
                                      (assoc (ldap-test-details) :ldap-port "" :ldap-enabled false))))))))
+
+(deftest ldap-settings-reset-test
+  (testing "PUT /api/ldap/settings clearing the settings disables LDAP and clears the host"
+    (ldap.test/with-ldap-server!
+      (mt/user-http-request :crowberto :put 200 "ldap/settings" (ldap-test-details))
+      (is (sso.settings/ldap-enabled))
+      (mt/with-dynamic-fn-redefs [ldap/test-ldap-connection (constantly {:status :SUCCESS})]
+        (mt/user-http-request :crowberto :put 200 "ldap/settings" {:ldap-host nil :ldap-enabled false}))
+      (is (not (sso.settings/ldap-enabled)))
+      (is (nil? (sso.settings/ldap-host))))))

--- a/test/metabase/task_history/task/task_run_heartbeat_test.clj
+++ b/test/metabase/task_history/task/task_run_heartbeat_test.clj
@@ -32,7 +32,8 @@
 (deftest send-heartbeat-ignores-other-processes-test
   (mt/with-model-cleanup [:model/TaskRun]
     (testing "send-heartbeat! does NOT update runs belonging to other processes"
-      (let [old-time      (t/minus (t/offset-date-time) (t/hours 3))
+      ;; millisecond-clean so app-DB storage rounding can't shift it (truncation below can't undo rounding-up)
+      (let [old-time      (t/truncate-to (t/minus (t/offset-date-time) (t/hours 3)) :millis)
             other-uuid    "other-process-uuid"]
         (mt/with-temp [:model/TaskRun {run-id :id} {:run_type     :sync
                                                     :entity_type  :database

--- a/test/metabase/timeline/api/timeline_test.clj
+++ b/test/metabase/timeline/api/timeline_test.clj
@@ -66,6 +66,18 @@
         (is (= '()
                (->> (collection-timelines-request coll-c true) first :events)))))))
 
+(deftest collection-archived-timelines-test
+  (testing "GET /api/timeline/collection/:id?archived=true returns only archived timelines"
+    (mt/with-temp [:model/Collection coll-b {:name "Collection B"}
+                   :model/Timeline _tl-b     {:name          "Timeline B"
+                                              :collection_id (u/the-id coll-b)}
+                   :model/Timeline _tl-b-old {:name          "Timeline B-old"
+                                              :collection_id (u/the-id coll-b)
+                                              :archived      true}]
+      (is (= #{"Timeline B-old"}
+             (timeline-names (mt/user-http-request :rasta :get 200
+                                                   (str "timeline/collection/" (u/the-id coll-b)) :archived true)))))))
+
 (deftest collection-timelines-permissions-test
   (testing "GET /api/timeline/collection/:id"
     (mt/with-temp [:model/Collection coll-a {:name "Collection A"}

--- a/test/metabase/transforms/test_util.clj
+++ b/test/metabase/transforms/test_util.clj
@@ -103,13 +103,13 @@
    the same bare name that may exist under a different database/schema, e.g. shared datasets on drivers like
    Redshift where multiple concurrent test runs' tables can share a name."
   [table-name]
-  (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
+  (let [schema (t2/select-one-fn :schema :model/Table :db_id (mt/id) :name "transforms_products")
+        pk     (if schema
+                 (t2/select-one-pk :model/Table :db_id (mt/id) :schema schema :name table-name)
+                 (t2/select-one-pk :model/Table :db_id (mt/id) :name table-name))]
     (->>
      (mt/rows (mt/process-query {:database (mt/id)
-                                 :query    {:source-table (t2/select-one-pk :model/Table
-                                                                            :db_id  (mt/id)
-                                                                            :schema schema
-                                                                            :name   table-name)}
+                                 :query    {:source-table pk}
                                  :type     :query}))
      (map (fn [x] (if (= :mongo driver/*driver*) (rest x) x))))))
 

--- a/test/metabase/transforms/test_util.clj
+++ b/test/metabase/transforms/test_util.clj
@@ -100,10 +100,13 @@
 
    The lookup is scoped to the current test database (`(mt/id)`) and to the schema of the `transforms_products`
    table (the schema all transform test targets are created in). This avoids matching an unrelated `Table` row with
-   the same bare name that may exist under a different database/schema, e.g. shared datasets on drivers like
-   Redshift where multiple concurrent test runs' tables can share a name."
+   the same bare name that may exist under a different database/schema. The schema is resolved via the table's id
+   because drivers like Redshift load datasets under prefixed physical names (`transforms_test_transforms_products`),
+   so a bare-name lookup finds nothing there; databases without the transforms dataset fall back to a db-scoped
+   bare-name lookup."
   [table-name]
-  (let [schema (t2/select-one-fn :schema :model/Table :db_id (mt/id) :name "transforms_products")
+  (let [schema (when-let [products-id (try (mt/id :transforms_products) (catch Exception _ nil))]
+                 (t2/select-one-fn :schema :model/Table products-id))
         pk     (if schema
                  (t2/select-one-pk :model/Table :db_id (mt/id) :schema schema :name table-name)
                  (t2/select-one-pk :model/Table :db_id (mt/id) :name table-name))]

--- a/test/metabase/transforms/test_util.clj
+++ b/test/metabase/transforms/test_util.clj
@@ -96,12 +96,22 @@
        ~@body)))
 
 (defn table-rows
+  "Fetch all rows of `table-name` in the current test database.
+
+   The lookup is scoped to the current test database (`(mt/id)`) and to the schema of the `transforms_products`
+   table (the schema all transform test targets are created in). This avoids matching an unrelated `Table` row with
+   the same bare name that may exist under a different database/schema, e.g. shared datasets on drivers like
+   Redshift where multiple concurrent test runs' tables can share a name."
   [table-name]
-  (->>
-   (mt/rows (mt/process-query {:database (mt/id)
-                               :query    {:source-table (t2/select-one-pk :model/Table :name table-name)}
-                               :type     :query}))
-   (map (fn [x] (if (= :mongo driver/*driver*) (rest x) x)))))
+  (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
+    (->>
+     (mt/rows (mt/process-query {:database (mt/id)
+                                 :query    {:source-table (t2/select-one-pk :model/Table
+                                                                            :db_id  (mt/id)
+                                                                            :schema schema
+                                                                            :name   table-name)}
+                                 :type     :query}))
+     (map (fn [x] (if (= :mongo driver/*driver*) (rest x) x))))))
 
 (defn parse-timestamp
   "Parse a local datetime and convert it to a ZonedDateTime in the default timezone."

--- a/test/metabase/transforms/test_util.clj
+++ b/test/metabase/transforms/test_util.clj
@@ -98,18 +98,17 @@
 (defn table-rows
   "Fetch all rows of `table-name` in the current test database.
 
-   The lookup is scoped to the current test database (`(mt/id)`) and to the schema of the `transforms_products`
-   table (the schema all transform test targets are created in). This avoids matching an unrelated `Table` row with
-   the same bare name that may exist under a different database/schema. The schema is resolved via the table's id
-   because drivers like Redshift load datasets under prefixed physical names (`transforms_test_transforms_products`),
-   so a bare-name lookup finds nothing there; databases without the transforms dataset fall back to a db-scoped
-   bare-name lookup."
+   Dataset tables (e.g. `transforms_products`) are resolved by their logical name via `mt/id`, which handles
+   drivers like Redshift that load datasets under prefixed physical names (`transforms_test_transforms_products`).
+   Transform TARGET tables are created with their exact requested name, so they are looked up by bare name scoped
+   to the current test database and, when the transforms dataset is loaded, to its schema — avoiding an unrelated
+   `Table` row with the same name under a different database/schema."
   [table-name]
-  (let [schema (when-let [products-id (try (mt/id :transforms_products) (catch Exception _ nil))]
-                 (t2/select-one-fn :schema :model/Table products-id))
-        pk     (if schema
+  (let [pk (or (try (mt/id (keyword table-name)) (catch Exception _ nil))
+               (if-let [schema (when-let [products-id (try (mt/id :transforms_products) (catch Exception _ nil))]
+                                 (t2/select-one-fn :schema :model/Table products-id))]
                  (t2/select-one-pk :model/Table :db_id (mt/id) :schema schema :name table-name)
-                 (t2/select-one-pk :model/Table :db_id (mt/id) :name table-name))]
+                 (t2/select-one-pk :model/Table :db_id (mt/id) :name table-name)))]
     (->>
      (mt/rows (mt/process-query {:database (mt/id)
                                  :query    {:source-table pk}

--- a/test/metabase/transforms_rest/api/transform_job_test.clj
+++ b/test/metabase/transforms_rest/api/transform_job_test.clj
@@ -506,3 +506,23 @@
                                                           :start_time (parse-instant "2025-09-01T10:00:00")}]
         (mt/user-http-request :rasta :get 403
                               (str "transform-job/" job-id "/runs/" run-id "/transform-runs"))))))
+
+(deftest built-in-jobs-and-tags-seeded-test
+  (testing "the built-in Hourly/Daily/Weekly/Monthly jobs and tags are pre-seeded (migration data)"
+    ;; Looked up by :name (stable) rather than :entity_id/:built_in_type: editing a built-in job in
+    ;; any way (even flipping :active, see update-all-jobs-active-test) permanently clears
+    ;; :built_in_type per metabase.transforms.models.transform-job's before-update hook ("never
+    ;; translate again"), so :built_in_type is not a stable signal once other tests in this
+    ;; JVM/app-db have exercised the update path on these rows. Names, seeded once in
+    ;; 057_update_migrations.yaml, remain stable.
+    (doseq [[job-name tag-name] [["Hourly job"  "hourly"]
+                                 ["Daily job"   "daily"]
+                                 ["Weekly job"  "weekly"]
+                                 ["Monthly job" "monthly"]]]
+      (let [job (t2/select-one :model/TransformJob :name job-name)
+            tag (t2/select-one :model/TransformTag :name tag-name)]
+        (is (some? job) (str "missing built-in job " job-name))
+        (is (some? tag) (str "missing built-in tag " tag-name))
+        (is (seq (:schedule job)) (str job-name " should carry a schedule"))
+        (is (t2/exists? :model/TransformJobTransformTag :job_id (:id job) :tag_id (:id tag))
+            (str job-name " should be linked to the " tag-name " tag"))))))

--- a/test/metabase/transforms_rest/api/transform_test.clj
+++ b/test/metabase/transforms_rest/api/transform_test.clj
@@ -6,6 +6,7 @@
    [medley.core :as m]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
+   [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.permissions.core :as perms]
@@ -15,12 +16,14 @@
    [metabase.test :as mt]
    [metabase.transforms-base.util :as transforms-base.u]
    [metabase.transforms-rest.api.transform]
+   [metabase.transforms.core :as transforms.core]
    [metabase.transforms.models.transform :as transform.model]
    [metabase.transforms.query-test-util :as query-test-util]
    [metabase.transforms.test-dataset :as transforms-dataset]
    [metabase.transforms.test-util :refer [get-test-schema
                                           parse-instant
                                           seconds-from-now-ns
+                                          table-rows
                                           utc-timestamp
                                           with-transform-cleanup!]]
    [metabase.util :as u]
@@ -1259,7 +1262,8 @@
                                  :target {:type "table" :name (mt/random-name)}})
           (mt/user-http-request :rasta :put 403 (str "transform/" (:id transform))
                                 {:name "Updated"})
-          (mt/user-http-request :rasta :delete 403 (str "transform/" (:id transform))))
+          (mt/user-http-request :rasta :delete 403 (str "transform/" (:id transform)))
+          (mt/user-http-request :rasta :post 403 (format "transform/%d/run" (:id transform))))
         (testing "Data analysts can read transforms"
           (mt/with-data-analyst-role! (mt/user->id :lucky)
             (mt/user-http-request :lucky :get 200 "transform")
@@ -1919,3 +1923,146 @@
             (mt/user-http-request :crowberto :get 400 "transform/run"
                                   :sort-column "bogus"
                                   :sort-direction "asc")))))))
+
+(deftest execute-transform-with-field-filter-template-tag-test
+  (testing "a required field-filter (:dimension) template tag resolves via its default value at unattended execution"
+    (mt/with-premium-features #{}
+      (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
+        (mt/dataset transforms-dataset/transforms-test
+          (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+            (mt/with-data-analyst-role! (mt/user->id :lucky)
+              (with-transform-cleanup! [table-name "field_filter_default_output"]
+                (let [mp           (mt/metadata-provider)
+                      category-col (lib.metadata/field mp (mt/id :transforms_products :category))
+                      query        (lib/with-template-tags
+                                     (lib/native-query mp "SELECT * FROM transforms_products WHERE {{ cat }}")
+                                     {"cat" {:id "cat" :name "cat" :display-name "Cat"
+                                             :type :dimension :widget-type :string/=
+                                             :dimension (lib/ref category-col)
+                                             :required true :default ["Gadget"]}})
+                      {id :id}     (mt/user-http-request :lucky :post 200 "transform"
+                                                         {:name   "Field Filter Transform"
+                                                          :source {:type "query" :query query}
+                                                          :target {:type   "table"
+                                                                   :schema (get-test-schema)
+                                                                   :name   table-name}})]
+                  (test-run! id)
+                  (check-query-results table-name [5 11 16] "Gadget"))))))))))
+
+(deftest execute-transform-with-table-template-tag-test
+  (testing "a table (table-variable) template tag substitutes a schema-qualified identifier at unattended execution"
+    (mt/with-premium-features #{}
+      (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
+        (mt/dataset transforms-dataset/transforms-test
+          (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+            (mt/with-data-analyst-role! (mt/user->id :lucky)
+              (with-transform-cleanup! [table-name "table_tag_output"]
+                (let [source-table-id (mt/id :transforms_products)
+                      query           (lib/with-template-tags
+                                        (lib/native-query (mt/metadata-provider) "SELECT * FROM {{ tbl }}")
+                                        {"tbl" {:id "tbl" :name "tbl" :display-name "Tbl" :type :table
+                                                :table-id source-table-id}})
+                      {id :id}        (mt/user-http-request :lucky :post 200 "transform"
+                                                            {:name   "Table Tag Transform"
+                                                             :source {:type "query" :query query}
+                                                             :target {:type   "table"
+                                                                      :schema (get-test-schema)
+                                                                      :name   table-name}})]
+                  (test-run! id)
+                  (wait-for-table table-name 5000)
+                  (is (= (count (table-rows "transforms_products"))
+                         (count (table-rows table-name)))))))))))))
+
+(deftest reject-target-name-collision-test
+  (testing "target-name collision with a pre-existing, non-transform table is rejected"
+    (mt/with-premium-features #{}
+      (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
+        (mt/dataset transforms-dataset/transforms-test
+          (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+            (mt/with-data-analyst-role! (mt/user->id :lucky)
+              (let [schema               (get-test-schema)
+                    existing-table-name  (t2/select-one-fn :name :model/Table (mt/id :transforms_products))
+                    other-existing-name  (t2/select-one-fn :name :model/Table (mt/id :transforms_orders))]
+                (testing "POST /api/transform"
+                  (mt/user-http-request :lucky :post 403 "transform"
+                                        {:name   "Colliding Transform"
+                                         :source {:type "query" :query (make-query "Gadget")}
+                                         :target {:type   "table"
+                                                  :schema schema
+                                                  :name   existing-table-name}}))
+                (testing "PUT /api/transform/:id (target-change collision)"
+                  (with-transform-cleanup! [table-name "collision_source"]
+                    (let [created (mt/user-http-request :lucky :post 200 "transform"
+                                                        {:name   "Non-colliding Transform"
+                                                         :source {:type "query" :query (make-query "Gadget")}
+                                                         :target {:type   "table"
+                                                                  :schema schema
+                                                                  :name   table-name}})]
+                      (mt/user-http-request :lucky :put 403 (format "transform/%d" (:id created))
+                                            {:target {:type   "table"
+                                                      :schema schema
+                                                      :name   other-existing-name}}))))))))))))
+
+(deftest delete-target-then-recreate-same-name-test
+  (testing "re-running after DELETE /api/transform/:id/table recreates the same target name"
+    (mt/with-premium-features #{}
+      (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
+        (mt/dataset transforms-dataset/transforms-test
+          (with-transform-cleanup! [table-name "gadget_products_recreate"]
+            (let [target     {:type "table" :schema (get-test-schema) :name table-name}
+                  definition {:name   "Recreate Target Transform"
+                              :source {:type "query" :query (make-query "Gadget")}
+                              :target target}
+                  {id :id}   (mt/user-http-request :crowberto :post 200 "transform" definition)]
+              (test-run! id)
+              (is (true? (transforms-base.u/target-table-exists? definition)))
+              (mt/user-http-request :crowberto :delete 204 (format "transform/%s/table" id))
+              (is (false? (transforms-base.u/target-table-exists? definition)))
+              (test-run! id)
+              (is (true? (transforms-base.u/target-table-exists? definition))))))))))
+
+(deftest get-transform-with-deleted-database-test
+  (testing "GET /api/transform/:id degrades gracefully when its source database has been deleted"
+    (mt/with-temp [:model/Database db {}]
+      (let [mp    (lib.metadata.jvm/application-database-metadata-provider (:id db))
+            query (lib/native-query mp "select 1")]
+        (mt/with-temp [:model/Transform transform {:source {:type "query" :query query}
+                                                   :target {:type "table" :name (mt/random-name)}}]
+          (t2/delete! :model/Database (:id db))
+          (is (=? {:id (:id transform)}
+                  (mt/user-http-request :crowberto :get 200 (str "transform/" (:id transform))))))))))
+
+(deftest cancel-transform-run-endpoint-test
+  (testing "POST /api/transform/:id/cancel"
+    (mt/with-premium-features #{}
+      (mt/test-driver :postgres
+        (mt/dataset transforms-dataset/transforms-test
+          (with-transform-cleanup! [table-name "cancel_endpoint_output"]
+            (let [query      (lib/native-query (mt/metadata-provider)
+                                               "SELECT a FROM (SELECT pg_sleep(5)) x, generate_series(1, 5) a")
+                  {id :id}   (mt/user-http-request :crowberto :post 200 "transform"
+                                                   {:name   "Slow Transform"
+                                                    :source {:type "query" :query query}
+                                                    :target {:type   "table"
+                                                             :schema (get-test-schema)
+                                                             :name   table-name}})]
+              (testing "cancelling a running transform synchronously marks the run canceling"
+                (mt/user-http-request :crowberto :post 202 (format "transform/%s/run" id))
+                (mt/user-http-request :crowberto :post 204 (format "transform/%s/cancel" id))
+                ;; A background poller (every 20s, see metabase.transforms.canceling/CancelRuns) drives
+                ;; the same transition, so an unlucky race can already land the run in "canceled" by the
+                ;; time we check here.
+                (is (contains? #{"canceling" "canceled"}
+                               (-> (mt/user-http-request :crowberto :get 200 (format "transform/%s" id))
+                                   :last_run :status))))
+              ;; Drive the cancelation to completion directly instead of waiting on the 20s background
+              ;; poller — the same mechanism metabase.transforms.canceling-test uses to settle a run
+              ;; synchronously. `running-run-for-transform-id` returns nil if the poller already beat us
+              ;; to it, in which case there's nothing left to do.
+              (when-let [run (transforms.core/running-run-for-transform-id id)]
+                (transforms.core/cancel-run! run (java.time.OffsetDateTime/now)))
+              (is (= "canceled"
+                     (-> (mt/user-http-request :crowberto :get 200 (format "transform/%s" id))
+                         :last_run :status)))
+              (testing "cancelling a transform with no running run is a 404"
+                (mt/user-http-request :crowberto :post 404 (format "transform/%s/cancel" id))))))))))

--- a/test/metabase/transforms_rest/api/transform_test.clj
+++ b/test/metabase/transforms_rest/api/transform_test.clj
@@ -5,6 +5,7 @@
    [clojure.test :refer :all]
    [medley.core :as m]
    [metabase.driver :as driver]
+   [metabase.driver.sql.util :as sql.u]
    [metabase.driver.util :as driver.u]
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.core :as lib]
@@ -1932,10 +1933,18 @@
           (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
             (mt/with-data-analyst-role! (mt/user->id :lucky)
               (with-transform-cleanup! [table-name "field_filter_default_output"]
-                (let [mp           (mt/metadata-provider)
-                      category-col (lib.metadata/field mp (mt/id :transforms_products :category))
+                (let [mp                                  (mt/metadata-provider)
+                      category-col                        (lib.metadata/field mp (mt/id :transforms_products :category))
+                      [source-schema source-table-name]    (t2/select-one-fn (juxt :schema :name) :model/Table
+                                                                             (mt/id :transforms_products))
+                      ;; Qualify the FROM clause with its schema so that drivers which require the WHERE clause's
+                      ;; field-filter substitution (a fully qualified `schema.table.column` reference) to agree with
+                      ;; the table expression named in FROM (e.g. ClickHouse) can resolve the query. An unqualified
+                      ;; `FROM transforms_products` combined with a qualified WHERE reference is invalid there.
+                      qualified-source-table              (sql.u/quote-name driver/*driver* :table
+                                                                            source-schema source-table-name)
                       query        (lib/with-template-tags
-                                     (lib/native-query mp "SELECT * FROM transforms_products WHERE {{ cat }}")
+                                     (lib/native-query mp (format "SELECT * FROM %s WHERE {{ cat }}" qualified-source-table))
                                      {"cat" {:id "cat" :name "cat" :display-name "Cat"
                                              :type :dimension :widget-type :string/=
                                              :dimension (lib/ref category-col)

--- a/test/metabase/users_rest/api_test.clj
+++ b/test/metabase/users_rest/api_test.clj
@@ -1768,9 +1768,10 @@
       (mt/with-fake-inbox
         (let [email (mt/random-email)
               resp  (mt/user-http-request :crowberto :post 200 "user" {:email email})]
-          (is (nil? (:first_name resp)))
-          (is (nil? (:last_name resp)))
-          (is (= email (:email resp))))))))
+          (is (=? {:first_name nil
+                   :last_name  nil
+                   :email      email}
+                  resp)))))))
 
 (deftest update-blank-name-rejected-test
   (testing "PUT /api/user/:id rejects a blank/whitespace first_name (#46449)"

--- a/test/metabase/users_rest/api_test.clj
+++ b/test/metabase/users_rest/api_test.clj
@@ -6,6 +6,7 @@
    [metabase.collections.models.collection :as collection]
    [metabase.config.core :as config]
    [metabase.models.interface :as mi]
+   [metabase.notification.test-util :as notification.tu]
    [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.permissions.util :as perms-util]
@@ -25,7 +26,7 @@
 
 (use-fixtures
   :once
-  (fixtures/initialize :test-users-personal-collections))
+  (fixtures/initialize :test-users-personal-collections :notifications))
 
 (def ^:private user-defaults
   (delay
@@ -1760,3 +1761,31 @@
   (testing "POST /api/user/:id/password-reset-url nonexistent user gets 404"
     (mt/user-http-request :crowberto :post 404
                           "user/999999/password-reset-url")))
+
+(deftest create-user-without-names-test
+  (testing "POST /api/user succeeds when first and last name are omitted (#22754)"
+    (mt/with-model-cleanup [:model/User]
+      (mt/with-fake-inbox
+        (let [email (mt/random-email)
+              resp  (mt/user-http-request :crowberto :post 200 "user" {:email email})]
+          (is (nil? (:first_name resp)))
+          (is (nil? (:last_name resp)))
+          (is (= email (:email resp))))))))
+
+(deftest update-blank-name-rejected-test
+  (testing "PUT /api/user/:id rejects a blank/whitespace first_name (#46449)"
+    (mt/with-temp [:model/User {id :id} {}]
+      (let [resp (mt/user-http-request :crowberto :put 400 (str "user/" id) {:first_name " "})]
+        (is (contains? (:errors resp) :first_name))))))
+
+(deftest invite-email-links-to-password-reset-test
+  (testing "POST /api/user with SMTP configured sends an invite email linking to the set-a-password flow (#23630)"
+    (mt/with-model-cleanup [:model/User]
+      (notification.tu/with-send-notification-sync
+        (mt/with-fake-inbox
+          (let [email (mt/random-email)]
+            (mt/user-http-request :crowberto :post 200 "user"
+                                  {:first_name "Inv" :last_name "Itee" :email email})
+            (let [body (-> @mt/inbox (get email) first :body first :content)]
+              (is (some? body))
+              (is (re-find #"/auth/reset_password/" body)))))))))

--- a/test/metabase/warehouse_schema_rest/api/field_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/field_test.clj
@@ -955,3 +955,25 @@
             (data-perms/set-database-permission! pg (mt/id) :perms/create-queries :query-builder)
             (is (= {:values [[1] [2] [3] [4]], :field_id (mt/id :venues :price), :has_more_values false}
                    (mt/user-http-request :rasta :get 200 (format "field/%d/values" (mt/id :venues :price)))))))))))
+
+(deftest update-has-field-values-test
+  (testing "PUT /api/field/:id can change has_field_values across the list/search/none filtering types"
+    (mt/with-temp [:model/Field {fid :id} {:base_type :type/Integer :has_field_values "list"}]
+      (doseq [v ["search" "none" "list"]]
+        (testing (format "has_field_values = %s" v)
+          (mt/user-http-request :crowberto :put 200 (format "field/%d" fid) {:has_field_values v})
+          (is (= (keyword v)
+                 (t2/select-one-fn :has_field_values :model/Field :id fid))))))))
+
+(deftest discard-field-values-test
+  (testing "POST /api/field/:id/discard_values"
+    (mt/with-temp [:model/Field       {fid :id} {:table_id (mt/id :venues)}
+                   :model/FieldValues {fv :id}  {:field_id fid :values [1 2 3]}]
+      (testing "requires metadata write permissions"
+        (is (= "You don't have permissions to do that."
+               (mt/user-http-request :rasta :post 403 (format "field/%d/discard_values" fid))))
+        (is (t2/exists? :model/FieldValues :id fv)))
+      (testing "an admin can discard the cached field values"
+        (is (= {:status "success"}
+               (mt/user-http-request :crowberto :post 200 (format "field/%d/discard_values" fid))))
+        (is (not (t2/exists? :model/FieldValues :id fv)))))))

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1213,7 +1213,7 @@
 (deftest trigger-metadata-sync-for-table-test
   (testing "Can we trigger a metadata sync for a table?"
     (let [sync-called? (promise)
-          timeout (* 10 1000)]
+          timeout (* 60 1000)]
       (mt/with-premium-features #{:audit-app}
         (mt/with-temp [:model/Database {db-id :id} {:engine "h2", :details (:details (mt/db))}
                        :model/Table    table       {:db_id db-id :schema "PUBLIC"}]
@@ -1227,7 +1227,7 @@
   (testing "POST /api/table/:id/sync_schema"
     (testing "User with manage-table-metadata permission can sync table"
       (let [sync-called? (promise)
-            timeout (* 10 1000)]
+            timeout (* 60 1000)]
         (mt/with-premium-features #{:audit-app}
           (mt/with-temp [:model/Database {db-id :id} {:engine "h2", :details (:details (mt/db))}
                          :model/Table    table       {:db_id db-id :schema "PUBLIC"}]

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1480,3 +1480,16 @@
           (data-perms/set-table-permission! (perms-group/all-users) table-id :perms/create-queries :query-builder)
           (let [response (mt/user-http-request :rasta :get 202 (format "table/%d/data" table-id))]
             (is (map? response))))))))
+
+(deftest bulk-update-tables-visibility-persists-test
+  (testing "PUT /api/table with an ids vector flips visibility_type on every listed table"
+    (mt/with-temp [:model/Table {t1 :id} {:db_id (mt/id) :visibility_type nil}
+                   :model/Table {t2 :id} {:db_id (mt/id) :visibility_type nil}]
+      (mt/user-http-request :crowberto :put 200 "table"
+                            {:ids [t1 t2] :visibility_type "hidden"})
+      (is (= [:hidden :hidden]
+             (map #(t2/select-one-fn :visibility_type :model/Table :id %) [t1 t2])))
+      (mt/user-http-request :crowberto :put 200 "table"
+                            {:ids [t1 t2] :visibility_type nil})
+      (is (= [nil nil]
+             (map #(t2/select-one-fn :visibility_type :model/Table :id %) [t1 t2]))))))

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -15,6 +15,8 @@
    [metabase.driver.settings :as driver.settings]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.util :as driver.u]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions :as perms]
@@ -35,7 +37,6 @@
    [metabase.test.data.users :as test.users]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.http-client :as client]
-   [metabase.test.util :as tu]
    [metabase.util :as u]
    [metabase.util.cron :as u.cron]
    [metabase.util.i18n :refer [deferred-tru]]
@@ -1228,10 +1229,18 @@
            (mt/user-http-request :lucky :get 200 "database?saved=true"))))))
 
 (deftest databases-list-include-saved-questions-test-3
-  (testing "GET /api/database?saved=true"
-    (testing "Omit virtual DB if nested queries are disabled"
-      (tu/with-temporary-setting-values [enable-nested-queries false]
-        (is (every? some? (:data (mt/user-http-request :lucky :get 200 "database?saved=true"))))))))
+  (testing "GET /api/database?saved=true -- Omit virtual DB if nested queries are disabled (#19341)"
+    (mt/with-temp [:model/Card _ (assoc (card-with-native-query "Some Card")
+                                        :result_metadata [{:name         "col_name"
+                                                           :display_name "Col Name"
+                                                           :base_type    :type/Text}])]
+      (testing "sanity check: the virtual DB is present when nested queries are enabled"
+        (is (some :is_saved_questions
+                  (:data (mt/user-http-request :lucky :get 200 "database?saved=true")))))
+      (testing "the virtual DB is omitted entirely when nested queries are disabled"
+        (mt/with-temp-env-var-value! ["MB_ENABLE_NESTED_QUERIES" "false"]
+          (is (not-any? :is_saved_questions
+                        (:data (mt/user-http-request :lucky :get 200 "database?saved=true")))))))))
 
 (deftest fetch-databases-with-invalid-driver-test
   (testing "GET /api/database"
@@ -3144,3 +3153,90 @@
                  (mt/user-http-request :crowberto :put 400 (format "database/%d" router-id)
                                        {:admin_details {:host             "admin-host"
                                                         :admin-connection true}}))))))))
+
+(deftest databases-list-can-upload-respects-view-data-test
+  (testing "GET /api/database/:id can_upload reflects the user's view-data permission, not just uploads_enabled"
+    (mt/with-temp [:model/Database {db-id :id} {:engine              :postgres
+                                                :uploads_enabled     true
+                                                :uploads_schema_name "public"}]
+      (mt/with-no-data-perms-for-all-users!
+        (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/manage-database :yes)
+        (testing "view-data blocked => can_upload is false"
+          (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/view-data :blocked)
+          (is (false? (:can_upload (mt/user-http-request :rasta :get 200 (str "database/" db-id))))))
+        (testing "unrestricted view-data + query-builder create-queries => can_upload is true"
+          (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/view-data :unrestricted)
+          (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/create-queries :query-builder)
+          (is (true? (:can_upload (mt/user-http-request :rasta :get 200 (str "database/" db-id))))))))))
+
+(deftest native-permissions-value-test
+  (testing "GET /api/database :native_permissions is :write only when create-queries is :query-builder-and-native (#39053)"
+    (mt/with-temp [:model/Database {db-id :id} {}]
+      (letfn [(native-perms []
+                (->> (mt/user-http-request :rasta :get 200 "database")
+                     :data
+                     (m/find-first (comp #{db-id} :id))
+                     :native_permissions
+                     keyword))]
+        (mt/with-no-data-perms-for-all-users!
+          (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/create-queries :query-builder)
+          (is (= :none (native-perms)))
+          (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/create-queries :query-builder-and-native)
+          (is (= :write (native-perms)))
+          (testing "revoking native access reverts :native_permissions to :none"
+            (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/create-queries :query-builder)
+            (is (= :none (native-perms)))))))))
+
+(deftest idfields-excludes-model-cards-test
+  (testing "GET /api/database/:id/idfields only returns real table/field pairs, never model Cards (#31663)"
+    (let [mp (mt/metadata-provider)]
+      (mt/with-temp [:model/Card _ {:type          :model
+                                    :name          "Orders Model"
+                                    :dataset_query (lib/query mp (lib.metadata/table mp (mt/id :orders)))}]
+        (let [rows (mt/user-http-request :crowberto :get 200 (format "database/%d/idfields" (mt/id)))]
+          (is (seq rows))
+          (is (every? #(t2/exists? :model/Table :id (:table_id %)) rows))
+          (is (every? #(t2/exists? :model/Field :id (:id %)) rows)))))))
+
+(deftest get-schema-tables-include-measures-test
+  (let [mp          (mt/metadata-provider)
+        schema      (t2/select-one-fn :schema :model/Table :id (mt/id :orders))
+        orders-name (t2/select-one-fn :name :model/Table :id (mt/id :orders))
+        people-name (t2/select-one-fn :name :model/Table :id (mt/id :people))]
+    (testing "GET /api/database/:id/schema/:schema?include_measures=true hydrates :measures per table"
+      (mt/with-temp [:model/Measure _ {:table_id   (mt/id :orders)
+                                       :name       "Some measure"
+                                       :creator_id (mt/user->id :crowberto)
+                                       :definition (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                                                       (lib/aggregate (lib/count)))}]
+        (let [tables  (mt/user-http-request :crowberto :get 200
+                                            (format "database/%d/schema/%s" (mt/id) schema)
+                                            :include_measures true)
+              by-name (into {} (map (juxt :name identity)) tables)]
+          (is (seq (:measures (get by-name orders-name))))
+          (is (= [] (:measures (get by-name people-name)))))))
+    (testing "measures key is omitted when include_measures is not passed"
+      (let [tables (mt/user-http-request :crowberto :get 200
+                                         (format "database/%d/schema/%s" (mt/id) schema))]
+        (is (not (contains? (first tables) :measures)))))))
+
+(deftest delete-database-cascades-to-content-test
+  (testing "DELETE /api/database/:id removes the database's dependent Cards and Segments"
+    (mt/with-temp [:model/Database {db-id :id} {}
+                   :model/Table    {t :id}     {:db_id db-id}
+                   :model/Card     {c :id}     {:database_id db-id :table_id t}
+                   :model/Segment  {s :id}     {:table_id t}]
+      (mt/user-http-request :crowberto :delete 204 (format "database/%d" db-id))
+      (is (not (t2/exists? :model/Database :id db-id)))
+      (is (not (t2/exists? :model/Card :id c)))
+      (is (not (t2/exists? :model/Segment :id s))))))
+
+(deftest restore-sample-database-endpoint-test
+  (testing "POST /api/database/sample_database"
+    (testing "requires a superuser"
+      (is (= "You don't have permissions to do that."
+             (mt/user-http-request :rasta :post 403 "database/sample_database"))))
+    (testing "restores and returns the sample database"
+      (mt/with-model-cleanup [:model/Database]
+        (is (=? {:is_sample true}
+                (mt/user-http-request :crowberto :post 200 "database/sample_database")))))))


### PR DESCRIPTION
## ⚠️ Contains one product fix (migration)

The new emoji-reactions test exposed **silent data loss on MySQL/MariaDB app DBs**: `comment_reaction.emoji` used `utf8mb4_unicode_ci`, which collates distinct emoji as EQUAL — reacting 🎉 after 👍 matched the existing row and deleted the first reaction instead of adding the second. Fixed with migration `v63.2026-07-06T00:00:00` changing the column to `utf8mb4_bin` (same precedent as the `metabase_field.name` fix), verified against real MySQL 8. Happy to split this into its own PR if preferred — say the word.

## Summary

Second parity pass, building on #77062 (MBQL-lib/QP parity — this PR is stacked on `e2e-parity`). All **426 Cypress e2e specs** were re-analyzed for every *other* backend behavior they exercise: REST API contracts, model/app-DB side effects, permission enforcement at the API layer, parameter values / chain-filter endpoints, embedding & public links, notifications/subscriptions, exports, transforms/data-studio, search, settings, and auth.

**~215 new deftests across ~75 test files** (test-only; no `src/` changes). 226 consolidated gaps → implemented → redundancy-reviewed (every kept test must be able to fail in a way no pre-existing test catches; 3 removed as subsumed) → full review pass (state-leak hunting, driver portability, conventions).

## Highlights

- **Dashboards API (47)**: param values/search endpoint families, mapping permission checks (FK targets, nested name refs), tabs/dashcard ops, dashboard-question archival semantics, visualizer dashcards
- **Cards/revisions**: metadata-override contracts, copy semantics, HTTP-level revert incl. `parameter_mappings` preservation (#35954, #15237)
- **Permissions**: graph partial-update response shape (#675), EE→OSS downgrade semantics, sandbox target normalization, published-tables × sandboxing/permissions intersections, DB-routing × sandboxing composition
- **Transforms/data-studio**: run cancellation endpoint, `reset-checkpoint` (zero prior coverage), template-tag execution, replacement field-ref upgrades, workspace config
- **Embedding/public**: checklist step computations, malformed `params` handling (#14474), preview locked+linked chain-filter (#41635), secret-key auto-generation
- **Notifications/sharing**: subscription/alert API gaps, whitelabel branding pinned in both pulse and notification pipelines, Slack `channel_id` persistence, pivot CSV attachments, unsubscribe-without-collection-perms
- **Collections/activity**: trash/archive semantics, bookmarks survival across moves, recents context exclusion, verified status in recents

## Notable quality work

- Proven-by-negation fix: the published-table permission tests originally mutated perms inside a rollback-only transaction invisible to the HTTP server — restructured with committed state and demonstrated the grant now flips the outcome.
- Two global state leaks caught and fixed (permission graph, `enable-embedding-static`); broad clean-JVM verification runs (639 OSS + 315 EE tests) green.

## Pre-existing issues surfaced (documented, not fixed here)

- `PUT /api/collection/:id` move-into-own-descendant returns 500 (should be 4xx) — pinned with a note
- `POST /api/email/test` returns 500 instead of 400 on connection failure (BLOCKED a planned test)
- embedding-hub `add-data` checklist key is `nil` on an empty app DB → response schema 400
- fresh-app-db failures in pre-existing `actions-are-skipped-test` and `data-isolation-strategy-test`
- measure `diff-strings` produces no sentence for `:definition`-only changes

## Test plan

- Every new test green locally on H2 (per-namespace + broad combined clean-JVM runs); postgres-gated tests validated against real Postgres
- `clj-kondo` and `cljfmt`: clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
