### PR TITLE
Reject replacing a dashcard's card with a question internal to another dashboard

### DIFF
--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -860,10 +860,10 @@
     (dashboard-card/delete-dashboard-cards! dashcard-ids)
     dashboard-cards))
 
-(defn- assert-new-dashcards-are-not-internal-to-other-dashboards [dashboard to-create]
+(defn- assert-dashcards-are-not-internal-to-other-dashboards [dashboard dashcards]
   (when-let [card-ids (seq (concat
-                            (seq (keep :card_id to-create))
-                            (->> to-create
+                            (seq (keep :card_id dashcards))
+                            (->> dashcards
                                  (mapcat :series)
                                  (keep :id))))]
     (api/check-400 (not (t2/exists? :model/Card
@@ -876,7 +876,9 @@
   [dashboard current-cards new-cards]
   (let [{:keys [to-create to-update to-delete]} (u/row-diff current-cards new-cards)]
     (dashboard/archive-or-unarchive-internal-dashboard-questions! (:id dashboard) new-cards)
-    (assert-new-dashcards-are-not-internal-to-other-dashboards dashboard to-create)
+    ;; Check both created and updated dashcards: a "Replace" keeps the dashcard id and only swaps
+    ;; card_id, so it lands in `to-update`, not `to-create` (UXW-4731).
+    (assert-dashcards-are-not-internal-to-other-dashboards dashboard (concat to-create to-update))
     (when (seq to-update)
       (update-dashcards! dashboard to-update))
     {:deleted-dashcards (when (seq to-delete)

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -5218,6 +5218,31 @@
       (t2/delete! :model/Dashboard :id dash-id)
       (is (not (t2/exists? :model/Card :dashboard_id dash-id))))))
 
+(deftest ^:parallel dashboard-internal-card-cannot-be-replaced-onto-another-dashboard-test
+  ;; UXW-4731: the add-card guard only checked newly-created dashcards, so "Replace" (which keeps the
+  ;; dashcard id and only swaps card_id -> lands in `to-update`) could smuggle a dashboard-internal card
+  ;; from another dashboard onto this one.
+  (mt/with-temp [:model/Dashboard     {source-dash-id :id} {}
+                 :model/Card          {dq-card-id :id}     {:dashboard_id source-dash-id}
+                 :model/DashboardCard  _                   {:card_id dq-card-id :dashboard_id source-dash-id}
+                 :model/Dashboard     {other-dash-id :id}  {}
+                 :model/Card          {regular-card-id :id} {}
+                 :model/DashboardCard {dashcard-id :id}    {:card_id regular-card-id :dashboard_id other-dash-id}]
+    (testing "Adding it as a new dashcard is rejected"
+      (mt/user-http-request :crowberto :put 400 (str "dashboard/" other-dash-id)
+                            {:dashcards [{:id -1 :size_x 1 :size_y 1 :row 0 :col 0 :card_id dq-card-id}]}))
+    (testing "Replacing an existing dashcard's card with it is also rejected"
+      (mt/user-http-request :crowberto :put 400 (str "dashboard/" other-dash-id)
+                            {:dashcards [{:id dashcard-id :size_x 1 :size_y 1 :row 0 :col 0 :card_id dq-card-id}]}))
+    (testing "Adding it as an extra series on an existing dashcard is also rejected"
+      (mt/user-http-request :crowberto :put 400 (str "dashboard/" other-dash-id)
+                            {:dashcards [{:id dashcard-id :size_x 1 :size_y 1 :row 0 :col 0
+                                          :card_id regular-card-id
+                                          :series [{:id dq-card-id}]}]}))
+    (testing "The foreign dashboard-internal card was not persisted onto the other dashboard"
+      (is (not (t2/exists? :model/DashboardCard :dashboard_id other-dash-id :card_id dq-card-id)))
+      (is (not (t2/exists? :model/DashboardCardSeries :card_id dq-card-id))))))
+
 (deftest dashboard-questions-are-archived-with-the-dashboard
   (testing "It gets archived with the dashboard"
     (mt/with-temp [:model/Dashboard {dash-id :id} {}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68612
### Description

Fixes [UXW-4731](https://linear.app/metabase/issue/UXW-4731/the-select-question-option-shows-questions-from-other-dashboards-save).

**Cause:** the dashboard-save guard only validated newly added dashcards, so replacing an existing card could silently attach a question that lives inside another dashboard (adding that same question correctly failed with a 400).

**Fix:** validate updated dashcards too (including extra series), so "Replace" is rejected the same way "Add" is.

- Behavior note: a dashboard that already contains a smuggled foreign question (from before this fix) will now fail to save when that specific card is edited, until it is removed.

### How to verify

- [ ] Create a question saved inside dashboard A (a dashboard question), then `PUT /api/dashboard/<B>` changing an existing dashcard's `card_id` to that question's id: expect 400 "Invalid Request." (before this fix it returned 200 and dashboard B kept rendering A's internal question).
- [ ] (Optional, UI) In one tab, edit dashboard B and Replace an existing card with a regular question. In a second tab, move that question into dashboard A. Back in the first tab, Save: it fails ("Save failed") instead of quietly hosting A's question.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
