### PR TITLE
fix(mcp): support missing discovery list methods

### DIFF
--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -56,7 +56,7 @@
   (jsonrpc-response
    id
    {:protocolVersion protocol-version
-    :capabilities    {:tools {:listChanged true} :resources {}}
+    :capabilities    {:tools {:listChanged true} :resources {} :prompts {}}
     :serverInfo      server-info}))
 
 (defn- mcp-app-ui-capability?

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -103,6 +103,9 @@
 (defn- handle-resources-templates-list [id _params]
   (jsonrpc-response id {:resourceTemplates []}))
 
+(defn- handle-prompts-list [id _params]
+  (jsonrpc-response id {:prompts []}))
+
 (defn- handle-ping [id _params]
   (jsonrpc-response id {}))
 
@@ -117,6 +120,7 @@
       "resources/list"            (handle-resources-list id params token-scopes)
       "resources/read"            (handle-resources-read id params session-id token-scopes)
       "resources/templates/list"  (handle-resources-templates-list id params)
+      "prompts/list"              (handle-prompts-list id params)
       "ping"                      (handle-ping id params)
       (if id
         (jsonrpc-error id -32601 (str "Method not found: " method))

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -100,6 +100,9 @@
           (:not-found :scope-denied) (jsonrpc-error id -32602 "Resource not found")
           :ok                        (jsonrpc-response id {:contents (:contents result)}))))))
 
+(defn- handle-resources-templates-list [id _params]
+  (jsonrpc-response id {:resourceTemplates []}))
+
 (defn- handle-ping [id _params]
   (jsonrpc-response id {}))
 
@@ -113,6 +116,7 @@
       "tools/call"                (handle-tools-call id params session-id token-scopes)
       "resources/list"            (handle-resources-list id params token-scopes)
       "resources/read"            (handle-resources-read id params session-id token-scopes)
+      "resources/templates/list"  (handle-resources-templates-list id params)
       "ping"                      (handle-ping id params)
       (if id
         (jsonrpc-error id -32601 (str "Method not found: " method))

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -242,7 +242,7 @@
       (is (= 1 (get-in response [:body :id])))
       (let [result (get-in response [:body :result])]
         (is (= "2025-03-26" (:protocolVersion result)))
-        (is (= {:tools {:listChanged true} :resources {}} (:capabilities result)))
+        (is (= {:tools {:listChanged true} :resources {} :prompts {}} (:capabilities result)))
         (is (= {:name "metabase" :version "0.1.0"} (:serverInfo result)))))))
 
 (deftest notifications-initialized-test

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -1320,6 +1320,15 @@
       (is (= {:resourceTemplates []}
              (get-in response [:body :result]))))))
 
+(deftest prompts-list-test
+  (testing "prompts/list returns an empty list of prompts"
+    (let [[session-id _] (initialize!)
+          response (mcp-request (jsonrpc-request "prompts/list")
+                                {"mcp-session-id" session-id})]
+      (is (= 200 (:status response)))
+      (is (= {:prompts []}
+             (get-in response [:body :result]))))))
+
 (def ^:private scoped-test-uri "test://mcp/api-test/scoped")
 
 (defn- dispatch-initialized-request [msg token-scopes]

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -1311,6 +1311,15 @@
                        :message #(str/starts-with? % "Missing required parameter")}}
               (:body response))))))
 
+(deftest resources-templates-list-test
+  (testing "resources/templates/list returns an empty list of resource templates"
+    (let [[session-id _] (initialize!)
+          response (mcp-request (jsonrpc-request "resources/templates/list")
+                                {"mcp-session-id" session-id})]
+      (is (= 200 (:status response)))
+      (is (= {:resourceTemplates []}
+             (get-in response [:body :result]))))))
+
 (def ^:private scoped-test-uri "test://mcp/api-test/scoped")
 
 (defn- dispatch-initialized-request [msg token-scopes]


### PR DESCRIPTION
Closes #77107

### Description

Metabase declares MCP discovery capabilities, but some standard discovery list methods were not handled.

This PR adds support for:

- `resources/templates/list`
- `prompts/list`

Metabase does not currently expose parameterized resource templates, so `resources/templates/list` returns the protocol-compliant empty response:

```json
{
  "resourceTemplates": []
}
```

Metabase does not currently expose prompts, so `prompts/list` returns the protocol-compliant empty response:

```json
{
  "prompts": []
}
```

Before this change, clients performing full MCP discovery could receive JSON-RPC `-32601 Method not found` errors for these methods. This can cause strict MCP clients or gateways to reject the server during discovery even though tools and concrete resources are available.

### How to verify

1. Connect an MCP client to Metabase and complete `initialize`.
2. Call `resources/templates/list` with the active `Mcp-Session-Id`.
3. Verify the response is HTTP 200 and contains:

```json
{
  "resourceTemplates": []
}
```

4. Call `prompts/list` with the active `Mcp-Session-Id`.
5. Verify the response is HTTP 200 and contains:

```json
{
  "prompts": []
}
```

6. Verify existing `resources/list`, `resources/read`, `tools/list`, and `tools/call` behavior is unchanged.

### Demo

N/A. Protocol compatibility fix covered by tests.

### Checklist

* [x] Tests have been added/updated to cover changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two additional JSON-RPC requests: one to list available resource templates and one to list available prompts.
  * The API now recognizes both requests and returns successful responses with empty arrays when no items are available.
* **Tests**
  * Updated initialization expectations and added coverage for both new list endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->