### PR TITLE
fix(sdk-bundle): restore back button after "Edit question" in embedded dashboards

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/EditableDashboard/enterprise.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/EditableDashboard/enterprise.unit.spec.tsx
@@ -129,6 +129,28 @@ describe("EditableDashboard", () => {
     expect(screen.getByText("Test dashboard")).toBeInTheDocument();
   });
 
+  it("should allow to go back to the dashboard after editing a question from the dashcard menu (EMB-2012)", async () => {
+    await setupEnterprise({ dashboardName: "Test dashboard" });
+
+    const dashcard = screen.getAllByTestId("dashcard").at(0);
+    await userEvent.click(within(dashcard!).getByTestId("dashcard-menu"));
+
+    const menu = await screen.findByRole("menu");
+    await userEvent.click(within(menu).getByText("Edit question"));
+
+    // We should be in the question view
+    expect(
+      await screen.findByTestId("query-visualization-root"),
+    ).toBeInTheDocument();
+
+    // The back button should be there, just like when drilling into a question
+    const backButton = await screen.findByLabelText("Back to Test dashboard");
+    await userEvent.click(backButton);
+
+    // We should be back on the dashboard
+    expect(await screen.findByTestId("dashboard-grid")).toBeInTheDocument();
+  });
+
   it("should allow to pass `dataPickerProps.entityTypes` to the query builder", async () => {
     await setupEnterprise({
       dataPickerProps: {

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -438,6 +438,23 @@ const SdkDashboardInner = ({
     ],
   );
 
+  // "Edit question" opens the card via adhocQuestionUrl without going through
+  // onNavigateToNewCardFromDashboard, so it never pushes to the navigation stack
+  // and the back button stays hidden. Push a virtual entry here so the question
+  // view renders a back button to the dashboard, matching the drill-in flow.
+  const onEditQuestionWithNav = useCallback(
+    (question: Parameters<typeof onEditQuestion>[0]) => {
+      sdkNavigation?.push({
+        type: "open-card",
+        virtual: true,
+        name: question.displayName() ?? t`Question`,
+        onPop: () => onNavigateBackToDashboard(),
+      });
+      onEditQuestion(question);
+    },
+    [onEditQuestion, sdkNavigation, onNavigateBackToDashboard],
+  );
+
   if (isLocaleLoading) {
     return (
       <MaybeStyledWrapper
@@ -598,7 +615,7 @@ const SdkDashboardInner = ({
           .with({ finalRenderMode: "dashboard" }, () => (
             <SdkDashboardProvider
               plugins={plugins}
-              onEditQuestion={onEditQuestion}
+              onEditQuestion={onEditQuestionWithNav}
             >
               {children ?? (
                 <MaybeStyledWrapper


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76796
Closes [EMB-2012: Embedded editableDashboard loses back navigation after "Edit Question"](https://linear.app/metabase/issue/EMB-2012/embedded-editabledashboard-loses-back-navigation-after-edit-question)

### Description

In the SDK's embedded `editableDashboard`, the question view's back button is
`SdkInternalNavigationBackButton`, which only renders when the internal
navigation stack has more than one entry (`canGoBack`). Drilling into a card
runs through `onNavigateToNewCardFromDashboard`, which pushes a virtual entry —
so the button appears. But **"Edit question"** goes through `onEditQuestion`,
which sets `adhocQuestionUrl` directly and never pushes to the stack, leaving it
at `[dashboard]`. Result: no back button, and no way back to the dashboard.

Fix: wrap `onEditQuestion` in `onEditQuestionWithNav`, which pushes a virtual
`open-card` entry (with `onPop` → navigate back to the dashboard) before opening
the question, mirroring the drill-in flow.

Before
<img width="1449" height="766" alt="SCR-20260709-nvzl" src="https://github.com/user-attachments/assets/81a65936-1e37-40b0-810f-dfe8a4faa32e" />

After
<img width="1449" height="766" alt="SCR-20260709-nvtw" src="https://github.com/user-attachments/assets/fd43c74d-34c2-4d4b-9403-3a9b0afd71d0" />

### How to verify

1. Embed an `editableDashboard` with the React SDK and set `enableEntityNavigation`.
2. Click the three-dot menu on a dashboard question card.
3. Select **Edit question**.
4. A **"Back to <dashboard name>"** button now renders in the question toolbar; clicking it returns to the dashboard — matching the drill-in and new-question flows.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR