### PR TITLE
Forward query edits from viz settings in SDK QuestionSettings

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -1,6 +1,11 @@
 const { H } = cy;
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  DATA_GROUP_ID,
+  ORDERS_DASHBOARD_ID,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
 import { questionAsPinMapWithTiles } from "e2e/test/scenarios/embedding/shared/embedding-questions";
 import { defer } from "metabase/utils/promise";
 const { PRODUCTS, PRODUCTS_ID, ORDERS, ORDERS_ID, FEEDBACK, FEEDBACK_ID } =
@@ -1676,6 +1681,47 @@ describe("issue 57028", () => {
     H.popover().within(() => {
       cy.findByPlaceholderText("Search the list").should("be.visible");
       cy.findAllByRole("checkbox").its("length").should("be.greaterThan", 0);
+    });
+  });
+});
+
+describe("issue 77135", () => {
+  it("should add/remove columns via viz settings for a user with query-builder-only permission (EMB-2057)", () => {
+    H.prepareSdkIframeEmbedTest({
+      withToken: "bleeding-edge",
+      signOut: false,
+    });
+
+    cy.updatePermissionsGraph({
+      [DATA_GROUP_ID]: {
+        [SAMPLE_DB_ID]: {
+          "view-data": "unrestricted",
+          "create-queries": "query-builder",
+        },
+      },
+    });
+
+    cy.updateCollectionGraph({
+      [DATA_GROUP_ID]: { root: "read" },
+    });
+
+    cy.signIn("nocollection");
+
+    H.visitCustomHtmlPage(`
+      ${H.getNewEmbedScriptTag()}
+      ${H.getNewEmbedConfigurationScript({})}
+      <metabase-question question-id="${ORDERS_QUESTION_ID}" />
+    `);
+
+    H.getSimpleEmbedIframeContent().within(() => {
+      H.tableInteractive().findByText("Tax").should("be.visible");
+
+      cy.findByTestId("viz-settings-button").click();
+      cy.findByRole("button", { name: /Add or remove columns/ }).click();
+
+      cy.findByLabelText("Tax").should("be.checked").click();
+
+      H.tableInteractive().findByText("Tax").should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -1,11 +1,6 @@
 const { H } = cy;
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  DATA_GROUP_ID,
-  ORDERS_DASHBOARD_ID,
-  ORDERS_QUESTION_ID,
-} from "e2e/support/cypress_sample_instance_data";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import { questionAsPinMapWithTiles } from "e2e/test/scenarios/embedding/shared/embedding-questions";
 import { defer } from "metabase/utils/promise";
 const { PRODUCTS, PRODUCTS_ID, ORDERS, ORDERS_ID, FEEDBACK, FEEDBACK_ID } =
@@ -1681,47 +1676,6 @@ describe("issue 57028", () => {
     H.popover().within(() => {
       cy.findByPlaceholderText("Search the list").should("be.visible");
       cy.findAllByRole("checkbox").its("length").should("be.greaterThan", 0);
-    });
-  });
-});
-
-describe("issue 77135", () => {
-  it("should add/remove columns via viz settings for a user with query-builder-only permission (EMB-2057)", () => {
-    H.prepareSdkIframeEmbedTest({
-      withToken: "bleeding-edge",
-      signOut: false,
-    });
-
-    cy.updatePermissionsGraph({
-      [DATA_GROUP_ID]: {
-        [SAMPLE_DB_ID]: {
-          "view-data": "unrestricted",
-          "create-queries": "query-builder",
-        },
-      },
-    });
-
-    cy.updateCollectionGraph({
-      [DATA_GROUP_ID]: { root: "read" },
-    });
-
-    cy.signIn("nocollection");
-
-    H.visitCustomHtmlPage(`
-      ${H.getNewEmbedScriptTag()}
-      ${H.getNewEmbedConfigurationScript({})}
-      <metabase-question question-id="${ORDERS_QUESTION_ID}" />
-    `);
-
-    H.getSimpleEmbedIframeContent().within(() => {
-      H.tableInteractive().findByText("Tax").should("be.visible");
-
-      cy.findByTestId("viz-settings-button").click();
-      cy.findByRole("button", { name: /Add or remove columns/ }).click();
-
-      cy.findByLabelText("Tax").should("be.checked").click();
-
-      H.tableInteractive().findByText("Tax").should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/reproductions.cy.spec.ts
@@ -1,0 +1,28 @@
+const { H } = cy;
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+
+describe("issue 77135", () => {
+  it("should add/remove columns via viz settings (EMB-2057)", () => {
+    H.prepareSdkIframeEmbedTest({
+      withToken: "bleeding-edge",
+      signOut: false,
+    });
+
+    H.visitCustomHtmlPage(`
+      ${H.getNewEmbedScriptTag()}
+      ${H.getNewEmbedConfigurationScript({})}
+      <metabase-question question-id="${ORDERS_QUESTION_ID}" />
+    `);
+
+    H.getSimpleEmbedIframeContent().within(() => {
+      H.tableInteractive().findByText("Tax").should("be.visible");
+
+      cy.findByTestId("viz-settings-button").click();
+      cy.findByRole("button", { name: /Add or remove columns/ }).click();
+
+      cy.findByLabelText("Tax").should("be.checked").click();
+
+      H.tableInteractive().findByText("Tax").should("not.exist");
+    });
+  });
+});

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/QuestionSettings/QuestionSettings.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/QuestionSettings/QuestionSettings.tsx
@@ -46,7 +46,7 @@ const QuestionSettingsContent = ({
   ) => {
     await updateQuestion(
       (nextQuestion ?? question).updateSettings(settings).lockDisplay(),
-      { run: !!nextQuestion },
+      { run: Boolean(nextQuestion) },
     );
   };
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/QuestionSettings/QuestionSettings.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/QuestionSettings/QuestionSettings.tsx
@@ -40,8 +40,14 @@ const QuestionSettingsContent = ({
     ];
   }, [queryResults, question]);
 
-  const onChange = async (settings: VisualizationSettings) => {
-    await updateQuestion(question.updateSettings(settings).lockDisplay());
+  const onChange = async (
+    settings: VisualizationSettings,
+    nextQuestion?: Question,
+  ) => {
+    await updateQuestion(
+      (nextQuestion ?? question).updateSettings(settings).lockDisplay(),
+      { run: !!nextQuestion },
+    );
   };
 
   const { chartSettings, handleChangeSettings, transformedSeries } =


### PR DESCRIPTION
Fixes EMB-2057

Closes https://github.com/metabase/metabase/issues/77135

### Description

"Add or remove columns" is unlike other viz settings — it also changes the question's query, not just `visualization_settings`. That edit arrives as a second `question` argument to `onChange`, but the SDK's `QuestionSettings.tsx` never used it — likely because every other settings change never sends one, so the argument went unhandled.

The fix uses that second argument when present, re-running the query so the edit actually takes effect.

### How to verify

You can also just run the new e2e test: `e2e/test/scenarios/embedding/sdk-iframe-embedding/reproductions.cy.spec.ts` ("issue 77135").

To render the SDK for real and verify manually:

1. Start the frontend dev server (also serves the embedding SDK bundle):
   ```sh
   bun run build-hot
   ```
2. Render `<InteractiveQuestion questionId={134} />` from `@metabase/embedding-sdk-react` in your own SDK setup, pointed at your local Metabase.
3. Open Visualization settings > "Add or remove columns", toggle a column off.
4. Confirm the column is actually removed from the rendered table.

### Demo

#### After
I just unchecked most of the fields

<img width="2356" height="837" alt="image" src="https://github.com/user-attachments/assets/7a565198-5da7-4f9d-a011-af1eeb74ca69" />

#### Before
Checkboxes not clickable at all
<img width="1362" height="953" alt="image" src="https://github.com/user-attachments/assets/4c687c93-1a30-4749-8978-d48b5d0842cf" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
