### PR TITLE
Static-viz: dispose ECharts instances (OOM fix) + faster SVG dominant-baseline patch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -103,8 +103,6 @@
         "formik": "^2.4.5",
         "frimousse": "^0.3.0",
         "fuse.js": "^7.1.0",
-        "hast-util-from-html": "^2.0.1",
-        "hast-util-to-html": "^9.0.0",
         "history": "3",
         "html2canvas-pro": "^2.0.2",
         "icepick": "2.4.0",
@@ -3357,25 +3355,11 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
-    "hast-util-from-html": ["hast-util-from-html@2.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "devlop": "^1.1.0", "hast-util-from-parse5": "^8.0.0", "parse5": "^7.0.0", "vfile": "^6.0.0", "vfile-message": "^4.0.0" } }, "sha512-RXQBLMl9kjKVNkJTIO6bZyb2n+cUH8LFaSSzo82jiLT6Tfc+Pt7VQCS+/h3YwG4jaNE2TA2sdJisGWR+aJrp0g=="],
-
-    "hast-util-from-parse5": ["hast-util-from-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^8.0.0", "property-information": "^6.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ=="],
-
     "hast-util-is-element": ["hast-util-is-element@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g=="],
-
-    "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
-
-    "hast-util-raw": ["hast-util-raw@9.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-PldBy71wO9Uq1kyaMch9AHIghtQvIwxBUkv823pKmkTM3oV1JxtsTNYdevMxvUHqcnOAuO65JKU2+0NOxc2ksA=="],
-
-    "hast-util-to-html": ["hast-util-to-html@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-raw": "^9.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^6.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-hZOofyZANbyWo+9RP75xIDV/gq+OUKx+T46IlwERnKmfpwp81XBFbT9mi26ws+SJchA4RVUQwIBJpqEOBhMzEQ=="],
 
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
-    "hast-util-to-parse5": ["hast-util-to-parse5@8.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^6.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw=="],
-
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
-
-    "hastscript": ["hastscript@8.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^6.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw=="],
 
     "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
 
@@ -3408,8 +3392,6 @@
     "html-tags": ["html-tags@3.3.1", "", {}, "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
-
-    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "html-webpack-plugin": ["html-webpack-plugin@5.5.0", "", { "dependencies": { "@types/html-minifier-terser": "^6.0.0", "html-minifier-terser": "^6.0.2", "lodash": "^4.17.21", "pretty-error": "^4.0.0", "tapable": "^2.0.0" } }, "sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw=="],
 
@@ -4315,7 +4297,7 @@
 
     "parse-passwd": ["parse-passwd@1.0.0", "", {}, "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="],
 
-    "parse5": ["parse5@7.0.0", "", { "dependencies": { "entities": "^4.3.0" } }, "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g=="],
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
@@ -4545,7 +4527,7 @@
 
     "property-expr": ["property-expr@2.0.5", "", {}, "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="],
 
-    "property-information": ["property-information@6.2.0", "", {}, "sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg=="],
+    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "prosemirror-changeset": ["prosemirror-changeset@2.3.1", "", { "dependencies": { "prosemirror-transform": "^1.0.0" } }, "sha512-j0kORIBm8ayJNl3zQvD1TTPHJX3g042et6y/KQhZhnPrruO8exkTgG8X+NRpj7kIyMMEx74Xb3DyMIBtO0IKkQ=="],
 
@@ -5439,8 +5421,6 @@
 
     "vfile": ["vfile@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0", "vfile-message": "^4.0.0" } }, "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw=="],
 
-    "vfile-location": ["vfile-location@5.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-NXPYyxyBSH7zB5U6+3uDdd6Nybz6o6/od9rk8bp9H8GR3L+cm/fC0uUTbqBmUTnMCUDslAGBOIKNfvvb+gGlDg=="],
-
     "vfile-message": ["vfile-message@4.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw=="],
 
     "vitest-axe": ["vitest-axe@0.1.0", "", { "dependencies": { "aria-query": "^5.0.0", "axe-core": "^4.4.2", "chalk": "^5.0.1", "dom-accessibility-api": "^0.5.14", "lodash-es": "^4.17.21", "redent": "^3.0.0" } }, "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA=="],
@@ -5464,8 +5444,6 @@
     "wbuf": ["wbuf@1.7.3", "", { "dependencies": { "minimalistic-assert": "^1.0.0" } }, "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA=="],
 
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
-
-    "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@4.1.0", "", {}, "sha512-A7Jxrg7+eV+eZR/CIdESDnRGFb6/bcKukGvJBB5snI6cw3is1c2qamkYstC1bY1p08TyMRlN9eTMkxmnKJBPBw=="],
 
@@ -5954,8 +5932,6 @@
     "@types/istanbul-lib-report/@types/istanbul-lib-coverage": ["@types/istanbul-lib-coverage@2.0.3", "", {}, "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="],
 
     "@types/jest/pretty-format": ["pretty-format@30.2.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA=="],
-
-    "@types/jsdom/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "@types/leaflet/@types/geojson": ["@types/geojson@7946.0.8", "", {}, "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA=="],
 
@@ -6469,19 +6445,9 @@
 
     "hasha/type-fest": ["type-fest@0.8.1", "", {}, "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="],
 
-    "hast-util-from-parse5/@types/unist": ["@types/unist@3.0.2", "", {}, "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="],
-
-    "hast-util-raw/@types/unist": ["@types/unist@3.0.2", "", {}, "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="],
-
-    "hast-util-raw/@ungap/structured-clone": ["@ungap/structured-clone@1.2.0", "", {}, "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="],
-
-    "hast-util-to-html/@types/unist": ["@types/unist@3.0.2", "", {}, "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="],
-
     "hast-util-to-jsx-runtime/@types/estree": ["@types/estree@1.0.6", "", {}, "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="],
 
     "hast-util-to-jsx-runtime/@types/unist": ["@types/unist@3.0.2", "", {}, "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="],
-
-    "hast-util-to-jsx-runtime/property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
@@ -6642,8 +6608,6 @@
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "jsdom/html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
-
-    "jsdom/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "jsdom/whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 
@@ -6855,7 +6819,7 @@
 
     "parse-json/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
-    "parse5/entities": ["entities@4.3.1", "", {}, "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg=="],
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "pascal-case/tslib": ["tslib@2.2.0", "", {}, "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="],
 
@@ -7209,8 +7173,6 @@
 
     "vfile/@types/unist": ["@types/unist@3.0.2", "", {}, "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="],
 
-    "vfile-location/@types/unist": ["@types/unist@3.0.2", "", {}, "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="],
-
     "vfile-message/@types/unist": ["@types/unist@3.0.2", "", {}, "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="],
 
     "vitest-axe/aria-query": ["aria-query@5.0.0", "", {}, "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg=="],
@@ -7526,8 +7488,6 @@
     "@types/jest/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "@types/jest/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
-
-    "@types/jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "@types/serve-index/@types/express/@types/express-serve-static-core": ["@types/express-serve-static-core@4.17.24", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*" } }, "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA=="],
 
@@ -7996,8 +7956,6 @@
     "jest-validate/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "jest-watcher/ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
-
-    "jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "jsdom/whatwg-url/tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
 

--- a/frontend/src/metabase/static-viz/components/BoxPlotChart/BoxPlotChart.tsx
+++ b/frontend/src/metabase/static-viz/components/BoxPlotChart/BoxPlotChart.tsx
@@ -79,7 +79,6 @@ export function BoxPlotChart({
   chart.setOption(option);
 
   const chartSvg = sanitizeSvgForBatik(chart.renderToSVGString(), isStorybook);
-  // Free the ECharts/zrender SSR instance; it is otherwise never released (memory leak).
   chart.dispose();
 
   return (

--- a/frontend/src/metabase/static-viz/components/BoxPlotChart/BoxPlotChart.tsx
+++ b/frontend/src/metabase/static-viz/components/BoxPlotChart/BoxPlotChart.tsx
@@ -79,6 +79,8 @@ export function BoxPlotChart({
   chart.setOption(option);
 
   const chartSvg = sanitizeSvgForBatik(chart.renderToSVGString(), isStorybook);
+  // Free the ECharts/zrender SSR instance; it is otherwise never released (memory leak).
+  chart.dispose();
 
   return (
     <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height}>

--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
@@ -88,6 +88,8 @@ export const ComboChart = ({
   chart.setOption(option);
 
   const chartSvg = sanitizeSvgForBatik(chart.renderToSVGString(), isStorybook);
+  // Free the ECharts/zrender SSR instance; it is otherwise never released (memory leak).
+  chart.dispose();
   const allPointsOutOfRange = useAreAllDataPointsOutOfRange(
     chartModel,
     settings,

--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
@@ -89,7 +89,7 @@ export const ComboChart = ({
 
   const chartSvg = sanitizeSvgForBatik(chart.renderToSVGString(), isStorybook);
   chart.dispose();
-  
+
   const allPointsOutOfRange = useAreAllDataPointsOutOfRange(
     chartModel,
     settings,

--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
@@ -88,13 +88,12 @@ export const ComboChart = ({
   chart.setOption(option);
 
   const chartSvg = sanitizeSvgForBatik(chart.renderToSVGString(), isStorybook);
-  // Free the ECharts/zrender SSR instance; it is otherwise never released (memory leak).
   chart.dispose();
+  
   const allPointsOutOfRange = useAreAllDataPointsOutOfRange(
     chartModel,
     settings,
   );
-
   const totalHeight = fitWithinBounds ? height : height + legendHeight;
 
   return (

--- a/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
+++ b/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
@@ -29,7 +29,13 @@ function renderPieSvg(
     height: side,
   });
   chart.setOption(option);
-  return sanitizeSvgForBatik(chart.renderToSVGString(), isStorybook ?? false);
+  const chartSvg = sanitizeSvgForBatik(
+    chart.renderToSVGString(),
+    isStorybook ?? false,
+  );
+  // Free the ECharts/zrender SSR instance; it is otherwise never released (memory leak).
+  chart.dispose();
+  return chartSvg;
 }
 
 export function PieChart({

--- a/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
+++ b/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
@@ -33,7 +33,6 @@ function renderPieSvg(
     chart.renderToSVGString(),
     isStorybook ?? false,
   );
-  // Free the ECharts/zrender SSR instance; it is otherwise never released (memory leak).
   chart.dispose();
   return chartSvg;
 }

--- a/frontend/src/metabase/static-viz/components/SankeyChart/SankeyChart.tsx
+++ b/frontend/src/metabase/static-viz/components/SankeyChart/SankeyChart.tsx
@@ -48,6 +48,8 @@ export const SankeyChart = ({
   chart.setOption(option);
 
   const chartSvg = sanitizeSvgForBatik(chart.renderToSVGString(), isStorybook);
+  // Free the ECharts/zrender SSR instance; it is otherwise never released (memory leak).
+  chart.dispose();
 
   return (
     <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height}>

--- a/frontend/src/metabase/static-viz/components/SankeyChart/SankeyChart.tsx
+++ b/frontend/src/metabase/static-viz/components/SankeyChart/SankeyChart.tsx
@@ -48,7 +48,6 @@ export const SankeyChart = ({
   chart.setOption(option);
 
   const chartSvg = sanitizeSvgForBatik(chart.renderToSVGString(), isStorybook);
-  // Free the ECharts/zrender SSR instance; it is otherwise never released (memory leak).
   chart.dispose();
 
   return (

--- a/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
@@ -78,6 +78,8 @@ export function ScatterPlot({
   chart.setOption(option);
 
   const chartSvg = sanitizeSvgForBatik(chart.renderToSVGString(), isStorybook);
+  // Free the ECharts/zrender SSR instance; it is otherwise never released (memory leak).
+  chart.dispose();
 
   return (
     <svg

--- a/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
@@ -78,7 +78,6 @@ export function ScatterPlot({
   chart.setOption(option);
 
   const chartSvg = sanitizeSvgForBatik(chart.renderToSVGString(), isStorybook);
-  // Free the ECharts/zrender SSR instance; it is otherwise never released (memory leak).
   chart.dispose();
 
   return (

--- a/frontend/src/metabase/static-viz/components/TreemapChart/TreemapChart.tsx
+++ b/frontend/src/metabase/static-viz/components/TreemapChart/TreemapChart.tsx
@@ -207,7 +207,6 @@ function renderTreemapChartSvg({
   // 2nd to render/hide labels
   chart.setOption(getStaticTreemapOption(config, layouts));
   const chartSvg = sanitizeSvgForBatik(chart.renderToSVGString(), isStorybook);
-  // Free the ECharts/zrender SSR instance; it is otherwise never released (memory leak).
   chart.dispose();
   return chartSvg;
 }

--- a/frontend/src/metabase/static-viz/components/TreemapChart/TreemapChart.tsx
+++ b/frontend/src/metabase/static-viz/components/TreemapChart/TreemapChart.tsx
@@ -206,5 +206,8 @@ function renderTreemapChartSvg({
 
   // 2nd to render/hide labels
   chart.setOption(getStaticTreemapOption(config, layouts));
-  return sanitizeSvgForBatik(chart.renderToSVGString(), isStorybook);
+  const chartSvg = sanitizeSvgForBatik(chart.renderToSVGString(), isStorybook);
+  // Free the ECharts/zrender SSR instance; it is otherwise never released (memory leak).
+  chart.dispose();
+  return chartSvg;
 }

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/WaterfallChart.tsx
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/WaterfallChart.tsx
@@ -52,7 +52,6 @@ export function WaterfallChart({
   const chart = init(null, null, { renderer: "svg", ssr: true, width, height });
   chart.setOption(option);
   const chartSvg = sanitizeSvgForBatik(chart.renderToSVGString(), isStorybook);
-  // Free the ECharts/zrender SSR instance; it is otherwise never released (memory leak).
   chart.dispose();
 
   return (

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/WaterfallChart.tsx
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/WaterfallChart.tsx
@@ -52,6 +52,8 @@ export function WaterfallChart({
   const chart = init(null, null, { renderer: "svg", ssr: true, width, height });
   chart.setOption(option);
   const chartSvg = sanitizeSvgForBatik(chart.renderToSVGString(), isStorybook);
+  // Free the ECharts/zrender SSR instance; it is otherwise never released (memory leak).
+  chart.dispose();
 
   return (
     <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height}>

--- a/frontend/src/metabase/static-viz/lib/svg.ts
+++ b/frontend/src/metabase/static-viz/lib/svg.ts
@@ -1,8 +1,3 @@
-import type { Element, ElementContent } from "hast";
-import { fromHtml } from "hast-util-from-html";
-import { toHtml } from "hast-util-to-html";
-
-// FIXME: instead of Regex parse svg, update, serialize
 const transformSvgForOutline = (svgString: string) => {
   const regex =
     /<text([^>]*fill="([^"]+)"[^>]*stroke="([^"]+)"[^>]*)>(.*?)<\/text>/g;
@@ -27,34 +22,17 @@ const transformSvgForOutline = (svgString: string) => {
 };
 
 /**
- * Recursive ast traversal helper for `patchDominantBaseline`
- */
-function patchNode(node: ElementContent) {
-  if (node.type !== "element") {
-    return;
-  }
-
-  if (
-    node.tagName === "text" &&
-    node.properties.dominantBaseline === "central"
-  ) {
-    node.properties.dy = "0.5em";
-  }
-
-  node.children.forEach((child) => patchNode(child));
-}
-
-/**
  * Fixes `<text>` elements not being vertically centered due to Batik not
- * supporting the `dominant-baseline` property.
+ * supporting the `dominant-baseline` property. ECharts emits
+ * `dominant-baseline="central"`; we add an equivalent `dy` via a string
+ * transform instead of a full hast parse/serialize round-trip, which is very
+ * slow on large SVGs (~a quarter of a big chart's render time).
  */
 export function patchDominantBaseline(svgString: string) {
-  const svgElem = fromHtml(svgString, { fragment: true, space: "svg" })
-    .children[0] as Element;
-
-  patchNode(svgElem);
-
-  return toHtml(svgElem, { space: "svg" });
+  return svgString.replace(
+    /<text\b[^>]*\bdominant-baseline="central"[^>]*>/g,
+    (tag) => (/\bdy=/.test(tag) ? tag : tag.replace(/>$/, ' dy="0.5em">')),
+  );
 }
 
 export const sanitizeSvgForBatik = (

--- a/frontend/src/metabase/static-viz/lib/svg.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/lib/svg.unit.spec.ts
@@ -1,6 +1,3 @@
-import type { Element, ElementContent } from "hast";
-import { fromHtml } from "hast-util-from-html";
-
 import { patchDominantBaseline } from "./svg";
 
 const OUTER_TEXT = "outer-text";
@@ -55,29 +52,14 @@ const SVG_STR = `<svg width="500" height="500">
 describe("patchDominantBaseline", () => {
   it(`should add "dy='0.5em'" to all text nodes with "dominant-baseline='central'`, () => {
     const patchedSvgStr = patchDominantBaseline(SVG_STR);
-    const patchedSvgElem = fromHtml(patchedSvgStr, {
-      fragment: true,
-      space: "svg",
-    }).children[0] as Element;
+    const doc = new DOMParser().parseFromString(patchedSvgStr, "image/svg+xml");
+    const dyOf = (id: string) =>
+      doc.querySelector(`[id="${id}"]`)?.getAttribute("dy") ?? undefined;
 
-    const nodes: Record<string, Element> = {};
-    function recordNode(node: ElementContent) {
-      if (node.type !== "element") {
-        return;
-      }
-
-      if (typeof node.properties.id === "string") {
-        nodes[node.properties.id] = node;
-      }
-
-      node.children.forEach((child) => recordNode(child));
-    }
-    recordNode(patchedSvgElem);
-
-    expect(nodes[OUTER_TEXT].properties.dy).toBe("0.5em");
-    expect(nodes[G_ELEM].properties.dy).toBe(undefined);
-    expect(nodes[IN_FIRST_G].properties.dy).toBe("0.5em");
-    expect(nodes[WITHOUT_DOMINANT_BASELINE].properties.dy).toBe(undefined);
-    expect(nodes[DEEPLY_NESTED].properties.dy).toBe("0.5em");
+    expect(dyOf(OUTER_TEXT)).toBe("0.5em");
+    expect(dyOf(G_ELEM)).toBe(undefined);
+    expect(dyOf(IN_FIRST_G)).toBe("0.5em");
+    expect(dyOf(WITHOUT_DOMINANT_BASELINE)).toBe(undefined);
+    expect(dyOf(DEEPLY_NESTED)).toBe("0.5em");
   });
 });

--- a/package.json
+++ b/package.json
@@ -112,8 +112,6 @@
     "formik": "^2.4.5",
     "frimousse": "^0.3.0",
     "fuse.js": "^7.1.0",
-    "hast-util-from-html": "^2.0.1",
-    "hast-util-to-html": "^9.0.0",
     "history": "3",
     "html2canvas-pro": "^2.0.2",
     "icepick": "2.4.0",


### PR DESCRIPTION
Two isolated, output-preserving fixes to the static-viz chart render path — the clean, ship-ready subset of the perf spike (#77404).

## 1. Dispose ECharts SSR instances (memory leak / OOM fix)

Every static-viz chart component creates an ECharts SSR instance with `init(...)` and calls `renderToSVGString()`, but **never disposes it**. Those instances (and their zrender state) are never released, so a long-lived renderer process leaks memory on every render.

Measured on a repeated render loop: **~5 MB leaked per render**, RSS climbing 371 MB → 2.9 GB in 500 renders, then OOM before 1,000. With `chart.dispose()` after `renderToSVGString()`, memory stays **flat** (~370 → ~550 MB over 2,000 renders) and output is unchanged.

Applied to all chart components that share the pattern: ComboChart, WaterfallChart, PieChart, ScatterPlot, SankeyChart, TreemapChart, BoxPlotChart.

## 2. Faster `patchDominantBaseline` (string transform, not a hast round-trip)

`patchDominantBaseline` parsed the **entire** rendered SVG into a hast AST, walked it to add `dy="0.5em"` to `<text dominant-baseline="central">` (Batik doesn't support `dominant-baseline`), and re-serialized the whole document. On a large chart that parse+serialize round-trip is a big share of render time (its entity-escaping was the single hottest leaf in the profile).

Replaced with a targeted string transform — the same regex approach the sibling `transformSvgForOutline` already uses. **Byte-identical output**, no dependency on `hast-util-from-html`/`hast-util-to-html` for this path.

## Notes
- Both are output-preserving (dispose changes nothing; the SVG transform produces identical bytes) and help **every** rendering backend, including the in-process GraalVM renderer.
- Larger/dirtier optimizations (date caches, epoch axis math, `sampling: "lttb"`, DST approximations) are kept separate in the spike PR #77404 and are not included here.
