### PR TITLE
remount EditorBubbleMenu on hide

### DIFF
--- a/frontend/src/metabase/rich_text_editing/tiptap/components/EditorBubbleMenu/EditorBubbleMenu.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/components/EditorBubbleMenu/EditorBubbleMenu.tsx
@@ -55,6 +55,7 @@ export const EditorBubbleMenu: React.FC<EditorBubbleMenuProps> = ({
 }) => {
   const forceUpdate = useForceUpdate();
   const [initialLinkUrl, setInitialLinkUrl] = useState<string | null>(null);
+  const [contentKey, setContentKey] = useState(0);
 
   const handleLinkClick = () => {
     const existingLink = editor.getAttributes("link");
@@ -92,8 +93,13 @@ export const EditorBubbleMenu: React.FC<EditorBubbleMenuProps> = ({
       className={className}
       editor={editor}
       options={{
-        onHide: () => setInitialLinkUrl(null),
         ...options,
+        onHide: () => {
+          setInitialLinkUrl(null);
+          //remount the content to clean up any lingering tooltips
+          setContentKey((key) => key + 1);
+          options?.onHide?.();
+        },
       }}
       shouldShow={({
         editor,
@@ -139,6 +145,7 @@ export const EditorBubbleMenu: React.FC<EditorBubbleMenuProps> = ({
       }}
     >
       <Flex
+        key={contentKey}
         gap={4}
         p="2px"
         className={S.bubbleMenu}

--- a/frontend/src/metabase/rich_text_editing/tiptap/components/EditorBubbleMenu/EditorBubbleMenu.unit.spec.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/components/EditorBubbleMenu/EditorBubbleMenu.unit.spec.tsx
@@ -1,0 +1,90 @@
+import userEvent from "@testing-library/user-event";
+import { type Editor, EditorContent, useEditor } from "@tiptap/react";
+import { StarterKit } from "@tiptap/starter-kit";
+
+import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
+
+import { EditorBubbleMenu } from "./EditorBubbleMenu";
+
+function setup() {
+  let editor: Editor | null = null;
+
+  function TestEditor() {
+    const instance = useEditor({
+      extensions: [StarterKit],
+      content: "<p>Hello world</p>",
+      immediatelyRender: true,
+    });
+
+    editor = instance;
+
+    if (!instance) {
+      return null;
+    }
+
+    return (
+      <>
+        <EditorContent editor={instance} />
+        <EditorBubbleMenu editor={instance} disallowedNodes={[]} />
+      </>
+    );
+  }
+
+  renderWithProviders(<TestEditor />);
+
+  return {
+    selectText: () =>
+      act(() => {
+        editor?.commands.setTextSelection({ from: 1, to: 6 });
+      }),
+    deleteText: () =>
+      act(() => {
+        editor?.chain().selectAll().deleteSelection().run();
+      }),
+    restoreText: () =>
+      act(() => {
+        editor?.commands.setContent("<p>Hello world</p>");
+      }),
+  };
+}
+
+function findBoldButton() {
+  return screen.findByRole(
+    "button",
+    { name: "text_bold icon" },
+    { timeout: 2000 },
+  );
+}
+
+describe("EditorBubbleMenu", () => {
+  it("should not leave an orphaned tooltip in the DOM after the menu hides (metabase#76365)", async () => {
+    const { selectText, deleteText } = setup();
+
+    selectText();
+    await userEvent.hover(await findBoldButton());
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Bold");
+    deleteText();
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should still show the bubble menu again after it has been hidden", async () => {
+    const { selectText, deleteText, restoreText } = setup();
+
+    selectText();
+    expect(await findBoldButton()).toBeInTheDocument();
+
+    deleteText();
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "text_bold icon" }),
+      ).not.toBeInTheDocument();
+    });
+
+    restoreText();
+    selectText();
+    expect(await findBoldButton()).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76365
### Description

This isn't my favourite solution to this problem, but it stems from the interop between tiptap and react. Tiptap yanks the BubbleMenu from the DOM on hide using element.remove() outside of react, and the tooltip is rendered in a portal. so it doesn't automatically get removed. Re-mounting the component on hide giving the tooltip a chance to clean up it's rendered elements. 

Ideally I'd wanted to handle this inside the formatButton component, but specifying `withPortal: false` messed with rendering, and any attempt to manually clean up the tooltip just looked messy.


### How to verify

1. Go to a document and start a comment on a section
2. Type out part of a comment, then highlight it to bring up the bubble menu
3. hover a format button to have the tooltip show, then press `delete` or `backspace`
4. the tooltip should disappear

### Demo


https://github.com/user-attachments/assets/d94f5df5-6559-4b31-89e9-0e21196e849d


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
