### PR TITLE
GDGT-2709: Update Alerts management page styling

### DIFF
--- a/frontend/src/metabase/common/monitor/selectors.ts
+++ b/frontend/src/metabase/common/monitor/selectors.ts
@@ -23,6 +23,13 @@ export function canAccessMonitoringTools(state: State) {
   );
 }
 
+export function canAccessAlertsManagement(state: State) {
+  if (getIsEmbeddingIframe(state)) {
+    return false;
+  }
+  return getUserIsAdmin(state);
+}
+
 export function canAccessMonitor(state: State) {
   return canAccessMonitorDiagnostics(state) || canAccessMonitoringTools(state);
 }

--- a/frontend/src/metabase/common/monitor/selectors.unit.spec.ts
+++ b/frontend/src/metabase/common/monitor/selectors.unit.spec.ts
@@ -2,6 +2,7 @@ import { createMockState } from "metabase/redux/store/mocks";
 import { createMockUser } from "metabase-types/api/mocks";
 
 import {
+  canAccessAlertsManagement,
   canAccessMonitor,
   canAccessMonitorDiagnostics,
   canAccessMonitoringTools,
@@ -166,5 +167,51 @@ describe("canAccessMonitoringTools", () => {
     });
 
     expect(canAccessMonitoringTools(state)).toBe(false);
+  });
+});
+
+describe("canAccessAlertsManagement", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getIsEmbeddingIframe.mockReturnValue(false);
+  });
+
+  it("returns false when in embedding iframe", () => {
+    getIsEmbeddingIframe.mockReturnValue(true);
+    const state = createMockState({
+      currentUser: createMockUser({ is_superuser: true }),
+    });
+
+    expect(canAccessAlertsManagement(state)).toBe(false);
+  });
+
+  it("returns true when user is admin", () => {
+    const state = createMockState({
+      currentUser: createMockUser({ is_superuser: true }),
+    });
+
+    expect(canAccessAlertsManagement(state)).toBe(true);
+  });
+
+  it("returns false for an analyst without admin", () => {
+    const state = createMockState({
+      currentUser: createMockUser({
+        is_superuser: false,
+        is_data_analyst: true,
+      }),
+    });
+
+    expect(canAccessAlertsManagement(state)).toBe(false);
+  });
+
+  it("returns false for a non-admin with the monitoring application permission", () => {
+    const state = createMockState({
+      currentUser: createMockUser({
+        is_superuser: false,
+        permissions: { can_access_monitoring: true },
+      }),
+    });
+
+    expect(canAccessAlertsManagement(state)).toBe(false);
   });
 });

--- a/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.tsx
+++ b/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import { useHasTokenFeature } from "metabase/common/hooks";
 import { useUserKeyValue } from "metabase/common/hooks/use-user-key-value";
 import {
+  canAccessAlertsManagement,
   canAccessMonitorDiagnostics,
   canAccessMonitoringTools,
 } from "metabase/common/monitor/selectors";
@@ -35,6 +36,7 @@ export function MonitorLayout({ children }: MonitorLayoutProps) {
   const hasAuditAppFeature = useHasTokenFeature("audit_app");
   const canAccessDiagnostics = useSelector(canAccessMonitorDiagnostics);
   const canAccessTools = useSelector(canAccessMonitoringTools);
+  const canAccessAlerts = useSelector(canAccessAlertsManagement);
 
   const upperNav = (
     <>
@@ -86,14 +88,16 @@ export function MonitorLayout({ children }: MonitorLayoutProps) {
             isSelected={pathname.startsWith(Urls.monitorModelCaching())}
             showLabel={isNavbarOpened}
           />
-          <AreaTab
-            label={t`Alerts management`}
-            icon="bell"
-            to={Urls.monitorNotifications()}
-            isSelected={pathname.startsWith(Urls.monitorNotifications())}
-            showLabel={isNavbarOpened}
-          />
         </>
+      )}
+      {canAccessAlerts && (
+        <AreaTab
+          label={t`Alerts management`}
+          icon="bell"
+          to={Urls.monitorNotifications()}
+          isSelected={pathname.startsWith(Urls.monitorNotifications())}
+          showLabel={isNavbarOpened}
+        />
       )}
     </>
   );

--- a/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.unit.spec.tsx
@@ -182,7 +182,7 @@ describe("MonitorLayout", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows Alerts management only for an admin", async () => {
+  it("hides Alerts management for an analyst even with the monitoring permission", async () => {
     setup({
       user: createMockUser({
         is_superuser: false,

--- a/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.unit.spec.tsx
@@ -158,7 +158,7 @@ describe("MonitorLayout", () => {
     });
   });
 
-  it("hides Dependency diagnostics for a monitoring-only user", async () => {
+  it("hides Dependency diagnostics for a monitoring-only user, and hides Alerts management (admin-only)", async () => {
     setup({
       user: createMockUser({
         is_superuser: false,
@@ -174,11 +174,30 @@ describe("MonitorLayout", () => {
     expect(
       screen.queryByRole("link", { name: "Dependency diagnostics" }),
     ).not.toBeInTheDocument();
-    ["Tasks", "Jobs", "Logs", "Model cache log", "Alerts management"].forEach(
-      (name) => {
-        expect(screen.getByRole("link", { name })).toBeInTheDocument();
-      },
-    );
+    ["Tasks", "Jobs", "Logs", "Model cache log"].forEach((name) => {
+      expect(screen.getByRole("link", { name })).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("link", { name: "Alerts management" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Alerts management only for an admin", async () => {
+    setup({
+      user: createMockUser({
+        is_superuser: false,
+        is_data_analyst: true,
+        permissions: { can_access_monitoring: true },
+      }),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("monitor-nav")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("link", { name: "Alerts management" }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders the content area", async () => {

--- a/frontend/src/metabase/monitor/components/MonitorPageContent/MonitorPageContent.module.css
+++ b/frontend/src/metabase/monitor/components/MonitorPageContent/MonitorPageContent.module.css
@@ -1,6 +1,12 @@
-.MonitorPageContent {
+.MonitorPageWrapper {
+  overflow: hidden;
   background-color: var(--mb-color-background_page-primary);
   border: 1px solid var(--mb-color-border-neutral);
   border-radius: var(--mantine-radius-md);
+}
+
+.MonitorPageContent {
   padding: var(--mantine-spacing-xl);
+  overflow: auto;
+  height: 100%;
 }

--- a/frontend/src/metabase/monitor/components/MonitorPageContent/MonitorPageContent.module.css
+++ b/frontend/src/metabase/monitor/components/MonitorPageContent/MonitorPageContent.module.css
@@ -1,0 +1,6 @@
+.MonitorPageContent {
+  background-color: var(--mb-color-background_page-primary);
+  border: 1px solid var(--mb-color-border-neutral);
+  border-radius: var(--mantine-radius-md);
+  padding: var(--mantine-spacing-xl);
+}

--- a/frontend/src/metabase/monitor/components/MonitorPageContent/MonitorPageContent.tsx
+++ b/frontend/src/metabase/monitor/components/MonitorPageContent/MonitorPageContent.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import type { ReactNode } from "react";
 
 import { Box, type BoxProps, Stack } from "metabase/ui";
@@ -13,7 +14,10 @@ export function MonitorPageContent({
   ...boxProps
 }: MonitorPageContentProps) {
   return (
-    <Box {...boxProps}>
+    <Box
+      {...boxProps}
+      className={cx(S.MonitorPageWrapper, boxProps?.className)}
+    >
       <Stack gap="lg" className={S.MonitorPageContent}>
         {children}
       </Stack>

--- a/frontend/src/metabase/monitor/components/MonitorPageContent/MonitorPageContent.tsx
+++ b/frontend/src/metabase/monitor/components/MonitorPageContent/MonitorPageContent.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+import { Box, type BoxProps, Stack } from "metabase/ui";
+
+import S from "./MonitorPageContent.module.css";
+
+type MonitorPageContentProps = {
+  children?: ReactNode;
+} & BoxProps;
+
+export function MonitorPageContent({
+  children,
+  ...boxProps
+}: MonitorPageContentProps) {
+  return (
+    <Box {...boxProps}>
+      <Stack gap="lg" className={S.MonitorPageContent}>
+        {children}
+      </Stack>
+    </Box>
+  );
+}

--- a/frontend/src/metabase/monitor/components/MonitorPageContent/index.ts
+++ b/frontend/src/metabase/monitor/components/MonitorPageContent/index.ts
@@ -1,0 +1,1 @@
+export { MonitorPageContent } from "./MonitorPageContent";

--- a/frontend/src/metabase/monitor/routes.tsx
+++ b/frontend/src/metabase/monitor/routes.tsx
@@ -34,6 +34,7 @@ export function getMonitorRoutes(
   CanAccessMonitor: RouteComponent,
   CanAccessMonitorDiagnostics: RouteComponent,
   CanAccessMonitoringTools: RouteComponent,
+  CanAccessAlertsManagement: RouteComponent,
 ) {
   return (
     <Route component={CanAccessMonitor}>
@@ -62,7 +63,6 @@ export function getMonitorRoutes(
 
         <Route component={CanAccessMonitoringTools}>
           <Route path="tasks">{getTasksRoutes()}</Route>
-          <Route path="notifications">{getNotificationsRoutes()}</Route>
           <Route path="jobs" component={JobInfoApp}>
             <Route path=":jobKey" />
           </Route>
@@ -76,6 +76,10 @@ export function getMonitorRoutes(
           <Route path="model-caching" component={ModelCachePage}>
             <ModalRoute path=":jobId" modal={ModelCacheRefreshJobModal} />
           </Route>
+        </Route>
+
+        <Route component={CanAccessAlertsManagement}>
+          <Route path="notifications">{getNotificationsRoutes()}</Route>
         </Route>
 
         <Route path="*" component={NotFound} />

--- a/frontend/src/metabase/monitor/routes.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/routes.unit.spec.tsx
@@ -98,6 +98,10 @@ const CanAccessMonitoringTools = ({ children }: { children?: ReactNode }) => (
   <>{children}</>
 );
 
+const CanAccessAlertsManagement = ({ children }: { children?: ReactNode }) => (
+  <>{children}</>
+);
+
 const UPSELL_TITLE =
   "Find and fix broken dependencies without hunting them down";
 
@@ -120,6 +124,7 @@ const setup = ({
         CanAccessMonitor,
         CanAccessMonitorDiagnostics,
         CanAccessMonitoringTools,
+        CanAccessAlertsManagement,
       )}
     </Route>,
     { withRouter: true, initialRoute },
@@ -134,10 +139,12 @@ const setupWithGuards = ({
   initialRoute,
   CanAccessMonitorDiagnostics: Diagnostics = CanAccessMonitorDiagnostics,
   CanAccessMonitoringTools: Tools = CanAccessMonitoringTools,
+  CanAccessAlertsManagement: AlertsManagement = CanAccessAlertsManagement,
 }: {
   initialRoute: string;
   CanAccessMonitorDiagnostics?: (props: { children?: ReactNode }) => ReactNode;
   CanAccessMonitoringTools?: (props: { children?: ReactNode }) => ReactNode;
+  CanAccessAlertsManagement?: (props: { children?: ReactNode }) => ReactNode;
 }) => {
   const store = getStore(
     mainReducers,
@@ -147,7 +154,13 @@ const setupWithGuards = ({
   return renderWithProviders(
     <Route path="/">
       {getMonitorRedirects()}
-      {getMonitorRoutes(store, CanAccessMonitor, Diagnostics, Tools)}
+      {getMonitorRoutes(
+        store,
+        CanAccessMonitor,
+        Diagnostics,
+        Tools,
+        AlertsManagement,
+      )}
     </Route>,
     { withRouter: true, initialRoute },
   );
@@ -243,6 +256,20 @@ describe("monitor routes", () => {
           await screen.findByTestId("unauthorized-marker"),
         ).toBeInTheDocument();
         expect(screen.queryByTestId("logs-page")).not.toBeInTheDocument();
+      });
+
+      it("blocks the notifications route when its own guard denies, independent of the Tools guard", async () => {
+        setupWithGuards({
+          initialRoute: "/monitor/notifications",
+          CanAccessAlertsManagement: DenyingGuard,
+        });
+
+        expect(
+          await screen.findByTestId("unauthorized-marker"),
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByTestId("notifications-page"),
+        ).not.toBeInTheDocument();
       });
 
       it("renders NotFound for unknown paths even when both section guards deny (catch-all sits outside the guards)", async () => {

--- a/frontend/src/metabase/monitor/tools/components/MonitorBackLink/MonitorBackLink.tsx
+++ b/frontend/src/metabase/monitor/tools/components/MonitorBackLink/MonitorBackLink.tsx
@@ -1,0 +1,19 @@
+import { MonitorHeaderTitle } from "metabase/monitor/components/MonitorHeaderTitle";
+import { Link } from "metabase/router";
+import { Flex, Icon } from "metabase/ui";
+
+type MonitorBackLinkProps = {
+  to: string;
+  label: string;
+};
+
+export const MonitorBackLink = ({ to, label }: MonitorBackLinkProps) => (
+  <Link to={to}>
+    <MonitorHeaderTitle>
+      <Flex align="center" gap="xs">
+        <Icon name="chevronleft" />
+        {label}
+      </Flex>
+    </MonitorHeaderTitle>
+  </Link>
+);

--- a/frontend/src/metabase/monitor/tools/components/MonitorBackLink/index.ts
+++ b/frontend/src/metabase/monitor/tools/components/MonitorBackLink/index.ts
@@ -1,0 +1,1 @@
+export { MonitorBackLink } from "./MonitorBackLink";

--- a/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.module.css
+++ b/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.module.css
@@ -3,7 +3,7 @@
 }
 
 .content {
-  overflow-y: auto;
+  overflow: auto;
 }
 
 .codeContainer {

--- a/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.module.css
+++ b/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.module.css
@@ -1,3 +1,11 @@
+.main {
+  overflow: hidden;
+}
+
+.content {
+  overflow-y: auto;
+}
+
 .codeContainer {
   border: var(--border-size) var(--border-style) var(--mb-color-border-neutral);
   border-radius: var(--default-border-radius);

--- a/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
@@ -28,6 +28,7 @@ import { openSaveDialog } from "metabase/utils/dom";
 import type { Database } from "metabase-types/api";
 
 import { formatTaskDetails, getFilename } from "../../utils";
+import { MonitorBackLink } from "../MonitorBackLink";
 import { TaskStatusBadge } from "../TaskStatusBadge";
 
 import S from "./TaskDetailsPage.module.css";
@@ -60,134 +61,136 @@ export const TaskDetailsPage = ({ params }: TaskDetailsPageProps) => {
   };
 
   return (
-    <SettingsSection>
-      <Flex align="center" gap="sm">
-        <Link to={Urls.monitorTasksList()}>
-          <Flex align="center" gap="xs" c="text-secondary">
-            <Icon name="chevronleft" />
-            {t`Back to Tasks`}
-          </Flex>
-        </Link>
-      </Flex>
+    <Flex h="100%" wrap="nowrap">
+      <Stack className={S.main} flex={1} gap="md">
+        <MonitorBackLink
+          to={Urls.monitorTasksList()}
+          label={t`Back to Tasks`}
+        />
 
-      <Stack gap="sm">
-        <MonitorHeaderTitle>{t`Task details`}</MonitorHeaderTitle>
-        <Flex gap="md">
-          <Text fw="bold" w={120}>{t`ID`}</Text>
-          <Text>{task.id}</Text>
-        </Flex>
-        <Flex gap="md">
-          <Text fw="bold" w={120}>{t`Task`}</Text>
-          <Text>{task.task}</Text>
-        </Flex>
-        <Flex gap="md" align="center">
-          <Text fw="bold" w={120}>{t`Status`}</Text>
-          <TaskStatusBadge task={task} />
-        </Flex>
-        {task.run_id !== null && (
-          <Flex gap="md" align="baseline">
-            <Text fw="bold" w={120}>{t`Task run`}</Text>
-            <Anchor
-              component={Link}
-              to={Urls.monitorTaskRunDetails(task.run_id)}
-            >
-              {t`Go to the corresponding run`}
-            </Anchor>
-          </Flex>
-        )}
-        <Flex gap="md">
-          <Text fw="bold" w={120}>{t`DB Name`}</Text>
-          <Text>
-            {isLoadingDatabases ? (
-              <Loader size="xs" />
-            ) : db ? (
-              dbName
-            ) : (
-              EMPTY_CELL_PLACEHOLDER
-            )}
-          </Text>
-        </Flex>
-        <Flex gap="md">
-          <Text fw="bold" w={120}>{t`DB Engine`}</Text>
-          <Text>
-            {isLoadingDatabases ? (
-              <Loader size="xs" />
-            ) : db ? (
-              dbEngine
-            ) : (
-              EMPTY_CELL_PLACEHOLDER
-            )}
-          </Text>
-        </Flex>
-        <Flex gap="md" align="baseline">
-          <Text fw="bold" w={120}>{t`Started at`}</Text>
-          <Tooltip label={task.started_at}>
-            <DateTime
-              value={task.started_at}
-              unit="minute"
-              data-testid="started-at"
-            />
-          </Tooltip>
-          <CopyButton value={task.started_at} />
-        </Flex>
-        <Flex gap="md">
-          <Text fw="bold" w={120}>{t`Ended at`}</Text>
-          {task.ended_at ? (
-            <Tooltip label={task.ended_at}>
-              <DateTime
-                value={task.ended_at}
-                unit="minute"
-                data-testid="ended-at"
-              />
-            </Tooltip>
-          ) : (
-            EMPTY_CELL_PLACEHOLDER
-          )}
-          {task.ended_at && <CopyButton value={task.ended_at} />}
-        </Flex>
-        <Flex gap="md">
-          <Text fw="bold" w={120}>{t`Duration (ms)`}</Text>
-          <Text>{task.duration}</Text>
-        </Flex>
-        <Flex justify="space-between" align="flex-end">
-          <MonitorHeaderTitle>{t`JSON details`}</MonitorHeaderTitle>
-          <Button
-            leftSection={<Icon name="download" />}
-            variant="filled"
-            onClick={handleDownload}
-          >{t`Download`}</Button>
-        </Flex>
-        <Box
-          className={S.codeContainer}
-          p={linesCount > 1 ? 0 : "xs"}
-          pos="relative"
-          mt="md"
-          data-testid="code-container"
-        >
-          <CodeEditor
-            language="json"
-            lineNumbers={linesCount > 1}
-            readOnly
-            value={code}
-          />
+        <Box className={S.content} flex="1 1 auto" mih={0}>
+          <SettingsSection>
+            <Stack gap="sm">
+              <MonitorHeaderTitle>{t`Task details`}</MonitorHeaderTitle>
+              <Flex gap="md">
+                <Text fw="bold" w={120}>{t`ID`}</Text>
+                <Text>{task.id}</Text>
+              </Flex>
+              <Flex gap="md">
+                <Text fw="bold" w={120}>{t`Task`}</Text>
+                <Text>{task.task}</Text>
+              </Flex>
+              <Flex gap="md" align="center">
+                <Text fw="bold" w={120}>{t`Status`}</Text>
+                <TaskStatusBadge task={task} />
+              </Flex>
+              {task.run_id !== null && (
+                <Flex gap="md" align="baseline">
+                  <Text fw="bold" w={120}>{t`Task run`}</Text>
+                  <Anchor
+                    component={Link}
+                    to={Urls.monitorTaskRunDetails(task.run_id)}
+                  >
+                    {t`Go to the corresponding run`}
+                  </Anchor>
+                </Flex>
+              )}
+              <Flex gap="md">
+                <Text fw="bold" w={120}>{t`DB Name`}</Text>
+                <Text>
+                  {isLoadingDatabases ? (
+                    <Loader size="xs" />
+                  ) : db ? (
+                    dbName
+                  ) : (
+                    EMPTY_CELL_PLACEHOLDER
+                  )}
+                </Text>
+              </Flex>
+              <Flex gap="md">
+                <Text fw="bold" w={120}>{t`DB Engine`}</Text>
+                <Text>
+                  {isLoadingDatabases ? (
+                    <Loader size="xs" />
+                  ) : db ? (
+                    dbEngine
+                  ) : (
+                    EMPTY_CELL_PLACEHOLDER
+                  )}
+                </Text>
+              </Flex>
+              <Flex gap="md" align="baseline">
+                <Text fw="bold" w={120}>{t`Started at`}</Text>
+                <Tooltip label={task.started_at}>
+                  <DateTime
+                    value={task.started_at}
+                    unit="minute"
+                    data-testid="started-at"
+                  />
+                </Tooltip>
+                <CopyButton value={task.started_at} />
+              </Flex>
+              <Flex gap="md">
+                <Text fw="bold" w={120}>{t`Ended at`}</Text>
+                {task.ended_at ? (
+                  <Tooltip label={task.ended_at}>
+                    <DateTime
+                      value={task.ended_at}
+                      unit="minute"
+                      data-testid="ended-at"
+                    />
+                  </Tooltip>
+                ) : (
+                  EMPTY_CELL_PLACEHOLDER
+                )}
+                {task.ended_at && <CopyButton value={task.ended_at} />}
+              </Flex>
+              <Flex gap="md">
+                <Text fw="bold" w={120}>{t`Duration (ms)`}</Text>
+                <Text>{task.duration}</Text>
+              </Flex>
+              <Flex justify="space-between" align="flex-end">
+                <MonitorHeaderTitle>{t`JSON details`}</MonitorHeaderTitle>
+                <Button
+                  leftSection={<Icon name="download" />}
+                  variant="filled"
+                  onClick={handleDownload}
+                >{t`Download`}</Button>
+              </Flex>
+              <Box
+                className={S.codeContainer}
+                p={linesCount > 1 ? 0 : "xs"}
+                pos="relative"
+                mt="md"
+                data-testid="code-container"
+              >
+                <CodeEditor
+                  language="json"
+                  lineNumbers={linesCount > 1}
+                  readOnly
+                  value={code}
+                />
 
-          <Box p="sm" pos="absolute" right={0} top={0}>
-            <CopyButton value={code} />
-          </Box>
+                <Box p="sm" pos="absolute" right={0} top={0}>
+                  <CopyButton value={code} />
+                </Box>
+              </Box>
+
+              <MonitorHeaderTitle>{t`Logs`}</MonitorHeaderTitle>
+              {hasLogs ? (
+                <Box className={S.codeContainer}>
+                  <LogsViewer
+                    logs={task?.logs ?? []}
+                    data-testid="task-logs"
+                  ></LogsViewer>
+                </Box>
+              ) : (
+                <Text>{t`There are no captured logs`}</Text>
+              )}
+            </Stack>
+          </SettingsSection>
         </Box>
-
-        <MonitorHeaderTitle>{t`Logs`}</MonitorHeaderTitle>
-        {hasLogs ? (
-          <Box className={S.codeContainer}>
-            <LogsViewer
-              logs={task?.logs ?? []}
-              data-testid="task-logs"
-            ></LogsViewer>
-          </Box>
-        ) : (
-          <Text>{t`There are no captured logs`}</Text>
-        )}
       </Stack>
-    </SettingsSection>
+    </Flex>
   );
 };

--- a/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import { useGetTaskQuery, useListDatabasesQuery } from "metabase/api";
 import { CodeEditor } from "metabase/common/components/CodeEditor";
 import { CopyButton } from "metabase/common/components/CopyButton";
@@ -10,6 +9,7 @@ import { DateTime } from "metabase/common/components/DateTime";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { LogsViewer } from "metabase/monitor/components/LogsViewer";
 import { MonitorHeaderTitle } from "metabase/monitor/components/MonitorHeaderTitle";
+import { MonitorPageContent } from "metabase/monitor/components/MonitorPageContent";
 import { Link } from "metabase/router";
 import {
   Anchor,
@@ -69,7 +69,7 @@ export const TaskDetailsPage = ({ params }: TaskDetailsPageProps) => {
         />
 
         <Box className={S.content} flex="1 1 auto" mih={0}>
-          <SettingsSection>
+          <MonitorPageContent>
             <Stack gap="sm">
               <MonitorHeaderTitle>{t`Task details`}</MonitorHeaderTitle>
               <Flex gap="md">
@@ -188,7 +188,7 @@ export const TaskDetailsPage = ({ params }: TaskDetailsPageProps) => {
                 <Text>{t`There are no captured logs`}</Text>
               )}
             </Stack>
-          </SettingsSection>
+          </MonitorPageContent>
         </Box>
       </Stack>
     </Flex>

--- a/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
@@ -68,128 +68,128 @@ export const TaskDetailsPage = ({ params }: TaskDetailsPageProps) => {
           label={t`Back to Tasks`}
         />
 
-        <Box className={S.content} flex="1 1 auto" mih={0}>
-          <MonitorPageContent>
-            <Stack gap="sm">
-              <MonitorHeaderTitle>{t`Task details`}</MonitorHeaderTitle>
-              <Flex gap="md">
-                <Text fw="bold" w={120}>{t`ID`}</Text>
-                <Text>{task.id}</Text>
-              </Flex>
-              <Flex gap="md">
-                <Text fw="bold" w={120}>{t`Task`}</Text>
-                <Text>{task.task}</Text>
-              </Flex>
-              <Flex gap="md" align="center">
-                <Text fw="bold" w={120}>{t`Status`}</Text>
-                <TaskStatusBadge task={task} />
-              </Flex>
-              {task.run_id !== null && (
-                <Flex gap="md" align="baseline">
-                  <Text fw="bold" w={120}>{t`Task run`}</Text>
-                  <Anchor
-                    component={Link}
-                    to={Urls.monitorTaskRunDetails(task.run_id)}
-                  >
-                    {t`Go to the corresponding run`}
-                  </Anchor>
-                </Flex>
-              )}
-              <Flex gap="md">
-                <Text fw="bold" w={120}>{t`DB Name`}</Text>
-                <Text>
-                  {isLoadingDatabases ? (
-                    <Loader size="xs" />
-                  ) : db ? (
-                    dbName
-                  ) : (
-                    EMPTY_CELL_PLACEHOLDER
-                  )}
-                </Text>
-              </Flex>
-              <Flex gap="md">
-                <Text fw="bold" w={120}>{t`DB Engine`}</Text>
-                <Text>
-                  {isLoadingDatabases ? (
-                    <Loader size="xs" />
-                  ) : db ? (
-                    dbEngine
-                  ) : (
-                    EMPTY_CELL_PLACEHOLDER
-                  )}
-                </Text>
-              </Flex>
+        {/* <Box flex="1 1 auto" mih={0}> */}
+        <MonitorPageContent className={S.content}>
+          <Stack gap="sm">
+            <MonitorHeaderTitle>{t`Task details`}</MonitorHeaderTitle>
+            <Flex gap="md">
+              <Text fw="bold" w={120}>{t`ID`}</Text>
+              <Text>{task.id}</Text>
+            </Flex>
+            <Flex gap="md">
+              <Text fw="bold" w={120}>{t`Task`}</Text>
+              <Text>{task.task}</Text>
+            </Flex>
+            <Flex gap="md" align="center">
+              <Text fw="bold" w={120}>{t`Status`}</Text>
+              <TaskStatusBadge task={task} />
+            </Flex>
+            {task.run_id !== null && (
               <Flex gap="md" align="baseline">
-                <Text fw="bold" w={120}>{t`Started at`}</Text>
-                <Tooltip label={task.started_at}>
-                  <DateTime
-                    value={task.started_at}
-                    unit="minute"
-                    data-testid="started-at"
-                  />
-                </Tooltip>
-                <CopyButton value={task.started_at} />
+                <Text fw="bold" w={120}>{t`Task run`}</Text>
+                <Anchor
+                  component={Link}
+                  to={Urls.monitorTaskRunDetails(task.run_id)}
+                >
+                  {t`Go to the corresponding run`}
+                </Anchor>
               </Flex>
-              <Flex gap="md">
-                <Text fw="bold" w={120}>{t`Ended at`}</Text>
-                {task.ended_at ? (
-                  <Tooltip label={task.ended_at}>
-                    <DateTime
-                      value={task.ended_at}
-                      unit="minute"
-                      data-testid="ended-at"
-                    />
-                  </Tooltip>
+            )}
+            <Flex gap="md">
+              <Text fw="bold" w={120}>{t`DB Name`}</Text>
+              <Text>
+                {isLoadingDatabases ? (
+                  <Loader size="xs" />
+                ) : db ? (
+                  dbName
                 ) : (
                   EMPTY_CELL_PLACEHOLDER
                 )}
-                {task.ended_at && <CopyButton value={task.ended_at} />}
-              </Flex>
-              <Flex gap="md">
-                <Text fw="bold" w={120}>{t`Duration (ms)`}</Text>
-                <Text>{task.duration}</Text>
-              </Flex>
-              <Flex justify="space-between" align="flex-end">
-                <MonitorHeaderTitle>{t`JSON details`}</MonitorHeaderTitle>
-                <Button
-                  leftSection={<Icon name="download" />}
-                  variant="filled"
-                  onClick={handleDownload}
-                >{t`Download`}</Button>
-              </Flex>
-              <Box
-                className={S.codeContainer}
-                p={linesCount > 1 ? 0 : "xs"}
-                pos="relative"
-                mt="md"
-                data-testid="code-container"
-              >
-                <CodeEditor
-                  language="json"
-                  lineNumbers={linesCount > 1}
-                  readOnly
-                  value={code}
+              </Text>
+            </Flex>
+            <Flex gap="md">
+              <Text fw="bold" w={120}>{t`DB Engine`}</Text>
+              <Text>
+                {isLoadingDatabases ? (
+                  <Loader size="xs" />
+                ) : db ? (
+                  dbEngine
+                ) : (
+                  EMPTY_CELL_PLACEHOLDER
+                )}
+              </Text>
+            </Flex>
+            <Flex gap="md" align="baseline">
+              <Text fw="bold" w={120}>{t`Started at`}</Text>
+              <Tooltip label={task.started_at}>
+                <DateTime
+                  value={task.started_at}
+                  unit="minute"
+                  data-testid="started-at"
                 />
-
-                <Box p="sm" pos="absolute" right={0} top={0}>
-                  <CopyButton value={code} />
-                </Box>
-              </Box>
-
-              <MonitorHeaderTitle>{t`Logs`}</MonitorHeaderTitle>
-              {hasLogs ? (
-                <Box className={S.codeContainer}>
-                  <LogsViewer
-                    logs={task?.logs ?? []}
-                    data-testid="task-logs"
-                  ></LogsViewer>
-                </Box>
+              </Tooltip>
+              <CopyButton value={task.started_at} />
+            </Flex>
+            <Flex gap="md">
+              <Text fw="bold" w={120}>{t`Ended at`}</Text>
+              {task.ended_at ? (
+                <Tooltip label={task.ended_at}>
+                  <DateTime
+                    value={task.ended_at}
+                    unit="minute"
+                    data-testid="ended-at"
+                  />
+                </Tooltip>
               ) : (
-                <Text>{t`There are no captured logs`}</Text>
+                EMPTY_CELL_PLACEHOLDER
               )}
-            </Stack>
-          </MonitorPageContent>
-        </Box>
+              {task.ended_at && <CopyButton value={task.ended_at} />}
+            </Flex>
+            <Flex gap="md">
+              <Text fw="bold" w={120}>{t`Duration (ms)`}</Text>
+              <Text>{task.duration}</Text>
+            </Flex>
+            <Flex justify="space-between" align="flex-end">
+              <MonitorHeaderTitle>{t`JSON details`}</MonitorHeaderTitle>
+              <Button
+                leftSection={<Icon name="download" />}
+                variant="filled"
+                onClick={handleDownload}
+              >{t`Download`}</Button>
+            </Flex>
+            <Box
+              className={S.codeContainer}
+              p={linesCount > 1 ? 0 : "xs"}
+              pos="relative"
+              mt="md"
+              data-testid="code-container"
+            >
+              <CodeEditor
+                language="json"
+                lineNumbers={linesCount > 1}
+                readOnly
+                value={code}
+              />
+
+              <Box p="sm" pos="absolute" right={0} top={0}>
+                <CopyButton value={code} />
+              </Box>
+            </Box>
+
+            <MonitorHeaderTitle>{t`Logs`}</MonitorHeaderTitle>
+            {hasLogs ? (
+              <Box className={S.codeContainer}>
+                <LogsViewer
+                  logs={task?.logs ?? []}
+                  data-testid="task-logs"
+                ></LogsViewer>
+              </Box>
+            ) : (
+              <Text>{t`There are no captured logs`}</Text>
+            )}
+          </Stack>
+        </MonitorPageContent>
+        {/* </Box> */}
       </Stack>
     </Flex>
   );

--- a/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.unit.spec.tsx
@@ -147,4 +147,15 @@ describe("TaskDetailsPage", () => {
     expect(screen.getByText("There are no captured logs")).toBeInTheDocument();
     expect(screen.queryByTestId("task-logs")).not.toBeInTheDocument();
   });
+
+  it("should show a link back to the tasks list", async () => {
+    setup();
+
+    await waitForLoaderToBeRemoved();
+
+    expect(screen.getByRole("link", { name: /Back to Tasks/ })).toHaveAttribute(
+      "href",
+      Urls.monitorTasksList(),
+    );
+  });
 });

--- a/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.module.css
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.module.css
@@ -3,5 +3,5 @@
 }
 
 .content {
-  overflow-y: auto;
+  overflow: auto;
 }

--- a/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.module.css
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.module.css
@@ -1,0 +1,7 @@
+.main {
+  overflow: hidden;
+}
+
+.content {
+  overflow-y: auto;
+}

--- a/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.tsx
@@ -50,118 +50,116 @@ export const TaskRunDetailsPage = ({ params }: TaskRunDetailsPageProps) => {
       <Stack className={S.main} flex={1} gap="md">
         <MonitorBackLink to={Urls.monitorTasksRuns()} label={t`Back to Runs`} />
 
-        <Box className={S.content} flex="1 1 auto" mih={0}>
-          <MonitorPageContent>
-            <Grid>
-              <Grid.Col span={{ base: 12, lg: "content" }} maw="50%">
-                <MonitorHeaderTitle mb="md">{t`Run details`}</MonitorHeaderTitle>
-                <Stack gap="sm">
-                  <Flex gap="md">
-                    <Text fw="bold" w={120}>{t`ID`}</Text>
-                    <Text>{taskRun.id}</Text>
-                  </Flex>
-                  <Flex gap="md">
-                    <Text fw="bold" w={120}>{t`Run type`}</Text>
-                    <Text>{formatTaskRunType(taskRun.run_type)}</Text>
-                  </Flex>
-                  <Flex gap="md">
-                    <Text fw="bold" w={120}>{t`Entity type`}</Text>
-                    <Text>{formatTaskRunEntityType(taskRun.entity_type)}</Text>
-                  </Flex>
-                  <Flex gap="md" align="baseline">
-                    <Text fw="bold" w={120}>{t`Entity`}</Text>
-                    <Anchor
-                      component={Link}
-                      to={getEntityUrl(
-                        taskRun.entity_type,
-                        taskRun.entity_id,
-                        taskRun.entity_name ?? undefined,
-                      )}
-                    >
-                      {taskRun.entity_name ?? taskRun.entity_id}
-                    </Anchor>
-                  </Flex>
-                  <Flex gap="md" align="center">
-                    <Text fw="bold" w={120}>{t`Status`}</Text>
-                    <TaskRunStatusBadge taskRun={taskRun} />
-                  </Flex>
-                  <Flex gap="md">
-                    <Text fw="bold" w={120}>{t`Started at`}</Text>
-                    <Tooltip label={taskRun.started_at}>
-                      <DateTime
-                        value={taskRun.started_at}
-                        unit="minute"
-                        data-testid="started-at"
-                      />
-                    </Tooltip>
-                    <CopyButton value={taskRun.started_at} />
-                  </Flex>
-                  <Flex gap="md">
-                    <Text fw="bold" w={120}>{t`Ended at`}</Text>
-                    {taskRun.ended_at ? (
-                      <>
-                        <Tooltip label={taskRun.ended_at}>
-                          <DateTime
-                            value={taskRun.ended_at}
-                            unit="minute"
-                            data-testid="ended-at"
-                          />
-                        </Tooltip>
-                        <CopyButton value={taskRun.ended_at} />
-                      </>
-                    ) : (
-                      EMPTY_CELL_PLACEHOLDER
+        <MonitorPageContent className={S.content}>
+          <Grid>
+            <Grid.Col span={{ base: 12, lg: "content" }} maw="50%">
+              <MonitorHeaderTitle mb="md">{t`Run details`}</MonitorHeaderTitle>
+              <Stack gap="sm">
+                <Flex gap="md">
+                  <Text fw="bold" w={120}>{t`ID`}</Text>
+                  <Text>{taskRun.id}</Text>
+                </Flex>
+                <Flex gap="md">
+                  <Text fw="bold" w={120}>{t`Run type`}</Text>
+                  <Text>{formatTaskRunType(taskRun.run_type)}</Text>
+                </Flex>
+                <Flex gap="md">
+                  <Text fw="bold" w={120}>{t`Entity type`}</Text>
+                  <Text>{formatTaskRunEntityType(taskRun.entity_type)}</Text>
+                </Flex>
+                <Flex gap="md" align="baseline">
+                  <Text fw="bold" w={120}>{t`Entity`}</Text>
+                  <Anchor
+                    component={Link}
+                    to={getEntityUrl(
+                      taskRun.entity_type,
+                      taskRun.entity_id,
+                      taskRun.entity_name ?? undefined,
                     )}
-                  </Flex>
-                  <Flex gap="md">
-                    <Text fw="bold" w={120}>{t`Task count`}</Text>
-                    <Text>{renderTaskRunCounters(taskRun)}</Text>
-                  </Flex>
-                </Stack>
-              </Grid.Col>
+                  >
+                    {taskRun.entity_name ?? taskRun.entity_id}
+                  </Anchor>
+                </Flex>
+                <Flex gap="md" align="center">
+                  <Text fw="bold" w={120}>{t`Status`}</Text>
+                  <TaskRunStatusBadge taskRun={taskRun} />
+                </Flex>
+                <Flex gap="md">
+                  <Text fw="bold" w={120}>{t`Started at`}</Text>
+                  <Tooltip label={taskRun.started_at}>
+                    <DateTime
+                      value={taskRun.started_at}
+                      unit="minute"
+                      data-testid="started-at"
+                    />
+                  </Tooltip>
+                  <CopyButton value={taskRun.started_at} />
+                </Flex>
+                <Flex gap="md">
+                  <Text fw="bold" w={120}>{t`Ended at`}</Text>
+                  {taskRun.ended_at ? (
+                    <>
+                      <Tooltip label={taskRun.ended_at}>
+                        <DateTime
+                          value={taskRun.ended_at}
+                          unit="minute"
+                          data-testid="ended-at"
+                        />
+                      </Tooltip>
+                      <CopyButton value={taskRun.ended_at} />
+                    </>
+                  ) : (
+                    EMPTY_CELL_PLACEHOLDER
+                  )}
+                </Flex>
+                <Flex gap="md">
+                  <Text fw="bold" w={120}>{t`Task count`}</Text>
+                  <Text>{renderTaskRunCounters(taskRun)}</Text>
+                </Flex>
+              </Stack>
+            </Grid.Col>
 
-              <Grid.Col span={{ base: 12, lg: "auto" }}>
-                <MonitorHeaderTitle mb="md">{t`Associated tasks`}</MonitorHeaderTitle>
-                <table
-                  className={cx(AdminS.ContentTable)}
-                  data-testid="task-run-tasks-table"
-                >
-                  <thead>
+            <Grid.Col span={{ base: 12, lg: "auto" }}>
+              <MonitorHeaderTitle mb="md">{t`Associated tasks`}</MonitorHeaderTitle>
+              <table
+                className={cx(AdminS.ContentTable)}
+                data-testid="task-run-tasks-table"
+              >
+                <thead>
+                  <tr>
+                    <Box component="th" w={200}>{t`Task`}</Box>
+                    <th>{t`Status`}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {taskRun.tasks.length === 0 && (
                     <tr>
-                      <Box component="th" w={200}>{t`Task`}</Box>
-                      <th>{t`Status`}</th>
+                      <td colSpan={2}>
+                        <Flex
+                          c="text-disabled"
+                          justify="center"
+                        >{t`No tasks`}</Flex>
+                      </td>
                     </tr>
-                  </thead>
-                  <tbody>
-                    {taskRun.tasks.length === 0 && (
-                      <tr>
-                        <td colSpan={2}>
-                          <Flex
-                            c="text-disabled"
-                            justify="center"
-                          >{t`No tasks`}</Flex>
-                        </td>
-                      </tr>
-                    )}
-                    {taskRun.tasks.map((task) => (
-                      <tr
-                        key={task.id}
-                        className={CS.cursorPointer}
-                        data-testid="task-run-task"
-                        onClick={() => onClickTask(task)}
-                      >
-                        <td className={CS.textBold}>{task.task}</td>
-                        <td>
-                          <TaskStatusBadge task={task} />
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </Grid.Col>
-            </Grid>
-          </MonitorPageContent>
-        </Box>
+                  )}
+                  {taskRun.tasks.map((task) => (
+                    <tr
+                      key={task.id}
+                      className={CS.cursorPointer}
+                      data-testid="task-run-task"
+                      onClick={() => onClickTask(task)}
+                    >
+                      <td className={CS.textBold}>{task.task}</td>
+                      <td>
+                        <TaskStatusBadge task={task} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </Grid.Col>
+          </Grid>
+        </MonitorPageContent>
       </Stack>
     </Flex>
   );

--- a/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.tsx
@@ -2,7 +2,6 @@ import cx from "classnames";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 
-import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import { useGetTaskRunQuery } from "metabase/api";
 import { CopyButton } from "metabase/common/components/CopyButton";
 import { DateTime } from "metabase/common/components/DateTime";
@@ -10,6 +9,7 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import AdminS from "metabase/css/admin.module.css";
 import CS from "metabase/css/core/index.css";
 import { MonitorHeaderTitle } from "metabase/monitor/components/MonitorHeaderTitle";
+import { MonitorPageContent } from "metabase/monitor/components/MonitorPageContent";
 import { useDispatch } from "metabase/redux";
 import { Link } from "metabase/router";
 import { Anchor, Box, Flex, Grid, Stack, Text, Tooltip } from "metabase/ui";
@@ -51,7 +51,7 @@ export const TaskRunDetailsPage = ({ params }: TaskRunDetailsPageProps) => {
         <MonitorBackLink to={Urls.monitorTasksRuns()} label={t`Back to Runs`} />
 
         <Box className={S.content} flex="1 1 auto" mih={0}>
-          <SettingsSection>
+          <MonitorPageContent>
             <Grid>
               <Grid.Col span={{ base: 12, lg: "content" }} maw="50%">
                 <MonitorHeaderTitle mb="md">{t`Run details`}</MonitorHeaderTitle>
@@ -160,7 +160,7 @@ export const TaskRunDetailsPage = ({ params }: TaskRunDetailsPageProps) => {
                 </table>
               </Grid.Col>
             </Grid>
-          </SettingsSection>
+          </MonitorPageContent>
         </Box>
       </Stack>
     </Flex>

--- a/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.tsx
@@ -12,16 +12,7 @@ import CS from "metabase/css/core/index.css";
 import { MonitorHeaderTitle } from "metabase/monitor/components/MonitorHeaderTitle";
 import { useDispatch } from "metabase/redux";
 import { Link } from "metabase/router";
-import {
-  Anchor,
-  Box,
-  Flex,
-  Grid,
-  Icon,
-  Stack,
-  Text,
-  Tooltip,
-} from "metabase/ui";
+import { Anchor, Box, Flex, Grid, Stack, Text, Tooltip } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
 import type { Task } from "metabase-types/api";
@@ -32,8 +23,11 @@ import {
   getEntityUrl,
   renderTaskRunCounters,
 } from "../../utils";
+import { MonitorBackLink } from "../MonitorBackLink";
 import { TaskRunStatusBadge } from "../TaskRunStatusBadge";
 import { TaskStatusBadge } from "../TaskStatusBadge";
+
+import S from "./TaskRunDetailsPage.module.css";
 
 type TaskRunDetailsPageProps = {
   params: { runId: number };
@@ -52,124 +46,123 @@ export const TaskRunDetailsPage = ({ params }: TaskRunDetailsPageProps) => {
   }
 
   return (
-    <SettingsSection>
-      <Flex align="center" gap="sm">
-        <Link to={Urls.monitorTasksRuns()}>
-          <Flex align="center" gap="xs" c="text-secondary">
-            <Icon name="chevronleft" />
-            {t`Back to Runs`}
-          </Flex>
-        </Link>
-      </Flex>
+    <Flex h="100%" wrap="nowrap">
+      <Stack className={S.main} flex={1} gap="md">
+        <MonitorBackLink to={Urls.monitorTasksRuns()} label={t`Back to Runs`} />
 
-      <Grid>
-        <Grid.Col span={{ base: 12, lg: "content" }} maw="50%">
-          <MonitorHeaderTitle mb="md">{t`Run details`}</MonitorHeaderTitle>
-          <Stack gap="sm">
-            <Flex gap="md">
-              <Text fw="bold" w={120}>{t`ID`}</Text>
-              <Text>{taskRun.id}</Text>
-            </Flex>
-            <Flex gap="md">
-              <Text fw="bold" w={120}>{t`Run type`}</Text>
-              <Text>{formatTaskRunType(taskRun.run_type)}</Text>
-            </Flex>
-            <Flex gap="md">
-              <Text fw="bold" w={120}>{t`Entity type`}</Text>
-              <Text>{formatTaskRunEntityType(taskRun.entity_type)}</Text>
-            </Flex>
-            <Flex gap="md" align="baseline">
-              <Text fw="bold" w={120}>{t`Entity`}</Text>
-              <Anchor
-                component={Link}
-                to={getEntityUrl(
-                  taskRun.entity_type,
-                  taskRun.entity_id,
-                  taskRun.entity_name ?? undefined,
-                )}
-              >
-                {taskRun.entity_name ?? taskRun.entity_id}
-              </Anchor>
-            </Flex>
-            <Flex gap="md" align="center">
-              <Text fw="bold" w={120}>{t`Status`}</Text>
-              <TaskRunStatusBadge taskRun={taskRun} />
-            </Flex>
-            <Flex gap="md">
-              <Text fw="bold" w={120}>{t`Started at`}</Text>
-              <Tooltip label={taskRun.started_at}>
-                <DateTime
-                  value={taskRun.started_at}
-                  unit="minute"
-                  data-testid="started-at"
-                />
-              </Tooltip>
-              <CopyButton value={taskRun.started_at} />
-            </Flex>
-            <Flex gap="md">
-              <Text fw="bold" w={120}>{t`Ended at`}</Text>
-              {taskRun.ended_at ? (
-                <>
-                  <Tooltip label={taskRun.ended_at}>
-                    <DateTime
-                      value={taskRun.ended_at}
-                      unit="minute"
-                      data-testid="ended-at"
-                    />
-                  </Tooltip>
-                  <CopyButton value={taskRun.ended_at} />
-                </>
-              ) : (
-                EMPTY_CELL_PLACEHOLDER
-              )}
-            </Flex>
-            <Flex gap="md">
-              <Text fw="bold" w={120}>{t`Task count`}</Text>
-              <Text>{renderTaskRunCounters(taskRun)}</Text>
-            </Flex>
-          </Stack>
-        </Grid.Col>
+        <Box className={S.content} flex="1 1 auto" mih={0}>
+          <SettingsSection>
+            <Grid>
+              <Grid.Col span={{ base: 12, lg: "content" }} maw="50%">
+                <MonitorHeaderTitle mb="md">{t`Run details`}</MonitorHeaderTitle>
+                <Stack gap="sm">
+                  <Flex gap="md">
+                    <Text fw="bold" w={120}>{t`ID`}</Text>
+                    <Text>{taskRun.id}</Text>
+                  </Flex>
+                  <Flex gap="md">
+                    <Text fw="bold" w={120}>{t`Run type`}</Text>
+                    <Text>{formatTaskRunType(taskRun.run_type)}</Text>
+                  </Flex>
+                  <Flex gap="md">
+                    <Text fw="bold" w={120}>{t`Entity type`}</Text>
+                    <Text>{formatTaskRunEntityType(taskRun.entity_type)}</Text>
+                  </Flex>
+                  <Flex gap="md" align="baseline">
+                    <Text fw="bold" w={120}>{t`Entity`}</Text>
+                    <Anchor
+                      component={Link}
+                      to={getEntityUrl(
+                        taskRun.entity_type,
+                        taskRun.entity_id,
+                        taskRun.entity_name ?? undefined,
+                      )}
+                    >
+                      {taskRun.entity_name ?? taskRun.entity_id}
+                    </Anchor>
+                  </Flex>
+                  <Flex gap="md" align="center">
+                    <Text fw="bold" w={120}>{t`Status`}</Text>
+                    <TaskRunStatusBadge taskRun={taskRun} />
+                  </Flex>
+                  <Flex gap="md">
+                    <Text fw="bold" w={120}>{t`Started at`}</Text>
+                    <Tooltip label={taskRun.started_at}>
+                      <DateTime
+                        value={taskRun.started_at}
+                        unit="minute"
+                        data-testid="started-at"
+                      />
+                    </Tooltip>
+                    <CopyButton value={taskRun.started_at} />
+                  </Flex>
+                  <Flex gap="md">
+                    <Text fw="bold" w={120}>{t`Ended at`}</Text>
+                    {taskRun.ended_at ? (
+                      <>
+                        <Tooltip label={taskRun.ended_at}>
+                          <DateTime
+                            value={taskRun.ended_at}
+                            unit="minute"
+                            data-testid="ended-at"
+                          />
+                        </Tooltip>
+                        <CopyButton value={taskRun.ended_at} />
+                      </>
+                    ) : (
+                      EMPTY_CELL_PLACEHOLDER
+                    )}
+                  </Flex>
+                  <Flex gap="md">
+                    <Text fw="bold" w={120}>{t`Task count`}</Text>
+                    <Text>{renderTaskRunCounters(taskRun)}</Text>
+                  </Flex>
+                </Stack>
+              </Grid.Col>
 
-        <Grid.Col span={{ base: 12, lg: "auto" }}>
-          <MonitorHeaderTitle mb="md">{t`Associated tasks`}</MonitorHeaderTitle>
-          <table
-            className={cx(AdminS.ContentTable)}
-            data-testid="task-run-tasks-table"
-          >
-            <thead>
-              <tr>
-                <Box component="th" w={200}>{t`Task`}</Box>
-                <th>{t`Status`}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {taskRun.tasks.length === 0 && (
-                <tr>
-                  <td colSpan={2}>
-                    <Flex
-                      c="text-disabled"
-                      justify="center"
-                    >{t`No tasks`}</Flex>
-                  </td>
-                </tr>
-              )}
-              {taskRun.tasks.map((task) => (
-                <tr
-                  key={task.id}
-                  className={CS.cursorPointer}
-                  data-testid="task-run-task"
-                  onClick={() => onClickTask(task)}
+              <Grid.Col span={{ base: 12, lg: "auto" }}>
+                <MonitorHeaderTitle mb="md">{t`Associated tasks`}</MonitorHeaderTitle>
+                <table
+                  className={cx(AdminS.ContentTable)}
+                  data-testid="task-run-tasks-table"
                 >
-                  <td className={CS.textBold}>{task.task}</td>
-                  <td>
-                    <TaskStatusBadge task={task} />
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </Grid.Col>
-      </Grid>
-    </SettingsSection>
+                  <thead>
+                    <tr>
+                      <Box component="th" w={200}>{t`Task`}</Box>
+                      <th>{t`Status`}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {taskRun.tasks.length === 0 && (
+                      <tr>
+                        <td colSpan={2}>
+                          <Flex
+                            c="text-disabled"
+                            justify="center"
+                          >{t`No tasks`}</Flex>
+                        </td>
+                      </tr>
+                    )}
+                    {taskRun.tasks.map((task) => (
+                      <tr
+                        key={task.id}
+                        className={CS.cursorPointer}
+                        data-testid="task-run-task"
+                        onClick={() => onClickTask(task)}
+                      >
+                        <td className={CS.textBold}>{task.task}</td>
+                        <td>
+                          <TaskStatusBadge task={task} />
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </Grid.Col>
+            </Grid>
+          </SettingsSection>
+        </Box>
+      </Stack>
+    </Flex>
   );
 };

--- a/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.unit.spec.tsx
@@ -50,6 +50,17 @@ describe("TaskRunDetailsPage", () => {
     });
   });
 
+  it("should show a link back to the runs list", async () => {
+    setup();
+
+    await waitForLoaderToBeRemoved();
+
+    expect(screen.getByRole("link", { name: /Back to Runs/ })).toHaveAttribute(
+      "href",
+      Urls.monitorTasksRuns(),
+    );
+  });
+
   it("should display formatted datetime for started_at and ended_at", async () => {
     const taskRun = createMockTaskRunExtended({
       started_at: "2023-03-04T01:45:26.005475-08:00",

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.module.css
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.module.css
@@ -1,0 +1,3 @@
+.main {
+  overflow: hidden;
+}

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.tsx
@@ -1,5 +1,5 @@
 import { useElementSize } from "@mantine/hooks";
-import type { Row, SortingState } from "@tanstack/react-table";
+import type { RowSelectionState, SortingState } from "@tanstack/react-table";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { push } from "react-router-redux";
 import { t } from "ttag";
@@ -22,13 +22,9 @@ import { Sidebar } from "metabase/monitor/components/MonitorLayout/Sidebar";
 import { useDispatch } from "metabase/redux";
 import { addUndo } from "metabase/redux/undo";
 import type { WithRouterProps } from "metabase/router";
-import { Flex, type SelectionState, Stack } from "metabase/ui";
+import { Flex, Stack } from "metabase/ui";
 import * as Urls from "metabase/urls";
-import type {
-  AdminNotification,
-  NotificationId,
-  UserId,
-} from "metabase-types/api";
+import type { NotificationId, UserId } from "metabase-types/api";
 
 import { ChangeOwnerModal } from "../ChangeOwnerModal";
 import { NotificationDetailSidebar } from "../NotificationDetailSidebar";
@@ -62,15 +58,8 @@ export const NotificationsAdminPage = ({
   const { ref: containerRef, width: containerWidth } = useElementSize();
   const dispatch = useDispatch();
   const [urlState, { patchUrlState }] = useUrlState(location, urlStateConfig);
-  const [selectedIds, setSelectedIds] = useState<Set<NotificationId>>(
-    new Set(),
-  );
-  const clearSelected = useCallback(() => setSelectedIds(new Set()), []);
-  const getSelectionState = useCallback(
-    (row: Row<AdminNotification>): SelectionState =>
-      selectedIds.has(row.original.id) ? "all" : "none",
-    [selectedIds],
-  );
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const clearSelected = useCallback(() => setRowSelection({}), []);
   const [isChangeOwnerOpened, setIsChangeOwnerOpened] = useState(false);
 
   const { modalContent: confirmContent, show: showConfirm } = useConfirmation();
@@ -80,11 +69,11 @@ export const NotificationsAdminPage = ({
   );
   const notifications = useMemo(() => data?.data ?? [], [data?.data]);
   const total = data?.total ?? 0;
-  const selectedCount = selectedIds.size;
   const selectedNotifications = useMemo(
-    () => notifications.filter((n) => selectedIds.has(n.id)),
-    [notifications, selectedIds],
+    () => notifications.filter((n) => rowSelection[String(n.id)]),
+    [notifications, rowSelection],
   );
+  const selectedCount = selectedNotifications.length;
 
   const { data: failingData, isLoading: isFailingLoading } =
     useAdminListNotificationsQuery({
@@ -168,26 +157,6 @@ export const NotificationsAdminPage = ({
     },
     [patchUrlState],
   );
-
-  const handleToggleRow = useCallback((id: NotificationId) => {
-    setSelectedIds((prev) =>
-      prev.has(id)
-        ? new Set([...prev].filter((x) => x !== id))
-        : new Set([...prev, id]),
-    );
-  }, []);
-
-  const handleToggleAll = useCallback(() => {
-    setSelectedIds((prev) => {
-      const allIds = notifications.map((n) => n.id);
-      const allSelected =
-        allIds.length > 0 && allIds.every((id) => prev.has(id));
-      if (allSelected) {
-        return new Set();
-      }
-      return new Set([...prev, ...allIds]);
-    });
-  }, [notifications]);
 
   const handleRowClick = (id: NotificationId) => {
     trackAlertsManagementAlertOpened(id, "table_row");
@@ -365,12 +334,11 @@ export const NotificationsAdminPage = ({
             notifications={notifications}
             error={error}
             isLoading={isLoading}
-            getSelectionState={getSelectionState}
+            rowSelection={rowSelection}
             selectedDetailId={notificationId}
             sorting={sorting}
             onSortingChange={handleSortingChange}
-            onToggleRow={handleToggleRow}
-            onToggleAll={handleToggleAll}
+            onRowSelectionChange={setRowSelection}
             onRowClick={handleRowClick}
           />
 

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.tsx
@@ -44,6 +44,7 @@ import {
   trackAlertsManagementSearchPerformed,
 } from "../analytics";
 
+import S from "./NotificationsAdminPage.module.css";
 import {
   DEFAULT_SORT_COLUMN,
   DEFAULT_SORT_DIRECTION,
@@ -339,54 +340,66 @@ export const NotificationsAdminPage = ({
   }
 
   return (
-    <Stack ref={containerRef} gap="lg">
-      <Flex align="center" gap="sm">
-        <MonitorHeaderTitle>{t`Alerts management`}</MonitorHeaderTitle>
-      </Flex>
+    <>
+      <Flex ref={containerRef} h="100%" wrap="nowrap">
+        <Stack className={S.main} flex={1} gap="md">
+          <MonitorHeaderTitle>{t`Alerts management`}</MonitorHeaderTitle>
 
-      <NotificationsTabs
-        tab={urlState.tab}
-        failingCount={failingCount}
-        ownerlessCount={ownerlessCount}
-        onChange={(patch) => patchUrlState({ ...patch, page: 0 })}
-      />
+          <NotificationsTabs
+            tab={urlState.tab}
+            failingCount={failingCount}
+            ownerlessCount={ownerlessCount}
+            onChange={(patch) => patchUrlState({ ...patch, page: 0 })}
+          />
 
-      <Flex gap="md" align="center">
-        <NotificationsSearchInput
-          value={urlState.query}
-          isLoading={isFetching}
-          onChange={handleSearchChange}
-        />
-        <NotificationsFilters state={urlState} onChange={patchUrlState} />
-      </Flex>
+          <Flex gap="md" align="center">
+            <NotificationsSearchInput
+              value={urlState.query}
+              isLoading={isFetching}
+              onChange={handleSearchChange}
+            />
+            <NotificationsFilters state={urlState} onChange={patchUrlState} />
+          </Flex>
 
-      <NotificationsTable
-        notifications={notifications}
-        error={error}
-        isLoading={isLoading}
-        getSelectionState={getSelectionState}
-        selectedDetailId={notificationId}
-        sorting={sorting}
-        onSortingChange={handleSortingChange}
-        onToggleRow={handleToggleRow}
-        onToggleAll={handleToggleAll}
-        onRowClick={handleRowClick}
-      />
+          <NotificationsTable
+            notifications={notifications}
+            error={error}
+            isLoading={isLoading}
+            getSelectionState={getSelectionState}
+            selectedDetailId={notificationId}
+            sorting={sorting}
+            onSortingChange={handleSortingChange}
+            onToggleRow={handleToggleRow}
+            onToggleAll={handleToggleAll}
+            onRowClick={handleRowClick}
+          />
 
-      <Flex
-        align="center"
-        justify="space-between"
-        p="md"
-        data-testid="notifications-admin-footer"
-      >
-        <PaginationControls
-          page={urlState.page}
-          pageSize={PAGE_SIZE}
-          itemsLength={notifications.length}
-          total={total}
-          onPreviousPage={() => patchUrlState({ page: urlState.page - 1 })}
-          onNextPage={() => patchUrlState({ page: urlState.page + 1 })}
-        />
+          <Flex justify="end">
+            <PaginationControls
+              page={urlState.page}
+              pageSize={PAGE_SIZE}
+              itemsLength={notifications.length}
+              total={total}
+              showTotal
+              onPreviousPage={() => patchUrlState({ page: urlState.page - 1 })}
+              onNextPage={() => patchUrlState({ page: urlState.page + 1 })}
+            />
+          </Flex>
+        </Stack>
+
+        {isSidebarOpen && (
+          <Sidebar containerWidth={containerWidth} defaultWidth={SIDEBAR_WIDTH}>
+            <NotificationDetailSidebar
+              notificationId={notificationId}
+              notificationSummary={notificationSummary}
+              isBulkLoading={isBulkLoading}
+              prevNotificationId={prevNotificationId}
+              nextNotificationId={nextNotificationId}
+              onClose={handleSidebarClose}
+              onDelete={(notification) => handleSidebarDelete(notification.id)}
+            />
+          </Sidebar>
+        )}
       </Flex>
 
       <BulkActionBar
@@ -421,21 +434,7 @@ export const NotificationsAdminPage = ({
         onConfirm={handleChangeOwnerConfirm}
       />
 
-      {isSidebarOpen && (
-        <Sidebar containerWidth={containerWidth} defaultWidth={SIDEBAR_WIDTH}>
-          <NotificationDetailSidebar
-            notificationId={notificationId}
-            notificationSummary={notificationSummary}
-            isBulkLoading={isBulkLoading}
-            prevNotificationId={prevNotificationId}
-            nextNotificationId={nextNotificationId}
-            onClose={handleSidebarClose}
-            onDelete={(notification) => handleSidebarDelete(notification.id)}
-          />
-        </Sidebar>
-      )}
-
       {confirmContent}
-    </Stack>
+    </>
   );
 };

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
@@ -439,6 +439,19 @@ describe("NotificationsAdminPage", () => {
       ).toBeInTheDocument();
     });
 
+    it("selects the keyboard-highlighted row via space", async () => {
+      setup({ notifications: [notification1, notification2] });
+      await waitForLoaderToBeRemoved();
+
+      screen.getByRole("treegrid", { name: "Notifications" }).focus();
+      await userEvent.keyboard("{ArrowDown} ");
+
+      const bar = await screen.findByTestId("toast-card");
+      expect(within(bar).getByText("1 alert selected")).toBeInTheDocument();
+      const row1 = screen.getByTestId("notification-row-1");
+      expect(within(row1).getByRole("checkbox")).toBeChecked();
+    });
+
     it("clears the selection with the Clear button", async () => {
       setup({ notifications: [notification1, notification2] });
       await waitForLoaderToBeRemoved();

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
@@ -384,6 +384,10 @@ describe("NotificationsAdminPage", () => {
       });
       await waitForLoaderToBeRemoved();
 
+      expect(await screen.findByTestId("pagination-total")).toHaveTextContent(
+        "120",
+      );
+
       const nextPage = screen.getByRole("button", { name: "Next page" });
       expect(nextPage).toBeEnabled();
 

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsTable/NotificationsTable.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsTable/NotificationsTable.tsx
@@ -1,10 +1,16 @@
-import type { Row, SortingState, Updater } from "@tanstack/react-table";
+import type {
+  OnChangeFn,
+  Row,
+  RowSelectionState,
+  SortingState,
+  Updater,
+} from "@tanstack/react-table";
 import { useCallback, useEffect, useMemo } from "react";
 import { t } from "ttag";
 
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { listChannelSummaries } from "metabase/monitor/tools/notifications/utils";
-import type { SelectionState, TreeTableColumnDef } from "metabase/ui";
+import type { TreeTableColumnDef } from "metabase/ui";
 import {
   Badge,
   Card,
@@ -30,12 +36,11 @@ type Props = {
   notifications: AdminNotification[];
   error: unknown;
   isLoading: boolean;
-  getSelectionState: (row: Row<AdminNotification>) => SelectionState;
+  rowSelection: RowSelectionState;
   selectedDetailId: NotificationId | undefined;
   sorting: SortingState;
   onSortingChange: (sorting: SortingState) => void;
-  onToggleRow: (id: NotificationId) => void;
-  onToggleAll: () => void;
+  onRowSelectionChange: OnChangeFn<RowSelectionState>;
   onRowClick?: (id: NotificationId) => void;
 };
 
@@ -45,12 +50,11 @@ export const NotificationsTable = ({
   notifications,
   error,
   isLoading,
-  getSelectionState,
+  rowSelection,
   selectedDetailId,
   sorting,
   onSortingChange,
-  onToggleRow,
-  onToggleAll,
+  onRowSelectionChange,
   onRowClick,
 }: Props) => {
   const selectedRowId =
@@ -62,13 +66,6 @@ export const NotificationsTable = ({
       onSortingChange(next);
     },
     [sorting, onSortingChange],
-  );
-
-  const handleCheckboxClick = useCallback(
-    (row: Row<AdminNotification>) => {
-      onToggleRow(row.original.id);
-    },
-    [onToggleRow],
   );
 
   const columns = useMemo<TreeTableColumnDef<AdminNotification>[]>(
@@ -200,12 +197,23 @@ export const NotificationsTable = ({
     [],
   );
 
+  const handleRowActivate = useCallback(
+    (row: Row<AdminNotification>) => {
+      onRowClick?.(row.original.id);
+    },
+    [onRowClick],
+  );
+
   const instance = useTreeTableInstance<AdminNotification>({
     data: notifications,
     columns,
     getNodeId,
     sorting,
     manualSorting: true,
+    enableRowSelection: true,
+    rowSelection,
+    onRowSelectionChange,
+    onRowActivate: handleRowActivate,
     onSortingChange: handleSortingChange,
     selectedRowId,
   });
@@ -214,13 +222,6 @@ export const NotificationsTable = ({
   useEffect(() => {
     setActiveRowId(selectedRowId);
   }, [selectedRowId, setActiveRowId]);
-
-  const handleRowClick = useCallback(
-    (row: Row<AdminNotification>) => {
-      onRowClick?.(row.original.id);
-    },
-    [onRowClick],
-  );
 
   const getRowProps = useCallback(
     (row: Row<AdminNotification>) => ({
@@ -255,12 +256,10 @@ export const NotificationsTable = ({
         instance={instance}
         hierarchical={false}
         showCheckboxes
-        getSelectionState={getSelectionState}
-        onCheckboxClick={handleCheckboxClick}
-        onHeaderCheckboxClick={onToggleAll}
+        onHeaderCheckboxClick={() => instance.table.toggleAllRowsSelected()}
         headerCheckboxAriaLabel={t`Select all`}
         ariaLabel={t`Notifications`}
-        onRowClick={handleRowClick}
+        onRowClick={handleRowActivate}
         getRowProps={getRowProps}
         emptyState={
           <Flex c="text-disabled" justify="center">{t`No results`}</Flex>

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsTable/NotificationsTable.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsTable/NotificationsTable.tsx
@@ -231,14 +231,26 @@ export const NotificationsTable = ({
 
   if (isLoading || error !== undefined) {
     return (
-      <Card withBorder p="lg" data-testid="notifications-admin-table">
+      <Card
+        flex="0 1 auto"
+        mih={0}
+        withBorder
+        p="lg"
+        data-testid="notifications-admin-table"
+      >
         <LoadingAndErrorWrapper loading={isLoading} error={error} />
       </Card>
     );
   }
 
   return (
-    <Card withBorder p={0} data-testid="notifications-admin-table">
+    <Card
+      flex="0 1 auto"
+      mih={0}
+      p={0}
+      withBorder
+      data-testid="notifications-admin-table"
+    >
       <TreeTable
         instance={instance}
         hierarchical={false}

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsTabs/NotificationsTabs.module.css
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsTabs/NotificationsTabs.module.css
@@ -4,7 +4,6 @@
 }
 
 .tab.tab {
-  padding: 6px 12px;
   background-color: transparent;
   color: var(--mb-color-text-primary);
   gap: var(--mantine-spacing-sm);
@@ -17,12 +16,6 @@
     background-color: var(--mb-color-background_surface-selected);
     color: var(--mb-color-core-brand);
   }
-}
-
-.tabLabel {
-  font-size: var(--mantine-font-size-md);
-  font-weight: bold;
-  line-height: 24px;
 }
 
 .tabSection[data-position="left"],

--- a/frontend/src/metabase/route-guards.tsx
+++ b/frontend/src/metabase/route-guards.tsx
@@ -3,6 +3,7 @@ import { connectedReduxRedirect } from "redux-auth-wrapper/history3/redirect";
 
 import { canAccessDataStudio } from "metabase/common/data-studio/selectors";
 import {
+  canAccessAlertsManagement,
   canAccessMonitor,
   canAccessMonitorDiagnostics,
   canAccessMonitoringTools,
@@ -159,6 +160,15 @@ const UserCanAccessMonitoringTools = connectedReduxRedirect<Props, State>({
   context: metabaseReduxContext,
 });
 
+const UserCanAccessAlertsManagement = connectedReduxRedirect<Props, State>({
+  wrapperDisplayName: "UserCanAccessAlertsManagement",
+  redirectPath: "/unauthorized",
+  allowRedirectBack: false,
+  authenticatedSelector: (state) => canAccessAlertsManagement(state),
+  redirectAction: routerActions.replace,
+  context: metabaseReduxContext,
+});
+
 const UserCanAccessTransforms = connectedReduxRedirect<Props, State>({
   wrapperDisplayName: "UserCanAccessTransforms",
   redirectPath: "/unauthorized",
@@ -203,6 +213,10 @@ export const CanAccessMonitorDiagnostics = UserCanAccessMonitorDiagnostics(
 );
 
 export const CanAccessMonitoringTools = UserCanAccessMonitoringTools(
+  ({ children }) => children,
+);
+
+export const CanAccessAlertsManagement = UserCanAccessAlertsManagement(
   ({ children }) => children,
 );
 

--- a/frontend/src/metabase/route-guards.unit.spec.tsx
+++ b/frontend/src/metabase/route-guards.unit.spec.tsx
@@ -12,6 +12,7 @@ import { Route } from "metabase/router";
 import { createMockUser } from "metabase-types/api/mocks";
 
 import {
+  CanAccessAlertsManagement,
   CanAccessMonitor,
   IsAuthenticated,
   IsNotAuthenticated,
@@ -177,6 +178,76 @@ describe("route-guards", () => {
       });
 
       expect(screen.getByText("monitor page")).toBeInTheDocument();
+    });
+  });
+
+  describe("CanAccessAlertsManagement", () => {
+    interface SetupOpts {
+      currentUser?: ReturnType<typeof createMockUser>;
+    }
+
+    const setup = ({ currentUser }: SetupOpts = {}) => {
+      return renderWithProviders(
+        <>
+          <Route component={CanAccessAlertsManagement}>
+            <Route
+              path="/monitor/notifications"
+              component={() => <div>alerts page</div>}
+            />
+          </Route>
+          <Route
+            path="/unauthorized"
+            component={() => <div>unauthorized</div>}
+          />
+        </>,
+        {
+          storeInitialState: createMockState({
+            currentUser,
+            settings: createMockSettingsState({ "has-user-setup": true }),
+          }),
+          withRouter: true,
+          initialRoute: "/monitor/notifications",
+        },
+      );
+    };
+
+    it("renders the page for superusers", async () => {
+      setup({ currentUser: createMockUser({ is_superuser: true }) });
+
+      expect(await screen.findByText("alerts page")).toBeInTheDocument();
+    });
+
+    it("redirects a non-admin with monitoring permission to unauthorized without redirect-back", async () => {
+      const { history } = setup({
+        currentUser: createMockUser({
+          is_superuser: false,
+          is_data_analyst: false,
+          permissions: { can_access_monitoring: true },
+        }),
+      });
+
+      await waitFor(() => {
+        expect(history?.getCurrentLocation().pathname).toBe("/unauthorized");
+      });
+
+      expect(history?.getCurrentLocation().query).toEqual({});
+      expect(screen.queryByText("alerts page")).not.toBeInTheDocument();
+    });
+
+    it("redirects an analyst to unauthorized without redirect-back", async () => {
+      const { history } = setup({
+        currentUser: createMockUser({
+          is_superuser: false,
+          is_data_analyst: true,
+        }),
+      });
+
+      await waitFor(() => {
+        expect(history?.getCurrentLocation().pathname).toBe("/unauthorized");
+      });
+
+      expect(history?.getCurrentLocation().query).toEqual({});
+      expect(screen.queryByText("alerts page")).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -73,6 +73,7 @@ import getCollectionTimelineRoutes from "metabase/timelines/collections/routes";
 
 import { trackPageView } from "./analytics";
 import {
+  CanAccessAlertsManagement,
   CanAccessDataModel,
   CanAccessDataStudio,
   CanAccessMonitor,
@@ -410,6 +411,7 @@ export const getRoutes = (store: AppStore) => {
             CanAccessMonitor,
             CanAccessMonitorDiagnostics,
             CanAccessMonitoringTools,
+            CanAccessAlertsManagement,
           )}
         </Route>
       </Route>


### PR DESCRIPTION
Closes [GDGT-2709: Update Alerts management page styling](https://linear.app/metabase/issue/GDGT-2709/update-alerts-management-page-styling)
Closes [GDGT-2794: Update Task / Run details page styling](https://linear.app/metabase/issue/GDGT-2794/update-task-run-details-page-styling)

Stacked on #77277.

### Description

This PR covers 2 tasks (sorry, hopefully it'd speed up Monitor project review a bit).

**Update Alerts management page styling**
Restyled the Alerts management page to match Monitor area.

- Removed vertical scroll on the page, only the table scrolls internally now.
- Moved pagination outside the table into a plain footer, and it now shows the total result count.

- **Also**, while testing I found that `/api/notification/admin*` endpoints are superuser-only on the backend, but the frontend route/nav link were gated by the same broader `can_access_monitoring` permission shared with every other Monitor Tools page. A non-admin with that permission (or a Data Analyst who separately has it) could reach the page, but every API call inside it would 403. Added a dedicated admin-only guard for this one route/nav link so it matches the backend restriction.

**Update Task / Run details page styling**
Extacted "Back" link from content area on Task/Run details pages, and removed dependency on page container from Admin by replacing it with local Monitor component `MonitorPageContent`.

- Also removed vertical scrolling.

### Demo

<img width="3840" height="1936" alt="image" src="https://github.com/user-attachments/assets/3434e9fd-c38b-4000-99f0-1b85898ceab4" />

<img width="3840" height="1936" alt="image" src="https://github.com/user-attachments/assets/f1acd44b-3918-4d24-90e8-040af407621a" />

<img width="3840" height="1936" alt="image" src="https://github.com/user-attachments/assets/c2e2eef0-bca1-4763-a369-255f42f5d046" />

### How to verify

1. Open `/monitor/notifications` as an admin — page doesn't scroll; the table scrolls internally, pagination sits below it showing the total count.
2. As a non-admin with the monitoring permission (or a Data Analyst), the "Alerts management" tab no longer appears in the nav, and navigating to `/monitor/notifications` directly redirects to `/unauthorized`.
3. Open `/monitor/tasks/runs` and `/monitor/tasks/list`, pick any record – check that the page has updated styling.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR