### PR TITLE
Dynamic/plugin route conformance

### DIFF
--- a/frontend/src/metabase/router/conformance/dynamic-routes.conformance.unit.spec.tsx
+++ b/frontend/src/metabase/router/conformance/dynamic-routes.conformance.unit.spec.tsx
@@ -1,0 +1,48 @@
+import { runDynamicBoth } from "./test-utils";
+
+describe("router/dynamic routes conformance", () => {
+  it("matches v7 when an enabled feature route is reachable", async () => {
+    const { facade, v7 } = await runDynamicBoth(
+      { featureEnabled: true, pluginLoaded: true },
+      "/feature",
+    );
+    expect(facade).toEqual(v7);
+    expect(facade["rr-page"]).toBe("feature");
+  });
+
+  it("matches v7 by rendering the upsell when the feature is disabled", async () => {
+    const { facade, v7 } = await runDynamicBoth(
+      { featureEnabled: false, pluginLoaded: true },
+      "/feature",
+    );
+    expect(facade).toEqual(v7);
+    expect(facade["rr-page"]).toBe("upsell");
+  });
+
+  it("matches v7 by reaching an array-interpolated plugin route", async () => {
+    const { facade, v7 } = await runDynamicBoth(
+      { featureEnabled: true, pluginLoaded: true },
+      "/ee/reports",
+    );
+    expect(facade).toEqual(v7);
+    expect(facade["rr-page"]).toBe("ee-reports");
+  });
+
+  it("matches v7 by falling through to the catch-all when the EE bundle is absent", async () => {
+    const { facade, v7 } = await runDynamicBoth(
+      { featureEnabled: true, pluginLoaded: false },
+      "/ee/reports",
+    );
+    expect(facade).toEqual(v7);
+    expect(facade["rr-page"]).toBe("not-found");
+  });
+
+  it("matches v7 when deep-linking straight to a disabled-feature route", async () => {
+    const { facade, v7 } = await runDynamicBoth(
+      { featureEnabled: false, pluginLoaded: false },
+      "/feature",
+    );
+    expect(facade).toEqual(v7);
+    expect(facade["rr-page"]).toBe("upsell");
+  });
+});

--- a/frontend/src/metabase/router/conformance/test-utils.tsx
+++ b/frontend/src/metabase/router/conformance/test-utils.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType } from "react";
+import type { ComponentType, PropsWithChildren, ReactElement } from "react";
 import { Route } from "react-router";
 import {
   MemoryRouter,
@@ -146,6 +146,93 @@ export async function runBoth(
   const v7 = await renderAndCollect(
     () => renderV7(Probe, renderOptions),
     interact,
+  );
+
+  return { facade, v7 };
+}
+
+/**
+ * The three moving parts of a dynamic/plugin route setup. `featureEnabled`
+ * drives the `isEnabled ? real : upsell` conditional; `pluginLoaded` drives the
+ * `{PLUGIN_*_ROUTES}` array interpolation (false models an OSS build where the
+ * enterprise bundle contributes nothing).
+ */
+export type DynamicRouteScenario = {
+  featureEnabled: boolean;
+  pluginLoaded: boolean;
+};
+
+/**
+ * Constructs one leaf route for a given engine. The facade builds a v3
+ * `component=` route, real v7 builds an `element=` route; both render a `Page`
+ * emitting the same `rr-page` readout so the harness can compare outcomes.
+ */
+type LeafRoute = (key: string, path: string, page: string) => ReactElement;
+
+const Passthrough = ({ children }: PropsWithChildren) => <>{children}</>;
+
+const Page = ({ name }: { name: string }) => (
+  <span data-testid="rr-page">{name}</span>
+);
+
+/**
+ * Assembles the sibling routes for a scenario from whichever engine's leaf
+ * constructor is supplied, so both engines route the exact same declarative
+ * shape: a feature-gated route, an array-interpolated plugin route, and a
+ * trailing catch-all.
+ */
+function dynamicSiblings(route: LeafRoute, scenario: DynamicRouteScenario) {
+  const gated = scenario.featureEnabled
+    ? route("feature", "feature", "feature")
+    : route("feature", "feature", "upsell");
+  const pluginRoutes = scenario.pluginLoaded
+    ? [route("ee", "ee/reports", "ee-reports")]
+    : [];
+  const catchAll = route("catch-all", "*", "not-found");
+  return [gated, ...pluginRoutes, catchAll];
+}
+
+function renderDynamicFacade(
+  scenario: DynamicRouteScenario,
+  initialRoute: string,
+) {
+  const leaf: LeafRoute = (key, path, page) => (
+    <Route key={key} path={path} component={() => <Page name={page} />} />
+  );
+  renderWithProviders(
+    <Route component={Passthrough}>{dynamicSiblings(leaf, scenario)}</Route>,
+    { withRouter: true, initialRoute },
+  );
+}
+
+function renderDynamicV7(scenario: DynamicRouteScenario, initialRoute: string) {
+  const leaf: LeafRoute = (key, path, page) => (
+    <V7Route key={key} path={path} element={<Page name={page} />} />
+  );
+  renderWithProviders(
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <V7Routes>{dynamicSiblings(leaf, scenario)}</V7Routes>
+    </MemoryRouter>,
+  );
+}
+
+/**
+ * Render the same dynamic/plugin route scenario against the facade and against
+ * real v7, deep-linking each to `initialRoute`, and return the `rr-` readouts
+ * from both so a spec can assert the mechanism resolves identically.
+ */
+export async function runDynamicBoth(
+  scenario: DynamicRouteScenario,
+  initialRoute: string,
+): Promise<{
+  facade: Record<string, string | null>;
+  v7: Record<string, string | null>;
+}> {
+  const facade = await renderAndCollect(() =>
+    renderDynamicFacade(scenario, initialRoute),
+  );
+  const v7 = await renderAndCollect(() =>
+    renderDynamicV7(scenario, initialRoute),
   );
 
   return { facade, v7 };


### PR DESCRIPTION
Closes DEV-2281

As the [migration plan](https://linear.app/metabase/document/react-router-v7-migration-plan-e2e69d5e41ad) predicted, the plugin route mechanism already ports 1:1 and already runs through the `metabase/router` facade, so there is no route restructuring to do here.

The runtime plugin injection is native to v7's declarative `<Routes>`. What this PR adds is a conformance lock-down that pins the four acceptance behaviors so the mechanism stays correct through the eventual engine swap.


Following the existing `conformance/` harness pattern (render the same shape against both the v3 facade and real v7, assert identical readouts):

- `test-utils.tsx` gains `runDynamicBoth(scenario, initialRoute)`. A single `dynamicSiblings()` builder expresses the three moving parts once: the `isEnabled ? real : upsell` conditional, the `{PLUGIN_*_ROUTES}` array interpolation, and the trailing catch-all. It is rendered against both engines through each engine's leaf constructor (v3 `component=`, v7 `element=`).
- `dynamic-routes.conformance.unit.spec.tsx` covers the acceptance criteria, each asserting the facade and v7 resolve to the same route:
  - feature on, route reachable
  - feature off, upsell (not a crash)
  - array-interpolated plugin route reachable
  - OSS build (plugin bundle absent), EE path falls through to the catch-all
  - deep-link straight to a disabled-feature route, upsell
