### PR TITLE
onboarding: add Github username to team, add Github -> Slack ID mapping

### DIFF
--- a/.github/team.json
+++ b/.github/team.json
@@ -47,7 +47,8 @@
       "members": [
         "fraserdrops",
         "nemanjaglumac",
-        "romeovs"
+        "romeovs",
+        "ChrisVandoo"
       ]
     },
     {

--- a/release/github-slack-map.json
+++ b/release/github-slack-map.json
@@ -20,6 +20,7 @@
   "camsaul": "U07DG6C3X",
   "cbalusek": "U02M2Q0DJLD",
   "chodorowicz": "U08TVCGSW7N",
+  "ChrisVandoo": "U0BEQ4H858D",
   "cdeweyx": "U02BX2BKPQS",
   "crisptrutski": "U06C5MNFF0S",
   "dahyeik": "U03MG3BCS22",


### PR DESCRIPTION
### Description

Updates `team.json` with my Github username under the DevEx team, adds my Github username to Slack ID mapping in `github-slack-map.json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal team membership records to include a new DevEx team member.
  * Added a new Slack account mapping for that member, improving internal identity matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->