### PR TITLE
Preserve MySQL role name case when expanding role grants

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -1118,8 +1118,9 @@
     #"^GRANT (.+) TO "
     :>>
     (fn [[_ roles]]
+      ;; role names are case-sensitive to MySQL, so they must be passed back to `SHOW GRANTS ... USING` verbatim
       {:type  :roles
-       :roles (set (map u/lower-case-en (str/split roles #",")))})))
+       :roles (set (str/split roles #","))})))
 
 (defn- privilege-grants-for-user
   "Returns a list of parsed privilege grants for a user, taking into account the roles that the user has.
@@ -1135,7 +1136,7 @@
          privilege-grants :privileges} (group-by :type grants)]
     (if (seq role-grants)
       (let [roles  (:roles (first role-grants))
-            grants (map parse-grant (query (str "SHOW GRANTS FOR " user "USING " (str/join "," roles))))
+            grants (map parse-grant (query (str "SHOW GRANTS FOR " user " USING " (str/join "," roles))))
             {privilege-grants :privileges} (group-by :type grants)]
         privilege-grants)
       privilege-grants)))

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -837,6 +837,10 @@
     (is (= {:type  :roles
             :roles #{"`example_role`@`%`" "`example_role_2`@`%`"}}
            (#'mysql/parse-grant "GRANT `example_role`@`%`,`example_role_2`@`%` TO 'metabase'@'localhost'")))
+    (testing "role names keep their case (GHY-3835): MySQL 8 backticked role identifiers are case-sensitive, so lowercasing them makes the follow-up `SHOW GRANTS ... USING` fail with error 3530"
+      (is (= {:type  :roles
+              :roles #{"`AWS_FOO_ROLE`@`%`"}}
+             (#'mysql/parse-grant "GRANT `AWS_FOO_ROLE`@`%` TO `mb_case_test`@`%`"))))
     (is (nil? (#'mysql/parse-grant "GRANT PROXY ON 'metabase'@'localhost' TO 'metabase'@'localhost' WITH GRANT OPTION")))
     (testing "REVOKE grants (emitted under partial_revokes) are ignored rather than throwing"
       (is (nil? (#'mysql/parse-grant "REVOKE INSERT ON `test-data`.`foo` FROM 'metabase'@'localhost'")))


### PR DESCRIPTION
Fixes #75446 / GHY-3835.

## Problem

During sync, the MySQL driver reads table privileges with `SHOW GRANTS FOR CURRENT_USER()`. If the user has role memberships, it runs a second query, `SHOW GRANTS FOR CURRENT_USER() USING <roles>`, to expand privileges inherited through the role hierarchy.

`parse-grant` lowercased the role names it pulled out of the first query. MySQL 8 treats backticked role identifiers as case-sensitive, so a real role `` `AWS_FOO_ROLE`@`%` `` came back as `` `aws_foo_role`@`%` `` and the follow-up query failed with error 3530:

```
`aws_foo_role`@`%` is not granted to `mb_case_test`@`%`
```

That error escapes `privilege-grants-for-user` and aborts the whole `db-metadata` sync step. It bites RDS/Aurora setups in particular, where AWS predefined roles (`AWS_SELECT_S3_ACCESS`, etc.) are conventionally uppercase.

## Fix

Drop the `map u/lower-case-en` from the `:roles` branch of `parse-grant`. The sibling `:privileges` branch keeps its lowercasing — that one normalizes privilege types (`SELECT`, `INSERT`, …) into keywords, which is correct. Role identifiers must round-trip verbatim.

Also adds the missing space before `USING` in the follow-up query. It parsed fine today only because the user identifier happens to end in a backtick.

## Testing

Added an uppercase-role assertion to `parse-grant-test` using the exact grant string from the report. It fails on `master` and passes with this change:

```
expected: {:type :roles, :roles #{"`AWS_FOO_ROLE`@`%`"}}
  actual: {:type :roles, :roles #{"`aws_foo_role`@`%`"}}
```

These are pure parsing tests over literal grant strings, so they pin the case-preservation behavior but do not exercise a live MySQL 8 connection. The end-to-end claim rests on MySQL's documented case-sensitivity for backticked role identifiers and the error-3530 trace in the linked issue.

To reproduce the original failure against a real MySQL 8 (not MariaDB):

```sql
CREATE DATABASE IF NOT EXISTS role_test;
USE role_test;
CREATE TABLE orders (id INT PRIMARY KEY);
CREATE ROLE `AWS_FOO_ROLE`@`%`;
GRANT INSERT ON role_test.orders TO `AWS_FOO_ROLE`@`%`;
CREATE USER 'mb_case_test'@'%' IDENTIFIED BY 'mb_case_test_pw';
GRANT SELECT ON role_test.orders TO 'mb_case_test'@'%';
GRANT `AWS_FOO_ROLE`@`%` TO 'mb_case_test'@'%';
```

Then connect Metabase as `mb_case_test` and sync.