### PR TITLE
Revert DDL assertion change in snowflake tests.

### DIFF
--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -184,7 +184,7 @@
   (testing "make sure we didn't break the code that is used to generate DDL statements when we add new test datasets"
     (with-redefs [test.data.snowflake/qualified-db-name (constantly "v4_test-data")]
       (testing "Create DB DDL statements"
-        (is (= "CREATE DATABASE IF NOT EXISTS \"v4_test-data\";"
+        (is (= "DROP DATABASE IF EXISTS \"v4_test-data\"; CREATE DATABASE \"v4_test-data\";"
                (sql.tx/create-db-sql :snowflake (mt/get-dataset-definition defs/test-data)))))
       (testing "Create Table DDL statements"
         (is (= (map

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -54,7 +54,7 @@
         (str "sha_" (config/current-major-version) "_"
              (tx/hash-dataset db-def) "_" database-name)
         :else
-        (str "sha__" (tx/hash-dataset db-def) "_" database-name)))
+        (str "sha_58_" (tx/hash-dataset db-def) "_" database-name)))
 
 (defmethod tx/dbdef->connection-details :snowflake
   [_driver context dbdef]


### PR DESCRIPTION
This got included in a backport from 46b7aa75bed05df42ab343460bf6f435082539dd along with some legitimate changes; it should not have been included since the corresponding implementation-side change didn't get backported. This brings back the original assertion.