### PR TITLE
Fix notification seed legacy template paths

### DIFF
--- a/src/metabase/notification/seed.clj
+++ b/src/metabase/notification/seed.clj
@@ -224,10 +224,17 @@
     :else
     :skip))
 
+(defn- hydrate-existing-notification
+  "Hydrate an existing notification row for comparison. Don't use [[models.notification/hydrate-notification]]
+   so we can migrate on schema changes."
+  [notification]
+  (t2/hydrate notification :creator :payload :subscriptions
+              [:handlers :channel :template [:recipients :recipients-detail]]))
+
 (defn- sync-notification!
   [{:keys [internal_id] :as row}]
   (let [existing-notification (some-> (t2/select-one :model/Notification :internal_id internal_id)
-                                      models.notification/hydrate-notification)]
+                                      hydrate-existing-notification)]
     (u/prog1 (action existing-notification row)
       (case <>
         :create

--- a/test/metabase/notification/seed_test.clj
+++ b/test/metabase/notification/seed_test.clj
@@ -7,6 +7,7 @@
    [metabase.notification.models :as models.notification]
    [metabase.notification.seed :as notification.seed]
    [metabase.test :as mt]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -51,6 +52,29 @@
       (doseq [path paths]
         (testing path
           (is (some? (.sourceAt loader path))))))))
+
+(deftest reseed-replaces-legacy-template-paths-test
+  (testing "re-seeding over rows whose template :path predates the current schema replaces them instead of throwing"
+    ;; before the handlebars 4.5.3 bump (#77134) seeded templates stored full classpath paths like
+    ;; `metabase/channel/email/new_user_invite.hbs`; the current schema only accepts bare names like
+    ;; `new_user_invite`. The seed must be able to read such pre-upgrade rows in order to replace them.
+    (mt/with-empty-h2-app-db!
+      (notification.seed/seed-notification!)
+      (let [template-id (t2/select-one-pk :model/ChannelTemplate :name "User joined Email template")
+            details     (t2/select-one-fn :details :model/ChannelTemplate :id template-id)
+            legacy-path "metabase/channel/email/new_user_invite.hbs"]
+        ;; plant the legacy path with a raw update: rows written by a pre-upgrade version never went
+        ;; through the current before-update validation, so neither should this
+        (t2/query {:update [:channel_template]
+                   :set    {:details (json/encode (assoc details :path legacy-path))}
+                   :where  [:= :id template-id]})
+        (is (= legacy-path (t2/select-one-fn (comp :path :details) :model/ChannelTemplate :id template-id)))
+        (testing "seed replaces the stale notification without throwing"
+          (is (= 1 (:replace (notification.seed/seed-notification!)))))
+        (testing "the recreated template has the current path"
+          (is (= "new_user_invite"
+                 (t2/select-one-fn (comp :path :details) :model/ChannelTemplate
+                                   :name "User joined Email template"))))))))
 
 (deftest sync-notification!-test
   (let [internal-id       (mt/random-name)


### PR DESCRIPTION
The handlebars bump PR (#77134) changed seeded channel template `:path` values from full classpath paths to just names, relying on the notification seed to replace stale rows at startup. But on dev, `sync-notification!` hydrated the existing row through `hydrate-notification` which is schema-validated and now rejects legagy paths. 
