### PR TITLE
Convert enterprise auth session middleware to TypeScript

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts
@@ -80,6 +80,8 @@ const SAVE_APPLICATION_PERMISSIONS =
 export const saveApplicationPermissions = createThunkAction(
   SAVE_APPLICATION_PERMISSIONS,
   () => async (dispatch, getState) => {
+    // getState() is typed as the base State, which doesn't include the
+    // enterprise plugin slice this reducer registers at runtime.
     const { applicationPermissions, applicationPermissionsRevision } = (
       getState() as ApplicationPermissionsState
     ).plugins.applicationPermissionsPlugin;

--- a/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.ts
+++ b/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.ts
@@ -41,44 +41,45 @@ export const createSessionMiddleware = (
 ): SessionMiddleware => {
   let intervalId: ReturnType<typeof setInterval> | undefined;
 
-  const sessionMiddlware: SessionMiddleware = (store) => (next) => (action) => {
-    if (
-      intervalId == null ||
-      (isAction(action) && resetActions.includes(action.type))
-    ) {
-      clearInterval(intervalId);
+  const sessionMiddleware: SessionMiddleware =
+    (store) => (next) => (action) => {
+      if (
+        intervalId == null ||
+        (isAction(action) && resetActions.includes(action.type))
+      ) {
+        clearInterval(intervalId);
 
-      let wasLoggedIn = getIsLoggedIn();
+        let wasLoggedIn = getIsLoggedIn();
 
-      // get the redirect url before refreshing the session because after the refresh the url will be reset
-      const redirectUrl = getRedirectUrl();
+        // get the redirect url before refreshing the session because after the refresh the url will be reset
+        const redirectUrl = getRedirectUrl();
 
-      if (wasLoggedIn && !!redirectUrl && !preventImmedidateRedirect()) {
-        store.dispatch(replace(redirectUrl));
+        if (wasLoggedIn && !!redirectUrl && !preventImmedidateRedirect()) {
+          store.dispatch(replace(redirectUrl));
+        }
+
+        intervalId = setInterval(async () => {
+          const isLoggedIn = getIsLoggedIn();
+
+          if (isLoggedIn !== wasLoggedIn) {
+            wasLoggedIn = isLoggedIn;
+
+            if (isLoggedIn) {
+              await store.dispatch(refreshSession())?.unwrap();
+
+              if (redirectUrl !== null) {
+                store.dispatch(replace(redirectUrl));
+              }
+            } else {
+              const url = location.pathname + location.search + location.hash;
+              store.dispatch(logout(url));
+            }
+          }
+        }, COOKIE_POOLING_TIMEOUT);
       }
 
-      intervalId = setInterval(async () => {
-        const isLoggedIn = getIsLoggedIn();
+      next(action);
+    };
 
-        if (isLoggedIn !== wasLoggedIn) {
-          wasLoggedIn = isLoggedIn;
-
-          if (isLoggedIn) {
-            await store.dispatch(refreshSession())?.unwrap();
-
-            if (redirectUrl !== null) {
-              store.dispatch(replace(redirectUrl));
-            }
-          } else {
-            const url = location.pathname + location.search + location.hash;
-            store.dispatch(logout(url));
-          }
-        }
-      }, COOKIE_POOLING_TIMEOUT);
-    }
-
-    next(action);
-  };
-
-  return sessionMiddlware;
+  return sessionMiddleware;
 };

--- a/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.ts
+++ b/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.ts
@@ -1,6 +1,9 @@
+import type { Action, Middleware, ThunkDispatch } from "@reduxjs/toolkit";
+import { isAction } from "@reduxjs/toolkit";
 import Cookies from "js-cookie";
 
 import { logout, refreshSession } from "metabase/redux/auth";
+import type { State } from "metabase/redux/store";
 import { replace } from "metabase/router";
 import { isSameOrSiteUrlOrigin } from "metabase/utils/dom";
 
@@ -26,14 +29,23 @@ const preventImmedidateRedirect = () => {
   return window.location.pathname.startsWith("/auth/login");
 };
 
-export const createSessionMiddleware = (
-  resetActions = [],
-  setInterval = global.setInterval,
-) => {
-  let intervalId;
+type SessionMiddleware = Middleware<
+  Record<string, never>,
+  State,
+  ThunkDispatch<State, unknown, Action>
+>;
 
-  const sessionMiddlware = (store) => (next) => (action) => {
-    if (intervalId == null || resetActions.includes(action.type)) {
+export const createSessionMiddleware = (
+  resetActions: string[] = [],
+  setInterval = global.setInterval,
+): SessionMiddleware => {
+  let intervalId: ReturnType<typeof setInterval> | undefined;
+
+  const sessionMiddlware: SessionMiddleware = (store) => (next) => (action) => {
+    if (
+      intervalId == null ||
+      (isAction(action) && resetActions.includes(action.type))
+    ) {
       clearInterval(intervalId);
 
       let wasLoggedIn = getIsLoggedIn();

--- a/frontend/src/metabase/plugins/oss/core.ts
+++ b/frontend/src/metabase/plugins/oss/core.ts
@@ -1,4 +1,4 @@
-import type { Middleware } from "@reduxjs/toolkit";
+import type { Action, Middleware, ThunkDispatch } from "@reduxjs/toolkit";
 import type { ComponentType, ReactNode } from "react";
 import { t } from "ttag";
 
@@ -67,7 +67,12 @@ export const PLUGIN_HOMEPAGE_SETTING: {
   CustomUrlOption: { label: string; Control: ComponentType } | null;
 } = getDefaultHomepageSetting();
 
-const getDefaultReduxMiddlewares = (): Middleware[] => [];
+// dispatch is typed as thunk-capable so EE middlewares can dispatch async thunks
+const getDefaultReduxMiddlewares = (): Middleware<
+  Record<string, never>,
+  State,
+  ThunkDispatch<State, unknown, Action>
+>[] => [];
 
 export const PLUGIN_REDUX_MIDDLEWARES = getDefaultReduxMiddlewares();
 


### PR DESCRIPTION
### Description

Part of [UXW-4762](https://linear.app/metabase/issue/UXW-4762/convert-enterprise-plugin-js-modules-to-ts)

Converts the enterprise auth session middleware to TS. The one OSS touch: `PLUGIN_REDUX_MIDDLEWARES`' element type becomes thunk-capable, since the middleware dispatches the `refreshSession`/`logout` async thunks and the plain `Middleware` dispatch type can't express that.

### How to verify

- [ ] EE: log in with a `redirect` query param and confirm it still lands on the target page; log out and back in (session cookie polling drives both paths through the middleware).

## Note to the reviewer

https://github.com/metabase/metabase/pull/77399/changes/ced44af46395f369cb05ffbb86d7af2552b4f1c9 fixed a typo `sessionMiddlware` is missing an 'e'. That resulted in github treating the file as deleted and created anew instead of just updated. So, a better diff to review would be https://github.com/metabase/metabase/pull/77399/commits/daec61a0649040b52d29755fdd7c14dac8b1bbad 