### PR TITLE
Add gpt-5.6 to openai supported-models

### DIFF
--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -228,8 +228,7 @@
    "gpt-5.5-pro"   "GPT-5.5 Pro"
    "gpt-5.4"       "GPT-5.4"
    "gpt-5.4-pro"   "GPT-5.4 Pro"
-   "gpt-5.4-mini"  "GPT-5.4 Mini"
-   "gpt-5"         "GPT-5"})
+   "gpt-5.4-mini"  "GPT-5.4 Mini"})
 
 (defn- supported-model?
   "Whether a `/v1/models` catalog entry is one of the [[supported-models]]."

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -221,12 +221,15 @@
 (def ^:private supported-models
   "OpenAI chat models offered in the Metabot model picker, as a map of model id -> display name.
   `list-models` returns the intersection of this map with the account's `/v1/models` catalog."
-  {"gpt-5.5"      "GPT-5.5"
-   "gpt-5.5-pro"  "GPT-5.5 Pro"
-   "gpt-5.4"      "GPT-5.4"
-   "gpt-5.4-pro"  "GPT-5.4 Pro"
-   "gpt-5.4-mini" "GPT-5.4 Mini"
-   "gpt-5"        "GPT-5"})
+  {"gpt-5.6-sol"   "GPT-5.6 Sol"
+   "gpt-5.6-terra" "GPT-5.6 Terra"
+   "gpt-5.6-luna"  "GPT-5.6 Luna"
+   "gpt-5.5"       "GPT-5.5"
+   "gpt-5.5-pro"   "GPT-5.5 Pro"
+   "gpt-5.4"       "GPT-5.4"
+   "gpt-5.4-pro"   "GPT-5.4 Pro"
+   "gpt-5.4-mini"  "GPT-5.4 Mini"
+   "gpt-5"         "GPT-5"})
 
 (defn- supported-model?
   "Whether a `/v1/models` catalog entry is one of the [[supported-models]]."

--- a/test/metabase/metabot/self/openai_test.clj
+++ b/test/metabase/metabot/self/openai_test.clj
@@ -307,7 +307,7 @@
 
 (deftest ^:parallel supported-model?-test
   (testing "whitelisted models are supported"
-    (doseq [id ["gpt-5.5" "gpt-5.4-mini" "gpt-5"]]
+    (doseq [id ["gpt-5.6-sol" "gpt-5.6-terra" "gpt-5.6-luna" "gpt-5.5" "gpt-5.4-mini" "gpt-5"]]
       (is (true? (#'openai/supported-model? {:id id})) id)))
   (testing "non-white-listed models are not supported"
     (doseq [id ["gpt-4.1" "gpt-4.1-mini" "gpt-4o" "o3" "text-embedding-3-small"]]
@@ -318,7 +318,9 @@
     (mt/with-temporary-setting-values [llm.settings/llm-openai-api-key "sk-test"]
       (with-redefs [http/request (fn [_]
                                    {:status 200
-                                    :body   {:data [{:id "gpt-5-mini"             :created 30}
+                                    :body   {:data [{:id "gpt-5.6-sol"            :created 40}
+                                                    {:id "gpt-5.6-luna"           :created 39}
+                                                    {:id "gpt-5-mini"             :created 30}
                                                     {:id "gpt-5"                  :created 28}
                                                     {:id "gpt-5.4"                :created 25}
                                                     {:id "gpt-4.1"                :created 20}
@@ -328,7 +330,9 @@
                                                     {:id "text-embedding-3-small" :created 8}
                                                     {:id "whisper-1"              :created 7}]}})]
         (is (= [{:id "gpt-5" :display_name "GPT-5"}
-                {:id "gpt-5.4" :display_name "GPT-5.4"}]
+                {:id "gpt-5.4" :display_name "GPT-5.4"}
+                {:id "gpt-5.6-luna" :display_name "GPT-5.6 Luna"}
+                {:id "gpt-5.6-sol" :display_name "GPT-5.6 Sol"}]
                (:models (openai/list-models))))))))
 
 ;;; ──────────────────────────────────────────────────────────────────
@@ -341,7 +345,7 @@
       (is (true? (#'openai/model-supports-temperature? model))
           model)))
   (testing "GPT-5 family and o-series reasoning models do not"
-    (doseq [model ["gpt-5" "gpt-5-mini" "gpt-5-nano" "gpt-5-2025-08-07"
+    (doseq [model ["gpt-5" "gpt-5-mini" "gpt-5-nano" "gpt-5-2025-08-07" "gpt-5.6-sol"
                    "o1" "o1-mini" "o3" "o3-mini" "o4-mini"]]
       (is (false? (#'openai/model-supports-temperature? model))
           model))))

--- a/test/metabase/metabot/self/openai_test.clj
+++ b/test/metabase/metabot/self/openai_test.clj
@@ -307,10 +307,10 @@
 
 (deftest ^:parallel supported-model?-test
   (testing "whitelisted models are supported"
-    (doseq [id ["gpt-5.6-sol" "gpt-5.6-terra" "gpt-5.6-luna" "gpt-5.5" "gpt-5.4-mini" "gpt-5"]]
+    (doseq [id ["gpt-5.6-sol" "gpt-5.6-terra" "gpt-5.6-luna" "gpt-5.5" "gpt-5.4-mini"]]
       (is (true? (#'openai/supported-model? {:id id})) id)))
   (testing "non-white-listed models are not supported"
-    (doseq [id ["gpt-4.1" "gpt-4.1-mini" "gpt-4o" "o3" "text-embedding-3-small"]]
+    (doseq [id ["gpt-5" "gpt-4.1" "gpt-4.1-mini" "gpt-4o" "o3" "text-embedding-3-small"]]
       (is (false? (#'openai/supported-model? {:id id})) id))))
 
 (deftest list-models-filters-catalog-to-whitelist-test
@@ -329,8 +329,7 @@
                                                     {:id "o3"                     :created 15}
                                                     {:id "text-embedding-3-small" :created 8}
                                                     {:id "whisper-1"              :created 7}]}})]
-        (is (= [{:id "gpt-5" :display_name "GPT-5"}
-                {:id "gpt-5.4" :display_name "GPT-5.4"}
+        (is (= [{:id "gpt-5.4" :display_name "GPT-5.4"}
                 {:id "gpt-5.6-luna" :display_name "GPT-5.6 Luna"}
                 {:id "gpt-5.6-sol" :display_name "GPT-5.6 Sol"}]
                (:models (openai/list-models))))))))


### PR DESCRIPTION
Closes [BOT-1834: Add gpt-5.6 to openai supported-models](https://linear.app/metabase/issue/BOT-1834/add-gpt-56-to-openai-supported-models)

### Description

* Add gpt-5.6 to openai `supported-models`
* Drop gpt-5 from openai `supported-models`

### Demo

<img width="802" height="694" alt="Screenshot 2026-07-09 at 1 12 16 PM" src="https://github.com/user-attachments/assets/c2c17aed-d300-422f-abe0-91ff1cbb7e1a" />

```
2026-07-09 20:00:56,270 INFO metabot.self :: :metabot.agent/call-llm (1525.265833ms) {:provider "openai", :model "gpt-5.6-sol", :part-count 1, :tool-count 13}
2026-07-09 20:00:56,270 DEBUG agent.core :: Iteration {:n 1, :parts-count 16}
2026-07-09 20:00:56,270 DEBUG agent.core :: Got parts {:count 16, :types [:start :text :text :text :text :text :text :text :text :text :text :text :text :text :text :usage]}
2026-07-09 20:00:56,270 INFO agent.core :: Agent loop complete {:iterations 1, :reason :stop}
2026-07-09 20:00:56,271 DEBUG agent.core :: :metabot.agent/loop-step (1555.443375ms) {:iteration 1}
2026-07-09 20:00:56,271 INFO agent.core :: :metabot.agent/run-agent-loop (1556.835667ms) {:profile-id :internal, :msg-count 1}
```
### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
