### PR TITLE
Wire the quarantine switch into the embedding e2e workflows

### DIFF
--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -95,6 +95,8 @@ jobs:
         env:
           CYPRESS_BROWSER: ${{ steps.cypress-prep.outputs.chrome-path }}
         run: node e2e/runner/run_cypress_ci.js component
+        # Keep this step continue-on-error because the quarantine logic controls whether it ultimately fails.
+        continue-on-error: true
 
       - name: Rewrite JUnit hook failures
         if: always()
@@ -120,19 +122,21 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.run-tests.outcome }}
+          run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
-      - name: Quarantine gate (dry run)
-        if: always()
-        continue-on-error: true
+      - name: Quarantine gate
+        if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' }}
+        continue-on-error: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
         timeout-minutes: 3
         uses: ./.github/actions/quarantine-gate
         with:
           adapter: e2e
           test-suite: ${{ env.CI_CONDUCTOR_TEST_SUITE }}
+          enforce-quarantine: ${{ vars.QUARANTINE_ENGINE == 'ci-conductor' }}
 
       - name: "SDK component tests > Upload Cypress Artifacts upon failure"
         uses: actions/upload-artifact@v7
-        if: failure()
+        if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' }}
         with:
           name: cypress-recording-embedding-sdk-react-${{ matrix.react-version }}
           path: |
@@ -141,7 +145,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: "SDK component tests > Publish Summary"
-        if: failure()
+        if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' }}
         uses: actions/github-script@v9
         with:
           script: | #js
@@ -273,6 +277,8 @@ jobs:
         run: |
           node e2e/runner/run_cypress_ci.js component \
             --expose grepTags="-@skip-backward-compatibility"
+        # Keep this step continue-on-error because the quarantine logic controls whether it ultimately fails.
+        continue-on-error: true
 
       - name: Rewrite JUnit hook failures
         if: always()
@@ -298,19 +304,21 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.run-tests.outcome }}
+          run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
-      - name: Quarantine gate (dry run)
-        if: always()
-        continue-on-error: true
+      - name: Quarantine gate
+        if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' }}
+        continue-on-error: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
         timeout-minutes: 3
         uses: ./.github/actions/quarantine-gate
         with:
           adapter: e2e
           test-suite: ${{ env.CI_CONDUCTOR_TEST_SUITE }}
+          enforce-quarantine: ${{ vars.QUARANTINE_ENGINE == 'ci-conductor' }}
 
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v7
-        if: failure()
+        if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' }}
         with:
           name: cypress-recording-embedding-sdk-cross-version
           path: |
@@ -319,7 +327,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish Summary
-        if: failure()
+        if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' }}
         uses: actions/github-script@v9
         with:
           script: | #js

--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -15,6 +15,10 @@ env:
   REPO_ID: ${{ github.event.repository.id }}
   COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
   TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
+  QUARANTINE_FAILURES_FILE: ${{ github.workspace }}/target/quarantine-failures.jsonl
+  # These suites have no Trunk wiring, so `Fail job if tests failed` is the arbiter
+  # until ci-conductor takes over. Exactly one of the two gates the job.
+  CI_CONDUCTOR_QUARANTINE_ACTIVE: ${{ vars.QUARANTINE_ENGINE == 'ci-conductor' }}
 jobs:
   get-sample-apps-data:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
@@ -189,15 +193,25 @@ jobs:
 
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v7
-        if: ${{ steps.check-sample-app-branch.outputs.sample_app_branch_exists == 'true' && steps.run-e2e-tests.outcome != 'success' }}
+        if: ${{ !cancelled() && steps.run-e2e-tests.outcome == 'failure' }}
         with:
           name: cypress-recording-sample-app-${{ matrix.test_suite }}-${{ matrix.environment }}-latest
           path: |
             ./e2e/tmp/${{ steps.get-sample-app-name.outputs.sample_app_name }}/cypress
           if-no-files-found: ignore
 
+      - name: Quarantine gate
+        if: ${{ !cancelled() && steps.run-e2e-tests.outcome == 'failure' }}
+        continue-on-error: ${{ env.CI_CONDUCTOR_QUARANTINE_ACTIVE != 'true' }}
+        timeout-minutes: 3
+        uses: ./.github/actions/quarantine-gate
+        with:
+          adapter: e2e
+          test-suite: ${{ env.CI_CONDUCTOR_TEST_SUITE }}
+          enforce-quarantine: ${{ env.CI_CONDUCTOR_QUARANTINE_ACTIVE }}
+
       - name: Fail job if tests failed
-        if: ${{ steps.check-sample-app-branch.outputs.sample_app_branch_exists == 'true' && steps.run-e2e-tests.outcome != 'success' }}
+        if: ${{ !cancelled() && steps.run-e2e-tests.outcome == 'failure' && env.CI_CONDUCTOR_QUARANTINE_ACTIVE != 'true' }}
         run: |
           exit 1
 
@@ -259,15 +273,25 @@ jobs:
 
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v7
-        if: ${{ steps.shoppy-prep.outputs.sample_app_branch_exists == 'true' && steps.run-e2e-tests.outcome != 'success' }}
+        if: ${{ !cancelled() && steps.run-e2e-tests.outcome == 'failure' }}
         with:
           name: cypress-recording-sample-app-shoppy-e2e-${{ matrix.environment }}-latest
           path: |
             ./e2e/tmp/shoppy/cypress
           if-no-files-found: ignore
 
+      - name: Quarantine gate
+        if: ${{ !cancelled() && steps.run-e2e-tests.outcome == 'failure' }}
+        continue-on-error: ${{ env.CI_CONDUCTOR_QUARANTINE_ACTIVE != 'true' }}
+        timeout-minutes: 3
+        uses: ./.github/actions/quarantine-gate
+        with:
+          adapter: e2e
+          test-suite: ${{ env.CI_CONDUCTOR_TEST_SUITE }}
+          enforce-quarantine: ${{ env.CI_CONDUCTOR_QUARANTINE_ACTIVE }}
+
       - name: Fail job if tests failed
-        if: ${{ steps.shoppy-prep.outputs.sample_app_branch_exists == 'true' && steps.run-e2e-tests.outcome != 'success' }}
+        if: ${{ !cancelled() && steps.run-e2e-tests.outcome == 'failure' && env.CI_CONDUCTOR_QUARANTINE_ACTIVE != 'true' }}
         run: |
           exit 1
 
@@ -378,7 +402,6 @@ jobs:
     name: e2e-host-app-${{ matrix.test_suite }}-tests-${{ matrix.environment }}-bundle
     env:
       CI_CONDUCTOR_TEST_SUITE: embedding-sdk-host-app
-      QUARANTINE_FAILURES_FILE: ${{ github.workspace }}/target/quarantine-failures.jsonl
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
       HOST_APP_ENVIRONMENT: ${{ matrix.environment }}
     permissions:
@@ -434,23 +457,24 @@ jobs:
 
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v7
-        if: ${{ steps.run-e2e-tests.outcome != 'success' }}
+        if: ${{ !cancelled() && steps.run-e2e-tests.outcome == 'failure' }}
         with:
           name: cypress-recording-host-app-${{ matrix.test_suite }}-${{ matrix.environment }}-latest
           path: |
             ./cypress
           if-no-files-found: ignore
 
-      - name: Quarantine gate (dry run)
-        if: always()
-        continue-on-error: true
+      - name: Quarantine gate
+        if: ${{ !cancelled() && steps.run-e2e-tests.outcome == 'failure' }}
+        continue-on-error: ${{ env.CI_CONDUCTOR_QUARANTINE_ACTIVE != 'true' }}
         timeout-minutes: 3
         uses: ./.github/actions/quarantine-gate
         with:
           adapter: e2e
           test-suite: ${{ env.CI_CONDUCTOR_TEST_SUITE }}
+          enforce-quarantine: ${{ env.CI_CONDUCTOR_QUARANTINE_ACTIVE }}
 
       - name: Fail job if tests failed
-        if: ${{ steps.run-e2e-tests.outcome != 'success' }}
+        if: ${{ !cancelled() && steps.run-e2e-tests.outcome == 'failure' && env.CI_CONDUCTOR_QUARANTINE_ACTIVE != 'true' }}
         run: |
           exit 1

--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -10,15 +10,6 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   HASH: ${{ github.event.pull_request.head.sha || github.sha }}-${{ github.run_attempt }}
   MB_EDITION: ee
-  CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
-  CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
-  REPO_ID: ${{ github.event.repository.id }}
-  COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-  TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
-  QUARANTINE_FAILURES_FILE: ${{ github.workspace }}/target/quarantine-failures.jsonl
-  # These suites have no Trunk wiring, so `Fail job if tests failed` is the arbiter
-  # until ci-conductor takes over. Exactly one of the two gates the job.
-  CI_CONDUCTOR_QUARANTINE_ACTIVE: ${{ vars.QUARANTINE_ENGINE == 'ci-conductor' }}
 jobs:
   get-sample-apps-data:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
@@ -107,7 +98,6 @@ jobs:
     timeout-minutes: 45
     name: e2e-sample-app-${{ matrix.test_suite }}-tests-${{ matrix.environment }}-bundle
     env:
-      CI_CONDUCTOR_TEST_SUITE: embedding-sdk-sample-app
       MB_EDITION: ee
       MB_RUN_MODE: e2e
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
@@ -193,25 +183,15 @@ jobs:
 
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v7
-        if: ${{ !cancelled() && steps.run-e2e-tests.outcome == 'failure' }}
+        if: ${{ steps.check-sample-app-branch.outputs.sample_app_branch_exists == 'true' && steps.run-e2e-tests.outcome != 'success' }}
         with:
           name: cypress-recording-sample-app-${{ matrix.test_suite }}-${{ matrix.environment }}-latest
           path: |
             ./e2e/tmp/${{ steps.get-sample-app-name.outputs.sample_app_name }}/cypress
           if-no-files-found: ignore
 
-      - name: Quarantine gate
-        if: ${{ !cancelled() && steps.run-e2e-tests.outcome == 'failure' }}
-        continue-on-error: ${{ env.CI_CONDUCTOR_QUARANTINE_ACTIVE != 'true' }}
-        timeout-minutes: 3
-        uses: ./.github/actions/quarantine-gate
-        with:
-          adapter: e2e
-          test-suite: ${{ env.CI_CONDUCTOR_TEST_SUITE }}
-          enforce-quarantine: ${{ env.CI_CONDUCTOR_QUARANTINE_ACTIVE }}
-
       - name: Fail job if tests failed
-        if: ${{ !cancelled() && steps.run-e2e-tests.outcome == 'failure' && env.CI_CONDUCTOR_QUARANTINE_ACTIVE != 'true' }}
+        if: ${{ steps.check-sample-app-branch.outputs.sample_app_branch_exists == 'true' && steps.run-e2e-tests.outcome != 'success' }}
         run: |
           exit 1
 
@@ -229,7 +209,6 @@ jobs:
     timeout-minutes: 45
     name: e2e-sample-app-shoppy-e2e-tests-${{ matrix.environment }}-bundle
     env:
-      CI_CONDUCTOR_TEST_SUITE: embedding-sdk-shoppy
       MB_EDITION: ee
       MB_RUN_MODE: e2e
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
@@ -273,25 +252,15 @@ jobs:
 
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v7
-        if: ${{ !cancelled() && steps.run-e2e-tests.outcome == 'failure' }}
+        if: ${{ steps.shoppy-prep.outputs.sample_app_branch_exists == 'true' && steps.run-e2e-tests.outcome != 'success' }}
         with:
           name: cypress-recording-sample-app-shoppy-e2e-${{ matrix.environment }}-latest
           path: |
             ./e2e/tmp/shoppy/cypress
           if-no-files-found: ignore
 
-      - name: Quarantine gate
-        if: ${{ !cancelled() && steps.run-e2e-tests.outcome == 'failure' }}
-        continue-on-error: ${{ env.CI_CONDUCTOR_QUARANTINE_ACTIVE != 'true' }}
-        timeout-minutes: 3
-        uses: ./.github/actions/quarantine-gate
-        with:
-          adapter: e2e
-          test-suite: ${{ env.CI_CONDUCTOR_TEST_SUITE }}
-          enforce-quarantine: ${{ env.CI_CONDUCTOR_QUARANTINE_ACTIVE }}
-
       - name: Fail job if tests failed
-        if: ${{ !cancelled() && steps.run-e2e-tests.outcome == 'failure' && env.CI_CONDUCTOR_QUARANTINE_ACTIVE != 'true' }}
+        if: ${{ steps.shoppy-prep.outputs.sample_app_branch_exists == 'true' && steps.run-e2e-tests.outcome != 'success' }}
         run: |
           exit 1
 
@@ -307,7 +276,6 @@ jobs:
     timeout-minutes: 45
     name: e2e-shoppy-synthetic-monitoring-tests
     env:
-      CI_CONDUCTOR_TEST_SUITE: embedding-sdk-shoppy-synthetic
       MB_EDITION: ee
       MB_RUN_MODE: e2e
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
@@ -401,7 +369,19 @@ jobs:
     timeout-minutes: 45
     name: e2e-host-app-${{ matrix.test_suite }}-tests-${{ matrix.environment }}-bundle
     env:
+      # Host apps are the only suite here running through Metabase's Cypress config,
+      # whose `after:spec` hook reports failures and writes QUARANTINE_FAILURES_FILE.
+      # Sample-app suites load their own config (no-op), so ci-conductor is scoped to this job.
+      CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+      CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
       CI_CONDUCTOR_TEST_SUITE: embedding-sdk-host-app
+      REPO_ID: ${{ github.event.repository.id }}
+      COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
+      QUARANTINE_FAILURES_FILE: ${{ github.workspace }}/target/quarantine-failures.jsonl
+      # `Fail job if tests failed` is the arbiter until ci-conductor takes over.
+      # Exactly one of the two gates the job.
+      CI_CONDUCTOR_QUARANTINE_ACTIVE: ${{ vars.QUARANTINE_ENGINE == 'ci-conductor' }}
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
       HOST_APP_ENVIRONMENT: ${{ matrix.environment }}
     permissions:


### PR DESCRIPTION
Resolves DEV-2350


## Summary

### SDK component tests
- Didn't have `continue-on-error`, so they were never properly wired to Trunk's quarantine enforcing mechanism
- This PR fixes that
- This PR also introduces an alternative CI Conductor quarantine along with the "switch" that controls the quarantine engine

Verdict: SDK component tests should now have a proper quarantine enforcement with two potential engines.

### Host apps tests
- Hasn't ever been wired to Trunk at all (missing `upload-test-results` composite action)
- This PR *deliberately doesn't introduce that wiring*
- Instead, it only introduces ci conductor quarantine that can either:
    1. enforce (controls the exit code)
    2. print the verdict (dry run) in which case the existing "Fail job if tests failed" controls the exit code
    
> [!IMPORTANT]
> 1. `e2e-shoppy-synthetic-tests` explicitly and deliberately does NOT have a quarantine gate.
> 2. sample apps are no-op as they have their own Cypress config that is not wired to ci-conductor