### PR TITLE
Native 2FA part 2: recovery codes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/mfa/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/mfa/api.clj
@@ -23,7 +23,7 @@
 (def ^:private verify-throttlers
   ;; Codes are 6 digits, so slow brute-force limits are load-bearing.
   {:user-id    (throttle/make-throttler :user-id, :attempts-threshold 5)
-   :ip-address (throttle/make-throttler :user-id, :attempts-threshold 50)})
+   :ip-address (throttle/make-throttler :ip-address, :attempts-threshold 50)})
 
 (def ^:private throttling-disabled? (config/config-bool :mb-disable-session-throttle))
 
@@ -41,8 +41,8 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/verify"
   "Complete a two-step login by verifying a one-time code. Takes the `mfa_token` returned by
-  `POST /api/session` and the `code` from the user's authenticator app; on success sets the
-  session cookie."
+  `POST /api/session` and either the 6-digit `code` from the user's authenticator app or one of
+  their single-use recovery codes; on success sets the session cookie."
   [_route-params
    _query-params
    {:keys [mfa_token code]} :- [:map
@@ -59,7 +59,7 @@
       (throw (invalid-token-ex)))
     (throttle-check (verify-throttlers :ip-address) (request/ip-address request))
     (throttle-check (verify-throttlers :user-id) user-id)
-    (if (enrollment/verify-totp-attempt! user-id code jti)
+    (if (enrollment/verify-attempt! user-id code jti)
       (let [user     (t2/select-one [:model/User :id :is_active :last_login :tenant_id] :id user-id)
             session  (auth-identity/create-session-with-auth-tracking! user (request/device-info request) first-factor)
             response (vary-meta {:id (str (:key session))} assoc :metabase-user-id (:user_id session))]

--- a/enterprise/backend/src/metabase_enterprise/mfa/enrollment.clj
+++ b/enterprise/backend/src/metabase_enterprise/mfa/enrollment.clj
@@ -1,7 +1,14 @@
 (ns metabase-enterprise.mfa.enrollment
   "Reads and writes a user's TOTP enrollment, stored in their `auth_identity` row (provider
-  `\"totp\"`) inside the `:credentials` JSON, encrypted with `MB_ENCRYPTION_SECRET_KEY` when one is
-  set. A user is enrolled only once `:confirmed_at` is present.
+  `\"totp\"`) inside the `:credentials` JSON. A user is enrolled only once `:confirmed_at` is
+  present.
+
+  The model's credentials transform is plain JSON, NOT encrypted-json — encryption of the TOTP
+  secret is this namespace's contract: any writer of `:secret` MUST store
+  `(encryption/maybe-encrypt secret)` (the read path [[stored-secret]] calls `maybe-decrypt`, which
+  passes plaintext through and will silently mask a writer that forgets). No writer exists yet;
+  enrollment creation arrives with the enrollment API. Recovery-code hashes and the replay/jti
+  bookkeeping need no encryption — they contain no recoverable secret.
 
   Also owns the two pieces of one-time-use state, both kept in the same credentials map so
   enforcement is correct across multiple app nodes with no schema migration:
@@ -9,10 +16,13 @@
   - `:last_used_step` — the last accepted TOTP time step. RFC 6238 §5.2: a verifier MUST NOT
     accept the same code twice, so verification rejects any step at or before it.
   - `:used_jtis` — `[{:jti ... :exp ...}, ...]` consumed challenge-token ids, pruned by expiry,
-    so one challenge token cannot mint two sessions."
+    so one challenge token cannot mint two sessions.
+  - `:recovery_codes` — bcrypt hashes of the unused recovery codes; a code is removed when used."
   (:require
+   [metabase-enterprise.mfa.recovery-codes :as recovery-codes]
    [metabase-enterprise.mfa.totp :as totp]
    [metabase.util.encryption :as encryption]
+   [metabase.util.password :as u.password]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -41,25 +51,54 @@
 (defn- jti-used? [credentials jti]
   (boolean (some #(= (:jti %) jti) (:used_jtis credentials))))
 
-(defn- consume! [auth-identity step jti]
-  (let [now         (quot (System/currentTimeMillis) 1000)
-        credentials (:credentials auth-identity)
-        used-jtis   (->> (:used_jtis credentials)
-                         (filterv #(> (:exp % 0) now)))]
-    (t2/update! :model/AuthIdentity (:id auth-identity)
-                {:credentials (assoc credentials
-                                     :last_used_step step
-                                     :used_jtis (conj used-jtis
-                                                      {:jti jti
-                                                       :exp (+ now (* 2 60 60))}))})))
+(defn- consume-jti
+  "Record `jti` as used (nil jti = session re-auth, nothing to record), pruning expired entries."
+  [credentials jti]
+  (if-not jti
+    credentials
+    (let [now (quot (System/currentTimeMillis) 1000)]
+      (update credentials :used_jtis
+              (fn [jtis]
+                (conj (filterv #(> (:exp % 0) now) jtis)
+                      {:jti jti :exp (+ now (* 2 60 60))}))))))
 
-(defn verify-totp-attempt!
-  "Verify `code` for `user-id` and atomically consume the (time step, challenge `jti`) pair.
+(defn- write-credentials! [auth-identity credentials jti]
+  (t2/update! :model/AuthIdentity (:id auth-identity)
+              {:credentials (consume-jti credentials jti)}))
 
-  True only when all hold: confirmed enrollment; the code matches within the validation window;
-  the matched step is strictly later than the last accepted step; and `jti` has not been used.
-  Runs in a transaction with the enrollment row locked so a concurrently replayed code or token
-  cannot pass twice."
+(defn- totp-attempt!
+  "When `code` is a valid, not-yet-used TOTP code: consume its time step (RFC 6238 §5.2) and return
+  true."
+  [auth-identity code jti]
+  (let [credentials (:credentials auth-identity)]
+    (when-let [secret (stored-secret auth-identity)]
+      (when-let [step (totp/matching-time-step secret code)]
+        (when (> step (long (:last_used_step credentials 0)))
+          (write-credentials! auth-identity (assoc credentials :last_used_step step) jti)
+          true)))))
+
+(defn- recovery-attempt!
+  "When `code` matches one of the stored (bcrypt-hashed) recovery codes: remove it — single-use —
+  and return true."
+  [auth-identity code jti]
+  (when (recovery-codes/recovery-code? code)
+    (let [credentials (:credentials auth-identity)
+          hashes      (:recovery_codes credentials)]
+      (when-let [used (first (filter #(u.password/bcrypt-verify code %) hashes))]
+        (write-credentials! auth-identity
+                            (assoc credentials :recovery_codes (filterv #(not= used %) hashes))
+                            jti)
+        true))))
+
+(defn verify-attempt!
+  "Verify a second-factor `code` — a 6-digit TOTP code or a recovery code — for `user-id`,
+  atomically consuming whatever it uses: the TOTP time step or the recovery code, plus the
+  challenge `jti` when one is given (pass nil for session re-auth, where no challenge token
+  exists).
+
+  True only for a confirmed enrollment with an unused jti and an unconsumed code. Runs in a
+  transaction with the enrollment row locked so a concurrently replayed code, recovery code, or
+  token cannot pass twice."
   [user-id code jti]
   (t2/with-transaction [_conn]
     (boolean
@@ -67,12 +106,31 @@
                                              :user_id user-id
                                              :provider provider-name
                                              {:for :update})]
-       (let [credentials (:credentials auth-identity)
-             secret      (stored-secret auth-identity)]
-         (when (and (confirmed? auth-identity)
-                    secret
-                    (not (jti-used? credentials jti)))
-           (when-let [step (totp/matching-time-step secret code)]
-             (when (> step (long (:last_used_step credentials 0)))
-               (consume! auth-identity step jti)
-               true))))))))
+       (when (and (confirmed? auth-identity)
+                  (not (jti-used? (:credentials auth-identity) jti)))
+         (or (totp-attempt! auth-identity code jti)
+             (recovery-attempt! auth-identity code jti)))))))
+
+;;; -------------------------------------------------- Recovery-code management --------------------------------------------------
+
+(defn reset-recovery-codes!
+  "Generate a fresh recovery-code set for `user-id`'s confirmed enrollment, replacing (and thereby
+  invalidating) the entire previous set. Returns the plaintext codes — the only time they exist in
+  plaintext; only bcrypt hashes are stored. Nil when the user has no confirmed enrollment."
+  [user-id]
+  (t2/with-transaction [_conn]
+    (when-let [auth-identity (t2/select-one :model/AuthIdentity
+                                            :user_id user-id
+                                            :provider provider-name
+                                            {:for :update})]
+      (when (confirmed? auth-identity)
+        (let [codes (recovery-codes/generate-codes)]
+          (t2/update! :model/AuthIdentity (:id auth-identity)
+                      {:credentials (assoc (:credentials auth-identity)
+                                           :recovery_codes (mapv u.password/hash-bcrypt codes))})
+          codes)))))
+
+(defn recovery-codes-remaining
+  "How many unused recovery codes `user-id` has left."
+  [user-id]
+  (count (get-in (totp-identity user-id) [:credentials :recovery_codes])))

--- a/enterprise/backend/src/metabase_enterprise/mfa/management.clj
+++ b/enterprise/backend/src/metabase_enterprise/mfa/management.clj
@@ -1,0 +1,36 @@
+(ns metabase-enterprise.mfa.management
+  "/api/ee/mfa endpoints that require a signed-in user (mounted behind auth in
+  `metabase-enterprise.mfa.routes`).
+
+  Not premium-feature-gated: these manage an *existing* enrollment, and per the fail-closed
+  license-lapse semantics a lapsed license must never strand an enrolled user."
+  (:require
+   [metabase-enterprise.mfa.enrollment :as enrollment]
+   [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
+   [metabase.config.core :as config]
+   [metabase.util.i18n :refer [deferred-tru]]
+   [metabase.util.malli.schema :as ms]
+   [throttle.core :as throttle]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private regenerate-throttler
+  ;; re-auth takes a 6-digit code, so this path needs brute-force limits like /verify
+  (throttle/make-throttler :user-id, :attempts-threshold 5))
+
+(def ^:private throttling-disabled? (config/config-bool :mb-disable-session-throttle))
+
+(api.macros/defendpoint :post "/recovery-codes" :- [:map [:codes [:sequential ms/NonBlankString]]]
+  "Regenerate the current user's recovery codes, invalidating the entire previous set. Re-auth is a
+  fresh second factor — a TOTP code or an unused recovery code — so a stolen password alone can
+  never rotate the codes. The plaintext codes are returned exactly once; only hashes are stored."
+  [_route-params
+   _query-params
+   {:keys [code]} :- [:map [:code ms/NonBlankString]]]
+  (when-not throttling-disabled?
+    (throttle/check regenerate-throttler api/*current-user-id*))
+  (when-not (enrollment/verify-attempt! api/*current-user-id* code nil)
+    (throw (ex-info (str (deferred-tru "Invalid authentication code."))
+                    {:status-code 401})))
+  {:codes (enrollment/reset-recovery-codes! api/*current-user-id*)})

--- a/enterprise/backend/src/metabase_enterprise/mfa/recovery_codes.clj
+++ b/enterprise/backend/src/metabase_enterprise/mfa/recovery_codes.clj
@@ -1,0 +1,34 @@
+(ns metabase-enterprise.mfa.recovery-codes
+  "Recovery-code generation and format. Codes are single-use fallbacks for a lost authenticator:
+  generated from a CSPRNG, shown to the user exactly once, and stored only as bcrypt hashes — a
+  recovery code is ever compared, never recovered, so hashed storage is safe even when no
+  `MB_ENCRYPTION_SECRET_KEY` is set."
+  (:import
+   (java.security SecureRandom)))
+
+(set! *warn-on-reflection* true)
+
+(def num-codes
+  "How many recovery codes a user gets per set."
+  10)
+
+;; no ambiguous chars (0/o, 1/l/i) — users type these from a printout
+(def ^:private alphabet "abcdefghjkmnpqrstvwxyz23456789")
+
+(def code-pattern
+  "What a recovery code looks like: two 5-char groups, ~49 bits of entropy."
+  (re-pattern (format "[%s]{5}-[%s]{5}" alphabet alphabet)))
+
+(defn recovery-code?
+  "Is `s` shaped like a recovery code (as opposed to a 6-digit TOTP code)?"
+  [s]
+  (boolean (and (string? s) (re-matches code-pattern s))))
+
+(defn- random-group ^String [^SecureRandom rng]
+  (apply str (repeatedly 5 #(nth alphabet (.nextInt rng (count alphabet))))))
+
+(defn generate-codes
+  "A fresh set of [[num-codes]] plaintext recovery codes."
+  []
+  (let [rng (SecureRandom.)]
+    (vec (repeatedly num-codes #(str (random-group rng) "-" (random-group rng))))))

--- a/enterprise/backend/src/metabase_enterprise/mfa/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/mfa/routes.clj
@@ -1,13 +1,19 @@
 (ns metabase-enterprise.mfa.routes
-  "Ring handler for /api/ee/mfa. Mounted with neither auth (the verify caller has no session yet)
-  nor a premium-feature gate (enforcement must survive license lapse — the feature check guards
-  setup paths, not verification)."
+  "Ring handler for /api/ee/mfa. Mounted without a premium-feature gate: enforcement and managing
+  an existing enrollment must survive license lapse — the feature check guards setup paths.
+  `/verify` is reachable with no session (the caller is mid-login); everything else requires one."
   (:require
    [metabase-enterprise.mfa.api]
-   [metabase.api.macros :as api.macros]))
+   [metabase-enterprise.mfa.management]
+   [metabase.api.macros :as api.macros]
+   [metabase.api.routes.common :refer [+auth]]
+   [metabase.api.util.handlers :as handlers]))
 
-(comment metabase-enterprise.mfa.api/keep-me)
+(comment metabase-enterprise.mfa.api/keep-me
+         metabase-enterprise.mfa.management/keep-me)
 
 (def ^{:arglists '([request respond raise])} routes
   "/api/ee/mfa routes"
-  (api.macros/ns-handler 'metabase-enterprise.mfa.api))
+  (handlers/routes
+   (api.macros/ns-handler 'metabase-enterprise.mfa.api)
+   (+auth (api.macros/ns-handler 'metabase-enterprise.mfa.management))))

--- a/enterprise/backend/test/metabase_enterprise/mfa/login_flow_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/mfa/login_flow_test.clj
@@ -4,6 +4,8 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase-enterprise.mfa.api :as mfa.api]
+   [metabase-enterprise.mfa.enrollment :as enrollment]
+   [metabase-enterprise.mfa.management :as mfa.management]
    [metabase-enterprise.mfa.totp :as totp]
    [metabase.auth-identity.core :as auth-identity]
    [metabase.session.api :as api.session]
@@ -16,7 +18,8 @@
 (defn- reset-throttlers! []
   (doseq [throttler (concat (vals @#'mfa.api/verify-throttlers)
                             (vals @#'api.session/login-throttlers)
-                            [@#'api.session/reset-password-throttler])]
+                            [@#'api.session/reset-password-throttler
+                             @#'mfa.management/regenerate-throttler])]
     (reset! (:attempts throttler) nil)))
 
 (use-fixtures :each (fn [f] (reset-throttlers!) (f)))
@@ -84,6 +87,34 @@
           (is (=? {:id string?}
                   (mt/client :post 200 "ee/mfa/verify"
                              {:mfa_token (:mfa_token resp) :code (totp/generate-code secret)}))))))))
+
+(deftest recovery-code-login-test
+  (with-enrolled-rasta! [_secret]
+    (let [[code & _] (enrollment/reset-recovery-codes! (mt/user->id :rasta))
+          resp       (mt/client :post 200 "session" (mt/user->credentials :rasta))]
+      (testing "a recovery code completes the two-step login in place of a TOTP code"
+        (is (=? {:id string?}
+                (mt/client :post 200 "ee/mfa/verify" {:mfa_token (:mfa_token resp) :code code}))))
+      (testing "single-use: the same recovery code is dead afterwards"
+        (let [resp' (mt/client :post 200 "session" (mt/user->credentials :rasta))]
+          (mt/client :post 401 "ee/mfa/verify" {:mfa_token (:mfa_token resp') :code code}))))))
+
+(deftest regenerate-recovery-codes-endpoint-test
+  (with-enrolled-rasta! [secret]
+    (let [user-id           (mt/user->id :rasta)
+          [c1 & _]          (enrollment/reset-recovery-codes! user-id)
+          login             (mt/client :post 200 "session" (mt/user->credentials :rasta))
+          {session-key :id} (mt/client :post 200 "ee/mfa/verify" {:mfa_token (:mfa_token login)
+                                                                  :code      (totp/generate-code secret)})]
+      (testing "requires a session"
+        (mt/client :post 401 "ee/mfa/recovery-codes" {:code c1}))
+      (testing "requires a fresh second factor, not just the session"
+        (mt/client session-key :post 401 "ee/mfa/recovery-codes" {:code "000000"}))
+      (testing "an unused recovery code re-auths; the whole old set is then invalid"
+        (let [resp (mt/client session-key :post 200 "ee/mfa/recovery-codes" {:code c1})]
+          (is (= 10 (count (:codes resp))))
+          (is (false? (enrollment/verify-attempt! user-id c1 nil))
+              "the re-auth code was consumed with the rest of the old set"))))))
 
 (deftest password-reset-issues-no-session-test
   (mt/with-premium-features #{:multi-factor-auth}

--- a/enterprise/backend/test/metabase_enterprise/mfa/recovery_codes_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/mfa/recovery_codes_test.clj
@@ -1,0 +1,81 @@
+(ns metabase-enterprise.mfa.recovery-codes-test
+  (:require
+   [clojure.set :as set]
+   [clojure.test :refer :all]
+   [java-time.api :as t]
+   [metabase-enterprise.mfa.enrollment :as enrollment]
+   [metabase-enterprise.mfa.recovery-codes :as recovery-codes]
+   [metabase-enterprise.mfa.totp :as totp]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(defn- fresh-jti [] (str (random-uuid)))
+
+(deftest generate-codes-test
+  (let [codes (recovery-codes/generate-codes)]
+    (is (= recovery-codes/num-codes (count codes)))
+    (is (every? recovery-codes/recovery-code? codes))
+    (is (= (count codes) (count (distinct codes))))
+    (testing "a TOTP code never looks like a recovery code"
+      (is (not (recovery-codes/recovery-code? "123456"))))))
+
+(defmacro ^:private with-confirmed-enrollment! [[user-id-binding secret-binding] & body]
+  `(let [~secret-binding (totp/generate-secret)]
+     (mt/with-temp [:model/User {~user-id-binding :id} {}
+                    :model/AuthIdentity ~'_ {:user_id     ~user-id-binding
+                                             :provider    "totp"
+                                             :credentials {:secret       ~secret-binding
+                                                           :confirmed_at (t/instant)}}]
+       ~@body)))
+
+(deftest reset-recovery-codes-test
+  (with-confirmed-enrollment! [user-id _secret]
+    (let [codes (enrollment/reset-recovery-codes! user-id)]
+      (is (= recovery-codes/num-codes (count codes)))
+      (is (= recovery-codes/num-codes (enrollment/recovery-codes-remaining user-id)))
+      (testing "only hashes are stored"
+        (let [stored (get-in (t2/select-one :model/AuthIdentity :user_id user-id :provider "totp")
+                             [:credentials :recovery_codes])]
+          (is (every? #(.startsWith ^String % "$2a$") stored))
+          (is (empty? (set/intersection (set codes) (set stored)))))))))
+
+(deftest reset-requires-confirmed-enrollment-test
+  (let [secret (totp/generate-secret)]
+    (mt/with-temp [:model/User {user-id :id} {}
+                   :model/AuthIdentity _ {:user_id     user-id
+                                          :provider    "totp"
+                                          :credentials {:secret secret}}]
+      (is (nil? (enrollment/reset-recovery-codes! user-id))))))
+
+(deftest recovery-code-single-use-test
+  (with-confirmed-enrollment! [user-id _secret]
+    (let [[code & _] (enrollment/reset-recovery-codes! user-id)]
+      (is (true? (enrollment/verify-attempt! user-id code (fresh-jti))))
+      (is (= (dec recovery-codes/num-codes) (enrollment/recovery-codes-remaining user-id)))
+      (testing "consumed — never accepted again"
+        (is (false? (enrollment/verify-attempt! user-id code (fresh-jti))))))))
+
+(deftest regenerate-invalidates-old-set-test
+  (with-confirmed-enrollment! [user-id _secret]
+    (let [[old-code & _] (enrollment/reset-recovery-codes! user-id)
+          new-codes      (enrollment/reset-recovery-codes! user-id)]
+      (testing "old set is dead in its entirety"
+        (is (false? (enrollment/verify-attempt! user-id old-code (fresh-jti)))))
+      (testing "new set works"
+        (is (true? (enrollment/verify-attempt! user-id (first new-codes) (fresh-jti))))))))
+
+(deftest recovery-path-consumes-jti-test
+  (with-confirmed-enrollment! [user-id secret]
+    (let [[code-a code-b & _] (enrollment/reset-recovery-codes! user-id)
+          jti                 (fresh-jti)]
+      (is (true? (enrollment/verify-attempt! user-id code-a jti)))
+      (testing "the jti is burned across factor kinds — a second unused recovery code can't reuse it"
+        (is (false? (enrollment/verify-attempt! user-id code-b jti))))
+      (testing "nor can a fresh TOTP code"
+        (is (false? (enrollment/verify-attempt! user-id (totp/generate-code secret) jti)))))))
+
+(deftest wrong-recovery-code-rejected-test
+  (with-confirmed-enrollment! [user-id _secret]
+    (enrollment/reset-recovery-codes! user-id)
+    (is (false? (enrollment/verify-attempt! user-id "aaaaa-aaaaa" (fresh-jti))))
+    (is (= recovery-codes/num-codes (enrollment/recovery-codes-remaining user-id)))))

--- a/enterprise/backend/test/metabase_enterprise/mfa/totp_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/mfa/totp_test.clj
@@ -15,7 +15,9 @@
       1111111109  "081804"
       1111111111  "050471"
       1234567890  "005924"
-      2000000000  "279037")))
+      2000000000  "279037"
+      ;; T > 32 bits — proves 64-bit time-step handling (RFC 6238 Appendix A note)
+      20000000000 "353130")))
 
 (deftest round-trip-test
   (let [secret (totp/generate-secret)]


### PR DESCRIPTION
Native 2FA part 2, stacked on #77449: recovery codes — the single-use fallback for a lost authenticator, and the v1 release bar per the [tech design](https://linear.app/metabase/document/tech-design-doc-222d90d0ad56).

## Model

A recovery code is only ever **compared, never recovered**: 10 codes per set from a CSPRNG (`xxxxx-xxxxx`, ambiguity-free alphabet, ~49 bits each), plaintext crosses the wire exactly once at generation, only bcrypt hashes are stored — safe at rest even with no `MB_ENCRYPTION_SECRET_KEY`.

- **Verify step**: `POST /api/ee/mfa/verify` now takes either a 6-digit TOTP code or a recovery code (formats are disjoint; dispatch is by shape). Consumption is removal, inside the same row-locked transaction as the TOTP step-consumption, and the challenge `jti` is burned across factor kinds — one token still can't mint two sessions no matter which factor finishes it.
- **Regenerate**: `POST /api/ee/mfa/recovery-codes` (session required) re-auths with a **fresh second factor**, not a password — enroll with the factor you have, manage with the factor you're managing; a stolen password alone can never rotate the codes. Invalidates the entire old set. Throttled like the verify path.
- Neither endpoint is premium-gated: managing an existing enrollment must survive license lapse (fail-closed semantics from part 1).

## RFC audit

An adversarial RFC 6238/4226 audit of the whole stack ran against this branch: **no MUST violated**; dynamic truncation, time-step math, and Appendix B vectors verified line-by-line. Follow-ups applied here: the >32-bit-T Appendix B vector added to the tests, IP-throttler label fix, generator/pattern alphabet unification, and the TOTP secret-encryption contract documented where the enrollment writer (next PR) will land — the model's JSON transform is not encrypted-json, so that writer MUST `maybe-encrypt`.

## Out of scope (lands with the enrollment UI PR)

Generation at enrollment-confirmation (one call to `reset-recovery-codes!`), and the show-once/download/copy/"N left" screens — they need the Security tab that PR builds. `recovery-codes-remaining` is already exposed for it.

Fixes GHY-4090
