### PR TITLE
Pool error fix

### DIFF
--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -142,8 +142,10 @@
             ;; format the Exception and return it
             (let [formatted-exception (format-exception* query e @extra-info)
                   query-canceled?     (some (comp :query/query-canceled? ex-data)
-                                            (u/full-exception-chain e))]
-              (when-not query-canceled?
+                                            (u/full-exception-chain e))
+                  pool-saturated?     (qp.error-type/connection-pool-saturated?
+                                       (:error_type formatted-exception))]
+              (when-not (or query-canceled? pool-saturated?)
                 (log/errorf "Error processing query: %s\n%s"
                             (or (:error formatted-exception) "Error running query")
                             (u/pprint-to-str formatted-exception)))

--- a/test/metabase/query_processor/middleware/catch_exceptions_test.clj
+++ b/test/metabase/query_processor/middleware/catch_exceptions_test.clj
@@ -127,6 +127,24 @@
              :data       {:cols []}}
             (catch-exceptions (fn [] (throw (Exception. "Something went wrong"))))))))
 
+(deftest ^:synchronized connection-pool-saturated-not-logged-test
+  (testing "connection-pool saturation is transient load shedding: fail the query (503 for clients) but don't log an error"
+    (doseq [error-type [qp.error-type/connection-pool-checkout-timeout
+                        qp.error-type/connection-pool-checkout-queue-full]]
+      (testing error-type
+        (mt/with-log-messages-for-level [messages [metabase.query-processor.middleware.catch-exceptions :error]]
+          (is (=? {:status     :failed
+                   :error_type error-type
+                   :error      "The pool is full"}
+                  (catch-exceptions (fn [] (throw (ex-info "The pool is full" {:type error-type}))))))
+          (is (empty? (messages)))))))
+  (testing "control: other errors still log"
+    (mt/with-log-messages-for-level [messages [metabase.query-processor.middleware.catch-exceptions :error]]
+      (is (=? {:status :failed}
+              (catch-exceptions (fn [] (throw (Exception. "Something went wrong"))))))
+      (is (=? [{:level :error, :message #"(?s)^Error processing query.*"}]
+              (messages))))))
+
 (deftest ^:parallel catch-exceptions-test
   (testing "include-query-execution-info-test"
     (testing "Should include info from QueryExecution if added to the thrown/raised Exception"


### PR DESCRIPTION
Pool checkout timeouts (`connection-pool-checkout-timeout`) and full checkout queues (`connection-pool-checkout-queue-full`) are transient load shedding: the query itself is fine, the client gets a 503 and may retry. They fire in bursts exactly when the instance is already overloaded, so logging every one — with the full pretty-printed exception map — floods the logs at the worst possible moment without adding information.

This skips the `Error processing query` log for any error whose `:error_type` isa `connection-pool-saturated` (both children), the same predicate `metabase.query-processor.streaming` already uses to map these errors to HTTP 503. Canceled queries were already skipped the same way; all other errors log as before (covered by a control assertion in the new test).
