### PR TITLE
Pin maildev to 2.2.1

### DIFF
--- a/e2e/test/scenarios/docker-compose.yml
+++ b/e2e/test/scenarios/docker-compose.yml
@@ -38,7 +38,9 @@ services:
   maildev-ssl:
     ## NOTE: Using this requires a root CA certificate to be added to the Java keystore.
     ## See maildev-keys/README.md for more info.
-    image: maildev/maildev:latest
+    ## Pinned: the unpinned `latest` tag moved to 3.0.0-rc.1 (2026-07-06), which
+    ## breaks the SSL/SMTP setup and fails the custom SMTP e2e tests.
+    image: maildev/maildev:2.2.1
     ports:
       - "1081:1081"
       - "465:465"


### PR DESCRIPTION
Pins maildev to 2.2.1

The maildev-ssl container in e2e/test/scenarios/docker-compose.yml used maildev/maildev:latest, which Docker Hub repushed on 2026-07-06 to point at 3.0.0-rc.1 — the first update since Dec 2024. The new RC breaks the SSL/SMTP setup on port 465, so the backend's connection validation fails when saving custom SMTP settings, and the custom_smtp_setup_success Snowplow assertion in settings.cy.spec.js times out.