### PR TITLE
execute_question: improve error codes

### DIFF
--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -1170,7 +1170,7 @@
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    _query-params
    _body]
-  (let [card (api/check-404 (t2/select-one :model/Card id))]
+  (let [card (api/read-check :model/Card id)]
     (reject-parameterized-card! card)
     (qp.card/process-query-for-card
      card :api

--- a/test/metabase/agent_api/api_test.clj
+++ b/test/metabase/agent_api/api_test.clj
@@ -728,7 +728,15 @@
                     :parameters    [{:id "p1" :name "Category" :slug "category" :type :category}]}]
       (is (re-find #"takes parameters"
                    (str (mt/user-http-request :crowberto :post 400
-                                              (format "agent/v1/question/%d/query" card-id))))))))
+                                              (format "agent/v1/question/%d/query" card-id)))))))
+  (testing "Read-check runs before the parameterized rejection, so an unreadable parameterized card is 403 — it does not leak that the card exists or is parameterized"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection {coll-id :id} {:name "No-Read Coll"}
+                     :model/Card       {card-id :id} {:collection_id coll-id
+                                                      :dataset_query (orders-limit-query 5)
+                                                      :parameters    [{:id "p1" :name "Category" :slug "category" :type :category}]}]
+        (mt/user-http-request :rasta :post 403
+                              (format "agent/v1/question/%d/query" card-id))))))
 
 (deftest create-question-explicit-null-collection-test
   (testing "An explicit null collection_id saves to the root collection, not the personal default"


### PR DESCRIPTION
## Problem

`execute_question` (`src/metabase/agent_api/api.clj`, added in #76720) fetched the card and immediately called `reject-parameterized-card!` — which throws a **400** — before any permission check ran:

```clojure
(let [card (api/check-404 (t2/select-one :model/Card id))]
  (reject-parameterized-card! card)   ; throws 400 before any perm check
  (qp.card/process-query-for-card card :api ...))
```

A user *without* read access to a **parameterized** card got a `400 "takes parameters"` instead of `403`/`404`, leaking that the card exists and that it is parameterized. The read check only happened later, inside `process-query-for-card`.

## Fix

Replace `check-404` + `select-one` with `api/read-check`, which fetches, 404s, and read-checks in one step — so an unreadable card is rejected before its parameters are ever inspected.

Added a regression test asserting an unreadable parameterized card returns `403`, not `400`.

## Notes

- `./bin/test-agent :only '[metabase.agent-api.api-test/execute-question-test metabase.agent-api.api-test/execute-question-rejects-parameterized-test]'` → 9 assertions, 0 failures.