### PR TITLE
[GDGT-2688] content diagnostics stale api

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2982,14 +2982,19 @@
 
   enterprise/content-diagnostics
   {:team "Gadget"
-   :api  #{metabase-enterprise.content-diagnostics.init}
-   :uses #{models
+   :api  #{metabase-enterprise.content-diagnostics.api
+           metabase-enterprise.content-diagnostics.init}
+   :uses #{api
+           collections
+           models
            premium-features
+           request
            settings
            task
            util
            enterprise/stale}
    :model-imports #{:model/Card
+                    :model/Collection
                     :model/Dashboard
                     :model/Document
                     :model/Transform

--- a/enterprise/backend/src/metabase_enterprise/api_routes/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/api_routes/routes.clj
@@ -14,6 +14,7 @@
    [metabase-enterprise.billing.api.routes]
    [metabase-enterprise.cloud-add-ons.api]
    [metabase-enterprise.cloud-proxy.api]
+   [metabase-enterprise.content-diagnostics.api]
    [metabase-enterprise.content-translation.routes]
    [metabase-enterprise.content-verification.api.routes]
    [metabase-enterprise.custom-viz-plugin.api]
@@ -57,6 +58,7 @@
    :attached-dwh               (deferred-tru "Attached DWH")
    :audit-app                  (deferred-tru "Audit app")
    :collection-cleanup         (deferred-tru "Collection Cleanup")
+   :content-diagnostics        (deferred-tru "Content Diagnostics")
    :content-translation        (deferred-tru "Content translation")
    :custom-viz                 (deferred-tru "Custom Visualizations")
    :library                    (deferred-tru "Library")
@@ -106,6 +108,7 @@
    "/ai-controls"                  (premium-handler metabase-enterprise.metabot.api.routes/routes :ai-controls)
    "/audit-app"                    (premium-handler metabase-enterprise.audit-app.api.routes/routes :audit-app)
    "/billing"                      metabase-enterprise.billing.api.routes/routes
+   "/content-diagnostics"          (premium-handler metabase-enterprise.content-diagnostics.api/routes :content-diagnostics)
    "/content-translation"          (premium-handler metabase-enterprise.content-translation.routes/routes :content-translation)
    "/custom-viz-plugin"            (premium-handler metabase-enterprise.custom-viz-plugin.api/routes :custom-viz)
    "/cloud-add-ons"                metabase-enterprise.cloud-add-ons.api/routes

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -214,7 +214,7 @@
    :name         :entity_name
    :created-at   :entity_created_at
    :created-by   :entity_creator_name
-   :last-used-at :last_active_at})
+   :last-active-at :last_active_at})
 
 (def ^:private stale-entity-types
   "Entity types the `stale` finding type covers - every covered type emits today (see
@@ -258,7 +258,7 @@
   collection are excluded. `entity-types` (repeatable; `card`|`dashboard`|`document`|`transform`, omitted =
   all). `threshold-days` (positive int) keeps findings with `last_active_at` on or before `today -
   threshold-days` (never-used always pass). `query` case-insensitively substring-matches the entity name.
-  `sort-column` (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`last-used-at`, default
+  `sort-column` (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`last-active-at`, default
   `detected-at`) + `sort-direction` (`asc`|`desc`, default `asc`); `id` is the stable tiebreak."
   [_route-params
    {:keys [include-personal-collections sort-column sort-direction entity-types threshold-days query]

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -1,0 +1,295 @@
+(ns metabase-enterprise.content-diagnostics.api
+  "Content Diagnostics API - a paginated, batch-hydrated latest-per-entity finding list, mounted
+  behind `premium-handler … :content-diagnostics` (`+auth` + feature gate). The scan runs on a Quartz job.
+
+  Response shape: a flat identity (`id, finding_type, entity_type, entity_id, detected_at,
+  entity_display_name`) plus a nested typed `details` merging the stored verdict with live-hydrated
+  `collection`, `description`, `owner`, and `creator`."
+  (:require
+   [clojure.string :as str]
+   [java-time.api :as t]
+   [medley.core :as m]
+   [metabase-enterprise.content-diagnostics.scan :as scan]
+   [metabase.api.macros :as api.macros]
+   [metabase.api.routes.common :refer [+auth]]
+   [metabase.collections.models.collection :as collection]
+   [metabase.request.core :as request]
+   [metabase.util :as u]
+   [metabase.util.malli.schema :as ms]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- valid-clause
+  "Result set for one `finding-type`: its latest finding per entity, excluding entities whose latest row
+  is invalidated (an older valid row does not resurface)."
+  [finding-type]
+  [:and
+   [:= :invalidated_at nil]
+   [:= :finding_type finding-type]
+   ;; latest finding per entity = MAX(id) per (entity_type, entity_id, finding_type). id is the recency
+   ;; key (monotonic; scan_id is a random UUID). Latest-per-entity, not newest-scan-only, so an entity a
+   ;; partial scan hasn't re-written yet still shows its last finding.
+   [:in :id {:select   [[[:max :id] :id]]
+             :from     [(t2/table-name :model/ContentDiagnosticsFinding)]
+             :group-by [:entity_type :entity_id :finding_type]}]])
+
+;;; ------------------------------ per-caller read-time filters (shared) --------------------------------
+;;; Resolved live at read time against each entity's *current* collection (not scan-time
+;;; `scope_collection_id`): visibility (always) + personal-collection exclusion (param-gated).
+
+(defn- entity-collection-clauses
+  "Per entity-type, a clause keeping findings whose entity's current `collection_id` satisfies `coll-pred`.
+  Resolved live against the entity's own table (`scan/entity-type->model`); entity-types with no model
+  contribute nothing. Callers combine the seq with `:or`/`:and`."
+  [coll-pred]
+  (for [[etype model] scan/entity-type->model]
+    [:and
+     [:= :entity_type (name etype)]
+     [:in :entity_id {:select [:id]
+                      :from   [(t2/table-name model)]
+                      :where  coll-pred}]]))
+
+(defn- visible-findings-clause
+  "Keep only findings whose entity is in a collection the current user can read - always applied.
+  Fail-closed: an entity-type with no collection model is dropped."
+  []
+  (into [:or] (entity-collection-clauses (collection/visible-collection-filter-clause :collection_id))))
+
+(defn- personal-collection-ids
+  "Live set of collection ids that are, or are nested under, a personal collection - a `personal_owner_id`
+  root plus any `location` descendant. Empty when there are none."
+  []
+  (if-let [roots (not-empty (t2/select-pks-vec :model/Collection :personal_owner_id [:not= nil]))]
+    (t2/select-pks-set :model/Collection
+                       {:where (into [:or [:in :id roots]]
+                                     (map (fn [pid] [:like :location (str "/" pid "/%")]))
+                                     roots)})
+    #{}))
+
+(defn- name-search-clause
+  "Case-insensitive substring match on the denormalized `entity_name`. Nil for a blank/absent query.
+  `%`/`_` are not escaped - they act as LIKE wildcards, matching the app's fuzzy name search."
+  [query]
+  (when-let [q (some-> query str/trim not-empty u/lower-case-en)]
+    [:like [:lower :entity_name] (str "%" q "%")]))
+
+(defn- exclude-personal-collections-clause
+  "WHERE fragment dropping findings whose entity currently lives in a personal collection (root and
+  regular-collection entities are kept). Nil when there is nothing to exclude."
+  []
+  (when-let [pids (seq (personal-collection-ids))]
+    (into [:and]
+          (map (fn [clause] [:not clause]))
+          (entity-collection-clauses [:in :collection_id pids]))))
+
+;;; ----------------------------------- display hydration (shared layer) --------------------------------
+;;; name/created_at/last_active_at/creator are denormalized (frozen at scan time); description + the
+;;; collection breadcrumb are live-hydrated, batched per entity-type.
+
+(defn- entity-context
+  "For one entity-type's id set → `{entity-id → row}`. Live-hydrates only the non-denormalized display
+  fields: `description`, `collection_id`, and (transform only) the owner. `document` has no description."
+  [entity-type ids]
+  (when-let [model (scan/entity-type->model entity-type)]
+    (let [cols (cond-> [:id :collection_id]
+                 (not= entity-type :document) (conj :description)
+                 (= entity-type :transform)   (conj :owner_user_id :owner_email))
+          rows (cond-> (t2/select (into [model] cols) :id [:in (set ids)])
+                 ;; reuse the transform model's batched :owner hydrate (user row, or {:email …} external)
+                 (= entity-type :transform) (t2/hydrate :owner))]
+      (m/index-by :id rows))))
+
+(defn- collection-breadcrumbs
+  "For a set of collection ids → `{collection-id → {:id :name :effective_ancestors [{:id :name} …]}}`.
+  Hydrates the permission-filtered `:effective_ancestors` breadcrumb. Selects the full row (the hydrate
+  needs `:location`). No entry for root/nil collections."
+  [coll-ids]
+  (when (seq coll-ids)
+    (let [colls (t2/hydrate (t2/select :model/Collection :id [:in (set coll-ids)])
+                            :effective_ancestors)]
+      (into {}
+            (map (fn [c]
+                   [(:id c)
+                    {:id                  (:id c)
+                     :name                (:name c)
+                     :effective_ancestors (mapv #(select-keys % [:id :name]) (:effective_ancestors c))}]))
+            colls))))
+
+(defn- normalized-owner
+  "Normalized `owner` from the transform `:owner` hydrate: `{id,name,email,type:user}` or, for an external
+  email-only owner, `{email,type:external}`. Nil for entity types with no owner (card/dashboard/document)."
+  [{:keys [owner]}]
+  (when owner
+    (let [{:keys [id common_name email]} owner]
+      (if id
+        {:id id :name common_name :email email :type :user}
+        {:email email :type :external}))))
+
+(defn- hydrate-findings
+  "Project stored findings into the response shape: flat identity + denormalized display fields, plus a
+  nested `details` = stored verdict + {collection, description, owner, creator}. Batched, page-size-independent."
+  [findings]
+  (let [ctx-by-type (into {} (for [[etype rows] (group-by :entity_type findings)]
+                               [etype (entity-context etype (map :entity_id rows))]))
+        coll-ids    (into #{} (keep (fn [{:keys [entity_type entity_id]}]
+                                      (get-in ctx-by-type [entity_type entity_id :collection_id])))
+                          findings)
+        breadcrumbs (collection-breadcrumbs coll-ids)]
+    (mapv (fn [{:keys [id finding_type entity_type entity_id detected_at last_active_at entity_created_at
+                       entity_name entity_creator_id entity_creator_name details]}]
+            (let [entity (get-in ctx-by-type [entity_type entity_id])]
+              {:id                  id
+               :finding_type        finding_type
+               :entity_type         entity_type
+               :entity_id           entity_id
+               :detected_at         detected_at
+               :entity_display_name entity_name
+               :last_active_at      last_active_at
+               :created_at          entity_created_at
+               :details             (merge details
+                                           {:collection  (get breadcrumbs (:collection_id entity))
+                                            :description (:description entity)
+                                            ;; only transforms have owner columns; null for the rest.
+                                            :owner       (normalized-owner entity)
+                                            ;; creator denormalized (id + common_name) - no live :creator hydrate.
+                                            :creator     (when entity_creator_id
+                                                           {:id entity_creator_id :name entity_creator_name :type :user})})}))
+          findings)))
+
+(defn- last-scan-at
+  "`detected_at` of the most recent finding overall (≈ the latest scan's time), or nil if none."
+  []
+  (t2/select-one-fn :detected_at :model/ContentDiagnosticsFinding {:order-by [[:detected_at :desc]]}))
+
+;;; -------------------------------------------- response schema ----------------------------------------
+
+(def ^:private NormalizedUser
+  "A finding's `owner`: a Metabase user `{id,name,email,type:user}`, or - for an external transform owner -
+  `{email,type:external}`, or nil. Keys optional to admit both variants."
+  [:maybe [:map
+           [:id    {:optional true} [:maybe :int]]
+           [:name  {:optional true} [:maybe :string]]
+           [:email {:optional true} [:maybe :string]]
+           [:type  :keyword]]])
+
+(def ^:private Creator
+  "A finding's `creator`: a Metabase user `{id,name,type:user}` (denormalized from
+  `entity_creator_id`/`entity_creator_name`), or nil. No `email` (not denormalized); `type` is always `:user`."
+  [:maybe [:map {:closed true}
+           [:id   :int]
+           [:name [:maybe :string]]
+           [:type [:= :user]]]])
+
+(def ^:private StaleFinding
+  "Response item for a `stale` finding: flat identity + nested typed `details`."
+  [:map
+   [:id                  :int]
+   [:finding_type        :keyword]
+   [:entity_type         :keyword]
+   [:entity_id           :int]
+   [:detected_at         some?]
+   [:entity_display_name [:maybe :string]]
+   ;; frozen scan-time activity anchor; nil ⇒ never used/ran (top-level, SQL-filterable by threshold-days)
+   [:last_active_at      [:maybe some?]]
+   ;; entity's created_at, denormalized at scan time (immutable ⇒ equals live)
+   [:created_at          [:maybe some?]]
+   [:details
+    [:map
+     [:collection     [:maybe :map]]
+     [:description    [:maybe :string]]
+     [:owner          NormalizedUser]
+     [:creator        Creator]
+     [:threshold_days {:optional true} :int]]]])
+
+(def ^:private sort-directions
+  "Valid sort directions for the stale list."
+  #{:asc :desc})
+
+(def ^:private sort-column->field
+  "Sortable stale-list params → their native `content_diagnostics_finding` column. Entity attributes are
+  denormalized at scan time (see `scan/stale-checker`), so sorting is a plain `ORDER BY` with no join."
+  {:detected-at  :detected_at
+   :entity-type  :entity_type
+   :name         :entity_name
+   :created-at   :entity_created_at
+   :created-by   :entity_creator_name
+   :last-used-at :last_active_at})
+
+(def ^:private stale-entity-types
+  "Entity types the `stale` finding type covers - every covered type emits today (see
+  `scan/entity-type->model`)."
+  #{:card :dashboard :document :transform})
+
+(defn- stale-where-clause
+  "WHERE for the stale list: the valid + permission-visible base, narrowed by the optional per-request
+  filters. Each optional filter is precomputed so a nil (no-op) filter is skipped, not conjoined as a
+  null AND-term."
+  [{:keys [include-personal-collections entity-types threshold-days query]}]
+  (let [personal-filter    (when-not include-personal-collections (exclude-personal-collections-clause))
+        entity-type-filter (when-let [types (not-empty (u/one-or-many entity-types))]
+                             [:in :entity_type (mapv name types)])
+        ;; "less stale than threshold-days" = active more recently than the cutoff → excluded. Never-used
+        ;; (`last_active_at` nil) is maximally stale, so it always passes. Mirrors the scan-time cutoff.
+        threshold-filter   (when threshold-days
+                             (let [cutoff (t/minus (t/local-date) (t/days threshold-days))]
+                               [:or [:= :last_active_at nil] [:<= :last_active_at cutoff]]))
+        name-search-filter (name-search-clause query)]
+    (cond-> [:and (valid-clause "stale") (visible-findings-clause)]
+      personal-filter    (conj personal-filter)
+      entity-type-filter (conj entity-type-filter)
+      threshold-filter   (conj threshold-filter)
+      name-search-filter (conj name-search-filter))))
+
+;;; ------------------------------------------------ endpoints ------------------------------------------
+
+(api.macros/defendpoint :get "/stale"
+  :- [:map
+      [:data         [:sequential StaleFinding]]
+      [:total        :int]
+      [:limit        [:maybe :int]]
+      [:offset       [:maybe :int]]
+      [:last_scan_at [:maybe some?]]]
+  "List **stale** findings - the latest valid `stale` finding per entity, permission-filtered
+  for the current user. Each item is a flat identity + a nested `details` (collection, `description`, `owner`,
+  `creator`, `threshold_days`). Paginated via `limit`/`offset`; `total` is the full valid count.
+
+  Params: `include-personal-collections` (default false) - when false, entities currently in a personal
+  collection are excluded. `entity-types` (repeatable; `card`|`dashboard`|`document`|`transform`, omitted =
+  all). `threshold-days` (positive int) keeps findings with `last_active_at` on or before `today -
+  threshold-days` (never-used always pass). `query` case-insensitively substring-matches the entity name.
+  `sort-column` (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`last-used-at`, default
+  `detected-at`) + `sort-direction` (`asc`|`desc`, default `asc`); `id` is the stable tiebreak."
+  [_route-params
+   {:keys [include-personal-collections sort-column sort-direction entity-types threshold-days query]
+    :or   {include-personal-collections false
+           sort-column                   :detected-at
+           sort-direction                :asc}}
+   :- [:map
+       [:include-personal-collections {:optional true} :boolean]
+       [:sort-column    {:optional true} (ms/enum-decode-keyword (keys sort-column->field))]
+       [:sort-direction {:optional true} (ms/enum-decode-keyword sort-directions)]
+       [:entity-types   {:optional true} [:or
+                                          (ms/enum-decode-keyword stale-entity-types)
+                                          [:sequential (ms/enum-decode-keyword stale-entity-types)]]]
+       [:threshold-days {:optional true} ms/PositiveInt]
+       [:query          {:optional true} :string]]]
+  (let [where (stale-where-clause {:include-personal-collections include-personal-collections
+                                   :entity-types                 entity-types
+                                   :threshold-days               threshold-days
+                                   :query                        query})
+        page  (t2/select :model/ContentDiagnosticsFinding
+                         (cond-> {:where    where
+                                  :order-by [[(sort-column->field sort-column) sort-direction]
+                                             [:id sort-direction]]}
+                           (request/limit)  (assoc :limit (request/limit))
+                           (request/offset) (assoc :offset (request/offset))))]
+    {:data         (hydrate-findings page)
+     :total        (t2/count :model/ContentDiagnosticsFinding {:where where})
+     :limit        (request/limit)
+     :offset       (request/offset)
+     :last_scan_at (last-scan-at)}))
+
+(def ^{:arglists '([request respond raise])} routes
+  "Ring routes for the Content Diagnostics API."
+  (api.macros/ns-handler *ns* +auth))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.content-diagnostics.scan-test
   "The scan pipeline runs the instance-wide `stale` checker, persists a snapshot, and supersedes
-  prior findings."
+  prior findings; the `GET /stale` API lists the latest valid finding per entity, live
+  permission-filtered and batch-hydrated."
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]
@@ -9,7 +10,10 @@
    [metabase-enterprise.content-diagnostics.scan :as scan]
    [metabase-enterprise.content-diagnostics.settings :as cd.settings]
    [metabase-enterprise.content-diagnostics.task.scan :as task.scan]
+   [metabase.collections.models.collection :as collection]
+   [metabase.permissions.core :as perms]
    [metabase.test :as mt]
+   [metabase.util :as u]
    [toucan2.core :as t2]))
 
 (defn- stale-instant
@@ -20,6 +24,12 @@
 
 (defn- fresh-instant []
   (t/offset-date-time))
+
+(defn- scope-prefix
+  "Unique per-test entity-name prefix, passed as `:query` so assertions only see rows the test
+  seeded - the findings table is shared, so an unscoped list read can see sibling tests' rows."
+  []
+  (str "cd-" (mt/random-name)))
 
 (defn- finding-for
   [rows entity-type entity-id]
@@ -133,3 +143,394 @@
         (mt/with-premium-features #{:content-diagnostics}
           (#'task.scan/scan-when-enabled!)
           (is (= 1 @scans)))))))
+
+(deftest api-latest-per-entity-and-hydration-test
+  (testing "GET /stale returns the latest valid finding per entity, batch-hydrated"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {coll-id :id} {}
+                         :model/Card {card-id :id} {:collection_id coll-id
+                                                    :name          "Quarterly Revenue"
+                                                    :creator_id    (mt/user->id :rasta)}]
+            ;; rasta reads this collection → the visibility filter scopes `total` to this card's findings
+            (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+            (let [prefix     (scope-prefix)
+                  card-name  (str prefix " Quarterly Revenue")
+                  insert     (fn [scan threshold]
+                               (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                                {:scan_id             scan
+                                                                 :entity_type         :card
+                                                                 :entity_id           card-id
+                                                                 :finding_type        :stale
+                                                                 :last_active_at      (t/offset-date-time 2025 9 1)
+                                                                 :entity_name         card-name
+                                                                 :entity_creator_id   (mt/user->id :rasta)
+                                                                 :entity_creator_name "Rasta Toucan"
+                                                                 :details             {:threshold_days threshold}})))
+                  old-id     (insert "scan-old" 30)
+                  new-id     (insert "scan-new" 90)
+                  fetch      #(mt/user-http-request :rasta :get 200 "ee/content-diagnostics/stale"
+                                                    :query prefix)
+                  fetched-ids (fn [resp] (set (map :id (:data resp))))]
+              ;; membership assertions (robust to other rows / pagination), not absolute page counts
+              (testing "the latest finding is returned, the superseded older one is not - and `total` counts only the latest"
+                (let [resp (fetch)
+                      ids  (fetched-ids resp)]
+                  (is (contains? ids new-id))
+                  (is (not (contains? ids old-id)))
+                  ;; total must exclude the older row even though it is stale=false: it isn't MAX(id) for the entity
+                  (is (= 1 (:total resp)))))
+              (testing "the returned finding has flat identity + a nested typed details (collection, description, owner, creator)"
+                (let [row (first (filter #(= new-id (:id %)) (:data (fetch))))]
+                  (testing "entity_display_name read from the denormalized entity_name"
+                    (is (= card-name (:entity_display_name row))))
+                  (testing "collection breadcrumb still live-hydrated (not denormalized)"
+                    (is (= coll-id (get-in row [:details :collection :id]))))
+                  (testing "threshold_days stays in details; last_active_at is hoisted to a top-level property"
+                    (is (= 90 (get-in row [:details :threshold_days])))
+                    (is (some? (:last_active_at row)))
+                    (is (not (contains? (:details row) :last_active_at))))
+                  (testing "creator read from the denormalized columns (id + common_name, no live hydrate)"
+                    (is (=? {:id   (mt/user->id :rasta)
+                             :name "Rasta Toucan"
+                             :type "user"}
+                            (get-in row [:details :creator]))))
+                  (testing "card has no owner column → owner is null"
+                    (is (nil? (get-in row [:details :owner]))))))
+              (testing "invalidating the latest hides the entity AND drops it from total; older row does NOT resurface"
+                (t2/update! :model/ContentDiagnosticsFinding new-id {:invalidated_at (t/offset-date-time)})
+                (let [resp (fetch)
+                      ids  (fetched-ids resp)]
+                  (is (not (contains? ids new-id)))
+                  (is (not (contains? ids old-id)))
+                  ;; total excludes the invalidated latest, and does not fall back to the older row
+                  (is (= 0 (:total resp))))))))))))
+
+(deftest api-include-personal-collections-test
+  (testing "GET /stale excludes personal-collection findings by default; includes them with the param"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          ;; rasta's permanent personal collection - never with-temp (a personal collection can't be deleted)
+          (let [pers-id (:id (collection/user->personal-collection (mt/user->id :rasta)))]
+            (mt/with-temp [:model/Collection {reg-id :id}     {}
+                           :model/Card       {reg-card :id}   {:collection_id reg-id}
+                           :model/Card       {pers-card :id}  {:collection_id pers-id}]
+              ;; rasta can read the regular collection; their own personal collection is always self-visible
+              (perms/grant-collection-read-permissions! (perms/all-users-group) reg-id)
+              (let [prefix     (scope-prefix)
+                    insert     (fn [card]
+                                 (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                                  {:scan_id      "p-scan"
+                                                                   :entity_type  :card
+                                                                   :entity_id    card
+                                                                   :entity_name  (str prefix "-" card)
+                                                                   :finding_type :stale
+                                                                   :details      {}})))
+                    reg-fid    (insert reg-card)
+                    pers-fid   (insert pers-card)
+                    fetch      (fn [& kvs] (apply mt/user-http-request :rasta :get 200
+                                                  "ee/content-diagnostics/stale" :query prefix kvs))
+                    fetched-ids (fn [resp] (set (map :id (:data resp))))]
+                (testing "default (param omitted) → personal-collection finding excluded, regular one returned"
+                  (let [resp (fetch)]
+                    (is (contains? (fetched-ids resp) reg-fid))
+                    (is (not (contains? (fetched-ids resp) pers-fid)))
+                    ;; total honors the live filter - only the regular finding counts
+                    (is (= 1 (:total resp)))))
+                (testing "include-personal-collections=false → identical to default"
+                  (let [ids (fetched-ids (fetch :include-personal-collections false))]
+                    (is (contains? ids reg-fid))
+                    (is (not (contains? ids pers-fid)))))
+                (testing "include-personal-collections=true → both returned, total counts both"
+                  (let [resp (fetch :include-personal-collections true)]
+                    (is (contains? (fetched-ids resp) reg-fid))
+                    (is (contains? (fetched-ids resp) pers-fid))
+                    (is (= 2 (:total resp)))))
+                (testing "exclusion is live: moving the card out of the personal collection re-surfaces it"
+                  (t2/update! :model/Card pers-card {:collection_id reg-id})
+                  (let [ids (fetched-ids (fetch))]                  ; default (exclude personal)
+                    (is (contains? ids pers-fid))))))))))))        ; now in a regular collection → returned
+
+(deftest api-paginates-test
+  (testing "GET /stale honors limit/offset and reports the full valid total"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          ;; real cards in a real collection - the read layer permission-filters against live entities
+          (mt/with-temp [:model/Collection {coll-id :id} {}
+                         :model/Card {c1 :id} {:collection_id coll-id}
+                         :model/Card {c2 :id} {:collection_id coll-id}
+                         :model/Card {c3 :id} {:collection_id coll-id}]
+            (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+            (let [prefix (scope-prefix)]
+              (doseq [cid [c1 c2 c3]]
+                (t2/insert! :model/ContentDiagnosticsFinding
+                            {:scan_id "p" :entity_type :card :entity_id cid
+                             :entity_name (str prefix "-" cid)
+                             :finding_type :stale :details {}}))
+              (let [page (fn [limit offset]
+                           (mt/user-http-request :rasta :get 200 "ee/content-diagnostics/stale"
+                                                 :query prefix :limit limit :offset offset))]
+                (testing "limit caps the page; total reflects the full valid set; limit/offset echoed back"
+                  (let [r (page 2 0)]
+                    (is (= 2 (count (:data r))))
+                    (is (= 3 (:total r)))
+                    (is (= 2 (:limit r)))
+                    (is (= 0 (:offset r)))))
+                (testing "offset advances to the remainder"
+                  (is (= 1 (count (:data (page 2 2))))))))))))))
+
+(deftest api-permission-filtered-test
+  (testing "GET /stale returns only findings whose entity the current user can read"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {readable :id}   {}
+                         :model/Collection {unreadable :id} {}
+                         :model/Card {r-card :id} {:collection_id readable}
+                         :model/Card {u-card :id} {:collection_id unreadable}]
+            (perms/grant-collection-read-permissions! (perms/all-users-group) readable)
+            (let [insert  (fn [card]
+                            (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                             {:scan_id      "perm"
+                                                              :entity_type  :card
+                                                              :entity_id    card
+                                                              :finding_type :stale
+                                                              :details      {}})))
+                  r-fid   (insert r-card)
+                  u-fid   (insert u-card)
+                  ids-for (fn [user] (set (map :id (:data (mt/user-http-request
+                                                           user :get 200 "ee/content-diagnostics/stale")))))]
+              (testing "non-admin sees only the finding in the readable collection"
+                (let [ids (ids-for :rasta)]
+                  (is (contains? ids r-fid))
+                  (is (not (contains? ids u-fid)))))
+              (testing "superuser sees findings in every collection"
+                (let [ids (ids-for :crowberto)]
+                  (is (contains? ids r-fid))
+                  (is (contains? ids u-fid)))))))))))
+
+(deftest api-sort-test
+  (testing "GET /stale honors sort-column + sort-direction (native columns only)"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {coll-id :id} {}
+                         :model/Card {card-id :id} {:collection_id coll-id}
+                         :model/Dashboard {dash-id :id} {:collection_id coll-id}]
+            (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+            ;; card flagged later than the dashboard → detected-at order ≠ entity-type order (each isolable)
+            (let [prefix   (scope-prefix)
+                  card-fid (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                            {:scan_id "s" :entity_type :card :entity_id card-id
+                                                             :entity_name (str prefix "-" card-id)
+                                                             :finding_type :stale :details {}
+                                                             :detected_at (t/offset-date-time 2025 6 1)}))
+                  dash-fid (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                            {:scan_id "s" :entity_type :dashboard :entity_id dash-id
+                                                             :entity_name (str prefix "-" dash-id)
+                                                             :finding_type :stale :details {}
+                                                             :detected_at (t/offset-date-time 2025 1 1)}))
+                  order    (fn [& kvs] (mapv :id (:data (apply mt/user-http-request :rasta :get 200
+                                                               "ee/content-diagnostics/stale"
+                                                               :query prefix kvs))))]
+              (testing "sort-column=entity-type - lexical card < dashboard"
+                (is (= [card-fid dash-fid] (order :sort-column "entity-type" :sort-direction "asc")))
+                (is (= [dash-fid card-fid] (order :sort-column "entity-type" :sort-direction "desc"))))
+              (testing "sort-column=detected-at - dashboard (Jan) before card (Jun)"
+                (is (= [dash-fid card-fid] (order :sort-column "detected-at" :sort-direction "asc")))
+                (is (= [card-fid dash-fid] (order :sort-column "detected-at" :sort-direction "desc"))))
+              (testing "default sort = detected-at asc"
+                (is (= [dash-fid card-fid] (order)))))))))))
+
+(deftest api-sort-by-entity-attrs-test
+  (testing "GET /stale sorts by denormalized entity columns (name / created-at / created-by / last-used-at)"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {coll-id :id} {}
+                         :model/Card {card-a :id} {:collection_id coll-id}
+                         :model/Card {card-b :id} {:collection_id coll-id}]
+            (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+            ;; each attr orders A,B differently so the column under test is isolated
+            ;; creator NAME order (Amy < Zoe) is the inverse of creator ID order (5 < 10) → isolates name-sort
+            (let [prefix (scope-prefix)
+                  insert (fn [row]
+                           (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                            (merge {:scan_id      "s"
+                                                                    :entity_type  :card
+                                                                    :finding_type :stale
+                                                                    :details      {}}
+                                                                   row))))
+                  a-fid  (insert {:entity_id           card-a
+                                  :entity_name         (str prefix " Alpha")
+                                  :entity_created_at   (t/offset-date-time 2025 1 1)
+                                  :entity_creator_id   10
+                                  :entity_creator_name "Amy"
+                                  :last_active_at      (t/offset-date-time 2025 6 1)})
+                  b-fid  (insert {:entity_id           card-b
+                                  :entity_name         (str prefix " Beta")
+                                  :entity_created_at   (t/offset-date-time 2025 6 1)
+                                  :entity_creator_id   5
+                                  :entity_creator_name "Zoe"
+                                  :last_active_at      (t/offset-date-time 2025 1 1)})
+                  order  (fn [& kvs] (mapv :id (:data (apply mt/user-http-request :rasta :get 200
+                                                             "ee/content-diagnostics/stale"
+                                                             :query prefix kvs))))]
+              (testing "name - Alpha < Beta"
+                (is (= [a-fid b-fid] (order :sort-column "name" :sort-direction "asc")))
+                (is (= [b-fid a-fid] (order :sort-column "name" :sort-direction "desc"))))
+              (testing "created-at - Jan before Jun"
+                (is (= [a-fid b-fid] (order :sort-column "created-at" :sort-direction "asc"))))
+              (testing "created-by - by creator NAME (Amy < Zoe), independent of the 10-vs-5 id order"
+                (is (= [a-fid b-fid] (order :sort-column "created-by" :sort-direction "asc")))
+                (is (= [b-fid a-fid] (order :sort-column "created-by" :sort-direction "desc"))))
+              (testing "last-used-at - Jan before Jun"
+                (is (= [b-fid a-fid] (order :sort-column "last-used-at" :sort-direction "asc")))))))))))
+
+(deftest api-entity-types-filter-test
+  (testing "GET /stale filters by entity-types (repeatable; omitted = all)"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {coll-id :id} {}
+                         ;; transforms only go in the :transforms collection namespace
+                         :model/Collection {tcoll-id :id} {:namespace "transforms"}
+                         :model/Card {card-id :id} {:collection_id coll-id}
+                         :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                         :model/Document {doc-id :id} {:collection_id coll-id}
+                         :model/Transform {transform-id :id} {:collection_id tcoll-id}]
+            (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+            (perms/grant-collection-read-permissions! (perms/all-users-group) tcoll-id)
+            (let [prefix        (scope-prefix)
+                  insert        (fn [etype eid]
+                                  (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                                   {:scan_id "e" :entity_type etype :entity_id eid
+                                                                    :entity_name (str prefix "-" eid)
+                                                                    :finding_type :stale :details {}})))
+                  card-fid      (insert :card card-id)
+                  dash-fid      (insert :dashboard dash-id)
+                  doc-fid       (insert :document doc-id)
+                  transform-fid (insert :transform transform-id)
+                  ids           (fn [& kvs] (set (map :id (:data (apply mt/user-http-request :rasta :get 200
+                                                                        "ee/content-diagnostics/stale"
+                                                                        :query prefix kvs)))))]
+              (testing "omitted → all entity types"
+                (is (= #{card-fid dash-fid doc-fid transform-fid} (ids))))
+              (testing "single value → only that type"
+                (is (= #{card-fid} (ids :entity-types "card")))
+                (is (= #{dash-fid} (ids :entity-types "dashboard")))
+                ;; also exercises document hydration (no description column → returned description: nil)
+                (is (= #{doc-fid} (ids :entity-types "document")))
+                (is (= #{transform-fid} (ids :entity-types "transform"))))
+              (testing "multiple values → union of the given types"
+                (is (= #{card-fid dash-fid} (ids :entity-types ["card" "dashboard"])))))))))))
+
+(deftest api-transform-owner-hydration-test
+  (testing "GET /stale hydrates the transform owner - a Metabase user or an external email, exclusively"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [;; transforms only go in the :transforms collection namespace
+                         :model/Collection {coll-id :id} {:namespace "transforms"}
+                         :model/Transform {owned-id :id}    {:collection_id coll-id
+                                                             :owner_user_id (mt/user->id :rasta)}
+                         :model/Transform {external-id :id} {:collection_id coll-id
+                                                             :owner_email   "etl@vendor.io"}]
+            (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+            (let [prefix       (scope-prefix)
+                  insert       (fn [tid]
+                                 (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                                  {:scan_id "o" :entity_type :transform :entity_id tid
+                                                                   :entity_name (str prefix "-" tid)
+                                                                   :finding_type :stale :details {}})))
+                  owned-fid    (insert owned-id)
+                  external-fid (insert external-id)
+                  rows         (:data (mt/user-http-request :rasta :get 200 "ee/content-diagnostics/stale"
+                                                            :query prefix))
+                  owner-for    (fn [fid] (get-in (first (filter #(= fid (:id %)) rows)) [:details :owner]))]
+              (testing "owner_user_id → full user object"
+                (is (=? {:id    (mt/user->id :rasta)
+                         :name  "Rasta Toucan"
+                         :email "rasta@metabase.com"
+                         :type  "user"}
+                        (owner-for owned-fid))))
+              (testing "owner_email (no Metabase account) → external"
+                (is (=? {:email "etl@vendor.io"
+                         :type  "external"}
+                        (owner-for external-fid)))))))))))
+
+(deftest api-threshold-days-filter-test
+  (testing "GET /stale threshold-days drops findings less stale than the cutoff; never-used always passes"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {coll-id :id} {}
+                         :model/Card {c-old :id}    {:collection_id coll-id}
+                         :model/Card {c-recent :id} {:collection_id coll-id}
+                         :model/Card {c-never :id}  {:collection_id coll-id}]
+            (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+            (let [prefix     (scope-prefix)
+                  insert     (fn [card active-at]
+                               (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                                {:scan_id "t" :entity_type :card :entity_id card
+                                                                 :entity_name (str prefix "-" card)
+                                                                 :finding_type :stale :details {}
+                                                                 :last_active_at active-at})))
+                  old-fid    (insert c-old    (t/minus (t/offset-date-time) (t/days 400)))
+                  recent-fid (insert c-recent (t/minus (t/offset-date-time) (t/days 100)))
+                  never-fid  (insert c-never  nil)
+                  ids        (fn [& kvs] (set (map :id (:data (apply mt/user-http-request :rasta :get 200
+                                                                     "ee/content-diagnostics/stale"
+                                                                     :query prefix kvs)))))]
+              (testing "no threshold → all three"
+                (is (= #{old-fid recent-fid never-fid} (ids))))
+              (testing "threshold-days=200 → keeps the 400-day-old + never-used, drops the 100-day-old"
+                (is (= #{old-fid never-fid} (ids :threshold-days "200"))))
+              (testing "threshold-days=50 → all qualify (each ≥50 days stale, or never used)"
+                (is (= #{old-fid recent-fid never-fid} (ids :threshold-days "50")))))))))))
+
+(deftest api-query-search-test
+  (testing "GET /stale ?query= case-insensitively substring-matches the denormalized entity name"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {coll-id :id} {}
+                         :model/Card {c-rev :id}  {:collection_id coll-id}
+                         :model/Card {c-cost :id} {:collection_id coll-id}]
+            (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+            (let [prefix   (scope-prefix)
+                  insert   (fn [card nm]
+                             (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                              {:scan_id "q" :entity_type :card :entity_id card
+                                                               :finding_type :stale :details {}
+                                                               :entity_name (str prefix " " nm)})))
+                  rev-fid  (insert c-rev  "Quarterly Revenue")
+                  cost-fid (insert c-cost "Cost Analysis")
+                  ids      (fn [& kvs] (set (map :id (:data (apply mt/user-http-request :rasta :get 200
+                                                                   "ee/content-diagnostics/stale" kvs)))))]
+              ;; the no-query/blank cases can't be prefix-scoped (that's what they test) → membership, not
+              ;; exact sets, so rows from other tests on the shared findings table can't break them
+              (testing "no query → all findings"
+                (is (set/subset? #{rev-fid cost-fid} (ids))))
+              (testing "substring match, case-insensitive"
+                (is (= #{rev-fid} (ids :query (u/upper-case-en (str prefix " quarterly rev")))))
+                (is (= #{cost-fid} (ids :query (u/lower-case-en (str prefix " cost"))))))
+              (testing "no match → empty"
+                (is (empty? (ids :query (str prefix " zzz")))))
+              (testing "blank query is a no-op → all findings"
+                (is (set/subset? #{rev-fid cost-fid} (ids :query "   ")))))))))))
+
+(deftest api-endpoint-is-feature-gated-test
+  (testing "GET /stale is gated on the :content-diagnostics premium feature (premium-handler)"
+    (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+      (testing "licensed → 200 with the paginated envelope"
+        (mt/with-premium-features #{:content-diagnostics}
+          (let [resp (mt/user-http-request :rasta :get 200 "ee/content-diagnostics/stale")]
+            (is (contains? resp :data))
+            (is (contains? resp :total)))))
+      (testing "unlicensed → 402"
+        (mt/with-premium-features #{}
+          (mt/user-http-request :rasta :get 402 "ee/content-diagnostics/stale"))))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -346,7 +346,7 @@
                 (is (= [dash-fid card-fid] (order)))))))))))
 
 (deftest api-sort-by-entity-attrs-test
-  (testing "GET /stale sorts by denormalized entity columns (name / created-at / created-by / last-used-at)"
+  (testing "GET /stale sorts by denormalized entity columns (name / created-at / created-by / last-active-at)"
     (mt/with-premium-features #{:content-diagnostics}
       (mt/with-non-admin-groups-no-root-collection-perms
         (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
@@ -387,8 +387,8 @@
               (testing "created-by - by creator NAME (Amy < Zoe), independent of the 10-vs-5 id order"
                 (is (= [a-fid b-fid] (order :sort-column "created-by" :sort-direction "asc")))
                 (is (= [b-fid a-fid] (order :sort-column "created-by" :sort-direction "desc"))))
-              (testing "last-used-at - Jan before Jun"
-                (is (= [b-fid a-fid] (order :sort-column "last-used-at" :sort-direction "asc")))))))))))
+              (testing "last-active-at - Jan before Jun"
+                (is (= [b-fid a-fid] (order :sort-column "last-active-at" :sort-direction "asc")))))))))))
 
 (deftest api-entity-types-filter-test
   (testing "GET /stale filters by entity-types (repeatable; omitted = all)"


### PR DESCRIPTION
### Description

This opens the feature gated endpoint of the stale findings API for content diagnostics use. 

We batch hydrate a limited set of attributes (collection/description/owner) lazily on read; this is to ensure we keep collection auth integrity and breadcrumb deeplinks accurate. 

We return the latest entity instance for each given finding type across all scans that has not been invalidated via the `invalidated-at` timestamp. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
