### PR TITLE
[log] Simplify metabase.util.log/with-thread-context-fn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -639,6 +639,7 @@
                                  :implicit-dependencies
                                  ;; too many false positives for now
                                  :unused-ret-vals
+                                 :unused-ret-vals-in-try
                                  ;; hard to clear on for metabase.util.match macros, and disabling the linter just
                                  ;; there doesn't seem to work
                                  :unused-meta-on-macro

--- a/src/metabase/util/log.clj
+++ b/src/metabase/util/log.clj
@@ -75,23 +75,17 @@
 (defn with-thread-context-fn
   "Not for public consumption. See macro docstring for details."
   [context-map f]
-  (let [context-map (perf/update-keys context-map #(str "mb-" (u.format/qualified-name %)))
-        context-keys (keys context-map)
-        ;; Store original values before modifying
-        original-context (into {}
-                               (keep (fn [k]
-                                       (when-let [v (ThreadContext/get (name k))]
-                                         [(name k) v])))
-                               context-keys)]
+  (let [;; Store original values before modifying
+        original-context (ThreadContext/getImmutableContext)]
     (try
-      (doseq [k context-keys]
-        (ThreadContext/put (name k) (str (get context-map k))))
+      (reduce-kv (fn [_ k v]
+                   (ThreadContext/put (perf/str "mb-" (u.format/qualified-name k))
+                                      (str v)))
+                 nil context-map)
       (f)
       (finally
-        (doseq [k context-keys]
-          (if-let [original (find original-context (name k))]
-            (ThreadContext/put (name k) (val original))
-            (ThreadContext/remove (name k))))))))
+        (ThreadContext/clearMap)
+        (ThreadContext/putAll original-context)))))
 
 (defmacro with-thread-context
   "Executes body with the given context map and message prefix in ThreadContext.

--- a/src/metabase/util/performance.cljc
+++ b/src/metabase/util/performance.cljc
@@ -2,7 +2,7 @@
   "Functions and utilities for faster processing. This namespace is compatible with both Clojure and ClojureScript.
   However, some functions are either not only available in CLJS, or offer passthrough non-improved functions."
   (:refer-clojure :exclude [reduce mapv run! some every? concat select-keys update-keys empty? not-empty doseq for
-                            first second update-vals get-in #?(:cljs clj->js)])
+                            first second update-vals get-in str #?(:cljs clj->js)])
   #?(:clj (:require
            [net.cgrand.macrovich :as macros])
      :cljs (:require
@@ -574,6 +574,36 @@
            (add-original-meta form))
        form))
    m))
+
+(defn str
+  "More efficient implementation of `clojure.core/str` because it has more non-variadic arities. Optimization is
+  Clojure-only, on other platforms it reverts back to `clojure.core/str`."
+  (^String [] "")
+  (^String [^Object a]
+   #?(:clj (if (nil? a) "" (.toString a))
+      :default (clojure.core/str a)))
+  (^String [^Object a, ^Object b]
+   #?(:clj (if (nil? a)
+             (str b)
+             (if (nil? b)
+               (.toString a)
+               (.concat (.toString a) (.toString b))))
+      :default (clojure.core/str a b)))
+  (^String [a b c]
+   #?(:clj (let [sb (StringBuilder.)]
+             (.append sb (str a))
+             (.append sb (str b))
+             (.append sb (str c))
+             (.toString sb))
+      :default (clojure.core/str a b c)))
+  (^String [a b c & more]
+   #?(:clj (let [sb (StringBuilder.)]
+             (.append sb (str a))
+             (.append sb (str b))
+             (.append sb (str c))
+             (run! #(.append sb (str %)) more)
+             (.toString sb))
+      :default (apply clojure.core/str a b c more))))
 
 ;;;; Faster clj->js implementation
 

--- a/test/metabase/util/performance_test.cljc
+++ b/test/metabase/util/performance_test.cljc
@@ -127,6 +127,16 @@
            (println x y)))
        #_=> "")))
 
+(deftest str-test
+  (is (= "" (perf/str nil)))
+  (is (= "1" (perf/str 1)))
+  (is (= "12" (perf/str 1 2)))
+  (is (= "1" (perf/str 1 nil)))
+  (is (= "2" (perf/str nil 2)))
+  (is (= "123" (perf/str 1 2 3)))
+  (is (= "13" (perf/str 1 nil 3)))
+  (is (= "1234567" (perf/str 1 2 3 4 5 6 7))))
+
 (deftest ^:parallel test-postwalk
   (are [before after] (= after (perf/postwalk #(cond-> %
                                                  (number? %) inc)


### PR DESCRIPTION
`with-thread-context` is used in many tests, so reducing its overhead should reflect well on total CI times.

Several ideas here:
- Use `ThreadContext/getImmutableContext` and replace context with it wholesale instead of trying to restore the original context key by key.
- Iterate the context map and immediately set ThreadContext instead of building an intermediate map.
-  Add `perf/str` function for more efficient concatenation of two strings. Long overdue.