### PR TITLE
Show redirect destination on the OAuth consent page

### DIFF
--- a/src/metabase/oauth_server/consent_page.clj
+++ b/src/metabase/oauth_server/consent_page.clj
@@ -7,6 +7,8 @@
    [metabase.appearance.core :as appearance]
    [metabase.system.core :as system]))
 
+(set! *warn-on-reflection* true)
+
 (defn- absolute-url
   "Resolve a potentially relative path to an absolute URL using site-url."
   [path]
@@ -138,6 +140,8 @@
                               padding: 0.75rem 1rem; margin-bottom: 1.5rem;
                               font-size: 0.8125rem; line-height: 1.45; color: #883b34; }
                    .warning .mark { flex: 0 0 auto; font-weight: 700; }
+                   .destination { text-align: center; font-size: 0.8125rem; color: #696e7b; margin-bottom: 1.5rem; }
+                   .destination strong { font-family: monospace; color: #4c5773; }
                    .actions { display: flex; gap: 0.75rem; }
                    button { flex: 1; padding: 0.75rem 1rem; border-radius: 8px; font-size: 0.875rem; font-weight: 700;
                             font-family: inherit; cursor: pointer;
@@ -162,6 +166,8 @@
              (or client-name "this application") " can do, including reading and changing all data you "
              "can reach. Only approve it for a tool you trust and control."]])
          (render-scope-list scopes)
+         (when-let [redirect-host (some-> (:redirect_uri oauth-params) not-empty (java.net.URI.) (.getHost))]
+           [:p.destination "Redirects to " [:strong redirect-host]])
          [:form {:method "POST" :action "/oauth/authorize/decision"}
           [:input {:type "hidden" :name "csrf_token" :value csrf-token}]
           [:input {:type "hidden" :name "params_sig" :value params-sig}]

--- a/test/metabase/oauth_server/consent_page_test.clj
+++ b/test/metabase/oauth_server/consent_page_test.clj
@@ -102,6 +102,30 @@
   (testing "no scope list is rendered when none were requested"
     (is (not (re-find #"class=\"scopes\"" (render-with-scopes! nil))))))
 
+(defn- render-with-redirect-uri! [redirect-uri]
+  (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+    (consent-page/render-consent-page
+     {:client-name  "Test App"
+      :oauth-params (cond-> {:response_type "code" :client_id "abc123"}
+                      redirect-uri (assoc :redirect_uri redirect-uri))
+      :nonce        "test-nonce"
+      :csrf-token   "test-csrf"})))
+
+(deftest consent-page-redirect-destination-test
+  (testing "the destination host the code will be sent to is shown"
+    (let [html (render-with-redirect-uri! "https://claude.ai/api/mcp/callback")]
+      (is (re-find #"Redirects to" html))
+      (is (re-find #"<strong>claude\.ai</strong>" html))))
+  (testing "only the parsed host is shown as the destination — userinfo can't spoof the bold host"
+    (let [html (render-with-redirect-uri! "https://evil.example@good.example/cb")]
+      (is (re-find #"<strong>good\.example</strong>" html))
+      (is (not (re-find #"<strong>evil\.example" html)))))
+  (testing "no destination row when there is no meaningful host (custom-scheme native redirect)"
+    (let [html (render-with-redirect-uri! "com.example.app:/oauth2redirect")]
+      (is (not (re-find #"Redirects to" html)))))
+  (testing "no destination row when redirect_uri is absent"
+    (is (not (re-find #"Redirects to" (render-with-redirect-uri! nil))))))
+
 (deftest consent-page-full-access-warning-test
   (testing "a full-access scope shows an explicit warning that it grants complete account access"
     (let [html (render-with-scopes! [{:scope        "mb:full"


### PR DESCRIPTION
### Description

Adds a "Redirects to <host>" line to the OAuth consent page so the user sees where the authorization code will be sent. 

### How to verify

Start an OAuth flow with redirect to actual external host and reach the consent page

### Demo

<img width="570" height="617" alt="Screenshot 2026-07-12 at 14 36 09" src="https://github.com/user-attachments/assets/e6a04878-8afc-44be-8790-ea6a29ee33fe" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/77578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

