### PR TITLE
Fix a couple of the more unreliable snowflake tests.

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -804,6 +804,10 @@
                                         driver/*driver*
                                         (t2/select-one :model/Database (mt/id)))
                                        :tables
+                                       ;; metabase-enterprise.transforms-inspector-test
+                                       ;; adds a bunch of new tables randomly
+                                       (into [])
+                                       (remove (partial re-find #"^g_"))
                                        (into #{}))
                       default-table-set (tables-set)
                       do-with-resolved-connection sql-jdbc.execute/do-with-resolved-connection]

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -824,7 +824,7 @@
             (is (= [expected]
                    (mt/first-row (qp/process-query query))))))))))
 
-(deftest ^:parallel local-date-time-parameter-test
+(deftest local-date-time-parameter-test
   (test-temporal-instance
    #t "2024-04-25T14:44:00"
    "2024-04-25T14:44:00Z"))
@@ -835,7 +835,7 @@
      #t "2024-04-25T14:44:00"
      "2024-04-25T14:44:00-07:00")))
 
-(deftest ^:parallel offset-date-time-parameter-test
+(deftest offset-date-time-parameter-test
   (test-temporal-instance
    #t "2024-04-25T14:44:00-07:00"
    "2024-04-25T21:44:00Z"))


### PR DESCRIPTION
The local-date-time-parameter-test test fails frequently with "statement is closed" on release branches but not at all on master. It's unclear to me why this would happen, but on master we removed the `^:parallel` marker, which I have to assume is what fixed it, so let's remove it here too (and backport further).

The resilient-connection-options-test test fails frequently because another test randomly introduces new tables into the default schema. That test should be fixed, but in the mean time, we can't make assumptions about all the tables being stable; we need to filter out the ones added by the transform tests.