### PR TITLE
Fill available space in the dashboard new-question query builder

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -624,18 +624,24 @@ const SdkDashboardInner = ({
                 />
               </MaybeStyledWrapper>
             ) : (
-              <DashboardQueryBuilder
-                onCreate={(question) => {
-                  setNewDashboardQuestionId(question.id);
-                  sdkNavigation?.pop(); // onPop handles setRenderMode("dashboard")
-                  dashboardContextProviderRef.current?.refetchDashboard();
-                }}
-                onNavigateBack={() => {
-                  sdkNavigation?.pop(); // onPop handles setRenderMode("dashboard")
-                }}
-                dataPickerProps={dataPickerProps}
-                onVisualizationChange={onVisualizationChange}
-              />
+              <MaybeStyledWrapper
+                skip={skipStyledWrapper}
+                className={className}
+                style={style}
+              >
+                <DashboardQueryBuilder
+                  onCreate={(question) => {
+                    setNewDashboardQuestionId(question.id);
+                    sdkNavigation?.pop(); // onPop handles setRenderMode("dashboard")
+                    dashboardContextProviderRef.current?.refetchDashboard();
+                  }}
+                  onNavigateBack={() => {
+                    sdkNavigation?.pop(); // onPop handles setRenderMode("dashboard")
+                  }}
+                  dataPickerProps={dataPickerProps}
+                  onVisualizationChange={onVisualizationChange}
+                />
+              </MaybeStyledWrapper>
             ),
           )
           .exhaustive()}
@@ -722,8 +728,9 @@ function DashboardQueryBuilder({
       }}
       entityTypes={dataPickerProps?.entityTypes}
       withChartTypeSelector
-      // The default value is 600px and it cuts off the "Visualize" button.
-      height="700px"
+      // Fill the available space so the query builder matches the dashboard's
+      // sizing instead of a fixed height that leaves whitespace / scrolls.
+      height="100%"
       onVisualizationChange={onVisualizationChange}
     />
   );


### PR DESCRIPTION
Closes [EMB-2055: Dashboard new-question flow shows cramped scrollable query builder](https://linear.app/metabase/issue/EMB-2055/dashboard-new-question-flow-shows-cramped-scrollable-query-builder)

### Description

Creating a new question from within an embedded dashboard (`EditableDashboard` →
edit → **+ Add questions** → **New Question**) rendered the notebook/query builder as
a fixed ~660×700px box floating in empty space — cramped, internally scrollable, and
surrounded by whitespace both horizontally and vertically. Creating a question via the
normal **New → Question** flow did not.

Root cause was in the `queryBuilder` render branch of `SdkDashboard.tsx`:

1. It was the **only** render branch that did not wrap its content in
   `MaybeStyledWrapper` → `SdkDashboardStyledWrapper` (a flex column with
   `align: stretch` / `min-height: 100%`). Without that full-size context under the
   definite-height SDK root, the query builder's `width: 100%` collapsed to the
   notebook's intrinsic width → horizontal whitespace.
2. It hardcoded `height="700px"` on the `SdkQuestion`, capping it regardless of
   viewport → vertical whitespace and internal scrolling.

The fix makes the branch symmetric with the `dashboard` branch: wrap it in
`MaybeStyledWrapper` and let the question fill its container with `height="100%"`.

### How to verify

1. `bun run build-embedding-sdk-package`
2. `bun run build-hot`
3. Run the backend and enable SDK embedding.
4. In a host app, render:
   ```tsx
   <MetabaseProvider authConfig={authConfig}>
     <EditableDashboard dashboardId={1} />
   </MetabaseProvider>
   ```
5. Edit the dashboard → **+ Add questions** → **New Question**.
6. Build up the query so the notebook grows tall, and resize the window.
7. On `master` the query builder is cramped/scrollable with whitespace; on this branch
   it fills the available space and responds to the viewport.

### Demo

Before
<img width="1450" height="1046" alt="SCR-20260708-nfav" src="https://github.com/user-attachments/assets/22e6c03d-2617-4cbb-8568-914061c1d37f" />


After
<img width="1450" height="1046" alt="SCR-20260708-newv" src="https://github.com/user-attachments/assets/29724e4d-f4a4-437b-bf60-a2666c5239d3" />



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
