### PR TITLE
Include all action-included models in the typed schema when a mutation is specified

### DIFF
--- a/skills/metabase-data-app-actions/SKILL.md
+++ b/skills/metabase-data-app-actions/SKILL.md
@@ -20,6 +20,8 @@ Actions belong to a model. They mutate that model's rows. Concretely:
 
 ## What's in the schema (and what isn't)
 
+Action entries are only generated when the typed schema includes models. Before writing action-invoking code, make sure the schema was generated with `includeModels=true`; with `database=<name-or-id>&includeModels=true`, Metabase includes models/actions for that database only. Do not rely on `questionCollections` for actions; question collections only add saved questions.
+
 Before writing any action-invoking code, look at the schema and enumerate what's available under `schema.models.<m>.actions` across the models the app cares about. The schema is your **complete** catalog of actions for the instance, not a catalog of model data to display. If a model's `actions` entry has `create`, `update`, `delete`, those are the actions invokable. Anything not present doesn't exist as far as the Data App is concerned.
 
 ## The hook

--- a/skills/metabase-data-app-semantic-layer/SKILL.md
+++ b/skills/metabase-data-app-semantic-layer/SKILL.md
@@ -46,10 +46,13 @@ Before generating, make sure the user has explicitly chosen the library scope th
 - `includeDataLibrary=true` for the whole `Library / Data` tree.
 - `includeMetricLibrary=true` for the whole `Library / metrics` tree.
 - `libraryCollections=<id-or-entity-id>[,<id-or-entity-id>]` for specific Data or metrics library subcollections.
-- `questionCollections=<id-or-entity-id>[,<id-or-entity-id>]` for specific normal collections that contain saved questions and models.
+- `questionCollections=<id-or-entity-id>[,<id-or-entity-id>]` for specific normal collections that contain saved questions.
+- `includeModels=true` for all readable models and their actions. When combined with `database=<name-or-id>`, it includes models for that database only.
 - `database=<name-or-id>` when the app should use tables from one database.
 
-Use `questionCollections` when the app needs generated `schema.questions.*` or `schema.models.*`. It can be combined with `libraryCollections`, `includeDataLibrary`, or `includeMetricLibrary` so one schema can include selected tables/metrics plus selected saved questions/models.
+Use `questionCollections` when the app needs generated `schema.questions.*`. Use `includeModels=true` when the app needs generated `schema.models.*` or any saved action under `schema.models.<model>.actions`. It can be combined with `libraryCollections`, `includeDataLibrary`, `includeMetricLibrary`, or `questionCollections` so one schema can include selected tables/metrics/questions plus all relevant models/actions.
+
+If the user asks for any mutation-like flow, such as creating, updating, deleting, submitting, approving, executing an action, or running a write operation, include `includeModels=true` in the typed-schema URL. Do this even when the user names one specific model/action, because actions are only discoverable through generated model entries.
 
 If the user did not already choose a library scope, stop and ask what they want. Warn before exporting the whole instance: including everything is noisy, bloats context, and makes agents more likely to pick irrelevant entities.
 
@@ -92,7 +95,7 @@ fi
 )
 ```
 
-When the app needs saved questions or models, include `questionCollections=<id-or-entity-id>[,<id-or-entity-id>]` in the typed-schema URL.
+When the app needs saved questions, include `questionCollections=<id-or-entity-id>[,<id-or-entity-id>]` in the typed-schema URL. When the app needs models or actions, include `includeModels=true`.
 
 If schema generation fails while building a selected saved question, model, or model action, do not hide, paraphrase away, or retry past the error. Surface the typed-schema error to the user, including the failing `card-id` / `card-name` / `card-type`, `model-id` / `model-name`, dropped action ids, and message when present. This usually means a selected model/question/action was readable enough to select, but its details could not be built, often because its source table, source card, or action details are not published, accessible, valid, or resolvable in the fetch context. The schema would otherwise omit the entire `schema.models.<model>` or `schema.questions.<question>` entry, or return a model whose `actions` map silently omits an action, so the user needs to curate or publish the missing dependency before regenerating.
 

--- a/skills/metabase-data-app-semantic-layer/SKILL.md
+++ b/skills/metabase-data-app-semantic-layer/SKILL.md
@@ -47,10 +47,10 @@ Before generating, make sure the user has explicitly chosen the library scope th
 - `includeMetricLibrary=true` for the whole `Library / metrics` tree.
 - `libraryCollections=<id-or-entity-id>[,<id-or-entity-id>]` for specific Data or metrics library subcollections.
 - `questionCollections=<id-or-entity-id>[,<id-or-entity-id>]` for specific normal collections that contain saved questions.
-- `includeModels=true` for all readable models and their actions. When combined with `database=<name-or-id>`, it includes models for that database only.
+- `includeModels=true` for readable models that have actions. When combined with `database=<name-or-id>`, it includes models with actions for that database only.
 - `database=<name-or-id>` when the app should use tables from one database.
 
-Use `questionCollections` when the app needs generated `schema.questions.*`. Use `includeModels=true` when the app needs generated `schema.models.*` or any saved action under `schema.models.<model>.actions`. It can be combined with `libraryCollections`, `includeDataLibrary`, `includeMetricLibrary`, or `questionCollections` so one schema can include selected tables/metrics/questions plus all relevant models/actions.
+Use `questionCollections` when the app needs generated `schema.questions.*`. Use `includeModels=true` when the app needs any saved action under `schema.models.<model>.actions`; models without executable actions are omitted to keep generated schemas compact. It can be combined with `libraryCollections`, `includeDataLibrary`, `includeMetricLibrary`, or `questionCollections` so one schema can include selected tables/metrics/questions plus all relevant actions.
 
 If the user asks for any mutation-like flow, such as creating, updating, deleting, submitting, approving, executing an action, or running a write operation, include `includeModels=true` in the typed-schema URL. Do this even when the user names one specific model/action, because actions are only discoverable through generated model entries.
 

--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -590,16 +590,8 @@
 
 (defn- action-schema
   "A pre-existing Metabase action. HTTP actions are filtered upstream because
-  the execute endpoint refuses to run them.
-
-  `model-columns` is the parent model's column-schema list (already rendered
-  by [[column-schema]]). It is NOT re-attached to the action — the action is
-  keyed under its model in the typed schema, so callers can reach the row
-  shape via `schema.models.<m>.columns` directly. The TS helper
-  `ActionResult<TAction, TModel>` threads that into the `row/create`
-  response shape."
-  [_model-columns
-   {:keys [id name description type kind parameters entity_id] :as action}]
+  the execute endpoint refuses to run them."
+  [{:keys [id name description type kind parameters entity_id] :as action}]
   (let [tag-types (query-action-template-tag-types action)
         implicit? (= (->keyword type) :implicit)]
     (assoc-some
@@ -616,11 +608,8 @@
 
 (defn- model-actions
   "Fetches non-archived, non-HTTP actions for a single model and emits each
-  in schema form. Returns nil when the model has no executable actions, so
-  `assoc-some` drops the empty `:actions` field. `model-columns` is the
-  parent model's already-rendered column schemas, passed through to
-  implicit actions for response-row typing."
-  [model model-columns]
+  in schema form. Returns nil when the model has no executable actions."
+  [model]
   (let [raw-actions (raw-model-actions (:id model))
         actions (try
                   (actions/select-actions
@@ -640,7 +629,7 @@
     (when (seq actions)
       (mapv (fn [action]
               (try
-                (action-schema model-columns action)
+                (action-schema action)
                 (catch Exception e
                   (throw (ex-info (model-action-error-message model action (ex-message e))
                                   (assoc (model-action-error-data model action (ex-data e))
@@ -650,23 +639,22 @@
 
 (defn- model-schema
   "A Metabase model (curated dataset). Shape parallels [[question-schema]] —
-  same id/name/columns/etc. — but with `:kind \"model\"` and an extra
-  `:actions` map of pre-existing actions bound to the model
-  (`action.model_id`)."
-  [{:keys [id name description verified display result-columns portable_entity_id] :as model}]
-  (let [columns (mapv column-schema result-columns)
-        action-schemas (model-actions model columns)]
-    (assoc-some
-     {:kind    "model"
-      :key     (generated-key name id)
-      :id      id
-      :name    name
-      :columns columns}
-     :display display
-     :entityId portable_entity_id
-     :description description
-     :verified (when verified true)
-     :actions (some-> action-schemas not-empty keyed-map))))
+  same id/name/etc. — but with `:kind \"model\"` and an extra `:actions` map
+  of pre-existing actions bound to the model (`action.model_id`). Returns nil
+  when the model has no executable actions."
+  [{:keys [id name description verified display portable_entity_id] :as model}]
+  (let [action-schemas (model-actions model)]
+    (when (seq action-schemas)
+      (assoc-some
+       {:kind    "model"
+        :key     (generated-key name id)
+        :id      id
+        :name    name}
+       :display display
+       :entityId portable_entity_id
+       :description description
+       :verified (when verified true)
+       :actions (keyed-map action-schemas)))))
 
 (defn- persisted-dimension->column
   [dimension]
@@ -961,9 +949,10 @@
    (model-schemas database-ids nil))
   ([database-ids collection-ids]
    (for [card (select-cards :model database-ids collection-ids)
-         :let [details (question-details card)]
-         :when details]
-     (model-schema details))))
+         :let [details (question-details card)
+               schema  (some-> details model-schema)]
+         :when schema]
+     schema)))
 
 (defn- metric-schemas
   ([database-ids]

--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -241,6 +241,11 @@
   (truthy-query-param? (or (query-param query-params :include-metric-library)
                            (query-param query-params :includeMetricLibrary))))
 
+(defn- query-include-models?
+  [query-params]
+  (truthy-query-param? (or (query-param query-params :include-models)
+                           (query-param query-params :includeModels))))
+
 (defn- query-question-collection-values
   [query-params]
   (query-comma-separated-values query-params [:question-collections
@@ -1032,18 +1037,23 @@
         library-scope              (library-scope query-params)
         database-ids               (database-ids-for-value (query-database-value query-params))
         question-collection-ids    (collection-scope question-collection-values)
+        include-models?            (query-include-models? query-params)
         models                     (cond
                                      database-ids
                                      (model-schemas database-ids)
 
-                                     question-collection-ids
-                                     (model-schemas nil question-collection-ids)
+                                     include-models?
+                                     (model-schemas nil)
 
                                      :else
                                      [])
         questions-only             (truthy-query-param? (query-param query-params :questions))]
     (cond
-      (or library-value library-collection-values library-scope question-collection-values)
+      (or library-value
+          library-collection-values
+          library-scope
+          question-collection-values
+          (and include-models? (nil? database-ids)))
       (let [questions           (if question-collection-values
                                   (question-schemas nil question-collection-ids)
                                   [])

--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -153,6 +153,13 @@
             (sorted-map)
             entities)))
 
+(defn- keyed-model-map
+  [models]
+  (reduce-kv (fn [m k model]
+               (assoc m k (select-keys model [:actions])))
+             (sorted-map)
+             (keyed-map models)))
+
 (defn- query-param
   [query-params k]
   (or (get query-params k)
@@ -638,23 +645,14 @@
             actions))))
 
 (defn- model-schema
-  "A Metabase model (curated dataset). Shape parallels [[question-schema]] —
-  same id/name/etc. — but with `:kind \"model\"` and an extra `:actions` map
-  of pre-existing actions bound to the model (`action.model_id`). Returns nil
-  when the model has no executable actions."
-  [{:keys [id name description verified display portable_entity_id] :as model}]
+  "A Metabase model (curated dataset) as an action namespace. Returns nil when
+  the model has no executable actions."
+  [{:keys [id name] :as model}]
   (let [action-schemas (model-actions model)]
     (when (seq action-schemas)
-      (assoc-some
-       {:kind    "model"
-        :key     (generated-key name id)
-        :id      id
-        :name    name}
-       :display display
-       :entityId portable_entity_id
-       :description description
-       :verified (when verified true)
-       :actions (keyed-map action-schemas)))))
+      {:key              (generated-key name id)
+       :keyDisambiguator id
+       :actions          (keyed-map action-schemas)})))
 
 (defn- persisted-dimension->column
   [dimension]
@@ -977,7 +975,7 @@
    :generatedAt   (str (Instant/now))
    :metabase      {:instanceUrl (system/site-url)}
    :questions     (keyed-map questions)
-   :models        (keyed-map models)
+   :models        (keyed-model-map models)
    :tables        (keyed-map tables)
    :metrics       (keyed-map metrics)))
 

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -128,6 +128,40 @@
            :display        "table"
            :result-columns [{:name "count", :display_name "Count", :type :number}]}))))
 
+(deftest model-schema-includes-actions-test
+  (with-redefs [typed-schemas.api/model-actions
+                (fn [model]
+                  (is (= 42 (:id model)))
+                  [{:kind "action", :key "create", :id 5}])]
+    (is (= {:kind    "model"
+            :key     "ordersModel"
+            :id      42
+            :name    "Orders model"
+            :actions {"create" {:kind "action", :key "create", :id 5}}}
+           (#'typed-schemas.api/model-schema
+            {:id             42
+             :name           "Orders model"})))))
+
+(deftest model-schemas-includes-actionable-models-test
+  (with-redefs [typed-schemas.api/select-cards
+                (fn [card-type database-ids collection-ids]
+                  (is (= :model card-type))
+                  (is (= #{1} database-ids))
+                  (is (nil? collection-ids))
+                  [{:id 42} {:id 43}])
+                typed-schemas.api/question-details
+                (fn [card]
+                  {:id   (:id card)
+                   :name (str "Model " (:id card))})
+                typed-schemas.api/model-actions
+                (fn [model]
+                  (when (= (:id model) 42)
+                    [{:kind "action", :key "create", :id 5}]))]
+    (is (= #{42}
+           (->> (#'typed-schemas.api/model-schemas #{1})
+                (map :id)
+                set)))))
+
 (deftest metric-source-id-test
   (testing "integer source-table emits sourceTableId but not sourceCardId"
     (let [card {:dataset_query {:query {:source-table 10}}}]
@@ -854,11 +888,11 @@
         (is (= #{10 42} (->> (:tables schema) vals (map :id) set)))
         (is (= #{1} (->> (:metrics schema) vals (map :id) set)))))))
 
-(deftest include-models-schema-includes-all-models-test
+(deftest include-models-schema-includes-actionable-models-test
   (with-redefs [typed-schemas.api/model-schemas
                 (fn [database-ids]
                   (is (nil? database-ids))
-                  [{:kind "model", :key "allModelsModel", :id 100}])
+                  [{:kind "model", :key "actionableModel", :id 100}])
                 typed-schemas.api/question-schemas
                 (fn
                   ([_database-ids]

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -747,7 +747,9 @@
   (is (= ["1" "2"]
          (#'typed-schemas.api/query-library-collection-values {:libraryCollections "1, 2"})))
   (is (= ["3" "4"]
-         (#'typed-schemas.api/query-question-collection-values {:questionCollections "3, 4"}))))
+         (#'typed-schemas.api/query-question-collection-values {:questionCollections "3, 4"})))
+  (is (true?
+       (#'typed-schemas.api/query-include-models? {:includeModels "true"}))))
 
 (deftest question-collection-scope-accepts-comma-separated-collection-ids-test
   (mt/with-temp [:model/Collection parent {:name "Question Parent"
@@ -852,6 +854,55 @@
         (is (= #{10 42} (->> (:tables schema) vals (map :id) set)))
         (is (= #{1} (->> (:metrics schema) vals (map :id) set)))))))
 
+(deftest include-models-schema-includes-all-models-test
+  (with-redefs [typed-schemas.api/model-schemas
+                (fn [database-ids]
+                  (is (nil? database-ids))
+                  [{:kind "model", :key "allModelsModel", :id 100}])
+                typed-schemas.api/question-schemas
+                (fn
+                  ([_database-ids]
+                   (is false "includeModels-only schemas should not load questions"))
+                  ([_database-ids _collection-ids]
+                   (is false "includeModels-only schemas should not load questions")))
+                typed-schemas.api/metric-schemas
+                (fn
+                  ([_database-ids]
+                   (is false "includeModels-only schemas should not load metrics"))
+                  ([_database-ids _collection-ids]
+                   (is false "includeModels-only schemas should not load metrics")))
+                typed-schemas.api/select-tables
+                (fn
+                  ([_database-ids]
+                   (is false "includeModels-only schemas should not load tables"))
+                  ([_database-ids _table-ids]
+                   (is false "includeModels-only schemas should not load tables")))]
+    (let [schema (#'typed-schemas.api/typed-schema {:includeModels "true"})]
+      (is (= {} (:questions schema)))
+      (is (= #{100} (->> (:models schema) vals (map :id) set)))
+      (is (= {} (:tables schema)))
+      (is (= {} (:metrics schema))))))
+
+(deftest include-models-with-database-scopes-models-test
+  (let [model-database-ids (atom [])]
+    (with-redefs [typed-schemas.api/database-ids-for-value (constantly #{42})
+                  typed-schemas.api/model-schemas (fn [database-ids]
+                                                    (swap! model-database-ids conj database-ids)
+                                                    [{:kind "model", :key "databaseModel", :id 100}])
+                  typed-schemas.api/question-schemas (fn
+                                                       ([_database-ids] [])
+                                                       ([_database-ids _collection-ids] []))
+                  typed-schemas.api/metric-schemas (fn
+                                                     ([_database-ids] [])
+                                                     ([_database-ids _collection-ids] []))
+                  typed-schemas.api/select-tables (fn
+                                                    ([_database-ids] [])
+                                                    ([_database-ids _table-ids] []))
+                  typed-schemas.api/table-schemas (constantly [])]
+      (let [schema (#'typed-schemas.api/typed-schema {:database "Boba" :includeModels "true"})]
+        (is (= [#{42}] @model-database-ids))
+        (is (= #{100} (->> (:models schema) vals (map :id) set)))))))
+
 (deftest question-collections-schema-includes-selected-question-collections-test
   (with-redefs [typed-schemas.api/collection-scope
                 (fn [collection-values]
@@ -863,13 +914,14 @@
                   (is (= #{30 40} collection-ids))
                   [{:type "card", :key "ordersByMonth", :id 1}])
                 typed-schemas.api/model-schemas
-                (fn [database-ids collection-ids]
-                  (is (nil? database-ids))
-                  (is (= #{30 40} collection-ids))
-                  [{:kind "model", :key "selectedQuestionCollectionModel", :id 100}])]
+                (fn
+                  ([_database-ids]
+                   (is false "question collection schemas should not load models"))
+                  ([_database-ids _collection-ids]
+                   (is false "question collection schemas should not load models")))]
     (let [schema (#'typed-schemas.api/typed-schema {:question-collections "30, 40"})]
       (is (= #{1} (->> (:questions schema) vals (map :id) set)))
-      (is (= #{100} (->> (:models schema) vals (map :id) set)))
+      (is (= {} (:models schema)))
       (is (= {} (:tables schema)))
       (is (= {} (:metrics schema))))))
 
@@ -889,10 +941,11 @@
                   (is (= #{30} collection-ids))
                   [{:type "card", :key "ordersByMonth", :id 1}])
                 typed-schemas.api/model-schemas
-                (fn [database-ids collection-ids]
-                  (is (nil? database-ids))
-                  (is (= #{30} collection-ids))
-                  [{:kind "model", :key "selectedQuestionCollectionModel", :id 100}])
+                (fn
+                  ([_database-ids]
+                   (is false "question collection schemas should not load models"))
+                  ([_database-ids _collection-ids]
+                   (is false "question collection schemas should not load models")))
                 typed-schemas.api/metric-schemas
                 (constantly [{:type "metric", :key "revenue", :id 2}])
                 typed-schemas.api/select-library-tables
@@ -903,6 +956,41 @@
                 (constantly [{:type "table", :key "orders", :id 3}])]
     (let [schema (#'typed-schemas.api/typed-schema {:library-collections  "10"
                                                     :question-collections "30"})]
+      (is (= #{1} (->> (:questions schema) vals (map :id) set)))
+      (is (= {} (:models schema)))
+      (is (= #{3} (->> (:tables schema) vals (map :id) set)))
+      (is (= #{2} (->> (:metrics schema) vals (map :id) set))))))
+
+(deftest library-and-question-collections-can-be-combined-with-include-models-test
+  (with-redefs [typed-schemas.api/library-collections-scope
+                (fn [collection-values]
+                  (is (= ["10"] collection-values))
+                  {:metric-collection-ids #{10}
+                   :data-collection-ids   #{10}})
+                typed-schemas.api/collection-scope
+                (fn [collection-values]
+                  (is (= ["30"] collection-values))
+                  #{30})
+                typed-schemas.api/question-schemas
+                (fn [database-ids collection-ids]
+                  (is (nil? database-ids))
+                  (is (= #{30} collection-ids))
+                  [{:type "card", :key "ordersByMonth", :id 1}])
+                typed-schemas.api/model-schemas
+                (fn [database-ids]
+                  (is (nil? database-ids))
+                  [{:kind "model", :key "selectedQuestionCollectionModel", :id 100}])
+                typed-schemas.api/metric-schemas
+                (constantly [{:type "metric", :key "revenue", :id 2}])
+                typed-schemas.api/select-library-tables
+                (constantly [{:id 3}])
+                typed-schemas.api/select-tables
+                (constantly [{:id 3}])
+                typed-schemas.api/table-schemas
+                (constantly [{:type "table", :key "orders", :id 3}])]
+    (let [schema (#'typed-schemas.api/typed-schema {:library-collections  "10"
+                                                    :question-collections "30"
+                                                    :includeModels        "true"})]
       (is (= #{1} (->> (:questions schema) vals (map :id) set)))
       (is (= #{100} (->> (:models schema) vals (map :id) set)))
       (is (= #{3} (->> (:tables schema) vals (map :id) set)))

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -133,11 +133,9 @@
                 (fn [model]
                   (is (= 42 (:id model)))
                   [{:kind "action", :key "create", :id 5}])]
-    (is (= {:kind    "model"
-            :key     "ordersModel"
-            :id      42
-            :name    "Orders model"
-            :actions {"create" {:kind "action", :key "create", :id 5}}}
+    (is (= {:key              "ordersModel"
+            :keyDisambiguator 42
+            :actions          {"create" {:kind "action", :key "create", :id 5}}}
            (#'typed-schemas.api/model-schema
             {:id             42
              :name           "Orders model"})))))
@@ -157,9 +155,9 @@
                 (fn [model]
                   (when (= (:id model) 42)
                     [{:kind "action", :key "create", :id 5}]))]
-    (is (= #{42}
+    (is (= #{"model42"}
            (->> (#'typed-schemas.api/model-schemas #{1})
-                (map :id)
+                (map :key)
                 set)))))
 
 (deftest metric-source-id-test
@@ -892,7 +890,8 @@
   (with-redefs [typed-schemas.api/model-schemas
                 (fn [database-ids]
                   (is (nil? database-ids))
-                  [{:kind "model", :key "actionableModel", :id 100}])
+                  [{:key     "actionableModel"
+                    :actions {"create" {:kind "action", :key "create", :id 1}}}])
                 typed-schemas.api/question-schemas
                 (fn
                   ([_database-ids]
@@ -913,7 +912,8 @@
                    (is false "includeModels-only schemas should not load tables")))]
     (let [schema (#'typed-schemas.api/typed-schema {:includeModels "true"})]
       (is (= {} (:questions schema)))
-      (is (= #{100} (->> (:models schema) vals (map :id) set)))
+      (is (= {"actionableModel" {:actions {"create" {:kind "action", :key "create", :id 1}}}}
+             (:models schema)))
       (is (= {} (:tables schema)))
       (is (= {} (:metrics schema))))))
 
@@ -922,7 +922,8 @@
     (with-redefs [typed-schemas.api/database-ids-for-value (constantly #{42})
                   typed-schemas.api/model-schemas (fn [database-ids]
                                                     (swap! model-database-ids conj database-ids)
-                                                    [{:kind "model", :key "databaseModel", :id 100}])
+                                                    [{:key     "databaseModel"
+                                                      :actions {"create" {:kind "action", :key "create", :id 1}}}])
                   typed-schemas.api/question-schemas (fn
                                                        ([_database-ids] [])
                                                        ([_database-ids _collection-ids] []))
@@ -935,7 +936,8 @@
                   typed-schemas.api/table-schemas (constantly [])]
       (let [schema (#'typed-schemas.api/typed-schema {:database "Boba" :includeModels "true"})]
         (is (= [#{42}] @model-database-ids))
-        (is (= #{100} (->> (:models schema) vals (map :id) set)))))))
+        (is (= {"databaseModel" {:actions {"create" {:kind "action", :key "create", :id 1}}}}
+               (:models schema)))))))
 
 (deftest question-collections-schema-includes-selected-question-collections-test
   (with-redefs [typed-schemas.api/collection-scope
@@ -1013,7 +1015,8 @@
                 typed-schemas.api/model-schemas
                 (fn [database-ids]
                   (is (nil? database-ids))
-                  [{:kind "model", :key "selectedQuestionCollectionModel", :id 100}])
+                  [{:key     "selectedQuestionCollectionModel"
+                    :actions {"create" {:kind "action", :key "create", :id 1}}}])
                 typed-schemas.api/metric-schemas
                 (constantly [{:type "metric", :key "revenue", :id 2}])
                 typed-schemas.api/select-library-tables
@@ -1026,6 +1029,7 @@
                                                     :question-collections "30"
                                                     :includeModels        "true"})]
       (is (= #{1} (->> (:questions schema) vals (map :id) set)))
-      (is (= #{100} (->> (:models schema) vals (map :id) set)))
+      (is (= {"selectedQuestionCollectionModel" {:actions {"create" {:kind "action", :key "create", :id 1}}}}
+             (:models schema)))
       (is (= #{3} (->> (:tables schema) vals (map :id) set)))
       (is (= #{2} (->> (:metrics schema) vals (map :id) set))))))


### PR DESCRIPTION
Closes EMB-2072

### Description

- Adds `includeModels=true` to typed schema generation so data apps can explicitly include readable models that have executable actions, scoped by `database` when present.
- To keep the generated schema compact for agents, models without actions and the columns field are omitted.
- `questionCollections` now only includes saved questions, and the data-app skill now requires `includeModels=true` for requests related to CRUD (create, update, delete) mutation operations.

### How to verify

Try a prompt that mentions a mutation operation, like "add a franchise". Here's what I used

```
Create a new metabase data app for executives to have an in depth understanding of the franchises.  I want to be able to add new franchise too.

I will use a custom version of the SDK, not 63-data-apps. Use this command to install custom version:

* npm pkg set dependencies.@metabase/embedding-sdk-react="file:../../../metabase/resources/embedding-sdk"
* npm install
```

It should generate an app with models, and the model schema should now be fairly small, e.g.

```js
const models = {
  franchisesModel: {
    kind: "model",
    key: "franchisesModel",
    id: 256,
    name: "Franchises Model",
    display: "table",
    actions: {
      create: {
        kind: "action",
        key: "create",
        id: 9,
        name: "Create",
        type: "implicit",
        parameters: [
          {
            slug: "id",
            displayName: "ID",
            jsType: "string",
            required: true
          },
          {
            slug: "tenant_id",
            displayName: "Tenant ID",
            jsType: "string",
            required: true
          },
          {
            slug: "name",
            displayName: "Name",
            jsType: "string",
            required: true
          },
          {
            slug: "owner_name",
            displayName: "Owner Name",
            jsType: "string",
            required: true
          },
          {
            slug: "plan",
            displayName: "Plan",
            jsType: "string",
            required: true
          },
          {
            slug: "opened_on",
            displayName: "Opened On",
            jsType: "Date",
            required: true
          }
        ],
        entityId: "cXENFLCrbnnpLi7pTvKQk",
        implicitKind: "row/create"
      },
    }
  }
} as const;

```

### Screenshot

Using the above prompt, the agent uses

<img width="300" alt="CleanShot 2569-07-08 at 23 13 32@2x" src="https://github.com/user-attachments/assets/65e54c88-5101-4667-8922-a1912d195473" />

It generated the "Add Franchise" form

<img width="2356" height="1802" alt="CleanShot 2569-07-08 at 23 12 54@2x" src="https://github.com/user-attachments/assets/5c1e10c6-2d0d-4176-88bd-30a0dccdf87f" />

It has good input validation

<img width="2030" height="1620" alt="CleanShot 2569-07-08 at 23 14 13@2x" src="https://github.com/user-attachments/assets/d88a052e-ed44-44aa-9732-665cbdf85999" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
