### PR TITLE
[GIT-74954] Fix search reindex hang on metric reference cycles

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.mysql
   "MySQL driver. Builds off of the SQL-JDBC driver."
-  (:refer-clojure :exclude [get-in some not-empty])
+  (:refer-clojure :exclude [get-in mapv some not-empty])
   (:require
    [buddy.core.codecs :as codecs]
    [clojure.java.io :as jio]
@@ -1377,10 +1377,10 @@
   [username schemas]
   (let [quoted-user      (quote-field username)
         source-databases (set schemas)]
-    (perf/mapv (fn [db]
-                 (format "GRANT SELECT ON %s.* TO %s@'%%'"
-                         (quote-schema db) quoted-user))
-               source-databases)))
+    (mapv (fn [db]
+            (format "GRANT SELECT ON %s.* TO %s@'%%'"
+                    (quote-schema db) quoted-user))
+          source-databases)))
 
 (defmethod driver/grant-workspace-read-access! :mysql
   [_driver database workspace schemas]

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -391,7 +391,9 @@
                             [_tag dest-field-id _opts]     (normalize-field dest-field)]
                         [:field dest-field-id {:source-field source-field-id}])
     :field            (let [[_tag id-or-name opts] x]
-                        (assert ((some-fn nil? map?) opts) "Attempted to normalize an MBQL 5 :field clause as MBQL 4")
+                        (when-not ((some-fn nil? map?) opts)
+                          (throw (ex-info "Attempted to normalize an MBQL 5 :field clause as MBQL 4"
+                                          {:clause x})))
                         ;; if someone accidentally nests `:field` clauses fix it for them
                         (if (and (sequential? id-or-name)
                                  ((some-fn keyword? string?) (first id-or-name))

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -76,7 +76,7 @@
     ((some-fn :display-name :lib/expression-name) (lib.options/options x))
     (try
       (display-name-method query stage-number x style)
-      (catch #?(:clj Throwable :cljs js/Error) e
+      (catch #?(:clj Exception :cljs js/Error) e
         (throw (ex-info (i18n/tru "Error calculating display name for {0}: {1}" (pr-str x) (ex-message e))
                         {:query query, :x x}
                         e)))))))
@@ -94,7 +94,7 @@
     (:name (lib.options/options x))
     (try
       (column-name-method query stage-number x)
-      (catch #?(:clj Throwable :cljs js/Error) e
+      (catch #?(:clj Exception :cljs js/Error) e
         (throw (ex-info (i18n/tru "Error calculating column name for {0}: {1}" (pr-str x) (ex-message e))
                         {:x            x
                          :query        query
@@ -267,7 +267,7 @@
      :display-name (display-name query stage-number x)}
     ;; if you see this error it's usually because you're calling [[metadata]] on something that you shouldn't be, for
     ;; example a query
-    (catch #?(:clj Throwable :cljs js/Error) e
+    (catch #?(:clj Exception :cljs js/Error) e
       (throw (ex-info (i18n/tru "Error calculating metadata for {0}: {1}"
                                 (pr-str (lib.dispatch/dispatch-value x))
                                 (ex-message e))
@@ -307,7 +307,7 @@
   (when-not (= (:lib/type (lib.util/query-stage query -1)) :mbql.stage/native)
     (try
       (describe-query query)
-      (catch #?(:clj Throwable :cljs js/Error) e
+      (catch #?(:clj Exception :cljs js/Error) e
         ;; Throttled: a search reindex can call this for many failing metric Cards, don't log them all.
         (log/throttle (* 10 1000)
                       (log/errorf e "Error calculating display name for query: %s" (ex-message e)))
@@ -384,7 +384,7 @@
    (letfn [(display-info* [x]
              (try
                (display-info-method query stage-number x)
-               (catch #?(:clj Throwable :cljs js/Error) e
+               (catch #?(:clj Exception :cljs js/Error) e
                  (throw (ex-info (i18n/tru "Error calculating display info for {0}: {1}"
                                            (lib.dispatch/dispatch-value x)
                                            (ex-message e))

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -74,12 +74,12 @@
    (or
     ;; if this is an MBQL clause with `:display-name` in the options map, then use that rather than calculating a name.
     ((some-fn :display-name :lib/expression-name) (lib.options/options x))
-    (try
-      (display-name-method query stage-number x style)
-      (catch #?(:clj Exception :cljs js/Error) e
-        (throw (ex-info (i18n/tru "Error calculating display name for {0}: {1}" (pr-str x) (ex-message e))
-                        {:query query, :x x}
-                        e)))))))
+    (lib.util/recover
+     (fn [] (display-name-method query stage-number x style))
+     (fn [e]
+       (throw (ex-info (i18n/tru "Error calculating display name for {0}: {1}" (pr-str x) (ex-message e))
+                       {:query query, :x x}
+                       e)))))))
 
 (mu/defn column-name :- ::lib.schema.common/non-blank-string
   "Calculate a database-friendly name to use for an expression."
@@ -92,14 +92,14 @@
    (or
     ;; if this is an MBQL clause with `:name` in the options map, then use that rather than calculating a name.
     (:name (lib.options/options x))
-    (try
-      (column-name-method query stage-number x)
-      (catch #?(:clj Exception :cljs js/Error) e
-        (throw (ex-info (i18n/tru "Error calculating column name for {0}: {1}" (pr-str x) (ex-message e))
-                        {:x            x
-                         :query        query
-                         :stage-number stage-number}
-                        e)))))))
+    (lib.util/recover
+     (fn [] (column-name-method query stage-number x))
+     (fn [e]
+       (throw (ex-info (i18n/tru "Error calculating column name for {0}: {1}" (pr-str x) (ex-message e))
+                       {:x            x
+                        :query        query
+                        :stage-number stage-number}
+                       e)))))))
 
 (defmethod display-name-method :default
   [_query _stage-number x _stage]
@@ -259,20 +259,20 @@
 
 (defmethod metadata-method :default
   [query stage-number x]
-  (try
-    {:lib/type     :metadata/column
-     ;; TODO -- effective-type
-     :base-type    (type-of query stage-number x)
-     :name         (column-name query stage-number x)
-     :display-name (display-name query stage-number x)}
-    ;; if you see this error it's usually because you're calling [[metadata]] on something that you shouldn't be, for
-    ;; example a query
-    (catch #?(:clj Exception :cljs js/Error) e
-      (throw (ex-info (i18n/tru "Error calculating metadata for {0}: {1}"
-                                (pr-str (lib.dispatch/dispatch-value x))
-                                (ex-message e))
-                      {:query query, :stage-number stage-number, :x x}
-                      e)))))
+  (lib.util/recover
+   (fn []
+     {:lib/type     :metadata/column
+      ;; TODO -- effective-type
+      :base-type    (type-of query stage-number x)
+      :name         (column-name query stage-number x)
+      :display-name (display-name query stage-number x)})
+   ;; This usually means [[metadata]] was called on something it shouldn't be, e.g. a query.
+   (fn [e]
+     (throw (ex-info (i18n/tru "Error calculating metadata for {0}: {1}"
+                               (pr-str (lib.dispatch/dispatch-value x))
+                               (ex-message e))
+                     {:query query, :stage-number stage-number, :x x}
+                     e)))))
 
 (mr/def ::metadata-map
   [:map [:lib/type [:and
@@ -305,13 +305,14 @@
   as [[describe-query]] except for native queries, where we don't describe anything."
   [query]
   (when-not (= (:lib/type (lib.util/query-stage query -1)) :mbql.stage/native)
-    (try
-      (describe-query query)
-      (catch #?(:clj Exception :cljs js/Error) e
-        ;; Throttled: a search reindex can call this for many failing metric Cards, don't log them all.
-        (log/throttle (* 10 1000)
-                      (log/errorf e "Error calculating display name for query: %s" (ex-message e)))
-        nil))))
+    (lib.util/recover
+     (fn [] (describe-query query))
+     (fn [e]
+       ;; Throttled: a bulk caller such as a search reindex can hit this for many failing metric Cards,
+       ;; so don't log every one.
+       (log/throttle (* 10 1000)
+                     (log/errorf e "Error calculating display name for query: %s" (ex-message e)))
+       nil))))
 
 (defmulti display-info-method
   "Implementation for [[display-info]]. Implementations that call [[display-name]] should use the `:default` display
@@ -382,14 +383,14 @@
     stage-number :- :int
     x]
    (letfn [(display-info* [x]
-             (try
-               (display-info-method query stage-number x)
-               (catch #?(:clj Exception :cljs js/Error) e
-                 (throw (ex-info (i18n/tru "Error calculating display info for {0}: {1}"
-                                           (lib.dispatch/dispatch-value x)
-                                           (ex-message e))
-                                 {:query query, :stage-number stage-number, :x x}
-                                 e)))))]
+             (lib.util/recover
+              (fn [] (display-info-method query stage-number x))
+              (fn [e]
+                (throw (ex-info (i18n/tru "Error calculating display info for {0}: {1}"
+                                          (lib.dispatch/dispatch-value x)
+                                          (ex-message e))
+                                {:query query, :stage-number stage-number, :x x}
+                                e)))))]
      #?(:clj
         (display-info* x)
         :cljs

--- a/src/metabase/lib/metric.cljc
+++ b/src/metabase/lib/metric.cljc
@@ -3,6 +3,7 @@
   stuff is TBH.)"
   (:refer-clojure :exclude [select-keys not-empty])
   (:require
+   [clojure.string :as str]
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.convert :as lib.convert]
@@ -140,17 +141,33 @@
     (#{:query :native} (lib.util/normalized-query-type query))
     mbql.normalize/normalize))
 
+(def ^:private ^:dynamic *metric-expansion-path*
+  "Metric card IDs whose [[lib.metadata.calculation/metadata-method]] `:metric` expansion is in flight on this
+  thread/binding, outermost first. A metric's metadata is computed from its inner aggregation, which may itself be a
+  `:metric` ref; a cycle in the metric reference graph would recurse unboundedly and overflow the stack (#74954)."
+  [])
+
+(defn- check-metric-cycle!
+  [metric-id]
+  (when (some #(= % metric-id) *metric-expansion-path*)
+    (throw (ex-info (i18n/tru "Metric cycle detected: {0}"
+                              (str/join " → " (conj *metric-expansion-path* metric-id)))
+                    {:metric-id  metric-id
+                     :cycle-path (conj *metric-expansion-path* metric-id)}))))
+
 (defmethod lib.metadata.calculation/metadata-method :metric
   [query _stage-number [_ opts metric-id]]
+  (check-metric-cycle! metric-id)
   (if-let [metric-meta (lib.metadata/metric query metric-id)]
-    (let [metric-query      (lib.query/query query (normalize-legacy-query (:dataset-query metric-meta)))
-          inner-aggregation (first (lib.aggregation/aggregations metric-query))
-          inner-meta        (lib.metadata.calculation/metadata metric-query -1 inner-aggregation)]
-      (-> inner-meta
-          (assoc :display-name (:name metric-meta) ; Metric card's name
-                 :name         (:name inner-meta)) ; Name of the inner aggregation column
-          ;; If the :metric ref has a :name option, that overrides the metric card's name.
-          (cond-> (:name opts) (assoc :name (:name opts)))))
+    (binding [*metric-expansion-path* (conj *metric-expansion-path* metric-id)]
+      (let [metric-query      (lib.query/query query (normalize-legacy-query (:dataset-query metric-meta)))
+            inner-aggregation (first (lib.aggregation/aggregations metric-query))
+            inner-meta        (lib.metadata.calculation/metadata metric-query -1 inner-aggregation)]
+        (-> inner-meta
+            (assoc :display-name (:name metric-meta) ; Metric card's name
+                   :name         (:name inner-meta)) ; Name of the inner aggregation column
+            ;; If the :metric ref has a :name option, that overrides the metric card's name.
+            (cond-> (:name opts) (assoc :name (:name opts))))))
     {:lib/type :metadata/metric
      :id metric-id
      :display-name (fallback-display-name)}))

--- a/src/metabase/lib/metric.cljc
+++ b/src/metabase/lib/metric.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.metric
   "A Metric is a special type of Card that you can do special metric stuff with. (Not sure exactly what said special
   stuff is TBH.)"
-  (:refer-clojure :exclude [select-keys not-empty])
+  (:refer-clojure :exclude [select-keys some not-empty])
   (:require
    [clojure.string :as str]
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
@@ -19,7 +19,7 @@
    [metabase.lib.util :as lib.util]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [select-keys not-empty]]))
+   [metabase.util.performance :refer [select-keys some not-empty]]))
 
 (defn- resolve-metric [query card-id]
   (when (pos-int? card-id)

--- a/src/metabase/lib/metric.cljc
+++ b/src/metabase/lib/metric.cljc
@@ -147,7 +147,11 @@
   `:metric` ref; a cycle in the metric reference graph would recurse unboundedly and overflow the stack (#74954)."
   [])
 
+;; Read-time backstop for cycles that slip past the card API's `check-card-overwrite`: serdes import, remote sync,
+;; direct writes, data predating the check. find-cycle can't help -- a cycle is only visible mid-expansion -- so we
+;; watch the in-flight path instead.
 (defn- check-metric-cycle!
+  "Throw if `metric-id` is already being expanded on this thread, i.e. its `:metric` refs form a cycle."
   [metric-id]
   (when (some #(= % metric-id) *metric-expansion-path*)
     (throw (ex-info (i18n/tru "Metric cycle detected: {0}"

--- a/src/metabase/lib/normalize.cljc
+++ b/src/metabase/lib/normalize.cljc
@@ -97,12 +97,12 @@
                               (throw (ex-info (i18n/tru "Normalization error")
                                               {:schema schema, :x x, :error error})))]
          (thunk))
-       (try
-         (thunk)
-         (catch #?(:clj Exception :cljs :default) e
-           (throw (ex-info (str "Uncaught normalization error: " (ex-message e))
-                           {:schema schema}
-                           e))))))))
+       (lib.util/recover
+        thunk
+        (fn [e]
+          (throw (ex-info (str "Uncaught normalization error: " (ex-message e))
+                          {:schema schema}
+                          e))))))))
 
 (mu/defn ->normalized-stage-metadata :- ::lib.schema.metadata/stage
   "Take a sequence of legacy or Lib metadata maps, convert to Lib-style if needed, then normalize them.

--- a/src/metabase/lib/normalize.cljc
+++ b/src/metabase/lib/normalize.cljc
@@ -99,7 +99,7 @@
          (thunk))
        (try
          (thunk)
-         (catch #?(:clj Throwable :cljs :default) e
+         (catch #?(:clj Exception :cljs :default) e
            (throw (ex-info (str "Uncaught normalization error: " (ex-message e))
                            {:schema schema}
                            e))))))))

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -183,7 +183,7 @@
       (merge
        mbql5-query
        (query-with-stages mp (:stages mbql5-query))))
-    (catch #?(:clj Throwable :cljs :default) e
+    (catch #?(:clj Exception :cljs :default) e
       (throw (ex-info (i18n/tru "Error creating query from legacy query: {0}" (ex-message e))
                       {:legacy-query legacy-query}
                       e)))))

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -175,18 +175,19 @@
 
 (defn- query-from-legacy-query
   [metadata-providerable legacy-query]
-  (try
-    (let [mbql5-query (binding [lib.schema.expression/*suppress-expression-type-check?* true]
-                        (lib.convert/->mbql5 (mbql.normalize/normalize-or-throw legacy-query)))
-          mp          (lib.metadata/->metadata-provider metadata-providerable (:database mbql5-query))
-          mbql5-query (add-types-to-fields mbql5-query mp)]
-      (merge
-       mbql5-query
-       (query-with-stages mp (:stages mbql5-query))))
-    (catch #?(:clj Exception :cljs :default) e
-      (throw (ex-info (i18n/tru "Error creating query from legacy query: {0}" (ex-message e))
-                      {:legacy-query legacy-query}
-                      e)))))
+  (lib.util/recover
+   (fn []
+     (let [mbql5-query (binding [lib.schema.expression/*suppress-expression-type-check?* true]
+                         (lib.convert/->mbql5 (mbql.normalize/normalize-or-throw legacy-query)))
+           mp          (lib.metadata/->metadata-provider metadata-providerable (:database mbql5-query))
+           mbql5-query (add-types-to-fields mbql5-query mp)]
+       (merge
+        mbql5-query
+        (query-with-stages mp (:stages mbql5-query)))))
+   (fn [e]
+     (throw (ex-info (i18n/tru "Error creating query from legacy query: {0}" (ex-message e))
+                     {:legacy-query legacy-query}
+                     e)))))
 
 (defmulti ^:private query-method
   "Implementation for [[query]]."

--- a/src/metabase/lib/schema/common.cljc
+++ b/src/metabase/lib/schema/common.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.schema.common
-  (:refer-clojure :exclude [update-keys every? #?@(:clj [some])])
+  (:refer-clojure :exclude [update-keys #?@(:clj [some])])
   (:require
    [clojure.string :as str]
    [medley.core :as m]

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -38,6 +38,18 @@
    :cljs
    (def format "Exactly like [[clojure.core/format]] but ClojureScript-friendly." gstring/format))
 
+;; AssertionError is recoverable too, not just Exception: callers run assert/:pre they don't own, and a
+;; bad-data assert should degrade through `handler` like any other exception. Fatal Errors still propagate.
+(defn recover
+  "Run `thunk`, returning its value; if it throws a recoverable throwable, return `(handler throwable)` instead.
+  Recoverable is any `Exception`, plus `AssertionError` on the JVM.
+  Fatal `Error`s -- stack overflow, OOM, linkage, thread death -- are never caught and propagate."
+  [thunk handler]
+  (try
+    (thunk)
+    (catch #?(:clj Exception :cljs :default) e (handler e))
+    #?(:clj (catch AssertionError e (handler e)))))
+
 ;;; TODO (Cam 9/8/25) -- overlapping functionality with [[metabase.lib.schema.common/is-clause?]]
 (defn clause?
   "Returns true if this is a **normalized** MBQL 5 clause."

--- a/src/metabase/lib_be/metadata/jvm.clj
+++ b/src/metabase/lib_be/metadata/jvm.clj
@@ -13,6 +13,7 @@
    [metabase.lib.normalize :as lib.normalize]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.lib.util :as lib.util]
    [metabase.models.interface :as mi]
    [metabase.settings.core :as setting]
    [metabase.util :as u]
@@ -536,12 +537,12 @@
   [database-id                                  :- ::lib.schema.id/database
    {metadata-type :lib/type, :as metadata-spec} :- ::lib.metadata.protocols/metadata-spec]
   (let [query (metadata-spec->honey-sql database-id metadata-spec)]
-    (try
-      (t2/select metadata-type query)
-      (catch Exception e
-        (throw (ex-info "Error fetching metadata with spec"
-                        {:metadata-spec metadata-spec, :query query}
-                        e))))))
+    (lib.util/recover
+     (fn [] (t2/select metadata-type query))
+     (fn [e]
+       (throw (ex-info "Error fetching metadata with spec"
+                       {:metadata-spec metadata-spec, :query query}
+                       e))))))
 
 (p/deftype+ UncachedApplicationDatabaseMetadataProvider [database-id]
   lib.metadata.protocols/MetadataProvider

--- a/src/metabase/lib_be/metadata/jvm.clj
+++ b/src/metabase/lib_be/metadata/jvm.clj
@@ -538,7 +538,7 @@
   (let [query (metadata-spec->honey-sql database-id metadata-spec)]
     (try
       (t2/select metadata-type query)
-      (catch Throwable e
+      (catch Exception e
         (throw (ex-info "Error fetching metadata with spec"
                         {:metadata-spec metadata-spec, :query query}
                         e))))))

--- a/src/metabase/lib_be/models/transforms.clj
+++ b/src/metabase/lib_be/models/transforms.clj
@@ -6,6 +6,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.util :as lib.util]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -38,46 +39,47 @@
                               [:map
                                {:closed true}
                                [:strict? {:optional true, :default false} [:maybe :boolean]]]]]
-   (try
-     (let [metadata-providerable (or metadata-providerable
-                                     (when-let [mp (:lib/metadata query)]
-                                       (when (lib/metadata-provider? mp)
-                                         mp))
-                                     lib.metadata.jvm/application-database-metadata-provider)]
-       (cond
-         (empty? query)
-         {}
+   (lib.util/recover
+    (fn []
+      (let [metadata-providerable (or metadata-providerable
+                                      (when-let [mp (:lib/metadata query)]
+                                        (when (lib/metadata-provider? mp)
+                                          mp))
+                                      lib.metadata.jvm/application-database-metadata-provider)]
+        (cond
+          (empty? query)
+          {}
 
-         (not (has-normalized-key? query :database))
-         (throw (ex-info "Query must include :database" {:query query}))
+          (not (has-normalized-key? query :database))
+          (throw (ex-info "Query must include :database" {:query query}))
 
-         (not (has-any-of-these-normalized-keys? query #{:lib/type :type}))
-         (throw (ex-info "Query must include :lib/type or :type" {:query query}))
+          (not (has-any-of-these-normalized-keys? query #{:lib/type :type}))
+          (throw (ex-info "Query must include :lib/type or :type" {:query query}))
 
-         (and (has-normalized-key? query :lib/type)
-              (has-any-of-these-normalized-keys? query #{:type :query :native}))
-         (throw (ex-info "MBQL 4 keys like :type, :query, or :native are not allowed in MBQL 5 queries with :lib/type"
-                         {:query query}))
+          (and (has-normalized-key? query :lib/type)
+               (has-any-of-these-normalized-keys? query #{:type :query :native}))
+          (throw (ex-info "MBQL 4 keys like :type, :query, or :native are not allowed in MBQL 5 queries with :lib/type"
+                          {:query query}))
 
-         (and (has-normalized-key? query :type)
-              (has-normalized-key? query :stages))
-         (throw (ex-info "MBQL 5 :stages is not allowed in an MBQL 4 query with :type" {:query query}))
+          (and (has-normalized-key? query :type)
+               (has-normalized-key? query :stages))
+          (throw (ex-info "MBQL 5 :stages is not allowed in an MBQL 4 query with :type" {:query query}))
 
-         (lib/cached-metadata-provider-with-cache? (:lib/metadata query))
-         (lib/normalize ::lib.schema/query query)
+          (lib/cached-metadata-provider-with-cache? (:lib/metadata query))
+          (lib/normalize ::lib.schema/query query)
 
-         :else
-         (->> query
-              (lib-be.bootstrap/resolve-database (when (lib/metadata-provider? metadata-providerable)
-                                                   metadata-providerable))
-              (lib/query metadata-providerable))))
-     ;; return an empty map if we are unable to normalize the query correctly to prevent breaking things downstream,
-     ;; unless strict mode is on (when we are saving a query)
-     (catch Exception e
-       (when strict?
-         (throw e))
-       (log/errorf e "Error normalizing query %s" (pr-str query))
-       {}))))
+          :else
+          (->> query
+               (lib-be.bootstrap/resolve-database (when (lib/metadata-provider? metadata-providerable)
+                                                    metadata-providerable))
+               (lib/query metadata-providerable)))))
+    ;; Normalization failed. Degrade to {} so bad stored data can't break callers,
+    ;; but in strict mode (saving) rethrow rather than persist a query we couldn't parse.
+    (fn [e]
+      (when strict?
+        (throw e))
+      (log/errorf e "Error normalizing query %s" (pr-str query))
+      {}))))
 
 (defn- transform-query-in [query]
   (when-not (map? query)
@@ -90,18 +92,17 @@
 
 (defn- transform-query-out [s]
   (when (some? s)
-    (try
-      (let [query (mi/json-out-without-keywordization s)]
-        ;; an explicit throw rather than `assert`: this handler must swallow bad data (returning `{}`) but let VM
-        ;; Errors unwind, and `AssertionError` is on the wrong side of that line (#74954)
-        (when-not (map? query)
-          (throw (ex-info (format "Expected deserialized query to be a map, got ^%s %s"
-                                  (.getCanonicalName (class query)) (pr-str query))
-                          {:query query})))
-        (normalize-query query))
-      (catch Exception e
-        (log/errorf e "Error deserializing dataset_query from app DB: %s" (ex-message e))
-        {}))))
+    (lib.util/recover
+     (fn []
+       (let [query (mi/json-out-without-keywordization s)]
+         (when-not (map? query)
+           (throw (ex-info (format "Expected deserialized query to be a map, got ^%s %s"
+                                   (.getCanonicalName (class query)) (pr-str query))
+                           {:query query})))
+         (normalize-query query)))
+     (fn [e]
+       (log/errorf e "Error deserializing dataset_query from app DB: %s" (ex-message e))
+       {}))))
 
 (def transform-query
   "Toucan 2 transform spec for Card `dataset_query` and other columns that store MBQL."

--- a/src/metabase/lib_be/models/transforms.clj
+++ b/src/metabase/lib_be/models/transforms.clj
@@ -73,7 +73,7 @@
               (lib/query metadata-providerable))))
      ;; return an empty map if we are unable to normalize the query correctly to prevent breaking things downstream,
      ;; unless strict mode is on (when we are saving a query)
-     (catch Throwable e
+     (catch Exception e
        (when strict?
          (throw e))
        (log/errorf e "Error normalizing query %s" (pr-str query))
@@ -92,10 +92,14 @@
   (when (some? s)
     (try
       (let [query (mi/json-out-without-keywordization s)]
-        (assert (map? query)
-                (format "Expected deserialized query to be a map, got ^%s %s" (.getCanonicalName (class query)) (pr-str query)))
+        ;; an explicit throw rather than `assert`: this handler must swallow bad data (returning `{}`) but let VM
+        ;; Errors unwind, and `AssertionError` is on the wrong side of that line (#74954)
+        (when-not (map? query)
+          (throw (ex-info (format "Expected deserialized query to be a map, got ^%s %s"
+                                  (.getCanonicalName (class query)) (pr-str query))
+                          {:query query})))
         (normalize-query query))
-      (catch Throwable e
+      (catch Exception e
         (log/errorf e "Error deserializing dataset_query from app DB: %s" (ex-message e))
         {}))))
 

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -654,16 +654,28 @@
       (pre-update-check-sandbox-constraints card changes)
       (assert-valid-type card))))
 
+(defn- metadata-provider-fetch?
+  "Whether `card` was selected as one of the lib metadata-provider models (`:metadata/card`, `:metadata/metric`, ...)
+  rather than as `:model/Card`. Those models `derive` from `:model/Card`, so this after-select runs for them too."
+  [card]
+  (= "metadata" (some-> (t2/model card) namespace)))
+
 (defn- add-query-description-to-metric-card
   "Add `:query_description` key to returned card.
 
   Some users were missing description that was present in v1 metric API responses. This new key compensates for that.
 
   This function is used in `t2/define-after-select :model/Card`. Metadata provider caching should be considered when
-  fetching multiple metric cards having common database, as done in eg. dashboard API context."
+  fetching multiple metric cards having common database, as done in eg. dashboard API context.
+
+  Metadata-provider fetches must be skipped: nothing consumes `:query_description` on lib metadata, and computing it
+  resolves the metric's own `:metric` refs through the metadata provider, whose card fetches re-enter this
+  after-select — with a cycle in the metric reference graph the recursion is unbounded and overflows the stack
+  (#74954)."
   [card]
   (if-not (and (map? card)
                (= :metric (:type card))
+               (not (metadata-provider-fetch? card))
                (-> card :dataset_query not-empty)
                (-> card :database_id))
     card

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -1266,4 +1266,9 @@
        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Error calculating display name"
                              (lib.metadata.calculation/display-name (lib.tu/venues-query)
                                                                     {:lib/type ::throws
-                                                                     :throwable (ex-info "boom" {})}))))))
+                                                                     :throwable (ex-info "boom" {})}))))
+     (testing "an AssertionError thrown while computing a display name is contained (wrapped), not propagated"
+       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Error calculating display name"
+                             (lib.metadata.calculation/display-name (lib.tu/venues-query)
+                                                                    {:lib/type ::throws
+                                                                     :throwable (AssertionError. "boom")}))))))

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -1236,3 +1236,34 @@
         (is (contains? nnames "Products → ID"))
         (is (contains? nnames "Products - User → ID"))
         (is (= 2 (count (filter #(str/includes? % "→ ID") nnames))))))))
+
+#?(:clj
+   (defmethod lib.metadata.calculation/display-name-method ::throws
+     [_query _stage-number x _style]
+     (throw (:throwable x))))
+
+#?(:clj
+   (deftest ^:synchronized suggested-name-vm-error-test
+     (testing "a VM Error thrown while describing the query propagates out of suggested-name"
+       (with-redefs [lib.metadata.calculation/describe-query (fn [_query] (throw (Error. "boom")))]
+         (is (thrown? Error
+                      (lib.metadata.calculation/suggested-name (lib.tu/venues-query))))))
+     (testing "an Exception thrown while describing the query yields nil"
+       (with-redefs [lib.metadata.calculation/describe-query (fn [_query] (throw (ex-info "boom" {})))]
+         (is (nil? (lib.metadata.calculation/suggested-name (lib.tu/venues-query))))))))
+
+#?(:clj
+   (deftest ^:parallel display-name-vm-error-test
+     (testing "a VM Error thrown while computing a display name propagates unwrapped"
+       (let [e (Error. "boom")]
+         (is (identical? e
+                         (try
+                           (lib.metadata.calculation/display-name (lib.tu/venues-query)
+                                                                  {:lib/type ::throws, :throwable e})
+                           nil
+                           (catch Error actual actual))))))
+     (testing "an Exception thrown while computing a display name is wrapped with context"
+       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Error calculating display name"
+                             (lib.metadata.calculation/display-name (lib.tu/venues-query)
+                                                                    {:lib/type ::throws
+                                                                     :throwable (ex-info "boom" {})}))))))

--- a/test/metabase/lib/metric_test.cljc
+++ b/test/metabase/lib/metric_test.cljc
@@ -303,3 +303,78 @@
       (let [query (lib/query metadata-provider-with-cards (card-key (lib.tu/mock-cards)))]
         (is (not (lib/uses-metric? query metric-id)))
         (is (nil? (lib.metric/available-metrics (lib/append-stage query))))))))
+
+(defn- referencing-metric-card
+  "A mock metric card whose definition has `aggregation` as its single aggregation."
+  [id card-name aggregation]
+  {:id            id
+   :name          card-name
+   :type          :metric
+   :database-id   (meta/id)
+   :table-id      (meta/id :venues)
+   :dataset-query {:database (meta/id)
+                   :type     :query
+                   :query    {:source-table (meta/id :venues)
+                              :aggregation  [aggregation]}}})
+
+(defn- query-aggregating-metric
+  "A query on `VENUES` aggregating `[:metric id]`, with `cards` served by the metadata provider."
+  [cards id]
+  (-> (lib/query (lib.tu/mock-metadata-provider meta/metadata-provider {:cards cards})
+                 (meta/table-metadata :venues))
+      (lib/aggregate [:metric {:lib/uuid (str (random-uuid))} id])))
+
+(defn- returned-columns-error
+  "The error thrown by [[lib/returned-columns]] on `query`, or nil if it computed successfully."
+  [query]
+  (try
+    (lib/returned-columns query)
+    nil
+    (catch #?(:clj Exception :cljs js/Error) e
+      e)))
+
+(deftest ^:parallel metric-metadata-mutual-reference-cycle-test
+  (testing "computing metadata for a metric whose references form a mutual cycle throws a cycle error (#74954)"
+    (let [query (query-aggregating-metric
+                 [(referencing-metric-card 1 "Metric A" [:metric 2])
+                  (referencing-metric-card 2 "Metric B" [:metric 1])]
+                 1)
+          e     (returned-columns-error query)]
+      (is (some? e))
+      (is (re-find #"Metric cycle detected" (ex-message e)))
+      (is (= [1 2 1]
+             (:cycle-path (ex-data e)))))))
+
+(deftest ^:parallel metric-metadata-self-reference-cycle-test
+  (testing "computing metadata for a metric that references itself throws a cycle error (#74954)"
+    (let [query (query-aggregating-metric
+                 [(referencing-metric-card 1 "Metric A" [:metric 1])]
+                 1)
+          e     (returned-columns-error query)]
+      (is (some? e))
+      (is (re-find #"Metric cycle detected" (ex-message e)))
+      (is (= [1 1]
+             (:cycle-path (ex-data e)))))))
+
+(deftest ^:parallel metric-metadata-reference-chain-test
+  (testing "an acyclic metric reference chain computes metadata, named for the outermost metric"
+    (let [query (query-aggregating-metric
+                 [(referencing-metric-card 1 "Metric A" [:metric 2])
+                  (referencing-metric-card 2 "Metric B" [:count])]
+                 1)]
+      (is (=? [{:name         "count"
+                :display-name "Metric A"}]
+              (lib/returned-columns query))))))
+
+(deftest ^:parallel metric-metadata-reference-diamond-test
+  (testing "two sibling metrics referencing the same base metric both compute metadata"
+    (let [cards [(referencing-metric-card 3 "Base Metric" [:count])
+                 (referencing-metric-card 1 "Left Metric" [:metric 3])
+                 (referencing-metric-card 2 "Right Metric" [:metric 3])]
+          query (-> (query-aggregating-metric cards 1)
+                    (lib/aggregate [:metric {:lib/uuid (str (random-uuid))} 2]))]
+      (is (=? [{:name         "count"
+                :display-name "Left Metric"}
+               {:name         "count_2"
+                :display-name "Right Metric"}]
+              (lib/returned-columns query))))))

--- a/test/metabase/lib/metric_test.cljc
+++ b/test/metabase/lib/metric_test.cljc
@@ -378,3 +378,19 @@
                {:name         "count_2"
                 :display-name "Right Metric"}]
               (lib/returned-columns query))))))
+
+#?(:clj
+   (deftest ^:parallel check-card-overwrite-rejects-metric-cycle-test
+     (testing "saving a metric whose :metric refs would close a cycle is rejected up front (#74954)"
+       ;; the write-time counterpart to the read-time `check-metric-cycle!` guard: the card API rejects cyclic saves,
+       ;; so the read-time guard only has to backstop non-API paths (serdes, remote sync, direct writes).
+       (let [mp        (lib.tu/mock-metadata-provider
+                        meta/metadata-provider
+                        {:cards [(referencing-metric-card 1 "Metric A" [:metric 2])
+                                 (referencing-metric-card 2 "Metric B" [:metric 1])]})
+             new-query (lib/query mp {:database (meta/id)
+                                      :type     :query
+                                      :query    {:source-table (meta/id :venues)
+                                                 :aggregation  [[:metric 2]]}})]
+         (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Cannot save card with cycles"
+                               (lib/check-card-overwrite 1 new-query)))))))

--- a/test/metabase/lib/normalize_test.cljc
+++ b/test/metabase/lib/normalize_test.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.normalize-test
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
+   #?@(:clj ([metabase.lib.normalize :as lib.normalize]))
    [clojure.test :refer [are deftest is testing]]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.cached-provider :as lib.metadata.cached-provider]
@@ -219,3 +220,16 @@
                         :lib/type     :mbql.stage/mbql}]
             :lib/type :mbql/query}
            (lib/normalize query)))))
+
+#?(:clj
+   (deftest ^:synchronized normalize-error-containment-test
+     (testing "an AssertionError from the coercer is contained (wrapped), not propagated"
+       (with-redefs-fn {#'lib.normalize/coercer (fn [_schema] (fn [_x] (throw (AssertionError. "boom"))))}
+         (fn []
+           (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Uncaught normalization error"
+                                 (lib/normalize {:lib/type :mbql/query}))))))
+     (testing "a fatal Error from the coercer propagates unwrapped"
+       (with-redefs-fn {#'lib.normalize/coercer (fn [_schema] (fn [_x] (throw (Error. "boom"))))}
+         (fn []
+           (is (thrown? Error
+                        (lib/normalize {:lib/type :mbql/query}))))))))

--- a/test/metabase/lib/normalize_test.cljc
+++ b/test/metabase/lib/normalize_test.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.normalize-test
   (:require
-   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    #?@(:clj ([metabase.lib.normalize :as lib.normalize]))
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [are deftest is testing]]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.cached-provider :as lib.metadata.cached-provider]

--- a/test/metabase/lib/query_test.cljc
+++ b/test/metabase/lib/query_test.cljc
@@ -631,3 +631,18 @@
                                             :type         :dimension
                                             :widget-type  :date/all-options
                                             :dimension    [:field 2 nil]}}}))))
+
+#?(:clj
+   (deftest ^:synchronized query-from-legacy-error-containment-test
+     (let [legacy {:database (meta/id), :type :query, :query {:source-table (meta/id :venues)}}]
+       (testing "an AssertionError thrown while converting a legacy query is contained (wrapped)"
+         ;; ->mbql5 is a multimethod, which with-dynamic-fn-redefs refuses; plain with-redefs is required here.
+         #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
+         (with-redefs [lib.convert/->mbql5 (fn [& _] (throw (AssertionError. "boom")))]
+           (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Error creating query from legacy query"
+                                 (lib/query meta/metadata-provider legacy)))))
+       (testing "a fatal Error thrown while converting a legacy query propagates unwrapped"
+         #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
+         (with-redefs [lib.convert/->mbql5 (fn [& _] (throw (Error. "boom")))]
+           (is (thrown? Error
+                        (lib/query meta/metadata-provider legacy))))))))

--- a/test/metabase/lib/util_test.cljc
+++ b/test/metabase/lib/util_test.cljc
@@ -379,3 +379,26 @@
                                                                                     {:name "count"}
                                                                                     {:name "CC", :lib/expression-name "CC"}]}}]}]}]}
               (lib.util/pipeline query))))))
+
+#?(:clj
+   (deftest ^:parallel recover-test
+     (testing "returns the thunk's value when nothing is thrown"
+       (is (= 42 (lib.util/recover (fn [] 42) (fn [_] :unreached)))))
+     (testing "recoverable throwables reach the handler unchanged -- any Exception, plus AssertionError"
+       (are [make] (let [e (make)]
+                     (identical? e (lib.util/recover (fn [] (throw e)) (fn [caught] caught))))
+         #(AssertionError. "bad data")
+         #(RuntimeException.)
+         #(ex-info "boom" {})
+         #(InterruptedException.)
+         #(java.util.concurrent.TimeoutException.)))
+     (testing "fatal Errors propagate uncaught, unchanged"
+       (are [make] (let [e (make)]
+                     (identical? e (try
+                                     (lib.util/recover (fn [] (throw e)) (fn [_] :unreached))
+                                     (catch Error caught caught))))
+         #(StackOverflowError.)
+         #(OutOfMemoryError.)
+         #(LinkageError.)
+         #(ThreadDeath.)
+         #(Error. "generic")))))

--- a/test/metabase/lib_be/metadata/jvm_test.clj
+++ b/test/metabase/lib_be/metadata/jvm_test.clj
@@ -307,3 +307,19 @@
         (let [mp (lib.metadata.jvm/application-database-metadata-provider db-id)]
           (is (= local-value
                  (lib.metadata/setting mp :unaggregated-query-row-limit))))))))
+
+(deftest metadatas-vm-error-propagates-test
+  (testing "a VM Error thrown during a metadata fetch propagates unwrapped"
+    (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+          e  (Error. "boom")]
+      (with-redefs [t2/select (fn [& _] (throw e))]
+        (is (identical? e
+                        (try
+                          (lib.metadata.protocols/metadatas mp {:lib/type :metadata/table, :id #{Integer/MAX_VALUE}})
+                          nil
+                          (catch Error actual actual)))))))
+  (testing "an Exception thrown during a metadata fetch is wrapped with the metadata spec"
+    (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))]
+      (with-redefs [t2/select (fn [& _] (throw (ex-info "boom" {})))]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Error fetching metadata with spec"
+                              (lib.metadata.protocols/metadatas mp {:lib/type :metadata/table, :id #{Integer/MAX_VALUE}})))))))

--- a/test/metabase/lib_be/metadata/jvm_test.clj
+++ b/test/metabase/lib_be/metadata/jvm_test.clj
@@ -312,7 +312,7 @@
   (testing "a VM Error thrown during a metadata fetch propagates unwrapped"
     (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
           e  (Error. "boom")]
-      (with-redefs [t2/select (fn [& _] (throw e))]
+      (mt/with-dynamic-fn-redefs [t2/select (fn [& _] (throw e))]
         (is (identical? e
                         (try
                           (lib.metadata.protocols/metadatas mp {:lib/type :metadata/table, :id #{Integer/MAX_VALUE}})
@@ -320,6 +320,6 @@
                           (catch Error actual actual)))))))
   (testing "an Exception thrown during a metadata fetch is wrapped with the metadata spec"
     (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))]
-      (with-redefs [t2/select (fn [& _] (throw (ex-info "boom" {})))]
+      (mt/with-dynamic-fn-redefs [t2/select (fn [& _] (throw (ex-info "boom" {})))]
         (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Error fetching metadata with spec"
                               (lib.metadata.protocols/metadatas mp {:lib/type :metadata/table, :id #{Integer/MAX_VALUE}})))))))

--- a/test/metabase/lib_be/models/transforms_test.clj
+++ b/test/metabase/lib_be/models/transforms_test.clj
@@ -4,6 +4,7 @@
    [metabase.lib-be.core :as lib-be]
    [metabase.lib-be.metadata.bootstrap :as lib-be.bootstrap]
    [metabase.models.interface :as mi]
+   [metabase.test :as mt]
    [metabase.util.json :as json]
    [metabase.util.malli :as mu]))
 
@@ -87,23 +88,27 @@
 
 (deftest transform-query-out-vm-error-propagates-test
   (testing "a VM Error thrown during dataset_query deserialization propagates instead of yielding an empty query"
-    (with-redefs [mi/json-out-without-keywordization (fn [_] (throw (Error. "boom")))]
+    (mt/with-dynamic-fn-redefs [mi/json-out-without-keywordization (fn [_] (throw (Error. "boom")))]
       (is (thrown? Error
                    ((:out lib-be/transform-query) "{}")))))
   (testing "an Exception thrown during dataset_query deserialization yields an empty query"
-    (with-redefs [mi/json-out-without-keywordization (fn [_] (throw (RuntimeException. "boom")))]
+    (mt/with-dynamic-fn-redefs [mi/json-out-without-keywordization (fn [_] (throw (RuntimeException. "boom")))]
+      (is (= {}
+             ((:out lib-be/transform-query) "{}")))))
+  (testing "an AssertionError thrown during dataset_query deserialization is contained, yielding an empty query"
+    (mt/with-dynamic-fn-redefs [mi/json-out-without-keywordization (fn [_] (throw (AssertionError. "boom")))]
       (is (= {}
              ((:out lib-be/transform-query) "{}"))))))
 
 (deftest normalize-query-vm-error-propagates-test
   (testing "a VM Error thrown during query normalization propagates instead of yielding an empty query"
-    (with-redefs [lib-be.bootstrap/resolve-database (fn [& _] (throw (Error. "boom")))]
+    (mt/with-dynamic-fn-redefs [lib-be.bootstrap/resolve-database (fn [& _] (throw (Error. "boom")))]
       (is (thrown? Error
                    (lib-be/normalize-query {:database 1
                                             :type     :query
                                             :query    {:source-table 2}})))))
   (testing "an Exception thrown during query normalization yields an empty query"
-    (with-redefs [lib-be.bootstrap/resolve-database (fn [& _] (throw (RuntimeException. "boom")))]
+    (mt/with-dynamic-fn-redefs [lib-be.bootstrap/resolve-database (fn [& _] (throw (RuntimeException. "boom")))]
       (is (= {}
              (lib-be/normalize-query {:database 1
                                       :type     :query

--- a/test/metabase/lib_be/models/transforms_test.clj
+++ b/test/metabase/lib_be/models/transforms_test.clj
@@ -2,6 +2,8 @@
   (:require
    [clojure.test :refer :all]
    [metabase.lib-be.core :as lib-be]
+   [metabase.lib-be.metadata.bootstrap :as lib-be.bootstrap]
+   [metabase.models.interface :as mi]
    [metabase.util.json :as json]
    [metabase.util.malli :as mu]))
 
@@ -82,3 +84,27 @@
                                               "widget-type"  "category/="
                                               "default"      nil}}
                           "query" "<<NATIVE QUERY>>"}})))))
+
+(deftest transform-query-out-vm-error-propagates-test
+  (testing "a VM Error thrown during dataset_query deserialization propagates instead of yielding an empty query"
+    (with-redefs [mi/json-out-without-keywordization (fn [_] (throw (Error. "boom")))]
+      (is (thrown? Error
+                   ((:out lib-be/transform-query) "{}")))))
+  (testing "an Exception thrown during dataset_query deserialization yields an empty query"
+    (with-redefs [mi/json-out-without-keywordization (fn [_] (throw (RuntimeException. "boom")))]
+      (is (= {}
+             ((:out lib-be/transform-query) "{}"))))))
+
+(deftest normalize-query-vm-error-propagates-test
+  (testing "a VM Error thrown during query normalization propagates instead of yielding an empty query"
+    (with-redefs [lib-be.bootstrap/resolve-database (fn [& _] (throw (Error. "boom")))]
+      (is (thrown? Error
+                   (lib-be/normalize-query {:database 1
+                                            :type     :query
+                                            :query    {:source-table 2}})))))
+  (testing "an Exception thrown during query normalization yields an empty query"
+    (with-redefs [lib-be.bootstrap/resolve-database (fn [& _] (throw (RuntimeException. "boom")))]
+      (is (= {}
+             (lib-be/normalize-query {:database 1
+                                      :type     :query
+                                      :query    {:source-table 2}}))))))

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -1177,6 +1177,52 @@
         (is (= "Orders, Count"
                (:query_description (t2/select-one :model/Card :id id))))))))
 
+(deftest ^:parallel query-description-skipped-for-metadata-provider-fetches-test
+  (testing "metadata-provider fetches of metric cards do not compute a query description (#74954)"
+    (let [mp (mt/metadata-provider)]
+      (mt/with-temp
+        [:model/Card
+         {id :id}
+         {:name "My metric"
+          :type :metric
+          :dataset_query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                             (lib/aggregate (lib/count))
+                             lib.convert/->legacy-MBQL)}]
+        (is (not (contains? (t2/select-one :metadata/metric :id id) :query-description)))
+        (is (not (contains? (t2/select-one :metadata/card :id id) :query-description)))))))
+
+(deftest query-description-metric-reference-cycle-test
+  (testing "selecting a metric card whose :metric references form a cycle completes with a :query_description (#74954)"
+    (letfn [(metric-query [metric-id]
+              {:database (mt/id)
+               :type     :query
+               :query    {:source-table (mt/id :orders)
+                          :aggregation  [["metric" metric-id]]}})]
+      ;; Search ingestion of a cycle-involved card recurses unboundedly in `lib.metadata.calculation/metadata-method
+      ;; :metric` (a separate defect from the one under test), so keep these cards out of the ingestion queue where
+      ;; concurrently-running tests would index them.
+      (binding [search.ingestion/*disable-updates* true]
+        (mt/with-temp
+          [:model/Card
+           {a-id :id}
+           {:name "Metric A"
+            :type :metric
+            :dataset_query (let [mp (mt/metadata-provider)]
+                             (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                                 (lib/aggregate (lib/count))
+                                 lib.convert/->legacy-MBQL))}
+           :model/Card
+           {b-id :id}
+           {:name "Metric B"
+            :type :metric
+            :dataset_query (metric-query a-id)}]
+          ;; close the cycle A -> B -> A; nothing rejects reference cycles at write time
+          (t2/update! :model/Card a-id {:dataset_query (metric-query b-id)})
+          (is (= "Orders, Metric B"
+                 (:query_description (t2/select-one :model/Card :id a-id))))
+          (is (= "Orders, Metric A"
+                 (:query_description (t2/select-one :model/Card :id b-id)))))))))
+
 (deftest before-update-card-schema-test
   (testing "card_schema gets set to current-schema-version on update"
     (mt/with-temp [:model/Card {card-id :id} {:card_schema 20}]

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -1179,6 +1179,9 @@
 
 (deftest ^:parallel query-description-skipped-for-metadata-provider-fetches-test
   (testing "metadata-provider fetches of metric cards do not compute a query description (#74954)"
+    ;; Pins `metadata-provider-fetch?`'s coupling to the `:metadata/*` model namespace: if those models stopped
+    ;; being recognized, the after-select would compute the description during a provider fetch (re-entering the
+    ;; metric recursion), and the skip assertions below would fail.
     (let [mp (mt/metadata-provider)]
       (mt/with-temp
         [:model/Card
@@ -1188,70 +1191,55 @@
           :dataset_query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
                              (lib/aggregate (lib/count))
                              lib.convert/->legacy-MBQL)}]
-        (is (not (contains? (t2/select-one :metadata/metric :id id) :query-description)))
-        (is (not (contains? (t2/select-one :metadata/card :id id) :query-description)))))))
+        (testing "provider fetches skip it"
+          (is (not (contains? (t2/select-one :metadata/metric :id id) :query-description)))
+          (is (not (contains? (t2/select-one :metadata/card :id id) :query-description))))
+        (testing "a real :model/Card fetch still computes it"
+          (is (= "Orders, Count"
+                 (:query_description (t2/select-one :model/Card :id id)))))))))
+
+(defn- do-with-metric-cycle
+  "Build two metric cards whose `:metric` refs form a cycle A → B → A and call `f` with their ids."
+  [f]
+  (letfn [(metric-query [metric-id]
+            {:database (mt/id)
+             :type     :query
+             :query    {:source-table (mt/id :orders)
+                        :aggregation  [["metric" metric-id]]}})]
+    (let [count-query (let [mp (mt/metadata-provider)]
+                        (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                            (lib/aggregate (lib/count))
+                            lib.convert/->legacy-MBQL))]
+      ;; the cyclic cards must stay out of the shared search queue that concurrent tests drain
+      (binding [search.ingestion/*disable-updates* true]
+        (mt/with-temp
+          [:model/Card {a-id :id} {:name "Metric A", :type :metric, :dataset_query count-query}
+           :model/Card {b-id :id} {:name "Metric B", :type :metric, :dataset_query (metric-query a-id)}]
+          ;; close the cycle with a raw update -- the card API rejects cyclic saves, so this is the non-API path
+          ;; (serdes, remote sync, pre-check data) by which a cycle actually reaches the DB
+          (t2/update! :model/Card a-id {:dataset_query (metric-query b-id)})
+          (f a-id b-id))))))
 
 (deftest query-description-metric-reference-cycle-test
   (testing "selecting a metric card whose :metric references form a cycle completes with a :query_description (#74954)"
-    (letfn [(metric-query [metric-id]
-              {:database (mt/id)
-               :type     :query
-               :query    {:source-table (mt/id :orders)
-                          :aggregation  [["metric" metric-id]]}})]
-      ;; Search ingestion of a cycle-involved card recurses unboundedly in `lib.metadata.calculation/metadata-method
-      ;; :metric` (a separate defect from the one under test), so keep these cards out of the ingestion queue where
-      ;; concurrently-running tests would index them.
-      (binding [search.ingestion/*disable-updates* true]
-        (mt/with-temp
-          [:model/Card
-           {a-id :id}
-           {:name "Metric A"
-            :type :metric
-            :dataset_query (let [mp (mt/metadata-provider)]
-                             (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
-                                 (lib/aggregate (lib/count))
-                                 lib.convert/->legacy-MBQL))}
-           :model/Card
-           {b-id :id}
-           {:name "Metric B"
-            :type :metric
-            :dataset_query (metric-query a-id)}]
-          ;; close the cycle A -> B -> A; nothing rejects reference cycles at write time
-          (t2/update! :model/Card a-id {:dataset_query (metric-query b-id)})
-          (is (= "Orders, Metric B"
-                 (:query_description (t2/select-one :model/Card :id a-id))))
-          (is (= "Orders, Metric A"
-                 (:query_description (t2/select-one :model/Card :id b-id)))))))))
+    (do-with-metric-cycle
+     (fn [a-id b-id]
+       (is (= "Orders, Metric B"
+              (:query_description (t2/select-one :model/Card :id a-id))))
+       (is (= "Orders, Metric A"
+              (:query_description (t2/select-one :model/Card :id b-id))))))))
 
 (deftest extract-temporal-info-metric-reference-cycle-test
   (testing "extract-temporal-info on a query aggregating a cycle-involved metric throws a cycle error (#74954)"
-    (letfn [(metric-query [metric-id]
-              {:database (mt/id)
-               :type     :query
-               :query    {:source-table (mt/id :orders)
-                          :aggregation  [["metric" metric-id]]}})]
-      ;; keep the cyclic cards out of the shared ingestion queue, where concurrently-running tests would index them
-      (binding [search.ingestion/*disable-updates* true]
-        (mt/with-temp
-          [:model/Card
-           {a-id :id}
-           {:name "Metric A"
-            :type :metric
-            :dataset_query (let [mp (mt/metadata-provider)]
-                             (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
-                                 (lib/aggregate (lib/count))
-                                 lib.convert/->legacy-MBQL))}
-           :model/Card
-           {b-id :id}
-           {:name "Metric B"
-            :type :metric
-            :dataset_query (metric-query a-id)}]
-          ;; close the cycle A -> B -> A; nothing rejects reference cycles at write time
-          (t2/update! :model/Card a-id {:dataset_query (metric-query b-id)})
-          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Metric cycle detected"
-                                (#'card/extract-temporal-info
-                                 {:dataset_query (json/encode (metric-query a-id))
-                                  :query_type    "query"}))))))))
+    (do-with-metric-cycle
+     (fn [a-id _b-id]
+       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Metric cycle detected"
+                             (#'card/extract-temporal-info
+                              {:dataset_query (json/encode {:database (mt/id)
+                                                            :type     :query
+                                                            :query    {:source-table (mt/id :orders)
+                                                                       :aggregation  [["metric" a-id]]}})
+                               :query_type    "query"})))))))
 
 (deftest before-update-card-schema-test
   (testing "card_schema gets set to current-schema-version on update"

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -1223,6 +1223,36 @@
           (is (= "Orders, Metric A"
                  (:query_description (t2/select-one :model/Card :id b-id)))))))))
 
+(deftest extract-temporal-info-metric-reference-cycle-test
+  (testing "extract-temporal-info on a query aggregating a cycle-involved metric throws a cycle error (#74954)"
+    (letfn [(metric-query [metric-id]
+              {:database (mt/id)
+               :type     :query
+               :query    {:source-table (mt/id :orders)
+                          :aggregation  [["metric" metric-id]]}})]
+      ;; keep the cyclic cards out of the shared ingestion queue, where concurrently-running tests would index them
+      (binding [search.ingestion/*disable-updates* true]
+        (mt/with-temp
+          [:model/Card
+           {a-id :id}
+           {:name "Metric A"
+            :type :metric
+            :dataset_query (let [mp (mt/metadata-provider)]
+                             (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                                 (lib/aggregate (lib/count))
+                                 lib.convert/->legacy-MBQL))}
+           :model/Card
+           {b-id :id}
+           {:name "Metric B"
+            :type :metric
+            :dataset_query (metric-query a-id)}]
+          ;; close the cycle A -> B -> A; nothing rejects reference cycles at write time
+          (t2/update! :model/Card a-id {:dataset_query (metric-query b-id)})
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Metric cycle detected"
+                                (#'card/extract-temporal-info
+                                 {:dataset_query (json/encode (metric-query a-id))
+                                  :query_type    "query"}))))))))
+
 (deftest before-update-card-schema-test
   (testing "card_schema gets set to current-schema-version on update"
     (mt/with-temp [:model/Card {card-id :id} {:card_schema 20}]

--- a/test/metabase/search/ingestion_test.clj
+++ b/test/metabase/search/ingestion_test.clj
@@ -3,13 +3,18 @@
    [clojure.core.cache :as cache]
    [clojure.test :refer :all]
    [metabase.lib-be.metadata.jvm :as metadata.jvm]
+   [metabase.lib.convert :as lib.convert]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.search.core :as search]
    [metabase.search.engine :as search.engine]
    [metabase.search.ingestion :as search.ingestion]
    [metabase.search.spec :as search.spec]
    [metabase.search.test-util :as search.tu]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.json :as json]
+   [toucan2.core :as t2]))
 
 (deftest extract-model-and-id
   (is (= ["action" "1895"] (#'search.ingestion/extract-model-and-id ["action" [:= 1895 :this.id]])))
@@ -113,6 +118,39 @@
     (let [spec {:attrs {:temporal-info {:fn       (fn [_] (throw (ex-info "boom" {})))
                                         :provides [:has-temporal-dim :non-temporal-dim-ids]}}}]
       (is (= {} (#'search.ingestion/execute-all-function-attrs spec {}))))))
+
+(deftest execute-all-function-attrs-metric-reference-cycle-test
+  (testing "a card whose metric references form a cycle yields a document without temporal keys, instead of throwing (#74954)"
+    (letfn [(metric-query [metric-id]
+              {:database (mt/id)
+               :type     :query
+               :query    {:source-table (mt/id :orders)
+                          :aggregation  [["metric" metric-id]]}})]
+      ;; keep the cyclic cards out of the shared ingestion queue, where concurrently-running tests would index them
+      (binding [search.ingestion/*disable-updates* true]
+        (mt/with-temp
+          [:model/Card
+           {a-id :id}
+           {:name "Metric A"
+            :type :metric
+            :dataset_query (let [mp (mt/metadata-provider)]
+                             (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                                 (lib/aggregate (lib/count))
+                                 lib.convert/->legacy-MBQL))}
+           :model/Card
+           {b-id :id}
+           {:name "Metric B"
+            :type :metric
+            :dataset_query (metric-query a-id)}]
+          ;; close the cycle A -> B -> A; nothing rejects reference cycles at write time
+          (t2/update! :model/Card a-id {:dataset_query (metric-query b-id)})
+          (let [result (#'search.ingestion/execute-all-function-attrs
+                        (search.spec/spec "card")
+                        {:dataset_query (json/encode (metric-query a-id))
+                         :query_type    "query"})]
+            (is (map? result))
+            (is (not (contains? result :has_temporal_dim)))
+            (is (not (contains? result :non_temporal_dim_ids)))))))))
 
 (deftest search-term-columns-test
   (testing "search-term-columns with vector format"


### PR DESCRIPTION
Fixes #74954

Instances with a cycle in their metric reference graph (metric A aggregates metric B, B aggregates A — nothing rejects this at save time) would freeze completely during the hourly SearchIndexReindex job: no requests served, CPU idle, health check green, until the container was restarted.

Root cause chain:
1. The reindex builds a search document for a metric card; computing its temporal info resolves the card's `:metric` refs through the metadata provider.
2. Provider card fetches fire the Card `after-select`, which computes a query description — resolving its `:metric` refs through the provider again. With a reference cycle, no fetch ever completes (the provider cache only stores completed fetches, so it can't break the loop)
3. From client instance heap dump, at ~11k frames the recursion throws `StackOverflowError`, which the deepest suggested-name catch Throwable swallows — and then tries to log on the exhausted stack
4. The log call enters `log4j`'s logger registry; a second `StackOverflowError` inside the locked region unwinds past the handler's `unlock()`, permanently leaking the registry's read lock.
5. One recursion level up, the next swallowed & logged attempt needs to create the logger (weak refs, GC'd under heap pressure) — the thread parks on the registry's write lock, queued behind its own leaked read hold, resulting in self-deadlock
6. Every other thread that logs queues behind the parked writer (readers included, per AQS semantics), wedging Quartz workers and Jetty threads; `DisallowConcurrentExecution` also blocks all future reindexes.
7. Only Quartz's misfire handler survives (`slf4j` caches its loggers strongly, bypassing the registry), and the health endpoint never logs — hence a "green" instance that serves nothing for 36 hours

Core changes:

- Skip `:query_description` computation for `metadata-provider` card fetches, breaking the `after-select` recursion (provider fetches are lib internal; nothing consumes the description there)
- Add a cycle guard to metric metadata expansion: a reference cycle now throws a diagnosable `"Metric cycle detected: A → B → A"` error instead of overflowing the stack. Search ingestion contains the error per-card — the card is still indexed (without temporal attributes) and the reindex completes.
- Narrow the `catch Throwable`s to `catch Exception` at the lib/lib-be sites inside these recursion paths, so any future VM Error unwinds to a shallow caller that can log it safely, instead of being swallowed mid stack
- Convert an assert in dataset_query deserialization to an explicit throw so bad data keeps its existing degrade-to-{} behavior under the narrowed catch