### PR TITLE
Remove querying e2e repros already covered by existing Lib/QP tests

### DIFF
--- a/e2e/test/scenarios/custom-column/custom-column-reproductions-1.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions-1.cy.spec.js
@@ -1391,37 +1391,3 @@ describe("issue 53527", () => {
     H.tableInteractive().findByText("ab").should("be.visible");
   });
 });
-
-describe("issue 48562", () => {
-  const questionDetails = {
-    query: {
-      "source-table": ORDERS_ID,
-      expressions: {
-        CustomColumn: ["contains", ["field", 10000, null], "abc"],
-      },
-      filter: ["+", 1, ["segment", 10001]],
-      aggregation: [["metric", 10002]],
-    },
-  };
-
-  beforeEach(() => {
-    H.restore();
-    cy.signInAsNormalUser();
-  });
-
-  it("should not crash when referenced columns, segments, and metrics do not exist (metabase#48562)", () => {
-    H.createQuestion(questionDetails, { visitQuestion: true });
-    H.openNotebook();
-
-    H.getNotebookStep("expression").findByText("CustomColumn").click();
-    H.CustomExpressionEditor.value().should("contain", "[Unknown Field]");
-    H.expressionEditorWidget().button("Cancel").click();
-
-    H.getNotebookStep("filter").findByText("1 + [Unknown Segment]").click();
-    H.CustomExpressionEditor.value().should("contain", "[Unknown Segment]");
-    H.expressionEditorWidget().button("Cancel").click();
-
-    H.getNotebookStep("summarize").findByText("[Unknown Metric]").click();
-    H.CustomExpressionEditor.value().should("contain", "[Unknown Metric]");
-  });
-});

--- a/e2e/test/scenarios/custom-column/custom-column-reproductions-2.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions-2.cy.spec.js
@@ -895,64 +895,6 @@ describe("issue 56602", () => {
   });
 });
 
-describe("issue 61010", () => {
-  const CUSTOM_COLUMN_NAME = "Foo";
-  const AGGREGATION_NAME = "New count";
-
-  beforeEach(() => {
-    H.restore();
-    cy.signInAsNormalUser();
-
-    H.createQuestion(
-      {
-        query: {
-          "source-table": ORDERS_ID,
-          expressions: {
-            [CUSTOM_COLUMN_NAME]: ["+", 1, 2],
-          },
-          aggregation: [
-            [
-              "aggregation-options",
-              ["+", ["count"], 1],
-              {
-                name: AGGREGATION_NAME,
-                "display-name": AGGREGATION_NAME,
-              },
-            ],
-          ],
-        },
-      },
-      { visitQuestion: true },
-    );
-
-    H.openNotebook();
-  });
-
-  it("should not be possible to reference a custom expression in itself (metabase#61010)", () => {
-    H.getNotebookStep("expression").findByText(CUSTOM_COLUMN_NAME).click();
-    H.CustomExpressionEditor.clear().type("[Fo");
-    H.CustomExpressionEditor.completions()
-      .findByText("Foo")
-      .should("not.exist");
-
-    H.CustomExpressionEditor.clear().type("[Foo]");
-    H.popover().findByText("Unknown column: Foo").should("be.visible");
-  });
-
-  it("should not be possible to reference an aggregation in itself(metabase#61010)", () => {
-    H.getNotebookStep("summarize").findByText(AGGREGATION_NAME).click();
-    H.CustomExpressionEditor.clear().type("[New cou");
-    H.CustomExpressionEditor.completions()
-      .findByText("New count")
-      .should("not.exist");
-
-    H.CustomExpressionEditor.clear().type("[New count]");
-    H.popover()
-      .findByText("Unknown Aggregation, Measure or Metric: New count")
-      .should("be.visible");
-  });
-});
-
 describe("issue 62987", () => {
   beforeEach(() => {
     H.restore();

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -2,7 +2,6 @@ const { H } = cy;
 import { SAMPLE_DB_ID, USERS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
-  ORDERS_COUNT_QUESTION_ID,
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
   SECOND_COLLECTION_ID,
@@ -385,35 +384,6 @@ describe("scenarios > question > new", () => {
       cy.get("header").findByText(NEW_COLLECTION);
     },
   );
-
-  it("should preserve the original question name (metabase#41196)", () => {
-    const originalQuestionName = "Foo";
-    const modifiedQuestionName = `${originalQuestionName} - Modified`;
-    const originalDescription = "Lorem ipsum dolor sit amet";
-
-    cy.request("PUT", `/api/card/${ORDERS_COUNT_QUESTION_ID}`, {
-      name: originalQuestionName,
-      description: originalDescription,
-    });
-
-    H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
-    cy.findByDisplayValue(originalQuestionName).should("exist");
-
-    cy.log("Change anything about this question to make it dirty");
-    H.tableHeaderClick("Count");
-    H.popover().icon("arrow_down").click();
-
-    cy.findByTestId("qb-header-action-panel").button("Save").click();
-    cy.findByTestId("save-question-modal").within(() => {
-      cy.findByText("Save as new question").click();
-
-      cy.findByLabelText("Name").should("have.value", modifiedQuestionName);
-      cy.findByLabelText("Description").should(
-        "have.value",
-        originalDescription,
-      );
-    });
-  });
 
   describe("add to a dashboard", () => {
     const collectionInRoot = {

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -510,29 +510,15 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     });
   });
 
-  it("should properly render previews (metabase#28726, metabase#29959, metabase#40608)", () => {
+  it("should properly render previews (metabase#28726, metabase#29959)", () => {
     H.startNewQuestion();
-
-    cy.log(
-      "Preview should not be possible without the source data (metabase#40608)",
-    );
-    H.getNotebookStep("data")
-      .as("dataStep")
-      .within(() => {
-        cy.findByPlaceholderText("Search for tables and more...").should(
-          "exist",
-        );
-        cy.icon("play").should("not.be.visible");
-      });
 
     H.miniPicker().within(() => {
       cy.findByText("Sample Database").click();
       cy.findByText("Orders").click();
     });
 
-    cy.get("@dataStep").icon("play").should("be.visible");
-    H.getNotebookStep("filter").icon("play").should("not.be.visible");
-    H.getNotebookStep("summarize").icon("play").should("not.be.visible");
+    H.getNotebookStep("data").as("dataStep");
 
     cy.get("@dataStep").within(() => {
       cy.icon("play").click();

--- a/e2e/test/scenarios/question/offset.cy.spec.ts
+++ b/e2e/test/scenarios/question/offset.cy.spec.ts
@@ -323,28 +323,6 @@ describe("scenarios > question > offset", () => {
       });
     });
 
-    it("should allow using OFFSET as a CASE argument (metabase#42377)", () => {
-      const formula = "Sum(case([Total] > 0, Offset([Total], -1)))";
-      const name = "Aggregation";
-      const query: StructuredQuery = {
-        "source-table": ORDERS_ID,
-      };
-
-      H.createQuestion({ query }, { visitQuestion: true });
-      H.openNotebook();
-      cy.button("Summarize").click();
-      addCustomAggregation({ formula, name, isFirst: true });
-
-      cy.findAllByTestId("notebook-cell-item").findByText(name).click();
-      H.CustomExpressionEditor.value().should("equal", formula);
-
-      cy.on("uncaught:exception", (error) => {
-        // this check is intended to catch possible normalization errors if BE or FE code changes
-        // does not run by default
-        expect(error.message.includes("Error normalizing")).to.be.false;
-      });
-    });
-
     it("should create filter and CC with offset aggregation and sort correctly", () => {
       H.openTable({ table: ORDERS_ID });
 


### PR DESCRIPTION
These five e2e repros are already covered by an existing backend deftest or a frontend unit test.

This was verified by generating a 'reverse-patch' which applies a change to re-add the broken code, then running the unit tests to see if any would catch the regression.

| Issue | Covered by |
|---|---|
| #42377 diagnose-expression throws when Offset is nested | `compile-expression.unit.spec.ts` |
| #41196 Suggest the original question name for derived question in a "save question" modal | `SaveQuestionModal.unit.spec.tsx` |
| #48562 Handle failing requests better when part of the notebook editor can still be rendered | `lib.aggregation-test` / `lib.fe-util-test` |
| #61010 It should not be possible to reference the aggregation itself in the expression editor | `lib.aggregation-test` + `lib.expression-test` |
| #40608 Notebook query preview exists even before the data source is selected | `lib.query-test/can-run-test` |

The #40608 repro tested three issues in one test (#28726 and #29959 as well), so only the part checking for a preview before the data source is picked came out, and the rest stayed.