### PR TITLE
[Metabot] Implement conversation branches in usage analytics

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_analytics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_analytics/api.clj
@@ -99,10 +99,6 @@
    [:updated_at        ms/TemporalInstant]])
 
 (def ^:private ConversationMessage
-  "One chat message in the conversation's flat message list. `:parent_message_id`
-   points at another message's `:id` (nil at the root); the client rebuilds the
-   branch tree from it, treating the newest of a set of sibling replies as the
-   current one. Extra chat-payload keys vary by `:type` and are left unconstrained."
   [:map
    [:id                :string]
    [:parent_message_id [:maybe :string]]

--- a/enterprise/backend/src/metabase_enterprise/metabot_analytics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_analytics/api.clj
@@ -98,6 +98,17 @@
    [:created_at        ms/TemporalInstant]
    [:updated_at        ms/TemporalInstant]])
 
+(def ^:private ConversationMessage
+  "One chat message in the conversation's flat message list. `:parent_message_id`
+   points at another message's `:id` (nil at the root); the client rebuilds the
+   branch tree from it, treating the newest of a set of sibling replies as the
+   current one. Extra chat-payload keys vary by `:type` and are left unconstrained."
+  [:map
+   [:id                :string]
+   [:parent_message_id [:maybe :string]]
+   [:role              [:enum "user" "agent"]]
+   [:type              :string]])
+
 (def ^:private ConversationDetail
   "Schema for full conversation detail response."
   [:map
@@ -109,7 +120,7 @@
    [:total_tokens    ms/IntGreaterThanOrEqualToZero]
    [:profile_id      [:maybe :string]]
    [:slack_permalink [:maybe :string]]
-   [:chat_messages   [:sequential :map]]
+   [:messages        [:sequential ConversationMessage]]
    [:queries         [:sequential GeneratedQuery]]
    [:search_count    ms/IntGreaterThanOrEqualToZero]
    [:query_count     ms/IntGreaterThanOrEqualToZero]

--- a/enterprise/backend/src/metabase_enterprise/metabot_analytics/conversations.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_analytics/conversations.clj
@@ -84,9 +84,7 @@
    "ip_address"        [:c.ip_address]})
 
 (def ^:private list-query
-  "HoneySQL query that selects one row per conversation with its aggregate message
-   stats. Counts every message, including soft-deleted regenerated attempts.
-   Filters, sorting, and paging are applied by [[list-conversations]]."
+  "Conversation rows with aggregate stats, including deleted attempts."
   {:select    [:c.*
                [[:count :m.id] :message_count]
                [[:count [:case [:= :m.role "user"] 1]] :user_message_count]
@@ -223,8 +221,7 @@
     (t2/hydrate rows :user)))
 
 (defn fetch-conversation-detail
-  "Fetch a conversation with its user info, flat message list, generated queries,
-  and user feedback. 404s if no conversation matches `conversation-id`."
+  "Fetch a conversation detail or throw a 404."
   [conversation-id]
   (let [conversation (t2/select-one :model/MetabotConversation :id conversation-id)]
     (api/check-404 conversation)

--- a/enterprise/backend/src/metabase_enterprise/metabot_analytics/conversations.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_analytics/conversations.clj
@@ -84,24 +84,20 @@
    "ip_address"        [:c.ip_address]})
 
 (def ^:private list-query
-  "HoneySQL query that selects one row per conversation with the aggregate
-   message stats the frontend needs. Filters, sorting, and paging are applied
-   by [[list-conversations]]."
+  "HoneySQL query that selects one row per conversation with its aggregate message
+   stats. Counts every message, including soft-deleted regenerated attempts.
+   Filters, sorting, and paging are applied by [[list-conversations]]."
   {:select    [:c.*
                [[:count :m.id] :message_count]
                [[:count [:case [:= :m.role "user"] 1]] :user_message_count]
                [[:count [:case [:= :m.role "assistant"] 1]] :assistant_message_count]
                [[:coalesce [:sum :m.total_tokens] 0] :total_tokens]
                [[:max :m.created_at] :last_message_at]
-               ;; First assistant message's profile_id, matching the
-               ;; `v_metabot_conversations` analytics view. User messages carry
-               ;; a placeholder `profile_id` and are excluded.
                [{:select   [:mm.profile_id]
                  :from     [[:metabot_message :mm]]
                  :where    [:and
                             [:= :mm.conversation_id :c.id]
-                            [:= :mm.role "assistant"]
-                            [:= :mm.deleted_at nil]]
+                            [:= :mm.role "assistant"]]
                  :order-by [[:mm.created_at :asc] [:mm.id :asc]]
                  :limit    1}
                 :profile_id]
@@ -117,9 +113,7 @@
                  0]
                 :cache_read_tokens]]
    :from      [[:metabot_conversation :c]]
-   :left-join [[:metabot_message :m] [:and
-                                      [:= :m.conversation_id :c.id]
-                                      [:= :m.deleted_at nil]]
+   :left-join [[:metabot_message :m] [:= :m.conversation_id :c.id]
                [:core_user :u]       [:= :u.id :c.user_id]]
    :group-by  [:c.id]})
 
@@ -156,8 +150,7 @@
   (let [conversation-ids (map :id rows)
         messages-by-conv (when (seq conversation-ids)
                            (->> (t2/select [:model/MetabotMessage :conversation_id :data :data_version]
-                                           :conversation_id [:in conversation-ids]
-                                           {:where [:= :deleted_at nil]})
+                                           :conversation_id [:in conversation-ids])
                                 (group-by :conversation_id)))]
     (map (fn [row]
            (let [msgs (get messages-by-conv (:id row) [])]
@@ -230,31 +223,28 @@
     (t2/hydrate rows :user)))
 
 (defn fetch-conversation-detail
-  "Fetch a conversation with its user info, the frontend-ready flattened
-   chat messages, the queries the bot generated, and any user-submitted feedback.
-   404s via `api/check-404` if no conversation matches `conversation-id`."
+  "Fetch a conversation with its user info, flat message list, generated queries,
+  and user feedback. 404s if no conversation matches `conversation-id`."
   [conversation-id]
   (let [conversation (t2/select-one :model/MetabotConversation :id conversation-id)]
     (api/check-404 conversation)
-    (let [messages (t2/select :model/MetabotMessage
-                              :conversation_id conversation-id
-                              {:where    [:= :deleted_at nil]
-                               :order-by [[:created_at :asc] [:id :asc]]})
-          hydrated (t2/hydrate conversation :user)]
+    (let [all-messages (t2/select :model/MetabotMessage
+                                  :conversation_id conversation-id
+                                  {:order-by [[:created_at :asc] [:id :asc]]})
+          hydrated     (t2/hydrate conversation :user)]
       {:conversation_id (:id conversation)
        :created_at      (:created_at conversation)
        :summary         (:summary conversation)
        :user            (trim-user (:user hydrated))
-       :message_count   (count messages)
-       :total_tokens    (transduce (keep :total_tokens) + 0 messages)
-       :profile_id      (some #(when (= :assistant (:role %)) (:profile_id %)) messages)
+       :message_count   (count all-messages)
+       :total_tokens    (transduce (keep :total_tokens) + 0 all-messages)
+       :profile_id      (some #(when (= :assistant (:role %)) (:profile_id %)) all-messages)
        :slack_permalink (slack-permalink conversation)
-       :chat_messages   (metabot-persistence/messages->chat-messages
-                         messages {:include-errored? true})
-       :queries         (analytics.queries/messages->generated-queries messages)
-       :search_count    (analytics.queries/count-tool-invocations messages "search")
+       :messages        (metabot-persistence/messages->flat-messages all-messages)
+       :queries         (analytics.queries/messages->generated-queries all-messages)
+       :search_count    (analytics.queries/count-tool-invocations all-messages "search")
        :query_count     (analytics.queries/count-tool-invocations
-                         messages metabot.tools/query-generation-tool-names)
+                         all-messages metabot.tools/query-generation-tool-names)
        :ip_address           (:ip_address conversation)
        :embedding_hostname   (:embedding_hostname conversation)
        :embedding_path       (:embedding_path conversation)

--- a/enterprise/backend/src/metabase_enterprise/metabot_analytics/conversations.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_analytics/conversations.clj
@@ -237,7 +237,8 @@
        :total_tokens    (transduce (keep :total_tokens) + 0 all-messages)
        :profile_id      (some #(when (= :assistant (:role %)) (:profile_id %)) all-messages)
        :slack_permalink (slack-permalink conversation)
-       :messages        (metabot-persistence/messages->flat-messages all-messages)
+       :messages        (metabot-persistence/messages->flat-messages
+                         all-messages {:include-rewound-errors? true})
        :queries         (analytics.queries/messages->generated-queries all-messages)
        :search_count    (analytics.queries/count-tool-invocations all-messages "search")
        :query_count     (analytics.queries/count-tool-invocations

--- a/enterprise/backend/test/metabase_enterprise/metabot_analytics/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_analytics/api_test.clj
@@ -21,7 +21,8 @@
                 ip-address (assoc :ip_address ip-address))))
 
 (defn- insert-message!
-  [{:keys [conversation-id created-at role profile-id total-tokens data data-version deleted-at]
+  [{:keys [conversation-id created-at role profile-id total-tokens data data-version
+           deleted-at external-id finished in-flight]
     :or   {data-version 2}}]
   (first (t2/insert-returning-pks!
           :model/MetabotMessage
@@ -31,9 +32,11 @@
                    :total_tokens    total-tokens
                    :data            data
                    :data_version    data-version
-                   :external_id     (str (random-uuid))}
-            created-at (assoc :created_at created-at)
-            deleted-at (assoc :deleted_at deleted-at)))))
+                   :external_id     (or external-id (str (random-uuid)))}
+            created-at       (assoc :created_at created-at)
+            deleted-at       (assoc :deleted_at deleted-at)
+            (some? finished) (assoc :finished finished)
+            in-flight        (assoc :finished nil)))))
 
 (defn- insert-usage!
   "Insert an `ai_usage_log` row for a conversation. `cache-read-tokens` may be
@@ -47,13 +50,6 @@
                        :completion_tokens 1
                        :total_tokens      2}
                 cache-read-tokens (assoc :cache_read_tokens cache-read-tokens))))
-
-(defn- delete-conversations!
-  "Delete seeded conversations and their `ai_usage_log` rows (no FK links the
-   two tables, so usage rows must be removed explicitly)."
-  [conversation-ids]
-  (t2/delete! :model/AiUsageLog {:where [:in :conversation_id (vec conversation-ids)]})
-  (t2/delete! :model/MetabotConversation {:where [:in :id (vec conversation-ids)]}))
 
 (defn- insert-feedback!
   [{:keys [message-id user-id positive issue-type freeform created-at updated-at]}]
@@ -89,7 +85,7 @@
             jan-3         (offset-date-time "2026-01-03T00:00:00Z")
             jan-4         (offset-date-time "2026-01-04T00:00:00Z")
             jan-5         (offset-date-time "2026-01-05T00:00:00Z")]
-        (try
+        (mt/with-model-cleanup [:model/MetabotMessage :model/AiUsageLog [:model/MetabotConversation :created_at]]
           (insert-conversation! {:conversation-id convo-1
                                  :user-id         test-user-id
                                  :created-at      jan-1
@@ -149,9 +145,7 @@
                   :response-path response-path
                   :convo-1       convo-1
                   :convo-2       convo-2
-                  :convo-3       convo-3})
-          (finally
-            (delete-conversations! [convo-1 convo-2 convo-3])))))))
+                  :convo-3       convo-3}))))))
 
 (deftest list-conversations-requires-superuser-test
   (mt/with-premium-features #{:audit-app}
@@ -171,11 +165,12 @@
         (is (= 50 (:limit response)))
         (is (= 0 (:offset response)))
         (is (= [convo-3 convo-2 convo-1] conversation-ids))
-        (is (nil? (:profile_id convo-3-response)))
-        (is (= 0 (:message_count convo-3-response)))
-        (is (= 0 (:assistant_message_count convo-3-response)))
-        (is (= 0 (:total_tokens convo-3-response)))
-        (is (= 0 (:cache_read_tokens convo-3-response)))
+        (testing "a soft-deleted / regenerated agent response still counts as spend"
+          (is (= "deleted-model" (:profile_id convo-3-response)))
+          (is (= 1 (:message_count convo-3-response)))
+          (is (= 1 (:assistant_message_count convo-3-response)))
+          (is (= 99 (:total_tokens convo-3-response)))
+          (is (= 0 (:cache_read_tokens convo-3-response))))
         (is (= {:conversation_id         convo-1
                 :summary                 "First conversation"
                 :message_count           2
@@ -202,6 +197,41 @@
                (select-keys convo-2-response [:conversation_id :message_count :user_message_count
                                               :assistant_message_count :total_tokens :cache_read_tokens
                                               :profile_id])))))))
+
+(deftest list-and-detail-agree-for-regenerated-conversation-test
+  (mt/with-premium-features #{:audit-app}
+    (testing "the list summary and the detail view report identical spend counts for a regenerated conversation"
+      (mt/with-temp [:model/User {owner-id :id} {}]
+        (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
+          (let [conversation-id (str (random-uuid))
+                t    #(offset-date-time (format "2026-01-0%dT00:00:00Z" %))
+                msg! #(insert-message! (assoc % :conversation-id conversation-id))]
+            (insert-conversation! {:conversation-id conversation-id :user-id owner-id
+                                   :created-at (t 1) :summary "Regeneration parity"})
+            (msg! {:created-at (t 1) :role "user" :profile-id "ignored-user-profile" :total-tokens 2
+                   :data [{:type "text" :text "find orders"}]})
+            ;; regenerated-away attempt that ran a search before being replaced
+            (msg! {:created-at (t 2) :role "assistant" :profile-id "internal" :total-tokens 10 :deleted-at (t 3)
+                   :data [{:type "text" :text "first"}
+                          {:type "tool-search" :toolCallId "s1" :state "output-available"
+                           :input {} :output {:output "results"}}]})
+            ;; the live reply that replaced it
+            (msg! {:created-at (t 3) :role "assistant" :profile-id "internal" :total-tokens 20
+                   :data [{:type "text" :text "kept"}]})
+            (let [summary (find-conversation
+                           (:data (mt/user-http-request :crowberto :get 200
+                                                        (str "ee/metabot-analytics/conversations?user_id=" owner-id)))
+                           conversation-id)
+                  detail  (mt/user-http-request :crowberto :get 200
+                                                (format "ee/metabot-analytics/conversations/%s" conversation-id))]
+              (is (some? summary) "the conversation appears in the list")
+              (doseq [k [:message_count :total_tokens :search_count :query_count]]
+                (is (= (get detail k) (get summary k))
+                    (format "%s must agree between list and detail" (name k))))
+              (testing "and the counts include the regenerated attempt"
+                (is (= 3 (:message_count detail)))
+                (is (= 32 (:total_tokens detail)) "2 + 10 (regenerated) + 20 (kept)")
+                (is (= 1 (:search_count detail)) "the search from the regenerated attempt still counts")))))))))
 
 (deftest list-conversations-pagination-test
   (with-list-conversations-fixture!
@@ -265,7 +295,7 @@
                                               :profile-id      profile-id
                                               :total-tokens    tokens
                                               :data            [{:type "text" :text "hi"}]}))]
-        (try
+        (mt/with-model-cleanup [:model/MetabotMessage :model/AiUsageLog [:model/MetabotConversation :created_at]]
           (insert-conversation! {:conversation-id convo-a :user-id user-a
                                  :created-at jan-1 :ip-address "10.0.0.3"})
           (insert-conversation! {:conversation-id convo-m :user-id user-m
@@ -285,9 +315,7 @@
           (thunk {:response-path response-path
                   :convo-a       convo-a
                   :convo-m       convo-m
-                  :convo-z       convo-z})
-          (finally
-            (delete-conversations! [convo-a convo-m convo-z])))))))
+                  :convo-z       convo-z}))))))
 
 (deftest list-conversations-sort-test
   (with-sortable-conversations-fixture!
@@ -351,7 +379,7 @@
       (let [convo-1 (str (random-uuid))
             convo-2 (str (random-uuid))
             convo-3 (str (random-uuid))]
-        (try
+        (mt/with-model-cleanup [[:model/MetabotConversation :created_at]]
           (insert-conversation! {:conversation-id convo-1 :user-id user-a
                                  :created-at (offset-date-time "2026-01-01T00:00:00Z")})
           (insert-conversation! {:conversation-id convo-2 :user-id user-a
@@ -364,9 +392,7 @@
                   :user-a-id   user-a
                   :convo-1     convo-1
                   :convo-2     convo-2
-                  :convo-3     convo-3})
-          (finally
-            (delete-conversations! [convo-1 convo-2 convo-3])))))))
+                  :convo-3     convo-3}))))))
 
 (deftest list-conversations-filter-test
   (with-filters-fixture!
@@ -405,7 +431,7 @@
             user-id         (mt/user->id :crowberto)
             jan-1           (offset-date-time "2026-01-01T00:00:00Z")
             jan-2           (offset-date-time "2026-01-02T00:00:00Z")]
-        (try
+        (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
           (insert-conversation! {:conversation-id conversation-id
                                  :user-id         user-id
                                  :created-at      jan-1
@@ -434,13 +460,132 @@
             (is (nil? (:slack_permalink response)))
             (is (= "internal" (:profile_id response))
                 "profile_id comes from the first assistant message, ignoring user-message placeholders")
-            (is (= 2 (count (:chat_messages response))))
+            (is (= 2 (:message_count response)))
             (is (= [] (:feedback response)))
-            (let [{:keys [role type externalId]} (last (:chat_messages response))]
-              (is (= ["agent" "text"] [role type]))
-              (is (string? externalId))))
-          (finally
-            (delete-conversations! [conversation-id])))))))
+            (is (= 2 (count (:messages response)))
+                "one user prompt + one assistant reply, as flat single-level chat messages")
+            (let [[user-msg asst-msg] (:messages response)]
+              (is (= ["user" "text" "hello"] [(:role user-msg) (:type user-msg) (:message user-msg)]))
+              (is (nil? (:parent_message_id user-msg)) "the root prompt has no parent")
+              (is (not (contains? asst-msg :kept))
+                  "no :kept on the wire; the client derives the current path from sibling order")
+              (is (= ["agent" "text"] [(:role asst-msg) (:type asst-msg)]))
+              (is (= (:id user-msg) (:parent_message_id asst-msg))
+                  "the reply points at its prompt's message id")
+              (is (string? (:externalId asst-msg)) "the agent message keeps its feedback external id"))))))))
+
+(defn- with-detail-conversation!
+  "Seed one audit-app conversation owned by :crowberto and invoke `thunk` with a
+  map of helpers for filling it in and reading it back:
+  `:conversation-id`; `:user-id` (:crowberto); `:t`, a jan-day (1-9) →
+  OffsetDateTime for ordering rows; `:msg!`, which inserts a message into the
+  conversation and returns its pk; and `:detail!`, which GETs and returns the
+  detail response. Rows are cleaned up automatically."
+  [thunk]
+  (mt/with-premium-features #{:audit-app}
+    (let [conversation-id (str (random-uuid))
+          user-id         (mt/user->id :crowberto)
+          t               #(offset-date-time (format "2026-01-0%dT00:00:00Z" %))
+          msg!            #(insert-message! (assoc % :conversation-id conversation-id))]
+      (mt/with-model-cleanup [:model/MetabotFeedback :model/MetabotMessage [:model/MetabotConversation :created_at]]
+        (insert-conversation! {:conversation-id conversation-id :user-id user-id :created-at (t 1)})
+        (thunk {:conversation-id conversation-id
+                :user-id         user-id
+                :t               t
+                :msg!            msg!
+                :detail!         #(mt/user-http-request :crowberto :get 200
+                                                        (format "ee/metabot-analytics/conversations/%s" conversation-id))})))))
+
+(deftest get-conversation-detail-attempts-test
+  (testing "a prompt's regenerated attempts surface as flat, chronologically ordered sibling messages"
+    (with-detail-conversation!
+      (fn [{:keys [msg! t detail!]}]
+        (msg! {:created-at (t 1) :role "user" :profile-id "p" :total-tokens 2 :data [{:type "text" :text "count the orders"}]})
+        (msg! {:created-at (t 2) :role "assistant" :profile-id "internal" :total-tokens 10 :deleted-at (t 4) :data [{:type "text" :text "first try"}]})
+        (msg! {:created-at (t 3) :role "assistant" :profile-id "internal" :total-tokens 20 :deleted-at (t 4) :data [{:type "text" :text "second try"}]})
+        (msg! {:created-at (t 4) :role "assistant" :profile-id "internal" :total-tokens 30 :data [{:type "text" :text "kept answer"}]})
+        (let [response  (detail!)
+              messages  (:messages response)
+              prompt    (first (filter #(= "user" (:role %)) messages))
+              attempts  (filter #(= "agent" (:role %)) messages)]
+          (is (= 4 (count messages)) "one prompt + three attempts, as flat single-level chat messages")
+          (is (= 3 (count attempts)))
+          (is (= ["first try" "second try" "kept answer"] (map :message attempts))
+              "attempts are ordered chronologically, so the newest (kept) reply is last")
+          (is (every? #(= (:id prompt) (:parent_message_id %)) attempts)
+              "every attempt is a sibling child of the one prompt")
+          (is (= 62 (:total_tokens response)) "totals include the discarded attempts' tokens (2 + 10 + 20 + 30)")
+          (is (= 4 (:message_count response))))))))
+
+(deftest get-conversation-detail-parent-pointers-test
+  (testing "a follow-up prompt points at the kept (live) reply, not a regenerated-away one"
+    (with-detail-conversation!
+      (fn [{:keys [msg! t detail!]}]
+        (msg! {:created-at (t 1) :role "user" :profile-id "p" :total-tokens 1 :data [{:type "text" :text "q1"}]})
+        (msg! {:created-at (t 2) :role "assistant" :profile-id "internal" :total-tokens 1 :deleted-at (t 3) :data [{:type "text" :text "discarded"}]})
+        (msg! {:created-at (t 3) :role "assistant" :profile-id "internal" :total-tokens 1 :data [{:type "text" :text "kept"}]})
+        (msg! {:created-at (t 4) :role "user" :profile-id "p" :total-tokens 1 :data [{:type "text" :text "q2"}]})
+        (msg! {:created-at (t 5) :role "assistant" :profile-id "internal" :total-tokens 1 :data [{:type "text" :text "a2"}]})
+        (let [messages (:messages (detail!))
+              by-text  (fn [txt] (first (filter #(= txt (:message %)) messages)))
+              q1 (by-text "q1"), kept (by-text "kept"), q2 (by-text "q2")]
+          (is (nil? (:parent_message_id q1)) "the first prompt is the root")
+          (is (= (:id q1) (:parent_message_id kept)) "the kept reply points at its prompt")
+          (is (= (:id kept) (:parent_message_id q2))
+              "the follow-up prompt branches off the kept reply, not the discarded one"))))))
+
+(deftest get-conversation-detail-turn-with-no-live-reply-test
+  (testing "a turn whose only reply was soft-deleted still keeps the following turn on the path"
+    (with-detail-conversation!
+      (fn [{:keys [msg! t detail!]}]
+        (msg! {:created-at (t 1) :role "user" :profile-id "p" :total-tokens 1 :data [{:type "text" :text "q1"}]})
+        ;; the only reply to q1 is soft-deleted, so this turn has no live reply
+        (msg! {:created-at (t 2) :role "assistant" :profile-id "internal" :total-tokens 1 :deleted-at (t 3) :data [{:type "text" :text "orphaned"}]})
+        (msg! {:created-at (t 4) :role "user" :profile-id "p" :total-tokens 1 :data [{:type "text" :text "q2"}]})
+        (msg! {:created-at (t 5) :role "assistant" :profile-id "internal" :total-tokens 1 :data [{:type "text" :text "a2"}]})
+        (let [messages (:messages (detail!))
+              by-text  (fn [txt] (first (filter #(= txt (:message %)) messages)))
+              q1 (by-text "q1"), q2 (by-text "q2")]
+          (is (some? q2) "the follow-up turn is not dropped")
+          (is (= (:id q1) (:parent_message_id q2))
+              "the follow-up prompt falls back to its predecessor prompt, not the previous turn"))))))
+
+(deftest get-conversation-detail-in-flight-attempt-test
+  (testing "a still-streaming reply surfaces as an in-progress message"
+    (with-detail-conversation!
+      (fn [{:keys [msg! detail!]}]
+        ;; No :created-at: the placeholder must be "just now" (within the grace
+        ;; window) to read as a live in-flight stream rather than an aborted turn.
+        (msg! {:role "user" :profile-id "p" :total-tokens 3 :data [{:type "text" :text "still thinking?"}]})
+        (msg! {:role "assistant" :profile-id "internal" :total-tokens 0 :data [] :in-flight true})
+        (let [response  (detail!)
+              attempts  (filter #(= "agent" (:role %)) (:messages response))]
+          (is (= 2 (count (:messages response))))
+          (is (= 1 (count attempts)))
+          (is (= "turn_in_progress" (:type (first attempts)))
+              "a still-streaming placeholder renders as an in-progress message")
+          (is (= 2 (:message_count response))
+              "every row counts (prompt + placeholder), so the count stays stable as the turn finishes"))))))
+
+(deftest get-conversation-detail-feedback-on-discarded-attempt-test
+  (testing "feedback on a regenerated-away attempt still resolves to that attempt's message"
+    (with-detail-conversation!
+      (fn [{:keys [msg! t user-id detail!]}]
+        (let [discarded-ext (str (random-uuid))]
+          (msg! {:created-at (t 1) :role "user" :profile-id "p" :total-tokens 2 :data [{:type "text" :text "help"}]})
+          (let [discarded-id (msg! {:created-at (t 2) :role "assistant" :profile-id "internal" :total-tokens 10
+                                    :deleted-at (t 3) :external-id discarded-ext :data [{:type "text" :text "thumbs-downed answer"}]})]
+            (msg! {:created-at (t 3) :role "assistant" :profile-id "internal" :total-tokens 20 :data [{:type "text" :text "kept answer"}]})
+            (insert-feedback! {:message-id discarded-id :user-id user-id :positive false
+                               :issue-type "incorrect" :freeform "wrong table" :created-at (t 2) :updated-at (t 2)})
+            (let [response     (detail!)
+                  feedback     (:feedback response)
+                  attempt-exts (->> (:messages response) (filter #(= "agent" (:role %))) (map :externalId) set)]
+              (is (= 1 (count feedback)))
+              (is (= discarded-ext (:external_id (first feedback)))
+                  "feedback carries the discarded attempt's external_id")
+              (is (contains? attempt-exts discarded-ext)
+                  "the discarded attempt is present in the messages so the FE can resolve the feedback"))))))))
 
 (deftest get-conversation-detail-queries-test
   (mt/with-premium-features #{:audit-app}
@@ -451,7 +596,7 @@
             jan-2           (offset-date-time "2026-01-02T00:00:00Z")
             jan-3           (offset-date-time "2026-01-03T00:00:00Z")
             sql             "SELECT * FROM orders"]
-        (try
+        (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
           (insert-conversation! {:conversation-id conversation-id
                                  :user-id         user-id
                                  :created-at      jan-1
@@ -505,9 +650,7 @@
               (is (nil?                  (:mbql q)))
               (is (= (mt/id)             (:database_id q)))
               ;; Tables extraction goes through the real Macaw path — sample data has an "orders" table.
-              (is (contains? (set (:tables q)) "orders"))))
-          (finally
-            (delete-conversations! [conversation-id])))))))
+              (is (contains? (set (:tables q)) "orders")))))))))
 
 (defn- search-part
   [call-id]
@@ -532,7 +675,7 @@
             jan-1         (offset-date-time "2026-02-01T00:00:00Z")
             jan-2         (offset-date-time "2026-02-02T00:00:00Z")
             jan-3         (offset-date-time "2026-02-03T00:00:00Z")]
-        (try
+        (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
           (insert-conversation! {:conversation-id convo-none
                                  :user-id         test-user-id
                                  :created-at      jan-1
@@ -581,9 +724,7 @@
           (thunk {:test-user-id  test-user-id
                   :convo-none    convo-none
                   :convo-two     convo-two
-                  :convo-errored convo-errored})
-          (finally
-            (delete-conversations! [convo-none convo-two convo-errored])))))))
+                  :convo-errored convo-errored}))))))
 
 (deftest search-count-test
   (with-search-count-fixture!
@@ -632,7 +773,7 @@
             mar-1       (offset-date-time "2026-03-10T00:00:00Z")
             mar-2       (offset-date-time "2026-03-11T00:00:00Z")
             mar-3       (offset-date-time "2026-03-12T00:00:00Z")]
-        (try
+        (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
           (insert-conversation! {:conversation-id convo-none
                                  :user-id         test-user-id
                                  :created-at      mar-1
@@ -680,9 +821,7 @@
           (thunk {:test-user-id test-user-id
                   :convo-none   convo-none
                   :convo-mixed  convo-mixed
-                  :convo-edits  convo-edits})
-          (finally
-            (delete-conversations! [convo-none convo-mixed convo-edits])))))))
+                  :convo-edits  convo-edits}))))))
 
 (deftest query-count-test
   (with-query-count-fixture!
@@ -706,7 +845,7 @@
       (let [conversation-id (str (random-uuid))
             user-id         (mt/user->id :crowberto)
             permalink       "https://example.slack.com/archives/C123/p1712785577123456"]
-        (try
+        (mt/with-model-cleanup [[:model/MetabotConversation :created_at]]
           (insert-conversation! {:conversation-id  conversation-id
                                  :user-id          user-id
                                  :summary          "Slack conversation"
@@ -719,9 +858,7 @@
                                                                             permalink)]
             (let [response (mt/user-http-request :crowberto :get 200
                                                  (format "ee/metabot-analytics/conversations/%s" conversation-id))]
-              (is (= permalink (:slack_permalink response)))))
-          (finally
-            (delete-conversations! [conversation-id])))))))
+              (is (= permalink (:slack_permalink response))))))))))
 
 (defn- with-ip-address-fixture!
   "Seed conversations with varying IP-address state so we can assert both list
@@ -737,7 +874,7 @@
             jan-1       (offset-date-time "2026-03-01T00:00:00Z")
             jan-2       (offset-date-time "2026-03-02T00:00:00Z")
             jan-3       (offset-date-time "2026-03-03T00:00:00Z")]
-        (try
+        (mt/with-model-cleanup [[:model/MetabotConversation :created_at]]
           (insert-conversation! {:conversation-id convo-web
                                  :user-id         test-user-id
                                  :created-at      jan-1
@@ -757,9 +894,7 @@
           (thunk {:test-user-id test-user-id
                   :convo-web    convo-web
                   :convo-slack  convo-slack
-                  :convo-null   convo-null})
-          (finally
-            (delete-conversations! [convo-web convo-slack convo-null])))))))
+                  :convo-null   convo-null}))))))
 
 (deftest ^:parallel get-conversation-detail-requires-superuser-test
   (mt/with-premium-features #{:audit-app}
@@ -784,7 +919,7 @@
             jan-1           (offset-date-time "2026-04-01T00:00:00Z")
             jan-2           (offset-date-time "2026-04-02T00:00:00Z")
             jan-3           (offset-date-time "2026-04-03T00:00:00Z")]
-        (try
+        (mt/with-model-cleanup [:model/MetabotFeedback :model/MetabotMessage [:model/MetabotConversation :created_at]]
           (insert-conversation! {:conversation-id conversation-id
                                  :user-id         user-id
                                  :created-at      jan-1
@@ -821,9 +956,7 @@
                        :first_name "Crowberto"
                        :last_name  "Corv"}]
                      (map #(select-keys (:user %) [:id :email :first_name :last_name]) feedback))
-                  "submitter is hydrated on each feedback row")))
-          (finally
-            (delete-conversations! [conversation-id])))))))
+                  "submitter is hydrated on each feedback row"))))))))
 
 (deftest get-conversation-detail-feedback-multi-user-test
   (mt/with-premium-features #{:audit-app}
@@ -836,7 +969,7 @@
               apr-1           (offset-date-time "2026-04-10T00:00:00Z")
               apr-2           (offset-date-time "2026-04-11T00:00:00Z")
               apr-3           (offset-date-time "2026-04-12T00:00:00Z")]
-          (try
+          (mt/with-model-cleanup [:model/MetabotFeedback :model/MetabotMessage [:model/MetabotConversation :created_at]]
             (insert-conversation! {:conversation-id conversation-id
                                    :user-id         owner-id
                                    :created-at      apr-1
@@ -872,9 +1005,7 @@
                        (select-keys (:user (get by-user participant-id)) [:id :email :first_name :last_name])))
                 (is (true? (:positive (get by-user owner-id))))
                 (is (false? (:positive (get by-user participant-id))))
-                (is (= "not-factual" (:issue_type (get by-user participant-id))))))
-            (finally
-              (delete-conversations! [conversation-id]))))))))
+                (is (= "not-factual" (:issue_type (get by-user participant-id))))))))))))
 
 (deftest ip-address-test
   (with-ip-address-fixture!

--- a/enterprise/backend/test/metabase_enterprise/metabot_analytics/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_analytics/api_test.clj
@@ -22,7 +22,8 @@
 
 (defn- insert-message!
   [{:keys [conversation-id created-at role profile-id total-tokens data data-version
-           deleted-at external-id finished in-flight]
+           deleted-at external-id finished]
+    :as   options
     :or   {data-version 2}}]
   (first (t2/insert-returning-pks!
           :model/MetabotMessage
@@ -35,8 +36,7 @@
                    :external_id     (or external-id (str (random-uuid)))}
             created-at       (assoc :created_at created-at)
             deleted-at       (assoc :deleted_at deleted-at)
-            (some? finished) (assoc :finished finished)
-            in-flight        (assoc :finished nil)))))
+            (contains? options :finished) (assoc :finished finished)))))
 
 (defn- insert-usage!
   "Insert an `ai_usage_log` row for a conversation. `cache-read-tokens` may be
@@ -50,6 +50,11 @@
                        :completion_tokens 1
                        :total_tokens      2}
                 cache-read-tokens (assoc :cache_read_tokens cache-read-tokens))))
+
+(defn- delete-conversations!
+  [conversation-ids]
+  (t2/delete! :model/AiUsageLog {:where [:in :conversation_id (vec conversation-ids)]})
+  (t2/delete! :model/MetabotConversation {:where [:in :id (vec conversation-ids)]}))
 
 (defn- insert-feedback!
   [{:keys [message-id user-id positive issue-type freeform created-at updated-at]}]
@@ -85,7 +90,7 @@
             jan-3         (offset-date-time "2026-01-03T00:00:00Z")
             jan-4         (offset-date-time "2026-01-04T00:00:00Z")
             jan-5         (offset-date-time "2026-01-05T00:00:00Z")]
-        (mt/with-model-cleanup [:model/MetabotMessage :model/AiUsageLog [:model/MetabotConversation :created_at]]
+        (try
           (insert-conversation! {:conversation-id convo-1
                                  :user-id         test-user-id
                                  :created-at      jan-1
@@ -145,7 +150,9 @@
                   :response-path response-path
                   :convo-1       convo-1
                   :convo-2       convo-2
-                  :convo-3       convo-3}))))))
+                  :convo-3       convo-3})
+          (finally
+            (delete-conversations! [convo-1 convo-2 convo-3])))))))
 
 (deftest list-conversations-requires-superuser-test
   (mt/with-premium-features #{:audit-app}
@@ -200,38 +207,50 @@
 
 (deftest list-and-detail-agree-for-regenerated-conversation-test
   (mt/with-premium-features #{:audit-app}
-    (testing "the list summary and the detail view report identical spend counts for a regenerated conversation"
+    (testing "the list summary and detail report the same counts for a regenerated conversation"
       (mt/with-temp [:model/User {owner-id :id} {}]
-        (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
-          (let [conversation-id (str (random-uuid))
-                t    #(offset-date-time (format "2026-01-0%dT00:00:00Z" %))
-                msg! #(insert-message! (assoc % :conversation-id conversation-id))]
-            (insert-conversation! {:conversation-id conversation-id :user-id owner-id
-                                   :created-at (t 1) :summary "Regeneration parity"})
-            (msg! {:created-at (t 1) :role "user" :profile-id "ignored-user-profile" :total-tokens 2
-                   :data [{:type "text" :text "find orders"}]})
-            ;; regenerated-away attempt that ran a search before being replaced
-            (msg! {:created-at (t 2) :role "assistant" :profile-id "internal" :total-tokens 10 :deleted-at (t 3)
-                   :data [{:type "text" :text "first"}
-                          {:type "tool-search" :toolCallId "s1" :state "output-available"
-                           :input {} :output {:output "results"}}]})
-            ;; the live reply that replaced it
-            (msg! {:created-at (t 3) :role "assistant" :profile-id "internal" :total-tokens 20
-                   :data [{:type "text" :text "kept"}]})
+        (let [conversation-id (str (random-uuid))
+              day             #(offset-date-time (format "2026-01-0%dT00:00:00Z" %))
+              insert!         #(insert-message! (assoc % :conversation-id conversation-id))]
+          (try
+            (insert-conversation! {:conversation-id conversation-id
+                                   :user-id         owner-id
+                                   :created-at      (day 1)
+                                   :summary         "Regeneration parity"})
+            (insert! {:created-at (day 1)
+                      :role "user"
+                      :profile-id "ignored-user-profile"
+                      :total-tokens 2
+                      :data [{:type "text" :text "find orders"}]})
+            (insert! {:created-at (day 2)
+                      :role "assistant"
+                      :profile-id "internal"
+                      :total-tokens 10
+                      :deleted-at (day 3)
+                      :data [{:type "text" :text "first"}
+                             {:type "tool-search"
+                              :toolCallId "s1"
+                              :state "output-available"
+                              :input {}
+                              :output {:output "results"}}]})
+            (insert! {:created-at (day 3)
+                      :role "assistant"
+                      :profile-id "internal"
+                      :total-tokens 20
+                      :data [{:type "text" :text "kept"}]})
             (let [summary (find-conversation
                            (:data (mt/user-http-request :crowberto :get 200
                                                         (str "ee/metabot-analytics/conversations?user_id=" owner-id)))
                            conversation-id)
                   detail  (mt/user-http-request :crowberto :get 200
                                                 (format "ee/metabot-analytics/conversations/%s" conversation-id))]
-              (is (some? summary) "the conversation appears in the list")
+              (is (some? summary))
               (doseq [k [:message_count :total_tokens :search_count :query_count]]
-                (is (= (get detail k) (get summary k))
-                    (format "%s must agree between list and detail" (name k))))
-              (testing "and the counts include the regenerated attempt"
-                (is (= 3 (:message_count detail)))
-                (is (= 32 (:total_tokens detail)) "2 + 10 (regenerated) + 20 (kept)")
-                (is (= 1 (:search_count detail)) "the search from the regenerated attempt still counts")))))))))
+                (is (= (get detail k) (get summary k))))
+              (is (= [3 32 1]
+                     ((juxt :message_count :total_tokens :search_count) detail))))
+            (finally
+              (delete-conversations! [conversation-id]))))))))
 
 (deftest list-conversations-pagination-test
   (with-list-conversations-fixture!
@@ -295,7 +314,7 @@
                                               :profile-id      profile-id
                                               :total-tokens    tokens
                                               :data            [{:type "text" :text "hi"}]}))]
-        (mt/with-model-cleanup [:model/MetabotMessage :model/AiUsageLog [:model/MetabotConversation :created_at]]
+        (try
           (insert-conversation! {:conversation-id convo-a :user-id user-a
                                  :created-at jan-1 :ip-address "10.0.0.3"})
           (insert-conversation! {:conversation-id convo-m :user-id user-m
@@ -315,7 +334,9 @@
           (thunk {:response-path response-path
                   :convo-a       convo-a
                   :convo-m       convo-m
-                  :convo-z       convo-z}))))))
+                  :convo-z       convo-z})
+          (finally
+            (delete-conversations! [convo-a convo-m convo-z])))))))
 
 (deftest list-conversations-sort-test
   (with-sortable-conversations-fixture!
@@ -379,7 +400,7 @@
       (let [convo-1 (str (random-uuid))
             convo-2 (str (random-uuid))
             convo-3 (str (random-uuid))]
-        (mt/with-model-cleanup [[:model/MetabotConversation :created_at]]
+        (try
           (insert-conversation! {:conversation-id convo-1 :user-id user-a
                                  :created-at (offset-date-time "2026-01-01T00:00:00Z")})
           (insert-conversation! {:conversation-id convo-2 :user-id user-a
@@ -392,7 +413,9 @@
                   :user-a-id   user-a
                   :convo-1     convo-1
                   :convo-2     convo-2
-                  :convo-3     convo-3}))))))
+                  :convo-3     convo-3})
+          (finally
+            (delete-conversations! [convo-1 convo-2 convo-3])))))))
 
 (deftest list-conversations-filter-test
   (with-filters-fixture!
@@ -431,7 +454,7 @@
             user-id         (mt/user->id :crowberto)
             jan-1           (offset-date-time "2026-01-01T00:00:00Z")
             jan-2           (offset-date-time "2026-01-02T00:00:00Z")]
-        (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
+        (try
           (insert-conversation! {:conversation-id conversation-id
                                  :user-id         user-id
                                  :created-at      jan-1
@@ -472,120 +495,119 @@
               (is (= ["agent" "text"] [(:role asst-msg) (:type asst-msg)]))
               (is (= (:id user-msg) (:parent_message_id asst-msg))
                   "the reply points at its prompt's message id")
-              (is (string? (:externalId asst-msg)) "the agent message keeps its feedback external id"))))))))
+              (is (string? (:externalId asst-msg)) "the agent message keeps its feedback external id")))
+          (finally
+            (delete-conversations! [conversation-id])))))))
 
 (defn- with-detail-conversation!
-  "Seed one audit-app conversation owned by :crowberto and invoke `thunk` with a
-  map of helpers for filling it in and reading it back:
-  `:conversation-id`; `:user-id` (:crowberto); `:t`, a jan-day (1-9) →
-  OffsetDateTime for ordering rows; `:msg!`, which inserts a message into the
-  conversation and returns its pk; and `:detail!`, which GETs and returns the
-  detail response. Rows are cleaned up automatically."
   [thunk]
   (mt/with-premium-features #{:audit-app}
     (let [conversation-id (str (random-uuid))
           user-id         (mt/user->id :crowberto)
-          t               #(offset-date-time (format "2026-01-0%dT00:00:00Z" %))
-          msg!            #(insert-message! (assoc % :conversation-id conversation-id))]
-      (mt/with-model-cleanup [:model/MetabotFeedback :model/MetabotMessage [:model/MetabotConversation :created_at]]
-        (insert-conversation! {:conversation-id conversation-id :user-id user-id :created-at (t 1)})
-        (thunk {:conversation-id conversation-id
-                :user-id         user-id
-                :t               t
-                :msg!            msg!
-                :detail!         #(mt/user-http-request :crowberto :get 200
-                                                        (format "ee/metabot-analytics/conversations/%s" conversation-id))})))))
+          day             #(offset-date-time (format "2026-01-0%dT00:00:00Z" %))
+          insert!         #(insert-message! (assoc % :conversation-id conversation-id))
+          fetch           #(mt/user-http-request :crowberto :get 200
+                                                 (format "ee/metabot-analytics/conversations/%s" conversation-id))]
+      (try
+        (insert-conversation! {:conversation-id conversation-id :user-id user-id :created-at (day 1)})
+        (thunk {:user-id user-id :day day :insert! insert! :fetch fetch})
+        (finally
+          (delete-conversations! [conversation-id]))))))
+
+(defn- message-by-text
+  [messages text]
+  (or (some #(when (= text (:message %)) %) messages)
+      (throw (ex-info (str "Message not found: " text) {:text text}))))
 
 (deftest get-conversation-detail-attempts-test
   (testing "a prompt's regenerated attempts surface as flat, chronologically ordered sibling messages"
     (with-detail-conversation!
-      (fn [{:keys [msg! t detail!]}]
-        (msg! {:created-at (t 1) :role "user" :profile-id "p" :total-tokens 2 :data [{:type "text" :text "count the orders"}]})
-        (msg! {:created-at (t 2) :role "assistant" :profile-id "internal" :total-tokens 10 :deleted-at (t 4) :data [{:type "text" :text "first try"}]})
-        (msg! {:created-at (t 3) :role "assistant" :profile-id "internal" :total-tokens 20 :deleted-at (t 4) :data [{:type "text" :text "second try"}]})
-        (msg! {:created-at (t 4) :role "assistant" :profile-id "internal" :total-tokens 30 :data [{:type "text" :text "kept answer"}]})
-        (let [response  (detail!)
-              messages  (:messages response)
-              prompt    (first (filter #(= "user" (:role %)) messages))
-              attempts  (filter #(= "agent" (:role %)) messages)]
-          (is (= 4 (count messages)) "one prompt + three attempts, as flat single-level chat messages")
-          (is (= 3 (count attempts)))
-          (is (= ["first try" "second try" "kept answer"] (map :message attempts))
-              "attempts are ordered chronologically, so the newest (kept) reply is last")
-          (is (every? #(= (:id prompt) (:parent_message_id %)) attempts)
-              "every attempt is a sibling child of the one prompt")
-          (is (= 62 (:total_tokens response)) "totals include the discarded attempts' tokens (2 + 10 + 20 + 30)")
-          (is (= 4 (:message_count response))))))))
+      (fn [{:keys [insert! day fetch]}]
+        (insert! {:created-at (day 1) :role "user" :profile-id "p" :total-tokens 2
+                  :data [{:type "text" :text "count the orders"}]})
+        (insert! {:created-at (day 2) :role "assistant" :profile-id "internal" :total-tokens 10
+                  :deleted-at (day 4) :data [{:type "text" :text "first try"}]})
+        (insert! {:created-at (day 3) :role "assistant" :profile-id "internal" :total-tokens 20
+                  :deleted-at (day 4) :data [{:type "text" :text "second try"}]})
+        (insert! {:created-at (day 4) :role "assistant" :profile-id "internal" :total-tokens 30
+                  :data [{:type "text" :text "kept answer"}]})
+        (let [{:keys [messages total_tokens message_count]} (fetch)
+              [prompt & attempts] messages]
+          (is (= ["first try" "second try" "kept answer"] (map :message attempts)))
+          (is (every? #(= (:id prompt) (:parent_message_id %)) attempts))
+          (is (= [62 4] [total_tokens message_count])))))))
 
 (deftest get-conversation-detail-parent-pointers-test
   (testing "a follow-up prompt points at the kept (live) reply, not a regenerated-away one"
     (with-detail-conversation!
-      (fn [{:keys [msg! t detail!]}]
-        (msg! {:created-at (t 1) :role "user" :profile-id "p" :total-tokens 1 :data [{:type "text" :text "q1"}]})
-        (msg! {:created-at (t 2) :role "assistant" :profile-id "internal" :total-tokens 1 :deleted-at (t 3) :data [{:type "text" :text "discarded"}]})
-        (msg! {:created-at (t 3) :role "assistant" :profile-id "internal" :total-tokens 1 :data [{:type "text" :text "kept"}]})
-        (msg! {:created-at (t 4) :role "user" :profile-id "p" :total-tokens 1 :data [{:type "text" :text "q2"}]})
-        (msg! {:created-at (t 5) :role "assistant" :profile-id "internal" :total-tokens 1 :data [{:type "text" :text "a2"}]})
-        (let [messages (:messages (detail!))
-              by-text  (fn [txt] (first (filter #(= txt (:message %)) messages)))
-              q1 (by-text "q1"), kept (by-text "kept"), q2 (by-text "q2")]
-          (is (nil? (:parent_message_id q1)) "the first prompt is the root")
-          (is (= (:id q1) (:parent_message_id kept)) "the kept reply points at its prompt")
-          (is (= (:id kept) (:parent_message_id q2))
-              "the follow-up prompt branches off the kept reply, not the discarded one"))))))
+      (fn [{:keys [insert! day fetch]}]
+        (insert! {:created-at (day 1) :role "user" :profile-id "p" :total-tokens 1
+                  :data [{:type "text" :text "q1"}]})
+        (insert! {:created-at (day 2) :role "assistant" :profile-id "internal" :total-tokens 1
+                  :deleted-at (day 3) :data [{:type "text" :text "discarded"}]})
+        (insert! {:created-at (day 3) :role "assistant" :profile-id "internal" :total-tokens 1
+                  :data [{:type "text" :text "kept"}]})
+        (insert! {:created-at (day 4) :role "user" :profile-id "p" :total-tokens 1
+                  :data [{:type "text" :text "q2"}]})
+        (insert! {:created-at (day 5) :role "assistant" :profile-id "internal" :total-tokens 1
+                  :data [{:type "text" :text "a2"}]})
+        (let [messages (:messages (fetch))
+              q1       (message-by-text messages "q1")
+              kept     (message-by-text messages "kept")
+              q2       (message-by-text messages "q2")]
+          (is (nil? (:parent_message_id q1)))
+          (is (= (:id q1) (:parent_message_id kept)))
+          (is (= (:id kept) (:parent_message_id q2))))))))
 
 (deftest get-conversation-detail-turn-with-no-live-reply-test
   (testing "a turn whose only reply was soft-deleted still keeps the following turn on the path"
     (with-detail-conversation!
-      (fn [{:keys [msg! t detail!]}]
-        (msg! {:created-at (t 1) :role "user" :profile-id "p" :total-tokens 1 :data [{:type "text" :text "q1"}]})
-        ;; the only reply to q1 is soft-deleted, so this turn has no live reply
-        (msg! {:created-at (t 2) :role "assistant" :profile-id "internal" :total-tokens 1 :deleted-at (t 3) :data [{:type "text" :text "orphaned"}]})
-        (msg! {:created-at (t 4) :role "user" :profile-id "p" :total-tokens 1 :data [{:type "text" :text "q2"}]})
-        (msg! {:created-at (t 5) :role "assistant" :profile-id "internal" :total-tokens 1 :data [{:type "text" :text "a2"}]})
-        (let [messages (:messages (detail!))
-              by-text  (fn [txt] (first (filter #(= txt (:message %)) messages)))
-              q1 (by-text "q1"), q2 (by-text "q2")]
-          (is (some? q2) "the follow-up turn is not dropped")
-          (is (= (:id q1) (:parent_message_id q2))
-              "the follow-up prompt falls back to its predecessor prompt, not the previous turn"))))))
+      (fn [{:keys [insert! day fetch]}]
+        (insert! {:created-at (day 1) :role "user" :profile-id "p" :total-tokens 1
+                  :data [{:type "text" :text "q1"}]})
+        (insert! {:created-at (day 2) :role "assistant" :profile-id "internal" :total-tokens 1
+                  :deleted-at (day 3) :data [{:type "text" :text "orphaned"}]})
+        (insert! {:created-at (day 4) :role "user" :profile-id "p" :total-tokens 1
+                  :data [{:type "text" :text "q2"}]})
+        (insert! {:created-at (day 5) :role "assistant" :profile-id "internal" :total-tokens 1
+                  :data [{:type "text" :text "a2"}]})
+        (let [messages (:messages (fetch))
+              q1       (message-by-text messages "q1")
+              q2       (message-by-text messages "q2")]
+          (is (= (:id q1) (:parent_message_id q2))))))))
 
 (deftest get-conversation-detail-in-flight-attempt-test
   (testing "a still-streaming reply surfaces as an in-progress message"
     (with-detail-conversation!
-      (fn [{:keys [msg! detail!]}]
-        ;; No :created-at: the placeholder must be "just now" (within the grace
-        ;; window) to read as a live in-flight stream rather than an aborted turn.
-        (msg! {:role "user" :profile-id "p" :total-tokens 3 :data [{:type "text" :text "still thinking?"}]})
-        (msg! {:role "assistant" :profile-id "internal" :total-tokens 0 :data [] :in-flight true})
-        (let [response  (detail!)
-              attempts  (filter #(= "agent" (:role %)) (:messages response))]
-          (is (= 2 (count (:messages response))))
-          (is (= 1 (count attempts)))
-          (is (= "turn_in_progress" (:type (first attempts)))
-              "a still-streaming placeholder renders as an in-progress message")
-          (is (= 2 (:message_count response))
-              "every row counts (prompt + placeholder), so the count stays stable as the turn finishes"))))))
+      (fn [{:keys [insert! fetch]}]
+        (insert! {:role "user" :profile-id "p" :total-tokens 3
+                  :data [{:type "text" :text "still thinking?"}]})
+        (insert! {:role "assistant" :profile-id "internal" :total-tokens 0 :data [] :finished nil})
+        (let [{:keys [messages message_count]} (fetch)]
+          (is (= ["user" "agent"] (map :role messages)))
+          (is (= "turn_in_progress" (:type (second messages))))
+          (is (= 2 message_count)))))))
 
 (deftest get-conversation-detail-feedback-on-discarded-attempt-test
   (testing "feedback on a regenerated-away attempt still resolves to that attempt's message"
     (with-detail-conversation!
-      (fn [{:keys [msg! t user-id detail!]}]
+      (fn [{:keys [insert! day user-id fetch]}]
         (let [discarded-ext (str (random-uuid))]
-          (msg! {:created-at (t 1) :role "user" :profile-id "p" :total-tokens 2 :data [{:type "text" :text "help"}]})
-          (let [discarded-id (msg! {:created-at (t 2) :role "assistant" :profile-id "internal" :total-tokens 10
-                                    :deleted-at (t 3) :external-id discarded-ext :data [{:type "text" :text "thumbs-downed answer"}]})]
-            (msg! {:created-at (t 3) :role "assistant" :profile-id "internal" :total-tokens 20 :data [{:type "text" :text "kept answer"}]})
+          (insert! {:created-at (day 1) :role "user" :profile-id "p" :total-tokens 2
+                    :data [{:type "text" :text "help"}]})
+          (let [discarded-id (insert! {:created-at (day 2) :role "assistant" :profile-id "internal"
+                                       :total-tokens 10 :deleted-at (day 3) :external-id discarded-ext
+                                       :data [{:type "text" :text "thumbs-downed answer"}]})]
+            (insert! {:created-at (day 3) :role "assistant" :profile-id "internal" :total-tokens 20
+                      :data [{:type "text" :text "kept answer"}]})
             (insert-feedback! {:message-id discarded-id :user-id user-id :positive false
-                               :issue-type "incorrect" :freeform "wrong table" :created-at (t 2) :updated-at (t 2)})
-            (let [response     (detail!)
-                  feedback     (:feedback response)
-                  attempt-exts (->> (:messages response) (filter #(= "agent" (:role %))) (map :externalId) set)]
+                               :issue-type "incorrect" :freeform "wrong table"
+                               :created-at (day 2) :updated-at (day 2)})
+            (let [{:keys [feedback messages]} (fetch)
+                  attempt-exts (into #{} (keep :externalId) messages)]
               (is (= 1 (count feedback)))
-              (is (= discarded-ext (:external_id (first feedback)))
-                  "feedback carries the discarded attempt's external_id")
-              (is (contains? attempt-exts discarded-ext)
-                  "the discarded attempt is present in the messages so the FE can resolve the feedback"))))))))
+              (is (= discarded-ext (:external_id (first feedback))))
+              (is (contains? attempt-exts discarded-ext)))))))))
 
 (deftest get-conversation-detail-queries-test
   (mt/with-premium-features #{:audit-app}
@@ -596,7 +618,7 @@
             jan-2           (offset-date-time "2026-01-02T00:00:00Z")
             jan-3           (offset-date-time "2026-01-03T00:00:00Z")
             sql             "SELECT * FROM orders"]
-        (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
+        (try
           (insert-conversation! {:conversation-id conversation-id
                                  :user-id         user-id
                                  :created-at      jan-1
@@ -650,7 +672,9 @@
               (is (nil?                  (:mbql q)))
               (is (= (mt/id)             (:database_id q)))
               ;; Tables extraction goes through the real Macaw path — sample data has an "orders" table.
-              (is (contains? (set (:tables q)) "orders")))))))))
+              (is (contains? (set (:tables q)) "orders"))))
+          (finally
+            (delete-conversations! [conversation-id])))))))
 
 (defn- search-part
   [call-id]
@@ -675,7 +699,7 @@
             jan-1         (offset-date-time "2026-02-01T00:00:00Z")
             jan-2         (offset-date-time "2026-02-02T00:00:00Z")
             jan-3         (offset-date-time "2026-02-03T00:00:00Z")]
-        (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
+        (try
           (insert-conversation! {:conversation-id convo-none
                                  :user-id         test-user-id
                                  :created-at      jan-1
@@ -724,7 +748,9 @@
           (thunk {:test-user-id  test-user-id
                   :convo-none    convo-none
                   :convo-two     convo-two
-                  :convo-errored convo-errored}))))))
+                  :convo-errored convo-errored})
+          (finally
+            (delete-conversations! [convo-none convo-two convo-errored])))))))
 
 (deftest search-count-test
   (with-search-count-fixture!
@@ -773,7 +799,7 @@
             mar-1       (offset-date-time "2026-03-10T00:00:00Z")
             mar-2       (offset-date-time "2026-03-11T00:00:00Z")
             mar-3       (offset-date-time "2026-03-12T00:00:00Z")]
-        (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
+        (try
           (insert-conversation! {:conversation-id convo-none
                                  :user-id         test-user-id
                                  :created-at      mar-1
@@ -821,7 +847,9 @@
           (thunk {:test-user-id test-user-id
                   :convo-none   convo-none
                   :convo-mixed  convo-mixed
-                  :convo-edits  convo-edits}))))))
+                  :convo-edits  convo-edits})
+          (finally
+            (delete-conversations! [convo-none convo-mixed convo-edits])))))))
 
 (deftest query-count-test
   (with-query-count-fixture!
@@ -845,7 +873,7 @@
       (let [conversation-id (str (random-uuid))
             user-id         (mt/user->id :crowberto)
             permalink       "https://example.slack.com/archives/C123/p1712785577123456"]
-        (mt/with-model-cleanup [[:model/MetabotConversation :created_at]]
+        (try
           (insert-conversation! {:conversation-id  conversation-id
                                  :user-id          user-id
                                  :summary          "Slack conversation"
@@ -858,7 +886,9 @@
                                                                             permalink)]
             (let [response (mt/user-http-request :crowberto :get 200
                                                  (format "ee/metabot-analytics/conversations/%s" conversation-id))]
-              (is (= permalink (:slack_permalink response))))))))))
+              (is (= permalink (:slack_permalink response)))))
+          (finally
+            (delete-conversations! [conversation-id])))))))
 
 (defn- with-ip-address-fixture!
   "Seed conversations with varying IP-address state so we can assert both list
@@ -874,7 +904,7 @@
             jan-1       (offset-date-time "2026-03-01T00:00:00Z")
             jan-2       (offset-date-time "2026-03-02T00:00:00Z")
             jan-3       (offset-date-time "2026-03-03T00:00:00Z")]
-        (mt/with-model-cleanup [[:model/MetabotConversation :created_at]]
+        (try
           (insert-conversation! {:conversation-id convo-web
                                  :user-id         test-user-id
                                  :created-at      jan-1
@@ -894,7 +924,9 @@
           (thunk {:test-user-id test-user-id
                   :convo-web    convo-web
                   :convo-slack  convo-slack
-                  :convo-null   convo-null}))))))
+                  :convo-null   convo-null})
+          (finally
+            (delete-conversations! [convo-web convo-slack convo-null])))))))
 
 (deftest ^:parallel get-conversation-detail-requires-superuser-test
   (mt/with-premium-features #{:audit-app}
@@ -919,7 +951,7 @@
             jan-1           (offset-date-time "2026-04-01T00:00:00Z")
             jan-2           (offset-date-time "2026-04-02T00:00:00Z")
             jan-3           (offset-date-time "2026-04-03T00:00:00Z")]
-        (mt/with-model-cleanup [:model/MetabotFeedback :model/MetabotMessage [:model/MetabotConversation :created_at]]
+        (try
           (insert-conversation! {:conversation-id conversation-id
                                  :user-id         user-id
                                  :created-at      jan-1
@@ -956,7 +988,9 @@
                        :first_name "Crowberto"
                        :last_name  "Corv"}]
                      (map #(select-keys (:user %) [:id :email :first_name :last_name]) feedback))
-                  "submitter is hydrated on each feedback row"))))))))
+                  "submitter is hydrated on each feedback row")))
+          (finally
+            (delete-conversations! [conversation-id])))))))
 
 (deftest get-conversation-detail-feedback-multi-user-test
   (mt/with-premium-features #{:audit-app}
@@ -969,7 +1003,7 @@
               apr-1           (offset-date-time "2026-04-10T00:00:00Z")
               apr-2           (offset-date-time "2026-04-11T00:00:00Z")
               apr-3           (offset-date-time "2026-04-12T00:00:00Z")]
-          (mt/with-model-cleanup [:model/MetabotFeedback :model/MetabotMessage [:model/MetabotConversation :created_at]]
+          (try
             (insert-conversation! {:conversation-id conversation-id
                                    :user-id         owner-id
                                    :created-at      apr-1
@@ -1005,7 +1039,9 @@
                        (select-keys (:user (get by-user participant-id)) [:id :email :first_name :last_name])))
                 (is (true? (:positive (get by-user owner-id))))
                 (is (false? (:positive (get by-user participant-id))))
-                (is (= "not-factual" (:issue_type (get by-user participant-id))))))))))))
+                (is (= "not-factual" (:issue_type (get by-user participant-id))))))
+            (finally
+              (delete-conversations! [conversation-id]))))))))
 
 (deftest ip-address-test
   (with-ip-address-fixture!

--- a/enterprise/backend/test/metabase_enterprise/metabot_analytics/v_metabot_conversations_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_analytics/v_metabot_conversations_test.clj
@@ -195,8 +195,8 @@
                    :profile_id              "nlq"}
                   r3)))))))
 
-(deftest deleted-messages-excluded-test
-  (testing "soft-deleted messages are excluded from counts"
+(deftest deleted-messages-included-test
+  (testing "soft-deleted messages are included in counts"
     (let [convo-id (str (random-uuid))
           now      (java.time.OffsetDateTime/now)
           earlier  (.minusHours now 1)]
@@ -205,9 +205,9 @@
                      :model/MetabotMessage      _ {:conversation_id convo-id :role "user"      :profile_id "nlq" :total_tokens 0 :data [] :created_at earlier}
                      :model/MetabotMessage      _ {:conversation_id convo-id :role "assistant" :profile_id "nlq" :total_tokens 0 :data [] :created_at now}
                      :model/MetabotMessage      _ {:conversation_id convo-id :role "assistant" :profile_id "nlq" :total_tokens 0 :data [] :deleted_at now}]
-        (is (=? {:message_count           2
+        (is (=? {:message_count           3
                  :user_message_count      1
-                 :assistant_message_count 1}
+                 :assistant_message_count 2}
                 (first (query-view [convo-id]))))))))
 
 (deftest user-display-name-test
@@ -343,7 +343,7 @@
           (is (nil? (:last_message_at row))))))))
 
 (deftest last-message-at-test
-  (testing "last_message_at reflects the most recent non-deleted message"
+  (testing "last_message_at reflects the most recent message"
     (let [convo-id (str (random-uuid))
           t1       (java.time.OffsetDateTime/parse "2026-01-01T12:00:00Z")
           t2-ts    (java.time.OffsetDateTime/parse "2026-01-02T12:00:00Z")
@@ -352,11 +352,10 @@
                      :model/MetabotConversation _ {:id convo-id :user_id user-id}
                      :model/MetabotMessage      _ {:conversation_id convo-id :role "user"      :profile_id "nlq" :total_tokens 0 :data [] :created_at t1}
                      :model/MetabotMessage      _ {:conversation_id convo-id :role "assistant" :profile_id "nlq" :total_tokens 0 :data [] :created_at t2-ts}
-                     ;; newest message is deleted — should not count
                      :model/MetabotMessage      _ {:conversation_id convo-id :role "assistant" :profile_id "nlq" :total_tokens 0 :data [] :created_at t3 :deleted_at t3}]
         (let [row (first (query-view [convo-id]))]
           ;; Compare instants to avoid DB-specific timestamp type differences
-          (is (= (t/instant t2-ts) (t/instant (:last_message_at row)))))))))
+          (is (= (t/instant t3) (t/instant (:last_message_at row)))))))))
 
 (deftest multiple-conversations-independent-test
   (testing "multiple conversations aggregate independently"

--- a/enterprise/backend/test/metabase_enterprise/metabot_analytics/v_metabot_messages_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_analytics/v_metabot_messages_test.clj
@@ -43,8 +43,8 @@
                   row))
           (is (some? (:created_at row))))))))
 
-(deftest deleted-messages-excluded-test
-  (testing "soft-deleted messages (deleted_at IS NOT NULL) are filtered out of the view"
+(deftest deleted-messages-included-test
+  (testing "soft-deleted messages are returned by the view"
     (let [convo-id (str (random-uuid))
           now      (java.time.OffsetDateTime/now)]
       (mt/with-temp [:model/User {user-id :id} {}
@@ -61,9 +61,9 @@
                                                              :data []
                                                              :deleted_at now}]
         (let [rows (query-view [convo-id])]
-          (is (= 1 (count rows)))
+          (is (= 2 (count rows)))
           (is (some? (find-row rows kept-id)))
-          (is (nil?  (find-row rows deleted-id))))))))
+          (is (some? (find-row rows deleted-id))))))))
 
 (deftest user-id-coalesces-to-conversation-owner-test
   (testing "user_id falls back to metabot_conversation.user_id when metabot_message.user_id is null"

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
@@ -11,6 +11,7 @@ import {
   Messages,
 } from "metabase/metabot/components/MetabotChat/MetabotChatMessage";
 import { getIssueTypeLabel } from "metabase/metabot/components/MetabotChat/feedback-issue-types";
+import { useBranchableMessages } from "metabase/metabot/hooks";
 import type {
   MetabotAgentTextChatMessage,
   MetabotChatMessage,
@@ -56,13 +57,20 @@ export function ConversationDetailPage({ params }: WithRouterProps) {
     refetchOnMountOrArgChange: true,
   });
 
-  const chatMessages = useMemo(() => {
-    return normalizeFetchedChatMessages(conversation?.chat_messages ?? [], {
-      isSlack:
-        conversation?.profile_id === "slackbot" ||
-        conversation?.profile_id === "slack",
-    });
-  }, [conversation]);
+  const isSlack =
+    conversation?.profile_id === "slackbot" ||
+    conversation?.profile_id === "slack";
+
+  const nodes = useMemo(() => conversation?.messages ?? [], [conversation]);
+
+  const { messages, getExtraAgentActions } = useBranchableMessages(nodes, {
+    isSlack,
+  });
+
+  const feedbackChatMessages = useMemo(
+    () => normalizeFetchedChatMessages(nodes, { isSlack }),
+    [nodes, isSlack],
+  );
 
   if (isLoading || error) {
     return (
@@ -108,7 +116,7 @@ export function ConversationDetailPage({ params }: WithRouterProps) {
                 <FeedbackCard
                   key={item.id}
                   feedback={item}
-                  chatMessages={chatMessages}
+                  chatMessages={feedbackChatMessages}
                 />
               ))}
             </Stack>
@@ -126,7 +134,8 @@ export function ConversationDetailPage({ params }: WithRouterProps) {
           </Flex>
           <Card withBorder shadow="none" p="xl">
             <Messages
-              messages={chatMessages}
+              messages={messages}
+              getExtraAgentActions={getExtraAgentActions}
               isDoingScience={false}
               debug
               readonly

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
@@ -61,15 +61,19 @@ export function ConversationDetailPage({ params }: WithRouterProps) {
     conversation?.profile_id === "slackbot" ||
     conversation?.profile_id === "slack";
 
-  const nodes = useMemo(() => conversation?.messages ?? [], [conversation]);
+  const conversationMessages = useMemo(
+    () => conversation?.messages ?? [],
+    [conversation?.messages],
+  );
 
-  const { messages, getExtraAgentActions } = useBranchableMessages(nodes, {
-    isSlack,
-  });
+  const { messages, getExtraAgentActions } = useBranchableMessages(
+    conversationMessages,
+    { isSlack },
+  );
 
-  const feedbackChatMessages = useMemo(
-    () => normalizeFetchedChatMessages(nodes, { isSlack }),
-    [nodes, isSlack],
+  const feedbackChatMessages = normalizeFetchedChatMessages(
+    conversationMessages,
+    { isSlack },
   );
 
   if (isLoading || error) {
@@ -179,18 +183,14 @@ function FeedbackCard({
   feedback: ConversationFeedback;
   chatMessages: MetabotChatMessage[];
 }) {
-  const agentResponse = useMemo(
-    () =>
-      feedback.external_id
-        ? chatMessages.find(
-            (m): m is MetabotAgentTextChatMessage =>
-              m.role === "agent" &&
-              m.type === "text" &&
-              m.externalId === feedback.external_id,
-          )
-        : undefined,
-    [feedback.external_id, chatMessages],
-  );
+  const agentResponse = feedback.external_id
+    ? chatMessages.find(
+        (message): message is MetabotAgentTextChatMessage =>
+          message.role === "agent" &&
+          message.type === "text" &&
+          message.externalId === feedback.external_id,
+      )
+    : undefined;
 
   const submitterName = feedback.user
     ? getUserName(feedback.user) || null

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
@@ -66,7 +66,7 @@ export function ConversationDetailPage({ params }: WithRouterProps) {
     [conversation?.messages],
   );
 
-  const { messages, getExtraAgentActions } = useBranchableMessages(
+  const { messages, getExtraActions } = useBranchableMessages(
     conversationMessages,
     { isSlack },
   );
@@ -139,7 +139,7 @@ export function ConversationDetailPage({ params }: WithRouterProps) {
           <Card withBorder shadow="none" p="xl">
             <Messages
               messages={messages}
-              getExtraAgentActions={getExtraAgentActions}
+              getExtraActions={getExtraActions}
               isDoingScience={false}
               debug
               readonly

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.unit.spec.tsx
@@ -1,0 +1,334 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import { Route } from "metabase/router";
+import { createMockUser } from "metabase-types/api/mocks";
+
+import type {
+  ConversationDetail,
+  ConversationFeedback,
+  ConversationMessage,
+} from "../../types";
+
+import { ConversationDetailPage } from "./ConversationDetailPage";
+
+jest.mock("metabase/admin/ai/MetabotAdminLayout", () => ({
+  MetabotAdminLayout: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// The header fires permission-group / tenant fetches irrelevant to these tests.
+jest.mock("./ConversationHeader", () => ({
+  ConversationHeader: () => null,
+}));
+
+const mockUseGetMetabotConversationQuery = jest.fn();
+jest.mock("../../api", () => ({
+  useGetMetabotConversationQuery: (...args: unknown[]) =>
+    mockUseGetMetabotConversationQuery(...args),
+}));
+
+type NodeSpec = {
+  // `externalId` doubles as the message's `id` (the tree key parents point at)
+  // and, for agent messages, its feedback `externalId`. The current-path reply is
+  // just the newest sibling, so fixtures list it last rather than flagging it.
+  externalId: string;
+  parentId: string | null;
+  role: "user" | "assistant";
+  message: string;
+  inFlight?: boolean;
+};
+
+// One flat, single-level chat message in the parent-pointer list the backend now
+// returns — a normal chat message plus `parent_message_id`.
+function node({
+  externalId,
+  parentId,
+  role,
+  message,
+  inFlight = false,
+}: NodeSpec): ConversationMessage {
+  const common = { id: externalId, parent_message_id: parentId };
+  if (inFlight) {
+    return { ...common, role: "agent", type: "turn_in_progress", externalId };
+  }
+  if (role === "user") {
+    return { ...common, role: "user", type: "text", message };
+  }
+  return { ...common, role: "agent", type: "text", message, externalId };
+}
+
+function createConversation(
+  messages: ConversationMessage[],
+  feedback: ConversationFeedback[] = [],
+): ConversationDetail {
+  return {
+    conversation_id: "convo-1",
+    created_at: "2026-01-01T00:00:00Z",
+    summary: "A conversation",
+    user: null,
+    message_count: 2,
+    total_tokens: 30,
+    profile_id: "internal",
+    slack_permalink: null,
+    messages,
+    queries: [],
+    search_count: 0,
+    query_count: 0,
+    ip_address: null,
+    embedding_hostname: null,
+    embedding_path: null,
+    user_agent: null,
+    sanitized_user_agent: null,
+    feedback,
+  };
+}
+
+function setup(conversation: ConversationDetail) {
+  mockUseGetMetabotConversationQuery.mockReturnValue({
+    data: conversation,
+    isLoading: false,
+    error: null,
+  });
+  return renderWithProviders(
+    <Route path="/conversations/:convoId" component={ConversationDetailPage} />,
+    {
+      withRouter: true,
+      initialRoute: "/conversations/convo-1",
+      storeInitialState: {
+        currentUser: createMockUser({ is_superuser: true }),
+      },
+    },
+  );
+}
+
+describe("ConversationDetailPage attempts", () => {
+  it("renders a single-attempt turn with no pager", () => {
+    setup(
+      createConversation([
+        node({ externalId: "u1", parentId: null, role: "user", message: "hi" }),
+        node({
+          externalId: "a1",
+          parentId: "u1",
+          role: "assistant",
+          message: "only answer",
+        }),
+      ]),
+    );
+
+    expect(screen.getByText("only answer")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Previous version" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("defaults a regenerated turn to the latest attempt and pages between attempts", async () => {
+    setup(
+      createConversation([
+        node({
+          externalId: "u1",
+          parentId: null,
+          role: "user",
+          message: "count orders",
+        }),
+        node({
+          externalId: "a1",
+          parentId: "u1",
+          role: "assistant",
+          message: "first try",
+        }),
+        node({
+          externalId: "a2",
+          parentId: "u1",
+          role: "assistant",
+          message: "kept answer",
+        }),
+      ]),
+    );
+
+    // Latest attempt is shown by default; earlier attempt is hidden.
+    expect(screen.getByText("kept answer")).toBeInTheDocument();
+    expect(screen.queryByText("first try")).not.toBeInTheDocument();
+    expect(screen.getByText("2 / 2")).toBeInTheDocument();
+
+    // At the newest attempt, forward is disabled and back is enabled.
+    expect(screen.getByRole("button", { name: "Next version" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Previous version" }),
+    ).toBeEnabled();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Previous version" }),
+    );
+
+    expect(screen.getByText("first try")).toBeInTheDocument();
+    expect(screen.queryByText("kept answer")).not.toBeInTheDocument();
+    expect(screen.getByText("1 / 2")).toBeInTheDocument();
+
+    // At the oldest attempt, back is disabled and forward is enabled.
+    expect(
+      screen.getByRole("button", { name: "Previous version" }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Next version" })).toBeEnabled();
+  });
+
+  it("shows an in-progress row with a reachable pager while a regeneration streams", async () => {
+    setup(
+      createConversation([
+        node({
+          externalId: "u1",
+          parentId: null,
+          role: "user",
+          message: "count orders",
+        }),
+        node({
+          externalId: "a1",
+          parentId: "u1",
+          role: "assistant",
+          message: "first try",
+        }),
+        node({
+          externalId: "a2",
+          parentId: "u1",
+          role: "assistant",
+          message: "",
+          inFlight: true,
+        }),
+      ]),
+    );
+
+    // The streaming attempt renders an explicit in-progress row (not a blank),
+    // and the pager stays visible so prior attempts remain reachable.
+    expect(
+      screen.getByTestId("metabot-response-in-progress"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Response in progress/)).toBeInTheDocument();
+    expect(screen.getByText("2 / 2")).toBeInTheDocument();
+    expect(screen.queryByText("first try")).not.toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Previous version" }),
+    );
+
+    expect(screen.getByText("first try")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("metabot-response-in-progress"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("1 / 2")).toBeInTheDocument();
+  });
+
+  it("truncates the conversation after a superseded attempt", async () => {
+    setup(
+      createConversation([
+        node({
+          externalId: "u1",
+          parentId: null,
+          role: "user",
+          message: "count orders",
+        }),
+        node({
+          externalId: "a1",
+          parentId: "u1",
+          role: "assistant",
+          message: "first try",
+        }),
+        node({
+          externalId: "a2",
+          parentId: "u1",
+          role: "assistant",
+          message: "kept answer",
+        }),
+        // The next prompt branched off the kept reply (a2).
+        node({
+          externalId: "u2",
+          parentId: "a2",
+          role: "user",
+          message: "and by month?",
+        }),
+        node({
+          externalId: "b1",
+          parentId: "u2",
+          role: "assistant",
+          message: "monthly answer",
+        }),
+      ]),
+    );
+
+    // The latest branch shows both turns.
+    expect(screen.getByText("kept answer")).toBeInTheDocument();
+    expect(screen.getByText("monthly answer")).toBeInTheDocument();
+
+    // Going back to the first turn's earlier attempt drops everything after it,
+    // since the rest of the conversation followed from the kept response.
+    await userEvent.click(
+      screen.getByRole("button", { name: "Previous version" }),
+    );
+
+    expect(screen.getByText("first try")).toBeInTheDocument();
+    expect(screen.queryByText("and by month?")).not.toBeInTheDocument();
+    expect(screen.queryByText("monthly answer")).not.toBeInTheDocument();
+  });
+
+  it("does not let admins submit feedback ratings from the transcript", () => {
+    setup(
+      createConversation([
+        node({ externalId: "u1", parentId: null, role: "user", message: "hi" }),
+        node({
+          externalId: "a1",
+          parentId: "u1",
+          role: "assistant",
+          message: "an answer",
+        }),
+      ]),
+    );
+
+    // The transcript is read-only for admins — no rating controls at all.
+    expect(
+      screen.queryByTestId("metabot-chat-message-thumbs-up"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("metabot-chat-message-thumbs-down"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("resolves feedback left on a regenerated-away attempt", () => {
+    const feedback: ConversationFeedback = {
+      id: 1,
+      metabot_id: 1,
+      message_id: "10",
+      user_id: 1,
+      external_id: "a1",
+      positive: false,
+      issue_type: "not-factual",
+      freeform_feedback: "wrong table",
+    };
+    setup(
+      createConversation(
+        [
+          node({
+            externalId: "u1",
+            parentId: null,
+            role: "user",
+            message: "count orders",
+          }),
+          node({
+            externalId: "a1",
+            parentId: "u1",
+            role: "assistant",
+            message: "discarded answer",
+          }),
+          node({
+            externalId: "a2",
+            parentId: "u1",
+            role: "assistant",
+            message: "kept answer",
+          }),
+        ],
+        [feedback],
+      ),
+    );
+
+    // The transcript defaults to the kept answer, so the discarded response only
+    // appears because the feedback card resolved it via the discarded attempt's id.
+    expect(screen.getByText("discarded answer")).toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.unit.spec.tsx
@@ -1,14 +1,10 @@
 import userEvent from "@testing-library/user-event";
 
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen, within } from "__support__/ui";
 import { Route } from "metabase/router";
 import { createMockUser } from "metabase-types/api/mocks";
 
-import type {
-  ConversationDetail,
-  ConversationFeedback,
-  ConversationMessage,
-} from "../../types";
+import type { ConversationDetail, ConversationFeedback } from "../../types";
 
 import { ConversationDetailPage } from "./ConversationDetailPage";
 
@@ -16,7 +12,7 @@ jest.mock("metabase/admin/ai/MetabotAdminLayout", () => ({
   MetabotAdminLayout: ({ children }: { children: React.ReactNode }) => children,
 }));
 
-// The header fires permission-group / tenant fetches irrelevant to these tests.
+// Avoid unrelated permission and tenant requests.
 jest.mock("./ConversationHeader", () => ({
   ConversationHeader: () => null,
 }));
@@ -27,34 +23,45 @@ jest.mock("../../api", () => ({
     mockUseGetMetabotConversationQuery(...args),
 }));
 
-type NodeSpec = {
-  // `externalId` doubles as the message's `id` (the tree key parents point at)
-  // and, for agent messages, its feedback `externalId`. The current-path reply is
-  // just the newest sibling, so fixtures list it last rather than flagging it.
-  externalId: string;
-  parentId: string | null;
-  role: "user" | "assistant";
-  message: string;
-  inFlight?: boolean;
-};
+type ConversationMessage = ConversationDetail["messages"][number];
 
-// One flat, single-level chat message in the parent-pointer list the backend now
-// returns — a normal chat message plus `parent_message_id`.
-function node({
-  externalId,
-  parentId,
-  role,
-  message,
-  inFlight = false,
-}: NodeSpec): ConversationMessage {
-  const common = { id: externalId, parent_message_id: parentId };
-  if (inFlight) {
-    return { ...common, role: "agent", type: "turn_in_progress", externalId };
-  }
-  if (role === "user") {
-    return { ...common, role: "user", type: "text", message };
-  }
-  return { ...common, role: "agent", type: "text", message, externalId };
+function userMessage(
+  id: string,
+  parentId: string | null,
+  message: string,
+): ConversationMessage {
+  return {
+    id,
+    parent_message_id: parentId,
+    role: "user",
+    type: "text",
+    message,
+  };
+}
+
+function agentMessage(
+  id: string,
+  parentId: string,
+  message: string,
+): ConversationMessage {
+  return {
+    id,
+    parent_message_id: parentId,
+    role: "agent",
+    type: "text",
+    message,
+    externalId: id,
+  };
+}
+
+function inProgressMessage(id: string, parentId: string): ConversationMessage {
+  return {
+    id,
+    parent_message_id: parentId,
+    role: "agent",
+    type: "turn_in_progress",
+    externalId: id,
+  };
 }
 
 function createConversation(
@@ -101,56 +108,19 @@ function setup(conversation: ConversationDetail) {
   );
 }
 
-describe("ConversationDetailPage attempts", () => {
-  it("renders a single-attempt turn with no pager", () => {
-    setup(
-      createConversation([
-        node({ externalId: "u1", parentId: null, role: "user", message: "hi" }),
-        node({
-          externalId: "a1",
-          parentId: "u1",
-          role: "assistant",
-          message: "only answer",
-        }),
-      ]),
-    );
-
-    expect(screen.getByText("only answer")).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "Previous version" }),
-    ).not.toBeInTheDocument();
-  });
-
+describe("ConversationDetailPage", () => {
   it("defaults a regenerated turn to the latest attempt and pages between attempts", async () => {
     setup(
       createConversation([
-        node({
-          externalId: "u1",
-          parentId: null,
-          role: "user",
-          message: "count orders",
-        }),
-        node({
-          externalId: "a1",
-          parentId: "u1",
-          role: "assistant",
-          message: "first try",
-        }),
-        node({
-          externalId: "a2",
-          parentId: "u1",
-          role: "assistant",
-          message: "kept answer",
-        }),
+        userMessage("u1", null, "count orders"),
+        agentMessage("a1", "u1", "first try"),
+        agentMessage("a2", "u1", "kept answer"),
       ]),
     );
 
-    // Latest attempt is shown by default; earlier attempt is hidden.
     expect(screen.getByText("kept answer")).toBeInTheDocument();
     expect(screen.queryByText("first try")).not.toBeInTheDocument();
     expect(screen.getByText("2 / 2")).toBeInTheDocument();
-
-    // At the newest attempt, forward is disabled and back is enabled.
     expect(screen.getByRole("button", { name: "Next version" })).toBeDisabled();
     expect(
       screen.getByRole("button", { name: "Previous version" }),
@@ -163,47 +133,36 @@ describe("ConversationDetailPage attempts", () => {
     expect(screen.getByText("first try")).toBeInTheDocument();
     expect(screen.queryByText("kept answer")).not.toBeInTheDocument();
     expect(screen.getByText("1 / 2")).toBeInTheDocument();
-
-    // At the oldest attempt, back is disabled and forward is enabled.
     expect(
       screen.getByRole("button", { name: "Previous version" }),
     ).toBeDisabled();
     expect(screen.getByRole("button", { name: "Next version" })).toBeEnabled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Next version" }));
+
+    expect(screen.getByText("kept answer")).toBeInTheDocument();
+    expect(screen.getByText("2 / 2")).toBeInTheDocument();
   });
 
   it("shows an in-progress row with a reachable pager while a regeneration streams", async () => {
     setup(
       createConversation([
-        node({
-          externalId: "u1",
-          parentId: null,
-          role: "user",
-          message: "count orders",
-        }),
-        node({
-          externalId: "a1",
-          parentId: "u1",
-          role: "assistant",
-          message: "first try",
-        }),
-        node({
-          externalId: "a2",
-          parentId: "u1",
-          role: "assistant",
-          message: "",
-          inFlight: true,
-        }),
+        userMessage("u1", null, "count orders"),
+        agentMessage("a1", "u1", "first try"),
+        inProgressMessage("a2", "u1"),
       ]),
     );
 
-    // The streaming attempt renders an explicit in-progress row (not a blank),
-    // and the pager stays visible so prior attempts remain reachable.
     expect(
       screen.getByTestId("metabot-response-in-progress"),
     ).toBeInTheDocument();
     expect(screen.getByText(/Response in progress/)).toBeInTheDocument();
     expect(screen.getByText("2 / 2")).toBeInTheDocument();
     expect(screen.queryByText("first try")).not.toBeInTheDocument();
+    const [, inProgressElement] = screen.getAllByTestId("metabot-chat-message");
+    expect(
+      within(inProgressElement).queryByTestId("metabot-chat-message-copy"),
+    ).not.toBeInTheDocument();
 
     await userEvent.click(
       screen.getByRole("button", { name: "Previous version" }),
@@ -219,46 +178,17 @@ describe("ConversationDetailPage attempts", () => {
   it("truncates the conversation after a superseded attempt", async () => {
     setup(
       createConversation([
-        node({
-          externalId: "u1",
-          parentId: null,
-          role: "user",
-          message: "count orders",
-        }),
-        node({
-          externalId: "a1",
-          parentId: "u1",
-          role: "assistant",
-          message: "first try",
-        }),
-        node({
-          externalId: "a2",
-          parentId: "u1",
-          role: "assistant",
-          message: "kept answer",
-        }),
-        // The next prompt branched off the kept reply (a2).
-        node({
-          externalId: "u2",
-          parentId: "a2",
-          role: "user",
-          message: "and by month?",
-        }),
-        node({
-          externalId: "b1",
-          parentId: "u2",
-          role: "assistant",
-          message: "monthly answer",
-        }),
+        userMessage("u1", null, "count orders"),
+        agentMessage("a1", "u1", "first try"),
+        agentMessage("a2", "u1", "kept answer"),
+        userMessage("u2", "a2", "and by month?"),
+        agentMessage("b1", "u2", "monthly answer"),
       ]),
     );
 
-    // The latest branch shows both turns.
     expect(screen.getByText("kept answer")).toBeInTheDocument();
     expect(screen.getByText("monthly answer")).toBeInTheDocument();
 
-    // Going back to the first turn's earlier attempt drops everything after it,
-    // since the rest of the conversation followed from the kept response.
     await userEvent.click(
       screen.getByRole("button", { name: "Previous version" }),
     );
@@ -271,17 +201,11 @@ describe("ConversationDetailPage attempts", () => {
   it("does not let admins submit feedback ratings from the transcript", () => {
     setup(
       createConversation([
-        node({ externalId: "u1", parentId: null, role: "user", message: "hi" }),
-        node({
-          externalId: "a1",
-          parentId: "u1",
-          role: "assistant",
-          message: "an answer",
-        }),
+        userMessage("u1", null, "hi"),
+        agentMessage("a1", "u1", "an answer"),
       ]),
     );
 
-    // The transcript is read-only for admins — no rating controls at all.
     expect(
       screen.queryByTestId("metabot-chat-message-thumbs-up"),
     ).not.toBeInTheDocument();
@@ -304,31 +228,14 @@ describe("ConversationDetailPage attempts", () => {
     setup(
       createConversation(
         [
-          node({
-            externalId: "u1",
-            parentId: null,
-            role: "user",
-            message: "count orders",
-          }),
-          node({
-            externalId: "a1",
-            parentId: "u1",
-            role: "assistant",
-            message: "discarded answer",
-          }),
-          node({
-            externalId: "a2",
-            parentId: "u1",
-            role: "assistant",
-            message: "kept answer",
-          }),
+          userMessage("u1", null, "count orders"),
+          agentMessage("a1", "u1", "discarded answer"),
+          agentMessage("a2", "u1", "kept answer"),
         ],
         [feedback],
       ),
     );
 
-    // The transcript defaults to the kept answer, so the discarded response only
-    // appears because the feedback card resolved it via the discarded attempt's id.
     expect(screen.getByText("discarded answer")).toBeInTheDocument();
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.unit.spec.tsx
@@ -1,5 +1,6 @@
 import userEvent from "@testing-library/user-event";
 
+import { setupMetabotConversationEndpoint } from "__support__/server-mocks";
 import { renderWithProviders, screen, within } from "__support__/ui";
 import { Route } from "metabase/router";
 import { createMockUser } from "metabase-types/api/mocks";
@@ -15,12 +16,6 @@ jest.mock("metabase/admin/ai/MetabotAdminLayout", () => ({
 // Avoid unrelated permission and tenant requests.
 jest.mock("./ConversationHeader", () => ({
   ConversationHeader: () => null,
-}));
-
-const mockUseGetMetabotConversationQuery = jest.fn();
-jest.mock("../../api", () => ({
-  useGetMetabotConversationQuery: (...args: unknown[]) =>
-    mockUseGetMetabotConversationQuery(...args),
 }));
 
 type ConversationMessage = ConversationDetail["messages"][number];
@@ -91,11 +86,7 @@ function createConversation(
 }
 
 function setup(conversation: ConversationDetail) {
-  mockUseGetMetabotConversationQuery.mockReturnValue({
-    data: conversation,
-    isLoading: false,
-    error: null,
-  });
+  setupMetabotConversationEndpoint(conversation);
   return renderWithProviders(
     <Route path="/conversations/:convoId" component={ConversationDetailPage} />,
     {
@@ -118,7 +109,7 @@ describe("ConversationDetailPage", () => {
       ]),
     );
 
-    expect(screen.getByText("kept answer")).toBeInTheDocument();
+    expect(await screen.findByText("kept answer")).toBeInTheDocument();
     expect(screen.queryByText("first try")).not.toBeInTheDocument();
     expect(screen.getByText("2 / 2")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Next version" })).toBeDisabled();
@@ -154,7 +145,7 @@ describe("ConversationDetailPage", () => {
     );
 
     expect(
-      screen.getByTestId("metabot-response-in-progress"),
+      await screen.findByTestId("metabot-response-in-progress"),
     ).toBeInTheDocument();
     expect(screen.getByText(/Response in progress/)).toBeInTheDocument();
     expect(screen.getByText("2 / 2")).toBeInTheDocument();
@@ -186,7 +177,7 @@ describe("ConversationDetailPage", () => {
       ]),
     );
 
-    expect(screen.getByText("kept answer")).toBeInTheDocument();
+    expect(await screen.findByText("kept answer")).toBeInTheDocument();
     expect(screen.getByText("monthly answer")).toBeInTheDocument();
 
     await userEvent.click(
@@ -198,7 +189,7 @@ describe("ConversationDetailPage", () => {
     expect(screen.queryByText("monthly answer")).not.toBeInTheDocument();
   });
 
-  it("does not let admins submit feedback ratings from the transcript", () => {
+  it("does not let admins submit feedback ratings from the transcript", async () => {
     setup(
       createConversation([
         userMessage("u1", null, "hi"),
@@ -206,6 +197,7 @@ describe("ConversationDetailPage", () => {
       ]),
     );
 
+    expect(await screen.findByText("an answer")).toBeInTheDocument();
     expect(
       screen.queryByTestId("metabot-chat-message-thumbs-up"),
     ).not.toBeInTheDocument();
@@ -214,7 +206,7 @@ describe("ConversationDetailPage", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("resolves feedback left on a regenerated-away attempt", () => {
+  it("resolves feedback left on a regenerated-away attempt", async () => {
     const feedback: ConversationFeedback = {
       id: 1,
       metabot_id: 1,
@@ -236,6 +228,6 @@ describe("ConversationDetailPage", () => {
       ),
     );
 
-    expect(screen.getByText("discarded answer")).toBeInTheDocument();
+    expect(await screen.findByText("discarded answer")).toBeInTheDocument();
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/types.ts
@@ -86,10 +86,6 @@ export type ConversationFeedback = MetabotFeedback & {
   external_id: string | null;
 };
 
-// NOTE: `parent_message_id` is derived on the client today; eventually it should
-// come from the server.
-export type ConversationMessage = ParentedChatMessage;
-
 export type ConversationDetail = {
   conversation_id: string;
   created_at: string;
@@ -99,7 +95,7 @@ export type ConversationDetail = {
   total_tokens: number;
   profile_id: MetabotProfileId | null;
   slack_permalink: string | null;
-  messages: ConversationMessage[];
+  messages: ParentedChatMessage[];
   queries: GeneratedQuery[];
   search_count: number;
   query_count: number;

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/types.ts
@@ -1,5 +1,5 @@
 import type { MetabotProfileId } from "metabase/metabot/constants";
-import type { FetchedChatMessage } from "metabase/metabot/utils/normalize-fetched-chat-messages";
+import type { ParentedChatMessage } from "metabase/metabot/utils/message-tree";
 import type {
   DatasetQuery,
   MetabotFeedback,
@@ -86,6 +86,10 @@ export type ConversationFeedback = MetabotFeedback & {
   external_id: string | null;
 };
 
+// NOTE: `parent_message_id` is derived on the client today; eventually it should
+// come from the server.
+export type ConversationMessage = ParentedChatMessage;
+
 export type ConversationDetail = {
   conversation_id: string;
   created_at: string;
@@ -95,7 +99,7 @@ export type ConversationDetail = {
   total_tokens: number;
   profile_id: MetabotProfileId | null;
   slack_permalink: string | null;
-  chat_messages: FetchedChatMessage[];
+  messages: ConversationMessage[];
   queries: GeneratedQuery[];
   search_count: number;
   query_count: number;

--- a/frontend/src/metabase/metabot/components/MetabotBranchPicker/MetabotBranchPicker.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotBranchPicker/MetabotBranchPicker.tsx
@@ -2,7 +2,6 @@ import { t } from "ttag";
 
 import { ActionIcon, Flex, Icon, Text, Tooltip } from "metabase/ui";
 
-// Pages between a prompt's regenerated replies, ChatGPT/Claude style.
 export const MetabotBranchPicker = ({
   index,
   count,

--- a/frontend/src/metabase/metabot/components/MetabotBranchPicker/MetabotBranchPicker.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotBranchPicker/MetabotBranchPicker.tsx
@@ -1,0 +1,40 @@
+import { t } from "ttag";
+
+import { ActionIcon, Flex, Icon, Text, Tooltip } from "metabase/ui";
+
+// Pages between a prompt's regenerated replies, ChatGPT/Claude style.
+export const MetabotBranchPicker = ({
+  index,
+  count,
+  onChange,
+}: {
+  index: number;
+  count: number;
+  onChange: (index: number) => void;
+}) => (
+  <Flex align="center" gap={2}>
+    <Tooltip label={t`Previous version`} disabled={index === 0}>
+      <ActionIcon
+        h="sm"
+        aria-label={t`Previous version`}
+        disabled={index === 0}
+        onClick={() => onChange(index - 1)}
+      >
+        <Icon name="chevronleft" size="0.75rem" />
+      </ActionIcon>
+    </Tooltip>
+    <Text size="sm" c="text-secondary">
+      {index + 1} / {count}
+    </Text>
+    <Tooltip label={t`Next version`} disabled={index === count - 1}>
+      <ActionIcon
+        h="sm"
+        aria-label={t`Next version`}
+        disabled={index === count - 1}
+        onClick={() => onChange(index + 1)}
+      >
+        <Icon name="chevronright" size="0.75rem" />
+      </ActionIcon>
+    </Tooltip>
+  </Flex>
+);

--- a/frontend/src/metabase/metabot/components/MetabotBranchPicker/index.ts
+++ b/frontend/src/metabase/metabot/components/MetabotBranchPicker/index.ts
@@ -1,0 +1,1 @@
+export { MetabotBranchPicker } from "./MetabotBranchPicker";

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -27,6 +27,7 @@ import {
   Flex,
   type FlexProps,
   Icon,
+  Loader,
   Text,
   Tooltip,
 } from "metabase/ui";
@@ -68,6 +69,7 @@ const isUserVisibleMessage = (message: MetabotChatMessage): boolean =>
     .with({ type: "tool_call" }, () => false)
     .with({ type: "turn_aborted" }, () => true)
     .with({ type: "turn_errored" }, () => true)
+    .with({ type: "turn_in_progress" }, () => true)
     .exhaustive();
 
 interface BaseMessageProps extends Omit<FlexProps, "onCopy"> {
@@ -175,6 +177,7 @@ interface AgentMessageProps extends Omit<BaseMessageProps, "message"> {
   setFeedbackMessage?: (data: { messageId: string; positive: boolean }) => void;
   submittedFeedback: "positive" | "negative" | undefined;
   onInternalLinkClick?: (link: string) => void;
+  extraActions?: ReactNode;
 }
 
 export const AgentMessage = ({
@@ -188,6 +191,7 @@ export const AgentMessage = ({
   submittedFeedback,
   onInternalLinkClick,
   hideActions,
+  extraActions,
   ...props
 }: AgentMessageProps) => {
   const messageId = "externalId" in message ? (message.externalId ?? "") : "";
@@ -217,9 +221,19 @@ export const AgentMessage = ({
         .with({ type: "turn_errored" }, (m) => (
           <AgentErroredTurnAlert message={m} debug={debug} />
         ))
+        .with({ type: "turn_in_progress" }, () => (
+          <Flex align="center" gap="sm" className={Styles.message}>
+            <Loader
+              type="dots"
+              size="sm"
+              data-testid="metabot-response-in-progress"
+            />
+            <Text c="text-secondary">{t`Response in progress…`}</Text>
+          </Flex>
+        ))
         .exhaustive()}
       {!hideActions && (
-        <Flex className={Styles.messageActions}>
+        <Flex className={Styles.messageActions} align="center">
           <Tooltip label={clipboard.copied ? t`Copied!` : t`Copy`}>
             <ActionIcon
               h="sm"
@@ -266,6 +280,7 @@ export const AgentMessage = ({
               </ActionIcon>
             </Tooltip>
           )}
+          {extraActions}
         </Flex>
       )}
     </MessageContainer>
@@ -411,6 +426,7 @@ export const Messages = ({
   debug,
   readonly = false,
   onInternalLinkClick,
+  getExtraAgentActions,
 }: {
   messages: MetabotChatMessage[];
   onRetryMessage?: (messageId: string) => void;
@@ -418,6 +434,7 @@ export const Messages = ({
   debug: boolean;
   readonly?: boolean;
   onInternalLinkClick?: (navigateToPath: string) => void;
+  getExtraAgentActions?: (message: MetabotChatMessage) => ReactNode;
 }) => {
   const visibleMessages = useMemo(
     () => (debug ? messages : messages.filter(isUserVisibleMessage)),
@@ -485,8 +502,11 @@ export const Messages = ({
             readonly={readonly}
             onRetry={isLastUserMessage ? onRetryMessage : undefined}
             getCopyText={() => getAgentReplyCopyText(message.id)}
-            setFeedbackMessage={(data) =>
-              setFeedbackState((prev) => ({ ...prev, modal: data }))
+            setFeedbackMessage={
+              readonly
+                ? undefined
+                : (data) =>
+                    setFeedbackState((prev) => ({ ...prev, modal: data }))
             }
             submittedFeedback={
               "externalId" in message && message.externalId
@@ -494,6 +514,7 @@ export const Messages = ({
                 : undefined
             }
             hideActions={next?.role === "agent" || (isDoingScience && !next)}
+            extraActions={getExtraAgentActions?.(message)}
             onInternalLinkClick={onInternalLinkClick}
           />
         ) : (

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -195,7 +195,9 @@ export const AgentMessage = ({
   ...props
 }: AgentMessageProps) => {
   const messageId = "externalId" in message ? (message.externalId ?? "") : "";
-  const canGiveFeedback = !!(setFeedbackMessage && messageId);
+  const isInProgress = message.type === "turn_in_progress";
+  const canGiveFeedback =
+    !readonly && !isInProgress && !!setFeedbackMessage && !!messageId;
   const clipboard = useClipboard({ timeout: 2000 });
 
   return (
@@ -234,15 +236,17 @@ export const AgentMessage = ({
         .exhaustive()}
       {!hideActions && (
         <Flex className={Styles.messageActions} align="center">
-          <Tooltip label={clipboard.copied ? t`Copied!` : t`Copy`}>
-            <ActionIcon
-              h="sm"
-              data-testid="metabot-chat-message-copy"
-              onClick={() => clipboard.copy(getCopyText())}
-            >
-              <Icon name="copy" size="1rem" />
-            </ActionIcon>
-          </Tooltip>
+          {!isInProgress && (
+            <Tooltip label={clipboard.copied ? t`Copied!` : t`Copy`}>
+              <ActionIcon
+                h="sm"
+                data-testid="metabot-chat-message-copy"
+                onClick={() => clipboard.copy(getCopyText())}
+              >
+                <Icon name="copy" size="1rem" />
+              </ActionIcon>
+            </Tooltip>
+          )}
           {canGiveFeedback && (
             <>
               <Tooltip label={t`Give positive feedback`}>
@@ -434,7 +438,7 @@ export const Messages = ({
   debug: boolean;
   readonly?: boolean;
   onInternalLinkClick?: (navigateToPath: string) => void;
-  getExtraAgentActions?: (message: MetabotChatMessage) => ReactNode;
+  getExtraAgentActions?: (messageId: string) => ReactNode;
 }) => {
   const visibleMessages = useMemo(
     () => (debug ? messages : messages.filter(isUserVisibleMessage)),
@@ -502,11 +506,8 @@ export const Messages = ({
             readonly={readonly}
             onRetry={isLastUserMessage ? onRetryMessage : undefined}
             getCopyText={() => getAgentReplyCopyText(message.id)}
-            setFeedbackMessage={
-              readonly
-                ? undefined
-                : (data) =>
-                    setFeedbackState((prev) => ({ ...prev, modal: data }))
+            setFeedbackMessage={(data) =>
+              setFeedbackState((prev) => ({ ...prev, modal: data }))
             }
             submittedFeedback={
               "externalId" in message && message.externalId
@@ -514,7 +515,7 @@ export const Messages = ({
                 : undefined
             }
             hideActions={next?.role === "agent" || (isDoingScience && !next)}
-            extraActions={getExtraAgentActions?.(message)}
+            extraActions={getExtraAgentActions?.(message.id)}
             onInternalLinkClick={onInternalLinkClick}
           />
         ) : (

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -100,12 +100,14 @@ export const MessageContainer = ({
 
 interface UserMessageProps extends Omit<BaseMessageProps, "message"> {
   message: MetabotUserChatMessage;
+  extraActions?: ReactNode;
 }
 
 export const UserMessage = ({
   message,
   className,
   hideActions,
+  extraActions,
   ...props
 }: UserMessageProps) => {
   const clipboard = useClipboard({ timeout: 2000 });
@@ -133,6 +135,7 @@ export const UserMessage = ({
             </ActionIcon>
           </Tooltip>
         )}
+        {extraActions}
       </Flex>
     </MessageContainer>
   );
@@ -430,7 +433,7 @@ export const Messages = ({
   debug,
   readonly = false,
   onInternalLinkClick,
-  getExtraAgentActions,
+  getExtraActions,
 }: {
   messages: MetabotChatMessage[];
   onRetryMessage?: (messageId: string) => void;
@@ -438,7 +441,7 @@ export const Messages = ({
   debug: boolean;
   readonly?: boolean;
   onInternalLinkClick?: (navigateToPath: string) => void;
-  getExtraAgentActions?: (messageId: string) => ReactNode;
+  getExtraActions?: (messageId: string) => ReactNode;
 }) => {
   const visibleMessages = useMemo(
     () => (debug ? messages : messages.filter(isUserVisibleMessage)),
@@ -515,7 +518,7 @@ export const Messages = ({
                 : undefined
             }
             hideActions={next?.role === "agent" || (isDoingScience && !next)}
-            extraActions={getExtraAgentActions?.(message.id)}
+            extraActions={getExtraActions?.(message.id)}
             onInternalLinkClick={onInternalLinkClick}
           />
         ) : (
@@ -524,6 +527,7 @@ export const Messages = ({
             data-testid="metabot-chat-message"
             message={message}
             hideActions={isDoingScience && visibleMessages.length === index + 1}
+            extraActions={getExtraActions?.(message.id)}
           />
         );
       })}

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.unit.spec.tsx
@@ -1,5 +1,9 @@
 import { renderWithProviders, screen, within } from "__support__/ui";
-import type { MetabotAgentChatMessage } from "metabase/metabot/state";
+import type {
+  MetabotAgentChatMessage,
+  MetabotChatMessage,
+} from "metabase/metabot/state";
+import { thumbsDown, thumbsUp } from "metabase/metabot/tests/utils";
 import { createMockUser } from "metabase-types/api/mocks";
 
 import { AgentMessage, Messages } from "./MetabotChatMessage";
@@ -39,6 +43,51 @@ describe("AgentMessage", () => {
     expect(
       within(agentMessage).queryByTestId("metabot-chat-message-copy"),
     ).not.toBeInTheDocument();
+  });
+
+  describe("feedback controls", () => {
+    const conversation: MetabotChatMessage[] = [
+      { id: "u1", role: "user", type: "text", message: "hi" },
+      {
+        id: "a1",
+        role: "agent",
+        type: "text",
+        message: "hello",
+        externalId: "a1-ext",
+      },
+    ];
+
+    it("shows feedback ratings in an interactive conversation", async () => {
+      renderWithProviders(
+        <Messages
+          messages={conversation}
+          isDoingScience={false}
+          debug={false}
+        />,
+      );
+
+      const [, agentMessage] = screen.getAllByTestId("metabot-chat-message");
+      expect(await thumbsUp(agentMessage)).toBeInTheDocument();
+      expect(await thumbsDown(agentMessage)).toBeInTheDocument();
+    });
+
+    it("hides feedback ratings in a read-only conversation", () => {
+      renderWithProviders(
+        <Messages
+          messages={conversation}
+          isDoingScience={false}
+          debug={false}
+          readonly
+        />,
+      );
+
+      expect(
+        screen.queryByTestId("metabot-chat-message-thumbs-up"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("metabot-chat-message-thumbs-down"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe("turn_errored", () => {

--- a/frontend/src/metabase/metabot/hooks/index.ts
+++ b/frontend/src/metabase/metabot/hooks/index.ts
@@ -1,5 +1,6 @@
 export { useIsAskPage } from "./use-is-ask-page";
 export { useMetabotEnabledEmbeddingAware } from "./use-metabot-embedding-aware-enabled";
+export { useBranchableMessages } from "./use-branchable-messages";
 export { useMetabotAgent } from "./use-metabot-agent";
 export { useMetabotAgentsManager } from "./use-metabot-agents-manager";
 export { useMetabotName } from "./use-metabot-name";

--- a/frontend/src/metabase/metabot/hooks/use-branchable-messages.tsx
+++ b/frontend/src/metabase/metabot/hooks/use-branchable-messages.tsx
@@ -1,77 +1,64 @@
-import { type ReactNode, useCallback, useMemo, useState } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 
 import { MetabotBranchPicker } from "metabase/metabot/components/MetabotBranchPicker";
 import type { MetabotChatMessage } from "metabase/metabot/state/types";
 import {
-  type ActiveResponse,
   type ParentedChatMessage,
-  type SelectedBranch,
   activeResponses,
-  indexChildrenByParent,
 } from "metabase/metabot/utils/message-tree";
 
-// Turns a flat parent-pointer message list into the transcript to render, walking
-// one path through its branches. Each regenerated reply gets a picker to page its
-// siblings; other consumers stay branch-free since a single reply never branches.
+type ActiveResponse = ReturnType<typeof activeResponses>[number];
+
 export function useBranchableMessages(
-  nodes: ParentedChatMessage[],
+  sourceMessages: ParentedChatMessage[],
   { isSlack = false }: { isSlack?: boolean } = {},
 ): {
   messages: MetabotChatMessage[];
-  getExtraAgentActions: (message: MetabotChatMessage) => ReactNode;
+  getExtraAgentActions: (messageId: string) => ReactNode;
 } {
-  // Which reply is selected at each branch point; unset branches show the newest.
-  const [selectedBranch, setSelectedBranch] = useState<SelectedBranch>({});
-  const selectBranch = useCallback(
-    (parentId: string, replyId: string) =>
-      setSelectedBranch((prev) => ({ ...prev, [parentId]: replyId })),
-    [],
-  );
+  const [selectedReplyByParentId, setSelectedReplyByParentId] = useState<
+    Record<string, string>
+  >({});
 
-  const responses = useMemo(
-    () =>
-      activeResponses(indexChildrenByParent(nodes), selectedBranch, {
-        isSlack,
-      }),
-    [nodes, selectedBranch, isSlack],
-  );
-  const messages = useMemo(
-    () => responses.flatMap((response) => response.messages),
-    [responses],
-  );
-  const pickerById = useMemo(
-    () => buildBranchPickers(responses, selectBranch),
-    [responses, selectBranch],
-  );
-  const getExtraAgentActions = useCallback(
-    (message: MetabotChatMessage) => pickerById[message.id],
-    [pickerById],
-  );
+  return useMemo(() => {
+    const selectBranch = (parentId: string, replyId: string) =>
+      setSelectedReplyByParentId((selected) => ({
+        ...selected,
+        [parentId]: replyId,
+      }));
+    const responses = activeResponses(sourceMessages, selectedReplyByParentId, {
+      isSlack,
+    });
+    const branchPickers = buildBranchPickers(responses, selectBranch);
 
-  return { messages, getExtraAgentActions };
+    return {
+      messages: responses.flatMap(({ messages }) => messages),
+      getExtraAgentActions: (messageId: string) => branchPickers[messageId],
+    };
+  }, [sourceMessages, selectedReplyByParentId, isSlack]);
 }
 
-// Map each branched response's last message to a picker that pages its siblings.
 function buildBranchPickers(
   responses: ActiveResponse[],
   selectBranch: (parentId: string, replyId: string) => void,
 ): Record<string, ReactNode> {
-  return Object.fromEntries(
-    responses.flatMap(({ branch, messages }) => {
-      const lastMessage = messages.at(-1);
-      if (!branch || !lastMessage) {
-        return [];
-      }
-      const picker = (
-        <MetabotBranchPicker
-          index={branch.currentIndex}
-          count={branch.siblingIds.length}
-          onChange={(next) =>
-            selectBranch(branch.parentId, branch.siblingIds[next])
-          }
-        />
-      );
-      return [[lastMessage.id, picker]];
-    }),
-  );
+  const pickers: Record<string, ReactNode> = {};
+  for (const { branch, messages } of responses) {
+    const lastMessage = messages.at(-1);
+    if (!branch || !lastMessage) {
+      continue;
+    }
+
+    // Agent actions render on the final message in a response.
+    pickers[lastMessage.id] = (
+      <MetabotBranchPicker
+        index={branch.currentIndex}
+        count={branch.replyIds.length}
+        onChange={(next) =>
+          selectBranch(branch.parentId, branch.replyIds[next])
+        }
+      />
+    );
+  }
+  return pickers;
 }

--- a/frontend/src/metabase/metabot/hooks/use-branchable-messages.tsx
+++ b/frontend/src/metabase/metabot/hooks/use-branchable-messages.tsx
@@ -1,0 +1,77 @@
+import { type ReactNode, useCallback, useMemo, useState } from "react";
+
+import { MetabotBranchPicker } from "metabase/metabot/components/MetabotBranchPicker";
+import type { MetabotChatMessage } from "metabase/metabot/state/types";
+import {
+  type ActiveResponse,
+  type ParentedChatMessage,
+  type SelectedBranch,
+  activeResponses,
+  indexChildrenByParent,
+} from "metabase/metabot/utils/message-tree";
+
+// Turns a flat parent-pointer message list into the transcript to render, walking
+// one path through its branches. Each regenerated reply gets a picker to page its
+// siblings; other consumers stay branch-free since a single reply never branches.
+export function useBranchableMessages(
+  nodes: ParentedChatMessage[],
+  { isSlack = false }: { isSlack?: boolean } = {},
+): {
+  messages: MetabotChatMessage[];
+  getExtraAgentActions: (message: MetabotChatMessage) => ReactNode;
+} {
+  // Which reply is selected at each branch point; unset branches show the newest.
+  const [selectedBranch, setSelectedBranch] = useState<SelectedBranch>({});
+  const selectBranch = useCallback(
+    (parentId: string, replyId: string) =>
+      setSelectedBranch((prev) => ({ ...prev, [parentId]: replyId })),
+    [],
+  );
+
+  const responses = useMemo(
+    () =>
+      activeResponses(indexChildrenByParent(nodes), selectedBranch, {
+        isSlack,
+      }),
+    [nodes, selectedBranch, isSlack],
+  );
+  const messages = useMemo(
+    () => responses.flatMap((response) => response.messages),
+    [responses],
+  );
+  const pickerById = useMemo(
+    () => buildBranchPickers(responses, selectBranch),
+    [responses, selectBranch],
+  );
+  const getExtraAgentActions = useCallback(
+    (message: MetabotChatMessage) => pickerById[message.id],
+    [pickerById],
+  );
+
+  return { messages, getExtraAgentActions };
+}
+
+// Map each branched response's last message to a picker that pages its siblings.
+function buildBranchPickers(
+  responses: ActiveResponse[],
+  selectBranch: (parentId: string, replyId: string) => void,
+): Record<string, ReactNode> {
+  return Object.fromEntries(
+    responses.flatMap(({ branch, messages }) => {
+      const lastMessage = messages.at(-1);
+      if (!branch || !lastMessage) {
+        return [];
+      }
+      const picker = (
+        <MetabotBranchPicker
+          index={branch.currentIndex}
+          count={branch.siblingIds.length}
+          onChange={(next) =>
+            selectBranch(branch.parentId, branch.siblingIds[next])
+          }
+        />
+      );
+      return [[lastMessage.id, picker]];
+    }),
+  );
+}

--- a/frontend/src/metabase/metabot/hooks/use-branchable-messages.tsx
+++ b/frontend/src/metabase/metabot/hooks/use-branchable-messages.tsx
@@ -14,7 +14,7 @@ export function useBranchableMessages(
   { isSlack = false }: { isSlack?: boolean } = {},
 ): {
   messages: MetabotChatMessage[];
-  getExtraAgentActions: (messageId: string) => ReactNode;
+  getExtraActions: (messageId: string) => ReactNode;
 } {
   const [selectedReplyByParentId, setSelectedReplyByParentId] = useState<
     Record<string, string>
@@ -33,7 +33,7 @@ export function useBranchableMessages(
 
     return {
       messages: responses.flatMap(({ messages }) => messages),
-      getExtraAgentActions: (messageId: string) => branchPickers[messageId],
+      getExtraActions: (messageId: string) => branchPickers[messageId],
     };
   }, [sourceMessages, selectedReplyByParentId, isSlack]);
 }

--- a/frontend/src/metabase/metabot/state/types.ts
+++ b/frontend/src/metabase/metabot/state/types.ts
@@ -79,12 +79,20 @@ export type MetabotAgentTurnErroredMessage = {
   externalId?: string;
 };
 
+export type MetabotAgentTurnInProgressMessage = {
+  id: string;
+  role: "agent";
+  type: "turn_in_progress";
+  externalId?: string;
+};
+
 export type MetabotAgentChatMessage =
   | MetabotAgentTextChatMessage
   | MetabotAgentDataPartMessage
   | MetabotDebugToolCallMessage
   | MetabotAgentTurnAbortedMessage
-  | MetabotAgentTurnErroredMessage;
+  | MetabotAgentTurnErroredMessage
+  | MetabotAgentTurnInProgressMessage;
 
 export type MetabotUserChatMessage = MetabotUserTextChatMessage;
 

--- a/frontend/src/metabase/metabot/utils/message-tree.ts
+++ b/frontend/src/metabase/metabot/utils/message-tree.ts
@@ -1,0 +1,123 @@
+import type { MetabotChatMessage } from "metabase/metabot/state/types";
+
+import {
+  type FetchedChatMessage,
+  normalizeFetchedChatMessages,
+} from "./normalize-fetched-chat-messages";
+
+// The backend can return a conversation as a flat list of messages, each
+// pointing at its parent. That makes a tree: a prompt's replies are its
+// children, and a regenerated reply is just another child sharing the same
+// parent. This module rebuilds that tree and walks one path through it.
+
+// A fetched chat message annotated with its parent, so the flat list forms a tree.
+export type ParentedChatMessage = FetchedChatMessage & {
+  parent_message_id: string | null;
+};
+
+type TreeNode = { id: string; parent_message_id: string | null };
+
+// Children grouped under each parent id (null holds the roots), preserving the
+// backend's oldest-to-newest order.
+export type BranchIndex<T extends TreeNode> = Map<string | null, T[]>;
+
+// The reply chosen at each branch point: parent id → chosen child id. A branch
+// left unset defaults to the newest reply.
+export type SelectedBranch = Record<string, string>;
+
+// Which reply is showing at a branch point, and its alternatives, so a picker
+// can page between them.
+export type BranchChoice = {
+  parentId: string;
+  currentIndex: number;
+  siblingIds: string[];
+};
+
+// One response along the active path: its rendered messages, plus the branch it
+// belongs to when the prompt was answered more than once.
+export type ActiveResponse = {
+  messages: MetabotChatMessage[];
+  branch: BranchChoice | null;
+};
+
+export function indexChildrenByParent<T extends TreeNode>(
+  nodes: T[],
+): BranchIndex<T> {
+  return nodes.reduce<BranchIndex<T>>((index, node) => {
+    const siblings = index.get(node.parent_message_id) ?? [];
+    return index.set(node.parent_message_id, [...siblings, node]);
+  }, new Map());
+}
+
+// Walk from the root, taking the selected (or newest) reply at each branch, into
+// the flat list of messages on the active path. An older reply has no children,
+// so choosing it naturally truncates everything downstream.
+export function activePath<T extends TreeNode>(
+  index: BranchIndex<T>,
+  selected: SelectedBranch,
+  parentId: string | null = null,
+): T[] {
+  const children = index.get(parentId) ?? [];
+  if (children.length === 0) {
+    return [];
+  }
+  const node = chooseReply(children, selected);
+  return [node, ...activePath(index, selected, node.id)];
+}
+
+export function activeResponses(
+  index: BranchIndex<ParentedChatMessage>,
+  selected: SelectedBranch,
+  { isSlack }: { isSlack: boolean },
+): ActiveResponse[] {
+  const path = activePath(index, selected);
+  return groupIntoResponses(path).map((response) => ({
+    messages: normalizeFetchedChatMessages(response, { isSlack }),
+    branch: branchAt(index, response),
+  }));
+}
+
+function chooseReply<T extends TreeNode>(
+  siblings: T[],
+  selected: SelectedBranch,
+): T {
+  const newest = siblings[siblings.length - 1];
+  const parentId = siblings[0].parent_message_id;
+  const chosenId = parentId == null ? undefined : selected[parentId];
+  return siblings.find((sibling) => sibling.id === chosenId) ?? newest;
+}
+
+// Split the path into responses: each user prompt stands alone, and its agent
+// reply (one or more chained blocks) groups into a single response.
+function groupIntoResponses(
+  path: ParentedChatMessage[],
+): ParentedChatMessage[][] {
+  return path.reduce<ParentedChatMessage[][]>((responses, node) => {
+    const current = responses[responses.length - 1];
+    const continuesReply =
+      current?.[0].role === "agent" && node.role === "agent";
+    return continuesReply
+      ? [...responses.slice(0, -1), [...current, node]]
+      : [...responses, [node]];
+  }, []);
+}
+
+function branchAt(
+  index: BranchIndex<ParentedChatMessage>,
+  response: ParentedChatMessage[],
+): BranchChoice | null {
+  const [head] = response;
+  const siblings = index.get(head.parent_message_id) ?? [];
+  const isRegenerated =
+    head.role === "agent" &&
+    head.parent_message_id != null &&
+    siblings.length > 1;
+  if (!isRegenerated) {
+    return null;
+  }
+  return {
+    parentId: head.parent_message_id as string,
+    currentIndex: siblings.indexOf(head),
+    siblingIds: siblings.map((sibling) => sibling.id),
+  };
+}

--- a/frontend/src/metabase/metabot/utils/message-tree.ts
+++ b/frontend/src/metabase/metabot/utils/message-tree.ts
@@ -5,119 +5,108 @@ import {
   normalizeFetchedChatMessages,
 } from "./normalize-fetched-chat-messages";
 
-// The backend can return a conversation as a flat list of messages, each
-// pointing at its parent. That makes a tree: a prompt's replies are its
-// children, and a regenerated reply is just another child sharing the same
-// parent. This module rebuilds that tree and walks one path through it.
-
-// A fetched chat message annotated with its parent, so the flat list forms a tree.
 export type ParentedChatMessage = FetchedChatMessage & {
   parent_message_id: string | null;
 };
 
-type TreeNode = { id: string; parent_message_id: string | null };
+type BranchIndex = Map<string | null, ParentedChatMessage[]>;
 
-// Children grouped under each parent id (null holds the roots), preserving the
-// backend's oldest-to-newest order.
-export type BranchIndex<T extends TreeNode> = Map<string | null, T[]>;
+type SelectedReplyByParentId = Record<string, string>;
 
-// The reply chosen at each branch point: parent id → chosen child id. A branch
-// left unset defaults to the newest reply.
-export type SelectedBranch = Record<string, string>;
-
-// Which reply is showing at a branch point, and its alternatives, so a picker
-// can page between them.
-export type BranchChoice = {
+type ResponseBranch = {
   parentId: string;
   currentIndex: number;
-  siblingIds: string[];
+  replyIds: string[];
 };
 
-// One response along the active path: its rendered messages, plus the branch it
-// belongs to when the prompt was answered more than once.
-export type ActiveResponse = {
+type ActiveResponse = {
   messages: MetabotChatMessage[];
-  branch: BranchChoice | null;
+  branch: ResponseBranch | null;
 };
 
-export function indexChildrenByParent<T extends TreeNode>(
-  nodes: T[],
-): BranchIndex<T> {
-  return nodes.reduce<BranchIndex<T>>((index, node) => {
-    const siblings = index.get(node.parent_message_id) ?? [];
-    return index.set(node.parent_message_id, [...siblings, node]);
-  }, new Map());
+function indexChildrenByParent(messages: ParentedChatMessage[]): BranchIndex {
+  const index: BranchIndex = new Map();
+  for (const message of messages) {
+    const siblings = index.get(message.parent_message_id);
+    if (siblings) {
+      siblings.push(message);
+    } else {
+      index.set(message.parent_message_id, [message]);
+    }
+  }
+  return index;
 }
 
-// Walk from the root, taking the selected (or newest) reply at each branch, into
-// the flat list of messages on the active path. An older reply has no children,
-// so choosing it naturally truncates everything downstream.
-export function activePath<T extends TreeNode>(
-  index: BranchIndex<T>,
-  selected: SelectedBranch,
-  parentId: string | null = null,
-): T[] {
-  const children = index.get(parentId) ?? [];
-  if (children.length === 0) {
-    return [];
+function activePath(
+  index: BranchIndex,
+  selectedReplyByParentId: SelectedReplyByParentId,
+): ParentedChatMessage[] {
+  const path: ParentedChatMessage[] = [];
+  let parentId: string | null = null;
+
+  while (true) {
+    const siblings = index.get(parentId);
+    if (!siblings?.length) {
+      return path;
+    }
+
+    const selectedId: string | undefined =
+      parentId === null ? undefined : selectedReplyByParentId[parentId];
+    // Siblings arrive oldest first; default to the newest.
+    const node: ParentedChatMessage =
+      siblings.find(({ id }) => id === selectedId) ??
+      siblings[siblings.length - 1];
+    path.push(node);
+    parentId = node.id;
   }
-  const node = chooseReply(children, selected);
-  return [node, ...activePath(index, selected, node.id)];
 }
 
 export function activeResponses(
-  index: BranchIndex<ParentedChatMessage>,
-  selected: SelectedBranch,
+  messages: ParentedChatMessage[],
+  selectedReplyByParentId: SelectedReplyByParentId,
   { isSlack }: { isSlack: boolean },
 ): ActiveResponse[] {
-  const path = activePath(index, selected);
+  const index = indexChildrenByParent(messages);
+  const path = activePath(index, selectedReplyByParentId);
   return groupIntoResponses(path).map((response) => ({
     messages: normalizeFetchedChatMessages(response, { isSlack }),
     branch: branchAt(index, response),
   }));
 }
 
-function chooseReply<T extends TreeNode>(
-  siblings: T[],
-  selected: SelectedBranch,
-): T {
-  const newest = siblings[siblings.length - 1];
-  const parentId = siblings[0].parent_message_id;
-  const chosenId = parentId == null ? undefined : selected[parentId];
-  return siblings.find((sibling) => sibling.id === chosenId) ?? newest;
-}
-
-// Split the path into responses: each user prompt stands alone, and its agent
-// reply (one or more chained blocks) groups into a single response.
 function groupIntoResponses(
   path: ParentedChatMessage[],
 ): ParentedChatMessage[][] {
-  return path.reduce<ParentedChatMessage[][]>((responses, node) => {
-    const current = responses[responses.length - 1];
-    const continuesReply =
-      current?.[0].role === "agent" && node.role === "agent";
-    return continuesReply
-      ? [...responses.slice(0, -1), [...current, node]]
-      : [...responses, [node]];
-  }, []);
+  const responses: ParentedChatMessage[][] = [];
+  for (const node of path) {
+    const current = responses.at(-1);
+    if (current?.[0].role === "agent" && node.role === "agent") {
+      current.push(node);
+    } else {
+      responses.push([node]);
+    }
+  }
+  return responses;
 }
 
 function branchAt(
-  index: BranchIndex<ParentedChatMessage>,
+  index: BranchIndex,
   response: ParentedChatMessage[],
-): BranchChoice | null {
-  const [head] = response;
-  const siblings = index.get(head.parent_message_id) ?? [];
-  const isRegenerated =
-    head.role === "agent" &&
-    head.parent_message_id != null &&
-    siblings.length > 1;
-  if (!isRegenerated) {
+): ResponseBranch | null {
+  const head = response[0];
+  const parentId = head.parent_message_id;
+  if (head.role !== "agent" || parentId === null) {
     return null;
   }
+
+  const siblings = index.get(head.parent_message_id) ?? [];
+  if (siblings.length < 2) {
+    return null;
+  }
+
   return {
-    parentId: head.parent_message_id as string,
-    currentIndex: siblings.indexOf(head),
-    siblingIds: siblings.map((sibling) => sibling.id),
+    parentId,
+    currentIndex: siblings.findIndex(({ id }) => id === head.id),
+    replyIds: siblings.map(({ id }) => id),
   };
 }

--- a/frontend/src/metabase/metabot/utils/message-tree.ts
+++ b/frontend/src/metabase/metabot/utils/message-tree.ts
@@ -13,6 +13,8 @@ type BranchIndex = Map<string | null, ParentedChatMessage[]>;
 
 type SelectedReplyByParentId = Record<string, string>;
 
+const ROOT_KEY = "__root__";
+
 type ResponseBranch = {
   parentId: string;
   currentIndex: number;
@@ -51,7 +53,7 @@ function activePath(
     }
 
     const selectedId: string | undefined =
-      parentId === null ? undefined : selectedReplyByParentId[parentId];
+      selectedReplyByParentId[parentId ?? ROOT_KEY];
     // Siblings arrive oldest first; default to the newest.
     const node: ParentedChatMessage =
       siblings.find(({ id }) => id === selectedId) ??
@@ -94,18 +96,13 @@ function branchAt(
   response: ParentedChatMessage[],
 ): ResponseBranch | null {
   const head = response[0];
-  const parentId = head.parent_message_id;
-  if (head.role !== "agent" || parentId === null) {
-    return null;
-  }
-
   const siblings = index.get(head.parent_message_id) ?? [];
   if (siblings.length < 2) {
     return null;
   }
 
   return {
-    parentId,
+    parentId: head.parent_message_id ?? ROOT_KEY,
     currentIndex: siblings.findIndex(({ id }) => id === head.id),
     replyIds: siblings.map(({ id }) => id),
   };

--- a/frontend/src/metabase/metabot/utils/message-tree.unit.spec.ts
+++ b/frontend/src/metabase/metabot/utils/message-tree.unit.spec.ts
@@ -1,0 +1,92 @@
+import {
+  type ParentedChatMessage,
+  activePath,
+  activeResponses,
+  indexChildrenByParent,
+} from "./message-tree";
+
+function user(id: string, parentId: string | null): ParentedChatMessage {
+  return {
+    id,
+    parent_message_id: parentId,
+    role: "user",
+    type: "text",
+    message: id,
+  };
+}
+
+function agent(id: string, parentId: string | null): ParentedChatMessage {
+  return {
+    id,
+    parent_message_id: parentId,
+    role: "agent",
+    type: "text",
+    message: id,
+    externalId: id,
+  };
+}
+
+// A prompt with two agent replies (a1 older, a2 newest), then a follow-up prompt
+// that branched off the newest reply.
+const regenerated: ParentedChatMessage[] = [
+  user("u1", null),
+  agent("a1", "u1"),
+  agent("a2", "u1"),
+  user("u2", "a2"),
+  agent("b1", "u2"),
+];
+
+describe("indexChildrenByParent", () => {
+  it("groups children under their parent id, roots under null", () => {
+    const index = indexChildrenByParent(regenerated);
+
+    expect(index.get(null)).toEqual([user("u1", null)]);
+    expect(index.get("u1")).toEqual([agent("a1", "u1"), agent("a2", "u1")]);
+    expect(index.get("a2")).toEqual([user("u2", "a2")]);
+  });
+});
+
+describe("activePath", () => {
+  const index = indexChildrenByParent(regenerated);
+
+  it("defaults each branch to its newest reply", () => {
+    expect(activePath(index, {}).map((node) => node.id)).toEqual([
+      "u1",
+      "a2",
+      "u2",
+      "b1",
+    ]);
+  });
+
+  it("follows a selected older reply and truncates everything downstream", () => {
+    expect(activePath(index, { u1: "a1" }).map((node) => node.id)).toEqual([
+      "u1",
+      "a1",
+    ]);
+  });
+});
+
+describe("activeResponses", () => {
+  const index = indexChildrenByParent(regenerated);
+
+  it("marks a regenerated reply with its branch and alternatives", () => {
+    const [prompt, reply] = activeResponses(index, {}, { isSlack: false });
+
+    expect(prompt.branch).toBeNull();
+    expect(reply.branch).toEqual({
+      parentId: "u1",
+      currentIndex: 1,
+      siblingIds: ["a1", "a2"],
+    });
+  });
+
+  it("leaves a single reply unbranched", () => {
+    const [reply] = activeResponses(
+      indexChildrenByParent([user("u1", null), agent("a1", "u1")]),
+      {},
+      { isSlack: false },
+    );
+
+    expect(reply.branch).toBeNull();
+  });
+});

--- a/frontend/src/metabase/metabot/utils/message-tree.unit.spec.ts
+++ b/frontend/src/metabase/metabot/utils/message-tree.unit.spec.ts
@@ -1,9 +1,4 @@
-import {
-  type ParentedChatMessage,
-  activePath,
-  activeResponses,
-  indexChildrenByParent,
-} from "./message-tree";
+import { type ParentedChatMessage, activeResponses } from "./message-tree";
 
 function user(id: string, parentId: string | null): ParentedChatMessage {
   return {
@@ -26,8 +21,6 @@ function agent(id: string, parentId: string | null): ParentedChatMessage {
   };
 }
 
-// A prompt with two agent replies (a1 older, a2 newest), then a follow-up prompt
-// that branched off the newest reply.
 const regenerated: ParentedChatMessage[] = [
   user("u1", null),
   agent("a1", "u1"),
@@ -36,57 +29,74 @@ const regenerated: ParentedChatMessage[] = [
   agent("b1", "u2"),
 ];
 
-describe("indexChildrenByParent", () => {
-  it("groups children under their parent id, roots under null", () => {
-    const index = indexChildrenByParent(regenerated);
-
-    expect(index.get(null)).toEqual([user("u1", null)]);
-    expect(index.get("u1")).toEqual([agent("a1", "u1"), agent("a2", "u1")]);
-    expect(index.get("a2")).toEqual([user("u2", "a2")]);
-  });
-});
-
-describe("activePath", () => {
-  const index = indexChildrenByParent(regenerated);
-
+describe("activeResponses", () => {
   it("defaults each branch to its newest reply", () => {
-    expect(activePath(index, {}).map((node) => node.id)).toEqual([
-      "u1",
-      "a2",
-      "u2",
-      "b1",
-    ]);
+    const responses = activeResponses(regenerated, {}, { isSlack: false });
+
+    expect(
+      responses.flatMap(({ messages }) => messages.map(({ id }) => id)),
+    ).toEqual(["u1", "a2", "u2", "b1"]);
   });
 
   it("follows a selected older reply and truncates everything downstream", () => {
-    expect(activePath(index, { u1: "a1" }).map((node) => node.id)).toEqual([
-      "u1",
-      "a1",
-    ]);
-  });
-});
+    const responses = activeResponses(
+      regenerated,
+      { u1: "a1" },
+      { isSlack: false },
+    );
 
-describe("activeResponses", () => {
-  const index = indexChildrenByParent(regenerated);
+    expect(
+      responses.flatMap(({ messages }) => messages.map(({ id }) => id)),
+    ).toEqual(["u1", "a1"]);
+  });
 
   it("marks a regenerated reply with its branch and alternatives", () => {
-    const [prompt, reply] = activeResponses(index, {}, { isSlack: false });
+    const [prompt, reply] = activeResponses(
+      regenerated,
+      {},
+      {
+        isSlack: false,
+      },
+    );
 
     expect(prompt.branch).toBeNull();
     expect(reply.branch).toEqual({
       parentId: "u1",
       currentIndex: 1,
-      siblingIds: ["a1", "a2"],
+      replyIds: ["a1", "a2"],
     });
   });
 
   it("leaves a single reply unbranched", () => {
-    const [reply] = activeResponses(
-      indexChildrenByParent([user("u1", null), agent("a1", "u1")]),
+    const [, reply] = activeResponses(
+      [user("u1", null), agent("a1", "u1")],
       {},
       { isSlack: false },
     );
 
     expect(reply.branch).toBeNull();
+  });
+
+  it("groups a multi-message reply", () => {
+    const messages = [
+      user("u1", null),
+      agent("a1", "u1"),
+      agent("a2", "u1"),
+      agent("a2-tool", "a2"),
+      user("u2", "a2-tool"),
+    ];
+    const [, reply, followUp] = activeResponses(
+      messages,
+      {},
+      { isSlack: false },
+    );
+
+    expect(reply.messages.map(({ id }) => id)).toEqual(["a2", "a2-tool"]);
+    expect(reply.branch).toEqual({
+      parentId: "u1",
+      currentIndex: 1,
+      replyIds: ["a1", "a2"],
+    });
+    expect(followUp.messages[0].id).toBe("u2");
   });
 });

--- a/frontend/src/metabase/metabot/utils/message-tree.unit.spec.ts
+++ b/frontend/src/metabase/metabot/utils/message-tree.unit.spec.ts
@@ -99,4 +99,72 @@ describe("activeResponses", () => {
     });
     expect(followUp.messages[0].id).toBe("u2");
   });
+
+  describe("user-prompt branches (rewound errored turn)", () => {
+    const rewoundAtRoot = [
+      user("uErr", null),
+      agent("aErr", "uErr"),
+      user("uLive", null),
+      agent("aLive", "uLive"),
+    ];
+
+    it("defaults to the newest root prompt and marks it with a branch on the prompt", () => {
+      const [prompt, reply] = activeResponses(
+        rewoundAtRoot,
+        {},
+        { isSlack: false },
+      );
+
+      expect(prompt.messages.map(({ id }) => id)).toEqual(["uLive"]);
+      expect(prompt.branch).toEqual({
+        parentId: "__root__",
+        currentIndex: 1,
+        replyIds: ["uErr", "uLive"],
+      });
+      expect(reply.messages.map(({ id }) => id)).toEqual(["aLive"]);
+    });
+
+    it("follows a selected older root prompt to reveal the rewound errored turn", () => {
+      const responses = activeResponses(
+        rewoundAtRoot,
+        { __root__: "uErr" },
+        { isSlack: false },
+      );
+
+      expect(
+        responses.flatMap(({ messages }) => messages.map(({ id }) => id)),
+      ).toEqual(["uErr", "aErr"]);
+    });
+
+    it("branches user prompts mid-thread too", () => {
+      const messages = [
+        user("u1", null),
+        agent("a1", "u1"),
+        user("uErr", "a1"),
+        agent("aErr", "uErr"),
+        user("uLive", "a1"),
+        agent("aLive", "uLive"),
+      ];
+
+      const promptResponse = activeResponses(
+        messages,
+        {},
+        { isSlack: false },
+      ).find(({ messages }) => messages[0]?.id === "uLive");
+      expect(promptResponse?.branch).toEqual({
+        parentId: "a1",
+        currentIndex: 1,
+        replyIds: ["uErr", "uLive"],
+      });
+
+      const selected = activeResponses(
+        messages,
+        { a1: "uErr" },
+        { isSlack: false },
+      );
+      expect(
+        selected.flatMap(({ messages }) => messages.map(({ id }) => id)),
+      ).toEqual(["u1", "a1", "uErr", "aErr"]);
+    });
+  });
 });

--- a/frontend/src/metabase/metabot/utils/slack-mrkdwn.ts
+++ b/frontend/src/metabase/metabot/utils/slack-mrkdwn.ts
@@ -37,5 +37,6 @@ export function convertSlackChatMessage(
     .with({ role: "agent", type: "tool_call" }, (m) => m)
     .with({ role: "agent", type: "turn_aborted" }, (m) => m)
     .with({ role: "agent", type: "turn_errored" }, (m) => m)
+    .with({ role: "agent", type: "turn_in_progress" }, (m) => m)
     .exhaustive();
 }

--- a/frontend/test/__support__/server-mocks/index.ts
+++ b/frontend/test/__support__/server-mocks/index.ts
@@ -32,6 +32,7 @@ export * from "./library";
 export * from "./logger";
 export * from "./measure";
 export * from "./metabot";
+export * from "./metabot-analytics";
 export * from "./metric";
 export * from "./model-indexes";
 export * from "./native-query-snippet";

--- a/frontend/test/__support__/server-mocks/metabot-analytics.ts
+++ b/frontend/test/__support__/server-mocks/metabot-analytics.ts
@@ -1,0 +1,12 @@
+import fetchMock from "fetch-mock";
+
+import type { ConversationDetail } from "metabase-enterprise/audit_app/metabot-analytics/types";
+
+export function setupMetabotConversationEndpoint(
+  conversation: ConversationDetail,
+) {
+  fetchMock.get(
+    `path:/api/ee/metabot-analytics/conversations/${conversation.conversation_id}`,
+    conversation,
+  );
+}

--- a/resources/migrations/064/20260713_metabot_analytics_views_include_deleted.yaml
+++ b/resources/migrations/064/20260713_metabot_analytics_views_include_deleted.yaml
@@ -1,0 +1,78 @@
+## Include soft-deleted (rewound / regenerated-away) metabot_message rows in the
+## instance analytics views, matching the admin metabot-analytics API, which now
+## surfaces deleted attempts so conversation branches are visible.
+##
+## v_metabot_conversations v4 drops the `deleted_at IS NULL` filters from its
+## message join and profile subqueries, so message_count / assistant_message_count
+## and profile now count every attempt. (Token totals already come from
+## ai_usage_log and were unaffected by the filter.)
+##
+## v_metabot_messages v2 drops the `WHERE m.deleted_at IS NULL` filter so deleted
+## message rows are returned.
+
+databaseChangeLog:
+  - logicalFilePath: migrations/064_update_migrations.yaml
+
+  - changeSet:
+      id: v64.2026-07-13T00:00:00
+      author: sloansparger
+      runOnChange: true
+      comment: Update v_metabot_conversations to include soft-deleted messages
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            path: ../instance_analytics_views/metabot_conversations/v4/postgres-metabot_conversations.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: ../instance_analytics_views/metabot_conversations/v4/mysql-metabot_conversations.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: ../instance_analytics_views/metabot_conversations/v4/h2-metabot_conversations.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            dbms: postgresql
+            path: ../instance_analytics_views/metabot_conversations/v3/postgres-metabot_conversations.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: ../instance_analytics_views/metabot_conversations/v3/mysql-metabot_conversations.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: ../instance_analytics_views/metabot_conversations/v3/h2-metabot_conversations.sql
+            relativeToChangelogFile: true
+
+  - changeSet:
+      id: v64.2026-07-13T00:00:01
+      author: sloansparger
+      runOnChange: true
+      comment: Update v_metabot_messages to include soft-deleted messages
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            path: ../instance_analytics_views/metabot_messages/v2/postgres-metabot_messages.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: ../instance_analytics_views/metabot_messages/v2/mysql-metabot_messages.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: ../instance_analytics_views/metabot_messages/v2/h2-metabot_messages.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            dbms: postgresql
+            path: ../instance_analytics_views/metabot_messages/v1/postgres-metabot_messages.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: ../instance_analytics_views/metabot_messages/v1/mysql-metabot_messages.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: ../instance_analytics_views/metabot_messages/v1/h2-metabot_messages.sql
+            relativeToChangelogFile: true

--- a/resources/migrations/instance_analytics_views/metabot_conversations/v4/h2-metabot_conversations.sql
+++ b/resources/migrations/instance_analytics_views/metabot_conversations/v4/h2-metabot_conversations.sql
@@ -1,0 +1,95 @@
+DROP VIEW IF EXISTS v_metabot_conversations;
+
+CREATE OR REPLACE VIEW v_metabot_conversations AS
+SELECT
+    c.id                                                              AS conversation_id,
+    c.created_at,
+    c.user_id,
+    c.summary,
+    COALESCE(u.first_name || ' ' || u.last_name, u.email)             AS user_display_name,
+    COUNT(m.id)                                                       AS message_count,
+    COUNT(CASE WHEN m.role = 'user' THEN 1 END)                       AS user_message_count,
+    COUNT(CASE WHEN m.role = 'assistant' THEN 1 END)                  AS assistant_message_count,
+    COALESCE(MAX(a.total_tokens), 0)                                  AS total_tokens,
+    COALESCE(MAX(a.prompt_tokens), 0)                                 AS prompt_tokens,
+    COALESCE(MAX(a.completion_tokens), 0)                             AS completion_tokens,
+    MAX(m.created_at)                                                 AS last_message_at,
+    (SELECT mm.profile_id
+     FROM metabot_message mm
+     WHERE mm.conversation_id = c.id
+       AND mm.role = 'assistant'
+     ORDER BY mm.created_at, mm.id
+     LIMIT 1)                                                         AS profile_id,
+    (SELECT CASE mm.profile_id
+                WHEN 'internal'                  THEN 'Internal'
+                WHEN 'embedding_next'            THEN 'Embedding'
+                WHEN 'nlq'                       THEN 'NLQ'
+                WHEN 'sql'                       THEN 'SQL'
+                WHEN 'slackbot'                  THEN 'Slackbot'
+                WHEN 'transforms_codegen'        THEN 'Transforms codegen'
+                WHEN 'document-generate-content' THEN 'Documents'
+                ELSE mm.profile_id
+            END
+     FROM metabot_message mm
+     WHERE mm.conversation_id = c.id
+       AND mm.role = 'assistant'
+     ORDER BY mm.created_at, mm.id
+     LIMIT 1)                                                         AS profile_name,
+    (SELECT pg.name
+     FROM permissions_group_membership pgm
+     JOIN permissions_group pg ON pg.id = pgm.group_id
+     WHERE pgm.user_id = c.user_id
+       AND pg.id != 1
+     ORDER BY pg.name
+     LIMIT 1)                                                         AS group_name,
+    (SELECT aul.source
+     FROM ai_usage_log aul
+     WHERE aul.conversation_id = c.id
+     ORDER BY aul.created_at
+     LIMIT 1)                                                         AS source,
+    (SELECT CASE aul.source
+                WHEN 'metabot_agent'                     THEN 'Metabot'
+                WHEN 'agent'                             THEN 'Metabot'
+                WHEN 'document_generate_content'         THEN 'Documents'
+                WHEN 'example_question_generation_batch' THEN 'Suggested Prompts'
+                WHEN 'slack'                             THEN 'Slackbot'
+                WHEN 'slackbot'                          THEN 'Slackbot'
+                WHEN 'oss-sql-gen'                       THEN 'SQL'
+                WHEN 'sql-gen'                           THEN 'SQL'
+                WHEN 'unknown'                           THEN 'Unknown'
+                ELSE aul.source
+            END
+     FROM ai_usage_log aul
+     WHERE aul.conversation_id = c.id
+     ORDER BY aul.created_at
+     LIMIT 1)                                                         AS source_name,
+    c.ip_address                                                      AS ip_address,
+    c.embedding_hostname                                              AS embedding_hostname,
+    c.embedding_path                                                  AS embedding_path,
+    c.user_agent                                                      AS user_agent,
+    c.sanitized_user_agent                                            AS sanitized_user_agent,
+    MAX(a.tenant_id)                                                  AS tenant_id,
+    MAX(t.name)                                                       AS tenant_name,
+    (SELECT aul.model
+     FROM ai_usage_log aul
+     WHERE aul.conversation_id = c.id
+     ORDER BY aul.created_at
+     LIMIT 1)                                                         AS model
+FROM metabot_conversation c
+LEFT JOIN core_user u
+    ON u.id = c.user_id
+LEFT JOIN metabot_message m
+    ON m.conversation_id = c.id
+LEFT JOIN (
+    SELECT
+        conversation_id,
+        COALESCE(SUM(prompt_tokens), 0)     AS prompt_tokens,
+        COALESCE(SUM(completion_tokens), 0) AS completion_tokens,
+        COALESCE(SUM(total_tokens), 0)      AS total_tokens,
+        MIN(tenant_id)                       AS tenant_id
+    FROM ai_usage_log
+    WHERE conversation_id IS NOT NULL
+    GROUP BY conversation_id
+) a ON a.conversation_id = c.id
+LEFT JOIN tenant t ON t.id = a.tenant_id
+GROUP BY c.id, c.created_at, c.user_id, c.summary, u.first_name, u.last_name, u.email;

--- a/resources/migrations/instance_analytics_views/metabot_conversations/v4/mysql-metabot_conversations.sql
+++ b/resources/migrations/instance_analytics_views/metabot_conversations/v4/mysql-metabot_conversations.sql
@@ -1,0 +1,95 @@
+DROP VIEW IF EXISTS v_metabot_conversations;
+
+CREATE OR REPLACE VIEW v_metabot_conversations AS
+SELECT
+    c.id                                                              AS conversation_id,
+    c.created_at,
+    c.user_id,
+    c.summary,
+    COALESCE(CONCAT(u.first_name, ' ', u.last_name), u.email)         AS user_display_name,
+    COUNT(m.id)                                                       AS message_count,
+    COUNT(CASE WHEN m.role = 'user' THEN 1 END)                       AS user_message_count,
+    COUNT(CASE WHEN m.role = 'assistant' THEN 1 END)                  AS assistant_message_count,
+    COALESCE(MAX(a.total_tokens), 0)                                  AS total_tokens,
+    COALESCE(MAX(a.prompt_tokens), 0)                                 AS prompt_tokens,
+    COALESCE(MAX(a.completion_tokens), 0)                             AS completion_tokens,
+    MAX(m.created_at)                                                 AS last_message_at,
+    (SELECT mm.profile_id
+     FROM metabot_message mm
+     WHERE mm.conversation_id = c.id
+       AND mm.role = 'assistant'
+     ORDER BY mm.created_at, mm.id
+     LIMIT 1)                                                         AS profile_id,
+    (SELECT CASE mm.profile_id
+                WHEN 'internal'                  THEN 'Internal'
+                WHEN 'embedding_next'            THEN 'Embedding'
+                WHEN 'nlq'                       THEN 'NLQ'
+                WHEN 'sql'                       THEN 'SQL'
+                WHEN 'slackbot'                  THEN 'Slackbot'
+                WHEN 'transforms_codegen'        THEN 'Transforms codegen'
+                WHEN 'document-generate-content' THEN 'Documents'
+                ELSE mm.profile_id
+            END
+     FROM metabot_message mm
+     WHERE mm.conversation_id = c.id
+       AND mm.role = 'assistant'
+     ORDER BY mm.created_at, mm.id
+     LIMIT 1)                                                         AS profile_name,
+    (SELECT pg.name
+     FROM permissions_group_membership pgm
+     JOIN permissions_group pg ON pg.id = pgm.group_id
+     WHERE pgm.user_id = c.user_id
+       AND pg.id != 1
+     ORDER BY pg.name
+     LIMIT 1)                                                         AS group_name,
+    (SELECT aul.source
+     FROM ai_usage_log aul
+     WHERE aul.conversation_id = c.id
+     ORDER BY aul.created_at
+     LIMIT 1)                                                         AS source,
+    (SELECT CASE aul.source
+                WHEN 'metabot_agent'                     THEN 'Metabot'
+                WHEN 'agent'                             THEN 'Metabot'
+                WHEN 'document_generate_content'         THEN 'Documents'
+                WHEN 'example_question_generation_batch' THEN 'Suggested Prompts'
+                WHEN 'slack'                             THEN 'Slackbot'
+                WHEN 'slackbot'                          THEN 'Slackbot'
+                WHEN 'oss-sql-gen'                       THEN 'SQL'
+                WHEN 'sql-gen'                           THEN 'SQL'
+                WHEN 'unknown'                           THEN 'Unknown'
+                ELSE aul.source
+            END
+     FROM ai_usage_log aul
+     WHERE aul.conversation_id = c.id
+     ORDER BY aul.created_at
+     LIMIT 1)                                                         AS source_name,
+    c.ip_address                                                      AS ip_address,
+    c.embedding_hostname                                              AS embedding_hostname,
+    c.embedding_path                                                  AS embedding_path,
+    c.user_agent                                                      AS user_agent,
+    c.sanitized_user_agent                                            AS sanitized_user_agent,
+    MAX(a.tenant_id)                                                  AS tenant_id,
+    MAX(t.name)                                                       AS tenant_name,
+    (SELECT aul.model
+     FROM ai_usage_log aul
+     WHERE aul.conversation_id = c.id
+     ORDER BY aul.created_at
+     LIMIT 1)                                                         AS model
+FROM metabot_conversation c
+LEFT JOIN core_user u
+    ON u.id = c.user_id
+LEFT JOIN metabot_message m
+    ON m.conversation_id = c.id
+LEFT JOIN (
+    SELECT
+        conversation_id,
+        COALESCE(SUM(prompt_tokens), 0)     AS prompt_tokens,
+        COALESCE(SUM(completion_tokens), 0) AS completion_tokens,
+        COALESCE(SUM(total_tokens), 0)      AS total_tokens,
+        MIN(tenant_id)                       AS tenant_id
+    FROM ai_usage_log
+    WHERE conversation_id IS NOT NULL
+    GROUP BY conversation_id
+) a ON a.conversation_id = c.id
+LEFT JOIN tenant t ON t.id = a.tenant_id
+GROUP BY c.id, c.created_at, c.user_id, c.summary, u.first_name, u.last_name, u.email;

--- a/resources/migrations/instance_analytics_views/metabot_conversations/v4/postgres-metabot_conversations.sql
+++ b/resources/migrations/instance_analytics_views/metabot_conversations/v4/postgres-metabot_conversations.sql
@@ -1,0 +1,95 @@
+DROP VIEW IF EXISTS v_metabot_conversations;
+
+CREATE OR REPLACE VIEW v_metabot_conversations AS
+SELECT
+    c.id                                                              AS conversation_id,
+    c.created_at,
+    c.user_id,
+    c.summary,
+    COALESCE(u.first_name || ' ' || u.last_name, u.email)            AS user_display_name,
+    COUNT(m.id)                                                       AS message_count,
+    COUNT(CASE WHEN m.role = 'user' THEN 1 END)                       AS user_message_count,
+    COUNT(CASE WHEN m.role = 'assistant' THEN 1 END)                  AS assistant_message_count,
+    COALESCE(MAX(a.total_tokens), 0)                                  AS total_tokens,
+    COALESCE(MAX(a.prompt_tokens), 0)                                 AS prompt_tokens,
+    COALESCE(MAX(a.completion_tokens), 0)                             AS completion_tokens,
+    MAX(m.created_at)                                                 AS last_message_at,
+    (SELECT mm.profile_id
+     FROM metabot_message mm
+     WHERE mm.conversation_id = c.id
+       AND mm.role = 'assistant'
+     ORDER BY mm.created_at, mm.id
+     LIMIT 1)                                                         AS profile_id,
+    (SELECT CASE mm.profile_id
+                WHEN 'internal'                  THEN 'Internal'
+                WHEN 'embedding_next'            THEN 'Embedding'
+                WHEN 'nlq'                       THEN 'NLQ'
+                WHEN 'sql'                       THEN 'SQL'
+                WHEN 'slackbot'                  THEN 'Slackbot'
+                WHEN 'transforms_codegen'        THEN 'Transforms codegen'
+                WHEN 'document-generate-content' THEN 'Documents'
+                ELSE mm.profile_id
+            END
+     FROM metabot_message mm
+     WHERE mm.conversation_id = c.id
+       AND mm.role = 'assistant'
+     ORDER BY mm.created_at, mm.id
+     LIMIT 1)                                                         AS profile_name,
+    (SELECT pg.name
+     FROM permissions_group_membership pgm
+     JOIN permissions_group pg ON pg.id = pgm.group_id
+     WHERE pgm.user_id = c.user_id
+       AND pg.id != 1
+     ORDER BY pg.name
+     LIMIT 1)                                                         AS group_name,
+    (SELECT aul.source
+     FROM ai_usage_log aul
+     WHERE aul.conversation_id = c.id
+     ORDER BY aul.created_at
+     LIMIT 1)                                                         AS source,
+    (SELECT CASE aul.source
+                WHEN 'metabot_agent'                     THEN 'Metabot'
+                WHEN 'agent'                             THEN 'Metabot'
+                WHEN 'document_generate_content'         THEN 'Documents'
+                WHEN 'example_question_generation_batch' THEN 'Suggested Prompts'
+                WHEN 'slack'                             THEN 'Slackbot'
+                WHEN 'slackbot'                          THEN 'Slackbot'
+                WHEN 'oss-sql-gen'                       THEN 'SQL'
+                WHEN 'sql-gen'                           THEN 'SQL'
+                WHEN 'unknown'                           THEN 'Unknown'
+                ELSE aul.source
+            END
+     FROM ai_usage_log aul
+     WHERE aul.conversation_id = c.id
+     ORDER BY aul.created_at
+     LIMIT 1)                                                         AS source_name,
+    c.ip_address                                                      AS ip_address,
+    c.embedding_hostname                                              AS embedding_hostname,
+    c.embedding_path                                                  AS embedding_path,
+    c.user_agent                                                      AS user_agent,
+    c.sanitized_user_agent                                            AS sanitized_user_agent,
+    MAX(a.tenant_id)                                                  AS tenant_id,
+    MAX(t.name)                                                       AS tenant_name,
+    (SELECT aul.model
+     FROM ai_usage_log aul
+     WHERE aul.conversation_id = c.id
+     ORDER BY aul.created_at
+     LIMIT 1)                                                         AS model
+FROM metabot_conversation c
+LEFT JOIN core_user u
+    ON u.id = c.user_id
+LEFT JOIN metabot_message m
+    ON m.conversation_id = c.id
+LEFT JOIN (
+    SELECT
+        conversation_id,
+        COALESCE(SUM(prompt_tokens), 0)     AS prompt_tokens,
+        COALESCE(SUM(completion_tokens), 0) AS completion_tokens,
+        COALESCE(SUM(total_tokens), 0)      AS total_tokens,
+        MIN(tenant_id)                       AS tenant_id
+    FROM ai_usage_log
+    WHERE conversation_id IS NOT NULL
+    GROUP BY conversation_id
+) a ON a.conversation_id = c.id
+LEFT JOIN tenant t ON t.id = a.tenant_id
+GROUP BY c.id, c.created_at, c.user_id, c.summary, u.first_name, u.last_name, u.email;

--- a/resources/migrations/instance_analytics_views/metabot_messages/v2/h2-metabot_messages.sql
+++ b/resources/migrations/instance_analytics_views/metabot_messages/v2/h2-metabot_messages.sql
@@ -1,0 +1,16 @@
+DROP VIEW IF EXISTS v_metabot_messages;
+
+CREATE OR REPLACE VIEW v_metabot_messages AS
+SELECT
+    m.id                           AS message_id,
+    m.conversation_id,
+    m.created_at,
+    m.role,
+    m.profile_id,
+    m.total_tokens,
+    COALESCE(m.user_id, c.user_id) AS user_id,
+    m.slack_msg_id,
+    m.channel_id
+FROM metabot_message m
+JOIN metabot_conversation c
+    ON c.id = m.conversation_id;

--- a/resources/migrations/instance_analytics_views/metabot_messages/v2/mysql-metabot_messages.sql
+++ b/resources/migrations/instance_analytics_views/metabot_messages/v2/mysql-metabot_messages.sql
@@ -1,0 +1,16 @@
+DROP VIEW IF EXISTS v_metabot_messages;
+
+CREATE OR REPLACE VIEW v_metabot_messages AS
+SELECT
+    m.id                           AS message_id,
+    m.conversation_id,
+    m.created_at,
+    m.role,
+    m.profile_id,
+    m.total_tokens,
+    COALESCE(m.user_id, c.user_id) AS user_id,
+    m.slack_msg_id,
+    m.channel_id
+FROM metabot_message m
+JOIN metabot_conversation c
+    ON c.id = m.conversation_id;

--- a/resources/migrations/instance_analytics_views/metabot_messages/v2/postgres-metabot_messages.sql
+++ b/resources/migrations/instance_analytics_views/metabot_messages/v2/postgres-metabot_messages.sql
@@ -1,0 +1,16 @@
+DROP VIEW IF EXISTS v_metabot_messages;
+
+CREATE OR REPLACE VIEW v_metabot_messages AS
+SELECT
+    m.id                           AS message_id,
+    m.conversation_id,
+    m.created_at,
+    m.role,
+    m.profile_id,
+    m.total_tokens,
+    COALESCE(m.user_id, c.user_id) AS user_id,
+    m.slack_msg_id,
+    m.channel_id
+FROM metabot_message m
+JOIN metabot_conversation c
+    ON c.id = m.conversation_id;

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -475,7 +475,12 @@
                     (tool-part->llm-messages part))))
         data))
 
-(defn- rows->turns
+(defn rows->turns
+  "Group a conversation's messages (ordered by created_at, id) into turns: each
+  `:user` row starts a new turn, and subsequent assistant rows are appended to
+  it. Accepts live and soft-deleted rows alike — when passed the full row set,
+  a retried prompt's turn holds all of its assistant attempts (soft-deleted
+  earlier attempts plus the one live reply) in order."
   [rows]
   (reduce (fn [turns row]
             (if (or (user-row? row) (empty? turns))
@@ -666,7 +671,7 @@
                                                 (some-> v class .getName))
                                      nil)))
 
-(defn- placeholder-still-active?
+(defn placeholder-still-active?
   "True if `row` is an in-flight placeholder created by [[start-turn!]] for a
   stream that hasn't yet completed: assistant role, `:finished` IS NULL (the
   schema-level placeholder marker), and `:created_at` within the grace window.
@@ -689,6 +694,50 @@
    (let [active (remove placeholder-still-active? messages)]
      (->> (if include-errored? active (drop-errored-pairs active))
           (into [] (mapcat message->chat-messages))))))
+
+(defn row->flat-messages
+  "Expand one message row into its flat chat messages, each stamped with a
+  `:parent_message_id`, and return `[messages last-id]` where `last-id` is the id
+  the next row hangs off of."
+  [row parent-id]
+  (let [blocks (if (placeholder-still-active? row)
+                 ;; A still-streaming placeholder has no content yet; emit an
+                 ;; in-progress marker so its response (and pager) still renders.
+                 [(cond-> {:id (or (:external_id row) (str (:id row)))
+                           :role "agent" :type "turn_in_progress"}
+                    (:external_id row) (assoc :externalId (:external_id row)))]
+                 (message->chat-messages row))]
+    ;; A row can render as several blocks; chain each onto the previous one.
+    (reduce (fn [[out prev] block]
+              (let [block (assoc block :parent_message_id prev)]
+                [(conj out block) (:id block)]))
+            [[] parent-id]
+            blocks)))
+
+(defn messages->flat-messages
+  "Flatten a conversation's messages (live + soft-deleted) into a single list of
+  chat messages, each stamped with its `:parent_message_id` so a client can
+  rebuild the branch tree. A turn whose prompt row was soft-deleted (an abandoned
+  resubmit) is dropped."
+  [all-messages]
+  (loop [turns (rows->turns all-messages), prev-last nil, acc []]
+    (if-let [turn (first turns)]
+      (let [prompt-row (u/seek #(= :user (:role %)) turn)]
+        (if (and prompt-row (nil? (:deleted_at prompt-row)))
+          (let [[p-msgs p-last] (row->flat-messages prompt-row prev-last)
+                assistants (filter #(= :assistant (:role %)) turn)
+                results    (map #(row->flat-messages % p-last) assistants)
+                kept-last  (some (fn [[row [_ last-id]]]
+                                   (when (nil? (:deleted_at row)) last-id))
+                                 (map vector assistants results))]
+            (recur (rest turns)
+                   ;; Next turn hangs off the kept reply; if every attempt was
+                   ;; soft-deleted, fall back to the prompt so we don't re-parent
+                   ;; onto the previous turn.
+                   (or kept-last p-last)
+                   (into (into acc p-msgs) (mapcat first) results)))
+          (recur (rest turns) prev-last acc)))
+      acc)))
 
 (defn conversation-detail
   "Conversation-with-chat-messages snapshot. Nil if not found."

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -701,24 +701,31 @@
             messages)))
 
 (defn messages->flat-messages
-  "Convert ordered live and deleted rows to chat messages with parent pointers."
-  [messages]
-  (loop [turns (rows->turns messages), parent-id nil, flat-messages []]
-    (if-let [turn (first turns)]
-      (let [prompt-row (u/seek #(= :user (:role %)) turn)]
-        (if (and prompt-row (nil? (:deleted_at prompt-row)))
-          (let [[prompt-messages prompt-last-id] (row->flat-messages prompt-row parent-id)
-                assistant-rows                  (filterv #(= :assistant (:role %)) turn)
-                attempts                        (mapv #(row->flat-messages % prompt-last-id) assistant-rows)
-                kept-last-id                    (->> (map vector assistant-rows attempts)
-                                                     (keep (fn [[row [_ last-id]]]
-                                                             (when (nil? (:deleted_at row)) last-id)))
-                                                     last)]
-            (recur (rest turns)
-                   (or kept-last-id prompt-last-id)
-                   (into (into flat-messages prompt-messages) (mapcat first) attempts)))
-          (recur (rest turns) parent-id flat-messages)))
-      flat-messages)))
+  "Convert ordered live and deleted rows to chat messages with parent pointers.
+  With `:include-rewound-errors?`, a turn whose prompt was soft-deleted is also
+  kept when it errored (a rewound failed turn), as a dead branch the main thread
+  does not descend from; by default such turns are dropped."
+  ([messages] (messages->flat-messages messages nil))
+  ([messages {:keys [include-rewound-errors?]}]
+   (loop [turns (rows->turns messages), parent-id nil, flat-messages []]
+     (if-let [turn (first turns)]
+       (let [prompt-row   (u/seek #(= :user (:role %)) turn)
+             prompt-live? (and prompt-row (nil? (:deleted_at prompt-row)))
+             errored?     (and include-rewound-errors?
+                               (some #(and (= :assistant (:role %)) (some? (:error %))) turn))]
+         (if (and prompt-row (or prompt-live? errored?))
+           (let [[prompt-messages prompt-last-id] (row->flat-messages prompt-row parent-id)
+                 assistant-rows                  (filterv #(= :assistant (:role %)) turn)
+                 attempts                        (mapv #(row->flat-messages % prompt-last-id) assistant-rows)
+                 kept-last-id                    (->> (map vector assistant-rows attempts)
+                                                      (keep (fn [[row [_ last-id]]]
+                                                              (when (nil? (:deleted_at row)) last-id)))
+                                                      last)]
+             (recur (rest turns)
+                    (if prompt-live? (or kept-last-id prompt-last-id) parent-id)
+                    (into (into flat-messages prompt-messages) (mapcat first) attempts)))
+           (recur (rest turns) parent-id flat-messages)))
+       flat-messages))))
 
 (defn conversation-detail
   "Conversation-with-chat-messages snapshot. Nil if not found."

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -475,12 +475,7 @@
                     (tool-part->llm-messages part))))
         data))
 
-(defn rows->turns
-  "Group a conversation's messages (ordered by created_at, id) into turns: each
-  `:user` row starts a new turn, and subsequent assistant rows are appended to
-  it. Accepts live and soft-deleted rows alike — when passed the full row set,
-  a retried prompt's turn holds all of its assistant attempts (soft-deleted
-  earlier attempts plus the one live reply) in order."
+(defn- rows->turns
   [rows]
   (reduce (fn [turns row]
             (if (or (user-row? row) (empty? turns))
@@ -671,15 +666,11 @@
                                                 (some-> v class .getName))
                                      nil)))
 
-(defn placeholder-still-active?
-  "True if `row` is an in-flight placeholder created by [[start-turn!]] for a
-  stream that hasn't yet completed: assistant role, `:finished` IS NULL (the
-  schema-level placeholder marker), and `:created_at` within the grace window.
-  Used by [[messages->chat-messages]] to suppress live placeholders from chat
-  reads so a reload mid-stream does not render an empty `turn_aborted` stub."
-  [{:keys [role finished created_at]}]
+(defn- placeholder-still-active?
+  [{:keys [role finished created_at deleted_at]}]
   (and (= :assistant role)
        (nil? finished)
+       (nil? deleted_at)
        (some? created_at)
        (when-let [then (->instant created_at)]
          (< (.toMillis (java.time.Duration/between then (Instant/now)))
@@ -695,49 +686,39 @@
      (->> (if include-errored? active (drop-errored-pairs active))
           (into [] (mapcat message->chat-messages))))))
 
-(defn row->flat-messages
-  "Expand one message row into its flat chat messages, each stamped with a
-  `:parent_message_id`, and return `[messages last-id]` where `last-id` is the id
-  the next row hangs off of."
+(defn- row->flat-messages
   [row parent-id]
-  (let [blocks (if (placeholder-still-active? row)
-                 ;; A still-streaming placeholder has no content yet; emit an
-                 ;; in-progress marker so its response (and pager) still renders.
-                 [(cond-> {:id (or (:external_id row) (str (:id row)))
-                           :role "agent" :type "turn_in_progress"}
-                    (:external_id row) (assoc :externalId (:external_id row)))]
-                 (message->chat-messages row))]
-    ;; A row can render as several blocks; chain each onto the previous one.
-    (reduce (fn [[out prev] block]
-              (let [block (assoc block :parent_message_id prev)]
-                [(conj out block) (:id block)]))
+  (let [messages (if (placeholder-still-active? row)
+                   [(cond-> {:id   (or (:external_id row) (str (:id row)))
+                             :role "agent"
+                             :type "turn_in_progress"}
+                      (:external_id row) (assoc :externalId (:external_id row)))]
+                   (message->chat-messages row))]
+    (reduce (fn [[messages parent-id] message]
+              (let [message (assoc message :parent_message_id parent-id)]
+                [(conj messages message) (:id message)]))
             [[] parent-id]
-            blocks)))
+            messages)))
 
 (defn messages->flat-messages
-  "Flatten a conversation's messages (live + soft-deleted) into a single list of
-  chat messages, each stamped with its `:parent_message_id` so a client can
-  rebuild the branch tree. A turn whose prompt row was soft-deleted (an abandoned
-  resubmit) is dropped."
-  [all-messages]
-  (loop [turns (rows->turns all-messages), prev-last nil, acc []]
+  "Convert ordered live and deleted rows to chat messages with parent pointers."
+  [messages]
+  (loop [turns (rows->turns messages), parent-id nil, flat-messages []]
     (if-let [turn (first turns)]
       (let [prompt-row (u/seek #(= :user (:role %)) turn)]
         (if (and prompt-row (nil? (:deleted_at prompt-row)))
-          (let [[p-msgs p-last] (row->flat-messages prompt-row prev-last)
-                assistants (filter #(= :assistant (:role %)) turn)
-                results    (map #(row->flat-messages % p-last) assistants)
-                kept-last  (some (fn [[row [_ last-id]]]
-                                   (when (nil? (:deleted_at row)) last-id))
-                                 (map vector assistants results))]
+          (let [[prompt-messages prompt-last-id] (row->flat-messages prompt-row parent-id)
+                assistant-rows                  (filterv #(= :assistant (:role %)) turn)
+                attempts                        (mapv #(row->flat-messages % prompt-last-id) assistant-rows)
+                kept-last-id                    (->> (map vector assistant-rows attempts)
+                                                     (keep (fn [[row [_ last-id]]]
+                                                             (when (nil? (:deleted_at row)) last-id)))
+                                                     last)]
             (recur (rest turns)
-                   ;; Next turn hangs off the kept reply; if every attempt was
-                   ;; soft-deleted, fall back to the prompt so we don't re-parent
-                   ;; onto the previous turn.
-                   (or kept-last p-last)
-                   (into (into acc p-msgs) (mapcat first) results)))
-          (recur (rest turns) prev-last acc)))
-      acc)))
+                   (or kept-last-id prompt-last-id)
+                   (into (into flat-messages prompt-messages) (mapcat first) attempts)))
+          (recur (rest turns) parent-id flat-messages)))
+      flat-messages)))
 
 (defn conversation-detail
   "Conversation-with-chat-messages snapshot. Nil if not found."

--- a/test/metabase/metabot/api/conversations_test.clj
+++ b/test/metabase/metabot/api/conversations_test.clj
@@ -149,7 +149,15 @@
           (binding [api/*current-user-id* other-id]
             (is (nil? (check! (str (random-uuid)))))))))))
 
-(def ^:private check-turn! @#'metabot.api/check-turn!)
+(def ^:private check-turn!* @#'metabot.api/check-turn!)
+(def ^:private make-out-of-sync-fn @#'metabot.api/make-out-of-sync-fn)
+
+(defn- check-turn!
+  "Shim over the 4-arg impl: reads live messages and builds `out-of-sync!` from `conversation-id`."
+  [conversation-id parent-message-id retry-message-id]
+  (check-turn!* (metabot.persistence/live-messages conversation-id)
+                parent-message-id retry-message-id
+                (make-out-of-sync-fn conversation-id parent-message-id retry-message-id)))
 
 (defn- rejection! [& args]
   (try (apply check-turn! args)
@@ -157,12 +165,12 @@
 
 (deftest check-turn-test
   (testing "check-turn! parent_message_id branches"
-    (testing "nil parent_message_id starts a turn on a brand-new conversation"
-      (is (= {:action :start} (check-turn! (str (random-uuid)) nil nil))))
     (mt/with-temp [:model/MetabotConversation {convo-id :id} {:user_id (mt/user->id :rasta)}
                    :model/MetabotMessage _leaf {:conversation_id convo-id
                                                 :role            "assistant"
                                                 :external_id     "leaf-ext"}]
+      (testing "nil parent_message_id starts a turn on a brand-new conversation"
+        (is (= {:action :start} (check-turn! (str (random-uuid)) nil nil))))
       (testing "nil parent_message_id is rejected once the conversation has a leaf message"
         (is (= {:status-code 409 :reason :parent-message-missing}
                (rejection! convo-id nil nil))))
@@ -183,8 +191,8 @@
                      :model/MetabotMessage _other {:conversation_id other-convo-id
                                                    :role            "assistant"
                                                    :external_id     "other-ext"}]
-        (testing "a parent_message_id belonging to a different conversation is rejected"
-          (is (=? {:reason :parent-message-different-conversation}
+        (testing "a parent_message_id belonging to a different conversation is not found in these messages"
+          (is (=? {:reason :parent-message-not-found}
                   (rejection! convo-id "other-ext" nil)))))
       (mt/with-temp [:model/MetabotMessage _user-msg {:conversation_id convo-id
                                                       :role            "user"
@@ -205,9 +213,9 @@
                                               :external_id     "a1"
                                               :created_at      (seconds-ago 30)}]
       (testing "retrying the last live user message is allowed"
-        (is (= {:action :retry} (check-turn! convo-id nil "u1"))))
+        (is (=? {:action :retry} (check-turn! convo-id nil "u1"))))
       (testing "parent_message_id is ignored when retry_message_id is present"
-        (is (= {:action :retry} (check-turn! convo-id "stale-or-anything" "u1"))))
+        (is (=? {:action :retry} (check-turn! convo-id "stale-or-anything" "u1"))))
       (testing "a retry_message_id that does not exist is rejected"
         (is (=? {:reason :retry-message-not-found}
                 (rejection! convo-id nil (str (random-uuid))))))
@@ -218,8 +226,8 @@
                      :model/MetabotMessage _other-u {:conversation_id other-convo-id
                                                      :role            "user"
                                                      :external_id     "other-u"}]
-        (testing "a retry_message_id belonging to a different conversation is rejected"
-          (is (=? {:reason :retry-message-different-conversation}
+        (testing "a retry_message_id belonging to a different conversation is not found in these messages"
+          (is (=? {:reason :retry-message-not-found}
                   (rejection! convo-id nil "other-u")))))
       (mt/with-temp [:model/MetabotMessage _u2 {:conversation_id convo-id
                                                 :role            "user"
@@ -233,7 +241,7 @@
           (is (=? {:reason :retry-message-not-last}
                   (rejection! convo-id nil "u1"))))
         (testing "the last user message is still retryable"
-          (is (= {:action :retry} (check-turn! convo-id nil "u2"))))))))
+          (is (=? {:action :retry} (check-turn! convo-id nil "u2"))))))))
 
 (deftest check-turn-replace-failed-turn-test
   (testing "check-turn! replaces trailing failed turns when the parent points before them"

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -1457,31 +1457,33 @@
   (testing "streaming-request passes metabot-id to native-agent-streaming-request"
     (let [captured-args (atom nil)
           test-metabot-id metabot.config/embedded-metabot-id]
-      (mt/with-dynamic-fn-redefs [metabot.config/check-metabot-enabled! (constantly nil)
-                                  api/check-conversation-access!        (constantly nil)
-                                  metabot.persistence/leaf-external-id  (constantly nil)
-                                  metabot.persistence/live-messages     (constantly [])
-                                  metabot.persistence/history           (constantly [])
-                                  metabot.persistence/start-turn!       (fn [& _]
-                                                                          {:assistant-msg-id 1
-                                                                           :assistant-external-id "ext-id"})
-                                  api/native-agent-streaming-request    (fn [args]
-                                                                          (reset! captured-args args)
-                                                                          ;; Return a minimal streaming response
-                                                                          nil)]
-        (api/streaming-request {:metabot_id      test-metabot-id
-                                :profile_id      nil
-                                :message         "test message"
-                                :context         {}
-                                :conversation_id (str (random-uuid))
-                                :state           {}
-                                :debug           false}
-                               {:origin nil :referer nil :user-agent nil :ip-address nil})
-        (testing "metabot-id is included in the arguments"
-          (is (some? (:metabot-id @captured-args))
-              "metabot-id should not be nil")
-          (is (= test-metabot-id (:metabot-id @captured-args))
-              "metabot-id should match the input metabot_id"))))))
+      (mt/with-model-cleanup [:model/MetabotMessage
+                              [:model/MetabotConversation :created_at]]
+        (mt/with-dynamic-fn-redefs [metabot.config/check-metabot-enabled! (constantly nil)
+                                    api/check-conversation-access!        (constantly nil)
+                                    metabot.persistence/leaf-external-id  (constantly nil)
+                                    metabot.persistence/live-messages     (constantly [])
+                                    metabot.persistence/history           (constantly [])
+                                    metabot.persistence/start-turn!       (fn [& _]
+                                                                            {:assistant-msg-id 1
+                                                                             :assistant-external-id "ext-id"})
+                                    api/native-agent-streaming-request    (fn [args]
+                                                                            (reset! captured-args args)
+                                                                            ;; Return a minimal streaming response
+                                                                            nil)]
+          (api/streaming-request {:metabot_id      test-metabot-id
+                                  :profile_id      nil
+                                  :message         "test message"
+                                  :context         {}
+                                  :conversation_id (str (random-uuid))
+                                  :state           {}
+                                  :debug           false}
+                                 {:origin nil :referer nil :user-agent nil :ip-address nil})
+          (testing "metabot-id is included in the arguments"
+            (is (some? (:metabot-id @captured-args))
+                "metabot-id should not be nil")
+            (is (= test-metabot-id (:metabot-id @captured-args))
+                "metabot-id should match the input metabot_id")))))))
 
 (deftest streaming-request-ip-address-test
   (mt/with-model-cleanup [:model/MetabotMessage

--- a/test/metabase/metabot/persistence_test.clj
+++ b/test/metabase/metabot/persistence_test.clj
@@ -129,20 +129,48 @@
     (is (= "hello!" (:message (nth result 1))))
     (is (= {:output "ok"} (json/decode+kw (:result (nth result 2)))))))
 
-(deftest ^:parallel rows->turns-groups-attempts-test
-  (testing "each user row starts a turn; assistant rows (soft-deleted attempts + the live one) append to it"
-    (let [now   (t/offset-date-time)
-          rows  [{:role :user      :external_id "u1"}
-                 {:role :assistant :external_id "a1" :deleted_at now}
-                 {:role :assistant :external_id "a2" :deleted_at now}
-                 {:role :assistant :external_id "a3"}
-                 {:role :user      :external_id "u2"}
-                 {:role :assistant :external_id "b1"}]
-          turns (metabot-persistence/rows->turns rows)]
-      (is (= 2 (count turns)))
-      (is (= ["u1" "a1" "a2" "a3"] (map :external_id (first turns)))
-          "a regenerated prompt keeps all of its attempts in one turn")
-      (is (= ["u2" "b1"] (map :external_id (second turns)))))))
+(deftest ^:parallel messages->flat-messages-test
+  (let [deleted-at (t/offset-date-time)
+        messages   (metabot-persistence/messages->flat-messages
+                    [{:role :user :data [{:type "text" :text "q1"}]}
+                     {:role       :assistant
+                      :deleted_at deleted-at
+                      :data       [{:type "text" :text "discarded-1"}
+                                   {:type "text" :text "discarded-2"}]}
+                     {:role :assistant :data [{:type "text" :text "older-live"}]}
+                     {:role :assistant :data [{:type "text" :text "kept-1"}
+                                              {:type "text" :text "kept-2"}]}
+                     {:role :user :data [{:type "text" :text "q2"}]}])
+        by-text    #(u/seek (fn [message] (= % (:message message))) messages)
+        q1         (by-text "q1")
+        discarded-1 (by-text "discarded-1")
+        discarded-2 (by-text "discarded-2")
+        older-live (by-text "older-live")
+        kept-1     (by-text "kept-1")
+        kept-2     (by-text "kept-2")
+        q2         (by-text "q2")]
+    (is (= ["q1" "discarded-1" "discarded-2" "older-live" "kept-1" "kept-2" "q2"]
+           (map :message messages)))
+    (is (= (:id q1) (:parent_message_id discarded-1)))
+    (is (= (:id discarded-1) (:parent_message_id discarded-2)))
+    (is (= (:id q1) (:parent_message_id older-live)))
+    (is (= (:id q1) (:parent_message_id kept-1)))
+    (is (= (:id kept-1) (:parent_message_id kept-2)))
+    (is (= (:id kept-2) (:parent_message_id q2)))))
+
+(deftest ^:parallel messages->flat-messages-deleted-placeholder-test
+  (let [now      (t/offset-date-time)
+        messages (metabot-persistence/messages->flat-messages
+                  [{:role :user :data [{:type "text" :text "q1"}]}
+                   {:id          1
+                    :role        :assistant
+                    :external_id "a1"
+                    :created_at  now
+                    :deleted_at  now
+                    :finished    nil
+                    :data        []}])]
+    (is (= ["text" "text"] (map :type messages)))
+    (is (false? (:finished (second messages))))))
 
 (deftest start-turn-persists-slack-conversation-metadata-test
   (t2/with-transaction [_conn nil {:rollback-only true}]

--- a/test/metabase/metabot/persistence_test.clj
+++ b/test/metabase/metabot/persistence_test.clj
@@ -129,6 +129,21 @@
     (is (= "hello!" (:message (nth result 1))))
     (is (= {:output "ok"} (json/decode+kw (:result (nth result 2)))))))
 
+(deftest ^:parallel rows->turns-groups-attempts-test
+  (testing "each user row starts a turn; assistant rows (soft-deleted attempts + the live one) append to it"
+    (let [now   (t/offset-date-time)
+          rows  [{:role :user      :external_id "u1"}
+                 {:role :assistant :external_id "a1" :deleted_at now}
+                 {:role :assistant :external_id "a2" :deleted_at now}
+                 {:role :assistant :external_id "a3"}
+                 {:role :user      :external_id "u2"}
+                 {:role :assistant :external_id "b1"}]
+          turns (metabot-persistence/rows->turns rows)]
+      (is (= 2 (count turns)))
+      (is (= ["u1" "a1" "a2" "a3"] (map :external_id (first turns)))
+          "a regenerated prompt keeps all of its attempts in one turn")
+      (is (= ["u2" "b1"] (map :external_id (second turns)))))))
+
 (deftest start-turn-persists-slack-conversation-metadata-test
   (t2/with-transaction [_conn nil {:rollback-only true}]
     (let [conversation-id (str (random-uuid))

--- a/test/metabase/metabot/persistence_test.clj
+++ b/test/metabase/metabot/persistence_test.clj
@@ -172,6 +172,42 @@
     (is (= ["text" "text"] (map :type messages)))
     (is (false? (:finished (second messages))))))
 
+(deftest ^:parallel messages->flat-messages-keeps-rewound-errored-turn-test
+  (let [deleted-at (t/offset-date-time)
+        rows       [{:id 1 :role :user :external_id "u1" :deleted_at deleted-at
+                     :data [{:type "text" :text "revenue"}]}
+                    {:id 2 :role :assistant :external_id "a1" :deleted_at deleted-at
+                     :finished true :error "{\"message\":\"boom\"}" :data []}
+                    {:id 3 :role :user :external_id "u2" :data [{:type "text" :text "orders"}]}
+                    {:id 4 :role :assistant :external_id "a2" :finished true
+                     :data [{:type "text" :text "here"}]}]]
+    (testing "with :include-rewound-errors? the rewound errored turn shows its prompt and error,
+              threaded as a dead branch the live follow-up does not descend from"
+      (let [messages (metabot-persistence/messages->flat-messages rows {:include-rewound-errors? true})
+            by-text  #(u/seek (fn [m] (= % (:message m))) messages)]
+        (is (= ["revenue" "" "orders" "here"] (map :message messages)))
+        (is (some (fn [m] (and (= "agent" (:role m)) (some? (:error m)))) messages)
+            "the errored reply's error survives")
+        (is (nil? (:parent_message_id (by-text "orders")))
+            "the live follow-up parents onto the root, not the rewound errored turn")))
+    (testing "by default the rewound errored turn is dropped"
+      (is (= ["orders" "here"]
+             (map :message (metabot-persistence/messages->flat-messages rows)))))))
+
+(deftest ^:parallel messages->flat-messages-drops-cleanly-superseded-turn-test
+  (testing "even with :include-rewound-errors?, a soft-deleted prompt with no error is dropped"
+    (let [deleted-at (t/offset-date-time)
+          messages   (metabot-persistence/messages->flat-messages
+                      [{:id 1 :role :user :external_id "u1" :deleted_at deleted-at
+                        :data [{:type "text" :text "stale-prompt"}]}
+                       {:id 2 :role :assistant :external_id "a1" :deleted_at deleted-at
+                        :finished true :data [{:type "text" :text "stale-reply"}]}
+                       {:id 3 :role :user :external_id "u2" :data [{:type "text" :text "orders"}]}
+                       {:id 4 :role :assistant :external_id "a2" :finished true
+                        :data [{:type "text" :text "here"}]}]
+                      {:include-rewound-errors? true})]
+      (is (= ["orders" "here"] (map :message messages))))))
+
 (deftest start-turn-persists-slack-conversation-metadata-test
   (t2/with-transaction [_conn nil {:rollback-only true}]
     (let [conversation-id (str (random-uuid))

--- a/test/metabase/metabot/persistence_test.clj
+++ b/test/metabase/metabot/persistence_test.clj
@@ -151,6 +151,7 @@
         q2         (by-text "q2")]
     (is (= ["q1" "discarded-1" "discarded-2" "older-live" "kept-1" "kept-2" "q2"]
            (map :message messages)))
+    (is (nil? (:parent_message_id q1)))
     (is (= (:id q1) (:parent_message_id discarded-1)))
     (is (= (:id discarded-1) (:parent_message_id discarded-2)))
     (is (= (:id q1) (:parent_message_id older-live)))


### PR DESCRIPTION
### Description

Adds support for showing different branches/versions of metabot responses for retried messages

https://www.loom.com/share/c12110cb7a834c9e9295859f95dd4297

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
