### PR TITLE
[GDGT-2784] add content diagnostics findings schema and module skeleton

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2983,14 +2983,8 @@
   enterprise/content-diagnostics
   {:team "Gadget"
    :api  #{metabase-enterprise.content-diagnostics.init}
-   :uses #{analytics-interface
-           api
-           collections
-           enterprise/stale
-           models
-           request
+   :uses #{models
            settings
-           task
            util}}
 
   enterprise/content-translation

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2980,6 +2980,19 @@
    :api  #{}
    :uses #{premium-features}}
 
+  enterprise/content-diagnostics
+  {:team "Gadget"
+   :api  #{metabase-enterprise.content-diagnostics.init}
+   :uses #{analytics-interface
+           api
+           collections
+           enterprise/stale
+           models
+           request
+           settings
+           task
+           util}}
+
   enterprise/content-translation
   {:team "UX West"
    :api  #{metabase-enterprise.content-translation.routes}

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/init.clj
@@ -1,0 +1,6 @@
+(ns metabase-enterprise.content-diagnostics.init
+  "Loader for the Content Diagnostics module — pulls in settings and models so their
+  `defsetting` / model registrations are registered at startup."
+  (:require
+   [metabase-enterprise.content-diagnostics.models.finding]
+   [metabase-enterprise.content-diagnostics.settings]))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/models/finding.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/models/finding.clj
@@ -1,0 +1,18 @@
+(ns metabase-enterprise.content-diagnostics.models.finding
+  "Toucan model for `content_diagnostics_finding` — a detected problem for one entity, from one scan run.
+  Scan-snapshot, latest-wins; a stamped `invalidated_at` evicts a superseded/invalidated finding from the
+  served set (NULL = active)."
+  (:require
+   [metabase.models.interface :as mi]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(methodical/defmethod t2/table-name :model/ContentDiagnosticsFinding [_model] :content_diagnostics_finding)
+
+(doto :model/ContentDiagnosticsFinding
+  (derive :metabase/model))
+
+(t2/deftransforms :model/ContentDiagnosticsFinding
+  {:entity_type  mi/transform-keyword
+   :finding_type mi/transform-keyword
+   :details      mi/transform-json})

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/settings.clj
@@ -4,10 +4,10 @@
    [metabase.util.i18n :refer [deferred-tru]]))
 
 (defsetting content-diagnostics-stale-threshold-days
-  (deferred-tru "Content unused beyond this many days is flagged stale by the Content Diagnostics.")
+  (deferred-tru "Content inactive beyond this many days is flagged stale by the Content Diagnostics.")
   :encryption :no
   :visibility :admin
   :default    90
   :type       :positive-integer
-  :export?    false
+  :export?    true
   :doc        false)

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/settings.clj
@@ -1,0 +1,13 @@
+(ns metabase-enterprise.content-diagnostics.settings
+  (:require
+   [metabase.settings.core :refer [defsetting]]
+   [metabase.util.i18n :refer [deferred-tru]]))
+
+(defsetting content-diagnostics-stale-threshold-days
+  (deferred-tru "Content unused beyond this many days is flagged stale by the Content Diagnostics.")
+  :encryption :no
+  :visibility :admin
+  :default    90
+  :type       :positive-integer
+  :export?    false
+  :doc        false)

--- a/enterprise/backend/src/metabase_enterprise/core/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/core/init.clj
@@ -10,6 +10,7 @@
    [metabase-enterprise.advanced-config.init]
    [metabase-enterprise.audit-app.init]
    [metabase-enterprise.cache.init]
+   [metabase-enterprise.content-diagnostics.init]
    [metabase-enterprise.custom-viz-plugin.init]
    [metabase-enterprise.data-complexity-score.init]
    [metabase-enterprise.database-replication.init]

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/entity_ids.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/entity_ids.clj
@@ -14,9 +14,15 @@
 (set! *warn-on-reflection* true)
 
 (def ^:private ignored-entity-id-table-names
-  "Legacy (V1) Metrics are no longer supported, and all their code has been removed. However the Tables are still in the
-  app DB (for now)... ignore them."
-  #{"metric" "METRIC" "metric_important_field" "METRIC_IMPORTANT_FIELD"})
+  "Tables whose `entity_id` column is not a serdes NanoID.
+
+  Legacy (V1) Metrics are no longer supported, and all their code has been removed. However the Tables are still in the
+  app DB (for now)... ignore them.
+
+  `content_diagnostics_finding` uses `entity_id` as a polymorphic integer reference to the flagged entity (paired with
+  `entity_type`), not as a serdes NanoID."
+  #{"metric" "METRIC" "metric_important_field" "METRIC_IMPORTANT_FIELD"
+    "content_diagnostics_finding" "CONTENT_DIAGNOSTICS_FINDING"})
 
 (defn- entity-id-table-names
   "Return a set of lower-cased names of all application database tables that have an `entity_id` column, excluding

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -77,6 +77,7 @@
    "Comment"
    "CommentReaction"
    "ConnectionImpersonation"
+   "ContentDiagnosticsFinding"
    "ContentTranslation"
    "DashboardBookmark"
    "DataComplexityScore"

--- a/enterprise/backend/test/metabase_enterprise/api/session_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api/session_test.clj
@@ -66,6 +66,7 @@
                               :database-routing
                               :tenants
                               :cloud-custom-smtp
+                              :content-diagnostics
                               :writable-connection}
     (is (= {:admin_security_center          false ;; requires self-hosted (non-cloud)
             :advanced_permissions           true
@@ -118,6 +119,7 @@
             :database_routing               true
             :tenants                        true
             :cloud_custom_smtp              true
+            :content_diagnostics            true
             :etl_connections                false
             :etl_connections_pg             false
             :dependencies                   false

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/models/finding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/models/finding_test.clj
@@ -1,0 +1,35 @@
+(ns metabase-enterprise.content-diagnostics.models.finding-test
+  "Schema ↔ model contract for `content_diagnostics_finding`: a round-trip pins that the migration's
+  columns and the model's `deftransforms` agree on every supported app-db (H2 locally; the CI backend
+  matrices re-run this against Postgres and MySQL)."
+  (:require
+   [clojure.test :refer :all]
+   [java-time.api :as t]
+   [metabase-enterprise.content-diagnostics.settings :as cd.settings]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(deftest finding-round-trip-test
+  (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+    (let [fid (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                               {:scan_id      "round-trip"
+                                                :entity_type  :card
+                                                :entity_id    1
+                                                :finding_type :stale
+                                                :details      {:threshold_days 90}}))
+          row (t2/select-one :model/ContentDiagnosticsFinding :id fid)]
+      (testing "keyword + JSON transforms round-trip; detected_at defaults; rows start active"
+        (is (=? {:scan_id        "round-trip"
+                 :entity_type    :card
+                 :finding_type   :stale
+                 :details        {:threshold_days 90}
+                 :detected_at    some?
+                 :invalidated_at nil}
+                row)))
+      (testing "stamping invalidated_at round-trips (the active-set filter's column)"
+        (t2/update! :model/ContentDiagnosticsFinding fid {:invalidated_at (t/offset-date-time)})
+        (is (some? (:invalidated_at (t2/select-one :model/ContentDiagnosticsFinding :id fid))))))))
+
+(deftest stale-threshold-setting-default-test
+  (testing "the staleness window defaults to 90 days"
+    (is (= 90 (cd.settings/content-diagnostics-stale-threshold-days)))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
@@ -52,6 +52,9 @@
     :model/CardBookmark
     :model/ChannelTemplate
     :model/CollectionBookmark
+    ;; Content Diagnostics findings are scan-snapshot runtime data (its `entity_id` column is a
+    ;; polymorphic reference to the flagged entity, not a serdes NanoID) -- not portable content.
+    :model/ContentDiagnosticsFinding
     :model/ContentTranslation
     :model/DashboardBookmark
     :model/DataComplexityScore

--- a/resources/migrations/063/20260616_content_diagnostics.yaml
+++ b/resources/migrations/063/20260616_content_diagnostics.yaml
@@ -1,0 +1,222 @@
+## Content Diagnostics — detected findings snapshot (scan-snapshot, latest-wins).
+## Persisted table: `content_diagnostics_finding`.
+
+databaseChangeLog:
+  - changeSet:
+      id: v63.2026-06-16T00:00:00
+      author: yb
+      comment: Content Diagnostics — content_diagnostics_finding (scan snapshot)
+      changes:
+        - createTable:
+            tableName: content_diagnostics_finding
+            remarks: One detected problem for one entity, from one scan run.
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: scan_id
+                  type: varchar(36)
+                  remarks: Groups all rows from one scan run (UUID). API serves the newest scan.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: entity_type
+                  type: varchar(32)
+                  remarks: Polymorphic — card/dashboard/document/collection/transform. No FK.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: entity_id
+                  type: int
+                  remarks: Polymorphic id of the flagged entity (no FK; paired with entity_type).
+                  constraints:
+                    nullable: false
+              - column:
+                  name: finding_type
+                  type: varchar(32)
+                  remarks: stale/duplicated/empty/crowded/sparse/slow/trash-not-emptied
+                  constraints:
+                    nullable: false
+              - column:
+                  name: scope_collection_id
+                  type: int
+                  remarks: collection the entity lived in at scan time (filter/sort); no FK
+              - column:
+                  name: details
+                  type: ${text.type}
+                  remarks: JSON evidence — e.g. {threshold_days, last_active_at}
+              - column:
+                  name: detected_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  remarks: When this finding was detected (per-finding freshness signal).
+                  constraints:
+                    nullable: false
+              - column:
+                  name: invalidated_at
+                  type: ${timestamp_type}
+                  remarks: stamped when invalidated/superseded; null = active (drives the served-set filter)
+
+  - changeSet:
+      id: v63.2026-06-16T00:00:01
+      author: yb
+      comment: Content Diagnostics — unique finding per scan (dedup)
+      changes:
+        - addUniqueConstraint:
+            tableName: content_diagnostics_finding
+            columnNames: scan_id, entity_type, entity_id, finding_type
+            constraintName: idx_uniq_cd_finding
+
+  - changeSet:
+      id: v63.2026-06-16T00:00:02
+      author: yb
+      comment: Content Diagnostics — index findings by scan + finding_type
+      changes:
+        - createIndex:
+            tableName: content_diagnostics_finding
+            indexName: idx_cd_finding_scan
+            columns:
+              - column:
+                  name: scan_id
+              - column:
+                  name: finding_type
+
+  - changeSet:
+      id: v63.2026-06-16T00:00:03
+      author: yb
+      comment: Content Diagnostics — index findings by entity
+      changes:
+        - createIndex:
+            tableName: content_diagnostics_finding
+            indexName: idx_cd_finding_entity
+            columns:
+              - column:
+                  name: entity_type
+              - column:
+                  name: entity_id
+
+  - changeSet:
+      id: v63.2026-06-16T00:00:04
+      author: yb
+      comment: Content Diagnostics — last_active_at (frozen staleness anchor, top-level + threshold filter)
+      changes:
+        - addColumn:
+            tableName: content_diagnostics_finding
+            columns:
+              - column:
+                  name: last_active_at
+                  type: ${timestamp_type}
+                  remarks: Entity's last activity at scan time (card last_used_at / dashboard last_viewed_at); null = never used/ran. Frozen verdict evidence; powers the threshold-days serve filter.
+
+  - changeSet:
+      id: v63.2026-06-16T00:00:05
+      author: yb
+      comment: Content Diagnostics — denormalized entity_name (sort key)
+      changes:
+        - addColumn:
+            tableName: content_diagnostics_finding
+            columns:
+              - column:
+                  name: entity_name
+                  type: varchar(254)
+                  remarks: Entity's name at scan time. Denormalized sort key (display still hydrates the live name).
+
+  - changeSet:
+      id: v63.2026-06-16T00:00:06
+      author: yb
+      comment: Content Diagnostics — denormalized entity_created_at (sort + display)
+      changes:
+        - addColumn:
+            tableName: content_diagnostics_finding
+            columns:
+              - column:
+                  name: entity_created_at
+                  type: ${timestamp_type}
+                  remarks: Entity's created_at (immutable). Denormalized for sort + display.
+
+  - changeSet:
+      id: v63.2026-06-16T00:00:07
+      author: yb
+      comment: Content Diagnostics — denormalized entity_creator_id (sort key)
+      changes:
+        - addColumn:
+            tableName: content_diagnostics_finding
+            columns:
+              - column:
+                  name: entity_creator_id
+                  type: int
+                  remarks: Entity's creator_id at scan time; no FK (polymorphic, mirrors entity_id). Sort key (groups by creator).
+
+  - changeSet:
+      id: v63.2026-06-16T00:00:08
+      author: yb
+      comment: Content Diagnostics — index findings by finding_type + entity_name
+      changes:
+        - createIndex:
+            tableName: content_diagnostics_finding
+            indexName: idx_cd_finding_ftype_name
+            columns:
+              - column:
+                  name: finding_type
+              - column:
+                  name: entity_name
+
+  - changeSet:
+      id: v63.2026-06-16T00:00:09
+      author: yb
+      comment: Content Diagnostics — index findings by finding_type + entity_created_at
+      changes:
+        - createIndex:
+            tableName: content_diagnostics_finding
+            indexName: idx_cd_finding_ftype_created
+            columns:
+              - column:
+                  name: finding_type
+              - column:
+                  name: entity_created_at
+
+  - changeSet:
+      id: v63.2026-06-16T00:00:10
+      author: yb
+      comment: Content Diagnostics — index findings by finding_type + last_active_at
+      changes:
+        - createIndex:
+            tableName: content_diagnostics_finding
+            indexName: idx_cd_finding_ftype_active
+            columns:
+              - column:
+                  name: finding_type
+              - column:
+                  name: last_active_at
+
+  - changeSet:
+      id: v63.2026-06-16T00:00:11
+      author: yb
+      comment: Content Diagnostics — denormalized entity_creator_name (sort by creator name + display)
+      changes:
+        - addColumn:
+            tableName: content_diagnostics_finding
+            columns:
+              - column:
+                  name: entity_creator_name
+                  type: varchar(254)
+                  remarks: Creator's common_name at scan time (resolved from creator_id). Sort key for created-by + served in details.creator; display prefers this over live hydration.
+
+  - changeSet:
+      id: v63.2026-06-16T00:00:12
+      author: yb
+      comment: Content Diagnostics — index findings by finding_type + entity_creator_name
+      changes:
+        - createIndex:
+            tableName: content_diagnostics_finding
+            indexName: idx_cd_finding_ftype_creator
+            columns:
+              - column:
+                  name: finding_type
+              - column:
+                  name: entity_creator_name

--- a/resources/migrations/064/20260708_content_diagnostics.yaml
+++ b/resources/migrations/064/20260708_content_diagnostics.yaml
@@ -3,7 +3,7 @@
 
 databaseChangeLog:
   - changeSet:
-      id: v63.2026-06-16T00:00:00
+      id: v64.ryvrr3
       author: yb
       comment: Content Diagnostics — content_diagnostics_finding (scan snapshot)
       changes:
@@ -61,9 +61,29 @@ databaseChangeLog:
                   name: invalidated_at
                   type: ${timestamp_type}
                   remarks: stamped when invalidated/superseded; null = active (drives the served-set filter)
+              - column:
+                  name: last_active_at
+                  type: ${timestamp_type}
+                  remarks: Entity's last activity at scan time (card last_used_at / dashboard last_viewed_at); null = never used/ran. Frozen verdict evidence; powers the threshold-days serve filter.
+              - column:
+                  name: entity_name
+                  type: varchar(254)
+                  remarks: Entity's name at scan time. Denormalized sort key (display still hydrates the live name).
+              - column:
+                  name: entity_created_at
+                  type: ${timestamp_type}
+                  remarks: Entity's created_at (immutable). Denormalized for sort + display.
+              - column:
+                  name: entity_creator_id
+                  type: int
+                  remarks: Entity's creator_id at scan time; no FK (polymorphic, mirrors entity_id). Sort key (groups by creator).
+              - column:
+                  name: entity_creator_name
+                  type: varchar(254)
+                  remarks: Creator's common_name at scan time (resolved from creator_id). Sort key for created-by + served in details.creator; display prefers this over live hydration.
 
   - changeSet:
-      id: v63.2026-06-16T00:00:01
+      id: v64.zncpq7
       author: yb
       comment: Content Diagnostics — unique finding per scan (dedup)
       changes:
@@ -73,7 +93,7 @@ databaseChangeLog:
             constraintName: idx_uniq_cd_finding
 
   - changeSet:
-      id: v63.2026-06-16T00:00:02
+      id: v64.k0fbrf
       author: yb
       comment: Content Diagnostics — index findings by scan + finding_type
       changes:
@@ -87,7 +107,7 @@ databaseChangeLog:
                   name: finding_type
 
   - changeSet:
-      id: v63.2026-06-16T00:00:03
+      id: v64.dc6ryp
       author: yb
       comment: Content Diagnostics — index findings by entity
       changes:
@@ -101,59 +121,7 @@ databaseChangeLog:
                   name: entity_id
 
   - changeSet:
-      id: v63.2026-06-16T00:00:04
-      author: yb
-      comment: Content Diagnostics — last_active_at (frozen staleness anchor, top-level + threshold filter)
-      changes:
-        - addColumn:
-            tableName: content_diagnostics_finding
-            columns:
-              - column:
-                  name: last_active_at
-                  type: ${timestamp_type}
-                  remarks: Entity's last activity at scan time (card last_used_at / dashboard last_viewed_at); null = never used/ran. Frozen verdict evidence; powers the threshold-days serve filter.
-
-  - changeSet:
-      id: v63.2026-06-16T00:00:05
-      author: yb
-      comment: Content Diagnostics — denormalized entity_name (sort key)
-      changes:
-        - addColumn:
-            tableName: content_diagnostics_finding
-            columns:
-              - column:
-                  name: entity_name
-                  type: varchar(254)
-                  remarks: Entity's name at scan time. Denormalized sort key (display still hydrates the live name).
-
-  - changeSet:
-      id: v63.2026-06-16T00:00:06
-      author: yb
-      comment: Content Diagnostics — denormalized entity_created_at (sort + display)
-      changes:
-        - addColumn:
-            tableName: content_diagnostics_finding
-            columns:
-              - column:
-                  name: entity_created_at
-                  type: ${timestamp_type}
-                  remarks: Entity's created_at (immutable). Denormalized for sort + display.
-
-  - changeSet:
-      id: v63.2026-06-16T00:00:07
-      author: yb
-      comment: Content Diagnostics — denormalized entity_creator_id (sort key)
-      changes:
-        - addColumn:
-            tableName: content_diagnostics_finding
-            columns:
-              - column:
-                  name: entity_creator_id
-                  type: int
-                  remarks: Entity's creator_id at scan time; no FK (polymorphic, mirrors entity_id). Sort key (groups by creator).
-
-  - changeSet:
-      id: v63.2026-06-16T00:00:08
+      id: v64.wvauho
       author: yb
       comment: Content Diagnostics — index findings by finding_type + entity_name
       changes:
@@ -167,7 +135,7 @@ databaseChangeLog:
                   name: entity_name
 
   - changeSet:
-      id: v63.2026-06-16T00:00:09
+      id: v64.4g0zeg
       author: yb
       comment: Content Diagnostics — index findings by finding_type + entity_created_at
       changes:
@@ -181,7 +149,7 @@ databaseChangeLog:
                   name: entity_created_at
 
   - changeSet:
-      id: v63.2026-06-16T00:00:10
+      id: v64.w9kr30
       author: yb
       comment: Content Diagnostics — index findings by finding_type + last_active_at
       changes:
@@ -195,20 +163,7 @@ databaseChangeLog:
                   name: last_active_at
 
   - changeSet:
-      id: v63.2026-06-16T00:00:11
-      author: yb
-      comment: Content Diagnostics — denormalized entity_creator_name (sort by creator name + display)
-      changes:
-        - addColumn:
-            tableName: content_diagnostics_finding
-            columns:
-              - column:
-                  name: entity_creator_name
-                  type: varchar(254)
-                  remarks: Creator's common_name at scan time (resolved from creator_id). Sort key for created-by + served in details.creator; display prefers this over live hydration.
-
-  - changeSet:
-      id: v63.2026-06-16T00:00:12
+      id: v64.s23vc8
       author: yb
       comment: Content Diagnostics — index findings by finding_type + entity_creator_name
       changes:

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -150,7 +150,8 @@
       :model/CustomVizPlugin
       :model/Workspace
       :model/WorkspaceDatabase
-      :model/TableRemapping])))
+      :model/TableRemapping
+      :model/ContentDiagnosticsFinding])))
 
 (defn- objects->columns+values
   "Given a sequence of objects/rows fetched from the H2 DB, return a the `columns` that should be used in the `INSERT`

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -32,6 +32,7 @@
     :model/Comment                           metabase.comments.models.comment
     :model/CommentReaction                   metabase.comments.models.comment-reaction
     :model/ConnectionImpersonation           metabase-enterprise.impersonation.models
+    :model/ContentDiagnosticsFinding         metabase-enterprise.content-diagnostics.models.finding
     :model/ContentTranslation                metabase.content-translation.models
     :model/CustomVizPlugin                   metabase-enterprise.custom-viz-plugin.models.custom-viz-plugin
     :model/Dashboard                         metabase.dashboards.models.dashboard

--- a/src/metabase/premium_features/settings.clj
+++ b/src/metabase/premium_features/settings.clj
@@ -239,6 +239,10 @@
   "Should we enable Collection Cleanup?"
   :collection-cleanup)
 
+(define-premium-feature ^{:added "0.64.0"} enable-content-diagnostics?
+  "Should we enable the Content Diagnostics?"
+  :content-diagnostics)
+
 (define-premium-feature ^{:added "0.51.0"} enable-database-auth-providers?
   "Should we enable database auth-providers?"
   :database-auth-providers)
@@ -381,6 +385,7 @@
    :cloud_custom_smtp              (cloud-custom-smtp?)
    :collection_cleanup             (enable-collection-cleanup?)
    :config_text_file               (enable-config-text-file?)
+   :content_diagnostics            (enable-content-diagnostics?)
    :content_translation            (enable-content-translation?)
    :content_verification           (enable-content-verification?)
    :custom-viz                     (enable-custom-viz?)

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -546,6 +546,7 @@
   or to this set, so that [[every-feature-is-accounted-for-test]] passes."
   #{:audit-app ;; tracked under :mb-analytics
     :collection-cleanup
+    :content-diagnostics
     :data-complexity-score
     :development-mode
     :library

--- a/test_resources/serialization_baseline/settings.yaml
+++ b/test_resources/serialization_baseline/settings.yaml
@@ -23,6 +23,7 @@ custom-geojson-enabled: null
 custom-homepage: null
 custom-homepage-dashboard: null
 custom-viz-enabled: null
+content-diagnostics-stale-threshold-days: null
 default-maps-enabled: null
 disable-cors-on-localhost: null
 email-max-recipients-per-message: null


### PR DESCRIPTION
### Description

Scaffolds the table schema for content-diagnostics-findings, and basic model interface, and some initial module setup.

This will be used as a foundation for more features around different types of content diagnostics findings we'll use to surface content-based issues that can be optimized further.

For the table schema, we are adding some columns that will hold denormalized data for more performant server-side sorting in a later PR: 
* entity_name
* entity_created_at
* entity_creator_id
* entity_creator_name

_(possibly we may add more columns for other denormalized data if there's FE requirements for server side sorting of other attributes, these are the confirmed ones so far)_

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
