### PR TITLE
Harden the glob in cross-version test scripts

### DIFF
--- a/cross-version/dev.sh
+++ b/cross-version/dev.sh
@@ -74,6 +74,8 @@ if [[ ! -d "$SPECS_DIR" ]]; then
   closest=""
   closest_dist=999
   for dir in "$REPO_ROOT"/e2e/cross-version/[0-9]*/; do
+    # Skip the literal pattern when the glob matches no numbered folders
+    [[ -d "$dir" ]] || continue
     v=$(basename "$dir")
     (( v < MAJOR )) && continue
     dist=$(( v - MAJOR ))

--- a/cross-version/test.sh
+++ b/cross-version/test.sh
@@ -89,6 +89,8 @@ run_e2e() {
   if [[ ! -d "$specs_dir" ]]; then
     local closest="" closest_dist=999
     for dir in "$REPO_ROOT"/e2e/cross-version/[0-9]*/; do
+      # Skip the literal pattern when the glob matches no numbered folders
+      [[ -d "$dir" ]] || continue
       local v=$(basename "$dir")
       (( v < major )) && continue
       local dist=$(( v - major ))


### PR DESCRIPTION
Resolves DEV-2304

Before this fix, you'd run into this error if there are no numbered folders inside e2e/cross-version/*

```
cross-version/dev.sh: line 97: ((: [0-9]*: syntax error: operand expected (error token is "[0-9]*")
```