### PR TITLE
Gdgt 2734 validate context builder and sandbox changes

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -582,6 +582,7 @@
    metabase.api.macros/defendpoint                                                                                           hooks.metabase.api.macros/defendpoint
    metabase.app-db.schema-migrations-test.impl/test-migrations                                                               hooks.metabase.app-db.schema-migrations-test.impl/test-migrations
    metabase.channel.render.js.svg/with-static-viz-context                                                                    hooks.common/with-one-top-level-binding
+   metabase.channel.render.js.svg/with-untrusted-static-viz-context                                                          hooks.common/with-one-top-level-binding
    metabase.channel.template.handlebars-helper/defhelper                                                                     hooks.metabase.channel.template.handlebars-helper/defhelper
    metabase.channel.template.handlebars-test/with-temp-template!                                                             hooks.common/with-vec-first-binding
    metabase.classloader.core/require                                                                                         hooks.clojure.core.require/lint-require

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -492,6 +492,7 @@
            appearance
            collections
            config
+           custom-viz-plugin
            dashboards
            driver
            events
@@ -687,6 +688,11 @@
   {:team "UX West"
    :api  #{}
    :uses :any}
+
+  custom-viz-plugin
+  {:team "Gadget"
+   :api  #{metabase.custom-viz-plugin.core}
+   :uses #{premium-features}}
 
   dashboards
   {:team "UX West"

--- a/deps.edn
+++ b/deps.edn
@@ -169,6 +169,7 @@
   org.eclipse.jgit/org.eclipse.jgit        {:mvn/version "7.3.0.202506031305-r"}; Java implementation of Git version control system
   org.flatland/ordered                      {:mvn/version "1.15.12"}            ; ordered maps & sets
   org.graalvm.polyglot/js-community         {:mvn/version "25.1.3" :extension "pom"} ; JavaScript engine
+  org.graalvm.polyglot/js-isolate-community  {:mvn/version "25.1.3" :extension "pom"} ; JS polyglot isolate for the SandboxPolicy/UNTRUSTED custom-viz plugin sandbox
   org.graalvm.polyglot/polyglot             {:mvn/version "25.1.3"}             ; GraalVM platform, required by JS engine
   org.graalvm.polyglot/python               {:mvn/version "25.1.3"
                                              :extension "pom"}

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/core.clj
@@ -1,0 +1,30 @@
+(ns metabase-enterprise.custom-viz-plugin.core
+  "Enterprise implementations of custom viz plugin functions using defenterprise."
+  (:require
+   [metabase-enterprise.custom-viz-plugin.cache :as cache]
+   [metabase-enterprise.custom-viz-plugin.manifest :as manifest]
+   [metabase.premium-features.core :refer [defenterprise]]))
+
+(defenterprise resolve-bundle
+  "Enterprise implementation: resolve the JS bundle for a plugin."
+  :feature :custom-viz
+  [plugin]
+  (cache/resolve-bundle plugin))
+
+(defenterprise resolve-asset
+  "Enterprise implementation: resolve a static asset for a plugin."
+  :feature :custom-viz
+  [plugin asset-path]
+  (cache/resolve-asset plugin asset-path))
+
+(defenterprise asset-paths
+  "Enterprise implementation: list static asset names from the manifest."
+  :feature :custom-viz
+  [parsed-manifest]
+  (manifest/asset-paths parsed-manifest))
+
+(defenterprise asset-content-type
+  "Enterprise implementation: return the MIME content type for an allowed asset file."
+  :feature :custom-viz
+  [path]
+  (manifest/asset-content-type path))

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/core.clj
@@ -3,7 +3,15 @@
   (:require
    [metabase-enterprise.custom-viz-plugin.cache :as cache]
    [metabase-enterprise.custom-viz-plugin.manifest :as manifest]
+   [metabase-enterprise.custom-viz-plugin.models.custom-viz-plugin :as models.custom-viz-plugin]
    [metabase.premium-features.core :refer [defenterprise]]))
+
+(defenterprise resolve-enabled-plugin
+  "Enterprise implementation: look up an enabled plugin by `identifier`, excluding
+   the bundle blob (re-fetched lazily from the cache by [[resolve-bundle]])."
+  :feature :custom-viz
+  [identifier]
+  (models.custom-viz-plugin/select-one-non-blob :identifier identifier :enabled true))
 
 (defenterprise resolve-bundle
   "Enterprise implementation: resolve the JS bundle for a plugin."

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/init.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.custom-viz-plugin.init
   (:require
    [metabase-enterprise.custom-viz-plugin.api]
+   [metabase-enterprise.custom-viz-plugin.core]
    [metabase-enterprise.custom-viz-plugin.settings]))

--- a/enterprise/frontend/src/custom-viz/package.json
+++ b/enterprise/frontend/src/custom-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/custom-viz",
-  "version": "1.0.4",
+  "version": "1.0.5-canary.0",
   "description": "Creating custom visualizations for Metabase",
   "type": "module",
   "bin": {

--- a/enterprise/frontend/src/custom-viz/src/types/viz.ts
+++ b/enterprise/frontend/src/custom-viz/src/types/viz.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from "react";
 
 import type { Column, RowValue, Series } from "./data";
+import type { TextHeightMeasurer, TextWidthMeasurer } from "./measure-text";
 import type {
   CreateDefineSetting,
   CustomVisualizationSettingDefinition,
@@ -87,6 +88,13 @@ export type CustomVisualization<TSettings extends Record<string, unknown>> = {
    * Out of scope for the near-membrane hardening; stays as a plain component.
    */
   VisualizationComponent: ComponentType<CustomVisualizationProps<TSettings>>;
+
+  /**
+   * Component that renders the visualization.
+   */
+  StaticVisualizationComponent?: ComponentType<
+    CustomStaticVisualizationProps<TSettings>
+  >;
 };
 
 export type VisualizationGridSize = {
@@ -119,6 +127,23 @@ export type CustomVisualizationProps<
   ) => void;
 
   onHover: (hoverObject?: HoverObject | null) => void;
+};
+
+export type ColorGetter = (colorName: string) => string;
+
+export interface RenderingContext {
+  getColor: ColorGetter;
+  measureText: TextWidthMeasurer;
+  measureTextHeight: TextHeightMeasurer;
+  fontFamily: string;
+}
+
+export type CustomStaticVisualizationProps<
+  TSettings extends Record<string, unknown>,
+> = {
+  series: Series;
+  settings: CustomVisualizationSettings<TSettings>;
+  renderingContext: RenderingContext;
 };
 
 /**

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-globals.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-globals.ts
@@ -1,4 +1,8 @@
 import type { ColumnTypes, CreateCustomVisualization } from "custom-viz";
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- typeof needs a value import
+import * as ReactModule from "react";
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- typeof needs a value import
+import * as JsxRuntimeModule from "react/jsx-runtime";
 
 import {
   measureText,
@@ -16,6 +20,10 @@ declare global {
       measureText: typeof measureText;
       measureTextWidth: typeof measureTextWidth;
       measureTextHeight: typeof measureTextHeight;
+      // Exposed only by the static-viz bundle (for plugin bundles that reference them); the app
+      // path (ensureVizApi) leaves these unset, so they're optional.
+      React?: typeof ReactModule;
+      jsxRuntime?: typeof JsxRuntimeModule;
     };
     __customVizPlugin__?: CreateCustomVisualization<Record<string, unknown>>;
   }

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-static.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-static.ts
@@ -1,0 +1,36 @@
+import MetabaseSettings from "metabase/utils/settings";
+import visualizations, { registerVisualization } from "metabase/visualizations";
+import {
+  defineSetting,
+  getCustomPluginIdentifier,
+} from "metabase/visualizations/custom-visualizations/custom-viz-utils";
+
+import { applyDefaultVisualizationProps } from "./custom-viz-common";
+
+// Registry for custom viz plugins in the GraalJS static-viz context.
+export const customVizRegistry: Map<string, any> = new Map();
+
+export function registerCustomVizPlugin(
+  factory: any,
+  identifier: string,
+  assets: any,
+) {
+  const assetMap = assets || {};
+  const getAssetUrl = (name: string) => assetMap[name] || "";
+  const locale = MetabaseSettings.get("site-locale") ?? "en";
+  const vizDef = factory({ defineSetting, getAssetUrl, locale });
+  const display = getCustomPluginIdentifier(identifier);
+  customVizRegistry.set(display, vizDef);
+
+  // Register in main visualizations Map so getVisualizationRaw() resolves
+  // the plugin's settings for getComputedSettingsForSeries()
+  const Component = (vizDef.StaticVisualizationComponent ??
+    (() => null)) as any;
+  applyDefaultVisualizationProps(Component, vizDef, {
+    identifier: display,
+    getUiName: () => identifier,
+  });
+  if (!visualizations.has(display)) {
+    registerVisualization(Component);
+  }
+}

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-static.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-static.ts
@@ -1,9 +1,13 @@
+// Deep import (not the metabase/plugins barrel): this module is loaded by the
+// static-viz bundles, which must not drag the app UI stack in via the barrel.
+import { PLUGIN_CUSTOM_VIZ_STATIC } from "metabase/plugins/oss/custom-viz-static";
 import MetabaseSettings from "metabase/utils/settings";
 import visualizations, { registerVisualization } from "metabase/visualizations";
 import {
   defineSetting,
   getCustomPluginIdentifier,
 } from "metabase/visualizations/custom-visualizations/custom-viz-utils";
+import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { applyDefaultVisualizationProps } from "./custom-viz-common";
 
@@ -33,5 +37,19 @@ export function registerCustomVizPlugin(factory: any, identifier: string) {
   });
   if (!visualizations.has(display)) {
     registerVisualization(Component);
+  }
+}
+
+/**
+ * Activate the EE custom-viz registry for static (GraalJS SSR) rendering. The
+ * static-render counterpart of custom_viz/index's initializePlugin, kept separate
+ * so the static-viz bundles don't pull in the interactive admin pages.
+ */
+export function initializeStaticVizPlugin() {
+  if (hasPremiumFeature("custom-viz")) {
+    Object.assign(PLUGIN_CUSTOM_VIZ_STATIC, {
+      customVizRegistry,
+      registerCustomVizPlugin,
+    });
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-static.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-static.ts
@@ -10,6 +10,12 @@ import { applyDefaultVisualizationProps } from "./custom-viz-common";
 // Registry for custom viz plugins in the GraalJS static-viz context.
 export const customVizRegistry: Map<string, any> = new Map();
 
+// Static SSR only renders a plugin's StaticVisualizationComponent and reads setting values via
+// getComputedSettingsForSeries; it never mounts the interactive setting widgets whose WidgetMount
+// carries the plugin-id marker. The numeric id also isn't available in this context (only the
+// identifier string), so a sentinel is sufficient and never observed.
+const STATIC_RENDER_PLUGIN_ID = -1;
+
 export function registerCustomVizPlugin(
   factory: any,
   identifier: string,
@@ -28,6 +34,7 @@ export function registerCustomVizPlugin(
     (() => null)) as any;
   applyDefaultVisualizationProps(Component, vizDef, {
     identifier: display,
+    pluginId: STATIC_RENDER_PLUGIN_ID,
     getUiName: () => identifier,
   });
   if (!visualizations.has(display)) {

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-static.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-static.ts
@@ -16,15 +16,9 @@ export const customVizRegistry: Map<string, any> = new Map();
 // identifier string), so a sentinel is sufficient and never observed.
 const STATIC_RENDER_PLUGIN_ID = -1;
 
-export function registerCustomVizPlugin(
-  factory: any,
-  identifier: string,
-  assets: any,
-) {
-  const assetMap = assets || {};
-  const getAssetUrl = (name: string) => assetMap[name] || "";
+export function registerCustomVizPlugin(factory: any, identifier: string) {
   const locale = MetabaseSettings.get("site-locale") ?? "en";
-  const vizDef = factory({ defineSetting, getAssetUrl, locale });
+  const vizDef = factory({ defineSetting, locale });
   const display = getCustomPluginIdentifier(identifier);
   customVizRegistry.set(display, vizDef);
 

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/index.ts
@@ -16,6 +16,10 @@ import {
   useCustomVizPlugins,
   useCustomVizPluginsIcon,
 } from "./custom-viz-plugins";
+import {
+  customVizRegistry,
+  registerCustomVizPlugin,
+} from "./custom-viz-static";
 import { isWidgetMount } from "./widget-mount";
 
 export function initializePlugin() {
@@ -32,6 +36,8 @@ export function initializePlugin() {
       releaseCustomVizAsset: () => {},
       useCustomVizPluginsIcon,
       isCustomVizDisplay,
+      customVizRegistry,
+      registerCustomVizPlugin,
       isWidgetMount,
       CustomVizSettingWidget,
     });

--- a/enterprise/frontend/src/metabase-enterprise/static-viz-overrides.ts
+++ b/enterprise/frontend/src/metabase-enterprise/static-viz-overrides.ts
@@ -1,8 +1,11 @@
-import { initializePlugin as initializeCustomVizPlugin } from "./custom_viz";
+// Applied inside the GraalJS static-viz contexts only. Uses the static-only
+// custom-viz initializer (registry, not the interactive admin pages) so the
+// static-viz bundles stay free of the app UI stack.
+import { initializeStaticVizPlugin } from "./custom_viz/custom-viz-static";
 import { applyWhitelabelOverride } from "./whitelabel/static-viz-overrides";
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default function apply() {
   applyWhitelabelOverride();
-  initializeCustomVizPlugin();
+  initializeStaticVizPlugin();
 }

--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -194,9 +194,10 @@ const elements = [
     "frontend/src/metabase/routes-public.tsx",
     "frontend/src/metabase/AppThemeProvider.tsx",
     "frontend/src/metabase/AppColorSchemeProvider.tsx",
-    // Entry point for the static-viz bundle (server-side chart rendering in
-    // GraalJS) - like app.js, it composes OSS + EE code for a build artifact.
+    // Entry points for the static-viz bundles (server-side chart rendering in
+    // GraalJS) - like app.js, they compose OSS + EE code for build artifacts.
     "frontend/src/metabase/static-viz/index.tsx",
+    "frontend/src/metabase/static-viz/index-custom.tsx",
   ].map((path) =>
     createElement({
       type: "app",

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -42,6 +42,7 @@ export {
 } from "./oss/collections";
 export { PLUGIN_CONTENT_TRANSLATION } from "./oss/content-translation";
 export { PLUGIN_CUSTOM_VIZ } from "./oss/custom-viz";
+export { PLUGIN_CUSTOM_VIZ_STATIC } from "./oss/custom-viz-static";
 export {
   PLUGIN_CONTENT_VERIFICATION,
   type ModelFilterControlsProps,
@@ -190,6 +191,7 @@ import { reinitialize as reinitializeContentTranslation } from "./oss/content-tr
 import { reinitialize as reinitializeContentVerification } from "./oss/content-verification";
 import { reinitialize as reinitializeCore } from "./oss/core";
 import { reinitialize as reinitializeCustomViz } from "./oss/custom-viz";
+import { reinitialize as reinitializeCustomVizStatic } from "./oss/custom-viz-static";
 import { reinitialize as reinitializeDatabase } from "./oss/database";
 import { reinitialize as reinitializeDependencies } from "./oss/dependencies";
 import { reinitialize as reinitializeEmbedding } from "./oss/embedding";
@@ -235,6 +237,7 @@ export function reinitialize() {
   reinitializeContentVerification();
   reinitializeCore();
   reinitializeCustomViz();
+  reinitializeCustomVizStatic();
   reinitializeDatabase();
   reinitializeEmbedding();
   reinitializeEmbeddingIframeSdk();

--- a/frontend/src/metabase/plugins/oss/custom-viz-static.ts
+++ b/frontend/src/metabase/plugins/oss/custom-viz-static.ts
@@ -1,0 +1,25 @@
+import type { ComponentType } from "react";
+
+// The static-render (GraalJS SSR) surface of the custom-viz plugin, split from
+// PLUGIN_CUSTOM_VIZ (./custom-viz) so the static-viz bundles can use the registry
+// without importing this barrel's UI dependencies (PluginPlaceholder -> metabase/ui).
+// Keep this module (and its imports) free of React components and app UI.
+
+const getDefaultPluginCustomVizStatic = () => ({
+  customVizRegistry: new Map<string, Record<string, ComponentType<any>>>(),
+  registerCustomVizPlugin: (
+    _factory: (
+      props: Record<string, unknown>,
+    ) => Record<string, ComponentType<any>>,
+    _identifier: string,
+  ) => {},
+});
+
+export const PLUGIN_CUSTOM_VIZ_STATIC = getDefaultPluginCustomVizStatic();
+
+/**
+ * @internal Do not call directly. Use the main reinitialize function from metabase/plugins instead.
+ */
+export function reinitialize() {
+  Object.assign(PLUGIN_CUSTOM_VIZ_STATIC, getDefaultPluginCustomVizStatic());
+}

--- a/frontend/src/metabase/plugins/oss/custom-viz.ts
+++ b/frontend/src/metabase/plugins/oss/custom-viz.ts
@@ -77,7 +77,6 @@ const getDefaultPluginCustomViz = () => ({
       props: Record<string, unknown>,
     ) => Record<string, ComponentType<any>>,
     _identifier: string,
-    _assets: Record<string, string> | undefined,
   ) => {},
 
   /**

--- a/frontend/src/metabase/plugins/oss/custom-viz.ts
+++ b/frontend/src/metabase/plugins/oss/custom-viz.ts
@@ -70,6 +70,16 @@ const getDefaultPluginCustomViz = () => ({
   // Must be functional in OSS — pure string check used by getSensibleVisualizations
   isCustomVizDisplay,
 
+  // Static viz rendering (GraalJS context)
+  customVizRegistry: new Map<string, Record<string, ComponentType<any>>>(),
+  registerCustomVizPlugin: (
+    _factory: (
+      props: Record<string, unknown>,
+    ) => Record<string, ComponentType<any>>,
+    _identifier: string,
+    _assets: Record<string, string> | undefined,
+  ) => {},
+
   /**
    *  Always false in OSS as there is no plugin to produce a mount handle.
    */

--- a/frontend/src/metabase/static-viz/components/StaticVisualization/StaticVisualization.tsx
+++ b/frontend/src/metabase/static-viz/components/StaticVisualization/StaticVisualization.tsx
@@ -1,4 +1,6 @@
-import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
+// Deep import (not the metabase/plugins barrel) so the static-viz bundle doesn't
+// drag the whole app UI stack in via the barrel's other plugin modules.
+import { PLUGIN_CUSTOM_VIZ_STATIC } from "metabase/plugins/oss/custom-viz-static";
 import { registerStaticVisualizations } from "metabase/static-viz/register";
 import { getVisualizationTransformed } from "metabase/visualizations";
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
@@ -74,7 +76,7 @@ export const StaticVisualization = ({
   }
 
   if (typeof display === "string" && display.startsWith("custom:")) {
-    const customViz = PLUGIN_CUSTOM_VIZ.customVizRegistry.get(display);
+    const customViz = PLUGIN_CUSTOM_VIZ_STATIC.customVizRegistry.get(display);
     if (customViz?.StaticVisualizationComponent) {
       const { StaticVisualizationComponent } = customViz;
       return (

--- a/frontend/src/metabase/static-viz/components/StaticVisualization/StaticVisualization.tsx
+++ b/frontend/src/metabase/static-viz/components/StaticVisualization/StaticVisualization.tsx
@@ -1,3 +1,4 @@
+import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
 import { registerStaticVisualizations } from "metabase/static-viz/register";
 import { getVisualizationTransformed } from "metabase/visualizations";
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
@@ -70,6 +71,25 @@ export const StaticVisualization = ({
     case "row":
       // TODO: replace with an ECharts implementation
       return <StaticRowChart {...props} />;
+  }
+
+  if (typeof display === "string" && display.startsWith("custom:")) {
+    const customViz = PLUGIN_CUSTOM_VIZ.customVizRegistry.get(display);
+    if (customViz?.StaticVisualizationComponent) {
+      const { StaticVisualizationComponent } = customViz;
+      return (
+        <StaticVisualizationComponent
+          series={rawSeries}
+          renderingContext={renderingContext}
+          settings={settings}
+          isStorybook={isStorybook}
+          hasDevWatermark={hasDevWatermark}
+        />
+      );
+    }
+    // Plugin registered but has no StaticVisualizationComponent.
+    // Return null so the Clojure side gets an empty string and falls back to table.
+    return null;
   }
 
   throw new Error(`Unsupported display type: ${display}`);

--- a/frontend/src/metabase/static-viz/components/StaticVisualization/StaticVisualizationCustom.tsx
+++ b/frontend/src/metabase/static-viz/components/StaticVisualization/StaticVisualizationCustom.tsx
@@ -1,0 +1,46 @@
+// Deep import (not the metabase/plugins barrel) so the slim bundle doesn't drag
+// the whole app UI stack in via the barrel's other plugin modules.
+import { PLUGIN_CUSTOM_VIZ_STATIC } from "metabase/plugins/oss/custom-viz-static";
+import { getVisualizationTransformed } from "metabase/visualizations";
+import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
+import type { StaticVisualizationProps } from "metabase/visualizations/types";
+
+/**
+ * Custom-viz-only variant of StaticVisualization for the slim bundle loaded into the
+ * untrusted plugin isolate. It deliberately imports none of the built-in chart
+ * components (and never calls registerStaticVisualizations), so the ECharts/visx
+ * stack stays out of the bundle. The isolate only ever renders `custom:` cards.
+ */
+export const StaticVisualizationCustom = ({
+  rawSeries,
+  renderingContext,
+  isStorybook,
+  hasDevWatermark,
+}: StaticVisualizationProps) => {
+  const display = rawSeries[0].card.display;
+  const transformedSeries = getVisualizationTransformed(rawSeries).series;
+  const settings = getComputedSettingsForSeries(transformedSeries);
+
+  if (typeof display === "string" && display.startsWith("custom:")) {
+    const customViz = PLUGIN_CUSTOM_VIZ_STATIC.customVizRegistry.get(display);
+    if (customViz?.StaticVisualizationComponent) {
+      const { StaticVisualizationComponent } = customViz;
+      return (
+        <StaticVisualizationComponent
+          series={rawSeries}
+          renderingContext={renderingContext}
+          settings={settings}
+          isStorybook={isStorybook}
+          hasDevWatermark={hasDevWatermark}
+        />
+      );
+    }
+    // Plugin registered but has no StaticVisualizationComponent.
+    // Return null so the Clojure side gets an empty string and falls back to table.
+    return null;
+  }
+
+  throw new Error(
+    `Unsupported display type in custom-viz static bundle: ${display}`,
+  );
+};

--- a/frontend/src/metabase/static-viz/index-custom.tsx
+++ b/frontend/src/metabase/static-viz/index-custom.tsx
@@ -1,0 +1,75 @@
+import "./mock-environment";
+import "fast-text-encoding";
+
+import ReactDOMServer from "react-dom/server";
+
+// eslint-disable-next-line import/order
+import enterpriseOverrides from "ee-overrides";
+import "metabase/utils/dayjs";
+
+import { StaticVisualizationCustom } from "metabase/static-viz/components/StaticVisualization/StaticVisualizationCustom";
+import {
+  type RenderChartOptions,
+  applyRenderChartSettings,
+  getRawSeriesWithDashcardSettings,
+  initializeStaticVizContext,
+  installStaticVizApi,
+  registerCustomVizPlugin,
+} from "metabase/static-viz/lib/entry-shared";
+import { createStaticRenderingContext } from "metabase/static-viz/lib/rendering-context";
+import { updateStartOfWeek } from "metabase/utils/i18n";
+import { extractRemappings } from "metabase/visualizations";
+import type {
+  DashCardVisualizationSettings,
+  RawSeries,
+} from "metabase-types/api";
+
+// Slim entry for the custom-viz-only static bundle (lib-static-viz-custom.bundle.js),
+// loaded into the untrusted plugin isolate. It exposes the same `StaticViz` interface
+// surface as ./index (minus LegacyRenderChart, which only the trusted pool invokes)
+// but renders exclusively `custom:` cards, so the built-in chart implementations and
+// the ECharts/visx/geo stack never enter this bundle. See StaticVisualizationCustom.
+
+installStaticVizApi();
+
+export type { RenderChartOptions };
+export { registerCustomVizPlugin };
+
+/**
+ * Initialize the static viz context: set settings and apply enterprise overrides.
+ * Must be called before registerCustomVizPlugin so that the EE registry is active.
+ */
+export function initializeContext(options: RenderChartOptions) {
+  initializeStaticVizContext(options, enterpriseOverrides);
+}
+
+export function RenderChart(
+  rawSeries: RawSeries,
+  dashcardSettings: DashCardVisualizationSettings,
+  options: RenderChartOptions,
+) {
+  applyRenderChartSettings(options, enterpriseOverrides);
+
+  const renderingContext = createStaticRenderingContext(
+    options.applicationColors,
+  );
+
+  updateStartOfWeek(options.startOfWeek);
+  const rawSeriesWithDashcardSettings = getRawSeriesWithDashcardSettings(
+    rawSeries,
+    dashcardSettings,
+  );
+  const rawSeriesWithRemappings = extractRemappings(
+    rawSeriesWithDashcardSettings,
+  );
+
+  const hasDevWatermark = Boolean(options.tokenFeatures.development_mode);
+
+  return ReactDOMServer.renderToStaticMarkup(
+    <StaticVisualizationCustom
+      rawSeries={rawSeriesWithRemappings}
+      renderingContext={renderingContext}
+      hasDevWatermark={hasDevWatermark}
+    />,
+  );
+}

--- a/frontend/src/metabase/static-viz/index.tsx
+++ b/frontend/src/metabase/static-viz/index.tsx
@@ -2,15 +2,12 @@ import "./mock-environment";
 import "fast-text-encoding";
 
 import { setPlatformAPI } from "echarts/core";
-import React from "react";
-import * as jsxRuntime from "react/jsx-runtime";
 import ReactDOMServer from "react-dom/server";
 
 // eslint-disable-next-line import/order
 import enterpriseOverrides from "ee-overrides";
 import "metabase/utils/dayjs";
 
-import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
 import {
   StaticChoropleth,
   getStaticChoroplethSettings,
@@ -18,75 +15,46 @@ import {
 import { StaticVisualization } from "metabase/static-viz/components/StaticVisualization";
 import { LegacyStaticChart } from "metabase/static-viz/containers/LegacyStaticChart";
 import type { LegacyStaticChartType } from "metabase/static-viz/containers/LegacyStaticChart/LegacyStaticChart";
+import {
+  type RenderChartOptions,
+  applyRenderChartSettings,
+  getRawSeriesWithDashcardSettings,
+  initializeStaticVizContext,
+  installStaticVizApi,
+  registerCustomVizPlugin,
+} from "metabase/static-viz/lib/entry-shared";
 import { createStaticRenderingContext } from "metabase/static-viz/lib/rendering-context";
 import { measureTextEChartsAdapter } from "metabase/static-viz/lib/text";
-import type { ColorPalette } from "metabase/ui/colors/types";
 import { updateStartOfWeek } from "metabase/utils/i18n";
-import MetabaseSettings from "metabase/utils/settings";
 import { extractRemappings, isCartesianChart } from "metabase/visualizations";
-import { formatValue as internalFormatValue } from "metabase/visualizations/lib/formatting/value";
-import { extendCardWithDashcardSettings } from "metabase/visualizations/lib/settings/typed-utils";
+// Deep imports (not the metabase/visualizer/utils barrel) so the static-viz
+// bundle doesn't drag the visualizer's app-side dependencies in via the barrel.
+import { createDataSource } from "metabase/visualizer/utils/data-source";
+import { getVisualizationColumns } from "metabase/visualizer/utils/get-visualization-columns";
+import { mergeVisualizerData } from "metabase/visualizer/utils/merge-data";
 import {
-  createDataSource,
-  getVisualizationColumns,
-  mergeVisualizerData,
   shouldSplitVisualizerSeries,
   splitVisualizerSeries,
-} from "metabase/visualizer/utils";
-import { customVizColumnTypes } from "metabase-lib/v1/types/utils/custom-viz-column-types";
+} from "metabase/visualizer/utils/split-series";
 import type {
   Card,
-  ColumnSettings,
   DashCardVisualizationSettings,
   Dataset,
   DatasetData,
-  DayOfWeekId,
-  FormattingSettings,
   GeoJSONData,
   RawSeries,
-  SettingKey,
-  TokenFeatures,
   VisualizerDataSourceId,
   VisualizerVizDefinition,
 } from "metabase-types/api";
 
-type StaticVizApiWindow = Omit<Window, "__METABASE_VIZ_API__"> & {
-  __METABASE_VIZ_API__?: Omit<
-    NonNullable<Window["__METABASE_VIZ_API__"]>,
-    // unsupported in static viz
-    "measureText" | "measureTextHeight" | "measureTextWidth"
-  >;
-};
-
-// Expose React, jsxRuntime, and utils for custom viz bundles that reference
-// window.__METABASE_VIZ_API__ via the metabaseVizExternals Vite plugin.
-(window as StaticVizApiWindow).__METABASE_VIZ_API__ = {
-  React,
-  jsxRuntime,
-  columnTypes: customVizColumnTypes,
-  formatValue: (value: unknown, options?: ColumnSettings) => {
-    const result = internalFormatValue(value, { ...options, jsx: false });
-    return String(result ?? "");
-  },
-};
+installStaticVizApi();
 
 setPlatformAPI({
   measureText: measureTextEChartsAdapter,
 });
 
-export type RenderChartOptions = {
-  tokenFeatures: TokenFeatures;
-  applicationColors: ColorPalette;
-  customFormatting: FormattingSettings;
-  startOfWeek: DayOfWeekId | null | undefined;
-  locale?: string | null;
-  // Explicit pixel dimensions for the chart. Use fitWithinBounds to have height include
-  // chart legends
-  width?: number;
-  height?: number;
-  // When true, width/height are treated as the exact output box
-  fitWithinBounds?: boolean;
-};
+export type { RenderChartOptions };
+export { registerCustomVizPlugin };
 
 type RenderChartDashcardSettings = DashCardVisualizationSettings & {
   visualization?: VisualizerVizDefinition;
@@ -102,22 +70,6 @@ export function LegacyRenderChart(
   return ReactDOMServer.renderToStaticMarkup(
     <LegacyStaticChart type={type} options={options} />,
   );
-}
-
-function getRawSeriesWithDashcardSettings(
-  rawSeries: RawSeries,
-  dashcardSettings: DashCardVisualizationSettings,
-): RawSeries {
-  return rawSeries.map((series, index) => {
-    const isMainCard = index === 0;
-    if (isMainCard) {
-      return {
-        ...series,
-        card: extendCardWithDashcardSettings(series.card, dashcardSettings),
-      };
-    }
-    return series;
-  });
 }
 
 function getVisualizerRawSeries(
@@ -152,29 +104,12 @@ function getVisualizerRawSeries(
   ];
 }
 
-export function registerCustomVizPlugin(
-  factory: Parameters<typeof PLUGIN_CUSTOM_VIZ.registerCustomVizPlugin>[0],
-  identifier: string,
-) {
-  PLUGIN_CUSTOM_VIZ.registerCustomVizPlugin(factory, identifier);
-}
-
 /**
  * Initialize the static viz context: set settings and apply enterprise overrides.
  * Must be called before registerCustomVizPlugin so that the EE registry is active.
  */
 export function initializeContext(options: RenderChartOptions) {
-  MetabaseSettings.set("token-features", options.tokenFeatures);
-  MetabaseSettings.set(
-    "application-colors" as SettingKey,
-    options.applicationColors,
-  );
-  MetabaseSettings.set("custom-formatting", options.customFormatting);
-  MetabaseSettings.set("site-locale", options.locale ?? "en");
-
-  if (typeof enterpriseOverrides === "function") {
-    enterpriseOverrides();
-  }
+  initializeStaticVizContext(options, enterpriseOverrides);
 }
 
 export function RenderChart(
@@ -182,17 +117,7 @@ export function RenderChart(
   dashcardSettings: RenderChartDashcardSettings,
   options: RenderChartOptions,
 ) {
-  MetabaseSettings.set("token-features", options.tokenFeatures);
-  MetabaseSettings.set(
-    "application-colors" as SettingKey,
-    options.applicationColors,
-  );
-
-  if (typeof enterpriseOverrides === "function") {
-    enterpriseOverrides();
-  }
-
-  MetabaseSettings.set("custom-formatting", options.customFormatting);
+  applyRenderChartSettings(options, enterpriseOverrides);
 
   const renderingContext = createStaticRenderingContext(
     options.applicationColors,

--- a/frontend/src/metabase/static-viz/index.tsx
+++ b/frontend/src/metabase/static-viz/index.tsx
@@ -21,7 +21,6 @@ import type { LegacyStaticChartType } from "metabase/static-viz/containers/Legac
 import { createStaticRenderingContext } from "metabase/static-viz/lib/rendering-context";
 import { measureTextEChartsAdapter } from "metabase/static-viz/lib/text";
 import type { ColorPalette } from "metabase/ui/colors/types";
-import type { OptionsType } from "metabase/utils/formatting/types";
 import { updateStartOfWeek } from "metabase/utils/i18n";
 import MetabaseSettings from "metabase/utils/settings";
 import { extractRemappings, isCartesianChart } from "metabase/visualizations";
@@ -37,6 +36,7 @@ import {
 import { customVizColumnTypes } from "metabase-lib/v1/types/utils/custom-viz-column-types";
 import type {
   Card,
+  ColumnSettings,
   DashCardVisualizationSettings,
   Dataset,
   DatasetData,
@@ -64,7 +64,7 @@ type StaticVizApiWindow = Omit<Window, "__METABASE_VIZ_API__"> & {
   React,
   jsxRuntime,
   columnTypes: customVizColumnTypes,
-  formatValue: (value: unknown, options?: OptionsType) => {
+  formatValue: (value: unknown, options?: ColumnSettings) => {
     const result = internalFormatValue(value, { ...options, jsx: false });
     return String(result ?? "");
   },

--- a/frontend/src/metabase/static-viz/index.tsx
+++ b/frontend/src/metabase/static-viz/index.tsx
@@ -2,12 +2,15 @@ import "./mock-environment";
 import "fast-text-encoding";
 
 import { setPlatformAPI } from "echarts/core";
+import React from "react";
+import * as jsxRuntime from "react/jsx-runtime";
 import ReactDOMServer from "react-dom/server";
 
 // eslint-disable-next-line import/order
 import enterpriseOverrides from "ee-overrides";
 import "metabase/utils/dayjs";
 
+import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
 import {
   StaticChoropleth,
   getStaticChoroplethSettings,
@@ -18,9 +21,11 @@ import type { LegacyStaticChartType } from "metabase/static-viz/containers/Legac
 import { createStaticRenderingContext } from "metabase/static-viz/lib/rendering-context";
 import { measureTextEChartsAdapter } from "metabase/static-viz/lib/text";
 import type { ColorPalette } from "metabase/ui/colors/types";
+import type { OptionsType } from "metabase/utils/formatting/types";
 import { updateStartOfWeek } from "metabase/utils/i18n";
 import MetabaseSettings from "metabase/utils/settings";
 import { extractRemappings, isCartesianChart } from "metabase/visualizations";
+import { formatValue as internalFormatValue } from "metabase/visualizations/lib/formatting/value";
 import { extendCardWithDashcardSettings } from "metabase/visualizations/lib/settings/typed-utils";
 import {
   createDataSource,
@@ -29,6 +34,7 @@ import {
   shouldSplitVisualizerSeries,
   splitVisualizerSeries,
 } from "metabase/visualizer/utils";
+import { customVizColumnTypes } from "metabase-lib/v1/types/utils/custom-viz-column-types";
 import type {
   Card,
   DashCardVisualizationSettings,
@@ -44,6 +50,26 @@ import type {
   VisualizerVizDefinition,
 } from "metabase-types/api";
 
+type StaticVizApiWindow = Omit<Window, "__METABASE_VIZ_API__"> & {
+  __METABASE_VIZ_API__?: Omit<
+    NonNullable<Window["__METABASE_VIZ_API__"]>,
+    // unsupported in static viz
+    "measureText" | "measureTextHeight" | "measureTextWidth"
+  >;
+};
+
+// Expose React, jsxRuntime, and utils for custom viz bundles that reference
+// window.__METABASE_VIZ_API__ via the metabaseVizExternals Vite plugin.
+(window as StaticVizApiWindow).__METABASE_VIZ_API__ = {
+  React,
+  jsxRuntime,
+  columnTypes: customVizColumnTypes,
+  formatValue: (value: unknown, options?: OptionsType) => {
+    const result = internalFormatValue(value, { ...options, jsx: false });
+    return String(result ?? "");
+  },
+};
+
 setPlatformAPI({
   measureText: measureTextEChartsAdapter,
 });
@@ -53,6 +79,7 @@ export type RenderChartOptions = {
   applicationColors: ColorPalette;
   customFormatting: FormattingSettings;
   startOfWeek: DayOfWeekId | null | undefined;
+  locale?: string | null;
   // Explicit pixel dimensions for the chart. Use fitWithinBounds to have height include
   // chart legends
   width?: number;
@@ -123,6 +150,32 @@ function getVisualizerRawSeries(
       columnValuesMapping,
     },
   ];
+}
+
+export function registerCustomVizPlugin(
+  factory: Parameters<typeof PLUGIN_CUSTOM_VIZ.registerCustomVizPlugin>[0],
+  identifier: string,
+  assets: Record<string, string> | undefined,
+) {
+  PLUGIN_CUSTOM_VIZ.registerCustomVizPlugin(factory, identifier, assets);
+}
+
+/**
+ * Initialize the static viz context: set settings and apply enterprise overrides.
+ * Must be called before registerCustomVizPlugin so that the EE registry is active.
+ */
+export function initializeContext(options: RenderChartOptions) {
+  MetabaseSettings.set("token-features", options.tokenFeatures);
+  MetabaseSettings.set(
+    "application-colors" as SettingKey,
+    options.applicationColors,
+  );
+  MetabaseSettings.set("custom-formatting", options.customFormatting);
+  MetabaseSettings.set("site-locale", options.locale ?? "en");
+
+  if (typeof enterpriseOverrides === "function") {
+    enterpriseOverrides();
+  }
 }
 
 export function RenderChart(

--- a/frontend/src/metabase/static-viz/index.tsx
+++ b/frontend/src/metabase/static-viz/index.tsx
@@ -155,9 +155,8 @@ function getVisualizerRawSeries(
 export function registerCustomVizPlugin(
   factory: Parameters<typeof PLUGIN_CUSTOM_VIZ.registerCustomVizPlugin>[0],
   identifier: string,
-  assets: Record<string, string> | undefined,
 ) {
-  PLUGIN_CUSTOM_VIZ.registerCustomVizPlugin(factory, identifier, assets);
+  PLUGIN_CUSTOM_VIZ.registerCustomVizPlugin(factory, identifier);
 }
 
 /**

--- a/frontend/src/metabase/static-viz/lib/entry-shared.ts
+++ b/frontend/src/metabase/static-viz/lib/entry-shared.ts
@@ -1,0 +1,123 @@
+import React from "react";
+import * as jsxRuntime from "react/jsx-runtime";
+
+// Deep import (not the metabase/plugins barrel) so the static-viz bundles don't
+// drag the whole app UI stack in via the barrel's other plugin modules.
+import { PLUGIN_CUSTOM_VIZ_STATIC } from "metabase/plugins/oss/custom-viz-static";
+import type { ColorPalette } from "metabase/ui/colors/types";
+import MetabaseSettings from "metabase/utils/settings";
+import { formatValue as internalFormatValue } from "metabase/visualizations/lib/formatting/value";
+import { extendCardWithDashcardSettings } from "metabase/visualizations/lib/settings/typed-utils";
+import { customVizColumnTypes } from "metabase-lib/v1/types/utils/custom-viz-column-types";
+import type {
+  ColumnSettings,
+  DashCardVisualizationSettings,
+  DayOfWeekId,
+  FormattingSettings,
+  RawSeries,
+  SettingKey,
+  TokenFeatures,
+} from "metabase-types/api";
+
+type StaticVizApiWindow = Omit<Window, "__METABASE_VIZ_API__"> & {
+  __METABASE_VIZ_API__?: Omit<
+    NonNullable<Window["__METABASE_VIZ_API__"]>,
+    // unsupported in static viz
+    "measureText" | "measureTextHeight" | "measureTextWidth"
+  >;
+};
+
+type EnterpriseOverrides = (() => void) | undefined;
+
+export type RenderChartOptions = {
+  tokenFeatures: TokenFeatures;
+  applicationColors: ColorPalette;
+  customFormatting: FormattingSettings;
+  startOfWeek: DayOfWeekId | null | undefined;
+  locale?: string | null;
+  // Explicit pixel dimensions for the chart. Use fitWithinBounds to have height include
+  // chart legends
+  width?: number;
+  height?: number;
+  // When true, width/height are treated as the exact output box
+  fitWithinBounds?: boolean;
+};
+
+/**
+ * Expose React, jsxRuntime, and utils for custom viz bundles that reference
+ * window.__METABASE_VIZ_API__ via the metabaseVizExternals Vite plugin.
+ */
+export function installStaticVizApi() {
+  (window as StaticVizApiWindow).__METABASE_VIZ_API__ = {
+    React,
+    jsxRuntime,
+    columnTypes: customVizColumnTypes,
+    formatValue: (value: unknown, options?: ColumnSettings) => {
+      const result = internalFormatValue(value, { ...options, jsx: false });
+      return String(result ?? "");
+    },
+  };
+}
+
+/**
+ * Initialize the static viz context: set settings and apply enterprise overrides.
+ * Must be called before registerCustomVizPlugin so that the EE registry is active.
+ */
+export function initializeStaticVizContext(
+  options: RenderChartOptions,
+  enterpriseOverrides: EnterpriseOverrides,
+) {
+  MetabaseSettings.set("token-features", options.tokenFeatures);
+  MetabaseSettings.set(
+    "application-colors" as SettingKey,
+    options.applicationColors,
+  );
+  MetabaseSettings.set("custom-formatting", options.customFormatting);
+  MetabaseSettings.set("site-locale", options.locale ?? "en");
+
+  if (typeof enterpriseOverrides === "function") {
+    enterpriseOverrides();
+  }
+}
+
+export function applyRenderChartSettings(
+  options: RenderChartOptions,
+  enterpriseOverrides: EnterpriseOverrides,
+) {
+  MetabaseSettings.set("token-features", options.tokenFeatures);
+  MetabaseSettings.set(
+    "application-colors" as SettingKey,
+    options.applicationColors,
+  );
+
+  if (typeof enterpriseOverrides === "function") {
+    enterpriseOverrides();
+  }
+
+  MetabaseSettings.set("custom-formatting", options.customFormatting);
+}
+
+export function getRawSeriesWithDashcardSettings(
+  rawSeries: RawSeries,
+  dashcardSettings: DashCardVisualizationSettings,
+): RawSeries {
+  return rawSeries.map((series, index) => {
+    const isMainCard = index === 0;
+    if (isMainCard) {
+      return {
+        ...series,
+        card: extendCardWithDashcardSettings(series.card, dashcardSettings),
+      };
+    }
+    return series;
+  });
+}
+
+export function registerCustomVizPlugin(
+  factory: Parameters<
+    typeof PLUGIN_CUSTOM_VIZ_STATIC.registerCustomVizPlugin
+  >[0],
+  identifier: string,
+) {
+  PLUGIN_CUSTOM_VIZ_STATIC.registerCustomVizPlugin(factory, identifier);
+}

--- a/resources/frontend_shared/static_viz_interface.js
+++ b/resources/frontend_shared/static_viz_interface.js
@@ -37,6 +37,17 @@ function funnel(data, settings, tokenFeatures) {
 }
 
 
+function initialize_context(options) {
+  StaticViz.initializeContext(JSON.parse(options));
+}
+
+function register_custom_viz_plugin(identifier, assetsJson) {
+  if (typeof __customVizPlugin__ === "function") {
+    var assets = assetsJson ? JSON.parse(assetsJson) : {};
+    StaticViz.registerCustomVizPlugin(__customVizPlugin__, identifier, assets);
+  }
+}
+
 function javascript_visualization(rawSeries, dashcardSettings, options) {
   const content = StaticViz.RenderChart(
     JSON.parse(rawSeries),

--- a/resources/frontend_shared/static_viz_interface.js
+++ b/resources/frontend_shared/static_viz_interface.js
@@ -41,10 +41,9 @@ function initialize_context(options) {
   StaticViz.initializeContext(JSON.parse(options));
 }
 
-function register_custom_viz_plugin(identifier, assetsJson) {
+function register_custom_viz_plugin(identifier) {
   if (typeof __customVizPlugin__ === "function") {
-    var assets = assetsJson ? JSON.parse(assetsJson) : {};
-    StaticViz.registerCustomVizPlugin(__customVizPlugin__, identifier, assets);
+    StaticViz.registerCustomVizPlugin(__customVizPlugin__, identifier);
   }
 }
 

--- a/rspack.static-viz.config.js
+++ b/rspack.static-viz.config.js
@@ -20,6 +20,88 @@ const ENTERPRISE_SRC_PATH =
 
 const devMode = WEBPACK_BUNDLE !== "production";
 
+const SLIM_BUNDLE_NAME = "lib-static-viz-custom";
+const SLIM_BUNDLE_ASSET = `${SLIM_BUNDLE_NAME}.bundle.js`;
+// The slim bundle exists so the untrusted custom-viz isolate never parses the
+// built-in chart stack (ECharts/zrender/visx + the 13 chart components — several
+// MB of the full bundle). The budget fails the build if that stack (or another
+// big dependency) silently leaks back in.
+//
+// The current floor is set by the settings/formatting machinery the custom-viz
+// SSR path shares with the app (lib/settings pulls the ChartSetting* widget
+// components and metabase/ui until the #77658 refactor arrives from master, plus
+// cljs metabase-lib for MBQL normalization). After merging master (#77658) this
+// budget should be tightened substantially.
+const SLIM_BUNDLE_MAX_BYTES = 10 * 1024 * 1024;
+// Built-in chart machinery that must never enter the slim custom-viz bundle.
+const SLIM_BUNDLE_FORBIDDEN_MODULE_RE =
+  /node_modules[\\/](echarts|zrender|@visx)[\\/]|static-viz[\\/]register\.ts|StaticVisualization[\\/]StaticVisualization\.tsx|StaticChoropleth/;
+
+class SlimStaticVizGuardPlugin {
+  apply(compiler) {
+    compiler.hooks.afterEmit.tap("SlimStaticVizGuardPlugin", (compilation) => {
+      const asset = compilation.getAsset(SLIM_BUNDLE_ASSET);
+      if (!asset) {
+        compilation.errors.push(
+          new Error(
+            `[slim static-viz] expected asset ${SLIM_BUNDLE_ASSET} was not emitted`,
+          ),
+        );
+        return;
+      }
+
+      const size = asset.source.size();
+      if (size > SLIM_BUNDLE_MAX_BYTES) {
+        compilation.errors.push(
+          new Error(
+            `[slim static-viz] ${SLIM_BUNDLE_ASSET} is ${size} bytes, over its ${SLIM_BUNDLE_MAX_BYTES}-byte budget. ` +
+              `This bundle is cold-parsed by the untrusted custom-viz isolate; a size jump usually means ` +
+              `the built-in chart stack (ECharts/visx/chart components) leaked back in via a new import.`,
+          ),
+        );
+      }
+
+      // Module-level tripwire: attribute every module (including ones nested in
+      // concatenated groups, which inherit their group's chunk membership) to the
+      // slim chunk and reject the build if any forbidden module landed in it.
+      const { chunks = [], modules = [] } = compilation.getStats().toJson({
+        all: false,
+        ids: true,
+        chunks: true,
+        modules: true,
+        nestedModules: true,
+        modulesSpace: Infinity,
+        nestedModulesSpace: Infinity,
+      });
+      const slimChunkId = chunks.find((chunk) =>
+        (chunk.names ?? []).includes(SLIM_BUNDLE_NAME),
+      )?.id;
+      const leakedModules = [];
+      const walk = (moduleList, inheritedMembership) => {
+        for (const module of moduleList ?? []) {
+          const inSlimChunk = module.chunks
+            ? module.chunks.includes(slimChunkId)
+            : inheritedMembership;
+          const name = module.nameForCondition || module.name || "";
+          if (inSlimChunk && SLIM_BUNDLE_FORBIDDEN_MODULE_RE.test(name)) {
+            leakedModules.push(name);
+          }
+          walk(module.modules, inSlimChunk);
+        }
+      };
+      walk(modules, false);
+      if (leakedModules.length > 0) {
+        compilation.errors.push(
+          new Error(
+            `[slim static-viz] built-in chart modules leaked into ${SLIM_BUNDLE_ASSET}:\n` +
+              leakedModules.slice(0, 20).join("\n"),
+          ),
+        );
+      }
+    });
+  }
+}
+
 module.exports = (env) => {
   return {
     mode: "production",
@@ -32,6 +114,16 @@ module.exports = (env) => {
     entry: {
       "lib-static-viz": {
         import: "./static-viz/index.tsx",
+        library: {
+          name: "StaticViz",
+          type: "var",
+        },
+      },
+      // Slim custom-viz-only bundle for the untrusted plugin isolate. Reuses the
+      // `StaticViz` global so frontend_shared/static_viz_interface.js works unchanged
+      // (each isolate loads exactly one of the two bundles).
+      [SLIM_BUNDLE_NAME]: {
+        import: "./static-viz/index-custom.tsx",
         library: {
           name: "StaticViz",
           type: "var",
@@ -141,6 +233,7 @@ module.exports = (env) => {
       minimize: false,
     },
     plugins: [
+      new SlimStaticVizGuardPlugin(),
       new rspack.EnvironmentPlugin({
         IS_EMBEDDING_SDK_BUILD: false,
       }),

--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -497,16 +497,19 @@
     :svg  (png->rendered-part render-type (js.svg/svg-string->bytes content))))
 
 (defn- custom-viz-bundles
-  "If the card has a custom:* display type, resolve the plugin's JS bundle for static rendering."
-  [card]
-  (when-let [identifier (render.util/custom-viz-identifier (:display card))]
-    (if-let [content (some-> (custom-viz-plugin/resolve-enabled-plugin identifier)
-                             custom-viz-plugin/resolve-bundle
-                             :content)]
-      (do (log/debugf "custom-viz: resolved bundle for plugin %s (%d chars)" identifier (count content))
-          [{:identifier identifier :source content}])
-      (log/warnf "custom-viz: no enabled plugin/bundle found for %s; static render will fall back to table"
-                 identifier))))
+  "If the card has a custom:* display type, resolve the plugin's JS bundle for static rendering. Returns nil for
+  visualizer dashcards: they render as the visualizer's built-in display even when the underlying card is a custom
+  viz, and the untrusted isolate's slim bundle has no built-in charts."
+  [card dashcard]
+  (when-not (render.util/is-visualizer-dashcard? dashcard)
+    (when-let [identifier (render.util/custom-viz-identifier (:display card))]
+      (if-let [content (some-> (custom-viz-plugin/resolve-enabled-plugin identifier)
+                               custom-viz-plugin/resolve-bundle
+                               :content)]
+        (do (log/debugf "custom-viz: resolved bundle for plugin %s (%d chars)" identifier (count content))
+            [{:identifier identifier :source content}])
+        (log/warnf "custom-viz: no enabled plugin/bundle found for %s; static render will fall back to table"
+                   identifier)))))
 
 ;; the `:javascript_visualization` render method
 ;; is and will continue to handle more and more 'isomorphic' chart types.
@@ -520,7 +523,7 @@
         viz-settings     (or (get dashcard :visualization_settings)
                              (get card :visualization_settings))
         {:keys [content] :as result} (js.svg/*javascript-visualization* cards-with-data viz-settings
-                                                                        (custom-viz-bundles card))]
+                                                                        (custom-viz-bundles card dashcard))]
     ;; If the custom viz plugin didn't define a StaticVisualizationComponent, RenderChart returns an
     ;; empty string. Fall back to table rendering.
     (if (and (render.util/custom-viz-display? (:display card))

--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -13,6 +13,7 @@
    [metabase.channel.render.table-data :as table-data]
    [metabase.channel.render.util :as render.util]
    [metabase.channel.settings :as channel.settings]
+   [metabase.custom-viz-plugin.core :as custom-viz-plugin]
    [metabase.formatter.core :as formatter]
    [metabase.geojson.api :as geojson.api]
    [metabase.geojson.settings :as geojson.settings]
@@ -29,7 +30,8 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.malli.schema :as ms])
+   [metabase.util.malli.schema :as ms]
+   [toucan2.core :as t2])
   (:import
    (java.net URL)
    (java.text DecimalFormat DecimalFormatSymbols)))
@@ -495,6 +497,36 @@
     :html {:content [:div content] :attachments nil}
     :svg  (png->rendered-part render-type (js.svg/svg-string->bytes content))))
 
+(defn- asset->data-uri
+  "Convert an asset's bytes to a data: URI string."
+  [^String asset-name ^bytes asset-bytes]
+  (let [content-type (or (custom-viz-plugin/asset-content-type asset-name)
+                         "application/octet-stream")]
+    (str "data:" content-type ";base64,"
+         (.encodeToString (java.util.Base64/getEncoder) asset-bytes))))
+
+(defn- custom-viz-bundles
+  "If the card has a custom:* display type, resolve the plugin's bundle and assets for static rendering.
+   Assets are included as a map of `{name -> data-uri}` so the static viz JS context
+   can resolve `getAssetUrl` calls without HTTP."
+  [card]
+  (when-let [identifier (render.util/custom-viz-identifier (:display card))]
+    (let [{:keys [manifest] :as plugin}
+          ;; do not load the (potentially multi-MB) :bundle blob just to read the manifest;
+          ;; resolve-bundle / resolve-asset re-fetch bytes from the cache as needed.
+          (t2/select-one [:model/CustomVizPlugin :id :identifier :enabled :manifest :bundle_hash :dev_bundle_url]
+                         :identifier identifier :enabled true)]
+      (when-let [content (some-> plugin
+                                 custom-viz-plugin/resolve-bundle
+                                 :content)]
+        (let [asset-names (some-> manifest custom-viz-plugin/asset-paths)
+              assets      (into {}
+                                (keep (fn [asset-name]
+                                        (when-let [bytes (custom-viz-plugin/resolve-asset plugin asset-name)]
+                                          [asset-name (asset->data-uri asset-name bytes)])))
+                                asset-names)]
+          [{:identifier identifier :source content :assets assets}])))))
+
 ;; the `:javascript_visualization` render method
 ;; is and will continue to handle more and more 'isomorphic' chart types.
 ;; Isomorphic in this context just means the frontend Code is mostly shared between the app and the static-viz
@@ -502,13 +534,18 @@
 ;; Because this effort began with LAB charts, this method is written to handle multi-series dashcards.
 ;; Trend charts were added more recently and will not have multi-series.
 (mu/defmethod render :javascript_visualization :- ::RenderedPartCard
-  [_chart-type render-type _timezone-id card dashcard data]
+  [_chart-type render-type timezone-id card dashcard data]
   (let [cards-with-data  (series-cards-with-data dashcard card data)
         viz-settings     (or (get dashcard :visualization_settings)
-                             (get card :visualization_settings))]
-    (javascript-visualization->rendered-part
-     render-type
-     (js.svg/*javascript-visualization* cards-with-data viz-settings))))
+                             (get card :visualization_settings))
+        {:keys [content] :as result} (js.svg/*javascript-visualization* cards-with-data viz-settings
+                                                                        (custom-viz-bundles card))]
+    ;; If the custom viz plugin didn't define a StaticVisualizationComponent, RenderChart returns an
+    ;; empty string. Fall back to table rendering.
+    (if (and (render.util/custom-viz-display? (:display card))
+             (str/blank? content))
+      (render :table render-type timezone-id card dashcard data)
+      (javascript-visualization->rendered-part render-type result))))
 
 (mu/defmethod render :region_map :- ::RenderedPartCard
   [_chart-type render-type timezone-id card dashcard data]
@@ -532,7 +569,7 @@
                                                                :region_name (:region_name geojson)}))]
         (javascript-visualization->rendered-part
          render-type
-         (js.svg/*javascript-visualization* cards-with-data viz-settings))))))
+         (js.svg/*javascript-visualization* cards-with-data viz-settings nil))))))
 
 (defn- number-at
   "The value of `row` at `idx` when it's a number, else nil."

--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -30,8 +30,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.malli.schema :as ms]
-   [toucan2.core :as t2])
+   [metabase.util.malli.schema :as ms])
   (:import
    (java.net URL)
    (java.text DecimalFormat DecimalFormatSymbols)))
@@ -501,15 +500,10 @@
   "If the card has a custom:* display type, resolve the plugin's JS bundle for static rendering."
   [card]
   (when-let [identifier (render.util/custom-viz-identifier (:display card))]
-    (let [plugin
-          ;; do not load the (potentially multi-MB) :bundle blob just to read the metadata;
-          ;; resolve-bundle re-fetches the bundle bytes from the cache as needed.
-          (t2/select-one [:model/CustomVizPlugin :id :identifier :enabled :bundle_hash :dev_bundle_url]
-                         :identifier identifier :enabled true)]
-      (when-let [content (some-> plugin
-                                 custom-viz-plugin/resolve-bundle
-                                 :content)]
-        [{:identifier identifier :source content}]))))
+    (when-let [content (some-> (custom-viz-plugin/resolve-enabled-plugin identifier)
+                               custom-viz-plugin/resolve-bundle
+                               :content)]
+      [{:identifier identifier :source content}])))
 
 ;; the `:javascript_visualization` render method
 ;; is and will continue to handle more and more 'isomorphic' chart types.

--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -497,35 +497,19 @@
     :html {:content [:div content] :attachments nil}
     :svg  (png->rendered-part render-type (js.svg/svg-string->bytes content))))
 
-(defn- asset->data-uri
-  "Convert an asset's bytes to a data: URI string."
-  [^String asset-name ^bytes asset-bytes]
-  (let [content-type (or (custom-viz-plugin/asset-content-type asset-name)
-                         "application/octet-stream")]
-    (str "data:" content-type ";base64,"
-         (.encodeToString (java.util.Base64/getEncoder) asset-bytes))))
-
 (defn- custom-viz-bundles
-  "If the card has a custom:* display type, resolve the plugin's bundle and assets for static rendering.
-   Assets are included as a map of `{name -> data-uri}` so the static viz JS context
-   can resolve `getAssetUrl` calls without HTTP."
+  "If the card has a custom:* display type, resolve the plugin's JS bundle for static rendering."
   [card]
   (when-let [identifier (render.util/custom-viz-identifier (:display card))]
-    (let [{:keys [manifest] :as plugin}
-          ;; do not load the (potentially multi-MB) :bundle blob just to read the manifest;
-          ;; resolve-bundle / resolve-asset re-fetch bytes from the cache as needed.
-          (t2/select-one [:model/CustomVizPlugin :id :identifier :enabled :manifest :bundle_hash :dev_bundle_url]
+    (let [plugin
+          ;; do not load the (potentially multi-MB) :bundle blob just to read the metadata;
+          ;; resolve-bundle re-fetches the bundle bytes from the cache as needed.
+          (t2/select-one [:model/CustomVizPlugin :id :identifier :enabled :bundle_hash :dev_bundle_url]
                          :identifier identifier :enabled true)]
       (when-let [content (some-> plugin
                                  custom-viz-plugin/resolve-bundle
                                  :content)]
-        (let [asset-names (some-> manifest custom-viz-plugin/asset-paths)
-              assets      (into {}
-                                (keep (fn [asset-name]
-                                        (when-let [bytes (custom-viz-plugin/resolve-asset plugin asset-name)]
-                                          [asset-name (asset->data-uri asset-name bytes)])))
-                                asset-names)]
-          [{:identifier identifier :source content :assets assets}])))))
+        [{:identifier identifier :source content}]))))
 
 ;; the `:javascript_visualization` render method
 ;; is and will continue to handle more and more 'isomorphic' chart types.

--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -500,10 +500,13 @@
   "If the card has a custom:* display type, resolve the plugin's JS bundle for static rendering."
   [card]
   (when-let [identifier (render.util/custom-viz-identifier (:display card))]
-    (when-let [content (some-> (custom-viz-plugin/resolve-enabled-plugin identifier)
-                               custom-viz-plugin/resolve-bundle
-                               :content)]
-      [{:identifier identifier :source content}])))
+    (if-let [content (some-> (custom-viz-plugin/resolve-enabled-plugin identifier)
+                             custom-viz-plugin/resolve-bundle
+                             :content)]
+      (do (log/debugf "custom-viz: resolved bundle for plugin %s (%d chars)" identifier (count content))
+          [{:identifier identifier :source content}])
+      (log/warnf "custom-viz: no enabled plugin/bundle found for %s; static render will fall back to table"
+                 identifier))))
 
 ;; the `:javascript_visualization` render method
 ;; is and will continue to handle more and more 'isomorphic' chart types.
@@ -522,7 +525,8 @@
     ;; empty string. Fall back to table rendering.
     (if (and (render.util/custom-viz-display? (:display card))
              (str/blank? content))
-      (render :table render-type timezone-id card dashcard data)
+      (do (log/debugf "custom-viz: plugin %s produced no static output; falling back to table" (:display card))
+          (render :table render-type timezone-id card dashcard data))
       (javascript-visualization->rendered-part render-type result))))
 
 (mu/defmethod render :region_map :- ::RenderedPartCard

--- a/src/metabase/channel/render/card.clj
+++ b/src/metabase/channel/render/card.clj
@@ -152,8 +152,9 @@
               tyype)]
       (cond
         (when-let [identifier (render.util/custom-viz-identifier display-type)]
-          (let [plugin (t2/select-one :model/CustomVizPlugin :identifier identifier :enabled true)]
-            (some-> plugin custom-viz-plugin/resolve-bundle :content)))
+          (some-> (custom-viz-plugin/resolve-enabled-plugin identifier)
+                  custom-viz-plugin/resolve-bundle
+                  :content))
         (chart-type :javascript_visualization "display-type is a custom visualization with static support")
 
         (or (empty? rows)

--- a/src/metabase/channel/render/card.clj
+++ b/src/metabase/channel/render/card.clj
@@ -7,6 +7,7 @@
    [metabase.channel.render.style :as style]
    [metabase.channel.render.util :as render.util]
    [metabase.channel.urls :as urls]
+   [metabase.custom-viz-plugin.core :as custom-viz-plugin]
    [metabase.dashboards.models.dashboard-card :as dashboard-card]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.util :as u]
@@ -150,6 +151,11 @@
                           tyype (pr-str card-name) (apply format reason args))
               tyype)]
       (cond
+        (when-let [identifier (render.util/custom-viz-identifier display-type)]
+          (let [plugin (t2/select-one :model/CustomVizPlugin :identifier identifier :enabled true)]
+            (some-> plugin custom-viz-plugin/resolve-bundle :content)))
+        (chart-type :javascript_visualization "display-type is a custom visualization with static support")
+
         (or (empty? rows)
             ;; Many aggregations result in [[nil]] if there are no rows to aggregate after filters
             (= [[nil]] (-> data :rows)))
@@ -197,6 +203,9 @@
 
         (= :pivot display-type)
         (chart-type :pivot "display-type is pivot")
+
+        (render.util/custom-viz-display? display-type)
+        (chart-type :table "display-type is a custom visualization without static support, falling back to table")
 
         :else
         (chart-type :table "no other chart types match")))))

--- a/src/metabase/channel/render/js/engine.clj
+++ b/src/metabase/channel/render/js/engine.clj
@@ -98,12 +98,22 @@
   "Conservative reserve (bytes) for process memory that is neither the JVM max heap nor the isolate heap:
   metaspace, code cache, thread stacks, direct byte buffers (e.g. Batik image buffers), and the GraalVM
   host-side runtime. Subtracted from the pod memory limit when sizing the isolate so their sum stays under the
-  cgroup ceiling. Deliberately generous — underestimating risks an OOM-kill of the whole pod."
-  (* 512 1024 1024))
+  cgroup ceiling. Kept generous (underestimating risks an OOM-kill of the whole pod) but not so large that a
+  big `-Xmx` starves the isolate below a renderable size — see [[isolate-heap-bytes]]. The remaining slack is
+  covered by [[isolate-memory-safety-margin-ratio]] on top of this."
+  (* 384 1024 1024))
 
 (def ^:private isolate-memory-safety-margin-ratio
   "Fraction of the pod memory limit kept free as headroom, on top of the explicit reserves."
-  0.15)
+  0.12)
+
+(def ^:private isolate-nonheap-reserve-bytes
+  "Headroom (bytes) kept between the per-context `sandbox.MaxHeapMemory` and the engine-wide
+  `engine.MaxIsolateMemory` for the isolate's own non-guest-heap memory (code cache, metadata, GC
+  bookkeeping). GraalVM requires `MaxHeapMemory` strictly below `MaxIsolateMemory`; the untrusted pool holds
+  exactly one context (see `metabase.channel.render.js.svg`), so the single context's guest heap gets the whole
+  isolate minus this reserve — no need to halve the isolate for a second context that never exists."
+  (* 96 1024 1024))
 
 (def ^:private target-max-isolate-memory-bytes
   "Isolate heap cap used when the pod can afford it. The ~16MB static-viz bundle plus a real render peak at
@@ -145,9 +155,10 @@
           iso-bytes    (if pod-limit
                          (isolate-heap-bytes pod-limit jvm-max-heap)
                          target-max-isolate-memory-bytes)
-          ;; per-context heap must be < engine-wide isolate memory; half keeps the invariant and matches the
-          ;; historical 1GB / 512MB pairing.
-          heap-bytes   (quot iso-bytes 2)
+          ;; per-context heap must be < engine-wide isolate memory. The pool holds exactly one context, so give
+          ;; that single context the whole isolate minus a small non-heap reserve rather than halving it (the
+          ;; old iso/2 needlessly capped guest heap at 50% for a second context that never exists).
+          heap-bytes   (- iso-bytes isolate-nonheap-reserve-bytes)
           config       {:max-isolate-memory (bytes->mb-option iso-bytes)
                         :max-heap-memory    (bytes->mb-option heap-bytes)}]
       (when (and pod-limit (<= iso-bytes min-max-isolate-memory-bytes))

--- a/src/metabase/channel/render/js/engine.clj
+++ b/src/metabase/channel/render/js/engine.clj
@@ -9,7 +9,10 @@
   (:require
    [clojure.core.memoize :as memoize]
    [clojure.java.io :as io]
-   [metabase.util.i18n :refer [trs]])
+   [metabase.util.format :as u.format]
+   [metabase.util.i18n :refer [trs]]
+   [metabase.util.log :as log]
+   [metabase.util.memory :as memory])
   (:import
    (java.io OutputStream)
    (org.graalvm.polyglot Context Engine HostAccess SandboxPolicy Source Value)))
@@ -81,15 +84,96 @@
       ([_])
       ([_ _ _]))))
 
+;;; ---- Isolate memory sizing (fail closed below the pod ceiling) ----
+;;;
+;;; The isolate is a separate heap but runs in the *same OS process* as the JVM, so its native memory counts
+;;; against the same pod/container cgroup. If it grows unbounded it pushes process RSS over the cgroup limit and
+;;; the kernel OOM-killer SIGKILLs the whole pod (uncatchable). To avoid that we size the isolate's own hard cap
+;;; (`engine.MaxIsolateMemory`) *below* the pod limit, so a runaway render hits the isolate's limit first and
+;;; throws a catchable `PolyglotException` (which the render path degrades to a placeholder) instead of getting
+;;; the pod killed. The cap is derived at startup from the detected pod limit rather than hard-coded, so it
+;;; self-adapts to the pod size.
+
+(def ^:private isolate-memory-overhead-bytes
+  "Conservative reserve (bytes) for process memory that is neither the JVM max heap nor the isolate heap:
+  metaspace, code cache, thread stacks, direct byte buffers (e.g. Batik image buffers), and the GraalVM
+  host-side runtime. Subtracted from the pod memory limit when sizing the isolate so their sum stays under the
+  cgroup ceiling. Deliberately generous — underestimating risks an OOM-kill of the whole pod."
+  (* 512 1024 1024))
+
+(def ^:private isolate-memory-safety-margin-ratio
+  "Fraction of the pod memory limit kept free as headroom, on top of the explicit reserves."
+  0.15)
+
+(def ^:private target-max-isolate-memory-bytes
+  "Isolate heap cap used when the pod can afford it. The ~16MB static-viz bundle plus a real render peak at
+  <=512MB (measured), so 1GB is comfortably enough; a larger cap would only let a runaway plugin grow bigger
+  before failing closed."
+  (* 1024 1024 1024))
+
+(def ^:private min-max-isolate-memory-bytes
+  "Floor for the derived isolate cap. Below this the bundle + echarts/React runtime can't reliably parse and
+  render. If the computed budget is below this, the pod is too small to render custom-viz safely — we clamp
+  here and warn; the residual OOM-kill risk is then a deployment problem (raise the pod limit / lower -Xmx)."
+  (* 384 1024 1024))
+
+(defn- isolate-heap-bytes
+  "Pure: isolate heap cap (bytes) such that `jvm-max-heap + cap + overhead + margin <= pod-limit`, clamped to
+  [[[min-max-isolate-memory-bytes]], [[target-max-isolate-memory-bytes]]]. A cap at the floor means the pod is
+  too small for a safe budget (caller warns)."
+  ^long [^long pod-limit ^long jvm-max-heap]
+  (let [margin (long (* isolate-memory-safety-margin-ratio pod-limit))
+        budget (- pod-limit jvm-max-heap isolate-memory-overhead-bytes margin)]
+    (-> budget
+        (min target-max-isolate-memory-bytes)
+        (max min-max-isolate-memory-bytes))))
+
+(defn- bytes->mb-option
+  "Format a byte count as an integer-megabyte GraalVM size-option string, e.g. 750780416 -> \"716MB\"."
+  ^String [^long bytes]
+  (str (quot bytes (* 1024 1024)) "MB"))
+
+(defonce ^:private
+  ^{:doc "Isolate memory caps, computed once from the detected pod/container memory limit so the isolate fails
+          closed (catchable) below the cgroup ceiling instead of getting the pod OOM-killed:
+          `{:max-isolate-memory <opt-str> :max-heap-memory <opt-str>}`. `:max-heap-memory` (per-context) is
+          kept strictly below `:max-isolate-memory` (engine-wide), as GraalVM requires."}
+  isolate-memory-config
+  (delay
+    (let [pod-limit    (memory/container-memory-limit)
+          jvm-max-heap (.maxMemory (Runtime/getRuntime))
+          iso-bytes    (if pod-limit
+                         (isolate-heap-bytes pod-limit jvm-max-heap)
+                         target-max-isolate-memory-bytes)
+          ;; per-context heap must be < engine-wide isolate memory; half keeps the invariant and matches the
+          ;; historical 1GB / 512MB pairing.
+          heap-bytes   (quot iso-bytes 2)
+          config       {:max-isolate-memory (bytes->mb-option iso-bytes)
+                        :max-heap-memory    (bytes->mb-option heap-bytes)}]
+      (when (and pod-limit (<= iso-bytes min-max-isolate-memory-bytes))
+        (log/warnf (str "static-viz isolate memory budget is at its floor (%s) for pod limit %s + JVM max heap "
+                        "%s; custom-viz rendering may still pressure the pod. Raise the pod memory limit or "
+                        "lower -Xmx.")
+                   (:max-isolate-memory config)
+                   (u.format/format-bytes pod-limit)
+                   (u.format/format-bytes jvm-max-heap)))
+      (log/infof "static-viz isolate memory: MaxIsolateMemory=%s MaxHeapMemory=%s (pod limit %s, JVM max heap %s)"
+                 (:max-isolate-memory config) (:max-heap-memory config)
+                 (if pod-limit (u.format/format-bytes pod-limit) "unknown")
+                 (u.format/format-bytes jvm-max-heap))
+      config)))
+
 (defn- new-untrusted-plugin-engine
   "Build the isolate `Engine` shared by every untrusted-plugin context. `engine.MaxIsolateMemory` caps the
-  whole isolate heap and must exceed the per-context `sandbox.MaxHeapMemory` set in [[untrusted-plugin-context]]."
+  whole isolate heap and must exceed the per-context `sandbox.MaxHeapMemory` set in [[untrusted-plugin-context]];
+  both are derived from the pod memory limit at startup (see [[isolate-memory-config]]) so the isolate fails
+  closed below the cgroup ceiling instead of OOM-killing the pod."
   ^Engine []
   (.. (Engine/newBuilder (into-array String ["js"]))
       ;; A shared engine and its contexts must declare the same sandbox policy, so the engine sets UNTRUSTED
       ;; too — otherwise creating an UNTRUSTED context on it would fail the engine/context policy-match check.
       (sandbox SandboxPolicy/UNTRUSTED)
-      (option "engine.MaxIsolateMemory" "1GB")
+      (option "engine.MaxIsolateMemory" (:max-isolate-memory @isolate-memory-config))
       (out discarding-output-stream)
       (err discarding-output-stream)
       (build)))
@@ -124,7 +208,9 @@
   host access and no IO, so data must cross the boundary as JSON strings. Requires `js-isolate-community` on
   the classpath. The `sandbox.*` limits below are all mandatory under `UNTRUSTED` — the context fails to build
   if any is unset. `max-cpu-time` is the `sandbox.MaxCPUTime` budget (default [[render-max-cpu-time]] for the
-  dev fresh-context path; the pool passes the larger cumulative [[pool-max-cpu-time]])."
+  dev fresh-context path; the pool passes the larger cumulative [[pool-max-cpu-time]]). `sandbox.MaxHeapMemory`
+  is derived from the pod memory limit at startup (see [[isolate-memory-config]]) so a runaway render fails
+  closed below the cgroup ceiling."
   (^Context [] (untrusted-plugin-context render-max-cpu-time))
   (^Context [^String max-cpu-time]
    (.. (Context/newBuilder (into-array String ["js"]))
@@ -141,7 +227,7 @@
        ;; allowExperimentalOptions left at default false
        ;; MaxCPUTimeCheckInterval left at its ~10ms default — negligible overshoot vs a multi-second budget.
        (option "sandbox.MaxCPUTime" max-cpu-time)
-       (option "sandbox.MaxHeapMemory" "512MB")
+       (option "sandbox.MaxHeapMemory" (:max-heap-memory @isolate-memory-config))
        (option "sandbox.MaxASTDepth" "5000")
        (option "sandbox.MaxThreads" "1")         ; single-threaded isolate; allowCreateThread also defaults to false
        (option "sandbox.MaxOutputStreamSize" "16MB")

--- a/src/metabase/channel/render/js/engine.clj
+++ b/src/metabase/channel/render/js/engine.clj
@@ -87,7 +87,7 @@
   ^Engine []
   (.. (Engine/newBuilder (into-array String ["js"]))
       (sandbox SandboxPolicy/UNTRUSTED)
-      (option "engine.MaxIsolateMemory" "512MB")
+      (option "engine.MaxIsolateMemory" "1GB")
       (out discarding-output-stream)
       (err discarding-output-stream)
       (build)))
@@ -114,7 +114,7 @@
       ;; target-type mappings). /UNTRUSTED is the policy's purpose-built strictest host-access mode.
       (allowHostAccess HostAccess/UNTRUSTED)
       (option "sandbox.MaxCPUTime" "30s")       ; guest CPU budget: cold static-viz bundle load (~4s) + plugin + render; matches the legacy render timeout
-      (option "sandbox.MaxHeapMemory" "256MB")  ; must be < engine.MaxIsolateMemory
+      (option "sandbox.MaxHeapMemory" "512MB")  ; must be < engine.MaxIsolateMemory; EE static-viz bundle + custom-viz render needs the headroom
       (option "sandbox.MaxASTDepth" "5000")     ; large bundles parse deep; 5000 clears React+ECharts
       (option "sandbox.MaxThreads" "1")
       (option "sandbox.MaxOutputStreamSize" "16MB")

--- a/src/metabase/channel/render/js/engine.clj
+++ b/src/metabase/channel/render/js/engine.clj
@@ -102,39 +102,53 @@
   shared-untrusted-plugin-engine
   (delay (new-untrusted-plugin-engine)))
 
+(def render-max-cpu-time
+  "Per-render guest CPU budget for untrusted custom-viz plugin execution. Must cover a *warm* static-viz bundle
+  load (parsed-source cache hit, ~3s) plus the chart + plugin render, with headroom for slow / CPU-throttled
+  hardware (coredev/containers run well under one core). The one-time *cold* parse of the ~16MB static-viz
+  bundle (>10s of guest CPU) is charged to [[warmup-max-cpu-time]] instead, at cache warm-up, so it does not
+  have to fit inside this per-render budget."
+  "30s")
+
+(def warmup-max-cpu-time
+  "One-time budget for the cold parse of the ~16MB static-viz bundle into the isolate at cache warm-up
+  (see `metabase.channel.render.js.svg`). Generous because a cold parse is >10s of guest CPU even on fast
+  hardware and considerably more on a throttled container; it runs once per process, off the render path."
+  "120s")
+
 (defn untrusted-plugin-context
   "Create a `SandboxPolicy/UNTRUSTED` GraalVM isolate `Context` for running untrusted custom-viz plugin JS.
   The guest runs in a separate isolate heap with VM-enforced CPU/heap/AST limits; like [[context]] it has no
   host access and no IO, so data must cross the boundary as JSON strings. Requires `js-isolate-community` on
   the classpath. The `sandbox.*` limits below are all mandatory under `UNTRUSTED` — the context fails to build
-  if any is unset."
-  ^Context []
-  (.. (Context/newBuilder (into-array String ["js"]))
-      (engine @shared-untrusted-plugin-engine)
-      (sandbox SandboxPolicy/UNTRUSTED)
-      ;; HostAccess/UNTRUSTED, not /NONE: the UNTRUSTED policy rejects /NONE (it still permits mutable
-      ;; target-type mappings). /UNTRUSTED is the policy's purpose-built strictest host-access mode.
-      (allowHostAccess HostAccess/UNTRUSTED)
-      ;; allowAllAccess (the master switch that would enable all of the below at once) is false by default; UNTRUSTED forbids true.
-      ;; allowHostClassLookup is false by default under SandboxPolicy/UNTRUSTED.
-      ;; allowIO is disabled by default under SandboxPolicy/UNTRUSTED.
-      ;; allowNativeAccess is false by default under SandboxPolicy/UNTRUSTED.
-      ;; allowEnvironmentAccess is NONE (no host env vars) by default under SandboxPolicy/UNTRUSTED.
-      ;; allowExperimentalOptions left at default false
-      ;; Guest CPU budget covering a bundle load + plugin render: cold first render ~6s (4s cold parse + render),
-      ;; warm renders ~2-3s (parsed-source cache). 10s leaves headroom for slower hardware while stopping a
-      ;; misbehaving plugin from monopolizing a render thread. MaxCPUTimeCheckInterval left at its ~10ms default.
-      (option "sandbox.MaxCPUTime" "10s")
-      (option "sandbox.MaxHeapMemory" "512MB")
-      (option "sandbox.MaxASTDepth" "5000")
-      (option "sandbox.MaxThreads" "1")         ; single-threaded isolate; allowCreateThread also defaults to false
-      (option "sandbox.MaxOutputStreamSize" "16MB")
-      (option "sandbox.MaxErrorStreamSize" "4MB")
-      ;; sandbox.MaxStatements skipped (and thus its MaxStatementsIncludeInternal modifier): fragile to tune and the compute axis is already covered by MaxCPUTime et al.
-      ;; sandbox.MaxStackFrames skipped too: runtime-recursion blowup surfaces as a contained guest error in the isolate.
-      (out discarding-output-stream)
-      (err discarding-output-stream)
-      (build)))
+  if any is unset. `max-cpu-time` is the `sandbox.MaxCPUTime` budget (default [[render-max-cpu-time]]); the
+  warm-up path passes [[warmup-max-cpu-time]] for the one-time cold bundle parse."
+  (^Context [] (untrusted-plugin-context render-max-cpu-time))
+  (^Context [^String max-cpu-time]
+   (.. (Context/newBuilder (into-array String ["js"]))
+       (engine @shared-untrusted-plugin-engine)
+       (sandbox SandboxPolicy/UNTRUSTED)
+       ;; HostAccess/UNTRUSTED, not /NONE: the UNTRUSTED policy rejects /NONE (it still permits mutable
+       ;; target-type mappings). /UNTRUSTED is the policy's purpose-built strictest host-access mode.
+       (allowHostAccess HostAccess/UNTRUSTED)
+       ;; allowAllAccess (the master switch that would enable all of the below at once) is false by default; UNTRUSTED forbids true.
+       ;; allowHostClassLookup is false by default under SandboxPolicy/UNTRUSTED.
+       ;; allowIO is disabled by default under SandboxPolicy/UNTRUSTED.
+       ;; allowNativeAccess is false by default under SandboxPolicy/UNTRUSTED.
+       ;; allowEnvironmentAccess is NONE (no host env vars) by default under SandboxPolicy/UNTRUSTED.
+       ;; allowExperimentalOptions left at default false
+       ;; MaxCPUTimeCheckInterval left at its ~10ms default — negligible overshoot vs a multi-second budget.
+       (option "sandbox.MaxCPUTime" max-cpu-time)
+       (option "sandbox.MaxHeapMemory" "512MB")
+       (option "sandbox.MaxASTDepth" "5000")
+       (option "sandbox.MaxThreads" "1")         ; single-threaded isolate; allowCreateThread also defaults to false
+       (option "sandbox.MaxOutputStreamSize" "16MB")
+       (option "sandbox.MaxErrorStreamSize" "4MB")
+       ;; sandbox.MaxStatements skipped (and thus its MaxStatementsIncludeInternal modifier): fragile to tune and the compute axis is already covered by MaxCPUTime et al.
+       ;; sandbox.MaxStackFrames skipped too: runtime-recursion blowup surfaces as a contained guest error in the isolate.
+       (out discarding-output-stream)
+       (err discarding-output-stream)
+       (build))))
 
 (defn load-js-string
   "Load a string literal source into the js context."
@@ -155,7 +169,7 @@
     ;; (running from source), so the failure only shows up when deployed. A literal Source carries only content
     ;; + name, so it marshals identically whether the resource lives on disk or inside the jar. `source` is kept
     ;; as the source name so stack traces still point at the right file.
-    (.eval context (.buildLiteral (Source/newBuilder "js" (slurp resource :encoding "UTF-8") source)))))
+    (.eval context (.buildLiteral (Source/newBuilder "js" ^String (slurp resource :encoding "UTF-8") ^String source)))))
 
 (defn execute-fn-name
   "Executes `js-fn-name` in js context with args"

--- a/src/metabase/channel/render/js/engine.clj
+++ b/src/metabase/channel/render/js/engine.clj
@@ -103,26 +103,28 @@
   (delay (new-untrusted-plugin-engine)))
 
 (def render-max-cpu-time
-  "Per-render guest CPU budget for untrusted custom-viz plugin execution. Must cover a *warm* static-viz bundle
-  load (parsed-source cache hit, ~3s) plus the chart + plugin render, with headroom for slow / CPU-throttled
-  hardware (coredev/containers run well under one core). The one-time *cold* parse of the ~16MB static-viz
-  bundle (>10s of guest CPU) is charged to [[warmup-max-cpu-time]] instead, at cache warm-up, so it does not
-  have to fit inside this per-render budget."
+  "`sandbox.MaxCPUTime` for a *non-pooled* untrusted context (the dev fresh-context path). Covers a cold parse
+  of the static-viz bundle plus a single render on dev hardware. Prod uses a pooled context with the larger,
+  cumulative [[pool-max-cpu-time]] instead — see `metabase.channel.render.js.svg`."
   "30s")
 
-(def warmup-max-cpu-time
-  "One-time budget for the cold parse of the ~16MB static-viz bundle into the isolate at cache warm-up
-  (see `metabase.channel.render.js.svg`). Generous because a cold parse is >10s of guest CPU even on fast
-  hardware and considerably more on a throttled container; it runs once per process, off the render path."
-  "120s")
+(def pool-max-cpu-time
+  "`sandbox.MaxCPUTime` for a *pooled*, long-lived untrusted context (the prod path). MaxCPUTime is a
+  *cumulative* per-context lifetime budget, not per-render: it must cover the one-time cold parse of the ~16MB
+  bundle at pool generation (>10s of guest CPU) plus the many renders the context then serves before the pool
+  recycles it. When exceeded the context is cancelled — the pool disposes and regenerates it. Sized generously
+  so, under normal load, the 10-minute pool expiry recycles a context before this cumulative cap does; it still
+  bounds a runaway plugin (to this many seconds of accumulated CPU) without a per-render cap. Trade-off of
+  pooling for speed: there is no tight per-render CPU bound, only this coarse cumulative one plus MaxHeapMemory."
+  "180s")
 
 (defn untrusted-plugin-context
   "Create a `SandboxPolicy/UNTRUSTED` GraalVM isolate `Context` for running untrusted custom-viz plugin JS.
   The guest runs in a separate isolate heap with VM-enforced CPU/heap/AST limits; like [[context]] it has no
   host access and no IO, so data must cross the boundary as JSON strings. Requires `js-isolate-community` on
   the classpath. The `sandbox.*` limits below are all mandatory under `UNTRUSTED` — the context fails to build
-  if any is unset. `max-cpu-time` is the `sandbox.MaxCPUTime` budget (default [[render-max-cpu-time]]); the
-  warm-up path passes [[warmup-max-cpu-time]] for the one-time cold bundle parse."
+  if any is unset. `max-cpu-time` is the `sandbox.MaxCPUTime` budget (default [[render-max-cpu-time]] for the
+  dev fresh-context path; the pool passes the larger cumulative [[pool-max-cpu-time]])."
   (^Context [] (untrusted-plugin-context render-max-cpu-time))
   (^Context [^String max-cpu-time]
    (.. (Context/newBuilder (into-array String ["js"]))

--- a/src/metabase/channel/render/js/engine.clj
+++ b/src/metabase/channel/render/js/engine.clj
@@ -121,7 +121,10 @@
       ;; allowNativeAccess is false by default under SandboxPolicy/UNTRUSTED.
       ;; allowEnvironmentAccess is NONE (no host env vars) by default under SandboxPolicy/UNTRUSTED.
       ;; allowExperimentalOptions left at default false
-      (option "sandbox.MaxCPUTime" "30s")       ; MaxCPUTimeCheckInterval left at its ~10ms default — negligible overshoot vs a 30s budget
+      ;; Guest CPU budget covering a bundle load + plugin render: cold first render ~6s (4s cold parse + render),
+      ;; warm renders ~2-3s (parsed-source cache). 10s leaves headroom for slower hardware while stopping a
+      ;; misbehaving plugin from monopolizing a render thread. MaxCPUTimeCheckInterval left at its ~10ms default.
+      (option "sandbox.MaxCPUTime" "10s")
       (option "sandbox.MaxHeapMemory" "512MB")
       (option "sandbox.MaxASTDepth" "5000")
       (option "sandbox.MaxThreads" "1")         ; single-threaded isolate; allowCreateThread also defaults to false

--- a/src/metabase/channel/render/js/engine.clj
+++ b/src/metabase/channel/render/js/engine.clj
@@ -148,7 +148,14 @@
     (when (nil? resource)
       (throw (ex-info (trs "Javascript resource not found: {0}" source)
                       {:source source})))
-    (.eval context (.build (Source/newBuilder "js" resource)))))
+    ;; Build a *literal* Source from the resource content rather than a URL-backed Source. A URL-backed
+    ;; Source fails to marshal across the `SandboxPolicy/UNTRUSTED` native-isolate boundary
+    ;; ([[untrusted-plugin-context]]) — GraalVM's SourceCopyMarshaller throws `ShouldNotReachHere` — when the
+    ;; resource is a `jar:` URL (i.e. running from the packaged uberjar). It happens to work from a `file:` URL
+    ;; (running from source), so the failure only shows up when deployed. A literal Source carries only content
+    ;; + name, so it marshals identically whether the resource lives on disk or inside the jar. `source` is kept
+    ;; as the source name so stack traces still point at the right file.
+    (.eval context (.buildLiteral (Source/newBuilder "js" (slurp resource :encoding "UTF-8") source)))))
 
 (defn execute-fn-name
   "Executes `js-fn-name` in js context with args"

--- a/src/metabase/channel/render/js/engine.clj
+++ b/src/metabase/channel/render/js/engine.clj
@@ -86,7 +86,9 @@
   whole isolate heap and must exceed the per-context `sandbox.MaxHeapMemory` set in [[untrusted-plugin-context]]."
   ^Engine []
   (.. (Engine/newBuilder (into-array String ["js"]))
-      (sandbox SandboxPolicy/UNTRUSTED) ;; host access policy suitable for a context with UNTRUSTED sandbox policy.
+      ;; A shared engine and its contexts must declare the same sandbox policy, so the engine sets UNTRUSTED
+      ;; too — otherwise creating an UNTRUSTED context on it would fail the engine/context policy-match check.
+      (sandbox SandboxPolicy/UNTRUSTED)
       (option "engine.MaxIsolateMemory" "1GB")
       (out discarding-output-stream)
       (err discarding-output-stream)
@@ -119,12 +121,14 @@
       ;; allowNativeAccess is false by default under SandboxPolicy/UNTRUSTED.
       ;; allowEnvironmentAccess is NONE (no host env vars) by default under SandboxPolicy/UNTRUSTED.
       ;; allowExperimentalOptions left at default false
-      (option "sandbox.MaxCPUTime" "30s")       ; guest CPU budget: cold static-viz bundle load (~4s) + plugin + render; matches the legacy render timeout
-      (option "sandbox.MaxHeapMemory" "512MB")  ; must be < engine.MaxIsolateMemory; EE static-viz bundle + custom-viz render needs the headroom
-      (option "sandbox.MaxASTDepth" "5000")     ; large bundles parse deep; 5000 clears React+ECharts
+      (option "sandbox.MaxCPUTime" "30s")       ; MaxCPUTimeCheckInterval left at its ~10ms default — negligible overshoot vs a 30s budget
+      (option "sandbox.MaxHeapMemory" "512MB")
+      (option "sandbox.MaxASTDepth" "5000")
       (option "sandbox.MaxThreads" "1")         ; single-threaded isolate; allowCreateThread also defaults to false
       (option "sandbox.MaxOutputStreamSize" "16MB")
       (option "sandbox.MaxErrorStreamSize" "4MB")
+      ;; sandbox.MaxStatements skipped (and thus its MaxStatementsIncludeInternal modifier): fragile to tune and the compute axis is already covered by MaxCPUTime et al.
+      ;; sandbox.MaxStackFrames skipped too: runtime-recursion blowup surfaces as a contained guest error in the isolate.
       (out discarding-output-stream)
       (err discarding-output-stream)
       (build)))

--- a/src/metabase/channel/render/js/engine.clj
+++ b/src/metabase/channel/render/js/engine.clj
@@ -11,7 +11,8 @@
    [clojure.java.io :as io]
    [metabase.util.i18n :refer [trs]])
   (:import
-   (org.graalvm.polyglot Context Engine HostAccess Source Value)))
+   (java.io OutputStream)
+   (org.graalvm.polyglot Context Engine HostAccess SandboxPolicy Source Value)))
 
 (set! *warn-on-reflection* true)
 
@@ -61,6 +62,65 @@
       (out System/out)
       (err System/err)
       (allowIO false)
+      (build)))
+
+;;; ---------------------------------------- Untrusted plugin sandbox ----------------------------------------
+;;;
+;;; Stronger sandbox for running *untrusted* custom-viz plugin JS (third-party bundles). Unlike [[context]],
+;;; which relies on `HostAccess/NONE` + config flags in the host JVM, this runs the guest inside a GraalVM
+;;; native-image isolate (separate VM, separate heap) under `SandboxPolicy/UNTRUSTED`, so CPU/heap limits and
+;;; speculative-execution mitigations are enforced by the VM. Requires the `js-isolate-community` artifact on
+;;; the classpath. Built-in static-viz keeps the faster in-process [[context]] path; only plugins pay for the
+;;; isolate.
+
+(def ^:private ^OutputStream discarding-output-stream
+  "Sink for untrusted-guest stdout/stderr — plugin console output is neither trusted nor useful in server
+  logs, and `SandboxPolicy/UNTRUSTED` bounds it via `sandbox.Max*StreamSize` regardless."
+  (proxy [OutputStream] []
+    (write
+      ([_])
+      ([_ _ _]))))
+
+(defn- new-untrusted-plugin-engine
+  "Build the isolate `Engine` shared by every untrusted-plugin context. `engine.MaxIsolateMemory` caps the
+  whole isolate heap and must exceed the per-context `sandbox.MaxHeapMemory` set in [[untrusted-plugin-context]]."
+  ^Engine []
+  (.. (Engine/newBuilder (into-array String ["js"]))
+      (sandbox SandboxPolicy/UNTRUSTED)
+      (option "engine.MaxIsolateMemory" "512MB")
+      (out discarding-output-stream)
+      (err discarding-output-stream)
+      (build)))
+
+(defonce ^:private
+  ^{:doc "GraalVM isolate `Engine` shared by every untrusted custom-viz plugin context. Contexts on a shared
+          engine still get isolated global scopes (one plugin can't see another's globals), while sharing the
+          isolate's Truffle runtime + parsed-source cache. Process-lifetime singleton (intentionally never
+          closed)."}
+  shared-untrusted-plugin-engine
+  (delay (new-untrusted-plugin-engine)))
+
+(defn untrusted-plugin-context
+  "Create a `SandboxPolicy/UNTRUSTED` GraalVM isolate `Context` for running untrusted custom-viz plugin JS.
+  The guest runs in a separate isolate heap with VM-enforced CPU/heap/AST limits; like [[context]] it has no
+  host access and no IO, so data must cross the boundary as JSON strings. Requires `js-isolate-community` on
+  the classpath. The `sandbox.*` limits below are all mandatory under `UNTRUSTED` — the context fails to build
+  if any is unset."
+  ^Context []
+  (.. (Context/newBuilder (into-array String ["js"]))
+      (engine @shared-untrusted-plugin-engine)
+      (sandbox SandboxPolicy/UNTRUSTED)
+      ;; HostAccess/UNTRUSTED, not /NONE: the UNTRUSTED policy rejects /NONE (it still permits mutable
+      ;; target-type mappings). /UNTRUSTED is the policy's purpose-built strictest host-access mode.
+      (allowHostAccess HostAccess/UNTRUSTED)
+      (option "sandbox.MaxCPUTime" "10s")       ; wall of guest CPU per render
+      (option "sandbox.MaxHeapMemory" "256MB")  ; must be < engine.MaxIsolateMemory
+      (option "sandbox.MaxASTDepth" "5000")     ; large bundles parse deep; 5000 clears React+ECharts
+      (option "sandbox.MaxThreads" "1")
+      (option "sandbox.MaxOutputStreamSize" "16MB")
+      (option "sandbox.MaxErrorStreamSize" "4MB")
+      (out discarding-output-stream)
+      (err discarding-output-stream)
       (build)))
 
 (defn load-js-string

--- a/src/metabase/channel/render/js/engine.clj
+++ b/src/metabase/channel/render/js/engine.clj
@@ -113,7 +113,7 @@
       ;; HostAccess/UNTRUSTED, not /NONE: the UNTRUSTED policy rejects /NONE (it still permits mutable
       ;; target-type mappings). /UNTRUSTED is the policy's purpose-built strictest host-access mode.
       (allowHostAccess HostAccess/UNTRUSTED)
-      (option "sandbox.MaxCPUTime" "10s")       ; wall of guest CPU per render
+      (option "sandbox.MaxCPUTime" "30s")       ; guest CPU budget: cold static-viz bundle load (~4s) + plugin + render; matches the legacy render timeout
       (option "sandbox.MaxHeapMemory" "256MB")  ; must be < engine.MaxIsolateMemory
       (option "sandbox.MaxASTDepth" "5000")     ; large bundles parse deep; 5000 clears React+ECharts
       (option "sandbox.MaxThreads" "1")

--- a/src/metabase/channel/render/js/engine.clj
+++ b/src/metabase/channel/render/js/engine.clj
@@ -86,7 +86,7 @@
   whole isolate heap and must exceed the per-context `sandbox.MaxHeapMemory` set in [[untrusted-plugin-context]]."
   ^Engine []
   (.. (Engine/newBuilder (into-array String ["js"]))
-      (sandbox SandboxPolicy/UNTRUSTED)
+      (sandbox SandboxPolicy/UNTRUSTED) ;; host access policy suitable for a context with UNTRUSTED sandbox policy.
       (option "engine.MaxIsolateMemory" "1GB")
       (out discarding-output-stream)
       (err discarding-output-stream)
@@ -113,10 +113,16 @@
       ;; HostAccess/UNTRUSTED, not /NONE: the UNTRUSTED policy rejects /NONE (it still permits mutable
       ;; target-type mappings). /UNTRUSTED is the policy's purpose-built strictest host-access mode.
       (allowHostAccess HostAccess/UNTRUSTED)
+      ;; allowAllAccess (the master switch that would enable all of the below at once) is false by default; UNTRUSTED forbids true.
+      ;; allowHostClassLookup is false by default under SandboxPolicy/UNTRUSTED.
+      ;; allowIO is disabled by default under SandboxPolicy/UNTRUSTED.
+      ;; allowNativeAccess is false by default under SandboxPolicy/UNTRUSTED.
+      ;; allowEnvironmentAccess is NONE (no host env vars) by default under SandboxPolicy/UNTRUSTED.
+      ;; allowExperimentalOptions left at default false
       (option "sandbox.MaxCPUTime" "30s")       ; guest CPU budget: cold static-viz bundle load (~4s) + plugin + render; matches the legacy render timeout
       (option "sandbox.MaxHeapMemory" "512MB")  ; must be < engine.MaxIsolateMemory; EE static-viz bundle + custom-viz render needs the headroom
       (option "sandbox.MaxASTDepth" "5000")     ; large bundles parse deep; 5000 clears React+ECharts
-      (option "sandbox.MaxThreads" "1")
+      (option "sandbox.MaxThreads" "1")         ; single-threaded isolate; allowCreateThread also defaults to false
       (option "sandbox.MaxOutputStreamSize" "16MB")
       (option "sandbox.MaxErrorStreamSize" "4MB")
       (out discarding-output-stream)

--- a/src/metabase/channel/render/js/svg.clj
+++ b/src/metabase/channel/render/js/svg.clj
@@ -28,25 +28,40 @@
 
 (set! *warn-on-reflection* true)
 
-;; the bundle path goes through webpack. Changes require a `bun run build-static-viz`
+;; the bundle paths go through webpack. Changes require a `bun run build-static-viz`
 (def ^:private bundle-path
   "frontend_client/app/dist/lib-static-viz.bundle.js")
+
+;; slim custom-viz-only bundle for the untrusted plugin isolate: the same render interface, but without the
+;; built-in chart implementations (ECharts/visx), which that isolate never renders. Cuts the isolate's
+;; cold-parse time and heap pressure. Built alongside [[bundle-path]] by `bun run build-static-viz`.
+(def ^:private custom-viz-bundle-path
+  "frontend_client/app/dist/lib-static-viz-custom.bundle.js")
 
 ;; the interface file does not go through webpack. Feel free to quickly change as needed and then re-require this
 ;; namespace to redef the `context`.
 (def ^:private interface-path
   "frontend_shared/static_viz_interface.js")
 
-(defn- load-viz-bundle [^Context context]
-  ;; make sure people don't try to load the static viz bundle as a side-effect of loading namespaces, because it might
-  ;; not have been built! If it's not built, we want to be able to give people a meaningful error (see the fixture
-  ;; in [[metabase.channel.render.js.svg-test]]) rather than have the test runner fail to start with a meaningless
-  ;; compilation error.
-  (when config/tests-available?
-    ((requiring-resolve 'mb.hawk.init/assert-tests-are-not-initializing) "(mt/id ...) or (data/id ...)"))
-  (doto context
-    (js.engine/load-resource bundle-path)
-    (js.engine/load-resource interface-path)))
+(defn- load-viz-bundle
+  ([^Context context]
+   (load-viz-bundle context bundle-path))
+  ([^Context context ^String viz-bundle-path]
+   ;; make sure people don't try to load the static viz bundle as a side-effect of loading namespaces, because it might
+   ;; not have been built! If it's not built, we want to be able to give people a meaningful error (see the fixture
+   ;; in [[metabase.channel.render.js.svg-test]]) rather than have the test runner fail to start with a meaningless
+   ;; compilation error.
+   (when config/tests-available?
+     ((requiring-resolve 'mb.hawk.init/assert-tests-are-not-initializing) "(mt/id ...) or (data/id ...)"))
+   (doto context
+     (js.engine/load-resource viz-bundle-path)
+     (js.engine/load-resource interface-path))))
+
+(defn- load-custom-viz-bundle
+  "Load the slim custom-viz-only static-viz bundle (plus the interface file) into `context`. Only the untrusted
+  isolate path uses this; the trusted in-process pool loads the full bundle."
+  [^Context context]
+  (load-viz-bundle context custom-viz-bundle-path))
 
 (def ^:private ^Pool static-viz-context-pool
   "Pool of Truffle JS engine objects. They are not thread-safe, so the access to them has to be carefully managed
@@ -114,9 +129,12 @@
 
 (def ^:private ^Pool untrusted-static-viz-context-pool
   "Pool of `SandboxPolicy/UNTRUSTED` isolate contexts for rendering untrusted custom-viz plugin JS. Mirrors
-  [[static-viz-context-pool]] but for the isolate path. Pooling is the whole point: the ~16MB static-viz bundle
-  is parsed *once* per pooled context (a >10s cold parse, far worse on CPU-throttled hardware) and reused across
-  renders, instead of the old unpooled path that re-parsed on every render (the 55s pulse-test regression).
+  [[static-viz-context-pool]] but for the isolate path, and loads the slim custom-viz-only bundle
+  ([[custom-viz-bundle-path]]) instead of the full one — this pool only ever renders `custom:` cards, so the
+  built-in chart stack would be pure parse-time/heap dead weight. Pooling is still the point: the bundle is
+  parsed *once* per pooled context (a multi-second cold parse, far worse on CPU-throttled hardware) and reused
+  across renders, instead of the old unpooled path that re-parsed on every render (the 55s pulse-test
+  regression).
 
   Capped at 1 context: each holds the bundle plus up to a 512MB isolate heap, and native isolate memory is what
   previously OOM-killed the server, so we keep exactly one and let `execute-fn-name`'s per-context lock serialize
@@ -130,11 +148,11 @@
   (let [base-controller (Pools/utilizationController 1.0 1 1)]
     (Pool. (reify IPool$Generator
              (generate [_ _]
-               ;; Cold-parses the ~16MB static-viz bundle into a fresh isolate; logged with timing because this
+               ;; Cold-parses the slim custom-viz bundle into a fresh isolate; logged with timing because this
                ;; is the dominant per-context cost and explains slow first/regenerated renders.
                (let [start (System/nanoTime)
-                     ctx   (load-viz-bundle (js.engine/untrusted-plugin-context js.engine/pool-max-cpu-time))]
-                 (log/infof "custom-viz: generated untrusted static-viz isolate context (cold-parsed bundle) in %.0fms"
+                     ctx   (load-custom-viz-bundle (js.engine/untrusted-plugin-context js.engine/pool-max-cpu-time))]
+                 (log/infof "custom-viz: generated untrusted static-viz isolate context (cold-parsed slim bundle) in %.0fms"
                             (/ (- (System/nanoTime) start) 1e6))
                  [ctx (+ (System/nanoTime) (.toNanos TimeUnit/MINUTES 10))]))
              (destroy [_ _ [^Context ctx _expiry]]
@@ -158,12 +176,12 @@
 
 (defn do-with-untrusted-static-viz-context
   "Impl for [[with-untrusted-static-viz-context]]. Acquires a pooled `SandboxPolicy/UNTRUSTED` isolate context
-  ([[untrusted-static-viz-context-pool]]) with the static-viz bundle already loaded, runs `f`, then releases it
+  ([[untrusted-static-viz-context-pool]]) with the slim custom-viz bundle already loaded, runs `f`, then releases it
   back to the pool. In dev, uses a fresh context each time (mirrors [[do-with-static-viz-context]]). A context
   cancelled by exhausting its cumulative `sandbox.MaxCPUTime` is disposed (not released) so the pool regenerates."
   [f]
   (if config/is-dev?
-    (let [^Context context (load-viz-bundle (js.engine/untrusted-plugin-context))]
+    (let [^Context context (load-custom-viz-bundle (js.engine/untrusted-plugin-context))]
       (try
         (f context)
         (finally

--- a/src/metabase/channel/render/js/svg.clj
+++ b/src/metabase/channel/render/js/svg.clj
@@ -61,12 +61,18 @@
   (let [base-controller (Pools/utilizationController 1.0 3 3)]
     (Pool. (reify IPool$Generator
              (generate [_ _]
-               ;; Generate a tuple of the context and the expiry timestamp.
-               [(load-viz-bundle (js.engine/context))
-                (+ (System/nanoTime) (.toNanos TimeUnit/MINUTES 10))])
+               ;; Generate a tuple of the context and the expiry timestamp. Timing logged so the in-process
+               ;; bundle load is directly comparable to the isolate's (see untrusted-static-viz-context-pool):
+               ;; the same ~16MB bundle, but no native-isolate Source marshalling, so this is much faster.
+               (let [start (System/nanoTime)
+                     ctx   (load-viz-bundle (js.engine/context))]
+                 (log/infof "static-viz: generated in-process context (loaded bundle) in %.0fms"
+                            (/ (- (System/nanoTime) start) 1e6))
+                 [ctx (+ (System/nanoTime) (.toNanos TimeUnit/MINUTES 10))]))
              (destroy [_ _ [^Context ctx _expiry]]
                ;; Close the context when it's disposed from the pool (expiry/shutdown). Without this, each disposed
                ;; static-viz context (~130 MB) leaks its native memory: GraalVM only releases it on `close`, not on GC.
+               (log/debug "static-viz: disposing in-process context")
                (try
                  (.close ctx true) ;; force close - can't wait for running code
                  (catch Exception _))))
@@ -438,9 +444,11 @@
                                                                          (json/encode cards-with-data)
                                                                          (json/encode dashcard-viz-settings)
                                                                          options))]
-                        (when custom-viz?
-                          (log/debugf "custom-viz: executed javascript_visualization for %s in %.0fms (output %d chars)"
-                                      ids (/ (- (System/nanoTime) start) 1e6) (count result)))
+                        ;; Logged for both paths so isolate vs in-process execute time is directly comparable.
+                        (log/debugf "%s: executed javascript_visualization%s in %.0fms (output %d chars)"
+                                    (if custom-viz? "custom-viz" "static-viz")
+                                    (if custom-viz? (str " for " ids) "")
+                                    (/ (- (System/nanoTime) start) 1e6) (count result))
                         result))
         response    (if custom-viz?
                       (let [start (System/nanoTime)]

--- a/src/metabase/channel/render/js/svg.clj
+++ b/src/metabase/channel/render/js/svg.clj
@@ -106,12 +106,11 @@
   `(do-with-static-viz-context (fn [~binding-name] ~@body)))
 
 (defn do-with-untrusted-static-viz-context
-  "Impl for [[with-untrusted-static-viz-context]]. Renders untrusted custom-viz plugin code in a fresh
-  `SandboxPolicy/UNTRUSTED` GraalVM isolate context (see [[js.engine/untrusted-plugin-context]]) with the
-  static-viz bundle loaded, then disposes it. Unlike [[do-with-static-viz-context]] this is NOT pooled:
-  each render gets a clean, fully-isolated context, so no context tainting is needed, and the isolate's
-  VM-enforced CPU/heap limits replace the old manual render timeout. The shared isolate engine's parsed-source
-  cache keeps re-loading the bundle cheap across renders."
+  "Impl for [[with-untrusted-static-viz-context]]. Loads the static-viz bundle into a fresh
+  `SandboxPolicy/UNTRUSTED` isolate context ([[js.engine/untrusted-plugin-context]]), runs `f`, then disposes it.
+  Unpooled unlike [[do-with-static-viz-context]] — each render gets a clean context (no tainting), and the
+  isolate's VM-enforced CPU/heap limits replace the old manual render timeout; the shared engine's parsed-source
+  cache keeps bundle reloads cheap."
   [f]
   (let [^Context context (load-viz-bundle (js.engine/untrusted-plugin-context))]
     (try

--- a/src/metabase/channel/render/js/svg.clj
+++ b/src/metabase/channel/render/js/svg.clj
@@ -13,8 +13,7 @@
    [metabase.lib-be.core :as lib-be]
    [metabase.premium-features.core :as premium-features]
    [metabase.util :as u]
-   [metabase.util.json :as json]
-   [metabase.util.log :as log])
+   [metabase.util.json :as json])
   (:import
    (io.aleph.dirigiste IPool$Controller IPool$Generator Pool Pools Stats)
    (java.io ByteArrayInputStream ByteArrayOutputStream)
@@ -23,7 +22,7 @@
    (org.apache.batik.anim.dom SAXSVGDocumentFactory SVGOMDocument)
    (org.apache.batik.transcoder TranscoderInput TranscoderOutput)
    (org.apache.batik.transcoder.image PNGTranscoder)
-   (org.graalvm.polyglot Context)
+   (org.graalvm.polyglot Context PolyglotException)
    (org.w3c.dom Element Node)))
 
 (set! *warn-on-reflection* true)
@@ -106,39 +105,74 @@
   [binding-name & body]
   `(do-with-static-viz-context (fn [~binding-name] ~@body)))
 
-(defn- warm-untrusted-source-cache!
-  "Parse the static-viz bundle + interface once into an isolate context with a generous CPU budget
-  ([[js.engine/warmup-max-cpu-time]]), populating the shared engine's parsed-source cache, then dispose the
-  context. The parsed-source cache lives on the shared engine and survives context disposal, so subsequent
-  per-render contexts get a cache-hit parse (~3s) that fits the tight per-render budget instead of paying the
-  >10s cold parse of the ~16MB bundle on every render. Best-effort: warm-up failures are logged and swallowed
-  so rendering still proceeds (parsing cold on the raised per-render budget)."
-  []
-  (try
-    (let [^Context context (load-viz-bundle (js.engine/untrusted-plugin-context js.engine/warmup-max-cpu-time))]
-      (try (.close context true) (catch Throwable _)))
-    (catch Throwable e
-      (log/warn e "Failed to warm untrusted static-viz source cache; custom-viz renders will parse the bundle cold"))))
+(def ^:private ^Pool untrusted-static-viz-context-pool
+  "Pool of `SandboxPolicy/UNTRUSTED` isolate contexts for rendering untrusted custom-viz plugin JS. Mirrors
+  [[static-viz-context-pool]] but for the isolate path. Pooling is the whole point: the ~16MB static-viz bundle
+  is parsed *once* per pooled context (a >10s cold parse, far worse on CPU-throttled hardware) and reused across
+  renders, instead of the old unpooled path that re-parsed on every render (the 55s pulse-test regression).
 
-(defonce ^:private untrusted-source-cache-warmed
-  ;; Realized lazily on the first custom-viz render (not at ns-load) so tests and servers that never render
-  ;; custom viz don't pay the cost, and the `load-viz-bundle` bundle-built guard still fires under test init.
-  (delay (warm-untrusted-source-cache!)))
+  Capped at 1 context: each holds the bundle plus up to a 512MB isolate heap, and native isolate memory is what
+  previously OOM-killed the server, so we keep exactly one and let `execute-fn-name`'s per-context lock serialize
+  renders. Contexts expire after 10 minutes (Truffle can leak) and are recycled; a context whose cumulative
+  `sandbox.MaxCPUTime` ([[js.engine/pool-max-cpu-time]]) is exhausted is cancelled and disposed by
+  [[do-with-untrusted-static-viz-context]] so the pool regenerates a fresh one.
+
+  Trade-off vs. the previous fresh-context-per-render design: reused contexts share JS global state across
+  renders (acceptable — the isolate still fully contains plugins from the host), and there is no tight per-render
+  CPU bound (only the coarse cumulative one)."
+  (let [base-controller (Pools/utilizationController 1.0 1 1)]
+    (Pool. (reify IPool$Generator
+             (generate [_ _]
+               [(load-viz-bundle (js.engine/untrusted-plugin-context js.engine/pool-max-cpu-time))
+                (+ (System/nanoTime) (.toNanos TimeUnit/MINUTES 10))])
+             (destroy [_ _ [^Context ctx _expiry]]
+               (try
+                 (.close ctx true) ;; force close - can't wait for running code
+                 (catch Exception _))))
+           (reify IPool$Controller
+             (shouldIncrement [_ k a b] (.shouldIncrement base-controller k a b))
+             (adjustment [_ stats]
+               (let [adj         (.adjustment base-controller stats)
+                     n           (some-> ^Stats (:engines stats) .getNumWorkers)
+                     engines-adj (:engines adj)]
+                 (if (and n engines-adj (<= (+ n engines-adj) 0))
+                   {}
+                   adj))))
+           65000
+           25
+           10000
+           TimeUnit/MILLISECONDS)))
 
 (defn do-with-untrusted-static-viz-context
-  "Impl for [[with-untrusted-static-viz-context]]. Loads the static-viz bundle into a fresh
-  `SandboxPolicy/UNTRUSTED` isolate context ([[js.engine/untrusted-plugin-context]]), runs `f`, then disposes it.
-  Unpooled unlike [[do-with-static-viz-context]] — each render gets a clean context (no tainting), and the
-  isolate's VM-enforced CPU/heap limits replace the old manual render timeout. The one-time cold parse of the
-  ~16MB bundle is warmed off the render path (see [[warm-untrusted-source-cache!]]) so the shared engine's
-  parsed-source cache keeps per-render bundle reloads cheap."
+  "Impl for [[with-untrusted-static-viz-context]]. Acquires a pooled `SandboxPolicy/UNTRUSTED` isolate context
+  ([[untrusted-static-viz-context-pool]]) with the static-viz bundle already loaded, runs `f`, then releases it
+  back to the pool. In dev, uses a fresh context each time (mirrors [[do-with-static-viz-context]]). A context
+  cancelled by exhausting its cumulative `sandbox.MaxCPUTime` is disposed (not released) so the pool regenerates."
   [f]
-  @untrusted-source-cache-warmed
-  (let [^Context context (load-viz-bundle (js.engine/untrusted-plugin-context))]
-    (try
-      (f context)
-      (finally
-        (try (.close context true) (catch Throwable _))))))
+  (if config/is-dev?
+    (let [^Context context (load-viz-bundle (js.engine/untrusted-plugin-context))]
+      (try
+        (f context)
+        (finally
+          (try (.close context true) (catch Throwable _)))))
+    (loop []
+      (let [[^Context context expiry-ts :as tuple] (.acquire untrusted-static-viz-context-pool :engines)]
+        (if (>= (System/nanoTime) expiry-ts)
+          (do (.dispose untrusted-static-viz-context-pool :engines tuple)
+              (recur))
+          (let [disposed? (volatile! false)]
+            (try
+              (f context)
+              (catch PolyglotException e
+                ;; A cancelled / resource-exhausted context is permanently unusable; dispose it so the pool
+                ;; regenerates a fresh one rather than handing a dead context to the next render.
+                (when (or (.isCancelled e) (.isResourceExhausted e))
+                  (vreset! disposed? true)
+                  (.dispose untrusted-static-viz-context-pool :engines tuple))
+                (throw e))
+              (finally
+                (when-not @disposed?
+                  (.release untrusted-static-viz-context-pool :engines tuple))))))))))
 
 (defmacro with-untrusted-static-viz-context
   "Like [[with-static-viz-context]] but binds `binding-name` to a sandboxed UNTRUSTED isolate context for

--- a/src/metabase/channel/render/js/svg.clj
+++ b/src/metabase/channel/render/js/svg.clj
@@ -13,7 +13,8 @@
    [metabase.lib-be.core :as lib-be]
    [metabase.premium-features.core :as premium-features]
    [metabase.util :as u]
-   [metabase.util.json :as json])
+   [metabase.util.json :as json]
+   [metabase.util.log :as log])
   (:import
    (io.aleph.dirigiste IPool$Controller IPool$Generator Pool Pools Stats)
    (java.io ByteArrayInputStream ByteArrayOutputStream)
@@ -105,13 +106,34 @@
   [binding-name & body]
   `(do-with-static-viz-context (fn [~binding-name] ~@body)))
 
+(defn- warm-untrusted-source-cache!
+  "Parse the static-viz bundle + interface once into an isolate context with a generous CPU budget
+  ([[js.engine/warmup-max-cpu-time]]), populating the shared engine's parsed-source cache, then dispose the
+  context. The parsed-source cache lives on the shared engine and survives context disposal, so subsequent
+  per-render contexts get a cache-hit parse (~3s) that fits the tight per-render budget instead of paying the
+  >10s cold parse of the ~16MB bundle on every render. Best-effort: warm-up failures are logged and swallowed
+  so rendering still proceeds (parsing cold on the raised per-render budget)."
+  []
+  (try
+    (let [^Context context (load-viz-bundle (js.engine/untrusted-plugin-context js.engine/warmup-max-cpu-time))]
+      (try (.close context true) (catch Throwable _)))
+    (catch Throwable e
+      (log/warn e "Failed to warm untrusted static-viz source cache; custom-viz renders will parse the bundle cold"))))
+
+(defonce ^:private untrusted-source-cache-warmed
+  ;; Realized lazily on the first custom-viz render (not at ns-load) so tests and servers that never render
+  ;; custom viz don't pay the cost, and the `load-viz-bundle` bundle-built guard still fires under test init.
+  (delay (warm-untrusted-source-cache!)))
+
 (defn do-with-untrusted-static-viz-context
   "Impl for [[with-untrusted-static-viz-context]]. Loads the static-viz bundle into a fresh
   `SandboxPolicy/UNTRUSTED` isolate context ([[js.engine/untrusted-plugin-context]]), runs `f`, then disposes it.
   Unpooled unlike [[do-with-static-viz-context]] — each render gets a clean context (no tainting), and the
-  isolate's VM-enforced CPU/heap limits replace the old manual render timeout; the shared engine's parsed-source
-  cache keeps bundle reloads cheap."
+  isolate's VM-enforced CPU/heap limits replace the old manual render timeout. The one-time cold parse of the
+  ~16MB bundle is warmed off the render path (see [[warm-untrusted-source-cache!]]) so the shared engine's
+  parsed-source cache keeps per-render bundle reloads cheap."
   [f]
+  @untrusted-source-cache-warmed
   (let [^Context context (load-viz-bundle (js.engine/untrusted-plugin-context))]
     (try
       (f context)

--- a/src/metabase/channel/render/js/svg.clj
+++ b/src/metabase/channel/render/js/svg.clj
@@ -104,6 +104,26 @@
   [binding-name & body]
   `(do-with-static-viz-context (fn [~binding-name] ~@body)))
 
+(defn do-with-untrusted-static-viz-context
+  "Impl for [[with-untrusted-static-viz-context]]. Renders untrusted custom-viz plugin code in a fresh
+  `SandboxPolicy/UNTRUSTED` GraalVM isolate context (see [[js.engine/untrusted-plugin-context]]) with the
+  static-viz bundle loaded, then disposes it. Unlike [[do-with-static-viz-context]] this is NOT pooled:
+  each render gets a clean, fully-isolated context, so no context tainting is needed, and the isolate's
+  VM-enforced CPU/heap limits replace the old manual render timeout. The shared isolate engine's parsed-source
+  cache keeps re-loading the bundle cheap across renders."
+  [f]
+  (let [^Context context (load-viz-bundle (js.engine/untrusted-plugin-context))]
+    (try
+      (f context)
+      (finally
+        (try (.close context true) (catch Throwable _))))))
+
+(defmacro with-untrusted-static-viz-context
+  "Like [[with-static-viz-context]] but binds `binding-name` to a sandboxed UNTRUSTED isolate context for
+  rendering untrusted custom-viz plugin code."
+  [binding-name & body]
+  `(do-with-untrusted-static-viz-context (fn [~binding-name] ~@body)))
+
 (defn- post-process
   "Mutate in place the elements of the svg document. Remove the fill=transparent attribute in favor of
   fill-opacity=0.0. Our svg image renderer only understands the latter. Mutation is unfortunately necessary as the
@@ -256,20 +276,32 @@
     (svg-string->bytes svg-string)))
 
 (defn ^:dynamic *javascript-visualization*
-  "Clojure entrypoint to render javascript visualizations. This functions is dynanic only for testing purposes."
-  [cards-with-data dashcard-viz-settings]
-  (let [response (with-static-viz-context context
-                   (.asString (js.engine/execute-fn-name context "javascript_visualization"
-                                                         (json/encode cards-with-data)
-                                                         (json/encode dashcard-viz-settings)
-                                                         (json/encode (cond-> {:applicationColors (appearance/application-colors)
-                                                                               :startOfWeek (lib-be/start-of-week)
-                                                                               :customFormatting (appearance/custom-formatting)
-                                                                               :tokenFeatures (premium-features/token-features)}
-                                                                        *chart-size*
-                                                                        (assoc :width (:width *chart-size*)
-                                                                               :height (:height *chart-size*)
-                                                                               :fitWithinBounds (boolean (:fit-within? *chart-size*))))))))]
+  "Clojure entrypoint to render javascript visualizations. This function is dynamic only for testing purposes.
+   `custom-viz-bundles` is an optional seq of `{:identifier str :source str :assets map}` maps for custom
+   visualization plugins. When present, rendering runs in a sandboxed UNTRUSTED isolate (the plugin code is
+   untrusted third-party JS); built-in charts keep using the fast pooled context."
+  [cards-with-data dashcard-viz-settings custom-viz-bundles]
+  (let [options     (json/encode (cond-> {:applicationColors (appearance/application-colors)
+                                          :startOfWeek       (lib-be/start-of-week)
+                                          :customFormatting  (appearance/custom-formatting)
+                                          :tokenFeatures     (premium-features/token-features)}
+                                   *chart-size*
+                                   (assoc :width (:width *chart-size*)
+                                          :height (:height *chart-size*)
+                                          :fitWithinBounds (boolean (:fit-within? *chart-size*)))))
+        custom-viz? (seq custom-viz-bundles)
+        run         (fn [context]
+                      (doseq [{:keys [identifier source assets]} custom-viz-bundles]
+                        (js.engine/load-js-string context source (str "custom-viz-" identifier ".js"))
+                        (js.engine/execute-fn-name context "register_custom_viz_plugin" identifier
+                                                   (json/encode (or assets {}))))
+                      (.asString (js.engine/execute-fn-name context "javascript_visualization"
+                                                            (json/encode cards-with-data)
+                                                            (json/encode dashcard-viz-settings)
+                                                            options)))
+        response    (if custom-viz?
+                      (with-untrusted-static-viz-context context (run context))
+                      (with-static-viz-context context (run context)))]
     (-> response
         json/decode+kw
         (update :type (fnil keyword "unknown")))))

--- a/src/metabase/channel/render/js/svg.clj
+++ b/src/metabase/channel/render/js/svg.clj
@@ -343,7 +343,7 @@
 
 (defn ^:dynamic *javascript-visualization*
   "Clojure entrypoint to render javascript visualizations. This function is dynamic only for testing purposes.
-   `custom-viz-bundles` is an optional seq of `{:identifier str :source str :assets map}` maps for custom
+   `custom-viz-bundles` is an optional seq of `{:identifier str :source str}` maps for custom
    visualization plugins. When present, rendering runs in a sandboxed UNTRUSTED isolate (the plugin code is
    untrusted third-party JS); built-in charts keep using the fast pooled context."
   [cards-with-data dashcard-viz-settings custom-viz-bundles]
@@ -361,10 +361,9 @@
                         ;; initialize_context applies EE overrides so the custom-viz registry is active
                         ;; before we register plugins; built-in charts don't need it (RenderChart handles setup).
                         (js.engine/execute-fn-name context "initialize_context" options)
-                        (doseq [{:keys [identifier source assets]} custom-viz-bundles]
+                        (doseq [{:keys [identifier source]} custom-viz-bundles]
                           (js.engine/load-js-string context source (str "custom-viz-" identifier ".js"))
-                          (js.engine/execute-fn-name context "register_custom_viz_plugin" identifier
-                                                     (json/encode (or assets {})))))
+                          (js.engine/execute-fn-name context "register_custom_viz_plugin" identifier)))
                       (.asString (js.engine/execute-fn-name context "javascript_visualization"
                                                             (json/encode cards-with-data)
                                                             (json/encode dashcard-viz-settings)

--- a/src/metabase/channel/render/js/svg.clj
+++ b/src/metabase/channel/render/js/svg.clj
@@ -13,7 +13,8 @@
    [metabase.lib-be.core :as lib-be]
    [metabase.premium-features.core :as premium-features]
    [metabase.util :as u]
-   [metabase.util.json :as json])
+   [metabase.util.json :as json]
+   [metabase.util.log :as log])
   (:import
    (io.aleph.dirigiste IPool$Controller IPool$Generator Pool Pools Stats)
    (java.io ByteArrayInputStream ByteArrayOutputStream)
@@ -123,9 +124,15 @@
   (let [base-controller (Pools/utilizationController 1.0 1 1)]
     (Pool. (reify IPool$Generator
              (generate [_ _]
-               [(load-viz-bundle (js.engine/untrusted-plugin-context js.engine/pool-max-cpu-time))
-                (+ (System/nanoTime) (.toNanos TimeUnit/MINUTES 10))])
+               ;; Cold-parses the ~16MB static-viz bundle into a fresh isolate; logged with timing because this
+               ;; is the dominant per-context cost and explains slow first/regenerated renders.
+               (let [start (System/nanoTime)
+                     ctx   (load-viz-bundle (js.engine/untrusted-plugin-context js.engine/pool-max-cpu-time))]
+                 (log/infof "custom-viz: generated untrusted static-viz isolate context (cold-parsed bundle) in %.0fms"
+                            (/ (- (System/nanoTime) start) 1e6))
+                 [ctx (+ (System/nanoTime) (.toNanos TimeUnit/MINUTES 10))]))
              (destroy [_ _ [^Context ctx _expiry]]
+               (log/debug "custom-viz: disposing untrusted static-viz isolate context")
                (try
                  (.close ctx true) ;; force close - can't wait for running code
                  (catch Exception _))))
@@ -168,6 +175,8 @@
                 ;; regenerates a fresh one rather than handing a dead context to the next render.
                 (when (or (.isCancelled e) (.isResourceExhausted e))
                   (vreset! disposed? true)
+                  (log/warnf "custom-viz: untrusted static-viz context hit a sandbox limit (cancelled=%s resource-exhausted=%s); disposing and regenerating. %s"
+                             (.isCancelled e) (.isResourceExhausted e) (.getMessage e))
                   (.dispose untrusted-static-viz-context-pool :engines tuple))
                 (throw e))
               (finally
@@ -412,20 +421,33 @@
                                           :height (:height *chart-size*)
                                           :fitWithinBounds (boolean (:fit-within? *chart-size*)))))
         custom-viz? (seq custom-viz-bundles)
+        ids         (mapv :identifier custom-viz-bundles)
         run         (fn [context]
                       (when custom-viz?
                         ;; initialize_context applies EE overrides so the custom-viz registry is active
                         ;; before we register plugins; built-in charts don't need it (RenderChart handles setup).
-                        (js.engine/execute-fn-name context "initialize_context" options)
-                        (doseq [{:keys [identifier source]} custom-viz-bundles]
-                          (js.engine/load-js-string context source (str "custom-viz-" identifier ".js"))
-                          (js.engine/execute-fn-name context "register_custom_viz_plugin" identifier)))
-                      (.asString (js.engine/execute-fn-name context "javascript_visualization"
-                                                            (json/encode cards-with-data)
-                                                            (json/encode dashcard-viz-settings)
-                                                            options)))
+                        (let [start (System/nanoTime)]
+                          (js.engine/execute-fn-name context "initialize_context" options)
+                          (doseq [{:keys [identifier source]} custom-viz-bundles]
+                            (js.engine/load-js-string context source (str "custom-viz-" identifier ".js"))
+                            (js.engine/execute-fn-name context "register_custom_viz_plugin" identifier))
+                          (log/debugf "custom-viz: registered plugin(s) %s in %.0fms"
+                                      ids (/ (- (System/nanoTime) start) 1e6))))
+                      (let [start  (System/nanoTime)
+                            result (.asString (js.engine/execute-fn-name context "javascript_visualization"
+                                                                         (json/encode cards-with-data)
+                                                                         (json/encode dashcard-viz-settings)
+                                                                         options))]
+                        (when custom-viz?
+                          (log/debugf "custom-viz: executed javascript_visualization for %s in %.0fms (output %d chars)"
+                                      ids (/ (- (System/nanoTime) start) 1e6) (count result)))
+                        result))
         response    (if custom-viz?
-                      (with-untrusted-static-viz-context context (run context))
+                      (let [start (System/nanoTime)]
+                        (log/infof "custom-viz: static-rendering plugin(s) %s" ids)
+                        (u/prog1 (with-untrusted-static-viz-context context (run context))
+                          (log/infof "custom-viz: static-rendered %s in %.0fms (incl. context acquire/generation)"
+                                     ids (/ (- (System/nanoTime) start) 1e6))))
                       (with-static-viz-context context (run context)))]
     (-> response
         json/decode+kw

--- a/src/metabase/channel/render/js/svg.clj
+++ b/src/metabase/channel/render/js/svg.clj
@@ -12,6 +12,7 @@
    [metabase.config.core :as config]
    [metabase.lib-be.core :as lib-be]
    [metabase.premium-features.core :as premium-features]
+   [metabase.util :as u]
    [metabase.util.json :as json])
   (:import
    (io.aleph.dirigiste IPool$Controller IPool$Generator Pool Pools Stats)
@@ -165,6 +166,72 @@
         (.setTextContent ""))
       node)))
 
+(defn- hsl->rgb
+  "Convert an HSL color to `[r g b]` (each an int in 0-255). `h` is in degrees; `s` and `l` are in [0,1]."
+  [h s l]
+  (let [h  (mod (double h) 360.0)
+        s  (double s)
+        l  (double l)
+        c  (* (- 1.0 (Math/abs (- (* 2.0 l) 1.0))) s)
+        hp (/ h 60.0)
+        x  (* c (- 1.0 (Math/abs (- (mod hp 2.0) 1.0))))
+        [r1 g1 b1] (cond
+                     (< hp 1.0) [c x 0.0]
+                     (< hp 2.0) [x c 0.0]
+                     (< hp 3.0) [0.0 c x]
+                     (< hp 4.0) [0.0 x c]
+                     (< hp 5.0) [x 0.0 c]
+                     :else      [c 0.0 x])
+        m  (- l (/ c 2.0))]
+    (mapv #(long (Math/round (* 255.0 (+ (double %) m)))) [r1 g1 b1])))
+
+(defn- ->hex-component ^String [n]
+  (format "%02X" (long (max 0 (min 255 (long (Math/round (double n))))))))
+
+(defn- css-color-fn->hex+alpha
+  "Parse a CSS `hsl()/hsla()/rgba()` color string into `[hex alpha]`, where `hex` is `#RRGGBB` and `alpha` is a double
+  in [0,1]. Positional parsing relies on the function name: `hsl*` treats the 2nd/3rd numbers as percentages, `rgb*`
+  treats the first three as 0-255. Returns nil if it can't be parsed."
+  [^String value]
+  (let [lower (u/lower-case-en (str/trim value))
+        nums  (mapv #(Double/parseDouble %) (re-seq #"-?\d*\.?\d+" lower))
+        alpha (get nums 3 1.0)]
+    (cond
+      (str/starts-with? lower "hsl")
+      (let [[h s l] nums
+            [r g b] (hsl->rgb h (/ s 100.0) (/ l 100.0))]
+        [(str "#" (->hex-component r) (->hex-component g) (->hex-component b)) alpha])
+
+      (str/starts-with? lower "rgb")
+      (let [[r g b] nums]
+        [(str "#" (->hex-component r) (->hex-component g) (->hex-component b)) alpha])
+
+      :else nil)))
+
+(defn- format-alpha ^String [alpha]
+  (-> (format "%.4f" (double alpha))
+      (str/replace #"0+$" "")
+      (str/replace #"\.$" "")))
+
+(def ^:private batik-unsafe-color-attr-re
+  ;; Batik implements CSS2, so its `fill`/`stroke` parser only understands hex/`rgb()`/named colors -- not the CSS3
+  ;; `hsl()`/`hsla()`/`rgba()` forms. Custom-viz plugin SVGs (and some ECharts label tints) emit these verbatim,
+  ;; making Batik throw "invalid CSS value" at transcode time.
+  #"(?i)(fill|stroke)=\"\s*(hsla?\([^\"]*\)|rgba\([^\"]*\))\s*\"")
+
+(defn- normalize-colors-for-batik
+  "Rewrite any `fill`/`stroke` attribute whose value is an `hsl()/hsla()/rgba()` color into a Batik-safe hex value plus
+  a separate `*-opacity` attribute (which Batik does support). No-op for colors Batik already understands."
+  [svg-string]
+  (str/replace svg-string batik-unsafe-color-attr-re
+               (fn [[whole attr value]]
+                 (if-let [[hex alpha] (css-color-fn->hex+alpha value)]
+                   (let [attr (u/lower-case-en attr)]
+                     (if (< (double alpha) 1.0)
+                       (str attr "=\"" hex "\" " attr "-opacity=\"" (format-alpha alpha) "\"")
+                       (str attr "=\"" hex "\"")))
+                   whole))))
+
 (defn- sanitize-svg
   "Using a regex of negated allowed characters according to the XML 1.0 spec, replace disallowed characters with an
   empty string."
@@ -180,7 +247,7 @@
     (str/replace svg-string allowed-chars "")))
 
 (defn- parse-svg-string [^String s]
-  (let [s (sanitize-svg s)
+  (let [s (-> s sanitize-svg normalize-colors-for-batik)
         factory (SAXSVGDocumentFactory. "org.apache.xerces.parsers.SAXParser")]
     (with-open [is (ByteArrayInputStream. (.getBytes ^String s StandardCharsets/UTF_8))]
       (.createDocument factory "file:///fake.svg" is))))

--- a/src/metabase/channel/render/js/svg.clj
+++ b/src/metabase/channel/render/js/svg.clj
@@ -291,10 +291,14 @@
                                           :fitWithinBounds (boolean (:fit-within? *chart-size*)))))
         custom-viz? (seq custom-viz-bundles)
         run         (fn [context]
-                      (doseq [{:keys [identifier source assets]} custom-viz-bundles]
-                        (js.engine/load-js-string context source (str "custom-viz-" identifier ".js"))
-                        (js.engine/execute-fn-name context "register_custom_viz_plugin" identifier
-                                                   (json/encode (or assets {}))))
+                      (when custom-viz?
+                        ;; initialize_context applies EE overrides so the custom-viz registry is active
+                        ;; before we register plugins; built-in charts don't need it (RenderChart handles setup).
+                        (js.engine/execute-fn-name context "initialize_context" options)
+                        (doseq [{:keys [identifier source assets]} custom-viz-bundles]
+                          (js.engine/load-js-string context source (str "custom-viz-" identifier ".js"))
+                          (js.engine/execute-fn-name context "register_custom_viz_plugin" identifier
+                                                     (json/encode (or assets {})))))
                       (.asString (js.engine/execute-fn-name context "javascript_visualization"
                                                             (json/encode cards-with-data)
                                                             (json/encode dashcard-viz-settings)

--- a/src/metabase/channel/render/pdf.clj
+++ b/src/metabase/channel/render/pdf.clj
@@ -586,7 +586,7 @@
                                  :fit-within? true}]
     (let [viz                    (or (:visualization_settings dashcard)
                                      (:visualization_settings card))
-          {:keys [content type]} (js.svg/*javascript-visualization* (cards-with-data card dashcard data) viz)]
+          {:keys [content type]} (js.svg/*javascript-visualization* (cards-with-data card dashcard data) viz nil)]
       (when (= :svg type)
         (js.svg/svg-string->bytes content)))))
 

--- a/src/metabase/channel/render/util.clj
+++ b/src/metabase/channel/render/util.clj
@@ -3,11 +3,28 @@
    [clojure.string :as str]
    [hiccup.core :refer [html]]
    [metabase.channel.render.style :as style]
+   [metabase.config.core :as config]
    [metabase.parameters.shared :as shared.params]
+   [metabase.premium-features.core :as premium-features]
    [metabase.system.core :as system]
    [metabase.util :as u]))
 
 ;;; --------------------------------------------------- Helpers ---------------------------------------------------
+
+(defn custom-viz-display?
+  "Returns true if `display-type` (keyword or string) is a custom visualization (prefixed with `custom:`)."
+  [display-type]
+  (some-> display-type name (str/starts-with? "custom:")))
+
+(defn custom-viz-identifier
+  "If `display-type` is a custom visualization and the custom-viz feature is enabled,
+   returns the plugin identifier (the part after `custom:`). Returns nil otherwise."
+  [display-type]
+  (when (and config/ee-available? (premium-features/enable-custom-viz?)
+             (custom-viz-display? display-type))
+    (subs (name display-type) (count "custom:"))))
+
+;;; ---------------------------------------------------
 
 (defn- extract-value-sources
   "Extracts column references from mappings that aren't strings"

--- a/src/metabase/custom_viz_plugin/core.clj
+++ b/src/metabase/custom_viz_plugin/core.clj
@@ -1,0 +1,33 @@
+(ns metabase.custom-viz-plugin.core
+  "OSS stubs for custom visualization plugin functions.
+   Enterprise implementations are in metabase-enterprise.custom-viz-plugin.core."
+  (:require
+   [metabase.premium-features.core :refer [defenterprise]]))
+
+(defenterprise resolve-bundle
+  "Resolve the JS bundle for a plugin. Returns {:content str :hash str} or nil.
+   OSS: always returns nil."
+  metabase-enterprise.custom-viz-plugin.core
+  [_plugin]
+  nil)
+
+(defenterprise resolve-asset
+  "Resolve a static asset for a plugin. Returns a byte array or nil.
+   OSS: always returns nil."
+  metabase-enterprise.custom-viz-plugin.core
+  [_plugin _asset-path]
+  nil)
+
+(defenterprise asset-paths
+  "List the static asset names from the manifest.
+   OSS: always returns empty vector."
+  metabase-enterprise.custom-viz-plugin.core
+  [_parsed-manifest]
+  [])
+
+(defenterprise asset-content-type
+  "Return the MIME content type for an allowed asset file, or nil if not recognized.
+   OSS: always returns nil."
+  metabase-enterprise.custom-viz-plugin.core
+  [_path]
+  nil)

--- a/src/metabase/custom_viz_plugin/core.clj
+++ b/src/metabase/custom_viz_plugin/core.clj
@@ -4,6 +4,15 @@
   (:require
    [metabase.premium-features.core :refer [defenterprise]]))
 
+(defenterprise resolve-enabled-plugin
+  "Look up an enabled custom-viz plugin by its `identifier`. Returns the plugin
+   record (without the multi-MB bundle blob) suitable for passing to
+   [[resolve-bundle]], or nil if no enabled plugin matches.
+   OSS: always returns nil (custom-viz plugins are an enterprise feature)."
+  metabase-enterprise.custom-viz-plugin.core
+  [_identifier]
+  nil)
+
 (defenterprise resolve-bundle
   "Resolve the JS bundle for a plugin. Returns {:content str :hash str} or nil.
    OSS: always returns nil."

--- a/src/metabase/util/memory.clj
+++ b/src/metabase/util/memory.clj
@@ -1,4 +1,10 @@
-(ns metabase.util.memory)
+(ns metabase.util.memory
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str])
+  (:import
+   (com.sun.management OperatingSystemMXBean)
+   (java.lang.management ManagementFactory)))
 
 (set! *warn-on-reflection* true)
 
@@ -21,3 +27,38 @@
             (/ free 1e9)
             (/ total 1e9)
             (double (/ free total)))))
+
+(def ^:private cgroup-unlimited-threshold
+  "cgroup v1 represents an unset memory limit as a huge sentinel (LONG_MAX rounded down to the
+  page size, e.g. 0x7FFFFFFFFFFFF000). Treat any value at or above this as 'no limit'."
+  0x7000000000000000)
+
+(defn- read-cgroup-memory-limit
+  "Read this container's memory limit in bytes from the cgroup filesystem, or nil when there is
+  no cgroup limit file (e.g. not containerized, or macOS) or the limit is 'unlimited'. Handles
+  cgroup v2 (`/sys/fs/cgroup/memory.max`) and v1 (`/sys/fs/cgroup/memory/memory.limit_in_bytes`)."
+  []
+  (letfn [(parse [path]
+            (try
+              (let [f (io/file path)]
+                (when (.exists f)
+                  (let [s (str/trim (slurp f))]
+                    (cond
+                      (= s "max")            nil ; cgroup v2 unlimited
+                      (re-matches #"\d+" s)  (let [v (Long/parseLong s)]
+                                               (when (< v cgroup-unlimited-threshold) v))))))
+              (catch Exception _ nil)))]
+    (or (parse "/sys/fs/cgroup/memory.max")                      ; cgroup v2
+        (parse "/sys/fs/cgroup/memory/memory.limit_in_bytes")))) ; cgroup v1
+
+(defn container-memory-limit
+  "Best-effort total memory available to this process, in bytes. Returns the container/cgroup
+  memory limit when one is set (the pod's memory ceiling), else the OS total physical memory,
+  else nil if neither can be determined. Used to size resource caps (e.g. the static-viz
+  render isolate) so they stay under the cgroup ceiling and fail closed instead of getting the
+  whole process OOM-killed."
+  []
+  (or (read-cgroup-memory-limit)
+      (let [os-bean (ManagementFactory/getOperatingSystemMXBean)]
+        (when (instance? OperatingSystemMXBean os-bean)
+          (.getTotalMemorySize ^OperatingSystemMXBean os-bean)))))

--- a/test/metabase/channel/render/js/engine_test.clj
+++ b/test/metabase/channel/render/js/engine_test.clj
@@ -75,3 +75,31 @@
             "termination should be resource exhaustion (heap limit), not some other error")
         (finally
           (.close context true))))))
+
+(deftest isolate-heap-bytes-test
+  (testing "isolate heap cap is derived to fail closed below the pod/cgroup ceiling"
+    (let [mb       (* 1024 1024)
+          gb       (* 1024 mb)
+          floor    (* 384 mb)
+          target   (* 1024 mb)
+          overhead (* 512 mb)]
+      (testing "a large pod is capped at the target — no benefit to handing a runaway more room"
+        (is (= target (#'js/isolate-heap-bytes (* 32 gb) (* 8 gb)))))
+      (testing "a mid-size pod shrinks the cap so JVM heap + cap + overhead + 15% margin fits under the pod"
+        (let [pod  (* 2 gb)
+              heap (* 512 mb)
+              cap  (#'js/isolate-heap-bytes pod heap)]
+          (is (< floor cap target) "cap lands strictly between floor and target")
+          (is (<= (+ heap cap overhead (long (* 0.15 pod))) pod)
+              "the reserved sum stays within the pod memory limit")))
+      (testing "a pod too small for a safe budget clamps to the floor (caller warns)"
+        (is (= floor (#'js/isolate-heap-bytes (* 1 gb) (* 256 mb))))))))
+
+(deftest isolate-memory-config-test
+  (testing "the startup-computed caps are valid GraalVM size strings"
+    (let [cfg      @@#'js/isolate-memory-config
+          ->mb     (fn [s] (Long/parseLong (subs s 0 (- (count s) 2))))]
+      (is (re-matches #"\d+MB" (:max-isolate-memory cfg)))
+      (is (re-matches #"\d+MB" (:max-heap-memory cfg)))
+      (testing "per-context heap is strictly below engine-wide isolate memory (GraalVM requires it)"
+        (is (< (->mb (:max-heap-memory cfg)) (->mb (:max-isolate-memory cfg))))))))

--- a/test/metabase/channel/render/js/engine_test.clj
+++ b/test/metabase/channel/render/js/engine_test.clj
@@ -58,8 +58,9 @@
 (deftest untrusted-plugin-context-enforces-heap-limit-test
   (testing "sandbox.MaxHeapMemory terminates a plugin that exhausts the isolate heap"
     (let [^Context context (js/untrusted-plugin-context)
-          ;; Retain a steadily growing list of materialized arrays until the per-context 512MB heap
-          ;; cap is hit. A single huge allocation can slip past the sampling-based limit, but
+          ;; Retain a steadily growing list of materialized arrays until the per-context heap cap
+          ;; (`sandbox.MaxHeapMemory`, derived at startup from the pod limit — see isolate-memory-config)
+          ;; is hit. A single huge allocation can slip past the sampling-based limit, but
           ;; sustained retention cannot. This stays within the isolate's own heap, so the host JVM
           ;; isn't the one running out of memory.
           ex      (try
@@ -82,16 +83,22 @@
           gb       (* 1024 mb)
           floor    (* 384 mb)
           target   (* 1024 mb)
-          overhead (* 512 mb)]
+          overhead (* 384 mb)]
       (testing "a large pod is capped at the target — no benefit to handing a runaway more room"
         (is (= target (#'js/isolate-heap-bytes (* 32 gb) (* 8 gb)))))
-      (testing "a mid-size pod shrinks the cap so JVM heap + cap + overhead + 15% margin fits under the pod"
+      (testing "a mid-size pod shrinks the cap so JVM heap + cap + overhead + 12% margin fits under the pod"
         (let [pod  (* 2 gb)
               heap (* 512 mb)
               cap  (#'js/isolate-heap-bytes pod heap)]
           (is (< floor cap target) "cap lands strictly between floor and target")
-          (is (<= (+ heap cap overhead (long (* 0.15 pod))) pod)
+          (is (<= (+ heap cap overhead (long (* 0.12 pod))) pod)
               "the reserved sum stays within the pod memory limit")))
+      (testing "the real PR-env case (2.8GB pod, 1.5GB -Xmx) now yields a renderable isolate (regression:
+                the old 512MB overhead + 15% margin left only ~431MB, right at the bundle cold-parse peak,
+                so custom-viz OOMed intermittently)"
+        (let [cap (#'js/isolate-heap-bytes (* 2917 mb) (* 1536 mb))]
+          (is (<= (* 600 mb) cap target)
+              "isolate cap clears ~600MB — comfortably above the measured ~431MB render peak")))
       (testing "a pod too small for a safe budget clamps to the floor (caller warns)"
         (is (= floor (#'js/isolate-heap-bytes (* 1 gb) (* 256 mb))))))))
 
@@ -102,4 +109,7 @@
       (is (re-matches #"\d+MB" (:max-isolate-memory cfg)))
       (is (re-matches #"\d+MB" (:max-heap-memory cfg)))
       (testing "per-context heap is strictly below engine-wide isolate memory (GraalVM requires it)"
-        (is (< (->mb (:max-heap-memory cfg)) (->mb (:max-isolate-memory cfg))))))))
+        (is (< (->mb (:max-heap-memory cfg)) (->mb (:max-isolate-memory cfg)))))
+      (testing "the single pooled context gets nearly the whole isolate (heap = isolate - 96MB reserve),
+                not the old iso/2 split that halved the guest heap"
+        (is (= (->mb (:max-heap-memory cfg)) (- (->mb (:max-isolate-memory cfg)) 96)))))))

--- a/test/metabase/channel/render/js/engine_test.clj
+++ b/test/metabase/channel/render/js/engine_test.clj
@@ -41,3 +41,24 @@
                        (js/load-js-string context "Java.type('java.lang.System')" "escape.js"))))
         (finally
           (.close context true))))))
+
+(deftest untrusted-plugin-context-enforces-heap-limit-test
+  (testing "sandbox.MaxHeapMemory terminates a plugin that exhausts the isolate heap"
+    (let [^Context context (js/untrusted-plugin-context)
+          ;; Retain a steadily growing list of materialized arrays until the per-context 512MB heap
+          ;; cap is hit. A single huge allocation can slip past the sampling-based limit, but
+          ;; sustained retention cannot. This stays within the isolate's own heap, so the host JVM
+          ;; isn't the one running out of memory.
+          ex      (try
+                    (js/load-js-string
+                     context
+                     "var a = []; for (var i = 0; i < 1e7; i++) { a.push(new Array(50000).fill(i)); } a.length"
+                     "oom.js")
+                    nil
+                    (catch PolyglotException e e))]
+      (try
+        (is (some? ex) "expected the runaway allocation to be terminated, not to complete")
+        (is (and ex (.isResourceExhausted ^PolyglotException ex))
+            "termination should be resource exhaustion (heap limit), not some other error")
+        (finally
+          (.close context true))))))

--- a/test/metabase/channel/render/js/engine_test.clj
+++ b/test/metabase/channel/render/js/engine_test.clj
@@ -42,6 +42,19 @@
         (finally
           (.close context true))))))
 
+(deftest untrusted-plugin-context-load-resource-test
+  (testing "load-resource evals into the UNTRUSTED isolate (regression: a URL-backed Source fails to marshal
+            across the native-isolate boundary from a jar: URL — SourceCopyMarshaller ShouldNotReachHere — so
+            load-resource must build a literal Source from the resource content)"
+    (let [^Context context (js/untrusted-plugin-context)]
+      (try
+        ;; a tiny JS resource on the test classpath; the point is that load-resource (not load-js-string)
+        ;; succeeds against the isolate, which is what breaks when the Source is URL-backed.
+        (js/load-resource context "metabase/channel/render/js/engine_test_resource.js")
+        (is (= 3 (.asLong (js/execute-fn-name context "engine_test_plus" 1 2))))
+        (finally
+          (.close context true))))))
+
 (deftest untrusted-plugin-context-enforces-heap-limit-test
   (testing "sandbox.MaxHeapMemory terminates a plugin that exhausts the isolate heap"
     (let [^Context context (js/untrusted-plugin-context)

--- a/test/metabase/channel/render/js/engine_test.clj
+++ b/test/metabase/channel/render/js/engine_test.clj
@@ -2,7 +2,9 @@
   (:require
    [clojure.test :refer :all]
    [metabase.channel.render.js.engine :as js]
-   [metabase.test :as mt]))
+   [metabase.test :as mt])
+  (:import
+   (org.graalvm.polyglot Context PolyglotException Value)))
 
 (set! *warn-on-reflection* true)
 
@@ -25,3 +27,17 @@
       (is (= (repeat 10 2)
              (mt/repeat-concurrently 10
                                      #(.asLong (js/execute-fn-name context "plus" 1 1))))))))
+
+(deftest untrusted-plugin-context-denies-host-access-test
+  (testing "the SandboxPolicy/UNTRUSTED isolate runs untrusted plugin JS with no host interop"
+    (let [^Context context (js/untrusted-plugin-context)]
+      (try
+        (testing "ordinary JS still evaluates, so the sandbox isn't just broken"
+          (is (= "3" (.asString ^Value (js/load-js-string context "'' + (1 + 2)" "ok.js")))))
+        (testing "the `Java` host-interop global is absent"
+          (is (= "undefined" (.asString ^Value (js/load-js-string context "typeof Java" "typeof.js")))))
+        (testing "untrusted guest code cannot reach host classes (no sandbox escape)"
+          (is (thrown? PolyglotException
+                       (js/load-js-string context "Java.type('java.lang.System')" "escape.js"))))
+        (finally
+          (.close context true))))))

--- a/test/metabase/channel/render/js/svg_test.clj
+++ b/test/metabase/channel/render/js/svg_test.clj
@@ -115,6 +115,18 @@
         ;; Observed ~2x cheaper; assert a generous 25% floor so the timing test stays robust to noise.
         (is (< warm (* 0.75 cold)))))))
 
+(deftest ^:mb/slow untrusted-context-loads-slim-bundle-test
+  (testing "the untrusted isolate pool loads the slim custom-viz bundle, exposing the interface surface it needs"
+    (js.svg/do-with-untrusted-static-viz-context
+     (fn [^Context ctx]
+       (doseq [fn-name ["RenderChart" "initializeContext" "registerCustomVizPlugin"]]
+         (is (= "function" (.asString (.eval ctx "js" (str "typeof StaticViz." fn-name))))
+             (str "slim bundle should expose StaticViz." fn-name)))
+       ;; LegacyRenderChart is only exported by the full bundle (only the trusted pool's gauge/funnel
+       ;; entrypoints call it), so its absence proves the slim bundle is what got loaded here.
+       (is (= "undefined" (.asString (.eval ctx "js" "typeof StaticViz.LegacyRenderChart")))
+           "the full static-viz bundle (LegacyRenderChart present) leaked into the untrusted pool")))))
+
 (deftest ^:mb/slow untrusted-static-viz-context-is-pooled-test
   (testing "pooled untrusted isolate contexts are reused across renders (bundle parsed once, not per render)"
     ;; Regression guard: the previous fresh-context-per-render path re-parsed the ~16MB bundle every render

--- a/test/metabase/channel/render/js/svg_test.clj
+++ b/test/metabase/channel/render/js/svg_test.clj
@@ -7,9 +7,11 @@
   resulting svg."
   (:require
    [clojure.test :refer :all]
+   [metabase.channel.render.js.engine :as js.engine]
    [metabase.channel.render.js.svg :as js.svg])
   (:import
    (org.apache.batik.anim.dom SVGOMDocument)
+   (org.graalvm.polyglot Context Engine HostAccess)
    (org.w3c.dom Element Node)))
 
 (set! *warn-on-reflection* true)
@@ -75,3 +77,40 @@
   (testing "Characters discouraged or not permitted by the xml 1.0 specification are removed. (#"
     (#'js.svg/parse-svg-string
      "<svg xmlns=\"http://www.w3.org/2000/svg\">\u001F</svg>")))
+
+(defn- context-on-engine ^Context [^Engine engine]
+  (.. (Context/newBuilder (into-array String ["js"]))
+      (engine engine)
+      (allowHostAccess HostAccess/NONE)
+      (build)))
+
+(defn- load-bundle-ms
+  "Load the static-viz bundle into a fresh context on `engine`, returning the wall-clock load time in ms."
+  ^double [^Engine engine]
+  (let [^Context ctx (context-on-engine engine)
+        start        (System/nanoTime)]
+    (try
+      (#'js.svg/load-viz-bundle ctx)
+      (/ (- (System/nanoTime) start) 1e6)
+      (finally (.close ctx true)))))
+
+(deftest ^:mb/slow shared-engine-parsed-source-cache-speeds-bundle-reloads-test
+  (testing "reloading the ~16MB static-viz bundle on the same engine reuses its parsed-source cache"
+    ;; Same Engine-level cache that keeps the untrusted-plugin isolate's per-render bundle reloads cheap
+    ;; (see do-with-untrusted-static-viz-context). Tested on the plain engine because an UNTRUSTED engine
+    ;; would need the full sandbox context builder; the parsed-source cache is identical for both.
+    ;;
+    ;; Pre-warm the host JVM's JS parser with a throwaway engine so the measured gap reflects the engine's
+    ;; parsed-source cache, not one-time JIT warmup.
+    (let [^Engine warmup (#'js.engine/new-js-engine)]
+      (load-bundle-ms warmup)
+      (load-bundle-ms warmup)
+      (.close warmup))
+    (let [^Engine engine (#'js.engine/new-js-engine)
+          cold           (load-bundle-ms engine)          ; first parse of the bundle on this engine: cold
+          warm           (min (load-bundle-ms engine)     ; reloads on the same engine hit the cache
+                              (load-bundle-ms engine))]
+      (.close engine)
+      (testing (format "(cold=%.0fms warm=%.0fms)" cold warm)
+        ;; Observed ~2x cheaper; assert a generous 25% floor so the timing test stays robust to noise.
+        (is (< warm (* 0.75 cold)))))))

--- a/test/metabase/channel/render/js/svg_test.clj
+++ b/test/metabase/channel/render/js/svg_test.clj
@@ -114,3 +114,15 @@
       (testing (format "(cold=%.0fms warm=%.0fms)" cold warm)
         ;; Observed ~2x cheaper; assert a generous 25% floor so the timing test stays robust to noise.
         (is (< warm (* 0.75 cold)))))))
+
+(deftest ^:mb/slow untrusted-static-viz-context-is-pooled-test
+  (testing "pooled untrusted isolate contexts are reused across renders (bundle parsed once, not per render)"
+    ;; Regression guard: the previous fresh-context-per-render path re-parsed the ~16MB bundle every render
+    ;; (a 55s pulse-test regression). The pool loads the bundle once and hands the same context to each render.
+    ;; Tests run in :test mode (config/is-dev? false), so do-with-untrusted... takes the pooled branch.
+    (let [ids (atom [])]
+      (dotimes [_ 3]
+        (js.svg/do-with-untrusted-static-viz-context
+         (fn [^Context ctx] (swap! ids conj (System/identityHashCode ctx)))))
+      (is (= 1 (count (distinct @ids)))
+          "the same pooled isolate context should serve every render"))))

--- a/test/metabase/channel/render/js/svg_test.clj
+++ b/test/metabase/channel/render/js/svg_test.clj
@@ -48,6 +48,29 @@
     (is (= "0.0"
            (.getAttribute line "fill-opacity")))))
 
+(deftest ^:parallel normalize-colors-for-batik-test
+  (let [normalize #'js.svg/normalize-colors-for-batik]
+    (testing "a fully opaque hsl() fill becomes hex with no opacity attribute"
+      (is (= "<rect fill=\"#FFFFFF\" />"
+             (normalize "<rect fill=\"hsl(0, 0%, 100%)\" />"))))
+    (testing "a translucent hsla() fill becomes hex plus a fill-opacity attribute (the custom-viz calendar-heatmap case)"
+      (is (= "<rect fill=\"#FFFFFF\" fill-opacity=\"0.95\" />"
+             (normalize "<rect fill=\"hsla(0, 0%, 100%, 0.95)\" />"))))
+    (testing "a translucent rgba() stroke becomes hex plus a stroke-opacity attribute"
+      (is (= "<path stroke=\"#0A1F22\" stroke-opacity=\"0.84\" />"
+             (normalize "<path stroke=\"rgba(10, 31, 34, 0.84)\" />"))))
+    (testing "Batik-safe hex, named, and rgb() colors are left untouched"
+      (let [svg "<rect fill=\"#0a1f22\" /><rect fill=\"black\" stroke=\"rgb(1, 2, 3)\" />"]
+        (is (= svg (normalize svg)))))))
+
+(deftest ^:parallel parse-svg-string-normalizes-unsafe-colors-test
+  (testing "parse-svg-string rewrites Batik-incompatible hsla() colors so transcoding won't throw"
+    (let [^SVGOMDocument document (parse-svg
+                                   "<svg xmlns=\"http://www.w3.org/2000/svg\"><rect fill=\"hsla(0, 0%, 100%, 0.95)\"></rect></svg>")
+          ^Element rect           (.. document (getDocumentElement) (getChildNodes) (item 0))]
+      (is (= "#FFFFFF" (.getAttribute rect "fill")))
+      (is (= "0.95" (.getAttribute rect "fill-opacity"))))))
+
 (deftest ^:parallel parse-svg-sanitizes-characters-test
   (testing "Characters discouraged or not permitted by the xml 1.0 specification are removed. (#"
     (#'js.svg/parse-svg-string

--- a/test/metabase/util/memory_test.clj
+++ b/test/metabase/util/memory_test.clj
@@ -1,0 +1,10 @@
+(ns metabase.util.memory-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.util.memory :as memory]))
+
+(deftest container-memory-limit-test
+  (testing "returns a positive byte count (the cgroup limit or host physical memory), or nil when neither
+            can be determined — never zero or negative"
+    (let [v (memory/container-memory-limit)]
+      (is (or (nil? v) (pos-int? v))))))

--- a/test_resources/metabase/channel/render/js/engine_test_resource.js
+++ b/test_resources/metabase/channel/render/js/engine_test_resource.js
@@ -1,0 +1,5 @@
+// Tiny JS resource used by metabase.channel.render.js.engine-test to exercise `load-resource` against the
+// UNTRUSTED isolate. Kept trivial on purpose — the test asserts the resource loads (marshals) at all.
+function engine_test_plus(x, y) {
+  return x + y;
+}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

- https://www.graalvm.org/latest/security-guide/sandboxing/
- canary SDK https://github.com/metabase/metabase/actions/runs/28864980332

### Calendar heatmap with static support
- https://github.com/metabase/custom-viz-calendar-heatmap/pull/32
- [Calendar Heatmap-1.0.2.tgz](https://github.com/user-attachments/files/29744519/Calendar.Heatmap-1.0.2.tgz)

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom visualizations in static rendering, including plugin-based chart display and asset loading.
  * Improved rendering for locale-aware and non-sandboxed visualizations.

* **Bug Fixes**
  * Custom visualizations now fall back more reliably when a static view isn’t available.
  * Fixed color handling in exported SVGs so translucent colors render correctly in downstream viewers.
  * Strengthened isolation for untrusted visualization code and added safer rendering limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->