### PR TITLE
Publish / unpublish tables trigger hooks properly

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_studio/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_studio/api/table.clj
@@ -127,10 +127,9 @@
           table-ids-to-update (when (seq downstream-ids)
                                 (t2/select-pks-set :model/Table :id [:in downstream-ids] :is_published true))]
       (when (seq table-ids-to-update)
-        (t2/query {:update (t2/table-name :model/Table)
-                   :set    {:collection_id nil
-                            :is_published  false}
-                   :where  [:in :id table-ids-to-update]})
+        (t2/update! :model/Table :id [:in table-ids-to-update]
+                    {:collection_id nil
+                     :is_published  false})
         ;; Publish events for audit log and remote sync tracking
         (let [updated-tables (t2/select :model/Table :id [:in table-ids-to-update])]
           (doseq [table updated-tables]
@@ -175,12 +174,11 @@
         ;; Get table IDs before update for event publishing
         table-ids-to-update (t2/select-pks-set :model/Table {:where update-where})]
     (api/check-403 (can-publish-all-tables? table-ids-to-update))
-    (t2/query {:update (t2/table-name :model/Table)
-               :set    {:collection_id (:id target-collection)
-                        :is_published  true}
-               :where  update-where})
-    ;; Publish events for audit log and remote sync tracking
     (when (seq table-ids-to-update)
+      (t2/update! :model/Table :id [:in table-ids-to-update]
+                  {:collection_id (:id target-collection)
+                   :is_published  true})
+      ;; Publish events for audit log and remote sync tracking
       (let [updated-tables (t2/select :model/Table :id [:in table-ids-to-update])]
         (doseq [table updated-tables]
           (events/publish-event! :event/table-publish {:object  table
@@ -201,12 +199,11 @@
         ;; Get table IDs before update for event publishing
         table-ids-to-update (t2/select-pks-set :model/Table {:where update-where})]
     (api/check-403 (can-publish-all-tables? table-ids-to-update))
-    (t2/query {:update (t2/table-name :model/Table)
-               :set    {:collection_id nil
-                        :is_published  false}
-               :where  update-where})
-    ;; Publish events for audit log and remote sync tracking
     (when (seq table-ids-to-update)
+      (t2/update! :model/Table :id [:in table-ids-to-update]
+                  {:collection_id nil
+                   :is_published  false})
+      ;; Publish events for audit log and remote sync tracking
       (let [updated-tables (t2/select :model/Table :id [:in table-ids-to-update])]
         (doseq [table updated-tables]
           (events/publish-event! :event/table-unpublish {:object  table

--- a/enterprise/backend/test/metabase_enterprise/data_studio/api/table_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/api/table_test.clj
@@ -2,6 +2,7 @@
   "Tests for /api/ee/data-studio/table endpoints (enterprise-only: publish-tables, unpublish-tables)."
   (:require
    [clojure.test :refer :all]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.collections.models.collection :as collection]
    [metabase.collections.test-utils :refer [without-library]]
@@ -99,6 +100,31 @@
          (is (=? {:collection_id subcollection-id
                   :is_published  true}
                  (t2/select-one :model/Table (mt/id :users)))))))))
+
+(deftest publish-tables-goes-through-toucan-hooks-test
+  (testing "publish/unpublish update via the Toucan pipeline, so model hooks fire"
+    (mt/with-premium-features #{:library}
+      (without-library
+       (mt/with-temp [:model/Collection {collection-id :id} {:type collection/library-data-collection-type}]
+         ;; a bumped updated_at proves the write went through the Toucan pipeline (:hook/timestamped?),
+         ;; the same pipeline that fires :hook/search-index; a raw UPDATE would leave it unchanged
+         (let [baseline   (t/offset-date-time 2020)
+               ;; raw update, precisely to keep the timestamped hook from overwriting the backdate
+               backdate!  #(t2/query {:update (t2/table-name :model/Table)
+                                      :set    {:updated_at baseline}
+                                      :where  [:= :id (mt/id :venues)]})
+               updated-at #(t2/select-one-fn :updated_at :model/Table (mt/id :venues))]
+           (backdate!)
+           (mt/user-http-request :crowberto :post 200 "ee/data-studio/table/publish-tables"
+                                 {:table_ids     [(mt/id :venues)]
+                                  :collection_id collection-id})
+           (testing "updated_at bumps on publish"
+             (is (pos? (compare (updated-at) baseline))))
+           (backdate!)
+           (mt/user-http-request :crowberto :post 204 "ee/data-studio/table/unpublish-tables"
+                                 {:table_ids [(mt/id :venues)]})
+           (testing "updated_at bumps on unpublish"
+             (is (pos? (compare (updated-at) baseline))))))))))
 
 (deftest requests-data-studio-feature-flag-test
   (mt/with-premium-features #{}


### PR DESCRIPTION
Table publish/unpublish updated `metabase_table` with raw `t2/query {:update ...}`, which skips the Toucan pipeline and every model hook on `:model/Table`:

- `:hook/search-index` never fires, so the search index goes stale — newly published tables don't show up in search-driven UIs (like the Library data reference pane) until the hourly reindex / semantic repair job catches up. Found while testing https://github.com/metabase/metabase/pull/76917, see the discussion starting at https://github.com/metabase/metabase/pull/76917#discussion_r3536711386.
- `:hook/timestamped?` never fires, so `updated_at` doesn't bump on publish/unpublish.
- The model's own `before-update` guards (e.g. tables may only move into Library Data collections) are bypassed; the endpoints duplicate that check inline.

The raw query dates back to #66262, when the update ran against a compound `where` that `t2/update!` can't express. Since #67327 the affected IDs are selected right before each update anyway (for event publishing), so `t2/update! :model/Table :id [:in table-ids-to-update] {...}` is a drop-in — it's already how the collection archive/delete paths unpublish tables.

Changes all three sites (`/publish-tables`, `/unpublish-tables`, `unpublish-downstream-fk-tables!`) to `t2/update!`. The endpoints now skip the update entirely when no tables match, same as the event-publishing code already did.

Not in scope, possible follow-up: publishing `:event/table-publish`/`:event/table-unpublish` from a Toucan hook instead of manually at each call site (the pattern `:model/Transform` uses). Today the collection archive/delete paths emit no `table-unpublish` events for the tables they directly unpublish — only downstream FK-remapped tables get events via `unpublish-downstream-fk-tables!`.

Regression test: `updated_at` must bump across publish/unpublish — a raw UPDATE leaves it unchanged, so it proves the write goes through the Toucan pipeline that also fires the search-index hook.
