### PR TITLE
Fix static-viz node renderer crash in mock-environment (v60)

### DIFF
--- a/frontend/src/metabase/static-viz/mock-environment.js
+++ b/frontend/src/metabase/static-viz/mock-environment.js
@@ -1,6 +1,18 @@
 /* eslint-disable no-prototype-builtins */
 import ResizeObserver from "resize-observer-polyfill";
 
+// Node.js (>= 21) defines `navigator` and `crypto` as accessor properties with only a getter, so plain
+// assignment throws under the node static-viz renderer. `defineProperty` replaces them (they are
+// configurable) with the same last-write-wins semantics as assignment on engines where they are absent
+// (GraalJS).
+const setGlobal = (name, value) => {
+  Object.defineProperty(global, name, {
+    value,
+    writable: true,
+    configurable: true,
+  });
+};
+
 global.ResizeObserver = ResizeObserver;
 
 global.EventTarget = function () {
@@ -127,7 +139,7 @@ Object.assign(global.document, {
   cookie: "",
 });
 
-global.navigator = {
+setGlobal("navigator", {
   userAgent: "GraalJS",
   language: "en-US",
   languages: ["en-US", "en"],
@@ -144,7 +156,7 @@ global.navigator = {
   mediaDevices: {
     getUserMedia: function () {},
   },
-};
+});
 
 const navigator = {
   userAgent: "GraalJS",
@@ -153,7 +165,7 @@ const navigator = {
   languages: ["en-US", "en"],
 };
 
-global.navigator = navigator;
+setGlobal("navigator", navigator);
 global.window.navigator = navigator;
 
 global.location = {
@@ -366,10 +378,10 @@ global.File = function (parts, filename, options) {
   return new global.Blob(parts, options);
 };
 
-global.crypto = {
+setGlobal("crypto", {
   getRandomValues: function () {},
   subtle: {},
-};
+});
 
 global.Headers = function () {
   return {


### PR DESCRIPTION
Follow-up to #77491. The node static-viz renderer (`MB_STATIC_VIZ_MODE=node`) crashed at bundle load on this branch:

```
TypeError: Cannot set property navigator of #<Object> which has only a getter
```

Node.js ≥ 21 defines `navigator` and `crypto` as getter-only accessors on `globalThis`, so `mock-environment.js`'s plain `global.navigator = …` / `global.crypto = …` assignments throw under node — the CLI process dies before its `{"ready":true}` handshake and every node-mode render fails with `static-viz node process failed to start`. GraalJS has neither global, which is why graal mode (the default) and CI never caught it. Master is unaffected (its `polyfill.ts` already defines globals via `defineProperty`).

Fix: replace the three assignments with `Object.defineProperty` (both properties are configurable in node), keeping the exact last-write-wins semantics on both engines.

Verified end-to-end on this branch with a real JVM: node-mode funnel + ComboChart + cell-background-colors renders, render-error recovery (process kept warm), per-spawn temp-file lifecycle, and graal mode unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)