### PR TITLE
await replaceCardWithVisualization

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/reproductions.cy.spec.ts
@@ -3,6 +3,11 @@ import type {
   DashboardDetails,
   StructuredQuestionDetails,
 } from "e2e/support/helpers";
+import {
+  ORDERS_COUNT_BY_CREATED_AT,
+  PRODUCTS_COUNT_BY_CREATED_AT,
+  createVisualizerDashcardWithTimeseriesBreakout,
+} from "e2e/support/test-visualizer-data";
 import type { DashboardCard, Parameter } from "metabase-types/api";
 
 const { H } = cy;
@@ -286,6 +291,74 @@ describe("issue 65908 (UXW-2293)", () => {
       cy.findByRole("main").should(($main) => {
         // 4 cards take about 2000px in height, so only 1 card should definitely take less than 1000px
         expect($main[0].scrollHeight).to.be.lessThan(1000);
+      });
+    });
+  });
+});
+
+describe("issue 76819 (UXW-4679)", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("saves a visualizer dashcard's axis edit even when the source-card refetch is slow (metabase#76819)", () => {
+    // Build a renderable combo visualizer dashcard directly via the API.
+    H.createQuestion(ORDERS_COUNT_BY_CREATED_AT).then(
+      ({ body: { id: ordersCardId } }) => {
+        H.createQuestion(PRODUCTS_COUNT_BY_CREATED_AT).then(
+          ({ body: { id: productsCardId } }) => {
+            H.createDashboard().then(({ body: { id: dashboardId } }) => {
+              cy.wrap(dashboardId).as("dashboardId");
+              cy.request("PUT", `/api/dashboard/${dashboardId}`, {
+                dashcards: [
+                  createVisualizerDashcardWithTimeseriesBreakout(
+                    ordersCardId,
+                    productsCardId,
+                    { id: -1, col: 0, row: 0, size_x: 12, size_y: 8 },
+                  ),
+                ],
+              });
+              H.visitDashboard(dashboardId);
+            });
+          },
+        );
+      },
+    );
+
+    H.editDashboard();
+    H.showDashcardVisualizerModalSettings(0, { isVisualizerCard: true });
+    H.modal().within(() => {
+      cy.findByRole("radio", { name: /axes/i }).click({ force: true });
+      cy.findByText("Auto y-axis range").click();
+    });
+
+    // Slow the source-card refetch that replaceCardWithVisualization awaits before
+    // committing the edit, so the async-commit window is wide and deterministic.
+    cy.intercept("GET", "/api/card/*", (req) => {
+      req.on("response", (res) => {
+        res.setDelay(1000);
+      });
+    }).as("slowGetCard");
+    cy.intercept("PUT", "/api/dashboard/*").as("saveDashboardPut");
+
+    // Save the modal edit and save the dashboard immediately. With the fix the Save button shows a loading state and
+    // the modal stays open until the commit lands; without it it closes early.
+    H.saveDashcardVisualizerModal({ mode: "update" });
+    H.dashboardSaveButton().click();
+
+    //Ensure that dashboard actually updated
+    cy.wait("@saveDashboardPut");
+    cy.findByTestId("edit-bar").should("not.exist");
+    cy.get<number>("@dashboardId").then((id) => {
+      cy.request("GET", `/api/dashboard/${id}`).then(({ body }) => {
+        const settings =
+          body.dashcards[0]?.visualization_settings?.visualization?.settings ??
+          {};
+        expect(
+          settings["graph.y_axis.auto_range"],
+          "axis edit should persist on the visualizer dashcard",
+        ).to.equal(false);
       });
     });
   });

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -521,14 +521,16 @@ class DashboardGridInner extends Component<
     );
   }
 
-  onVisualizerModalSave = (visualization: VisualizerVizDefinition) => {
+  onVisualizerModalSave = async (visualization: VisualizerVizDefinition) => {
     const { visualizerModalStatus } = this.state;
 
     if (!visualizerModalStatus) {
       return;
     }
 
-    this.props.replaceCardWithVisualization({
+    // Await the commit before closing — closing early lets a dashboard save
+    // run against the not-yet-updated dashcard and drop the change.
+    await this.props.replaceCardWithVisualization({
       dashcardId: visualizerModalStatus.dashcardId,
       visualization,
     });

--- a/frontend/src/metabase/visualizer/components/Header/Header.tsx
+++ b/frontend/src/metabase/visualizer/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -24,7 +24,7 @@ import {
 import S from "./Header.module.css";
 
 interface HeaderProps {
-  onSave: (visualization: VisualizerVizDefinition) => void;
+  onSave: (visualization: VisualizerVizDefinition) => void | Promise<void>;
   onClose: () => void;
   saveLabel?: string;
   allowSaveWhenPristine?: boolean;
@@ -49,12 +49,19 @@ export function Header({
 
   const dispatch = useDispatch();
 
-  const handleSave = () => {
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSave = async () => {
     trackVisualizerSaveClicked();
 
-    onSave(
-      _.pick(visualizerState, ["display", "columnValuesMapping", "settings"]),
-    );
+    setIsSaving(true);
+    try {
+      await onSave(
+        _.pick(visualizerState, ["display", "columnValuesMapping", "settings"]),
+      );
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   const handleChangeTitle = useCallback(
@@ -116,6 +123,7 @@ export function Header({
       <Button
         variant="filled"
         size="sm"
+        loading={isSaving}
         disabled={!saveButtonEnabled}
         onClick={handleSave}
       >

--- a/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
+++ b/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
@@ -62,7 +62,7 @@ const isVerticalDraggedItem = (draggedItem: DraggedItem | null) => {
 
 interface VisualizerProps {
   className?: string;
-  onSave: (visualization: VisualizerVizDefinition) => void;
+  onSave: (visualization: VisualizerVizDefinition) => void | Promise<void>;
   onClose: () => void;
   saveLabel?: string;
   allowSaveWhenPristine?: boolean;


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76819
### Description

This is already done in v63 and above, but this PR eliminates a race condition where hitting save on the visualizer modal kicks off a process where we re-fetch every card involved in the updated visualization before committing the change to local state. If the user *saves* the dashboard before that change is committed, then it will "miss the train". Even worse, it will eventually apply, and unless the dashboard is refreshed, it won't be obvious that it didn't properly save.

The solution is fairly simple, we need to await `replaceCardWithVisualization` before closing the visualizer. A loading state was added to the save button, otherwise it would look like the visualizer was just hanging

### How to verify

1. Open a dashboard, add a card, click "visualize another way" and add another series (not actually needed, but helps the possible race condition)
2. save the dashboard, then go back into edit mode
3. at this point, throttle your chrome network connection
4. Open the visualizer, make a change
5. Then as quickly as you can, hit save on the visualizer and then the dashboard
6. If you comment out the `await`, you should find that there is no actual `PUT /dashboard`

### Demo


https://github.com/user-attachments/assets/a1e1450b-52bc-4d70-8ff6-4a98acbe6427



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
