### PR TITLE
Downgrade SQLite -> H2 sample DB

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1884,7 +1884,8 @@
            settings
            sync
            util}
-   :model-imports #{:model/Database}}
+   :model-imports #{:model/Database
+                    :model/Table}}
 
   search
   {:team "UX West"

--- a/src/metabase/sample_data/impl.clj
+++ b/src/metabase/sample_data/impl.clj
@@ -97,13 +97,38 @@
     (catch Throwable e
       (log/error e "Failed to load sample database"))))
 
+(defn- migrate-sample-database-engine-in-place!
+  "A newer version left behind a non-H2 (SQLite) sample database that this version cannot use. The only
+  app-db differences between the two are the Database record's engine/details and the tables' schema
+  (SQLite reports no schema, H2 uses \"PUBLIC\"), so instead of deleting and rebuilding, edit those in
+  place and re-sync to reconcile the remaining sync-derived field metadata. Every Database/Table/Field id
+  is kept, so sample content, user-created content, and permissions all survive with no remapping."
+  [old-sample-db]
+  (log/infof "Migrating sample database engine from %s to :h2 in place" (:engine old-sample-db))
+  (let [details (try-to-extract-sample-database!)]
+    (t2/with-transaction [_conn]
+      ;; The Database model's before-update forbids changing a sample database's engine, so set the engine
+      ;; column directly. Details still go through the model so they get encrypted as usual. Engine is
+      ;; flipped first so the table update below dispatches on H2, not the (undriverable) SQLite engine.
+      (t2/query {:update (t2/table-name :model/Database)
+                 :set    {:engine "h2"}
+                 :where  [:= :id (:id old-sample-db)]})
+      (t2/update! :model/Database (:id old-sample-db) {:details details})
+      (t2/update! :model/Table :db_id (:id old-sample-db) {:schema "PUBLIC"}))
+    (sync/sync-database! (t2/select-one :model/Database :id (:id old-sample-db)))))
+
 (defn update-sample-database-if-needed!
-  "Update the path to the sample database DB if it exists in case the JAR has moved."
+  "Reconcile the existing sample database on launch. If a newer version left behind a non-H2 sample
+  database this version can't use (e.g. after a downgrade), convert it to H2 in place (see
+  [[migrate-sample-database-engine-in-place!]]); otherwise just refresh its connection details in case
+  the JAR has moved."
   ([]
    (update-sample-database-if-needed! (t2/select-one :model/Database :is_sample true)))
 
   ([sample-db]
    (when sample-db
-     (let [intended (try-to-extract-sample-database!)]
-       (when (not= (:details sample-db) intended)
-         (t2/update! :model/Database (:id sample-db) {:details intended}))))))
+     (if (not= :h2 (:engine sample-db))
+       (migrate-sample-database-engine-in-place! sample-db)
+       (let [intended (try-to-extract-sample-database!)]
+         (when (not= (:details sample-db) intended)
+           (t2/update! :model/Database (:id sample-db) {:details intended})))))))

--- a/test/metabase/sample_data/impl_test.clj
+++ b/test/metabase/sample_data/impl_test.clj
@@ -8,6 +8,7 @@
    [metabase.app-db.core :as mdb]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.plugins.impl :as plugins]
+   [metabase.query-processor :as qp]
    [metabase.sample-data.impl :as sample-data]
    [metabase.sync.core :as sync]
    [metabase.sync.task.sync-databases-test :as task.sync-databases-test]
@@ -50,6 +51,43 @@
   (t2/select-one :model/Field :name field-name, :table_id (u/the-id (table db table-name))))
 
 ;;; ----------------------------------------------------- Tests ------------------------------------------------------
+
+(deftest migrate-sample-database-engine-in-place-downgrade-test
+  (testing "On launch, a SQLite sample database left by a newer version is converted to H2 in place: every
+           Database/Table/Field id is kept, so sample and user content survive and still query."
+    (mt/with-model-cleanup [:model/Database :model/Card]
+      ;; Fake the post-downgrade state with raw SQL (this version has no SQLite driver): a SQLite sample DB
+      ;; whose ORDERS table + TOTAL field the newer version synced (schema nil), and a user question on it.
+      (t2/query {:insert-into :metabase_database
+                 :values [{:name "Sample Database" :engine "sqlite" :is_sample true :details "{}"
+                           :created_at :%now :updated_at :%now}]})
+      (let [db-id (t2/select-one-pk :model/Database :is_sample true :engine "sqlite")]
+        (t2/query {:insert-into :metabase_table
+                   :values [{:db_id db-id :name "ORDERS" :schema nil :active true :created_at :%now :updated_at :%now}]})
+        (let [orders-id (t2/select-one-pk :model/Table :db_id db-id :name "ORDERS")]
+          (t2/query {:insert-into :metabase_field
+                     :values [{:table_id orders-id :name "TOTAL" :base_type "type/Float" :database_type "REAL"
+                               :position 0 :created_at :%now :updated_at :%now}]})
+          (let [total-id (t2/select-one-pk :model/Field :table_id orders-id :name "TOTAL")
+                card     (t2/insert-returning-instance! :model/Card
+                                                        {:name "user q" :database_id db-id :table_id orders-id
+                                                         :display "scalar" :visualization_settings {} :creator_id (mt/user->id :rasta)
+                                                         :dataset_query {:database db-id :type :query
+                                                                         :query {:source-table orders-id
+                                                                                 :aggregation [[:sum [:field total-id nil]]]}}})]
+            ;; ---- the conversion under test (via the real startup entry point) ----
+            (#'sample-data/update-sample-database-if-needed! (t2/select-one :model/Database :id db-id))
+            (testing "the database record is now H2"
+              (is (= :h2 (:engine (t2/select-one :model/Database :id db-id)))))
+            (testing "the ORDERS table + TOTAL field keep their ids, now with schema = PUBLIC"
+              (is (= orders-id (t2/select-one-pk :model/Table :db_id db-id :name "ORDERS")))
+              (is (= "PUBLIC"  (t2/select-one-fn :schema :model/Table :id orders-id)))
+              (is (= total-id  (t2/select-one-pk :model/Field :table_id orders-id :name "TOTAL"))))
+            (testing "the user card survives with its id and still queries the (now H2) sample DB"
+              (is (t2/exists? :model/Card :id (:id card)))
+              (let [result (qp/process-query (:dataset_query (t2/select-one :model/Card :id (:id card))))]
+                (is (= :completed (:status result)))
+                (is (pos? (count (mt/rows result))))))))))))
 
 (def ^:private extracted-db-path-regex #"^file:.*plugins/sample-database.db;USER=GUEST;PASSWORD=guest.*")
 


### PR DESCRIPTION
### Description

Backport version of https://github.com/metabase/metabase/pull/77297

Most of the code touched in the parent PR was introduced in v63 so those changes are absent in this backport and the forthcoming backports to earlier versions.

This handles the downgrade side. Previously, when downgrading from a version with the SQLite sample DB to a version that normally has the H2 sample DB:

* The outgoing SQLite sample db was deleted
* All query content targeting the sample db was deleted
* No replacement H2 sample DB was created on downgrade, leaving the system with neither a sample DB nor sample content

Now, on downgrade:

* The outgoing SQLite sample database record will have its `:driver` mutated to `:h2`
* Table records will have their `:schema` mutated from `nil` to `"PUBLIC"` to reflect the schema difference between H2 and SQLite
* The Sample DB will be resynced to update all the data warehouse metadata to reflect the H2 sample DB.