### PR TITLE
Add MCP CRUD tools for Segments

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -173,6 +173,7 @@
               query-permissions
               query-processor
               request
+              segments
               server
               settings
               util}
@@ -181,6 +182,7 @@
                     :model/Dashboard
                     :model/DashboardCard
                     :model/Database
+                    :model/Segment
                     :model/Table
                     :model/User}}
 

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -137,6 +137,7 @@
      sample-data
      search
      secrets
+     segments
      server
      session
      settings

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -32,6 +32,7 @@
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.streaming :as qp.streaming]
    [metabase.request.core :as request]
+   [metabase.segments.schema :as segments.schema]
    [metabase.server.streaming-response :as streaming-response]
    [metabase.util :as u]
    [metabase.util.json :as json]
@@ -1089,6 +1090,163 @@
                    (str "Card " id " is not a metric. Use update_question to update questions."))
     (apply-agent-card-patch! card-before-update body
                              {:validate-query! check-metric-query-can-be-saved!})))
+
+;;; -------------------------------------------------- Create Segment ------------------------------------------------
+;;
+;; A Segment (`:model/Segment`) is a table-scoped reusable filter, not a card: it has no collection,
+;; display, or visualization settings, and its permission model is table-based (admin or data
+;; analyst with unrestricted view-data on the parent table). So these endpoints don't share the
+;; card-mutation helper stack above; they mirror REST `/api/segment` instead.
+
+(mr/def ::create-segment-request
+  [:map
+   [:name        ms/NonBlankString]
+   [:query       ms/NonBlankString]
+   [:description {:optional true} [:maybe :string]]])
+
+(mr/def ::update-segment-request
+  "Patch shape for `update_segment`. Every field is optional; only the fields the caller passes
+  are changed. `:query` accepts a base64-encoded MBQL string (or query_handle UUID resolved
+  upstream in the MCP layer) and must still describe a valid segment. `:revision_message` is
+  recorded in the segment's revision history."
+  [:map
+   [:name             {:optional true} [:maybe ms/NonBlankString]]
+   [:description      {:optional true} [:maybe :string]]
+   [:archived         {:optional true} [:maybe :boolean]]
+   [:query            {:optional true} [:maybe ms/NonBlankString]]
+   [:revision_message {:optional true} [:maybe ms/NonBlankString]]])
+
+(mr/def ::segment-response
+  "Returned by `create_segment` / `update_segment`. `definition_description` is the
+  human-readable rendering of the segment's filters — the read-back an LLM should report."
+  [:map
+   [:id                     ms/PositiveInt]
+   [:name                   ms/NonBlankString]
+   [:table_id               ms/PositiveInt]
+   [:description            [:maybe :string]]
+   [:definition_description [:maybe :string]]
+   [:archived               :boolean]])
+
+(defn- segment-response
+  [segment]
+  (let [segment (t2/hydrate segment :definition_description)]
+    {:id                     (:id segment)
+     :name                   (:name segment)
+     :table_id               (:table_id segment)
+     :description            (:description segment)
+     :definition_description (:definition_description segment)
+     :archived               (boolean (:archived segment))}))
+
+(defn- decode-segment-definition
+  "Decode a base64 `:query` payload (a resolved query_handle) into a normalized MBQL 5 query map,
+  the shape `:model/Segment` stores as its `:definition`."
+  [encoded]
+  (-> encoded u/decode-base64 json/decode+kw lib-be/normalize-query))
+
+(defn- check-segment-definition-can-be-saved!
+  "Throw a 400 unless `definition` is a valid segment definition (see
+  `::segments.schema/segment`). The model's before-insert/update hooks run the same validation
+  via `mu/validate-throw`, but that surfaces as a 500; checking here first gives the LLM an
+  actionable message."
+  [definition]
+  (when-not (mr/validate ::segments.schema/segment definition)
+    (throw (ex-info (str "This query can't be saved as a segment. A segment is a reusable filter: "
+                         "a single-stage query over one table with at least one filter and no other "
+                         "clauses (no aggregation, breakout, joins, expressions, fields, order-by, "
+                         "or limit). Construct a query with only filters before saving it.")
+                    {:status-code 400}))))
+
+(api.macros/defendpoint :post "/v1/segment" :- ::segment-response
+  "Create a segment — a named, reusable filter for a table.
+
+  The `query` parameter accepts a `query_handle` (UUID) returned by `construct_query`, or a
+  base64-encoded MBQL string. MCP callers should always use the handle. The query must be a
+  single-stage query against a table whose only clauses are filters. The segment's target table
+  is derived from the query's source table.
+
+  Requires curate permissions on the underlying data: admins and data analysts only."
+  {:scope metabot/agent-segment-create
+   :tool  {:name "create_segment"
+           :description (str "Save a query's filters as a reusable segment in Metabase. "
+                             "Pass the `query_handle` returned by `construct_query`. "
+                             "The query must be a single-stage query on a table containing ONLY "
+                             "filters — no aggregation, breakout, joins, expressions, order-by, or "
+                             "limit. The segment attaches to the query's source table. "
+                             "Requires admin or data-analyst permissions.")}}
+  [_route-params
+   _query-params
+   {:keys [query description] segment-name :name} :- ::create-segment-request]
+  (let [definition (decode-segment-definition query)
+        _          (check-segment-definition-can-be-saved! definition)
+        table-id   (lib/primary-source-table-id definition)]
+    (api/check-400 (int? table-id)
+                   "A segment must be built directly on a table, not on a saved question.")
+    (api/create-check :model/Segment {:table_id table-id})
+    (let [segment (api/check-500
+                   (first (t2/insert-returning-instances! :model/Segment
+                                                          :table_id    table-id
+                                                          :creator_id  api/*current-user-id*
+                                                          :name        segment-name
+                                                          :description description
+                                                          :definition  definition)))]
+      (events/publish-event! :event/segment-create {:object segment :user-id api/*current-user-id*})
+      (segment-response segment))))
+
+;;; -------------------------------------------------- Update Segment ------------------------------------------------
+
+(api.macros/defendpoint :put "/v1/segment/:id" :- ::segment-response
+  "Update a segment. Patch semantics - only fields that you pass are changed.
+
+  Set `archived: true` to archive (segments have no hard delete). Pass `query` (a query_handle
+  from construct_query, or a base64 MBQL string) to replace the segment's filter definition; the
+  replacement must still be a valid segment (single stage, filters only). An optional
+  `revision_message` is recorded in the segment's revision history.
+
+  Requires curate permissions on the underlying data: admins and data analysts only."
+  {:scope metabot/agent-segment-update
+   :tool  {:name "update_segment"
+           :description (str "Update a segment. Patch semantics - only fields you pass are changed. "
+                             "To archive, set archived true. Segments have no hard delete: to delete "
+                             "or remove a segment, archive it (set archived true) - this is a soft "
+                             "delete that can be reversed by setting archived false. "
+                             "To replace the filter definition, pass "
+                             "query (a query_handle from construct_query) - it must still be a "
+                             "single-stage table query containing only filters. Optionally pass "
+                             "revision_message to annotate the change in revision history.")}}
+  [{:keys [id]} :- [:map [:id ms/PositiveInt]]
+   _query-params
+   body :- ::update-segment-request]
+  (api/write-check :model/Segment id)
+  (let [new-definition (when-some [encoded (:query body)]
+                         (let [definition (decode-segment-definition encoded)]
+                           (check-segment-definition-can-be-saved! definition)
+                           ;; Reject definitions referencing this segment (directly or transitively).
+                           ;; The model's before-update hook runs the same check, but without a
+                           ;; :status-code it would surface as a 500; mirror the metric path's
+                           ;; promotion to a 400.
+                           (try
+                             (lib/check-segment-overwrite id definition)
+                             (catch clojure.lang.ExceptionInfo e
+                               (let [data (ex-data e)]
+                                 (throw (ex-info (ex-message e)
+                                                 (assoc data :status-code (or (:status-code data) 400))
+                                                 e)))))
+                           definition))
+        ;; :name is non-nullable on the model, so an explicit null is ignored rather than applied;
+        ;; :description is nullable and an explicit null clears it.
+        changes        (cond-> {}
+                         (some? (:name body))          (assoc :name (:name body))
+                         (contains? body :description) (assoc :description (:description body))
+                         (contains? body :archived)    (assoc :archived (boolean (:archived body)))
+                         new-definition                (assoc :definition new-definition))]
+    (when (seq changes)
+      (t2/update! :model/Segment id changes))
+    (let [updated (t2/select-one :model/Segment :id id)]
+      (events/publish-event! :event/segment-update
+                             (cond-> {:object updated :user-id api/*current-user-id*}
+                               (:revision_message body)
+                               (assoc :revision-message (:revision_message body))))
+      (segment-response updated))))
 
 ;;; ------------------------------------------------- Update Question ------------------------------------------------
 

--- a/src/metabase/mcp/README.md
+++ b/src/metabase/mcp/README.md
@@ -66,6 +66,8 @@ Access tokens are scoped to limit what tools a client can use:
 | `agent:question:execute`  | `execute_question`                                                                                             |
 | `agent:metric:create`     | `create_metric`                                                                                                |
 | `agent:metric:update`     | `update_metric` (also covers "move metric to collection")                                                      |
+| `agent:segment:create`    | `create_segment`                                                                                               |
+| `agent:segment:update`    | `update_segment` (also covers archiving)                                                                       |
 | `agent:dashboard:create`  | `create_dashboard`                                                                                             |
 | `agent:dashboard:update`  | `update_dashboard`                                                                                             |
 | `agent:collection:create` | `create_collection`                                                                                            |
@@ -108,6 +110,8 @@ The MCP server exposes these tools, dynamically generated from the Agent API end
 | ------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `create_metric`     | Save a query as a reusable metric. Accepts a `query_handle` from `construct_query`. The query needs one aggregation and at most one date grouping. |
 | `update_metric`     | Update a saved metric. Patch semantics. Setting `collection_id` moves it; setting `archived` archives it. A replacement `query` must still be a valid metric. |
+| `create_segment`    | Save a query's filters as a reusable segment on a table. Accepts a `query_handle` from `construct_query`; the query must be a single-stage table query with only filters. Admin/data-analyst only. |
+| `update_segment`    | Update a segment. Patch semantics. Setting `archived: true` archives it. A replacement `query` must still be a valid segment. Admin/data-analyst only. |
 | `create_question`   | Save a query as a named question (card). Accepts a `query_handle` from `construct_query` (MBQL) or `construct_native_query` (native SQL). Saving native requires native-query DB permission. |
 | `update_question`   | Update a saved question. Patch semantics. Setting `collection_id` moves the card. Setting `archived` archives it. Replacing the query accepts a `construct_query` or `construct_native_query` handle. |
 | `create_dashboard`  | Create a new dashboard, optionally populated with saved questions (auto-positioned on the grid).                  |

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -331,7 +331,8 @@
 ;; handle, but it's a UI tool that resolves the handle itself (see `metabase.mcp.resources`) and
 ;; never reaches this dispatch path, so it's intentionally absent here.
 (def ^:private tools-accepting-query-handle
-  #{"execute_query" "query" "create_question" "update_question" "create_metric" "update_metric"})
+  #{"execute_query" "query" "create_question" "update_question" "create_metric" "update_metric"
+    "create_segment" "update_segment"})
 
 ;; Tools whose 200 body is `{:query base64}` and gets stored as a handle, returning `{:query_handle}`.
 ;; `construct_query` (MBQL) and `construct_native_query` (native SQL) both follow this contract.

--- a/src/metabase/metabot/core.clj
+++ b/src/metabase/metabot/core.clj
@@ -25,6 +25,8 @@
   agent-metric-update
   agent-resource-read
   agent-search
+  agent-segment-create
+  agent-segment-update
   agent-sql-construct
   agent-sql-create
   agent-sql-execute]

--- a/src/metabase/metabot/scope.clj
+++ b/src/metabase/metabot/scope.clj
@@ -50,6 +50,12 @@
 (api-scope/defscope agent-metric-update "agent:metric:update"
   (deferred-tru "Update metrics"))
 
+;; Segment (table-scoped reusable filters via Agent API)
+(api-scope/defscope agent-segment-create "agent:segment:create"
+  (deferred-tru "Create segments"))
+(api-scope/defscope agent-segment-update "agent:segment:update"
+  (deferred-tru "Update segments"))
+
 ;; Transforms
 (api-scope/defscope agent-transforms-read "agent:transforms:read"
   (deferred-tru "View transforms"))
@@ -177,7 +183,8 @@
   "Map from metabot permission type to the wildcard scope strings granted when
   that permission is `:yes`."
   {:permission/metabot-sql-generation #{"agent:sql:*" "agent:transforms:*" "agent:snippets:*"}
-   :permission/metabot-nlq            #{"agent:notebook:*" "agent:query:*" "agent:question:*" "agent:metric:*"}
+   :permission/metabot-nlq            #{"agent:notebook:*" "agent:query:*" "agent:question:*" "agent:metric:*"
+                                        "agent:segment:*"}
    :permission/metabot-other-tools    #{"agent:viz:*" "agent:dashboard:*" "agent:document:*" "agent:alert:*"
                                         "agent:collection:*"}})
 

--- a/test/metabase/agent_api/api_test.clj
+++ b/test/metabase/agent_api/api_test.clj
@@ -986,6 +986,121 @@
         (mt/user-http-request :rasta :put 403 (str "agent/v1/metric/" card-id)
                               {:name "Forbidden Rename"})))))
 
+;;; ------------------------------------------------ Create Segment Tests -------------------------------------------
+
+(defn- construct-orders-filter-query
+  "Construct a filter-only ORDERS query via /v2/construct-query (as `user`) and return the
+  base64 `:query` payload for the segment endpoints."
+  [user & filters]
+  (:query (mt/user-http-request user :post 200 "agent/v2/construct-query"
+                                {:query (orders-query :filters (vec filters))})))
+
+(deftest create-segment-test
+  (testing "Creates a segment from a filter-only query, deriving table_id from the query"
+    (let [encoded (construct-orders-filter-query :crowberto ["not-null" {} (orders-field-ref "ID")])
+          resp    (mt/user-http-request :crowberto :post 200 "agent/v1/segment"
+                                        {:name        "Agent Test Segment"
+                                         :query       encoded
+                                         :description "Orders with an ID"})]
+      (is (=? {:id                     pos?
+               :name                   "Agent Test Segment"
+               :table_id               (mt/id :orders)
+               :description            "Orders with an ID"
+               :definition_description string?
+               :archived               false}
+              resp))
+      (let [persisted (t2/select-one :model/Segment :id (:id resp))]
+        (is (= (mt/id :orders) (:table_id persisted)))
+        (is (seq (:filters (first (:stages (:definition persisted)))))))
+      (t2/delete! :model/Segment :id (:id resp)))))
+
+(deftest create-segment-rejects-invalid-definition-test
+  (testing "Returns 400 when the query has an aggregation"
+    (let [encoded (:query (mt/user-http-request :crowberto :post 200 "agent/v2/construct-query"
+                                                {:query (orders-query
+                                                         :aggregation [["count" {}]]
+                                                         :filters     [["not-null" {} (orders-field-ref "ID")]])}))]
+      (is (str/includes?
+           (mt/user-http-request :crowberto :post 400 "agent/v1/segment"
+                                 {:name  "Not A Segment"
+                                  :query encoded})
+           "segment"))))
+  (testing "Returns 400 when the query has no filters"
+    (let [encoded (:query (mt/user-http-request :crowberto :post 200 "agent/v2/construct-query"
+                                                {:query (orders-query :limit 10)}))]
+      (is (str/includes?
+           (mt/user-http-request :crowberto :post 400 "agent/v1/segment"
+                                 {:name  "Not A Segment Either"
+                                  :query encoded})
+           "segment")))))
+
+(deftest create-segment-permission-test
+  (testing "Returns 403 for a regular user (segments require admin or data-analyst)"
+    (let [encoded (construct-orders-filter-query :rasta ["not-null" {} (orders-field-ref "ID")])]
+      (mt/user-http-request :rasta :post 403 "agent/v1/segment"
+                            {:name  "Forbidden Segment"
+                             :query encoded}))))
+
+;;; ------------------------------------------------ Update Segment Tests -------------------------------------------
+
+(deftest update-segment-patch-fields-test
+  (testing "Patches simple fields (name, description) on a segment"
+    (mt/with-temp [:model/Segment {segment-id :id} {:name "Agent Segment Original"}]
+      (let [resp (mt/user-http-request :crowberto :put 200 (str "agent/v1/segment/" segment-id)
+                                       {:name        "Renamed Segment"
+                                        :description "Set by agent"})]
+        (is (=? {:id          segment-id
+                 :name        "Renamed Segment"
+                 :description "Set by agent"
+                 :archived    false}
+                resp)))
+      (is (= "Renamed Segment" (t2/select-one-fn :name :model/Segment :id segment-id))))))
+
+(deftest update-segment-archive-test
+  (testing "archived: true archives; archived: false unarchives"
+    (mt/with-temp [:model/Segment {segment-id :id} {:name "Segment To Archive"}]
+      (is (true? (:archived (mt/user-http-request :crowberto :put 200 (str "agent/v1/segment/" segment-id)
+                                                  {:archived true}))))
+      (is (true? (t2/select-one-fn :archived :model/Segment :id segment-id)))
+      (is (false? (:archived (mt/user-http-request :crowberto :put 200 (str "agent/v1/segment/" segment-id)
+                                                   {:archived false}))))
+      (is (false? (t2/select-one-fn :archived :model/Segment :id segment-id))))))
+
+(deftest update-segment-replace-definition-test
+  (testing "Replacing the definition via :query persists and re-derives table_id"
+    (mt/with-temp [:model/Segment {segment-id :id} {:name "Segment To Redefine"}]
+      (let [encoded (construct-orders-filter-query :crowberto [">" {} (orders-field-ref "TOTAL") 100])
+            resp    (mt/user-http-request :crowberto :put 200 (str "agent/v1/segment/" segment-id)
+                                          {:query            encoded
+                                           :revision_message "sharpened the filter"})]
+        (is (= (mt/id :orders) (:table_id resp)))
+        (let [persisted (t2/select-one :model/Segment :id segment-id)]
+          (is (= (mt/id :orders) (:table_id persisted)))
+          (is (seq (:filters (first (:stages (:definition persisted)))))))))))
+
+(deftest update-segment-rejects-invalid-definition-test
+  (testing "Returns 400 when a replacement query is not a valid segment, leaving the row untouched"
+    (mt/with-temp [:model/Segment {segment-id :id} {:name "Segment With Bad Redefine"}]
+      (let [encoded (:query (mt/user-http-request :crowberto :post 200 "agent/v2/construct-query"
+                                                  {:query (orders-query :aggregation [["count" {}]]
+                                                                        :filters [["not-null" {} (orders-field-ref "ID")]])}))]
+        (is (str/includes?
+             (mt/user-http-request :crowberto :put 400 (str "agent/v1/segment/" segment-id)
+                                   {:query encoded})
+             "segment"))
+        (is (= "Segment With Bad Redefine" (t2/select-one-fn :name :model/Segment :id segment-id)))))))
+
+(deftest update-segment-not-found-test
+  (testing "Returns 404 when segment does not exist"
+    (mt/user-http-request :crowberto :put 404 "agent/v1/segment/999999"
+                          {:name "doesn't matter"})))
+
+(deftest update-segment-write-perm-test
+  (testing "Returns 403 for a regular user (segments require admin or data-analyst)"
+    (mt/with-temp [:model/Segment {segment-id :id} {:name "Protected Segment"}]
+      (mt/user-http-request :rasta :put 403 (str "agent/v1/segment/" segment-id)
+                            {:name "Forbidden Rename"}))))
+
 ;;; ----------------------------------------------- Create Dashboard Tests ------------------------------------------
 
 (deftest create-dashboard-test

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -276,6 +276,7 @@
     "create_dashboard"
     "create_metric"
     "create_question"
+    "create_segment"
     "execute_query"
     "execute_question"
     "execute_sql"
@@ -286,6 +287,7 @@
     "update_dashboard"
     "update_metric"
     "update_question"
+    "update_segment"
     "visualize_query"})
 
 (deftest ui-tools-declare-required-extensions-test
@@ -665,7 +667,8 @@
   #{"search" "construct_query" "construct_native_query" "query" "execute_query" "execute_sql"
     "read_resource"
     "create_question" "execute_question" "create_metric" "create_dashboard"
-    "update_question" "update_metric" "update_dashboard" "create_collection"})
+    "update_question" "update_metric" "update_dashboard" "create_collection"
+    "create_segment" "update_segment"})
 
 (deftest tools-call-smoke-test-covers-all-agent-api-backed-tools-test
   (testing "every Agent API-backed tool is exercised by the smoke test"
@@ -693,10 +696,17 @@
                                 :stages   [{:lib/type     "mbql.stage/mbql"
                                             :source-table [db-name "PUBLIC" "ORDERS"]
                                             :aggregation  [["count" {}]]}]}
+                ;; A segment needs a filters-only stage — `create_segment` rejects anything else.
+                segment-query  {:lib/type "mbql/query"
+                                :stages   [{:lib/type     "mbql.stage/mbql"
+                                            :source-table [db-name "PUBLIC" "ORDERS"]
+                                            :filters      [["not-null" {}
+                                                            ["field" {} [db-name "PUBLIC" "ORDERS" "ID"]]]]}]}
                 ;; Track write-tool outputs in atoms so the `finally` cleanup runs even if an
                 ;; assertion in `call-tool` fails partway through the sequence.
                 question-id    (atom nil)
                 metric-id      (atom nil)
+                segment-id     (atom nil)
                 dash-id        (atom nil)
                 coll-id        (atom nil)]
             (try
@@ -742,6 +752,15 @@
                     _              (call-tool session-id "update_metric"
                                               {:id          (:id metric-data)
                                                :description "Smoke updated metric"})
+                    segment-handle (call-tool session-id "construct_query" {:query segment-query})
+                    segment-data   (call-tool session-id "create_segment"
+                                              {:name         "Smoke Segment"
+                                               :query_handle (:query_handle segment-handle)})
+                    _              (reset! segment-id (:id segment-data))
+                    _              (is (= (mt/id :orders) (:table_id segment-data)))
+                    _              (call-tool session-id "update_segment"
+                                              {:id          (:id segment-data)
+                                               :description "Smoke updated segment"})
                     _              (call-tool session-id "execute_question"
                                               {:id (:id question-data)})
                     dash-data      (call-tool session-id "create_dashboard"
@@ -758,6 +777,7 @@
               (finally
                 (when-let [qid @question-id] (t2/delete! :model/Card :id qid))
                 (when-let [mid @metric-id]   (t2/delete! :model/Card :id mid))
+                (when-let [sid @segment-id]  (t2/delete! :model/Segment :id sid))
                 (when-let [did @dash-id]     (t2/delete! :model/Dashboard :id did))
                 (when-let [cid @coll-id]     (t2/delete! :model/Collection :id cid))))))))))
 

--- a/test/metabase/metabot/scope_test.clj
+++ b/test/metabase/metabot/scope_test.clj
@@ -121,6 +121,8 @@
     (is (api-scope/registered-scope? "agent:question:update"))
     (is (api-scope/registered-scope? "agent:metric:create"))
     (is (api-scope/registered-scope? "agent:metric:update"))
+    (is (api-scope/registered-scope? "agent:segment:create"))
+    (is (api-scope/registered-scope? "agent:segment:update"))
     (is (api-scope/registered-scope? "agent:dashboard:update"))
     (is (api-scope/registered-scope? "agent:collection:create"))
     (is (api-scope/registered-scope? "agent:sql:execute"))))
@@ -130,6 +132,8 @@
     (is (= "agent:question:update" scope/agent-question-update))
     (is (= "agent:metric:create" scope/agent-metric-create))
     (is (= "agent:metric:update" scope/agent-metric-update))
+    (is (= "agent:segment:create" scope/agent-segment-create))
+    (is (= "agent:segment:update" scope/agent-segment-update))
     (is (= "agent:dashboard:update" scope/agent-dashboard-update))
     (is (= "agent:collection:create" scope/agent-collection-create))
     (is (= "agent:sql:execute" scope/agent-sql-execute))))
@@ -144,6 +148,11 @@
   (testing "agent:metric:update granted via metabot-nlq wildcard"
     (let [scopes (scope/user-metabot-perms->scopes {:permission/metabot-nlq :yes})]
       (is (api-scope/scope-matches? scopes "agent:metric:update"))))
+  (testing "agent:segment:create/update granted via metabot-nlq wildcard"
+    (let [scopes (scope/user-metabot-perms->scopes {:permission/metabot-nlq :yes})]
+      (is (contains? scopes "agent:segment:*"))
+      (is (api-scope/scope-matches? scopes "agent:segment:create"))
+      (is (api-scope/scope-matches? scopes "agent:segment:update"))))
   (testing "agent:dashboard:update granted via metabot-other-tools wildcard"
     (let [scopes (scope/user-metabot-perms->scopes {:permission/metabot-other-tools :yes})]
       (is (api-scope/scope-matches? scopes "agent:dashboard:update"))))
@@ -159,6 +168,7 @@
                                                     :permission/metabot-other-tools    :no
                                                     :permission/metabot-sql-generation :no})]
       (is (not (api-scope/scope-matches? scopes "agent:question:update")))
+      (is (not (api-scope/scope-matches? scopes "agent:segment:create")))
       (is (not (api-scope/scope-matches? scopes "agent:dashboard:update")))
       (is (not (api-scope/scope-matches? scopes "agent:collection:create")))
       (is (not (api-scope/scope-matches? scopes "agent:sql:execute"))))))


### PR DESCRIPTION
References [BOT-1829: MCP CRUD for metrics, segments, and measures](https://linear.app/metabase/issue/BOT-1829/mcp-crud-for-metrics-segments-and-measures)

This PR adds MCP CRUD support for Segments.