### PR TITLE
Agents should report errors when models, actions or questions cannot be schema generated

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2470,7 +2470,8 @@
            models
            system
            util}
-   :model-imports #{:model/Card
+   :model-imports #{:model/Action
+                    :model/Card
                     :model/Collection
                     :model/Database
                     :model/Field

--- a/skills/metabase-data-app-semantic-layer/SKILL.md
+++ b/skills/metabase-data-app-semantic-layer/SKILL.md
@@ -92,6 +92,8 @@ fi
 
 When the app needs saved questions or models, include `questionCollections=<id-or-entity-id>[,<id-or-entity-id>]` in the typed-schema URL.
 
+If schema generation fails while building a selected saved question or model, do not hide, paraphrase away, or retry past the error. Surface the typed-schema error to the user, including the failing `card-id` / `card-type` and message when present. This usually means a selected model/question was readable enough to select, but its details could not be built, often because its source table or source card is not published, accessible, or resolvable in the fetch context. The schema would otherwise omit the entire `schema.models.<model>` or `schema.questions.<question>` entry, including model actions, so the user needs to curate or publish the missing dependency before regenerating.
+
 ## Standard pattern
 
 ```ts

--- a/skills/metabase-data-app-semantic-layer/SKILL.md
+++ b/skills/metabase-data-app-semantic-layer/SKILL.md
@@ -92,7 +92,7 @@ fi
 
 When the app needs saved questions or models, include `questionCollections=<id-or-entity-id>[,<id-or-entity-id>]` in the typed-schema URL.
 
-If schema generation fails while building a selected saved question or model, do not hide, paraphrase away, or retry past the error. Surface the typed-schema error to the user, including the failing `card-id` / `card-type` and message when present. This usually means a selected model/question was readable enough to select, but its details could not be built, often because its source table or source card is not published, accessible, or resolvable in the fetch context. The schema would otherwise omit the entire `schema.models.<model>` or `schema.questions.<question>` entry, including model actions, so the user needs to curate or publish the missing dependency before regenerating.
+If schema generation fails while building a selected saved question, model, or model action, do not hide, paraphrase away, or retry past the error. Surface the typed-schema error to the user, including the failing `card-id` / `card-name` / `card-type`, `model-id` / `model-name`, dropped action ids, and message when present. This usually means a selected model/question/action was readable enough to select, but its details could not be built, often because its source table, source card, or action details are not published, accessible, valid, or resolvable in the fetch context. The schema would otherwise omit the entire `schema.models.<model>` or `schema.questions.<question>` entry, or return a model whose `actions` map silently omits an action, so the user needs to curate or publish the missing dependency before regenerating.
 
 ## Standard pattern
 

--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -390,6 +390,65 @@
     :card-type (:type card)}
    :status-code (:status-code m)))
 
+(defn- model-action-error-message
+  ([model error-message]
+   (format "Failed to build action schemas for model \"%s\" (card %s): %s"
+           (or (:name model) "Untitled")
+           (:id model)
+           (or error-message "unknown error")))
+  ([model action error-message]
+   (format "Failed to build action schema for action \"%s\" (action %s, type %s) on model \"%s\" (card %s): %s"
+           (or (:name action) "Untitled")
+           (:id action)
+           (or (some-> (:type action) name) "unknown")
+           (or (:name model) "Untitled")
+           (:id model)
+           (or error-message "unknown error"))))
+
+(defn- model-action-error-data
+  ([model m]
+   (assoc-some
+    {:model-id   (:id model)
+     :model-name (:name model)}
+    :status-code (:status-code m)))
+  ([model action m]
+   (assoc-some
+    (assoc (model-action-error-data model m)
+           :action-id   (:id action)
+           :action-name (:name action)
+           :action-type (:type action))
+    :status-code (:status-code m))))
+
+(defn- raw-model-actions
+  [model-id]
+  (t2/select :model/Action
+             :model_id model-id
+             :archived false
+             :type [:not= "http"]))
+
+(defn- dropped-actions
+  [raw-actions actions]
+  (let [action-ids (set (map :id actions))]
+    (not-empty
+     (remove #(contains? action-ids (:id %)) raw-actions))))
+
+(defn- dropped-actions-message
+  [model dropped-actions]
+  (format "Failed to build action schemas for model \"%s\" (card %s): selected actions were dropped while normalizing action details: %s"
+          (or (:name model) "Untitled")
+          (:id model)
+          (str/join ", "
+                    (for [action dropped-actions]
+                      (format "%s (action %s, type %s)"
+                              (or (:name action) "Untitled")
+                              (:id action)
+                              (or (some-> (:type action) name) "unknown"))))))
+
+(defn- dropped-actions-data
+  [model dropped-actions]
+  (assoc (model-action-error-data model nil)
+         :dropped-actions (mapv #(select-keys % [:id :name :type]) dropped-actions)))
+
 (defn- question-details
   [card]
   (let [response (try
@@ -556,23 +615,42 @@
   `assoc-some` drops the empty `:actions` field. `model-columns` is the
   parent model's already-rendered column schemas, passed through to
   implicit actions for response-row typing."
-  [model-id model-columns]
-  (let [actions (actions/select-actions
-                 nil
-                 :model_id model-id
-                 :archived false
-                 :type [:not= "http"])]
+  [model model-columns]
+  (let [raw-actions (raw-model-actions (:id model))
+        actions (try
+                  (actions/select-actions
+                   nil
+                   :model_id (:id model)
+                   :archived false
+                   :type [:not= "http"])
+                  (catch Exception e
+                    (throw (ex-info (model-action-error-message model (ex-message e))
+                                    (assoc (model-action-error-data model (ex-data e))
+                                           :cause-message (ex-message e))
+                                    e))))
+        dropped (dropped-actions raw-actions actions)]
+    (when dropped
+      (throw (ex-info (dropped-actions-message model dropped)
+                      (dropped-actions-data model dropped))))
     (when (seq actions)
-      (mapv #(action-schema model-columns %) actions))))
+      (mapv (fn [action]
+              (try
+                (action-schema model-columns action)
+                (catch Exception e
+                  (throw (ex-info (model-action-error-message model action (ex-message e))
+                                  (assoc (model-action-error-data model action (ex-data e))
+                                         :cause-message (ex-message e))
+                                  e)))))
+            actions))))
 
 (defn- model-schema
   "A Metabase model (curated dataset). Shape parallels [[question-schema]] —
   same id/name/columns/etc. — but with `:kind \"model\"` and an extra
   `:actions` map of pre-existing actions bound to the model
   (`action.model_id`)."
-  [{:keys [id name description verified display result-columns portable_entity_id]}]
+  [{:keys [id name description verified display result-columns portable_entity_id] :as model}]
   (let [columns (mapv column-schema result-columns)
-        action-schemas (model-actions id columns)]
+        action-schemas (model-actions model columns)]
     (assoc-some
      {:kind    "model"
       :key     (generated-key name id)

--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -370,15 +370,46 @@
                     :order-by [[:name :asc] [:id :asc]]})
         (filter mi/can-read?))))
 
+(defn- card-type-name
+  [card]
+  (some-> (:type card) name))
+
+(defn- schema-details-error-message
+  [card error-message]
+  (format "Failed to build schema details for %s \"%s\" (card %s): %s"
+          (or (card-type-name card) "card")
+          (or (:name card) "Untitled")
+          (:id card)
+          (or error-message "unknown error")))
+
+(defn- schema-details-error-data
+  [card m]
+  (assoc-some
+   {:card-id   (:id card)
+    :card-name (:name card)
+    :card-type (:type card)}
+   :status-code (:status-code m)))
+
 (defn- question-details
   [card]
-  (-> (entity-details/get-report-details {:report-id             (:id card)
-                                          :with-field-values?    false
-                                          :with-related-tables?  false
-                                          :with-metrics?         false
-                                          :with-measures?        false
-                                          :with-segments?        false})
-      :structured-output))
+  (let [response (try
+                   (entity-details/get-report-details {:report-id             (:id card)
+                                                       :with-field-values?    false
+                                                       :with-related-tables?  false
+                                                       :with-metrics?         false
+                                                       :with-measures?        false
+                                                       :with-segments?        false})
+                   (catch Exception e
+                     (throw (ex-info (schema-details-error-message card (ex-message e))
+                                     (assoc (schema-details-error-data card (ex-data e))
+                                            :cause-message (ex-message e))
+                                     e))))]
+    (or (:structured-output response)
+        (let [error-message (:output response)]
+          (throw (ex-info (schema-details-error-message card error-message)
+                          (assoc (schema-details-error-data card response)
+                                 :error-message error-message
+                                 :response response)))))))
 
 (defn- metric-result-column
   [card]

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.actions.core :as actions]
    [metabase.collections.models.collection :as collection]
    [metabase.metabot.tools.entity-details :as entity-details]
    [metabase.models.interface :as mi]
@@ -552,6 +553,64 @@
               :status-code   500
               :cause-message "Invalid output: [\"Valid Table metadata, got: nil\"]"}
              (select-keys (ex-data e) [:card-id :card-name :card-type :status-code :cause-message]))))))
+
+(deftest model-schema-surfaces-action-selection-errors-test
+  (with-redefs [typed-schemas.api/raw-model-actions (constantly [])
+                actions/select-actions (fn [& _]
+                                         (throw (ex-info "action lookup failed"
+                                                         {:status-code 500})))]
+    (let [e (is (thrown? clojure.lang.ExceptionInfo
+                         (#'typed-schemas.api/model-schema {:id             100
+                                                            :name           "Broken model"
+                                                            :result-columns []})))]
+      (is (= "Failed to build action schemas for model \"Broken model\" (card 100): action lookup failed"
+             (ex-message e)))
+      (is (= {:model-id      100
+              :model-name    "Broken model"
+              :status-code   500
+              :cause-message "action lookup failed"}
+             (select-keys (ex-data e) [:model-id :model-name :status-code :cause-message]))))))
+
+(deftest model-schema-surfaces-action-rendering-errors-test
+  (with-redefs [actions/select-actions (constantly [{:id   200
+                                                     :name "Broken action"
+                                                     :type :query}])
+                typed-schemas.api/raw-model-actions (constantly [{:id   200
+                                                                  :name "Broken action"
+                                                                  :type :query}])
+                typed-schemas.api/action-schema (fn [& _]
+                                                  (throw (ex-info "action parameters are invalid"
+                                                                  {:status-code 500})))]
+    (let [e (is (thrown? clojure.lang.ExceptionInfo
+                         (#'typed-schemas.api/model-schema {:id             100
+                                                            :name           "Broken model"
+                                                            :result-columns []})))]
+      (is (= "Failed to build action schema for action \"Broken action\" (action 200, type query) on model \"Broken model\" (card 100): action parameters are invalid"
+             (ex-message e)))
+      (is (= {:model-id      100
+              :model-name    "Broken model"
+              :action-id     200
+              :action-name   "Broken action"
+              :action-type   :query
+              :status-code   500
+              :cause-message "action parameters are invalid"}
+             (select-keys (ex-data e) [:model-id :model-name :action-id :action-name :action-type :status-code :cause-message]))))))
+
+(deftest model-schema-surfaces-dropped-action-errors-test
+  (with-redefs [typed-schemas.api/raw-model-actions (constantly [{:id   200
+                                                                  :name "Broken action"
+                                                                  :type :broken}])
+                actions/select-actions (constantly [])]
+    (let [e (is (thrown? clojure.lang.ExceptionInfo
+                         (#'typed-schemas.api/model-schema {:id             100
+                                                            :name           "Broken model"
+                                                            :result-columns []})))]
+      (is (= "Failed to build action schemas for model \"Broken model\" (card 100): selected actions were dropped while normalizing action details: Broken action (action 200, type broken)"
+             (ex-message e)))
+      (is (= {:model-id        100
+              :model-name      "Broken model"
+              :dropped-actions [{:id 200, :name "Broken action", :type :broken}]}
+             (select-keys (ex-data e) [:model-id :model-name :dropped-actions]))))))
 
 (deftest library-and-database-are-mutually-exclusive-test
   (mt/user-http-request-full-response

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.collections.models.collection :as collection]
+   [metabase.metabot.tools.entity-details :as entity-details]
    [metabase.models.interface :as mi]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -520,6 +521,37 @@
       (#'typed-schemas.api/typed-schema {:database "Boba"})
       (#'typed-schemas.api/typed-schema {:database "Boba" :questions "true"})
       (is (= [#{42} #{42}] @model-database-ids)))))
+
+(deftest model-schemas-surface-detail-errors-test
+  (with-redefs [typed-schemas.api/select-cards (constantly [{:id 100 :type "model" :name "Broken model"}])
+                entity-details/get-report-details (constantly {:output "source table not found"
+                                                               :status-code 404})]
+    (let [e (is (thrown? clojure.lang.ExceptionInfo
+                         (doall (#'typed-schemas.api/model-schemas #{1}))))]
+      (is (= "Failed to build schema details for model \"Broken model\" (card 100): source table not found"
+             (ex-message e)))
+      (is (= {:card-id       100
+              :card-name     "Broken model"
+              :card-type     "model"
+              :status-code   404
+              :error-message "source table not found"}
+             (select-keys (ex-data e) [:card-id :card-name :card-type :status-code :error-message]))))))
+
+(deftest model-schemas-surface-detail-exceptions-test
+  (with-redefs [typed-schemas.api/select-cards (constantly [{:id 100 :type "model" :name "Broken model"}])
+                entity-details/get-report-details (fn [_]
+                                                    (throw (ex-info "Invalid output: [\"Valid Table metadata, got: nil\"]"
+                                                                    {:status-code 500})))]
+    (let [e (is (thrown? clojure.lang.ExceptionInfo
+                         (doall (#'typed-schemas.api/model-schemas #{1}))))]
+      (is (= "Failed to build schema details for model \"Broken model\" (card 100): Invalid output: [\"Valid Table metadata, got: nil\"]"
+             (ex-message e)))
+      (is (= {:card-id       100
+              :card-name     "Broken model"
+              :card-type     "model"
+              :status-code   500
+              :cause-message "Invalid output: [\"Valid Table metadata, got: nil\"]"}
+             (select-keys (ex-data e) [:card-id :card-name :card-type :status-code :cause-message]))))))
 
 (deftest library-and-database-are-mutually-exclusive-test
   (mt/user-http-request-full-response


### PR DESCRIPTION
Closes EMB-2066

### Description

Typed schema generation used to silently omit selected saved questions or models when `entity-details/get-report-details` returned an error response without `:structured-output`. For models, that meant the entire `schema.models.<model>` entry disappeared, including model-bound actions, making the generated schema look stale or incomplete.

This changes question/model detail generation to surface that failure as an `ExceptionInfo` that names the selected card id/name/type and preserves the original message/status plus the raw response or thrown cause. It also wraps model action lookup/rendering failures with the parent model/action context, detects selected actions dropped during action normalization, adds regression tests for these failure modes, and updates the data-app semantic-layer skill so agents surface typed-schema generation errors instead of retrying past them.

### Screenshots

Here's what Claude will tell you if your actions are broken

<img width="1304" height="370" alt="image" src="https://github.com/user-attachments/assets/93e479a2-a61e-4697-9bf5-65830114a787" />

Example model-detail error:

```text
Failed to build schema details for model "Franchises Model" (card 256): Invalid output: ["Valid Table metadata, got: nil"]
```

Example action-normalization error:

```text
Failed to build action schemas for model "Franchises Model" (card 256): selected actions were dropped while normalizing action details: Delete (action 7, type broken)
```

### How to verify

#### Broken model details

1. In a local instance with the Boba git-sync content loaded, choose a model that is selected by a question collection. For example, `Franchises Model` is card `256` in the `Boba Shop Questions` collection `26`.
2. Save the model's original query so you can restore it. From `/Users/poom/Workspaces/metabase/git-sync`:
   ```bash
   mb card get 256 \
     --url "$DATA_APP_MB_URL" \
     --api-key "$DATA_APP_MB_API_KEY" \
     --json \
     --fields dataset_query \
     | jq '.dataset_query' > /tmp/franchises-model-query.json
   ```
3. Confirm the baseline schema includes the model:
   ```bash
   curl -H "x-api-key: $DATA_APP_MB_API_KEY" \
     "$DATA_APP_MB_URL/api/typed-schemas/v1/json?questionCollections=26"
   ```
4. Make the model detail builder fail by patching the model to use a real table from a different database while leaving `dataset_query.database` pointed at Boba. For example, table `125` is `report_card` from the Internal Metabase Database, while database `3` is Boba:
   ```bash
   mb card update 256 \
     --url "$DATA_APP_MB_URL" \
     --api-key "$DATA_APP_MB_API_KEY" \
     --skip-validate \
     --body '{"dataset_query":{"lib/type":"mbql/query","database":3,"stages":[{"lib/type":"mbql.stage/mbql","source-table":125}]}}'
   ```
   The source table id must exist so `report_card.table_id` remains FK-valid, but it must be invalid for the selected query database so model details cannot be built.
5. Request the schema again:
   ```bash
   curl -H "x-api-key: $DATA_APP_MB_API_KEY" \
     "$DATA_APP_MB_URL/api/typed-schemas/v1/json?questionCollections=26"
   ```
6. Confirm the request fails with the model-detail error instead of returning a schema that silently omits the model from `schema.models`.
7. Restore the model's original query:
   ```bash
   mb card update 256 \
     --url "$DATA_APP_MB_URL" \
     --api-key "$DATA_APP_MB_API_KEY" \
     --skip-validate \
     --body "$(jq -c '{dataset_query: .}' /tmp/franchises-model-query.json)"
   ```

#### Broken actions

1. Confirm the baseline schema includes all three `Franchises Model` actions:
   ```bash
   curl -H "x-api-key: $DATA_APP_MB_API_KEY" \
     "$DATA_APP_MB_URL/api/typed-schemas/v1/json?questionCollections=26" \
     | jq '.models.franchisesModel.actions | keys'
   ```
   The keys should include `create`, `delete`, and `update`.
2. From `/Users/poom/Workspaces/metabase/metabase`, make the `Delete` action row invalid by changing action `7` to an unknown type:
   ```bash
   ./bin/mage -repl '(do (require (quote [toucan2.core :as t2])) (t2/update! :model/Action 7 {:type "broken"}) (select-keys (t2/select-one :model/Action :id 7) [:id :name :type :model_id]))'
   ```
   This reproduces an action-specific corrupt state: the action row is selected by `model_id = 256`, but action normalization cannot build a supported query/implicit action from it.
3. Request the schema again:
   ```bash
   curl -H "x-api-key: $DATA_APP_MB_API_KEY" \
     "$DATA_APP_MB_URL/api/typed-schemas/v1/json?questionCollections=26"
   ```
4. Confirm the request fails with an action-normalization error that names the model and dropped action, instead of returning a model whose `actions` map silently omits `delete`.
5. Restore the action:
   ```bash
   ./bin/mage -repl '(do (require (quote [toucan2.core :as t2])) (t2/update! :model/Action 7 {:type "implicit"}) (select-keys (t2/select-one :model/Action :id 7) [:id :name :type :model_id]))'
   ```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
