### PR TITLE
Avoid loading any H2 classes until/unless the H2 lib is on the classpath

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -829,7 +829,6 @@
            metabase.driver.common
            metabase.driver.connection
            metabase.driver.ddl.interface
-           metabase.driver.h2
            metabase.driver.impl
            metabase.driver.init
            metabase.driver.mysql

--- a/src/metabase/app_db/core.clj
+++ b/src/metabase/app_db/core.clj
@@ -16,6 +16,7 @@
    [metabase.app-db.encryption :as mdb.encryption]
    [metabase.app-db.env :as mdb.env]
    [metabase.app-db.format]
+   [metabase.app-db.h2 :as mdb.h2]
    [metabase.app-db.jdbc-protocols :as mdb.jdbc-protocols]
    [metabase.app-db.liquibase :as liquibase]
    [metabase.app-db.query]
@@ -46,6 +47,8 @@
   broken-out-details->DataSource]
  [mdb.env
   db-file]
+ [mdb.h2
+  jdbc-sql-syntax-error-exception-classname]
  [mdb.jdbc-protocols
   clob->str]
  [mdb.encryption

--- a/src/metabase/app_db/h2.clj
+++ b/src/metabase/app_db/h2.clj
@@ -1,0 +1,11 @@
+(ns metabase.app-db.h2
+  "Single home for the H2-specific values and adapters referenced from otherwise-H2-free app-db code.")
+
+(def statement-was-canceled-error-code
+  "Value of `org.h2.api.ErrorCode/STATEMENT_WAS_CANCELED`, inlined so callers can recognize an H2
+  query cancelation without the H2 library on the classpath."
+  57014)
+
+(def jdbc-sql-syntax-error-exception-classname
+  "Class name of H2's syntax-error exception, matched by name so callers need not import the class."
+  "org.h2.jdbc.JdbcSQLSyntaxErrorException")

--- a/src/metabase/app_db/jdbc_protocols.clj
+++ b/src/metabase/app_db/jdbc_protocols.clj
@@ -76,8 +76,8 @@
     (jdbc/set-parameter (double ratio) stmt i)))
 
 (defn clob->str
-  "Convert an H2 clob to a String."
-  ^String [^org.h2.jdbc.JdbcClob clob]
+  "Convert a JDBC clob to a String."
+  ^String [^java.sql.Clob clob]
   (when clob
     (letfn [(->str [^BufferedReader buffered-reader]
               (loop [acc []]
@@ -90,18 +90,21 @@
           (with-open [buffered-reader (BufferedReader. reader)]
             (->str buffered-reader)))))))
 
+;; CLOB/BLOB are handled via the java.sql interfaces (not the concrete driver classes) so this
+;; always-loaded namespace carries no compile-time reference to any specific JDBC driver -- in
+;; particular it loads fine when the H2 library has been stripped from the classpath.
 (extend-protocol jdbc/IResultSetReadColumn
   org.postgresql.util.PGobject
   (result-set-read-column [clob _ _]
     (.getValue clob))
 
-  org.h2.jdbc.JdbcClob
+  java.sql.Clob
   (result-set-read-column [clob _ _]
     (clob->str clob))
 
-  org.h2.jdbc.JdbcBlob
-  (result-set-read-column [^org.h2.jdbc.JdbcBlob blob _ _]
-    (.getBytes blob 0 (.length blob))))
+  java.sql.Blob
+  (result-set-read-column [^java.sql.Blob blob _ _]
+    (.getBytes blob 1 (int (.length blob)))))
 
 (defmulti ^:private read-column
   {:arglists '([rs rsmeta i])}

--- a/src/metabase/app_db/query_cancelation.clj
+++ b/src/metabase/app_db/query_cancelation.clj
@@ -1,4 +1,6 @@
-(ns metabase.app-db.query-cancelation)
+(ns metabase.app-db.query-cancelation
+  (:require
+   [metabase.app-db.h2 :as mdb.h2]))
 
 (set! *warn-on-reflection* true)
 
@@ -9,7 +11,7 @@
 
 (defmethod query-canceled-exception?* :h2
   [_db-type ^java.sql.SQLException e]
-  (= (.getErrorCode e) org.h2.api.ErrorCode/STATEMENT_WAS_CANCELED))
+  (= (.getErrorCode e) mdb.h2/statement-was-canceled-error-code))
 
 (defn- sql-state
   [^java.sql.SQLException e]

--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -13,7 +13,6 @@
    [metabase.core.config-from-file :as config-from-file]
    [metabase.core.init]
    [metabase.core.perf :as perf]
-   [metabase.driver.h2]
    [metabase.driver.mysql]
    [metabase.driver.postgres]
    [metabase.embedding.settings :as embed.settings]
@@ -46,8 +45,8 @@
 
 (comment
   metabase.core.init/keep-me
-  ;; Load up the drivers shipped as part of the main codebase, so they will show up in the list of available DB types
-  metabase.driver.h2/keep-me
+  ;; Load up the drivers shipped as part of the main codebase, so they will show up in the list of available DB types.
+  ;; H2 is intentionally omitted: lazy-loaded on demand so the H2 library can be absent from the classpath.
   metabase.driver.mysql/keep-me
   metabase.driver.postgres/keep-me
   ;; Make sure the custom Metabase logger code gets loaded up so we use our custom logger for performance reasons.

--- a/src/metabase/driver/init.clj
+++ b/src/metabase/driver/init.clj
@@ -7,8 +7,9 @@
    [metabase.driver.common.table-rows-sample]
    [metabase.driver.events.driver-notifications]
    [metabase.driver.events.report-timezone-updated]
-   ;; Load up the drivers shipped as part of the main codebase, so they will show up in the list of available DB types
-   [metabase.driver.h2]
+   ;; Load up the drivers shipped as part of the main codebase, so they will show up in the list of available DB types.
+   ;; H2 is intentionally not loaded here: it is lazy-loaded on demand so the H2 library can be absent from the
+   ;; classpath.
    [metabase.driver.mysql]
    [metabase.driver.postgres]
    [metabase.driver.settings]

--- a/src/metabase/driver/sqlite.clj
+++ b/src/metabase/driver/sqlite.clj
@@ -115,7 +115,8 @@
   [_ {:keys [db read-only?]
       :or   {db "sqlite.db"}
       :as   details}]
-  (merge {:subprotocol "sqlite"
+  (merge {:classname   "org.sqlite.JDBC"
+          :subprotocol "sqlite"
           :subname     db}
          (dissoc details :db :read-only?)
          ;; SQLite-JDBC can't flip a live connection to read-only, so set it at open time via `open_mode`.

--- a/src/metabase/query_processor/middleware/cache_backend/db.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/db.clj
@@ -25,10 +25,9 @@
   {:arglists '([cached])}
   (comp type :results))
 
-;; H2 returns a blob type
-(defmethod results-as-bytes org.h2.jdbc.JdbcBlob
-  [{:keys [^org.h2.jdbc.JdbcBlob results]}]
-  (.getBytes results 1 (.length results)))
+(defmethod results-as-bytes java.sql.Blob
+  [{:keys [^java.sql.Blob results]}]
+  (.getBytes results 1 (int (.length results))))
 
 ;; MySQL/Mariadb/Postgresql return a byte array
 (defmethod results-as-bytes :default

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -22,7 +22,6 @@
    [metabase.util.string :as string]
    [toucan2.core :as t2])
   (:import
-   (org.h2.jdbc JdbcSQLSyntaxErrorException)
    (org.postgresql.util PSQLException)))
 
 (comment
@@ -288,7 +287,8 @@
   ;; Use with care, obviously this can give false positives if used with a query that's *actually* malformed.
   ;; TODO we should handle the MySQL and MariaDB flavors here too
   (or (instance? PSQLException (ex-cause e))
-      (instance? JdbcSQLSyntaxErrorException (ex-cause e))))
+      (= mdb/jdbc-sql-syntax-error-exception-classname
+         (some-> e ex-cause class .getName))))
 
 (defn- retry-upsert-ex [table-type table-name-before table-name-after e-before e-after]
   (ex-info "Failed retrying search index batch upsert"


### PR DESCRIPTION
(cherry picked from commit 51e50d157c6d794a567f94d5be8857b14335fcf2)

### Description

Backport of https://github.com/metabase/metabase/pull/76842