### PR TITLE
Drop stale api dep and model import from the indexes module

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1070,12 +1070,10 @@
    :api  #{metabase.indexes.models.table-index
            metabase.indexes.reconcile
            metabase.indexes.schema}
-   :uses #{api
-           driver
+   :uses #{driver
            models
            util}
-   :model-exports #{:model/TableIndex}
-   :model-imports #{:model/Database}}
+   :model-exports #{:model/TableIndex}}
 
   indexes-rest
   {:team "Gadget"


### PR DESCRIPTION
moving the index rest api into `indexes-rest` (#77285) left the `indexes` module still declaring a dependency on the `api` module and a `:model/Database` import it no longer uses. `metabase.core.modules-test` failed on it (model-config-not-stale + modules-config-up-to-date) across every app db. dropped both.