### PR TITLE
Add MCP CRUD support for measures

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -181,6 +181,7 @@
                     :model/Dashboard
                     :model/DashboardCard
                     :model/Database
+                    :model/Measure
                     :model/Table
                     :model/User}}
 

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -18,6 +18,7 @@
    [metabase.events.core :as events]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
+   [metabase.lib.schema.measure :as lib.schema.measure]
    [metabase.metabot.config :as metabot.config]
    [metabase.metabot.core :as metabot]
    [metabase.metabot.feedback :as metabot.feedback]
@@ -1089,6 +1090,169 @@
                    (str "Card " id " is not a metric. Use update_question to update questions."))
     (apply-agent-card-patch! card-before-update body
                              {:validate-query! check-metric-query-can-be-saved!})))
+
+;;; -------------------------------------------------- Create Measure ------------------------------------------------
+;;
+;; A Measure (`:model/Measure`) is a table-scoped reusable aggregation, not a card: it has no
+;; collection, display, or visualization settings, and its permission model is table-based (admin
+;; or data analyst with unrestricted view-data on the parent table). So these endpoints don't share
+;; the card-mutation helper stack above; they mirror REST `/api/measure` instead.
+
+(mr/def ::create-measure-request
+  [:map
+   [:name        ms/NonBlankString]
+   [:query       ms/NonBlankString]
+   [:description {:optional true} [:maybe :string]]])
+
+(mr/def ::update-measure-request
+  "Patch shape for `update_measure`. Every field is optional; only the fields the caller passes
+  are changed. `:query` accepts a base64-encoded MBQL string (or query_handle UUID resolved
+  upstream in the MCP layer) and must still describe a valid measure. `:revision_message` is
+  recorded in the measure's revision history."
+  [:map
+   [:name             {:optional true} [:maybe ms/NonBlankString]]
+   [:description      {:optional true} [:maybe :string]]
+   [:archived         {:optional true} [:maybe :boolean]]
+   [:query            {:optional true} [:maybe ms/NonBlankString]]
+   [:revision_message {:optional true} [:maybe ms/NonBlankString]]])
+
+(mr/def ::measure-response
+  "Returned by `create_measure` / `update_measure`. `definition_description` is the
+  human-readable rendering of the measure's aggregation — the read-back an LLM should report."
+  [:map
+   [:id                     ms/PositiveInt]
+   [:name                   ms/NonBlankString]
+   [:table_id               ms/PositiveInt]
+   [:description            [:maybe :string]]
+   [:definition_description [:maybe :string]]
+   [:archived               :boolean]])
+
+(defn- measure-response
+  [measure]
+  (let [measure (t2/hydrate measure :definition_description)]
+    {:id                     (:id measure)
+     :name                   (:name measure)
+     :table_id               (:table_id measure)
+     :description            (:description measure)
+     :definition_description (:definition_description measure)
+     :archived               (boolean (:archived measure))}))
+
+(defn- decode-measure-definition
+  "Decode a base64 `:query` payload (a resolved query_handle) into a normalized MBQL 5 query map,
+  the shape `:model/Measure` stores as its `:definition`."
+  [encoded]
+  (-> encoded u/decode-base64 json/decode+kw lib-be/normalize-query))
+
+(defn- check-measure-definition-can-be-saved!
+  "Throw a 400 unless `definition` is a valid measure definition (see
+  `::lib.schema.measure/definition`). The model's before-insert/update hooks run the same
+  validation via `mu/validate-throw`, but that surfaces as a 500; checking here first gives the
+  LLM an actionable message."
+  [definition]
+  (when-not (mr/validate ::lib.schema.measure/definition definition)
+    (throw (ex-info (str "This query can't be saved as a measure. A measure is a reusable "
+                         "aggregation: a single-stage query over one table with exactly one "
+                         "aggregation and no other clauses (no filters, breakout, joins, "
+                         "expressions, fields, order-by, or limit), and it can't reference "
+                         "metrics. Construct a query with a single aggregation before saving it.")
+                    {:status-code 400}))))
+
+(defn- check-measure-overwrite-400!
+  "Run `lib/check-measure-overwrite` (cycle detection and referenced-measure existence), promoting
+  any failure to a 400. The model's before-insert/update hooks run the same check, but without a
+  :status-code it would surface as a 500; a 400 gives the LLM an actionable message."
+  [measure-id definition]
+  (try
+    (lib/check-measure-overwrite measure-id definition)
+    (catch clojure.lang.ExceptionInfo e
+      (let [data (ex-data e)]
+        (throw (ex-info (ex-message e)
+                        (assoc data :status-code (or (:status-code data) 400))
+                        e))))))
+
+(api.macros/defendpoint :post "/v1/measure" :- ::measure-response
+  "Create a measure — a named, reusable aggregation for a table.
+
+  The `query` parameter accepts a `query_handle` (UUID) returned by `construct_query`, or a
+  base64-encoded MBQL string. MCP callers should always use the handle. The query must be a
+  single-stage query against a table whose only clause is exactly one aggregation. The measure's
+  target table is derived from the query's source table.
+
+  Requires curate permissions on the underlying data: admins and data analysts only."
+  {:scope metabot/agent-measure-create
+   :tool  {:name "create_measure"
+           :description (str "Save a query's aggregation as a reusable measure in Metabase. "
+                             "Pass the `query_handle` returned by `construct_query`. "
+                             "The query must be a single-stage query on a table containing ONLY "
+                             "one aggregation (e.g. count, sum, average) — no filters, breakout, "
+                             "joins, expressions, order-by, or limit. The measure attaches to the "
+                             "query's source table. Requires admin or data-analyst permissions.")}}
+  [_route-params
+   _query-params
+   {:keys [query description] measure-name :name} :- ::create-measure-request]
+  (let [definition (decode-measure-definition query)
+        _          (check-measure-definition-can-be-saved! definition)
+        table-id   (lib/primary-source-table-id definition)]
+    (api/check-400 (int? table-id)
+                   "A measure must be built directly on a table, not on a saved question.")
+    (api/create-check :model/Measure {:table_id table-id})
+    (check-measure-overwrite-400! nil definition)
+    (let [measure (api/check-500
+                   (first (t2/insert-returning-instances! :model/Measure
+                                                          :table_id    table-id
+                                                          :creator_id  api/*current-user-id*
+                                                          :name        measure-name
+                                                          :description description
+                                                          :definition  definition)))]
+      (events/publish-event! :event/measure-create {:object measure :user-id api/*current-user-id*})
+      (measure-response measure))))
+
+;;; -------------------------------------------------- Update Measure ------------------------------------------------
+
+(api.macros/defendpoint :put "/v1/measure/:id" :- ::measure-response
+  "Update a measure. Patch semantics - only fields that you pass are changed.
+
+  Set `archived: true` to archive the measure — this is also how a measure is deleted; there is
+  no hard delete. Pass `query` (a query_handle from construct_query, or a base64 MBQL string)
+  to replace the measure's aggregation definition;
+  the replacement must still be a valid measure (single stage, exactly one aggregation, nothing
+  else). An optional `revision_message` is recorded in the measure's revision history.
+
+  Requires curate permissions on the underlying data: admins and data analysts only."
+  {:scope metabot/agent-measure-update
+   :tool  {:name "update_measure"
+           :description (str "Update a measure. Patch semantics - only fields you pass are changed. "
+                             "To delete (archive) a measure, set archived true - measures have no "
+                             "hard delete, so this is also the tool for deleting one. To replace the "
+                             "aggregation definition, pass query (a query_handle from construct_query) "
+                             "- it must still be a single-stage table query containing only one "
+                             "aggregation. Optionally pass revision_message to annotate the change "
+                             "in revision history.")}}
+  [{:keys [id]} :- [:map [:id ms/PositiveInt]]
+   _query-params
+   body :- ::update-measure-request]
+  (api/write-check :model/Measure id)
+  (let [new-definition (when-some [encoded (:query body)]
+                         (let [definition (decode-measure-definition encoded)]
+                           (check-measure-definition-can-be-saved! definition)
+                           ;; Reject definitions referencing this measure (directly or transitively).
+                           (check-measure-overwrite-400! id definition)
+                           definition))
+        ;; :name is non-nullable on the model, so an explicit null is ignored rather than applied;
+        ;; :description is nullable and an explicit null clears it.
+        changes        (cond-> {}
+                         (some? (:name body))          (assoc :name (:name body))
+                         (contains? body :description) (assoc :description (:description body))
+                         (contains? body :archived)    (assoc :archived (boolean (:archived body)))
+                         new-definition                (assoc :definition new-definition))]
+    (when (seq changes)
+      (t2/update! :model/Measure id changes))
+    (let [updated (t2/select-one :model/Measure :id id)]
+      (events/publish-event! :event/measure-update
+                             (cond-> {:object updated :user-id api/*current-user-id*}
+                               (:revision_message body)
+                               (assoc :revision-message (:revision_message body))))
+      (measure-response updated))))
 
 ;;; ------------------------------------------------- Update Question ------------------------------------------------
 

--- a/src/metabase/mcp/README.md
+++ b/src/metabase/mcp/README.md
@@ -66,6 +66,8 @@ Access tokens are scoped to limit what tools a client can use:
 | `agent:question:execute`  | `execute_question`                                                                                             |
 | `agent:metric:create`     | `create_metric`                                                                                                |
 | `agent:metric:update`     | `update_metric` (also covers "move metric to collection")                                                      |
+| `agent:measure:create`    | `create_measure`                                                                                               |
+| `agent:measure:update`    | `update_measure` (also covers archiving, which doubles as deletion)                                            |
 | `agent:dashboard:create`  | `create_dashboard`                                                                                             |
 | `agent:dashboard:update`  | `update_dashboard`                                                                                             |
 | `agent:collection:create` | `create_collection`                                                                                            |
@@ -108,6 +110,8 @@ The MCP server exposes these tools, dynamically generated from the Agent API end
 | ------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `create_metric`     | Save a query as a reusable metric. Accepts a `query_handle` from `construct_query`. The query needs one aggregation and at most one date grouping. |
 | `update_metric`     | Update a saved metric. Patch semantics. Setting `collection_id` moves it; setting `archived` archives it. A replacement `query` must still be a valid metric. |
+| `create_measure`    | Save a query's aggregation as a reusable measure on a table. Accepts a `query_handle` from `construct_query`; the query must be a single-stage table query with exactly one aggregation and nothing else. Admin/data-analyst only. |
+| `update_measure`    | Update a measure. Patch semantics. Setting `archived: true` archives it — measures have no hard delete, so this is also how one is deleted. A replacement `query` must still be a valid measure. Admin/data-analyst only. |
 | `create_question`   | Save a query as a named question (card). Accepts a `query_handle` from `construct_query` (MBQL) or `construct_native_query` (native SQL). Saving native requires native-query DB permission. |
 | `update_question`   | Update a saved question. Patch semantics. Setting `collection_id` moves the card. Setting `archived` archives it. Replacing the query accepts a `construct_query` or `construct_native_query` handle. |
 | `create_dashboard`  | Create a new dashboard, optionally populated with saved questions (auto-positioned on the grid).                  |

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -331,7 +331,8 @@
 ;; handle, but it's a UI tool that resolves the handle itself (see `metabase.mcp.resources`) and
 ;; never reaches this dispatch path, so it's intentionally absent here.
 (def ^:private tools-accepting-query-handle
-  #{"execute_query" "query" "create_question" "update_question" "create_metric" "update_metric"})
+  #{"execute_query" "query" "create_question" "update_question" "create_metric" "update_metric"
+    "create_measure" "update_measure"})
 
 ;; Tools whose 200 body is `{:query base64}` and gets stored as a handle, returning `{:query_handle}`.
 ;; `construct_query` (MBQL) and `construct_native_query` (native SQL) both follow this contract.

--- a/src/metabase/metabot/core.clj
+++ b/src/metabase/metabot/core.clj
@@ -21,6 +21,8 @@
   agent-question-create
   agent-question-execute
   agent-question-update
+  agent-measure-create
+  agent-measure-update
   agent-metric-create
   agent-metric-update
   agent-resource-read

--- a/src/metabase/metabot/scope.clj
+++ b/src/metabase/metabot/scope.clj
@@ -50,6 +50,12 @@
 (api-scope/defscope agent-metric-update "agent:metric:update"
   (deferred-tru "Update metrics"))
 
+;; Measure (table-scoped reusable aggregations via Agent API)
+(api-scope/defscope agent-measure-create "agent:measure:create"
+  (deferred-tru "Create measures"))
+(api-scope/defscope agent-measure-update "agent:measure:update"
+  (deferred-tru "Update measures"))
+
 ;; Transforms
 (api-scope/defscope agent-transforms-read "agent:transforms:read"
   (deferred-tru "View transforms"))
@@ -177,7 +183,8 @@
   "Map from metabot permission type to the wildcard scope strings granted when
   that permission is `:yes`."
   {:permission/metabot-sql-generation #{"agent:sql:*" "agent:transforms:*" "agent:snippets:*"}
-   :permission/metabot-nlq            #{"agent:notebook:*" "agent:query:*" "agent:question:*" "agent:metric:*"}
+   :permission/metabot-nlq            #{"agent:notebook:*" "agent:query:*" "agent:question:*" "agent:metric:*"
+                                        "agent:measure:*"}
    :permission/metabot-other-tools    #{"agent:viz:*" "agent:dashboard:*" "agent:document:*" "agent:alert:*"
                                         "agent:collection:*"}})
 

--- a/test/metabase/agent_api/api_test.clj
+++ b/test/metabase/agent_api/api_test.clj
@@ -986,6 +986,120 @@
         (mt/user-http-request :rasta :put 403 (str "agent/v1/metric/" card-id)
                               {:name "Forbidden Rename"})))))
 
+;;; ------------------------------------------------ Create Measure Tests -------------------------------------------
+
+(defn- construct-orders-aggregation-query
+  "Construct an aggregation-only ORDERS query via /v2/construct-query (as `user`) and return the
+  base64 `:query` payload for the measure endpoints."
+  [user aggregation]
+  (:query (mt/user-http-request user :post 200 "agent/v2/construct-query"
+                                {:query (orders-query :aggregation [aggregation])})))
+
+(deftest create-measure-test
+  (testing "Creates a measure from an aggregation-only query, deriving table_id from the query"
+    (let [encoded (construct-orders-aggregation-query :crowberto ["count" {}])
+          resp    (mt/user-http-request :crowberto :post 200 "agent/v1/measure"
+                                        {:name        "Agent Test Measure"
+                                         :query       encoded
+                                         :description "Count of orders"})]
+      (is (=? {:id                     pos?
+               :name                   "Agent Test Measure"
+               :table_id               (mt/id :orders)
+               :description            "Count of orders"
+               :definition_description string?
+               :archived               false}
+              resp))
+      (let [persisted (t2/select-one :model/Measure :id (:id resp))]
+        (is (= (mt/id :orders) (:table_id persisted)))
+        (is (= 1 (count (:aggregation (first (:stages (:definition persisted))))))))
+      (t2/delete! :model/Measure :id (:id resp)))))
+
+(deftest create-measure-rejects-invalid-definition-test
+  (testing "Returns 400 when the query has no aggregation"
+    (let [encoded (:query (mt/user-http-request :crowberto :post 200 "agent/v2/construct-query"
+                                                {:query (orders-query :limit 10)}))]
+      (is (str/includes?
+           (mt/user-http-request :crowberto :post 400 "agent/v1/measure"
+                                 {:name  "Not A Measure"
+                                  :query encoded})
+           "measure"))))
+  (testing "Returns 400 when the query has a filter alongside the aggregation"
+    (let [encoded (:query (mt/user-http-request :crowberto :post 200 "agent/v2/construct-query"
+                                                {:query (orders-query
+                                                         :aggregation [["count" {}]]
+                                                         :filters     [["not-null" {} (orders-field-ref "ID")]])}))]
+      (is (str/includes?
+           (mt/user-http-request :crowberto :post 400 "agent/v1/measure"
+                                 {:name  "Not A Measure Either"
+                                  :query encoded})
+           "measure")))))
+
+(deftest create-measure-permission-test
+  (testing "Returns 403 for a regular user (measures require admin or data-analyst)"
+    (let [encoded (construct-orders-aggregation-query :rasta ["count" {}])]
+      (mt/user-http-request :rasta :post 403 "agent/v1/measure"
+                            {:name  "Forbidden Measure"
+                             :query encoded}))))
+
+;;; ------------------------------------------------ Update Measure Tests -------------------------------------------
+
+(deftest update-measure-patch-fields-test
+  (testing "Patches simple fields (name, description) on a measure"
+    (mt/with-temp [:model/Measure {measure-id :id} {:name "Agent Measure Original"}]
+      (let [resp (mt/user-http-request :crowberto :put 200 (str "agent/v1/measure/" measure-id)
+                                       {:name        "Renamed Measure"
+                                        :description "Set by agent"})]
+        (is (=? {:id          measure-id
+                 :name        "Renamed Measure"
+                 :description "Set by agent"
+                 :archived    false}
+                resp)))
+      (is (= "Renamed Measure" (t2/select-one-fn :name :model/Measure :id measure-id))))))
+
+(deftest update-measure-archive-test
+  (testing "archived: true archives; archived: false unarchives"
+    (mt/with-temp [:model/Measure {measure-id :id} {:name "Measure To Archive"}]
+      (is (true? (:archived (mt/user-http-request :crowberto :put 200 (str "agent/v1/measure/" measure-id)
+                                                  {:archived true}))))
+      (is (true? (t2/select-one-fn :archived :model/Measure :id measure-id)))
+      (is (false? (:archived (mt/user-http-request :crowberto :put 200 (str "agent/v1/measure/" measure-id)
+                                                   {:archived false}))))
+      (is (false? (t2/select-one-fn :archived :model/Measure :id measure-id))))))
+
+(deftest update-measure-replace-definition-test
+  (testing "Replacing the definition via :query persists and re-derives table_id"
+    (mt/with-temp [:model/Measure {measure-id :id} {:name "Measure To Redefine"}]
+      (let [encoded (construct-orders-aggregation-query :crowberto ["sum" {} (orders-field-ref "TOTAL")])
+            resp    (mt/user-http-request :crowberto :put 200 (str "agent/v1/measure/" measure-id)
+                                          {:query            encoded
+                                           :revision_message "swapped count for sum"})]
+        (is (= (mt/id :orders) (:table_id resp)))
+        (let [persisted (t2/select-one :model/Measure :id measure-id)]
+          (is (= (mt/id :orders) (:table_id persisted)))
+          (is (= 1 (count (:aggregation (first (:stages (:definition persisted))))))))))))
+
+(deftest update-measure-rejects-invalid-definition-test
+  (testing "Returns 400 when a replacement query is not a valid measure, leaving the row untouched"
+    (mt/with-temp [:model/Measure {measure-id :id} {:name "Measure With Bad Redefine"}]
+      (let [encoded (:query (mt/user-http-request :crowberto :post 200 "agent/v2/construct-query"
+                                                  {:query (orders-query :filters [["not-null" {} (orders-field-ref "ID")]])}))]
+        (is (str/includes?
+             (mt/user-http-request :crowberto :put 400 (str "agent/v1/measure/" measure-id)
+                                   {:query encoded})
+             "measure"))
+        (is (= "Measure With Bad Redefine" (t2/select-one-fn :name :model/Measure :id measure-id)))))))
+
+(deftest update-measure-not-found-test
+  (testing "Returns 404 when measure does not exist"
+    (mt/user-http-request :crowberto :put 404 "agent/v1/measure/999999"
+                          {:name "doesn't matter"})))
+
+(deftest update-measure-write-perm-test
+  (testing "Returns 403 for a regular user (measures require admin or data-analyst)"
+    (mt/with-temp [:model/Measure {measure-id :id} {:name "Protected Measure"}]
+      (mt/user-http-request :rasta :put 403 (str "agent/v1/measure/" measure-id)
+                            {:name "Forbidden Rename"}))))
+
 ;;; ----------------------------------------------- Create Dashboard Tests ------------------------------------------
 
 (deftest create-dashboard-test

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -274,6 +274,7 @@
     "construct_native_query"
     "create_collection"
     "create_dashboard"
+    "create_measure"
     "create_metric"
     "create_question"
     "execute_query"
@@ -284,6 +285,7 @@
     "render_drill_through"
     "search"
     "update_dashboard"
+    "update_measure"
     "update_metric"
     "update_question"
     "visualize_query"})
@@ -665,7 +667,8 @@
   #{"search" "construct_query" "construct_native_query" "query" "execute_query" "execute_sql"
     "read_resource"
     "create_question" "execute_question" "create_metric" "create_dashboard"
-    "update_question" "update_metric" "update_dashboard" "create_collection"})
+    "update_question" "update_metric" "update_dashboard" "create_collection"
+    "create_measure" "update_measure"})
 
 (deftest tools-call-smoke-test-covers-all-agent-api-backed-tools-test
   (testing "every Agent API-backed tool is exercised by the smoke test"
@@ -693,10 +696,17 @@
                                 :stages   [{:lib/type     "mbql.stage/mbql"
                                             :source-table [db-name "PUBLIC" "ORDERS"]
                                             :aggregation  [["count" {}]]}]}
+                ;; A measure needs an aggregation-only stage — `create_measure` rejects anything else.
+                ;; Same shape as `metric-query`, but constructed separately: each handle is single-use.
+                measure-query  {:lib/type "mbql/query"
+                                :stages   [{:lib/type     "mbql.stage/mbql"
+                                            :source-table [db-name "PUBLIC" "ORDERS"]
+                                            :aggregation  [["count" {}]]}]}
                 ;; Track write-tool outputs in atoms so the `finally` cleanup runs even if an
                 ;; assertion in `call-tool` fails partway through the sequence.
                 question-id    (atom nil)
                 metric-id      (atom nil)
+                measure-id     (atom nil)
                 dash-id        (atom nil)
                 coll-id        (atom nil)]
             (try
@@ -742,6 +752,15 @@
                     _              (call-tool session-id "update_metric"
                                               {:id          (:id metric-data)
                                                :description "Smoke updated metric"})
+                    measure-handle (call-tool session-id "construct_query" {:query measure-query})
+                    measure-data   (call-tool session-id "create_measure"
+                                              {:name         "Smoke Measure"
+                                               :query_handle (:query_handle measure-handle)})
+                    _              (reset! measure-id (:id measure-data))
+                    _              (is (= (mt/id :orders) (:table_id measure-data)))
+                    _              (call-tool session-id "update_measure"
+                                              {:id          (:id measure-data)
+                                               :description "Smoke updated measure"})
                     _              (call-tool session-id "execute_question"
                                               {:id (:id question-data)})
                     dash-data      (call-tool session-id "create_dashboard"
@@ -758,6 +777,7 @@
               (finally
                 (when-let [qid @question-id] (t2/delete! :model/Card :id qid))
                 (when-let [mid @metric-id]   (t2/delete! :model/Card :id mid))
+                (when-let [sid @measure-id]  (t2/delete! :model/Measure :id sid))
                 (when-let [did @dash-id]     (t2/delete! :model/Dashboard :id did))
                 (when-let [cid @coll-id]     (t2/delete! :model/Collection :id cid))))))))))
 

--- a/test/metabase/metabot/scope_test.clj
+++ b/test/metabase/metabot/scope_test.clj
@@ -121,6 +121,8 @@
     (is (api-scope/registered-scope? "agent:question:update"))
     (is (api-scope/registered-scope? "agent:metric:create"))
     (is (api-scope/registered-scope? "agent:metric:update"))
+    (is (api-scope/registered-scope? "agent:measure:create"))
+    (is (api-scope/registered-scope? "agent:measure:update"))
     (is (api-scope/registered-scope? "agent:dashboard:update"))
     (is (api-scope/registered-scope? "agent:collection:create"))
     (is (api-scope/registered-scope? "agent:sql:execute"))))
@@ -130,6 +132,8 @@
     (is (= "agent:question:update" scope/agent-question-update))
     (is (= "agent:metric:create" scope/agent-metric-create))
     (is (= "agent:metric:update" scope/agent-metric-update))
+    (is (= "agent:measure:create" scope/agent-measure-create))
+    (is (= "agent:measure:update" scope/agent-measure-update))
     (is (= "agent:dashboard:update" scope/agent-dashboard-update))
     (is (= "agent:collection:create" scope/agent-collection-create))
     (is (= "agent:sql:execute" scope/agent-sql-execute))))
@@ -144,6 +148,11 @@
   (testing "agent:metric:update granted via metabot-nlq wildcard"
     (let [scopes (scope/user-metabot-perms->scopes {:permission/metabot-nlq :yes})]
       (is (api-scope/scope-matches? scopes "agent:metric:update"))))
+  (testing "agent:measure:create/update granted via metabot-nlq wildcard"
+    (let [scopes (scope/user-metabot-perms->scopes {:permission/metabot-nlq :yes})]
+      (is (contains? scopes "agent:measure:*"))
+      (is (api-scope/scope-matches? scopes "agent:measure:create"))
+      (is (api-scope/scope-matches? scopes "agent:measure:update"))))
   (testing "agent:dashboard:update granted via metabot-other-tools wildcard"
     (let [scopes (scope/user-metabot-perms->scopes {:permission/metabot-other-tools :yes})]
       (is (api-scope/scope-matches? scopes "agent:dashboard:update"))))
@@ -159,6 +168,7 @@
                                                     :permission/metabot-other-tools    :no
                                                     :permission/metabot-sql-generation :no})]
       (is (not (api-scope/scope-matches? scopes "agent:question:update")))
+      (is (not (api-scope/scope-matches? scopes "agent:measure:create")))
       (is (not (api-scope/scope-matches? scopes "agent:dashboard:update")))
       (is (not (api-scope/scope-matches? scopes "agent:collection:create")))
       (is (not (api-scope/scope-matches? scopes "agent:sql:execute"))))))


### PR DESCRIPTION
References [BOT-1829: MCP CRUD for metrics, segments, and measures](https://linear.app/metabase/issue/BOT-1829/mcp-crud-for-metrics-segments-and-measures)

This PR implements CRUD support for measures.
