### PR TITLE
Convert whitelabel, visualization register, and store glue modules to TypeScript

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/whitelabel.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/whitelabel.ts
@@ -1,7 +1,7 @@
 import { mutateColors } from "metabase/ui/colors/colors";
 import MetabaseSettings from "metabase/utils/settings";
 
-export function updateColors() {
+export function updateColors(): void {
   const scheme = MetabaseSettings.get("application-colors") || {};
   mutateColors(scheme);
 }

--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -320,7 +320,7 @@ const elements = [
   createElement({
     type: "shared",
     name: "redux-store",
-    pattern: "frontend/src/metabase/store.js",
+    pattern: "frontend/src/metabase/store.ts",
     mode: "full",
   }),
 ];

--- a/frontend/src/metabase/dashboard/visualizations/register.ts
+++ b/frontend/src/metabase/dashboard/visualizations/register.ts
@@ -8,11 +8,17 @@ import { LinkViz } from "./LinkViz";
 import { Text } from "./Text";
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
-export default function () {
+export default function (): void {
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(ActionViz);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(DashCardPlaceholder);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(Heading);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(LinkViz);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(IFrameViz);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(Text);
 }

--- a/frontend/src/metabase/store.ts
+++ b/frontend/src/metabase/store.ts
@@ -1,20 +1,33 @@
+import type {
+  Middleware,
+  Reducer,
+  Store,
+  UnknownAction,
+} from "@reduxjs/toolkit";
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
+import type { History } from "history";
 
 import { Api } from "metabase/api";
 import { PLUGIN_REDUX_MIDDLEWARES } from "metabase/plugins";
+import type { State } from "metabase/redux/store";
 import { routerMiddleware, routing } from "metabase/router";
 
 export function getStore(
-  reducers,
-  history,
-  initialState,
-  extraMiddlewares = [],
-) {
+  // the reducer map and preloaded state vary per app entry point (main,
+  // public, embed, SDK), so their shapes are consciously loose
+  reducers: Record<string, Reducer<any, any, any>>,
+  history?: History | null,
+  initialState?: unknown,
+  extraMiddlewares: Middleware[] = [],
+): Store<State> {
+  // assert the app-level State since the true shape depends on the caller's
+  // reducer map; the unknown preloaded-state generic accepts entry points'
+  // partial initial state
   const reducer = combineReducers({
     ...reducers,
     routing,
     [Api.reducerPath]: Api.reducer,
-  });
+  }) as unknown as Reducer<State, UnknownAction, unknown>;
 
   return configureStore({
     reducer,

--- a/frontend/src/metabase/utils/settings.ts
+++ b/frontend/src/metabase/utils/settings.ts
@@ -2,32 +2,35 @@ import _ from "underscore";
 
 import type {
   ColorSettings,
+  EnterpriseSettingKey,
+  EnterpriseSettings,
   PasswordComplexity,
-  SettingKey,
-  Settings,
 } from "metabase-types/api";
 
 type SettingListener = (value: any) => void;
 
 class MetabaseSettings {
-  _settings: Partial<Settings>;
+  _settings: Partial<EnterpriseSettings>;
   _listeners: Partial<{ [key: string]: SettingListener[] }> = {};
 
-  constructor(settings: Partial<Settings> = {}) {
+  constructor(settings: Partial<EnterpriseSettings> = {}) {
     this._settings = settings;
   }
 
   /**
    * @deprecated use getSetting(state, key)
    */
-  get<T extends SettingKey>(key: T): Partial<Settings>[T] {
+  get<T extends EnterpriseSettingKey>(key: T): Partial<EnterpriseSettings>[T] {
     return this._settings[key];
   }
 
   /**
    * @deprecated set setting values in the redux store
    */
-  set<T extends SettingKey>(key: T, value: Settings[T]) {
+  set<T extends EnterpriseSettingKey>(
+    key: T,
+    value: Partial<EnterpriseSettings>[T],
+  ): void {
     if (this._settings[key] !== value) {
       this._settings[key] = value;
       const listeners = this._listeners[key];
@@ -45,9 +48,9 @@ class MetabaseSettings {
   /**
    * @deprecated set setting values in the redux store
    */
-  setAll(settings: Settings) {
-    // Unjustified type cast. FIXME
-    const keys = Object.keys(settings) as SettingKey[];
+  setAll(settings: Partial<EnterpriseSettings>): void {
+    // Object.keys widens keys to string[]
+    const keys = Object.keys(settings) as EnterpriseSettingKey[];
 
     keys.forEach((key) => {
       this.set(key, settings[key]);
@@ -57,7 +60,7 @@ class MetabaseSettings {
   /**
    * @deprecated call appropriate actions when modifying the setting
    */
-  on(key: SettingKey, callback: SettingListener) {
+  on(key: EnterpriseSettingKey, callback: SettingListener): void {
     this._listeners[key] = this._listeners[key] || [];
     this._listeners[key].push(callback);
   }
@@ -65,7 +68,7 @@ class MetabaseSettings {
   /**
    * @deprecated remove an event listener
    */
-  off(key: SettingKey, callback: SettingListener) {
+  off(key: EnterpriseSettingKey, callback: SettingListener): void {
     this._listeners[key] =
       this._listeners[key]?.filter((c) => c !== callback) || [];
   }
@@ -210,9 +213,8 @@ class MetabaseSettings {
    *
    * Only use this when Redux store is not always available, e.g. in ThemeProvider
    */
-  applicationColors(): ColorSettings {
-    // Unjustified type cast. FIXME
-    return this.get("application-colors" as SettingKey) as ColorSettings;
+  applicationColors(): ColorSettings | undefined {
+    return this.get("application-colors") ?? undefined;
   }
 }
 

--- a/frontend/src/metabase/visualizations/register.ts
+++ b/frontend/src/metabase/visualizations/register.ts
@@ -26,29 +26,51 @@ import { TreemapChart } from "./visualizations/TreemapChart";
 import { WaterfallChart } from "./visualizations/WaterfallChart";
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
-export default function () {
+export default function (): void {
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(Scalar);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(SmartScalar);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(Progress);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(Gauge);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(Table);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(LineChart);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(AreaChart);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(BarChart);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(WaterfallChart);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(ComboChart);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(RowChart);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(ScatterPlot);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(BoxPlot);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(PieChart);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(Map);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(Funnel);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(ObjectDetail);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(PivotTable);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(SankeyChart);
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(TreemapChart);
 
+  // @ts-expect-error: incompatible prop types with registerVisualization
   registerVisualization(ListViz);
 
+  // @ts-expect-error: incompatible prop types with registerVisualization
   setDefaultVisualization(Table);
 }


### PR DESCRIPTION
 ### Description

Fixes [UXW-4761](https://linear.app/metabase/issue/UXW-4761/convert-trivial-side-effectglue-js-modules-to-ts).

Converts the four lowest-risk glue `.js` files (whitelabel color hook, both visualization registration modules, store factory) to TS. No behavior changes.

- The registration calls need `@ts-expect-error` markers: the `Visualization` type's width/height contract doesn't match what components declare. This was previously hidden by the unchecked JS boundary; same convention as existing stories/specs, and the markers become compile errors (and get removed) once [UXW-3855](https://linear.app/metabase/issue/UXW-3855) fixes the contract.
- `MetabaseSettings` is widened to enterprise setting keys (same union `useSetting` already uses) so enterprise callers type-check; this also let a pre-existing double cast in it be removed.
- `getStore`'s reducer map and initial state are consciously loose, mirroring the test-support store factory: their shapes genuinely vary per app entry point (main, public, embed, SDK).
- Incidental: the module-boundaries lint config referenced `store.js` by exact path, updated to `store.ts`.

### How to verify

- [ ] Open a dashboard with a chart card and a text card; both render (exercises both registration modules and the store).
- [ ] On an EE instance with custom brand colors, the whitelabeled colors still apply after a page load.

### Demo

#### Before

#### After


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
