### PR TITLE
Log only the error message for failed queries

### DIFF
--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -146,9 +146,8 @@
                   pool-saturated?     (qp.error-type/connection-pool-saturated?
                                        (:error_type formatted-exception))]
               (when-not (or query-canceled? pool-saturated?)
-                (log/errorf "Error processing query: %s\n%s"
-                            (or (:error formatted-exception) "Error running query")
-                            (u/pprint-to-str formatted-exception)))
+                (log/errorf "Error processing query: %s"
+                            (or (:error formatted-exception) "Error running query")))
               ;; ensure always a message on the error otherwise FE thinks query was successful. (#23258, #23281)
               (let [result (update formatted-exception
                                    :error (fnil identity (trs "Error running query")))]

--- a/test/metabase/query_processor/middleware/catch_exceptions_test.clj
+++ b/test/metabase/query_processor/middleware/catch_exceptions_test.clj
@@ -145,6 +145,22 @@
       (is (=? [{:level :error, :message #"(?s)^Error processing query.*"}]
               (messages))))))
 
+(deftest ^:synchronized error-log-excludes-stack-trace-and-query-test
+  (testing "the error log carries only the error message — no stack trace and nothing carrying the query/user data"
+    (mt/with-log-messages-for-level [messages [metabase.query-processor.middleware.catch-exceptions :error]]
+      (let [result (catch-exceptions
+                    (fn [] (throw (ex-info "boom" {:secret-in-ex-data "hunter2-ex-data"})))
+                    {:query {:source-table 3, :filter [:= [:field 5 nil] "hunter2-query"]}})]
+        (is (=? [{:level :error, :message "Error processing query: boom"}]
+                (messages)))
+        (testing "the userland response still has the full detail"
+          (is (=? {:status     :failed
+                   :error      "boom"
+                   :stacktrace vector?
+                   :ex-data    {:secret-in-ex-data "hunter2-ex-data"}
+                   :json_query {:query {:filter [:= [:field 5 nil] "hunter2-query"]}}}
+                  result)))))))
+
 (deftest ^:parallel catch-exceptions-test
   (testing "include-query-execution-info-test"
     (testing "Should include info from QueryExecution if added to the thrown/raised Exception"

--- a/test/metabase/query_processor/middleware/catch_exceptions_test.clj
+++ b/test/metabase/query_processor/middleware/catch_exceptions_test.clj
@@ -4,6 +4,8 @@
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.query-processor.compile :as qp.compile]
@@ -148,9 +150,12 @@
 (deftest ^:synchronized error-log-excludes-stack-trace-and-query-test
   (testing "the error log carries only the error message — no stack trace and nothing carrying the query/user data"
     (mt/with-log-messages-for-level [messages [metabase.query-processor.middleware.catch-exceptions :error]]
-      (let [result (catch-exceptions
+      (let [mp     (mt/metadata-provider)
+            query  (-> (lib/query mp (lib.metadata/table mp (mt/id :venues)))
+                       (lib/filter (lib/= (lib.metadata/field mp (mt/id :venues :name)) "hunter2-query")))
+            result (catch-exceptions
                     (fn [] (throw (ex-info "boom" {:secret-in-ex-data "hunter2-ex-data"})))
-                    {:query {:source-table 3, :filter [:= [:field 5 nil] "hunter2-query"]}})]
+                    query)]
         (is (=? [{:level :error, :message "Error processing query: boom"}]
                 (messages)))
         (testing "the userland response still has the full detail"
@@ -158,7 +163,7 @@
                    :error      "boom"
                    :stacktrace vector?
                    :ex-data    {:secret-in-ex-data "hunter2-ex-data"}
-                   :json_query {:query {:filter [:= [:field 5 nil] "hunter2-query"]}}}
+                   :json_query map?}
                   result)))))))
 
 (deftest ^:parallel catch-exceptions-test


### PR DESCRIPTION
Follow-up to #77212. The QP error log included the whole pretty-printed formatted exception: the query in several forms (`:json_query`, `:preprocessed`, `:native`), `:ex-data` (which frequently embeds query fragments or other user data), and full stack traces. None of that belongs in the log — and it was also a significant source of log volume and large-string allocation on failing instances.

Now the log line is just `Error processing query: <message>`. The userland response is unchanged and still carries the full detail (covered by the new test).
