### PR TITLE
[DO NOT MERGE] Static-viz render perf: date/SVG/ECharts optimizations (+ dispose leak fix)

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
@@ -76,7 +76,6 @@ export const ComboChart = ({
   const option = getCartesianChartOption(
     chartModel,
     chartLayout,
-    false,
     null,
     [],
     settings,
@@ -88,6 +87,9 @@ export const ComboChart = ({
   chart.setOption(option);
 
   const chartSvg = sanitizeSvgForBatik(chart.renderToSVGString(), isStorybook);
+  // Free the ECharts/zrender instance; SSR instances are otherwise never released, leaking ~MBs per
+  // render in a long-lived renderer process.
+  chart.dispose();
   const allPointsOutOfRange = useAreAllDataPointsOutOfRange(
     chartModel,
     settings,

--- a/frontend/src/metabase/static-viz/lib/svg.ts
+++ b/frontend/src/metabase/static-viz/lib/svg.ts
@@ -1,8 +1,3 @@
-import type { Element, ElementContent } from "hast";
-import { fromHtml } from "hast-util-from-html";
-import { toHtml } from "hast-util-to-html";
-
-// FIXME: instead of Regex parse svg, update, serialize
 const transformSvgForOutline = (svgString: string) => {
   const regex =
     /<text([^>]*fill="([^"]+)"[^>]*stroke="([^"]+)"[^>]*)>(.*?)<\/text>/g;
@@ -27,34 +22,17 @@ const transformSvgForOutline = (svgString: string) => {
 };
 
 /**
- * Recursive ast traversal helper for `patchDominantBaseline`
- */
-function patchNode(node: ElementContent) {
-  if (node.type !== "element") {
-    return;
-  }
-
-  if (
-    node.tagName === "text" &&
-    node.properties.dominantBaseline === "central"
-  ) {
-    node.properties.dy = "0.5em";
-  }
-
-  node.children.forEach((child) => patchNode(child));
-}
-
-/**
  * Fixes `<text>` elements not being vertically centered due to Batik not
- * supporting the `dominant-baseline` property.
+ * supporting the `dominant-baseline` property. ECharts emits
+ * `dominant-baseline="central"`; we add an equivalent `dy` via a string
+ * transform instead of a full hast parse/serialize round-trip, which is very
+ * slow on large SVGs (~a quarter of a big chart's render time).
  */
 export function patchDominantBaseline(svgString: string) {
-  const svgElem = fromHtml(svgString, { fragment: true, space: "svg" })
-    .children[0] as Element;
-
-  patchNode(svgElem);
-
-  return toHtml(svgElem, { space: "svg" });
+  return svgString.replace(
+    /<text\b[^>]*\bdominant-baseline="central"[^>]*>/g,
+    (tag) => (/\bdy=/.test(tag) ? tag : tag.replace(/>$/, ' dy="0.5em">')),
+  );
 }
 
 export const sanitizeSvgForBatik = (

--- a/frontend/src/metabase/utils/dayjs.ts
+++ b/frontend/src/metabase/utils/dayjs.ts
@@ -35,3 +35,19 @@ dayjs.extend(parseZone);
 dayjs.extend(duration);
 dayjs.extend(isBetween);
 dayjs.extend(preParsePostFormat);
+
+// NOTE(bench): dirty memoization of dayjs `.format()` on the hot static-viz render path. `.format()`
+// is pure for a given instant + utc offset + pattern, so cache by those. Unbounded and locale-blind —
+// throwaway experiment only (a real version would scope the cache per render and key on locale).
+const _dayjsFormat = (dayjs as any).prototype.format;
+const _dayjsFormatCache = new Map<string, string>();
+(dayjs as any).prototype.format = function (formatStr?: string) {
+  const key = `${this.valueOf()} ${this.utcOffset()} ${formatStr ?? ""}`;
+  const cached = _dayjsFormatCache.get(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const result = _dayjsFormat.call(this, formatStr);
+  _dayjsFormatCache.set(key, result);
+  return result;
+};

--- a/frontend/src/metabase/utils/time-dayjs.ts
+++ b/frontend/src/metabase/utils/time-dayjs.ts
@@ -65,11 +65,27 @@ const NUMERIC_UNIT_FORMATS: Record<string, (value: number) => Dayjs> = {
 
 // only attempt to parse the timezone if we're sure we have one (either Z or ±hh:mm or +-hhmm)
 // moment normally interprets the DD in YYYY-MM-DD as an offset :-/
+// Parse-once cache: the cartesian chart pipeline parses the same raw values many times
+// (tryGetDate, dataset transforms, interval detection…). dayjs values are immutable, so handing back
+// a shared instance is safe. NOTE(bench): unbounded — production would want an LRU/per-render cache.
+const parseTimestampCache = new Map<string, Dayjs>();
+
 export function parseTimestamp(
   value: any,
   unit: DatetimeUnit | null = null,
   isLocal = false,
 ) {
+  const cacheKey =
+    typeof value === "string" || typeof value === "number"
+      ? `${typeof value} ${value} ${unit} ${isLocal}`
+      : null;
+  if (cacheKey !== null) {
+    const cached = parseTimestampCache.get(cacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+  }
+
   let result: Dayjs;
   if (dayjs.isDayjs(value)) {
     result = value;
@@ -111,7 +127,11 @@ export function parseTimestamp(
   } else {
     result = dayjs.utc(value);
   }
-  return isLocal ? result.local() : result;
+  const parsed = isLocal ? result.local() : result;
+  if (cacheKey !== null) {
+    parseTimestampCache.set(cacheKey, parsed);
+  }
+  return parsed;
 }
 
 export function getRelativeTime(timestamp: string) {

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
@@ -754,8 +754,13 @@ export function getTimeSeriesXAxisModel(
     // Safari doesn't support offset-based timezones (e.g., "+07:00") in the Date object,
     // which Day.js relies on. To avoid runtime exceptions, we manually adjust the time
     // when an offset is provided. Otherwise, we use Day.js timezone conversion.
+    //
+    // Return a numeric epoch (ms) rather than formatting each row to an ISO string — the per-row
+    // dayjs `.format()` is a large share of a big time-series chart's render cost, and the ECharts
+    // time axis (with useUTC) consumes the shifted epoch directly (see `fromEChartsAxisValue`).
+    // Shifting by whole minutes is exact, so add the offset in ms instead of building a new dayjs.
     return offsetMinutes != null
-      ? date.add(offsetMinutes, "minute").format()
+      ? date.valueOf() + offsetMinutes * 60_000
       : date.tz(timezone).format("YYYY-MM-DDTHH:mm:ss[Z]");
   };
   const fromEChartsAxisValue = (rawValue: number) => {

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
@@ -678,12 +678,38 @@ const interpolateTimeSeriesData = (
       : date.isBefore(end, unit);
   };
 
+  // NOTE(bench): fast path for fixed-length units (day and smaller, not weekly-in-timezone). The gap
+  // loop then runs in integer epoch-ms with no dayjs allocation per step — this loop is a big share of
+  // a business-day-gapped chart's render cost. `Math.floor(ms / unitMs)` reproduces dayjs `startOf(unit)`
+  // for UTC-aligned values (which type/Date timestamps are), so `isBefore(end, unit)` becomes a bucket
+  // comparison. Variable units (month/quarter/year) and weekly-in-timezone keep the dayjs path.
+  const SINGLE_UNIT_MS: Partial<Record<string, number>> = {
+    ms: 1,
+    second: 1000,
+    minute: 60_000,
+    hour: 3_600_000,
+    day: 86_400_000,
+  };
+  const fastUnitMs = isWeeklyIntervalInTimezone ? undefined : SINGLE_UNIT_MS[unit];
+
   for (let i = 0; i < dataset.length; i++) {
     const datum = dataset[i];
     result.push(datum);
 
     if (i === dataset.length - 1) {
       break;
+    }
+
+    if (fastUnitMs != null) {
+      const stepMs = fastUnitMs * count;
+      const endMs = parseTimestamp(dataset[i + 1][X_AXIS_DATA_KEY]).valueOf();
+      const endBucket = Math.floor(endMs / fastUnitMs);
+      let ms = parseTimestamp(datum[X_AXIS_DATA_KEY]).valueOf() + stepMs;
+      while (Math.floor(ms / fastUnitMs) < endBucket) {
+        result.push({ [X_AXIS_DATA_KEY]: new Date(ms).toISOString() });
+        ms += stepMs;
+      }
+      continue;
     }
 
     const end = parseTimestamp(dataset[i + 1][X_AXIS_DATA_KEY]);

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -658,6 +658,8 @@ const buildEChartsLineAreaSeries = (
     z: Z_INDEXES.lineAreaSeries,
     id: seriesModel.dataKey,
     type: "line",
+    // NOTE(bench): built-in LTTB downsampling — draw ~1 point/pixel while keeping the full data model.
+    sampling: "lttb",
     lineStyle: {
       color: seriesModel.color,
       type: seriesSettings["line.style"],

--- a/frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.ts
@@ -24,12 +24,29 @@ import type { ShowWarning } from "../../types";
 import type { ChartLayout } from "../layout/types";
 import { getPaddedAxisLabel } from "../option/utils";
 
+// NOTE(bench): the chart pipeline calls tryGetDate on the same raw values many times; the `.isValid()`
+// check on each call is a large residual cost. Cache the date-or-null result. Unbounded — throwaway.
+const tryGetDateCache = new Map<string, Dayjs | null>();
 export const tryGetDate = (rowValue: RowValue): Dayjs | null => {
   if (typeof rowValue === "boolean") {
     return null;
   }
+  const key =
+    typeof rowValue === "string" || typeof rowValue === "number"
+      ? `${typeof rowValue} ${rowValue}`
+      : null;
+  if (key !== null) {
+    const cached = tryGetDateCache.get(key);
+    if (cached !== undefined) {
+      return cached;
+    }
+  }
   const date = parseTimestamp(rowValue);
-  return date.isValid() ? date : null;
+  const result = date.isValid() ? date : null;
+  if (key !== null) {
+    tryGetDateCache.set(key, result);
+  }
+  return result;
 };
 
 export const msToDays = (ms: number) => ms / (24 * 60 * 60 * 1000);
@@ -363,17 +380,24 @@ const OFFSET_PATTERN = /^([+-])(\d{2}):(\d{2})$/;
 const tryParseOffsetMinutes = (maybeOffset: string): number | undefined => {
   const match = maybeOffset.match(OFFSET_PATTERN);
 
-  if (!match) {
-    return undefined;
+  if (match) {
+    const [, sign, hours, minutes] = match;
+    const offsetSign = sign === "+" ? 1 : -1;
+    const offsetHours = parseInt(hours, 10);
+    const offsetMinutes = parseInt(minutes, 10);
+    return (offsetHours * 60 + offsetMinutes) * offsetSign;
   }
 
-  const [, sign, hours, minutes] = match;
-  const offsetSign = sign === "+" ? 1 : -1;
-  const offsetHours = parseInt(hours, 10);
-  const offsetMinutes = parseInt(minutes, 10);
-  const totalOffsetMinutes = (offsetHours * 60 + offsetMinutes) * offsetSign;
-
-  return totalOffsetMinutes;
+  // Named IANA zone (e.g. "America/Los_Angeles"): resolve it to a single numeric offset once so
+  // callers can shift by a fixed amount instead of paying dayjs `.tz()` per row — that per-row
+  // conversion is ~half the render time of a large time-series chart. Only imprecise across DST
+  // transitions that fall within the chart's data range.
+  try {
+    const resolved = dayjs().tz(maybeOffset).utcOffset();
+    return Number.isFinite(resolved) ? resolved : undefined;
+  } catch {
+    return undefined;
+  }
 };
 
 // We should always have results_timezone, but just in case we fallback to UTC
@@ -403,8 +427,14 @@ export function getTimezoneOrOffset(
       ? tryParseOffsetMinutes(results_timezone)
       : undefined;
 
-  const timezone =
-    offsetMinutes == null ? results_timezone || DEFAULT_TIMEZONE : undefined;
+  // Keep the IANA zone name (never a fixed-offset string, which dayjs `.tz()` can't consume) so
+  // consumers that need real per-instant DST math still have it — e.g. weekly-bucket interpolation
+  // across DST boundaries. Axis-value conversion prefers the numeric `offsetMinutes` above for speed.
+  const isFixedOffset =
+    results_timezone != null && OFFSET_PATTERN.test(results_timezone);
+  const timezone = isFixedOffset
+    ? undefined
+    : results_timezone || DEFAULT_TIMEZONE;
 
   return {
     timezone,


### PR DESCRIPTION
> **Spike / not for merge as-is.** Exploration of static-viz chart render performance. Each change was measured in isolation on a 1,259-point time-series line chart rendered in Node (V8 JIT) via a throwaway harness. Some changes are clean and ship-worthy; others are dirty (unbounded caches, DST approximations) and need hardening. This PR exists to capture the findings + a prioritized next-steps list.

## Headline

Per render of the heavy chart: **~133ms → ~14ms (≈9.5×)**. The single most important find is a **memory-leak fix** (`dispose()`), independent of speed.

## Changes in this PR

| change | file | effect | status |
|---|---|---|---|
| **`chart.dispose()`** after `renderToSVGString()` | `ComboChart.tsx` | fixes an OOM: SSR ECharts instances were never released (~5MB/render → OOM <1k renders). Flat memory after. | ✅ **real bug fix** |
| `sampling: "lttb"` on line series | `option/series.ts` | draw ~1 point/px, full data model kept | ✅ clean (built-in ECharts) |
| axis values as numeric epoch (`valueOf`) instead of per-row ISO `.format()` | `model/axis.ts` | ECharts time axis consumes epoch directly | ✅ clean, output-identical |
| axis offset via epoch arithmetic (`valueOf() + offsetMinutes*60000`) | `model/axis.ts` | avoids a dayjs object per row | ✅ clean, exact |
| SVG `patchDominantBaseline` string transform instead of hast parse/serialize round-trip | `static-viz/lib/svg.ts` | drops a full AST round-trip over the whole SVG | ✅ clean, output-identical |
| time-bucket interpolation in integer epoch-ms for fixed units | `model/dataset.ts` | no dayjs alloc per gap-fill step | ⚠️ DST-boundary approximation (see below) |
| resolve named timezone → single numeric offset | `cartesian/utils/timeseries.ts` | enables the cheap fixed-offset path (kills per-row `.tz()`) | ⚠️ DST-boundary approximation |
| memoize `parseTimestamp` | `utils/time-dayjs.ts` | parse each distinct value once | ⚠️ **unbounded cache** |
| memoize `tryGetDate` | `cartesian/utils/timeseries.ts` | collapses repeated `.isValid()` | ⚠️ **unbounded cache** |
| memoize dayjs `.format()` (prototype patch) | `utils/dayjs.ts` | biggest single win; format is pure per (instant, offset, pattern) | 🔴 **unbounded + locale-blind** |

## Clean vs needs-hardening

- **Ship-worthy as-is:** `dispose()`, `sampling: "lttb"`, numeric-epoch axis, epoch offset arithmetic, SVG string transform. All output-identical (or visually so), no correctness caveat.
- **Needs hardening before merge:**
  - The three caches (`parseTimestamp`, `tryGetDate`, dayjs `.format`) are **unbounded module-level Maps** — they'd grow without limit in a long-lived process, and the `.format` one is **locale-blind** (would return a stale-locale string if locale changes between renders). Real versions need an LRU or per-render scope, and a locale component in the key.
  - The **DST approximations** (single-offset resolution + epoch interpolation) diverge from the dayjs path only at DST transitions *within* a chart's data range — measured impact on the test chart was a single sub-pixel interpolation point (2,258/2,258 vertices identical, 2-char SVG diff). Fine for a static raster, but it is a behavior change; wants a decision + tests.

## What can be done next

1. **Land `dispose()` everywhere now** — apply the same one-liner to the other chart components that share the `init(...)`-without-`dispose()` pattern (`WaterfallChart`, `PieChart`, `ScatterPlot`, `SankeyChart`, `TreemapChart`, `BoxPlotChart`). This is a real OOM fix and should go in independent of the perf work.
2. **Land the clean perf wins** (epoch axis/offset, SVG string transform, `sampling`) as a normal PR with unit tests.
3. **Harden the caches** — bound them (LRU) or scope per-render; add locale to the `.format` key. Then they're safe.
4. **Decide on the DST approximations** — either accept (with tests pinning the behavior) or keep the dayjs path for DST-crossing ranges only.
5. **Bigger swing — run the pipeline JIT'd, not interpreted.** Profiling showed the render is 100% pure-JS ECharts/zrender (no native lib; text via `server-text-width`). The in-process GraalVM renderer runs it *interpreted*; Node/V8 JITs it, which is most of why it's faster off-JVM. This is the strongest argument for the remote/Lambda renderer the `StaticVizRenderer` protocol now enables.
6. **Optional native path:** ECharts' Canvas renderer + `node-canvas` (native Cairo) would emit PNG directly and skip Batik rasterization — Node-only, doesn't help the JS layout that dominates, but could win end-to-end. Worth a spike separately.

## Where the floor is

- **Absolute pipeline floor ~4.3ms** (trivial chart) — all necessary JS: build model/layout/option → ECharts init/setOption/serialize. Confirmed **React SSR is *not* the bottleneck** (fully bypassing `renderToStaticMarkup` and returning a raw string saved ~0). ECharts instance-reuse was a dead end (no gain + corrupts SSR state).
- The rest scales with data points; `sampling`/downsampling is the lever. Below the floor needs a lighter engine or the native canvas path.

## How it was measured

Throwaway Node harness (Hono server + `render-worker` bundle + `autocannon`), 16-logical/12-physical-core machine, cluster (process-per-core). Not included in this PR. Per-render numbers are `hrtime` averages over 100–200 renders after warmup; output equivalence checked by canonicalizing zrender's auto-generated class/clip IDs and comparing md5.
