### PR TITLE
fix: Toaster crash on long-running questions from color-mix tokens

### DIFF
--- a/frontend/src/metabase/common/components/Toaster/Toaster.styled.tsx
+++ b/frontend/src/metabase/common/components/Toaster/Toaster.styled.tsx
@@ -69,13 +69,9 @@ export const ToasterButton = styled.button`
 export const ToasterDismiss = styled.button`
   cursor: pointer;
   transition: color 200ms ease;
-  color: var(--mb-color-background_page-tertiary-inverse);
+  color: var(--mb-color-text-primary-inverse);
 
   &:hover {
-    color: color-mix(
-      in srgb,
-      var(--mb-color-background_page-tertiary-inverse),
-      white 30%
-    );
+    color: color-mix(in srgb, var(--mb-color-text-primary-inverse), white 30%);
   }
 `;

--- a/frontend/src/metabase/common/components/Toaster/Toaster.styled.tsx
+++ b/frontend/src/metabase/common/components/Toaster/Toaster.styled.tsx
@@ -1,8 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
 import styled from "@emotion/styled";
 
-import { alpha, lighten } from "metabase/ui/colors";
-
 interface ToasterContainerProps {
   show: boolean;
   fixed?: boolean;
@@ -44,7 +42,11 @@ export const ToasterMessage = styled.p`
 export const ToasterButton = styled.button`
   display: flex;
   padding: 7px 18px;
-  background-color: ${() => alpha("background_page-primary", 0.1)};
+  background-color: color-mix(
+    in srgb,
+    var(--mb-color-background_page-primary) 10%,
+    transparent
+  );
   border-radius: 6px;
   color: var(--mb-color-text-primary-inverse);
   height: fit-content;
@@ -56,7 +58,11 @@ export const ToasterButton = styled.button`
 
   &:hover {
     cursor: pointer;
-    background-color: ${() => alpha("background_page-primary", 0.3)};
+    background-color: color-mix(
+      in srgb,
+      var(--mb-color-background_page-primary) 30%,
+      transparent
+    );
   }
 `;
 
@@ -66,6 +72,10 @@ export const ToasterDismiss = styled.button`
   color: var(--mb-color-background_page-tertiary-inverse);
 
   &:hover {
-    color: ${() => lighten("background_page-tertiary-inverse", 0.3)};
+    color: color-mix(
+      in srgb,
+      var(--mb-color-background_page-tertiary-inverse),
+      white 30%
+    );
   }
 `;


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #77124
Closes [GDGT-2779](https://linear.app/metabase/issue/GDGT-2779), #77124

### Description

The Toaster's styled-components computed colors at render time with the JS `color` library (via the deprecated `lighten()`/`alpha()` helpers). One of the tokens they parsed — `background_page-tertiary-inverse` — is now defined as a `color-mix(...)` value. The `color` library can't parse `color-mix()`, so it threw `Unable to parse color from string` and crashed.

This PR replaces those runtime helper calls with CSS `color-mix()` on the variables directly, so the mixing happens in CSS (where `color-mix()`/`var()` resolve) rather than being parsed by the JS library.

### How to verify

1. Trigger the notification toast (run a question long enough that the "notify me when done" toast appears, or lower `VISUALIZATION_SLOW_TIMEOUT` locally).
2. The toast appears with no console error / crash; the dismiss (×) and action button colors transition as before.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR