### PR TITLE
Fix forbidden react-router-redux import in transforms route-guards

### DIFF
--- a/frontend/src/metabase/transforms/route-guards.tsx
+++ b/frontend/src/metabase/transforms/route-guards.tsx
@@ -1,8 +1,8 @@
-import { routerActions } from "react-router-redux";
 import { connectedReduxRedirect } from "redux-auth-wrapper/history3/redirect";
 
 import { metabaseReduxContext } from "metabase/redux";
 import type { State } from "metabase/redux/store";
+import { routerActions } from "metabase/router";
 import { getSetting } from "metabase/selectors/settings";
 import * as Urls from "metabase/urls";
 


### PR DESCRIPTION
`frontend/src/metabase/transforms/route-guards.tsx` still imported `routerActions` from `react-router-redux`, which the router migration (DEV-2272) forbids. It was added after that ticket merged.

Swaps the import to the re-owned `routerActions` from `metabase/router`, matching the pattern already used in `route-guards.tsx` and `admin/utils.ts`. No behavior change: the action creator is byte-identical to the one it shadows.