### PR TITLE
Move leftover-index cleanup into a finally

### DIFF
--- a/src/metabase/transforms/util.clj
+++ b/src/metabase/transforms/util.clj
@@ -185,12 +185,12 @@
                 (try
                   (transforms-base.u/apply-target-indexes! transform)
                   (transforms-base.u/verify-managed-indexes! transform)
-                  (table-index/mark-unverified-running-indexes-failed!
-                   running-indexes
-                   "Index status could not be verified after the transform completed.")
-                  (catch Throwable t
-                    (table-index/mark-unverified-running-indexes-failed! running-indexes (ex-message t))
-                    (throw t)))))
+                  (finally
+                    ;; Fail any request verification couldn't settle -- whether apply/verify threw or just left it
+                    ;; running. On a throw the exception still propagates to the run-level catch.
+                    (table-index/mark-unverified-running-indexes-failed!
+                     running-indexes
+                     "Index status could not be verified after the transform completed.")))))
             (transforms-base.u/save-watermark! (:id transform) source-range-params)
             (transform-run/succeed-started-run! run-id)
             ;; Narrow try/catch so an emission throw doesn't trigger the outer catch's


### PR DESCRIPTION
follow-up to bronsa's review on #77285: the leftover-index cleanup (`mark-unverified-running-indexes-failed!`) ran in both the success path and the catch, only differing in the message, so it's just finally-shaped cleanup. moved it into a finally and dropped the catch (the exception still propagates to the run-level catch on its own).

one small tradeoff: a failed index now gets the generic "could not be verified" message instead of the exception's, but the run records the actual error anyway.
