### PR TITLE
Minify the static-viz bundle

### DIFF
--- a/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
+++ b/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
@@ -1,7 +1,8 @@
 import { Group } from "@visx/group";
-import { init } from "echarts";
+import { init } from "echarts/core";
 
 import { sanitizeSvgForBatik } from "metabase/static-viz/lib/svg";
+import { registerEChartsModules } from "metabase/visualizations/echarts";
 import { DIMENSIONS } from "metabase/visualizations/echarts/pie/constants";
 import { getPieChartFormatters } from "metabase/visualizations/echarts/pie/format";
 import { getPieChartModel } from "metabase/visualizations/echarts/pie/model";
@@ -13,6 +14,8 @@ import { LEGEND_ITEM_MARGIN_RIGHT_GRID } from "../Legend/constants";
 import type { StaticChartProps } from "../StaticVisualization";
 
 import { getPieChartLegend, getPieChartSideLegend } from "./legend";
+
+registerEChartsModules();
 
 function renderPieSvg(
   option: ReturnType<typeof getPieChartOption>,

--- a/rspack.static-viz.config.js
+++ b/rspack.static-viz.config.js
@@ -76,8 +76,8 @@ module.exports = (env) => {
                   },
                 },
 
-                sourceMaps: true,
-                minify: false, // produces same bundle size, but cuts 1s locally
+                sourceMaps: false,
+                minify: true,
                 env: {
                   targets: ["defaults"],
                 },
@@ -138,7 +138,7 @@ module.exports = (env) => {
       },
     },
     optimization: {
-      minimize: false,
+      minimize: true,
     },
     plugins: [
       new rspack.EnvironmentPlugin({


### PR DESCRIPTION
Enable rspack minification for the static-viz bundle that GraalVM parses for chart rendering. Both flags (`optimization.minimize` and the swc-loader `minify`) were off, shipping an unminified bundle. Turning them on shrinks the source GraalVM parses and retains, cutting parse time and the engine's parsed footprint. Verified a real `gauge` render round-trips through GraalVM on the minified bundle.

Also drops the swc `sourceMaps` flag and the stale `// produces same bundle size, but cuts 1s locally` comment. No `devtool` is set, so rspack was discarding the per-module maps swc generated; the shipped artifact has no source maps before or after this change.

| | before | after |
|---|---|---|
| size | 27.2 MB | 6.7 MB (-75%) |
| lines | 564,774 | 58 |
| gzipped | 4.25 MB | 1.74 MB (-59%) |

