### PR TITLE
Do not duplicate user context between system prompt and last user message

### DIFF
--- a/resources/metabot/prompts/message_injection.selmer
+++ b/resources/metabot/prompts/message_injection.selmer
@@ -12,5 +12,9 @@ Here is some information about the user:
 
 {{ viewing_context|safe }}
 {% endif %}
+{% if recent_views %}
+
+{{ recent_views|safe }}
+{% endif %}
 
 </context>

--- a/resources/metabot/prompts/system/embedding-next.selmer
+++ b/resources/metabot/prompts/system/embedding-next.selmer
@@ -40,30 +40,3 @@ Your job is to answer analytical questions by producing visualizations. For othe
 
 {{ custom_instructions|safe }}
 {% endif %}
-
-<<<METABOT_CACHE_BREAKPOINT>>>
-
-# Important Context
-
-Current date and time: {{current_time}}
-
-In the system, the first day of the week (index 1) is: {{ first_day_of_week }}
-{% if current_user_info %}
-
-<user_context>
-Here is some information about the user:
-{{ current_user_info|safe }}
-{% if viewing_context %}
-{{ viewing_context|safe }}
-{% endif %}
-</user_context>
-{% elif viewing_context %}
-
-<user_context>
-{{ viewing_context|safe }}
-</user_context>
-{% endif %}
-{% if recent_views %}
-
-{{ recent_views|safe }}
-{% endif %}

--- a/resources/metabot/prompts/system/internal.selmer
+++ b/resources/metabot/prompts/system/internal.selmer
@@ -60,12 +60,3 @@ You answer analytical questions and help users find existing content. When a req
 
 {{ custom_instructions|safe }}
 {% endif %}
-
-<<<METABOT_CACHE_BREAKPOINT>>>
-
-# Important Context
-
-{% if recent_views %}
-
-{{ recent_views|safe }}
-{% endif %}

--- a/resources/metabot/prompts/system/natural-language-querying-fallback.selmer
+++ b/resources/metabot/prompts/system/natural-language-querying-fallback.selmer
@@ -47,30 +47,3 @@ Your job is to answer analytical questions by producing visualizations. For othe
 
 {{ custom_instructions|safe }}
 {% endif %}
-
-<<<METABOT_CACHE_BREAKPOINT>>>
-
-# Important Context
-
-Current date and time: {{current_time}}
-
-In the system, the first day of the week (index 1) is: {{ first_day_of_week }}
-{% if current_user_info %}
-
-<user_context>
-Here is some information about the user:
-{{ current_user_info|safe }}
-{% if viewing_context %}
-{{ viewing_context|safe }}
-{% endif %}
-</user_context>
-{% elif viewing_context %}
-
-<user_context>
-{{ viewing_context|safe }}
-</user_context>
-{% endif %}
-{% if recent_views %}
-
-{{ recent_views|safe }}
-{% endif %}

--- a/resources/metabot/prompts/system/natural-language-querying-only.selmer
+++ b/resources/metabot/prompts/system/natural-language-querying-only.selmer
@@ -47,30 +47,3 @@ Your job is to answer analytical questions by producing visualizations. For othe
 
 {{ custom_instructions|safe }}
 {% endif %}
-
-<<<METABOT_CACHE_BREAKPOINT>>>
-
-# Important Context
-
-Current date and time: {{current_time}}
-
-In the system, the first day of the week (index 1) is: {{ first_day_of_week }}
-{% if current_user_info %}
-
-<user_context>
-Here is some information about the user:
-{{ current_user_info|safe }}
-{% if viewing_context %}
-{{ viewing_context|safe }}
-{% endif %}
-</user_context>
-{% elif viewing_context %}
-
-<user_context>
-{{ viewing_context|safe }}
-</user_context>
-{% endif %}
-{% if recent_views %}
-
-{{ recent_views|safe }}
-{% endif %}

--- a/resources/metabot/prompts/system/slackbot.selmer
+++ b/resources/metabot/prompts/system/slackbot.selmer
@@ -403,9 +403,3 @@ Where:
 
 </csv_uploads>
 {% endif %}
-
-<<<METABOT_CACHE_BREAKPOINT>>>
-
-# Runtime Context
-
-Current date and time: {{ current_time }}

--- a/resources/metabot/prompts/system/sql-querying-only.selmer
+++ b/resources/metabot/prompts/system/sql-querying-only.selmer
@@ -360,30 +360,3 @@ The target database uses the **{{sql_dialect}}** SQL dialect.{% if sql_dialect_l
 
 {{ custom_instructions|safe }}
 {% endif %}
-
-<<<METABOT_CACHE_BREAKPOINT>>>
-
-# Important Context
-
-Current date and time: {{current_time}}
-
-In the system, the first day of the week (index 1) is: {{ first_day_of_week }}
-{% if current_user_info %}
-
-<user_context>
-Here is some information about the user:
-{{ current_user_info|safe }}
-{% if viewing_context %}
-{{ viewing_context|safe }}
-{% endif %}
-</user_context>
-{% elif viewing_context %}
-
-<user_context>
-{{ viewing_context|safe }}
-</user_context>
-{% endif %}
-{% if recent_views %}
-
-{{ recent_views|safe }}
-{% endif %}

--- a/resources/metabot/prompts/system/transform-codegen.selmer
+++ b/resources/metabot/prompts/system/transform-codegen.selmer
@@ -374,30 +374,3 @@ This ensures you have full context about referenced entities before making chang
 {% include "metabot/prompts/shared/prompt_snippets/field-references.selmer" %}
 
 {% include "metabot/prompts/shared/skills.selmer" %}
-
-<<<METABOT_CACHE_BREAKPOINT>>>
-
-# Important Context
-
-Current date and time: {{current_time}}
-
-In the system, the first day of the week (index 1) is: {{ first_day_of_week }}
-{% if current_user_info %}
-
-<user_context>
-Here is some information about the user:
-{{ current_user_info|safe }}
-{% if viewing_context %}
-{{ viewing_context|safe }}
-{% endif %}
-</user_context>
-{% elif viewing_context %}
-
-<user_context>
-{{ viewing_context|safe }}
-</user_context>
-{% endif %}
-{% if recent_views %}
-
-{{ recent_views|safe }}
-{% endif %}

--- a/src/metabase/metabot/agent/messages.clj
+++ b/src/metabase/metabot/agent/messages.clj
@@ -183,7 +183,7 @@
 ;;; ──────────────────────────────────────────────────────────────────
 
 (defn build-system-message
-  "Build system message with templated prompt and enriched context.
+  "Build system message with templated prompt.
 
   Parameters:
   - context: Context map from API (with user_is_viewing, user_recently_viewed, etc.)
@@ -192,8 +192,10 @@
 
   Returns message map with {:role \"system\" :content \"...\"}."
   [context profile tools]
-  (let [enriched-context (user-context/enrich-context-for-template context)
-        content          (prompts/build-system-message-content
-                          profile enriched-context tools (:capabilities context))]
+  (let [content (prompts/build-system-message-content
+                 profile
+                 {:sql_dialect (user-context/extract-sql-dialect context)}
+                 tools
+                 (:capabilities context))]
     {:role    "system"
      :content content}))

--- a/src/metabase/metabot/agent/prompts.clj
+++ b/src/metabase/metabot/agent/prompts.clj
@@ -62,17 +62,7 @@
 
   Parameters:
   - template: Template string (from load-system-prompt-template)
-  - context: Map of template variables
-
-   Common context variables:
-   - :current-user-info - Formatted current user info and glossary
-   - :current-time - User's current time string
-  - :first-day-of-week - Calendar week start (default \"Sunday\")
-  - :sql-dialect - SQL dialect name
-  - :sql-dialect-instructions - Dialect-specific guidance (markdown)
-  - :tool-instructions - Vector of tool instruction maps
-  - :viewing-context - Formatted user viewing context
-  - :recent-views - Formatted recent views"
+  - context: Map of template variables"
   [template context]
   (try
     (selmer/render template context)
@@ -139,7 +129,7 @@
 
   Parameters:
   - profile: Profile map with :prompt-template key
-  - context: Agent context map with user info, viewing context, etc.
+  - context: Template context map; only :sql_dialect (or :sql-dialect) is read
   - tools: Tool registry map (name -> tool def/var)
   - capabilities: Sequence of capability strings/keywords for the request, used to
     gate which skills appear in the manifest.
@@ -149,6 +139,10 @@
   loaded on demand via the `load_skill` tool. SQL dialect instructions are
   preloaded into the message stream (see `metabase.metabot.skills`), not here.
 
+  Per-request user context (current time, user info, viewing context, recent
+  views) is injected into the last user message via [[inject-context]], not
+  rendered here to help keep the system prompt cacheable.
+
   Returns rendered system message string."
   [{:keys [prompt-template] :as profile} context tools capabilities]
   (let [template-name (or prompt-template "internal.selmer")
@@ -157,16 +151,6 @@
       (let [sql-dialect          (or (get context :sql_dialect)
                                      (get context :sql-dialect))
             {:keys [always-on catalog]} (skills/build-skill-manifest profile (keys tools) capabilities)
-            current-user-info    (or (get context :current_user_info)
-                                     (get context :current-user-info))
-            current-time         (or (get context :current_time)
-                                     (get context :current-time))
-            first-day-of-week    (or (get context :first_day_of_week)
-                                     (get context :first-day-of-week "Sunday"))
-            viewing-context      (or (get context :viewing_context)
-                                     (get context :viewing-context))
-            recent-views         (or (get context :recent_views)
-                                     (get context :recent-views))
             perms                (or scope/*current-user-metabot-permissions*
                                      scope/perm-type-defaults)
             ;; The SQL guidance tells the model to load SQL skills and use the SQL tools, so gate it
@@ -176,9 +160,6 @@
                                       (boolean (some sql-generation-tool-names (keys tools))))
             has-nlq?             (= :yes (:permission/metabot-nlq perms))
             template-context     {:metabot_name              (metabot.settings/metabot-name)
-                                  :current_time             current-time
-                                  :current_user_info        current-user-info
-                                  :first_day_of_week        first-day-of-week
                                   :sql_dialect              sql-dialect
                                   :sql_dialect_loaded       (some? (skills/dialect-skill sql-dialect))
                                   ;; `not-empty` so an empty catalog is nil (falsy) — Selmer treats
@@ -187,8 +168,6 @@
                                   ;; load, nudging the model into pointless `load_skill` calls.
                                   :skill_catalog            (not-empty catalog)
                                   :skill_always_on          (mapv :body always-on)
-                                  :viewing_context          viewing-context
-                                  :recent_views             recent-views
                                   :has_sql_generation       has-sql?
                                   :has_nlq                  has-nlq?
                                   :has_query_tools          (or has-sql? has-nlq?)
@@ -216,7 +195,7 @@
   (let [;; Injection is performed only when the hardcoded keys are present in in context to avoid
         ;; insertion e.g. insertion of blank xml tags.
         injection (when (some #(string? (not-empty (get context %)))
-                              [:viewing_context :current_time :current_user_info])
+                              [:viewing_context :current_time :current_user_info :recent_views])
                     (selmer/render (get-cached-message-injection-template)
                                    context))]
     (str injection str*)))

--- a/src/metabase/metabot/agent/user_context.clj
+++ b/src/metabase/metabot/agent/user_context.clj
@@ -1,5 +1,5 @@
 (ns metabase.metabot.agent.user-context
-  "User context enrichment and formatting for agent system messages.
+  "User context enrichment and formatting for injecting into the prompt.
 
   Handles formatting of viewing context (what the user is currently looking at),
   recent views, user time formatting, and SQL dialect extraction from context."
@@ -348,7 +348,7 @@
                     (te/field "Selected text" text))))))))
 
 (defn format-viewing-context
-  "Format user's current viewing context for injection into system message.
+  "Format user's current viewing context.
 
   Handles different context types:
   - adhoc: Notebook query editor
@@ -370,7 +370,7 @@
 ;;; Recent Views Formatting
 
 (defn format-recent-views
-  "Format user's recently viewed items for injection into system message.
+  "Format user's recently viewed items.
 
   Returns formatted string for template variable {{recent_views}}."
   [context]
@@ -386,7 +386,7 @@
                 "Otherwise, use the search tool to find relevant entities."))))
 
 (defn format-current-user-info
-  "Format the current user and glossary for injection into the system message.
+  "Format the current user and glossary.
 
   Returns XML for template variable {{current_user_info}}."
   [_context]
@@ -403,19 +403,17 @@
 ;;; Context Enrichment
 
 (defn enrich-context-for-template
-  "Enrich context with all necessary variables for system prompt template rendering.
+  "Enrich context with all necessary variables for rendering the message-injection template.
 
   Takes raw context from API and returns map suitable for template rendering:
   - :current_time - Formatted user time string
   - :first_day_of_week - Calendar week start (default 'Sunday')
-  - :sql_dialect - SQL dialect name (lowercase)
   - :current_user_info - Formatted current user info and glossary
   - :viewing_context - Formatted viewing context
   - :recent_views - Formatted recent views"
   [context]
   {:current_time (format-current-time context)
    :first_day_of_week (get context :first_day_of_week "Sunday")
-   :sql_dialect (extract-sql-dialect context)
    :current_user_info (format-current-user-info context)
    :viewing_context (format-viewing-context context)
    :recent_views (format-recent-views context)})

--- a/src/metabase/metabot/api/document.clj
+++ b/src/metabase/metabot/api/document.clj
@@ -94,7 +94,9 @@
     (metabot.config/check-metabot-enabled! metabot-id)
     (metabot.usage/check-metabase-managed-free-limit!)
     (let [context      (assoc
-                        (metabot.context/create-context {:capabilities #{"permission:write_sql_queries"}})
+                        (metabot.context/create-context {:capabilities #{"permission:write_sql_queries"}}
+                                                        {:metabot-id metabot-id
+                                                         :profile-id :document-generate-content})
                         :references references)
           parts        (into [] (metabot.agent/run-agent-loop
                                  {:messages      [{:role    :user

--- a/src/metabase/metabot/context.clj
+++ b/src/metabase/metabot/context.clj
@@ -273,11 +273,14 @@
     (filter (fn [{:keys [model id]}] (contains? curated [(name model) id])) recents)))
 
 (def ^:private profiles-excluding-recent-views
-  "Profiles for which recent views are never injected. The nlq profile discovers data through the curated
-  library tool rather than general instance search, so arbitrary recently-viewed items (which may not be
-  curated) would undermine that guarantee. (A :nlq request served the general-search fallback keeps the
-  external profile-id :nlq, so this is reached via :nlq; :nlq-fallback is listed for a direct request.)"
-  #{:nlq :nlq-fallback})
+  "Profiles for which recent views are never injected.
+
+  The nlq profile discovers data through the curated library tool rather than general instance search, so arbitrary
+  recently-viewed items (which may not be curated) would undermine that guarantee. (A :nlq request served the
+  general-search fallback keeps the external profile-id :nlq, so this is reached via :nlq; :nlq-fallback is listed for
+  a direct request.)  The slackbot and document-generate-content profiles historically did not include recent views,
+  so we preserve that behavior."
+  #{:nlq :nlq-fallback :slackbot :document-generate-content})
 
 (defn- add-recent-views
   "Add user's recent views to the context since these have a higher likelihood of being relevant to a user's query.

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -259,21 +259,21 @@
   blocks: a cached static prefix and an uncached dynamic suffix. The model sees
   the concatenation; the split is purely a wire-protocol device for caching.
 
-  If the sentinel is absent, fall back to a single cached content block covering
-  the whole prompt."
+  If the sentinel is absent (or nothing but whitespace follows it) fall back to
+  a single cached content block covering the whole prompt."
   [system]
-  (let [idx (.indexOf ^String system ^String system-cache-breakpoint-sentinel)]
-    (if (neg? idx)
+  (let [idx    (.indexOf ^String system ^String system-cache-breakpoint-sentinel)
+        suffix (when-not (neg? idx)
+                 (str/triml (subs system (+ idx (count system-cache-breakpoint-sentinel)))))]
+    (if (or (neg? idx) (str/blank? suffix))
       [{:type          "text"
-        :text          system
+        :text          (if (neg? idx) system (str/trimr (subs system 0 idx)))
         :cache_control {:type "ephemeral"}}]
-      (let [prefix (str/trimr (subs system 0 idx))
-            suffix (str/triml (subs system (+ idx (count system-cache-breakpoint-sentinel))))]
-        [{:type          "text"
-          :text          prefix
-          :cache_control {:type "ephemeral"}}
-         {:type "text"
-          :text suffix}]))))
+      [{:type          "text"
+        :text          (str/trimr (subs system 0 idx))
+        :cache_control {:type "ephemeral"}}
+       {:type "text"
+        :text suffix}])))
 
 (defn- anthropic-error-msg
   "Canonical, status-specific Anthropic error message."

--- a/src/metabase/slackbot/streaming.clj
+++ b/src/metabase/slackbot/streaming.clj
@@ -201,7 +201,8 @@
                          {:current_time_with_timezone (str (java.time.OffsetDateTime/now))
                           :capabilities               capabilities
                           :slack_channel_id           channel-id}
-                         {:metabot-id metabot.config/internal-metabot-id})
+                         {:metabot-id metabot.config/internal-metabot-id
+                          :profile-id :slackbot})
         messages        (conj (vec history) request-message)
         parts-atom      (atom [])
         memory-atom     (atom nil)

--- a/test/metabase/metabot/agent/messages_test.clj
+++ b/test/metabase/metabot/agent/messages_test.clj
@@ -5,6 +5,7 @@
    [metabase.lib.core :as lib]
    [metabase.metabot.agent.memory :as memory]
    [metabase.metabot.agent.messages :as messages]
+   [metabase.metabot.agent.user-context :as user-context]
    [metabase.test :as mt]))
 
 ;;; ──────────────────────────────────────────────────────────────────
@@ -233,6 +234,17 @@
                     (memory/initialize [{:role :user :content "Hi"}] {})))]
       (is (str/includes? content "Sales")))))
 
+(deftest ^:parallel context-injection-recent-views-test
+  (testing "includes recent views in the injected context"
+    (let [content (last-user-content
+                   (messages/build-message-history
+                    {:user_recently_viewed [{:type "question" :id 7 :name "Monthly Revenue"}]
+                     :user_is_viewing      [{:type "dashboard" :id 1 :name "Sales"}]}
+                    (memory/initialize [{:role :user :content "Hi"}] {})))]
+      (is (str/includes? content "recently viewed"))
+      (is (str/includes? content "Monthly Revenue"))
+      (is (str/ends-with? content "Hi")))))
+
 (deftest ^:parallel context-injection-viewing-native-query-test
   (testing "includes SQL and schema when user is viewing a native query"
     (let [mp (mt/metadata-provider)
@@ -271,14 +283,44 @@
                    :model           "claude-sonnet-4-5-20250929"}]
       (is (=? {:role "system" :content #"(?s).*Metabot.*"}
               (messages/build-system-message {} profile {})))))
-  (testing "includes viewing context when provided"
-    (let [context {:user_is_viewing [{:type "dashboard" :id 1 :name "Sales Dashboard"}]}
-          profile {:prompt-template "internal.selmer"
-                   :model           "claude-sonnet-4-5-20250929"}]
-      (is (=? {:content #(not (str/blank? %))}
-              (messages/build-system-message context profile {})))))
   (testing "handles empty context gracefully"
     (let [profile {:prompt-template "internal.selmer"
                    :model           "claude-sonnet-4-5-20250929"}]
       (is (=? {:content #(not (str/blank? %))}
               (messages/build-system-message {} profile {}))))))
+
+(deftest build-system-message-excludes-user-context-test
+  (testing "viewing context does not leak into the system message (it is injected into the last user message)"
+    (let [context {:user_is_viewing [{:type "dashboard" :id 1 :name "Sales Dashboard"}]}
+          profile {:prompt-template "internal.selmer"
+                   :model           "claude-sonnet-4-5-20250929"}]
+      (is (=? {:content #(not (str/includes? % "Sales Dashboard"))}
+              (messages/build-system-message context profile {}))))))
+
+(deftest build-system-message-does-not-enrich-context-test
+  (testing "building the system message never runs the expensive context formatting"
+    (let [calls   (atom 0)
+          profile {:prompt-template "internal.selmer"
+                   :model           "claude-sonnet-4-5-20250929"}]
+      (mt/with-dynamic-fn-redefs [user-context/enrich-context-for-template
+                                  (fn [_] (swap! calls inc) {})]
+        (messages/build-system-message
+         {:user_is_viewing [{:type "dashboard" :id 1 :name "Sales"}]}
+         profile
+         {})
+        (is (zero? @calls))))))
+
+(deftest build-message-history-enriches-context-once-test
+  (testing "one LLM call formats the user context exactly once (in build-message-history)"
+    (let [calls   (atom 0)
+          profile {:prompt-template "internal.selmer"
+                   :model           "claude-sonnet-4-5-20250929"}
+          context {:user_is_viewing [{:type "dashboard" :id 1 :name "Sales"}]}
+          orig    (mt/original-fn #'user-context/enrich-context-for-template)]
+      (mt/with-dynamic-fn-redefs [user-context/enrich-context-for-template
+                                  (fn [ctx] (swap! calls inc) (orig ctx))]
+        (messages/build-system-message context profile {})
+        (messages/build-message-history
+         context
+         (memory/initialize [{:role :user :content "Hello"}] {}))
+        (is (= 1 @calls))))))

--- a/test/metabase/metabot/agent/prompt_cache_test.clj
+++ b/test/metabase/metabot/agent/prompt_cache_test.clj
@@ -1,14 +1,14 @@
 (ns metabase.metabot.agent.prompt-cache-test
   "Tests that protect the Anthropic prompt-cache contract.
 
-  Everything before `<<<METABOT_CACHE_BREAKPOINT>>>` in a system prompt is sent
-  as a cacheable prefix. Per-request values (current time, user info, viewing
-  context, recent views) must not leak into that prefix, or the cache
-  invalidates on every request.
+  The entire system prompt is sent as a cacheable prefix. Per-request values
+  (current time, user info, viewing context, recent views) are injected into
+  the last user message (see `message_injection.selmer`), never rendered into
+  the system prompt.
 
   Snippets under `shared/prompt_snippets/` are also asserted to be free of
   Selmer template directives, since they are intended to be safe to embed
-  anywhere in the cacheable prefix without coupling to runtime context."
+  anywhere in the cacheable prompt without coupling to runtime context."
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
@@ -17,8 +17,6 @@
    [metabase.metabot.scope :as scope]))
 
 (set! *warn-on-reflection* true)
-
-(def ^:private cache-breakpoint "<<<METABOT_CACHE_BREAKPOINT>>>")
 
 (def ^:private all-yes-perms
   {:permission/metabot-sql-generation :yes
@@ -48,13 +46,38 @@
   (testing "snippet directory exists and has files (guards against the previous test silently passing)"
     (is (seq (snippet-files)))))
 
-(def ^:private system-templates-with-breakpoint
-  ["internal.selmer"
-   "embedding-next.selmer"
-   "natural-language-querying-only.selmer"
-   "sql-querying-only.selmer"
-   "slackbot.selmer"
-   "transform-codegen.selmer"])
+(def ^:private system-templates-dir "metabot/prompts/system")
+
+(defn- system-template-files []
+  (->> (io/resource system-templates-dir)
+       io/file
+       file-seq
+       (filter #(.isFile ^java.io.File %))
+       (filter #(str/ends-with? (.getName ^java.io.File %) ".selmer"))))
+
+(def ^:private per-request-template-vars
+  "Template variables that vary per request. These belong to the message-injection
+  template (message_injection.selmer), never to system prompts — a system prompt
+  referencing one would render blank (they are no longer supplied) and would have
+  signalled per-request content in the cacheable prompt."
+  [#"current_time"
+   #"current_user_info"
+   #"viewing_context"
+   #"recent_views"
+   #"first_day_of_week"])
+
+(deftest ^:parallel system-templates-have-no-per-request-vars-test
+  (testing "system prompt templates must not reference per-request context variables"
+    (doseq [^java.io.File f (system-template-files)]
+      (let [body (slurp f)]
+        (testing (.getName f)
+          (doseq [pattern per-request-template-vars]
+            (is (not (re-find pattern body))
+                (str "system template references per-request variable " pattern))))))))
+
+(deftest ^:parallel system-templates-directory-not-empty-test
+  (testing "system template directory exists and has files (guards against the previous test silently passing)"
+    (is (seq (system-template-files)))))
 
 (defn- render
   [template-name per-request-context]
@@ -65,26 +88,22 @@
      {}
      [])))
 
-(defn- prefix-of [rendered]
-  (let [idx (.indexOf ^String rendered ^String cache-breakpoint)]
-    (when (neg? idx)
-      (throw (ex-info "Rendered template is missing the cache breakpoint sentinel"
-                      {:rendered rendered})))
-    (subs rendered 0 idx)))
-
-(deftest ^:parallel cache-prefix-is-stable-across-per-request-values-test
-  (testing "the prefix before <<<METABOT_CACHE_BREAKPOINT>>> must not vary with per-request context"
-    (doseq [template system-templates-with-breakpoint]
-      (testing template
-        (let [a (render template
-                        {:current_time      "2026-01-01T00:00:00Z"
-                         :current_user_info "User: Alice"
-                         :viewing_context   "viewing dashboard 1"
-                         :recent_views      "recent: card 1"})
-              b (render template
-                        {:current_time      "2026-12-31T23:59:59Z"
-                         :current_user_info "User: Bob"
-                         :viewing_context   "viewing dashboard 2"
-                         :recent_views      "recent: card 2"})]
-          (is (= (prefix-of a) (prefix-of b))
-              "cacheable prefix changed when only per-request values changed"))))))
+(deftest ^:parallel system-prompt-is-stable-across-per-request-values-test
+  (testing "the rendered system prompt must not vary with per-request context"
+    (doseq [^java.io.File f (system-template-files)]
+      (let [template (.getName f)]
+        (testing template
+          (let [a (render template
+                          {:current_time      "2026-01-01T00:00:00Z"
+                           :current_user_info "User: Alice"
+                           :viewing_context   "viewing dashboard 1"
+                           :recent_views      "recent: card 1"
+                           :first_day_of_week "Monday"})
+                b (render template
+                          {:current_time      "2026-12-31T23:59:59Z"
+                           :current_user_info "User: Bob"
+                           :viewing_context   "viewing dashboard 2"
+                           :recent_views      "recent: card 2"
+                           :first_day_of_week "Friday"})]
+            (is (= a b)
+                "system prompt changed when only per-request values changed")))))))

--- a/test/metabase/metabot/agent/prompts_test.clj
+++ b/test/metabase/metabot/agent/prompts_test.clj
@@ -79,7 +79,6 @@
   (testing "builds complete system message"
     (let [profile {:prompt-template "embedding-next.selmer"}
           context {:current_time "2024-01-15 14:30:00"
-                   :first_day_of_week "Sunday"
                    :sql-dialect "postgresql"}
           tools {}
           content (prompts/build-system-message-content profile context tools [])]
@@ -87,7 +86,8 @@
       (is (string? content))
       (is (> (count content) 100))
       (is (re-find #"Metabot" content))
-      (is (re-find #"2024-01-15 14:30:00" content)))))
+      (is (not (str/includes? content "2024-01-15 14:30:00"))
+          "current time is not in system message (moved to message injection)"))))
 
 (deftest ^:parallel build-system-message-content-test-2
   (testing "includes dialect instructions when dialect specified"
@@ -146,3 +146,39 @@
       (is (some? content))
       (is (not (str/includes? content "Here is some information about the user:")))
       (is (not (str/includes? content "<user><name>Jane Doe</name></user>"))))))
+
+(deftest ^:parallel build-system-message-content-test-7
+  (testing "viewing context and recent views are not in system message (moved to message injection)"
+    (let [profile {:prompt-template "internal.selmer"}
+          context {:viewing_context "The user is currently looking at dashboard 42."
+                   :recent_views    "Here are some items the user has recently viewed: card 7"}
+          tools {}
+          content (prompts/build-system-message-content profile context tools [])]
+      (is (some? content))
+      (is (not (str/includes? content "dashboard 42")))
+      (is (not (str/includes? content "recently viewed"))))))
+
+(deftest ^:parallel inject-context-test
+  (testing "prepends the rendered context block to the message"
+    (let [injected (prompts/inject-context {:current_time      "2024-01-15 14:30:00"
+                                            :first_day_of_week "Monday"}
+                                           "Show me revenue")]
+      (is (str/starts-with? injected "<context>"))
+      (is (str/ends-with? injected "Show me revenue"))
+      (is (str/includes? injected "2024-01-15 14:30:00"))
+      (is (str/includes? injected "Monday")))))
+
+(deftest ^:parallel inject-context-recent-views-test
+  (testing "recent views are injected into the message"
+    (let [recent   "Here are some items the user has recently viewed: card 7"
+          injected (prompts/inject-context {:recent_views recent} "Show me revenue")]
+      (is (str/starts-with? injected "<context>"))
+      (is (str/includes? injected recent)))))
+
+(deftest ^:parallel inject-context-no-context-test
+  (testing "message is returned unchanged when there is nothing to inject"
+    (is (= "Hi" (prompts/inject-context {} "Hi")))
+    (is (= "Hi" (prompts/inject-context {:viewing_context ""
+                                         :current_time    ""
+                                         :recent_views    ""}
+                                        "Hi")))))

--- a/test/metabase/metabot/agent/user_context_test.clj
+++ b/test/metabase/metabot/agent/user_context_test.clj
@@ -277,13 +277,11 @@
             result (user-context/enrich-context-for-template context)]
         (is (contains? result :current_time))
         (is (contains? result :first_day_of_week))
-        (is (contains? result :sql_dialect))
         (is (contains? result :current_user_info))
         (is (contains? result :viewing_context))
         (is (contains? result :recent_views))
         (is (string? (:current_time result)))
         (is (= "Monday" (:first_day_of_week result)))
-        (is (= "postgresql" (:sql_dialect result)))
         (is (= "<user>Jane Doe</user>" (:current_user_info result)))
         (is (string? (:viewing_context result)))
         (is (string? (:recent_views result))))))
@@ -297,7 +295,6 @@
                                            :id 123
                                            :name "users"}]}
           result (user-context/enrich-context-for-template context)]
-      (is (= "postgresql" (:sql_dialect result)))
       (is (re-find #"SQL editor" (:viewing_context result)))
       (is (re-find #"SELECT \* FROM users" (:viewing_context result)))))
   (testing "uses default first_day_of_week when not provided"
@@ -309,7 +306,6 @@
           result (user-context/enrich-context-for-template context)]
       (is (some? (:current_time result)))
       (is (= "Sunday" (:first_day_of_week result)))
-      (is (nil? (:sql_dialect result)))
       (is (= "" (:viewing_context result)))
       (is (= "" (:recent_views result))))))
 

--- a/test/metabase/metabot/context_test.clj
+++ b/test/metabase/metabot/context_test.clj
@@ -228,6 +228,24 @@
       (is (not (contains? (#'context/add-recent-views {:user_recently_viewed [{:id 1 :name "stale"}]} {})
                           :user_recently_viewed))))))
 
+(deftest recent-views-excluded-for-nlq-profile-test
+  (testing "The :nlq profile never gets recent views, and caller-supplied ones are stripped"
+    (is (not (contains? (#'context/add-recent-views {:user_recently_viewed [{:id 1 :name "stale"}]}
+                                                    {:profile-id :nlq})
+                        :user_recently_viewed)))))
+
+(deftest recent-views-excluded-for-slackbot-profile-test
+  (testing "The :slackbot profile never gets recent views, and caller-supplied ones are stripped"
+    (is (not (contains? (#'context/add-recent-views {:user_recently_viewed [{:id 1 :name "stale"}]}
+                                                    {:profile-id :slackbot})
+                        :user_recently_viewed)))))
+
+(deftest recent-views-excluded-for-document-generate-content-profile-test
+  (testing "The :document-generate-content profile never gets recent views, and caller-supplied ones are stripped"
+    (is (not (contains? (#'context/add-recent-views {:user_recently_viewed [{:id 1 :name "stale"}]}
+                                                    {:profile-id :document-generate-content})
+                        :user_recently_viewed)))))
+
 (deftest recent-views-verified-content-filter-test
   (testing "Recent views filtering by curated content (verified is one curation signal)"
     (mt/with-test-user :rasta

--- a/test/metabase/metabot/self/claude_test.clj
+++ b/test/metabase/metabot/self/claude_test.clj
@@ -407,6 +407,17 @@
         (let [body (capture-claude-request-body! {:input input})]
           (is (not (contains? body :system))))))))
 
+(deftest claude-system-cache-breakpoint-blank-suffix-test
+  (mt/with-temporary-setting-values [llm.settings/llm-anthropic-api-key "sk-ant-test"]
+    (testing "a trailing sentinel with nothing after it produces a single cached block, not an empty text block (the API rejects empty text)"
+      (let [body (capture-claude-request-body!
+                  {:input  [{:role :user :content "hi"}]
+                   :system "Stable prefix content.\n\n<<<METABOT_CACHE_BREAKPOINT>>>\n\n"})]
+        (is (= [{:type          "text"
+                 :text          "Stable prefix content."
+                 :cache_control {:type "ephemeral"}}]
+               (:system body)))))))
+
 (deftest system-templates-cache-breakpoint-presence-test
   (testing "every selmer template that contains per-request volatile content carries exactly one cache breakpoint sentinel"
     (let [system-dir (io/file (io/resource "metabot/prompts/system"))


### PR DESCRIPTION
Closes [BOT-1793: Metabot related-tables and context follow ups](https://linear.app/metabase/issue/BOT-1793/metabot-related-tables-and-context-follow-ups)

### Description

Do not duplicate user context between system prompt and last user message

In #71045 we moved most of the user context out of internal.selmer system prompt and injected it into the last user
message. However, other system prompts still injected user context into the system prompt, so we wound up formatting and including it twice. If the `:user_is_viewing` context happens to be large (many related tables / fields), then the memory and token cost can be significant (#76493).

This commit removes everything from system prompts that was already being injected into the last user message, namely:

- `current_time`
- `first_day_of_week`
- `current_user_info`
- `viewing_context`

It also moves `recent_views` into the last user message (not previously included there).

In addition to saving input tokens and memory, this should also help with caching on providers like openai that do automatic prefix caching, since we now always inject the current date/time near the end of the prompt.

This also means all system prompts can drop the `<<<METABOT_CACHE_BREAKPOINT>>>` since they no longer have any dynamic content after the breakpoint.

Add `:slackbot` and `:document-generate-content` to `profiles-excluding-recent-views`

Their system prompt never included `recent_views`, so preserve the behavior now that we inject `recent_views` in the last user message.

Alternatively, we could move everything back into the system message (see #77238), but keeping dynamic content near the end of the prompt seems preferable for prompt caching.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
