### PR TITLE
Name the referring entity in remote sync not-found errors

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -185,7 +185,7 @@
                 (count ingest-errors)
                 (str/join "; " (for [ie ingest-errors
                                      :let [{:keys [file reason]} (ex-data ie)]]
-                                 (cond-> file
+                                 (cond-> (quoted file)
                                    reason (str ": " reason))))))
 
       :else

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -134,6 +134,28 @@
             (format "%s references %s, which" (describe-entity referrer) (describe-entity missing))
             (describe-entity missing))))
 
+(defn- sentence
+  "Terminates `s` with a period unless it already ends with one. Returns nil for blank input."
+  [s]
+  (when (seq s)
+    (cond-> s
+      (not (str/ends-with? s ".")) (str "."))))
+
+(defn load-failure-message
+  "Renders the user-facing message for content that could not be written to the appdb.
+
+  `entity` is `{:model :id :name}` describing the content that failed; `reason` is the underlying error text, and
+  may be nil. `stripped-keys`, when present, names the keys that were removed to break a circular dependency —
+  a partial row for `entity` may have been committed."
+  [{:keys [entity reason stripped-keys]}]
+  (->> [(format "Import failed: could not save %s." (describe-entity entity))
+        (sentence reason)
+        (when (seq stripped-keys)
+          (format "It may have been saved without: %s."
+                  (str/join ", " (map (comp quoted name) (sort stripped-keys)))))]
+       (remove nil?)
+       (str/join " ")))
+
 (defn- cause-with-error
   "Returns the first exception in `e`'s cause chain whose ex-data `:error` is `error-type`, or nil."
   [e error-type]
@@ -175,9 +197,16 @@
         (missing-reference-message {:missing  {:model model :id id}
                                     :referrer referrer}))
 
+      ;; the entity that failed to load is the one holding the reference to the absent database
       missing-db
       (missing-reference-message {:missing  {:model "Database" :id (:db-name (ex-data missing-db))}
-                                  :referrer (:referrer (ex-data e))})
+                                  :referrer (:entity (ex-data e))})
+
+      (= (:error (ex-data e)) :metabase-enterprise.serialization.v2.load/load-failure)
+      (let [{:keys [entity stripped-keys]} (ex-data e)]
+        (load-failure-message {:entity        entity
+                               :reason        (some-> e ex-cause ex-message)
+                               :stripped-keys stripped-keys}))
 
       (seq (:ingest-errors (ex-data e)))
       (let [ingest-errors (:ingest-errors (ex-data e))]

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -123,7 +123,7 @@
     entity-name (str " " (quoted entity-name))
     id          (str " (" (quoted id) ")")))
 
-(defn missing-reference-message
+(defn- missing-reference-message
   "Renders the user-facing message for an import that references content absent from this instance.
 
   `missing` is `{:model :id :name}` describing the content that could not be found; `referrer` is the same shape
@@ -141,7 +141,7 @@
     (cond-> s
       (not (str/ends-with? s ".")) (str "."))))
 
-(defn load-failure-message
+(defn- load-failure-message
   "Renders the user-facing message for content that could not be written to the appdb.
 
   `entity` is `{:model :id :name}` describing the content that failed; `reason` is the underlying error text, and

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -134,51 +134,62 @@
             (format "%s references %s, which" (describe-entity referrer) (describe-entity missing))
             (describe-entity missing))))
 
+(defn- cause-with-error
+  "Returns the first exception in `e`'s cause chain whose ex-data `:error` is `error-type`, or nil."
+  [e error-type]
+  (->> (iterate ex-cause e)
+       (take-while some?)
+       (some (fn [ex]
+               (when (= error-type (:error (ex-data ex)))
+                 ex)))))
+
 (defn source-error-message
   "Constructs user-friendly error messages from remote sync source exceptions.
 
   Takes a throwable exception and returns a string message that categorizes the error (network, authentication,
   repository not found, branch, or generic) based on the exception type and message content."
   [e]
-  (cond
-    (or (instance? java.net.UnknownHostException e)
-        (instance? java.net.UnknownHostException (ex-cause e)))
-    "Network error: Unable to reach git repository host"
+  (let [missing-db (cause-with-error e :metabase.models.serialization.resolve.db/database-not-found)]
+    (cond
+      (or (instance? java.net.UnknownHostException e)
+          (instance? java.net.UnknownHostException (ex-cause e)))
+      "Network error: Unable to reach git repository host"
 
-    (str/includes? (ex-message e) "Authentication failed")
-    "Authentication failed: Please check your git credentials"
+      (str/includes? (ex-message e) "Authentication failed")
+      "Authentication failed: Please check your git credentials"
 
-    (str/includes? (ex-message e) "Repository not found")
-    "Repository not found: Please check the repository URL"
+      (str/includes? (ex-message e) "Repository not found")
+      "Repository not found: Please check the repository URL"
 
-    (str/includes? (ex-message e) "branch")
-    "Branch error: Please check the specified branch exists"
+      (str/includes? (ex-message e) "branch")
+      "Branch error: Please check the specified branch exists"
 
-    (some-> e ex-cause ex-message (str/includes? "Can't create a tenant collection without tenants enabled"))
-    "This repository contains tenant collections, but the tenants feature is disabled on your instance."
+      (some-> e ex-cause ex-message (str/includes? "Can't create a tenant collection without tenants enabled"))
+      "This repository contains tenant collections, but the tenants feature is disabled on your instance."
 
-    (str/includes? (ex-message e) "Missing commit")
-    "Repository cache is stale: the remote repository may have been force-pushed. Please retry the operation."
+      (str/includes? (ex-message e) "Missing commit")
+      "Repository cache is stale: the remote repository may have been force-pushed. Please retry the operation."
 
-    (= (:error (ex-data e)) :metabase-enterprise.serialization.v2.load/not-found)
-    (let [{:keys [model id referrer]} (ex-data e)]
-      (missing-reference-message {:missing  {:model model :id id}
-                                  :referrer referrer}))
+      (= (:error (ex-data e)) :metabase-enterprise.serialization.v2.load/not-found)
+      (let [{:keys [model id referrer]} (ex-data e)]
+        (missing-reference-message {:missing  {:model model :id id}
+                                    :referrer referrer}))
 
-    (some-> e ex-cause ex-message (str/includes? "database not found"))
-    (format "Import failed: A referenced database does not exist on this instance. %s" (ex-message (ex-cause e)))
+      missing-db
+      (missing-reference-message {:missing  {:model "Database" :id (:db-name (ex-data missing-db))}
+                                  :referrer (:referrer (ex-data e))})
 
-    (seq (:ingest-errors (ex-data e)))
-    (let [ingest-errors (:ingest-errors (ex-data e))]
-      (format "Failed to read %d file(s) from the repository: %s"
-              (count ingest-errors)
-              (str/join "; " (for [ie ingest-errors
-                                   :let [{:keys [file reason]} (ex-data ie)]]
-                               (cond-> file
-                                 reason (str ": " reason))))))
+      (seq (:ingest-errors (ex-data e)))
+      (let [ingest-errors (:ingest-errors (ex-data e))]
+        (format "Failed to read %d file(s) from the repository: %s"
+                (count ingest-errors)
+                (str/join "; " (for [ie ingest-errors
+                                     :let [{:keys [file reason]} (ex-data ie)]]
+                                 (cond-> file
+                                   reason (str ": " reason))))))
 
-    :else
-    (format "Failed to reload from git repository: %s" (ex-message e))))
+      :else
+      (format "Failed to reload from git repository: %s" (ex-message e)))))
 
 (defn- get-conflicts
   "Detects conflicts that would prevent or complicate import. Returns a map with two classes:

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -111,6 +111,29 @@
         where-clause (t2/delete! model-key {:where where-clause})
         :else        (t2/delete! model-key)))))
 
+(defn- quoted
+  "Wraps `s` in backticks so that leading and trailing whitespace is visible to the reader."
+  [s]
+  (str "`" s "`"))
+
+(defn- describe-entity
+  "Renders `{:model :id :name}` as e.g. ``Card `Orders by Month` (`abc123`)``. Omits whichever of name/id is nil."
+  [{:keys [model id] entity-name :name}]
+  (cond-> (or model "Content")
+    entity-name (str " " (quoted entity-name))
+    id          (str " (" (quoted id) ")")))
+
+(defn missing-reference-message
+  "Renders the user-facing message for an import that references content absent from this instance.
+
+  `missing` is `{:model :id :name}` describing the content that could not be found; `referrer` is the same shape
+  for the entity holding the dangling reference, and may be nil when it is unknown. `:name` may be nil on either."
+  [{:keys [missing referrer]}]
+  (format "Import failed: %s does not exist on this instance. Make sure all referenced databases and other dependencies are set up before importing."
+          (if referrer
+            (format "%s references %s, which" (describe-entity referrer) (describe-entity missing))
+            (describe-entity missing))))
+
 (defn source-error-message
   "Constructs user-friendly error messages from remote sync source exceptions.
 
@@ -138,8 +161,9 @@
     "Repository cache is stale: the remote repository may have been force-pushed. Please retry the operation."
 
     (= (:error (ex-data e)) :metabase-enterprise.serialization.v2.load/not-found)
-    (let [{:keys [model id]} (ex-data e)]
-      (format "Import failed: %s '%s' does not exist on this instance. Make sure all referenced databases and other dependencies are set up before importing." model id))
+    (let [{:keys [model id referrer]} (ex-data e)]
+      (missing-reference-message {:missing  {:model model :id id}
+                                  :referrer referrer}))
 
     (some-> e ex-cause ex-message (str/includes? "database not found"))
     (format "Import failed: A referenced database does not exist on this instance. %s" (ex-message (ex-cause e)))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -61,17 +61,16 @@
                          :error  ::no-known-references})))))
 
 (defn- load-deps!
-  "Given a list of `deps` (hierarchies), [[load-one]] them all. `referrer` describes the entity holding the
-  references, and is attached to any `::not-found` error they raise.
+  "Given a list of `deps` (hierarchies), [[load-one]] them all.
   If [[load-one]] throws because it can't find that entity in the filesystem, check if it's already loaded in
   our database."
-  [ctx referrer deps]
+  [ctx deps]
   (binding [*warned-version-mismatch* (if (nil? *warned-version-mismatch*) (atom false) *warned-version-mismatch*)]
     (if (empty? deps)
       ctx
       (letfn [(loader [ctx dep]
                 (try
-                  (load-one! ctx dep referrer)
+                  (load-one! ctx dep)
                   (catch Exception e
                     (cond
                       ;; It was missing, but we found it locally, so just return the context.
@@ -117,6 +116,19 @@
      :name  (when (string? (:name ingested))
               (:name ingested))}))
 
+(defn- rethrow-with-referrer
+  "Always throws. Rethrows `e` with `referrer` attached when it is a `::not-found` error that does not name one yet,
+  and unchanged otherwise.
+
+  Only the nearest enclosing [[load-one!]] attaches itself, since it unwinds first and later frames see the key
+  already present. `e` becomes the cause, preserving the stack trace of the original detection site."
+  [e referrer]
+  (let [data (ex-data e)]
+    (if (and (= ::not-found (:error data))
+             (not (contains? data :referrer)))
+      (throw (ex-info (ex-message e) (assoc data :referrer referrer) e))
+      (throw e))))
+
 (defn- valid-model-name-for-load? [model-name]
   ;; linear scan, but small n
   (->> (concat serdes.models/inlined-models
@@ -159,10 +171,8 @@
   [[metabase.models.serialization/load-one!]] and its various overridable parts, which see.
 
   The only tangling stuff is handling circular dependencies: parts of this is handled by the `serdes/load-one!`
-  function, just outright skipping processing for parts of ingested data.
-
-  `referrer` describes the entity whose dependency list named `path`, or nil at the top level."
-  [{:keys [expanding seen circular ingestion] :as ctx} path referrer]
+  function, just outright skipping processing for parts of ingested data."
+  [{:keys [expanding seen circular ingestion] :as ctx} path]
   (log/debug "Requested" (cond-> {:path (serdes/log-path-str path)}
                            (circular path) (assoc :stripped true)))
   (cond
@@ -174,8 +184,7 @@
                             (load-one! (-> ctx
                                            (update :expanding disj path)
                                            (update :circular conj path))
-                                       path
-                                       referrer))
+                                       path))
     (seen path)           ctx           ; Already been done, can skip it.
     :else
     (let [ingested (serdes.ingest/ingest-one ingestion path)]
@@ -186,11 +195,10 @@
                   model (:model missing)
                   id    (:id missing)]
               (throw (ex-info (format "%s '%s' was not found" model id)
-                              {:path     (serdes/log-path-str path)
-                               :model    model
-                               :id       id
-                               :referrer referrer
-                               :error    ::not-found}))))
+                              {:path  (serdes/log-path-str path)
+                               :model model
+                               :id    id
+                               :error ::not-found}))))
           (log/debug "Local" {:path (serdes/log-path-str path)})
           ctx)
         (let [_                  (log/trace "Loading" (cond-> {:path (serdes/log-path-str path)}
@@ -217,12 +225,14 @@
                                               {:entity_id (:entity_id ingested)
                                                :level     (count expanding)
                                                :deps      (str "[" (str/join ", " (map serdes/log-path-str deps)) "]")}))
-              self               (entity-reference rebuilt-path ingested)
-              ctx                (-> ctx
-                                     (update :expanding conj path)
-                                     (load-deps! self deps)
-                                     (update :seen conj path)
-                                     (update :expanding disj path))
+              ctx                (try
+                                   (-> ctx
+                                       (update :expanding conj path)
+                                       (load-deps! deps)
+                                       (update :seen conj path)
+                                       (update :expanding disj path))
+                                   (catch Exception e
+                                     (rethrow-with-referrer e (entity-reference rebuilt-path ingested))))
               _                  (when (seq deps)
                                    (log/debug "Ended loading dependencies" {:entity_id (:entity_id ingested)
                                                                             :level     (count expanding)}))
@@ -296,7 +306,7 @@
           (log/infof "Starting deserialization, total %s documents" (count contents))
           (reduce (fn [ctx item]
                     (try
-                      (load-one! ctx item nil)
+                      (load-one! ctx item)
                       (catch Exception e
                         (when-not continue-on-error
                           (throw e))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -256,7 +256,7 @@
                                                   (str/join ", " (sort (map name (keys-to-strip ingested)))))
                                           ""))
                                 (-> (path-error-data ::load-failure expanding path)
-                                    (assoc :referrer (entity-reference rebuilt-path ingested))
+                                    (assoc :entity (entity-reference rebuilt-path ingested))
                                     (cond-> stripped? (assoc :stripped-keys (keys-to-strip ingested))))
                                 e))))))))))
 

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -61,16 +61,17 @@
                          :error  ::no-known-references})))))
 
 (defn- load-deps!
-  "Given a list of `deps` (hierarchies), [[load-one]] them all.
+  "Given a list of `deps` (hierarchies), [[load-one]] them all. `referrer` describes the entity holding the
+  references, and is attached to any `::not-found` error they raise.
   If [[load-one]] throws because it can't find that entity in the filesystem, check if it's already loaded in
   our database."
-  [ctx deps]
+  [ctx referrer deps]
   (binding [*warned-version-mismatch* (if (nil? *warned-version-mismatch*) (atom false) *warned-version-mismatch*)]
     (if (empty? deps)
       ctx
       (letfn [(loader [ctx dep]
                 (try
-                  (load-one! ctx dep)
+                  (load-one! ctx dep referrer)
                   (catch Exception e
                     (cond
                       ;; It was missing, but we found it locally, so just return the context.
@@ -105,6 +106,16 @@
      :model      last-model
      :table      (some->> last-model (keyword "model") t2/table-name)
      :error      error-type}))
+
+(defn- entity-reference
+  "Describes the entity at `path` as `{:model :id :name}` for use in user-facing error messages.
+  `:name` is nil for models whose name is absent or not a plain string (e.g. Settings, templated Card names)."
+  [path ingested]
+  (let [self (last path)]
+    {:model (:model self)
+     :id    (:id self)
+     :name  (when (string? (:name ingested))
+              (:name ingested))}))
 
 (defn- valid-model-name-for-load? [model-name]
   ;; linear scan, but small n
@@ -148,8 +159,10 @@
   [[metabase.models.serialization/load-one!]] and its various overridable parts, which see.
 
   The only tangling stuff is handling circular dependencies: parts of this is handled by the `serdes/load-one!`
-  function, just outright skipping processing for parts of ingested data."
-  [{:keys [expanding seen circular ingestion] :as ctx} path]
+  function, just outright skipping processing for parts of ingested data.
+
+  `referrer` describes the entity whose dependency list named `path`, or nil at the top level."
+  [{:keys [expanding seen circular ingestion] :as ctx} path referrer]
   (log/debug "Requested" (cond-> {:path (serdes/log-path-str path)}
                            (circular path) (assoc :stripped true)))
   (cond
@@ -161,7 +174,8 @@
                             (load-one! (-> ctx
                                            (update :expanding disj path)
                                            (update :circular conj path))
-                                       path))
+                                       path
+                                       referrer))
     (seen path)           ctx           ; Already been done, can skip it.
     :else
     (let [ingested (serdes.ingest/ingest-one ingestion path)]
@@ -172,10 +186,11 @@
                   model (:model missing)
                   id    (:id missing)]
               (throw (ex-info (format "%s '%s' was not found" model id)
-                              {:path  (serdes/log-path-str path)
-                               :model model
-                               :id    id
-                               :error ::not-found}))))
+                              {:path     (serdes/log-path-str path)
+                               :model    model
+                               :id       id
+                               :referrer referrer
+                               :error    ::not-found}))))
           (log/debug "Local" {:path (serdes/log-path-str path)})
           ctx)
         (let [_                  (log/trace "Loading" (cond-> {:path (serdes/log-path-str path)}
@@ -202,9 +217,10 @@
                                               {:entity_id (:entity_id ingested)
                                                :level     (count expanding)
                                                :deps      (str "[" (str/join ", " (map serdes/log-path-str deps)) "]")}))
+              self               (entity-reference rebuilt-path ingested)
               ctx                (-> ctx
                                      (update :expanding conj path)
-                                     (load-deps! deps)
+                                     (load-deps! self deps)
                                      (update :seen conj path)
                                      (update :expanding disj path))
               _                  (when (seq deps)
@@ -280,7 +296,7 @@
           (log/infof "Starting deserialization, total %s documents" (count contents))
           (reduce (fn [ctx item]
                     (try
-                      (load-one! ctx item)
+                      (load-one! ctx item nil)
                       (catch Exception e
                         (when-not continue-on-error
                           (throw e))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -255,8 +255,9 @@
                                           (format " (it may have been left without these keys, which were stripped to break a circular dependency: %s)"
                                                   (str/join ", " (sort (map name (keys-to-strip ingested)))))
                                           ""))
-                                (cond-> (path-error-data ::load-failure expanding path)
-                                  stripped? (assoc :stripped-keys (keys-to-strip ingested)))
+                                (-> (path-error-data ::load-failure expanding path)
+                                    (assoc :referrer (entity-reference rebuilt-path ingested))
+                                    (cond-> stripped? (assoc :stripped-keys (keys-to-strip ingested))))
                                 e))))))))))
 
 (defn new-context

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -121,12 +121,13 @@
   and unchanged otherwise.
 
   Only the nearest enclosing [[load-one!]] attaches itself, since it unwinds first and later frames see the key
-  already present. `e` becomes the cause, preserving the stack trace of the original detection site."
+  already present. The replacement inherits `e`'s cause rather than nesting `e` beneath itself: error reporting
+  renders the whole cause chain, so nesting would print the same message twice joined by `caused by:`."
   [e referrer]
   (let [data (ex-data e)]
     (if (and (= ::not-found (:error data))
              (not (contains? data :referrer)))
-      (throw (ex-info (ex-message e) (assoc data :referrer referrer) e))
+      (throw (ex-info (ex-message e) (assoc data :referrer referrer) (ex-cause e)))
       (throw e))))
 
 (defn- valid-model-name-for-load? [model-name]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -104,8 +104,26 @@
                       :model "Database"
                       :id    "clickhouse"
                       :error :metabase-enterprise.serialization.v2.load/not-found})]
-      (is (= "Import failed: Database 'clickhouse' does not exist on this instance. Make sure all referenced databases and other dependencies are set up before importing."
+      (is (= "Import failed: Database (`clickhouse`) does not exist on this instance. Make sure all referenced databases and other dependencies are set up before importing."
              (impl/source-error-message e)))))
+  (testing "source-error-message names the entity holding the dangling reference when known (GHY-3992)"
+    (let [e (ex-info "Collection 'xyz789' was not found"
+                     {:path     "Collection xyz789"
+                      :model    "Collection"
+                      :id       "xyz789"
+                      :referrer {:model "Card" :id "abc123" :name "Orders by Month"}
+                      :error    :metabase-enterprise.serialization.v2.load/not-found})]
+      (is (= (str "Import failed: Card `Orders by Month` (`abc123`) references Collection (`xyz789`), which does not "
+                  "exist on this instance. Make sure all referenced databases and other dependencies are set up "
+                  "before importing.")
+             (impl/source-error-message e)))))
+  (testing "trailing whitespace in a referenced name is visible because names are backtick-quoted (GHY-3992)"
+    (let [e (ex-info "Database 'My Database ' was not found"
+                     {:path  "Database My Database "
+                      :model "Database"
+                      :id    "My Database "
+                      :error :metabase-enterprise.serialization.v2.load/not-found})]
+      (is (str/includes? (impl/source-error-message e) "Database (`My Database `)"))))
   (testing "source-error-message produces helpful message for FK database-not-found errors"
     (let [cause (ex-info "table id present, but database not found: [clickhouse nil some_table]"
                          {:table-id ["clickhouse" nil "some_table"]})

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -139,8 +139,8 @@
                           :db-name  "clickhouse"
                           :error    :metabase.models.serialization.resolve.db/database-not-found})
           e     (ex-info "Failed to load into database for Card abc123"
-                         {:path     "Card abc123"
-                          :referrer {:model "Card" :id "abc123" :name "Some card"}}
+                         {:path   "Card abc123"
+                          :entity {:model "Card" :id "abc123" :name "Some card"}}
                          cause)]
       (is (= (str "Import failed: Card `Some card` (`abc123`) references Database (`clickhouse`), which does not "
                   "exist on this instance. Make sure all referenced databases and other dependencies are set up "
@@ -153,6 +153,57 @@
           middle (ex-info "wrapped by an intervening helper" {} root)
           e      (ex-info "Failed to load into database for Card abc123" {:path "Card abc123"} middle)]
       (is (str/includes? (impl/source-error-message e) "Database (`clickhouse`)")))))
+
+(deftest source-error-message-load-failure-test
+  (testing "source-error-message names the entity and the underlying reason (GHY-3992)"
+    (let [cause (ex-info "NOT NULL constraint failed: report_card.display" {})
+          e     (ex-info "Failed to load into database for Card abc123"
+                         {:path   "Card abc123"
+                          :entity {:model "Card" :id "abc123" :name "Orders by Month"}
+                          :error  :metabase-enterprise.serialization.v2.load/load-failure}
+                         cause)]
+      (is (= (str "Import failed: could not save Card `Orders by Month` (`abc123`). "
+                  "NOT NULL constraint failed: report_card.display.")
+             (impl/source-error-message e)))))
+  (testing "a reason that already ends in a period is not double-punctuated"
+    (let [e (ex-info "Failed to load into database for Card abc123"
+                     {:entity {:model "Card" :id "abc123" :name "Orders by Month"}
+                      :error  :metabase-enterprise.serialization.v2.load/load-failure}
+                     (ex-info "Something went wrong." {}))]
+      (is (str/ends-with? (impl/source-error-message e) "went wrong."))))
+  (testing "a load-failure with no cause omits the reason clause"
+    (let [e (ex-info "Failed to load into database for Card abc123"
+                     {:entity {:model "Card" :id "abc123" :name "Orders by Month"}
+                      :error  :metabase-enterprise.serialization.v2.load/load-failure})]
+      (is (= "Import failed: could not save Card `Orders by Month` (`abc123`)."
+             (impl/source-error-message e)))))
+  (testing "stripped keys are reported, since a partial row may have been committed (GHY-3992)"
+    (let [cause (ex-info "some db error" {})
+          e     (ex-info "Failed to load into database for Dashboard xyz"
+                         {:path          "Dashboard xyz"
+                          :entity        {:model "Dashboard" :id "xyz" :name "Sales"}
+                          :stripped-keys #{:parameters :dashcards}
+                          :error         :metabase-enterprise.serialization.v2.load/load-failure}
+                         cause)]
+      (is (= (str "Import failed: could not save Dashboard `Sales` (`xyz`). some db error. "
+                  "It may have been saved without: `dashcards`, `parameters`.")
+             (impl/source-error-message e)))))
+  (testing "a database-not-found cause still wins over the generic load-failure branch"
+    (let [cause (ex-info "table id present, but database not found: [ch nil t]"
+                         {:db-name "ch"
+                          :error   :metabase.models.serialization.resolve.db/database-not-found})
+          e     (ex-info "Failed to load into database for Card abc123"
+                         {:entity {:model "Card" :id "abc123" :name "Some card"}
+                          :error  :metabase-enterprise.serialization.v2.load/load-failure}
+                         cause)]
+      (is (str/includes? (impl/source-error-message e) "references Database (`ch`)"))))
+  (testing "a tenant-collection cause still wins over the generic load-failure branch"
+    (let [cause (ex-info "Can't create a tenant collection without tenants enabled" {})
+          e     (ex-info "Failed to load into database for Collection abc"
+                         {:entity {:model "Collection" :id "abc"}
+                          :error  :metabase-enterprise.serialization.v2.load/load-failure}
+                         cause)]
+      (is (str/includes? (impl/source-error-message e) "tenants feature is disabled")))))
 
 (deftest source-error-message-ingest-errors-test
   (testing "source-error-message lists each unreadable file with its parse reason (GHY-3887)"

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -124,13 +124,26 @@
                       :id    "My Database "
                       :error :metabase-enterprise.serialization.v2.load/not-found})]
       (is (str/includes? (impl/source-error-message e) "Database (`My Database `)"))))
-  (testing "source-error-message produces helpful message for FK database-not-found errors"
+  (testing "source-error-message names the card and the missing database for FK database-not-found errors"
     (let [cause (ex-info "table id present, but database not found: [clickhouse nil some_table]"
-                         {:table-id ["clickhouse" nil "some_table"]})
+                         {:table-id ["clickhouse" nil "some_table"]
+                          :db-name  "clickhouse"
+                          :error    :metabase.models.serialization.resolve.db/database-not-found})
           e     (ex-info "Failed to load into database for Card abc123"
-                         {:path "Card abc123"}
+                         {:path     "Card abc123"
+                          :referrer {:model "Card" :id "abc123" :name "Some card"}}
                          cause)]
-      (is (str/includes? (impl/source-error-message e) "A referenced database does not exist on this instance"))))
+      (is (= (str "Import failed: Card `Some card` (`abc123`) references Database (`clickhouse`), which does not "
+                  "exist on this instance. Make sure all referenced databases and other dependencies are set up "
+                  "before importing.")
+             (impl/source-error-message e)))))
+  (testing "database-not-found is found anywhere in the cause chain, not only at the immediate cause"
+    (let [root   (ex-info "table id present, but database not found: [clickhouse nil t]"
+                          {:db-name "clickhouse"
+                           :error   :metabase.models.serialization.resolve.db/database-not-found})
+          middle (ex-info "wrapped by an intervening helper" {} root)
+          e      (ex-info "Failed to load into database for Card abc123" {:path "Card abc123"} middle)]
+      (is (str/includes? (impl/source-error-message e) "Database (`clickhouse`)"))))
   (testing "source-error-message lists each unreadable file with its parse reason (GHY-3887)"
     (let [ingest-err (ex-info "Failed to parse file: collections/transforms/a.yaml"
                               {:file "collections/transforms/a.yaml"

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -124,6 +124,15 @@
                       :id    "My Database "
                       :error :metabase-enterprise.serialization.v2.load/not-found})]
       (is (str/includes? (impl/source-error-message e) "Database (`My Database `)"))))
+  (testing "trailing whitespace in a referenced name is visible because names are backtick-quoted (GHY-3992)"
+    (let [e (ex-info "Database 'My Database ' was not found"
+                     {:path  "Database My Database "
+                      :model "Database"
+                      :id    "My Database "
+                      :error :metabase-enterprise.serialization.v2.load/not-found})]
+      (is (str/includes? (impl/source-error-message e) "Database (`My Database `)")))))
+
+(deftest source-error-message-database-not-found-test
   (testing "source-error-message names the card and the missing database for FK database-not-found errors"
     (let [cause (ex-info "table id present, but database not found: [clickhouse nil some_table]"
                          {:table-id ["clickhouse" nil "some_table"]
@@ -143,7 +152,9 @@
                            :error   :metabase.models.serialization.resolve.db/database-not-found})
           middle (ex-info "wrapped by an intervening helper" {} root)
           e      (ex-info "Failed to load into database for Card abc123" {:path "Card abc123"} middle)]
-      (is (str/includes? (impl/source-error-message e) "Database (`clickhouse`)"))))
+      (is (str/includes? (impl/source-error-message e) "Database (`clickhouse`)")))))
+
+(deftest source-error-message-ingest-errors-test
   (testing "source-error-message lists each unreadable file with its parse reason (GHY-3887)"
     (let [ingest-err (ex-info "Failed to parse file: collections/transforms/a.yaml"
                               {:file "collections/transforms/a.yaml"
@@ -154,8 +165,23 @@
                               ingest-err)
           msg        (impl/source-error-message e)]
       (is (str/includes? msg "Failed to read 1 file(s)"))
-      (is (str/includes? msg "collections/transforms/a.yaml"))
-      (is (str/includes? msg "found character '@'")))))
+      (is (str/includes? msg "`collections/transforms/a.yaml`"))
+      (is (str/includes? msg "found character '@'"))))
+  (testing "file paths are backtick-quoted so surrounding whitespace is visible (GHY-3992)"
+    (let [ingest-err (ex-info "Failed to read file: collections/bar .yaml"
+                              {:file   "collections/bar .yaml"
+                               :reason "IOException"})
+          e          (ex-info "Failed to read 1 file(s) during ingestion: collections/bar .yaml"
+                              {:ingest-errors [ingest-err]}
+                              ingest-err)]
+      (is (= "Failed to read 1 file(s) from the repository: `collections/bar .yaml`: IOException"
+             (impl/source-error-message e)))))
+  (testing "each unreadable file is quoted independently when several fail"
+    (let [errs [(ex-info "a" {:file "a.yaml" :reason "bad"})
+                (ex-info "b" {:file "b.yaml" :reason "worse"})]
+          e    (ex-info "Failed to read 2 file(s) during ingestion" {:ingest-errors errs} (first errs))]
+      (is (= "Failed to read 2 file(s) from the repository: `a.yaml`: bad; `b.yaml`: worse"
+             (impl/source-error-message e))))))
 
 ;; We need to make sure the task-id we use to track the Remote Sync is not bound to a transactions because of the behavior of
 ;; update-sync-progress. So the follow two tests cannot use with-temp to create models

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -117,20 +117,16 @@
                   "exist on this instance. Make sure all referenced databases and other dependencies are set up "
                   "before importing.")
              (impl/source-error-message e)))))
-  (testing "trailing whitespace in a referenced name is visible because names are backtick-quoted (GHY-3992)"
-    (let [e (ex-info "Database 'My Database ' was not found"
-                     {:path  "Database My Database "
-                      :model "Database"
-                      :id    "My Database "
-                      :error :metabase-enterprise.serialization.v2.load/not-found})]
-      (is (str/includes? (impl/source-error-message e) "Database (`My Database `)"))))
-  (testing "trailing whitespace in a referenced name is visible because names are backtick-quoted (GHY-3992)"
-    (let [e (ex-info "Database 'My Database ' was not found"
-                     {:path  "Database My Database "
-                      :model "Database"
-                      :id    "My Database "
-                      :error :metabase-enterprise.serialization.v2.load/not-found})]
-      (is (str/includes? (impl/source-error-message e) "Database (`My Database `)")))))
+  (testing "surrounding whitespace in a referenced name is visible because names are backtick-quoted (GHY-3992)"
+    (doseq [db-name ["My Database " " My Database" "My Database"]]
+      (let [e (ex-info (format "Database '%s' was not found" db-name)
+                       {:path  (str "Database " db-name)
+                        :model "Database"
+                        :id    db-name
+                        :error :metabase-enterprise.serialization.v2.load/not-found})]
+        (is (str/includes? (impl/source-error-message e)
+                           (format "Database (`%s`)" db-name))
+            (format "expected %s to be quoted verbatim" (pr-str db-name)))))))
 
 (deftest source-error-message-database-not-found-test
   (testing "source-error-message names the card and the missing database for FK database-not-found errors"

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1258,7 +1258,11 @@
               (is (= {:model "Database" :id "bad-db"}
                      (select-keys (ex-data e) [:model :id])))
               (is (= {:model "Card" :id "0123456789abcdef_0123" :name "Some card"}
-                     (:referrer (ex-data e)))))))
+                     (:referrer (ex-data e)))))
+            ;; attaching the referrer must not nest the original beneath itself: error reporting renders the
+            ;; whole cause chain, and a self-nested exception prints the same message twice
+            (testing "attaching the referrer does not duplicate the error through the cause chain"
+              (is (nil? (ex-cause e))))))
         ;; `result-metadata-deps` derives deps only from each entry's `:field_ref`, never from its `:table_id`.
         ;; So a result_metadata `:table_id` naming an absent database gets past dependency resolution and only
         ;; fails inside `serdes/load-one!`, where `import-table-fk` raises ::database-not-found. (The Card's own

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1260,7 +1260,43 @@
                 (is (= {:model "Database" :id "bad-db"}
                        (select-keys (ex-data e) [:model :id])))
                 (is (= {:model "Card" :id "0123456789abcdef_0123" :name "Some card"}
-                       (:referrer (ex-data e))))))))))))
+                       (:referrer (ex-data e))))))))
+        ;; `result-metadata-deps` derives deps only from each entry's `:field_ref`, never from its `:table_id`.
+        ;; So a result_metadata `:table_id` naming an absent database gets past dependency resolution and only
+        ;; fails inside `serdes/load-one!`, where `import-table-fk` raises ::database-not-found. (The Card's own
+        ;; top-level `table_id` cannot be used here: `populate-query-fields` recomputes it from `dataset_query`.)
+        (testing "a result_metadata table_id naming an absent database names the database and the card (GHY-3992)"
+          (let [ingestion (ingestion-in-memory [{:serdes/meta     [{:model "Card" :id "0123456789abcdef_0123"}]
+                                                 :created_at      (t/instant)
+                                                 :creator_id      "glee@rush.yyz"
+                                                 :database_id     "my-db"
+                                                 :dataset_query   {:database "my-db"
+                                                                   :type     :query
+                                                                   :query    {:source-table ["my-db" nil "CUSTOMERS"]}}
+                                                 :display         :table
+                                                 :entity_id       "0123456789abcdef_0123"
+                                                 :name            "Some card"
+                                                 :result_metadata [{:name      "STATE"
+                                                                    :base_type :type/Text
+                                                                    :table_id  ["absent-db" nil "CUSTOMERS"]}]
+                                                 :table_id        ["my-db" nil "CUSTOMERS"]
+                                                 :visualization_settings {}}])
+                e         (try
+                            (serdes.load/load-metabase! ingestion)
+                            nil
+                            (catch clojure.lang.ExceptionInfo e e))
+                root      (->> (iterate ex-cause e)
+                               (take-while some?)
+                               (some #(when (= :metabase.models.serialization.resolve.db/database-not-found
+                                               (:error (ex-data %)))
+                                        %)))]
+            (is (some? e))
+            (testing "the root cause carries the missing database name"
+              (is (some? root))
+              (is (= "absent-db" (:db-name (ex-data root)))))
+            (testing "the outer load-failure names the referring card"
+              (is (= {:model "Card" :id "0123456789abcdef_0123" :name "Some card"}
+                     (:referrer (ex-data e)))))))))))
 
 (deftest card-with-snippet-test
   (let [db1s      (atom nil)

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1250,7 +1250,17 @@
                                                  :visualization_settings {}}])]
             (is (thrown-with-msg? clojure.lang.ExceptionInfo
                                   #"was not found"
-                                  (serdes.load/load-metabase! ingestion)))))))))
+                                  (serdes.load/load-metabase! ingestion)))
+            (testing "the not-found error names the entity holding the dangling reference (GHY-3992)"
+              (let [e (try
+                        (serdes.load/load-metabase! ingestion)
+                        nil
+                        (catch clojure.lang.ExceptionInfo e e))]
+                (is (some? e))
+                (is (= {:model "Database" :id "bad-db"}
+                       (select-keys (ex-data e) [:model :id])))
+                (is (= {:model "Card" :id "0123456789abcdef_0123" :name "Some card"}
+                       (:referrer (ex-data e))))))))))))
 
 (deftest card-with-snippet-test
   (let [db1s      (atom nil)

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1247,20 +1247,18 @@
                                                  :entity_id     "0123456789abcdef_0123"
                                                  :name          "Some card"
                                                  :table_id      ["bad-db" nil "CUSTOMERS"]
-                                                 :visualization_settings {}}])]
-            (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                                  #"was not found"
-                                  (serdes.load/load-metabase! ingestion)))
+                                                 :visualization_settings {}}])
+                e         (try
+                            (serdes.load/load-metabase! ingestion)
+                            nil
+                            (catch clojure.lang.ExceptionInfo e e))]
+            (is (some? e))
+            (is (re-find #"was not found" (ex-message e)))
             (testing "the not-found error names the entity holding the dangling reference (GHY-3992)"
-              (let [e (try
-                        (serdes.load/load-metabase! ingestion)
-                        nil
-                        (catch clojure.lang.ExceptionInfo e e))]
-                (is (some? e))
-                (is (= {:model "Database" :id "bad-db"}
-                       (select-keys (ex-data e) [:model :id])))
-                (is (= {:model "Card" :id "0123456789abcdef_0123" :name "Some card"}
-                       (:referrer (ex-data e))))))))
+              (is (= {:model "Database" :id "bad-db"}
+                     (select-keys (ex-data e) [:model :id])))
+              (is (= {:model "Card" :id "0123456789abcdef_0123" :name "Some card"}
+                     (:referrer (ex-data e)))))))
         ;; `result-metadata-deps` derives deps only from each entry's `:field_ref`, never from its `:table_id`.
         ;; So a result_metadata `:table_id` naming an absent database gets past dependency resolution and only
         ;; fails inside `serdes/load-one!`, where `import-table-fk` raises ::database-not-found. (The Card's own

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1294,9 +1294,9 @@
             (testing "the root cause carries the missing database name"
               (is (some? root))
               (is (= "absent-db" (:db-name (ex-data root)))))
-            (testing "the outer load-failure names the referring card"
+            (testing "the outer load-failure names the card that failed to load"
               (is (= {:model "Card" :id "0123456789abcdef_0123" :name "Some card"}
-                     (:referrer (ex-data e)))))))))))
+                     (:entity (ex-data e)))))))))))
 
 (deftest card-with-snippet-test
   (let [db1s      (atom nil)

--- a/src/metabase/models/serialization/resolve/db.clj
+++ b/src/metabase/models/serialization/resolve/db.clj
@@ -126,8 +126,10 @@
       (or (t2/select-one-fn :id :model/Table :name table-name :schema schema :db_id db-id)
           (synthesize-table! db-id schema table-name))
       (throw (ex-info (format "table id present, but database not found: %s" table-id)
-                      {:table-id table-id
-                       :database-names (sort (t2/select-fn-vec :name :model/Table))})))))
+                      {:table-id       table-id
+                       :db-name        db-name
+                       :database-names (sort (t2/select-fn-vec :name :model/Database))
+                       :error          ::database-not-found})))))
 
 (defn import-field-fk
   "Given [db-name schema table-name field-name ...], return numeric field_id. If part of the parent


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68706
Closes GHY-3992.

When a remote sync import fails on missing content, the error identified that content only by its raw serdes id — a NanoID — with no indication of what referenced it. Diagnosing a failed sync meant reading a stack trace out of the logs, or querying the application database.

Every content-related failure now names the entity involved and backtick-quotes names and ids so leading and trailing whitespace is visible.

**A referenced entity is absent from the repo** (`::not-found`):

> Before: `Import failed: Collection 'xyz789' does not exist on this instance. …`
>
> After: ``Import failed: Card `Orders by Month` (`abc123`) references Collection (`xyz789`), which does not exist on this instance. …``

**A `table_id` names a database that doesn't exist here** (`::database-not-found`). This branch used to match `"database not found"` against the cause's message text and then interpolate that raw internal string into the user-facing error:

> Before: `Import failed: A referenced database does not exist on this instance. table id present, but database not found: [clickhouse nil some_table]`
>
> After: ``Import failed: Card `Some card` (`abc123`) references Database (`clickhouse`), which does not exist on this instance. …``

**Content that could not be written to the appdb** (`::load-failure`) used to fall through to the generic fallback, showing a NanoID and burying the stripped-keys note inside the raw `ex-message`:

> Before: `Failed to reload from git repository: Failed to load into database for Dashboard xyz (it may have been left without these keys, which were stripped to break a circular dependency: dashcards, parameters)`
>
> After: ``Import failed: could not save Dashboard `Sales` (`xyz`). some db error. It may have been saved without: `dashcards`, `parameters`.``

That last sentence matters: it means a partial row for the entity survived the import, which the user previously had no way to learn.

**Unreadable repository files** are now quoted individually, which is what makes a stray space visible:

> ``Failed to read 2 file(s) from the repository: `collections/foo/card.yaml`: mapping values are not allowed here; `collections/bar .yaml`: found character '@'…``

Quoting the id also covers the reported trailing-space case directly, since a `Database`'s serdes id *is* its name: ``Import failed: Database (`My Database `) does not exist on this instance. …``

## How the referrer is found

Exception unwinding already encodes the reference relationship. When a dependency's `load-one!` throws `::not-found`, the first frame to catch it on the way out is the immediate parent — the entity whose dependency list named it. The parent attaches itself; outer frames see the key already present and rethrow untouched:

```clojure
(defn- rethrow-with-referrer
  [e referrer]
  (let [data (ex-data e)]
    (if (and (= ::not-found (:error data))
             (not (contains? data :referrer)))
      (throw (ex-info (ex-message e) (assoc data :referrer referrer) (ex-cause e)))
      (throw e))))
```

Two details are load-bearing. The `contains?` guard: without it the outermost frame wins and the top-level entity gets labelled as the referrer. And the replacement inherits `e`'s cause rather than nesting `e` beneath itself — error reporting renders the whole cause chain, so nesting prints the same message twice joined by `caused by:`, which breaks the single-line `error_message` regexes in the serialization snowplow tests.

`load-one!` and `load-deps!` keep their original arities and the `::not-found` throw site is untouched — the only change to `load-one!` is a `try`/`catch` around the existing dependency-loading thread.

For the database case, `import-table-fk` now tags its throw with `:error ::database-not-found` and `:db-name`, `::load-failure` carries the failing entity, and the render walks the whole cause chain rather than checking only `ex-cause` (`with-retries`/diehard sits between the throw and the catch).

## Notes

The missing entity's own name is deliberately not rendered. `::not-found` fires precisely because no YAML for it exists anywhere in the repo, so there is no name to read — only the referrer can be named.

Message construction lives in `missing-reference-message`, so the format can be changed without touching the throw sites.

The `::load-failure` ex-data names the failing entity under `:entity`, not `:referrer`. It is a referrer only relative to the missing Database in the `::database-not-found` case, where that branch reads `:entity` and passes it as the referrer. `::not-found` keeps `:referrer`, where it genuinely is the parent.

The `::load-failure` branch is ordered after the tenant-collection and database-not-found branches, both of which match on causes that a `::load-failure` wraps.

Also fixes `:database-names` in the `import-table-fk` ex-data, which selected names from `:model/Table` rather than `:model/Database`. It has no consumers.

No fallback is added for a nil `:file` in the ingest-errors branch: all three producers (`ingest.clj` `file-hierarchy!`, and `ingestable.clj`'s read and parse failures) always set it, and only `YamlIngestion` and `IngestableSnapshot` produce a non-empty `ingest-errors` — the other `Ingestable`s delegate.

## Scope

`::circular` still renders through the generic `Failed to reload from git repository: <ex-message>` fallback. Rendering its loop needs an ordered expansion chain, and `:deps-chain` is `expanding`, which is a **set** — it records which entities are mid-expansion, not the order. That is a change to the load loop rather than a formatting fix, and `::circular` only fires when the key-stripping recovery at `load.clj:182` has already run and failed, so it is left for a follow-up.

## Testing

The unit tests for `source-error-message` hand-build their `ex-info`, so they cannot prove the throw sites actually attach what the renderer reads. Two end-to-end tests in `load_test.clj` cover that:

- a Card referencing a missing Database carries the Card as `:referrer` on the `::not-found` error;
- a Card whose `result_metadata` `:table_id` names an absent database produces a `::database-not-found` root cause with `:db-name`, and a `::load-failure` naming the Card.

That second one is deliberately routed through `result_metadata`. It is the only path that reaches `import-table-fk` with an undeclared database: `result-metadata-deps` derives deps solely from each entry's `:field_ref`, and a Card's own top-level `table_id` is recomputed from `dataset_query` by `populate-query-fields` on insert, so a `table_id` written into the YAML never reaches the resolver.

`metabase-enterprise.remote-sync.impl-test` and `metabase-enterprise.serialization.v2.load-test` show no regressions: 599 assertions, with the same 3 failures and 4 errors present on a clean tree (verified against a stashed baseline, identical test names). `metabase.models.serialization.resolve.db-test` passes 20/20. Kondo clean on all five files.
