### PR TITLE
Fix transforms-root breadcrumb link in remote-sync changes list (GHY-3901)

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/AllChangesView.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/AllChangesView.unit.spec.tsx
@@ -274,6 +274,38 @@ describe("AllChangesView", () => {
       expect(screen.getByText("Transform in Collection")).toBeInTheDocument();
     });
 
+    it("should link the Transforms virtual root to the transforms list, not a dead collection URL (GHY-3901)", async () => {
+      const transformsCollection = createMockCollection({
+        id: 100,
+        name: "My Transforms Collection",
+        namespace: "transforms",
+        effective_ancestors: [],
+      });
+      const transformEntity = createMockRemoteSyncEntity({
+        id: 200,
+        name: "Transform in Collection",
+        model: "transform",
+        collection_id: 100,
+        sync_status: "create",
+      });
+
+      setup({
+        entities: [transformEntity],
+        collections: [transformsCollection],
+        isTransformsSyncEnabled: true,
+      });
+
+      // The virtual root uses the sentinel id -1, which must not leak into a
+      // /collection/-1-transforms URL.
+      const transformsRootLink = await screen.findByRole("link", {
+        name: "Transforms",
+      });
+      expect(transformsRootLink).toHaveAttribute(
+        "href",
+        "/data-studio/transforms",
+      );
+    });
+
     it("should display nested transforms collections with Transforms virtual root in path", async () => {
       const childTransformsCollection = createMockCollection({
         id: 101,

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/CollectionPath.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/ChangesLists/CollectionPath.tsx
@@ -1,13 +1,21 @@
 import { Fragment } from "react";
 
 import { Anchor, Group, Text } from "metabase/ui";
-import { collection as collectionUrl } from "metabase/urls";
+import { collection as collectionUrl, transformList } from "metabase/urls";
 
-import type { CollectionPathSegment } from "../../utils";
+import { type CollectionPathSegment, TRANSFORMS_ROOT_ID } from "../../utils";
 
 interface CollectionPathProps {
   segments: CollectionPathSegment[];
 }
+
+const segmentUrl = (segment: CollectionPathSegment): string =>
+  // The Transforms root is a virtual collection (sentinel id -1) with no real
+  // collection page, so link it to the transforms list instead of building a
+  // dead /collection/-1-... URL.
+  segment.id === TRANSFORMS_ROOT_ID
+    ? transformList()
+    : collectionUrl({ id: segment.id, name: segment.name });
 
 // TODO: see if we can use the CollectionBreadcrumb component here
 export const CollectionPath = ({ segments }: CollectionPathProps) => {
@@ -21,10 +29,7 @@ export const CollectionPath = ({ segments }: CollectionPathProps) => {
             </Text>
           )}
           <Anchor
-            href={collectionUrl({
-              id: segment.id,
-              name: segment.name,
-            })}
+            href={segmentUrl(segment)}
             target="_blank"
             size="sm"
             c="text-secondary"


### PR DESCRIPTION
## Summary

In the remote-sync push/pull changes list, clicking the **"Transforms" group header** produced a broken link with a hyphen at the start of the last path segment — e.g. `/collection/-1-transforms` — which is a dead link.

**Root cause:** the "Transforms" group is backed by a *virtual* collection using the sentinel id `TRANSFORMS_ROOT_ID = -1`. Every `-1` case is special-cased in `displayGroups.ts` (grouping, item filtering, status icon) **except** the header breadcrumb. `CollectionPath` builds a collection URL from every segment id, so the sentinel flowed into `collectionUrl({ id: -1, name: "Transforms" })` → `appendSlug("/collection/-1", "transforms")` → `/collection/-1-transforms`. There is no collection `-1`, so the link is dead.

Note: the transform *items* in that group already link correctly to `/data-studio/transforms/<id>`; only the group-header breadcrumb was wrong.

## Fix

Point the transforms-root breadcrumb segment at the transforms list (`/data-studio/transforms` via `transformList()`) instead of building a collection URL from the sentinel id. The guard sits at the single render site in `CollectionPath`, so it covers both the virtual-root group and the transforms-namespace prefix prepended to sub-collection paths.

## Testing

- New unit test in `AllChangesView.unit.spec.tsx` asserts the "Transforms" breadcrumb links to `/data-studio/transforms` (not `/collection/-1-...`).
- `AllChangesView` suite: 35/35 pass.
- `type-check-pure` and `eslint` clean.

Fixes GHY-3901.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed collection path links so the “Transforms” root now opens the correct page instead of an invalid collection URL.
  * Improved link handling in collection breadcrumbs to ensure virtual root items navigate properly.
* **Tests**
  * Added coverage for the “Transforms” root link behavior to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->