### PR TITLE
Use qualified db names for locks in snowflake.

### DIFF
--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -692,7 +692,7 @@
                               dataset-name)))
 
 (defmethod test.data.impl.get-or-create/dataset-lock :snowflake
-  [_driver dataset-name]
+  [_driver dataset]
   (reify ReadWriteLock
     (readLock [_]
       (reify Lock
@@ -701,6 +701,6 @@
     (writeLock [_]
       (reify Lock
         (lock [_]
-          (lock! dataset-name))
+          (lock! (qualified-db-name dataset)))
         (unlock [_]
-          (with-write-stmt! (partial unlock! dataset-name)))))))
+          (with-write-stmt! (partial unlock! (qualified-db-name dataset))))))))

--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -57,14 +57,14 @@
 
   Because each driver and dataset has its own lock, various datasets can be loaded in parallel, but this will prevent
   the same dataset from being loaded multiple times."
-  {:arglists '(^java.util.concurrent.locks.ReadWriteLock [driver dataset-name])}
+  {:arglists '(^java.util.concurrent.locks.ReadWriteLock [driver dataset])}
   tx/dispatch-on-driver-with-test-extensions
   :hierarchy #'driver/hierarchy)
 
 (defmethod dataset-lock :default
-  [driver dataset-name]
-  {:pre [(keyword? driver) (string? dataset-name)]}
-  (let [key-path [driver dataset-name]]
+  [driver {:keys [database-name] :as _dbdef}]
+  {:pre [(keyword? driver) (string? database-name)]}
+  (let [key-path [driver database-name]]
     (or
      (get-in @dataset-locks key-path)
      (locking dataset-locks
@@ -77,8 +77,8 @@
           (swap! dataset-locks assoc-in key-path lock)
           lock))))))
 
-(defn- get-existing-database-with-read-lock [driver {:keys [database-name], :as dbdef}]
-  (let [lock (dataset-lock driver database-name)]
+(defn- get-existing-database-with-read-lock [driver dbdef]
+  (let [lock (dataset-lock driver dbdef)]
     (try
       (.. lock readLock lock)
       (tx/metabase-instance dbdef driver)
@@ -469,8 +469,8 @@
        thunk)
       (thunk))))
 
-(defn- create-and-sync-database-with-write-lock! [driver {:keys [database-name], :as dbdef}]
-  (let [lock (dataset-lock driver database-name)]
+(defn- create-and-sync-database-with-write-lock! [driver dbdef]
+  (let [lock (dataset-lock driver dbdef)]
     (try
       (.. lock writeLock lock)
       (or
@@ -490,7 +490,7 @@
     (log/infof "Test data for %s %s was loaded by previous session, checking to see if data needs to be reloaded..."
                driver
                (pr-str database-name))
-    (let [lock (dataset-lock driver database-name)]
+    (let [lock (dataset-lock driver dbdef)]
       (try
         (.. lock writeLock lock)
         ;; once we acquire the write lock, check that the value of `created_at` hasn't been updated by another thread

--- a/test/metabase/test/data/mysql.clj
+++ b/test/metabase/test/data/mysql.clj
@@ -116,8 +116,9 @@
 ;;; use one single global lock for all datasets. MySQL needs a global lock to do DDL stuff and blows up if other queries
 ;;; are running at the same time even if they are in different logical databases
 (defmethod test.data.impl.get-or-create/dataset-lock :mysql
-  [driver _dataset-name]
-  ((get-method test.data.impl.get-or-create/dataset-lock :sql-jdbc) driver ""))
+  [driver _dataset]
+  ((get-method test.data.impl.get-or-create/dataset-lock :sql-jdbc)
+   driver {:database-name ""}))
 
 (defmethod sql.tx/create-index-sql :mysql
   ([driver table-name field-names]

--- a/test/metabase/upload/impl_test.clj
+++ b/test/metabase/upload/impl_test.clj
@@ -421,17 +421,14 @@
 (deftest with-upload-table!-and-do-with-uploaded-example-csv!-test
   (testing "with-upload-table! and do-with-uploaded-example-csv! should ACTUALLY clean up after themselves"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads :schemas)
-      (letfn [(table-names []
-                (into #{} (map :name) (:tables (driver/describe-database driver/*driver* (mt/db)))))]
-        (let [original-table-names (table-names)]
-          (with-upload-table! [table (create-upload-table!)]
-            (do-with-uploaded-example-csv!
-             {:grant-permission? false
-              :schema-name       (:schema table)
-              :table-prefix      "uploaded_magic_"}
-             (constantly nil)))
-          (is (= original-table-names
-                 (table-names))))))))
+      (with-upload-table! [table (create-upload-table!)]
+        (do-with-uploaded-example-csv!
+         {:grant-permission? false
+          :schema-name       (:schema table)
+          :table-prefix      "uploaded_magic_"}
+         (constantly nil)))
+      (is (not (some #(re-find #"uploaded_magic_" (:name % ""))
+                     (driver/describe-database driver/*driver* (mt/db))))))))
 
 (deftest create-from-csv-display-name-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)


### PR DESCRIPTION
We're seeing some timeouts in Snowflake on CI. There are a few reasons for this, but part of it is that we are locking a lot waiting for access to the datasets. These locks are currently based on unqualified database names, not hashed and branch-qualified, so they lock more often than they need to. Using the qualified names spreads things out a bit.

In order to do this, we need to change the `dataset-lock` method to take the whole dataset (to hash it) not just the dataset's database-name.

BONUS CHANGE: one of the upload tests was asserting that the set of tables stayed the same, but on a shared cloud DB that's not a good assumption! Fix it to assert specifically that the generated table was removed.