### PR TITLE
Enforce the 50 MB CSV upload limit on the backend

### DIFF
--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -382,9 +382,10 @@
         decoded ((decoder schema) params)]
     (when-not (mr/validate schema decoded)
       (throw (ex-info (format "Invalid %s" (case params-type
-                                             :route "route parameters"
-                                             :query "query parameters"
-                                             :body  "body"))
+                                             :route   "route parameters"
+                                             :query   "query parameters"
+                                             :body    "body"
+                                             :request "request"))
                       (let [explanation     (mr/explain schema decoded)
                             specific-errors (invalid-params-specific-errors explanation)
                             errors          (invalid-params-errors explanation)]

--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -608,7 +608,7 @@
 (defn wrap-multipart-tempfile-cleanup
   "Middleware, applied inside [[ring.middleware.multipart-params/wrap-multipart-params]], that deletes the parsed
   multipart tempfiles when the handler throws, e.g. when param validation rejects the request.
-  Without it rejected uploads sit on disk until Ring's temp-file store expires them an hour later.
+  Ring's temp-file store only sweeps orphaned tempfiles after an hour.
   Handlers that complete normally own the tempfiles they consume and must delete them themselves."
   [handler]
   (fn
@@ -649,8 +649,8 @@
                                    (ring.middleware.multipart-params/wrap-multipart-params
                                     (wrap-multipart-tempfile-cleanup handler#)
                                     ~(if (map? multipart) multipart {})))])]
-    ;; middleware are applied left-to-right, so later entries run first on the request. Multipart parsing goes
-    ;; first (innermost) so scope rejections respond 403 before the request body is parsed to tempfiles.
+    ;; later entries wrap outer and run first on the request: scope checks must reject before multipart parses
+    ;; the body to tempfiles, so multipart goes first (innermost).
     (vec (concat multipart-middleware scope-middleware))))
 
 (mu/defn- apply-middleware :- ::handler

--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -650,8 +650,8 @@
                                    (ring.middleware.multipart-params/wrap-multipart-params
                                     (wrap-multipart-tempfile-cleanup handler#)
                                     ~(if (map? multipart) multipart {})))])]
-    ;; later entries wrap outer and run first on the request: scope checks must reject before multipart parses
-    ;; the body to tempfiles, so multipart goes first (innermost).
+    ;; [[apply-middleware]] wraps left-to-right, so the last entry is outermost and sees the request first.
+    ;; Scope goes last: a scope rejection must respond 403 before multipart parses the body to tempfiles.
     (vec (concat multipart-middleware scope-middleware))))
 
 (mu/defn- apply-middleware :- ::handler

--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -606,8 +606,9 @@
     (io/delete-file f :silently)))
 
 (defn wrap-multipart-tempfile-cleanup
-  "Middleware, applied inside [[ring.middleware.multipart-params/wrap-multipart-params]], that deletes the parsed
-  multipart tempfiles when the handler throws, e.g. when param validation rejects the request.
+  "Ring middleware that deletes the parsed multipart tempfiles when the wrapped handler throws,
+  e.g. when param validation rejects the request.
+  Applied inside [[ring.middleware.multipart-params/wrap-multipart-params]].
   Ring's temp-file store only sweeps orphaned tempfiles after an hour.
   Handlers that complete normally own the tempfiles they consume and must delete them themselves."
   [handler]

--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -348,8 +348,19 @@
    params-type :- ::param-type]
   (get-in args [:params params-type :binding] '_))
 
+(defn- redact-files
+  "Replace [[java.io.File]] values (multipart tempfiles) so validation errors don't leak server temp paths."
+  [x]
+  (cond
+    (instance? java.io.File x) "<redacted File>"
+    (map? x)                   (update-vals x redact-files)
+    (sequential? x)            (mapv redact-files x)
+    :else x))
+
 (defn- invalid-params-specific-errors [explanation]
   (-> explanation
+      (update :value redact-files)
+      (update :errors (partial mapv #(update % :value redact-files)))
       me/with-spell-checking
       (me/humanize {:wrap mu/humanize-include-value})))
 

--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -15,6 +15,7 @@
   On that note please don't add any unrelated macros to this namespace! Do cleanup first."
   (:require
    [clojure.core.specs.alpha]
+   [clojure.java.io :as io]
    [clojure.spec.alpha :as s]
    [clojure.string :as str]
    [clout.core :as clout]
@@ -584,6 +585,37 @@
         (when-not (instance? org.eclipse.jetty.ee9.nested.HttpInput body)
           body))))
 
+(defn- delete-multipart-tempfiles!
+  [request]
+  (doseq [v     (vals (:multipart-params request))
+          v     (if (sequential? v) v [v])
+          :when (map? v)
+          :let  [f (:tempfile v)]
+          :when f]
+    (io/delete-file f :silently)))
+
+(defn wrap-multipart-tempfile-cleanup
+  "Middleware, applied inside [[ring.middleware.multipart-params/wrap-multipart-params]], that deletes the parsed
+  multipart tempfiles when the handler throws, e.g. when param validation rejects the request.
+  Without it rejected uploads sit on disk until Ring's temp-file store expires them an hour later.
+  Handlers that complete normally own the tempfiles they consume and must delete them themselves."
+  [handler]
+  (fn
+    ([request]
+     (try
+       (handler request)
+       (catch Throwable e
+         (delete-multipart-tempfiles! request)
+         (throw e))))
+    ([request respond raise]
+     (try
+       (handler request respond (fn [e]
+                                  (delete-multipart-tempfiles! request)
+                                  (raise e)))
+       (catch Throwable e
+         (delete-multipart-tempfiles! request)
+         (throw e))))))
+
 (mu/defn- middleware-forms
   "Middleware to apply to base handler. Supports:
 
@@ -603,9 +635,10 @@
         multipart        (:multipart metadata)]
     (cond-> (vec scope-middleware)
       multipart
-      (conj (if (map? multipart)
-              `(fn [handler#] (ring.middleware.multipart-params/wrap-multipart-params handler# ~multipart))
-              'ring.middleware.multipart-params/wrap-multipart-params)))))
+      (conj `(fn [handler#]
+               (ring.middleware.multipart-params/wrap-multipart-params
+                (wrap-multipart-tempfile-cleanup handler#)
+                ~(if (map? multipart) multipart {})))))))
 
 (mu/defn- apply-middleware :- ::handler
   [handler    :- ::handler

--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -627,18 +627,20 @@
    Endpoints without `:scope` get [[metabase.api.macros.scope/ensure-scopes-checked]] to prevent scoped
    tokens from reaching endpoints that haven't opted in."
   [{:keys [metadata], :as _args} :- ::parsed-args]
-  (let [scope            (:scope metadata)
-        scope-middleware (cond
-                           (= scope :unchecked) []
-                           (some? scope) [(list 'metabase.api.macros.scope/enforce-scope scope)]
-                           :else ['metabase.api.macros.scope/ensure-scopes-checked])
-        multipart        (:multipart metadata)]
-    (cond-> (vec scope-middleware)
-      multipart
-      (conj `(fn [handler#]
-               (ring.middleware.multipart-params/wrap-multipart-params
-                (wrap-multipart-tempfile-cleanup handler#)
-                ~(if (map? multipart) multipart {})))))))
+  (let [scope                (:scope metadata)
+        scope-middleware     (cond
+                               (= scope :unchecked) []
+                               (some? scope) [(list 'metabase.api.macros.scope/enforce-scope scope)]
+                               :else ['metabase.api.macros.scope/ensure-scopes-checked])
+        multipart            (:multipart metadata)
+        multipart-middleware (when multipart
+                               [`(fn [handler#]
+                                   (ring.middleware.multipart-params/wrap-multipart-params
+                                    (wrap-multipart-tempfile-cleanup handler#)
+                                    ~(if (map? multipart) multipart {})))])]
+    ;; middleware are applied left-to-right, so later entries run first on the request. Multipart parsing goes
+    ;; first (innermost) so scope rejections respond 403 before the request body is parsed to tempfiles.
+    (vec (concat multipart-middleware scope-middleware))))
 
 (mu/defn- apply-middleware :- ::handler
   [handler    :- ::handler

--- a/src/metabase/upload/api.clj
+++ b/src/metabase/upload/api.clj
@@ -39,7 +39,7 @@
 
   The file may be at most 50 MB; larger uploads are rejected with a 413 response."
   {:multipart {:max-file-size  upload/max-upload-size-bytes
-               :max-file-count upload/max-upload-file-count}}
+               :max-file-count upload/max-upload-part-count}}
   ;; TODO -- not clear collection_id and file are supposed to come from `:multipart-params`
   [_route-params
    _query-params

--- a/src/metabase/upload/api.clj
+++ b/src/metabase/upload/api.clj
@@ -38,7 +38,8 @@
   "Create a table and model populated with the values from the attached CSV. Returns the model ID if successful.
 
   The file may be at most 50 MB; larger uploads are rejected with a 413 response."
-  {:multipart {:max-file-size upload/max-upload-size-bytes}}
+  {:multipart {:max-file-size  upload/max-upload-size-bytes
+               :max-file-count upload/max-upload-file-count}}
   ;; TODO -- not clear collection_id and file are supposed to come from `:multipart-params`
   [_route-params
    _query-params

--- a/src/metabase/upload/api.clj
+++ b/src/metabase/upload/api.clj
@@ -35,7 +35,8 @@
 ;;
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/csv"
-  "Create a table and model populated with the values from the attached CSV. Returns the model ID if successful.
+  "Create a table and model populated with the values from the attached CSV.
+  Returns the model ID if successful.
 
   The file may be at most 50 MB; larger uploads are rejected with a 413 response."
   {:multipart {:max-file-size  upload/max-upload-size-bytes

--- a/src/metabase/upload/api.clj
+++ b/src/metabase/upload/api.clj
@@ -47,7 +47,7 @@
    {{collection-id "collection_id", file "file"} :multipart-params, :as _request}
    :- [:map
        [:multipart-params
-        [:map
+        [:map {:closed true}
          ["collection_id" [:maybe
                            {:decode/api (fn [collection-id]
                                           (when-not (= collection-id "root")

--- a/src/metabase/upload/api.clj
+++ b/src/metabase/upload/api.clj
@@ -35,8 +35,10 @@
 ;;
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/csv"
-  "Create a table and model populated with the values from the attached CSV. Returns the model ID if successful."
-  {:multipart true}
+  "Create a table and model populated with the values from the attached CSV. Returns the model ID if successful.
+
+  The file may be at most 50 MB; larger uploads are rejected with a 413 response."
+  {:multipart {:max-file-size upload/max-upload-size-bytes}}
   ;; TODO -- not clear collection_id and file are supposed to come from `:multipart-params`
   [_route-params
    _query-params

--- a/src/metabase/upload/core.clj
+++ b/src/metabase/upload/core.clj
@@ -15,6 +15,7 @@
   can-create-upload?
   create-csv-upload!
   delete-upload!
+  max-upload-size-bytes
   model-hydrate-based-on-upload
   update-action-schema
   update-csv!])

--- a/src/metabase/upload/core.clj
+++ b/src/metabase/upload/core.clj
@@ -15,6 +15,7 @@
   can-create-upload?
   create-csv-upload!
   delete-upload!
+  max-upload-file-count
   max-upload-size-bytes
   model-hydrate-based-on-upload
   update-action-schema

--- a/src/metabase/upload/core.clj
+++ b/src/metabase/upload/core.clj
@@ -15,7 +15,7 @@
   can-create-upload?
   create-csv-upload!
   delete-upload!
-  max-upload-file-count
+  max-upload-part-count
   max-upload-size-bytes
   model-hydrate-based-on-upload
   update-action-schema

--- a/src/metabase/upload/impl.clj
+++ b/src/metabase/upload/impl.clj
@@ -45,8 +45,8 @@
 
 (def max-upload-size-bytes
   "Maximum size in bytes of a file that can be uploaded to create or update an upload table.
-  Keep in sync with `MAX_UPLOAD_SIZE` in `frontend/src/metabase/redux/uploads.ts` and the documented limit in
-  `docs/exploration-and-organization/uploads.md`."
+  Keep in sync with `MAX_UPLOAD_SIZE` in `frontend/src/metabase/redux/uploads.ts`.
+  The limit documented in `docs/exploration-and-organization/uploads.md` must match as well."
   (* 50 1024 1024))
 
 ;; TODO: move these to a more appropriate namespace if they need to be reused

--- a/src/metabase/upload/impl.clj
+++ b/src/metabase/upload/impl.clj
@@ -49,6 +49,10 @@
   The limit documented in `docs/exploration-and-organization/uploads.md` must match as well."
   (* 50 1024 1024))
 
+(def max-upload-file-count
+  "Maximum number of multipart files accepted by upload-table CSV endpoints."
+  1)
+
 ;; TODO: move these to a more appropriate namespace if they need to be reused
 (defmulti max-bytes
   "This tracks the size of various text fields in bytes."

--- a/src/metabase/upload/impl.clj
+++ b/src/metabase/upload/impl.clj
@@ -43,6 +43,12 @@
 
 (set! *warn-on-reflection* true)
 
+(def max-upload-size-bytes
+  "Maximum size in bytes of a file that can be uploaded to create or update an upload table.
+  Keep in sync with `MAX_UPLOAD_SIZE` in `frontend/src/metabase/redux/uploads.ts` and the documented limit in
+  `docs/exploration-and-organization/uploads.md`."
+  (* 50 1024 1024))
+
 ;; TODO: move these to a more appropriate namespace if they need to be reused
 (defmulti max-bytes
   "This tracks the size of various text fields in bytes."

--- a/src/metabase/upload/impl.clj
+++ b/src/metabase/upload/impl.clj
@@ -49,9 +49,11 @@
   The limit documented in `docs/exploration-and-organization/uploads.md` must match as well."
   (* 50 1024 1024))
 
-(def max-upload-file-count
-  "Maximum number of multipart files accepted by upload-table CSV endpoints."
-  1)
+(def max-upload-part-count
+  "Maximum number of multipart parts accepted by the CSV upload endpoints.
+  Ring's :max-file-count option counts every part, form fields included, so this must allow for the
+  collection_id field the frontend sends alongside the file part."
+  2)
 
 ;; TODO: move these to a more appropriate namespace if they need to be reused
 (defmulti max-bytes

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -462,8 +462,10 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/:id/append-csv"
   "Inserts the rows of an uploaded CSV file into the table identified by `:id`. The table must have been created by
-  uploading a CSV file."
-  {:multipart true}
+  uploading a CSV file.
+
+  The file may be at most 50 MB; larger uploads are rejected with a 413 response."
+  {:multipart {:max-file-size upload/max-upload-size-bytes}}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    _query-params
@@ -486,8 +488,10 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/:id/replace-csv"
   "Replaces the contents of the table identified by `:id` with the rows of an uploaded CSV file. The table must have
-  been created by uploading a CSV file."
-  {:multipart true}
+  been created by uploading a CSV file.
+
+  The file may be at most 50 MB; larger uploads are rejected with a 413 response."
+  {:multipart {:max-file-size upload/max-upload-size-bytes}}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    _query-params

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -465,7 +465,8 @@
   uploading a CSV file.
 
   The file may be at most 50 MB; larger uploads are rejected with a 413 response."
-  {:multipart {:max-file-size upload/max-upload-size-bytes}}
+  {:multipart {:max-file-size  upload/max-upload-size-bytes
+               :max-file-count upload/max-upload-file-count}}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    _query-params
@@ -491,7 +492,8 @@
   been created by uploading a CSV file.
 
   The file may be at most 50 MB; larger uploads are rejected with a 413 response."
-  {:multipart {:max-file-size upload/max-upload-size-bytes}}
+  {:multipart {:max-file-size  upload/max-upload-size-bytes
+               :max-file-count upload/max-upload-file-count}}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    _query-params

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -471,13 +471,16 @@
                     [:id ms/PositiveInt]]
    _query-params
    _body
+   ;; Closed, and collection_id constrained to a plain text field (the frontend sends it), so a second file part
+   ;; can't be smuggled in under another part name and silently ignored.
    {:keys [multipart-params], :as _request} :- [:map
                                                 [:multipart-params
-                                                 [:map
+                                                 [:map {:closed true}
                                                   ["file"
                                                    [:map
                                                     [:filename :string]
-                                                    [:tempfile (ms/InstanceOfClass java.io.File)]]]]]]]
+                                                    [:tempfile (ms/InstanceOfClass java.io.File)]]]
+                                                  ["collection_id" {:optional true} :string]]]]]
   (update-csv! {:table-id id
                 :filename (get-in multipart-params ["file" :filename])
                 :file     (get-in multipart-params ["file" :tempfile])
@@ -498,13 +501,16 @@
                     [:id ms/PositiveInt]]
    _query-params
    _body
+   ;; Closed, and collection_id constrained to a plain text field (the frontend sends it), so a second file part
+   ;; can't be smuggled in under another part name and silently ignored.
    {:keys [multipart-params], :as _request} :- [:map
                                                 [:multipart-params
-                                                 [:map
+                                                 [:map {:closed true}
                                                   ["file"
                                                    [:map
                                                     [:filename :string]
-                                                    [:tempfile (ms/InstanceOfClass java.io.File)]]]]]]]
+                                                    [:tempfile (ms/InstanceOfClass java.io.File)]]]
+                                                  ["collection_id" {:optional true} :string]]]]]
   (update-csv! {:table-id id
                 :filename (get-in multipart-params ["file" :filename])
                 :file     (get-in multipart-params ["file" :tempfile])

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -471,8 +471,8 @@
                     [:id ms/PositiveInt]]
    _query-params
    _body
-   ;; Closed, and collection_id constrained to a plain text field (the frontend sends it), so a second file part
-   ;; can't be smuggled in under another part name and silently ignored.
+   ;; Closed so a file part smuggled under another part name is rejected; collection_id is the text field the
+   ;; frontend sends alongside the file.
    {:keys [multipart-params], :as _request} :- [:map
                                                 [:multipart-params
                                                  [:map {:closed true}
@@ -501,8 +501,8 @@
                     [:id ms/PositiveInt]]
    _query-params
    _body
-   ;; Closed, and collection_id constrained to a plain text field (the frontend sends it), so a second file part
-   ;; can't be smuggled in under another part name and silently ignored.
+   ;; Closed so a file part smuggled under another part name is rejected; collection_id is the text field the
+   ;; frontend sends alongside the file.
    {:keys [multipart-params], :as _request} :- [:map
                                                 [:multipart-params
                                                  [:map {:closed true}

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -466,7 +466,7 @@
 
   The file may be at most 50 MB; larger uploads are rejected with a 413 response."
   {:multipart {:max-file-size  upload/max-upload-size-bytes
-               :max-file-count upload/max-upload-file-count}}
+               :max-file-count upload/max-upload-part-count}}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    _query-params
@@ -493,7 +493,7 @@
 
   The file may be at most 50 MB; larger uploads are rejected with a 413 response."
   {:multipart {:max-file-size  upload/max-upload-size-bytes
-               :max-file-count upload/max-upload-file-count}}
+               :max-file-count upload/max-upload-part-count}}
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    _query-params

--- a/test/metabase/api/macros_test.clj
+++ b/test/metabase/api/macros_test.clj
@@ -98,7 +98,7 @@
             (neat))
     {:route {:path "/move/:id", :regexes {:id #"[abc]{4}"}}}))
 
-(deftest ^:parallel multipart-tempfile-cleanup-test
+(deftest ^:parallel multipart-tempfile-cleanup-on-throw-test
   (testing "tempfiles are deleted when the handler throws, e.g. on a param validation 400"
     (let [file-1  (java.io.File/createTempFile "cleanup-test" nil)
           file-2  (java.io.File/createTempFile "cleanup-test" nil)
@@ -111,7 +111,23 @@
                      (throw (ex-info "Invalid request" {:status-code 400}))))]
       (is (thrown-with-msg? Exception #"Invalid request" (handler request)))
       (is (not (.exists file-1)))
-      (is (not (.exists file-2)))))
+      (is (not (.exists file-2))))))
+
+(deftest ^:parallel multipart-tempfile-cleanup-on-raise-test
+  (testing "async arity: tempfiles are deleted when the handler raises"
+    (let [file    (java.io.File/createTempFile "cleanup-test" nil)
+          request {:multipart-params {"file" {:filename "a.csv", :tempfile file}}}
+          raised  (atom nil)
+          handler (api.macros/wrap-multipart-tempfile-cleanup
+                   (fn [_request _respond raise]
+                     (raise (ex-info "Invalid request" {:status-code 400}))))]
+      (handler request
+               (fn [_response] (is false "respond should not be called"))
+               (fn [e] (reset! raised e)))
+      (is (some? @raised))
+      (is (not (.exists file))))))
+
+(deftest ^:parallel multipart-tempfile-preserved-on-success-test
   (testing "tempfiles are left alone when the handler completes (it owns and deletes what it consumes)"
     (let [file    (java.io.File/createTempFile "cleanup-test" nil)
           request {:multipart-params {"file" {:filename "a.csv", :tempfile file}}}

--- a/test/metabase/api/macros_test.clj
+++ b/test/metabase/api/macros_test.clj
@@ -4,6 +4,8 @@
    [metabase.api.macros :as api.macros]
    [metabase.util.malli.registry :as mr]))
 
+(set! *warn-on-reflection* true)
+
 (deftest ^:parallel parse-args-test
   (are [args expected] (= expected
                           (#'api.macros/parse-args args))

--- a/test/metabase/api/macros_test.clj
+++ b/test/metabase/api/macros_test.clj
@@ -96,6 +96,29 @@
             (neat))
     {:route {:path "/move/:id", :regexes {:id #"[abc]{4}"}}}))
 
+(deftest ^:parallel multipart-tempfile-cleanup-test
+  (testing "tempfiles are deleted when the handler throws, e.g. on a param validation 400"
+    (let [file-1  (java.io.File/createTempFile "cleanup-test" nil)
+          file-2  (java.io.File/createTempFile "cleanup-test" nil)
+          request {:multipart-params {"file"     {:filename "a.csv", :tempfile file-1}
+                                      ;; duplicate part names arrive as a vector of values
+                                      "sneaky"   [{:filename "b.csv", :tempfile file-2}]
+                                      "some_id"  "123"}}
+          handler (api.macros/wrap-multipart-tempfile-cleanup
+                   (fn [_request]
+                     (throw (ex-info "Invalid request" {:status-code 400}))))]
+      (is (thrown-with-msg? Exception #"Invalid request" (handler request)))
+      (is (not (.exists file-1)))
+      (is (not (.exists file-2)))))
+  (testing "tempfiles are left alone when the handler completes (it owns and deletes what it consumes)"
+    (let [file    (java.io.File/createTempFile "cleanup-test" nil)
+          request {:multipart-params {"file" {:filename "a.csv", :tempfile file}}}
+          handler (api.macros/wrap-multipart-tempfile-cleanup (fn [_request] :ok))]
+      (try
+        (is (= :ok (handler request)))
+        (is (.exists file))
+        (finally (.delete file))))))
+
 (deftest ^:parallel parse-args-metadata-test
   (testing "metadata map is parsed correctly"
     (are [args expected] (= expected

--- a/test/metabase/upload/api_test.clj
+++ b/test/metabase/upload/api_test.clj
@@ -37,12 +37,12 @@
 
 (deftest csv-upload-too-large-test
   (testing "POST /api/upload/csv rejects files over the size cap with a 413, before the body reaches the handler"
-    ;; one byte over the cap is enough — the multipart layer aborts streaming the file part as soon as it passes the
-    ;; limit, so this never buffers the whole body.
+    ;; One byte over the cap is enough: the multipart middleware aborts streaming the file part as soon as it
+    ;; crosses the limit, so the oversized body is never fully buffered.
     (let [oversized (byte-array (inc upload/max-upload-size-bytes))
           calls     (atom 0)]
-      ;; `with-redefs` because the request is handled on a server thread, which doesn't inherit this thread's dynamic
-      ;; bindings, so an `mt/with-dynamic-fn-redefs` spy would be invisible to it.
+      ;; Plain `with-redefs` is required here: the request is handled on a server thread, which doesn't inherit
+      ;; this thread's dynamic bindings, so an `mt/with-dynamic-fn-redefs` spy would be invisible to it.
       #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
       (with-redefs [upload.api/from-csv! (fn [& _] (swap! calls inc) {:status 200})]
         (is (= "Uploaded content exceeded limits."

--- a/test/metabase/upload/api_test.clj
+++ b/test/metabase/upload/api_test.clj
@@ -39,8 +39,14 @@
   (testing "POST /api/upload/csv rejects files over the size cap with a 413, before the body reaches the handler"
     ;; one byte over the cap is enough — the multipart layer aborts streaming the file part as soon as it passes the
     ;; limit, so this never buffers the whole body.
-    (let [oversized (byte-array (inc upload/max-upload-size-bytes))]
-      (is (= "Uploaded content exceeded limits."
-             (mt/user-http-request :crowberto :post 413 "upload/csv"
-                                   {:request-options {:headers {"content-type" "multipart/form-data"}}}
-                                   {:file oversized}))))))
+    (let [oversized (byte-array (inc upload/max-upload-size-bytes))
+          calls     (atom 0)]
+      ;; `with-redefs` because the request is handled on a server thread, which doesn't inherit this thread's dynamic
+      ;; bindings, so an `mt/with-dynamic-fn-redefs` spy would be invisible to it.
+      #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
+      (with-redefs [upload.api/from-csv! (fn [& _] (swap! calls inc) {:status 200})]
+        (is (= "Uploaded content exceeded limits."
+               (mt/user-http-request :crowberto :post 413 "upload/csv"
+                                     {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                     {:file oversized})))
+        (is (zero? @calls) "the endpoint body should never run")))))

--- a/test/metabase/upload/api_test.clj
+++ b/test/metabase/upload/api_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [metabase.test :as mt]
    [metabase.upload.api :as upload.api]
+   [metabase.upload.core :as upload]
    [metabase.upload.impl-test :as upload-test]
    [toucan2.core :as t2]))
 
@@ -33,3 +34,13 @@
                  status))
           (is (= body
                  (t2/select-one-pk :model/Card :database_id (mt/id)))))))))
+
+(deftest csv-upload-too-large-test
+  (testing "POST /api/upload/csv rejects files over the size cap with a 413, before the body reaches the handler"
+    ;; one byte over the cap is enough — the multipart layer aborts streaming the file part as soon as it passes the
+    ;; limit, so this never buffers the whole body.
+    (let [oversized (byte-array (inc upload/max-upload-size-bytes))]
+      (is (= "Uploaded content exceeded limits."
+             (mt/user-http-request :crowberto :post 413 "upload/csv"
+                                   {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                   {:file oversized}))))))

--- a/test/metabase/upload/api_test.clj
+++ b/test/metabase/upload/api_test.clj
@@ -48,13 +48,24 @@
                                      {:file oversized})))
         (is (zero? @calls) "the endpoint body should never run")))))
 
-(deftest csv-upload-too-many-files-test
-  (testing "POST /api/upload/csv rejects multiple file parts with a 413, before the body reaches the handler"
+(deftest csv-upload-too-many-parts-test
+  (testing "POST /api/upload/csv rejects requests with too many multipart parts with a 413, before the body reaches the handler"
     (let [calls (atom 0)]
       (mt/with-dynamic-fn-redefs [upload.api/from-csv! (fn [& _] (swap! calls inc) {:status 200})]
         (is (= "Uploaded content exceeded limits."
                (mt/user-http-request :crowberto :post 413 "upload/csv"
                                      {:request-options {:headers {"content-type" "multipart/form-data"}}}
-                                     [[:file (byte-array [97 44 98 10 49 44 50])]
+                                     [[:collection_id "root"]
+                                      [:file (byte-array [97 44 98 10 49 44 50])]
                                       [:file (byte-array [99 44 100 10 51 44 52])]])))
         (is (zero? @calls) "the endpoint body should never run")))))
+
+(deftest csv-upload-with-collection-id-test
+  (testing "POST /api/upload/csv accepts the collection_id field the frontend sends alongside the file"
+    (let [calls (atom 0)]
+      (mt/with-dynamic-fn-redefs [upload.api/from-csv! (fn [& _] (swap! calls inc) {:status 200, :body 1})]
+        (mt/user-http-request :crowberto :post 200 "upload/csv"
+                              {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                              [[:collection_id "root"]
+                               [:file (byte-array [97 44 98 10 49 44 50])]])
+        (is (= 1 @calls) "the endpoint body should run")))))

--- a/test/metabase/upload/api_test.clj
+++ b/test/metabase/upload/api_test.clj
@@ -69,3 +69,13 @@
                               [[:collection_id "root"]
                                [:file (byte-array [97 44 98 10 49 44 50])]])
         (is (= 1 @calls) "the endpoint body should run")))))
+
+(deftest csv-upload-smuggled-file-part-test
+  (testing "POST /api/upload/csv rejects a second file part smuggled as collection_id"
+    (let [calls (atom 0)]
+      (mt/with-dynamic-fn-redefs [upload.api/from-csv! (fn [& _] (swap! calls inc) {:status 200})]
+        (mt/user-http-request :crowberto :post 400 "upload/csv"
+                              {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                              [[:file (byte-array [97 44 98 10 49 44 50])]
+                               [:collection_id (byte-array [99 44 100 10 51 44 52])]])
+        (is (zero? @calls) "the endpoint body should never run")))))

--- a/test/metabase/upload/api_test.clj
+++ b/test/metabase/upload/api_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.upload.api-test
   (:require
    [clojure.java.io :as io]
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.test :as mt]
    [metabase.upload.api :as upload.api]
@@ -94,8 +95,10 @@
   (testing "POST /api/upload/csv rejects a second file part smuggled as collection_id"
     (let [calls (atom 0)]
       (mt/with-dynamic-fn-redefs [upload.api/from-csv! (fn [& _] (swap! calls inc) {:status 200})]
-        (mt/user-http-request :crowberto :post 400 "upload/csv"
-                              {:request-options {:headers {"content-type" "multipart/form-data"}}}
-                              [[:file (byte-array [97 44 98 10 49 44 50])]
-                               [:collection_id (byte-array [99 44 100 10 51 44 52])]])
+        (let [response (mt/user-http-request :crowberto :post 400 "upload/csv"
+                                             {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                             [[:file (byte-array [97 44 98 10 49 44 50])]
+                                              [:collection_id (byte-array [99 44 100 10 51 44 52])]])]
+          (testing "the validation error does not leak the tempfile path"
+            (is (not (str/includes? (pr-str response) "ring-multipart-")))))
         (is (zero? @calls) "the endpoint body should never run")))))

--- a/test/metabase/upload/api_test.clj
+++ b/test/metabase/upload/api_test.clj
@@ -50,3 +50,17 @@
                                      {:request-options {:headers {"content-type" "multipart/form-data"}}}
                                      {:file oversized})))
         (is (zero? @calls) "the endpoint body should never run")))))
+
+(deftest csv-upload-too-many-files-test
+  (testing "POST /api/upload/csv rejects multiple file parts with a 413, before the body reaches the handler"
+    (let [calls (atom 0)]
+      ;; Plain `with-redefs` is required here: the request is handled on a server thread, which doesn't inherit
+      ;; this thread's dynamic bindings, so an `mt/with-dynamic-fn-redefs` spy would be invisible to it.
+      #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
+      (with-redefs [upload.api/from-csv! (fn [& _] (swap! calls inc) {:status 200})]
+        (is (= "Uploaded content exceeded limits."
+               (mt/user-http-request :crowberto :post 413 "upload/csv"
+                                     {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                     [[:file (byte-array [97 44 98 10 49 44 50])]
+                                      [:file (byte-array [99 44 100 10 51 44 52])]])))
+        (is (zero? @calls) "the endpoint body should never run")))))

--- a/test/metabase/upload/api_test.clj
+++ b/test/metabase/upload/api_test.clj
@@ -48,6 +48,17 @@
                                      {:file oversized})))
         (is (zero? @calls) "the endpoint body should never run")))))
 
+(deftest csv-upload-at-size-cap-test
+  (testing "POST /api/upload/csv accepts a file of exactly the size cap, guarding against an off-by-one"
+    (let [at-cap (byte-array upload/max-upload-size-bytes)
+          calls  (atom 0)]
+      (mt/with-dynamic-fn-redefs [upload.api/from-csv! (fn [& _] (swap! calls inc) {:status 200, :body 1})]
+        (mt/user-http-request :crowberto :post 200 "upload/csv"
+                              {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                              [[:collection_id "root"]
+                               [:file at-cap]])
+        (is (= 1 @calls) "the endpoint body should run")))))
+
 (deftest csv-upload-too-many-parts-test
   (testing "POST /api/upload/csv rejects requests with too many multipart parts with a 413, before the body reaches the handler"
     (let [calls (atom 0)]

--- a/test/metabase/upload/api_test.clj
+++ b/test/metabase/upload/api_test.clj
@@ -51,7 +51,7 @@
         (is (zero? @calls) "the endpoint body should never run")))))
 
 (deftest csv-upload-at-size-cap-test
-  (testing "POST /api/upload/csv accepts a file of exactly the size cap, guarding against an off-by-one"
+  (testing "POST /api/upload/csv accepts a file of exactly the size cap"
     (let [at-cap (byte-array upload/max-upload-size-bytes)
           calls  (atom 0)]
       ;; like the real handler, the stub owns the uploaded tempfile and must delete it

--- a/test/metabase/upload/api_test.clj
+++ b/test/metabase/upload/api_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.upload.api-test
   (:require
+   [clojure.java.io :as io]
    [clojure.test :refer :all]
    [metabase.test :as mt]
    [metabase.upload.api :as upload.api]
@@ -52,7 +53,11 @@
   (testing "POST /api/upload/csv accepts a file of exactly the size cap, guarding against an off-by-one"
     (let [at-cap (byte-array upload/max-upload-size-bytes)
           calls  (atom 0)]
-      (mt/with-dynamic-fn-redefs [upload.api/from-csv! (fn [& _] (swap! calls inc) {:status 200, :body 1})]
+      ;; like the real handler, the stub owns the uploaded tempfile and must delete it
+      (mt/with-dynamic-fn-redefs [upload.api/from-csv! (fn [{:keys [file]}]
+                                                         (swap! calls inc)
+                                                         (io/delete-file file :silently)
+                                                         {:status 200, :body 1})]
         (mt/user-http-request :crowberto :post 200 "upload/csv"
                               {:request-options {:headers {"content-type" "multipart/form-data"}}}
                               [[:collection_id "root"]
@@ -74,7 +79,11 @@
 (deftest csv-upload-with-collection-id-test
   (testing "POST /api/upload/csv accepts the collection_id field the frontend sends alongside the file"
     (let [calls (atom 0)]
-      (mt/with-dynamic-fn-redefs [upload.api/from-csv! (fn [& _] (swap! calls inc) {:status 200, :body 1})]
+      ;; like the real handler, the stub owns the uploaded tempfile and must delete it
+      (mt/with-dynamic-fn-redefs [upload.api/from-csv! (fn [{:keys [file]}]
+                                                         (swap! calls inc)
+                                                         (io/delete-file file :silently)
+                                                         {:status 200, :body 1})]
         (mt/user-http-request :crowberto :post 200 "upload/csv"
                               {:request-options {:headers {"content-type" "multipart/form-data"}}}
                               [[:collection_id "root"]

--- a/test/metabase/upload/api_test.clj
+++ b/test/metabase/upload/api_test.clj
@@ -37,16 +37,18 @@
           (is (= body
                  (t2/select-one-pk :model/Card :database_id (mt/id)))))))))
 
+(def ^:private multipart-request-options
+  {:request-options {:headers {"content-type" "multipart/form-data"}}})
+
 (deftest csv-upload-too-large-test
-  (testing "POST /api/upload/csv rejects files over the size cap with a 413, before the body reaches the handler"
+  (testing "POST /api/upload/csv rejects a file over the size cap with a 413"
     ;; One byte over the cap is enough: the multipart middleware aborts streaming the file part as soon as it
     ;; crosses the limit, so the oversized body is never fully buffered.
     (let [oversized (byte-array (inc upload/max-upload-size-bytes))
           calls     (atom 0)]
       (mt/with-dynamic-fn-redefs [upload.api/from-csv! (fn [& _] (swap! calls inc) {:status 200})]
         (is (= "Uploaded content exceeded limits."
-               (mt/user-http-request :crowberto :post 413 "upload/csv"
-                                     {:request-options {:headers {"content-type" "multipart/form-data"}}}
+               (mt/user-http-request :crowberto :post 413 "upload/csv" multipart-request-options
                                      {:file oversized})))
         (is (zero? @calls) "the endpoint body should never run")))))
 
@@ -59,19 +61,17 @@
                                                          (swap! calls inc)
                                                          (io/delete-file file :silently)
                                                          {:status 200, :body 1})]
-        (mt/user-http-request :crowberto :post 200 "upload/csv"
-                              {:request-options {:headers {"content-type" "multipart/form-data"}}}
+        (mt/user-http-request :crowberto :post 200 "upload/csv" multipart-request-options
                               [[:collection_id "root"]
                                [:file at-cap]])
         (is (= 1 @calls) "the endpoint body should run")))))
 
 (deftest csv-upload-too-many-parts-test
-  (testing "POST /api/upload/csv rejects requests with too many multipart parts with a 413, before the body reaches the handler"
+  (testing "POST /api/upload/csv rejects too many multipart parts with a 413"
     (let [calls (atom 0)]
       (mt/with-dynamic-fn-redefs [upload.api/from-csv! (fn [& _] (swap! calls inc) {:status 200})]
         (is (= "Uploaded content exceeded limits."
-               (mt/user-http-request :crowberto :post 413 "upload/csv"
-                                     {:request-options {:headers {"content-type" "multipart/form-data"}}}
+               (mt/user-http-request :crowberto :post 413 "upload/csv" multipart-request-options
                                      [[:collection_id "root"]
                                       [:file (byte-array [97 44 98 10 49 44 50])]
                                       [:file (byte-array [99 44 100 10 51 44 52])]])))
@@ -85,8 +85,7 @@
                                                          (swap! calls inc)
                                                          (io/delete-file file :silently)
                                                          {:status 200, :body 1})]
-        (mt/user-http-request :crowberto :post 200 "upload/csv"
-                              {:request-options {:headers {"content-type" "multipart/form-data"}}}
+        (mt/user-http-request :crowberto :post 200 "upload/csv" multipart-request-options
                               [[:collection_id "root"]
                                [:file (byte-array [97 44 98 10 49 44 50])]])
         (is (= 1 @calls) "the endpoint body should run")))))
@@ -95,8 +94,7 @@
   (testing "POST /api/upload/csv rejects a second file part smuggled as collection_id"
     (let [calls (atom 0)]
       (mt/with-dynamic-fn-redefs [upload.api/from-csv! (fn [& _] (swap! calls inc) {:status 200})]
-        (let [response (mt/user-http-request :crowberto :post 400 "upload/csv"
-                                             {:request-options {:headers {"content-type" "multipart/form-data"}}}
+        (let [response (mt/user-http-request :crowberto :post 400 "upload/csv" multipart-request-options
                                              [[:file (byte-array [97 44 98 10 49 44 50])]
                                               [:collection_id (byte-array [99 44 100 10 51 44 52])]])]
           (testing "the validation error does not leak the tempfile path"

--- a/test/metabase/upload/api_test.clj
+++ b/test/metabase/upload/api_test.clj
@@ -41,10 +41,7 @@
     ;; crosses the limit, so the oversized body is never fully buffered.
     (let [oversized (byte-array (inc upload/max-upload-size-bytes))
           calls     (atom 0)]
-      ;; Plain `with-redefs` is required here: the request is handled on a server thread, which doesn't inherit
-      ;; this thread's dynamic bindings, so an `mt/with-dynamic-fn-redefs` spy would be invisible to it.
-      #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
-      (with-redefs [upload.api/from-csv! (fn [& _] (swap! calls inc) {:status 200})]
+      (mt/with-dynamic-fn-redefs [upload.api/from-csv! (fn [& _] (swap! calls inc) {:status 200})]
         (is (= "Uploaded content exceeded limits."
                (mt/user-http-request :crowberto :post 413 "upload/csv"
                                      {:request-options {:headers {"content-type" "multipart/form-data"}}}
@@ -54,10 +51,7 @@
 (deftest csv-upload-too-many-files-test
   (testing "POST /api/upload/csv rejects multiple file parts with a 413, before the body reaches the handler"
     (let [calls (atom 0)]
-      ;; Plain `with-redefs` is required here: the request is handled on a server thread, which doesn't inherit
-      ;; this thread's dynamic bindings, so an `mt/with-dynamic-fn-redefs` spy would be invisible to it.
-      #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
-      (with-redefs [upload.api/from-csv! (fn [& _] (swap! calls inc) {:status 200})]
+      (mt/with-dynamic-fn-redefs [upload.api/from-csv! (fn [& _] (swap! calls inc) {:status 200})]
         (is (= "Uploaded content exceeded limits."
                (mt/user-http-request :crowberto :post 413 "upload/csv"
                                      {:request-options {:headers {"content-type" "multipart/form-data"}}}

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -18,6 +18,7 @@
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
    [metabase.test.http-client :as client]
+   [metabase.upload.core :as upload]
    [metabase.upload.impl-test :as upload-test]
    [metabase.util :as u]
    [metabase.warehouse-schema-rest.api.table :as api.table]
@@ -1194,6 +1195,17 @@
                             :table-id (:id table)
                             :file     file}))
             (is (not (.exists file)) "File should be deleted after replace-csv!")))))))
+
+(deftest update-csv-too-large-test
+  ;; one byte over the cap is enough — the multipart layer aborts streaming the file part as soon as it passes the
+  ;; limit, so this never buffers the whole body.
+  (let [oversized (byte-array (inc upload/max-upload-size-bytes))]
+    (doseq [endpoint ["append-csv" "replace-csv"]]
+      (testing (format "POST /api/table/:id/%s rejects files over the size cap with a 413, before the body reaches the handler" endpoint)
+        (is (= "Uploaded content exceeded limits."
+               (mt/user-http-request :crowberto :post 413 (format "table/%d/%s" (mt/id :venues) endpoint)
+                                     {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                     {:file oversized})))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          POST /api/table/:id/sync_schema                                       |

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1201,10 +1201,7 @@
   ;; crosses the limit, so the oversized body is never fully buffered.
   (let [oversized (byte-array (inc upload/max-upload-size-bytes))
         calls     (atom 0)]
-    ;; Plain `with-redefs` is required here: the request is handled on a server thread, which doesn't inherit
-    ;; this thread's dynamic bindings, so an `mt/with-dynamic-fn-redefs` spy would be invisible to it.
-    #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
-    (with-redefs [api.table/update-csv! (fn [& _] (swap! calls inc) nil)]
+    (mt/with-dynamic-fn-redefs [api.table/update-csv! (fn [& _] (swap! calls inc) nil)]
       (doseq [endpoint ["append-csv" "replace-csv"]]
         (testing (format "POST /api/table/:id/%s rejects files over the size cap with a 413, before the body reaches the handler" endpoint)
           (is (= "Uploaded content exceeded limits."
@@ -1215,10 +1212,7 @@
 
 (deftest update-csv-too-many-files-test
   (let [calls (atom 0)]
-    ;; Plain `with-redefs` is required here: the request is handled on a server thread, which doesn't inherit
-    ;; this thread's dynamic bindings, so an `mt/with-dynamic-fn-redefs` spy would be invisible to it.
-    #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
-    (with-redefs [api.table/update-csv! (fn [& _] (swap! calls inc) nil)]
+    (mt/with-dynamic-fn-redefs [api.table/update-csv! (fn [& _] (swap! calls inc) nil)]
       (doseq [endpoint ["append-csv" "replace-csv"]]
         (testing (format "POST /api/table/:id/%s rejects multiple file parts with a 413, before the body reaches the handler"
                          endpoint)

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1236,6 +1236,17 @@
                                  [:file (byte-array [97 44 98 10 49 44 50])]])))
       (is (= 2 @calls) "the endpoint bodies should run"))))
 
+(deftest update-csv-smuggled-file-part-test
+  (let [calls (atom 0)]
+    (mt/with-dynamic-fn-redefs [api.table/update-csv! (fn [& _] (swap! calls inc) nil)]
+      (doseq [endpoint ["append-csv" "replace-csv"]]
+        (testing (format "POST /api/table/:id/%s rejects a second file part smuggled under another part name" endpoint)
+          (mt/user-http-request :crowberto :post 400 (format "table/%d/%s" (mt/id :venues) endpoint)
+                                {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                [[:file (byte-array [97 44 98 10 49 44 50])]
+                                 [:collection_id (byte-array [99 44 100 10 51 44 52])]])))
+      (is (zero? @calls) "the endpoint bodies should never run"))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          POST /api/table/:id/sync_schema                                       |
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1197,12 +1197,12 @@
             (is (not (.exists file)) "File should be deleted after replace-csv!")))))))
 
 (deftest update-csv-too-large-test
-  ;; one byte over the cap is enough — the multipart layer aborts streaming the file part as soon as it passes the
-  ;; limit, so this never buffers the whole body.
+  ;; One byte over the cap is enough: the multipart middleware aborts streaming the file part as soon as it
+  ;; crosses the limit, so the oversized body is never fully buffered.
   (let [oversized (byte-array (inc upload/max-upload-size-bytes))
         calls     (atom 0)]
-    ;; `with-redefs` because the request is handled on a server thread, which doesn't inherit this thread's dynamic
-    ;; bindings, so an `mt/with-dynamic-fn-redefs` spy would be invisible to it.
+    ;; Plain `with-redefs` is required here: the request is handled on a server thread, which doesn't inherit
+    ;; this thread's dynamic bindings, so an `mt/with-dynamic-fn-redefs` spy would be invisible to it.
     #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
     (with-redefs [api.table/update-csv! (fn [& _] (swap! calls inc) nil)]
       (doseq [endpoint ["append-csv" "replace-csv"]]

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1210,18 +1210,31 @@
                                        {:file oversized})))))
       (is (zero? @calls) "the endpoint bodies should never run"))))
 
-(deftest update-csv-too-many-files-test
+(deftest update-csv-too-many-parts-test
   (let [calls (atom 0)]
     (mt/with-dynamic-fn-redefs [api.table/update-csv! (fn [& _] (swap! calls inc) nil)]
       (doseq [endpoint ["append-csv" "replace-csv"]]
-        (testing (format "POST /api/table/:id/%s rejects multiple file parts with a 413, before the body reaches the handler"
+        (testing (format "POST /api/table/:id/%s rejects requests with too many multipart parts with a 413, before the body reaches the handler"
                          endpoint)
           (is (= "Uploaded content exceeded limits."
                  (mt/user-http-request :crowberto :post 413 (format "table/%d/%s" (mt/id :venues) endpoint)
                                        {:request-options {:headers {"content-type" "multipart/form-data"}}}
-                                       [[:file (byte-array [97 44 98 10 49 44 50])]
+                                       [[:collection_id "root"]
+                                        [:file (byte-array [97 44 98 10 49 44 50])]
                                         [:file (byte-array [99 44 100 10 51 44 52])]])))))
       (is (zero? @calls) "the endpoint bodies should never run"))))
+
+(deftest update-csv-with-extra-field-test
+  (let [calls (atom 0)]
+    (mt/with-dynamic-fn-redefs [api.table/update-csv! (fn [& _] (swap! calls inc) {:status 200, :body ""})]
+      (doseq [endpoint ["append-csv" "replace-csv"]]
+        (testing (format "POST /api/table/:id/%s accepts the collection_id field the frontend sends alongside the file"
+                         endpoint)
+          (mt/user-http-request :crowberto :post 200 (format "table/%d/%s" (mt/id :venues) endpoint)
+                                {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                [[:collection_id "root"]
+                                 [:file (byte-array [97 44 98 10 49 44 50])]])))
+      (is (= 2 @calls) "the endpoint bodies should run"))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          POST /api/table/:id/sync_schema                                       |

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1239,12 +1239,14 @@
 (deftest update-csv-smuggled-file-part-test
   (let [calls (atom 0)]
     (mt/with-dynamic-fn-redefs [api.table/update-csv! (fn [& _] (swap! calls inc) nil)]
-      (doseq [endpoint ["append-csv" "replace-csv"]]
-        (testing (format "POST /api/table/:id/%s rejects a second file part smuggled under another part name" endpoint)
+      (doseq [endpoint  ["append-csv" "replace-csv"]
+              ;; collection_id is caught by its :string constraint, unknown names by the closed map
+              part-name [:collection_id :unexpected_part]]
+        (testing (format "POST /api/table/:id/%s rejects a second file part smuggled as %s" endpoint (name part-name))
           (mt/user-http-request :crowberto :post 400 (format "table/%d/%s" (mt/id :venues) endpoint)
                                 {:request-options {:headers {"content-type" "multipart/form-data"}}}
                                 [[:file (byte-array [97 44 98 10 49 44 50])]
-                                 [:collection_id (byte-array [99 44 100 10 51 44 52])]])))
+                                 [part-name (byte-array [99 44 100 10 51 44 52])]])))
       (is (zero? @calls) "the endpoint bodies should never run"))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1197,6 +1197,9 @@
                             :file     file}))
             (is (not (.exists file)) "File should be deleted after replace-csv!")))))))
 
+(def ^:private multipart-request-options
+  {:request-options {:headers {"content-type" "multipart/form-data"}}})
+
 (deftest update-csv-too-large-test
   ;; One byte over the cap is enough: the multipart middleware aborts streaming the file part as soon as it
   ;; crosses the limit, so the oversized body is never fully buffered.
@@ -1204,10 +1207,10 @@
         calls     (atom 0)]
     (mt/with-dynamic-fn-redefs [api.table/update-csv! (fn [& _] (swap! calls inc) nil)]
       (doseq [endpoint ["append-csv" "replace-csv"]]
-        (testing (format "POST /api/table/:id/%s rejects files over the size cap with a 413, before the body reaches the handler" endpoint)
+        (testing (format "POST /api/table/:id/%s rejects a file over the size cap with a 413" endpoint)
           (is (= "Uploaded content exceeded limits."
                  (mt/user-http-request :crowberto :post 413 (format "table/%d/%s" (mt/id :venues) endpoint)
-                                       {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                       multipart-request-options
                                        {:file oversized})))))
       (is (zero? @calls) "the endpoint bodies should never run"))))
 
@@ -1215,11 +1218,10 @@
   (let [calls (atom 0)]
     (mt/with-dynamic-fn-redefs [api.table/update-csv! (fn [& _] (swap! calls inc) nil)]
       (doseq [endpoint ["append-csv" "replace-csv"]]
-        (testing (format "POST /api/table/:id/%s rejects requests with too many multipart parts with a 413, before the body reaches the handler"
-                         endpoint)
+        (testing (format "POST /api/table/:id/%s rejects too many multipart parts with a 413" endpoint)
           (is (= "Uploaded content exceeded limits."
                  (mt/user-http-request :crowberto :post 413 (format "table/%d/%s" (mt/id :venues) endpoint)
-                                       {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                       multipart-request-options
                                        [[:collection_id "root"]
                                         [:file (byte-array [97 44 98 10 49 44 50])]
                                         [:file (byte-array [99 44 100 10 51 44 52])]])))))
@@ -1233,10 +1235,9 @@
                                                         (io/delete-file file :silently)
                                                         {:status 200, :body ""})]
       (doseq [endpoint ["append-csv" "replace-csv"]]
-        (testing (format "POST /api/table/:id/%s accepts the collection_id field the frontend sends alongside the file"
-                         endpoint)
+        (testing (format "POST /api/table/:id/%s accepts the collection_id field the frontend sends" endpoint)
           (mt/user-http-request :crowberto :post 200 (format "table/%d/%s" (mt/id :venues) endpoint)
-                                {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                multipart-request-options
                                 [[:collection_id "root"]
                                  [:file (byte-array [97 44 98 10 49 44 50])]])))
       (is (= 2 @calls) "the endpoint bodies should run"))))
@@ -1247,9 +1248,10 @@
       (doseq [endpoint  ["append-csv" "replace-csv"]
               ;; collection_id is caught by its :string constraint, unknown names by the closed map
               part-name [:collection_id :unexpected_part]]
-        (testing (format "POST /api/table/:id/%s rejects a second file part smuggled as %s" endpoint (name part-name))
+        (testing (format "POST /api/table/:id/%s rejects a second file part smuggled as %s"
+                         endpoint (name part-name))
           (mt/user-http-request :crowberto :post 400 (format "table/%d/%s" (mt/id :venues) endpoint)
-                                {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                multipart-request-options
                                 [[:file (byte-array [97 44 98 10 49 44 50])]
                                  [part-name (byte-array [99 44 100 10 51 44 52])]])))
       (is (zero? @calls) "the endpoint bodies should never run"))))

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1213,6 +1213,22 @@
                                        {:file oversized})))))
       (is (zero? @calls) "the endpoint bodies should never run"))))
 
+(deftest update-csv-too-many-files-test
+  (let [calls (atom 0)]
+    ;; Plain `with-redefs` is required here: the request is handled on a server thread, which doesn't inherit
+    ;; this thread's dynamic bindings, so an `mt/with-dynamic-fn-redefs` spy would be invisible to it.
+    #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
+    (with-redefs [api.table/update-csv! (fn [& _] (swap! calls inc) nil)]
+      (doseq [endpoint ["append-csv" "replace-csv"]]
+        (testing (format "POST /api/table/:id/%s rejects multiple file parts with a 413, before the body reaches the handler"
+                         endpoint)
+          (is (= "Uploaded content exceeded limits."
+                 (mt/user-http-request :crowberto :post 413 (format "table/%d/%s" (mt/id :venues) endpoint)
+                                       {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                       [[:file (byte-array [97 44 98 10 49 44 50])]
+                                        [:file (byte-array [99 44 100 10 51 44 52])]])))))
+      (is (zero? @calls) "the endpoint bodies should never run"))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          POST /api/table/:id/sync_schema                                       |
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -1199,13 +1199,19 @@
 (deftest update-csv-too-large-test
   ;; one byte over the cap is enough — the multipart layer aborts streaming the file part as soon as it passes the
   ;; limit, so this never buffers the whole body.
-  (let [oversized (byte-array (inc upload/max-upload-size-bytes))]
-    (doseq [endpoint ["append-csv" "replace-csv"]]
-      (testing (format "POST /api/table/:id/%s rejects files over the size cap with a 413, before the body reaches the handler" endpoint)
-        (is (= "Uploaded content exceeded limits."
-               (mt/user-http-request :crowberto :post 413 (format "table/%d/%s" (mt/id :venues) endpoint)
-                                     {:request-options {:headers {"content-type" "multipart/form-data"}}}
-                                     {:file oversized})))))))
+  (let [oversized (byte-array (inc upload/max-upload-size-bytes))
+        calls     (atom 0)]
+    ;; `with-redefs` because the request is handled on a server thread, which doesn't inherit this thread's dynamic
+    ;; bindings, so an `mt/with-dynamic-fn-redefs` spy would be invisible to it.
+    #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
+    (with-redefs [api.table/update-csv! (fn [& _] (swap! calls inc) nil)]
+      (doseq [endpoint ["append-csv" "replace-csv"]]
+        (testing (format "POST /api/table/:id/%s rejects files over the size cap with a 413, before the body reaches the handler" endpoint)
+          (is (= "Uploaded content exceeded limits."
+                 (mt/user-http-request :crowberto :post 413 (format "table/%d/%s" (mt/id :venues) endpoint)
+                                       {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                       {:file oversized})))))
+      (is (zero? @calls) "the endpoint bodies should never run"))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          POST /api/table/:id/sync_schema                                       |

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -2,6 +2,7 @@
   "Tests for /api/table endpoints."
   {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.warehouse-schema-rest.api.table-test]}}}}}}
   (:require
+   [clojure.java.io :as io]
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
    [clojure.test :refer :all]
@@ -1226,7 +1227,11 @@
 
 (deftest update-csv-with-extra-field-test
   (let [calls (atom 0)]
-    (mt/with-dynamic-fn-redefs [api.table/update-csv! (fn [& _] (swap! calls inc) {:status 200, :body ""})]
+    ;; like the real handler, the stub owns the uploaded tempfile and must delete it
+    (mt/with-dynamic-fn-redefs [api.table/update-csv! (fn [{:keys [file]}]
+                                                        (swap! calls inc)
+                                                        (io/delete-file file :silently)
+                                                        {:status 200, :body ""})]
       (doseq [endpoint ["append-csv" "replace-csv"]]
         (testing (format "POST /api/table/:id/%s accepts the collection_id field the frontend sends alongside the file"
                          endpoint)


### PR DESCRIPTION
Surfaced by [this Slack thread](https://metaboat.slack.com/archives/C05MPF0TM3L/p1783537764505329?thread_ts=1783473739.294159&cid=C05MPF0TM3L): the 50 MB limit on CSV uploads was only enforced client-side (`MAX_UPLOAD_SIZE` in `frontend/src/metabase/redux/uploads.ts`), so requests sent directly to the API could upload files of unbounded size. The backend had no cap at all.

## What this does

Bounds the multipart request on the three CSV upload endpoints:

- `POST /api/upload/csv`
- `POST /api/table/:id/append-csv`
- `POST /api/table/:id/replace-csv`

**Per-part size cap.** Passes `:max-file-size` (50 MB, matching the frontend constant and the [documented limit](https://www.metabase.com/docs/latest/exploration-and-organization/uploads#file-size-limit)) to the multipart middleware. Ring hands the limit to Commons FileUpload's `setFileSizeMax` and responds with its built-in `content-too-large-handler`, so oversized uploads are rejected with a **413** as soon as the part crosses the limit — the body is never fully buffered and the request never reaches the handler. This is the same mechanism the custom-viz-plugin bundle endpoint already uses. The limit applies to every part, form fields included.

**Part-count cap.** Passes `:max-file-count` as well. Ring's option counts *every* multipart part (form fields included, despite the name), so the cap is 2: the frontend sends a `collection_id` field alongside the file on all three endpoints. A third part gets a **413**. Together the two caps bound the whole multipart body at ~100 MB, streamed to disk temp files.

**No smuggled file parts.** The append/replace `multipart-params` schemas are now closed maps: the only file-valued part accepted is `file`, and `collection_id` must be a plain text field. A second ≤50 MB file hidden under another part name is rejected with a **400** instead of being parsed and silently ignored. (`/csv` already rejected this via its `collection_id` schema.)

**Tempfile cleanup on rejection.** Two `defendpoint` fixes so rejected uploads don't leave parsed temp files on disk until Ring's 1-hour expiry sweep:
- multipart handlers are wrapped with `wrap-multipart-tempfile-cleanup`, which deletes every parsed `:tempfile` when the handler throws (e.g. schema validation 400s);
- scope checks now run *before* multipart parsing, so scoped-token 403s respond before the body is read at all.

**Drive-by `defendpoint` fix.** A failing *request* schema used to throw `No matching clause: :request` and surface as a 500; it now produces a proper 400 like route/query/body schemas.

Both size and part-count constants live in `metabase.upload.impl` (exported via `metabase.upload.core`), with docstring notes on keeping the size in sync with the frontend constant and the docs.

## Notes

- This is a behavior change for direct API users who were uploading files over 50 MB: those requests now fail with a 413. That matches the documented limit, but flagging it in case anyone depends on the old behavior. Likewise, requests with extra/unknown multipart parts now fail with a 413/400.
- Row/column counts are still unbounded except indirectly via the byte cap (and the warehouse's own limits at `CREATE TABLE` time). If we want explicit row/column guards they'd go in `metabase.upload.impl`; deliberately out of scope here.
- If 50 MB turns out to be too rigid for self-hosted instances, the constant could become a config-only setting in a follow-up; the multipart options are evaluated at namespace load, so it'd be restart-to-apply.
