### PR TITLE
Apply global dashboardCardMenu plugin from MetabaseProvider to dashboards

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -37,6 +37,7 @@ import { useSdkDispatch, useSdkSelector } from "embedding-sdk-bundle/store";
 import { setInitialGuestToken } from "embedding-sdk-bundle/store/guest-embed";
 import {
   getIsGuestEmbed,
+  getPlugins,
   getSessionTokenState,
 } from "embedding-sdk-bundle/store/selectors";
 import type { MetabaseQuestion } from "embedding-sdk-bundle/types";
@@ -325,8 +326,15 @@ const SdkDashboardInner = ({
     dashboardId,
   });
 
+  // `dashboardCardMenu` can be supplied either directly on the dashboard via
+  // `plugins`, or globally through `MetabaseProvider` (stored in the SDK Redux
+  // state). The local prop takes precedence, then the global plugin, and
+  // finally the component's built-in default menu.
+  const globalPlugins = useSdkSelector(getPlugins);
   const finalDashcardMenu =
-    plugins?.dashboard?.dashboardCardMenu ?? dashcardMenu;
+    plugins?.dashboard?.dashboardCardMenu ??
+    globalPlugins?.dashboard?.dashboardCardMenu ??
+    dashcardMenu;
 
   const [renderModeState, setRenderMode] = useState<
     "dashboard" | "queryBuilder"

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/tests/SdkDashboard.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/tests/SdkDashboard.unit.spec.tsx
@@ -182,4 +182,55 @@ describe("SdkDashboard", () => {
     expect(dashcardMenuPopover).not.toBeInTheDocument();
     expect(onClickCustomAction).toHaveBeenCalled();
   });
+
+  it("should render a custom dashcard menu if one is provided globally via MetabaseProvider (metabase#EMB-2049)", async () => {
+    const onClickCustomAction = jest.fn();
+    await setup({
+      props: {
+        withDownloads: true,
+      },
+      providerProps: {
+        pluginsConfig: {
+          dashboard: {
+            dashboardCardMenu: {
+              withDownloads: true,
+              withEditLink: true,
+              customItems: [
+                {
+                  iconName: "chevronright",
+                  label: "Custom Action",
+                  onClick: onClickCustomAction,
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    expect(await screen.findByTestId("dashboard-grid")).toBeInTheDocument();
+
+    const dashcard = screen.getAllByTestId("dashcard").at(0);
+    expect(dashcard).toBeInTheDocument();
+
+    await userEvent.click(within(dashcard!).getByTestId("dashcard-menu"));
+
+    const dashcardMenuPopover = await screen.findByRole("menu");
+    expect(
+      within(dashcardMenuPopover).getByText("Download results"),
+    ).toBeInTheDocument();
+    expect(
+      within(dashcardMenuPopover).getByText("Edit question"),
+    ).toBeInTheDocument();
+    expect(
+      within(dashcardMenuPopover).getByText("Custom Action"),
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      within(dashcardMenuPopover).getByText("Custom Action"),
+    );
+
+    expect(dashcardMenuPopover).not.toBeInTheDocument();
+    expect(onClickCustomAction).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76896
Closes [EMB-2049: Global `dashboardCardMenu` plugin passed to `MetabaseProvider` does not work](https://linear.app/metabase/issue/EMB-2049/global-dashboardcardmenu-plugin-passed-to-metabaseprovider-does-not)

### Description

Passing `dashboardCardMenu` through `MetabaseProvider`'s `pluginsConfig` is meant to behave as a global plugin applying to all dashboards, but it was dead code — the menu only honored the dashboard-level `plugins` prop.

In `SdkDashboardInner`, `finalDashcardMenu` resolved the menu solely from the local `plugins` prop, ignoring the global plugins stored in the SDK Redux state (where `MetabaseProvider`'s `pluginsConfig` lands via `setPlugins`). This single value drives the dashcard menu for every SDK dashboard (`InteractiveDashboard`, `EditableDashboard`, `StaticDashboard`), so the global config was silently dropped.

The fix reads the global plugins and slots them into the precedence chain: the local prop wins, then the global plugin, then the component's built-in default menu — so a global `dashboardCardMenu` now behaves the same as passing it directly to the dashboard.

Before:
<img width="1448" height="764" alt="SCR-20260710-igml" src="https://github.com/user-attachments/assets/b25ba4dc-e553-4e55-b95f-a819b7b98ba6" />


After:
<img width="1448" height="764" alt="SCR-20260710-igjt" src="https://github.com/user-attachments/assets/a566d6e5-0d94-4753-8102-744d46e1b6af" />


### How to verify

Render an `InteractiveDashboard` under a `MetabaseProvider` whose `pluginsConfig`
defines a global `dashboardCardMenu`:

```tsx
const pluginsConfig = {
  dashboard: {
    dashboardCardMenu: {
      customItems: [
        {
          iconName: "chevronright",
          label: "Custom Action",
          onClick: () => alert("global plugin fired"),
        },
      ],
    },
  },
};

<MetabaseProvider authConfig={authConfig} pluginsConfig={pluginsConfig}>
  <InteractiveDashboard dashboardId={1} withDownloads />
</MetabaseProvider>;
```

Open a question card's `⋯` menu — "Custom Action" now appears. Before this change only
the default menu showed. Passing the same config via the dashboard's own `plugins` prop
still works and takes precedence.

### Demo

_n/a — covered by unit test._

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
