### PR TITLE
[BOT-1833] Fix semantic search orphan table cleanup

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/migration.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/migration.clj
@@ -106,7 +106,7 @@
       0))
 
 (defn maybe-migrate-dynamic-schema!
-  "Migration for dynamic tables (index_table_xyzs) if appropriate."
+  "Migration for dynamic tables (the index_<provider>_<model>_<dims> index tables) if appropriate."
   [tx {:keys [index-metadata] :as opts}]
   (let [db-version (lowest-dynamic-db-version index-metadata tx)]
     (cond

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/migration/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/migration/impl.clj
@@ -282,7 +282,7 @@
                                             {:curated true :official_collection true}))))))))
 
 (defn migrate-dynamic-schema!
-  "Migrate runtime-managed schema, ie. schema of the `index_...` index tables. Migration author is responsible for
+  "Migrate runtime-managed schema, i.e. the schema of the `index_...` index tables. Migration author is responsible for
   removing leftovers if necessary."
   [tx {:keys [index-metadata] :as _opts}]
   ;; migration 1: all tables dropped in schema migration in single function call

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/migration/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/migration/impl.clj
@@ -67,8 +67,8 @@
   (semantic.index-metadata/ensure-control-row-exists! tx index-metadata))
 
 (def dynamic-schema-version
-  "Code version of dynamic schema (index_table_xyzs). If higher than what's found in db dynamic schema migration will
-  be attempted."
+  "Code version of dynamic schema (the index_<provider>_<model>_<dims> index tables). If higher than what's found in
+  db dynamic schema migration will be attempted."
   5)
 
 (defn- alter-index-tables!
@@ -282,8 +282,8 @@
                                             {:curated true :official_collection true}))))))))
 
 (defn migrate-dynamic-schema!
-  "Migrate runtime-managed schema, ie. schema of `index_table_...` tables. Migration author is responsible for removing
-  leftovers if necessary."
+  "Migrate runtime-managed schema, ie. schema of the `index_...` index tables. Migration author is responsible for
+  removing leftovers if necessary."
   [tx {:keys [index-metadata] :as _opts}]
   ;; migration 1: all tables dropped in schema migration in single function call
   ;; migration 2: add personal_owner_id column to index tables

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/dlq.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/dlq.clj
@@ -51,7 +51,7 @@
   "Generates the DLQ table name keyword for a specific index (metadata record).
 
   Uses the index-table-qualifier format string from index-metadata to construct
-  a table name like 'index_table_dlq_{index-id}'."
+  a table name like 'dlq_{index-id}'."
   [index-metadata index-id]
   (let [{:keys [index-table-qualifier]} index-metadata]
     (keyword (format index-table-qualifier (str "dlq_" index-id)))))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -295,20 +295,20 @@
 
 (def ^:private index-table-name-pattern
   "Recognizes every table-name shape produced by [[model-table-name]] (optionally with the force-reset
-  suffix appended by [[metabase-enterprise.semantic-search.pgvector-api/fresh-index]]) and
-  [[hash-identifier-if-exceeds-pg-limit]]:
+  suffix appended by [[metabase-enterprise.semantic-search.pgvector-api/fresh-index]]),
+  [[hash-identifier-if-exceeds-pg-limit]], and the legacy pre-BOT-337 naming era:
 
     index_<provider>_<model>_<dims>            e.g. index_ais_text_3_sm_1536
     index_<provider>_<model>_<dims>_<digits>   force-reset suffix ([[model-table-suffix]])
     index_<40-hex-sha1>                        names exceeding the 63-byte pg identifier limit
+    index_table_<anything>                     legacy pre-BOT-337 naming (index_table_<provider>_<model>_<dims>)
 
   The provider/model segments are only lightly sanitized (see [[embedding/abbrev-model-name]]), so no
   character class is assumed for them; the trailing _<digits> (vector dimensions or force-reset suffix)
-  is what gives the shape structure. Legacy pre-BOT-337 names (index_table_<provider>_<model>_<dims>)
-  also match via the first alternative and must continue to: they are the bulk of historical orphans.
-  Deliberately does NOT match the control-plane tables (index_metadata, index_control, index_gate):
-  they have no trailing _<digits> and are not 40-hex."
-  #"\Aindex_(?:.+_\d+|[0-9a-f]{40})\z")
+  gives the modern shapes their structure, while the index_table_ prefix — used exclusively by the
+  legacy era — claims anything under it. Deliberately does NOT match the control-plane tables
+  (index_metadata, index_control, index_gate): no trailing _<digits>, not 40-hex, not index_table_."
+  #"\Aindex_(?:.+_\d+|[0-9a-f]{40}|table_.+)\z")
 
 (defn index-table-name?
   "Does the bare (schema- and qualifier-stripped) table name look like a semantic-search index table?

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -304,13 +304,16 @@
 
   The provider/model segments are only lightly sanitized (see [[embedding/abbrev-model-name]]), so no
   character class is assumed for them; the trailing _<digits> (vector dimensions or force-reset suffix)
-  is what gives the shape structure. Deliberately does NOT match the control-plane tables
-  (index_metadata, index_control, index_gate): they have no trailing _<digits> and are not 40-hex."
-  #"index_(?:.+_\d+|[0-9a-f]{40})")
+  is what gives the shape structure. Legacy pre-BOT-337 names (index_table_<provider>_<model>_<dims>)
+  also match via the first alternative and must continue to: they are the bulk of historical orphans.
+  Deliberately does NOT match the control-plane tables (index_metadata, index_control, index_gate):
+  they have no trailing _<digits> and are not 40-hex."
+  #"\Aindex_(?:.+_\d+|[0-9a-f]{40})\z")
 
 (defn index-table-name?
   "Does the bare (schema- and qualifier-stripped) table name look like a semantic-search index table?
-  Used by the cleanup task to decide orphan candidacy; see [[index-table-name-pattern]] for the shapes."
+  Matching names are orphan-cleanup candidates, i.e. may be dropped if not registered in the metadata
+  table; see [[index-table-name-pattern]] for the shapes."
   [bare-table-name]
   (boolean (re-matches index-table-name-pattern bare-table-name)))
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -267,6 +267,8 @@
   When we do so we need to be sure any index names do not exceed the postgres limit for names. This function will hash the identifier
   if it exceeds the length, and will get a name like index_${sha1} instead.
 
+  Table names produced here must stay recognizable by [[index-table-name?]].
+
   Note: The index parameters will still be available in index_metadata"
   [identifier]
   (if (<= (count identifier) 63)
@@ -281,13 +283,36 @@
   (mod (.toEpochSecond (t/offset-date-time)) 10000000))
 
 (defn model-table-name
-  "Returns a default table name for a model. If the table name would exceed the 63 byte postgres limit, a hashed name is preferred."
+  "Returns a default table name for a model. If the table name would exceed the 63 byte postgres limit, a hashed name is preferred.
+
+  Table names produced here must stay recognizable by [[index-table-name?]]."
   [embedding-model]
   (let [{:keys [model-name provider vector-dimensions]} embedding-model
         provider-name (embedding/abbrev-provider-name provider)
         abbrev-model-name (embedding/abbrev-model-name model-name)
         ideal-table-name (str "index_" provider-name "_" abbrev-model-name "_" vector-dimensions)]
     (hash-identifier-if-exceeds-pg-limit ideal-table-name)))
+
+(def ^:private index-table-name-pattern
+  "Recognizes every table-name shape produced by [[model-table-name]] (optionally with the force-reset
+  suffix appended by [[metabase-enterprise.semantic-search.pgvector-api/fresh-index]]) and
+  [[hash-identifier-if-exceeds-pg-limit]]:
+
+    index_<provider>_<model>_<dims>            e.g. index_ais_text_3_sm_1536
+    index_<provider>_<model>_<dims>_<digits>   force-reset suffix ([[model-table-suffix]])
+    index_<40-hex-sha1>                        names exceeding the 63-byte pg identifier limit
+
+  The provider/model segments are only lightly sanitized (see [[embedding/abbrev-model-name]]), so no
+  character class is assumed for them; the trailing _<digits> (vector dimensions or force-reset suffix)
+  is what gives the shape structure. Deliberately does NOT match the control-plane tables
+  (index_metadata, index_control, index_gate): they have no trailing _<digits> and are not 40-hex."
+  #"index_(?:.+_\d+|[0-9a-f]{40})")
+
+(defn index-table-name?
+  "Does the bare (schema- and qualifier-stripped) table name look like a semantic-search index table?
+  Used by the cleanup task to decide orphan candidacy; see [[index-table-name-pattern]] for the shapes."
+  [bare-table-name]
+  (boolean (re-matches index-table-name-pattern bare-table-name)))
 
 (defn default-index
   "Returns the default index spec for a model."
@@ -560,7 +585,7 @@
   (def index (default-index embedding-model))
   (drop-index-table! db index)
   (create-index-table-if-not-exists! db index)
-  (jdbc/execute! db ["select table_name from INFORMATION_SCHEMA.tables where table_name like 'index_table_%'"]))
+  (jdbc/execute! db ["select table_name from INFORMATION_SCHEMA.tables where table_name like 'index\\_%'"]))
 
 (defn- personal-collection-filter
   "Generate a WHERE condition for personal collection filtering based on the filter type.

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_cleanup.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_cleanup.clj
@@ -9,6 +9,7 @@
    [honey.sql.helpers :as sql.helpers]
    [java-time.api :as t]
    [metabase-enterprise.semantic-search.env :as semantic.env]
+   [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.index-metadata :as semantic.index-metadata]
    [metabase-enterprise.semantic-search.settings :as semantic.settings]
    [metabase-enterprise.semantic-search.util :as semantic.u]
@@ -36,17 +37,36 @@
   [schema table-names]
   (map #(cond->> % schema (str schema ".")) table-names))
 
+(defn- like-escape
+  "Escape LIKE wildcards so `s` only matches itself (Postgres's default escape character is backslash)."
+  [s]
+  (str/replace s #"([\\%_])" "\\\\$1"))
+
 (defn- orphan-index-tables
-  "Returns a list of semantic search index tables which are not referenced in the metadata table.
-  Not expected to occur, but if it does, these tables can be dropped.
+  "Returns a list of semantic search index tables which are not registered in the metadata table's
+  table_name column. Not expected to occur (index tables are created in the same transaction that
+  registers them), but if it does, these tables can be dropped.
+
+  Candidacy is decided by table-name shape ([[semantic.index/index-table-name?]]); the control-plane
+  tables (metadata/control/gate) share the index_ prefix but are excluded both by shape and by name.
+  Matching is index-table-qualifier-aware, so a config with a distinguishing qualifier (e.g. test
+  configs) only ever sees its own tables.
+
   With a `:schema` (shared app-db mode) only tables inside the module's schema are considered, and the
   returned names are schema-qualified to match how the metadata table stores them."
-  ;; TODO (Chris 2026-07-09) -- BOT-1833: the LIKE 'index_table_%' pattern predates the
-  ;; index_<provider>_<model>_<dims> naming, so it matches nothing and orphan detection is a no-op. A fix
-  ;; needs shape-aware matching that excludes index_metadata/index_control/index_gate (not registered in
-  ;; metadata.table_name — a naive 'index\_%' pattern would drop them as orphans).
-  [pgvector {:keys [metadata-table-name schema]}]
-  (let [;; information_schema reports bare names; stored metadata names are qualified when we have a schema
+  [pgvector {:keys [metadata-table-name control-table-name gate-table-name index-table-qualifier schema]}]
+  (let [;; the qualifier may embed the app-db schema ("<schema>.%s") — information_schema reports bare
+        ;; table names, so build the LIKE pattern and the qualifier stripping from its name part only
+        [prefix suffix]     (str/split (semantic.u/table-name-part index-table-qualifier) #"%s" -1)
+        like-pattern        (str (like-escape prefix) "index\\_%" (like-escape suffix))
+        control-plane-names (into #{} (map semantic.u/table-name-part)
+                                  [metadata-table-name control-table-name gate-table-name])
+        index-shaped?       (fn [table-name]
+                              ;; the LIKE prefilter guarantees the literal qualifier prefix/suffix, so
+                              ;; strip them to recover the bare index_… name the naming code produced
+                              (semantic.index/index-table-name?
+                               (subs table-name (count prefix) (- (count table-name) (count suffix)))))
+        ;; information_schema reports bare names; stored metadata names are qualified when we have a schema
         stored-name (if schema
                       [:|| [:inline (str schema ".")] :t.table_name]
                       :t.table_name)
@@ -56,12 +76,14 @@
              :left-join [[(keyword metadata-table-name) :meta]
                          [:= :meta.table_name stored-name]]
              :where (scope-where-to-schema [:and
-                                            [:like :t.table_name [:inline "index_table_%"]]
+                                            [:like :t.table_name [:inline like-pattern]]
                                             [:= :meta.table_name nil]]
                                            schema)}
             (sql/format :quoted true))]
     (->> (jdbc/execute! pgvector orphaned-tables-sql {:builder-fn jdbc.rs/as-unqualified-lower-maps})
          (map :table_name)
+         (remove control-plane-names)
+         (filter index-shaped?)
          (requalify-table-names schema))))
 
 (defn- parse-repair-table-timestamp
@@ -190,7 +212,9 @@
     (when (seq tables-to-drop)
       (log/infof "Found %d semantic search index tables to clean up" (count tables-to-drop))
       (doseq [table-name stale-table-names]
-        (log/info "Dropping stale/orphaned semantic search index:" table-name))
+        (log/info "Dropping stale semantic search index:" table-name))
+      (doseq [table-name orphaned-table-names]
+        (log/info "Dropping orphaned semantic search index:" table-name))
       (jdbc/execute! pgvector drop-table-sql))))
 
 (defn- cleanup-stale-indexes-and-gate-tombstones!

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_cleanup.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_cleanup.clj
@@ -50,10 +50,12 @@
   Candidacy is decided by table-name shape ([[semantic.index/index-table-name?]]); the control-plane
   tables (metadata/control/gate) share the index_ prefix but are excluded both by shape and by name.
   Matching is index-table-qualifier-aware, so a config with a distinguishing qualifier (e.g. test
-  configs) only ever sees its own tables.
+  configs) only ever sees its own tables. Only base tables are candidates — never views.
 
   With a `:schema` (shared app-db mode) only tables inside the module's schema are considered, and the
-  returned names are schema-qualified to match how the metadata table stores them."
+  returned names are schema-qualified to match how the metadata table stores them. Without one
+  (dedicated pgvector DB) the scan is limited to current_schema(), where the unqualified DROP that
+  consumes these names resolves — tables in other schemas would be detected but never dropped."
   [pgvector {:keys [metadata-table-name control-table-name gate-table-name index-table-qualifier schema]}]
   (let [;; the qualifier may embed the app-db schema ("<schema>.%s") — information_schema reports bare
         ;; table names, so build the LIKE pattern and the qualifier stripping from its name part only
@@ -75,10 +77,13 @@
              :from [[:information_schema.tables :t]]
              :left-join [[(keyword metadata-table-name) :meta]
                          [:= :meta.table_name stored-name]]
-             :where (scope-where-to-schema [:and
-                                            [:like :t.table_name [:inline like-pattern]]
-                                            [:= :meta.table_name nil]]
-                                           schema)}
+             :where [:and
+                     [:like :t.table_name [:inline like-pattern]]
+                     [:= :meta.table_name nil]
+                     [:= :t.table_type [:inline "BASE TABLE"]]
+                     [:= :t.table_schema (if schema
+                                           [:inline schema]
+                                           [:current_schema])]]}
             (sql/format :quoted true))]
     (->> (jdbc/execute! pgvector orphaned-tables-sql {:builder-fn jdbc.rs/as-unqualified-lower-maps})
          (map :table_name)
@@ -201,21 +206,26 @@
     (catch Exception e
       (log/error e "Failed to clean up tombstone records from gate table"))))
 
+(defn- drop-index-table!
+  "Drops one stale/orphaned index table, isolating failures: one undroppable table (e.g. one with a
+  dependent view) must not abort the rest of the cleanup batch."
+  [pgvector kind table-name]
+  (try
+    (log/infof "Dropping %s semantic search index: %s" kind table-name)
+    (jdbc/execute! pgvector (sql/format (sql.helpers/drop-table :if-exists (keyword table-name))
+                                        :quoted true))
+    (catch Exception e
+      (log/warnf e "Failed to drop %s semantic search index %s" kind table-name))))
+
 (defn- cleanup-stale-indexes!
   [pgvector index-metadata]
-  (let [stale-table-names    (map keyword (stale-index-tables pgvector index-metadata))
-        orphaned-table-names (map keyword (orphan-index-tables pgvector index-metadata))
-        tables-to-drop       (concat stale-table-names orphaned-table-names)
-        drop-table-sql       (sql/format
-                              (apply sql.helpers/drop-table :if-exists tables-to-drop)
-                              :quoted true)]
-    (when (seq tables-to-drop)
-      (log/infof "Found %d semantic search index tables to clean up" (count tables-to-drop))
-      (doseq [table-name stale-table-names]
-        (log/info "Dropping stale semantic search index:" table-name))
-      (doseq [table-name orphaned-table-names]
-        (log/info "Dropping orphaned semantic search index:" table-name))
-      (jdbc/execute! pgvector drop-table-sql))))
+  (let [stale-table-names    (stale-index-tables pgvector index-metadata)
+        orphaned-table-names (orphan-index-tables pgvector index-metadata)]
+    (when (or (seq stale-table-names) (seq orphaned-table-names))
+      (log/infof "Found %d semantic search index tables to clean up"
+                 (+ (count stale-table-names) (count orphaned-table-names)))
+      (run! #(drop-index-table! pgvector "stale" %) stale-table-names)
+      (run! #(drop-index-table! pgvector "orphaned" %) orphaned-table-names))))
 
 (defn- cleanup-stale-indexes-and-gate-tombstones!
   []

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_cleanup.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_cleanup.clj
@@ -208,24 +208,35 @@
 
 (defn- drop-index-table!
   "Drops one stale/orphaned index table, isolating failures: one undroppable table (e.g. one with a
-  dependent view) must not abort the rest of the cleanup batch."
+  dependent view) must not abort the rest of the cleanup batch.
+  Returns :dropped, :missing (referenced table no longer exists), or :failed."
   [pgvector kind table-name]
   (try
     (log/infof "Dropping %s semantic search index: %s" kind table-name)
-    (jdbc/execute! pgvector (sql/format (sql.helpers/drop-table :if-exists (keyword table-name))
-                                        :quoted true))
+    (jdbc/execute! pgvector (sql/format (sql.helpers/drop-table (keyword table-name)) :quoted true))
+    :dropped
+    ;; no IF EXISTS: a vacuous drop must not count as :dropped, so let 42P01 (undefined_table) tell us
+    (catch java.sql.SQLException e
+      (if (= "42P01" (.getSQLState e))
+        (do (log/infof "Skipping %s semantic search index %s: table no longer exists" kind table-name)
+            :missing)
+        (do (log/warnf e "Failed to drop %s semantic search index %s" kind table-name)
+            :failed)))
     (catch Exception e
-      (log/warnf e "Failed to drop %s semantic search index %s" kind table-name))))
+      (log/warnf e "Failed to drop %s semantic search index %s" kind table-name)
+      :failed)))
 
 (defn- cleanup-stale-indexes!
   [pgvector index-metadata]
   (let [stale-table-names    (stale-index-tables pgvector index-metadata)
-        orphaned-table-names (orphan-index-tables pgvector index-metadata)]
-    (when (or (seq stale-table-names) (seq orphaned-table-names))
-      (log/infof "Found %d semantic search index tables to clean up"
-                 (+ (count stale-table-names) (count orphaned-table-names)))
-      (run! #(drop-index-table! pgvector "stale" %) stale-table-names)
-      (run! #(drop-index-table! pgvector "orphaned" %) orphaned-table-names))))
+        orphaned-table-names (orphan-index-tables pgvector index-metadata)
+        found                (+ (count stale-table-names) (count orphaned-table-names))]
+    (when (pos? found)
+      (log/infof "Found %d semantic search index tables to clean up" found)
+      (let [outcomes (concat (mapv #(drop-index-table! pgvector "stale" %) stale-table-names)
+                             (mapv #(drop-index-table! pgvector "orphaned" %) orphaned-table-names))
+            dropped  (count (filter #{:dropped} outcomes))]
+        (log/infof "Dropped %d of %d semantic search index tables" dropped found)))))
 
 (defn- cleanup-stale-indexes-and-gate-tombstones!
   []

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -168,18 +168,21 @@
             (is (not (contains? (set (map first @analytics-calls))
                                 :metabase-search/semantic-vector-inner-ms)))))))))
 
-(deftest index-table-name?-test
+(deftest ^:parallel index-table-name?-test
   (testing "recognizes every shape the naming code produces"
     (are [table-name] (semantic.index/index-table-name? table-name)
       ;; model-table-name for the current default and mock models
       (semantic.index/model-table-name {:provider "ai-service" :model-name "text-embedding-3-small" :vector-dimensions 1536})
       (semantic.index/model-table-name semantic.tu/mock-embedding-model)
       "index_ollama_mxbai_lg_1024"
-      ;; force-reset suffix (pgvector-api/fresh-index)
+      ;; force-reset suffix, as pgvector-api/fresh-index builds it
+      (str (semantic.index/model-table-name semantic.tu/mock-embedding-model) "_" (semantic.index/model-table-suffix))
       "index_ollama_mxbai_lg_1024_1234567"
       ;; hashed shape for names exceeding the pg identifier limit
       (semantic.index/hash-identifier-if-exceeds-pg-limit (apply str "index_" (repeat 60 "x")))
-      (str "index_" (apply str (repeat 40 "a")))))
+      (str "index_" (apply str (repeat 40 "a")))
+      ;; legacy pre-BOT-337 naming: these historical orphans must stay recognizable so cleanup reaps them
+      "index_table_ollama_mxbai_lg_1024"))
   (testing "rejects the control-plane and other non-index tables"
     (are [table-name] (not (semantic.index/index-table-name? table-name))
       "index_metadata"
@@ -188,8 +191,11 @@
       "migration"
       "dlq_1"
       "repair_1751000000000_1"
-      ;; the pre-BOT-337 naming: index_-prefixed but no trailing _<digits>
+      ;; index_-prefixed but no trailing _<digits>
       "index_table_stale"
+      ;; a valid shape as a substring must not match
+      "xindex_ollama_mxbai_lg_1024"
+      "index_ollama_mxbai_lg_1024 junk"
       ;; wrong-length hex
       (str "index_" (apply str (repeat 39 "a")))
       (str "index_" (apply str (repeat 41 "a"))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -168,6 +168,32 @@
             (is (not (contains? (set (map first @analytics-calls))
                                 :metabase-search/semantic-vector-inner-ms)))))))))
 
+(deftest index-table-name?-test
+  (testing "recognizes every shape the naming code produces"
+    (are [table-name] (semantic.index/index-table-name? table-name)
+      ;; model-table-name for the current default and mock models
+      (semantic.index/model-table-name {:provider "ai-service" :model-name "text-embedding-3-small" :vector-dimensions 1536})
+      (semantic.index/model-table-name semantic.tu/mock-embedding-model)
+      "index_ollama_mxbai_lg_1024"
+      ;; force-reset suffix (pgvector-api/fresh-index)
+      "index_ollama_mxbai_lg_1024_1234567"
+      ;; hashed shape for names exceeding the pg identifier limit
+      (semantic.index/hash-identifier-if-exceeds-pg-limit (apply str "index_" (repeat 60 "x")))
+      (str "index_" (apply str (repeat 40 "a")))))
+  (testing "rejects the control-plane and other non-index tables"
+    (are [table-name] (not (semantic.index/index-table-name? table-name))
+      "index_metadata"
+      "index_control"
+      "index_gate"
+      "migration"
+      "dlq_1"
+      "repair_1751000000000_1"
+      ;; the pre-BOT-337 naming: index_-prefixed but no trailing _<digits>
+      "index_table_stale"
+      ;; wrong-length hex
+      (str "index_" (apply str (repeat 39 "a")))
+      (str "index_" (apply str (repeat 41 "a"))))))
+
 (defn- expected-index-defs
   "The index-DDL contract of [[semantic.index/create-index-table-if-not-exists!]] for `index`.
   Maps the name of each index it must create to a pattern its pg_indexes indexdef must match."

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -181,8 +181,9 @@
       ;; hashed shape for names exceeding the pg identifier limit
       (semantic.index/hash-identifier-if-exceeds-pg-limit (apply str "index_" (repeat 60 "x")))
       (str "index_" (apply str (repeat 40 "a")))
-      ;; legacy pre-BOT-337 naming: these historical orphans must stay recognizable so cleanup reaps them
-      "index_table_ollama_mxbai_lg_1024"))
+      ;; legacy pre-BOT-337 era: anything under the index_table_ prefix is reapable
+      "index_table_ollama_mxbai_lg_1024"
+      "index_table_stale"))
   (testing "rejects the control-plane and other non-index tables"
     (are [table-name] (not (semantic.index/index-table-name? table-name))
       "index_metadata"
@@ -191,8 +192,9 @@
       "migration"
       "dlq_1"
       "repair_1751000000000_1"
-      ;; index_-prefixed but no trailing _<digits>
-      "index_table_stale"
+      ;; index_-prefixed but no trailing _<digits> and not the legacy index_table_ prefix
+      "index_tablex"
+      "index_table_"
       ;; a valid shape as a substring must not match
       "xindex_ollama_mxbai_lg_1024"
       "index_ollama_mxbai_lg_1024 junk"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
@@ -162,20 +162,34 @@
           ;; outside this config's qualifier: must be invisible to its scan
           unqualified-table "index_ollama_decoytest_1024"
           registered-table (qualify "index_ollama_registered_1024")
+          ;; index-shaped VIEW: not a base table, so never an orphan candidate (and DROP TABLE would choke on it)
+          index-shaped-view (qualify "index_ollama_viewtest_1024")
+          ;; index-shaped, but outside current_schema(): the unqualified DROP could not reach it, so the
+          ;; scan must not see it either
+          side-schema (str "cleanup_side_" uniq-id)
+          side-schema-orphan (str side-schema "." (qualify "index_ollama_sidetest_1024"))
+          ;; a genuine orphan made undroppable by a dependent view: its failure must not abort the batch
+          blocked-orphan (qualify "index_ollama_blockedtest_1024")
+          blocking-view (qualify "blocked_orphan_dep")
           survivors (concat control-plane-decoys [non-index-shaped unqualified-table registered-table])]
       (with-open [_ (semantic.tu/open-metadata! pgvector index-metadata)]
         (try
-          (run! #(create-table! pgvector %) (concat orphan-tables survivors))
+          (run! #(create-table! pgvector %) (concat orphan-tables survivors [blocked-orphan]))
+          (jdbc/execute! pgvector [(str "CREATE SCHEMA " side-schema)])
+          (create-table! pgvector side-schema-orphan)
+          (jdbc/execute! pgvector [(str "CREATE VIEW " index-shaped-view " AS SELECT 1 AS id")])
+          (jdbc/execute! pgvector [(str "CREATE VIEW " blocking-view " AS SELECT id FROM " blocked-orphan)])
           (insert-metadata-with-timestamps! pgvector index-metadata {:table-name registered-table})
-          (testing "detects exactly the unregistered index-shaped tables under this config's qualifier"
-            (is (= (set orphan-tables)
+          (testing "detects exactly the unregistered index-shaped base tables under this config's qualifier and schema"
+            (is (= (set (conj orphan-tables blocked-orphan))
                    (set (orphan-index-tables pgvector index-metadata)))))
-          (testing "cleanup drops the orphans"
+          (testing "cleanup drops the orphans; an undroppable orphan is skipped without aborting the batch"
             (cleanup-stale-indexes! pgvector index-metadata)
             (doseq [table orphan-tables]
-              (is (not (semantic.tu/table-exists-in-db? table)) table)))
-          (testing "control-plane decoys, registered, differently-qualified, and non-index-shaped tables survive"
-            (doseq [table survivors]
+              (is (not (semantic.tu/table-exists-in-db? table)) table))
+            (is (semantic.tu/table-exists-in-db? blocked-orphan)))
+          (testing "control-plane decoys, registered, differently-qualified, view, and non-index-shaped tables survive"
+            (doseq [table (concat survivors [index-shaped-view side-schema-orphan])]
               (is (semantic.tu/table-exists-in-db? table) table)))
           (testing "the config's own metadata/control/gate tables survive"
             (doseq [table [(:metadata-table-name index-metadata)
@@ -183,7 +197,10 @@
                            (:gate-table-name index-metadata)]]
               (is (semantic.tu/table-exists-in-db? table) table)))
           (finally
-            (doseq [table (concat orphan-tables survivors)]
+            (jdbc/execute! pgvector [(str "DROP VIEW IF EXISTS " blocking-view)])
+            (jdbc/execute! pgvector [(str "DROP VIEW IF EXISTS " index-shaped-view)])
+            (jdbc/execute! pgvector [(str "DROP SCHEMA IF EXISTS " side-schema " CASCADE")])
+            (doseq [table (concat orphan-tables survivors [blocked-orphan])]
               (jdbc/execute! pgvector [(str "DROP TABLE IF EXISTS " table)]))))))))
 
 (deftest orphan-index-tables-schema-scoping-test

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
@@ -88,14 +88,12 @@
       (with-open [_ (semantic.tu/open-metadata! pgvector index-metadata)]
         (semantic.index-metadata/ensure-control-row-exists! pgvector index-metadata)
         (testing "drops stale tables and leaves recent ones"
-          (let [stale-table "index_table_stale"
-                orphaned-table "index_table_orphaned"
-                recent-table "index_table_recent"
-                active-table "index_table_active"
+          (let [stale-table "index_ollama_staletest_1024"
+                recent-table "index_ollama_recenttest_1024"
+                active-table "index_ollama_activetest_1024"
                 recent-time (t/minus (t/offset-date-time) (t/hours (dec retention-hours)))]
             (try
               (create-table! pgvector stale-table)
-              (create-table! pgvector orphaned-table)
               (create-table! pgvector recent-table)
               (create-table! pgvector active-table)
               (insert-metadata-with-timestamps! pgvector index-metadata {:table-name stale-table
@@ -107,22 +105,19 @@
                                                                        :index-created-at old-time})]
                 (set-active-index! pgvector (:control-table-name index-metadata) active-index-id))
               (is (semantic.tu/table-exists-in-db? stale-table))
-              (is (semantic.tu/table-exists-in-db? orphaned-table))
               (is (semantic.tu/table-exists-in-db? recent-table))
               (is (semantic.tu/table-exists-in-db? active-table))
-              ;; Run cleanup function and ensure only the stale & orphaned tables is dropped
+              ;; Run cleanup function and ensure only the stale table is dropped
               (mt/with-dynamic-fn-redefs [semantic.env/get-pgvector-datasource! (constantly pgvector)
                                           semantic.env/get-index-metadata (constantly index-metadata)]
                 (mt/with-temporary-setting-values [semantic.settings/stale-index-retention-hours retention-hours]
                   (cleanup-stale-indexes! pgvector index-metadata)))
               (is (not (semantic.tu/table-exists-in-db? stale-table)))
-              (is (not (semantic.tu/table-exists-in-db? orphaned-table)))
               (is (semantic.tu/table-exists-in-db? recent-table))
               (is (semantic.tu/table-exists-in-db? active-table))
               (finally
                 (jdbc/execute! pgvector [(str "DROP TABLE IF EXISTS " recent-table)])
                 (jdbc/execute! pgvector [(str "DROP TABLE IF EXISTS " stale-table)])
-                (jdbc/execute! pgvector [(str "DROP TABLE IF EXISTS " orphaned-table)])
                 (jdbc/execute! pgvector [(str "DROP TABLE IF EXISTS " active-table)])))))
         (testing "handles non-existent tables gracefully"
           (let [nonexistent-table "nonexistent_table"]
@@ -138,6 +133,95 @@
                                         semantic.env/get-index-metadata (constantly index-metadata)]
               (cleanup-stale-indexes! pgvector index-metadata)
               (is (not (semantic.tu/table-exists-in-db? nonexistent-table))))))))))
+
+(deftest orphan-index-cleanup-test
+  (mt/with-premium-features #{:semantic-search}
+    (let [pgvector (semantic.env/get-pgvector-datasource!)
+          ;; not unique-index-metadata: its nanoTime qualifier would push a qualified index_<40-hex>
+          ;; decoy past postgres's 63-char identifier limit (and silent truncation)
+          uniq-id (mod (System/nanoTime) 1000000)
+          fmt (str "mock_%s_" uniq-id)
+          index-metadata {:version "0"
+                          :metadata-table-name (format fmt "metadata")
+                          :control-table-name (format fmt "control")
+                          :gate-table-name (format fmt "gate")
+                          :index-table-qualifier fmt}
+          qualify #(format (:index-table-qualifier index-metadata) %)
+          orphan-index-tables #'sut/orphan-index-tables
+          cleanup-stale-indexes! #'sut/cleanup-stale-indexes!
+          ;; the three shapes model-table-name/fresh-index produce, none registered in metadata
+          orphan-tables [(qualify "index_ollama_decoytest_1024")
+                         (qualify "index_ollama_decoytest_1024_1234567")
+                         (qualify (str "index_" (apply str (repeat 40 "a"))))]
+          ;; share the index_ prefix but must never be treated as orphans
+          control-plane-decoys [(qualify "index_metadata")
+                                (qualify "index_control")
+                                (qualify "index_gate")]
+          ;; index_-prefixed but not a shape the naming code produces
+          non-index-shaped (qualify "index_not_an_index")
+          ;; outside this config's qualifier: must be invisible to its scan
+          unqualified-table "index_ollama_decoytest_1024"
+          registered-table (qualify "index_ollama_registered_1024")
+          survivors (concat control-plane-decoys [non-index-shaped unqualified-table registered-table])]
+      (with-open [_ (semantic.tu/open-metadata! pgvector index-metadata)]
+        (try
+          (run! #(create-table! pgvector %) (concat orphan-tables survivors))
+          (insert-metadata-with-timestamps! pgvector index-metadata {:table-name registered-table})
+          (testing "detects exactly the unregistered index-shaped tables under this config's qualifier"
+            (is (= (set orphan-tables)
+                   (set (orphan-index-tables pgvector index-metadata)))))
+          (testing "cleanup drops the orphans"
+            (cleanup-stale-indexes! pgvector index-metadata)
+            (doseq [table orphan-tables]
+              (is (not (semantic.tu/table-exists-in-db? table)) table)))
+          (testing "control-plane decoys, registered, differently-qualified, and non-index-shaped tables survive"
+            (doseq [table survivors]
+              (is (semantic.tu/table-exists-in-db? table) table)))
+          (testing "the config's own metadata/control/gate tables survive"
+            (doseq [table [(:metadata-table-name index-metadata)
+                           (:control-table-name index-metadata)
+                           (:gate-table-name index-metadata)]]
+              (is (semantic.tu/table-exists-in-db? table) table)))
+          (finally
+            (doseq [table (concat orphan-tables survivors)]
+              (jdbc/execute! pgvector [(str "DROP TABLE IF EXISTS " table)]))))))))
+
+(deftest orphan-index-tables-schema-scoping-test
+  (mt/with-premium-features #{:semantic-search}
+    (let [pgvector (semantic.env/get-pgvector-datasource!)
+          uniq-id (mod (System/nanoTime) 1000000)
+          schema (str "cleanup_module_" uniq-id)
+          other-schema (str "cleanup_other_" uniq-id)
+          ;; mirrors index-metadata/app-db-index-metadata: schema-qualified names, "<schema>.%s" qualifier
+          index-metadata {:version "0"
+                          :schema schema
+                          :metadata-table-name (str schema ".index_metadata")
+                          :control-table-name (str schema ".index_control")
+                          :gate-table-name (str schema ".index_gate")
+                          :index-table-qualifier (str schema ".%s")}
+          orphan-index-tables #'sut/orphan-index-tables
+          in-schema-orphan (str schema ".index_ollama_decoytest_1024")
+          out-of-schema-orphan (str other-schema ".index_ollama_decoytest_1024")]
+      (try
+        (jdbc/execute! pgvector [(str "CREATE SCHEMA " schema)])
+        (jdbc/execute! pgvector [(str "CREATE SCHEMA " other-schema)])
+        (with-open [_ (semantic.tu/open-metadata! pgvector index-metadata)]
+          (create-table! pgvector in-schema-orphan)
+          (create-table! pgvector out-of-schema-orphan)
+          (testing "only index-shaped tables inside the module schema are orphan candidates, returned schema-qualified"
+            (is (= [in-schema-orphan]
+                   (orphan-index-tables pgvector index-metadata))))
+          (testing "cleanup drops the in-schema orphan and leaves the control plane and other schemas alone"
+            (#'sut/cleanup-stale-indexes! pgvector index-metadata)
+            (is (not (semantic.tu/table-exists-in-db? in-schema-orphan)))
+            (is (semantic.tu/table-exists-in-db? out-of-schema-orphan))
+            (doseq [table [(:metadata-table-name index-metadata)
+                           (:control-table-name index-metadata)
+                           (:gate-table-name index-metadata)]]
+              (is (semantic.tu/table-exists-in-db? table) table))))
+        (finally
+          (jdbc/execute! pgvector [(str "DROP SCHEMA IF EXISTS " schema " CASCADE")])
+          (jdbc/execute! pgvector [(str "DROP SCHEMA IF EXISTS " other-schema " CASCADE")]))))))
 
 (deftest tombstone-cleanup-test
   (mt/with-premium-features #{:semantic-search}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
@@ -149,10 +149,12 @@
           qualify #(format (:index-table-qualifier index-metadata) %)
           orphan-index-tables #'sut/orphan-index-tables
           cleanup-stale-indexes! #'sut/cleanup-stale-indexes!
-          ;; the three shapes model-table-name/fresh-index produce, none registered in metadata
+          ;; the shapes model-table-name/fresh-index produce plus a legacy pre-BOT-337 straggler,
+          ;; none registered in metadata
           orphan-tables [(qualify "index_ollama_decoytest_1024")
                          (qualify "index_ollama_decoytest_1024_1234567")
-                         (qualify (str "index_" (apply str (repeat 40 "a"))))]
+                         (qualify (str "index_" (apply str (repeat 40 "a"))))
+                         (qualify "index_table_legacytest")]
           ;; share the index_ prefix but must never be treated as orphans
           control-plane-decoys [(qualify "index_metadata")
                                 (qualify "index_control")

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/vector_strategy_matrix_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/vector_strategy_matrix_test.clj
@@ -482,7 +482,7 @@
 (def ^:private packed-index
   "The index for [[graph-approximation-test]]'s 32-d packed dataset."
   (semantic.index/default-index {:provider "mock" :model-name "packed" :vector-dimensions 32}
-                                :table-name "index_table_packed_test"))
+                                :table-name "index_mock_packed_32"))
 
 (defn- make-packed-dataset
   "`n` filler cards packed at near-identical distances from the probe, so the true top-20 differ from any


### PR DESCRIPTION
Closes [BOT-1833: Semantic index orphan cleanup does nothing](https://linear.app/metabase/issue/BOT-1833/semantic-index-orphan-cleanup-does-nothing)

`orphan-index-tables` prefiltered `information_schema.tables` with `LIKE 'index_table_%'`, a naming scheme retired by BOT-337 (Aug 2025), so orphan detection has matched nothing since. The naive widening to `index_%` would not be sufficient: `index_metadata`, `index_control`, and `index_gate` tables share the prefix, are never registered in `index_metadata.table_name`, and would be dropped as orphans.

Changes:

- Add `index-table-name?` to `semantic.index`, next to `model-table-name`: recognizes the three shapes the naming code produces (`index_<provider>_<model>_<dims>`, `force-reset _<digits>` suffix,` index_<40-hex>` for names over the 63-byte pg limit) and structurally rejects the control-plane tables.
- Rewrite `orphan-index-tables`: escaped qualifier-aware LIKE prefilter in SQL (built from the qualifier's name part, so app-db mode's `"<schema>.%s"` works against bare catalog names), then shape check plus config-driven control-plane name exclusion in Clojure. Schema scoping from BOT-1796 is preserved.