### PR TITLE
Wire embedding tests to ci-conductor

### DIFF
--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -8,6 +8,11 @@ env:
   TERM: xterm
   TZ: US/Pacific # to make Node match the instance tz
   MB_EDITION: "ee"
+  CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+  CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
+  REPO_ID: ${{ github.event.repository.id }}
+  COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
 
 jobs:
   sdk-component-tests:
@@ -19,6 +24,7 @@ jobs:
         react-version: [18, 19]
       fail-fast: false
     env:
+      CI_CONDUCTOR_TEST_SUITE: embedding-sdk-component-react-${{ matrix.react-version }}
       # Sensitive env vars (tokens, secrets) starting with `CYPRESS_` are accessed via async `cy.env()`
       # Example: `cy.env(["FOO"]).then(({ FOO }) => ...)`
       # For non-sensitive config, use `Cypress.expose()` in cypress config instead (synchronous)
@@ -68,6 +74,8 @@ jobs:
 
       - name: Run Metabase
         run: node e2e/runner/run_cypress_ci.js start
+
+      - uses: ./.github/actions/resolve-job-id
 
       - name: Make app db snapshot
         env:
@@ -168,6 +176,7 @@ jobs:
     env:
       MB_RUN_MODE: "e2e"
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
+      CI_CONDUCTOR_TEST_SUITE: embedding-sdk-component-backward-compatibility
       # Sensitive env vars (tokens, secrets) starting with `CYPRESS_` are accessed via async `cy.env()`
       # Example: `cy.env(["FOO"]).then(({ FOO }) => ...)`
       # For non-sensitive config, use `Cypress.expose()` in cypress config instead (synchronous)
@@ -236,6 +245,8 @@ jobs:
 
       - name: Run Metabase
         run: node e2e/runner/run_cypress_ci.js start
+
+      - uses: ./.github/actions/resolve-job-id
 
       - name: Make app db snapshot
         env:

--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -13,6 +13,7 @@ env:
   REPO_ID: ${{ github.event.repository.id }}
   COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
   TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
+  QUARANTINE_FAILURES_FILE: ${{ github.workspace }}/target/quarantine-failures.jsonl
 
 jobs:
   sdk-component-tests:
@@ -119,6 +120,15 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.run-tests.outcome }}
+
+      - name: Quarantine gate (dry run)
+        if: always()
+        continue-on-error: true
+        timeout-minutes: 3
+        uses: ./.github/actions/quarantine-gate
+        with:
+          adapter: e2e
+          test-suite: ${{ env.CI_CONDUCTOR_TEST_SUITE }}
 
       - name: "SDK component tests > Upload Cypress Artifacts upon failure"
         uses: actions/upload-artifact@v7
@@ -288,6 +298,15 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.run-tests.outcome }}
+
+      - name: Quarantine gate (dry run)
+        if: always()
+        continue-on-error: true
+        timeout-minutes: 3
+        uses: ./.github/actions/quarantine-gate
+        with:
+          adapter: e2e
+          test-suite: ${{ env.CI_CONDUCTOR_TEST_SUITE }}
 
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v7

--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -378,6 +378,7 @@ jobs:
     name: e2e-host-app-${{ matrix.test_suite }}-tests-${{ matrix.environment }}-bundle
     env:
       CI_CONDUCTOR_TEST_SUITE: embedding-sdk-host-app
+      QUARANTINE_FAILURES_FILE: ${{ github.workspace }}/target/quarantine-failures.jsonl
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
       HOST_APP_ENVIRONMENT: ${{ matrix.environment }}
     permissions:
@@ -439,6 +440,15 @@ jobs:
           path: |
             ./cypress
           if-no-files-found: ignore
+
+      - name: Quarantine gate (dry run)
+        if: always()
+        continue-on-error: true
+        timeout-minutes: 3
+        uses: ./.github/actions/quarantine-gate
+        with:
+          adapter: e2e
+          test-suite: ${{ env.CI_CONDUCTOR_TEST_SUITE }}
 
       - name: Fail job if tests failed
         if: ${{ steps.run-e2e-tests.outcome != 'success' }}

--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -10,6 +10,11 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   HASH: ${{ github.event.pull_request.head.sha || github.sha }}-${{ github.run_attempt }}
   MB_EDITION: ee
+  CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+  CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
+  REPO_ID: ${{ github.event.repository.id }}
+  COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
 jobs:
   get-sample-apps-data:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
@@ -98,6 +103,7 @@ jobs:
     timeout-minutes: 45
     name: e2e-sample-app-${{ matrix.test_suite }}-tests-${{ matrix.environment }}-bundle
     env:
+      CI_CONDUCTOR_TEST_SUITE: embedding-sdk-sample-app
       MB_EDITION: ee
       MB_RUN_MODE: e2e
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
@@ -171,6 +177,8 @@ jobs:
       - name: Log free disk space
         run: df -h /
 
+      - uses: ./.github/actions/resolve-job-id
+
       - name: Run e2e tests for Sample App
         id: run-e2e-tests
         if: ${{ steps.check-sample-app-branch.outputs.sample_app_branch_exists == 'true' }}
@@ -207,6 +215,7 @@ jobs:
     timeout-minutes: 45
     name: e2e-sample-app-shoppy-e2e-tests-${{ matrix.environment }}-bundle
     env:
+      CI_CONDUCTOR_TEST_SUITE: embedding-sdk-shoppy
       MB_EDITION: ee
       MB_RUN_MODE: e2e
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
@@ -237,6 +246,8 @@ jobs:
           metastore-dev-server-url: ${{ secrets.METASTORE_DEV_SERVER_URL }}
           shoppy-datadog-application-id: ${{ secrets.SHOPPY_METABASE_APP_DATADOG_APPLICATION_ID }}
           shoppy-datadog-client-token: ${{ secrets.SHOPPY_METABASE_APP_DATADOG_CLIENT_TOKEN }}
+
+      - uses: ./.github/actions/resolve-job-id
 
       - name: Run e2e tests for Shoppy
         id: run-e2e-tests
@@ -272,6 +283,7 @@ jobs:
     timeout-minutes: 45
     name: e2e-shoppy-synthetic-monitoring-tests
     env:
+      CI_CONDUCTOR_TEST_SUITE: embedding-sdk-shoppy-synthetic
       MB_EDITION: ee
       MB_RUN_MODE: e2e
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
@@ -315,6 +327,8 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/actions/resolve-job-id
 
       - name: Run synthetic monitoring tests
         id: run-e2e-tests
@@ -363,6 +377,7 @@ jobs:
     timeout-minutes: 45
     name: e2e-host-app-${{ matrix.test_suite }}-tests-${{ matrix.environment }}-bundle
     env:
+      CI_CONDUCTOR_TEST_SUITE: embedding-sdk-host-app
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
       HOST_APP_ENVIRONMENT: ${{ matrix.environment }}
     permissions:
@@ -398,6 +413,8 @@ jobs:
 
       - name: Run Metabase
         run: node e2e/runner/run_cypress_ci.js start
+
+      - uses: ./.github/actions/resolve-job-id
 
       - name: Generate database snapshots
         run: |

--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -34,6 +34,7 @@ const {
   CI_CONDUCTOR_BASE_URL,
   CI_CONDUCTOR_WEBHOOK_SECRET,
   CI_CONDUCTOR_DRY_RUN,
+  CI_CONDUCTOR_TEST_SUITE,
   REPO_ID,
   GITHUB_RUN_ID,
   GITHUB_RUN_ATTEMPT,
@@ -337,7 +338,7 @@ export async function reportFailedTestsToConductor(
       run_id: toNumber(GITHUB_RUN_ID),
       attempt: toNumber(GITHUB_RUN_ATTEMPT),
       job_id: getJobId(),
-      test_suite: "e2e",
+      test_suite: CI_CONDUCTOR_TEST_SUITE || "e2e",
       // PR head sha / target branch when set by e2e-test.yml, else the ambient
       // (push/local) values. Empty strings collapse to null.
       sha: COMMIT_SHA || GITHUB_SHA || null,


### PR DESCRIPTION
Resolves DEV-2303 (test reporting)
Resolves DEV-2308 (quarantine dry run)

## Summary

Wires various embedding e2e suites to the ci-conductor failed test reporting mechanism by adding necessary environment variables. Each suite is distinct - controlled by `CI_CONDUCTOR_TEST_SUITE`

> [!IMPORTANT]
> This PR wires the quarantine dry run to all embedding workflows in https://github.com/metabase/metabase/pull/77184/commits/38b5d325f55935bf40b7bbf56b055772fac0fa10