### PR TITLE
Don't fail dashboard subscriptions when a filter's default is an empty list

### DIFF
--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -50,22 +50,30 @@
 (def ^:private attachment-text-length-limit                  2000)
 
 (defn- parameter-markdown
+  "mrkdwn for one dashboard filter, or nil if it fails to render (a broken filter shouldn't fail the send)."
   [parameter]
-  (truncate
-   (format "*%s*\n%s" (:name parameter) (shared.params/value-string parameter (system/site-locale)))
-   attachment-text-length-limit))
+  (try
+    (truncate
+     (format "*%s*\n%s" (:name parameter) (shared.params/value-string parameter (system/site-locale)))
+     attachment-text-length-limit)
+    (catch Throwable e
+      (log/errorf e "Error rendering filter %s; skipping it" (:name parameter)))))
+
+(defn- parameter-fields
+  [parameters]
+  (for [parameter parameters
+        :let [markdown (parameter-markdown parameter)]
+        :when markdown]
+    {:type "mrkdwn"
+     :text markdown}))
 
 (defn- maybe-append-params-block
   "Appends an inline parameters block to a collection of blocks if parameters exist."
   [blocks inline-parameters]
-  (if (seq inline-parameters)
-    (conj blocks {:type "section"
-                  :fields (mapv
-                           (fn [parameter]
-                             {:type "mrkdwn"
-                              :text (parameter-markdown parameter)})
-                           inline-parameters)})
-    blocks))
+  (let [fields (parameter-fields inline-parameters)]
+    (cond-> blocks
+      (seq fields) (conj {:type "section"
+                          :fields (vec fields)}))))
 
 (defn- text->markdown-section
   [text]
@@ -238,9 +246,7 @@
                                    (conj
                                     {:type "mrkdwn"
                                      :text  "Made with Metabase :blue_heart:"}))}
-        filter-fields   (for [parameter top-level-params]
-                          {:type "mrkdwn"
-                           :text (parameter-markdown parameter)})
+        filter-fields   (parameter-fields top-level-params)
         filter-section  (when (seq filter-fields)
                           {:type   "section"
                            :fields filter-fields})]
@@ -255,8 +261,7 @@
              [(format "*%s*" (:name dashboard))
               (mkdwn-link-text (urls/dashboard-url (:id dashboard) all-params)
                                (format "Sent from %s by %s" (appearance/site-name) creator-name))]
-             (for [parameter top-level-params]
-               (parameter-markdown parameter)))))
+             (keep parameter-markdown top-level-params))))
 
 (defn- dashboard-pdf
   "Render the whole dashboard to a PDF for Slack, returning `{:bytes ... :filename ...}` or `nil` if rendering fails.

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -50,30 +50,22 @@
 (def ^:private attachment-text-length-limit                  2000)
 
 (defn- parameter-markdown
-  "mrkdwn for one dashboard filter, or nil if it fails to render (a broken filter shouldn't fail the send)."
   [parameter]
-  (try
-    (truncate
-     (format "*%s*\n%s" (:name parameter) (shared.params/value-string parameter (system/site-locale)))
-     attachment-text-length-limit)
-    (catch Throwable e
-      (log/errorf e "Error rendering filter %s; skipping it" (:name parameter)))))
-
-(defn- parameter-fields
-  [parameters]
-  (for [parameter parameters
-        :let [markdown (parameter-markdown parameter)]
-        :when markdown]
-    {:type "mrkdwn"
-     :text markdown}))
+  (truncate
+   (format "*%s*\n%s" (:name parameter) (shared.params/value-string parameter (system/site-locale)))
+   attachment-text-length-limit))
 
 (defn- maybe-append-params-block
   "Appends an inline parameters block to a collection of blocks if parameters exist."
   [blocks inline-parameters]
-  (let [fields (parameter-fields inline-parameters)]
-    (cond-> blocks
-      (seq fields) (conj {:type "section"
-                          :fields (vec fields)}))))
+  (if (seq inline-parameters)
+    (conj blocks {:type "section"
+                  :fields (mapv
+                           (fn [parameter]
+                             {:type "mrkdwn"
+                              :text (parameter-markdown parameter)})
+                           inline-parameters)})
+    blocks))
 
 (defn- text->markdown-section
   [text]
@@ -246,7 +238,9 @@
                                    (conj
                                     {:type "mrkdwn"
                                      :text  "Made with Metabase :blue_heart:"}))}
-        filter-fields   (parameter-fields top-level-params)
+        filter-fields   (for [parameter top-level-params]
+                          {:type "mrkdwn"
+                           :text (parameter-markdown parameter)})
         filter-section  (when (seq filter-fields)
                           {:type   "section"
                            :fields filter-fields})]
@@ -261,7 +255,8 @@
              [(format "*%s*" (:name dashboard))
               (mkdwn-link-text (urls/dashboard-url (:id dashboard) all-params)
                                (format "Sent from %s by %s" (appearance/site-name) creator-name))]
-             (keep parameter-markdown top-level-params))))
+             (for [parameter top-level-params]
+               (parameter-markdown parameter)))))
 
 (defn- dashboard-pdf
   "Render the whole dashboard to a PDF for Slack, returning `{:bytes ... :filename ...}` or `nil` if rendering fails.

--- a/src/metabase/channel/render/util.clj
+++ b/src/metabase/channel/render/util.clj
@@ -5,7 +5,8 @@
    [metabase.channel.render.style :as style]
    [metabase.parameters.shared :as shared.params]
    [metabase.system.core :as system]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [metabase.util.log :as log]))
 
 ;;; --------------------------------------------------- Helpers ---------------------------------------------------
 
@@ -222,18 +223,24 @@
      :rows (apply mapv vector unzipped-rows)}))
 
 (defn render-parameters
-  "Renders parameters as inline left-aligned spans for use inside a dashcard."
+  "Renders parameters as inline left-aligned spans for use inside a dashcard. A parameter that fails to render is
+  skipped so it doesn't fail the whole notification."
   [parameters]
   (html
    (let [locale (system/site-locale)]
      [:div {:style (style/style {:font-size "14px"
                                  :font-weight 700
                                  :padding-bottom "8px"})}
-      (for [{:keys [name] :as param} parameters]
+      (for [{:keys [name] :as param} parameters
+            :let [value-str (try
+                              (shared.params/value-string param locale)
+                              (catch Throwable e
+                                (log/errorf e "Error rendering filter %s; skipping it" name)))]
+            :when value-str]
         [:div
          {:style (style/style {:margin-bottom "4px"})}
          [:span {:style (style/style {:color style/color-text-dark
                                       :padding-right "8px"})}
           name]
          [:span {:style (style/style {:color style/color-text-medium})}
-          (shared.params/value-string param locale)]])])))
+          value-str]])])))

--- a/src/metabase/channel/render/util.clj
+++ b/src/metabase/channel/render/util.clj
@@ -223,22 +223,24 @@
      :rows (apply mapv vector unzipped-rows)}))
 
 (defn render-parameters
-  "Renders parameters as inline left-aligned spans for use inside a dashcard. Returns nil if rendering fails, as a
-  safeguard so a broken filter doesn't fail the whole notification."
+  "Renders parameters as inline left-aligned spans for use inside a dashcard. A parameter that fails to render is
+  skipped so it doesn't fail the whole notification."
   [parameters]
-  (try
-    (html
-     (let [locale (system/site-locale)]
-       [:div {:style (style/style {:font-size "14px"
-                                   :font-weight 700
-                                   :padding-bottom "8px"})}
-        (for [{:keys [name] :as param} parameters]
-          [:div
-           {:style (style/style {:margin-bottom "4px"})}
-           [:span {:style (style/style {:color style/color-text-dark
-                                        :padding-right "8px"})}
-            name]
-           [:span {:style (style/style {:color style/color-text-medium})}
-            (shared.params/value-string param locale)]])]))
-    (catch Throwable e
-      (log/error e "Error rendering filters; skipping them"))))
+  (html
+   (let [locale (system/site-locale)]
+     [:div {:style (style/style {:font-size "14px"
+                                 :font-weight 700
+                                 :padding-bottom "8px"})}
+      (for [{:keys [name] :as param} parameters
+            :let [value-str (try
+                              (shared.params/value-string param locale)
+                              (catch Throwable e
+                                (log/errorf e "Error rendering filter %s; skipping it" name)))]
+            :when value-str]
+        [:div
+         {:style (style/style {:margin-bottom "4px"})}
+         [:span {:style (style/style {:color style/color-text-dark
+                                      :padding-right "8px"})}
+          name]
+         [:span {:style (style/style {:color style/color-text-medium})}
+          value-str]])])))

--- a/src/metabase/channel/render/util.clj
+++ b/src/metabase/channel/render/util.clj
@@ -223,24 +223,22 @@
      :rows (apply mapv vector unzipped-rows)}))
 
 (defn render-parameters
-  "Renders parameters as inline left-aligned spans for use inside a dashcard. A parameter that fails to render is
-  skipped so it doesn't fail the whole notification."
+  "Renders parameters as inline left-aligned spans for use inside a dashcard. Returns nil if rendering fails, as a
+  safeguard so a broken filter doesn't fail the whole notification."
   [parameters]
-  (html
-   (let [locale (system/site-locale)]
-     [:div {:style (style/style {:font-size "14px"
-                                 :font-weight 700
-                                 :padding-bottom "8px"})}
-      (for [{:keys [name] :as param} parameters
-            :let [value-str (try
-                              (shared.params/value-string param locale)
-                              (catch Throwable e
-                                (log/errorf e "Error rendering filter %s; skipping it" name)))]
-            :when value-str]
-        [:div
-         {:style (style/style {:margin-bottom "4px"})}
-         [:span {:style (style/style {:color style/color-text-dark
-                                      :padding-right "8px"})}
-          name]
-         [:span {:style (style/style {:color style/color-text-medium})}
-          value-str]])])))
+  (try
+    (html
+     (let [locale (system/site-locale)]
+       [:div {:style (style/style {:font-size "14px"
+                                   :font-weight 700
+                                   :padding-bottom "8px"})}
+        (for [{:keys [name] :as param} parameters]
+          [:div
+           {:style (style/style {:margin-bottom "4px"})}
+           [:span {:style (style/style {:color style/color-text-dark
+                                        :padding-right "8px"})}
+            name]
+           [:span {:style (style/style {:color style/color-text-medium})}
+            (shared.params/value-string param locale)]])]))
+    (catch Throwable e
+      (log/error e "Error rendering filters; skipping them"))))

--- a/src/metabase/parameters/shared.cljc
+++ b/src/metabase/parameters/shared.cljc
@@ -211,8 +211,8 @@
     * missing value key => default"
   [parameter]
   (let [value (get parameter :value (:default parameter))]
-    (when-not (and (coll? value) (empty? value))
-      value)))
+    (cond-> value
+      (coll? value) not-empty)))
 
 (defn value-string
   "Returns the value(s) of a dashboard filter, formatted appropriately."

--- a/src/metabase/parameters/shared.cljc
+++ b/src/metabase/parameters/shared.cljc
@@ -165,6 +165,7 @@
   on the values. The conjunction parameter determines whether to use 'and' or 'or' to join the last two items."
   [values & {:keys [conjunction] :or {conjunction (trs "and")}}]
   (condp = (count values)
+    0 ""
     1 (str (first values))
     2 (trs "{0} {1} {2}" (first values) conjunction (second values))
     (trs "{0}, {1}, {2} {3}"
@@ -206,10 +207,12 @@
 
 (defn param-val-or-default
   "Returns the parameter value, such that:
-    * nil value => nil
+    * nil value or empty collection => nil
     * missing value key => default"
   [parameter]
-  (get parameter :value (:default parameter)))
+  (let [value (get parameter :value (:default parameter))]
+    (when-not (and (coll? value) (empty? value))
+      value)))
 
 (defn value-string
   "Returns the value(s) of a dashboard filter, formatted appropriately."

--- a/test/metabase/parameters/shared_test.cljc
+++ b/test/metabase/parameters/shared_test.cljc
@@ -420,7 +420,16 @@
       (is (= "my default value"
              (param-val-or-default {:default "my default value"}))))
     (testing "When the parameter’s :value is explicitly nil (i.e. for no-op filters), do not fallback to the :default key"
-      (is (nil? (param-val-or-default {:value nil :default "my default value"}))))))
+      (is (nil? (param-val-or-default {:value nil :default "my default value"}))))
+    (testing "Empty collections count as no value (#76854)"
+      (is (nil? (param-val-or-default {:default []})))
+      (is (nil? (param-val-or-default {:value [] :default ["CA"]}))))))
+
+(deftest ^:parallel value-string-empty-value-test
+  (testing "Filters with an empty list of values render as an empty string instead of throwing (#76854)"
+    (is (= "" (params/value-string {:type "string/=" :default []} "en")))
+    (is (= "" (params/value-string {:type "string/=" :value []} "en")))
+    (is (= "" (params/formatted-list [])))))
 
 (deftest ^:parallel value-string-contains-test
   (testing "string/contains parameters are correctly formatted"

--- a/test/metabase/pulse/dashboard_subscription_test.clj
+++ b/test/metabase/pulse/dashboard_subscription_test.clj
@@ -561,7 +561,13 @@
          (is (= (rasta-dashsub-message {:message [{"Aviary KPIs" true
                                                    "State"       false}
                                                   pulse.test-util/png-attachment]})
-                (mt/summarize-multipart-single-email email #"Aviary KPIs" #"State")))))}}))
+                (mt/summarize-multipart-single-email email #"Aviary KPIs" #"State")))))
+
+     :slack
+     (fn [_ [message]]
+       (testing "slack message is still delivered, with the broken filters left out"
+         (is (some? message))
+         (is (not (str/includes? (pr-str message) "*State*")))))}}))
 
 (deftest dashboard-with-header-filters-test
   (tests!

--- a/test/metabase/pulse/dashboard_subscription_test.clj
+++ b/test/metabase/pulse/dashboard_subscription_test.clj
@@ -561,13 +561,7 @@
          (is (= (rasta-dashsub-message {:message [{"Aviary KPIs" true
                                                    "State"       false}
                                                   pulse.test-util/png-attachment]})
-                (mt/summarize-multipart-single-email email #"Aviary KPIs" #"State")))))
-
-     :slack
-     (fn [_ [message]]
-       (testing "slack message is still delivered, with the broken filters left out"
-         (is (some? message))
-         (is (not (str/includes? (pr-str message) "*State*")))))}}))
+                (mt/summarize-multipart-single-email email #"Aviary KPIs" #"State")))))}}))
 
 (deftest dashboard-with-header-filters-test
   (tests!

--- a/test/metabase/pulse/dashboard_subscription_test.clj
+++ b/test/metabase/pulse/dashboard_subscription_test.clj
@@ -16,6 +16,7 @@
    [metabase.notification.payload.execute :as notification.payload.execute]
    [metabase.notification.payload.temp-storage :as notification.temp-storage]
    [metabase.notification.test-util :as notification.tu]
+   [metabase.parameters.shared :as shared.params]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.pulse.send :as pulse.send]
@@ -540,6 +541,33 @@
                                                      #"Aviary KPIs"
                                                      #"Quarter and Year"
                                                      #"State")))))}}))
+
+(deftest filter-render-failure-doesnt-fail-subscription-test
+  (tests!
+   {:pulse     {:skip_if_empty false}
+    :dashboard pulse.test-util/test-dashboard}
+   "A filter that fails to render is skipped instead of failing the whole subscription"
+   {:card (pulse.test-util/checkins-query-card {})
+
+    :fixture
+    (fn [_ thunk]
+      (with-redefs [shared.params/value-string (fn [& _] (throw (ex-info "boom" {})))]
+        (thunk)))
+
+    :assert
+    {:email
+     (fn [_ [email]]
+       (testing "email is still delivered, with the broken filters left out"
+         (is (= (rasta-dashsub-message {:message [{"Aviary KPIs" true
+                                                   "State"       false}
+                                                  pulse.test-util/png-attachment]})
+                (mt/summarize-multipart-single-email email #"Aviary KPIs" #"State")))))
+
+     :slack
+     (fn [_ [message]]
+       (testing "slack message is still delivered, with the broken filters left out"
+         (is (some? message))
+         (is (not (str/includes? (pr-str message) "*State*")))))}}))
 
 (deftest dashboard-with-header-filters-test
   (tests!

--- a/test/metabase/pulse/dashboard_subscription_test.clj
+++ b/test/metabase/pulse/dashboard_subscription_test.clj
@@ -512,6 +512,35 @@
                                {:type "section" :text {:type "plain_text" :text "1,000"}}]}
                     message)))))}})))
 
+(deftest dashboard-filter-with-empty-default-test
+  (tests!
+   {:pulse     {:skip_if_empty false}
+    :dashboard (update pulse.test-util/test-dashboard :parameters
+                       (fn [params]
+                         (for [param params]
+                           (cond-> param
+                             (= "State" (:name param)) (assoc :default [])))))}
+   "Dashboard subscription whose text filter had its default value cleared to [] still sends (#76854)"
+   {:card (pulse.test-util/checkins-query-card {})
+
+    :fixture
+    (fn [_ thunk]
+      (thunk))
+
+    :assert
+    {:email
+     (fn [_ [email]]
+       (testing "The subscription is delivered and the empty filter is left out"
+         (is (some? email))
+         (is (= (rasta-dashsub-message {:message [{"Aviary KPIs"      true
+                                                   "Quarter and Year" true
+                                                   "State"            false}
+                                                  pulse.test-util/png-attachment]})
+                (mt/summarize-multipart-single-email email
+                                                     #"Aviary KPIs"
+                                                     #"Quarter and Year"
+                                                     #"State")))))}}))
+
 (deftest dashboard-with-header-filters-test
   (tests!
    {:pulse     {:skip_if_empty false}


### PR DESCRIPTION
removing the default value from a dashboard text filter can save it as `default: []`. subscriptions are supposed to leave out filters that have no value, but the check is plain truthiness and `[]` is truthy in clojure, so the empty filter slips through and `formatted-list` throws IndexOutOfBoundsException on the empty list. that kills the whole send.

the fix: treat empty collections as no value, so the filter is excluded from the subscription just like a filter that never had a default. also made `formatted-list` return "" for empty input, and wrapped `render-parameters` in a try/catch as a safeguard so a filter that fails to render drops the filters section instead of failing the send.

Fixes https://github.com/metabase/metabase/issues/76854