### PR TITLE
Fix weak assertion in create-table-from-schema!-test

### DIFF
--- a/test/metabase/transforms/execute_test.clj
+++ b/test/metabase/transforms/execute_test.clj
@@ -144,7 +144,7 @@
         (testing "create-table-from-schema! should create the table successfully"
           (transforms-base.u/create-table-from-schema! driver db-id table-schema)
           (let [table-exists? (driver/table-exists? driver (mt/db) {:schema schema-name :name table-name})]
-            (is (some? table-exists?) "Table should exist in the database schema")
+            (is (true? table-exists?) "Table should exist in the database schema")
             (driver/drop-table! driver db-id (:name table-schema))))))))
 
 (deftest transform-schema-created-if-needed-test


### PR DESCRIPTION
If `driver/table-exists?` returns `false` for a missing table, it is still `some?`, so the assertion could never fail. 

Assert `true?` instead!