### PR TITLE
GDGT-2789: Throw-away BE implementation

### DIFF
--- a/src/metabase/public_sharing_rest/api.clj
+++ b/src/metabase/public_sharing_rest/api.clj
@@ -113,7 +113,8 @@
   [results]
   (u/select-nested-keys
    results
-   [[:data :cols :rows :rows_truncated :insights :requested_timezone :results_timezone]
+   ;; :referenced_cards (GDGT-2789) carries dynamic-goal values for public/embedded cards.
+   [[:data :cols :rows :rows_truncated :insights :requested_timezone :results_timezone :referenced_cards]
     [:json_query :parameters]
     :status]))
 

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -24,6 +24,7 @@
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.pivot :as qp.pivot]
+   [metabase.query-processor.referenced-cards :as qp.referenced-cards]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.streaming :as qp.streaming]
    [metabase.server.core :as server]
@@ -54,7 +55,7 @@
 
 (mu/defn- run-streaming-query :- (ms/InstanceOfClass metabase.server.streaming_response.StreamingResponse)
   [{:keys [database], :as query}
-   & {:keys [context export-format was-pivot]
+   & {:keys [context export-format was-pivot referenced-cards-specs]
       :or   {context       :ad-hoc
              export-format :api}}]
   (span/with-span!
@@ -79,31 +80,38 @@
                            (= (:type source-card) :model)
                            (assoc :metadata/model-metadata (:result_metadata source-card)))]
       (qp.streaming/streaming-response [rff export-format]
-        (if was-pivot
-          (let [constraints (if (= export-format :api)
-                              (qp.constraints/default-query-constraints)
-                              (:constraints query))]
-            (qp.pivot/run-pivot-query (-> query
-                                          (assoc :constraints constraints)
-                                          ;; Use assoc rather than merge so :info comes entirely from the
-                                          ;; server-built map. :info carries :card-id and similar fields the
-                                          ;; server derives, so we replace it rather than combining it with
-                                          ;; whatever was on the incoming query.
-                                          (assoc :info info))
-                                      rff))
-          (qp/process-query (assoc query :info info) rff))))))
+        ;; THROW-AWAY (GDGT-2789): run any referenced queries (e.g. dynamic Gauge goals) and add their
+        ;; values under `data.referenced_cards`. Must happen before `process-query` sets up the QP store.
+        (let [rff (qp.referenced-cards/wrap-rff rff referenced-cards-specs)]
+          (if was-pivot
+            (let [constraints (if (= export-format :api)
+                                (qp.constraints/default-query-constraints)
+                                (:constraints query))]
+              (qp.pivot/run-pivot-query (-> query
+                                            (assoc :constraints constraints)
+                                            ;; Use assoc rather than merge so :info comes entirely from the
+                                            ;; server-built map. :info carries :card-id and similar fields the
+                                            ;; server derives, so we replace it rather than combining it with
+                                            ;; whatever was on the incoming query.
+                                            (assoc :info info))
+                                        rff))
+            (qp/process-query (assoc query :info info) rff)))))))
 
 (api.macros/defendpoint :post "/"
   :- (server/streaming-response-schema ::qp.schema/query-result)
   "Execute a query and retrieve the results in the usual format. The query will not use the cache."
   [_route-params
    _query-params
-   query :- [:map
-             [:database {:optional true} [:maybe :int]]]]
+   ;; THROW-AWAY (GDGT-2789): `referenced_cards` requests values from other cards (dynamic Gauge goals).
+   {:keys [referenced_cards] :as query} :- [:map
+                                            [:database {:optional true} [:maybe :int]]
+                                            [:referenced_cards {:optional true} qp.referenced-cards/specs-schema]]]
   (run-streaming-query
    (-> query
+       (dissoc :referenced_cards)
        (update-in [:middleware :js-int-to-string?] (fnil identity true))
-       qp/userland-query-with-default-constraints)))
+       qp/userland-query-with-default-constraints)
+   :referenced-cards-specs referenced_cards))
 
 ;;; ----------------------------------- Downloading Query Results in Other Formats -----------------------------------
 

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -339,6 +339,16 @@
         qp          (if (= :pivot (:display card))
                       qp.pivot/run-pivot-query
                       (or qp process-query-for-card-default-qp))
+        ;; THROW-AWAY (GDGT-2789): if the (merged) viz settings reference other cards for dynamic goals
+        ;; (`GoalSource`s in :graph.goal_value / :gauge.segments / :scalar.segments), run those queries and
+        ;; inject their values under `data.referenced_cards`. Wrapping the qp here (rather than the
+        ;; `:make-run`) covers every card/dashcard/embed/public endpoint, since they all funnel through here
+        ;; and ultimately call `(qp query rff)`. Resolved at runtime to avoid a load cycle (referenced-cards
+        ;; requires this namespace).
+        qp          (if (or (:graph.goal_value merged-viz) (:gauge.segments merged-viz) (:scalar.segments merged-viz))
+                      ((requiring-resolve 'metabase.query-processor.referenced-cards/wrap-qp-for-card)
+                       qp merged-viz)
+                      qp)
         runner      (make-run qp export-format)
         query       (-> (query-for-card card parameters constraints middleware {:dashboard-id dashboard-id})
                         (assoc :viz-settings merged-viz)

--- a/src/metabase/query_processor/referenced_cards.clj
+++ b/src/metabase/query_processor/referenced_cards.clj
@@ -1,0 +1,156 @@
+(ns metabase.query-processor.referenced-cards
+  "THROW-AWAY backend implementation for the \"Dynamic goals\" project (GDGT-2789).
+
+  Implements Option 5 from the tech doc: query-executing endpoints run a set of *referenced* queries
+  (e.g. the card + column that supplies a Gauge chart's dynamic goal/range) and add the computed values
+  to the response under `data.referenced_cards`.
+
+    {:data {:cols [...] :rows [...]
+            :referenced_cards {\"1\" {:status \"completed\"
+                                    :data   {:cols [...] :rows [[123 456]]}}
+                               \"2\" {:status \"failed\"
+                                    :error  \"...\"}}}}
+
+  Two ways referenced cards are supplied:
+
+  * POST `/api/dataset` (ad-hoc questions) passes them explicitly in the request body as
+    `referenced_cards` (see [[metabase.query-processor.api]]).
+  * Saved-card endpoints (2-8) derive them from the card's (merged) `visualization_settings`: any
+    `GoalSource` reference (`{:card_id, :column}`) found in `:graph.goal_value`, or in the `:min`/`:max`
+    of `:gauge.segments` / `:scalar.segments` entries. A plain number (static goal) or a bare string
+    (self-column reference, à la Progress bar) is not a referenced card. See [[viz-settings->specs]].
+
+  Referenced queries are executed *eagerly*, before the main query's QP store/metadata-provider is
+  established, because a nested [[metabase.query-processor/process-query]] against a different database
+  would clash with the outer store (see [[metabase.query-processor.store/validate-existing-provider]]).
+
+  This is deliberately minimal and is expected to be thrown away once the FE contract is settled."
+  (:require
+   [metabase.api.common :as api]
+   [metabase.query-processor :as qp]
+   [metabase.query-processor.card :as qp.card]
+   [metabase.query-processor.pipeline :as qp.pipeline]
+   [metabase.query-processor.streaming :as qp.streaming]
+   [metabase.util.log :as log]
+   [metabase.util.performance :as perf]
+   ^{:clj-kondo/ignore [:discouraged-namespace]} [toucan2.core :as t2]))
+
+(def specs-schema
+  "Malli schema for the `referenced_cards` request/viz-setting value: a list of `{card_id, columns}` specs."
+  [:maybe [:sequential [:map
+                        [:card_id :int]
+                        [:columns {:optional true} [:maybe [:sequential :string]]]]]])
+
+(def ^:private single-row-constraints
+  "Referenced queries only ever need their first row, so cap them to a single row."
+  {:max-results 1, :max-results-bare-rows 1})
+
+(defn- project-columns
+  "Narrow `data` (`{:cols [...] :rows [...]}`) to just the requested `columns` (matched by `:name`).
+  Returns `data` unchanged when no columns are requested."
+  [{:keys [cols rows] :as data} columns]
+  (if (seq columns)
+    (let [cols      (vec cols)
+          name->idx (into {} (map-indexed (fn [i col] [(:name col) i])) cols)
+          idxs      (into [] (keep name->idx) columns)]
+      (assoc data
+             ;; `cols`/`row` are vectors used as index functions over `idxs`.
+             :cols (perf/mapv cols idxs)
+             :rows (perf/mapv (fn [row] (let [row (vec row)] (perf/mapv row idxs))) rows)))
+    data))
+
+(defn- run-referenced-card
+  "Run the query for a single referenced card spec, returning a result map. Never throws: any failure
+  (missing card, no read permission, query error, ...) is captured as `{:status \"failed\" :error ...}`."
+  [{:keys [card_id columns]}]
+  (try
+    (let [card   (api/read-check (api/check-404 (t2/select-one :model/Card :id card_id)))
+          query  (qp.card/query-for-card card [] single-row-constraints nil)
+          ;; This may run inside another query's streaming response, which rebinds the pipeline result
+          ;; handler / cancel channel to write to the *outer* stream. Reset them so this nested query
+          ;; delivers its result normally as an in-memory map instead of clobbering the outer response.
+          result (binding [qp.pipeline/*result*        qp.pipeline/default-result-handler
+                           qp.pipeline/*canceled-chan* nil]
+                   (qp/process-query query))]
+      {:status "completed"
+       :data   (-> (:data result)
+                   (perf/select-keys [:cols :rows])
+                   (project-columns columns))})
+    (catch Throwable e
+      (log/warnf e "Failed to run referenced card %s" card_id)
+      {:status "failed"
+       :error  (or (ex-message e) "Failed to run referenced query")})))
+
+(defn referenced-cards-result
+  "Run every referenced query in `specs` and return a map of `card_id` -> result map. Returns `nil` when
+  there are no specs (so callers can `if-let` on it). Must be called *before* the main query's QP store
+  is established."
+  [specs]
+  (when (seq specs)
+    ;; Key by the card id as a *string* so the map serializes cleanly to JSON (`{\"1\": {...}}`).
+    (into {} (map (fn [{:keys [card_id] :as spec}]
+                    [(str card_id) (run-referenced-card spec)]))
+          specs)))
+
+(defn- inject-referenced-cards
+  "Decorate `rff` so the completed response's `:data` gets a `:referenced_cards` key holding `result`."
+  [rff result]
+  (qp.streaming/transforming-query-response
+   rff
+   (fn [response] (assoc-in response [:data :referenced_cards] result))))
+
+(defn wrap-rff
+  "Eagerly compute referenced-card results for `specs` and decorate `rff` so they are added to the response
+  under `data.referenced_cards`. Returns `rff` unchanged when there are no specs. Used by POST /api/dataset
+  (ad-hoc questions). MUST be called before [[metabase.query-processor/process-query]] runs for the main
+  query."
+  [rff specs]
+  (if-let [result (referenced-cards-result specs)]
+    (inject-referenced-cards rff result)
+    rff))
+
+(defn wrap-qp
+  "Given a base query-processor fn `(fn [query rff])` and referenced-card `specs`, return a qp that injects
+  the referenced-card results under `data.referenced_cards`.
+
+  This is `:make-run`-agnostic: every run-fn (default, and the public/embed variants) ultimately calls
+  `(qp query rff)`, so wrapping the qp covers the saved-card, dashcard, embed and public card endpoints
+  from the single seam in [[metabase.query-processor.card/process-query-for-card]].
+
+  The referenced queries run eagerly when this is called, which MUST be before the outer card query's QP
+  store is established. Returns `qp` unchanged when there are no specs."
+  [qp specs]
+  (if-let [result (referenced-cards-result specs)]
+    (fn [query rff]
+      (qp query (inject-referenced-cards rff result)))
+    qp))
+
+(defn- ->goal-source
+  "If `goal-value` is a `GoalSource` reference (a map with `:card_id` and `:column`), return it; otherwise
+  nil (a static number, or a bare-string self-column reference — neither runs an extra query)."
+  [goal-value]
+  (when (and (map? goal-value) (:card_id goal-value) (:column goal-value))
+    (select-keys goal-value [:card_id :column])))
+
+(defn viz-settings->specs
+  "Extract referenced-card specs from a card's (merged) `viz` settings per the dynamic-goals contract:
+  `GoalSource` references found in `:graph.goal_value`, and in the `:min`/`:max` of each `:gauge.segments`
+  / `:scalar.segments` entry. Returns specs grouped by card id as `[{:card_id N :columns [...]}]` (the
+  shape [[referenced-cards-result]] expects), or nil when there are no dynamic references."
+  [viz]
+  (let [segments (concat (:gauge.segments viz) (:scalar.segments viz))
+        sources  (keep ->goal-source
+                       (cons (:graph.goal_value viz)
+                             (mapcat (juxt :min :max) segments)))]
+    (when (seq sources)
+      (mapv (fn [[card-id ss]]
+              {:card_id card-id
+               :columns (vec (distinct (map :column ss)))})
+            (group-by :card_id sources)))))
+
+(defn wrap-qp-for-card
+  "Central hook for the saved-card / dashcard / embed / public endpoints (2-8): derive referenced-card
+  specs from a card's merged `viz` settings (see [[viz-settings->specs]]) and wrap `qp` to inject their
+  values under `data.referenced_cards`. Returns `qp` unchanged when there are no dynamic references."
+  [qp viz]
+  (wrap-qp qp (viz-settings->specs viz)))

--- a/test/metabase/query_processor/referenced_cards_test.clj
+++ b/test/metabase/query_processor/referenced_cards_test.clj
@@ -1,0 +1,146 @@
+(ns metabase.query-processor.referenced-cards-test
+  "Tests for the THROW-AWAY dynamic-goals backend (GDGT-2789): running referenced queries and adding
+  their values under `data.referenced_cards`."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.query-processor.referenced-cards :as referenced-cards]
+   [metabase.test :as mt]
+   [metabase.test.http-client :as client]))
+
+(defn- ref-cards
+  "Pull the `referenced_cards` map out of an API query response. The test HTTP client parses numeric
+  JSON keys back into numbers, so this map is keyed by the (integer) card id."
+  [response]
+  (get-in response [:data :referenced_cards]))
+
+(deftest dataset-endpoint-request-referenced-cards-test
+  (testing "POST /api/dataset runs the cards named in the request `referenced_cards` and adds their values"
+    (mt/with-temp [:model/Card {goal-id :id} {:dataset_query (mt/mbql-query checkins {:aggregation [[:count]]})}]
+      (let [response (mt/user-http-request
+                      :crowberto :post 202 "dataset"
+                      (assoc (mt/mbql-query venues {:aggregation [[:count]]})
+                             :referenced_cards [{:card_id goal-id :columns ["count"]}]))
+            goal     (get (ref-cards response) goal-id)]
+        (testing "main query still returns normally"
+          (is (= "completed" (:status response)))
+          (is (= [[100]] (get-in response [:data :rows]))))
+        (testing "referenced card value is attached under data.referenced_cards"
+          (is (nil? (:error goal)))
+          (is (= "completed" (:status goal)))
+          (is (= [[1000]] (get-in goal [:data :rows])))
+          (is (= ["count"] (map :name (get-in goal [:data :cols])))))))))
+
+(deftest dataset-endpoint-column-projection-test
+  (testing "only the requested columns are returned for a referenced card"
+    (mt/with-temp [:model/Card {goal-id :id} {:dataset_query (mt/mbql-query venues)}]
+      (let [response (mt/user-http-request
+                      :crowberto :post 202 "dataset"
+                      (assoc (mt/mbql-query venues {:aggregation [[:count]]})
+                             :referenced_cards [{:card_id goal-id :columns ["NAME" "PRICE"]}]))
+            goal     (get (ref-cards response) goal-id)]
+        (is (= "completed" (:status goal)))
+        (is (= ["NAME" "PRICE"] (map :name (get-in goal [:data :cols]))))
+        (testing "capped to a single row"
+          (is (= 1 (count (get-in goal [:data :rows])))))))))
+
+(deftest dataset-endpoint-error-handling-test
+  (testing "a referenced card that cannot be resolved fails softly without failing the main query"
+    (let [response (mt/user-http-request
+                    :crowberto :post 202 "dataset"
+                    (assoc (mt/mbql-query venues {:aggregation [[:count]]})
+                           :referenced_cards [{:card_id Integer/MAX_VALUE :columns ["count"]}]))
+          goal     (get (ref-cards response) Integer/MAX_VALUE)]
+      (testing "main query still succeeds"
+        (is (= "completed" (:status response)))
+        (is (= [[100]] (get-in response [:data :rows]))))
+      (testing "referenced card is marked failed with an error"
+        (is (= "failed" (:status goal)))
+        (is (string? (:error goal)))))))
+
+(deftest dataset-endpoint-no-referenced-cards-test
+  (testing "omitting `referenced_cards` leaves the response untouched"
+    (let [response (mt/user-http-request
+                    :crowberto :post 202 "dataset"
+                    (mt/mbql-query venues {:aggregation [[:count]]}))]
+      (is (= "completed" (:status response)))
+      (is (nil? (get-in response [:data :referenced_cards]))))))
+
+(deftest viz-settings->specs-test
+  (testing "GoalSource references are extracted from the 3 dynamic-goal viz settings and grouped by card"
+    (testing "a :graph.goal_value GoalSource"
+      (is (= [{:card_id 1 :columns ["total"]}]
+             (referenced-cards/viz-settings->specs {:graph.goal_value {:card_id 1 :column "total"}}))))
+    (testing ":gauge.segments and :scalar.segments min/max, grouped + de-duped by card"
+      (is (= {1 ["sum" "avg"]
+              2 ["total"]}
+             (into {} (map (juxt :card_id :columns))
+                   (referenced-cards/viz-settings->specs
+                    {:gauge.segments  [{:min 0 :max {:card_id 1 :column "sum"}}
+                                       {:min {:card_id 1 :column "avg"} :max {:card_id 1 :column "sum"}}]
+                     :scalar.segments [{:min {:card_id 2 :column "total"} :max nil :color "red"}]})))))
+    (testing "static numbers and bare-string self-column references are ignored"
+      (is (nil? (referenced-cards/viz-settings->specs
+                 {:graph.goal_value 100
+                  :gauge.segments   [{:min 0 :max 50}
+                                     {:min "self_col" :max 100}]})))))
+  (testing "no goal settings at all -> nil"
+    (is (nil? (referenced-cards/viz-settings->specs {})))))
+
+(deftest card-endpoint-viz-settings-referenced-cards-test
+  (testing "POST /api/card/:id/query derives referenced cards from a :graph.goal_value GoalSource"
+    (mt/with-temp [:model/Card {goal-id :id} {:dataset_query (mt/mbql-query checkins {:aggregation [[:count]]})}
+                   :model/Card {chart-id :id} {:dataset_query          (mt/mbql-query venues {:aggregation [[:count]]})
+                                               :visualization_settings {:graph.goal_value {:card_id goal-id
+                                                                                           :column  "count"}}}]
+      (let [response (mt/user-http-request :crowberto :post 202 (format "card/%d/query" chart-id))
+            goal     (get (ref-cards response) goal-id)]
+        (testing "main card query returns normally"
+          (is (= "completed" (:status response)))
+          (is (= [[100]] (get-in response [:data :rows]))))
+        (testing "referenced card value is attached"
+          (is (= "completed" (:status goal)))
+          (is (= [[1000]] (get-in goal [:data :rows]))))))))
+
+(deftest card-endpoint-no-referenced-cards-test
+  (testing "a card with only a static goal value is unaffected"
+    (mt/with-temp [:model/Card {chart-id :id} {:dataset_query          (mt/mbql-query venues {:aggregation [[:count]]})
+                                               :visualization_settings {:graph.goal_value 100}}]
+      (let [response (mt/user-http-request :crowberto :post 202 (format "card/%d/query" chart-id))]
+        (is (= "completed" (:status response)))
+        (is (nil? (get-in response [:data :referenced_cards])))))))
+
+(deftest dashcard-endpoint-referenced-cards-test
+  (testing "POST /api/dashboard/.../dashcard/.../card/.../query reads a GoalSource from the *merged* viz settings"
+    (mt/with-temp [:model/Card      {goal-id :id}     {:dataset_query (mt/mbql-query checkins {:aggregation [[:count]]})}
+                   :model/Card      {chart-id :id}    {:dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}
+                   :model/Dashboard {dash-id :id}     {}
+                   ;; the dynamic goal lives on the DASHCARD's viz settings — exercises the card+dashcard merge
+                   :model/DashboardCard {dashcard-id :id} {:dashboard_id            dash-id
+                                                           :card_id                 chart-id
+                                                           :visualization_settings  {:gauge.segments
+                                                                                     [{:min 0
+                                                                                       :max {:card_id goal-id
+                                                                                             :column  "count"}}]}}]
+      (let [response (mt/user-http-request :crowberto :post 202
+                                           (format "dashboard/%d/dashcard/%d/card/%d/query" dash-id dashcard-id chart-id))
+            goal     (get (ref-cards response) goal-id)]
+        (is (= "completed" (:status response)))
+        (is (= "completed" (:status goal)))
+        (is (= [[1000]] (get-in goal [:data :rows])))))))
+
+(deftest public-card-endpoint-referenced-cards-test
+  (testing "GET /api/public/card/:uuid/query injects referenced_cards (survives the public result whitelist)"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (mt/with-temp [:model/Card {goal-id :id} {:dataset_query (mt/mbql-query checkins {:aggregation [[:count]]})}
+                     :model/Card {uuid :public_uuid} {:dataset_query           (mt/mbql-query venues {:aggregation [[:count]]})
+                                                      :public_uuid             (str (random-uuid))
+                                                      :visualization_settings  {:scalar.segments
+                                                                                [{:min   {:card_id goal-id
+                                                                                          :column  "count"}
+                                                                                  :max   nil
+                                                                                  :color "red"}]}}]
+        (let [response (client/client :get 202 (str "public/card/" uuid "/query"))
+              goal     (get (ref-cards response) goal-id)]
+          (is (= "completed" (:status response)))
+          (is (= "completed" (:status goal)))
+          (is (= [[1000]] (get-in goal [:data :rows]))))))))


### PR DESCRIPTION
Closes [GDGT-2789](https://linear.app/metabase/issue/GDGT-2789/throw-away-be-implementation)

### Description

This is meant to be reverted in the feature branch, so no review necessary.