### PR TITLE
Support OpenRouter

### DIFF
--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
@@ -1661,12 +1661,15 @@ expect(
       ).toHaveLength(2);
     });
 
-    const modelRequest = fetchMock.callHistory
-      .calls("path:/api/metabot/settings", { method: "PUT" })
-      .at(-1);
-    expect(modelRequest?.options?.body).toBe(
-      JSON.stringify({ provider: "openrouter", model: "openai/gpt-5.4-mini" }),
-    );
+    expect(
+      fetchMock.callHistory.lastCall("path:/api/metabot/settings", {
+        method: "PUT",
+        body: {
+          provider: "openrouter",
+          model: "openai/gpt-5.4-mini",
+        },
+      }),
+    ).toBeDefined();
 
     expect(
       screen.queryByRole("button", { name: "Connect" }),

--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
@@ -1639,15 +1639,15 @@ describe("AIProviderSettingsSection", () => {
       ).toHaveLength(1);
     });
 
-    const connectRequest = fetchMock.callHistory
-      .calls("path:/api/metabot/settings", { method: "PUT" })
-      .at(-1);
-    expect(connectRequest?.options?.body).toBe(
-      JSON.stringify({
-        provider: "openrouter",
-        "api-key": "sk-or-v1-openrouter-test",
-      }),
-    );
+expect(
+  fetchMock.callHistory.lastCall("path:/api/metabot/settings", {
+    method: "PUT",
+    body: {
+      provider: "openrouter",
+      "api-key": "sk-or-v1-openrouter-test",
+    },
+  }),
+).toBeDefined();
 
     await screen.findByLabelText("Model");
     await openModelSelector();

--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
@@ -1639,15 +1639,15 @@ describe("AIProviderSettingsSection", () => {
       ).toHaveLength(1);
     });
 
-expect(
-  fetchMock.callHistory.lastCall("path:/api/metabot/settings", {
-    method: "PUT",
-    body: {
-      provider: "openrouter",
-      "api-key": "sk-or-v1-openrouter-test",
-    },
-  }),
-).toBeDefined();
+    expect(
+      fetchMock.callHistory.lastCall("path:/api/metabot/settings", {
+        method: "PUT",
+        body: {
+          provider: "openrouter",
+          "api-key": "sk-or-v1-openrouter-test",
+        },
+      }),
+    ).toBeDefined();
 
     await screen.findByLabelText("Model");
     await openModelSelector();

--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
@@ -96,11 +96,11 @@ const DEFAULT_RESPONSES: Record<MetabotProvider, MetabotSettingsResponse> = {
     ],
   },
   openrouter: {
-    value: "openrouter/openai/gpt-4.1-mini",
+    value: "openrouter/openai/gpt-5.4-mini",
     models: [
       {
-        id: "openai/gpt-4.1-mini",
-        display_name: "OpenAI GPT-4.1 mini",
+        id: "openai/gpt-5.4-mini",
+        display_name: "OpenAI: GPT-5.4 Mini",
         group: "OpenAI",
       },
     ],
@@ -586,7 +586,7 @@ describe("AIProviderSettingsSection", () => {
     expect(openaiOption).not.toHaveAttribute("data-combobox-disabled");
   });
 
-  it("shows Coming soon for unsupported providers and disables them", async () => {
+  it("shows OpenRouter as selectable in the provider dropdown", async () => {
     await setup({ savedProviderValue: null, isConfigured: false });
 
     await userEvent.click(screen.getByLabelText("Provider"));
@@ -594,9 +594,10 @@ describe("AIProviderSettingsSection", () => {
     const openrouterOption = await screen.findByRole("option", {
       name: /OpenRouter/,
     });
-    expect(openrouterOption).toHaveAttribute("data-combobox-disabled");
+    expect(openrouterOption).toBeInTheDocument();
+    expect(openrouterOption).not.toHaveAttribute("data-combobox-disabled");
 
-    expect(screen.getAllByText("Coming soon")).toHaveLength(1);
+    expect(screen.queryByText("Coming soon")).not.toBeInTheDocument();
   });
 
   it("BOT-1429: keeps the form interactive while session-properties refetches in the background", async () => {
@@ -1601,6 +1602,95 @@ describe("AIProviderSettingsSection", () => {
           body: {
             "llm-metabot-provider": null,
             "llm-openai-api-key": null,
+          },
+        }),
+      ).toBe(true);
+    });
+
+    expect(
+      await screen.findByText("Connect to an AI provider"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Provider")).toHaveValue("");
+  });
+
+  it("connects to OpenRouter by saving the API key and selecting a model", async () => {
+    await setup({
+      savedProviderValue: null,
+      isConfigured: false,
+      apiKeyValues: { openrouter: null },
+      updateResponse: {
+        value: "openrouter/anthropic/claude-sonnet-4.6",
+        models: DEFAULT_RESPONSES.openrouter.models,
+      },
+    });
+
+    await selectProvider("OpenRouter");
+    await userEvent.type(
+      screen.getByLabelText("API key"),
+      "sk-or-v1-openrouter-test",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory.calls("path:/api/metabot/settings", {
+          method: "PUT",
+        }),
+      ).toHaveLength(1);
+    });
+
+    const connectRequest = fetchMock.callHistory
+      .calls("path:/api/metabot/settings", { method: "PUT" })
+      .at(-1);
+    expect(connectRequest?.options?.body).toBe(
+      JSON.stringify({
+        provider: "openrouter",
+        "api-key": "sk-or-v1-openrouter-test",
+      }),
+    );
+
+    await screen.findByLabelText("Model");
+    await openModelSelector();
+    await userEvent.click(await screen.findByText("OpenAI: GPT-5.4 Mini"));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory.calls("path:/api/metabot/settings", {
+          method: "PUT",
+        }),
+      ).toHaveLength(2);
+    });
+
+    const modelRequest = fetchMock.callHistory
+      .calls("path:/api/metabot/settings", { method: "PUT" })
+      .at(-1);
+    expect(modelRequest?.options?.body).toBe(
+      JSON.stringify({ provider: "openrouter", model: "openai/gpt-5.4-mini" }),
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Connect" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("disconnects OpenRouter by clearing both the provider and API key settings", async () => {
+    await setup({
+      savedProviderValue: "openrouter/openai/gpt-5.4-mini",
+      isConfigured: true,
+      apiKeyValues: { openrouter: "**********st" },
+    });
+
+    await screen.findByText("Connected to OpenRouter");
+    await screen.findByLabelText("API key");
+    await confirmDisconnectProvider();
+
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory.called("path:/api/setting", {
+          method: "PUT",
+          body: {
+            "llm-metabot-provider": null,
+            "llm-openrouter-api-key": null,
           },
         }),
       ).toBe(true);

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/utils.ts
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/utils.ts
@@ -97,7 +97,8 @@ export function isAvailableProvider(provider: MetabotProvider): boolean {
     provider === "azure" ||
     provider === "bedrock" ||
     provider === "metabase" ||
-    provider === "openai"
+    provider === "openai" ||
+    provider === "openrouter"
   );
 }
 

--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -476,7 +476,7 @@
   than the raw model name returned by the API.
 
   The `metabase/` routing prefix is stripped so usage keys reflect the actual
-  provider/model (e.g. `openrouter/anthropic/claude-haiku-4-5`) regardless of
+  provider/model (e.g. `openrouter/anthropic/claude-haiku-4.5`) regardless of
   whether the request was routed through the AI proxy.
   Non-usage parts pass through unchanged."
   [usage-atom provider-and-model]

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -405,13 +405,17 @@
 
 (defn- openrouter-model-group
   [{:keys [display_name id]}]
-  (or (some-> display_name
-              (str/split #": " 2)
-              first)
-      (some-> id
-              (str/split #"/" 2)
-              first
-              title-case-token)))
+  (cond
+    (and display_name (str/includes? display_name ": "))
+    (-> display_name
+        (str/split #": " 2)
+        first)
+
+    (and id (str/includes? id "/"))
+    (-> id
+        (str/split #"/" 2)
+        first
+        title-case-token)))
 
 (defn- decorate-provider-model
   [provider model]

--- a/src/metabase/metabot/provider_util.clj
+++ b/src/metabase/metabot/provider_util.clj
@@ -2,7 +2,7 @@
   "Utility functions for parsing `provider-and-model` strings.
 
   These strings have the format `provider/model` (e.g. `anthropic/claude-haiku-4-5`,
-  `openrouter/anthropic/claude-haiku-4-5`) or `metabase/provider/model` when routed
+  `openrouter/anthropic/claude-haiku-4.5`) or `metabase/provider/model` when routed
   through the Metabase Cloud AI proxy."
   (:require
    [clojure.string :as str]))
@@ -41,7 +41,7 @@
   "Extract the model name from a provider-and-model string.
   For `metabase/anthropic/model` returns `\"model\"`.
   For `anthropic/model` returns `\"model\"`.
-  For `openrouter/anthropic/claude-haiku-4-5` returns `\"anthropic/claude-haiku-4-5\"`."
+  For `openrouter/anthropic/claude-haiku-4.5` returns `\"anthropic/claude-haiku-4.5\"`."
   [provider-and-model]
   (when provider-and-model
     (let [[first-seg rest-seg] (str/split provider-and-model #"/" 2)]
@@ -51,8 +51,8 @@
 
 (defn strip-metabase-prefix
   "Strip the `metabase/` routing prefix from a provider-and-model string.
-  For `metabase/openrouter/anthropic/claude-haiku-4-5` returns
-  `\"openrouter/anthropic/claude-haiku-4-5\"`.
+  For `metabase/openrouter/anthropic/claude-haiku-4.5` returns
+  `\"openrouter/anthropic/claude-haiku-4.5\"`.
   Returns the input unchanged if no prefix is present."
   [provider-and-model]
   (if (metabase-provider? provider-and-model)

--- a/src/metabase/metabot/self.clj
+++ b/src/metabase/metabot/self.clj
@@ -162,7 +162,7 @@
 
   Prometheus + Snowplow:
     - `:profile-id` — the profile id (e.g. `:internal`)
-    - `:model`      — the model (e.g. `openrouter/anthropic/claude-haiku-4-5`)
+    - `:model`      — the model (e.g. `openrouter/anthropic/claude-haiku-4.5`)
     - `:tag`        — the specific purpose for which the tokens were used (e.g. 'agent', 'sql-fixing')
 
    Snowplow only:
@@ -269,7 +269,7 @@
   "Call an LLM and stream processed parts.
 
   `provider-and-model` is a string like `anthropic/claude-haiku-4-5` or
-  `openrouter/anthropic/claude-haiku-4-5`.  The first segment selects the
+  `openrouter/anthropic/claude-haiku-4.5`.  The first segment selects the
   provider adapter; the rest is the model name passed to the API.
 
   `parts` is a sequence of AISDK parts (`:text`, `:tool-input`, `:tool-output`)
@@ -328,7 +328,7 @@
   Includes the same retry logic as [[call-llm]] for transient errors.
 
   Args:
-    model         - Model identifier (e.g. \"openrouter/anthropic/claude-haiku-4-5\")
+    model         - Model identifier (e.g. \"openrouter/anthropic/claude-haiku-4.5\")
     messages      - Sequence of Chat Completions message maps
                     (e.g. [{:role \"user\" :content \"...\"}])
     json-schema   - JSON Schema map for the expected response shape

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -312,8 +312,6 @@
   "Fetch the full Anthropic model catalog (`GET /v1/models`).
   No-arg uses the configured API key. Opts map supports `:credentials` (`{:api-key ...}`) and `:ai-proxy?`."
   [{:keys [credentials ai-proxy?]}]
-  (when (and credentials (str/blank? (:api-key credentials)))
-    (throw (core/missing-api-key-ex "Anthropic")))
   (try
     (let [auth (core/resolve-auth "anthropic" "Anthropic"
                                   (when-let [k (or (not-empty (:api-key credentials))

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -252,7 +252,7 @@
   by other provider adapters."
   "<<<METABOT_CACHE_BREAKPOINT>>>")
 
-(defn- system->cached-content-blocks
+(defn system->cached-content-blocks
   "Wrap a rendered system prompt for Anthropic, applying ephemeral cache_control.
 
   If `system` contains the cache breakpoint sentinel, split it into two content

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -241,8 +241,6 @@
   [{:keys [credentials ai-proxy?]}]
   (when ai-proxy?
     (throw (ai-proxy-unsupported-ex)))
-  (when (and credentials (str/blank? (:api-key credentials)))
-    (throw (core/missing-api-key-ex "OpenAI")))
   (try
     (let [auth (core/resolve-auth "openai" "OpenAI"
                                   (when-let [k (or (not-empty (:api-key credentials))

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -146,8 +146,6 @@
   [{:keys [credentials ai-proxy?]}]
   (when ai-proxy?
     (throw (ai-proxy-unsupported-ex)))
-  (when (and credentials (str/blank? (:api-key credentials)))
-    (throw (core/missing-api-key-ex "OpenRouter")))
   (try
     (let [auth (core/resolve-auth "openrouter" "OpenRouter"
                                   (when-let [k (or (not-empty (:api-key credentials))

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -92,6 +92,11 @@
                 :description doc
                 :parameters  (mjs/transform params {:additionalProperties false})}}))
 
+(defn- ai-proxy-unsupported-ex []
+  (ex-info (tru "AI proxy is not supported for OpenRouter")
+           {:api-error  true
+            :error-code :proxy-unsupported}))
+
 (defn- openrouter-error-msg
   "Canonical, status-specific OpenRouter error message."
   [res]
@@ -137,8 +142,10 @@
 
 (defn- list-all-models
   "Fetch the full OpenRouter model catalog (`GET /v1/models`).
-  No-arg uses the configured API key. Opts map supports `:credentials` (`{:api-key ...}`) and `:ai-proxy?`."
+  `:ai-proxy?` is not supported for OpenRouter and throws when true."
   [{:keys [credentials ai-proxy?]}]
+  (when ai-proxy?
+    (throw (ai-proxy-unsupported-ex)))
   (when (and credentials (str/blank? (:api-key credentials)))
     (throw (core/missing-api-key-ex "OpenRouter")))
   (try
@@ -160,7 +167,8 @@
 
 (defn list-models
   "List the OpenRouter models supported by this adapter (see [[supported-models]]).
-  No-arg uses the configured API key. Opts map supports `:credentials` (`{:api-key ...}`) and `:ai-proxy?`."
+  No-arg uses the configured API key. Opts map supports `:credentials` (`{:api-key ...}`) and `:ai-proxy?`.
+  `:ai-proxy?` is not supported for OpenRouter and throws when true."
   ([] (list-models {}))
   ([opts]
    {:models (->> (list-all-models opts)
@@ -290,9 +298,12 @@
   "Perform a streaming request to the Chat Completions API.
 
   Works with OpenRouter, or any OpenAI-compatible endpoint that supports
-  `/v1/chat/completions` (e.g. vLLM, Ollama, Together, etc.)."
+  `/v1/chat/completions` (e.g. vLLM, Ollama, Together, etc.).
+  `:ai-proxy?` is not supported for OpenRouter and throws when true."
   [{:keys [model system input tools temperature max-tokens tool_choice schema ai-proxy?]
     :or   {model "anthropic/claude-haiku-4.5"}} :- core/LLMRequestOpts]
+  (when ai-proxy?
+    (throw (ai-proxy-unsupported-ex)))
   (let [messages  (cond-> (parts->cc-messages input)
                     system (as-> msgs (into [{:role "system" :content system}] msgs)))
         all-tools (or (when schema

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -148,12 +148,14 @@
    "anthropic/claude-sonnet-4.6" "Claude Sonnet 4.6"
    "anthropic/claude-sonnet-4.5" "Claude Sonnet 4.5"
    "anthropic/claude-haiku-4.5"  "Claude Haiku 4.5"
+   "openai/gpt-5.6-sol"          "GPT-5.6 Sol"
+   "openai/gpt-5.6-terra"        "GPT-5.6 Terra"
+   "openai/gpt-5.6-luna"         "GPT-5.6 Luna"
    "openai/gpt-5.5"              "GPT-5.5"
    "openai/gpt-5.5-pro"          "GPT-5.5 Pro"
    "openai/gpt-5.4"              "GPT-5.4"
    "openai/gpt-5.4-pro"          "GPT-5.4 Pro"
-   "openai/gpt-5.4-mini"         "GPT-5.4 Mini"
-   "openai/gpt-5"                "GPT-5"})
+   "openai/gpt-5.4-mini"         "GPT-5.4 Mini"})
 
 (defn- supported-model?
   "Whether a `/v1/models` catalog entry is one of the [[supported-models]]."

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -11,6 +11,7 @@
    [clojure.string :as str]
    [malli.json-schema :as mjs]
    [metabase.llm.settings :as llm]
+   [metabase.metabot.self.claude :as claude]
    [metabase.metabot.self.core :as core]
    [metabase.metabot.self.debug :as debug]
    [metabase.metabot.self.schema :as schema]
@@ -22,6 +23,25 @@
    [metabase.util.o11y :refer [with-span]]))
 
 (set! *warn-on-reflection* true)
+
+(defn- openrouter-usage->aisdk-usage
+  "Convert an OpenRouter Chat Completions `usage` block into the AISDK `:usage` shape.
+
+  OpenRouter normalizes usage to the OpenAI shape regardless of the upstream
+  provider: `prompt_tokens` is the total input count, and the cache buckets are
+  a subset breakdown of it under `prompt_tokens_details`:
+
+      cached_tokens      — input tokens read from the provider cache
+      cache_write_tokens — input tokens written to the provider cache;
+                           Anthropic models only. OpenAI caching is
+                           automatic, its writes are free and reported
+                           as 0 (or omitted entirely)."
+  [u]
+  (let [details (:prompt_tokens_details u)]
+    {:promptTokens        (:prompt_tokens u 0)
+     :completionTokens    (:completion_tokens u 0)
+     :cacheCreationTokens (or (:cache_write_tokens details) 0)
+     :cacheReadTokens     (or (:cached_tokens details) 0)}))
 
 ;;; AISDK parts → Chat Completions messages
 
@@ -285,12 +305,59 @@
                                                                @current-type (close!))
              ;; Usage (often on a separate final chunk with empty choices)
              (some? usage)                                    (rf {:type  :usage
-                                                                   :usage {:promptTokens     (:prompt_tokens usage 0)
-                                                                           :completionTokens (:completion_tokens usage 0)}
+                                                                   :usage (openrouter-usage->aisdk-usage usage)
                                                                    :id    @message-id
                                                                    :model @model-name}))))))))
 
 ;;; HTTP request
+
+(defn- anthropic-model?
+  "Whether an OpenRouter model id routes to Anthropic (e.g. `anthropic/claude-haiku-4.5`)."
+  [model]
+  (str/starts-with? (str model) "anthropic/"))
+
+(defn- system->cc-message
+  "Build the Chat Completions system message for `system`.
+
+  Anthropic models get explicit prompt-cache breakpoints: the content becomes
+  Anthropic-style text blocks with `cache_control` markers (see
+  [[claude/system->cached-content-blocks]]), which OpenRouter passes through to
+  Anthropic unchanged. Anthropic's cache prefix orders tools before system, so a
+  breakpoint on the system blocks caches the tool definitions too; OpenRouter
+  doesn't document `cache_control` on tool definitions, so unlike claude.clj we
+  don't put a separate breakpoint there.
+
+  Other models (OpenAI) get a plain string system message: OpenAI prompt caching
+  is automatic server-side and takes no request markup."
+  [system model]
+  {:role    "system"
+   :content (cond-> system
+              (anthropic-model? model) claude/system->cached-content-blocks)})
+
+(mu/defn openrouter-request-body
+  "Build the Chat Completions request body for an LLM request."
+  [{:keys [model system input tools temperature max-tokens tool_choice schema]
+    :or   {model "anthropic/claude-haiku-4.5"}} :- core/LLMRequestOpts]
+  (let [messages  (cond-> (parts->cc-messages input)
+                    system (as-> msgs (into [(system->cc-message system model)] msgs)))
+        all-tools (or (when schema
+                        ;; Structured output: force a tool call with the given JSON schema
+                        [{:type     "function"
+                          :function {:name        "structured_output"
+                                     :description "Output structured data"
+                                     :parameters  schema}}])
+                      (seq (mapv tool->openai-chat tools)))]
+    (cond-> {:model             model
+             :stream            true
+             :stream_options    {:include_usage true}
+             :messages          messages}
+      all-tools   (assoc :tools       (vec all-tools)
+                         :tool_choice (cond
+                                        schema      "required"
+                                        tool_choice tool_choice
+                                        :else       "auto"))
+      temperature (assoc :temperature temperature)
+      max-tokens  (assoc :max_tokens max-tokens))))
 
 (mu/defn openrouter-raw
   "Perform a streaming request to the Chat Completions API.
@@ -298,34 +365,15 @@
   Works with OpenRouter, or any OpenAI-compatible endpoint that supports
   `/v1/chat/completions` (e.g. vLLM, Ollama, Together, etc.).
   `:ai-proxy?` is not supported for OpenRouter and throws when true."
-  [{:keys [model system input tools temperature max-tokens tool_choice schema ai-proxy?]
+  [{:keys [model tools ai-proxy?] :as opts
     :or   {model "anthropic/claude-haiku-4.5"}} :- core/LLMRequestOpts]
   (when ai-proxy?
     (throw (ai-proxy-unsupported-ex)))
-  (let [messages  (cond-> (parts->cc-messages input)
-                    system (as-> msgs (into [{:role "system" :content system}] msgs)))
-        all-tools (or (when schema
-                        ;; Structured output: force a tool call with the given JSON schema
-                        [{:type     "function"
-                          :function {:name        "structured_output"
-                                     :description "Output structured data"
-                                     :parameters  schema}}])
-                      (seq (mapv tool->openai-chat tools)))
-        req       (cond-> {:model             model
-                           :stream            true
-                           :stream_options    {:include_usage true}
-                           :messages          messages}
-                    all-tools   (assoc :tools       (vec all-tools)
-                                       :tool_choice (cond
-                                                      schema      "required"
-                                                      tool_choice tool_choice
-                                                      :else       "auto"))
-                    temperature (assoc :temperature temperature)
-                    max-tokens  (assoc :max_tokens max-tokens))]
-    (log/debug "OpenRouter request" {:model model :msg-count (count messages) :tools (count (or tools []))})
+  (let [req (openrouter-request-body opts)]
+    (log/debug "OpenRouter request" {:model model :msg-count (count (:messages req)) :tools (count (or tools []))})
     (with-span :info {:name       :metabot.openrouter/request
                       :model      model
-                      :msg-count  (count messages)
+                      :msg-count  (count (:messages req))
                       :tool-count (count (or tools []))}
       (try
         (let [api-key  (not-empty (llm/llm-openrouter-api-key))

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -107,32 +107,67 @@
       503 (tru "OpenRouter service is unavailable")
       (tru "OpenRouter API error (HTTP {0})" status))))
 
+(def ^:private supported-models
+  "OpenRouter models offered in the Metabot model picker, as a map of model id -> display name.
+  `list-models` returns the intersection of this map with the `/v1/models` catalog.
+  Mirrors the models whitelisted for the direct anthropic and openai providers; note that
+  OpenRouter model IDs use dots in version numbers (`claude-haiku-4.5`), unlike the
+  Anthropic API's hyphenated IDs (`claude-haiku-4-5`)."
+  {"anthropic/claude-fable-5"    "Claude Fable 5"
+   "anthropic/claude-opus-4.8"   "Claude Opus 4.8"
+   "anthropic/claude-opus-4.7"   "Claude Opus 4.7"
+   "anthropic/claude-opus-4.6"   "Claude Opus 4.6"
+   "anthropic/claude-opus-4.5"   "Claude Opus 4.5"
+   "anthropic/claude-opus-4.1"   "Claude Opus 4.1"
+   "anthropic/claude-sonnet-5"   "Claude Sonnet 5"
+   "anthropic/claude-sonnet-4.6" "Claude Sonnet 4.6"
+   "anthropic/claude-sonnet-4.5" "Claude Sonnet 4.5"
+   "anthropic/claude-haiku-4.5"  "Claude Haiku 4.5"
+   "openai/gpt-5.5"              "GPT-5.5"
+   "openai/gpt-5.5-pro"          "GPT-5.5 Pro"
+   "openai/gpt-5.4"              "GPT-5.4"
+   "openai/gpt-5.4-pro"          "GPT-5.4 Pro"
+   "openai/gpt-5.4-mini"         "GPT-5.4 Mini"
+   "openai/gpt-5"                "GPT-5"})
+
+(defn- supported-model?
+  "Whether a `/v1/models` catalog entry is one of the [[supported-models]]."
+  [{:keys [id]}]
+  (contains? supported-models id))
+
+(defn- list-all-models
+  "Fetch the full OpenRouter model catalog (`GET /v1/models`).
+  No-arg uses the configured API key. Opts map supports `:credentials` (`{:api-key ...}`) and `:ai-proxy?`."
+  [{:keys [credentials ai-proxy?]}]
+  (when (and credentials (str/blank? (:api-key credentials)))
+    (throw (core/missing-api-key-ex "OpenRouter")))
+  (try
+    (let [auth (core/resolve-auth "openrouter" "OpenRouter"
+                                  (when-let [k (or (not-empty (:api-key credentials))
+                                                   (not-empty (llm/llm-openrouter-api-key)))]
+                                    {:url     (llm/llm-openrouter-api-base-url)
+                                     :headers {"Authorization" (str "Bearer " k)}})
+                                  ai-proxy?)
+          res  (core/request auth {:method  :get
+                                   :url     "/v1/models"
+                                   :as      :json
+                                   :headers {"Content-Type" "application/json"
+                                             "HTTP-Referer" "https://metabase.com"
+                                             "X-Title"      "Metabase"}})]
+      (get-in res [:body :data]))
+    (catch Exception e
+      (core/rethrow-api-error! "openrouter" openrouter-error-msg e))))
+
 (defn list-models
-  "List available OpenRouter models.
+  "List the OpenRouter models supported by this adapter (see [[supported-models]]).
   No-arg uses the configured API key. Opts map supports `:credentials` (`{:api-key ...}`) and `:ai-proxy?`."
   ([] (list-models {}))
-  ([{:keys [credentials ai-proxy?]}]
-   (when (and credentials (str/blank? (:api-key credentials)))
-     (throw (core/missing-api-key-ex "OpenRouter")))
-   (try
-     (let [auth (core/resolve-auth "openrouter" "OpenRouter"
-                                   (when-let [k (or (not-empty (:api-key credentials))
-                                                    (not-empty (llm/llm-openrouter-api-key)))]
-                                     {:url     (llm/llm-openrouter-api-base-url)
-                                      :headers {"Authorization" (str "Bearer " k)}})
-                                   ai-proxy?)
-           res  (core/request auth {:method  :get
-                                    :url     "/v1/models"
-                                    :as      :json
-                                    :headers {"Content-Type" "application/json"
-                                              "HTTP-Referer" "https://metabase.com"
-                                              "X-Title"      "Metabase"}})]
-       {:models (mapv (fn [model]
-                        {:id           (:id model)
-                         :display_name (or (:name model) (:id model))})
-                      (reverse (sort-by :created (get-in res [:body :data]))))})
-     (catch Exception e
-       (core/rethrow-api-error! "openrouter" openrouter-error-msg e)))))
+  ([opts]
+   {:models (->> (list-all-models opts)
+                 (filter supported-model?)
+                 (sort-by :id)
+                 (mapv (fn [{:keys [id] :as model}]
+                         {:id id :display_name (or (:name model) (supported-models id))})))}))
 
 ;;; Streaming response → AISDK v5 chunks
 

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -257,7 +257,7 @@
   Works with OpenRouter, or any OpenAI-compatible endpoint that supports
   `/v1/chat/completions` (e.g. vLLM, Ollama, Together, etc.)."
   [{:keys [model system input tools temperature max-tokens tool_choice schema ai-proxy?]
-    :or   {model "anthropic/claude-haiku-4-5"}} :- core/LLMRequestOpts]
+    :or   {model "anthropic/claude-haiku-4.5"}} :- core/LLMRequestOpts]
   (let [messages  (cond-> (parts->cc-messages input)
                     system (as-> msgs (into [{:role "system" :content system}] msgs)))
         all-tools (or (when schema

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -118,6 +118,12 @@
   "Default OpenAI model used for Metabot when no explicit model is selected."
   "gpt-5.4")
 
+(def ^:private default-openrouter-llm-metabot-model
+  "Default OpenRouter model used for Metabot when no explicit model is selected.
+  Note that OpenRouter model IDs use dots in version numbers (`claude-sonnet-4.6`),
+  unlike the Anthropic API's hyphenated IDs (`claude-sonnet-4-6`)."
+  "anthropic/claude-sonnet-4.6")
+
 (def default-llm-metabot-provider
   "Default provider/model used for Metabot when no explicit model is selected."
   (str "anthropic/" default-anthropic-llm-metabot-model))
@@ -130,6 +136,7 @@
   {"anthropic"                            default-anthropic-llm-metabot-model
    "bedrock"                              default-bedrock-llm-metabot-model
    "openai"                               default-openai-llm-metabot-model
+   "openrouter"                           default-openrouter-llm-metabot-model
    provider-util/metabase-provider-prefix default-llm-metabot-provider})
 
 (def default-metabase-llm-metabot-provider
@@ -248,7 +255,7 @@
     (validate-direct-provider! value)))
 
 (defsetting llm-metabot-provider
-  (deferred-tru "The AI provider and model for Metabot. Format: provider/model-name, e.g. `anthropic/claude-haiku-4-5`, `openai/gpt-5.4`, `openrouter/anthropic/claude-haiku-4-5`.")
+  (deferred-tru "The AI provider and model for Metabot. Format: provider/model-name, e.g. `anthropic/claude-haiku-4-5`, `openai/gpt-5.4`, `openrouter/anthropic/claude-haiku-4.5`.")
   :type             :string
   :encryption       :no
   :default          default-llm-metabot-provider

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -334,6 +334,24 @@
              (mt/user-http-request :crowberto :get 200 "metabot/settings"
                                    :provider "openrouter"))))))
 
+(deftest settings-get-groups-openrouter-models-without-vendor-prefix-test
+  (testing "models whose display_name has no `Vendor: ` prefix are grouped by the vendor from the model id"
+    (mt/with-temporary-setting-values [llm.settings/llm-openrouter-api-key "sk-or-v1-valid"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [_provider _opts]
+                                                             {:models [{:id "anthropic/claude-fable-5"
+                                                                        :display_name "Claude Fable 5"}
+                                                                       {:id "openai/gpt-5.5"
+                                                                        :display_name "GPT-5.5"}]})]
+        (is (= {:value  (metabot.settings/llm-metabot-provider)
+                :models [{:id "anthropic/claude-fable-5"
+                          :display_name "Claude Fable 5"
+                          :group "Anthropic"}
+                         {:id "openai/gpt-5.5"
+                          :display_name "GPT-5.5"
+                          :group "OpenAI"}]}
+               (mt/user-http-request :crowberto :get 200 "metabot/settings"
+                                     :provider "openrouter")))))))
+
 (deftest settings-get-groups-openai-models-test
   (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "openai/gpt-5-mini"
                                      llm.settings/llm-openai-api-key       "sk-valid"]

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -438,6 +438,32 @@
         (is (= "sk-fresh"
                (llm.settings/llm-openai-api-key)))))))
 
+(deftest settings-put-connect-openrouter-defaults-model-test
+  (testing "connecting openrouter with only an api-key switches to the default openrouter model"
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-haiku-4-5"
+                                       llm.settings/llm-openrouter-api-key   nil]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn
+                                                             ([provider]
+                                                              (is (= "openrouter" provider))
+                                                              {:models [{:id "anthropic/claude-sonnet-4.6"
+                                                                         :display_name "Anthropic: Claude Sonnet 4.6"}]})
+                                                             ([provider {:keys [credentials]}]
+                                                              (is (= "openrouter" provider))
+                                                              (is (= {:api-key "sk-or-v1-fresh"} credentials))
+                                                              {:models [{:id "anthropic/claude-sonnet-4.6"
+                                                                         :display_name "Anthropic: Claude Sonnet 4.6"}]}))]
+        (is (= {:value  "openrouter/anthropic/claude-sonnet-4.6"
+                :models [{:id "anthropic/claude-sonnet-4.6"
+                          :display_name "Anthropic: Claude Sonnet 4.6"
+                          :group "Anthropic"}]}
+               (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                     {:provider "openrouter"
+                                      :api-key  "sk-or-v1-fresh"})))
+        (is (= "openrouter/anthropic/claude-sonnet-4.6"
+               (metabot.settings/llm-metabot-provider)))
+        (is (= "sk-or-v1-fresh"
+               (llm.settings/llm-openrouter-api-key)))))))
+
 (deftest settings-put-updates-metabase-provider-without-api-key-test
   (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-haiku-4-5"]
     (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn

--- a/test/metabase/metabot/self/claude_test.clj
+++ b/test/metabase/metabot/self/claude_test.clj
@@ -467,6 +467,34 @@
                    #"No Anthropic API key is set"
                    (claude/list-models {}))))))))))
 
+(deftest list-models-explicit-credentials-test
+  (testing "a passed-in api-key is used over the configured key"
+    (mt/with-temporary-setting-values [llm.settings/llm-anthropic-api-key "sk-ant-setting"]
+      (mt/with-dynamic-fn-redefs [http/request (fn [req]
+                                                 (is (=? {:headers {"x-api-key" "sk-ant-explicit"}}
+                                                         req))
+                                                 {:body "{\"data\":[]}"})]
+        (is (= {:models []}
+               (claude/list-models {:credentials {:api-key "sk-ant-explicit"}})))))))
+
+(deftest list-models-blank-credentials-fall-back-to-configured-key-test
+  (testing "a blank passed-in api-key falls back to the configured key"
+    (mt/with-temporary-setting-values [llm.settings/llm-anthropic-api-key "sk-ant-setting"]
+      (mt/with-dynamic-fn-redefs [http/request (fn [req]
+                                                 (is (=? {:headers {"x-api-key" "sk-ant-setting"}}
+                                                         req))
+                                                 {:body "{\"data\":[]}"})]
+        (is (= {:models []}
+               (claude/list-models {:credentials {:api-key ""}})))))))
+
+(deftest list-models-blank-credentials-without-configured-key-test
+  (testing "throws when the passed-in api-key is blank and no key is configured"
+    (mt/with-dynamic-fn-redefs [llm.settings/llm-anthropic-api-key (constantly nil)]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"No Anthropic API key is set"
+           (claude/list-models {:credentials {:api-key ""}}))))))
+
 (deftest ^:parallel supported-model?-test
   (testing "whitelisted models are supported"
     (doseq [id ["claude-fable-5" "claude-opus-4-8" "claude-sonnet-5" "claude-haiku-4-5-20251001"]]

--- a/test/metabase/metabot/self/openai_test.clj
+++ b/test/metabase/metabot/self/openai_test.clj
@@ -334,6 +334,34 @@
                 {:id "gpt-5.6-sol" :display_name "GPT-5.6 Sol"}]
                (:models (openai/list-models))))))))
 
+(deftest list-models-explicit-credentials-test
+  (testing "a passed-in api-key is used over the configured key"
+    (mt/with-temporary-setting-values [llm.settings/llm-openai-api-key "sk-setting"]
+      (mt/with-dynamic-fn-redefs [http/request (fn [req]
+                                                 (is (=? {:headers {"Authorization" "Bearer sk-explicit"}}
+                                                         req))
+                                                 {:status 200 :body {:data []}})]
+        (is (= {:models []}
+               (openai/list-models {:credentials {:api-key "sk-explicit"}})))))))
+
+(deftest list-models-blank-credentials-fall-back-to-configured-key-test
+  (testing "a blank passed-in api-key falls back to the configured key"
+    (mt/with-temporary-setting-values [llm.settings/llm-openai-api-key "sk-setting"]
+      (mt/with-dynamic-fn-redefs [http/request (fn [req]
+                                                 (is (=? {:headers {"Authorization" "Bearer sk-setting"}}
+                                                         req))
+                                                 {:status 200 :body {:data []}})]
+        (is (= {:models []}
+               (openai/list-models {:credentials {:api-key ""}})))))))
+
+(deftest list-models-blank-credentials-without-configured-key-test
+  (testing "throws when the passed-in api-key is blank and no key is configured"
+    (mt/with-temporary-setting-values [llm.settings/llm-openai-api-key nil]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"No OpenAI API key is set"
+           (openai/list-models {:credentials {:api-key ""}}))))))
+
 ;;; ──────────────────────────────────────────────────────────────────
 ;;; temperature support tests
 ;;; ──────────────────────────────────────────────────────────────────

--- a/test/metabase/metabot/self/openrouter_test.clj
+++ b/test/metabase/metabot/self/openrouter_test.clj
@@ -223,3 +223,23 @@
                  clojure.lang.ExceptionInfo
                  #"No OpenRouter API key is set"
                  (openrouter/openrouter-raw {:input [{:role :user :content "hi"}]})))))))))
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; list-models tests
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest list-models-filters-catalog-to-whitelist-test
+  (testing "list-models keeps only whitelisted models sorted by id, preferring the catalog display name"
+    (mt/with-temporary-setting-values [llm.settings/llm-openrouter-api-key "sk-or-v1-test"]
+      (with-redefs [http/request (fn [_]
+                                   {:status 200
+                                    :body   {:data [{:id "qwen/qwen3.7-max"            :name "Qwen: Qwen3.7 Max"            :created 40}
+                                                    {:id "openai/gpt-5.4"              :name "OpenAI: GPT-5.4"              :created 30}
+                                                    {:id "openai/gpt-oss-120b:free"    :name "OpenAI: gpt-oss-120b (free)"  :created 28}
+                                                    {:id "anthropic/claude-sonnet-4.6" :created 25}
+                                                    {:id "anthropic/claude-haiku-4.5"  :name "Anthropic: Claude Haiku 4.5"  :created 20}
+                                                    {:id "openai/gpt-4o"               :name "OpenAI: GPT-4o"               :created 10}]}})]
+        (is (= [{:id "anthropic/claude-haiku-4.5"  :display_name "Anthropic: Claude Haiku 4.5"}
+                {:id "anthropic/claude-sonnet-4.6" :display_name "Claude Sonnet 4.6"}
+                {:id "openai/gpt-5.4"              :display_name "OpenAI: GPT-5.4"}]
+               (:models (openrouter/list-models))))))))

--- a/test/metabase/metabot/self/openrouter_test.clj
+++ b/test/metabase/metabot/self/openrouter_test.clj
@@ -333,15 +333,22 @@
     (mt/with-temporary-setting-values [llm.settings/llm-openrouter-api-key "sk-or-v1-test"]
       (with-redefs [http/request (fn [_]
                                    {:status 200
-                                    :body   {:data [{:id "qwen/qwen3.7-max"            :name "Qwen: Qwen3.7 Max"            :created 40}
+                                    :body   {:data [{:id "openai/gpt-5.6-sol"          :name "OpenAI: GPT-5.6 Sol"          :created 50}
+                                                    {:id "openai/gpt-5.6-terra"        :name "OpenAI: GPT-5.6 Terra"        :created 49}
+                                                    {:id "openai/gpt-5.6-luna"         :name "OpenAI: GPT-5.6 Luna"         :created 48}
+                                                    {:id "qwen/qwen3.7-max"            :name "Qwen: Qwen3.7 Max"            :created 40}
                                                     {:id "openai/gpt-5.4"              :name "OpenAI: GPT-5.4"              :created 30}
                                                     {:id "openai/gpt-oss-120b:free"    :name "OpenAI: gpt-oss-120b (free)"  :created 28}
-                                                    {:id "anthropic/claude-sonnet-4.6" :created 25}
+                                                    {:id "anthropic/claude-sonnet-4.6"                                      :created 25}
                                                     {:id "anthropic/claude-haiku-4.5"  :name "Anthropic: Claude Haiku 4.5"  :created 20}
-                                                    {:id "openai/gpt-4o"               :name "OpenAI: GPT-4o"               :created 10}]}})]
+                                                    {:id "openai/gpt-4o"               :name "OpenAI: GPT-4o"               :created 10}
+                                                    {:id "openai/gpt-5"                :name "OpenAI: GPT-5"                :created 5}]}})]
         (is (= [{:id "anthropic/claude-haiku-4.5"  :display_name "Anthropic: Claude Haiku 4.5"}
                 {:id "anthropic/claude-sonnet-4.6" :display_name "Claude Sonnet 4.6"}
-                {:id "openai/gpt-5.4"              :display_name "OpenAI: GPT-5.4"}]
+                {:id "openai/gpt-5.4"              :display_name "OpenAI: GPT-5.4"}
+                {:id "openai/gpt-5.6-luna"         :display_name "OpenAI: GPT-5.6 Luna"}
+                {:id "openai/gpt-5.6-sol"          :display_name "OpenAI: GPT-5.6 Sol"}
+                {:id "openai/gpt-5.6-terra"        :display_name "OpenAI: GPT-5.6 Terra"}]
                (:models (openrouter/list-models))))))))
 
 (deftest list-models-explicit-credentials-test

--- a/test/metabase/metabot/self/openrouter_test.clj
+++ b/test/metabase/metabot/self/openrouter_test.clj
@@ -89,6 +89,52 @@
               {:type :text :text "It's 2:00 PM in Kyiv."}])))))
 
 ;;; ──────────────────────────────────────────────────────────────────
+;;; openrouter-request-body prompt-caching tests
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest ^:parallel request-body-anthropic-system-cached-block-test
+  (testing "anthropic models wrap the system prompt in a single cache_control content block"
+    (let [body (openrouter/openrouter-request-body
+                {:model  "anthropic/claude-haiku-4.5"
+                 :system "You are a helpful assistant."
+                 :input  [{:role :user :content "hi"}]})]
+      (is (= {:role    "system"
+              :content [{:type          "text"
+                         :text          "You are a helpful assistant."
+                         :cache_control {:type "ephemeral"}}]}
+             (-> body :messages first))))))
+
+(deftest ^:parallel request-body-anthropic-system-sentinel-split-test
+  (testing "anthropic models split the system prompt at the sentinel into cached prefix + uncached suffix"
+    (let [body (openrouter/openrouter-request-body
+                {:model  "anthropic/claude-haiku-4.5"
+                 :system "Stable prefix content.\n\n<<<METABOT_CACHE_BREAKPOINT>>>\n\nDynamic suffix content."
+                 :input  [{:role :user :content "hi"}]})]
+      (is (= {:role    "system"
+              :content [{:type          "text"
+                         :text          "Stable prefix content."
+                         :cache_control {:type "ephemeral"}}
+                        {:type "text"
+                         :text "Dynamic suffix content."}]}
+             (-> body :messages first))))))
+
+(deftest ^:parallel request-body-openai-system-plain-string-test
+  (testing "openai models get a plain string system message with no cache markup"
+    (let [body (openrouter/openrouter-request-body
+                {:model  "openai/gpt-5.4"
+                 :system "You are a helpful assistant."
+                 :input  [{:role :user :content "hi"}]})]
+      (is (= {:role "system" :content "You are a helpful assistant."}
+             (-> body :messages first))))))
+
+(deftest ^:parallel request-body-no-system-message-test
+  (testing "no system message is added when system is not provided"
+    (let [body (openrouter/openrouter-request-body
+                {:model "anthropic/claude-haiku-4.5"
+                 :input [{:role :user :content "hi"}]})]
+      (is (= ["user"] (map :role (:messages body)))))))
+
+;;; ──────────────────────────────────────────────────────────────────
 ;;; Streaming chunk conversion tests
 ;;; ──────────────────────────────────────────────────────────────────
 
@@ -184,6 +230,51 @@
                 :usage {:promptTokens pos-int? :completionTokens pos-int?}}]
               (remove #(= (:type %) :text) res)))
       (is (< 10 (count (filter #(= (:type %) :text) res)))))))
+
+(deftest ^:parallel openrouter-usage-cache-tokens-test
+  (testing "cache read/write counts are extracted from prompt_tokens_details"
+    (let [chunks [{:id      "gen-1"
+                   :model   "anthropic/claude-haiku-4.5"
+                   :choices [{:delta {:role "assistant" :content "Hello"}}]}
+                  {:choices [{:delta {} :finish_reason "stop"}]}
+                  ;; OpenRouter reports usage on a final chunk with empty choices.
+                  ;; prompt_tokens is the total input; the cache buckets are a
+                  ;; subset breakdown, so no summing happens on our side.
+                  {:choices []
+                   :usage   {:prompt_tokens         5000
+                             :completion_tokens     7
+                             :total_tokens          5007
+                             :prompt_tokens_details {:cached_tokens      4200
+                                                     :cache_write_tokens 250
+                                                     :audio_tokens       0}}}]
+          usage  (->> (into [] (openrouter/openrouter->aisdk-chunks-xf) chunks)
+                      (filter #(= :usage (:type %)))
+                      first)]
+      (is (=? {:type  :usage
+               :id    "gen-1"
+               :model "anthropic/claude-haiku-4.5"
+               :usage {:promptTokens        5000
+                       :completionTokens    7
+                       :cacheCreationTokens 250
+                       :cacheReadTokens     4200}}
+              usage)))))
+
+(deftest ^:parallel openrouter-usage-missing-cache-details-test
+  (testing "missing prompt_tokens_details (or missing cache fields) default to 0"
+    (let [chunks [{:id      "gen-2"
+                   :model   "openai/gpt-5.4"
+                   :choices [{:delta {:role "assistant" :content "Hi"}}]}
+                  {:choices [{:delta {} :finish_reason "stop"}]}
+                  {:choices []
+                   :usage   {:prompt_tokens 10 :completion_tokens 3 :total_tokens 13}}]
+          usage  (->> (into [] (openrouter/openrouter->aisdk-chunks-xf) chunks)
+                      (filter #(= :usage (:type %)))
+                      first)]
+      (is (= {:promptTokens        10
+              :completionTokens    3
+              :cacheCreationTokens 0
+              :cacheReadTokens     0}
+             (:usage usage))))))
 
 (deftest openrouter-auth-preferences-test
   (mt/with-premium-features #{:metabase-ai-managed}

--- a/test/metabase/metabot/self/openrouter_test.clj
+++ b/test/metabase/metabot/self/openrouter_test.clj
@@ -199,17 +199,6 @@
                      :headers {"Authorization" "Bearer sk-or-v1-byok"}
                      :body    string?}
                     (openrouter/openrouter-raw {:input [{:role :user :content "hi"}]})))))
-        (testing "Uses ai proxy when explicitly requested"
-          (mt/with-temporary-setting-values [llm.settings/llm-openrouter-api-key nil]
-            (with-redefs [self.core/sse-reducible identity
-                          debug/capture-stream    (fn [r _] r)
-                          http/request            (fn [req] {:body req})]
-              (is (=? {:method  :post
-                       :url     "https://proxy.example/openrouter/v1/chat/completions"
-                       :headers {"x-metabase-instance-token" "proxy-token"}
-                       :body    string?}
-                      (openrouter/openrouter-raw {:input [{:role :user :content "hi"}]
-                                                  :ai-proxy? true}))))))
         (testing "Does not fall back to ai proxy when BYOK is missing"
           (mt/with-temporary-setting-values [llm.settings/llm-openrouter-api-key nil]
             (is (thrown-with-msg?
@@ -223,6 +212,26 @@
                  clojure.lang.ExceptionInfo
                  #"No OpenRouter API key is set"
                  (openrouter/openrouter-raw {:input [{:role :user :content "hi"}]})))))))))
+
+(deftest list-models-ai-proxy-unsupported-test
+  (testing "ai-proxy? throws before credentials are even consulted"
+    (mt/with-temporary-setting-values [llm.settings/llm-openrouter-api-key nil]
+      (with-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"AI proxy is not supported for OpenRouter"
+             (openrouter/list-models {:ai-proxy? true})))))))
+
+(deftest openrouter-raw-ai-proxy-unsupported-test
+  (testing "ai-proxy? throws before credentials are even consulted"
+    (mt/with-temporary-setting-values [llm.settings/llm-openrouter-api-key nil]
+      (with-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"AI proxy is not supported for OpenRouter"
+             (openrouter/openrouter-raw {:model "anthropic/claude-haiku-4.5"
+                                         :input [{:role :user :content "hi"}]
+                                         :ai-proxy? true})))))))
 
 ;;; ──────────────────────────────────────────────────────────────────
 ;;; list-models tests

--- a/test/metabase/metabot/self/openrouter_test.clj
+++ b/test/metabase/metabot/self/openrouter_test.clj
@@ -252,3 +252,31 @@
                 {:id "anthropic/claude-sonnet-4.6" :display_name "Claude Sonnet 4.6"}
                 {:id "openai/gpt-5.4"              :display_name "OpenAI: GPT-5.4"}]
                (:models (openrouter/list-models))))))))
+
+(deftest list-models-explicit-credentials-test
+  (testing "a passed-in api-key is used over the configured key"
+    (mt/with-temporary-setting-values [llm.settings/llm-openrouter-api-key "sk-or-v1-setting"]
+      (mt/with-dynamic-fn-redefs [http/request (fn [req]
+                                                 (is (=? {:headers {"Authorization" "Bearer sk-or-v1-explicit"}}
+                                                         req))
+                                                 {:status 200 :body {:data []}})]
+        (is (= {:models []}
+               (openrouter/list-models {:credentials {:api-key "sk-or-v1-explicit"}})))))))
+
+(deftest list-models-blank-credentials-fall-back-to-configured-key-test
+  (testing "a blank passed-in api-key falls back to the configured key"
+    (mt/with-temporary-setting-values [llm.settings/llm-openrouter-api-key "sk-or-v1-setting"]
+      (mt/with-dynamic-fn-redefs [http/request (fn [req]
+                                                 (is (=? {:headers {"Authorization" "Bearer sk-or-v1-setting"}}
+                                                         req))
+                                                 {:status 200 :body {:data []}})]
+        (is (= {:models []}
+               (openrouter/list-models {:credentials {:api-key ""}})))))))
+
+(deftest list-models-blank-credentials-without-configured-key-test
+  (testing "throws when the passed-in api-key is blank and no key is configured"
+    (mt/with-temporary-setting-values [llm.settings/llm-openrouter-api-key nil]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"No OpenRouter API key is set"
+           (openrouter/list-models {:credentials {:api-key ""}}))))))


### PR DESCRIPTION
Closes [BOT-1664: Support OpenRouter models](https://linear.app/metabase/issue/BOT-1664/support-openrouter-models)

### Description

Adds OpenRouter as a supported LLM provider for Metabot.

* Fix `metabase.metabot.api/openrouter-model-group`. Fallback to parsing the `id` if the `display_name` has no ":"-separated prefix.
* Add a default OpenRouter model so connect-without-model works.
* Use real dotted OpenRouter model IDs in defaults and docs
* FE: enable openrouter provider in metabot admin UI config
* Whitelist openrouter models. Filter openrouter `list-models` down to the same curated Anthropic and OpenAI model set the direct providers support.
* Throw an exception if callers pass `:ai-proxy` true for openrouter. Similar to bedrock and openai, supporting this would require work on the ai-service side, and we already reject non-anthropic providers in `validate-metabase-managed-provider!`
* Remove explicit credentials check in `list-all-models`. Allow callers to omit the creds and fallback to the configured api key from settings. `core/resolve-auth` still handles the auth check and will throw if no credentials are provided or configured.
* Support prompt caching for openrouter. Report `:cacheCreationTokens` and `:cacheReadTokens` in the `:usage`. For anthropic models, add the `:cache_control` breakpoint on the system message to enable caching (openai caching is automatic).

### Demo

<img width="800" height="792" alt="Screenshot 2026-07-09 at 2 30 51 PM" src="https://github.com/user-attachments/assets/7a98eba1-f762-4175-a4aa-224779912d6a" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
