### PR TITLE
Extract common and scope helpers + tests for typed schema module

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2504,6 +2504,7 @@
            metrics
            models
            system
+           types
            util}
    :model-imports #{:model/Action
                     :model/Card

--- a/skills/metabase-data-app-actions/SKILL.md
+++ b/skills/metabase-data-app-actions/SKILL.md
@@ -20,7 +20,7 @@ Actions belong to a model. They mutate that model's rows. Concretely:
 
 ## What's in the schema (and what isn't)
 
-Action entries are only generated when the typed schema includes models. Before writing action-invoking code, make sure the schema was generated with `includeModels=true`; with `database=<name-or-id>&includeModels=true`, Metabase includes models/actions for that database only. Do not rely on `questionCollections` for actions; question collections only add saved questions.
+Action entries are only generated when the typed schema includes models. Before writing action-invoking code, make sure the schema was generated with `include-models=true`; with `database=<name-or-id>&include-models=true`, Metabase includes models/actions for that database only. Do not rely on `question-collections` for actions; question collections only add saved questions.
 
 Before writing any action-invoking code, look at the schema and enumerate what's available under `schema.models.<m>.actions` across the models the app cares about. The schema is your **complete** catalog of actions for the instance, not a catalog of model data to display. If a model's `actions` entry has `create`, `update`, `delete`, those are the actions invokable. Anything not present doesn't exist as far as the Data App is concerned.
 

--- a/skills/metabase-data-app-semantic-layer/SKILL.md
+++ b/skills/metabase-data-app-semantic-layer/SKILL.md
@@ -43,16 +43,16 @@ If the schema file already exists, use it. If it is missing or stale, treat sche
 
 Before generating, make sure the user has explicitly chosen the library scope the app needs:
 
-- `includeDataLibrary=true` for the whole `Library / Data` tree.
-- `includeMetricLibrary=true` for the whole `Library / metrics` tree.
-- `libraryCollections=<id-or-entity-id>[,<id-or-entity-id>]` for specific Data or metrics library subcollections.
-- `questionCollections=<id-or-entity-id>[,<id-or-entity-id>]` for specific normal collections that contain saved questions.
-- `includeModels=true` for readable models that have actions. When combined with `database=<name-or-id>`, it includes models with actions for that database only.
+- `include-data-library=true` for the whole `Library / Data` tree.
+- `include-metric-library=true` for the whole `Library / metrics` tree.
+- `library-collections=<id-or-entity-id>[,<id-or-entity-id>]` for specific Data or metrics library subcollections.
+- `question-collections=<id-or-entity-id>[,<id-or-entity-id>]` for specific normal collections that contain saved questions.
+- `include-models=true` for readable models that have actions. When combined with `database=<name-or-id>`, it includes models with actions for that database only.
 - `database=<name-or-id>` when the app should use tables from one database.
 
-Use `questionCollections` when the app needs generated `schema.questions.*`. Use `includeModels=true` when the app needs any saved action under `schema.models.<model>.actions`; models without executable actions are omitted to keep generated schemas compact. It can be combined with `libraryCollections`, `includeDataLibrary`, `includeMetricLibrary`, or `questionCollections` so one schema can include selected tables/metrics/questions plus all relevant actions.
+Use `question-collections` when the app needs generated `schema.questions.*`. Use `include-models=true` when the app needs any saved action under `schema.models.<model>.actions`; models without executable actions are omitted to keep generated schemas compact. It can be combined with `library-collections`, `include-data-library`, `include-metric-library`, or `question-collections` so one schema can include selected tables/metrics/questions plus all relevant actions.
 
-If the user asks for any mutation-like flow, such as creating, updating, deleting, submitting, approving, executing an action, or running a write operation, include `includeModels=true` in the typed-schema URL. Do this even when the user names one specific model/action, because actions are only discoverable through generated model entries.
+If the user asks for any mutation-like flow, such as creating, updating, deleting, submitting, approving, executing an action, or running a write operation, include `include-models=true` in the typed-schema URL. Do this even when the user names one specific model/action, because actions are only discoverable through generated model entries.
 
 If the user did not already choose a library scope, stop and ask what they want. Warn before exporting the whole instance: including everything is noisy, bloats context, and makes agents more likely to pick irrelevant entities.
 
@@ -91,11 +91,11 @@ fi
     -o src/metabase.data.ts \
     -H "x-api-key: $DATA_APP_MB_API_KEY" \
     -H "Accept: text/typescript" \
-    "$DATA_APP_MB_URL/api/typed-schemas/v1/typescript?includeDataLibrary=true&includeMetricLibrary=true"
+    "$DATA_APP_MB_URL/api/typed-schemas/v1/typescript?include-data-library=true&include-metric-library=true"
 )
 ```
 
-When the app needs saved questions, include `questionCollections=<id-or-entity-id>[,<id-or-entity-id>]` in the typed-schema URL. When the app needs models or actions, include `includeModels=true`.
+When the app needs saved questions, include `question-collections=<id-or-entity-id>[,<id-or-entity-id>]` in the typed-schema URL. When the app needs models or actions, include `include-models=true`.
 
 If schema generation fails while building a selected saved question, model, or model action, do not hide, paraphrase away, or retry past the error. Surface the typed-schema error to the user, including the failing `card-id` / `card-name` / `card-type`, `model-id` / `model-name`, dropped action ids, and message when present. This usually means a selected model/question/action was readable enough to select, but its details could not be built, often because its source table, source card, or action details are not published, accessible, valid, or resolvable in the fetch context. The schema would otherwise omit the entire `schema.models.<model>` or `schema.questions.<question>` entry, or return a model whose `actions` map silently omits an action, so the user needs to curate or publish the missing dependency before regenerating.
 

--- a/skills/metabase-data-app-semantic-layer/SKILL.md
+++ b/skills/metabase-data-app-semantic-layer/SKILL.md
@@ -50,7 +50,7 @@ Before generating, make sure the user has explicitly chosen the library scope th
 - `include-models=true` for readable models that have actions. When combined with `database=<name-or-id>`, it includes models with actions for that database only.
 - `database=<name-or-id>` when the app should use tables from one database.
 
-Use `question-collections` when the app needs generated `schema.questions.*`. Use `include-models=true` when the app needs any saved action under `schema.models.<model>.actions`; models without executable actions are omitted to keep generated schemas compact. It can be combined with `library-collections`, `include-data-library`, `include-metric-library`, or `question-collections` so one schema can include selected tables/metrics/questions plus all relevant actions.
+Use `question-collections` when the app needs `schema.questions.*` to be generated. Use `include-models=true` when the app needs any saved action under `schema.models.<model>.actions`; models without executable actions are omitted to keep generated schemas compact. It can be combined with `library-collections`, `include-data-library`, `include-metric-library`, or `question-collections` so one schema can include selected tables/metrics/questions plus all relevant actions.
 
 If the user asks for any mutation-like flow, such as creating, updating, deleting, submitting, approving, executing an action, or running a write operation, include `include-models=true` in the typed-schema URL. Do this even when the user names one specific model/action, because actions are only discoverable through generated model entries.
 

--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
+   [medley.core :as m]
    [metabase.actions.core :as actions]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
@@ -14,6 +15,8 @@
    [metabase.metrics.core :as metrics]
    [metabase.models.interface :as mi]
    [metabase.system.core :as system]
+   [metabase.typed-schemas.api.common :as common]
+   [metabase.typed-schemas.api.query-params :as qp]
    [metabase.util :as u]
    [metabase.util.json :as json]
    [toucan2.core :as t2])
@@ -69,305 +72,6 @@
    :unit         "Unit"
    :verified     "Verified"})
 
-(defn- js-type
-  [{:keys [type base_type effective_type] :as _column}]
-  (case type
-    :number   "number"
-    :boolean  "boolean"
-    :string   "string"
-    :date     "Date"
-    :datetime "Date"
-    :time     "Date"
-    (let [schema-type (or effective_type base_type)]
-      (cond
-        (some-> schema-type (str/includes? "Boolean")) "boolean"
-        (some-> schema-type (str/includes? "Number"))  "number"
-        (some-> schema-type (str/includes? "Integer")) "number"
-        (some-> schema-type (str/includes? "Float"))   "number"
-        (some-> schema-type (str/includes? "Decimal")) "number"
-        (some-> schema-type (str/includes? "Date"))    "Date"
-        (some-> schema-type (str/includes? "Time"))    "Date"
-        (some-> schema-type (str/includes? "Text"))    "string"
-        (some-> schema-type (str/includes? "UUID"))    "string"
-        :else                                          "unknown"))))
-
-(defn- assoc-some
-  [m & kvs]
-  (reduce (fn [m [k v]]
-            (cond-> m
-              (some? v) (assoc k v)))
-          m
-          (partition 2 kvs)))
-
-(defn- column-schema
-  [{:keys [name display_name base_type effective_type semantic_type description unit] :as column}]
-  (let [effective-type (or effective_type base_type)]
-    (assoc-some
-     {:type        "column"
-      :name        name
-      :displayName (or display_name name)
-      :jsType      (js-type column)}
-     :baseType base_type
-     :effectiveType (when (not= effective-type base_type) effective-type)
-     :semanticType semantic_type
-     :description description
-     :unit unit)))
-
-(defn- generated-key
-  [entity-name id]
-  (let [k (some-> entity-name u/->camelCaseEn)]
-    (if (str/blank? k)
-      (str "entity" id)
-      k)))
-
-(defn- pascal-case
-  [s]
-  (when-not (str/blank? s)
-    (str (u/upper-case-en (subs s 0 1))
-         (subs s 1))))
-
-(defn- keyed-map
-  [entities]
-  (let [entities          (vec entities)
-        base-key->count   (frequencies (map :key entities))
-        duplicate-key?    (fn [base-key]
-                            (> (get base-key->count base-key 0) 1))
-        candidate-key     (fn [entity]
-                            (let [base-key (:key entity)]
-                              (if-not (duplicate-key? base-key)
-                                base-key
-                                (str base-key (or (:keyDisambiguator entity)
-                                                  (:tableId entity)
-                                                  (:id entity))))))
-        candidate->count  (frequencies (map candidate-key entities))
-        disambiguated-key (fn [entity]
-                            (let [candidate (candidate-key entity)]
-                              (if (= 1 (get candidate->count candidate))
-                                candidate
-                                (str candidate (:id entity)))))]
-    (reduce (fn [m entity]
-              (let [key (disambiguated-key entity)]
-                (assoc m key (-> entity
-                                 (dissoc :keyDisambiguator)
-                                 (assoc :key key)))))
-            (sorted-map)
-            entities)))
-
-(defn- keyed-model-map
-  [models]
-  (reduce-kv (fn [m k model]
-               (assoc m k (select-keys model [:actions])))
-             (sorted-map)
-             (keyed-map models)))
-
-(defn- query-param
-  [query-params k]
-  (or (get query-params k)
-      (get query-params (name k))))
-
-(defn- truthy-query-param?
-  [v]
-  (contains? #{true "true" "1"} v))
-
-(def ^:private library-data-entity-id
-  "librarylibrarydatadat")
-
-(def ^:private library-metrics-entity-id
-  "librarylibrarymetrics")
-
-(defn- query-database-value
-  [query-params]
-  (some-> (or (query-param query-params :database)
-              (query-param query-params :database-name))
-          str/trim
-          not-empty))
-
-(defn- parse-id
-  [s]
-  (try
-    (Long/parseLong s)
-    (catch NumberFormatException _
-      nil)))
-
-(defn- database-ids-for-value
-  [database-value]
-  (when database-value
-    (let [database-id (parse-id database-value)]
-      (->> (if database-id
-             (t2/select :model/Database :id database-id)
-             (t2/select :model/Database :name database-value))
-           (filter mi/can-read?)
-           (map :id)
-           set))))
-
-(defn- database-id-filter-clause
-  [database-ids column]
-  (when database-ids
-    (if (seq database-ids)
-      [:in column database-ids]
-      [:= column -1])))
-
-(defn- id-filter-clause
-  [ids column]
-  (when ids
-    (if (seq ids)
-      [:in column ids]
-      [:= column -1])))
-
-(defn- query-library-value
-  [query-params]
-  (some-> (query-param query-params :library)
-          str/trim
-          not-empty))
-
-(defn- query-comma-separated-values
-  [query-params ks]
-  (when-let [value (some-> (->> ks
-                                (keep #(query-param query-params %))
-                                first)
-                           str/trim
-                           not-empty)]
-    (->> (str/split value #",")
-         (map str/trim)
-         (remove str/blank?)
-         seq)))
-
-(defn- query-library-collection-values
-  [query-params]
-  (query-comma-separated-values query-params [:library-collections
-                                              :libraryCollections
-                                              :collections]))
-
-(defn- query-include-data-library?
-  [query-params]
-  (truthy-query-param? (or (query-param query-params :include-data-library)
-                           (query-param query-params :includeDataLibrary))))
-
-(defn- query-include-metric-library?
-  [query-params]
-  (truthy-query-param? (or (query-param query-params :include-metric-library)
-                           (query-param query-params :includeMetricLibrary))))
-
-(defn- query-include-models?
-  [query-params]
-  (truthy-query-param? (or (query-param query-params :include-models)
-                           (query-param query-params :includeModels))))
-
-(defn- query-question-collection-values
-  [query-params]
-  (query-comma-separated-values query-params [:question-collections
-                                              :questionCollections]))
-
-(defn- library-collection-for-value
-  [library-value]
-  (when library-value
-    (let [collection-id (parse-id library-value)]
-      (->> (if collection-id
-             (t2/select :model/Collection :id collection-id)
-             (t2/select :model/Collection :name library-value))
-           (filter #(contains? collection/library-collection-types (:type %)))
-           (filter mi/can-read?)
-           first))))
-
-(defn- library-collection-for-ref
-  [collection-value]
-  (let [collection-id (parse-id collection-value)]
-    (->> (if collection-id
-           (t2/select :model/Collection :id collection-id)
-           (t2/select :model/Collection :entity_id collection-value))
-         (filter #(contains? collection/library-collection-types (:type %)))
-         (filter mi/can-read?)
-         first)))
-
-(defn- library-collection-for-entity-id
-  [entity-id]
-  (->> (t2/select :model/Collection :entity_id entity-id)
-       (filter #(contains? collection/library-collection-types (:type %)))
-       (filter mi/can-read?)
-       first))
-
-(defn- collection-for-ref
-  [collection-value]
-  (let [collection-id (parse-id collection-value)]
-    (->> (if collection-id
-           (t2/select :model/Collection :id collection-id)
-           (t2/select :model/Collection :entity_id collection-value))
-         (filter mi/can-read?)
-         first)))
-
-(defn- collection-scope
-  [collection-values]
-  (when (seq collection-values)
-    (let [collections (for [collection-value collection-values]
-                        (or (collection-for-ref collection-value)
-                            (api/check-404 false)))]
-      (->> collections
-           (mapcat #(cons % (collection/descendants-flat %)))
-           (map :id)
-           set))))
-
-(defn- library-collection-scope*
-  [library-collections]
-  (let [ids          (->> library-collections
-                          (mapcat #(cons % (collection/descendants-flat %)))
-                          (map :id)
-                          set)
-        rows         (t2/select [:model/Collection :id :type] :id [:in ids])
-        ids-for-type (fn [collection-type]
-                       (->> rows
-                            (filter #(= (:type %) collection-type))
-                            (map :id)
-                            set))]
-    {:library-collections  library-collections
-     :collection-ids        ids
-     :data-collection-ids   (ids-for-type collection/library-data-collection-type)
-     :metric-collection-ids (ids-for-type collection/library-metrics-collection-type)}))
-
-(defn- library-collection-scope
-  [library-value]
-  (when library-value
-    (let [library (or (library-collection-for-value library-value)
-                      (api/check-404 false))]
-      (library-collection-scope* [library]))))
-
-(defn- library-collections-scope
-  [collection-values]
-  (when (seq collection-values)
-    (let [collections (for [collection-value collection-values]
-                        (or (library-collection-for-ref collection-value)
-                            (api/check-404 false)))]
-      (library-collection-scope* collections))))
-
-(defn- included-library-root-collections
-  [query-params]
-  (keep (fn [[include? entity-id]]
-          (when include?
-            (or (library-collection-for-entity-id entity-id)
-                (api/check-404 false))))
-        [[(query-include-data-library? query-params) library-data-entity-id]
-         [(query-include-metric-library? query-params) library-metrics-entity-id]]))
-
-(defn- library-scope
-  [query-params]
-  (let [library-value             (query-library-value query-params)
-        library-collection-values (query-library-collection-values query-params)
-        included-roots            (included-library-root-collections query-params)
-        collection-scope          (cond
-                                    library-value
-                                    (library-collection-scope library-value)
-
-                                    library-collection-values
-                                    (library-collections-scope library-collection-values))]
-    (cond
-      (and collection-scope (seq included-roots))
-      (library-collection-scope* (concat (:library-collections collection-scope) included-roots))
-
-      (seq included-roots)
-      (library-collection-scope* included-roots)
-
-      :else
-      collection-scope)))
-
 (defn- select-cards
   ([card-type database-ids]
    (select-cards card-type database-ids nil))
@@ -377,8 +81,8 @@
                                        [:= :type (name card-type)]
                                        [:= :archived false]
                                        (collection/visible-collection-filter-clause :collection_id)]
-                                database-ids (conj (database-id-filter-clause database-ids :database_id))
-                                collection-ids (conj (id-filter-clause collection-ids :collection_id)))
+                                database-ids (conj (qp/database-id-filter-clause database-ids :database_id))
+                                collection-ids (conj (qp/id-filter-clause collection-ids :collection_id)))
                     :order-by [[:name :asc] [:id :asc]]})
         (filter mi/can-read?))))
 
@@ -396,7 +100,7 @@
 
 (defn- schema-details-error-data
   [card m]
-  (assoc-some
+  (m/assoc-some
    {:card-id   (:id card)
     :card-name (:name card)
     :card-type (:type card)}
@@ -419,12 +123,12 @@
 
 (defn- model-action-error-data
   ([model m]
-   (assoc-some
+   (m/assoc-some
     {:model-id   (:id model)
      :model-name (:name model)}
     :status-code (:status-code m)))
   ([model action m]
-   (assoc-some
+   (m/assoc-some
     (assoc (model-action-error-data model m)
            :action-id   (:id action)
            :action-name (:name action)
@@ -506,13 +210,13 @@
 
 (defn- question-schema
   [{:keys [id name description verified display result-columns portable_entity_id]}]
-  (assoc-some
+  (m/assoc-some
    {:type    "card"
-    :key     (generated-key name id)
+    :key     (common/generated-key name id)
     :id      id
     :name    name
     :display display
-    :columns (mapv column-schema result-columns)}
+    :columns (mapv common/column-schema result-columns)}
    :entityId portable_entity_id
    :description description
    :verified (when verified true)))
@@ -589,7 +293,7 @@
                            (get tag-types
                                 (template-tag-name-from-target target)))
                           "unknown")]
-    (assoc-some
+    (m/assoc-some
      {:slug resolved-slug
       :displayName (or display-name name resolved-slug)
       :jsType resolved-type}
@@ -601,9 +305,9 @@
   [{:keys [id name description type kind parameters entity_id] :as action}]
   (let [tag-types (query-action-template-tag-types action)
         implicit? (= (->keyword type) :implicit)]
-    (assoc-some
+    (m/assoc-some
      {:kind       "action"
-      :key        (generated-key name id)
+      :key        (common/generated-key name id)
       :id         id
       :name       name
       :type       (some-> type clojure.core/name)
@@ -650,9 +354,9 @@
   [{:keys [id name] :as model}]
   (let [action-schemas (model-actions model)]
     (when (seq action-schemas)
-      {:key              (generated-key name id)
+      {:key              (common/generated-key name id)
        :keyDisambiguator id
-       :actions          (keyed-map action-schemas)})))
+       :actions          (common/keyed-map action-schemas)})))
 
 (defn- persisted-dimension->column
   [dimension]
@@ -691,10 +395,10 @@
          column       (if (:sources dimension)
                         (persisted-dimension->column dimension)
                         dimension)]
-     (assoc-some
-      (assoc (column-schema column)
+     (m/assoc-some
+      (assoc (common/column-schema column)
              :type "column"
-             :key (generated-key (:name column) dimension-id)
+             :key (common/generated-key (:name column) dimension-id)
              :id (str dimension-id))
       :sourceName (when (integer? table-id)
                     (get table-source-name-by-id table-id))
@@ -712,10 +416,10 @@
   ([{:keys [id field_id] :as field} source-name]
    (let [field-id (or id field_id)
          table-id (or (:table_id field) (:table-id field) (field-table-id field-id))]
-     (assoc-some
-      (assoc (column-schema field)
+     (m/assoc-some
+      (assoc (common/column-schema field)
              :type "column"
-             :key (generated-key (:name field) field-id)
+             :key (common/generated-key (:name field) field-id)
              :id field-id)
       :sourceName source-name
       :fieldId (when (integer? field-id) field-id)
@@ -735,9 +439,9 @@
   [dimensions dimension-mappings]
   (let [mapping-by-dimension-id (into {} (map (juxt :dimension-id identity)) dimension-mappings)]
     (mapv (fn [{:keys [id] :as dimension}]
-            (assoc-some dimension
-                        :source-field-id (some-> (get mapping-by-dimension-id id)
-                                                 mapping-source-field-id)))
+            (m/assoc-some dimension
+                          :source-field-id (some-> (get mapping-by-dimension-id id)
+                                                   mapping-source-field-id)))
           dimensions)))
 
 (defn- metric-dimensions
@@ -759,7 +463,7 @@
    (when (seq table-rows)
      (->> table-rows
           (map (fn [{:keys [id name display_name]}]
-                 [id (pascal-case (generated-key (or display_name name) id))]))
+                 [id (common/pascal-case (common/generated-key (or display_name name) id))]))
           (into {})))))
 
 (defn- table-source-names
@@ -821,7 +525,7 @@
 (defn- metric-schema
   [{:keys [id name description verified portable_entity_id base_table_portable_fk] :as details}
    card]
-  (let [result-column (or (some-> (metric-result-column card) column-schema)
+  (let [result-column (or (some-> (metric-result-column card) common/column-schema)
                           (fallback-metric-column details))
         source-card-id-value (source-card-id card)
         dimensions    (cond->> (or (seq (metric-dimensions details))
@@ -841,9 +545,9 @@
                                distinct
                                sort
                                vec)]
-    (assoc-some
+    (m/assoc-some
      {:type       "metric"
-      :key        (generated-key name id)
+      :key        (common/generated-key name id)
       :id         id
       :name       name
       :columns    [result-column]}
@@ -855,7 +559,7 @@
      :verified (when verified true)
      :sourceTable (source-table-schema base_table_portable_fk)
      :mappedTableIds (not-empty mapped-table-ids)
-     :dimensions (not-empty (keyed-map dimension-schemas)))))
+     :dimensions (not-empty (common/keyed-map dimension-schemas)))))
 
 (defn- select-tables
   ([database-ids]
@@ -863,8 +567,8 @@
   ([database-ids table-ids]
    (->> (t2/select :model/Table
                    {:where    (cond-> [:and [:= :active true]]
-                                database-ids (conj (database-id-filter-clause database-ids :db_id))
-                                table-ids (conj (id-filter-clause table-ids :id)))
+                                database-ids (conj (qp/database-id-filter-clause database-ids :db_id))
+                                table-ids (conj (qp/id-filter-clause table-ids :id)))
                     :order-by [[:name :asc] [:id :asc]]})
         (filter mi/can-read?))))
 
@@ -874,15 +578,15 @@
                   {:where    [:and
                               [:= :active true]
                               [:= :is_published true]
-                              (id-filter-clause data-collection-ids :collection_id)]
+                              (qp/id-filter-clause data-collection-ids :collection_id)]
                    :order-by [[:name :asc] [:id :asc]]})
        (filter mi/can-read?)))
 
 (defn- segment-schema
   [table-id {:keys [id name description display-name portable-entity-id portable_entity_id]}]
-  (assoc-some
+  (m/assoc-some
    {:type    "segment"
-    :key     (generated-key (or display-name name) id)
+    :key     (common/generated-key (or display-name name) id)
     :id      id
     :tableId table-id
     :name    name}
@@ -891,29 +595,29 @@
 
 (defn- measure-schema
   [table-id database-id {:keys [id name description display-name portable-entity-id portable_entity_id]}]
-  (assoc-some
+  (m/assoc-some
    {:type    "measure"
-    :key     (generated-key (or display-name name) id)
+    :key     (common/generated-key (or display-name name) id)
     :id      id
     :tableId table-id
     :name    name
-    :columns [(or (some-> (measure-result-column database-id id) column-schema)
+    :columns [(or (some-> (measure-result-column database-id id) common/column-schema)
                   (fallback-metric-column {:name (or display-name name)}))]}
    :entityId (or portable_entity_id portable-entity-id)
    :description description))
 
 (defn- table-schema
   [{:keys [id name description display_name database_id database_name database_schema portable_entity_id fields segments measures]}]
-  (let [segments-map (keyed-map (map #(segment-schema id %) segments))
-        measures-map (keyed-map (map #(measure-schema id database_id %) measures))]
-    (assoc-some
+  (let [segments-map (common/keyed-map (map #(segment-schema id %) segments))
+        measures-map (common/keyed-map (map #(measure-schema id database_id %) measures))]
+    (m/assoc-some
      {:type         "table"
-      :key          (generated-key (or display_name name) id)
+      :key          (common/generated-key (or display_name name) id)
       :id           id
       :name         (or display_name name)
       :databaseName database_name
       :tableName    name
-      :fields       (keyed-map (map #(field-schema % name) fields))}
+      :fields       (common/keyed-map (map #(field-schema % name) fields))}
      :entityId portable_entity_id
      :description description
      :schemaName database_schema
@@ -974,24 +678,24 @@
    :schemaVersion 2
    :generatedAt   (str (Instant/now))
    :metabase      {:instanceUrl (system/site-url)}
-   :questions     (keyed-map questions)
-   :models        (keyed-model-map models)
-   :tables        (keyed-map tables)
-   :metrics       (keyed-map metrics)))
+   :questions     (common/keyed-map questions)
+   :models        (common/keyed-model-map models)
+   :tables        (common/keyed-map tables)
+   :metrics       (common/keyed-map metrics)))
 
 (defn- validate-query-params!
   [query-params]
-  (let [library-value              (query-library-value query-params)
-        library-collection-values  (query-library-collection-values query-params)
-        question-collection-values (query-question-collection-values query-params)
-        include-library-root?      (or (query-include-data-library? query-params)
-                                       (query-include-metric-library? query-params))
+  (let [library-value              (qp/query-library-value query-params)
+        library-collection-values  (qp/query-library-collection-values query-params)
+        question-collection-values (qp/query-question-collection-values query-params)
+        include-library-root?      (or (qp/query-include-data-library? query-params)
+                                       (qp/query-include-metric-library? query-params))
         collection-scoped?         (or library-value
                                        library-collection-values
                                        question-collection-values
                                        include-library-root?)
-        database-value             (query-database-value query-params)
-        questions-only             (truthy-query-param? (query-param query-params :questions))]
+        database-value             (qp/query-database-value query-params)
+        questions-only             (qp/truthy-query-param? (qp/query-param query-params :questions))]
     (api/check-400
      (not (and library-value (or library-collection-values include-library-root?)))
      "The library query parameter is mutually exclusive with library-collections, includeDataLibrary, and includeMetricLibrary.")
@@ -1018,13 +722,13 @@
 (defn- typed-schema
   [query-params]
   (validate-query-params! query-params)
-  (let [library-value              (query-library-value query-params)
-        library-collection-values  (query-library-collection-values query-params)
-        question-collection-values (query-question-collection-values query-params)
-        library-scope              (library-scope query-params)
-        database-ids               (database-ids-for-value (query-database-value query-params))
-        question-collection-ids    (collection-scope question-collection-values)
-        include-models?            (query-include-models? query-params)
+  (let [library-value              (qp/query-library-value query-params)
+        library-collection-values  (qp/query-library-collection-values query-params)
+        question-collection-values (qp/query-question-collection-values query-params)
+        library-scope              (qp/library-scope query-params)
+        database-ids               (qp/database-ids-for-value (qp/query-database-value query-params))
+        question-collection-ids    (qp/collection-scope question-collection-values)
+        include-models?            (qp/query-include-models? query-params)
         models                     (cond
                                      database-ids
                                      (model-schemas database-ids)
@@ -1034,7 +738,7 @@
 
                                      :else
                                      [])
-        questions-only             (truthy-query-param? (query-param query-params :questions))]
+        questions-only             (qp/truthy-query-param? (qp/query-param query-params :questions))]
     (cond
       (or library-value
           library-collection-values

--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -695,10 +695,10 @@
                                        question-collection-values
                                        include-library-root?)
         database-value             (qp/query-database-value query-params)
-        questions-only             (qp/truthy-query-param? (qp/query-param query-params :questions))]
+        questions-only             (qp/truthy-query-param? (:questions query-params))]
     (api/check-400
      (not (and library-value (or library-collection-values include-library-root?)))
-     "The library query parameter is mutually exclusive with library-collections, includeDataLibrary, and includeMetricLibrary.")
+     "The library query parameter is mutually exclusive with library-collections, include-data-library, and include-metric-library.")
     (api/check-400
      (not (and collection-scoped? database-value))
      "Collection-scoped query parameters and database query parameters are mutually exclusive.")
@@ -738,7 +738,7 @@
 
                                      :else
                                      [])
-        questions-only             (qp/truthy-query-param? (qp/query-param query-params :questions))]
+        questions-only             (qp/truthy-query-param? (:questions query-params))]
     (cond
       (or library-value
           library-collection-values

--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -16,7 +16,7 @@
    [metabase.models.interface :as mi]
    [metabase.system.core :as system]
    [metabase.typed-schemas.api.common :as common]
-   [metabase.typed-schemas.api.query-params :as qp]
+   [metabase.typed-schemas.api.scope :as scope]
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]
@@ -82,8 +82,8 @@
                                        [:= :type (name card-type)]
                                        [:= :archived false]
                                        (collection/visible-collection-filter-clause :collection_id)]
-                                database-ids (conj (qp/database-id-filter-clause database-ids :database_id))
-                                collection-ids (conj (qp/id-filter-clause collection-ids :collection_id)))
+                                database-ids (conj (scope/database-id-filter-clause database-ids :database_id))
+                                collection-ids (conj (scope/id-filter-clause collection-ids :collection_id)))
                     :order-by [[:name :asc] [:id :asc]]})
         (filter mi/can-read?))))
 
@@ -568,8 +568,8 @@
   ([database-ids table-ids]
    (->> (t2/select :model/Table
                    {:where    (cond-> [:and [:= :active true]]
-                                database-ids (conj (qp/database-id-filter-clause database-ids :db_id))
-                                table-ids (conj (qp/id-filter-clause table-ids :id)))
+                                database-ids (conj (scope/database-id-filter-clause database-ids :db_id))
+                                table-ids (conj (scope/id-filter-clause table-ids :id)))
                     :order-by [[:name :asc] [:id :asc]]})
         (filter mi/can-read?))))
 
@@ -579,7 +579,7 @@
                   {:where    [:and
                               [:= :active true]
                               [:= :is_published true]
-                              (qp/id-filter-clause data-collection-ids :collection_id)]
+                              (scope/id-filter-clause data-collection-ids :collection_id)]
                    :order-by [[:name :asc] [:id :asc]]})
        (filter mi/can-read?)))
 
@@ -686,17 +686,17 @@
 
 (defn- validate-query-params!
   [query-params]
-  (let [library-value              (qp/query-library-value query-params)
-        library-collection-values  (qp/query-library-collection-values query-params)
-        question-collection-values (qp/query-question-collection-values query-params)
-        include-library-root?      (or (qp/query-include-data-library? query-params)
-                                       (qp/query-include-metric-library? query-params))
+  (let [library-value              (scope/query-library-value query-params)
+        library-collection-values  (scope/query-library-collection-values query-params)
+        question-collection-values (scope/query-question-collection-values query-params)
+        include-library-root?      (or (scope/query-include-data-library? query-params)
+                                       (scope/query-include-metric-library? query-params))
         collection-scoped?         (or library-value
                                        library-collection-values
                                        question-collection-values
                                        include-library-root?)
-        database-value             (qp/query-database-value query-params)
-        questions-only             (qp/truthy-query-param? (:questions query-params))]
+        database-value             (scope/query-database-value query-params)
+        questions-only             (scope/truthy-query-param? (:questions query-params))]
     (api/check-400
      (not (and library-value (or library-collection-values include-library-root?)))
      "The library query parameter is mutually exclusive with library-collections, include-data-library, and include-metric-library.")
@@ -723,13 +723,13 @@
 (defn- typed-schema
   [query-params]
   (validate-query-params! query-params)
-  (let [library-value              (qp/query-library-value query-params)
-        library-collection-values  (qp/query-library-collection-values query-params)
-        question-collection-values (qp/query-question-collection-values query-params)
-        library-scope              (qp/library-scope query-params)
-        database-ids               (qp/database-ids-for-value (qp/query-database-value query-params))
-        question-collection-ids    (qp/collection-scope question-collection-values)
-        include-models?            (qp/query-include-models? query-params)
+  (let [library-value              (scope/query-library-value query-params)
+        library-collection-values  (scope/query-library-collection-values query-params)
+        question-collection-values (scope/query-question-collection-values query-params)
+        library-scope              (scope/library-scope query-params)
+        database-ids               (scope/database-ids-for-value (scope/query-database-value query-params))
+        question-collection-ids    (scope/collection-scope question-collection-values)
+        include-models?            (scope/query-include-models? query-params)
         models                     (cond
                                      database-ids
                                      (model-schemas database-ids)
@@ -739,7 +739,7 @@
 
                                      :else
                                      [])
-        questions-only             (qp/truthy-query-param? (:questions query-params))]
+        questions-only             (scope/truthy-query-param? (:questions query-params))]
     (cond
       (or library-value
           library-collection-values

--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -19,6 +19,7 @@
    [metabase.typed-schemas.api.query-params :as qp]
    [metabase.util :as u]
    [metabase.util.json :as json]
+   [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2])
   (:import
    (java.time Instant)))
@@ -1097,23 +1098,47 @@
   [schema]
   (render-schema-module schema " as const"))
 
+(def ^:private TypedSchemaQueryParams
+  [:map
+   [:database {:optional true} [:maybe ms/NonBlankString]]
+   [:database-name {:optional true} [:maybe ms/NonBlankString]]
+   [:library {:optional true} [:maybe ms/NonBlankString]]
+   [:library-collections {:optional true} [:maybe ms/NonBlankString]]
+   [:collections {:optional true} [:maybe ms/NonBlankString]]
+   [:question-collections {:optional true} [:maybe ms/NonBlankString]]
+   [:include-data-library {:optional true} [:maybe :boolean]]
+   [:include-metric-library {:optional true} [:maybe :boolean]]
+   [:include-models {:optional true} [:maybe :boolean]]
+   [:questions {:optional true} [:maybe :boolean]]])
+
 (api.macros/defendpoint :get "/v1/javascript" :- :any
   "Generate a JavaScript semantic schema module."
-  [_route-params query-params _body _request respond _raise]
+  [_route-params
+   query-params :- TypedSchemaQueryParams
+   _body
+   _request
+   respond
+   _raise]
   (respond {:status  200
             :headers javascript-response-headers
             :body    (render-javascript (typed-schema query-params))}))
 
 (api.macros/defendpoint :get "/v1/typescript" :- :any
   "Generate a TypeScript semantic schema module."
-  [_route-params query-params _body _request respond _raise]
+  [_route-params
+   query-params :- TypedSchemaQueryParams
+   _body
+   _request
+   respond
+   _raise]
   (respond {:status  200
             :headers typescript-response-headers
             :body    (render-typescript (typed-schema query-params))}))
 
 (api.macros/defendpoint :get "/v1/json" :- :any
   "Generate a JSON semantic schema."
-  [_route-params query-params]
+  [_route-params
+   query-params :- TypedSchemaQueryParams]
   (typed-schema query-params))
 
 (def ^{:arglists '([request respond raise])} routes

--- a/src/metabase/typed_schemas/api/common.clj
+++ b/src/metabase/typed_schemas/api/common.clj
@@ -3,31 +3,49 @@
   (:require
    [clojure.string :as str]
    [medley.core :as m]
+   [metabase.types.core]
    [metabase.util :as u]))
 
 (set! *warn-on-reflection* true)
 
+(comment metabase.types.core/keep-me)
+
+;; Action parameters in generated schemas use these primitive types.
+(def ^:private primitive-type->js-type
+  {:number   "number"
+   :boolean  "boolean"
+   :string   "string"
+   :date     "Date"
+   :datetime "Date"
+   :time     "Date"})
+
+(defn- type-keyword
+  [schema-type]
+  (cond
+    (keyword? schema-type) schema-type
+    (string? schema-type)  (let [schema-type (str/replace schema-type #"^:" "")]
+                             (if (str/includes? schema-type "/")
+                               (keyword schema-type)
+                               (keyword "type" schema-type)))))
+
+;; Result columns and fields use Metabase base/effective types. For example,
+;; `:type/Integer` maps to "number", and `:type/UUID` maps to "string".
+(defn- schema-type->js-type
+  [schema-type]
+  (let [schema-type (type-keyword schema-type)]
+    (cond
+      (nil? schema-type)                     "unknown"
+      (isa? schema-type :type/Boolean)       "boolean"
+      (isa? schema-type :type/Number)        "number"
+      (isa? schema-type :type/Temporal)      "Date"
+      (isa? schema-type :type/Text)          "string"
+      (isa? schema-type :type/TextLike)      "string"
+      :else                                  "unknown")))
+
 (defn- js-type
   [{:keys [type base_type effective_type] :as _column}]
-  (case type
-    :number   "number"
-    :boolean  "boolean"
-    :string   "string"
-    :date     "Date"
-    :datetime "Date"
-    :time     "Date"
-    (let [schema-type (or effective_type base_type)]
-      (cond
-        (some-> schema-type (str/includes? "Boolean")) "boolean"
-        (some-> schema-type (str/includes? "Number"))  "number"
-        (some-> schema-type (str/includes? "Integer")) "number"
-        (some-> schema-type (str/includes? "Float"))   "number"
-        (some-> schema-type (str/includes? "Decimal")) "number"
-        (some-> schema-type (str/includes? "Date"))    "Date"
-        (some-> schema-type (str/includes? "Time"))    "Date"
-        (some-> schema-type (str/includes? "Text"))    "string"
-        (some-> schema-type (str/includes? "UUID"))    "string"
-        :else                                          "unknown"))))
+  (or (get primitive-type->js-type type)
+      (schema-type->js-type (or effective_type base_type))))
 
 (defn column-schema
   "Returns the typed-schema representation for a result column or field-like map."
@@ -47,50 +65,49 @@
 (defn generated-key
   "Returns a stable JavaScript object key for an entity name and id."
   [entity-name id]
-  (let [k (some-> entity-name u/->camelCaseEn)]
-    (if (str/blank? k)
+  (let [generated-key (some-> entity-name u/->camelCaseEn)]
+    (if (str/blank? generated-key)
       (str "entity" id)
-      k)))
+      generated-key)))
 
 (defn pascal-case
-  "Capitalizes the first character of `s` without changing the rest."
-  [s]
-  (when-not (str/blank? s)
-    (str (u/upper-case-en (subs s 0 1))
-         (subs s 1))))
+  "Capitalizes the first character of string without changing the rest."
+  [string]
+  (when-not (str/blank? string)
+    (str (u/upper-case-en (subs string 0 1))
+         (subs string 1))))
+
+(defn- duplicate-key?
+  [key->count key]
+  (> (get key->count key 0) 1))
+
+(defn- keyed-map-candidate-key
+  [key->count {:keys [key id]
+               key-disambiguator :keyDisambiguator
+               table-id :tableId}]
+  (cond-> key
+    (duplicate-key? key->count key) (str (or key-disambiguator table-id id))))
 
 (defn keyed-map
   "Returns a sorted map keyed by each entity key, disambiguating duplicate keys."
   [entities]
-  (let [entities          (vec entities)
-        base-key->count   (frequencies (map :key entities))
-        duplicate-key?    (fn [base-key]
-                            (> (get base-key->count base-key 0) 1))
-        candidate-key     (fn [entity]
-                            (let [base-key (:key entity)]
-                              (if-not (duplicate-key? base-key)
-                                base-key
-                                (str base-key (or (:keyDisambiguator entity)
-                                                  (:tableId entity)
-                                                  (:id entity))))))
-        candidate->count  (frequencies (map candidate-key entities))
-        disambiguated-key (fn [entity]
-                            (let [candidate (candidate-key entity)]
-                              (if (= 1 (get candidate->count candidate))
-                                candidate
-                                (str candidate (:id entity)))))]
-    (reduce (fn [m entity]
-              (let [key (disambiguated-key entity)]
-                (assoc m key (-> entity
-                                 (dissoc :keyDisambiguator)
-                                 (assoc :key key)))))
-            (sorted-map)
-            entities)))
+  (let [entities         (vec entities)
+        base-key->count  (frequencies (map :key entities))
+        candidate-keys   (mapv (partial keyed-map-candidate-key base-key->count) entities)
+        candidate->count (frequencies candidate-keys)]
+    (into (sorted-map)
+          (map (fn [[entity candidate-key]]
+                 (let [key (cond-> candidate-key
+                             (duplicate-key? candidate->count candidate-key) (str (:id entity)))]
+                   [key (-> entity
+                            (dissoc :keyDisambiguator)
+                            (assoc :key key))])))
+          (map vector entities candidate-keys))))
 
 (defn keyed-model-map
   "Returns a sorted model map keyed by model key, exposing only action namespaces."
   [models]
-  (reduce-kv (fn [m k model]
-               (assoc m k (select-keys model [:actions])))
+  (reduce-kv (fn [model-map model-key model]
+               (assoc model-map model-key (select-keys model [:actions])))
              (sorted-map)
              (keyed-map models)))

--- a/src/metabase/typed_schemas/api/common.clj
+++ b/src/metabase/typed_schemas/api/common.clj
@@ -1,0 +1,96 @@
+(ns metabase.typed-schemas.api.common
+  "Shared helpers for typed-schema generation."
+  (:require
+   [clojure.string :as str]
+   [medley.core :as m]
+   [metabase.util :as u]))
+
+(set! *warn-on-reflection* true)
+
+(defn- js-type
+  [{:keys [type base_type effective_type] :as _column}]
+  (case type
+    :number   "number"
+    :boolean  "boolean"
+    :string   "string"
+    :date     "Date"
+    :datetime "Date"
+    :time     "Date"
+    (let [schema-type (or effective_type base_type)]
+      (cond
+        (some-> schema-type (str/includes? "Boolean")) "boolean"
+        (some-> schema-type (str/includes? "Number"))  "number"
+        (some-> schema-type (str/includes? "Integer")) "number"
+        (some-> schema-type (str/includes? "Float"))   "number"
+        (some-> schema-type (str/includes? "Decimal")) "number"
+        (some-> schema-type (str/includes? "Date"))    "Date"
+        (some-> schema-type (str/includes? "Time"))    "Date"
+        (some-> schema-type (str/includes? "Text"))    "string"
+        (some-> schema-type (str/includes? "UUID"))    "string"
+        :else                                          "unknown"))))
+
+(defn column-schema
+  "Returns the typed-schema representation for a result column or field-like map."
+  [{:keys [name display_name base_type effective_type semantic_type description unit] :as column}]
+  (let [effective-type (or effective_type base_type)]
+    (m/assoc-some
+     {:type        "column"
+      :name        name
+      :displayName (or display_name name)
+      :jsType      (js-type column)}
+     :baseType base_type
+     :effectiveType (when (not= effective-type base_type) effective-type)
+     :semanticType semantic_type
+     :description description
+     :unit unit)))
+
+(defn generated-key
+  "Returns a stable JavaScript object key for an entity name and id."
+  [entity-name id]
+  (let [k (some-> entity-name u/->camelCaseEn)]
+    (if (str/blank? k)
+      (str "entity" id)
+      k)))
+
+(defn pascal-case
+  "Capitalizes the first character of `s` without changing the rest."
+  [s]
+  (when-not (str/blank? s)
+    (str (u/upper-case-en (subs s 0 1))
+         (subs s 1))))
+
+(defn keyed-map
+  "Returns a sorted map keyed by each entity key, disambiguating duplicate keys."
+  [entities]
+  (let [entities          (vec entities)
+        base-key->count   (frequencies (map :key entities))
+        duplicate-key?    (fn [base-key]
+                            (> (get base-key->count base-key 0) 1))
+        candidate-key     (fn [entity]
+                            (let [base-key (:key entity)]
+                              (if-not (duplicate-key? base-key)
+                                base-key
+                                (str base-key (or (:keyDisambiguator entity)
+                                                  (:tableId entity)
+                                                  (:id entity))))))
+        candidate->count  (frequencies (map candidate-key entities))
+        disambiguated-key (fn [entity]
+                            (let [candidate (candidate-key entity)]
+                              (if (= 1 (get candidate->count candidate))
+                                candidate
+                                (str candidate (:id entity)))))]
+    (reduce (fn [m entity]
+              (let [key (disambiguated-key entity)]
+                (assoc m key (-> entity
+                                 (dissoc :keyDisambiguator)
+                                 (assoc :key key)))))
+            (sorted-map)
+            entities)))
+
+(defn keyed-model-map
+  "Returns a sorted model map keyed by model key, exposing only action namespaces."
+  [models]
+  (reduce-kv (fn [m k model]
+               (assoc m k (select-keys model [:actions])))
+             (sorted-map)
+             (keyed-map models)))

--- a/src/metabase/typed_schemas/api/query_params.clj
+++ b/src/metabase/typed_schemas/api/query_params.clj
@@ -1,0 +1,229 @@
+(ns metabase.typed-schemas.api.query-params
+  "Query parameter parsing and scope resolution for typed-schema endpoints."
+  (:require
+   [clojure.string :as str]
+   [metabase.api.common :as api]
+   [metabase.collections.models.collection :as collection]
+   [metabase.models.interface :as mi]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn query-param
+  "Returns query param `k`, accepting either keyword or string query maps."
+  [query-params k]
+  (or (get query-params k)
+      (get query-params (name k))))
+
+(defn truthy-query-param?
+  "Returns true when a query param value should be interpreted as enabled."
+  [v]
+  (contains? #{true "true" "1"} v))
+
+(def library-data-entity-id
+  "Entity id of the root Data library collection."
+  "librarylibrarydatadat")
+
+(def library-metrics-entity-id
+  "Entity id of the root metrics library collection."
+  "librarylibrarymetrics")
+
+(defn query-database-value
+  "Returns the requested database id/name query param."
+  [query-params]
+  (some-> (or (query-param query-params :database)
+              (query-param query-params :database-name))
+          str/trim
+          not-empty))
+
+(defn database-ids-for-value
+  "Returns readable database ids matching `database-value`."
+  [database-value]
+  (when database-value
+    (let [database-id (parse-long database-value)]
+      (->> (if database-id
+             (t2/select :model/Database :id database-id)
+             (t2/select :model/Database :name database-value))
+           (filter mi/can-read?)
+           (map :id)
+           set))))
+
+(defn database-id-filter-clause
+  "Returns a Honey SQL filter clause for optional database ids."
+  [database-ids column]
+  (when database-ids
+    (if (seq database-ids)
+      [:in column database-ids]
+      [:= column -1])))
+
+(defn id-filter-clause
+  "Returns a Honey SQL filter clause for optional ids."
+  [ids column]
+  (when ids
+    (if (seq ids)
+      [:in column ids]
+      [:= column -1])))
+
+(defn query-library-value
+  "Returns the `library` query param."
+  [query-params]
+  (some-> (query-param query-params :library)
+          str/trim
+          not-empty))
+
+(defn- query-comma-separated-values
+  [query-params ks]
+  (when-let [value (some-> (->> ks
+                                (keep #(query-param query-params %))
+                                first)
+                           str/trim
+                           not-empty)]
+    (->> (str/split value #",")
+         (map str/trim)
+         (remove str/blank?)
+         seq)))
+
+(defn query-library-collection-values
+  "Returns requested library collection refs."
+  [query-params]
+  (query-comma-separated-values query-params [:library-collections
+                                              :libraryCollections
+                                              :collections]))
+
+(defn query-include-data-library?
+  "Returns true when the root Data library should be included."
+  [query-params]
+  (truthy-query-param? (or (query-param query-params :include-data-library)
+                           (query-param query-params :includeDataLibrary))))
+
+(defn query-include-metric-library?
+  "Returns true when the root metrics library should be included."
+  [query-params]
+  (truthy-query-param? (or (query-param query-params :include-metric-library)
+                           (query-param query-params :includeMetricLibrary))))
+
+(defn query-include-models?
+  "Returns true when readable model action namespaces should be included."
+  [query-params]
+  (truthy-query-param? (or (query-param query-params :include-models)
+                           (query-param query-params :includeModels))))
+
+(defn query-question-collection-values
+  "Returns requested question collection refs."
+  [query-params]
+  (query-comma-separated-values query-params [:question-collections
+                                              :questionCollections]))
+
+(defn- library-collection-for-value
+  [library-value]
+  (when library-value
+    (let [collection-id (parse-long library-value)]
+      (->> (if collection-id
+             (t2/select :model/Collection :id collection-id)
+             (t2/select :model/Collection :name library-value))
+           (filter #(contains? collection/library-collection-types (:type %)))
+           (filter mi/can-read?)
+           first))))
+
+(defn- library-collection-for-ref
+  [collection-value]
+  (let [collection-id (parse-long collection-value)]
+    (->> (if collection-id
+           (t2/select :model/Collection :id collection-id)
+           (t2/select :model/Collection :entity_id collection-value))
+         (filter #(contains? collection/library-collection-types (:type %)))
+         (filter mi/can-read?)
+         first)))
+
+(defn- library-collection-for-entity-id
+  [entity-id]
+  (->> (t2/select :model/Collection :entity_id entity-id)
+       (filter #(contains? collection/library-collection-types (:type %)))
+       (filter mi/can-read?)
+       first))
+
+(defn- collection-for-ref
+  [collection-value]
+  (let [collection-id (parse-long collection-value)]
+    (->> (if collection-id
+           (t2/select :model/Collection :id collection-id)
+           (t2/select :model/Collection :entity_id collection-value))
+         (filter mi/can-read?)
+         first)))
+
+(defn collection-scope
+  "Returns ids for requested normal collections and descendants."
+  [collection-values]
+  (when (seq collection-values)
+    (let [collections (for [collection-value collection-values]
+                        (or (collection-for-ref collection-value)
+                            (api/check-404 false)))]
+      (->> collections
+           (mapcat #(cons % (collection/descendants-flat %)))
+           (map :id)
+           set))))
+
+(defn- library-collection-scope*
+  [library-collections]
+  (let [ids          (->> library-collections
+                          (mapcat #(cons % (collection/descendants-flat %)))
+                          (map :id)
+                          set)
+        rows         (t2/select [:model/Collection :id :type] :id [:in ids])
+        ids-for-type (fn [collection-type]
+                       (->> rows
+                            (filter #(= (:type %) collection-type))
+                            (map :id)
+                            set))]
+    {:library-collections  library-collections
+     :collection-ids        ids
+     :data-collection-ids   (ids-for-type collection/library-data-collection-type)
+     :metric-collection-ids (ids-for-type collection/library-metrics-collection-type)}))
+
+(defn library-collection-scope
+  "Returns the library scope for one named or numeric library collection."
+  [library-value]
+  (when library-value
+    (let [library (or (library-collection-for-value library-value)
+                      (api/check-404 false))]
+      (library-collection-scope* [library]))))
+
+(defn library-collections-scope
+  "Returns the library scope for requested library collection refs."
+  [collection-values]
+  (when (seq collection-values)
+    (let [collections (for [collection-value collection-values]
+                        (or (library-collection-for-ref collection-value)
+                            (api/check-404 false)))]
+      (library-collection-scope* collections))))
+
+(defn- included-library-root-collections
+  [query-params]
+  (keep (fn [[include? entity-id]]
+          (when include?
+            (or (library-collection-for-entity-id entity-id)
+                (api/check-404 false))))
+        [[(query-include-data-library? query-params) library-data-entity-id]
+         [(query-include-metric-library? query-params) library-metrics-entity-id]]))
+
+(defn library-scope
+  "Returns the requested library scope for data and metric library params."
+  [query-params]
+  (let [library-value             (query-library-value query-params)
+        library-collection-values (query-library-collection-values query-params)
+        included-roots            (included-library-root-collections query-params)
+        collection-scope          (cond
+                                    library-value
+                                    (library-collection-scope library-value)
+
+                                    library-collection-values
+                                    (library-collections-scope library-collection-values))]
+    (cond
+      (and collection-scope (seq included-roots))
+      (library-collection-scope* (concat (:library-collections collection-scope) included-roots))
+
+      (seq included-roots)
+      (library-collection-scope* included-roots)
+
+      :else
+      collection-scope)))

--- a/src/metabase/typed_schemas/api/query_params.clj
+++ b/src/metabase/typed_schemas/api/query_params.clj
@@ -14,11 +14,11 @@
   [v]
   (contains? #{true "true" "1"} v))
 
-(def library-data-entity-id
+(def ^:private library-data-entity-id
   "Entity id of the root Data library collection."
   "librarylibrarydatadat")
 
-(def library-metrics-entity-id
+(def ^:private library-metrics-entity-id
   "Entity id of the root metrics library collection."
   "librarylibrarymetrics")
 
@@ -66,8 +66,8 @@
           not-empty))
 
 (defn- query-comma-separated-values
-  [query-params ks]
-  (when-let [value (some-> (->> ks
+  [query-params param-keys]
+  (when-let [value (some-> (->> param-keys
                                 (keep query-params)
                                 first)
                            str/trim

--- a/src/metabase/typed_schemas/api/query_params.clj
+++ b/src/metabase/typed_schemas/api/query_params.clj
@@ -9,12 +9,6 @@
 
 (set! *warn-on-reflection* true)
 
-(defn query-param
-  "Returns query param `k`, accepting either keyword or string query maps."
-  [query-params k]
-  (or (get query-params k)
-      (get query-params (name k))))
-
 (defn truthy-query-param?
   "Returns true when a query param value should be interpreted as enabled."
   [v]
@@ -31,8 +25,8 @@
 (defn query-database-value
   "Returns the requested database id/name query param."
   [query-params]
-  (some-> (or (query-param query-params :database)
-              (query-param query-params :database-name))
+  (some-> (or (:database query-params)
+              (:database-name query-params))
           str/trim
           not-empty))
 
@@ -67,14 +61,14 @@
 (defn query-library-value
   "Returns the `library` query param."
   [query-params]
-  (some-> (query-param query-params :library)
+  (some-> (:library query-params)
           str/trim
           not-empty))
 
 (defn- query-comma-separated-values
   [query-params ks]
   (when-let [value (some-> (->> ks
-                                (keep #(query-param query-params %))
+                                (keep query-params)
                                 first)
                            str/trim
                            not-empty)]
@@ -87,32 +81,27 @@
   "Returns requested library collection refs."
   [query-params]
   (query-comma-separated-values query-params [:library-collections
-                                              :libraryCollections
                                               :collections]))
 
 (defn query-include-data-library?
   "Returns true when the root Data library should be included."
   [query-params]
-  (truthy-query-param? (or (query-param query-params :include-data-library)
-                           (query-param query-params :includeDataLibrary))))
+  (truthy-query-param? (:include-data-library query-params)))
 
 (defn query-include-metric-library?
   "Returns true when the root metrics library should be included."
   [query-params]
-  (truthy-query-param? (or (query-param query-params :include-metric-library)
-                           (query-param query-params :includeMetricLibrary))))
+  (truthy-query-param? (:include-metric-library query-params)))
 
 (defn query-include-models?
   "Returns true when readable model action namespaces should be included."
   [query-params]
-  (truthy-query-param? (or (query-param query-params :include-models)
-                           (query-param query-params :includeModels))))
+  (truthy-query-param? (:include-models query-params)))
 
 (defn query-question-collection-values
   "Returns requested question collection refs."
   [query-params]
-  (query-comma-separated-values query-params [:question-collections
-                                              :questionCollections]))
+  (query-comma-separated-values query-params [:question-collections]))
 
 (defn- library-collection-for-value
   [library-value]

--- a/src/metabase/typed_schemas/api/scope.clj
+++ b/src/metabase/typed_schemas/api/scope.clj
@@ -1,5 +1,5 @@
-(ns metabase.typed-schemas.api.query-params
-  "Query parameter parsing and scope resolution for typed-schema endpoints."
+(ns metabase.typed-schemas.api.scope
+  "Scope resolution for typed-schema endpoints."
   (:require
    [clojure.string :as str]
    [metabase.api.common :as api]

--- a/test/metabase/typed_schemas/api/common_test.clj
+++ b/test/metabase/typed_schemas/api/common_test.clj
@@ -1,0 +1,62 @@
+(ns metabase.typed-schemas.api.common-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.typed-schemas.api.common :as typed-schemas.api.common]))
+
+(deftest column-schema-includes-description-test
+  (is (= {:type          "column"
+          :name          "name"
+          :displayName   "Name"
+          :baseType      "type/Text"
+          :jsType        "string"
+          :description   "Name of the customer"}
+         (#'typed-schemas.api.common/column-schema {:name         "name"
+                                                    :display_name "Name"
+                                                    :base_type    "type/Text"
+                                                    :description  "Name of the customer"}))))
+
+(deftest column-schema-maps-metabase-types-test
+  (are [column js-type] (= js-type
+                           (:jsType (#'typed-schemas.api.common/column-schema column)))
+    {:name "bool", :base_type :type/Boolean}        "boolean"
+    {:name "int", :base_type :type/Integer}         "number"
+    {:name "date", :base_type :type/DateTime}       "Date"
+    {:name "uuid", :base_type :type/UUID}           "string"
+    {:name "string", :base_type "type/Text"}        "string"
+    {:name "decimal", :base_type "Decimal"}         "number"
+    {:name "effective", :effective_type :type/Text} "string"
+    {:name "unknown", :base_type :type/Structured}  "unknown"))
+
+(deftest keyed-map-disambiguates-duplicate-keys-with-readable-suffix-test
+  (is (= {"channelOrderItems" {:key     "channelOrderItems"
+                               :id      "40f15584-bca0-4557-910d-e5e789757f23"
+                               :tableId 261}
+          "channelOrders"     {:key     "channelOrders"
+                               :id      "ca9bef16-d484-4add-8245-ddbc78287e8f"
+                               :tableId 167}}
+         (#'typed-schemas.api.common/keyed-map
+          [{:key     "channel"
+            :id      "ca9bef16-d484-4add-8245-ddbc78287e8f"
+            :tableId 167
+            :keyDisambiguator "Orders"}
+           {:key     "channel"
+            :id      "40f15584-bca0-4557-910d-e5e789757f23"
+            :tableId 261
+            :keyDisambiguator "OrderItems"}]))))
+
+(deftest keyed-map-falls-back-to-id-when-readable-suffix-does-not-disambiguate-test
+  (is (= {"channelOrders1" {:key     "channelOrders1"
+                            :id      1
+                            :tableId 167}
+          "channelOrders2" {:key     "channelOrders2"
+                            :id      2
+                            :tableId 168}}
+         (#'typed-schemas.api.common/keyed-map
+          [{:key     "channel"
+            :id      1
+            :tableId 167
+            :keyDisambiguator "Orders"}
+           {:key     "channel"
+            :id      2
+            :tableId 168
+            :keyDisambiguator "Orders"}]))))

--- a/test/metabase/typed_schemas/api/scope_test.clj
+++ b/test/metabase/typed_schemas/api/scope_test.clj
@@ -1,0 +1,147 @@
+(ns metabase.typed-schemas.api.scope-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.collections.models.collection :as collection]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [metabase.typed-schemas.api.scope :as typed-schemas.api.scope]))
+
+(use-fixtures :once (fixtures/initialize :db :test-users))
+
+(deftest library-collection-scope-accepts-subcollection-id-test
+  (mt/with-temp [:model/Collection root  {:name "Library"
+                                          :type "library"
+                                          :location "/"}
+                 :model/Collection data  {:name "Data"
+                                          :type "library-data"
+                                          :location (collection/children-location root)}
+                 :model/Collection child {:name "Boba Data"
+                                          :type "library-data"
+                                          :location (collection/children-location data)}]
+    (mt/with-test-user :crowberto
+      (is (= {:collection-ids        #{(:id child)}
+              :data-collection-ids   #{(:id child)}
+              :metric-collection-ids #{}}
+             (select-keys (#'typed-schemas.api.scope/library-collection-scope (str (:id child)))
+                          [:collection-ids :data-collection-ids :metric-collection-ids]))))))
+
+(deftest library-collections-scope-accepts-comma-separated-subcollection-ids-test
+  (mt/with-temp [:model/Collection root          {:name "Library"
+                                                  :type "library"
+                                                  :location "/"}
+                 :model/Collection data          {:name "Data"
+                                                  :type "library-data"
+                                                  :location (collection/children-location root)}
+                 :model/Collection metrics       {:name "Metrics"
+                                                  :type "library-metrics"
+                                                  :location (collection/children-location root)}
+                 :model/Collection data-child    {:name "Boba Data"
+                                                  :type "library-data"
+                                                  :location (collection/children-location data)}
+                 :model/Collection data-grandkid {:name "Boba Data Nested"
+                                                  :type "library-data"
+                                                  :location (collection/children-location data-child)}
+                 :model/Collection metric-child  {:name "Boba Metrics"
+                                                  :type "library-metrics"
+                                                  :location (collection/children-location metrics)}]
+    (mt/with-test-user :crowberto
+      (is (= {:collection-ids        #{(:id data-child) (:id data-grandkid) (:id metric-child)}
+              :data-collection-ids   #{(:id data-child) (:id data-grandkid)}
+              :metric-collection-ids #{(:id metric-child)}}
+             (select-keys (#'typed-schemas.api.scope/library-collections-scope
+                           (#'typed-schemas.api.scope/query-library-collection-values
+                            {:library-collections (format "%d, %d"
+                                                          (:id data-child)
+                                                          (:id metric-child))}))
+                          [:collection-ids :data-collection-ids :metric-collection-ids]))))))
+
+(deftest library-collections-scope-accepts-representation-entity-ids-test
+  (mt/with-temp [:model/Collection root         {:name "Library"
+                                                 :type "library"
+                                                 :location "/"}
+                 :model/Collection data         {:name "Data"
+                                                 :type "library-data"
+                                                 :location (collection/children-location root)}
+                 :model/Collection website      {:name      "Website"
+                                                 :type      "library-data"
+                                                 :entity_id "g-jLnamuHKdezZMthJ-z7"
+                                                 :location  (collection/children-location data)}
+                 :model/Collection website-page {:name "Website Page"
+                                                 :type "library-data"
+                                                 :location (collection/children-location website)}]
+    (mt/with-test-user :crowberto
+      (is (= {:collection-ids        #{(:id website) (:id website-page)}
+              :data-collection-ids   #{(:id website) (:id website-page)}
+              :metric-collection-ids #{}}
+             (select-keys (#'typed-schemas.api.scope/library-collections-scope ["g-jLnamuHKdezZMthJ-z7"])
+                          [:collection-ids :data-collection-ids :metric-collection-ids]))))))
+
+(deftest library-scope-includes-canonical-data-and-metrics-libraries-test
+  (with-redefs [typed-schemas.api.scope/library-data-entity-id    "test-library-data"
+                typed-schemas.api.scope/library-metrics-entity-id "test-library-metrics"]
+    (mt/with-temp [:model/Collection root         {:name "Library"
+                                                   :type "library"
+                                                   :location "/"}
+                   :model/Collection data         {:name      "Data"
+                                                   :type      "library-data"
+                                                   :entity_id "test-library-data"
+                                                   :location  (collection/children-location root)}
+                   :model/Collection metrics      {:name      "Metrics"
+                                                   :type      "library-metrics"
+                                                   :entity_id "test-library-metrics"
+                                                   :location  (collection/children-location root)}
+                   :model/Collection data-child   {:name "Boba Data"
+                                                   :type "library-data"
+                                                   :location (collection/children-location data)}
+                   :model/Collection metric-child {:name "Boba Metrics"
+                                                   :type "library-metrics"
+                                                   :location (collection/children-location metrics)}]
+      (mt/with-test-user :crowberto
+        (is (= {:collection-ids        #{(:id data) (:id data-child) (:id metrics) (:id metric-child)}
+                :data-collection-ids   #{(:id data) (:id data-child)}
+                :metric-collection-ids #{(:id metrics) (:id metric-child)}}
+               (select-keys (#'typed-schemas.api.scope/library-scope
+                             {:include-data-library   "true"
+                              :include-metric-library "true"})
+                            [:collection-ids :data-collection-ids :metric-collection-ids])))))))
+
+(deftest ^:parallel query-collection-values-use-kebab-case-params-test
+  (is (= ["1" "2"]
+         (#'typed-schemas.api.scope/query-library-collection-values {:library-collections "1, 2"})))
+  (is (= ["3" "4"]
+         (#'typed-schemas.api.scope/query-question-collection-values {:question-collections "3, 4"})))
+  (is (true?
+       (#'typed-schemas.api.scope/query-include-models? {:include-models "true"})))
+  (is (nil?
+       (#'typed-schemas.api.scope/query-library-collection-values {:libraryCollections "1, 2"})))
+  (is (nil?
+       (#'typed-schemas.api.scope/query-question-collection-values {:questionCollections "3, 4"})))
+  (is (false?
+       (#'typed-schemas.api.scope/query-include-models? {:includeModels "true"}))))
+
+(deftest question-collection-scope-accepts-comma-separated-collection-ids-test
+  (mt/with-temp [:model/Collection parent {:name "Question Parent"
+                                           :location "/"}
+                 :model/Collection child  {:name "Question Child"
+                                           :location (collection/children-location parent)}]
+    (mt/with-test-user :crowberto
+      (is (= #{(:id parent) (:id child)}
+             (#'typed-schemas.api.scope/collection-scope
+              (#'typed-schemas.api.scope/query-question-collection-values
+               {:question-collections (str (:id parent))})))))))
+
+(deftest question-collection-scope-accepts-representation-entity-ids-test
+  (mt/with-temp [:model/Collection parent {:name      "Question Parent"
+                                           :entity_id "question-entity-id-1"
+                                           :location  "/"}
+                 :model/Collection child  {:name "Question Child"
+                                           :location (collection/children-location parent)}]
+    (mt/with-test-user :crowberto
+      (is (= #{(:id parent) (:id child)}
+             (#'typed-schemas.api.scope/collection-scope ["question-entity-id-1"]))))))
+
+(deftest question-collection-scope-rejects-missing-collection-ref-test
+  (mt/with-test-user :crowberto
+    (let [e (is (thrown? clojure.lang.ExceptionInfo
+                         (#'typed-schemas.api.scope/collection-scope ["missing-entity-id-1"])))]
+      (is (= 404 (:status-code (ex-data e)))))))

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -9,6 +9,8 @@
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.typed-schemas.api :as typed-schemas.api]
+   [metabase.typed-schemas.api.common :as typed-schemas.api.common]
+   [metabase.typed-schemas.api.query-params :as typed-schemas.api.query-params]
    [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db :web-server :test-users))
@@ -20,10 +22,10 @@
           :baseType      "type/Text"
           :jsType        "string"
           :description   "Name of the customer"}
-         (#'typed-schemas.api/column-schema {:name         "name"
-                                             :display_name "Name"
-                                             :base_type    "type/Text"
-                                             :description  "Name of the customer"}))))
+         (#'typed-schemas.api.common/column-schema {:name         "name"
+                                                    :display_name "Name"
+                                                    :base_type    "type/Text"
+                                                    :description  "Name of the customer"}))))
 
 (deftest metric-dimension-schema-uses-dimension-id-test
   (is (= {:type          "column"
@@ -180,7 +182,7 @@
           "channelOrders"     {:key     "channelOrders"
                                :id      "ca9bef16-d484-4add-8245-ddbc78287e8f"
                                :tableId 167}}
-         (#'typed-schemas.api/keyed-map
+         (#'typed-schemas.api.common/keyed-map
           [{:key     "channel"
             :id      "ca9bef16-d484-4add-8245-ddbc78287e8f"
             :tableId 167
@@ -197,7 +199,7 @@
           "channelOrders2" {:key     "channelOrders2"
                             :id      2
                             :tableId 168}}
-         (#'typed-schemas.api/keyed-map
+         (#'typed-schemas.api.common/keyed-map
           [{:key     "channel"
             :id      1
             :tableId 167
@@ -537,7 +539,7 @@
 
 (deftest database-filter-scopes-models-test
   (let [model-database-ids (atom [])]
-    (with-redefs [typed-schemas.api/database-ids-for-value (constantly #{42})
+    (with-redefs [typed-schemas.api.query-params/database-ids-for-value (constantly #{42})
                   typed-schemas.api/model-schemas (fn [database-ids]
                                                     (swap! model-database-ids conj database-ids)
                                                     [])
@@ -692,7 +694,7 @@
       (is (= {:collection-ids        #{(:id child)}
               :data-collection-ids   #{(:id child)}
               :metric-collection-ids #{}}
-             (select-keys (#'typed-schemas.api/library-collection-scope (str (:id child)))
+             (select-keys (#'typed-schemas.api.query-params/library-collection-scope (str (:id child)))
                           [:collection-ids :data-collection-ids :metric-collection-ids]))))))
 
 (deftest library-collections-scope-accepts-comma-separated-subcollection-ids-test
@@ -718,8 +720,8 @@
       (is (= {:collection-ids        #{(:id data-child) (:id data-grandkid) (:id metric-child)}
               :data-collection-ids   #{(:id data-child) (:id data-grandkid)}
               :metric-collection-ids #{(:id metric-child)}}
-             (select-keys (#'typed-schemas.api/library-collections-scope
-                           (#'typed-schemas.api/query-library-collection-values
+             (select-keys (#'typed-schemas.api.query-params/library-collections-scope
+                           (#'typed-schemas.api.query-params/query-library-collection-values
                             {:library-collections (format "%d, %d"
                                                           (:id data-child)
                                                           (:id metric-child))}))
@@ -743,12 +745,12 @@
       (is (= {:collection-ids        #{(:id website) (:id website-page)}
               :data-collection-ids   #{(:id website) (:id website-page)}
               :metric-collection-ids #{}}
-             (select-keys (#'typed-schemas.api/library-collections-scope ["g-jLnamuHKdezZMthJ-z7"])
+             (select-keys (#'typed-schemas.api.query-params/library-collections-scope ["g-jLnamuHKdezZMthJ-z7"])
                           [:collection-ids :data-collection-ids :metric-collection-ids]))))))
 
 (deftest library-scope-includes-canonical-data-and-metrics-libraries-test
-  (with-redefs [typed-schemas.api/library-data-entity-id    "test-library-data"
-                typed-schemas.api/library-metrics-entity-id "test-library-metrics"]
+  (with-redefs [typed-schemas.api.query-params/library-data-entity-id    "test-library-data"
+                typed-schemas.api.query-params/library-metrics-entity-id "test-library-metrics"]
     (mt/with-temp [:model/Collection root         {:name "Library"
                                                    :type "library"
                                                    :location "/"}
@@ -770,18 +772,18 @@
         (is (= {:collection-ids        #{(:id data) (:id data-child) (:id metrics) (:id metric-child)}
                 :data-collection-ids   #{(:id data) (:id data-child)}
                 :metric-collection-ids #{(:id metrics) (:id metric-child)}}
-               (select-keys (#'typed-schemas.api/library-scope
+               (select-keys (#'typed-schemas.api.query-params/library-scope
                              {:includeDataLibrary   "true"
                               :includeMetricLibrary "true"})
                             [:collection-ids :data-collection-ids :metric-collection-ids])))))))
 
 (deftest query-collection-values-accept-camel-case-aliases-test
   (is (= ["1" "2"]
-         (#'typed-schemas.api/query-library-collection-values {:libraryCollections "1, 2"})))
+         (#'typed-schemas.api.query-params/query-library-collection-values {:libraryCollections "1, 2"})))
   (is (= ["3" "4"]
-         (#'typed-schemas.api/query-question-collection-values {:questionCollections "3, 4"})))
+         (#'typed-schemas.api.query-params/query-question-collection-values {:questionCollections "3, 4"})))
   (is (true?
-       (#'typed-schemas.api/query-include-models? {:includeModels "true"}))))
+       (#'typed-schemas.api.query-params/query-include-models? {:includeModels "true"}))))
 
 (deftest question-collection-scope-accepts-comma-separated-collection-ids-test
   (mt/with-temp [:model/Collection parent {:name "Question Parent"
@@ -790,8 +792,8 @@
                                            :location (collection/children-location parent)}]
     (mt/with-test-user :crowberto
       (is (= #{(:id parent) (:id child)}
-             (#'typed-schemas.api/collection-scope
-              (#'typed-schemas.api/query-question-collection-values
+             (#'typed-schemas.api.query-params/collection-scope
+              (#'typed-schemas.api.query-params/query-question-collection-values
                {:question-collections (str (:id parent))})))))))
 
 (deftest question-collection-scope-accepts-representation-entity-ids-test
@@ -802,17 +804,17 @@
                                            :location (collection/children-location parent)}]
     (mt/with-test-user :crowberto
       (is (= #{(:id parent) (:id child)}
-             (#'typed-schemas.api/collection-scope ["question-entity-id-1"]))))))
+             (#'typed-schemas.api.query-params/collection-scope ["question-entity-id-1"]))))))
 
 (deftest question-collection-scope-rejects-missing-collection-ref-test
   (mt/with-test-user :crowberto
     (let [e (is (thrown? clojure.lang.ExceptionInfo
-                         (#'typed-schemas.api/collection-scope ["missing-entity-id-1"])))]
+                         (#'typed-schemas.api.query-params/collection-scope ["missing-entity-id-1"])))]
       (is (= 404 (:status-code (ex-data e)))))))
 
 (deftest library-schema-includes-metric-mapped-tables-test
   (let [selected-table-ids (atom nil)]
-    (with-redefs [typed-schemas.api/library-collection-scope
+    (with-redefs [typed-schemas.api.query-params/library-collection-scope
                   (constantly {:metric-collection-ids #{20}
                                :data-collection-ids   #{10}})
                   typed-schemas.api/model-schemas
@@ -848,7 +850,7 @@
 
 (deftest collections-schema-includes-selected-data-and-metric-collections-test
   (let [selected-table-ids (atom nil)]
-    (with-redefs [typed-schemas.api/library-collections-scope
+    (with-redefs [typed-schemas.api.query-params/library-collections-scope
                   (fn [collection-values]
                     (is (= ["10" "20"] collection-values))
                     {:metric-collection-ids #{20}
@@ -919,7 +921,7 @@
 
 (deftest include-models-with-database-scopes-models-test
   (let [model-database-ids (atom [])]
-    (with-redefs [typed-schemas.api/database-ids-for-value (constantly #{42})
+    (with-redefs [typed-schemas.api.query-params/database-ids-for-value (constantly #{42})
                   typed-schemas.api/model-schemas (fn [database-ids]
                                                     (swap! model-database-ids conj database-ids)
                                                     [{:key     "databaseModel"
@@ -940,7 +942,7 @@
                (:models schema)))))))
 
 (deftest question-collections-schema-includes-selected-question-collections-test
-  (with-redefs [typed-schemas.api/collection-scope
+  (with-redefs [typed-schemas.api.query-params/collection-scope
                 (fn [collection-values]
                   (is (= ["30" "40"] collection-values))
                   #{30 40})
@@ -962,12 +964,12 @@
       (is (= {} (:metrics schema))))))
 
 (deftest library-and-question-collections-can-be-combined-test
-  (with-redefs [typed-schemas.api/library-collections-scope
+  (with-redefs [typed-schemas.api.query-params/library-collections-scope
                 (fn [collection-values]
                   (is (= ["10"] collection-values))
                   {:metric-collection-ids #{10}
                    :data-collection-ids   #{10}})
-                typed-schemas.api/collection-scope
+                typed-schemas.api.query-params/collection-scope
                 (fn [collection-values]
                   (is (= ["30"] collection-values))
                   #{30})
@@ -998,12 +1000,12 @@
       (is (= #{2} (->> (:metrics schema) vals (map :id) set))))))
 
 (deftest library-and-question-collections-can-be-combined-with-include-models-test
-  (with-redefs [typed-schemas.api/library-collections-scope
+  (with-redefs [typed-schemas.api.query-params/library-collections-scope
                 (fn [collection-values]
                   (is (= ["10"] collection-values))
                   {:metric-collection-ids #{10}
                    :data-collection-ids   #{10}})
-                typed-schemas.api/collection-scope
+                typed-schemas.api.query-params/collection-scope
                 (fn [collection-values]
                   (is (= ["30"] collection-values))
                   #{30})

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -10,7 +10,7 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.typed-schemas.api :as typed-schemas.api]
    [metabase.typed-schemas.api.common :as typed-schemas.api.common]
-   [metabase.typed-schemas.api.query-params :as typed-schemas.api.query-params]
+   [metabase.typed-schemas.api.scope :as typed-schemas.api.scope]
    [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db :web-server :test-users))
@@ -562,7 +562,7 @@
 
 (deftest database-filter-scopes-models-test
   (let [model-database-ids (atom [])]
-    (with-redefs [typed-schemas.api.query-params/database-ids-for-value (constantly #{42})
+    (with-redefs [typed-schemas.api.scope/database-ids-for-value (constantly #{42})
                   typed-schemas.api/model-schemas (fn [database-ids]
                                                     (swap! model-database-ids conj database-ids)
                                                     [])
@@ -717,7 +717,7 @@
       (is (= {:collection-ids        #{(:id child)}
               :data-collection-ids   #{(:id child)}
               :metric-collection-ids #{}}
-             (select-keys (#'typed-schemas.api.query-params/library-collection-scope (str (:id child)))
+             (select-keys (#'typed-schemas.api.scope/library-collection-scope (str (:id child)))
                           [:collection-ids :data-collection-ids :metric-collection-ids]))))))
 
 (deftest library-collections-scope-accepts-comma-separated-subcollection-ids-test
@@ -743,8 +743,8 @@
       (is (= {:collection-ids        #{(:id data-child) (:id data-grandkid) (:id metric-child)}
               :data-collection-ids   #{(:id data-child) (:id data-grandkid)}
               :metric-collection-ids #{(:id metric-child)}}
-             (select-keys (#'typed-schemas.api.query-params/library-collections-scope
-                           (#'typed-schemas.api.query-params/query-library-collection-values
+             (select-keys (#'typed-schemas.api.scope/library-collections-scope
+                           (#'typed-schemas.api.scope/query-library-collection-values
                             {:library-collections (format "%d, %d"
                                                           (:id data-child)
                                                           (:id metric-child))}))
@@ -768,12 +768,12 @@
       (is (= {:collection-ids        #{(:id website) (:id website-page)}
               :data-collection-ids   #{(:id website) (:id website-page)}
               :metric-collection-ids #{}}
-             (select-keys (#'typed-schemas.api.query-params/library-collections-scope ["g-jLnamuHKdezZMthJ-z7"])
+             (select-keys (#'typed-schemas.api.scope/library-collections-scope ["g-jLnamuHKdezZMthJ-z7"])
                           [:collection-ids :data-collection-ids :metric-collection-ids]))))))
 
 (deftest library-scope-includes-canonical-data-and-metrics-libraries-test
-  (with-redefs [typed-schemas.api.query-params/library-data-entity-id    "test-library-data"
-                typed-schemas.api.query-params/library-metrics-entity-id "test-library-metrics"]
+  (with-redefs [typed-schemas.api.scope/library-data-entity-id    "test-library-data"
+                typed-schemas.api.scope/library-metrics-entity-id "test-library-metrics"]
     (mt/with-temp [:model/Collection root         {:name "Library"
                                                    :type "library"
                                                    :location "/"}
@@ -795,24 +795,24 @@
         (is (= {:collection-ids        #{(:id data) (:id data-child) (:id metrics) (:id metric-child)}
                 :data-collection-ids   #{(:id data) (:id data-child)}
                 :metric-collection-ids #{(:id metrics) (:id metric-child)}}
-               (select-keys (#'typed-schemas.api.query-params/library-scope
+               (select-keys (#'typed-schemas.api.scope/library-scope
                              {:include-data-library   "true"
                               :include-metric-library "true"})
                             [:collection-ids :data-collection-ids :metric-collection-ids])))))))
 
 (deftest ^:parallel query-collection-values-use-kebab-case-params-test
   (is (= ["1" "2"]
-         (#'typed-schemas.api.query-params/query-library-collection-values {:library-collections "1, 2"})))
+         (#'typed-schemas.api.scope/query-library-collection-values {:library-collections "1, 2"})))
   (is (= ["3" "4"]
-         (#'typed-schemas.api.query-params/query-question-collection-values {:question-collections "3, 4"})))
+         (#'typed-schemas.api.scope/query-question-collection-values {:question-collections "3, 4"})))
   (is (true?
-       (#'typed-schemas.api.query-params/query-include-models? {:include-models "true"})))
+       (#'typed-schemas.api.scope/query-include-models? {:include-models "true"})))
   (is (nil?
-       (#'typed-schemas.api.query-params/query-library-collection-values {:libraryCollections "1, 2"})))
+       (#'typed-schemas.api.scope/query-library-collection-values {:libraryCollections "1, 2"})))
   (is (nil?
-       (#'typed-schemas.api.query-params/query-question-collection-values {:questionCollections "3, 4"})))
+       (#'typed-schemas.api.scope/query-question-collection-values {:questionCollections "3, 4"})))
   (is (false?
-       (#'typed-schemas.api.query-params/query-include-models? {:includeModels "true"}))))
+       (#'typed-schemas.api.scope/query-include-models? {:includeModels "true"}))))
 
 (deftest question-collection-scope-accepts-comma-separated-collection-ids-test
   (mt/with-temp [:model/Collection parent {:name "Question Parent"
@@ -821,8 +821,8 @@
                                            :location (collection/children-location parent)}]
     (mt/with-test-user :crowberto
       (is (= #{(:id parent) (:id child)}
-             (#'typed-schemas.api.query-params/collection-scope
-              (#'typed-schemas.api.query-params/query-question-collection-values
+             (#'typed-schemas.api.scope/collection-scope
+              (#'typed-schemas.api.scope/query-question-collection-values
                {:question-collections (str (:id parent))})))))))
 
 (deftest question-collection-scope-accepts-representation-entity-ids-test
@@ -833,17 +833,17 @@
                                            :location (collection/children-location parent)}]
     (mt/with-test-user :crowberto
       (is (= #{(:id parent) (:id child)}
-             (#'typed-schemas.api.query-params/collection-scope ["question-entity-id-1"]))))))
+             (#'typed-schemas.api.scope/collection-scope ["question-entity-id-1"]))))))
 
 (deftest question-collection-scope-rejects-missing-collection-ref-test
   (mt/with-test-user :crowberto
     (let [e (is (thrown? clojure.lang.ExceptionInfo
-                         (#'typed-schemas.api.query-params/collection-scope ["missing-entity-id-1"])))]
+                         (#'typed-schemas.api.scope/collection-scope ["missing-entity-id-1"])))]
       (is (= 404 (:status-code (ex-data e)))))))
 
 (deftest library-schema-includes-metric-mapped-tables-test
   (let [selected-table-ids (atom nil)]
-    (with-redefs [typed-schemas.api.query-params/library-collection-scope
+    (with-redefs [typed-schemas.api.scope/library-collection-scope
                   (constantly {:metric-collection-ids #{20}
                                :data-collection-ids   #{10}})
                   typed-schemas.api/model-schemas
@@ -879,7 +879,7 @@
 
 (deftest collections-schema-includes-selected-data-and-metric-collections-test
   (let [selected-table-ids (atom nil)]
-    (with-redefs [typed-schemas.api.query-params/library-collections-scope
+    (with-redefs [typed-schemas.api.scope/library-collections-scope
                   (fn [collection-values]
                     (is (= ["10" "20"] collection-values))
                     {:metric-collection-ids #{20}
@@ -950,7 +950,7 @@
 
 (deftest include-models-with-database-scopes-models-test
   (let [model-database-ids (atom [])]
-    (with-redefs [typed-schemas.api.query-params/database-ids-for-value (constantly #{42})
+    (with-redefs [typed-schemas.api.scope/database-ids-for-value (constantly #{42})
                   typed-schemas.api/model-schemas (fn [database-ids]
                                                     (swap! model-database-ids conj database-ids)
                                                     [{:key     "databaseModel"
@@ -971,7 +971,7 @@
                (:models schema)))))))
 
 (deftest question-collections-schema-includes-selected-question-collections-test
-  (with-redefs [typed-schemas.api.query-params/collection-scope
+  (with-redefs [typed-schemas.api.scope/collection-scope
                 (fn [collection-values]
                   (is (= ["30" "40"] collection-values))
                   #{30 40})
@@ -993,12 +993,12 @@
       (is (= {} (:metrics schema))))))
 
 (deftest library-and-question-collections-can-be-combined-test
-  (with-redefs [typed-schemas.api.query-params/library-collections-scope
+  (with-redefs [typed-schemas.api.scope/library-collections-scope
                 (fn [collection-values]
                   (is (= ["10"] collection-values))
                   {:metric-collection-ids #{10}
                    :data-collection-ids   #{10}})
-                typed-schemas.api.query-params/collection-scope
+                typed-schemas.api.scope/collection-scope
                 (fn [collection-values]
                   (is (= ["30"] collection-values))
                   #{30})
@@ -1029,12 +1029,12 @@
       (is (= #{2} (->> (:metrics schema) vals (map :id) set))))))
 
 (deftest library-and-question-collections-can-be-combined-with-include-models-test
-  (with-redefs [typed-schemas.api.query-params/library-collections-scope
+  (with-redefs [typed-schemas.api.scope/library-collections-scope
                 (fn [collection-values]
                   (is (= ["10"] collection-values))
                   {:metric-collection-ids #{10}
                    :data-collection-ids   #{10}})
-                typed-schemas.api.query-params/collection-scope
+                typed-schemas.api.scope/collection-scope
                 (fn [collection-values]
                   (is (= ["30"] collection-values))
                   #{30})

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -773,16 +773,22 @@
                 :data-collection-ids   #{(:id data) (:id data-child)}
                 :metric-collection-ids #{(:id metrics) (:id metric-child)}}
                (select-keys (#'typed-schemas.api.query-params/library-scope
-                             {:includeDataLibrary   "true"
-                              :includeMetricLibrary "true"})
+                             {:include-data-library   "true"
+                              :include-metric-library "true"})
                             [:collection-ids :data-collection-ids :metric-collection-ids])))))))
 
-(deftest query-collection-values-accept-camel-case-aliases-test
+(deftest query-collection-values-use-kebab-case-params-test
   (is (= ["1" "2"]
-         (#'typed-schemas.api.query-params/query-library-collection-values {:libraryCollections "1, 2"})))
+         (#'typed-schemas.api.query-params/query-library-collection-values {:library-collections "1, 2"})))
   (is (= ["3" "4"]
-         (#'typed-schemas.api.query-params/query-question-collection-values {:questionCollections "3, 4"})))
+         (#'typed-schemas.api.query-params/query-question-collection-values {:question-collections "3, 4"})))
   (is (true?
+       (#'typed-schemas.api.query-params/query-include-models? {:include-models "true"})))
+  (is (nil?
+       (#'typed-schemas.api.query-params/query-library-collection-values {:libraryCollections "1, 2"})))
+  (is (nil?
+       (#'typed-schemas.api.query-params/query-question-collection-values {:questionCollections "3, 4"})))
+  (is (false?
        (#'typed-schemas.api.query-params/query-include-models? {:includeModels "true"}))))
 
 (deftest question-collection-scope-accepts-comma-separated-collection-ids-test
@@ -897,22 +903,22 @@
                 typed-schemas.api/question-schemas
                 (fn
                   ([_database-ids]
-                   (is false "includeModels-only schemas should not load questions"))
+                   (is false "include-models-only schemas should not load questions"))
                   ([_database-ids _collection-ids]
-                   (is false "includeModels-only schemas should not load questions")))
+                   (is false "include-models-only schemas should not load questions")))
                 typed-schemas.api/metric-schemas
                 (fn
                   ([_database-ids]
-                   (is false "includeModels-only schemas should not load metrics"))
+                   (is false "include-models-only schemas should not load metrics"))
                   ([_database-ids _collection-ids]
-                   (is false "includeModels-only schemas should not load metrics")))
+                   (is false "include-models-only schemas should not load metrics")))
                 typed-schemas.api/select-tables
                 (fn
                   ([_database-ids]
-                   (is false "includeModels-only schemas should not load tables"))
+                   (is false "include-models-only schemas should not load tables"))
                   ([_database-ids _table-ids]
-                   (is false "includeModels-only schemas should not load tables")))]
-    (let [schema (#'typed-schemas.api/typed-schema {:includeModels "true"})]
+                   (is false "include-models-only schemas should not load tables")))]
+    (let [schema (#'typed-schemas.api/typed-schema {:include-models "true"})]
       (is (= {} (:questions schema)))
       (is (= {"actionableModel" {:actions {"create" {:kind "action", :key "create", :id 1}}}}
              (:models schema)))
@@ -936,7 +942,7 @@
                                                     ([_database-ids] [])
                                                     ([_database-ids _table-ids] []))
                   typed-schemas.api/table-schemas (constantly [])]
-      (let [schema (#'typed-schemas.api/typed-schema {:database "Boba" :includeModels "true"})]
+      (let [schema (#'typed-schemas.api/typed-schema {:database "Boba" :include-models "true"})]
         (is (= [#{42}] @model-database-ids))
         (is (= {"databaseModel" {:actions {"create" {:kind "action", :key "create", :id 1}}}}
                (:models schema)))))))
@@ -1029,7 +1035,7 @@
                 (constantly [{:type "table", :key "orders", :id 3}])]
     (let [schema (#'typed-schemas.api/typed-schema {:library-collections  "10"
                                                     :question-collections "30"
-                                                    :includeModels        "true"})]
+                                                    :include-models        "true"})]
       (is (= #{1} (->> (:questions schema) vals (map :id) set)))
       (is (= {"selectedQuestionCollectionModel" {:actions {"create" {:kind "action", :key "create", :id 1}}}}
              (:models schema)))

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -27,6 +27,18 @@
                                                     :base_type    "type/Text"
                                                     :description  "Name of the customer"}))))
 
+(deftest column-schema-maps-metabase-types-test
+  (are [column js-type] (= js-type
+                           (:jsType (#'typed-schemas.api.common/column-schema column)))
+    {:name "bool", :base_type :type/Boolean}        "boolean"
+    {:name "int", :base_type :type/Integer}         "number"
+    {:name "date", :base_type :type/DateTime}       "Date"
+    {:name "uuid", :base_type :type/UUID}           "string"
+    {:name "string", :base_type "type/Text"}        "string"
+    {:name "decimal", :base_type "Decimal"}         "number"
+    {:name "effective", :effective_type :type/Text} "string"
+    {:name "unknown", :base_type :type/Structured}  "unknown"))
+
 (deftest metric-dimension-schema-uses-dimension-id-test
   (is (= {:type          "column"
           :name          "category"
@@ -515,6 +527,17 @@
     (is (map? (get-in response [:body :tables])))
     (is (map? (get-in response [:body :metrics])))))
 
+(deftest query-params-are-coerced-at-endpoint-test
+  (with-redefs [typed-schemas.api/typed-schema identity]
+    (let [response (mt/user-http-request
+                    :crowberto
+                    :get
+                    200
+                    "typed-schemas/v1/json?include-models=true&questions=false&library-collections=1,2")]
+      (is (true? (:include-models response)))
+      (is (false? (:questions response)))
+      (is (= "1,2" (:library-collections response))))))
+
 (deftest database-filter-test
   (testing "a non-matching database name returns an empty semantic schema"
     (let [response (mt/user-http-request-full-response
@@ -777,7 +800,7 @@
                               :include-metric-library "true"})
                             [:collection-ids :data-collection-ids :metric-collection-ids])))))))
 
-(deftest query-collection-values-use-kebab-case-params-test
+(deftest ^:parallel query-collection-values-use-kebab-case-params-test
   (is (= ["1" "2"]
          (#'typed-schemas.api.query-params/query-library-collection-values {:library-collections "1, 2"})))
   (is (= ["3" "4"]

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -3,41 +3,15 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.actions.core :as actions]
-   [metabase.collections.models.collection :as collection]
    [metabase.metabot.tools.entity-details :as entity-details]
    [metabase.models.interface :as mi]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.typed-schemas.api :as typed-schemas.api]
-   [metabase.typed-schemas.api.common :as typed-schemas.api.common]
    [metabase.typed-schemas.api.scope :as typed-schemas.api.scope]
    [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db :web-server :test-users))
-
-(deftest column-schema-includes-description-test
-  (is (= {:type          "column"
-          :name          "name"
-          :displayName   "Name"
-          :baseType      "type/Text"
-          :jsType        "string"
-          :description   "Name of the customer"}
-         (#'typed-schemas.api.common/column-schema {:name         "name"
-                                                    :display_name "Name"
-                                                    :base_type    "type/Text"
-                                                    :description  "Name of the customer"}))))
-
-(deftest column-schema-maps-metabase-types-test
-  (are [column js-type] (= js-type
-                           (:jsType (#'typed-schemas.api.common/column-schema column)))
-    {:name "bool", :base_type :type/Boolean}        "boolean"
-    {:name "int", :base_type :type/Integer}         "number"
-    {:name "date", :base_type :type/DateTime}       "Date"
-    {:name "uuid", :base_type :type/UUID}           "string"
-    {:name "string", :base_type "type/Text"}        "string"
-    {:name "decimal", :base_type "Decimal"}         "number"
-    {:name "effective", :effective_type :type/Text} "string"
-    {:name "unknown", :base_type :type/Structured}  "unknown"))
 
 (deftest metric-dimension-schema-uses-dimension-id-test
   (is (= {:type          "column"
@@ -186,40 +160,6 @@
   (testing "stage source-card emits sourceCardId"
     (is (= 42 (#'typed-schemas.api/source-card-id
                {:dataset_query {:stages [{:source-card 42}]}})))))
-
-(deftest keyed-map-disambiguates-duplicate-keys-with-readable-suffix-test
-  (is (= {"channelOrderItems" {:key     "channelOrderItems"
-                               :id      "40f15584-bca0-4557-910d-e5e789757f23"
-                               :tableId 261}
-          "channelOrders"     {:key     "channelOrders"
-                               :id      "ca9bef16-d484-4add-8245-ddbc78287e8f"
-                               :tableId 167}}
-         (#'typed-schemas.api.common/keyed-map
-          [{:key     "channel"
-            :id      "ca9bef16-d484-4add-8245-ddbc78287e8f"
-            :tableId 167
-            :keyDisambiguator "Orders"}
-           {:key     "channel"
-            :id      "40f15584-bca0-4557-910d-e5e789757f23"
-            :tableId 261
-            :keyDisambiguator "OrderItems"}]))))
-
-(deftest keyed-map-falls-back-to-id-when-readable-suffix-does-not-disambiguate-test
-  (is (= {"channelOrders1" {:key     "channelOrders1"
-                            :id      1
-                            :tableId 167}
-          "channelOrders2" {:key     "channelOrders2"
-                            :id      2
-                            :tableId 168}}
-         (#'typed-schemas.api.common/keyed-map
-          [{:key     "channel"
-            :id      1
-            :tableId 167
-            :keyDisambiguator "Orders"}
-           {:key     "channel"
-            :id      2
-            :tableId 168
-            :keyDisambiguator "Orders"}]))))
 
 (deftest table-source-names-filters-unreadable-tables-test
   (with-redefs [t2/select (constantly [{:id 10 :name "orders" :display_name "Orders"}
@@ -702,144 +642,6 @@
    :get
    400
    "typed-schemas/v1/json?library=1&library-collections=2"))
-
-(deftest library-collection-scope-accepts-subcollection-id-test
-  (mt/with-temp [:model/Collection root  {:name "Library"
-                                          :type "library"
-                                          :location "/"}
-                 :model/Collection data  {:name "Data"
-                                          :type "library-data"
-                                          :location (collection/children-location root)}
-                 :model/Collection child {:name "Boba Data"
-                                          :type "library-data"
-                                          :location (collection/children-location data)}]
-    (mt/with-test-user :crowberto
-      (is (= {:collection-ids        #{(:id child)}
-              :data-collection-ids   #{(:id child)}
-              :metric-collection-ids #{}}
-             (select-keys (#'typed-schemas.api.scope/library-collection-scope (str (:id child)))
-                          [:collection-ids :data-collection-ids :metric-collection-ids]))))))
-
-(deftest library-collections-scope-accepts-comma-separated-subcollection-ids-test
-  (mt/with-temp [:model/Collection root          {:name "Library"
-                                                  :type "library"
-                                                  :location "/"}
-                 :model/Collection data          {:name "Data"
-                                                  :type "library-data"
-                                                  :location (collection/children-location root)}
-                 :model/Collection metrics       {:name "Metrics"
-                                                  :type "library-metrics"
-                                                  :location (collection/children-location root)}
-                 :model/Collection data-child    {:name "Boba Data"
-                                                  :type "library-data"
-                                                  :location (collection/children-location data)}
-                 :model/Collection data-grandkid {:name "Boba Data Nested"
-                                                  :type "library-data"
-                                                  :location (collection/children-location data-child)}
-                 :model/Collection metric-child  {:name "Boba Metrics"
-                                                  :type "library-metrics"
-                                                  :location (collection/children-location metrics)}]
-    (mt/with-test-user :crowberto
-      (is (= {:collection-ids        #{(:id data-child) (:id data-grandkid) (:id metric-child)}
-              :data-collection-ids   #{(:id data-child) (:id data-grandkid)}
-              :metric-collection-ids #{(:id metric-child)}}
-             (select-keys (#'typed-schemas.api.scope/library-collections-scope
-                           (#'typed-schemas.api.scope/query-library-collection-values
-                            {:library-collections (format "%d, %d"
-                                                          (:id data-child)
-                                                          (:id metric-child))}))
-                          [:collection-ids :data-collection-ids :metric-collection-ids]))))))
-
-(deftest library-collections-scope-accepts-representation-entity-ids-test
-  (mt/with-temp [:model/Collection root         {:name "Library"
-                                                 :type "library"
-                                                 :location "/"}
-                 :model/Collection data         {:name "Data"
-                                                 :type "library-data"
-                                                 :location (collection/children-location root)}
-                 :model/Collection website      {:name      "Website"
-                                                 :type      "library-data"
-                                                 :entity_id "g-jLnamuHKdezZMthJ-z7"
-                                                 :location  (collection/children-location data)}
-                 :model/Collection website-page {:name "Website Page"
-                                                 :type "library-data"
-                                                 :location (collection/children-location website)}]
-    (mt/with-test-user :crowberto
-      (is (= {:collection-ids        #{(:id website) (:id website-page)}
-              :data-collection-ids   #{(:id website) (:id website-page)}
-              :metric-collection-ids #{}}
-             (select-keys (#'typed-schemas.api.scope/library-collections-scope ["g-jLnamuHKdezZMthJ-z7"])
-                          [:collection-ids :data-collection-ids :metric-collection-ids]))))))
-
-(deftest library-scope-includes-canonical-data-and-metrics-libraries-test
-  (with-redefs [typed-schemas.api.scope/library-data-entity-id    "test-library-data"
-                typed-schemas.api.scope/library-metrics-entity-id "test-library-metrics"]
-    (mt/with-temp [:model/Collection root         {:name "Library"
-                                                   :type "library"
-                                                   :location "/"}
-                   :model/Collection data         {:name      "Data"
-                                                   :type      "library-data"
-                                                   :entity_id "test-library-data"
-                                                   :location  (collection/children-location root)}
-                   :model/Collection metrics      {:name      "Metrics"
-                                                   :type      "library-metrics"
-                                                   :entity_id "test-library-metrics"
-                                                   :location  (collection/children-location root)}
-                   :model/Collection data-child   {:name "Boba Data"
-                                                   :type "library-data"
-                                                   :location (collection/children-location data)}
-                   :model/Collection metric-child {:name "Boba Metrics"
-                                                   :type "library-metrics"
-                                                   :location (collection/children-location metrics)}]
-      (mt/with-test-user :crowberto
-        (is (= {:collection-ids        #{(:id data) (:id data-child) (:id metrics) (:id metric-child)}
-                :data-collection-ids   #{(:id data) (:id data-child)}
-                :metric-collection-ids #{(:id metrics) (:id metric-child)}}
-               (select-keys (#'typed-schemas.api.scope/library-scope
-                             {:include-data-library   "true"
-                              :include-metric-library "true"})
-                            [:collection-ids :data-collection-ids :metric-collection-ids])))))))
-
-(deftest ^:parallel query-collection-values-use-kebab-case-params-test
-  (is (= ["1" "2"]
-         (#'typed-schemas.api.scope/query-library-collection-values {:library-collections "1, 2"})))
-  (is (= ["3" "4"]
-         (#'typed-schemas.api.scope/query-question-collection-values {:question-collections "3, 4"})))
-  (is (true?
-       (#'typed-schemas.api.scope/query-include-models? {:include-models "true"})))
-  (is (nil?
-       (#'typed-schemas.api.scope/query-library-collection-values {:libraryCollections "1, 2"})))
-  (is (nil?
-       (#'typed-schemas.api.scope/query-question-collection-values {:questionCollections "3, 4"})))
-  (is (false?
-       (#'typed-schemas.api.scope/query-include-models? {:includeModels "true"}))))
-
-(deftest question-collection-scope-accepts-comma-separated-collection-ids-test
-  (mt/with-temp [:model/Collection parent {:name "Question Parent"
-                                           :location "/"}
-                 :model/Collection child  {:name "Question Child"
-                                           :location (collection/children-location parent)}]
-    (mt/with-test-user :crowberto
-      (is (= #{(:id parent) (:id child)}
-             (#'typed-schemas.api.scope/collection-scope
-              (#'typed-schemas.api.scope/query-question-collection-values
-               {:question-collections (str (:id parent))})))))))
-
-(deftest question-collection-scope-accepts-representation-entity-ids-test
-  (mt/with-temp [:model/Collection parent {:name      "Question Parent"
-                                           :entity_id "question-entity-id-1"
-                                           :location  "/"}
-                 :model/Collection child  {:name "Question Child"
-                                           :location (collection/children-location parent)}]
-    (mt/with-test-user :crowberto
-      (is (= #{(:id parent) (:id child)}
-             (#'typed-schemas.api.scope/collection-scope ["question-entity-id-1"]))))))
-
-(deftest question-collection-scope-rejects-missing-collection-ref-test
-  (mt/with-test-user :crowberto
-    (let [e (is (thrown? clojure.lang.ExceptionInfo
-                         (#'typed-schemas.api.scope/collection-scope ["missing-entity-id-1"])))]
-      (is (= 404 (:status-code (ex-data e)))))))
 
 (deftest library-schema-includes-metric-mapped-tables-test
   (let [selected-table-ids (atom nil)]


### PR DESCRIPTION
Closes [EMB-2075: Extract typed schema common helpers](https://linear.app/metabase/issue/EMB-2075/extract-typed-schema-common-helpers)

PR 1/5 of [EMB-2062: Code cleanup: split `src/metabase/typed_schemas/api.clj` to multiple files](https://linear.app/metabase/issue/EMB-2062/code-cleanup-split-srcmetabasetyped-schemasapiclj-to-multiple-files)

### Description

Extract shared typed-schema helpers into `metabase.typed-schemas.api.common` and query parameter parsing/validation into `metabase.typed-schemas.api.query-params`, keeping endpoint behavior in `api.clj` smaller and easier to review.

It also updates the data-app skill docs for the kebab-case typed-schema query params. We want to use kebab-case, not camelCase for query parameters.

### How to verify

Existing backend tests should continue to pass. Schema generation via `/api/typed-schemas/v1/typescript` endpoint should continue to work.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

