### PR TITLE
Publish table publish/unpublish events from Toucan hooks

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2697,6 +2697,7 @@
            audit-app
            collections
            driver
+           events
            lib
            lib-be
            models

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3131,7 +3131,6 @@
    :api  #{metabase-enterprise.data-studio.api}
    :uses #{api
            collections
-           events
            models
            permissions
            premium-features

--- a/enterprise/backend/src/metabase_enterprise/data_studio/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_studio/api/table.clj
@@ -166,7 +166,9 @@
                              [:or where [:and [:in :id upstream-ids] [:= :is_published false]]]
                              where)
         table-ids-to-update (t2/select-pks-set :model/Table {:where update-where})
-        selected-ids        (t2/select-pks-set :model/Table {:where where})
+        ;; intersect so nothing outside the permission-checked set can be updated
+        selected-ids        (set/intersection table-ids-to-update
+                                              (t2/select-pks-set :model/Table {:where where}))
         upstream-only-ids   (set/difference table-ids-to-update selected-ids)]
     (api/check-403 (can-publish-all-tables? table-ids-to-update))
     (when (seq selected-ids)

--- a/enterprise/backend/src/metabase_enterprise/data_studio/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_studio/api/table.clj
@@ -165,11 +165,18 @@
         update-where       (if (seq upstream-ids)
                              [:or where [:and [:in :id upstream-ids] [:= :is_published false]]]
                              where)
-        ;; Get table IDs before update for event publishing
-        table-ids-to-update (t2/select-pks-set :model/Table {:where update-where})]
+        table-ids-to-update (t2/select-pks-set :model/Table {:where update-where})
+        selected-ids        (t2/select-pks-set :model/Table {:where where})
+        upstream-only-ids   (set/difference table-ids-to-update selected-ids)]
     (api/check-403 (can-publish-all-tables? table-ids-to-update))
-    (when (seq table-ids-to-update)
-      (t2/update! :model/Table :id [:in table-ids-to-update]
+    (when (seq selected-ids)
+      (t2/update! :model/Table :id [:in selected-ids]
+                  {:collection_id (:id target-collection)
+                   :is_published  true}))
+    ;; Recheck is_published at update time: an upstream table published concurrently since the select
+    ;; above must not be moved into this request's collection.
+    (when (seq upstream-only-ids)
+      (t2/update! :model/Table :id [:in upstream-only-ids] :is_published false
                   {:collection_id (:id target-collection)
                    :is_published  true}))
     {:target_collection target-collection}))
@@ -185,7 +192,6 @@
         update-where    (if (seq downstream-ids)
                           [:or where [:in :id downstream-ids]]
                           where)
-        ;; Get table IDs before update for event publishing
         table-ids-to-update (t2/select-pks-set :model/Table {:where update-where})]
     (api/check-403 (can-publish-all-tables? table-ids-to-update))
     (when (seq table-ids-to-update)

--- a/enterprise/backend/src/metabase_enterprise/data_studio/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_studio/api/table.clj
@@ -7,7 +7,6 @@
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.collections.core :as collection]
-   [metabase.events.core :as events]
    [metabase.models.interface :as mi]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.util.i18n :refer [tru]]
@@ -129,12 +128,7 @@
       (when (seq table-ids-to-update)
         (t2/update! :model/Table :id [:in table-ids-to-update]
                     {:collection_id nil
-                     :is_published  false})
-        ;; Publish events for audit log and remote sync tracking
-        (let [updated-tables (t2/select :model/Table :id [:in table-ids-to-update])]
-          (doseq [table updated-tables]
-            (events/publish-event! :event/table-unpublish {:object  table
-                                                           :user-id api/*current-user-id*})))))))
+                     :is_published  false})))))
 
 ;;; ------------------------------------------------ Response Schemas ------------------------------------------------
 
@@ -177,12 +171,7 @@
     (when (seq table-ids-to-update)
       (t2/update! :model/Table :id [:in table-ids-to-update]
                   {:collection_id (:id target-collection)
-                   :is_published  true})
-      ;; Publish events for audit log and remote sync tracking
-      (let [updated-tables (t2/select :model/Table :id [:in table-ids-to-update])]
-        (doseq [table updated-tables]
-          (events/publish-event! :event/table-publish {:object  table
-                                                       :user-id api/*current-user-id*}))))
+                   :is_published  true}))
     {:target_collection target-collection}))
 
 (api.macros/defendpoint :post "/unpublish-tables" :- :nil
@@ -202,12 +191,7 @@
     (when (seq table-ids-to-update)
       (t2/update! :model/Table :id [:in table-ids-to-update]
                   {:collection_id nil
-                   :is_published  false})
-      ;; Publish events for audit log and remote sync tracking
-      (let [updated-tables (t2/select :model/Table :id [:in table-ids-to-update])]
-        (doseq [table updated-tables]
-          (events/publish-event! :event/table-unpublish {:object  table
-                                                         :user-id api/*current-user-id*}))))
+                   :is_published  false}))
     nil))
 
 (def ^{:arglists '([request respond raise])} routes

--- a/enterprise/backend/test/metabase_enterprise/data_studio/api/table_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/api/table_test.clj
@@ -367,6 +367,18 @@
                  :model/Dimension  _            {:field_id y-fk :human_readable_field_id x-name :type :external}]
     (f {:coll-a coll-a :coll-b coll-b :x-id x-id :y-id y-id})))
 
+(deftest unpublish-on-collection-archive-emits-events-test
+  (mt/with-premium-features #{:library :audit-app}
+    (testing "archiving a Library collection emits table-unpublish events for its own tables, not just FK-linked ones"
+      (with-fk-linked-published-tables
+        (fn [{:keys [coll-a x-id y-id]}]
+          (mt/with-current-user (mt/user->id :crowberto)
+            (collection/archive-or-unarchive-collection!
+             (t2/select-one :model/Collection :id coll-a) {:archived true}))
+          (doseq [table-id [x-id y-id]]
+            (is (=? {:topic :table-unpublish :model "Table" :model_id table-id}
+                    (mt/latest-audit-log-entry "table-unpublish" table-id)))))))))
+
 (deftest unpublish-fk-linked-tables-on-collection-delete-test
   (mt/with-premium-features #{:library}
     (testing "deleting a Library collection unpublishes its tables and their FK-linked tables in other collections"

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -5,6 +5,7 @@
    [metabase.audit-app.core :as audit]
    [metabase.collections.models.collection :as collection]
    [metabase.driver :as driver]
+   [metabase.events.core :as events]
    [metabase.models.humanization :as humanization]
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
@@ -16,7 +17,8 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [methodical.core :as methodical]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2]
+   [toucan2.realize :as t2.realize]))
 
 ;;; ----------------------------------------------- Constants + Entity -----------------------------------------------
 
@@ -188,6 +190,45 @@
   ;; foreign key constraints in generated columns. #44866
   (t2/delete! :model/Field :table_id (:id table)))
 
+(def ^:private ^ThreadLocal pending-published-state-events
+  "Map of table id to a staged :event/table-publish or :event/table-unpublish topic.
+  Publish-state transitions are only detectable in before-update (after-update receives re-fetched
+  instances without change information), but events must be emitted after the update so that handlers
+  which re-query the table observe its new state.
+  Both hooks run on the calling thread within one Toucan pipeline, so a thread-local bridges them;
+  emitting from after-update also means a failed update publishes nothing."
+  (ThreadLocal.))
+
+(defn- stage-published-state-event!
+  "Stage :event/table-publish or :event/table-unpublish for after-update to emit when `changes` flip the
+  table's published state, or move a published table to another collection.
+  Skipped during serdes load, which includes remote-sync imports."
+  [table changes]
+  (let [staged         (or (.get pending-published-state-events) {})
+        was-published? (boolean (:is_published (t2/original table)))
+        published?     (boolean (get changes :is_published was-published?))
+        topic          (when-not mi/*deserializing?*
+                         (cond
+                           (not= was-published? published?)
+                           (if published? :event/table-publish :event/table-unpublish)
+
+                           (and published? (contains? changes :collection_id))
+                           :event/table-publish))]
+    (.set pending-published-state-events
+          (if topic
+            (assoc staged (:id table) topic)
+            (dissoc staged (:id table))))))
+
+(t2/define-after-update :model/Table
+  [table]
+  (let [staged (.get pending-published-state-events)]
+    (when-let [topic (get staged (:id table))]
+      (.set pending-published-state-events (dissoc staged (:id table)))
+      ;; realize, since after-update receives lazy TransientRows and event handlers need a full instance
+      (events/publish-event! topic {:object  (t2.realize/realize table)
+                                    :user-id api/*current-user-id*})))
+  nil)
+
 (t2/define-before-update :model/Table
   [table]
   (let [changes        (t2/changes table)
@@ -218,6 +259,7 @@
                    (= new-data-source :metabase-transform))
           (throw (ex-info "Cannot set data_source to metabase-transform"
                           {:status-code 400})))))
+    (stage-published-state-event! table changes)
     ;; Sync visibility_type and data_layer fields
     (let [changes (sync-visibility-fields changes original-table)]
       (cond

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -20,6 +20,8 @@
    [toucan2.core :as t2]
    [toucan2.realize :as t2.realize]))
 
+(set! *warn-on-reflection* true)
+
 ;;; ----------------------------------------------- Constants + Entity -----------------------------------------------
 
 (def visibility-types


### PR DESCRIPTION
Stacked on #77374.

`:event/table-publish` / `:event/table-unpublish` were published manually at each call site, which is easy to miss — the collection archive/delete paths emit no unpublish events for the tables they directly unpublish (only downstream FK-remapped tables get events via `unpublish-downstream-fk-tables!`), so the audit log and remote-sync tracking never see those unpublishes. This moves the events into the `:model/Table` Toucan hooks (the pattern `:model/Transform` uses), so every code path that flips a table's published state emits them.

**Design note:** the two halves of the work live in different hooks out of necessity. Only `before-update` can see `t2/changes` (after-update receives re-fetched instances), but events must be emitted *after* the write because handlers re-query the table — remote-sync hydrates `model_collection_id` from the DB, and a pre-write event would record the stale collection. So `before-update` stages the detected transition in a thread-local and `after-update` publishes it; both run on the calling thread within one Toucan pipeline. A nice side effect: if the UPDATE fails, no event is emitted (the manual version had the same property; a naive before-update publish would not).

Behavior changes:
- The collection archive/delete paths now emit `table-unpublish` for the tables they directly unpublish (new audit rows + remote-sync tracking). This looks like it was always the intent — the FK-linked tables already got events.
- Publishing an already-published table to the same collection no longer emits an event (Toucan computes per-row diffs, so a no-op update stages nothing). Moving a published table to a different collection still emits `table-publish`, matching the endpoint's previous behavior.
- Events are suppressed during serdes load (`mi/*deserializing?*`), which covers remote-sync imports — same guard `:model/Transform` uses.
