### PR TITLE
Fix the shadow-cljs warning from lib.core's macro re-export

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -759,6 +759,7 @@
    metabase.test/with-temporary-raw-setting-values                                              macros.metabase.test.util/with-temporary-raw-setting-values
    metabase.users.models.user-test/with-groups!                                                 macros.metabase.users.models.user-test/with-groups!
    metabase.util.namespaces/import-fn                                                           macros.metabase.util.namespaces/import-fn
+   metabase.util.namespaces/import-macro                                                        macros.metabase.util.namespaces/import-macro
    metabase.xrays.related-test/with-world                                                       macros.metabase.xrays.related-test/with-world}}
 
  :config-in-comment

--- a/.clj-kondo/macros/metabase/util/namespaces.clj
+++ b/.clj-kondo/macros/metabase/util/namespaces.clj
@@ -6,3 +6,8 @@
    `(def ~(-> sym name symbol) "docstring" ~sym))
   ([sym name]
    `(def ~name "docstring" ~sym)))
+
+(defmacro import-macro
+  "Kondo macro replacement for [[metabase.util.namespaces/import-macro]]."
+  [sym]
+  `(def ~(-> sym name symbol) "docstring" ~sym))

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -1422,7 +1422,6 @@
   ->legacy-MBQL
   ->mbql5
   legacy-default-join-alias
-  with-aggregation-list
   without-cleaning]
  [metabase.lib.convert.metadata-to-legacy
   lib-metadata-column->legacy-metadata-column
@@ -1667,6 +1666,8 @@
   any-native-stage-not-introduced-by-sandbox?
   replace-field-ids
   replace-table-ids])
+
+(shared.ns/import-macro lib.convert/with-aggregation-list)
 
 #?(:clj
    (defmacro with-card-clean-hook

--- a/src/metabase/util/namespaces.clj
+++ b/src/metabase/util/namespaces.clj
@@ -23,6 +23,15 @@
      :clj `(p/import-fn ~target ~sym)
      :cljs (redef target sym))))
 
+(defmacro import-macro
+  "Imports a single macro from another namespace, for JVM Clojure only.
+  In CLJS this expands to nothing: a macro has no runtime value to re-export, so CLJS callers must require the
+  defining namespace directly."
+  [target]
+  (macros/case
+    :clj `(p/import-macro ~target)
+    :cljs nil))
+
 (defmacro import-fns
   "Imports defns from other namespaces.
   This uses [[import-fn]] to create pass-through local functions that reload nicely.


### PR DESCRIPTION
Every release CLJS build logs one warning ([example, master uberjar build](https://github.com/metabase/metabase/actions/runs/29077421127/job/86319565039)):

```
------ WARNING #1 - :undeclared-var --------------------------------------------
 File: src/metabase/lib/core.cljc:1407:1
 Can't take value of macro metabase.lib.convert/with-aggregation-list
```

`with-aggregation-list` is a macro, and `shared.ns/import-fns` has no CLJS story for macros: it expands to `(def with-aggregation-list lib.convert/with-aggregation-list)`, and a macro has no value to take. The var is `undefined` in CLJS. Nothing hits it today — frontend callers go through `lib.convert` directly — so the cost is build noise, plus a runtime `undefined is not a function` waiting for the first CLJS caller.

Fix: a `shared.ns/import-macro` helper — potemkin's `import-macro` on the JVM, nothing in CLJS — and `with-aggregation-list` moves out of the `import-fns` block onto it. `shadow-cljs release app` is down to [0 warnings](https://github.com/metabase/metabase/actions/runs/29089401898/job/86351268330); the JVM re-export is unchanged (still a macro, and the one JVM caller still compiles).
