### PR TITLE
[test] Don't attach unrolled query args to thread context

### DIFF
--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -42,7 +42,6 @@
    [metabase.test.util.misc :as tu.misc]
    [metabase.test.util.thread-local :as tu.thread-local]
    [metabase.test.util.timezone :as test.tz]
-   [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.log.capture]
    [metabase.util.random :as u.random]
@@ -354,12 +353,10 @@
    #_model       :default
    #_built-query :default]
   [query-type model built-query]
-  (u/prog1 built-query
-    (let [compiled-query-arg-map (into {} (map-indexed (fn [i v] [(str "compiled-query-arg-" i) v]) (rest <>)))]
-      (log/with-context (merge {:query-type query-type
-                                :model model
-                                :compiled-query (first <>)
-                                :compiled-query-args (rest <>)}
-                               compiled-query-arg-map)
-        (when config/is-test?
-          (log/info "Compiled query"))))))
+  (log/with-context {:query-type query-type
+                     :model model
+                     :compiled-query (first built-query)
+                     :compiled-query-args (rest built-query)}
+    (when config/is-test?
+      (log/info "Compiled query")))
+  built-query)


### PR DESCRIPTION
Given that the debugging context receives the full ` :compiled-query-args` list as one of the keys, it feels unnecessary to additionally unroll this list into separate keyvals to add to the context. During debugging, I discovered that some of the testing queries (and thus, the context maps) have hunderds of args. Putting all of that onto the context twice slows down `with-thread-context-fn`.