### PR TITLE
chore: prepare SDK release workflow for 63 beta

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,25 +13,25 @@ enterprise/frontend/src/metabase-enterprise/dependencies @metabase/graphy
 
 # @metabase/embedding
 
-frontend/src/metabase/embedding @metabase/embedding
-frontend/src/metabase/embedding-sdk @metabase/embedding
-frontend/src/embedding-sdk-bundle @metabase/embedding
-frontend/src/embedding-sdk-shared @metabase/embedding
-frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion @metabase/embedding
-frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard @metabase/embedding
+# frontend/src/metabase/embedding @metabase/embedding
+# frontend/src/metabase/embedding-sdk @metabase/embedding
+# frontend/src/embedding-sdk-bundle @metabase/embedding
+# frontend/src/embedding-sdk-shared @metabase/embedding
+# frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion @metabase/embedding
+# frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard @metabase/embedding
 
-enterprise/frontend/src/embedding @metabase/embedding
-enterprise/frontend/src/embedding-sdk-ee @metabase/embedding
-enterprise/frontend/src/embedding-sdk-package @metabase/embedding
+# enterprise/frontend/src/embedding @metabase/embedding
+# enterprise/frontend/src/embedding-sdk-ee @metabase/embedding
+# enterprise/frontend/src/embedding-sdk-package @metabase/embedding
 
-enterprise/frontend/src/metabase-enterprise/embedding @metabase/embedding
-enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk @metabase/embedding
-enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup @metabase/embedding
-enterprise/frontend/src/metabase-enterprise/embedding-sdk @metabase/embedding
+# enterprise/frontend/src/metabase-enterprise/embedding @metabase/embedding
+# enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk @metabase/embedding
+# enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup @metabase/embedding
+# enterprise/frontend/src/metabase-enterprise/embedding-sdk @metabase/embedding
 
-e2e/test-component @metabase/embedding
-e2e/test/scenarios/embedding @metabase/embedding
-e2e/embedding-sdk-host-apps @metabase/embedding
+# e2e/test-component @metabase/embedding
+# e2e/test/scenarios/embedding @metabase/embedding
+# e2e/embedding-sdk-host-apps @metabase/embedding
 
 # @metabase/tech-writers
 docs @metabase/tech-writers

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -8,9 +8,9 @@ on:
         description: "Branch we want to release the SDK from (to release from other branches use the workflow from those branches)"
         type: choice
         required: true
-        default: "master"
+        default: "release-x.63.x"
         options:
-          - master
+          - release-x.63.x
 
 concurrency:
   # We want to ensure only one job is running at a time per branch because
@@ -376,15 +376,6 @@ jobs:
           name: metabase-sdk
           path: sdk
 
-      - name: Compute master tag
-        id: compute-tag
-        run: |
-          if [ -n "${{ needs.determine-sdk-version.outputs.pre_release_label }}" ]; then
-            echo "masterTag=${{ needs.determine-sdk-version.outputs.pre_release_label }}" >> $GITHUB_OUTPUT
-          else
-            echo "masterTag=nightly" >> $GITHUB_OUTPUT
-          fi
-
       # Trusted publishing requires npm >= 11.5.1 and Node >= 22.14.0.
       # Node 22.x line bundles npm 10.x, so pin Node 24.x which ships npm 11.x.
       - name: Setup Node.js for npm publish with trusted publishing
@@ -396,9 +387,7 @@ jobs:
       - name: Publish to NPM
         working-directory: sdk
         run: |
-          TAG="${{ steps.compute-tag.outputs.masterTag }}"
-          echo "Resolved npm tag: $TAG"
-          npm publish --tag "$TAG"
+          npm publish --tag 63-beta
 
   # When a newer release branch goes gold, remove this entire job from this branch.
   tag-latest:

--- a/enterprise/frontend/src/embedding-sdk-package/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk-package/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.63.0-alpha",
+  "version": "0.63.0-beta",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {


### PR DESCRIPTION
Fixes EMB-2069

## Summary

Beta checklist for `release-x.63.x` per the [Embedding Checklist](https://app.notion.com/p/metabase/Embedding-Checklist-What-to-do-after-cutting-a-new-release-branch-20269354c90180808329eab86e59f20d). Mirrors the 62 beta prep PR (#75231).

- Update release workflow `branch` input: default and options changed from `master` to `release-x.63.x`
- Remove `Compute master tag` step (only needed for master/nightly releases)
- Hardcode npm publish tag to `63-beta`
- Bump `package.template.json` version from `0.63.0-alpha` to `0.63.0-beta`
- Comment out `@metabase/embedding` CODEOWNERS entries so the team doesn't get pinged on bot-approved PRs in this branch

## Notes

- Did **not** touch the `tag-latest` job — it already exists with `if: false` on this branch (arrived via backport, unlike at 62 beta time). Leaving it guarded is correct pre-gold; it gets enabled at after-gold.
- Did **not** re-add `.npmrc`/`NPM_RELEASE_TOKEN` — this branch uses OIDC trusted publishing.
- After this merges, trigger the SDK release from `release-x.63.x` (step 6 in the checklist).