### PR TITLE
Contain AssertionError at the lib recovery boundaries

### DIFF
--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -74,12 +74,12 @@
    (or
     ;; if this is an MBQL clause with `:display-name` in the options map, then use that rather than calculating a name.
     ((some-fn :display-name :lib/expression-name) (lib.options/options x))
-    (try
-      (display-name-method query stage-number x style)
-      (catch #?(:clj Exception :cljs js/Error) e
-        (throw (ex-info (i18n/tru "Error calculating display name for {0}: {1}" (pr-str x) (ex-message e))
-                        {:query query, :x x}
-                        e)))))))
+    (lib.util/recover
+     (fn [] (display-name-method query stage-number x style))
+     (fn [e]
+       (throw (ex-info (i18n/tru "Error calculating display name for {0}: {1}" (pr-str x) (ex-message e))
+                       {:query query, :x x}
+                       e)))))))
 
 (mu/defn column-name :- ::lib.schema.common/non-blank-string
   "Calculate a database-friendly name to use for an expression."
@@ -92,14 +92,14 @@
    (or
     ;; if this is an MBQL clause with `:name` in the options map, then use that rather than calculating a name.
     (:name (lib.options/options x))
-    (try
-      (column-name-method query stage-number x)
-      (catch #?(:clj Exception :cljs js/Error) e
-        (throw (ex-info (i18n/tru "Error calculating column name for {0}: {1}" (pr-str x) (ex-message e))
-                        {:x            x
-                         :query        query
-                         :stage-number stage-number}
-                        e)))))))
+    (lib.util/recover
+     (fn [] (column-name-method query stage-number x))
+     (fn [e]
+       (throw (ex-info (i18n/tru "Error calculating column name for {0}: {1}" (pr-str x) (ex-message e))
+                       {:x            x
+                        :query        query
+                        :stage-number stage-number}
+                       e)))))))
 
 (defmethod display-name-method :default
   [_query _stage-number x _stage]
@@ -259,20 +259,20 @@
 
 (defmethod metadata-method :default
   [query stage-number x]
-  (try
-    {:lib/type     :metadata/column
-     ;; TODO -- effective-type
-     :base-type    (type-of query stage-number x)
-     :name         (column-name query stage-number x)
-     :display-name (display-name query stage-number x)}
-    ;; if you see this error it's usually because you're calling [[metadata]] on something that you shouldn't be, for
-    ;; example a query
-    (catch #?(:clj Exception :cljs js/Error) e
-      (throw (ex-info (i18n/tru "Error calculating metadata for {0}: {1}"
-                                (pr-str (lib.dispatch/dispatch-value x))
-                                (ex-message e))
-                      {:query query, :stage-number stage-number, :x x}
-                      e)))))
+  (lib.util/recover
+   (fn []
+     {:lib/type     :metadata/column
+      ;; TODO -- effective-type
+      :base-type    (type-of query stage-number x)
+      :name         (column-name query stage-number x)
+      :display-name (display-name query stage-number x)})
+   ;; This usually means [[metadata]] was called on something it shouldn't be, e.g. a query.
+   (fn [e]
+     (throw (ex-info (i18n/tru "Error calculating metadata for {0}: {1}"
+                               (pr-str (lib.dispatch/dispatch-value x))
+                               (ex-message e))
+                     {:query query, :stage-number stage-number, :x x}
+                     e)))))
 
 (mr/def ::metadata-map
   [:map [:lib/type [:and
@@ -305,13 +305,14 @@
   as [[describe-query]] except for native queries, where we don't describe anything."
   [query]
   (when-not (= (:lib/type (lib.util/query-stage query -1)) :mbql.stage/native)
-    (try
-      (describe-query query)
-      (catch #?(:clj Exception :cljs js/Error) e
-        ;; Throttled: a search reindex can call this for many failing metric Cards, don't log them all.
-        (log/throttle (* 10 1000)
-                      (log/errorf e "Error calculating display name for query: %s" (ex-message e)))
-        nil))))
+    (lib.util/recover
+     (fn [] (describe-query query))
+     (fn [e]
+       ;; Throttled: a bulk caller such as a search reindex can hit this for many failing metric Cards,
+       ;; so don't log every one.
+       (log/throttle (* 10 1000)
+                     (log/errorf e "Error calculating display name for query: %s" (ex-message e)))
+       nil))))
 
 (defmulti display-info-method
   "Implementation for [[display-info]]. Implementations that call [[display-name]] should use the `:default` display
@@ -382,14 +383,14 @@
     stage-number :- :int
     x]
    (letfn [(display-info* [x]
-             (try
-               (display-info-method query stage-number x)
-               (catch #?(:clj Exception :cljs js/Error) e
-                 (throw (ex-info (i18n/tru "Error calculating display info for {0}: {1}"
-                                           (lib.dispatch/dispatch-value x)
-                                           (ex-message e))
-                                 {:query query, :stage-number stage-number, :x x}
-                                 e)))))]
+             (lib.util/recover
+              (fn [] (display-info-method query stage-number x))
+              (fn [e]
+                (throw (ex-info (i18n/tru "Error calculating display info for {0}: {1}"
+                                          (lib.dispatch/dispatch-value x)
+                                          (ex-message e))
+                                {:query query, :stage-number stage-number, :x x}
+                                e)))))]
      #?(:clj
         (display-info* x)
         :cljs

--- a/src/metabase/lib/metric.cljc
+++ b/src/metabase/lib/metric.cljc
@@ -147,7 +147,11 @@
   `:metric` ref; a cycle in the metric reference graph would recurse unboundedly and overflow the stack (#74954)."
   [])
 
+;; Read-time backstop for cycles that slip past the card API's `check-card-overwrite`: serdes import, remote sync,
+;; direct writes, data predating the check. find-cycle can't help -- a cycle is only visible mid-expansion -- so we
+;; watch the in-flight path instead.
 (defn- check-metric-cycle!
+  "Throw if `metric-id` is already being expanded on this thread, i.e. its `:metric` refs form a cycle."
   [metric-id]
   (when (some #(= % metric-id) *metric-expansion-path*)
     (throw (ex-info (i18n/tru "Metric cycle detected: {0}"

--- a/src/metabase/lib/normalize.cljc
+++ b/src/metabase/lib/normalize.cljc
@@ -97,12 +97,12 @@
                               (throw (ex-info (i18n/tru "Normalization error")
                                               {:schema schema, :x x, :error error})))]
          (thunk))
-       (try
-         (thunk)
-         (catch #?(:clj Exception :cljs :default) e
-           (throw (ex-info (str "Uncaught normalization error: " (ex-message e))
-                           {:schema schema}
-                           e))))))))
+       (lib.util/recover
+        thunk
+        (fn [e]
+          (throw (ex-info (str "Uncaught normalization error: " (ex-message e))
+                          {:schema schema}
+                          e))))))))
 
 (mu/defn ->normalized-stage-metadata :- ::lib.schema.metadata/stage
   "Take a sequence of legacy or Lib metadata maps, convert to Lib-style if needed, then normalize them.

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -175,18 +175,19 @@
 
 (defn- query-from-legacy-query
   [metadata-providerable legacy-query]
-  (try
-    (let [mbql5-query (binding [lib.schema.expression/*suppress-expression-type-check?* true]
-                        (lib.convert/->mbql5 (mbql.normalize/normalize-or-throw legacy-query)))
-          mp          (lib.metadata/->metadata-provider metadata-providerable (:database mbql5-query))
-          mbql5-query (add-types-to-fields mbql5-query mp)]
-      (merge
-       mbql5-query
-       (query-with-stages mp (:stages mbql5-query))))
-    (catch #?(:clj Exception :cljs :default) e
-      (throw (ex-info (i18n/tru "Error creating query from legacy query: {0}" (ex-message e))
-                      {:legacy-query legacy-query}
-                      e)))))
+  (lib.util/recover
+   (fn []
+     (let [mbql5-query (binding [lib.schema.expression/*suppress-expression-type-check?* true]
+                         (lib.convert/->mbql5 (mbql.normalize/normalize-or-throw legacy-query)))
+           mp          (lib.metadata/->metadata-provider metadata-providerable (:database mbql5-query))
+           mbql5-query (add-types-to-fields mbql5-query mp)]
+       (merge
+        mbql5-query
+        (query-with-stages mp (:stages mbql5-query)))))
+   (fn [e]
+     (throw (ex-info (i18n/tru "Error creating query from legacy query: {0}" (ex-message e))
+                     {:legacy-query legacy-query}
+                     e)))))
 
 (defmulti ^:private query-method
   "Implementation for [[query]]."

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -38,6 +38,18 @@
    :cljs
    (def format "Exactly like [[clojure.core/format]] but ClojureScript-friendly." gstring/format))
 
+;; AssertionError is recoverable too, not just Exception: callers run assert/:pre they don't own, and a
+;; bad-data assert should degrade through `handler` like any other exception. Fatal Errors still propagate.
+(defn recover
+  "Run `thunk`, returning its value; if it throws a recoverable throwable, return `(handler throwable)` instead.
+  Recoverable is any `Exception`, plus `AssertionError` on the JVM.
+  Fatal `Error`s -- stack overflow, OOM, linkage, thread death -- are never caught and propagate."
+  [thunk handler]
+  (try
+    (thunk)
+    (catch #?(:clj Exception :cljs :default) e (handler e))
+    #?(:clj (catch AssertionError e (handler e)))))
+
 ;;; TODO (Cam 9/8/25) -- overlapping functionality with [[metabase.lib.schema.common/is-clause?]]
 (defn clause?
   "Returns true if this is a **normalized** MBQL 5 clause."

--- a/src/metabase/lib_be/metadata/jvm.clj
+++ b/src/metabase/lib_be/metadata/jvm.clj
@@ -13,6 +13,7 @@
    [metabase.lib.normalize :as lib.normalize]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.lib.util :as lib.util]
    [metabase.models.interface :as mi]
    [metabase.settings.core :as setting]
    [metabase.util :as u]
@@ -536,12 +537,12 @@
   [database-id                                  :- ::lib.schema.id/database
    {metadata-type :lib/type, :as metadata-spec} :- ::lib.metadata.protocols/metadata-spec]
   (let [query (metadata-spec->honey-sql database-id metadata-spec)]
-    (try
-      (t2/select metadata-type query)
-      (catch Exception e
-        (throw (ex-info "Error fetching metadata with spec"
-                        {:metadata-spec metadata-spec, :query query}
-                        e))))))
+    (lib.util/recover
+     (fn [] (t2/select metadata-type query))
+     (fn [e]
+       (throw (ex-info "Error fetching metadata with spec"
+                       {:metadata-spec metadata-spec, :query query}
+                       e))))))
 
 (p/deftype+ UncachedApplicationDatabaseMetadataProvider [database-id]
   lib.metadata.protocols/MetadataProvider

--- a/src/metabase/lib_be/models/transforms.clj
+++ b/src/metabase/lib_be/models/transforms.clj
@@ -6,6 +6,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.util :as lib.util]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -38,46 +39,47 @@
                               [:map
                                {:closed true}
                                [:strict? {:optional true, :default false} [:maybe :boolean]]]]]
-   (try
-     (let [metadata-providerable (or metadata-providerable
-                                     (when-let [mp (:lib/metadata query)]
-                                       (when (lib/metadata-provider? mp)
-                                         mp))
-                                     lib.metadata.jvm/application-database-metadata-provider)]
-       (cond
-         (empty? query)
-         {}
+   (lib.util/recover
+    (fn []
+      (let [metadata-providerable (or metadata-providerable
+                                      (when-let [mp (:lib/metadata query)]
+                                        (when (lib/metadata-provider? mp)
+                                          mp))
+                                      lib.metadata.jvm/application-database-metadata-provider)]
+        (cond
+          (empty? query)
+          {}
 
-         (not (has-normalized-key? query :database))
-         (throw (ex-info "Query must include :database" {:query query}))
+          (not (has-normalized-key? query :database))
+          (throw (ex-info "Query must include :database" {:query query}))
 
-         (not (has-any-of-these-normalized-keys? query #{:lib/type :type}))
-         (throw (ex-info "Query must include :lib/type or :type" {:query query}))
+          (not (has-any-of-these-normalized-keys? query #{:lib/type :type}))
+          (throw (ex-info "Query must include :lib/type or :type" {:query query}))
 
-         (and (has-normalized-key? query :lib/type)
-              (has-any-of-these-normalized-keys? query #{:type :query :native}))
-         (throw (ex-info "MBQL 4 keys like :type, :query, or :native are not allowed in MBQL 5 queries with :lib/type"
-                         {:query query}))
+          (and (has-normalized-key? query :lib/type)
+               (has-any-of-these-normalized-keys? query #{:type :query :native}))
+          (throw (ex-info "MBQL 4 keys like :type, :query, or :native are not allowed in MBQL 5 queries with :lib/type"
+                          {:query query}))
 
-         (and (has-normalized-key? query :type)
-              (has-normalized-key? query :stages))
-         (throw (ex-info "MBQL 5 :stages is not allowed in an MBQL 4 query with :type" {:query query}))
+          (and (has-normalized-key? query :type)
+               (has-normalized-key? query :stages))
+          (throw (ex-info "MBQL 5 :stages is not allowed in an MBQL 4 query with :type" {:query query}))
 
-         (lib/cached-metadata-provider-with-cache? (:lib/metadata query))
-         (lib/normalize ::lib.schema/query query)
+          (lib/cached-metadata-provider-with-cache? (:lib/metadata query))
+          (lib/normalize ::lib.schema/query query)
 
-         :else
-         (->> query
-              (lib-be.bootstrap/resolve-database (when (lib/metadata-provider? metadata-providerable)
-                                                   metadata-providerable))
-              (lib/query metadata-providerable))))
-     ;; return an empty map if we are unable to normalize the query correctly to prevent breaking things downstream,
-     ;; unless strict mode is on (when we are saving a query)
-     (catch Exception e
-       (when strict?
-         (throw e))
-       (log/errorf e "Error normalizing query %s" (pr-str query))
-       {}))))
+          :else
+          (->> query
+               (lib-be.bootstrap/resolve-database (when (lib/metadata-provider? metadata-providerable)
+                                                    metadata-providerable))
+               (lib/query metadata-providerable)))))
+    ;; Normalization failed. Degrade to {} so bad stored data can't break callers,
+    ;; but in strict mode (saving) rethrow rather than persist a query we couldn't parse.
+    (fn [e]
+      (when strict?
+        (throw e))
+      (log/errorf e "Error normalizing query %s" (pr-str query))
+      {}))))
 
 (defn- transform-query-in [query]
   (when-not (map? query)
@@ -90,18 +92,17 @@
 
 (defn- transform-query-out [s]
   (when (some? s)
-    (try
-      (let [query (mi/json-out-without-keywordization s)]
-        ;; an explicit throw rather than `assert`: this handler must swallow bad data (returning `{}`) but let VM
-        ;; Errors unwind, and `AssertionError` is on the wrong side of that line (#74954)
-        (when-not (map? query)
-          (throw (ex-info (format "Expected deserialized query to be a map, got ^%s %s"
-                                  (.getCanonicalName (class query)) (pr-str query))
-                          {:query query})))
-        (normalize-query query))
-      (catch Exception e
-        (log/errorf e "Error deserializing dataset_query from app DB: %s" (ex-message e))
-        {}))))
+    (lib.util/recover
+     (fn []
+       (let [query (mi/json-out-without-keywordization s)]
+         (when-not (map? query)
+           (throw (ex-info (format "Expected deserialized query to be a map, got ^%s %s"
+                                   (.getCanonicalName (class query)) (pr-str query))
+                           {:query query})))
+         (normalize-query query)))
+     (fn [e]
+       (log/errorf e "Error deserializing dataset_query from app DB: %s" (ex-message e))
+       {}))))
 
 (def transform-query
   "Toucan 2 transform spec for Card `dataset_query` and other columns that store MBQL."

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -1266,4 +1266,9 @@
        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Error calculating display name"
                              (lib.metadata.calculation/display-name (lib.tu/venues-query)
                                                                     {:lib/type ::throws
-                                                                     :throwable (ex-info "boom" {})}))))))
+                                                                     :throwable (ex-info "boom" {})}))))
+     (testing "an AssertionError thrown while computing a display name is contained (wrapped), not propagated"
+       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Error calculating display name"
+                             (lib.metadata.calculation/display-name (lib.tu/venues-query)
+                                                                    {:lib/type ::throws
+                                                                     :throwable (AssertionError. "boom")}))))))

--- a/test/metabase/lib/metric_test.cljc
+++ b/test/metabase/lib/metric_test.cljc
@@ -378,3 +378,19 @@
                {:name         "count_2"
                 :display-name "Right Metric"}]
               (lib/returned-columns query))))))
+
+#?(:clj
+   (deftest ^:parallel check-card-overwrite-rejects-metric-cycle-test
+     (testing "saving a metric whose :metric refs would close a cycle is rejected up front (#74954)"
+       ;; the write-time counterpart to the read-time `check-metric-cycle!` guard: the card API rejects cyclic saves,
+       ;; so the read-time guard only has to backstop non-API paths (serdes, remote sync, direct writes).
+       (let [mp        (lib.tu/mock-metadata-provider
+                        meta/metadata-provider
+                        {:cards [(referencing-metric-card 1 "Metric A" [:metric 2])
+                                 (referencing-metric-card 2 "Metric B" [:metric 1])]})
+             new-query (lib/query mp {:database (meta/id)
+                                      :type     :query
+                                      :query    {:source-table (meta/id :venues)
+                                                 :aggregation  [[:metric 2]]}})]
+         (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Cannot save card with cycles"
+                               (lib/check-card-overwrite 1 new-query)))))))

--- a/test/metabase/lib/normalize_test.cljc
+++ b/test/metabase/lib/normalize_test.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.normalize-test
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
+   #?@(:clj ([metabase.lib.normalize :as lib.normalize]))
    [clojure.test :refer [are deftest is testing]]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.cached-provider :as lib.metadata.cached-provider]
@@ -219,3 +220,16 @@
                         :lib/type     :mbql.stage/mbql}]
             :lib/type :mbql/query}
            (lib/normalize query)))))
+
+#?(:clj
+   (deftest ^:synchronized normalize-error-containment-test
+     (testing "an AssertionError from the coercer is contained (wrapped), not propagated"
+       (with-redefs-fn {#'lib.normalize/coercer (fn [_schema] (fn [_x] (throw (AssertionError. "boom"))))}
+         (fn []
+           (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Uncaught normalization error"
+                                 (lib/normalize {:lib/type :mbql/query}))))))
+     (testing "a fatal Error from the coercer propagates unwrapped"
+       (with-redefs-fn {#'lib.normalize/coercer (fn [_schema] (fn [_x] (throw (Error. "boom"))))}
+         (fn []
+           (is (thrown? Error
+                        (lib/normalize {:lib/type :mbql/query}))))))))

--- a/test/metabase/lib/query_test.cljc
+++ b/test/metabase/lib/query_test.cljc
@@ -631,3 +631,18 @@
                                             :type         :dimension
                                             :widget-type  :date/all-options
                                             :dimension    [:field 2 nil]}}}))))
+
+#?(:clj
+   (deftest ^:synchronized query-from-legacy-error-containment-test
+     (let [legacy {:database (meta/id), :type :query, :query {:source-table (meta/id :venues)}}]
+       (testing "an AssertionError thrown while converting a legacy query is contained (wrapped)"
+         ;; ->mbql5 is a multimethod, which with-dynamic-fn-redefs refuses; plain with-redefs is required here.
+         #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
+         (with-redefs [lib.convert/->mbql5 (fn [& _] (throw (AssertionError. "boom")))]
+           (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Error creating query from legacy query"
+                                 (lib/query meta/metadata-provider legacy)))))
+       (testing "a fatal Error thrown while converting a legacy query propagates unwrapped"
+         #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
+         (with-redefs [lib.convert/->mbql5 (fn [& _] (throw (Error. "boom")))]
+           (is (thrown? Error
+                        (lib/query meta/metadata-provider legacy))))))))

--- a/test/metabase/lib/util_test.cljc
+++ b/test/metabase/lib/util_test.cljc
@@ -379,3 +379,26 @@
                                                                                     {:name "count"}
                                                                                     {:name "CC", :lib/expression-name "CC"}]}}]}]}]}
               (lib.util/pipeline query))))))
+
+#?(:clj
+   (deftest ^:parallel recover-test
+     (testing "returns the thunk's value when nothing is thrown"
+       (is (= 42 (lib.util/recover (fn [] 42) (fn [_] :unreached)))))
+     (testing "recoverable throwables reach the handler unchanged -- any Exception, plus AssertionError"
+       (are [make] (let [e (make)]
+                     (identical? e (lib.util/recover (fn [] (throw e)) (fn [caught] caught))))
+         #(AssertionError. "bad data")
+         #(RuntimeException.)
+         #(ex-info "boom" {})
+         #(InterruptedException.)
+         #(java.util.concurrent.TimeoutException.)))
+     (testing "fatal Errors propagate uncaught, unchanged"
+       (are [make] (let [e (make)]
+                     (identical? e (try
+                                     (lib.util/recover (fn [] (throw e)) (fn [_] :unreached))
+                                     (catch Error caught caught))))
+         #(StackOverflowError.)
+         #(OutOfMemoryError.)
+         #(LinkageError.)
+         #(ThreadDeath.)
+         #(Error. "generic")))))

--- a/test/metabase/lib_be/metadata/jvm_test.clj
+++ b/test/metabase/lib_be/metadata/jvm_test.clj
@@ -312,7 +312,7 @@
   (testing "a VM Error thrown during a metadata fetch propagates unwrapped"
     (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
           e  (Error. "boom")]
-      (with-redefs [t2/select (fn [& _] (throw e))]
+      (mt/with-dynamic-fn-redefs [t2/select (fn [& _] (throw e))]
         (is (identical? e
                         (try
                           (lib.metadata.protocols/metadatas mp {:lib/type :metadata/table, :id #{Integer/MAX_VALUE}})
@@ -320,6 +320,6 @@
                           (catch Error actual actual)))))))
   (testing "an Exception thrown during a metadata fetch is wrapped with the metadata spec"
     (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))]
-      (with-redefs [t2/select (fn [& _] (throw (ex-info "boom" {})))]
+      (mt/with-dynamic-fn-redefs [t2/select (fn [& _] (throw (ex-info "boom" {})))]
         (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Error fetching metadata with spec"
                               (lib.metadata.protocols/metadatas mp {:lib/type :metadata/table, :id #{Integer/MAX_VALUE}})))))))

--- a/test/metabase/lib_be/models/transforms_test.clj
+++ b/test/metabase/lib_be/models/transforms_test.clj
@@ -4,6 +4,7 @@
    [metabase.lib-be.core :as lib-be]
    [metabase.lib-be.metadata.bootstrap :as lib-be.bootstrap]
    [metabase.models.interface :as mi]
+   [metabase.test :as mt]
    [metabase.util.json :as json]
    [metabase.util.malli :as mu]))
 
@@ -87,23 +88,27 @@
 
 (deftest transform-query-out-vm-error-propagates-test
   (testing "a VM Error thrown during dataset_query deserialization propagates instead of yielding an empty query"
-    (with-redefs [mi/json-out-without-keywordization (fn [_] (throw (Error. "boom")))]
+    (mt/with-dynamic-fn-redefs [mi/json-out-without-keywordization (fn [_] (throw (Error. "boom")))]
       (is (thrown? Error
                    ((:out lib-be/transform-query) "{}")))))
   (testing "an Exception thrown during dataset_query deserialization yields an empty query"
-    (with-redefs [mi/json-out-without-keywordization (fn [_] (throw (RuntimeException. "boom")))]
+    (mt/with-dynamic-fn-redefs [mi/json-out-without-keywordization (fn [_] (throw (RuntimeException. "boom")))]
+      (is (= {}
+             ((:out lib-be/transform-query) "{}")))))
+  (testing "an AssertionError thrown during dataset_query deserialization is contained, yielding an empty query"
+    (mt/with-dynamic-fn-redefs [mi/json-out-without-keywordization (fn [_] (throw (AssertionError. "boom")))]
       (is (= {}
              ((:out lib-be/transform-query) "{}"))))))
 
 (deftest normalize-query-vm-error-propagates-test
   (testing "a VM Error thrown during query normalization propagates instead of yielding an empty query"
-    (with-redefs [lib-be.bootstrap/resolve-database (fn [& _] (throw (Error. "boom")))]
+    (mt/with-dynamic-fn-redefs [lib-be.bootstrap/resolve-database (fn [& _] (throw (Error. "boom")))]
       (is (thrown? Error
                    (lib-be/normalize-query {:database 1
                                             :type     :query
                                             :query    {:source-table 2}})))))
   (testing "an Exception thrown during query normalization yields an empty query"
-    (with-redefs [lib-be.bootstrap/resolve-database (fn [& _] (throw (RuntimeException. "boom")))]
+    (mt/with-dynamic-fn-redefs [lib-be.bootstrap/resolve-database (fn [& _] (throw (RuntimeException. "boom")))]
       (is (= {}
              (lib-be/normalize-query {:database 1
                                       :type     :query

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -1179,6 +1179,9 @@
 
 (deftest ^:parallel query-description-skipped-for-metadata-provider-fetches-test
   (testing "metadata-provider fetches of metric cards do not compute a query description (#74954)"
+    ;; Pins `metadata-provider-fetch?`'s coupling to the `:metadata/*` model namespace: if those models stopped
+    ;; being recognized, the after-select would compute the description during a provider fetch (re-entering the
+    ;; metric recursion), and the skip assertions below would fail.
     (let [mp (mt/metadata-provider)]
       (mt/with-temp
         [:model/Card
@@ -1188,70 +1191,55 @@
           :dataset_query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
                              (lib/aggregate (lib/count))
                              lib.convert/->legacy-MBQL)}]
-        (is (not (contains? (t2/select-one :metadata/metric :id id) :query-description)))
-        (is (not (contains? (t2/select-one :metadata/card :id id) :query-description)))))))
+        (testing "provider fetches skip it"
+          (is (not (contains? (t2/select-one :metadata/metric :id id) :query-description)))
+          (is (not (contains? (t2/select-one :metadata/card :id id) :query-description))))
+        (testing "a real :model/Card fetch still computes it"
+          (is (= "Orders, Count"
+                 (:query_description (t2/select-one :model/Card :id id)))))))))
+
+(defn- do-with-metric-cycle
+  "Build two metric cards whose `:metric` refs form a cycle A → B → A and call `f` with their ids."
+  [f]
+  (letfn [(metric-query [metric-id]
+            {:database (mt/id)
+             :type     :query
+             :query    {:source-table (mt/id :orders)
+                        :aggregation  [["metric" metric-id]]}})]
+    (let [count-query (let [mp (mt/metadata-provider)]
+                        (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                            (lib/aggregate (lib/count))
+                            lib.convert/->legacy-MBQL))]
+      ;; the cyclic cards must stay out of the shared search queue that concurrent tests drain
+      (binding [search.ingestion/*disable-updates* true]
+        (mt/with-temp
+          [:model/Card {a-id :id} {:name "Metric A", :type :metric, :dataset_query count-query}
+           :model/Card {b-id :id} {:name "Metric B", :type :metric, :dataset_query (metric-query a-id)}]
+          ;; close the cycle with a raw update -- the card API rejects cyclic saves, so this is the non-API path
+          ;; (serdes, remote sync, pre-check data) by which a cycle actually reaches the DB
+          (t2/update! :model/Card a-id {:dataset_query (metric-query b-id)})
+          (f a-id b-id))))))
 
 (deftest query-description-metric-reference-cycle-test
   (testing "selecting a metric card whose :metric references form a cycle completes with a :query_description (#74954)"
-    (letfn [(metric-query [metric-id]
-              {:database (mt/id)
-               :type     :query
-               :query    {:source-table (mt/id :orders)
-                          :aggregation  [["metric" metric-id]]}})]
-      ;; Search ingestion of a cycle-involved card recurses unboundedly in `lib.metadata.calculation/metadata-method
-      ;; :metric` (a separate defect from the one under test), so keep these cards out of the ingestion queue where
-      ;; concurrently-running tests would index them.
-      (binding [search.ingestion/*disable-updates* true]
-        (mt/with-temp
-          [:model/Card
-           {a-id :id}
-           {:name "Metric A"
-            :type :metric
-            :dataset_query (let [mp (mt/metadata-provider)]
-                             (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
-                                 (lib/aggregate (lib/count))
-                                 lib.convert/->legacy-MBQL))}
-           :model/Card
-           {b-id :id}
-           {:name "Metric B"
-            :type :metric
-            :dataset_query (metric-query a-id)}]
-          ;; close the cycle A -> B -> A; nothing rejects reference cycles at write time
-          (t2/update! :model/Card a-id {:dataset_query (metric-query b-id)})
-          (is (= "Orders, Metric B"
-                 (:query_description (t2/select-one :model/Card :id a-id))))
-          (is (= "Orders, Metric A"
-                 (:query_description (t2/select-one :model/Card :id b-id)))))))))
+    (do-with-metric-cycle
+     (fn [a-id b-id]
+       (is (= "Orders, Metric B"
+              (:query_description (t2/select-one :model/Card :id a-id))))
+       (is (= "Orders, Metric A"
+              (:query_description (t2/select-one :model/Card :id b-id))))))))
 
 (deftest extract-temporal-info-metric-reference-cycle-test
   (testing "extract-temporal-info on a query aggregating a cycle-involved metric throws a cycle error (#74954)"
-    (letfn [(metric-query [metric-id]
-              {:database (mt/id)
-               :type     :query
-               :query    {:source-table (mt/id :orders)
-                          :aggregation  [["metric" metric-id]]}})]
-      ;; keep the cyclic cards out of the shared ingestion queue, where concurrently-running tests would index them
-      (binding [search.ingestion/*disable-updates* true]
-        (mt/with-temp
-          [:model/Card
-           {a-id :id}
-           {:name "Metric A"
-            :type :metric
-            :dataset_query (let [mp (mt/metadata-provider)]
-                             (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
-                                 (lib/aggregate (lib/count))
-                                 lib.convert/->legacy-MBQL))}
-           :model/Card
-           {b-id :id}
-           {:name "Metric B"
-            :type :metric
-            :dataset_query (metric-query a-id)}]
-          ;; close the cycle A -> B -> A; nothing rejects reference cycles at write time
-          (t2/update! :model/Card a-id {:dataset_query (metric-query b-id)})
-          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Metric cycle detected"
-                                (#'card/extract-temporal-info
-                                 {:dataset_query (json/encode (metric-query a-id))
-                                  :query_type    "query"}))))))))
+    (do-with-metric-cycle
+     (fn [a-id _b-id]
+       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Metric cycle detected"
+                             (#'card/extract-temporal-info
+                              {:dataset_query (json/encode {:database (mt/id)
+                                                            :type     :query
+                                                            :query    {:source-table (mt/id :orders)
+                                                                       :aggregation  [["metric" a-id]]}})
+                               :query_type    "query"})))))))
 
 (deftest before-update-card-schema-test
   (testing "card_schema gets set to current-schema-version on update"


### PR DESCRIPTION
Refs #74954. Stacked on `git-74954-search-reindex-hangs` (#77556) — merge in or cherry-pick if that's easier than re-applying.

The catch-narrowing in #77556 (`Throwable` → `Exception`) lets `AssertionError` slip past the lib recovery boundaries. Asserts and `:pre` we don't own fire under them (`lib.convert`, `legacy_mbql`, the display asserts), and one escaping aborts the reindex the same way #74954 did, on a different input. #77556 already handles the `:out` transform; this covers the other four boundaries.

Adds `lib.util/recover`: run a thunk, hand recoverable throwables (any `Exception`, plus `AssertionError` on the JVM) to a handler, let fatal `Error`s propagate. Replaces the boundary `try`/`catch` at all five sites with it. Tests: a `recover` unit table plus a containment case per boundary.
