### PR TITLE
Hex-encode string literals in the mysql if-not-exists create-index path

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -2,6 +2,7 @@
   "MySQL driver. Builds off of the SQL-JDBC driver."
   (:refer-clojure :exclude [get-in some not-empty])
   (:require
+   [buddy.core.codecs :as codecs]
    [clojure.java.io :as jio]
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
@@ -1480,10 +1481,12 @@
             target
             cols)))
 
-(defn- sql-string-literal
-  "A MySQL `'...'` string literal for trusted `s`, escaping embedded quotes."
-  [s]
-  (str \' (sql.u/escape-sql s :ansi) \'))
+(defn- utf8-string-expr
+  "A MySQL expression evaluating to the string `s`, hex-encoded so there is nothing to escape and SQL injection is
+  impossible. Index names are unvalidated free-form user input and `sql.u/escape-sql` is explicitly not safe for that
+  (a backslash defeats its quote-doubling, and its escaping is session-dependent), so we use the hex pattern instead."
+  [^String s]
+  (format "CONVERT(UNHEX('%s') USING utf8mb4)" (codecs/bytes->hex (.getBytes s "UTF-8"))))
 
 (defmethod driver/compile-create-index :mysql
   [_driver schema table {index-name :name, :keys [if-not-exists] :as structured}]
@@ -1491,15 +1494,16 @@
     (if-not if-not-exists
       [[create]]
       ;; MySQL has no `CREATE INDEX IF NOT EXISTS`, and the apply path re-issues creates on full rebuilds, so guard
-      ;; with dynamic SQL that runs the create only when no index of this name exists. Identifiers are inlined as
-      ;; string literals because the MariaDB driver rejects `?` placeholders inside the `SET @var := (SELECT ...)`.
+      ;; with dynamic SQL that runs the create only when no index of this name exists. Strings (including the whole
+      ;; CREATE statement) are inlined as hex-encoded expressions rather than bound params because the MariaDB driver
+      ;; rejects `?` placeholders inside `SET @var := (SELECT ...)`.
       [[(format "SET @mb_idx_exists := (SELECT COUNT(*) FROM information_schema.statistics
                                         WHERE table_schema = %s AND table_name = %s AND index_name = %s)"
-                (if (not-empty schema) (sql-string-literal schema) "DATABASE()")
-                (sql-string-literal table)
-                (sql-string-literal index-name))]
+                (if (not-empty schema) (utf8-string-expr schema) "DATABASE()")
+                (utf8-string-expr table)
+                (utf8-string-expr index-name))]
        [(format "SET @mb_idx_sql := IF(@mb_idx_exists > 0, 'DO 0', %s)"
-                (sql-string-literal create))]
+                (utf8-string-expr create))]
        ["PREPARE mb_idx_stmt FROM @mb_idx_sql"]
        ["EXECUTE mb_idx_stmt"]
        ["DEALLOCATE PREPARE mb_idx_stmt"]])))

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -2,6 +2,7 @@
   {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.driver.mysql-test]}
                                                             metabase.test.data/run-mbql-query {:namespaces [metabase.driver.mysql-test]}}}}}}
   (:require
+   [buddy.core.codecs :as codecs]
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -1118,3 +1119,68 @@
           "no literal IF NOT EXISTS clause")
       (is (str/includes? (first (last stmts)) "DEALLOCATE PREPARE")
           "ends by deallocating the prepared guard statement"))))
+
+(deftest ^:parallel compile-create-index-hex-escaping-test
+  (let [hex     (fn [^String s] (codecs/bytes->hex (.getBytes s "UTF-8")))
+        expr    (fn [s] (format "CONVERT(UNHEX('%s') USING utf8mb4)" (hex s)))
+        decode  (fn [h] (String. ^bytes (codecs/hex->bytes h) "UTF-8"))
+        compile (fn [schema table nm]
+                  (driver/compile-create-index
+                   :mysql schema table
+                   {:kind :btree :name nm :if-not-exists true :columns [{:name "category"}]}))
+        joined  (fn [stmts] (str/join "\n" (map first stmts)))]
+    (testing ":if-not-exists true guards the create with dynamic SQL, inlining every string as hex"
+      (let [stmts        (compile nil "t" "by_cat")
+            sql          (joined stmts)
+            plain-create (ffirst (driver/compile-create-index
+                                  :mysql nil "t"
+                                  {:kind :btree :name "by_cat" :columns [{:name "category"}]}))]
+        (testing "shape: existence check, IF guard, then PREPARE/EXECUTE/DEALLOCATE"
+          (is (= 5 (count stmts)))
+          (is (str/includes? (ffirst stmts)
+                             "@mb_idx_exists := (SELECT COUNT(*) FROM information_schema.statistics"))
+          (is (str/includes? (first (nth stmts 1)) "@mb_idx_sql := IF(@mb_idx_exists > 0, 'DO 0'"))
+          (is (= ["PREPARE mb_idx_stmt FROM @mb_idx_sql"] (nth stmts 2)))
+          (is (= ["EXECUTE mb_idx_stmt"] (nth stmts 3)))
+          (is (= ["DEALLOCATE PREPARE mb_idx_stmt"] (nth stmts 4))))
+        (testing "table and index name are compared as hex-encoded utf8mb4 expressions"
+          (is (str/includes? sql (str "table_name = " (expr "t"))))
+          (is (str/includes? sql (str "index_name = " (expr "by_cat")))))
+        (testing "the embedded CREATE is exactly the plain create, hex-encoded"
+          (is (str/includes? sql (expr plain-create)))
+          (is (str/starts-with? (decode (hex plain-create)) "CREATE INDEX")))
+        (testing "no schema compares against DATABASE(), not a hex literal"
+          (is (str/includes? sql "table_schema = DATABASE()")))))
+    (testing "an explicit schema is inlined as hex too"
+      (is (str/includes? (joined (compile "s" "t" "by_cat"))
+                         (str "table_schema = " (expr "s")))))
+    (testing "a backslash in the name (which defeats ansi quote-doubling) is hex-encoded, never literal"
+      (let [nm  "my\\index"
+            sql (joined (compile nil "t" nm))]
+        (is (str/includes? (hex nm) "5c")
+            "sanity: the name's hex includes the backslash byte 5c")
+        (is (str/includes? sql (hex nm))
+            "the exact bytes (backslash included) are inlined as hex")
+        (is (str/includes? sql (str "index_name = " (expr nm))))
+        (is (not (str/includes? sql "\\"))
+            "no raw backslash survives anywhere in the SQL, so it cannot escape a literal")
+        (is (= nm (decode (hex nm)))
+            "the hex round-trips back to the original name")))
+    (testing "an injection-style name is hex-encoded and cannot break out of a literal"
+      (let [nm  "a' OR 1=1 -- "
+            sql (joined (compile nil "t" nm))]
+        (is (str/includes? sql (hex nm))
+            "the payload is inlined as hex")
+        (is (str/includes? sql (str "index_name = " (expr nm))))
+        (is (not (str/includes? sql "1=1"))
+            "the injection text never appears unencoded")
+        (is (not (str/includes? sql "OR 1=1")))
+        (is (= nm (decode (hex nm)))
+            "the hex round-trips back to the original name")))
+    (testing ":if-not-exists false emits the plain single-statement CREATE, no dynamic SQL"
+      (let [stmts (driver/compile-create-index
+                   :mysql nil "t"
+                   {:kind :btree :name "by_cat" :if-not-exists false :columns [{:name "category"}]})]
+        (is (= [["CREATE INDEX `by_cat` ON `t` (`category`)"]] stmts))
+        (is (not (str/includes? (ffirst stmts) "PREPARE")))
+        (is (not (str/includes? (ffirst stmts) "UNHEX")))))))


### PR DESCRIPTION
splitting the mysql fix out of #77092 so it can be reviewed on its own.

mysql has no `CREATE INDEX IF NOT EXISTS`, so we guard the create with dynamic sql and inline the schema/table/index name as string literals (the mariadb driver rejects `?` placeholders inside `SET @var := (...)`). those literals were ansi-escaped, but index names are free-form user input and a backslash defeats the quote doubling, so a crafted name could break out of the literal.

the fix: inline every string as `CONVERT(UNHEX('...') USING utf8mb4)` instead. nothing to escape, and it doesn't depend on sql_mode.
