### PR TITLE
Fix metabot semantic-search tests not runing in CI 

### DIFF
--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -34,7 +34,7 @@ jobs:
           - name: Semantic Search Tests
             build-static-viz: false
             test-args: >-
-              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/entity_retrieval" "enterprise/backend/test/metabase_enterprise/metabot_v3/tools/semantic_search_test.clj"]'
+              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/entity_retrieval" "enterprise/backend/test/metabase_enterprise/metabot/tools/semantic_search_test.clj"]'
             exclude-tag: ':mb/driver-tests'
 
     services:
@@ -93,7 +93,7 @@ jobs:
           - name: Semantic Search Tests
             build-static-viz: false
             test-args: >-
-              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/entity_retrieval" "enterprise/backend/test/metabase_enterprise/metabot_v3/tools/semantic_search_test.clj"]'
+              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/entity_retrieval" "enterprise/backend/test/metabase_enterprise/metabot/tools/semantic_search_test.clj"]'
             exclude-tag: ':mb/driver-tests'
 
     services:
@@ -166,7 +166,7 @@ jobs:
           - name: Semantic Search Tests
             build-static-viz: false
             test-args: >-
-              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/entity_retrieval" "enterprise/backend/test/metabase_enterprise/metabot_v3/tools/semantic_search_test.clj"]'
+              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/entity_retrieval" "enterprise/backend/test/metabase_enterprise/metabot/tools/semantic_search_test.clj"]'
             exclude-tag: ':mb/driver-tests'
 
     services:
@@ -239,7 +239,7 @@ jobs:
           - name: Semantic Search Tests
             build-static-viz: false
             test-args: >-
-              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/entity_retrieval" "enterprise/backend/test/metabase_enterprise/metabot_v3/tools/semantic_search_test.clj"]'
+              :only '["enterprise/backend/test/metabase_enterprise/semantic_search" "enterprise/backend/test/metabase_enterprise/entity_retrieval" "enterprise/backend/test/metabase_enterprise/metabot/tools/semantic_search_test.clj"]'
             exclude-tag: ':mb/driver-tests'
 
     services:


### PR DESCRIPTION
The semantic-search workflow's `:only` list still references `metabase_enterprise/metabot_v3/tools/semantic_search_test.clj`, but #71068 (2026-03-23) renamed the directory to `metabot/`. 

The test runner tolerates a missing path, so the metabot semantic search tool tests have silently not run in any of the four semantic-search CI jobs since. **_Maybe we should detect these kinds of configuration issues and make them fail?_**

The tests pass against current master (verified locally with a dedicated pgvector database). 