### PR TITLE
fix: shrink static embed iframe on content height decrease (EMB-1496)

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -1121,6 +1121,102 @@ describe("scenarios > embedding > dashboard appearance", () => {
     });
   });
 
+  it("should shrink iframe height when navigating from a tall tab to a short tab (metabase#71512)", () => {
+    const TAB_TALL = { id: 1, name: "Tall tab" };
+    const TAB_SHORT = { id: 2, name: "Short tab" };
+
+    const dashboardDetails = {
+      name: "dashboard name",
+      enable_embedding: true,
+      tabs: [TAB_TALL, TAB_SHORT],
+    };
+
+    const questionDetails = {
+      name: "Line chart",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        breakout: [
+          [
+            "field",
+            ORDERS.CREATED_AT,
+            { "base-type": "type/DateTime", "temporal-unit": "month" },
+          ],
+        ],
+        limit: 5,
+      },
+      display: "bar",
+    };
+
+    H.createQuestion(questionDetails)
+      .then(({ body: { id: card_id } }) => {
+        H.createDashboardWithTabs({
+          ...dashboardDetails,
+          dashcards: [
+            {
+              id: -1,
+              card_id,
+              dashboard_tab_id: TAB_TALL.id,
+              row: 0,
+              col: 0,
+              size_x: 8,
+              size_y: 20,
+            },
+            {
+              id: -2,
+              card_id,
+              dashboard_tab_id: TAB_SHORT.id,
+              row: 0,
+              col: 0,
+              size_x: 8,
+              size_y: 2,
+            },
+          ],
+        });
+      })
+      .then((dashboard) => {
+        return H.getEmbeddedPageUrl({
+          resource: { dashboard: dashboard.id },
+          params: {},
+        });
+      })
+      .then((urlOptions) => {
+        const baseUrl = Cypress.config("baseUrl");
+        Cypress.config("baseUrl", null);
+        cy.visit(
+          `e2e/test/scenarios/embedding/embedding-dashboard.html?iframeUrl=${baseUrl + urlOptions.url}`,
+        );
+      });
+
+    H.getIframeBody().within(() => {
+      cy.findByText(questionDetails.name).should("exist");
+    });
+
+    // let the resizer settle on the tall tab before capturing the "grown" height
+    cy.wait(1000);
+
+    cy.get("#iframe")
+      .invoke("prop", "clientHeight")
+      .should("be.greaterThan", 1000)
+      .then((tallHeight) => {
+        H.getIframeBody().within(() => {
+          cy.findByRole("tab", { name: TAB_SHORT.name }).click();
+          cy.findByRole("tab", { name: TAB_SHORT.name }).should(
+            "have.attr",
+            "aria-selected",
+            "true",
+          );
+        });
+
+        // give iframe-resizer a chance to recompute after the tab switch
+        cy.wait(1000);
+
+        cy.get("#iframe")
+          .invoke("prop", "clientHeight")
+          .should("be.lessThan", tallHeight);
+      });
+  });
+
   it("should allow to set locale from the `#locale` hash parameter (metabase#50182)", () => {
     cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {
       enable_embedding: true,

--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -1192,29 +1192,24 @@ describe("scenarios > embedding > dashboard appearance", () => {
       cy.findByText(questionDetails.name).should("exist");
     });
 
-    // let the resizer settle on the tall tab before capturing the "grown" height
-    cy.wait(1000);
-
+    // the tall tab grows the iframe past 1000px
     cy.get("#iframe")
       .invoke("prop", "clientHeight")
-      .should("be.greaterThan", 1000)
-      .then((tallHeight) => {
-        H.getIframeBody().within(() => {
-          cy.findByRole("tab", { name: TAB_SHORT.name }).click();
-          cy.findByRole("tab", { name: TAB_SHORT.name }).should(
-            "have.attr",
-            "aria-selected",
-            "true",
-          );
-        });
+      .should("be.greaterThan", 1000);
 
-        // give iframe-resizer a chance to recompute after the tab switch
-        cy.wait(1000);
+    H.getIframeBody().within(() => {
+      cy.findByRole("tab", { name: TAB_SHORT.name }).click();
+      cy.findByRole("tab", { name: TAB_SHORT.name }).should(
+        "have.attr",
+        "aria-selected",
+        "true",
+      );
+    });
 
-        cy.get("#iframe")
-          .invoke("prop", "clientHeight")
-          .should("be.lessThan", tallHeight);
-      });
+    // switching to the short tab shrinks the iframe well below the tall
+    // height -- assert a 500px ceiling (the real shrunk height is smaller
+    // still); the assertion retries until the resizer recomputes
+    cy.get("#iframe").invoke("prop", "clientHeight").should("be.lessThan", 500);
   });
 
   it("should allow to set locale from the `#locale` hash parameter (metabase#50182)", () => {

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -1,6 +1,5 @@
 import cx from "classnames";
-import { type ReactNode, useRef, useState } from "react";
-import { useMount } from "react-use";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import _ from "underscore";
 
 import { TitleAndDescription } from "metabase/common/components/TitleAndDescription";
@@ -130,9 +129,12 @@ export const EmbedFrame = ({
   const [hasFrameScroll, setHasFrameScroll] = useState(!isEmbeddingSdk());
   const rootRef = useRef<HTMLDivElement>(null);
 
-  useMount(() => {
-    initializeIframeResizer(() => setHasFrameScroll(false), rootRef.current);
-  });
+  useEffect(() => {
+    return initializeIframeResizer(
+      () => setHasFrameScroll(false),
+      rootRef.current,
+    );
+  }, []);
 
   const parameterPanelRef = useRef<HTMLElement>(null);
   const {

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -128,9 +128,10 @@ export const EmbedFrame = ({
   });
 
   const [hasFrameScroll, setHasFrameScroll] = useState(!isEmbeddingSdk());
+  const rootRef = useRef<HTMLDivElement>(null);
 
   useMount(() => {
-    initializeIframeResizer(() => setHasFrameScroll(false));
+    initializeIframeResizer(() => setHasFrameScroll(false), rootRef.current);
   });
 
   const parameterPanelRef = useRef<HTMLElement>(null);
@@ -182,6 +183,7 @@ export const EmbedFrame = ({
 
   return (
     <Root
+      ref={rootRef}
       hasScroll={hasFrameScroll}
       isBordered={bordered}
       hasVisibleOverflowWhenPriting={isPublicDashboard}

--- a/frontend/src/metabase/utils/dom.ts
+++ b/frontend/src/metabase/utils/dom.ts
@@ -148,7 +148,10 @@ export function isSameOrSiteUrlOrigin(url: string): boolean {
   return isSameOrigin(url) || isSiteUrlOrigin(url);
 }
 
-export function initializeIframeResizer(onReady = () => {}): void {
+export function initializeIframeResizer(
+  onReady = () => {},
+  contentElement?: Element | null,
+): void {
   if (!isWithinIframe()) {
     return;
   }
@@ -161,14 +164,38 @@ export function initializeIframeResizer(onReady = () => {}): void {
   } else {
     window.iFrameResizer = {
       autoResize: true,
-      heightCalculationMethod: "max",
-      onReady,
+      heightCalculationMethod: "lowestElement",
+      onReady: () => {
+        onReady();
+        if (contentElement) {
+          observeContentElementHeight(contentElement);
+        }
+      },
     };
 
     // Make iframe-resizer available to the embed
     // We only care about contentWindow so require that minified file
     import("iframe-resizer/js/iframeResizer.contentWindow.js");
   }
+}
+
+// The app shell wraps embed content in a scrollable container pinned to the
+// viewport height, so the page can scroll internally. That means
+// document/body scrollHeight (and even bounding-rect-based measurements
+// like "lowestElement") can never report less than the iframe's current
+// height once it has grown -- the wrapping container always presents its
+// own fixed size to everything above it. `contentElement` is the actual
+// embed content (not the scrolling wrapper), so we measure its real height
+// and push it to the parent directly via `window.parentIFrame.size()`,
+// bypassing iframe-resizer's built-in (viewport-bound) calculation.
+function observeContentElementHeight(contentElement: Element): void {
+  const reportHeight = () => {
+    window.parentIFrame?.size(contentElement.getBoundingClientRect().height);
+  };
+
+  const resizeObserver = new ResizeObserver(reportHeight);
+  resizeObserver.observe(contentElement);
+  reportHeight();
 }
 
 export function isEventOverElement(

--- a/frontend/src/metabase/utils/dom.ts
+++ b/frontend/src/metabase/utils/dom.ts
@@ -148,12 +148,14 @@ export function isSameOrSiteUrlOrigin(url: string): boolean {
   return isSameOrigin(url) || isSiteUrlOrigin(url);
 }
 
+// Returns a cleanup function (disconnects the content-height observer) meant to
+// be returned from the caller's `useEffect` so it runs on unmount.
 export function initializeIframeResizer(
   onReady = () => {},
   contentElement?: Element | null,
-): void {
+): () => void {
   if (!isWithinIframe()) {
-    return;
+    return () => {};
   }
 
   // Make iFrameResizer available so that embed users can
@@ -161,41 +163,40 @@ export function initializeIframeResizer(
   if (window.iFrameResizer) {
     console.error("iFrameResizer resizer already defined.");
     onReady();
-  } else {
-    window.iFrameResizer = {
-      autoResize: true,
-      heightCalculationMethod: "lowestElement",
-      onReady: () => {
-        onReady();
-        if (contentElement) {
-          observeContentElementHeight(contentElement);
-        }
-      },
-    };
-
-    // Make iframe-resizer available to the embed
-    // We only care about contentWindow so require that minified file
-    import("iframe-resizer/js/iframeResizer.contentWindow.js");
+    return () => {};
   }
-}
 
-// The app shell wraps embed content in a scrollable container pinned to the
-// viewport height, so the page can scroll internally. That means
-// document/body scrollHeight (and even bounding-rect-based measurements
-// like "lowestElement") can never report less than the iframe's current
-// height once it has grown -- the wrapping container always presents its
-// own fixed size to everything above it. `contentElement` is the actual
-// embed content (not the scrolling wrapper), so we measure its real height
-// and push it to the parent directly via `window.parentIFrame.size()`,
-// bypassing iframe-resizer's built-in (viewport-bound) calculation.
-function observeContentElementHeight(contentElement: Element): void {
-  const reportHeight = () => {
-    window.parentIFrame?.size(contentElement.getBoundingClientRect().height);
+  let disconnectObserver: (() => void) | undefined;
+
+  window.iFrameResizer = {
+    autoResize: true,
+    heightCalculationMethod: "lowestElement",
+    onReady: () => {
+      onReady();
+      if (contentElement) {
+        disconnectObserver = observeContentElementHeight(contentElement);
+      }
+    },
   };
 
-  const resizeObserver = new ResizeObserver(reportHeight);
+  // Make iframe-resizer available to the embed
+  // We only care about contentWindow so require that minified file
+  import("iframe-resizer/js/iframeResizer.contentWindow.js");
+
+  return () => disconnectObserver?.();
+}
+
+// `contentElement` is the real embed content, not the app shell's viewport-
+// pinned scroll wrapper. Measuring it directly and pushing the height via
+// `parentIFrame.size()` lets the iframe shrink -- something iframe-resizer's
+// viewport-bound calculation can't do once the frame has grown.
+function observeContentElementHeight(contentElement: Element): () => void {
+  const resizeObserver = new ResizeObserver(([entry]) => {
+    window.parentIFrame?.size(entry.contentRect.height);
+  });
   resizeObserver.observe(contentElement);
-  reportHeight();
+
+  return () => resizeObserver.disconnect();
 }
 
 export function isEventOverElement(

--- a/frontend/src/types/global.d.ts
+++ b/frontend/src/types/global.d.ts
@@ -36,6 +36,12 @@ interface Window {
     onReady?: () => void;
   };
 
+  // Set by iframe-resizer's contentWindow script once it's initialized;
+  // lets embed content explicitly report its real size to the parent.
+  parentIFrame?: {
+    size: (customHeight?: number, customWidth?: number) => void;
+  };
+
   MetabaseSiteLocalization?: {
     headers: {
       language: string;


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71512
Fixes https://linear.app/metabase/issue/EMB-1496/static-embedding-never-shrink

### Description

Static embeds (signed `/embed/dashboard/:token`) grow to fit their content but never shrink back — switching from a tall dashboard tab to a short one leaves a big empty gap below. The iframe-resizer was set to only ever grow; this makes the height track content both ways, so it shrinks when the content gets shorter.

**Scope: master only, no backport.** Static embedding has been superseded by Guest embeds (its setup UI is guest-only from v58 on) and this is a low-severity (P3) polish, so it isn't worth backporting. The signed-embed runtime is still live on current versions, so the fix still benefits existing static embeds.

### How to verify

There's no way to create a static embed through the UI on master (the Embed flow is Guest-only now), so verification is the e2e repro. It drives the real signed-embed runtime and asserts the iframe grows on a tall tab, then shrinks after switching to a short tab:

- `e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js` → "should shrink iframe height when navigating from a tall tab to a short tab (metabase#71512)"

### Demo

#### After: There is no scrollbar

<img width="1229" height="776" alt="image" src="https://github.com/user-attachments/assets/94e8762b-43ac-47b1-9cfb-0e6c89691460" />

#### Before: There is a scrollbar left because that is how tall the first tab is
<img width="1234" height="774" alt="image" src="https://github.com/user-attachments/assets/4627f791-7357-4b42-a196-a820ea16c4ee" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass stress testing (n/a)
