### PR TITLE
Fix snippet template-tag id churn in serdes round-trip (GHY-4067)

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/remote_sync/snippets_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/snippets_test.clj
@@ -12,9 +12,16 @@
    [metabase-enterprise.remote-sync.source.protocol :as source.p]
    [metabase-enterprise.remote-sync.spec :as spec]
    [metabase-enterprise.remote-sync.test-helpers :as test-helpers]
+   [metabase-enterprise.serialization.test-util :as ts]
+   [metabase-enterprise.serialization.v2.extract :as extract]
+   [metabase-enterprise.serialization.v2.ingest :as ingest]
+   [metabase-enterprise.serialization.v2.load :as serdes.load]
+   [metabase-enterprise.serialization.v2.storage :as storage]
+   [metabase-enterprise.serialization.v2.storage.files :as storage.files]
    [metabase.collections.models.collection :as collection]
    [metabase.collections.test-utils :as collections.tu]
    [metabase.events.core :as events]
+   [metabase.models.serialization :as serdes]
    [metabase.search.core :as search]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -418,3 +425,30 @@ is_sample: false
               (testing "the archived snippet's tracking row is dropped after export (it left the synced set)"
                 (is (nil? (t2/select-one :model/RemoteSyncObject :model_type "NativeQuerySnippet" :model_id snippet-id))
                     "RemoteSyncObject entry for the archived snippet should be deleted")))))))))
+
+;;; --------------------------------------- Serdes Round-Trip Stability ----------------------------------------
+
+(deftest template-tag-ids-survive-export-import-round-trip-test
+  (testing "GHY-4067: a snippet's template-tag ids must not change across an export/import round-trip (no spurious churn)"
+    (mt/with-premium-features #{:serialization}
+      (ts/with-random-dump-dir [dump-dir "remote-sync-snippet-"]
+        (mt/with-temp [:model/Collection {coll-id :id} {:name "Snippets Collection" :namespace :snippets}
+                       :model/NativeQuerySnippet {snippet-id :id snippet-eid :entity_id}
+                       {:name "roundtrip-snippet"
+                        :content "where a = {{field1}} and b = {{field2}}"
+                        :collection_id coll-id}]
+          (let [tag-ids #(update-vals (:template_tags (t2/select-one :model/NativeQuerySnippet :id snippet-id)) :id)
+                before  (tag-ids)]
+            (is (= #{"field1" "field2"} (set (keys before)))
+                "sanity check: the snippet has two template tags")
+            ;; Real export to YAML on disk, then real import back. Ingest keywordizes the tag-name keys,
+            ;; which is what used to defeat template-tag id preservation in the load hook.
+            (storage/store! (serdes/with-cache
+                              (into [] (extract/extract {:targets       [["NativeQuerySnippet" snippet-eid]]
+                                                         :no-settings   true
+                                                         :no-data-model true})))
+                            (storage.files/file-writer dump-dir))
+            (serdes/with-cache
+              (serdes.load/load-metabase! (ingest/ingest-yaml dump-dir)))
+            (is (= before (tag-ids))
+                "template-tag ids should be identical after an export/import round-trip")))))))

--- a/src/metabase/native_query_snippets/models/native_query_snippet.clj
+++ b/src/metabase/native_query_snippets/models/native_query_snippet.clj
@@ -174,11 +174,15 @@
                                                    where (sql.helpers/where :or where))))
 
 (defmethod serdes/make-spec "NativeQuerySnippet" [_model-name _opts]
-  {:copy      [:archived :content :description :entity_id :name :template_tags]
+  {:copy      [:archived :content :description :entity_id :name]
    :skip      []
    :transform {:created_at    (serdes/date)
                :collection_id (serdes/fk :model/Collection)
-               :creator_id    (serdes/fk :model/User)}
+               :creator_id    (serdes/fk :model/User)
+               ;; Normalize on import so template-tag name keys come back as strings (YAML ingest keywordizes
+               ;; them).
+               :template_tags {:export identity
+                               :import #(lib/normalize :metabase.lib.schema.template-tag/template-tag-map %)}}
    :defaults {:archived false}})
 
 (defmethod serdes/required "NativeQuerySnippet"


### PR DESCRIPTION
## Problem

Every remote-sync export produced a spurious diff for any snippet with template variables: the template-tag `id` UUIDs changed even though the snippet was otherwise identical (same content, name, tag names). This churned the git repo on every sync cycle.

## Root cause

The ids are regenerated on **import**, not export:

1. On serdes YAML ingest, `parse-key` keywordizes every map key — including template-tag *name* keys (`field1` → `:field1`). Export writes them as strings; ingest reads them back as keywords.
2. On load, the snippet is upserted, and `NativeQuerySnippet`'s before-insert/before-update hook calls `add-template-tags`, which re-recognizes tags from the SQL and mints a fresh `(str (random-uuid))` for each.
3. The hook preserves the old id via `(get-in old-tags [(:name tag) :id])`, but `(:name tag)` is a **string** while the ingested `old-tags` is **keyword-keyed**, so the lookup misses and the fresh UUID sticks.

The churn is cosmetic (ids stay internally consistent, queries keep working) — the harm is noisy diffs on every sync.

## Fix

Move `:template_tags` out of `:copy` into a `:transform` in `NativeQuerySnippet`'s serdes `make-spec`, normalizing the map on import (`lib/normalize :metabase.lib.schema.template-tag/template-tag-map`) so tag-name keys are strings before the model hooks run. Export output is byte-for-byte unchanged.

## Test

`template-tag-ids-survive-export-import-round-trip-test` — a real `store!`/`ingest-yaml`/`load-metabase!` round-trip asserting template-tag ids are unchanged. Verified failing before the fix, passing after.

Fixes GHY-4067.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import/export behavior for native query snippets so template tags keep their IDs after a round trip.
  * Snippet exports and re-imports now preserve template tag data more reliably, reducing issues with saved queries changing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->