### PR TITLE
Fix index manager review findings

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1067,15 +1067,25 @@
 
   indexes
   {:team "Gadget"
-   :api  #{metabase.indexes.api
-           metabase.indexes.models.table-index
-           metabase.indexes.reconcile}
+   :api  #{metabase.indexes.models.table-index
+           metabase.indexes.reconcile
+           metabase.indexes.schema}
    :uses #{api
            driver
            models
            util}
    :model-exports #{:model/TableIndex}
+   :model-imports #{:model/Database}}
+
+  indexes-rest
+  {:team "Gadget"
+   :api  #{metabase.indexes-rest.api}
+   :uses #{api
+           indexes
+           transforms-base
+           util}
    :model-imports #{:model/Database
+                    :model/TableIndex
                     :model/Transform}}
 
   initialization-status

--- a/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
@@ -725,16 +725,56 @@
                                                                     target transform-type checkpoint-config)
                         schema  (:schema target)]
                     (mt/with-temp [:model/Transform transform payload]
-                      (with-redefs [transforms.execute/hydrate-transform-indexes (constantly indexes)]
-                        (testing "first (full) run creates the declared indexes"
-                          (execute-transform-with-ordering! transform transform-type checkpoint-field
-                                                            {:run-method :manual})
-                          (transforms.tu/wait-for-table table-name 10000)
-                          (is (= expected (physical-indexes (mt/db) schema table-name))))
-                        (testing "append run preserves the indexes"
-                          (with-insert-test-products! [{:name "Incremental Index Product" :category "Gadget"
-                                                        :price 379.99 :created-at "2024-01-20T10:00:00"}]
-                            (let [transform (t2/select-one :model/Transform (:id transform))]
-                              (execute-transform-with-ordering! transform transform-type checkpoint-field
-                                                                {:run-method :manual})
-                              (is (= expected (physical-indexes (mt/db) schema table-name))))))))))))))))))
+                      (t2/insert! :model/TableIndex (for [index indexes]
+                                                      {:transform_id (:id transform)
+                                                       :index_name   (or (:name index) (name (:kind index)))
+                                                       :structured   index}))
+                      (testing "first (full) run creates the declared indexes"
+                        (execute-transform-with-ordering! transform transform-type checkpoint-field
+                                                          {:run-method :manual})
+                        (transforms.tu/wait-for-table table-name 10000)
+                        (is (= expected (physical-indexes (mt/db) schema table-name))))
+                      (testing "append run preserves the indexes"
+                        (with-insert-test-products! [{:name "Incremental Index Product" :category "Gadget"
+                                                      :price 379.99 :created-at "2024-01-20T10:00:00"}]
+                          (let [transform (t2/select-one :model/Transform (:id transform))]
+                            (execute-transform-with-ordering! transform transform-type checkpoint-field
+                                                              {:run-method :manual})
+                            (is (= expected (physical-indexes (mt/db) schema table-name)))))))))))))))))
+
+(deftest ^:synchronized index-added-mid-lifecycle-forces-rebuild-test
+  (testing "an index request created after the watermark is set forces the next run to rebuild and apply it"
+    ;; Nothing resets the watermark here: the pending TableIndex row alone must flip `full-incremental-run?`, so a
+    ;; broken pending-changes gate would leave this run an append and the index would never reach the warehouse.
+    (mt/test-drivers (incremental-index-test-drivers)
+      (mt/with-premium-features #{:transforms-basic}
+        (mt/dataset transforms-dataset/transforms-test
+          (let [{:keys [expected physical-indexes]} (index-util/driver-cases driver/*driver*)
+                checkpoint-config (:integer checkpoint-configs)
+                checkpoint-field  (:field-name checkpoint-config)]
+            ;; name-set catalogs only (postgres/mysql); other drivers report shapes this test can't extend generically
+            (when (set? expected)
+              (with-transform-cleanup! [{table-name :name :as target} (target-table-gen "incremental_midrun_idx")]
+                (mt/with-temp [:model/Transform transform (make-incremental-transform-payload
+                                                           "Mid-lifecycle Index Transform"
+                                                           target :mbql checkpoint-config)]
+                  (testing "a first run establishes the watermark"
+                    (execute-transform-with-ordering! transform :mbql checkpoint-field {:run-method :manual})
+                    (transforms.tu/wait-for-table table-name 10000)
+                    (is (some? (get-checkpoint-value (:id transform)))))
+                  (t2/insert! :model/TableIndex {:transform_id (:id transform)
+                                                 :index_name   "mid_run_idx"
+                                                 :structured   {:kind :btree :name "mid_run_idx"
+                                                                :columns [{:name "price"}]}})
+                  (testing "the watermark survives the request untouched"
+                    (is (some? (get-checkpoint-value (:id transform)))))
+                  (testing "the next run rebuilds and the index lands in the warehouse"
+                    (let [transform (t2/select-one :model/Transform (:id transform))]
+                      (execute-transform-with-ordering! transform :mbql checkpoint-field {:run-method :manual})
+                      (is (contains? (physical-indexes (mt/db) (:schema target) table-name) "mid_run_idx"))
+                      (is (= :succeeded (t2/select-one-fn :status :model/TableIndex
+                                                          :transform_id (:id transform)
+                                                          :index_name "mid_run_idx")))))
+                  (testing "once settled, the run after that appends again"
+                    (let [transform (t2/select-one :model/Transform (:id transform))]
+                      (is (not (transforms-base.u/full-incremental-run? transform))))))))))))))

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -363,8 +363,7 @@
           ;;            Added premium-features to driver-affecting-overrides (#69561)
           ;; 2026-04-07 Bumped to 41 due to agent-lib addition (Metabot MBQL improvements #71524)
           ;; 2026-06-04 Bumped to 42 due to run-tracking addition (Zombie transform reaper #75194)
-          ;; 2026-06-24 Bumped to 43 due to indexes addition (Index manager #75848)
-          ;; 2026-07-08 Bumped to 44 due to indexes-rest addition (Index manager #75848)
+          ;; 2026-06-24 Bumped to 44 for indexes + indexes-rest (Index manager #75848)
           max-allowed-count 44]
       (is (<= (count modules-triggering-drivers) max-allowed-count)
           (format "Too many modules trigger driver tests! Expected <= %d, got %d.

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -364,7 +364,8 @@
           ;; 2026-04-07 Bumped to 41 due to agent-lib addition (Metabot MBQL improvements #71524)
           ;; 2026-06-04 Bumped to 42 due to run-tracking addition (Zombie transform reaper #75194)
           ;; 2026-06-24 Bumped to 43 due to indexes addition (Index manager #75848)
-          max-allowed-count 43]
+          ;; 2026-07-08 Bumped to 44 due to indexes-rest addition (Index manager #75848)
+          max-allowed-count 44]
       (is (<= (count modules-triggering-drivers) max-allowed-count)
           (format "Too many modules trigger driver tests! Expected <= %d, got %d.
                    Modules triggering driver tests: %s

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -257,10 +257,18 @@
   ;; filenames as table/column names. But its an approximation
   206)
 
+(defn- escape-ident
+  ;; Backslash-escape rather than double the backtick: ClickHouse identifiers follow string-literal escaping, where
+  ;; a preceding backslash would defeat quote-doubling.
+  [s]
+  (-> s
+      (str/replace "\\" "\\\\")
+      (str/replace "`" "\\`")))
+
 (defn- quote-name [s]
   (let [s (if (and (keyword? s) (namespace s)) (str (namespace s) "." (name s)) s)
         parts (filter identity (str/split (name s) #"\."))]
-    (str/join "." (map #(str "`" % "`") parts))))
+    (str/join "." (map #(str "`" (escape-ident %) "`") parts))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          Indexes (Index Manager)                                               |

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse/index_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse/index_test.clj
@@ -90,7 +90,12 @@
             ["ALTER TABLE `events` MATERIALIZE INDEX `idx_a`"]]
            (driver/compile-create-index :clickhouse nil "events"
                                         {:name "idx_a" :columns [{:name "a"}] :type :minmax :granularity 4
-                                         :if-not-exists true})))))
+                                         :if-not-exists true}))))
+  (testing "backticks and backslashes in identifiers are escaped, so a hostile name cannot break out"
+    (is (= [["ALTER TABLE `events` ADD INDEX `idx\\`; DROP TABLE x; --` (`a\\\\\\`b`) TYPE minmax GRANULARITY 1"]
+            ["ALTER TABLE `events` MATERIALIZE INDEX `idx\\`; DROP TABLE x; --`"]]
+           (driver/compile-create-index :clickhouse nil "events"
+                                        {:name "idx`; DROP TABLE x; --" :columns [{:name "a\\`b"}] :type :minmax})))))
 
 ;;; --------------------------------------- Live execute path ----------------------------------------
 

--- a/modules/drivers/redshift/test/metabase/driver/redshift/index_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift/index_test.clj
@@ -141,7 +141,7 @@
                 ;; unique per-case table names so the two seams (and parallel runs) don't collide in the shared schema
                 (let [ctas-table   (tx/db-qualified-table-name (:name database) "sk_ctas")
                       create-table (tx/db-qualified-table-name (:name database) "sk_create")
-                      drop!        (fn [t] (jdbc/execute! spec (format "DROP TABLE IF EXISTS \"%s\".\"%s\"" schema t)))]
+                      drop!        (fn [t] (jdbc/execute! spec [(format "DROP TABLE IF EXISTS \"%s\".\"%s\"" schema t)]))]
                   (testing "CTAS seam (compile-transform): run the rendered CTAS, read the sortkey back"
                     (drop! ctas-table)
                     (try

--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -31,7 +31,7 @@
    [metabase.glossary.api]
    [metabase.health-inspector.api]
    [metabase.indexed-entities.api]
-   [metabase.indexes.api]
+   [metabase.indexes-rest.api]
    [metabase.llm.api]
    [metabase.logger.api]
    [metabase.login-history.api]
@@ -98,7 +98,7 @@
          metabase.geojson.api/keep-me
          metabase.glossary.api/keep-me
          metabase.indexed-entities.api/keep-me
-         metabase.indexes.api/keep-me
+         metabase.indexes-rest.api/keep-me
          metabase.logger.api/keep-me
          metabase.login-history.api/keep-me
          metabase.mcp.api/keep-me
@@ -199,7 +199,7 @@
    "/glossary"             (+auth 'metabase.glossary.api)
    "/google"               (+auth metabase.sso.api/google-auth-routes)
    "/health-inspector"     (+auth 'metabase.health-inspector.api)
-   "/index"                (+auth 'metabase.indexes.api)
+   "/index"                (+auth 'metabase.indexes-rest.api)
    "/ldap"                 (+auth metabase.sso.api/ldap-routes)
    "/llm"                  (+auth metabase.llm.api/routes)
    "/logger"               (+auth 'metabase.logger.api)

--- a/src/metabase/indexes/models/table_index.clj
+++ b/src/metabase/indexes/models/table_index.clj
@@ -45,42 +45,20 @@
 (def ^:private defaults
   {:status :create-pending})
 
-(defn- reset-incremental-checkpoint!
-  [transform-id]
-  (when (= :table-incremental
-           (some-> (t2/select-one-fn :target :model/Transform :id transform-id)
-                   :type
-                   keyword))
-    ;; Indexes are applied only when a transform recreates its target table. Resetting the checkpoint makes the next
-    ;; incremental run perform that rebuild, matching the existing checkpoint-strategy change behavior.
-    (t2/update! :model/Transform transform-id {:last_checkpoint_value nil})))
-
 (defn- pending-status-for-changes
   [changes]
   (cond
     (contains? changes :structured) :update-pending
     (contains? pending-statuses (:status changes)) (:status changes)))
 
-(defn- transform-id
-  [idx]
-  (or (:transform_id idx)
-      (:transform_id (t2/original idx))))
-
 (t2/define-before-insert :model/TableIndex
   [req]
   (merge defaults req))
-
-(t2/define-after-insert :model/TableIndex
-  [idx]
-  (reset-incremental-checkpoint! (:transform_id idx))
-  idx)
 
 (t2/define-before-update :model/TableIndex
   [idx]
   (let [changes (t2/changes idx)
         status  (pending-status-for-changes changes)]
-    (when status
-      (reset-incremental-checkpoint! (transform-id idx)))
     (cond-> idx
       status (assoc :status status
                     :error_message nil))))
@@ -100,10 +78,10 @@
 (defn select-applicable-for-transform
   "Rows whose structured definitions should be applied to `transform-id`'s target table."
   [transform-id]
-  (filter applicable?
-          (t2/select :model/TableIndex
-                     :transform_id transform-id
-                     {:order-by [[:index_name :asc]]})))
+  (t2/select :model/TableIndex
+             :transform_id transform-id
+             :status [:not= :delete-pending]
+             {:order-by [[:index_name :asc]]}))
 
 (defn select-for-verification
   "Rows the current execution can update while verifying indexes.
@@ -127,16 +105,14 @@
 (defn select-applicable-by-id
   "Fetch a single applicable index request by id."
   [id]
-  (some-> (t2/select-one :model/TableIndex :id id)
-          (as-> idx (when (applicable? idx) idx))))
+  (t2/select-one :model/TableIndex :id id :status [:not= :delete-pending]))
 
 (defn pending-changes-for-transform?
   "True when `transform-id` has index changes that require a full rebuild to apply."
   [transform-id]
   (boolean
    (when transform-id
-     (some #(contains? pending-statuses (:status %))
-           (t2/select :model/TableIndex :transform_id transform-id)))))
+     (t2/exists? :model/TableIndex :transform_id transform-id :status [:in pending-statuses]))))
 
 (defn mark-runnable-indexes-running!
   "Mark hydrated index requests that this run will apply as running.

--- a/src/metabase/indexes/schema.clj
+++ b/src/metabase/indexes/schema.clj
@@ -10,9 +10,18 @@
 
 (set! *warn-on-reflection* true)
 
+(mr/def ::index-name
+  "Free-form user input, inlined (quoted and escaped) into DDL. 63 is the Postgres identifier limit, the tightest
+  engine we support."
+  [:string {:min 1 :max 63}])
+
+(mr/def ::column-name
+  ;; looser than ::index-name: column names must match real warehouse columns, and some engines allow up to 255
+  [:string {:min 1 :max 255}])
+
 (mr/def ::column
   [:map
-   [:name :string]
+   [:name ::column-name]
    [:direction {:optional true} [:enum :asc :desc]]])
 
 (mr/def ::classical-index
@@ -20,9 +29,9 @@
   [:map
    [:kind [:enum :btree :hash :gin :gist :brin :spgist :fulltext :spatial
            :clustered :nonclustered :columnstore]]
-   [:name :string]
+   [:name ::index-name]
    [:columns [:vector {:min 1} ::column]]
-   [:include {:optional true} [:vector :string]]
+   [:include {:optional true} [:vector ::column-name]]
    [:unique {:optional true} :boolean]])
 
 (mr/def ::sortkey
@@ -46,7 +55,7 @@
   "Snowflake (standalone) / BigQuery (inline) clustering. `:name` is required for the standalone form."
   [:map
    [:kind [:= :clustering]]
-   [:name {:optional true} :string]
+   [:name {:optional true} ::index-name]
    [:columns [:vector {:min 1} ::column]]])
 
 (mr/def ::order-by
@@ -60,25 +69,10 @@
   can't supply yet."
   [:map
    [:kind [:= :skip-index]]
-   [:name :string]
+   [:name ::index-name]
    [:columns [:vector {:min 1} ::column]]
    [:type [:enum :minmax :bloom_filter]]
    [:granularity {:optional true} pos-int?]])
-
-(mr/def ::index-structured
-  "A single structured index definition, dispatched on `:kind`. The shape stored in
-  `metabase_table_indexes.structured` and handed to the driver index multimethods."
-  [:multi {:dispatch :kind}
-   [:btree ::classical-index] [:hash ::classical-index] [:gin ::classical-index]
-   [:gist ::classical-index] [:brin ::classical-index] [:spgist ::classical-index]
-   [:fulltext ::classical-index] [:spatial ::classical-index]
-   [:clustered ::classical-index] [:nonclustered ::classical-index] [:columnstore ::classical-index]
-   [:sortkey ::sortkey] [:distkey ::distkey] [:clustering ::clustering]
-   [:order-by ::order-by] [:skip-index ::skip-index]])
-
-(def statuses
-  "Valid lifecycle states for a table index request."
-  #{:create-pending :update-pending :delete-pending :running :succeeded :failed})
 
 (defn keywordize-structured
   "Re-keywordize the structured map's enum-valued fields after JSON storage flattened them to strings."
@@ -89,3 +83,19 @@
     (:type structured)    (update :type keyword)
     (:columns structured) (update :columns (fn [cols]
                                              (mapv #(cond-> % (:direction %) (update :direction keyword)) cols)))))
+
+(mr/def ::index-structured
+  "A single structured index definition, dispatched on `:kind`. The shape stored in
+  `metabase_table_indexes.structured` and handed to the driver index multimethods."
+  ;; :decode/normalize runs before the :multi dispatch, so API input with string-valued enum fields decodes cleanly.
+  [:multi {:dispatch :kind, :decode/normalize keywordize-structured}
+   [:btree ::classical-index] [:hash ::classical-index] [:gin ::classical-index]
+   [:gist ::classical-index] [:brin ::classical-index] [:spgist ::classical-index]
+   [:fulltext ::classical-index] [:spatial ::classical-index]
+   [:clustered ::classical-index] [:nonclustered ::classical-index] [:columnstore ::classical-index]
+   [:sortkey ::sortkey] [:distkey ::distkey] [:clustering ::clustering]
+   [:order-by ::order-by] [:skip-index ::skip-index]])
+
+(def statuses
+  "Valid lifecycle states for a table index request."
+  #{:create-pending :update-pending :delete-pending :running :succeeded :failed})

--- a/src/metabase/indexes_rest/api.clj
+++ b/src/metabase/indexes_rest/api.clj
@@ -1,4 +1,4 @@
-(ns metabase.indexes.api
+(ns metabase.indexes-rest.api
   "Table-index endpoints, mounted at `/api/index`. Two concepts: `GET /` is a transform's merged index reality
   (warehouse indexes plus managed requests); `/request/:id` is CRUD over a single index request. An index
   belongs to a transform's output, so reads require read access to that transform and mutations require write access
@@ -10,6 +10,7 @@
    [metabase.indexes.models.table-index :as table-index]
    [metabase.indexes.reconcile :as reconcile]
    [metabase.indexes.schema :as schema]
+   [metabase.transforms-base.interface :as transforms-base.i]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
@@ -65,11 +66,13 @@
   `:metabase_managed`; managed ones also carry `:request` (status + definition)."
   [_route-params
    {:keys [transform-id]} :- [:map [:transform-id ms/PositiveInt]]]
-  (let [transform (api/read-check :model/Transform transform-id)
-        {:keys [database schema] table-name :name} (:target transform)
-        managed   (table-index/select-for-transform transform-id)
-        warehouse (or (reconcile/fetch-warehouse-indexes (t2/select-one :model/Database database) schema table-name)
-                      [])]
+  (let [transform   (api/read-check :model/Transform transform-id)
+        database-id (transforms-base.i/target-db-id transform)
+        {:keys [schema] table-name :name} (:target transform)
+        managed     (table-index/select-for-transform transform-id)
+        warehouse   (or (reconcile/fetch-warehouse-indexes (t2/select-one :model/Database database-id)
+                                                           schema table-name)
+                        [])]
     {:data (reconcile/merge-indexes managed warehouse)}))
 
 (api.macros/defendpoint :get "/request/:id" :- RequestIndex
@@ -85,18 +88,22 @@
    _query-params
    {:keys [transform_id structured]} :- [:map
                                          [:transform_id ms/PositiveInt]
-                                         [:structured :map]]]
+                                         [:structured ::schema/index-structured]]]
   (api/write-check :model/Transform transform_id)
-  (let [structured (schema/keywordize-structured structured)
-        idx-name   (reconcile/index-name structured)]
+  (let [idx-name  (reconcile/index-name structured)
+        duplicate (tru "An index named \"{0}\" already exists for this transform." idx-name)]
     ;; (transform_id, index_name) is unique; reject a duplicate cleanly instead of hitting the constraint.
-    (api/check-400 (not (table-index/exists-for-transform? transform_id idx-name))
-                   (tru "An index named \"{0}\" already exists for this transform." idx-name))
-    (t2/insert-returning-instance! :model/TableIndex
-                                   {:transform_id transform_id
-                                    :index_name   idx-name
-                                    :structured   structured
-                                    :created_by   api/*current-user-id*})))
+    (api/check-400 (not (table-index/exists-for-transform? transform_id idx-name)) duplicate)
+    (try
+      (t2/insert-returning-instance! :model/TableIndex
+                                     {:transform_id transform_id
+                                      :index_name   idx-name
+                                      :structured   structured
+                                      :created_by   api/*current-user-id*})
+      (catch Exception e
+        ;; the pre-check races a concurrent create; if the row exists now, surface the same 400
+        (api/check-400 (not (table-index/exists-for-transform? transform_id idx-name)) duplicate)
+        (throw e)))))
 
 (defn- assert-stable-key!
   [existing structured]
@@ -112,9 +119,8 @@
   "Replace the structured definition of an index request, marking it update-pending."
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    _query-params
-   {:keys [structured]} :- [:map [:structured :map]]]
-  (let [structured (schema/keywordize-structured structured)
-        existing   (api/check-404 (table-index/select-applicable-by-id id))]
+   {:keys [structured]} :- [:map [:structured ::schema/index-structured]]]
+  (let [existing (api/check-404 (table-index/select-applicable-by-id id))]
     (write-check-owner! existing)
     (assert-stable-key! existing structured)
     ;; toucan2 has no instance-returning update, so re-select; in a tx so we return exactly what we wrote.
@@ -124,7 +130,8 @@
 
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :delete "/request/:id"
-  "Delete an index request."
+  "Mark an index request `delete-pending`. The physical index is only dropped when the target table is next rebuilt
+  (pending changes force a full run), so the row stays visible in this state until that rebuild removes it."
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
   (let [existing (api/check-404 (table-index/select-applicable-by-id id))]
     (write-check-owner! existing)

--- a/src/metabase/transforms/execute.clj
+++ b/src/metabase/transforms/execute.clj
@@ -2,24 +2,11 @@
   (:require
    [metabase.indexes.models.table-index :as table-index]
    [metabase.transforms-base.interface :as transforms-base.i]
+   [metabase.transforms-base.util :as transforms-base.u]
    [metabase.transforms.interface :as transforms.i]
    [metabase.transforms.query-impl :as transforms.query-impl]))
 
 (set! *warn-on-reflection* true)
-
-(defn- select-transform-index-requests
-  [transform]
-  (vec (table-index/select-applicable-for-transform (:id transform))))
-
-(defn hydrate-transform-indexes
-  "Structured index defs for `transform`, read from its managed `TableIndex` rows (ordered by name)."
-  [transform]
-  (mapv :structured (select-transform-index-requests transform)))
-
-(defn hydrate-transform-index-ids
-  "Applicable index request ids for `transform`, hydrated with the target at execution start."
-  [transform]
-  (mapv :id (select-transform-index-requests transform)))
 
 (defn- resolve-target
   "Apply the workspace target-rewrite hook before dispatch. On a workspaced child
@@ -37,14 +24,17 @@
   known DB id to look up `db-workspace-namespace`.
 
   Also hydrates the declared indexes and their request ids onto the target so the base reads them off
-  `(:indexes target)` and `(:index-request-ids target)` at every table-creation seam."
+  `(:indexes target)` and `(:index-request-ids target)` at every table-creation seam, and stashes
+  `:full-incremental-run?` so that (DB-backed) decision is made once and stays stable for the whole run."
   [transform]
-  (-> (if-let [db-id (transforms-base.i/target-db-id transform)]
-        (assoc transform :target
-               (transforms.query-impl/resolve-transform-target db-id (:target transform)))
-        transform)
-      (assoc-in [:target :indexes] (vec (hydrate-transform-indexes transform)))
-      (assoc-in [:target :index-request-ids] (vec (hydrate-transform-index-ids transform)))))
+  (let [requests (table-index/select-applicable-for-transform (:id transform))]
+    (-> (if-let [db-id (transforms-base.i/target-db-id transform)]
+          (assoc transform :target
+                 (transforms.query-impl/resolve-transform-target db-id (:target transform)))
+          transform)
+        (assoc-in [:target :indexes] (mapv :structured requests))
+        (assoc-in [:target :index-request-ids] (into [] (keep :id) requests))
+        (assoc :full-incremental-run? (transforms-base.u/full-incremental-run? transform)))))
 
 (defn execute!
   "Run `transform` and sync its target table.

--- a/src/metabase/transforms/util.clj
+++ b/src/metabase/transforms/util.clj
@@ -148,8 +148,7 @@
       (try
         (let [source-range-params (transforms-base.u/get-source-range-params transform)
               full-incremental?   (transforms-base.u/full-incremental-run? transform)
-              full-create?        (or (= :table (keyword (:type (:target transform))))
-                                      full-incremental?)
+              full-create?        (transforms-base.u/full-create-run? transform)
               ;; Efficiency metrics (rows-available / rows-processed) are only meaningful when this run's
               ;; rows-affected count can be trusted. On drivers that declare
               ;; `:transforms/accurate-rows-affected` false, a full-rebuild (CTAS) run reports a bogus

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -71,6 +71,11 @@
   [transform]
   (type-is? (:source transform) :python))
 
+(defn table-target?
+  "True if `transform` writes to a plain table, recreated on every run."
+  [transform]
+  (type-is? (:target transform) :table))
+
 (defn incremental-target?
   "True if `transform` writes to an incremental table."
   [transform]
@@ -97,11 +102,24 @@
   "True when an incremental transform should drop-and-recreate the target rather than append.
   Fires when `last_checkpoint_value` is nil (first run, or after the before-update hook clears the watermark on
   a `checkpoint-filter-field-id` change), or when pending index changes require rebuilding the table to apply
-  physical index state."
+  physical index state.
+
+  The pending-changes check reads the app DB, so execution computes this once
+  (see [[metabase.transforms.execute]]) and stashes it as `:full-incremental-run?` on the transform; when that
+  key is present it is returned as-is, keeping the answer stable for the whole run."
   [{:keys [id] :as transform}]
-  (and (incremental-target? transform)
-       (or (nil? (:last_checkpoint_value transform))
-           (table-index/pending-changes-for-transform? id))))
+  (if (contains? transform :full-incremental-run?)
+    (:full-incremental-run? transform)
+    (and (incremental-target? transform)
+         (or (nil? (:last_checkpoint_value transform))
+             (table-index/pending-changes-for-transform? id)))))
+
+(defn full-create-run?
+  "True when this run (re)creates the target table -- a plain `:table` run or a full-reset incremental run -- so
+  index requests are applied and verified."
+  [transform]
+  (or (table-target? transform)
+      (full-incremental-run? transform)))
 
 ;;; ------------------------------------------------- Table Template Tags -------------------------------------------------
 
@@ -632,12 +650,6 @@
               (mark-index-failed! transform-id index t)
               (throw t))))))))
 
-(defn- full-create-run?
-  "True when this run recreates the target table (a `:table` run or a full-reset incremental run), so its indexes are (re)applied."
-  [transform]
-  (or (= :table (keyword (:type (:target transform))))
-      (full-incremental-run? transform)))
-
 (defn apply-target-indexes!
   "Apply the target's standalone indexes, on full-create runs only (a `:table` run or a full-reset incremental run
   recreates the table; appends keep the live table and its indexes). Runs before the run is marked succeeded, so a
@@ -675,8 +687,13 @@
                 (if (= :delete-row status)
                   (t2/delete! :model/TableIndex :id [:in (map :id rows)])
                   (t2/update! :model/TableIndex :id [:in (map :id rows)]
-                              {:status           status
-                               :last_executed_at :%now}))))
+                              ;; keep error_message in step with the status transition
+                              (cond-> {:status           status
+                                       :last_executed_at :%now}
+                                (= status :succeeded)
+                                (assoc :error_message nil)
+                                (= status :failed)
+                                (assoc :error_message "Index was not found on the target table after the transform ran."))))))
             (log/warnf "verify-managed-indexes!: could not read indexes for %s.%s; leaving %d request(s) unchanged"
                        schema table-name (count managed))))))))
 

--- a/test/metabase/indexes/models/table_index_test.clj
+++ b/test/metabase/indexes/models/table_index_test.clj
@@ -140,3 +140,19 @@
                                                                     :columns [{:name "c"}]}}]
     (is (= #{running-id deleted-id}
            (set (map :id (table-index/select-for-verification transform-id [running-id pending-id])))))))
+
+(deftest select-applicable-for-transform-test
+  (testing "returns the transform's rows ordered by name, excluding delete-pending"
+    (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)
+                   :model/TableIndex {b-id :id} {:transform_id transform-id
+                                                 :index_name   "b_idx"
+                                                 :structured   {:kind :btree :name "b_idx" :columns [{:name "x"}]}}
+                   :model/TableIndex {a-id :id} {:transform_id transform-id
+                                                 :index_name   "a_idx"
+                                                 :structured   {:kind :btree :name "a_idx" :columns [{:name "y"}]}}
+                   :model/TableIndex _ {:transform_id transform-id
+                                        :index_name   "deleted_idx"
+                                        :status       :delete-pending
+                                        :structured   {:kind :btree :name "deleted_idx" :columns [{:name "z"}]}}]
+      (is (= [a-id b-id]
+             (map :id (table-index/select-applicable-for-transform transform-id)))))))

--- a/test/metabase/indexes_rest/api_test.clj
+++ b/test/metabase/indexes_rest/api_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.indexes.api-test
+(ns metabase.indexes-rest.api-test
   (:require
    [clojure.test :refer :all]
    [metabase.driver]
@@ -113,6 +113,20 @@
                    (mt/user-http-request :crowberto :post 400 "index/request"
                                          {:transform_id transform-id :structured btree}))))))
 
+(deftest malformed-structured-rejected-test
+  (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)]
+    (testing "an unknown :kind is rejected before it can reach the DB"
+      (mt/user-http-request :crowberto :post 400 "index/request"
+                            {:transform_id transform-id :structured (assoc btree :kind "not_a_kind")}))
+    (testing "a name over the 63-char limit is rejected"
+      (mt/user-http-request :crowberto :post 400 "index/request"
+                            {:transform_id transform-id
+                             :structured   (assoc btree :name (apply str (repeat 64 "a")))}))
+    (testing "a 63-char name is accepted (boundary)"
+      (mt/user-http-request :crowberto :post 200 "index/request"
+                            {:transform_id transform-id
+                             :structured   (assoc btree :name (apply str (repeat 63 "a")))}))))
+
 (deftest put-cannot-change-index-key-test
   (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)]
     (let [created (mt/user-http-request :crowberto :post 200 "index/request"
@@ -139,23 +153,25 @@
 (deftest incremental-mutations-force-next-run-to-rebuild-test
   (mt/with-temp [:model/Transform {transform-id :id} (assoc (temp-incremental-transform-spec)
                                                             :last_checkpoint_value "100")]
-    (testing "POST clears the checkpoint so the new index can be applied"
-      (let [created (mt/user-http-request :crowberto :post 200 "index/request"
-                                          {:transform_id transform-id :structured btree})]
-        (is (nil? (t2/select-one-fn :last_checkpoint_value :model/Transform transform-id)))
-        (testing "PUT clears the checkpoint so the changed structure can be applied"
-          (t2/update! :model/Transform transform-id {:last_checkpoint_value "200"})
-          (mt/user-http-request :crowberto :put 200 (str "index/request/" (:id created))
-                                {:structured (assoc btree :columns [{:name "price"}])})
-          (is (nil? (t2/select-one-fn :last_checkpoint_value :model/Transform transform-id))))
-        (testing "DELETE clears the checkpoint so the old index can be dropped by the rebuild"
-          (t2/update! :model/Transform transform-id {:last_checkpoint_value "300"})
-          (mt/user-http-request :crowberto :delete 204 (str "index/request/" (:id created)))
-          (is (nil? (t2/select-one-fn :last_checkpoint_value :model/Transform transform-id))))
-        (testing "pending index status still forces a full rebuild if an in-flight run saves a checkpoint"
-          (t2/update! :model/Transform transform-id {:last_checkpoint_value "400"})
-          (is (#'transforms-base.u/full-incremental-run?
-               (t2/select-one :model/Transform transform-id))))))))
+    (letfn [(full-run? []
+              (transforms-base.u/full-incremental-run? (t2/select-one :model/Transform transform-id)))]
+      (testing "no index changes: the watermark alone decides, so the next run appends"
+        (is (not (full-run?))))
+      (testing "POST leaves the watermark alone; the pending row forces the rebuild"
+        (let [created (mt/user-http-request :crowberto :post 200 "index/request"
+                                            {:transform_id transform-id :structured btree})]
+          (is (= "100" (t2/select-one-fn :last_checkpoint_value :model/Transform transform-id)))
+          (is (full-run?))
+          (testing "PUT keeps forcing it (update-pending)"
+            (mt/user-http-request :crowberto :put 200 (str "index/request/" (:id created))
+                                  {:structured (assoc btree :columns [{:name "price"}])})
+            (is (full-run?)))
+          (testing "DELETE keeps forcing it (delete-pending), so the rebuild can drop the old index"
+            (mt/user-http-request :crowberto :delete 204 (str "index/request/" (:id created)))
+            (is (full-run?)))
+          (testing "once the request settles, runs go back to appending"
+            (t2/update! (t2/table-name :model/TableIndex) (:id created) {:status "succeeded"})
+            (is (not (full-run?)))))))))
 
 (deftest inline-kind-index-name-test
   (testing "an inline kind with no :name gets its index_name from :kind"

--- a/test/metabase/transforms/index_test.clj
+++ b/test/metabase/transforms/index_test.clj
@@ -1,8 +1,8 @@
 (ns ^:mb/driver-tests metabase.transforms.index-test
   "End-to-end: indexes declared on a transform target reach the physical table when the transform runs, across
   re-runs and failures, for both transform kinds (SQL builds the table with a CTAS, Python with `create-table!`).
-  Per-driver cases and helpers live in [[metabase.transforms.index-test-util]]. Each test stubs
-  [[metabase.transforms.execute/hydrate-transform-indexes]] to inject its case."
+  Per-driver cases and helpers live in [[metabase.transforms.index-test-util]]. Each test persists real
+  `:model/TableIndex` rows for its case, so the run reads them exactly like user-created requests."
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
@@ -35,9 +35,19 @@
    :source-tables   [(transforms.tu/source-table-entry "transforms_products" (mt/id :transforms_products))]
    :body            "def transform(transforms_products):\n    return transforms_products"})
 
+(defn- create-index-requests!
+  "Persist `indexes` as `:model/TableIndex` rows for `transform-id`, so the run picks them up like real user-created
+  requests. Cleaned up with the transform (FK cascade)."
+  [transform-id indexes]
+  (when (seq indexes)
+    (t2/insert! :model/TableIndex (for [index indexes]
+                                    {:transform_id transform-id
+                                     :index_name   (or (:name index) (name (:kind index)))
+                                     :structured   index}))))
+
 (defn- test-declared-indexes!
-  "Run a transform (source from the 0-arg `make-source`) with the driver's `:indexes` hydrated onto its target, then
-  assert `:physical-indexes` reads `:expected` from the catalog. Runs twice to check they survive a rebuild."
+  "Run a transform (source from the 0-arg `make-source`) with the driver's `:indexes` persisted as its index requests,
+  then assert `:physical-indexes` reads `:expected` from the catalog. Runs twice to check they survive a rebuild."
   [{:keys [indexes expected physical-indexes]} make-source]
   (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
     (with-transform-cleanup! [{table-name :name :as target}
@@ -48,14 +58,14 @@
       (mt/with-temp [:model/Transform transform {:name   "index-transform"
                                                  :source (make-source)
                                                  :target target}]
-        (with-redefs [transforms.execute/hydrate-transform-indexes (constantly indexes)]
-          (testing "a full run applies the declared indexes to the physical table"
-            (transforms.execute/execute! transform {:run-method :manual})
-            (transforms.tu/wait-for-table table-name 10000)
-            (is (= expected (physical-indexes (mt/db) schema table-name))))
-          (testing "a re-run rebuilds the table and the indexes come back the same"
-            (transforms.execute/execute! transform {:run-method :manual})
-            (is (= expected (physical-indexes (mt/db) schema table-name)))))))))
+        (create-index-requests! (:id transform) indexes)
+        (testing "a full run applies the declared indexes to the physical table"
+          (transforms.execute/execute! transform {:run-method :manual})
+          (transforms.tu/wait-for-table table-name 10000)
+          (is (= expected (physical-indexes (mt/db) schema table-name))))
+        (testing "a re-run rebuilds the table and the indexes come back the same"
+          (transforms.execute/execute! transform {:run-method :manual})
+          (is (= expected (physical-indexes (mt/db) schema table-name))))))))
 
 (deftest ^:synchronized declared-indexes-applied-and-replayed-test
   (mt/test-drivers (index-util/index-test-drivers)
@@ -76,7 +86,7 @@
 
 (deftest ^:synchronized managed-indexes-verified-against-warehouse-after-run-test
   (testing "real managed index rows are created by the run and then verified :succeeded against the warehouse"
-    ;; Reuses the driver create-index cases, but instead of stubbing hydrate-transform-indexes it persists real
+    ;; Reuses the driver create-index cases, but instead of stubbing select-applicable-for-transform it persists real
     ;; :model/TableIndex rows. The run reads them (real hydrate), applies them, and verify-managed-indexes! confirms
     ;; each landed via fetch-table-indexes -- the whole create-then-verify loop on a live warehouse.
     (mt/test-drivers (index-util/index-test-drivers)
@@ -88,10 +98,7 @@
             (mt/with-temp [:model/Transform {tid :id :as transform} {:name   "index-verify-transform"
                                                                      :source (query-source)
                                                                      :target target}]
-              (doseq [idx indexes]
-                (t2/insert! :model/TableIndex {:transform_id tid
-                                               :index_name   (or (:name idx) (name (:kind idx)))
-                                               :structured   idx}))
+              (create-index-requests! tid indexes)
               (transforms.execute/execute! transform {:run-method :manual})
               (transforms.tu/wait-for-table table-name 10000)
               (testing "every managed row is verified succeeded"
@@ -118,15 +125,15 @@
                 (mt/with-temp [:model/Transform transform {:name   "index-fail-transform"
                                                            :source (query-source)
                                                            :target target}]
-                  (with-redefs [transforms.execute/hydrate-transform-indexes (constantly bogus)]
-                    (testing "execute! throws"
-                      (is (thrown? Throwable
-                                   (transforms.execute/execute! transform {:run-method :manual}))))
-                    (testing "and the run is recorded as failed"
-                      (is (= :failed
-                             (t2/select-one-fn :status :model/TransformRun
-                                               :transform_id (:id transform)
-                                               {:order-by [[:id :desc]]}))))))))))))))
+                  (create-index-requests! (:id transform) bogus)
+                  (testing "execute! throws"
+                    (is (thrown? Throwable
+                                 (transforms.execute/execute! transform {:run-method :manual}))))
+                  (testing "and the run is recorded as failed"
+                    (is (= :failed
+                           (t2/select-one-fn :status :model/TransformRun
+                                             :transform_id (:id transform)
+                                             {:order-by [[:id :desc]]})))))))))))))
 
 (deftest ^:synchronized declared-index-creation-is-idempotent-test
   (testing "re-applying a target's indexes is a no-op (CREATE INDEX IF NOT EXISTS), not an error"
@@ -147,14 +154,14 @@
                 (mt/with-temp [:model/Transform transform {:name   "index-idempotent-transform"
                                                            :source (query-source)
                                                            :target target}]
-                  (with-redefs [transforms.execute/hydrate-transform-indexes (constantly indexes)]
-                    (transforms.execute/execute! transform {:run-method :manual})
-                    (transforms.tu/wait-for-table table-name 10000)
-                    (is (= expected (physical-indexes db schema table-name)) "indexes present after the run")
-                    (testing "re-applying the same indexes leaves the catalog unchanged and does not throw"
-                      (transforms-base.u/apply-target-indexes!
-                       (assoc-in transform [:target :indexes] indexes))
-                      (is (= expected (physical-indexes db schema table-name))))))))))))))
+                  (create-index-requests! (:id transform) indexes)
+                  (transforms.execute/execute! transform {:run-method :manual})
+                  (transforms.tu/wait-for-table table-name 10000)
+                  (is (= expected (physical-indexes db schema table-name)) "indexes present after the run")
+                  (testing "re-applying the same indexes leaves the catalog unchanged and does not throw"
+                    (transforms-base.u/apply-target-indexes!
+                     (assoc-in transform [:target :indexes] indexes))
+                    (is (= expected (physical-indexes db schema table-name)))))))))))))
 
 (defn- fetch-schema
   "Schema the fetch-correctness suite creates its table in and passes to fetch-table-indexes. nil for sql-jdbc drivers
@@ -210,24 +217,6 @@
   (testing "fetch-table-indexes has no safe default: its method throws for such a driver"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"fetch-table-indexes is not implemented for driver :h2"
                           (driver/fetch-table-indexes :h2 nil "public" "t")))))
-
-(deftest ^:parallel hydrate-transform-indexes-test
-  (testing "returns the structured defs of a transform's managed indexes, ordered by name"
-    (mt/with-temp [:model/Transform {tid :id} {:name               (mt/random-name)
-                                               :source             {:type "query"}
-                                               :source_database_id (mt/id)
-                                               :target             {:database (mt/id) :type "table" :schema "public" :name "t"}}
-                   :model/TableIndex {b-id :id} {:transform_id tid :index_name "b_idx"
-                                                 :structured {:kind :btree :name "b_idx" :columns [{:name "x"}]}}
-                   :model/TableIndex {a-id :id} {:transform_id tid :index_name "a_idx"
-                                                 :structured {:kind :btree :name "a_idx" :columns [{:name "y"}]}}
-                   :model/TableIndex _ {:transform_id tid :index_name "deleted_idx"
-                                        :status :delete-pending
-                                        :structured {:kind :btree :name "deleted_idx" :columns [{:name "z"}]}}]
-      (is (= ["a_idx" "b_idx"]
-             (map :name (transforms.execute/hydrate-transform-indexes {:id tid}))))
-      (is (= [a-id b-id]
-             (transforms.execute/hydrate-transform-index-ids {:id tid}))))))
 
 (deftest ^:synchronized verify-managed-indexes!-test
   (mt/with-temp [:model/Transform {tid :id} {:name               (mt/random-name)


### PR DESCRIPTION
a batch of fixes for bronsa's review comments on #75848, pulled into their own branch so they're easy to review together.

- moved the index rest api into a new `indexes-rest` module so `GET /index` resolves the target db through `target-db-id` instead of reading it off the target (which is nil for query transforms). that also breaks the indexes -> transforms cycle bronsa flagged.
- POST/PUT `/request` now validate `structured` against the schema and 400 on bad input, keywordizing via `:decode/normalize`. index names are capped at 63 chars.
- clickhouse identifiers now escape backticks and backslashes. the old `quote-name` didn't, so a crafted index/column name could break out of the quotes.
- dropped the checkpoint-reset hooks on TableIndex. a pending index row already forces a full rebuild via `pending-changes-for-transform?`, so nulling the watermark was redundant, and it was what created the indexes -> transforms cycle.
- filter delete-pending in sql instead of in memory, collapsed the two index selects in execute into one, and compute `full-incremental-run?` once per run.

two threads i'm answering in comments rather than code: the `finally` question on verify (the three outcomes diverge so it can't be a blanket finally), and the charset limit (left permissive since names are quoted/escaped per driver now).
