### PR TITLE
Refactor module infrastructure for nested modules

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1090,4 +1090,8 @@
    {:discouraged-java-method
     {java.lang.System {exit
                        {:level :error
-                        :message "Don't use System/exit directly. Instead use mage.util/exit and let mage handle exiting the process"}}}}}}}
+                        :message "Don't use System/exit directly. Instead use mage.util/exit and let mage handle exiting the process"}}}
+
+    ;; mage runs under babashka, which bundles cheshire; metabase.util.json isn't on its classpath.
+    :discouraged-namespace
+    {cheshire.core {:level :off}}}}}}

--- a/.clj-kondo/config/modules/module-stats.edn
+++ b/.clj-kondo/config/modules/module-stats.edn
@@ -3,7 +3,10 @@
  :largest-ns-scc 504
  :largest-scc-modules 102
  :largest-scc-namespaces 1403
- :max-file-deftests 18549
+ :max-file-deftests 18554
  :max-file-test-namespaces 1466
  :module-count 202
+ :module-exports 0
+ :ns-prefix-overrides 0
+ :parent-team-mismatches 3
  :total-api 554}

--- a/.clj-kondo/config/modules/module-stats.edn
+++ b/.clj-kondo/config/modules/module-stats.edn
@@ -3,8 +3,8 @@
  :largest-ns-scc 504
  :largest-scc-modules 102
  :largest-scc-namespaces 1403
- :max-file-deftests 18554
- :max-file-test-namespaces 1466
+ :max-file-deftests 18601
+ :max-file-test-namespaces 1468
  :module-count 202
  :module-exports 0
  :ns-prefix-overrides 0

--- a/.clj-kondo/config/modules/module-stats.edn
+++ b/.clj-kondo/config/modules/module-stats.edn
@@ -14,8 +14,8 @@
  :largest-scc-modules-with-model-imports 118
  :largest-scc-namespaces 1427
  :largest-scc-namespaces-with-model-imports 1534
- :max-file-deftests 19410
- :max-file-test-namespaces 1488
+ :max-file-deftests 19463
+ :max-file-test-namespaces 1490
  :model-import-bypass-modules 2
  :module-count 204
  :module-exports 0

--- a/.clj-kondo/config/modules/module-stats.edn
+++ b/.clj-kondo/config/modules/module-stats.edn
@@ -1,21 +1,24 @@
-{:api-any-namespaces 82
+{:api-any-namespaces 81
  :cyclic-components 3
  :cyclic-components-with-model-imports 2
- :cyclic-edges 1017
- :cyclic-edges-with-model-imports 1432
+ :cyclic-edges 1016
+ :cyclic-edges-with-model-imports 1422
  :cyclic-modules 109
  :cyclic-modules-with-model-imports 121
- :cyclic-namespaces 1575
- :cyclic-namespaces-with-model-imports 1666
- :driver-test-triggering-namespaces 734
+ :cyclic-namespaces 1479
+ :cyclic-namespaces-with-model-imports 1559
+ :driver-test-triggering-namespaces 696
  :largest-api 31
- :largest-ns-scc 538
+ :largest-ns-scc 509
  :largest-scc-modules 104
  :largest-scc-modules-with-model-imports 118
- :largest-scc-namespaces 1517
- :largest-scc-namespaces-with-model-imports 1637
- :max-file-deftests 19677
- :max-file-test-namespaces 1508
+ :largest-scc-namespaces 1427
+ :largest-scc-namespaces-with-model-imports 1534
+ :max-file-deftests 19410
+ :max-file-test-namespaces 1488
  :model-import-bypass-modules 2
  :module-count 204
- :total-api 566}
+ :module-exports 0
+ :ns-prefix-overrides 0
+ :parent-team-mismatches 3
+ :total-api 561}

--- a/.clj-kondo/config/modules/module-stats.edn
+++ b/.clj-kondo/config/modules/module-stats.edn
@@ -1,24 +1,24 @@
-{:api-any-namespaces 81
+{:api-any-namespaces 82
  :cyclic-components 3
  :cyclic-components-with-model-imports 2
- :cyclic-edges 1016
- :cyclic-edges-with-model-imports 1422
+ :cyclic-edges 1017
+ :cyclic-edges-with-model-imports 1432
  :cyclic-modules 109
  :cyclic-modules-with-model-imports 121
- :cyclic-namespaces 1479
- :cyclic-namespaces-with-model-imports 1559
- :driver-test-triggering-namespaces 696
+ :cyclic-namespaces 1575
+ :cyclic-namespaces-with-model-imports 1666
+ :driver-test-triggering-namespaces 734
  :largest-api 31
- :largest-ns-scc 509
+ :largest-ns-scc 538
  :largest-scc-modules 104
  :largest-scc-modules-with-model-imports 118
- :largest-scc-namespaces 1427
- :largest-scc-namespaces-with-model-imports 1534
- :max-file-deftests 19463
- :max-file-test-namespaces 1490
+ :largest-scc-namespaces 1517
+ :largest-scc-namespaces-with-model-imports 1637
+ :max-file-deftests 19729
+ :max-file-test-namespaces 1510
  :model-import-bypass-modules 2
  :module-count 204
  :module-exports 0
  :ns-prefix-overrides 0
  :parent-team-mismatches 3
- :total-api 561}
+ :total-api 566}

--- a/.clj-kondo/config/modules/ratchets.edn
+++ b/.clj-kondo/config/modules/ratchets.edn
@@ -1,1 +1,1 @@
-{:api-any 1, :driver-test-exempt-modules 67, :friend-edges 28, :friend-reaches 136, :legacy-rest-modules 15, :uses-any 4}
+{:api-any 1, :cross-subtree-cycle-pairs 46, :driver-test-exempt-modules 67, :friend-edges 28, :friend-reaches 136, :legacy-rest-modules 15, :top-level-modules 178, :uses-any 4}

--- a/.clj-kondo/config/modules/ratchets.edn
+++ b/.clj-kondo/config/modules/ratchets.edn
@@ -1,1 +1,1 @@
-{:api-any 1, :cross-subtree-cycle-pairs 46, :driver-test-exempt-modules 67, :driver-test-triggering-modules 46, :friend-edges 28, :friend-reaches 104, :standalone-rest-modules 15, :top-level-modules 178, :uses-any 4}
+{:api-any 1, :cross-subtree-cycle-pairs 47, :driver-test-exempt-modules 67, :driver-test-triggering-modules 46, :friend-edges 28, :friend-reaches 104, :standalone-rest-modules 15, :top-level-modules 179, :uses-any 4}

--- a/.clj-kondo/config/modules/ratchets.edn
+++ b/.clj-kondo/config/modules/ratchets.edn
@@ -1,1 +1,1 @@
-{:api-any 1, :driver-test-exempt-modules 67, :driver-test-triggering-modules 46, :friend-edges 28, :friend-reaches 104, :standalone-rest-modules 15, :uses-any 4}
+{:api-any 1, :cross-subtree-cycle-pairs 46, :driver-test-exempt-modules 67, :driver-test-triggering-modules 46, :friend-edges 28, :friend-reaches 104, :standalone-rest-modules 15, :top-level-modules 178, :uses-any 4}

--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -17,7 +17,7 @@
                   :deprecated-var                                                      86
                   :discouraged-java-method                                             4
                   :discouraged-namespace                                               71
-                  :discouraged-var                                                     134
+                  :discouraged-var                                                     135
                   :duplicate-require                                                   1
                   :equals-true                                                         1
                   :main-without-gen-class                                              1
@@ -54,7 +54,7 @@
  :config-counts  {:constant-condition                      1
                   :deprecated-namespace                    7
                   :deprecated-var                          16
-                  :discouraged-namespace                   14
+                  :discouraged-namespace                   15
                   :discouraged-var                         14
                   :inline-def                              1
                   :main-without-gen-class                  1

--- a/.clj-kondo/src/hooks/clojure/core/ns.clj
+++ b/.clj-kondo/src/hooks/clojure/core/ns.clj
@@ -74,14 +74,14 @@
 (defn- lint-modules [ns-form-node config]
   (let [ns-symb (ns-form-node->ns-symb ns-form-node)]
     (when-not (modules/ignored-namespace? config ns-symb)
-      (when-let [current-module (modules/module ns-symb)]
+      (when-let [current-module (modules/module config ns-symb)]
         (let [required-namespace-symb-nodes (-> ns-form-node
                                                 ns-form-node->require-node
                                                 require-node->namespace-symb-nodes)]
           (doseq [node  required-namespace-symb-nodes
                   :when (not (contains? (hooks.common/ignored-linters node) :metabase/modules))
                   :let  [required-namespace (hooks/sexpr node)
-                         error              (modules/usage-error config current-module required-namespace)]
+                         error              (modules/usage-error config ns-symb current-module required-namespace)]
                   :when error]
             (hooks/reg-finding! (assoc (meta node)
                                        :message error

--- a/.clj-kondo/src/hooks/clojure/core/ns.clj
+++ b/.clj-kondo/src/hooks/clojure/core/ns.clj
@@ -92,14 +92,14 @@
 (defn- lint-modules [ns-form-node config]
   (let [ns-symb (ns-form-node->ns-symb ns-form-node)]
     (when-not (modules/ignored-namespace? config ns-symb)
-      (when-let [current-module (modules/module ns-symb)]
+      (when-let [current-module (modules/module config ns-symb)]
         (let [required-namespace-symb-nodes (-> ns-form-node
                                                 ns-form-node->require-node
                                                 require-node->namespace-symb-nodes)]
           (doseq [node  required-namespace-symb-nodes
                   :when (not (contains? (hooks.common/ignored-linters node) :metabase/modules))
                   :let  [required-namespace (hooks/sexpr node)
-                         error              (modules/usage-error config current-module required-namespace)]
+                         error              (modules/usage-error config ns-symb current-module required-namespace)]
                   :when error]
             (hooks/reg-finding! (assoc (meta node)
                                        :message error

--- a/.clj-kondo/src/hooks/clojure/core/require.clj
+++ b/.clj-kondo/src/hooks/clojure/core/require.clj
@@ -11,11 +11,11 @@
          (every? simple-symbol? required-namespaces)]}
   (when-not (modules/ignored-namespace? config current-ns)
     ;; ignore namespaces outside of the module system
-    (when-let [current-module (modules/module current-ns)]
+    (when-let [current-module (modules/module config current-ns)]
       (doseq [required-namespace required-namespaces]
         ;; ignore namespaces outside of the module system.
-        (when (modules/module required-namespace)
-          (when-let [error (modules/usage-error config current-module required-namespace)]
+        (when (modules/module config required-namespace)
+          (when-let [error (modules/usage-error config current-ns current-module required-namespace)]
             (hooks/reg-finding! (assoc (meta node)
                                        :message error
                                        :type    :metabase/modules))))))))

--- a/.clj-kondo/src/hooks/clojure/test.clj
+++ b/.clj-kondo/src/hooks/clojure/test.clj
@@ -151,10 +151,12 @@
           (str/starts-with? (name ns-symb) prefix))
         ["build-drivers."
          "build."
+         "dev." ; dev tooling
          "i18n." ; bin/i18n
          "lint-migrations-file-test"
-         "mage."
+         "mage." ; mage build tool
          "main-test" ; bin/release-list
+         "metabase.dev." ; dev tooling tests
          "metabase.deps-edn-test"
          "metabase.driver."
          "metabase.test."
@@ -171,8 +173,9 @@
                ;; only warn once per namespace
                (not (contains? @warned-namespaces ns-symb)))
       (swap! warned-namespaces conj ns-symb)
-      (let [known-modules  (set (keys (:metabase/modules (modules/config input))))
-            current-module (modules/module ns-symb)]
+      (let [config         (modules/config input)
+            known-modules  (set (keys (:metabase/modules config)))
+            current-module (modules/module config ns-symb)]
         (when (or (not current-module)
                   (not (contains? known-modules current-module)))
           (hooks/reg-finding! (assoc (meta node)

--- a/.clj-kondo/src/hooks/clojure/test.clj
+++ b/.clj-kondo/src/hooks/clojure/test.clj
@@ -171,12 +171,14 @@
           (str/starts-with? (name ns-symb) prefix))
         ["build-drivers."
          "build."
+         "dev." ; dev tooling
          "hooks." ; clj-kondo hook tests, outside the module system
          "i18n." ; bin/i18n
          "lint-migrations-file-test"
          "load-namespaces." ; bin/load-namespaces
-         "mage."
+         "mage." ; mage build tool
          "main-test" ; bin/release-list
+         "metabase.dev." ; dev tooling tests
          "metabase.deps-edn-test"
          "metabase.driver."
          "metabase.test."
@@ -193,8 +195,9 @@
                ;; only warn once per namespace
                (not (contains? @warned-namespaces ns-symb)))
       (swap! warned-namespaces conj ns-symb)
-      (let [known-modules  (set (keys (:metabase/modules (modules/config input))))
-            current-module (modules/module ns-symb)]
+      (let [config         (modules/config input)
+            known-modules  (set (keys (:metabase/modules config)))
+            current-module (modules/module config ns-symb)]
         (when (or (not current-module)
                   (not (contains? known-modules current-module)))
           (hooks/reg-finding! (assoc (meta node)

--- a/.clj-kondo/src/hooks/common/modules.clj
+++ b/.clj-kondo/src/hooks/common/modules.clj
@@ -2,38 +2,384 @@
   (:require
    [clojure.string :as str]))
 
-(defn ignored-namespace? [config ns-symb]
+(defn ignored-namespace?
+  "Whether `ns-symb` matches one of the configured module-linter exclusions."
+  [config ns-symb]
   (some
    (fn [pattern-str]
      (re-find (re-pattern pattern-str) (str ns-symb)))
    (:ignored-namespace-patterns config)))
 
-(defn config [{:keys [config], :as _hook-input}]
-  (merge (get-in config [:linters :metabase/modules])
-         (select-keys config [:metabase/modules])))
+;;;; -------------------------------------------------------------------------
+;;;; Module identity and hierarchy
+;;;;
+;;;; Modules are symbols. Top-level modules have no namespace part (or
+;;;; `enterprise`). Nested modules use dotted names:
+;;;;
+;;;;   `lib`              — top-level module
+;;;;   `lib.schema`       — nested child of `lib`
+;;;;   `enterprise/foo`   — top-level enterprise module
+;;;;   `enterprise/foo.bar` — nested child of `enterprise/foo`
+;;;;
+;;;; Parent/child relationships are derived from the dotted name.
+;;;; -------------------------------------------------------------------------
+
+(defn- declared-modules
+  "Set of module symbols declared in the `:metabase/modules` map of `config`."
+  [config]
+  (set (keys (get config :metabase/modules))))
+
+(defn- split-module
+  "Split a module symbol into `[ns-part name-parts]` where `ns-part` is the
+  namespace component of the symbol (usually `nil` or `\"enterprise\"`) and
+  `name-parts` is the vector of dotted segments of the name.
+
+    (split-module 'lib)                  => [nil [\"lib\"]]
+    (split-module 'lib.schema)           => [nil [\"lib\" \"schema\"]]
+    (split-module 'enterprise/foo.bar)   => [\"enterprise\" [\"foo\" \"bar\"]]"
+  [m]
+  [(namespace m) (str/split (name m) #"\.")])
+
+(defn- join-module
+  "Inverse of `split-module`. Construct a module symbol from `[ns-part name-parts]`."
+  [[ns-part name-parts]]
+  (if ns-part
+    (symbol ns-part (str/join "." name-parts))
+    (symbol (str/join "." name-parts))))
+
+(defn- parent-module
+  "The direct parent module of `m`, or `nil` if `m` is top-level.
+
+  Two sources of parent-child relationships:
+
+    1. **Dotted names**: `lib.schema` is a child of `lib`. Pure
+       syntactic — always active.
+
+    2. **`enterprise/X` shorthand**: `enterprise/X` is a child of the
+       OSS module `X` (a simple symbol with no namespace part), but
+       ONLY when `X` is actually declared in `declared-modules`. If
+       `X` isn't declared, `enterprise/X` is treated as top-level.
+       This branch is active only when the caller provides a
+       `declared-modules` set.
+
+  Examples:
+
+    (parent-module 'lib.schema)                 => 'lib
+    (parent-module 'lib.schema.foo)             => 'lib.schema
+    (parent-module 'lib)                        => nil
+    (parent-module 'enterprise/foo.bar)         => 'enterprise/foo
+    (parent-module 'enterprise/foo)             => nil       ; no shorthand without declared
+    (parent-module #{'foo} 'enterprise/foo)     => 'foo      ; shorthand: foo declared
+    (parent-module #{} 'enterprise/foo)         => nil       ; shorthand: foo not declared
+    (parent-module #{'foo} 'enterprise/other)   => nil       ; shorthand: other not declared"
+  ([m] (parent-module nil m))
+  ([declared-modules m]
+   (let [[ns-part parts] (split-module m)]
+     (cond
+       ;; Dotted name: pure syntactic parent.
+       (> (count parts) 1)
+       (join-module [ns-part (butlast parts)])
+
+       ;; `enterprise/X` shorthand: parent is OSS `X` if declared.
+       (and (= ns-part "enterprise") declared-modules)
+       (let [oss (symbol (first parts))]
+         (when (contains? declared-modules oss) oss))
+
+       :else nil))))
+
+(defn- ancestor-chain
+  "Seq of ancestor modules of `m`, from direct parent up to top-level ancestor.
+  Empty if `m` is top-level. Honors the `enterprise/X` shorthand when
+  `declared-modules` is provided."
+  ([m] (ancestor-chain nil m))
+  ([declared-modules m]
+   (take-while some?
+               (iterate #(parent-module declared-modules %)
+                        (parent-module declared-modules m)))))
+
+(defn- ancestor?
+  "True if `maybe-ancestor` is a strict ancestor of `maybe-descendant`
+  (parent, grandparent, etc., but not the module itself)."
+  ([a b] (ancestor? nil a b))
+  ([declared-modules maybe-ancestor maybe-descendant]
+   (boolean (some #(= maybe-ancestor %)
+                  (ancestor-chain declared-modules maybe-descendant)))))
+
+;;;; -------------------------------------------------------------------------
+;;;; Visibility rules
+;;;;
+;;;; Every dependency must be declared in `:uses`, with no exceptions and no
+;;;; inheriting from ancestors. Cross-module access goes through the target's
+;;;; `:api`, with exactly one tree-based exception: subtree trust, where a
+;;;; descendant may reach past its ancestors' `:api` (see
+;;;; [[allowed-module-namespace?]]). The trust is unidirectional — parents go
+;;;; through their children's `:api` like any other consumer, and siblings get
+;;;; nothing from each other. `:module-exports` controls a separate axis: which
+;;;; nested modules may be *named* at all from outside their subtree.
+;;;;
+;;;; The `:module-exports` config key on a module is a SET of direct-child module
+;;;; symbols that the parent explicitly promotes to externally-referenceable
+;;;; status. An unopened nested child is private to its top-level subtree:
+;;;; only modules sharing the same top-level ancestor may name it in their
+;;;; `:uses`. An opened child may be named by anyone. Either way, the
+;;;; dependency must be declared and the access must respect the target's
+;;;; `:api`.
+;;;;
+;;;; The opened-child-naming rule is enforced in two places. For set-valued
+;;;; `:uses` it's a property of the config declarations, checked by
+;;;; `uses-references-must-be-namable-test` in modules-test. Modules with
+;;;; `:uses :any` declare nothing for that test to validate, so for them the
+;;;; same rule is enforced here at require-lint time against the concrete
+;;;; resolved module (see [[namable-from?]] and [[usage-error]]).
+;;;;
+;;;; The helpers below also back config validation; at require-lint time the
+;;;; hook itself uses them only for the `:uses :any` namability check.
+;;;; -------------------------------------------------------------------------
+
+(defn- top-level-oss-module?
+  "True if `m` is a top-level OSS module symbol — i.e., no namespace part
+  and a name with no dots. `lib` qualifies; `lib.schema` does not (nested);
+  `enterprise/lib` does not (enterprise namespace part)."
+  [m]
+  (and (nil? (namespace m))
+       (not (str/includes? (name m) "."))))
+
+(defn- open-children
+  "Set of direct child module symbols that `parent` exposes. Combines the
+  explicit `:module-exports` set from config with the auto-opened `enterprise/X`
+  counterpart if `parent` is a top-level OSS module `X` and `enterprise/X`
+  is declared. The auto-open exists so that outside callers (e.g. the
+  `metabase-enterprise.core.init` loader chain) can statically reference
+  each OSS module's EE companion without needing to explicitly list it
+  in `:module-exports`."
+  [config parent]
+  (let [explicit (set (get-in config [:metabase/modules parent :module-exports]))
+        ee-child (when (top-level-oss-module? parent)
+                   (let [candidate (symbol "enterprise" (name parent))]
+                     (when (contains? (declared-modules config) candidate)
+                       candidate)))]
+    (cond-> explicit
+      ee-child (conj ee-child))))
+
+(defn- opens-child?
+  "True if `parent` exposes `child` via its `:module-exports` set (explicit or
+  auto-opened via the `enterprise/X` shorthand)."
+  [config parent child]
+  (contains? (open-children config parent) child))
+
+(defn- externally-visible?
+  "True if `m` may be named in the `:uses` of a module that is NOT in `m`'s
+  top-level subtree. This is the case iff `m` is top-level, OR `m`'s parent
+  has `m` in its `:module-exports` set AND the parent is itself externally visible.
+
+  Used by the subtree-membership lint to validate `:uses` declarations.
+  NOT used at require-lint time — requires are checked strictly against
+  the caller's declared `:uses` and the target's `:api`."
+  [config m]
+  (let [declared (declared-modules config)]
+    (loop [m m]
+      (if-let [p (parent-module declared m)]
+        (if (opens-child? config p m)
+          (recur p)
+          false)
+        true))))
+
+(defn- top-level-ancestor
+  "The top-level module at the root of `m`'s subtree, or `m` itself if it is top-level."
+  [declared-modules m]
+  (or (last (ancestor-chain declared-modules m)) m))
+
+(defn- namable-from?
+  "True if `current-module` may name `required-module` at all under the strict model: the target is
+  externally visible (top-level, or in `:module-exports` of every ancestor up to the root), or the two
+  share a top-level subtree. Mirrors `can-be-named-by?` in `metabase.core.modules-test`, which validates
+  declared `:uses` sets; this require-time version covers modules whose `:uses` is `:any` and therefore
+  declare nothing for that test to check."
+  [config current-module required-module]
+  (let [declared (declared-modules config)]
+    (or (externally-visible? config required-module)
+        (= (top-level-ancestor declared current-module)
+           (top-level-ancestor declared required-module)))))
+
+;;;; -------------------------------------------------------------------------
+;;;; Namespace → module resolution (prefix-map based)
+;;;;
+;;;; Each declared module has an effective `:ns-prefix` — the namespace-
+;;;; prefix string it owns. By convention the default prefix is derived
+;;;; from the module's symbol name (e.g. `lib.schema` defaults to
+;;;; `"metabase.lib.schema"`, `enterprise/transforms.python` defaults to
+;;;; `"metabase-enterprise.transforms.python"`). A module may override
+;;;; this with an explicit `:ns-prefix` in its config — used when the
+;;;; source files follow a different naming convention than the module
+;;;; tree (e.g. nesting `lib.be` as a child of `lib` while its source
+;;;; files remain `metabase.lib-be.*`).
+;;;;
+;;;; Resolution builds a prefix-string → module-symbol map from all
+;;;; declared modules and finds the longest matching prefix for the
+;;;; given namespace symbol, matching only at segment boundaries (so
+;;;; `metabase.lib.bert` never matches prefix `metabase.lib.be`).
+;;;; -------------------------------------------------------------------------
+
+(defn- default-ns-prefix
+  "Derive the default `:ns-prefix` for a module symbol. For a top-level
+  module `lib` this is `\"metabase.lib\"`. For a nested module `lib.schema`
+  it's `\"metabase.lib.schema\"`. For enterprise modules the prefix root is
+  `metabase-enterprise.` instead of `metabase.`.
+
+    (default-ns-prefix 'lib)                 => \"metabase.lib\"
+    (default-ns-prefix 'lib.schema)          => \"metabase.lib.schema\"
+    (default-ns-prefix 'enterprise/foo.bar)  => \"metabase-enterprise.foo.bar\""
+  [m]
+  (if (= (namespace m) "enterprise")
+    (str "metabase-enterprise." (name m))
+    (str "metabase." (name m))))
+
+(defn- module-ns-prefix
+  "Effective namespace prefix for a module: explicit `:ns-prefix` from the
+  module's config if set, else the name-derived default."
+  [config m]
+  (or (get-in config [:metabase/modules m :ns-prefix])
+      (default-ns-prefix m)))
+
+(defn- build-prefix->module
+  "Build the map of `ns-prefix-string → module-symbol` from all declared
+  modules. Used as the lookup table for longest-prefix resolution."
+  [config]
+  (into {}
+        (map (fn [m] [(module-ns-prefix config m) m]))
+        (keys (get config :metabase/modules))))
+
+(defonce ^:private prefix->module-cache
+  (atom nil))
+
+(defn- cached-prefix->module
+  [config]
+  (let [modules (:metabase/modules config)
+        cached  @prefix->module-cache]
+    (if (identical? modules (:modules cached))
+      (:prefix->module cached)
+      (let [prefix->module (build-prefix->module config)]
+        (reset! prefix->module-cache {:modules modules, :prefix->module prefix->module})
+        prefix->module))))
+
+(defn config
+  "Extract the module-linter config and precompute its namespace resolver."
+  [{:keys [config], :as _hook-input}]
+  (let [config (merge (get-in config [:linters :metabase/modules])
+                      (select-keys config [:metabase/modules]))]
+    (assoc config ::prefix->module (cached-prefix->module config))))
+
+(defn- ns-starts-with-prefix?
+  "True if namespace string `ns-str` is either exactly equal to `prefix` or
+  begins with `prefix` followed by a `.` (segment boundary). Prevents false
+  matches like `metabase.lib.bert` vs prefix `metabase.lib.be`."
+  [ns-str prefix]
+  (or (= ns-str prefix)
+      (str/starts-with? ns-str (str prefix "."))))
+
+(defn- longest-matching-prefix
+  "Scan `prefix->module` and return the module whose `:ns-prefix` is the
+  longest string prefix of `ns-str` at segment boundaries. Returns `nil`
+  if no declared module owns the namespace."
+  [prefix->module ns-str]
+  (second
+   (reduce-kv
+    (fn [[best-prefix :as best] prefix module]
+      (if (and (ns-starts-with-prefix? ns-str prefix)
+               (or (nil? best-prefix)
+                   (> (count prefix) (count best-prefix))))
+        [prefix module]
+        best))
+    nil
+    prefix->module)))
+
+(defn- normalize-test-namespace
+  "Normalize exact `-test` namespaces back to their module/source namespace
+  for module resolution.
+
+  This keeps namespace-based resolution aligned with file-path-based helpers
+  for module-level test files such as `test/metabase/lib/schema_test.cljc`,
+  whose declared namespace is `metabase.lib.schema-test` but whose owning
+  module should resolve as `lib.schema` rather than top-level `lib`."
+  [ns-symb]
+  (if (str/ends-with? (name ns-symb) "-test")
+    (symbol (str/replace (name ns-symb) #"-test$" ""))
+    ns-symb))
 
 (defn module
-  "E.g.
+  "Resolve a namespace symbol to the module symbol that owns it.
 
-    (module 'metabase.qp.middleware.wow) => 'qp
-    (module 'metabase-enterprise.whatever.core) => enterprise/whatever"
-  [ns-symb]
-  {:pre [(simple-symbol? ns-symb)]}
-  ;; treat something like `metabase.driver-test` (for a module that hasn't fully been updated to use `.core`
-  ;; namespaces) as being in the `driver` module
-  (let [ns-symb (if (str/ends-with? (name ns-symb) "-test")
-                  (symbol (str/replace (name ns-symb) #"-test$" ""))
-                  ns-symb)]
-    (or (some->> (re-find #"^metabase-enterprise\.([^.]+)" (str ns-symb))
-                 second
-                 (symbol "enterprise"))
-        (some-> (re-find #"^metabase\.([^.]+)" (str ns-symb))
-                second
-                symbol))))
+  Uses the `:ns-prefix` mechanism: each declared module has an effective
+  namespace prefix (explicit via `:ns-prefix` in config or derived from
+  the module's symbol name). Resolution is a longest-prefix match over
+  the set of declared prefixes at segment boundaries.
+
+  With one arg (legacy, used by callers without access to a config):
+  fall back to the single-segment first-element extraction — the flat
+  mapping behavior that predates nested modules. Equivalent to
+  `(module nil ns-symb)`.
+
+  With two args: if `config` is non-nil and declares modules, use the
+  prefix-map lookup. Falls through to the single-segment regex if no
+  declared prefix matches, preserving backwards compatibility.
+
+  CANONICAL: this function is the source-of-truth definition of the
+  namespace→module resolution algorithm. Two other sites duplicate its
+  behavior because they live in different classpath contexts and cannot
+  share code:
+
+    - dev/src/dev/deps_graph.clj              (namespace-symbol based)
+    - mage/src/mage/modules.clj/file->module  (file-path based)
+
+  If you change the algorithm here, update both of the above sites. The
+  consistency test `metabase.core.modules-consistency-test` verifies they
+  stay in sync.
+
+  Examples:
+
+    (module 'metabase.qp.middleware.wow)
+      => 'qp   ; single-segment fallback
+
+    (module config 'metabase.lib.schema.foo)
+      => 'lib.schema   ; if lib.schema is declared with default :ns-prefix
+
+    (module config 'metabase.lib-be.foo)
+      => 'lib.be       ; if lib.be declares :ns-prefix \"metabase.lib-be\"
+
+    (module 'metabase-enterprise.whatever.core)
+      => enterprise/whatever"
+  ([ns-symb] (module nil ns-symb))
+  ([config ns-symb]
+   {:pre [(simple-symbol? ns-symb)]}
+   ;; Treat exact `-test` namespaces as their source/module namespace so
+   ;; `metabase.lib.schema-test` resolves to `lib.schema`, while still
+   ;; supporting older flat cases like `metabase.driver-test` -> `driver`.
+   (let [ns-symb (normalize-test-namespace ns-symb)]
+     (or
+      ;; Primary path: prefix-map longest match over declared modules.
+      (when (seq (get config :metabase/modules))
+        (longest-matching-prefix (or (::prefix->module config)
+                                     (build-prefix->module config))
+                                 (str ns-symb)))
+      ;; Fallback: single-segment extraction via the original regexes.
+      ;; Preserved byte-for-byte so the consistency test can compare
+      ;; regex literals across the three mapping sites.
+      (some->> (re-find #"^metabase-enterprise\.([^.]+)" (str ns-symb))
+               second
+               (symbol "enterprise"))
+      (some-> (re-find #"^metabase\.([^.]+)" (str ns-symb))
+              second
+              symbol)))))
+
+;;;; -------------------------------------------------------------------------
+;;;; Access checks
+;;;; -------------------------------------------------------------------------
 
 (defn- module-api-namespaces
-  "Set of API namespace symbols for a given module. `:any` means you can use anything, there are no API namespaces for
-  this module (yet). If unspecified, the default is just the `<module>.core` namespace."
+  "Set of API namespace symbols for a given module. `:any` means you can use
+  anything, there are no API namespaces for this module (yet). If unspecified,
+  the default is the module's `.api`, `.core`, and `.init` namespaces derived
+  from the effective `:ns-prefix` (which may be explicit or name-derived)."
   [config module]
   (let [module-config (get-in config [:metabase/modules module :api])]
     (cond
@@ -44,17 +390,15 @@
       module-config
 
       :else
-      (let [ns-prefix (if (= (namespace module) "enterprise")
-                        (str "metabase-enterprise." (name module))
-                        (name module))]
+      (let [ns-prefix (module-ns-prefix config module)]
         #{(symbol (str ns-prefix ".api"))
           (symbol (str ns-prefix ".core"))
           (symbol (str ns-prefix ".init"))}))))
 
 (defn- module-friends
-  [config module]
   "Set of modules that are `:friends` of `module`, i.e. allowed to use *any* namespace from the module, not just the
   designated [[module-api-namespaces]]."
+  [config module]
   (set (get-in config [:metabase/modules module :friends])))
 
 (defn allowed-modules
@@ -62,34 +406,117 @@
   [config module]
   (get-in config [:metabase/modules module :uses]))
 
-(defn allowed-module? [config module required-module]
-  (let [allowed-modules (allowed-modules config module)]
+(defn allowed-module?
+  "True if `current-module` is allowed to depend on `required-module` based on
+  `current-module`'s `:uses` declaration.
+
+  Strict exact-match: the resolved required module must be a literal entry
+  in `current-module`'s `:uses` set. There is no walking of `:module-exports` chains,
+  no inheriting from ancestors. If `lib.schema` is what the require resolves
+  to, then `:uses #{lib.schema}` is what's required — `:uses #{lib}` does
+  NOT cover it.
+
+  The `:any` value is the one wildcard: a module declared `:uses :any` may
+  depend on anything (subject to the orthogonal subtree-membership rules
+  enforced at config-validation time)."
+  [config current-module required-module]
+  (let [allowed-modules (allowed-modules config current-module)]
     (or (= allowed-modules :any)
-        (contains? (set allowed-modules) required-module))))
+        ;; coerce to a set: `:uses` is normally a set, but a hand-edited vector would make `contains?`
+        ;; test index membership and reject every legitimately-declared dependency.
+        (boolean (contains? (set allowed-modules) required-module)))))
 
-(defn- allowed-module-namespace? [config current-module ns-symb]
-  (let [module                (module ns-symb)
-        module-api-namespaces (module-api-namespaces config module)
-        module-friends        (module-friends config module)]
-    (or (empty? module-api-namespaces)
-        (contains? module-api-namespaces ns-symb)
-        (contains? module-friends current-module))))
+(defn- rest-module?
+  "Whether `module` is a canonical nested `.rest` module or uses the deprecated `-rest` compatibility form."
+  [module]
+  (let [module-name (str module)]
+    (or (str/ends-with? module-name "-rest")
+        (str/ends-with? module-name ".rest"))))
 
-(defn- rest-module? [module]
-  (str/ends-with? module "-rest"))
+(defn- routes-module?
+  "Whether `module` is a route aggregator allowed to assemble REST routes."
+  [module]
+  (let [module-name (str module)]
+    (or (str/ends-with? module-name "-routes")
+        (str/ends-with? module-name ".routes"))))
 
-(defn- routes-module? [module]
-  (str/ends-with? module "-routes"))
+(defn- core-module?
+  "Whether `module` is a core initializer allowed to load route aggregators."
+  [module]
+  (= (name module) "core"))
 
-(defn- core-module? [module]
-  (str/ends-with? module "core"))
+(defn- allowed-rest-consumer?
+  "Whether `module` may depend on REST modules."
+  [module]
+  ((some-fn rest-module? routes-module? core-module?) module))
+
+(defn- descendant-of?
+  "True if `viewer` is a descendant of `viewed` in the module tree (or they
+  are the same module). Used for subtree trust — descendants are allowed
+  to reach into their ancestors' internals past `:api`, but NOT the other
+  way around. The `:api` is the outward-facing contract of a module; even
+  its parent must respect it when reaching in.
+
+  This is asymmetric on purpose: parent → child goes through the child's
+  `:api`, child → parent bypasses `:api` (subject to the normal `:uses`
+  declaration requirement)."
+  [declared-modules viewer viewed]
+  (or (= viewer viewed)
+      (ancestor? declared-modules viewed viewer)))
+
+(defn- allowed-module-namespace?
+  "True if `ns-symb` (the namespace being required) is an allowed reference
+  from `current-module`.
+
+  Two access paths:
+
+    1. **Subtree trust (descendants only)**: if `current-module` is a
+       descendant of the resolved required module (or the same module),
+       the access is allowed regardless of `:api`. A descendant is
+       conceptually inside its ancestor and can see past the ancestor's
+       public contract. The `:uses` declaration is still required, so
+       the dependency is still recorded in the module graph — what's
+       relaxed is only the `:api` restriction. Note that this is
+       UNIDIRECTIONAL: a parent reaching into its child's internals is
+       NOT allowed — the parent must go through the child's `:api` like
+       any other consumer.
+
+    2. **Standard `:api` check**: for all other relationships (parent
+       reading child, siblings, cousins, unrelated), the required
+       namespace must be in the required module's `:api` set, OR
+       `current-module` must appear in the required module's `:friends`
+       list (as an audited bypass)."
+  [config current-module ns-symb]
+  (let [required-module (module config ns-symb)
+        declared        (declared-modules config)]
+    (if (descendant-of? declared current-module required-module)
+      true
+      (let [api-namespaces (module-api-namespaces config required-module)
+            friends        (module-friends config required-module)]
+        (or (nil? api-namespaces)
+            (contains? api-namespaces ns-symb)
+            (contains? friends current-module))))))
 
 (defn usage-error
-  "Find usage errors when a `required-namespace` is required in the `current-module`. Returns a string describing the
-  error type if there is one, otherwise `nil` if there are no errors."
-  [config current-module required-namespace]
+  "Find usage errors when a `required-namespace` is required from `current-ns`
+  (which belongs to `current-module`). Returns a string describing the error
+  type if there is one, otherwise `nil` if there are no errors.
+
+  The required module must be in current's `:uses` (always, even between
+  relatives), and the required namespace must be in the required module's
+  `:api` — unless current is a descendant of the required module (subtree
+  trust) or appears in its `:friends`. Non-REST modules may not depend on REST
+  modules, except for route aggregators and core initializers. See
+  [[allowed-module-namespace?]] for the access-path details. When current's
+  `:uses` is `:any`, the namability rule (see [[namable-from?]]) is additionally
+  enforced here, since the config-level test only covers set-valued `:uses`.
+
+  `current-ns` is accepted but currently unused by the check. It's kept in
+  the signature because the hook callers already have it handy and future
+  lints may want the caller namespace for more precise error messages."
+  [config _current-ns current-module required-namespace]
   ;; ignore stuff not in a module i.e. non-Metabase stuff.
-  (when-let [required-module (module required-namespace)]
+  (when-let [required-module (module config required-namespace)]
     (when-not (= current-module required-module)
       (cond
         (not (allowed-module? config current-module required-module))
@@ -98,19 +525,26 @@
                 current-module
                 current-module)
 
+        (and (not (allowed-rest-consumer? current-module))
+             (rest-module? required-module))
+        (format "Do not use REST modules (%s) in non-REST modules (%s) -- move things from %s to %s if needed"
+                required-module
+                current-module
+                required-module
+                (symbol (str/replace (str required-module) #"(?:-rest|\.rest)$" "")))
+
+        ;; `:uses :any` skips the declaration-level namability test (it only validates set-valued
+        ;; `:uses`), so enforce the same rule here against the concrete resolved module.
+        (and (= (allowed-modules config current-module) :any)
+             (not (namable-from? config current-module required-module)))
+        (format "Module %s is nested and not exported by its ancestors; %s may not use it. Add it to its parent's :module-exports chain, or move the caller into the %s subtree. [:metabase/modules %s :module-exports]"
+                required-module
+                current-module
+                (top-level-ancestor (declared-modules config) required-module)
+                (parent-module (declared-modules config) required-module))
+
         (not (allowed-module-namespace? config current-module required-namespace))
         (format "Namespace %s is not an allowed external API namespace for the %s module. [:metabase/modules %s :api]"
                 required-namespace
                 required-module
-                required-module)
-
-        ;; (for now) rest modules are allowed to use one another; `routes` is ok because it collects routes together
-        ;; and `core` is ok because [[metabase.core.init]] might need to init some of the `-routes` modules'
-        ;; namespaces
-        (and (not ((some-fn rest-module? routes-module? core-module?) current-module))
-             (rest-module? required-module))
-        (format "Do not use -rest modules (%s) in non-rest modules (%s) -- move things from %s to %s if needed"
-                required-module
-                current-module
-                required-module
-                (symbol (str/replace required-module #"-rest$" "")))))))
+                required-module)))))

--- a/.clj-kondo/src/hooks/common/modules.clj
+++ b/.clj-kondo/src/hooks/common/modules.clj
@@ -105,6 +105,22 @@
    (boolean (some #(= maybe-ancestor %)
                   (ancestor-chain declared-modules maybe-descendant)))))
 
+(defn- descendant-of?
+  "True if `viewer` is a descendant of `viewed` in the module tree (or they
+  are the same module) — i.e. whether `viewer` sits inside the subtree
+  rooted at `viewed`.
+
+  Two things are phrased in terms of this predicate, both deliberately
+  asymmetric. Subtree trust: descendants are allowed to reach into their
+  ancestors' internals past `:api`, but NOT the other way around — the
+  `:api` is the outward-facing contract of a module, and even its parent
+  must respect it when reaching in. And privacy scoping: an unopened
+  nested module is namable exactly from the subtree of the ancestor that
+  keeps it private (see [[visibility-root]])."
+  [declared-modules viewer viewed]
+  (or (= viewer viewed)
+      (ancestor? declared-modules viewed viewer)))
+
 ;;;; -------------------------------------------------------------------------
 ;;;; Visibility rules
 ;;;;
@@ -119,11 +135,20 @@
 ;;;;
 ;;;; The `:module-exports` config key on a module is a SET of direct-child module
 ;;;; symbols that the parent explicitly promotes to externally-referenceable
-;;;; status. An unopened nested child is private to its top-level subtree:
-;;;; only modules sharing the same top-level ancestor may name it in their
-;;;; `:uses`. An opened child may be named by anyone. Either way, the
-;;;; dependency must be declared and the access must respect the target's
-;;;; `:api`.
+;;;; status. An unopened nested child is private to the subtree of the NEAREST
+;;;; ancestor that does not export the module below it on the path: only that
+;;;; ancestor and its descendants may name it in their `:uses`. Each export
+;;;; widens that scope by exactly one level, and a child exported all the way up
+;;;; to a top-level module may be named by anyone. Either way, the dependency
+;;;; must be declared and the access must respect the target's `:api`.
+;;;;
+;;;; That nearest-non-exporting-ancestor scoping is the rule Go's `internal/`
+;;;; directories and Rust's module privacy both settle on: `x.internal.y` is
+;;;; visible to the tree rooted at `x`, wherever `x` sits in the hierarchy —
+;;;; not to the whole top-level tree that happens to contain `x`. At nesting
+;;;; depth 2 the two coincide; at depth 3 or more, scoping to the top-level
+;;;; subtree would let a cousin elsewhere under the same top-level module name
+;;;; a deeply-private one.
 ;;;;
 ;;;; The opened-child-naming rule is enforced in two places. For set-valued
 ;;;; `:uses` it's a property of the config declarations, checked by
@@ -167,39 +192,49 @@
   [config parent child]
   (contains? (open-children config parent) child))
 
+(defn- visibility-root
+  "The module whose subtree `m` is private to, or `nil` if `m` may be named from anywhere.
+
+  Walks up from `m` to the nearest ancestor that does NOT have the module below it on the path
+  in its `:module-exports` set, and returns that ancestor — everything in its subtree may name
+  `m`, everything outside may not. If every ancestor on the way up exports the next module on
+  the path, the chain reaches a top-level module unobstructed, `m` is externally visible, and
+  there is no subtree to scope to, so this returns `nil`.
+
+  This is the `internal/` rule: `x.internal.y` is private to the tree rooted at `x`, wherever
+  `x` sits in the hierarchy — NOT to the top-level tree that contains `x`."
+  [config m]
+  (let [declared (declared-modules config)]
+    (loop [m m]
+      (when-let [p (parent-module declared m)]
+        (if (opens-child? config p m)
+          (recur p)
+          p)))))
+
 (defn- externally-visible?
-  "True if `m` may be named in the `:uses` of a module that is NOT in `m`'s
-  top-level subtree. This is the case iff `m` is top-level, OR `m`'s parent
-  has `m` in its `:module-exports` set AND the parent is itself externally visible.
+  "True if `m` may be named in the `:uses` of any module at all, wherever it sits in the tree.
+  This is the case iff `m` is top-level, OR `m`'s parent has `m` in its `:module-exports` set
+  AND the parent is itself externally visible — i.e. iff `m` has no [[visibility-root]].
 
   Used by the subtree-membership lint to validate `:uses` declarations.
   NOT used at require-lint time — requires are checked strictly against
   the caller's declared `:uses` and the target's `:api`."
   [config m]
-  (let [declared (declared-modules config)]
-    (loop [m m]
-      (if-let [p (parent-module declared m)]
-        (if (opens-child? config p m)
-          (recur p)
-          false)
-        true))))
-
-(defn- top-level-ancestor
-  "The top-level module at the root of `m`'s subtree, or `m` itself if it is top-level."
-  [declared-modules m]
-  (or (last (ancestor-chain declared-modules m)) m))
+  (nil? (visibility-root config m)))
 
 (defn- namable-from?
-  "True if `current-module` may name `required-module` at all under the strict model: the target is
-  externally visible (top-level, or in `:module-exports` of every ancestor up to the root), or the two
-  share a top-level subtree. Mirrors `can-be-named-by?` in `metabase.core.modules-test`, which validates
-  declared `:uses` sets; this require-time version covers modules whose `:uses` is `:any` and therefore
-  declare nothing for that test to check."
+  "True if `current-module` may name `required-module` at all under the strict model: either the
+  target is externally visible (top-level, or in `:module-exports` of every ancestor up to the
+  root), or `current-module` sits inside the subtree of the target's [[visibility-root]] — the
+  nearest ancestor keeping it private. Mirrors `can-be-named-by?` in `metabase.core.modules-test`,
+  which validates declared `:uses` sets; this require-time version covers modules whose `:uses` is
+  `:any` and therefore declare nothing for that test to check."
   [config current-module required-module]
   (let [declared (declared-modules config)]
     (or (externally-visible? config required-module)
-        (= (top-level-ancestor declared current-module)
-           (top-level-ancestor declared required-module)))))
+        (descendant-of? declared
+                        current-module
+                        (visibility-root config required-module)))))
 
 ;;;; -------------------------------------------------------------------------
 ;;;; Namespace → module resolution (prefix-map based)
@@ -450,20 +485,6 @@
   [module]
   ((some-fn rest-module? routes-module? core-module?) module))
 
-(defn- descendant-of?
-  "True if `viewer` is a descendant of `viewed` in the module tree (or they
-  are the same module). Used for subtree trust — descendants are allowed
-  to reach into their ancestors' internals past `:api`, but NOT the other
-  way around. The `:api` is the outward-facing contract of a module; even
-  its parent must respect it when reaching in.
-
-  This is asymmetric on purpose: parent → child goes through the child's
-  `:api`, child → parent bypasses `:api` (subject to the normal `:uses`
-  declaration requirement)."
-  [declared-modules viewer viewed]
-  (or (= viewer viewed)
-      (ancestor? declared-modules viewed viewer)))
-
 (defn- allowed-module-namespace?
   "True if `ns-symb` (the namespace being required) is an allowed reference
   from `current-module`.
@@ -540,7 +561,7 @@
         (format "Module %s is nested and not exported by its ancestors; %s may not use it. Add it to its parent's :module-exports chain, or move the caller into the %s subtree. [:metabase/modules %s :module-exports]"
                 required-module
                 current-module
-                (top-level-ancestor (declared-modules config) required-module)
+                (visibility-root config required-module)
                 (parent-module (declared-modules config) required-module))
 
         (not (allowed-module-namespace? config current-module required-namespace))

--- a/.clj-kondo/src/hooks/common/modules.clj
+++ b/.clj-kondo/src/hooks/common/modules.clj
@@ -192,6 +192,19 @@
   [config parent child]
   (contains? (open-children config parent) child))
 
+(defn- blocking-export
+  "The first blocked export while walking from `m` toward the root, or `nil` if the whole chain
+  is exported. Returns a map containing both the `:ancestor` whose `:module-exports` blocks the
+  path and the direct `:child` that it would need to export."
+  [config m]
+  (let [declared (declared-modules config)]
+    (loop [child m]
+      (when-let [ancestor (parent-module declared child)]
+        (if (opens-child? config ancestor child)
+          (recur ancestor)
+          {:ancestor ancestor
+           :child    child})))))
+
 (defn- visibility-root
   "The module whose subtree `m` is private to, or `nil` if `m` may be named from anywhere.
 
@@ -204,12 +217,7 @@
   This is the `internal/` rule: `x.internal.y` is private to the tree rooted at `x`, wherever
   `x` sits in the hierarchy — NOT to the top-level tree that contains `x`."
   [config m]
-  (let [declared (declared-modules config)]
-    (loop [m m]
-      (when-let [p (parent-module declared m)]
-        (if (opens-child? config p m)
-          (recur p)
-          p)))))
+  (:ancestor (blocking-export config m)))
 
 (defn- externally-visible?
   "True if `m` may be named in the `:uses` of any module at all, wherever it sits in the tree.
@@ -558,11 +566,14 @@
         ;; `:uses`), so enforce the same rule here against the concrete resolved module.
         (and (= (allowed-modules config current-module) :any)
              (not (namable-from? config current-module required-module)))
-        (format "Module %s is nested and not exported by its ancestors; %s may not use it. Add it to its parent's :module-exports chain, or move the caller into the %s subtree. [:metabase/modules %s :module-exports]"
-                required-module
-                current-module
-                (visibility-root config required-module)
-                (parent-module (declared-modules config) required-module))
+        (let [{:keys [ancestor child]} (blocking-export config required-module)]
+          (format "Module %s is nested and not exported by its ancestors; %s may not use it. Add %s to %s's :module-exports, or move the caller into the %s subtree. [:metabase/modules %s :module-exports]"
+                  required-module
+                  current-module
+                  child
+                  ancestor
+                  ancestor
+                  ancestor))
 
         (not (allowed-module-namespace? config current-module required-namespace))
         (format "Namespace %s is not an allowed external API namespace for the %s module. [:metabase/modules %s :api]"

--- a/.clj-kondo/src/hooks/common/modules.clj
+++ b/.clj-kondo/src/hooks/common/modules.clj
@@ -2,38 +2,384 @@
   (:require
    [clojure.string :as str]))
 
-(defn ignored-namespace? [config ns-symb]
+(defn ignored-namespace?
+  "Whether `ns-symb` matches one of the configured module-linter exclusions."
+  [config ns-symb]
   (some
    (fn [pattern-str]
      (re-find (re-pattern pattern-str) (str ns-symb)))
    (:ignored-namespace-patterns config)))
 
-(defn config [{:keys [config], :as _hook-input}]
-  (merge (get-in config [:linters :metabase/modules])
-         (select-keys config [:metabase/modules])))
+;;;; -------------------------------------------------------------------------
+;;;; Module identity and hierarchy
+;;;;
+;;;; Modules are symbols. Top-level modules have no namespace part (or
+;;;; `enterprise`). Nested modules use dotted names:
+;;;;
+;;;;   `lib`              — top-level module
+;;;;   `lib.schema`       — nested child of `lib`
+;;;;   `enterprise/foo`   — top-level enterprise module
+;;;;   `enterprise/foo.bar` — nested child of `enterprise/foo`
+;;;;
+;;;; Parent/child relationships are derived from the dotted name.
+;;;; -------------------------------------------------------------------------
+
+(defn- declared-modules
+  "Set of module symbols declared in the `:metabase/modules` map of `config`."
+  [config]
+  (set (keys (get config :metabase/modules))))
+
+(defn- split-module
+  "Split a module symbol into `[ns-part name-parts]` where `ns-part` is the
+  namespace component of the symbol (usually `nil` or `\"enterprise\"`) and
+  `name-parts` is the vector of dotted segments of the name.
+
+    (split-module 'lib)                  => [nil [\"lib\"]]
+    (split-module 'lib.schema)           => [nil [\"lib\" \"schema\"]]
+    (split-module 'enterprise/foo.bar)   => [\"enterprise\" [\"foo\" \"bar\"]]"
+  [m]
+  [(namespace m) (str/split (name m) #"\.")])
+
+(defn- join-module
+  "Inverse of `split-module`. Construct a module symbol from `[ns-part name-parts]`."
+  [[ns-part name-parts]]
+  (if ns-part
+    (symbol ns-part (str/join "." name-parts))
+    (symbol (str/join "." name-parts))))
+
+(defn- parent-module
+  "The direct parent module of `m`, or `nil` if `m` is top-level.
+
+  Two sources of parent-child relationships:
+
+    1. **Dotted names**: `lib.schema` is a child of `lib`. Pure
+       syntactic — always active.
+
+    2. **`enterprise/X` shorthand**: `enterprise/X` is a child of the
+       OSS module `X` (a simple symbol with no namespace part), but
+       ONLY when `X` is actually declared in `declared-modules`. If
+       `X` isn't declared, `enterprise/X` is treated as top-level.
+       This branch is active only when the caller provides a
+       `declared-modules` set.
+
+  Examples:
+
+    (parent-module 'lib.schema)                 => 'lib
+    (parent-module 'lib.schema.foo)             => 'lib.schema
+    (parent-module 'lib)                        => nil
+    (parent-module 'enterprise/foo.bar)         => 'enterprise/foo
+    (parent-module 'enterprise/foo)             => nil       ; no shorthand without declared
+    (parent-module #{'foo} 'enterprise/foo)     => 'foo      ; shorthand: foo declared
+    (parent-module #{} 'enterprise/foo)         => nil       ; shorthand: foo not declared
+    (parent-module #{'foo} 'enterprise/other)   => nil       ; shorthand: other not declared"
+  ([m] (parent-module nil m))
+  ([declared-modules m]
+   (let [[ns-part parts] (split-module m)]
+     (cond
+       ;; Dotted name: pure syntactic parent.
+       (> (count parts) 1)
+       (join-module [ns-part (butlast parts)])
+
+       ;; `enterprise/X` shorthand: parent is OSS `X` if declared.
+       (and (= ns-part "enterprise") declared-modules)
+       (let [oss (symbol (first parts))]
+         (when (contains? declared-modules oss) oss))
+
+       :else nil))))
+
+(defn- ancestor-chain
+  "Seq of ancestor modules of `m`, from direct parent up to top-level ancestor.
+  Empty if `m` is top-level. Honors the `enterprise/X` shorthand when
+  `declared-modules` is provided."
+  ([m] (ancestor-chain nil m))
+  ([declared-modules m]
+   (take-while some?
+               (iterate #(parent-module declared-modules %)
+                        (parent-module declared-modules m)))))
+
+(defn- ancestor?
+  "True if `maybe-ancestor` is a strict ancestor of `maybe-descendant`
+  (parent, grandparent, etc., but not the module itself)."
+  ([a b] (ancestor? nil a b))
+  ([declared-modules maybe-ancestor maybe-descendant]
+   (boolean (some #(= maybe-ancestor %)
+                  (ancestor-chain declared-modules maybe-descendant)))))
+
+;;;; -------------------------------------------------------------------------
+;;;; Visibility rules
+;;;;
+;;;; Every dependency must be declared in `:uses`, with no exceptions and no
+;;;; inheriting from ancestors. Cross-module access goes through the target's
+;;;; `:api`, with exactly one tree-based exception: subtree trust, where a
+;;;; descendant may reach past its ancestors' `:api` (see
+;;;; [[allowed-module-namespace?]]). The trust is unidirectional — parents go
+;;;; through their children's `:api` like any other consumer, and siblings get
+;;;; nothing from each other. `:module-exports` controls a separate axis: which
+;;;; nested modules may be *named* at all from outside their subtree.
+;;;;
+;;;; The `:module-exports` config key on a module is a SET of direct-child module
+;;;; symbols that the parent explicitly promotes to externally-referenceable
+;;;; status. An unopened nested child is private to its top-level subtree:
+;;;; only modules sharing the same top-level ancestor may name it in their
+;;;; `:uses`. An opened child may be named by anyone. Either way, the
+;;;; dependency must be declared and the access must respect the target's
+;;;; `:api`.
+;;;;
+;;;; The opened-child-naming rule is enforced in two places. For set-valued
+;;;; `:uses` it's a property of the config declarations, checked by
+;;;; `uses-references-must-be-namable-test` in modules-test. Modules with
+;;;; `:uses :any` declare nothing for that test to validate, so for them the
+;;;; same rule is enforced here at require-lint time against the concrete
+;;;; resolved module (see [[namable-from?]] and [[usage-error]]).
+;;;;
+;;;; The helpers below also back config validation; at require-lint time the
+;;;; hook itself uses them only for the `:uses :any` namability check.
+;;;; -------------------------------------------------------------------------
+
+(defn- top-level-oss-module?
+  "True if `m` is a top-level OSS module symbol — i.e., no namespace part
+  and a name with no dots. `lib` qualifies; `lib.schema` does not (nested);
+  `enterprise/lib` does not (enterprise namespace part)."
+  [m]
+  (and (nil? (namespace m))
+       (not (str/includes? (name m) "."))))
+
+(defn- open-children
+  "Set of direct child module symbols that `parent` exposes. Combines the
+  explicit `:module-exports` set from config with the auto-opened `enterprise/X`
+  counterpart if `parent` is a top-level OSS module `X` and `enterprise/X`
+  is declared. The auto-open exists so that outside callers (e.g. the
+  `metabase-enterprise.core.init` loader chain) can statically reference
+  each OSS module's EE companion without needing to explicitly list it
+  in `:module-exports`."
+  [config parent]
+  (let [explicit (set (get-in config [:metabase/modules parent :module-exports]))
+        ee-child (when (top-level-oss-module? parent)
+                   (let [candidate (symbol "enterprise" (name parent))]
+                     (when (contains? (declared-modules config) candidate)
+                       candidate)))]
+    (cond-> explicit
+      ee-child (conj ee-child))))
+
+(defn- opens-child?
+  "True if `parent` exposes `child` via its `:module-exports` set (explicit or
+  auto-opened via the `enterprise/X` shorthand)."
+  [config parent child]
+  (contains? (open-children config parent) child))
+
+(defn- externally-visible?
+  "True if `m` may be named in the `:uses` of a module that is NOT in `m`'s
+  top-level subtree. This is the case iff `m` is top-level, OR `m`'s parent
+  has `m` in its `:module-exports` set AND the parent is itself externally visible.
+
+  Used by the subtree-membership lint to validate `:uses` declarations.
+  NOT used at require-lint time — requires are checked strictly against
+  the caller's declared `:uses` and the target's `:api`."
+  [config m]
+  (let [declared (declared-modules config)]
+    (loop [m m]
+      (if-let [p (parent-module declared m)]
+        (if (opens-child? config p m)
+          (recur p)
+          false)
+        true))))
+
+(defn- top-level-ancestor
+  "The top-level module at the root of `m`'s subtree, or `m` itself if it is top-level."
+  [declared-modules m]
+  (or (last (ancestor-chain declared-modules m)) m))
+
+(defn- namable-from?
+  "True if `current-module` may name `required-module` at all under the strict model: the target is
+  externally visible (top-level, or in `:module-exports` of every ancestor up to the root), or the two
+  share a top-level subtree. Mirrors `can-be-named-by?` in `metabase.core.modules-test`, which validates
+  declared `:uses` sets; this require-time version covers modules whose `:uses` is `:any` and therefore
+  declare nothing for that test to check."
+  [config current-module required-module]
+  (let [declared (declared-modules config)]
+    (or (externally-visible? config required-module)
+        (= (top-level-ancestor declared current-module)
+           (top-level-ancestor declared required-module)))))
+
+;;;; -------------------------------------------------------------------------
+;;;; Namespace → module resolution (prefix-map based)
+;;;;
+;;;; Each declared module has an effective `:ns-prefix` — the namespace-
+;;;; prefix string it owns. By convention the default prefix is derived
+;;;; from the module's symbol name (e.g. `lib.schema` defaults to
+;;;; `"metabase.lib.schema"`, `enterprise/transforms.python` defaults to
+;;;; `"metabase-enterprise.transforms.python"`). A module may override
+;;;; this with an explicit `:ns-prefix` in its config — used when the
+;;;; source files follow a different naming convention than the module
+;;;; tree (e.g. nesting `lib.be` as a child of `lib` while its source
+;;;; files remain `metabase.lib-be.*`).
+;;;;
+;;;; Resolution builds a prefix-string → module-symbol map from all
+;;;; declared modules and finds the longest matching prefix for the
+;;;; given namespace symbol, matching only at segment boundaries (so
+;;;; `metabase.lib.bert` never matches prefix `metabase.lib.be`).
+;;;; -------------------------------------------------------------------------
+
+(defn- default-ns-prefix
+  "Derive the default `:ns-prefix` for a module symbol. For a top-level
+  module `lib` this is `\"metabase.lib\"`. For a nested module `lib.schema`
+  it's `\"metabase.lib.schema\"`. For enterprise modules the prefix root is
+  `metabase-enterprise.` instead of `metabase.`.
+
+    (default-ns-prefix 'lib)                 => \"metabase.lib\"
+    (default-ns-prefix 'lib.schema)          => \"metabase.lib.schema\"
+    (default-ns-prefix 'enterprise/foo.bar)  => \"metabase-enterprise.foo.bar\""
+  [m]
+  (if (= (namespace m) "enterprise")
+    (str "metabase-enterprise." (name m))
+    (str "metabase." (name m))))
+
+(defn- module-ns-prefix
+  "Effective namespace prefix for a module: explicit `:ns-prefix` from the
+  module's config if set, else the name-derived default."
+  [config m]
+  (or (get-in config [:metabase/modules m :ns-prefix])
+      (default-ns-prefix m)))
+
+(defn- build-prefix->module
+  "Build the map of `ns-prefix-string → module-symbol` from all declared
+  modules. Used as the lookup table for longest-prefix resolution."
+  [config]
+  (into {}
+        (map (fn [m] [(module-ns-prefix config m) m]))
+        (keys (get config :metabase/modules))))
+
+(defonce ^:private prefix->module-cache
+  (atom nil))
+
+(defn- cached-prefix->module
+  [config]
+  (let [modules (:metabase/modules config)
+        cached  @prefix->module-cache]
+    (if (identical? modules (:modules cached))
+      (:prefix->module cached)
+      (let [prefix->module (build-prefix->module config)]
+        (reset! prefix->module-cache {:modules modules, :prefix->module prefix->module})
+        prefix->module))))
+
+(defn config
+  "Extract the module-linter config and precompute its namespace resolver."
+  [{:keys [config], :as _hook-input}]
+  (let [config (merge (get-in config [:linters :metabase/modules])
+                      (select-keys config [:metabase/modules]))]
+    (assoc config ::prefix->module (cached-prefix->module config))))
+
+(defn- ns-starts-with-prefix?
+  "True if namespace string `ns-str` is either exactly equal to `prefix` or
+  begins with `prefix` followed by a `.` (segment boundary). Prevents false
+  matches like `metabase.lib.bert` vs prefix `metabase.lib.be`."
+  [ns-str prefix]
+  (or (= ns-str prefix)
+      (str/starts-with? ns-str (str prefix "."))))
+
+(defn- longest-matching-prefix
+  "Scan `prefix->module` and return the module whose `:ns-prefix` is the
+  longest string prefix of `ns-str` at segment boundaries. Returns `nil`
+  if no declared module owns the namespace."
+  [prefix->module ns-str]
+  (second
+   (reduce-kv
+    (fn [[best-prefix :as best] prefix module]
+      (if (and (ns-starts-with-prefix? ns-str prefix)
+               (or (nil? best-prefix)
+                   (> (count prefix) (count best-prefix))))
+        [prefix module]
+        best))
+    nil
+    prefix->module)))
+
+(defn- normalize-test-namespace
+  "Normalize exact `-test` namespaces back to their module/source namespace
+  for module resolution.
+
+  This keeps namespace-based resolution aligned with file-path-based helpers
+  for module-level test files such as `test/metabase/lib/schema_test.cljc`,
+  whose declared namespace is `metabase.lib.schema-test` but whose owning
+  module should resolve as `lib.schema` rather than top-level `lib`."
+  [ns-symb]
+  (if (str/ends-with? (name ns-symb) "-test")
+    (symbol (str/replace (name ns-symb) #"-test$" ""))
+    ns-symb))
 
 (defn module
-  "E.g.
+  "Resolve a namespace symbol to the module symbol that owns it.
 
-    (module 'metabase.qp.middleware.wow) => 'qp
-    (module 'metabase-enterprise.whatever.core) => enterprise/whatever"
-  [ns-symb]
-  {:pre [(simple-symbol? ns-symb)]}
-  ;; treat something like `metabase.driver-test` (for a module that hasn't fully been updated to use `.core`
-  ;; namespaces) as being in the `driver` module
-  (let [ns-symb (if (str/ends-with? (name ns-symb) "-test")
-                  (symbol (str/replace (name ns-symb) #"-test$" ""))
-                  ns-symb)]
-    (or (some->> (re-find #"^metabase-enterprise\.([^.]+)" (str ns-symb))
-                 second
-                 (symbol "enterprise"))
-        (some-> (re-find #"^metabase\.([^.]+)" (str ns-symb))
-                second
-                symbol))))
+  Uses the `:ns-prefix` mechanism: each declared module has an effective
+  namespace prefix (explicit via `:ns-prefix` in config or derived from
+  the module's symbol name). Resolution is a longest-prefix match over
+  the set of declared prefixes at segment boundaries.
+
+  With one arg (legacy, used by callers without access to a config):
+  fall back to the single-segment first-element extraction — the flat
+  mapping behavior that predates nested modules. Equivalent to
+  `(module nil ns-symb)`.
+
+  With two args: if `config` is non-nil and declares modules, use the
+  prefix-map lookup. Falls through to the single-segment regex if no
+  declared prefix matches, preserving backwards compatibility.
+
+  CANONICAL: this function is the source-of-truth definition of the
+  namespace→module resolution algorithm. Two other sites duplicate its
+  behavior because they live in different classpath contexts and cannot
+  share code:
+
+    - dev/src/dev/deps_graph.clj              (namespace-symbol based)
+    - mage/src/mage/modules.clj/file->module  (file-path based)
+
+  If you change the algorithm here, update both of the above sites. The
+  consistency test `metabase.core.modules-consistency-test` verifies they
+  stay in sync.
+
+  Examples:
+
+    (module 'metabase.qp.middleware.wow)
+      => 'qp   ; single-segment fallback
+
+    (module config 'metabase.lib.schema.foo)
+      => 'lib.schema   ; if lib.schema is declared with default :ns-prefix
+
+    (module config 'metabase.lib-be.foo)
+      => 'lib.be       ; if lib.be declares :ns-prefix \"metabase.lib-be\"
+
+    (module 'metabase-enterprise.whatever.core)
+      => enterprise/whatever"
+  ([ns-symb] (module nil ns-symb))
+  ([config ns-symb]
+   {:pre [(simple-symbol? ns-symb)]}
+   ;; Treat exact `-test` namespaces as their source/module namespace so
+   ;; `metabase.lib.schema-test` resolves to `lib.schema`, while still
+   ;; supporting older flat cases like `metabase.driver-test` -> `driver`.
+   (let [ns-symb (normalize-test-namespace ns-symb)]
+     (or
+      ;; Primary path: prefix-map longest match over declared modules.
+      (when (seq (get config :metabase/modules))
+        (longest-matching-prefix (or (::prefix->module config)
+                                     (build-prefix->module config))
+                                 (str ns-symb)))
+      ;; Fallback: single-segment extraction via the original regexes.
+      ;; Preserved byte-for-byte so the consistency test can compare
+      ;; regex literals across the three mapping sites.
+      (some->> (re-find #"^metabase-enterprise\.([^.]+)" (str ns-symb))
+               second
+               (symbol "enterprise"))
+      (some-> (re-find #"^metabase\.([^.]+)" (str ns-symb))
+              second
+              symbol)))))
+
+;;;; -------------------------------------------------------------------------
+;;;; Access checks
+;;;; -------------------------------------------------------------------------
 
 (defn- module-api-namespaces
-  "Set of API namespace symbols for a given module. `:any` means you can use anything, there are no API namespaces for
-  this module (yet). If unspecified, the default is just the `<module>.core` namespace."
+  "Set of API namespace symbols for a given module. `:any` means you can use
+  anything, there are no API namespaces for this module (yet). If unspecified,
+  the default is the module's `.api`, `.core`, and `.init` namespaces derived
+  from the effective `:ns-prefix` (which may be explicit or name-derived)."
   [config module]
   (let [module-config (get-in config [:metabase/modules module :api])]
     (cond
@@ -44,17 +390,15 @@
       module-config
 
       :else
-      (let [ns-prefix (if (= (namespace module) "enterprise")
-                        (str "metabase-enterprise." (name module))
-                        (name module))]
+      (let [ns-prefix (module-ns-prefix config module)]
         #{(symbol (str ns-prefix ".api"))
           (symbol (str ns-prefix ".core"))
           (symbol (str ns-prefix ".init"))}))))
 
 (defn- module-friends
-  [config module]
   "Set of modules that are `:friends` of `module`, i.e. allowed to use *any* namespace from the module, not just the
   designated [[module-api-namespaces]]."
+  [config module]
   (set (get-in config [:metabase/modules module :friends])))
 
 (defn allowed-modules
@@ -62,34 +406,117 @@
   [config module]
   (get-in config [:metabase/modules module :uses]))
 
-(defn allowed-module? [config module required-module]
-  (let [allowed-modules (allowed-modules config module)]
+(defn allowed-module?
+  "True if `current-module` is allowed to depend on `required-module` based on
+  `current-module`'s `:uses` declaration.
+
+  Strict exact-match: the resolved required module must be a literal entry
+  in `current-module`'s `:uses` set. There is no walking of `:module-exports` chains,
+  no inheriting from ancestors. If `lib.schema` is what the require resolves
+  to, then `:uses #{lib.schema}` is what's required — `:uses #{lib}` does
+  NOT cover it.
+
+  The `:any` value is the one wildcard: a module declared `:uses :any` may
+  depend on anything (subject to the orthogonal subtree-membership rules
+  enforced at config-validation time)."
+  [config current-module required-module]
+  (let [allowed-modules (allowed-modules config current-module)]
     (or (= allowed-modules :any)
-        (contains? (set allowed-modules) required-module))))
+        ;; coerce to a set: `:uses` is normally a set, but a hand-edited vector would make `contains?`
+        ;; test index membership and reject every legitimately-declared dependency.
+        (boolean (contains? (set allowed-modules) required-module)))))
 
-(defn- allowed-module-namespace? [config current-module ns-symb]
-  (let [module                (module ns-symb)
-        module-api-namespaces (module-api-namespaces config module)
-        module-friends        (module-friends config module)]
-    (or (nil? module-api-namespaces)
-        (contains? module-api-namespaces ns-symb)
-        (contains? module-friends current-module))))
+(defn- rest-module?
+  "Whether `module` is a canonical nested `.rest` module or uses the deprecated `-rest` compatibility form."
+  [module]
+  (let [module-name (str module)]
+    (or (str/ends-with? module-name "-rest")
+        (str/ends-with? module-name ".rest"))))
 
-(defn- rest-module? [module]
-  (str/ends-with? module "-rest"))
+(defn- routes-module?
+  "Whether `module` is a route aggregator allowed to assemble REST routes."
+  [module]
+  (let [module-name (str module)]
+    (or (str/ends-with? module-name "-routes")
+        (str/ends-with? module-name ".routes"))))
 
-(defn- routes-module? [module]
-  (str/ends-with? module "-routes"))
+(defn- core-module?
+  "Whether `module` is a core initializer allowed to load route aggregators."
+  [module]
+  (= (name module) "core"))
 
-(defn- core-module? [module]
-  (str/ends-with? module "core"))
+(defn- allowed-rest-consumer?
+  "Whether `module` may depend on REST modules."
+  [module]
+  ((some-fn rest-module? routes-module? core-module?) module))
+
+(defn- descendant-of?
+  "True if `viewer` is a descendant of `viewed` in the module tree (or they
+  are the same module). Used for subtree trust — descendants are allowed
+  to reach into their ancestors' internals past `:api`, but NOT the other
+  way around. The `:api` is the outward-facing contract of a module; even
+  its parent must respect it when reaching in.
+
+  This is asymmetric on purpose: parent → child goes through the child's
+  `:api`, child → parent bypasses `:api` (subject to the normal `:uses`
+  declaration requirement)."
+  [declared-modules viewer viewed]
+  (or (= viewer viewed)
+      (ancestor? declared-modules viewed viewer)))
+
+(defn- allowed-module-namespace?
+  "True if `ns-symb` (the namespace being required) is an allowed reference
+  from `current-module`.
+
+  Two access paths:
+
+    1. **Subtree trust (descendants only)**: if `current-module` is a
+       descendant of the resolved required module (or the same module),
+       the access is allowed regardless of `:api`. A descendant is
+       conceptually inside its ancestor and can see past the ancestor's
+       public contract. The `:uses` declaration is still required, so
+       the dependency is still recorded in the module graph — what's
+       relaxed is only the `:api` restriction. Note that this is
+       UNIDIRECTIONAL: a parent reaching into its child's internals is
+       NOT allowed — the parent must go through the child's `:api` like
+       any other consumer.
+
+    2. **Standard `:api` check**: for all other relationships (parent
+       reading child, siblings, cousins, unrelated), the required
+       namespace must be in the required module's `:api` set, OR
+       `current-module` must appear in the required module's `:friends`
+       list (as an audited bypass)."
+  [config current-module ns-symb]
+  (let [required-module (module config ns-symb)
+        declared        (declared-modules config)]
+    (if (descendant-of? declared current-module required-module)
+      true
+      (let [api-namespaces (module-api-namespaces config required-module)
+            friends        (module-friends config required-module)]
+        (or (nil? api-namespaces)
+            (contains? api-namespaces ns-symb)
+            (contains? friends current-module))))))
 
 (defn usage-error
-  "Find usage errors when a `required-namespace` is required in the `current-module`. Returns a string describing the
-  error type if there is one, otherwise `nil` if there are no errors."
-  [config current-module required-namespace]
+  "Find usage errors when a `required-namespace` is required from `current-ns`
+  (which belongs to `current-module`). Returns a string describing the error
+  type if there is one, otherwise `nil` if there are no errors.
+
+  The required module must be in current's `:uses` (always, even between
+  relatives), and the required namespace must be in the required module's
+  `:api` — unless current is a descendant of the required module (subtree
+  trust) or appears in its `:friends`. Non-REST modules may not depend on REST
+  modules, except for route aggregators and core initializers. See
+  [[allowed-module-namespace?]] for the access-path details. When current's
+  `:uses` is `:any`, the namability rule (see [[namable-from?]]) is additionally
+  enforced here, since the config-level test only covers set-valued `:uses`.
+
+  `current-ns` is accepted but currently unused by the check. It's kept in
+  the signature because the hook callers already have it handy and future
+  lints may want the caller namespace for more precise error messages."
+  [config _current-ns current-module required-namespace]
   ;; ignore stuff not in a module i.e. non-Metabase stuff.
-  (when-let [required-module (module required-namespace)]
+  (when-let [required-module (module config required-namespace)]
     (when-not (= current-module required-module)
       (cond
         (not (allowed-module? config current-module required-module))
@@ -98,19 +525,26 @@
                 current-module
                 current-module)
 
+        (and (not (allowed-rest-consumer? current-module))
+             (rest-module? required-module))
+        (format "Do not use REST modules (%s) in non-REST modules (%s) -- move things from %s to %s if needed"
+                required-module
+                current-module
+                required-module
+                (symbol (str/replace (str required-module) #"(?:-rest|\.rest)$" "")))
+
+        ;; `:uses :any` skips the declaration-level namability test (it only validates set-valued
+        ;; `:uses`), so enforce the same rule here against the concrete resolved module.
+        (and (= (allowed-modules config current-module) :any)
+             (not (namable-from? config current-module required-module)))
+        (format "Module %s is nested and not exported by its ancestors; %s may not use it. Add it to its parent's :module-exports chain, or move the caller into the %s subtree. [:metabase/modules %s :module-exports]"
+                required-module
+                current-module
+                (top-level-ancestor (declared-modules config) required-module)
+                (parent-module (declared-modules config) required-module))
+
         (not (allowed-module-namespace? config current-module required-namespace))
         (format "Namespace %s is not an allowed external API namespace for the %s module. [:metabase/modules %s :api]"
                 required-namespace
                 required-module
-                required-module)
-
-        ;; (for now) rest modules are allowed to use one another; `routes` is ok because it collects routes together
-        ;; and `core` is ok because [[metabase.core.init]] might need to init some of the `-routes` modules'
-        ;; namespaces
-        (and (not ((some-fn rest-module? routes-module? core-module?) current-module))
-             (rest-module? required-module))
-        (format "Do not use -rest modules (%s) in non-rest modules (%s) -- move things from %s to %s if needed"
-                required-module
-                current-module
-                required-module
-                (symbol (str/replace required-module #"-rest$" "")))))))
+                required-module)))))

--- a/.clj-kondo/src/hooks/common/modules.clj
+++ b/.clj-kondo/src/hooks/common/modules.clj
@@ -277,7 +277,7 @@
     (str "metabase-enterprise." (name m))
     (str "metabase." (name m))))
 
-(defn- module-ns-prefix
+(defn module-ns-prefix
   "Effective namespace prefix for a module: explicit `:ns-prefix` from the
   module's config if set, else the name-derived default."
   [config m]

--- a/.clj-kondo/src/hooks/metabase/toucan/db_ns.clj
+++ b/.clj-kondo/src/hooks/metabase/toucan/db_ns.clj
@@ -1,20 +1,11 @@
 (ns hooks.metabase.toucan.db-ns
-  "Lint that application database query calls -- Toucan 2's `t2/select`, `t2/query`, `t2/insert!`, `t2/update!`,
-  `t2/delete!` and friends, plus the `metabase.app-db.core` wrappers around them such as `mdb/query` and
-  `mdb/update-or-insert!` -- live in a module's own `db` namespace. Every other namespace in a module goes
-  through those functions instead of talking to the application database directly.
+  "Lints application database calls -- Toucan 2's `t2/select`, `t2/query`, `t2/insert!` and friends, plus
+  the `metabase.app-db.core` wrappers such as `mdb/query` -- outside their module's `db` namespace.
 
-  A module owns exactly one such namespace: its effective `:ns-prefix` plus `.db`. That is `metabase.queries.db`
-  for a top-level module and `metabase.metabot.llm.db` for a nested one, so a submodule keeps its own queries
-  rather than pushing them up into its parent. Resolving through the module config rather than matching the
-  shape of the name is what separates a submodule's `db` from `metabase.queries.models.db`, which names no
-  module and stays a finding.
+  A module's `db` namespace is its effective `:ns-prefix` plus `.db`: `metabase.queries.db` for a top-level
+  module, `metabase.metabot.llm.db` for a nested one. Driver namespaces and test files are exempt.
 
-  Driver modules are the exception: individual drivers are not declared modules, so `metabase.driver.<driver>.db`
-  is allowed by name.
-
-  Registered as an `:analyze-call` hook on each of those functions in `.clj-kondo/config.edn`. The hook
-  returns its input unchanged so Kondo's normal analysis of the call (arity, var usage) still runs."
+  Registered as an `:analyze-call` hook on each of those functions in `.clj-kondo/config.edn`."
   (:require
    [clj-kondo.hooks-api :as hooks]
    [hooks.common.modules :as modules]))
@@ -28,6 +19,8 @@
   [config ns-symb]
   (let [ns-str (name ns-symb)]
     (boolean
+     ;; Resolved through the module config rather than matched by name: `metabase.queries.models.db` is
+     ;; shaped like a module db namespace but names no module, and has to stay a finding.
      (or (when-let [module (modules/module config ns-symb)]
            (= ns-str (str (modules/module-ns-prefix config module) ".db")))
          (re-matches driver-db-namespace ns-str)))))
@@ -39,8 +32,8 @@
   (boolean (and filename (re-find #"(?:^|/)test/" filename))))
 
 (defn lint-query-call
-  "Register a `:metabase/t2-query-namespace` finding when a Toucan 2 query call appears outside its module's
-  `db` namespace."
+  "Registers a `:metabase/t2-query-namespace` finding when the call in `input` sits outside its module's `db`
+  namespace. Returns `input` unchanged, so Kondo's own analysis of the call still runs."
   [{:keys [node ns filename] :as input}]
   (when (and ns
              (not (db-namespace? (modules/config input) ns))
@@ -48,7 +41,7 @@
     (let [fn-node (first (:children node))]
       (hooks/reg-finding!
        (assoc (meta fn-node)
-              :message (format "Application database query calls like `%s` must live in their module's db namespace (`<module>.db`, at whatever depth the module sits, or `metabase.driver.<driver>.db`)"
+              :message (format "Application database calls like `%s` belong in their module's `db` namespace"
                                (hooks/sexpr fn-node))
               :type :metabase/t2-query-namespace))))
   input)

--- a/.clj-kondo/src/hooks/metabase/toucan/db_ns.clj
+++ b/.clj-kondo/src/hooks/metabase/toucan/db_ns.clj
@@ -1,17 +1,36 @@
 (ns hooks.metabase.toucan.db-ns
   "Lint that application database query calls -- Toucan 2's `t2/select`, `t2/query`, `t2/insert!`, `t2/update!`,
   `t2/delete!` and friends, plus the `metabase.app-db.core` wrappers around them such as `mdb/query` and
-  `mdb/update-or-insert!` -- live in a module's `db` namespace, i.e. `metabase[-enterprise].<module>.db` (or `metabase.driver.<driver>.db` for
-  driver modules). Every other namespace in a module goes through those functions instead of talking to the
-  application database directly.
+  `mdb/update-or-insert!` -- live in a module's own `db` namespace. Every other namespace in a module goes
+  through those functions instead of talking to the application database directly.
+
+  A module owns exactly one such namespace: its effective `:ns-prefix` plus `.db`. That is `metabase.queries.db`
+  for a top-level module and `metabase.metabot.llm.db` for a nested one, so a submodule keeps its own queries
+  rather than pushing them up into its parent. Resolving through the module config rather than matching the
+  shape of the name is what separates a submodule's `db` from `metabase.queries.models.db`, which names no
+  module and stays a finding.
+
+  Driver modules are the exception: individual drivers are not declared modules, so `metabase.driver.<driver>.db`
+  is allowed by name.
 
   Registered as an `:analyze-call` hook on each of those functions in `.clj-kondo/config.edn`. The hook
   returns its input unchanged so Kondo's normal analysis of the call (arity, var usage) still runs."
   (:require
-   [clj-kondo.hooks-api :as hooks]))
+   [clj-kondo.hooks-api :as hooks]
+   [hooks.common.modules :as modules]))
 
-(defn- db-namespace? [ns-sym]
-  (boolean (re-matches #"^metabase(?:-enterprise)?\.(?:driver\.)?[^.]+\.db$" (name ns-sym))))
+(def ^:private driver-db-namespace
+  "`metabase.driver.<driver>.db`. Drivers live under the one `driver` module, so no `:ns-prefix` names them."
+  #"^metabase\.driver\.[^.]+\.db$")
+
+(defn- db-namespace?
+  "Whether `ns-symb` is the `db` namespace of the module that owns it."
+  [config ns-symb]
+  (let [ns-str (name ns-symb)]
+    (boolean
+     (or (when-let [module (modules/module config ns-symb)]
+           (= ns-str (str (modules/module-ns-prefix config module) ".db")))
+         (re-matches driver-db-namespace ns-str)))))
 
 (defn- test-file?
   "Whether `filename` is in a test source tree. Test namespaces are exempt through the `test-namespaces` group in
@@ -20,16 +39,16 @@
   (boolean (and filename (re-find #"(?:^|/)test/" filename))))
 
 (defn lint-query-call
-  "Register a `:metabase/t2-query-namespace` finding when a Toucan 2 query call appears outside a `<module>.db`
-  namespace."
+  "Register a `:metabase/t2-query-namespace` finding when a Toucan 2 query call appears outside its module's
+  `db` namespace."
   [{:keys [node ns filename] :as input}]
   (when (and ns
-             (not (db-namespace? ns))
+             (not (db-namespace? (modules/config input) ns))
              (not (test-file? filename)))
     (let [fn-node (first (:children node))]
       (hooks/reg-finding!
        (assoc (meta fn-node)
-              :message (format "Application database query calls like `%s` must live in metabase[-enterprise].<module>.db (or metabase.driver.<driver>.db) namespaces"
+              :message (format "Application database query calls like `%s` must live in their module's db namespace (`<module>.db`, at whatever depth the module sits, or `metabase.driver.<driver>.db`)"
                                (hooks/sexpr fn-node))
               :type :metabase/t2-query-namespace))))
   input)

--- a/.clj-kondo/test/hooks/metabase/toucan/db_ns_test.clj
+++ b/.clj-kondo/test/hooks/metabase/toucan/db_ns_test.clj
@@ -5,14 +5,19 @@
    [clojure.test :refer :all]
    [hooks.metabase.toucan.db-ns :as toucan.db-ns]))
 
-(defn- lint-query-call [form ns-sym & [filename]]
+(defn- lint-query-call
+  "Run the hook over `form` as if it appeared in `ns-sym`. `:modules` is the `:metabase/modules` map the module
+  linter would supply; without it the hook falls back to single-segment resolution, which is what a repo with no
+  nested modules declared looks like."
+  [form ns-sym & {:keys [filename modules]}]
   (binding [clj-kondo.impl.utils/*ctx* {:config     {:linters {:metabase/t2-query-namespace {:level :warning}}}
                                         :ignores    (atom nil)
                                         :findings   (atom [])
                                         :namespaces (atom {})}]
     (let [input  {:node     (hooks/parse-string (pr-str form))
                   :ns       ns-sym
-                  :filename (or filename "src/metabase/foo/bar.clj")}
+                  :filename (or filename "src/metabase/foo/bar.clj")
+                  :config   (when modules {:metabase/modules modules})}
           output (toucan.db-ns/lint-query-call input)]
       (is (identical? (:node input) (:node output))
           "the hook must return the node unchanged so Kondo's normal analysis still runs")
@@ -37,9 +42,9 @@
             (lint-query-call '(t2/delete! :model/Card :id 1) 'metabase.queries.dashboards-db))))
   (testing "files in a test source tree are exempt even when the namespace name doesn't look like a test"
     (is (empty? (lint-query-call '(t2/update! :model/User 1 {:sso_source nil}) 'metabase.sso.test-helpers
-                                 "test/metabase/sso/test_helpers.clj")))
+                                 :filename "test/metabase/sso/test_helpers.clj")))
     (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase-enterprise.remote-sync.test-helpers
-                                 "/repo/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj"))))
+                                 :filename "/repo/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj"))))
   (testing "app-db wrappers around Toucan 2 are reported the same way"
     (is (=? [{:type    :metabase/t2-query-namespace
               :message #".*`mdb/update-or-insert!`.*"}]
@@ -48,3 +53,25 @@
     (is (=? [{:type    :metabase/t2-query-namespace
               :message #".*`toucan2.core/insert!`.*"}]
             (lint-query-call '(toucan2.core/insert! :model/Card {}) 'metabase.queries.models.card)))))
+
+(deftest ^:parallel t2-query-namespace-follows-the-module-tree-test
+  (let [modules '{queries      {}
+                  metabot      {}
+                  metabot.llm  {}
+                  lib.be       {:ns-prefix "metabase.lib-be"}
+                  enterprise/sandbox {}}]
+    (testing "a nested module owns its own db namespace"
+      (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase.metabot.llm.db :modules modules))))
+    (testing "the parent's db namespace stays its own"
+      (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase.metabot.db :modules modules))))
+    (testing "a module with an explicit :ns-prefix is resolved through it, not through its dotted name"
+      (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase.lib-be.db :modules modules)))
+      (is (=? [{:type :metabase/t2-query-namespace}]
+              (lint-query-call '(t2/select :model/Card) 'metabase.lib.be.db :modules modules))))
+    (testing "a db namespace under a directory that names no module is still a finding"
+      (is (=? [{:type :metabase/t2-query-namespace}]
+              (lint-query-call '(t2/query {:select [:*]}) 'metabase.queries.models.db :modules modules)))
+      (is (=? [{:type :metabase/t2-query-namespace}]
+              (lint-query-call '(t2/query {:select [:*]}) 'metabase.metabot.llm.models.db :modules modules))))
+    (testing "enterprise modules resolve through the metabase-enterprise root"
+      (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase-enterprise.sandbox.db :modules modules))))))

--- a/.clj-kondo/test/hooks/metabase/toucan/db_ns_test.clj
+++ b/.clj-kondo/test/hooks/metabase/toucan/db_ns_test.clj
@@ -6,9 +6,8 @@
    [hooks.metabase.toucan.db-ns :as toucan.db-ns]))
 
 (defn- lint-query-call
-  "Run the hook over `form` as if it appeared in `ns-sym`. `:modules` is the `:metabase/modules` map the module
-  linter would supply; without it the hook falls back to single-segment resolution, which is what a repo with no
-  nested modules declared looks like."
+  "Runs the hook over `form` as if it appeared in `ns-sym`, with optional `filename` and `modules` (the
+  `:metabase/modules` map). Returns the findings it registered."
   [form ns-sym & {:keys [filename modules]}]
   (binding [clj-kondo.impl.utils/*ctx* {:config     {:linters {:metabase/t2-query-namespace {:level :warning}}}
                                         :ignores    (atom nil)
@@ -41,10 +40,13 @@
     (is (=? [{:type :metabase/t2-query-namespace}]
             (lint-query-call '(t2/delete! :model/Card :id 1) 'metabase.queries.dashboards-db))))
   (testing "files in a test source tree are exempt even when the namespace name doesn't look like a test"
-    (is (empty? (lint-query-call '(t2/update! :model/User 1 {:sso_source nil}) 'metabase.sso.test-helpers
+    (is (empty? (lint-query-call '(t2/update! :model/User 1 {:sso_source nil})
+                                 'metabase.sso.test-helpers
                                  :filename "test/metabase/sso/test_helpers.clj")))
-    (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase-enterprise.remote-sync.test-helpers
-                                 :filename "/repo/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj"))))
+    (is (empty? (lint-query-call '(t2/select :model/Card)
+                                 'metabase-enterprise.remote-sync.test-helpers
+                                 :filename (str "/repo/enterprise/backend/test/metabase_enterprise"
+                                                "/remote_sync/test_helpers.clj")))))
   (testing "app-db wrappers around Toucan 2 are reported the same way"
     (is (=? [{:type    :metabase/t2-query-namespace
               :message #".*`mdb/update-or-insert!`.*"}]
@@ -64,14 +66,15 @@
       (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase.metabot.llm.db :modules modules))))
     (testing "the parent's db namespace stays its own"
       (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase.metabot.db :modules modules))))
-    (testing "a module with an explicit :ns-prefix is resolved through it, not through its dotted name"
+    (testing "a module with an explicit :ns-prefix is resolved through it, not its dotted name"
       (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase.lib-be.db :modules modules)))
       (is (=? [{:type :metabase/t2-query-namespace}]
               (lint-query-call '(t2/select :model/Card) 'metabase.lib.be.db :modules modules))))
-    (testing "a db namespace under a directory that names no module is still a finding"
+    (testing "a db namespace under a directory naming no module is still a finding"
       (is (=? [{:type :metabase/t2-query-namespace}]
               (lint-query-call '(t2/query {:select [:*]}) 'metabase.queries.models.db :modules modules)))
       (is (=? [{:type :metabase/t2-query-namespace}]
               (lint-query-call '(t2/query {:select [:*]}) 'metabase.metabot.llm.models.db :modules modules))))
     (testing "enterprise modules resolve through the metabase-enterprise root"
-      (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase-enterprise.sandbox.db :modules modules))))))
+      (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase-enterprise.sandbox.db
+                                   :modules modules))))))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,11 +81,12 @@ modules need reordering) are printed as `WARNING:` lines for you to resolve by h
 Two committed tracking files sit next to the config:
 
 - `ratchets.edn` — anti-pattern counts that may only go down (friend edges and reaches, `:any` escapes,
-  driver-test exemptions, legacy `-rest` modules). `./bin/mage modules-validate --update-ratchets`
-  blesses decreases; an increase needs a hand edit justified in the commit message.
+  top-level module count, cross-subtree cycle pairs, driver-test exemptions, legacy `-rest` modules).
+  `./bin/mage modules-validate --update-ratchets` blesses decreases; an increase needs a hand edit
+  justified in the commit message.
 - `module-stats.edn` — surface and coupling sizes expected to move in both directions (total/largest
-  `:api`, module count, `:api :any` namespace exposure, largest-SCC sizes at module and namespace
-  granularity). `fix-modules-config` rewrites it; the PR diff is the review signal.
+  `:api`, module counts, `:module-exports`, `:api :any` namespace exposure, largest-SCC sizes at module
+  and namespace granularity). `fix-modules-config` rewrites it; the PR diff is the review signal.
 
 `driver-test-overrides.edn` holds the CI driver-test exemption set (consumed by `mage`'s
 affected-modules logic); `metabase.core.modules-test` fails entries the dependency graph no longer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,11 +81,12 @@ modules need reordering) are printed as `WARNING:` lines for you to resolve by h
 Two committed tracking files sit next to the config:
 
 - `ratchets.edn` — anti-pattern counts that may only go down (friend edges and reaches, `:any` escapes,
-  driver-test exemptions, standalone `-rest` modules). `./bin/mage modules-validate --update-ratchets`
+  top-level module count, cross-subtree cycle pairs, driver-test exemptions and the modules that still
+  trigger driver tests, standalone `-rest` modules). `./bin/mage modules-validate --update-ratchets`
   blesses decreases; an increase needs a hand edit justified in the commit message.
 - `module-stats.edn` — surface and coupling sizes expected to move in both directions (total/largest
-  `:api`, module count, `:api :any` namespace exposure, largest-SCC sizes at module and namespace
-  granularity). `fix-modules-config` rewrites it; the PR diff is the review signal.
+  `:api`, module counts, `:module-exports`, `:api :any` namespace exposure, largest-SCC sizes at module
+  and namespace granularity). `fix-modules-config` rewrites it; the PR diff is the review signal.
 
 `driver-test-overrides.edn` holds the CI driver-test exemption set (consumed by `mage`'s
 affected-modules logic); `metabase.core.modules-test` fails entries the dependency graph no longer

--- a/bb.edn
+++ b/bb.edn
@@ -268,9 +268,19 @@
    :requires [[mage.modules]]
    :task (task! (mage.modules/cli-validate-config! parsed))}
 
+  modules-expanded-config
+  {:doc "Print module config with inherited values, defaults, and wildcards expanded"
+   :examples [["./bin/mage modules-expanded-config" "Print effective module config as EDN"]]
+   :requires [[mage.modules]]
+   :task (task! (mage.modules/cli-print-expanded-config! parsed))}
+
   modules-tree
-  {:doc "Print the declared modules, one per line, enterprise modules last"
-   :examples [["./bin/mage modules-tree" "Print every declared module"]]
+  {:doc "Print the module hierarchy as a tree (enterprise extensions nested under the module they extend)"
+   :examples [["./bin/mage modules-tree" "Print the full module tree; * marks modules kept in place via :ns-prefix"]
+              ["./bin/mage modules-tree --nested-only" "Only print modules that have nested children"]
+              ["./bin/mage modules-tree --prefixes" "Print the :ns-prefix instead of the star"]]
+   :options [["-n" "--nested-only" "Only print modules that have nested children"]
+             ["-p" "--prefixes" "Print the :ns-prefix instead of the star"]]
    :requires [[mage.modules]]
    :task (task! (mage.modules/cli-print-module-tree parsed))}
 

--- a/bb.edn
+++ b/bb.edn
@@ -267,9 +267,19 @@
    :requires [[mage.modules]]
    :task (task! (mage.modules/cli-validate-config! parsed))}
 
+  modules-expanded-config
+  {:doc "Print module config with inherited values, defaults, and wildcards expanded"
+   :examples [["./bin/mage modules-expanded-config" "Print effective module config as EDN"]]
+   :requires [[mage.modules]]
+   :task (task! (mage.modules/cli-print-expanded-config! parsed))}
+
   modules-tree
-  {:doc "Print the declared modules, one per line, enterprise modules last"
-   :examples [["./bin/mage modules-tree" "Print every declared module"]]
+  {:doc "Print the module hierarchy as a tree (enterprise extensions nested under the module they extend)"
+   :examples [["./bin/mage modules-tree" "Print the full module tree; * marks modules kept in place via :ns-prefix"]
+              ["./bin/mage modules-tree --nested-only" "Only print modules that have nested children"]
+              ["./bin/mage modules-tree --prefixes" "Print the :ns-prefix instead of the star"]]
+   :options [["-n" "--nested-only" "Only print modules that have nested children"]
+             ["-p" "--prefixes" "Print the :ns-prefix instead of the star"]]
    :requires [[mage.modules]]
    :task (task! (mage.modules/cli-print-module-tree parsed))}
 

--- a/dev/src/dev/deps_graph.clj
+++ b/dev/src/dev/deps_graph.clj
@@ -951,25 +951,24 @@
       (symbol (str prefix ".core"))
       (symbol (str prefix ".init"))}))
 
-(defn- module-top-level-ancestor
-  [declared-modules module]
-  (or (last (module-ancestor-chain declared-modules module)) module))
-
-(defn- externally-referenceable-module?
+(defn- module-visibility-root
+  "The module whose subtree `module` is private to, or `nil` if it may be named from anywhere.
+  Mirror of `hooks.common.modules/visibility-root` — see that function for the semantics."
   [config module]
   (let [declared-modules (set (keys config))]
     (loop [module module]
-      (if-let [parent (module-parent declared-modules module)]
-        (and (contains? (expanded-module-exports config parent) module)
-             (recur parent))
-        true))))
+      (when-let [parent (module-parent declared-modules module)]
+        (if (contains? (expanded-module-exports config parent) module)
+          (recur parent)
+          parent)))))
 
 (defn- module-namable-from?
   [config caller target]
-  (let [declared-modules (set (keys config))]
-    (or (= (module-top-level-ancestor declared-modules caller)
-           (module-top-level-ancestor declared-modules target))
-        (externally-referenceable-module? config target))))
+  (let [declared-modules (set (keys config))
+        root             (module-visibility-root config target)]
+    (or (nil? root)
+        (= root caller)
+        (boolean (some #(= root %) (module-ancestor-chain declared-modules caller))))))
 
 (defn- expanded-module-uses
   [config module]

--- a/dev/src/dev/deps_graph.clj
+++ b/dev/src/dev/deps_graph.clj
@@ -676,16 +676,10 @@
    (let [fd (partial file-dependencies prefix->module)]
      (map fd (find-source-files)))))
 
-(defn configured-dependencies
-  "Scan dependencies using every declared module's effective namespace prefix."
-  []
-  (let [config (kondo-config)]
-    (dependencies (build-prefix->module config))))
-
 (defn external-usages
   "All usages of a module named by `module-symb` outside that module."
   ([module-symb]
-   (external-usages (configured-dependencies) module-symb))
+   (external-usages (dependencies) module-symb))
 
   ([deps module-symb]
    (for [dep    deps
@@ -700,7 +694,7 @@
 (defn external-usages-by-namespace
   "Return a map of module namespace => set of external namespaces using it"
   ([module-symb]
-   (external-usages-by-namespace (configured-dependencies) module-symb))
+   (external-usages-by-namespace (dependencies) module-symb))
 
   ([deps module-symb]
    (into (sorted-map)
@@ -808,7 +802,7 @@
 (defn module-usages-of-other-module
   "Information about how `module-x` uses `module-y`."
   ([module-x module-y]
-   (module-usages-of-other-module (configured-dependencies) module-x module-y))
+   (module-usages-of-other-module (dependencies) module-x module-y))
 
   ([deps module-x module-y]
    (let [module-x-ns->module-y-ns (->> (external-usages deps module-y)
@@ -1085,7 +1079,7 @@
     {api      []                         ; settings depends on api directly
      api-keys [permissions collections]} ; settings depends on permissions which depends on collections which depends on api-keys"
   ([module]
-   (all-module-deps-paths (configured-dependencies) module))
+   (all-module-deps-paths (dependencies) module))
   ([deps module]
    (all-module-deps-paths deps module (sorted-map) (atom #{}) []))
   ([deps module acc already-seen path]
@@ -1115,7 +1109,7 @@
               ...}
      ...}"
   ([module]
-   (module-dependencies-by-namespace (configured-dependencies) module))
+   (module-dependencies-by-namespace (dependencies) module))
 
   ([deps module]
    (into (sorted-map)
@@ -1133,7 +1127,7 @@
     ;; =>
     #{request}"
   [module namespace-symb-or-set]
-  (let [deps            (configured-dependencies)
+  (let [deps            (dependencies)
         namespace-symbs (if (symbol? namespace-symb-or-set)
                           #{namespace-symb-or-set}
                           namespace-symb-or-set)
@@ -1147,7 +1141,7 @@
 (defn leaf-modules
   "Modules that are leaf nodes in the module dependency tree -- nothing else depends on them."
   ([]
-   (leaf-modules (configured-dependencies)))
+   (leaf-modules (dependencies)))
   ([deps]
    (into (sorted-set)
          (comp (map :module)
@@ -1160,7 +1154,7 @@
   "Modules that `module` does not depend on, either directly or indirectly -- changes to any of these modules should not
   affect `module`."
   [module]
-  (let [deps        (configured-dependencies)
+  (let [deps        (dependencies)
         all-modules (into (sorted-set) (map :module) deps)
         module-deps (set (keys (all-module-deps-paths deps module)))]
     #_{:clj-kondo/ignore [:discouraged-var]}
@@ -1286,7 +1280,7 @@
 (defn- indirect-dependents
   "Set of modules that either directly or indirectly depend on `module`."
   ([module]
-   (indirect-dependents (configured-dependencies) module))
+   (indirect-dependents (dependencies) module))
   ([deps module]
    (indirect-dependents deps module (sorted-set)))
   ([deps module acc]

--- a/dev/src/dev/deps_graph.clj
+++ b/dev/src/dev/deps_graph.clj
@@ -67,7 +67,8 @@
   []
   (edn/read-string (slurp driver-test-overrides-path)))
 
-(declare kondo-config external-usages module-dependencies dependencies module->test-files)
+(declare kondo-config module-parent module-ancestor-chain external-usages module-dependencies
+         dependencies build-prefix->module default-ns-prefix module-team module->test-files)
 
 (defn friend-reach-count
   "Number of actual privileged reaches: (friend namespace → internal namespace) require pairs that are
@@ -86,6 +87,23 @@
                       (and (contains? friends module)
                            (not (contains? api depends-on-namespace))))
                     (external-usages deps grantor))))))
+
+(defn cross-subtree-cycle-pair-count
+  "Number of mutually-dependent module pairs whose top-level ancestors differ. A cycle inside one
+  top-level subtree (a parent and its nested child requiring each other) is internal organization and
+  does not count; a mutual dependency between two different top-level subtrees does. Modules are NOT
+  collapsed to their subtree roots first — collapsing unions every child's dependencies into the root
+  and manufactures pairs no actual requires form, which would punish natural nesting."
+  [deps config]
+  (let [declared (set (keys config))
+        root     (fn [m] (or (last (module-ancestor-chain declared m)) m))
+        graph    (module-dependencies deps)]
+    (count (for [[m ds] graph
+                 d ds
+                 :when (and (neg? (compare m d)) ; count each unordered pair once
+                            (contains? (get graph d #{}) m)
+                            (not= (root m) (root d)))]
+             [m d]))))
 
 ;;; Tarjan SCC lives here rather than in `dev.module-scc` (which builds on it) so
 ;;; [[module-boundary-stats]] can size the components without a circular require.
@@ -148,14 +166,18 @@
   "Current module-boundary anti-pattern counts. One-way ratchets: each may only go down.
   Raising one is a deliberate act — edit `ratchets.edn` by hand and justify it in the commit."
   ([]
-   (module-boundary-debt (dependencies) (kondo-config)))
+   (let [config (kondo-config)]
+     (module-boundary-debt (dependencies (build-prefix->module config)) config)))
   ([deps config]
-   (let [values (vals config)]
+   (let [values   (vals config)
+         declared (set (keys config))]
      {:api-any               (count (filter #(= :any (:api %)) values))
       :friend-edges          (transduce (map (comp count :friends)) + 0 values)
       :friend-reaches        (friend-reach-count deps config)
+      :cross-subtree-cycle-pairs (cross-subtree-cycle-pair-count deps config)
       :driver-test-exempt-modules (count (:exempt-modules (driver-test-overrides)))
       :legacy-rest-modules   (count (filter #(str/ends-with? (str %) "-rest") (keys config)))
+      :top-level-modules     (count (remove #(module-parent declared %) (keys config)))
       :uses-any              (count (filter #(= :any (:uses %)) values))})))
 
 (defn- deftest-form-count
@@ -170,10 +192,11 @@
   so the per-file maximum is the per-module maximum.
   Returns `{:test-namespaces _, :deftests _}` — the worst case counted in whole test namespaces and in
   individual `deftest` forms, each maximized over modules independently."
-  [deps]
-  (let [modules        (into (sorted-set) (keep :module) deps)
+  [deps config]
+  (let [prefix->mod    (build-prefix->module config)
+        modules        (into (sorted-set) (keep :module) deps)
         module->tests  (into {}
-                             (map (juxt identity module->test-files))
+                             (map (juxt identity #(module->test-files config prefix->mod %)))
                              modules)
         file->deftests (into {}
                              (map (juxt identity deftest-form-count))
@@ -198,13 +221,23 @@
      :deftests        (reduce max 0 (map #(transduce (keep file->deftests) + 0 %) blasts))}))
 
 (defn module-boundary-stats
-  "Public-surface size stats. Expected to move in both directions — carving a module out grows
-  `:total-api` while shrinking `:largest-api`, and neither direction is good or bad on its own.
-  Committed to `module-stats.edn` so PR diffs surface the movement for review.
+  "Public-surface size stats. Expected to move in both directions — carving a child module grows
+  `:total-api` and `:module-exports` while shrinking `:largest-api`, and none of those directions is
+  good or bad on its own. Committed to `module-stats.edn` so PR diffs surface the movement for review.
 
   `:api-any-namespaces` is the hidden surface of `:api :any` modules: every one of their namespaces is
   effectively public, so it is counted here namespace-weighted (the `:api-any` module count itself is a
   ratchet).
+
+  `:ns-prefix-overrides` counts modules whose `:ns-prefix` differs from their name-derived default —
+  each is a module name that lies about where its namespaces live, usually a config-only nesting whose
+  source rename hasn't happened yet. An explicit prefix equal to the default is documentation, not a
+  mismatch, and does not count. Expected to grow with config-only carves; a candidate ratchet once the
+  source renames catch up.
+
+  `:parent-team-mismatches` counts nested modules whose effective `:team` differs from their parent's.
+  Meaningless for top-level modules (no parent) and zero for children that inherit; in practice these are
+  `enterprise/X` companions owned by a different team than the OSS `X`. Moves with reorgs, hence a stat.
 
   The SCC stats size the mutual-dependency blob at both granularities; they grow with ordinary feature
   work inside the blob, hence stats rather than ratchets.
@@ -225,11 +258,13 @@
   ([]
    (module-boundary-stats nil))
   ([opts]
-   (module-boundary-stats (dependencies) (kondo-config) opts))
+   (let [config (kondo-config)]
+     (module-boundary-stats (dependencies (build-prefix->module config)) config opts)))
   ([deps config]
    (module-boundary-stats deps config nil))
   ([deps config {:keys [fast?]}]
    (let [values      (vals config)
+         declared    (set (keys config))
          api-sizes   (keep (fn [{:keys [api]}]
                              (when (set? api)
                                (count api)))
@@ -246,8 +281,18 @@
               :largest-scc-modules (count module-scc)
               :largest-scc-namespaces (count (filter #(contains? module-scc (:module %)) deps))
               :module-count       (count config)
+              :module-exports     (transduce (map (comp count :module-exports)) + 0 values)
+              :ns-prefix-overrides (count (filter (fn [[m {:keys [ns-prefix]}]]
+                                                    (and ns-prefix
+                                                         (not= ns-prefix (default-ns-prefix m))))
+                                                  config))
+              :parent-team-mismatches (count (filter (fn [m]
+                                                       (when-let [parent (module-parent declared m)]
+                                                         (not= (module-team config m)
+                                                               (module-team config parent))))
+                                                     declared))
               :total-api          (reduce + 0 api-sizes)}
-       (not fast?) (merge (let [test-blast (max-test-blast-radius deps)]
+       (not fast?) (merge (let [test-blast (max-test-blast-radius deps config)]
                             {:max-file-deftests        (:deftests test-blast)
                              :max-file-test-namespaces (:test-namespaces test-blast)}))))))
 
@@ -343,18 +388,99 @@
   (mapcat ns.find/find-sources-in-dir
           (list* (source-root) (enterprise-source-root) (drivers-source-roots))))
 
-(mu/defn- module :- [:maybe symbol?]
-  "E.g.
+(defn- module-split
+  "Split a module symbol into `[ns-part name-parts-vec]`. Mirror of
+  `hooks.common.modules/split-module`. Used by `module-parent` to walk the
+  nested-module hierarchy (which is separate from `:ns-prefix`)."
+  [m]
+  [(namespace m) (str/split (name m) #"\.")])
 
-    (module 'metabase.qp.middleware.wow) => 'qp
-    (module 'metabase-enterprise.whatever.core) => enterprise/whatever"
-  [ns-symb :- simple-symbol?]
-  (or (some->> (re-find #"^metabase-enterprise\.([^.]+)" (str ns-symb))
+(defn- module-join
+  "Inverse of `module-split`."
+  [[ns-part name-parts]]
+  (if ns-part
+    (symbol ns-part (str/join "." name-parts))
+    (symbol (str/join "." name-parts))))
+
+(defn default-ns-prefix
+  "Default `:ns-prefix` for a module symbol, derived from its name. Mirror of
+  `hooks.common.modules/default-ns-prefix` — see that function for details."
+  [m]
+  (if (= (namespace m) "enterprise")
+    (str "metabase-enterprise." (name m))
+    (str "metabase." (name m))))
+
+(defn module-ns-prefix
+  "Effective `:ns-prefix` for a module: explicit from the module's config
+  entry, else the name-derived default. `modules-config` is the inner map
+  from `kondo-config` (keyed by module symbol)."
+  [modules-config m]
+  (or (get-in modules-config [m :ns-prefix])
+      (default-ns-prefix m)))
+
+(defn build-prefix->module
+  "Build the `{ns-prefix-string module-symbol}` map from all declared modules
+  in `modules-config`. Used as the lookup table for longest-prefix resolution."
+  [modules-config]
+  (into {}
+        (map (fn [m] [(module-ns-prefix modules-config m) m]))
+        (keys modules-config)))
+
+(defn- ns-starts-with-prefix? [ns-str prefix]
+  (or (= ns-str prefix)
+      (str/starts-with? ns-str (str prefix "."))))
+
+(defn- longest-matching-prefix
+  "Scan `prefix->module` and return the module whose ns-prefix is the longest
+  string prefix of `ns-str` at segment boundaries."
+  [prefix->module ns-str]
+  (second
+   (reduce-kv
+    (fn [[best-prefix :as best] prefix module]
+      (if (and (ns-starts-with-prefix? ns-str prefix)
+               (or (nil? best-prefix)
+                   (> (count prefix) (count best-prefix))))
+        [prefix module]
+        best))
+    nil
+    prefix->module)))
+
+(defn- normalize-test-namespace [ns-symb]
+  (if (str/ends-with? (name ns-symb) "-test")
+    (symbol (str/replace (name ns-symb) #"-test$" ""))
+    ns-symb))
+
+(mu/defn- module :- [:maybe symbol?]
+  "Resolve a namespace symbol to a module symbol via prefix-map lookup.
+
+  The 2-arity form takes a pre-computed `prefix->module` map (as produced
+  by `build-prefix->module`) and does longest-prefix-at-segment-boundaries
+  matching. The 1-arity form is a flat fallback using single-segment regex
+  extraction — retained for backwards compat and for callers that don't
+  have a prefix map handy.
+
+  MIRROR: deliberate duplicate of the canonical
+  `hooks.common.modules/module` function. They live in different classpath
+  contexts and cannot share source. See
+  `metabase.core.modules-consistency-test` for the tripwire that keeps
+  them in sync."
+  ([ns-symb :- simple-symbol?]
+   (module nil ns-symb))
+  ([prefix->module :- [:maybe [:map-of :string symbol?]]
+    ns-symb :- simple-symbol?]
+   (let [ns-symb (normalize-test-namespace ns-symb)]
+     (or
+      ;; Primary path: prefix-map longest match over declared modules.
+      (when (seq prefix->module)
+        (longest-matching-prefix prefix->module (str ns-symb)))
+      ;; Fallback: single-segment extraction. Regex literals preserved
+      ;; byte-for-byte to match the kondo hook for the consistency test.
+      (some->> (re-find #"^metabase-enterprise\.([^.]+)" (str ns-symb))
                second
                (symbol "enterprise"))
       (some-> (re-find #"^metabase\.([^.]+)" (str ns-symb))
               second
-              symbol)))
+              symbol)))))
 
 (def ^:private require-symbols
   '#{require
@@ -484,45 +610,48 @@
                                               [:namespace simple-symbol?]
                                               [:module    symbol?]
                                               [:dynamic {:optional true} :keyword]]]]]
-  [file :- [:or
-            string?
-            [:fn {:error/message "Instance of a java.io.File"} #(instance? java.io.File %)]]]
-  (try
-    (let [decl         (ns.file/read-file-ns-decl file)
-          ns-symb      (ns.parse/name-from-ns-decl decl)
-          static-deps  (ns.parse/deps-from-ns-decl decl)
-          dynamic-deps (for [symb (find-dynamically-loaded-namespaces file)]
-                         (vary-meta symb assoc ::dynamic :require-and-friends))
-          ;;
-          ;; excluded from the diff for now, see https://metaboat.slack.com/archives/C0669P4AF9N/p1745875106092029 for
-          ;; rationale.
-          ;;
-          ;; defenterprise-deps (for [symb (find-defenterprises file)]
-          ;;                      (vary-meta symb assoc ::dynamic :defenterprise))
-          ;; defenterprise-schema-deps (for [symb (find-defenterprise-schemas file)]
-          ;;                             (vary-meta symb assoc ::dynamic :defenterprise-schema))
-          deps         (into (sorted-set) cat
-                             [static-deps
-                              dynamic-deps
-                              #_defenterprise-deps
-                              #_defenterprise-schema-deps])]
-      {:namespace ns-symb
-       :filename  (file->path-relative-to-project-root file)
-       :module    (module ns-symb)
-       :deps      (sort-by pr-str
-                           (keep (fn [required-ns]
-                                   (when-let [module (module required-ns)]
-                                     (when-not (some-> ignored-dependencies ns-symb required-ns)
-                                       (merge
-                                        {:namespace required-ns
-                                         :module    module}
-                                        (when-let [dynamic-type (::dynamic (meta required-ns))]
-                                          {:dynamic dynamic-type})))))
-                                 deps))})
-    (catch Throwable e
-      (throw (ex-info (format "Error calculating dependencies for %s" file)
-                      {:file file}
-                      e)))))
+  ([file]
+   (file-dependencies nil file))
+  ([prefix->module :- [:maybe [:map-of :string symbol?]]
+    file :- [:or
+             string?
+             [:fn {:error/message "Instance of a java.io.File"} #(instance? java.io.File %)]]]
+   (try
+     (let [decl         (ns.file/read-file-ns-decl file)
+           ns-symb      (ns.parse/name-from-ns-decl decl)
+           static-deps  (ns.parse/deps-from-ns-decl decl)
+           dynamic-deps (for [symb (find-dynamically-loaded-namespaces file)]
+                          (vary-meta symb assoc ::dynamic :require-and-friends))
+           ;;
+           ;; excluded from the diff for now, see https://metaboat.slack.com/archives/C0669P4AF9N/p1745875106092029 for
+           ;; rationale.
+           ;;
+           ;; defenterprise-deps (for [symb (find-defenterprises file)]
+           ;;                      (vary-meta symb assoc ::dynamic :defenterprise))
+           ;; defenterprise-schema-deps (for [symb (find-defenterprise-schemas file)]
+           ;;                             (vary-meta symb assoc ::dynamic :defenterprise-schema))
+           deps         (into (sorted-set) cat
+                              [static-deps
+                               dynamic-deps
+                               #_defenterprise-deps
+                               #_defenterprise-schema-deps])]
+       {:namespace ns-symb
+        :filename  (file->path-relative-to-project-root file)
+        :module    (module prefix->module ns-symb)
+        :deps      (sort-by pr-str
+                            (keep (fn [required-ns]
+                                    (when-let [module (module prefix->module required-ns)]
+                                      (when-not (some-> ignored-dependencies ns-symb required-ns)
+                                        (merge
+                                         {:namespace required-ns
+                                          :module    module}
+                                         (when-let [dynamic-type (::dynamic (meta required-ns))]
+                                           {:dynamic dynamic-type})))))
+                                  deps))})
+     (catch Throwable e
+       (throw (ex-info (format "Error calculating dependencies for %s" file)
+                       {:file file}
+                       e))))))
 
 (comment
   (file-dependencies "src/metabase/app_db/setup.clj")
@@ -532,15 +661,31 @@
   (file-dependencies "src/metabase/query_processor/middleware/permissions.clj"))
 
 (defn dependencies
-  "Calculate information about all the modules dependencies for all *SOURCE* files in the Metabase project by parsing
-  the files."
+  "Calculate information about all the modules dependencies for all *SOURCE*
+  files in the Metabase project by parsing the files.
+
+  The no-arg form resolves namespaces against the current module config, so
+  nested modules map to themselves rather than collapsing into their
+  top-level parent. Pass an explicit `prefix->module` (a pre-computed
+  `{ns-prefix-string module-symbol}` map) to reuse a map you already built;
+  pass `nil` for the flat single-segment extraction (pre-nested-modules
+  behavior), used only by the consistency tests."
+  ([]
+   (dependencies (build-prefix->module (kondo-config))))
+  ([prefix->module]
+   (let [fd (partial file-dependencies prefix->module)]
+     (map fd (find-source-files)))))
+
+(defn configured-dependencies
+  "Scan dependencies using every declared module's effective namespace prefix."
   []
-  (map file-dependencies (find-source-files)))
+  (let [config (kondo-config)]
+    (dependencies (build-prefix->module config))))
 
 (defn external-usages
   "All usages of a module named by `module-symb` outside that module."
   ([module-symb]
-   (external-usages (dependencies) module-symb))
+   (external-usages (configured-dependencies) module-symb))
 
   ([deps module-symb]
    (for [dep    deps
@@ -555,7 +700,7 @@
 (defn external-usages-by-namespace
   "Return a map of module namespace => set of external namespaces using it"
   ([module-symb]
-   (external-usages-by-namespace (dependencies) module-symb))
+   (external-usages-by-namespace (configured-dependencies) module-symb))
 
   ([deps module-symb]
    (into (sorted-map)
@@ -572,17 +717,43 @@
   [kondo-config module-symb]
   (get-in kondo-config [module-symb :friends]))
 
+(declare module-ancestor-chain)
+
 (defn externally-used-namespaces-ignoring-friends
-  "All namespaces from a module that are used outside that module, excluding usages by `:friends` of the module."
+  "All namespaces from a module that are used outside that module, excluding
+  usages by `:friends` of the module AND usages by descendants of the
+  module (subtree trust).
+
+  Subtree trust means a descendant reaching into its ancestor's internals is
+  allowed via `:uses` alone, without the namespace needing to appear in the
+  ancestor's `:api`. Existing API entries that are still used by descendants
+  are retained, however. This makes adopting nesting monotonic: it does not
+  force an unrelated config cleanup, while new descendant-only uses do not
+  enlarge the API. Ancestors, siblings, cousins, and unrelated consumers
+  still count because they must respect `module-symb`'s `:api`."
   ([module-symb]
-   (externally-used-namespaces-ignoring-friends (dependencies) (kondo-config) module-symb))
+   (let [config (kondo-config)]
+     (externally-used-namespaces-ignoring-friends
+      (dependencies (build-prefix->module config)) config module-symb)))
 
   ([deps kondo-config module-symb]
-   (let [friends (module-friends kondo-config module-symb)]
+   (let [friends       (module-friends kondo-config module-symb)
+         declared      (set (keys kondo-config))
+         descendant-of-me? (fn [other]
+                             ;; `other` is a descendant of `module-symb` iff
+                             ;; `module-symb` appears in `other`'s ancestor chain.
+                             (some #(= module-symb %)
+                                   (module-ancestor-chain declared other)))
+         usages        (remove #(contains? friends (:module %))
+                               (external-usages deps module-symb))
+         configured-api (get-in kondo-config [module-symb :api])]
      (into (sorted-set)
-           (comp (remove #(contains? friends (:module %)))
+           (comp (filter (fn [{:keys [module depends-on-namespace]}]
+                           (or (not (descendant-of-me? module))
+                               (and (set? configured-api)
+                                    (contains? configured-api depends-on-namespace)))))
                  (map :depends-on-namespace))
-           (external-usages deps module-symb)))))
+           usages))))
 
 (defn module-dependencies
   "Build a graph of module => set of modules it directly depends on."
@@ -637,7 +808,7 @@
 (defn module-usages-of-other-module
   "Information about how `module-x` uses `module-y`."
   ([module-x module-y]
-   (module-usages-of-other-module (dependencies) module-x module-y))
+   (module-usages-of-other-module (configured-dependencies) module-x module-y))
 
   ([deps module-x module-y]
    (let [module-x-ns->module-y-ns (->> (external-usages deps module-y)
@@ -676,10 +847,54 @@
                [k (count v)]))
         (full-dependencies deps)))
 
+(defn module-parent
+  "Direct parent of a nested module symbol, or nil if top-level.
+  Mirror of `hooks.common.modules/parent-module`. Public so the
+  modules-test suite can use it for the subtree-membership lint check.
+
+  With an optional `declared-modules` set, activates the `enterprise/X`
+  shorthand: `enterprise/X` is treated as a nested child of the OSS
+  module `X` when `X` is declared. Without the set, `enterprise/X`
+  is treated as top-level (pure syntactic behavior)."
+  ([m] (module-parent nil m))
+  ([declared-modules m]
+   (let [[ns-part parts] (module-split m)]
+     (cond
+       (> (count parts) 1)
+       (module-join [ns-part (butlast parts)])
+
+       (and (= ns-part "enterprise") declared-modules)
+       (let [oss (symbol (first parts))]
+         (when (contains? declared-modules oss) oss))
+
+       :else nil))))
+
+(defn module-ancestor-chain
+  "Seq of ancestor module symbols of `m`, from direct parent up to top-level
+  ancestor. Empty if `m` is top-level. Public for use by the
+  subtree-membership lint check in the modules-test suite. Honors the
+  `enterprise/X` shorthand when `declared-modules` is provided."
+  ([m] (module-ancestor-chain nil m))
+  ([declared-modules m]
+   (take-while some?
+               (iterate #(module-parent declared-modules %)
+                        (module-parent declared-modules m)))))
+
 (defn generate-config
-  "Generate the Kondo config that should go in `.clj-kondo/config/modules/config.edn`."
+  "Generate the Kondo config that should go in `.clj-kondo/config/modules/config.edn`.
+
+  Under the strict module model, every dependency is explicit — there are
+  no implicit edges based on tree structure. `generate-config` produces a
+  literal one-to-one mapping from actual code dependencies (resolved via
+  the prefix map) to `:uses` entries, with no filtering.
+
+  Reads the current kondo config to discover declared modules (and their
+  `:ns-prefix`es), then uses longest-prefix matching to assign each
+  namespace to its owning module."
   ([]
-   (generate-config (dependencies) (kondo-config)))
+   (let [kc          (kondo-config)
+         prefix->mod (build-prefix->module kc)]
+     (generate-config (dependencies prefix->mod) kc)))
 
   ([deps kondo-config]
    (into (sorted-map)
@@ -697,6 +912,119 @@
       ;; ignore the config for [[metabase.connection-pool]] which comes from one of our libraries.
       (dissoc 'connection-pool)))
 
+(defn module-team-source
+  "Closest module at or above `module` that explicitly declares `:team`, or `nil` when none does."
+  [config module]
+  (let [declared-modules (set (keys config))]
+    (loop [module module]
+      (cond
+        (contains? (get config module) :team) module
+        :else (when-let [parent (module-parent declared-modules module)]
+                (recur parent))))))
+
+(defn module-team
+  "Effective team for `module`, inherited from its closest configured ancestor when omitted locally."
+  [config module]
+  (some->> (module-team-source config module)
+           (get config)
+           :team))
+
+(defn- top-level-oss-module?
+  [module]
+  (and (nil? (namespace module))
+       (not (str/includes? (name module) "."))))
+
+(defn- expanded-module-exports
+  [config module]
+  (let [explicit     (set (get-in config [module :module-exports]))
+        ee-companion (when (top-level-oss-module? module)
+                       (let [candidate (symbol "enterprise" (name module))]
+                         (when (contains? config candidate)
+                           candidate)))]
+    (cond-> explicit
+      ee-companion (conj ee-companion))))
+
+(defn- default-api-namespaces
+  [config module]
+  (let [prefix (module-ns-prefix config module)]
+    #{(symbol (str prefix ".api"))
+      (symbol (str prefix ".core"))
+      (symbol (str prefix ".init"))}))
+
+(defn- module-top-level-ancestor
+  [declared-modules module]
+  (or (last (module-ancestor-chain declared-modules module)) module))
+
+(defn- externally-referenceable-module?
+  [config module]
+  (let [declared-modules (set (keys config))]
+    (loop [module module]
+      (if-let [parent (module-parent declared-modules module)]
+        (and (contains? (expanded-module-exports config parent) module)
+             (recur parent))
+        true))))
+
+(defn- module-namable-from?
+  [config caller target]
+  (let [declared-modules (set (keys config))]
+    (or (= (module-top-level-ancestor declared-modules caller)
+           (module-top-level-ancestor declared-modules target))
+        (externally-referenceable-module? config target))))
+
+(defn- expanded-module-uses
+  [config module]
+  (let [uses (get-in config [module :uses])]
+    (if (= uses :any)
+      (into (sorted-set)
+            (comp (remove #{module})
+                  (filter (partial module-namable-from? config module)))
+            (keys config))
+      (set uses))))
+
+(defn- module->owned-namespaces
+  [deps]
+  (reduce (fn [result {:keys [module namespace]}]
+            (cond-> result
+              module (update module (fnil conj (sorted-set)) namespace)))
+          (sorted-map)
+          deps))
+
+(defn expanded-kondo-config
+  "Return module config with config-only defaults and inherited properties materialized.
+
+  Expands effective `:team`, `:ns-prefix`, default API namespaces, empty boundary sets, automatic EE companion
+  exports, and `:uses :any`. The no-argument form also scans source dependencies to expand `:api :any` to every
+  namespace owned by that module."
+  ([]
+   (let [config (kondo-config)]
+     (expanded-kondo-config config (dependencies (build-prefix->module config)))))
+  ([config]
+   (expanded-kondo-config config nil))
+  ([config deps]
+   (let [module->namespaces (when deps (module->owned-namespaces deps))]
+     (into (sorted-map)
+           (map (fn [[module module-config]]
+                  [module (-> module-config
+                              (assoc :team (module-team config module)
+                                     :ns-prefix (module-ns-prefix config module)
+                                     :api (if (contains? module-config :api)
+                                            (if (and (= :any (:api module-config)) deps)
+                                              (get module->namespaces module (sorted-set))
+                                              (:api module-config))
+                                            (default-api-namespaces config module))
+                                     :uses (expanded-module-uses config module)
+                                     :friends (set (:friends module-config))
+                                     :module-exports (expanded-module-exports config module)))]))
+           config))))
+
+(defn print-expanded-kondo-config
+  "Print [[expanded-kondo-config]] as stable EDN. Accepts an ignored map for `clojure -X`."
+  ([]
+   (print-expanded-kondo-config nil))
+  ([_opts]
+   #_{:clj-kondo/ignore [:discouraged-var]}
+   (prn (expanded-kondo-config))))
+
 (defn- kondo-config-diff-ignore-any
   "Ignore entries in the config that use `:any`."
   [diff]
@@ -712,12 +1040,22 @@
 (defn kondo-config-diff
   "Return the difference between declared module boundaries and dependencies found in source."
   ([]
-   (kondo-config-diff (dependencies)))
+   (let [kc          (kondo-config)
+         prefix->mod (build-prefix->module kc)]
+     (kondo-config-diff (dependencies prefix->mod))))
 
   ([deps]
-   (let [kondo-config (kondo-config)]
+   (let [kondo-config  (kondo-config)
+         ;; keys a human owns; `generate-config` only emits :api and :uses, so leaving any of these in
+         ;; would diff them as extraneous and suggest deleting them.
+         human-owned   [:team
+                        :friends
+                        :model-imports
+                        :model-exports
+                        :module-exports
+                        :ns-prefix]]
      (-> (ddiff/diff
-          (update-vals kondo-config #(dissoc % :team :friends :model-imports :model-exports))
+          (update-vals kondo-config #(apply dissoc % human-owned))
           (generate-config deps kondo-config))
          ddiff/minimize
          kondo-config-diff-ignore-any
@@ -748,7 +1086,7 @@
     {api      []                         ; settings depends on api directly
      api-keys [permissions collections]} ; settings depends on permissions which depends on collections which depends on api-keys"
   ([module]
-   (all-module-deps-paths (dependencies) module))
+   (all-module-deps-paths (configured-dependencies) module))
   ([deps module]
    (all-module-deps-paths deps module (sorted-map) (atom #{}) []))
   ([deps module acc already-seen path]
@@ -778,7 +1116,7 @@
               ...}
      ...}"
   ([module]
-   (module-dependencies-by-namespace (dependencies) module))
+   (module-dependencies-by-namespace (configured-dependencies) module))
 
   ([deps module]
    (into (sorted-map)
@@ -796,7 +1134,7 @@
     ;; =>
     #{request}"
   [module namespace-symb-or-set]
-  (let [deps            (dependencies)
+  (let [deps            (configured-dependencies)
         namespace-symbs (if (symbol? namespace-symb-or-set)
                           #{namespace-symb-or-set}
                           namespace-symb-or-set)
@@ -810,7 +1148,7 @@
 (defn leaf-modules
   "Modules that are leaf nodes in the module dependency tree -- nothing else depends on them."
   ([]
-   (leaf-modules (dependencies)))
+   (leaf-modules (configured-dependencies)))
   ([deps]
    (into (sorted-set)
          (comp (map :module)
@@ -823,7 +1161,7 @@
   "Modules that `module` does not depend on, either directly or indirectly -- changes to any of these modules should not
   affect `module`."
   [module]
-  (let [deps        (dependencies)
+  (let [deps        (configured-dependencies)
         all-modules (into (sorted-set) (map :module) deps)
         module-deps (set (keys (all-module-deps-paths deps module)))]
     #_{:clj-kondo/ignore [:discouraged-var]}
@@ -838,23 +1176,23 @@
 (defn- simulate-rename
   "Create a new version of `deps` as they would appear if you renamed namespace(s).
 
-    (simulate-rename deps '{metabase.users.api metabase.users-rest.api})"
-  ([deps old-namespace new-namespace]
+    (simulate-rename deps prefix->module '{metabase.users.api metabase.users-rest.api})"
+  ([deps prefix->module old-namespace new-namespace]
    (for [dep deps]
      (-> dep
          (cond-> (= (:namespace dep) old-namespace)
            (assoc :namespace new-namespace
-                  :module (module new-namespace)))
+                  :module (module prefix->module new-namespace)))
          (update :deps (fn [deps]
                          (for [dep deps]
                            (if (= (:namespace dep) old-namespace)
-                             {:namespace new-namespace, :module (module new-namespace)}
+                             {:namespace new-namespace, :module (module prefix->module new-namespace)}
                              dep)))))))
 
-  ([deps old-namespace->new-namespace]
+  ([deps prefix->module old-namespace->new-namespace]
    (reduce
     (fn [deps [old-namespace new-namespace]]
-      (simulate-rename deps old-namespace new-namespace))
+      (simulate-rename deps prefix->module old-namespace new-namespace))
     deps
     old-namespace->new-namespace)))
 
@@ -864,9 +1202,11 @@
 
     (dependencies-eliminated-by-renaming-namespaces 'users '{metabase.users.api metabase.users-rest.api})"
   [module old-namespace->new-namespace]
-  (let [deps            (dependencies)
+  (let [config          (kondo-config)
+        prefix->module  (build-prefix->module config)
+        deps            (dependencies prefix->module)
         old-module-deps (into (sorted-set) (keys (all-module-deps-paths deps module)))
-        new-deps        (simulate-rename deps old-namespace->new-namespace)
+        new-deps        (simulate-rename deps prefix->module old-namespace->new-namespace)
         new-module-deps (into (sorted-set) (keys (all-module-deps-paths new-deps module)))]
     (set/difference old-module-deps new-module-deps)))
 
@@ -909,12 +1249,14 @@
   "Given a collection of `test-filenames`, return the set of source filenames (relative to the project root directory)
   that when changed should trigger these tests."
   ([test-filenames]
-   (test-filenames->relevant-source-filenames (dependencies) test-filenames))
-  ([deps test-filenames]
+   (let [modules-config (kondo-config)
+         prefix->mod    (build-prefix->module modules-config)]
+     (test-filenames->relevant-source-filenames (dependencies prefix->mod) prefix->mod test-filenames)))
+  ([deps prefix->mod test-filenames]
    (into
     (sorted-set)
     (comp (map file->namespace)
-          (map module)
+          (map (partial module prefix->mod))
           (distinct)
           (mapcat (fn [module]
                     (into #{module} (module->all-deps deps module))))
@@ -945,7 +1287,7 @@
 (defn- indirect-dependents
   "Set of modules that either directly or indirectly depend on `module`."
   ([module]
-   (indirect-dependents (dependencies) module))
+   (indirect-dependents (configured-dependencies) module))
   ([deps module]
    (indirect-dependents deps module (sorted-set)))
   ([deps module acc]
@@ -971,12 +1313,29 @@
 (def ^:private test-source-file-extensions
   [".clj" ".cljc" ".cljs" ".bb"])
 
-(defn- module->test-directory [module]
-  (let [parent-dir (case (namespace module)
-                     nil          "test/metabase/"
-                     "enterprise" "enterprise/backend/test/metabase_enterprise/")
-        module-dir (str/replace (name module) #"-" "_")]
-    (str parent-dir module-dir)))
+(defn- ns-prefix->test-path-fragment [ns-prefix]
+  (->> (str/split ns-prefix #"\.")
+       (map #(str/replace % #"-" "_"))
+       (str/join "/")))
+
+(defn- module->test-path-prefix [modules-config module]
+  (let [ns-prefix   (module-ns-prefix modules-config module)
+        [parent-dir ns-fragment]
+        (cond
+          (str/starts-with? ns-prefix "metabase-enterprise.")
+          ["enterprise/backend/test/metabase_enterprise/"
+           (subs ns-prefix (count "metabase-enterprise."))]
+
+          (str/starts-with? ns-prefix "metabase.")
+          ["test/metabase/"
+           (subs ns-prefix (count "metabase."))]
+
+          :else
+          (throw (ex-info (str "Cannot derive a test path for module " module ": its :ns-prefix "
+                               (pr-str ns-prefix) " is not under metabase. or metabase-enterprise.")
+                          {:module module, :ns-prefix ns-prefix})))]
+    (str parent-dir
+         (ns-prefix->test-path-fragment ns-fragment))))
 
 (defn- existing-test-file-paths [path-prefix]
   (into (sorted-set)
@@ -987,28 +1346,43 @@
         test-source-file-extensions))
 
 (mu/defn- module->test-files :- [:set :string]
-  "Return the set of test filenames associated with a `module`: the files under its test directory plus
-  the module-level `<module>_test.*` file next to it when one exists."
-  [module-sym :- :symbol]
-  (let [path-prefix (module->test-directory module-sym)]
-    (into (existing-test-file-paths path-prefix)
-          (map file->path-relative-to-project-root)
-          (ns.find/find-sources-in-dir (io/file path-prefix)))))
+  "Return the set of test filenames associated with a `module`. The 2-arity form rebuilds the
+  `prefix->module` lookup on every call; pass a shared one to the 3-arity form when resolving many
+  modules (as [[source-filenames->relevant-test-filenames]] does over a module's transitive dependents)."
+  ([modules-config :- [:map-of :any :any]
+    module-sym :- :symbol]
+   (module->test-files modules-config (build-prefix->module modules-config) module-sym))
+  ([modules-config :- [:map-of :any :any]
+    prefix->module :- [:maybe [:map-of :string symbol?]]
+    module-sym :- :symbol]
+   (let [path-prefix  (module->test-path-prefix modules-config module-sym)
+         test-dir     (io/file path-prefix)
+         nested-tests (when (.isDirectory test-dir)
+                        (into
+                         (sorted-set)
+                         (comp (filter #(= module-sym
+                                           (module prefix->module (file->namespace %))))
+                               (map file->path-relative-to-project-root))
+                         (ns.find/find-sources-in-dir test-dir)))]
+     (into (existing-test-file-paths path-prefix)
+           nested-tests))))
 
 (defn source-filenames->relevant-test-filenames
   "Given a collection of `source-filenames`, return the set of test filenames (relative to the project root directory)
   that we should re-run when any of `source-filenames` change."
   ([source-filenames]
-   (source-filenames->relevant-test-filenames (dependencies) source-filenames))
-  ([deps source-filenames]
+   (let [modules-config (kondo-config)
+         prefix->mod    (build-prefix->module modules-config)]
+     (source-filenames->relevant-test-filenames (dependencies prefix->mod) modules-config prefix->mod source-filenames)))
+  ([deps modules-config prefix->mod source-filenames]
    (into
     (sorted-set)
     (comp (map file->namespace)
-          (map module)
+          (map (partial module prefix->mod))
           (remove nil?)
           (distinct)
           (mapcat #(module->dependents deps %))
-          (mapcat module->test-files))
+          (mapcat #(module->test-files modules-config prefix->mod %)))
     source-filenames)))
 
 (comment
@@ -1062,17 +1436,20 @@
 
 (defn model-ownership
   "Scan all source files via [[find-model-definitions]], building a map of `:model/X` => module symbol.
-  The module is derived from the defining namespace via [[module]]."
+  The module is derived from the defining namespace via [[module]], using the
+  prefix map built from the current kondo config so that nested modules
+  (and modules with explicit `:ns-prefix`) resolve correctly."
   []
-  (into (sorted-map)
-        (for [file  (find-source-files)
-              :let  [ns-symb (-> (ns.file/read-file-ns-decl file)
-                                 ns.parse/name-from-ns-decl)
-                     mod     (module ns-symb)
-                     models  (find-model-definitions file)]
-              :when mod
-              model models]
-          [model mod])))
+  (let [prefix->mod (build-prefix->module (kondo-config))]
+    (into (sorted-map)
+          (for [file  (find-source-files)
+                :let  [ns-symb (-> (ns.file/read-file-ns-decl file)
+                                   ns.parse/name-from-ns-decl)
+                       mod     (module prefix->mod ns-symb)
+                       models  (find-model-definitions file)]
+                :when mod
+                model models]
+            [model mod]))))
 
 (def ^:private model-boundary-exempt-namespaces
   "Namespaces that are exempt from model boundary checking. These are 'glue' namespaces that intentionally reference
@@ -1104,26 +1481,30 @@
 (defn model-references-by-module
   "Scan all source files and build a map of `{module => #{:model/X ...}}` — the set of model keywords
   referenced in each module's source files. Exempt namespaces (e.g. `metabase.models.resolution`) are excluded.
-  Includes all modules (including bypass modules) — callers filter as needed."
+  Includes all modules (including bypass modules) — callers filter as needed.
+
+  Uses the prefix map from the current kondo config so nested modules
+  resolve via [[module]] correctly."
   []
-  (reduce
-   (fn [acc file]
-     (try
-       (let [ns-symb (-> (ns.file/read-file-ns-decl file)
-                         ns.parse/name-from-ns-decl)
-             mod     (module ns-symb)]
-         (if (and mod (not (contains? model-boundary-exempt-namespaces ns-symb)))
-           (let [models (find-model-keywords file)]
-             (if (seq models)
-               (update acc mod (fnil into (sorted-set)) models)
-               acc))
-           acc))
-       (catch Throwable e
-         (throw (ex-info (format "Error scanning model references in %s" (str file))
-                         {:file file}
-                         e)))))
-   (sorted-map)
-   (find-source-files)))
+  (let [prefix->mod (build-prefix->module (kondo-config))]
+    (reduce
+     (fn [acc file]
+       (try
+         (let [ns-symb (-> (ns.file/read-file-ns-decl file)
+                           ns.parse/name-from-ns-decl)
+               mod     (module prefix->mod ns-symb)]
+           (if (and mod (not (contains? model-boundary-exempt-namespaces ns-symb)))
+             (let [models (find-model-keywords file)]
+               (if (seq models)
+                 (update acc mod (fnil into (sorted-set)) models)
+                 acc))
+             acc))
+         (catch Throwable e
+           (throw (ex-info (format "Error scanning model references in %s" (str file))
+                           {:file file}
+                           e)))))
+     (sorted-map)
+     (find-source-files))))
 
 (defn model-boundary-violations
   "Find all model boundary violations across the codebase.
@@ -1141,36 +1522,37 @@
   ([kondo-config]
    (model-boundary-violations kondo-config (model-ownership)))
   ([kondo-config ownership]
-   (into []
-         (comp
-          (mapcat
-           (fn [file]
-             (try
-               (let [ns-symb (-> (ns.file/read-file-ns-decl file)
-                                 ns.parse/name-from-ns-decl)
-                     mod     (module ns-symb)]
-                 (when (and mod
-                            (not (contains? model-boundary-exempt-namespaces ns-symb)))
-                   (let [model-imports (get-in kondo-config [mod :model-imports] #{})
-                         models       (find-model-keywords file)
-                         rel-path     (file->path-relative-to-project-root file)]
-                     (for [model          models
-                           :let           [defining-mod  (get ownership model)]
-                           :when          (not= defining-mod mod)
-                           :let           [model-exports (when defining-mod
-                                                           (get-in kondo-config [defining-mod :model-exports] #{}))]
-                           violation-type (model-reference-violations
-                                           model defining-mod model-exports model-imports)]
-                       {:file            rel-path
-                        :module          mod
-                        :model           model
-                        :defining-module defining-mod
-                        :violation-type  violation-type}))))
-               (catch Throwable e
-                 (throw (ex-info (format "Error checking model boundaries in %s" (str file))
-                                 {:file file}
-                                 e)))))))
-         (find-source-files))))
+   (let [prefix->mod (build-prefix->module kondo-config)]
+     (into []
+           (comp
+            (mapcat
+             (fn [file]
+               (try
+                 (let [ns-symb (-> (ns.file/read-file-ns-decl file)
+                                   ns.parse/name-from-ns-decl)
+                       mod     (module prefix->mod ns-symb)]
+                   (when (and mod
+                              (not (contains? model-boundary-exempt-namespaces ns-symb)))
+                     (let [model-imports (get-in kondo-config [mod :model-imports] #{})
+                           models       (find-model-keywords file)
+                           rel-path     (file->path-relative-to-project-root file)]
+                       (for [model          models
+                             :let           [defining-mod  (get ownership model)]
+                             :when          (not= defining-mod mod)
+                             :let           [model-exports (when defining-mod
+                                                             (get-in kondo-config [defining-mod :model-exports] #{}))]
+                             violation-type (model-reference-violations
+                                             model defining-mod model-exports model-imports)]
+                         {:file            rel-path
+                          :module          mod
+                          :model           model
+                          :defining-module defining-mod
+                          :violation-type  violation-type}))))
+                 (catch Throwable e
+                   (throw (ex-info (format "Error checking model boundaries in %s" (str file))
+                                   {:file file}
+                                   e)))))))
+           (find-source-files)))))
 
 (comment
   (model-ownership)

--- a/dev/src/dev/deps_graph.clj
+++ b/dev/src/dev/deps_graph.clj
@@ -74,7 +74,8 @@
   []
   (edn/read-string (slurp driver-test-overrides-path)))
 
-(declare kondo-config external-usages module-dependencies dependencies module->test-files
+(declare kondo-config module-parent module-ancestor-chain external-usages module-dependencies
+         dependencies build-prefix->module default-ns-prefix module-team module->test-files
          full-dependencies)
 
 (defn driver-test-triggering-modules
@@ -112,6 +113,23 @@
                       (and (contains? friends module)
                            (not (contains? api depends-on-namespace))))
                     (external-usages deps grantor))))))
+
+(defn cross-subtree-cycle-pair-count
+  "Number of mutually-dependent module pairs whose top-level ancestors differ. A cycle inside one
+  top-level subtree (a parent and its nested child requiring each other) is internal organization and
+  does not count; a mutual dependency between two different top-level subtrees does. Modules are NOT
+  collapsed to their subtree roots first — collapsing unions every child's dependencies into the root
+  and manufactures pairs no actual requires form, which would punish natural nesting."
+  [deps config]
+  (let [declared (set (keys config))
+        root     (fn [m] (or (last (module-ancestor-chain declared m)) m))
+        graph    (module-dependencies deps)]
+    (count (for [[m ds] graph
+                 d ds
+                 :when (and (neg? (compare m d)) ; count each unordered pair once
+                            (contains? (get graph d #{}) m)
+                            (not= (root m) (root d)))]
+             [m d]))))
 
 ;;; Tarjan SCC lives here rather than in `dev.module-scc` (which builds on it) so
 ;;; [[module-boundary-stats]] can size the components without a circular require.
@@ -251,15 +269,19 @@
   mean anything together. Dropping an exemption lowers the first and raises the second, so it needs a hand
   edit here and a reason in the commit — which is the point, since the trade is CI minutes for coverage."
   ([]
-   (module-boundary-debt (dependencies) (kondo-config)))
+   (let [config (kondo-config)]
+     (module-boundary-debt (dependencies (build-prefix->module config)) config)))
   ([deps config]
-   (let [values (vals config)]
+   (let [values   (vals config)
+         declared (set (keys config))]
      {:api-any                        (count (filter #(= :any (:api %)) values))
+      :cross-subtree-cycle-pairs      (cross-subtree-cycle-pair-count deps config)
       :driver-test-exempt-modules     (count (:exempt-modules (driver-test-overrides)))
       :driver-test-triggering-modules (count (driver-test-triggering-modules deps config))
       :friend-edges                   (transduce (map (comp count :friends)) + 0 values)
       :friend-reaches                 (friend-reach-count deps config)
       :standalone-rest-modules        (count (filter #(str/ends-with? (str %) "-rest") (keys config)))
+      :top-level-modules              (count (remove #(module-parent declared %) (keys config)))
       :uses-any                       (count (filter #(= :any (:uses %)) values))})))
 
 (defn- deftest-form-count
@@ -274,10 +296,11 @@
   so the per-file maximum is the per-module maximum.
   Returns `{:test-namespaces _, :deftests _}` — the worst case counted in whole test namespaces and in
   individual `deftest` forms, each maximized over modules independently."
-  [deps]
-  (let [modules        (into (sorted-set) (keep :module) deps)
+  [deps config]
+  (let [prefix->mod    (build-prefix->module config)
+        modules        (into (sorted-set) (keep :module) deps)
         module->tests  (into {}
-                             (map (juxt identity module->test-files))
+                             (map (juxt identity #(module->test-files config prefix->mod %)))
                              modules)
         file->deftests (into {}
                              (map (juxt identity deftest-form-count))
@@ -302,13 +325,23 @@
      :deftests        (reduce max 0 (map #(transduce (keep file->deftests) + 0 %) blasts))}))
 
 (defn module-boundary-stats
-  "Public-surface size stats. Expected to move in both directions — carving a module out grows
-  `:total-api` while shrinking `:largest-api`, and neither direction is good or bad on its own.
-  Committed to `module-stats.edn` so PR diffs surface the movement for review.
+  "Public-surface size stats. Expected to move in both directions — carving a child module grows
+  `:total-api` and `:module-exports` while shrinking `:largest-api`, and none of those directions is
+  good or bad on its own. Committed to `module-stats.edn` so PR diffs surface the movement for review.
 
   `:api-any-namespaces` is the hidden surface of `:api :any` modules: every one of their namespaces is
   effectively public, so it is counted here namespace-weighted (the `:api-any` module count itself is a
   ratchet).
+
+  `:ns-prefix-overrides` counts modules whose `:ns-prefix` differs from their name-derived default —
+  each is a module name that lies about where its namespaces live, usually a config-only nesting whose
+  source rename hasn't happened yet. An explicit prefix equal to the default is documentation, not a
+  mismatch, and does not count. Expected to grow with config-only carves; a candidate ratchet once the
+  source renames catch up.
+
+  `:parent-team-mismatches` counts nested modules whose effective `:team` differs from their parent's.
+  Meaningless for top-level modules (no parent) and zero for children that inherit; in practice these are
+  `enterprise/X` companions owned by a different team than the OSS `X`. Moves with reorgs, hence a stat.
 
   The SCC stats size the mutual-dependency blob at both granularities; they grow with ordinary feature
   work inside the blob, hence stats rather than ratchets.
@@ -348,11 +381,13 @@
   ([]
    (module-boundary-stats nil))
   ([opts]
-   (module-boundary-stats (dependencies) (kondo-config) opts))
+   (let [config (kondo-config)]
+     (module-boundary-stats (dependencies (build-prefix->module config)) config opts)))
   ([deps config]
    (module-boundary-stats deps config nil))
   ([deps config {:keys [fast?]}]
    (let [values          (vals config)
+         declared        (set (keys config))
          api-sizes       (keep (fn [{:keys [api]}]
                                  (when (set? api)
                                    (count api)))
@@ -365,7 +400,15 @@
          scc-namespaces  (fn [component] (count (filter #(contains? component (:module %)) deps)))
          api-any-nses    (count (filter #(contains? any-modules (:module %)) deps))
          bypass-modules  (count (filter #(= :bypass (:model-imports %)) values))
-         triggering      (driver-test-triggering-modules deps config)
+         triggering       (driver-test-triggering-modules deps config)
+         prefix-overrides (count (filter (fn [[m {:keys [ns-prefix]}]]
+                                           (and ns-prefix (not= ns-prefix (default-ns-prefix m))))
+                                         config))
+         team-mismatches  (count (filter (fn [m]
+                                           (when-let [parent (module-parent declared m)]
+                                             (not= (module-team config m)
+                                                   (module-team config parent))))
+                                         declared))
          cycles          (cycle-stats module-graph ns-counts)
          combined-cycles (cycle-stats combined-graph ns-counts)
          ;; components come back largest first, so the biggest cycle is the head of the list
@@ -393,8 +436,12 @@
               :largest-scc-namespaces-with-model-imports (scc-namespaces combined-scc)
               :model-import-bypass-modules               bypass-modules
               :module-count                              (count config)
+              :module-exports                            (transduce (map (comp count :module-exports))
+                                                                    + 0 values)
+              :ns-prefix-overrides                       prefix-overrides
+              :parent-team-mismatches                    team-mismatches
               :total-api                                 (reduce + 0 api-sizes)}
-       (not fast?) (merge (let [test-blast (max-test-blast-radius deps)]
+       (not fast?) (merge (let [test-blast (max-test-blast-radius deps config)]
                             {:max-file-deftests        (:deftests test-blast)
                              :max-file-test-namespaces (:test-namespaces test-blast)}))))))
 
@@ -495,18 +542,99 @@
   (mapcat ns.find/find-sources-in-dir
           (list* (source-root) (enterprise-source-root) (plugin-source-roots))))
 
-(mu/defn- module :- [:maybe symbol?]
-  "E.g.
+(defn- module-split
+  "Split a module symbol into `[ns-part name-parts-vec]`. Mirror of
+  `hooks.common.modules/split-module`. Used by `module-parent` to walk the
+  nested-module hierarchy (which is separate from `:ns-prefix`)."
+  [m]
+  [(namespace m) (str/split (name m) #"\.")])
 
-    (module 'metabase.qp.middleware.wow) => 'qp
-    (module 'metabase-enterprise.whatever.core) => enterprise/whatever"
-  [ns-symb :- simple-symbol?]
-  (or (some->> (re-find #"^metabase-enterprise\.([^.]+)" (str ns-symb))
+(defn- module-join
+  "Inverse of `module-split`."
+  [[ns-part name-parts]]
+  (if ns-part
+    (symbol ns-part (str/join "." name-parts))
+    (symbol (str/join "." name-parts))))
+
+(defn default-ns-prefix
+  "Default `:ns-prefix` for a module symbol, derived from its name. Mirror of
+  `hooks.common.modules/default-ns-prefix` — see that function for details."
+  [m]
+  (if (= (namespace m) "enterprise")
+    (str "metabase-enterprise." (name m))
+    (str "metabase." (name m))))
+
+(defn module-ns-prefix
+  "Effective `:ns-prefix` for a module: explicit from the module's config
+  entry, else the name-derived default. `modules-config` is the inner map
+  from `kondo-config` (keyed by module symbol)."
+  [modules-config m]
+  (or (get-in modules-config [m :ns-prefix])
+      (default-ns-prefix m)))
+
+(defn build-prefix->module
+  "Build the `{ns-prefix-string module-symbol}` map from all declared modules
+  in `modules-config`. Used as the lookup table for longest-prefix resolution."
+  [modules-config]
+  (into {}
+        (map (fn [m] [(module-ns-prefix modules-config m) m]))
+        (keys modules-config)))
+
+(defn- ns-starts-with-prefix? [ns-str prefix]
+  (or (= ns-str prefix)
+      (str/starts-with? ns-str (str prefix "."))))
+
+(defn- longest-matching-prefix
+  "Scan `prefix->module` and return the module whose ns-prefix is the longest
+  string prefix of `ns-str` at segment boundaries."
+  [prefix->module ns-str]
+  (second
+   (reduce-kv
+    (fn [[best-prefix :as best] prefix module]
+      (if (and (ns-starts-with-prefix? ns-str prefix)
+               (or (nil? best-prefix)
+                   (> (count prefix) (count best-prefix))))
+        [prefix module]
+        best))
+    nil
+    prefix->module)))
+
+(defn- normalize-test-namespace [ns-symb]
+  (if (str/ends-with? (name ns-symb) "-test")
+    (symbol (str/replace (name ns-symb) #"-test$" ""))
+    ns-symb))
+
+(mu/defn- module :- [:maybe symbol?]
+  "Resolve a namespace symbol to a module symbol via prefix-map lookup.
+
+  The 2-arity form takes a pre-computed `prefix->module` map (as produced
+  by `build-prefix->module`) and does longest-prefix-at-segment-boundaries
+  matching. The 1-arity form is a flat fallback using single-segment regex
+  extraction — retained for backwards compat and for callers that don't
+  have a prefix map handy.
+
+  MIRROR: deliberate duplicate of the canonical
+  `hooks.common.modules/module` function. They live in different classpath
+  contexts and cannot share source. See
+  `metabase.core.modules-consistency-test` for the tripwire that keeps
+  them in sync."
+  ([ns-symb :- simple-symbol?]
+   (module nil ns-symb))
+  ([prefix->module :- [:maybe [:map-of :string symbol?]]
+    ns-symb :- simple-symbol?]
+   (let [ns-symb (normalize-test-namespace ns-symb)]
+     (or
+      ;; Primary path: prefix-map longest match over declared modules.
+      (when (seq prefix->module)
+        (longest-matching-prefix prefix->module (str ns-symb)))
+      ;; Fallback: single-segment extraction. Regex literals preserved
+      ;; byte-for-byte to match the kondo hook for the consistency test.
+      (some->> (re-find #"^metabase-enterprise\.([^.]+)" (str ns-symb))
                second
                (symbol "enterprise"))
       (some-> (re-find #"^metabase\.([^.]+)" (str ns-symb))
               second
-              symbol)))
+              symbol)))))
 
 (def ^:private require-symbols
   '#{require
@@ -636,45 +764,48 @@
                                               [:namespace simple-symbol?]
                                               [:module    symbol?]
                                               [:dynamic {:optional true} :keyword]]]]]
-  [file :- [:or
-            string?
-            [:fn {:error/message "Instance of a java.io.File"} #(instance? java.io.File %)]]]
-  (try
-    (let [decl         (ns.file/read-file-ns-decl file)
-          ns-symb      (ns.parse/name-from-ns-decl decl)
-          static-deps  (ns.parse/deps-from-ns-decl decl)
-          dynamic-deps (for [symb (find-dynamically-loaded-namespaces file)]
-                         (vary-meta symb assoc ::dynamic :require-and-friends))
-          ;;
-          ;; excluded from the diff for now, see https://metaboat.slack.com/archives/C0669P4AF9N/p1745875106092029 for
-          ;; rationale.
-          ;;
-          ;; defenterprise-deps (for [symb (find-defenterprises file)]
-          ;;                      (vary-meta symb assoc ::dynamic :defenterprise))
-          ;; defenterprise-schema-deps (for [symb (find-defenterprise-schemas file)]
-          ;;                             (vary-meta symb assoc ::dynamic :defenterprise-schema))
-          deps         (into (sorted-set) cat
-                             [static-deps
-                              dynamic-deps
-                              #_defenterprise-deps
-                              #_defenterprise-schema-deps])]
-      {:namespace ns-symb
-       :filename  (file->path-relative-to-project-root file)
-       :module    (module ns-symb)
-       :deps      (sort-by pr-str
-                           (keep (fn [required-ns]
-                                   (when-let [module (module required-ns)]
-                                     (when-not (some-> ignored-dependencies ns-symb required-ns)
-                                       (merge
-                                        {:namespace required-ns
-                                         :module    module}
-                                        (when-let [dynamic-type (::dynamic (meta required-ns))]
-                                          {:dynamic dynamic-type})))))
-                                 deps))})
-    (catch Throwable e
-      (throw (ex-info (format "Error calculating dependencies for %s" file)
-                      {:file file}
-                      e)))))
+  ([file]
+   (file-dependencies nil file))
+  ([prefix->module :- [:maybe [:map-of :string symbol?]]
+    file :- [:or
+             string?
+             [:fn {:error/message "Instance of a java.io.File"} #(instance? java.io.File %)]]]
+   (try
+     (let [decl         (ns.file/read-file-ns-decl file)
+           ns-symb      (ns.parse/name-from-ns-decl decl)
+           static-deps  (ns.parse/deps-from-ns-decl decl)
+           dynamic-deps (for [symb (find-dynamically-loaded-namespaces file)]
+                          (vary-meta symb assoc ::dynamic :require-and-friends))
+           ;;
+           ;; excluded from the diff for now, see https://metaboat.slack.com/archives/C0669P4AF9N/p1745875106092029 for
+           ;; rationale.
+           ;;
+           ;; defenterprise-deps (for [symb (find-defenterprises file)]
+           ;;                      (vary-meta symb assoc ::dynamic :defenterprise))
+           ;; defenterprise-schema-deps (for [symb (find-defenterprise-schemas file)]
+           ;;                             (vary-meta symb assoc ::dynamic :defenterprise-schema))
+           deps         (into (sorted-set) cat
+                              [static-deps
+                               dynamic-deps
+                               #_defenterprise-deps
+                               #_defenterprise-schema-deps])]
+       {:namespace ns-symb
+        :filename  (file->path-relative-to-project-root file)
+        :module    (module prefix->module ns-symb)
+        :deps      (sort-by pr-str
+                            (keep (fn [required-ns]
+                                    (when-let [module (module prefix->module required-ns)]
+                                      (when-not (some-> ignored-dependencies ns-symb required-ns)
+                                        (merge
+                                         {:namespace required-ns
+                                          :module    module}
+                                         (when-let [dynamic-type (::dynamic (meta required-ns))]
+                                           {:dynamic dynamic-type})))))
+                                  deps))})
+     (catch Throwable e
+       (throw (ex-info (format "Error calculating dependencies for %s" file)
+                       {:file file}
+                       e))))))
 
 (comment
   (file-dependencies "src/metabase/app_db/setup.clj")
@@ -684,15 +815,31 @@
   (file-dependencies "src/metabase/query_processor/middleware/permissions.clj"))
 
 (defn dependencies
-  "Calculate information about all the modules dependencies for all *SOURCE* files in the Metabase project by parsing
-  the files."
+  "Calculate information about all the modules dependencies for all *SOURCE*
+  files in the Metabase project by parsing the files.
+
+  The no-arg form resolves namespaces against the current module config, so
+  nested modules map to themselves rather than collapsing into their
+  top-level parent. Pass an explicit `prefix->module` (a pre-computed
+  `{ns-prefix-string module-symbol}` map) to reuse a map you already built;
+  pass `nil` for the flat single-segment extraction (pre-nested-modules
+  behavior), used only by the consistency tests."
+  ([]
+   (dependencies (build-prefix->module (kondo-config))))
+  ([prefix->module]
+   (let [fd (partial file-dependencies prefix->module)]
+     (map fd (find-source-files)))))
+
+(defn configured-dependencies
+  "Scan dependencies using every declared module's effective namespace prefix."
   []
-  (map file-dependencies (find-source-files)))
+  (let [config (kondo-config)]
+    (dependencies (build-prefix->module config))))
 
 (defn external-usages
   "All usages of a module named by `module-symb` outside that module."
   ([module-symb]
-   (external-usages (dependencies) module-symb))
+   (external-usages (configured-dependencies) module-symb))
 
   ([deps module-symb]
    (for [dep    deps
@@ -707,7 +854,7 @@
 (defn external-usages-by-namespace
   "Return a map of module namespace => set of external namespaces using it"
   ([module-symb]
-   (external-usages-by-namespace (dependencies) module-symb))
+   (external-usages-by-namespace (configured-dependencies) module-symb))
 
   ([deps module-symb]
    (into (sorted-map)
@@ -724,17 +871,43 @@
   [kondo-config module-symb]
   (get-in kondo-config [module-symb :friends]))
 
+(declare module-ancestor-chain)
+
 (defn externally-used-namespaces-ignoring-friends
-  "All namespaces from a module that are used outside that module, excluding usages by `:friends` of the module."
+  "All namespaces from a module that are used outside that module, excluding
+  usages by `:friends` of the module AND usages by descendants of the
+  module (subtree trust).
+
+  Subtree trust means a descendant reaching into its ancestor's internals is
+  allowed via `:uses` alone, without the namespace needing to appear in the
+  ancestor's `:api`. Existing API entries that are still used by descendants
+  are retained, however. This makes adopting nesting monotonic: it does not
+  force an unrelated config cleanup, while new descendant-only uses do not
+  enlarge the API. Ancestors, siblings, cousins, and unrelated consumers
+  still count because they must respect `module-symb`'s `:api`."
   ([module-symb]
-   (externally-used-namespaces-ignoring-friends (dependencies) (kondo-config) module-symb))
+   (let [config (kondo-config)]
+     (externally-used-namespaces-ignoring-friends
+      (dependencies (build-prefix->module config)) config module-symb)))
 
   ([deps kondo-config module-symb]
-   (let [friends (module-friends kondo-config module-symb)]
+   (let [friends       (module-friends kondo-config module-symb)
+         declared      (set (keys kondo-config))
+         descendant-of-me? (fn [other]
+                             ;; `other` is a descendant of `module-symb` iff
+                             ;; `module-symb` appears in `other`'s ancestor chain.
+                             (some #(= module-symb %)
+                                   (module-ancestor-chain declared other)))
+         usages        (remove #(contains? friends (:module %))
+                               (external-usages deps module-symb))
+         configured-api (get-in kondo-config [module-symb :api])]
      (into (sorted-set)
-           (comp (remove #(contains? friends (:module %)))
+           (comp (filter (fn [{:keys [module depends-on-namespace]}]
+                           (or (not (descendant-of-me? module))
+                               (and (set? configured-api)
+                                    (contains? configured-api depends-on-namespace)))))
                  (map :depends-on-namespace))
-           (external-usages deps module-symb)))))
+           usages))))
 
 (defn module-dependencies
   "Build a graph of module => set of modules it directly depends on."
@@ -789,7 +962,7 @@
 (defn module-usages-of-other-module
   "Information about how `module-x` uses `module-y`."
   ([module-x module-y]
-   (module-usages-of-other-module (dependencies) module-x module-y))
+   (module-usages-of-other-module (configured-dependencies) module-x module-y))
 
   ([deps module-x module-y]
    (let [module-x-ns->module-y-ns (->> (external-usages deps module-y)
@@ -828,10 +1001,54 @@
                [k (count v)]))
         (full-dependencies deps)))
 
+(defn module-parent
+  "Direct parent of a nested module symbol, or nil if top-level.
+  Mirror of `hooks.common.modules/parent-module`. Public so the
+  modules-test suite can use it for the subtree-membership lint check.
+
+  With an optional `declared-modules` set, activates the `enterprise/X`
+  shorthand: `enterprise/X` is treated as a nested child of the OSS
+  module `X` when `X` is declared. Without the set, `enterprise/X`
+  is treated as top-level (pure syntactic behavior)."
+  ([m] (module-parent nil m))
+  ([declared-modules m]
+   (let [[ns-part parts] (module-split m)]
+     (cond
+       (> (count parts) 1)
+       (module-join [ns-part (butlast parts)])
+
+       (and (= ns-part "enterprise") declared-modules)
+       (let [oss (symbol (first parts))]
+         (when (contains? declared-modules oss) oss))
+
+       :else nil))))
+
+(defn module-ancestor-chain
+  "Seq of ancestor module symbols of `m`, from direct parent up to top-level
+  ancestor. Empty if `m` is top-level. Public for use by the
+  subtree-membership lint check in the modules-test suite. Honors the
+  `enterprise/X` shorthand when `declared-modules` is provided."
+  ([m] (module-ancestor-chain nil m))
+  ([declared-modules m]
+   (take-while some?
+               (iterate #(module-parent declared-modules %)
+                        (module-parent declared-modules m)))))
+
 (defn generate-config
-  "Generate the Kondo config that should go in `.clj-kondo/config/modules/config.edn`."
+  "Generate the Kondo config that should go in `.clj-kondo/config/modules/config.edn`.
+
+  Under the strict module model, every dependency is explicit — there are
+  no implicit edges based on tree structure. `generate-config` produces a
+  literal one-to-one mapping from actual code dependencies (resolved via
+  the prefix map) to `:uses` entries, with no filtering.
+
+  Reads the current kondo config to discover declared modules (and their
+  `:ns-prefix`es), then uses longest-prefix matching to assign each
+  namespace to its owning module."
   ([]
-   (generate-config (dependencies) (kondo-config)))
+   (let [kc          (kondo-config)
+         prefix->mod (build-prefix->module kc)]
+     (generate-config (dependencies prefix->mod) kc)))
 
   ([deps kondo-config]
    (into (sorted-map)
@@ -849,6 +1066,119 @@
       ;; ignore the config for [[metabase.connection-pool]] which comes from one of our libraries.
       (dissoc 'connection-pool)))
 
+(defn module-team-source
+  "Closest module at or above `module` that explicitly declares `:team`, or `nil` when none does."
+  [config module]
+  (let [declared-modules (set (keys config))]
+    (loop [module module]
+      (cond
+        (contains? (get config module) :team) module
+        :else (when-let [parent (module-parent declared-modules module)]
+                (recur parent))))))
+
+(defn module-team
+  "Effective team for `module`, inherited from its closest configured ancestor when omitted locally."
+  [config module]
+  (some->> (module-team-source config module)
+           (get config)
+           :team))
+
+(defn- top-level-oss-module?
+  [module]
+  (and (nil? (namespace module))
+       (not (str/includes? (name module) "."))))
+
+(defn- expanded-module-exports
+  [config module]
+  (let [explicit     (set (get-in config [module :module-exports]))
+        ee-companion (when (top-level-oss-module? module)
+                       (let [candidate (symbol "enterprise" (name module))]
+                         (when (contains? config candidate)
+                           candidate)))]
+    (cond-> explicit
+      ee-companion (conj ee-companion))))
+
+(defn- default-api-namespaces
+  [config module]
+  (let [prefix (module-ns-prefix config module)]
+    #{(symbol (str prefix ".api"))
+      (symbol (str prefix ".core"))
+      (symbol (str prefix ".init"))}))
+
+(defn- module-top-level-ancestor
+  [declared-modules module]
+  (or (last (module-ancestor-chain declared-modules module)) module))
+
+(defn- externally-referenceable-module?
+  [config module]
+  (let [declared-modules (set (keys config))]
+    (loop [module module]
+      (if-let [parent (module-parent declared-modules module)]
+        (and (contains? (expanded-module-exports config parent) module)
+             (recur parent))
+        true))))
+
+(defn- module-namable-from?
+  [config caller target]
+  (let [declared-modules (set (keys config))]
+    (or (= (module-top-level-ancestor declared-modules caller)
+           (module-top-level-ancestor declared-modules target))
+        (externally-referenceable-module? config target))))
+
+(defn- expanded-module-uses
+  [config module]
+  (let [uses (get-in config [module :uses])]
+    (if (= uses :any)
+      (into (sorted-set)
+            (comp (remove #{module})
+                  (filter (partial module-namable-from? config module)))
+            (keys config))
+      (set uses))))
+
+(defn- module->owned-namespaces
+  [deps]
+  (reduce (fn [result {:keys [module namespace]}]
+            (cond-> result
+              module (update module (fnil conj (sorted-set)) namespace)))
+          (sorted-map)
+          deps))
+
+(defn expanded-kondo-config
+  "Return module config with config-only defaults and inherited properties materialized.
+
+  Expands effective `:team`, `:ns-prefix`, default API namespaces, empty boundary sets, automatic EE companion
+  exports, and `:uses :any`. The no-argument form also scans source dependencies to expand `:api :any` to every
+  namespace owned by that module."
+  ([]
+   (let [config (kondo-config)]
+     (expanded-kondo-config config (dependencies (build-prefix->module config)))))
+  ([config]
+   (expanded-kondo-config config nil))
+  ([config deps]
+   (let [module->namespaces (when deps (module->owned-namespaces deps))]
+     (into (sorted-map)
+           (map (fn [[module module-config]]
+                  [module (-> module-config
+                              (assoc :team (module-team config module)
+                                     :ns-prefix (module-ns-prefix config module)
+                                     :api (if (contains? module-config :api)
+                                            (if (and (= :any (:api module-config)) deps)
+                                              (get module->namespaces module (sorted-set))
+                                              (:api module-config))
+                                            (default-api-namespaces config module))
+                                     :uses (expanded-module-uses config module)
+                                     :friends (set (:friends module-config))
+                                     :module-exports (expanded-module-exports config module)))]))
+           config))))
+
+(defn print-expanded-kondo-config
+  "Print [[expanded-kondo-config]] as stable EDN. Accepts an ignored map for `clojure -X`."
+  ([]
+   (print-expanded-kondo-config nil))
+  ([_opts]
+   #_{:clj-kondo/ignore [:discouraged-var]}
+   (prn (expanded-kondo-config))))
+
 (defn- kondo-config-diff-ignore-any
   "Ignore entries in the config that use `:any`."
   [diff]
@@ -864,12 +1194,22 @@
 (defn kondo-config-diff
   "Return the difference between declared module boundaries and dependencies found in source."
   ([]
-   (kondo-config-diff (dependencies)))
+   (let [kc          (kondo-config)
+         prefix->mod (build-prefix->module kc)]
+     (kondo-config-diff (dependencies prefix->mod))))
 
   ([deps]
-   (let [kondo-config (kondo-config)]
+   (let [kondo-config  (kondo-config)
+         ;; keys a human owns; `generate-config` only emits :api and :uses, so leaving any of these in
+         ;; would diff them as extraneous and suggest deleting them.
+         human-owned   [:team
+                        :friends
+                        :model-imports
+                        :model-exports
+                        :module-exports
+                        :ns-prefix]]
      (-> (ddiff/diff
-          (update-vals kondo-config #(dissoc % :team :friends :model-imports :model-exports))
+          (update-vals kondo-config #(apply dissoc % human-owned))
           (generate-config deps kondo-config))
          ddiff/minimize
          kondo-config-diff-ignore-any
@@ -900,7 +1240,7 @@
     {api      []                         ; settings depends on api directly
      api-keys [permissions collections]} ; settings depends on permissions which depends on collections which depends on api-keys"
   ([module]
-   (all-module-deps-paths (dependencies) module))
+   (all-module-deps-paths (configured-dependencies) module))
   ([deps module]
    (all-module-deps-paths deps module (sorted-map) (atom #{}) []))
   ([deps module acc already-seen path]
@@ -930,7 +1270,7 @@
               ...}
      ...}"
   ([module]
-   (module-dependencies-by-namespace (dependencies) module))
+   (module-dependencies-by-namespace (configured-dependencies) module))
 
   ([deps module]
    (into (sorted-map)
@@ -948,7 +1288,7 @@
     ;; =>
     #{request}"
   [module namespace-symb-or-set]
-  (let [deps            (dependencies)
+  (let [deps            (configured-dependencies)
         namespace-symbs (if (symbol? namespace-symb-or-set)
                           #{namespace-symb-or-set}
                           namespace-symb-or-set)
@@ -962,7 +1302,7 @@
 (defn leaf-modules
   "Modules that are leaf nodes in the module dependency tree -- nothing else depends on them."
   ([]
-   (leaf-modules (dependencies)))
+   (leaf-modules (configured-dependencies)))
   ([deps]
    (into (sorted-set)
          (comp (map :module)
@@ -975,7 +1315,7 @@
   "Modules that `module` does not depend on, either directly or indirectly -- changes to any of these modules should not
   affect `module`."
   [module]
-  (let [deps        (dependencies)
+  (let [deps        (configured-dependencies)
         all-modules (into (sorted-set) (map :module) deps)
         module-deps (set (keys (all-module-deps-paths deps module)))]
     ;; dev REPL tool; the summary line is for the human at the console
@@ -991,23 +1331,23 @@
 (defn- simulate-rename
   "Create a new version of `deps` as they would appear if you renamed namespace(s).
 
-    (simulate-rename deps '{metabase.users.api metabase.users-rest.api})"
-  ([deps old-namespace new-namespace]
+    (simulate-rename deps prefix->module '{metabase.users.api metabase.users-rest.api})"
+  ([deps prefix->module old-namespace new-namespace]
    (for [dep deps]
      (-> dep
          (cond-> (= (:namespace dep) old-namespace)
            (assoc :namespace new-namespace
-                  :module (module new-namespace)))
+                  :module (module prefix->module new-namespace)))
          (update :deps (fn [deps]
                          (for [dep deps]
                            (if (= (:namespace dep) old-namespace)
-                             {:namespace new-namespace, :module (module new-namespace)}
+                             {:namespace new-namespace, :module (module prefix->module new-namespace)}
                              dep)))))))
 
-  ([deps old-namespace->new-namespace]
+  ([deps prefix->module old-namespace->new-namespace]
    (reduce
     (fn [deps [old-namespace new-namespace]]
-      (simulate-rename deps old-namespace new-namespace))
+      (simulate-rename deps prefix->module old-namespace new-namespace))
     deps
     old-namespace->new-namespace)))
 
@@ -1017,9 +1357,11 @@
 
     (dependencies-eliminated-by-renaming-namespaces 'users '{metabase.users.api metabase.users-rest.api})"
   [module old-namespace->new-namespace]
-  (let [deps            (dependencies)
+  (let [config          (kondo-config)
+        prefix->module  (build-prefix->module config)
+        deps            (dependencies prefix->module)
         old-module-deps (into (sorted-set) (keys (all-module-deps-paths deps module)))
-        new-deps        (simulate-rename deps old-namespace->new-namespace)
+        new-deps        (simulate-rename deps prefix->module old-namespace->new-namespace)
         new-module-deps (into (sorted-set) (keys (all-module-deps-paths new-deps module)))]
     (set/difference old-module-deps new-module-deps)))
 
@@ -1062,12 +1404,14 @@
   "Given a collection of `test-filenames`, return the set of source filenames (relative to the project root directory)
   that when changed should trigger these tests."
   ([test-filenames]
-   (test-filenames->relevant-source-filenames (dependencies) test-filenames))
-  ([deps test-filenames]
+   (let [modules-config (kondo-config)
+         prefix->mod    (build-prefix->module modules-config)]
+     (test-filenames->relevant-source-filenames (dependencies prefix->mod) prefix->mod test-filenames)))
+  ([deps prefix->mod test-filenames]
    (into
     (sorted-set)
     (comp (map file->namespace)
-          (map module)
+          (map (partial module prefix->mod))
           (distinct)
           (mapcat (fn [module]
                     (into #{module} (module->all-deps deps module))))
@@ -1098,7 +1442,7 @@
 (defn- indirect-dependents
   "Set of modules that either directly or indirectly depend on `module`."
   ([module]
-   (indirect-dependents (dependencies) module))
+   (indirect-dependents (configured-dependencies) module))
   ([deps module]
    (indirect-dependents deps module (sorted-set)))
   ([deps module acc]
@@ -1124,12 +1468,29 @@
 (def ^:private test-source-file-extensions
   [".clj" ".cljc" ".cljs" ".bb"])
 
-(defn- module->test-directory [module]
-  (let [parent-dir (case (namespace module)
-                     nil          "test/metabase/"
-                     "enterprise" "enterprise/backend/test/metabase_enterprise/")
-        module-dir (str/replace (name module) #"-" "_")]
-    (str parent-dir module-dir)))
+(defn- ns-prefix->test-path-fragment [ns-prefix]
+  (->> (str/split ns-prefix #"\.")
+       (map #(str/replace % #"-" "_"))
+       (str/join "/")))
+
+(defn- module->test-path-prefix [modules-config module]
+  (let [ns-prefix   (module-ns-prefix modules-config module)
+        [parent-dir ns-fragment]
+        (cond
+          (str/starts-with? ns-prefix "metabase-enterprise.")
+          ["enterprise/backend/test/metabase_enterprise/"
+           (subs ns-prefix (count "metabase-enterprise."))]
+
+          (str/starts-with? ns-prefix "metabase.")
+          ["test/metabase/"
+           (subs ns-prefix (count "metabase."))]
+
+          :else
+          (throw (ex-info (str "Cannot derive a test path for module " module ": its :ns-prefix "
+                               (pr-str ns-prefix) " is not under metabase. or metabase-enterprise.")
+                          {:module module, :ns-prefix ns-prefix})))]
+    (str parent-dir
+         (ns-prefix->test-path-fragment ns-fragment))))
 
 (defn- existing-test-file-paths [path-prefix]
   (into (sorted-set)
@@ -1140,28 +1501,43 @@
         test-source-file-extensions))
 
 (mu/defn- module->test-files :- [:set :string]
-  "Return the set of test filenames associated with a `module`: the files under its test directory plus
-  the module-level `<module>_test.*` file next to it when one exists."
-  [module-sym :- :symbol]
-  (let [path-prefix (module->test-directory module-sym)]
-    (into (existing-test-file-paths path-prefix)
-          (map file->path-relative-to-project-root)
-          (ns.find/find-sources-in-dir (io/file path-prefix)))))
+  "Return the set of test filenames associated with a `module`. The 2-arity form rebuilds the
+  `prefix->module` lookup on every call; pass a shared one to the 3-arity form when resolving many
+  modules (as [[source-filenames->relevant-test-filenames]] does over a module's transitive dependents)."
+  ([modules-config :- [:map-of :any :any]
+    module-sym :- :symbol]
+   (module->test-files modules-config (build-prefix->module modules-config) module-sym))
+  ([modules-config :- [:map-of :any :any]
+    prefix->module :- [:maybe [:map-of :string symbol?]]
+    module-sym :- :symbol]
+   (let [path-prefix  (module->test-path-prefix modules-config module-sym)
+         test-dir     (io/file path-prefix)
+         nested-tests (when (.isDirectory test-dir)
+                        (into
+                         (sorted-set)
+                         (comp (filter #(= module-sym
+                                           (module prefix->module (file->namespace %))))
+                               (map file->path-relative-to-project-root))
+                         (ns.find/find-sources-in-dir test-dir)))]
+     (into (existing-test-file-paths path-prefix)
+           nested-tests))))
 
 (defn source-filenames->relevant-test-filenames
   "Given a collection of `source-filenames`, return the set of test filenames (relative to the project root directory)
   that we should re-run when any of `source-filenames` change."
   ([source-filenames]
-   (source-filenames->relevant-test-filenames (dependencies) source-filenames))
-  ([deps source-filenames]
+   (let [modules-config (kondo-config)
+         prefix->mod    (build-prefix->module modules-config)]
+     (source-filenames->relevant-test-filenames (dependencies prefix->mod) modules-config prefix->mod source-filenames)))
+  ([deps modules-config prefix->mod source-filenames]
    (into
     (sorted-set)
     (comp (map file->namespace)
-          (map module)
+          (map (partial module prefix->mod))
           (remove nil?)
           (distinct)
           (mapcat #(module->dependents deps %))
-          (mapcat module->test-files))
+          (mapcat #(module->test-files modules-config prefix->mod %)))
     source-filenames)))
 
 (comment
@@ -1215,17 +1591,20 @@
 
 (defn model-ownership
   "Scan all source files via [[find-model-definitions]], building a map of `:model/X` => module symbol.
-  The module is derived from the defining namespace via [[module]]."
+  The module is derived from the defining namespace via [[module]], using the
+  prefix map built from the current kondo config so that nested modules
+  (and modules with explicit `:ns-prefix`) resolve correctly."
   []
-  (into (sorted-map)
-        (for [file  (find-source-files)
-              :let  [ns-symb (-> (ns.file/read-file-ns-decl file)
-                                 ns.parse/name-from-ns-decl)
-                     mod     (module ns-symb)
-                     models  (find-model-definitions file)]
-              :when mod
-              model models]
-          [model mod])))
+  (let [prefix->mod (build-prefix->module (kondo-config))]
+    (into (sorted-map)
+          (for [file  (find-source-files)
+                :let  [ns-symb (-> (ns.file/read-file-ns-decl file)
+                                   ns.parse/name-from-ns-decl)
+                       mod     (module prefix->mod ns-symb)
+                       models  (find-model-definitions file)]
+                :when mod
+                model models]
+            [model mod]))))
 
 (def ^:private model-boundary-exempt-namespaces
   "Namespaces that are exempt from model boundary checking. These are 'glue' namespaces that intentionally reference
@@ -1257,26 +1636,30 @@
 (defn model-references-by-module
   "Scan all source files and build a map of `{module => #{:model/X ...}}` — the set of model keywords
   referenced in each module's source files. Exempt namespaces (e.g. `metabase.models.resolution`) are excluded.
-  Includes all modules (including bypass modules) — callers filter as needed."
+  Includes all modules (including bypass modules) — callers filter as needed.
+
+  Uses the prefix map from the current kondo config so nested modules
+  resolve via [[module]] correctly."
   []
-  (reduce
-   (fn [acc file]
-     (try
-       (let [ns-symb (-> (ns.file/read-file-ns-decl file)
-                         ns.parse/name-from-ns-decl)
-             mod     (module ns-symb)]
-         (if (and mod (not (contains? model-boundary-exempt-namespaces ns-symb)))
-           (let [models (find-model-keywords file)]
-             (if (seq models)
-               (update acc mod (fnil into (sorted-set)) models)
-               acc))
-           acc))
-       (catch Throwable e
-         (throw (ex-info (format "Error scanning model references in %s" (str file))
-                         {:file file}
-                         e)))))
-   (sorted-map)
-   (find-source-files)))
+  (let [prefix->mod (build-prefix->module (kondo-config))]
+    (reduce
+     (fn [acc file]
+       (try
+         (let [ns-symb (-> (ns.file/read-file-ns-decl file)
+                           ns.parse/name-from-ns-decl)
+               mod     (module prefix->mod ns-symb)]
+           (if (and mod (not (contains? model-boundary-exempt-namespaces ns-symb)))
+             (let [models (find-model-keywords file)]
+               (if (seq models)
+                 (update acc mod (fnil into (sorted-set)) models)
+                 acc))
+             acc))
+         (catch Throwable e
+           (throw (ex-info (format "Error scanning model references in %s" (str file))
+                           {:file file}
+                           e)))))
+     (sorted-map)
+     (find-source-files))))
 
 (defn model-boundary-violations
   "Find all model boundary violations across the codebase.
@@ -1294,36 +1677,37 @@
   ([kondo-config]
    (model-boundary-violations kondo-config (model-ownership)))
   ([kondo-config ownership]
-   (into []
-         (comp
-          (mapcat
-           (fn [file]
-             (try
-               (let [ns-symb (-> (ns.file/read-file-ns-decl file)
-                                 ns.parse/name-from-ns-decl)
-                     mod     (module ns-symb)]
-                 (when (and mod
-                            (not (contains? model-boundary-exempt-namespaces ns-symb)))
-                   (let [model-imports (get-in kondo-config [mod :model-imports] #{})
-                         models       (find-model-keywords file)
-                         rel-path     (file->path-relative-to-project-root file)]
-                     (for [model          models
-                           :let           [defining-mod  (get ownership model)]
-                           :when          (not= defining-mod mod)
-                           :let           [model-exports (when defining-mod
-                                                           (get-in kondo-config [defining-mod :model-exports] #{}))]
-                           violation-type (model-reference-violations
-                                           model defining-mod model-exports model-imports)]
-                       {:file            rel-path
-                        :module          mod
-                        :model           model
-                        :defining-module defining-mod
-                        :violation-type  violation-type}))))
-               (catch Throwable e
-                 (throw (ex-info (format "Error checking model boundaries in %s" (str file))
-                                 {:file file}
-                                 e)))))))
-         (find-source-files))))
+   (let [prefix->mod (build-prefix->module kondo-config)]
+     (into []
+           (comp
+            (mapcat
+             (fn [file]
+               (try
+                 (let [ns-symb (-> (ns.file/read-file-ns-decl file)
+                                   ns.parse/name-from-ns-decl)
+                       mod     (module prefix->mod ns-symb)]
+                   (when (and mod
+                              (not (contains? model-boundary-exempt-namespaces ns-symb)))
+                     (let [model-imports (get-in kondo-config [mod :model-imports] #{})
+                           models       (find-model-keywords file)
+                           rel-path     (file->path-relative-to-project-root file)]
+                       (for [model          models
+                             :let           [defining-mod  (get ownership model)]
+                             :when          (not= defining-mod mod)
+                             :let           [model-exports (when defining-mod
+                                                             (get-in kondo-config [defining-mod :model-exports] #{}))]
+                             violation-type (model-reference-violations
+                                             model defining-mod model-exports model-imports)]
+                         {:file            rel-path
+                          :module          mod
+                          :model           model
+                          :defining-module defining-mod
+                          :violation-type  violation-type}))))
+                 (catch Throwable e
+                   (throw (ex-info (format "Error checking model boundaries in %s" (str file))
+                                   {:file file}
+                                   e)))))))
+           (find-source-files)))))
 
 (comment
   (model-ownership)

--- a/dev/src/dev/deps_graph.clj
+++ b/dev/src/dev/deps_graph.clj
@@ -1105,25 +1105,24 @@
       (symbol (str prefix ".core"))
       (symbol (str prefix ".init"))}))
 
-(defn- module-top-level-ancestor
-  [declared-modules module]
-  (or (last (module-ancestor-chain declared-modules module)) module))
-
-(defn- externally-referenceable-module?
+(defn- module-visibility-root
+  "The module whose subtree `module` is private to, or `nil` if it may be named from anywhere.
+  Mirror of `hooks.common.modules/visibility-root` — see that function for the semantics."
   [config module]
   (let [declared-modules (set (keys config))]
     (loop [module module]
-      (if-let [parent (module-parent declared-modules module)]
-        (and (contains? (expanded-module-exports config parent) module)
-             (recur parent))
-        true))))
+      (when-let [parent (module-parent declared-modules module)]
+        (if (contains? (expanded-module-exports config parent) module)
+          (recur parent)
+          parent)))))
 
 (defn- module-namable-from?
   [config caller target]
-  (let [declared-modules (set (keys config))]
-    (or (= (module-top-level-ancestor declared-modules caller)
-           (module-top-level-ancestor declared-modules target))
-        (externally-referenceable-module? config target))))
+  (let [declared-modules (set (keys config))
+        root             (module-visibility-root config target)]
+    (or (nil? root)
+        (= root caller)
+        (boolean (some #(= root %) (module-ancestor-chain declared-modules caller))))))
 
 (defn- expanded-module-uses
   [config module]

--- a/dev/src/dev/deps_graph.clj
+++ b/dev/src/dev/deps_graph.clj
@@ -830,16 +830,10 @@
    (let [fd (partial file-dependencies prefix->module)]
      (map fd (find-source-files)))))
 
-(defn configured-dependencies
-  "Scan dependencies using every declared module's effective namespace prefix."
-  []
-  (let [config (kondo-config)]
-    (dependencies (build-prefix->module config))))
-
 (defn external-usages
   "All usages of a module named by `module-symb` outside that module."
   ([module-symb]
-   (external-usages (configured-dependencies) module-symb))
+   (external-usages (dependencies) module-symb))
 
   ([deps module-symb]
    (for [dep    deps
@@ -854,7 +848,7 @@
 (defn external-usages-by-namespace
   "Return a map of module namespace => set of external namespaces using it"
   ([module-symb]
-   (external-usages-by-namespace (configured-dependencies) module-symb))
+   (external-usages-by-namespace (dependencies) module-symb))
 
   ([deps module-symb]
    (into (sorted-map)
@@ -962,7 +956,7 @@
 (defn module-usages-of-other-module
   "Information about how `module-x` uses `module-y`."
   ([module-x module-y]
-   (module-usages-of-other-module (configured-dependencies) module-x module-y))
+   (module-usages-of-other-module (dependencies) module-x module-y))
 
   ([deps module-x module-y]
    (let [module-x-ns->module-y-ns (->> (external-usages deps module-y)
@@ -1239,7 +1233,7 @@
     {api      []                         ; settings depends on api directly
      api-keys [permissions collections]} ; settings depends on permissions which depends on collections which depends on api-keys"
   ([module]
-   (all-module-deps-paths (configured-dependencies) module))
+   (all-module-deps-paths (dependencies) module))
   ([deps module]
    (all-module-deps-paths deps module (sorted-map) (atom #{}) []))
   ([deps module acc already-seen path]
@@ -1269,7 +1263,7 @@
               ...}
      ...}"
   ([module]
-   (module-dependencies-by-namespace (configured-dependencies) module))
+   (module-dependencies-by-namespace (dependencies) module))
 
   ([deps module]
    (into (sorted-map)
@@ -1287,7 +1281,7 @@
     ;; =>
     #{request}"
   [module namespace-symb-or-set]
-  (let [deps            (configured-dependencies)
+  (let [deps            (dependencies)
         namespace-symbs (if (symbol? namespace-symb-or-set)
                           #{namespace-symb-or-set}
                           namespace-symb-or-set)
@@ -1301,7 +1295,7 @@
 (defn leaf-modules
   "Modules that are leaf nodes in the module dependency tree -- nothing else depends on them."
   ([]
-   (leaf-modules (configured-dependencies)))
+   (leaf-modules (dependencies)))
   ([deps]
    (into (sorted-set)
          (comp (map :module)
@@ -1314,7 +1308,7 @@
   "Modules that `module` does not depend on, either directly or indirectly -- changes to any of these modules should not
   affect `module`."
   [module]
-  (let [deps        (configured-dependencies)
+  (let [deps        (dependencies)
         all-modules (into (sorted-set) (map :module) deps)
         module-deps (set (keys (all-module-deps-paths deps module)))]
     ;; dev REPL tool; the summary line is for the human at the console
@@ -1441,7 +1435,7 @@
 (defn- indirect-dependents
   "Set of modules that either directly or indirectly depend on `module`."
   ([module]
-   (indirect-dependents (configured-dependencies) module))
+   (indirect-dependents (dependencies) module))
   ([deps module]
    (indirect-dependents deps module (sorted-set)))
   ([deps module acc]

--- a/dev/src/dev/module_metrics.clj
+++ b/dev/src/dev/module_metrics.clj
@@ -38,11 +38,11 @@
           deps))
 
 (defn- canonical-api-namespaces
-  "The conventional API namespaces for `module`, derived from its name."
-  [_config module]
-  (let [prefix (if (= (namespace module) "enterprise")
-                 (str "metabase-enterprise." (name module))
-                 (str "metabase." (name module)))]
+  "The default API namespaces for `module`, derived from its effective `:ns-prefix` so that
+  explicit-prefix modules like `actions.rest` (prefix `metabase.actions-rest`) get
+  `metabase.actions-rest.api` rather than a name-derived guess."
+  [config module]
+  (let [prefix (deps-graph/module-ns-prefix config module)]
     (into (sorted-set)
           (map (fn [suffix]
                  (symbol (str prefix "." suffix))))
@@ -85,6 +85,13 @@
                   (max 0))]
       (nth sorted-values idx))))
 
+(defn- top-level-module?
+  "True if `m` has no parent module. A dotted child (`lib.schema`) and an `enterprise/x` whose OSS `x`
+  is declared both have parents; a standalone `enterprise/x` (no OSS counterpart) is top-level. Uses
+  the same `module-parent` resolution as the ratchet count, so the two agree."
+  [declared-modules m]
+  (nil? (deps-graph/module-parent declared-modules m)))
+
 (defn- file-loc
   "Line count of source `filename`, or 0 if it can't be read (e.g. synthetic filenames in tests)."
   [filename]
@@ -113,7 +120,8 @@
 (defn- build-graph-context
   "Build all shared intermediate data structures needed by both per-module and repo-level metrics."
   [deps config]
-  (let [modules'                 (modules deps config)
+  (let [prefix->mod              (deps-graph/build-prefix->module config)
+        modules'                 (modules deps config)
         direct-deps-graph        (merge (zipmap modules' (repeat (sorted-set)))
                                         (deps-graph/module-dependencies deps))
         module->paths            (into (sorted-map)
@@ -139,12 +147,13 @@
         module->relevant-test-files (into (sorted-map)
                                           (map (fn [module]
                                                  [module (deps-graph/source-filenames->relevant-test-filenames
-                                                          deps (get module->sources module))]))
+                                                          deps config prefix->mod (get module->sources module))]))
                                           modules')
         all-test-files           (into (sorted-set) (mapcat val) module->relevant-test-files)
         sccs                     (deps-graph/strongly-connected-components direct-deps-graph)
         module->scc              (into {} (for [component sccs, m component] [m component]))]
-    {:modules                  modules'
+    {:prefix->mod              prefix->mod
+     :modules                  modules'
      :direct-deps-graph        direct-deps-graph
      :module->paths            module->paths
      :transitive-deps-graph    transitive-deps-graph
@@ -162,7 +171,8 @@
   [deps config {:keys [modules direct-deps-graph module->paths transitive-deps-graph
                        direct-dependents-graph transitive-dependents module->nses module->sources
                        module->relevant-test-files sccs module->scc]}]
-  (let [largest-cycle (largest-cyclic-component direct-deps-graph sccs)]
+  (let [largest-cycle    (largest-cyclic-component direct-deps-graph sccs)
+        declared-modules (set (keys config))]
     (into []
           (map (fn [module]
                  (let [direct-deps               (get direct-deps-graph module)
@@ -195,6 +205,7 @@
                        reachable-namespace-count (reduce + 0 (map #(count (get module->nses %)) transitive-deps))]
                    (ordered-map/ordered-map
                     :module module
+                    :top-level? (top-level-module? declared-modules module)
                     :dependencies
                     (ordered-map/ordered-map
                      :direct-count (count direct-deps)
@@ -241,14 +252,16 @@
 (defn metrics
   "Per-module dependency, cycle, boundary, size, and blast-radius metrics, grouped by concern."
   ([]
-   (metrics (deps-graph/dependencies) (deps-graph/kondo-config)))
+   (let [config (deps-graph/kondo-config)]
+     (metrics (deps-graph/dependencies (deps-graph/build-prefix->module config)) config)))
   ([deps config]
    (metrics* deps config (build-graph-context deps config))))
 
 (defn repo-metrics
   "Repository-wide summaries derived from [[metrics]]."
   ([]
-   (repo-metrics (deps-graph/dependencies) (deps-graph/kondo-config)))
+   (let [config (deps-graph/kondo-config)]
+     (repo-metrics (deps-graph/dependencies (deps-graph/build-prefix->module config)) config)))
   ([deps config]
    (let [ctx                         (build-graph-context deps config)
          module-metrics              (metrics* deps config ctx)
@@ -291,6 +304,7 @@
       :graph
       (ordered-map/ordered-map
        :module-count module-count
+       :top-level-module-count (count (filter :top-level? module-metrics))
        :edge-count edge-count
        :mean-out-degree (safe-ratio edge-count module-count)
        :max-in-degree (reduce max 0 in-degrees)
@@ -339,9 +353,11 @@
 (defn csv
   "Write [[metrics]] as CSV to `*out*`."
   ([]
-   (csv (deps-graph/dependencies) (deps-graph/kondo-config)))
+   (let [config (deps-graph/kondo-config)]
+     (csv (deps-graph/dependencies (deps-graph/build-prefix->module config)) config)))
   ([deps config]
    (let [paths [[:module]
+                [:top-level?]
                 [:dependencies :direct-count]
                 [:dependencies :transitive-count]
                 [:dependencies :reachable-namespace-count]
@@ -381,11 +397,11 @@
   (deps-graph/kondo-config))
 
 (defn deps
-  "Scan source dependencies."
+  "Scan source dependencies using the config's effective namespace prefixes."
   ([]
    (deps (config)))
-  ([_config]
-   (deps-graph/dependencies)))
+  ([config]
+   (deps-graph/dependencies (deps-graph/build-prefix->module config))))
 
 (defn churn-weighted-blast-radius
   "Churn-weighted selective-CI cost: replay the last `days` days of commits (default 90) and, per commit,
@@ -398,7 +414,7 @@
    (let [modules      (modules deps config)
          graph        (merge (zipmap modules (repeat #{}))
                              (deps-graph/module-dependencies deps))
-         module->tests (module-scc/module->test-files modules)
+         module->tests (module-scc/module->test-files config modules)
          file->module (into {} (map (juxt :filename :module)) deps)
          commits      (module-scc/commit-file-lists days)]
      (module-scc/expected-tests-per-commit graph module->tests file->module commits))))

--- a/dev/src/dev/module_metrics.clj
+++ b/dev/src/dev/module_metrics.clj
@@ -38,11 +38,11 @@
           deps))
 
 (defn- canonical-api-namespaces
-  "The conventional API namespaces for `module`, derived from its name."
-  [_config module]
-  (let [prefix (if (= (namespace module) "enterprise")
-                 (str "metabase-enterprise." (name module))
-                 (str "metabase." (name module)))]
+  "The default API namespaces for `module`, derived from its effective `:ns-prefix` so that
+  explicit-prefix modules like `actions.rest` (prefix `metabase.actions-rest`) get
+  `metabase.actions-rest.api` rather than a name-derived guess."
+  [config module]
+  (let [prefix (deps-graph/module-ns-prefix config module)]
     (into (sorted-set)
           (map (fn [suffix]
                  (symbol (str prefix "." suffix))))
@@ -84,6 +84,13 @@
                   dec
                   (max 0))]
       (nth sorted-values idx))))
+
+(defn- top-level-module?
+  "True if `m` has no parent module. A dotted child (`lib.schema`) and an `enterprise/x` whose OSS `x`
+  is declared both have parents; a standalone `enterprise/x` (no OSS counterpart) is top-level. Uses
+  the same `module-parent` resolution as the ratchet count, so the two agree."
+  [declared-modules m]
+  (nil? (deps-graph/module-parent declared-modules m)))
 
 (defn- file-loc
   "Line count of source `filename`, or 0 if it can't be read (e.g. synthetic filenames in tests)."
@@ -149,7 +156,8 @@
 (defn- build-graph-context
   "Build all shared intermediate data structures needed by both per-module and repo-level metrics."
   [deps config]
-  (let [modules'                 (modules deps config)
+  (let [prefix->mod              (deps-graph/build-prefix->module config)
+        modules'                 (modules deps config)
         direct-deps-graph        (merge (zipmap modules' (repeat (sorted-set)))
                                         (deps-graph/module-dependencies deps))
         module->paths            (into (sorted-map)
@@ -175,7 +183,7 @@
         module->relevant-test-files (into (sorted-map)
                                           (map (fn [module]
                                                  [module (deps-graph/source-filenames->relevant-test-filenames
-                                                          deps (get module->sources module))]))
+                                                          deps config prefix->mod (get module->sources module))]))
                                           modules')
         all-test-files           (into (sorted-set) (mapcat val) module->relevant-test-files)
         ;; The require graph plus the model-import edges the config records. A module that reads another
@@ -186,7 +194,8 @@
                                              (deps-graph/model-import-dependencies config))
         sccs                     (deps-graph/strongly-connected-components direct-deps-graph)
         module->scc              (into {} (for [component sccs, m component] [m component]))]
-    {:modules                  modules'
+    {:prefix->mod              prefix->mod
+     :modules                  modules'
      :direct-deps-graph        direct-deps-graph
      :combined-deps-graph      combined-deps-graph
      :module->paths            module->paths
@@ -205,7 +214,8 @@
   [deps config {:keys [modules direct-deps-graph module->paths transitive-deps-graph
                        direct-dependents-graph transitive-dependents module->nses module->sources
                        module->relevant-test-files sccs module->scc]}]
-  (let [largest-cycle (largest-cyclic-component direct-deps-graph sccs)]
+  (let [largest-cycle    (largest-cyclic-component direct-deps-graph sccs)
+        declared-modules (set (keys config))]
     (into []
           (map (fn [module]
                  (let [direct-deps               (get direct-deps-graph module)
@@ -238,6 +248,7 @@
                        reachable-namespace-count (reduce + 0 (map #(count (get module->nses %)) transitive-deps))]
                    (ordered-map/ordered-map
                     :module module
+                    :top-level? (top-level-module? declared-modules module)
                     :dependencies
                     (ordered-map/ordered-map
                      :direct-count (count direct-deps)
@@ -284,14 +295,16 @@
 (defn metrics
   "Per-module dependency, cycle, boundary, size, and blast-radius metrics, grouped by concern."
   ([]
-   (metrics (deps-graph/dependencies) (deps-graph/kondo-config)))
+   (let [config (deps-graph/kondo-config)]
+     (metrics (deps-graph/dependencies (deps-graph/build-prefix->module config)) config)))
   ([deps config]
    (metrics* deps config (build-graph-context deps config))))
 
 (defn repo-metrics
   "Repository-wide summaries derived from [[metrics]]."
   ([]
-   (repo-metrics (deps-graph/dependencies) (deps-graph/kondo-config)))
+   (let [config (deps-graph/kondo-config)]
+     (repo-metrics (deps-graph/dependencies (deps-graph/build-prefix->module config)) config)))
   ([deps config]
    (let [ctx                         (build-graph-context deps config)
          module-metrics              (metrics* deps config ctx)
@@ -329,6 +342,7 @@
       :graph
       (ordered-map/ordered-map
        :module-count module-count
+       :top-level-module-count (count (filter :top-level? module-metrics))
        :edge-count edge-count
        :mean-out-degree (safe-ratio edge-count module-count)
        :max-in-degree (reduce max 0 in-degrees)
@@ -381,9 +395,11 @@
 (defn csv
   "Write [[metrics]] as CSV to `*out*`."
   ([]
-   (csv (deps-graph/dependencies) (deps-graph/kondo-config)))
+   (let [config (deps-graph/kondo-config)]
+     (csv (deps-graph/dependencies (deps-graph/build-prefix->module config)) config)))
   ([deps config]
    (let [paths [[:module]
+                [:top-level?]
                 [:dependencies :direct-count]
                 [:dependencies :transitive-count]
                 [:dependencies :reachable-namespace-count]
@@ -423,11 +439,11 @@
   (deps-graph/kondo-config))
 
 (defn deps
-  "Scan source dependencies."
+  "Scan source dependencies using the config's effective namespace prefixes."
   ([]
    (deps (config)))
-  ([_config]
-   (deps-graph/dependencies)))
+  ([config]
+   (deps-graph/dependencies (deps-graph/build-prefix->module config))))
 
 (defn churn-weighted-blast-radius
   "Churn-weighted selective-CI cost: replay the last `days` days of commits (default 90) and, per commit,
@@ -440,7 +456,7 @@
    (let [modules      (modules deps config)
          graph        (merge (zipmap modules (repeat #{}))
                              (deps-graph/module-dependencies deps))
-         module->tests (module-scc/module->test-files modules)
+         module->tests (module-scc/module->test-files config modules)
          file->module (into {} (map (juxt :filename :module)) deps)
          commits      (module-scc/commit-file-lists days)]
      (module-scc/expected-tests-per-commit graph module->tests file->module commits))))

--- a/dev/src/dev/module_scc.clj
+++ b/dev/src/dev/module_scc.clj
@@ -220,9 +220,9 @@
 (defn module->test-files
   "Map of module → set of its test files, via the same filesystem mapping the selective-CI helpers use.
   ([[dev.deps-graph/module->test-files]] is private; this is dev tooling, so we go through the var.)"
-  [modules]
+  [config modules]
   (into (sorted-map)
-        (map (fn [m] [m (#'deps-graph/module->test-files m)]))
+        (map (fn [m] [m (#'deps-graph/module->test-files config m)]))
         modules))
 
 ;;;; ------------------------------------------------------------------------------------------------
@@ -384,7 +384,9 @@
            :num-commits-skipped (- (count commits) (count counts)))))
 
 (comment
-  (def deps*    (deps-graph/dependencies))
+  (def config*  (deps-graph/kondo-config))
+  (def prefix*  (deps-graph/build-prefix->module config*))
+  (def deps*    (deps-graph/dependencies prefix*))
   (def graph*   (deps-graph/module-dependencies deps*))
 
   (dissoc (scc-summary graph*) :largest-scc-members)
@@ -392,7 +394,7 @@
   (take 10 (node-cut-impacts graph*))
   (take 10 (edge-cut-impacts graph*))
 
-  (def m->tests* (module->test-files (sort (into (set (keys graph*)) (mapcat val) graph*))))
+  (def m->tests* (module->test-files config* (sort (into (set (keys graph*)) (mapcat val) graph*))))
   ;; sanity check: on the unmodified graph the median should be pegged at ~the full test-file count
   (dissoc (predicted-test-blast-radius graph* m->tests*) :per-module)
   ;; predicted payoff of the best carve candidate

--- a/dev/src/dev/module_scc.clj
+++ b/dev/src/dev/module_scc.clj
@@ -229,9 +229,9 @@
 (defn module->test-files
   "Map of module → set of its test files, via the same filesystem mapping the selective-CI helpers use.
   ([[dev.deps-graph/module->test-files]] is private; this is dev tooling, so we go through the var.)"
-  [modules]
+  [config modules]
   (into (sorted-map)
-        (map (fn [m] [m (#'deps-graph/module->test-files m)]))
+        (map (fn [m] [m (#'deps-graph/module->test-files config m)]))
         modules))
 
 ;;;; ------------------------------------------------------------------------------------------------
@@ -393,7 +393,9 @@
            :num-commits-skipped (- (count commits) (count counts)))))
 
 (comment
-  (def deps*    (deps-graph/dependencies))
+  (def config*  (deps-graph/kondo-config))
+  (def prefix*  (deps-graph/build-prefix->module config*))
+  (def deps*    (deps-graph/dependencies prefix*))
   (def graph*   (deps-graph/module-dependencies deps*))
 
   (dissoc (scc-summary graph*) :largest-scc-members)
@@ -411,7 +413,7 @@
   (take 10 (node-cut-impacts graph*))
   (take 10 (edge-cut-impacts graph*))
 
-  (def m->tests* (module->test-files (sort (into (set (keys graph*)) (mapcat val) graph*))))
+  (def m->tests* (module->test-files config* (sort (into (set (keys graph*)) (mapcat val) graph*))))
   ;; sanity check: on the unmodified graph the median should be pegged at ~the full test-file count
   (dissoc (predicted-test-blast-radius graph* m->tests*) :per-module)
   ;; predicted payoff of the best carve candidate

--- a/dev/src/dev/modules_config.clj
+++ b/dev/src/dev/modules_config.clj
@@ -4,9 +4,9 @@
   The heavy lifting already lives in [[dev.deps-graph]] (which computes the correct `:api` and `:uses`
   for every module) and [[dev.model-boundary-config]] (which computes `:model-exports`/`:model-imports`).
   This namespace ties them together into a single writer that rewrites the four *generated* keys in place,
-  sorted, while preserving everything a human owns: `:team`, `:friends`, header/footer comments, inline
-  `;;` annotations on set elements, the `:ignored-namespace-patterns` key, and the sentinel values
-  `:any`/`:bypass`.
+  sorted, while preserving everything a human owns: `:team`, `:friends`, `:ns-prefix`, `:module-exports`,
+  header/footer comments, inline `;;` annotations on set elements, the `:ignored-namespace-patterns` key,
+  and the sentinel values `:any`/`:bypass`.
 
   Usage:
 
@@ -18,8 +18,9 @@
 
   Scope: this auto-fixes the *content and ordering* of `:api`, `:uses`, `:model-exports`, and
   `:model-imports` for modules that already exist in the config. Structural changes — adding a brand new
-  module (which needs a human-assigned `:team`), removing a stale one, or reordering modules — are only
-  *reported* as warnings, never performed, since they require judgement this tool doesn't have."
+  module (whose namespace prefix and ownership may need human input), removing a stale one, or reordering
+  modules — are only *reported* as warnings, never performed, since they require judgement this tool
+  doesn't have."
   (:require
    [clojure.string :as str]
    [dev.deps-graph :as deps-graph]
@@ -209,7 +210,8 @@
   seconds."
   ([]
    (let [config (deps-graph/kondo-config)
-         f-deps (future (deps-graph/dependencies))
+         prefix->module (deps-graph/build-prefix->module config)
+         f-deps (future (deps-graph/dependencies prefix->module))
          f-own  (future (deps-graph/model-ownership))
          f-refs (future (deps-graph/model-references-by-module))]
      (compute-desired config @f-deps @f-own @f-refs)))
@@ -242,7 +244,8 @@
         sorted?     (= file-modules (sort-module-names file-modules))]
     (cond-> []
       (seq to-add)
-      (conj (str "New module(s) not in config — add them by hand (they need a :team): "
+      (conj (str "New module(s) not in config — add them by hand (choose their namespace prefix and "
+                 "ownership; nested modules may inherit :team): "
                  (str/join ", " to-add)))
 
       (not sorted?)

--- a/dev/test/dev/modules_config_test.clj
+++ b/dev/test/dev/modules_config_test.clj
@@ -4,6 +4,8 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [dev.deps-graph :as deps-graph]
+   [dev.model-boundary-config :as mbc]
    [dev.modules-config :as mc]
    [rewrite-clj.node :as n]
    [rewrite-clj.parser :as r.parser]))
@@ -53,6 +55,23 @@
       (is (= #{:model/Beta :model/Gamma} (get-in desired ['alpha :model-imports]))))
     (testing "a :bypass module drives no imports and its references don't force exports"
       (is (= #{} (get-in desired ['gamma :model-imports]))))))
+
+(deftest compute-desired-scans-with-the-configured-prefixes-test
+  (let [config '{parent       {:team "T"}
+                 parent.child {:ns-prefix metabase.special-child}}
+        expected-prefixes (deps-graph/build-prefix->module config)
+        seen-prefixes (promise)]
+    (with-redefs [deps-graph/kondo-config (constantly config)
+                  deps-graph/dependencies (fn [prefix->module]
+                                            (deliver seen-prefixes prefix->module)
+                                            [])
+                  deps-graph/model-ownership (constantly {})
+                  deps-graph/model-references-by-module (constantly {})
+                  deps-graph/generate-config (constantly {})
+                  mbc/compute-model-boundaries (constantly {})]
+      (mc/compute-desired)
+      (is (= expected-prefixes @seen-prefixes)
+          "the rewrite scan must resolve explicit and nested namespace prefixes like validation does"))))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; Sorting (must match metabase.core.modules-test)
@@ -104,6 +123,17 @@
                                        :uses #{other}
                                        :model-imports #{:model/X}}}))))))
 
+(deftest ^:parallel nested-module-metadata-is-preserved-test
+  (let [input (str "{:metabase/modules {parent {:team \"T\" :api #{}} "
+                   "parent.child {:ns-prefix metabase.special-child "
+                   ":module-exports #{parent.grandchild} :api #{}}}}")
+        output (rewrite input '{parent       {:api #{}}
+                                parent.child {:api #{metabase.special-child.core}}})
+        modules (parse-modules output)]
+    (is (= "T" (get-in modules ['parent :team])))
+    (is (= 'metabase.special-child (get-in modules ['parent.child :ns-prefix])))
+    (is (= '#{parent.grandchild} (get-in modules ['parent.child :module-exports])))))
+
 (deftest ^:parallel missing-key-is-appended-test
   (let [input  "{:metabase/modules {m {:team \"T\"}}}"
         output (rewrite input '{m {:api #{metabase.m.core}}})]
@@ -137,7 +167,7 @@
 ;;;; ---------------------------------------------------------------------------
 
 (deftest ^:parallel structural-warnings-test
-  (testing "a desired module absent from the file is reported (needs a human-assigned :team)"
+  (testing "a desired module absent from the file is reported for human structural decisions"
     (let [{:keys [warnings]} (mc/rewrite-config "{:metabase/modules {a {:uses #{}}}}"
                                                 '{a {:uses #{}} b {:uses #{}}})]
       (is (some #(str/includes? % "b") warnings))))

--- a/dev/test/metabase/core/modules_test.clj
+++ b/dev/test/metabase/core/modules_test.clj
@@ -228,19 +228,12 @@
   [config]
   (set (keys config)))
 
-(defn- top-level-ancestor
-  "Return the topmost ancestor of module `m` (or `m` itself if it's already
-  top-level). Used for subtree-membership checks. Honors the `enterprise/X`
+(defn- in-subtree?
+  "True if `m` is `root` or one of its descendants. Honors the `enterprise/X`
   shorthand when `declared` is provided."
-  [declared m]
-  (or (last (dev.deps-graph/module-ancestor-chain declared m)) m))
-
-(defn- same-subtree?
-  "True if `caller` and `target` share a top-level ancestor — i.e., they're
-  both descendants of the same top-level module (or one of them is the
-  top-level ancestor of the other)."
-  [declared caller target]
-  (= (top-level-ancestor declared caller) (top-level-ancestor declared target)))
+  [declared root m]
+  (or (= root m)
+      (boolean (some #(= root %) (dev.deps-graph/module-ancestor-chain declared m)))))
 
 (defn- top-level-oss-module?
   "True if `m` is a top-level OSS module symbol — no namespace part and a
@@ -262,45 +255,59 @@
     (cond-> explicit
       ee-child (conj ee-child))))
 
-(defn- externally-referenceable?
-  "True if `target` may be named in the `:uses` of a module outside its
-  top-level subtree. Equivalent to: every ancestor in the chain from
-  target up to top-level is `:module-exports`ed by its parent (and the top-level
-  ancestor is implicitly externally referenceable). Mirror of the
-  `externally-visible?` helper in the kondo hook."
+(defn- visibility-root
+  "The module whose subtree `target` is private to, or `nil` if `target` may be
+  named from anywhere. Walk up from `target` to the nearest ancestor that does
+  NOT `:module-exports` the module below it on the path; `nil` means the chain
+  reached top-level unobstructed. Mirror of the `visibility-root` helper in the
+  kondo hook."
   [config target]
   (let [declared (declared-modules-set config)]
     (loop [m target]
-      (if-let [p (dev.deps-graph/module-parent declared m)]
+      (when-let [p (dev.deps-graph/module-parent declared m)]
         (if (contains? (open-children* config p) m)
           (recur p)
-          false)
-        true))))
+          p)))))
+
+(defn- externally-referenceable?
+  "True if `target` may be named in the `:uses` of any module at all, wherever
+  it sits in the tree. Equivalent to: every ancestor in the chain from target
+  up to top-level is `:module-exports`ed by its parent (and the top-level
+  ancestor is implicitly externally referenceable) — i.e. `target` has no
+  `visibility-root`. Mirror of the `externally-visible?` helper in the kondo
+  hook."
+  [config target]
+  (nil? (visibility-root config target)))
 
 (defn- can-be-named-by?
   "True if `caller` is permitted to put `target` in its `:uses` declaration
   under the strict module model. Permitted iff:
-    - they share a top-level subtree (anyone in the same subtree can name
-      anyone else in the subtree), OR
-    - `target` is externally referenceable (top-level OR `:module-exports`ed all the
-      way from the root).
+    - `target` is externally referenceable (top-level OR `:module-exports`ed all
+      the way from the root), OR
+    - `caller` is inside the subtree of `target`'s `visibility-root` — the
+      nearest ancestor that keeps `target` private. Note this is the *nearest*
+      such ancestor, not the top-level one: sharing a top-level ancestor is not
+      on its own enough to name a deeply-private module.
 
   Uses the declared-modules set (from the config) so that the `enterprise/X`
   shorthand is honored: `enterprise/X` is treated as a child of the OSS
-  module `X` when `X` is declared."
+  module `X` when `X` is declared.
+
+  Mirror of `namable-from?` in `.clj-kondo/src/hooks/common/modules.clj`; the
+  two are meant to agree."
   [config caller target]
   (let [declared (declared-modules-set config)]
     (or (= caller target)
-        (same-subtree? declared caller target)
-        (externally-referenceable? config target))))
+        (externally-referenceable? config target)
+        (in-subtree? declared (visibility-root config target) caller))))
 
 (deftest ^:parallel uses-references-must-be-namable-test
   (testing (str "Every entry in a module's `:uses` must be a module that the caller is "
-                "allowed to name. Outside-of-subtree callers may only name modules that "
-                "are externally referenceable (top-level OR `:module-exports`ed by every ancestor "
-                "from the root). Same-subtree callers may name any module in the subtree.")
-    (let [config   (dev.deps-graph/kondo-config)
-          declared (declared-modules-set config)]
+                "allowed to name. A nested module is namable from the subtree of the nearest "
+                "ancestor that does not `:module-exports` it; outside that subtree it is namable "
+                "only if it is externally referenceable (top-level OR `:module-exports`ed by "
+                "every ancestor from the root).")
+    (let [config (dev.deps-graph/kondo-config)]
       (doseq [[caller cfg] config
               :let          [uses (:uses cfg)]
               :when         (set? uses)
@@ -314,14 +321,44 @@
           (is (can-be-named-by? config caller target)
               (format
                (str "%s declares :uses #{%s} but cannot name %s under the strict module model. "
-                    "Either: (a) move %s into %s's top-level subtree (currently %s vs %s), or "
-                    "(b) ensure %s is externally referenceable by adding it to its parent's "
-                    ":module-exports set (and recursively up to the top-level).")
+                    "%s is private to the %s subtree, and %s is outside it. Either: (a) move %s "
+                    "into that subtree, or (b) widen %s's visibility by adding it to its parent's "
+                    ":module-exports set (and recursively up, as far as it needs to go).")
                caller target target
-               target caller
-               (top-level-ancestor declared caller)
-               (top-level-ancestor declared target)
-               target)))))))
+               target (visibility-root config target) caller
+               caller target)))))))
+
+(deftest ^:parallel can-be-named-by?-test
+  (testing (str "Naming scope is the subtree of the nearest ancestor that does not export the "
+                "module below it on the path — not the whole top-level subtree. Mirrors "
+                "`namable-from?` in the kondo hook; the two must agree.")
+    (let [config {'outer        {}
+                  'outer.a      {}
+                  'outer.a.leaf {}
+                  'outer.a.sib  {}
+                  'outer.b      {}
+                  'outer.b.deep {}
+                  'unrelated    {}}]
+      (testing "top-level modules are namable from anywhere"
+        (is (true? (can-be-named-by? config 'unrelated 'outer))))
+      (testing "an unopened leaf is namable only from its nearest non-exporting ancestor's subtree"
+        (is (true?  (can-be-named-by? config 'outer.a 'outer.a.leaf)))
+        (is (true?  (can-be-named-by? config 'outer.a.sib 'outer.a.leaf)))
+        (is (false? (can-be-named-by? config 'outer 'outer.a.leaf)))
+        (is (false? (can-be-named-by? config 'outer.b 'outer.a.leaf))
+            "sharing the top-level module `outer` is not enough")
+        (is (false? (can-be-named-by? config 'outer.b.deep 'outer.a.leaf)))
+        (is (false? (can-be-named-by? config 'unrelated 'outer.a.leaf))))
+      (testing "exporting the leaf widens the scope to the whole `outer` subtree, but no further"
+        (let [config (assoc-in config ['outer.a :module-exports] #{'outer.a.leaf})]
+          (is (true?  (can-be-named-by? config 'outer 'outer.a.leaf)))
+          (is (true?  (can-be-named-by? config 'outer.b.deep 'outer.a.leaf)))
+          (is (false? (can-be-named-by? config 'unrelated 'outer.a.leaf)))))
+      (testing "exporting the whole chain makes the leaf namable from anywhere"
+        (let [config (-> config
+                         (assoc-in ['outer.a :module-exports] #{'outer.a.leaf})
+                         (assoc-in ['outer :module-exports] #{'outer.a}))]
+          (is (true? (can-be-named-by? config 'unrelated 'outer.a.leaf))))))))
 
 (deftest ^:parallel ns-prefix-uniqueness-test
   (testing (str "Every module has a unique effective :ns-prefix (explicit via :ns-prefix "

--- a/dev/test/metabase/core/modules_test.clj
+++ b/dev/test/metabase/core/modules_test.clj
@@ -39,13 +39,55 @@
 (def ^:private teams-to-reassign #{"Admin Webapp" "DashViz"})
 
 (deftest all-modules-have-teams-test
-  (testing "All modules should have a valid :team owner"
-    (let [teams (teams)]
-      (doseq [[module config] (modules-config)]
+  (testing "All modules should have a valid effective :team owner"
+    (let [teams  (teams)
+          config (dev.deps-graph/expanded-kondo-config (modules-config))]
+      (doseq [[module config] config]
         (testing (format "\n'%s' module" module)
           (is (or (contains? teams (:team config))
                   (contains? teams-to-reassign (:team config)))
               "Should have a valid :team key"))))))
+
+(deftest ^:parallel expanded-kondo-config-test
+  (let [config {'parent               {:team "Parent"}
+                'parent.child         {:ns-prefix "metabase.legacy-child"}
+                'parent.child.leaf    {:team "Leaf"}
+                'enterprise/parent    {}
+                'enterprise/standalone {:team "Enterprise"}}
+        expanded (dev.deps-graph/expanded-kondo-config config)]
+    (testing "children inherit team ownership from the closest configured ancestor"
+      (is (= "Parent" (get-in expanded ['parent.child :team])))
+      (is (= 'parent (dev.deps-graph/module-team-source config 'parent.child))))
+    (testing "an explicit child team overrides its ancestors"
+      (is (= "Leaf" (get-in expanded ['parent.child.leaf :team])))
+      (is (= 'parent.child.leaf (dev.deps-graph/module-team-source config 'parent.child.leaf))))
+    (testing "declared enterprise companions inherit from their OSS parent"
+      (is (= "Parent" (get-in expanded ['enterprise/parent :team])))
+      (is (= 'parent (dev.deps-graph/module-team-source config 'enterprise/parent))))
+    (testing "standalone enterprise modules keep their own ownership"
+      (is (= "Enterprise" (get-in expanded ['enterprise/standalone :team])))
+      (is (= 'enterprise/standalone
+             (dev.deps-graph/module-team-source config 'enterprise/standalone))))
+    (testing "config-only defaults are materialized"
+      (is (= "metabase.legacy-child" (get-in expanded ['parent.child :ns-prefix])))
+      (is (= '#{metabase.legacy-child.api metabase.legacy-child.core metabase.legacy-child.init}
+             (get-in expanded ['parent.child :api])))
+      (is (= #{} (get-in expanded ['parent.child :uses])))
+      (is (= #{} (get-in expanded ['parent.child :friends])))
+      (is (= '#{enterprise/parent} (get-in expanded ['parent :module-exports])))))
+  (testing "wildcards expand to their effective config and source-aware values"
+    (let [config   {'caller        {:uses :any}
+                    'parent        {:module-exports #{'parent.open}}
+                    'parent.hidden {}
+                    'parent.open   {}
+                    'public        {:api :any}}
+          deps     [{:module 'public :namespace 'metabase.public.alpha}
+                    {:module 'public :namespace 'metabase.public.beta}]
+          expanded (dev.deps-graph/expanded-kondo-config config deps)]
+      (is (= '#{parent parent.open public}
+             (get-in expanded ['caller :uses])))
+      (is (= '#{metabase.public.alpha metabase.public.beta}
+             (get-in expanded ['public :api]))))))
 
 (defn- modules-config-zipper
   "Return a zipper pointing to the modules config map node (the value of the `:metabase/modules` key)."
@@ -147,11 +189,16 @@
 (deftest modules-config-up-to-date-test
   (testing (str "Please update .clj-kondo/config/modules/config.edn 🥰\n"
                 "[Pro Tip: use (dev.deps-graph/print-kondo-config-diff) to see the changes you need to make in a nicer format]\n")
-    (let [deps     (dev.deps-graph/dependencies)
-          actual   (dev.deps-graph/kondo-config)
-          expected (dev.deps-graph/generate-config deps actual)
-          modules  (set/union (set (keys expected))
-                              (set (keys actual)))]
+    ;; Compute dependencies with awareness of the declared modules and their
+    ;; `:ns-prefix`es, so nested modules (e.g. `lib.schema` as a child of
+    ;; `lib`, or `lib.be` with an explicit :ns-prefix "metabase.lib-be")
+    ;; resolve via longest-prefix matching at segment boundaries.
+    (let [actual      (dev.deps-graph/kondo-config)
+          prefix->mod (dev.deps-graph/build-prefix->module actual)
+          deps        (dev.deps-graph/dependencies prefix->mod)
+          expected    (dev.deps-graph/generate-config deps actual)
+          modules     (set/union (set (keys expected))
+                                 (set (keys actual)))]
       (doseq [module modules
               :let   [_ (testing (format "Remove %s" (pr-str module))
                           (is (seq (get expected module))))]
@@ -176,6 +223,154 @@
         (testing (format "Remove %s from %s" (pr-str extraneous) (pr-str ks))
           (is (empty? extraneous)))))))
 
+(defn- declared-modules-set
+  "Set of declared module symbols from the kondo config (the outer keys)."
+  [config]
+  (set (keys config)))
+
+(defn- top-level-ancestor
+  "Return the topmost ancestor of module `m` (or `m` itself if it's already
+  top-level). Used for subtree-membership checks. Honors the `enterprise/X`
+  shorthand when `declared` is provided."
+  [declared m]
+  (or (last (dev.deps-graph/module-ancestor-chain declared m)) m))
+
+(defn- same-subtree?
+  "True if `caller` and `target` share a top-level ancestor — i.e., they're
+  both descendants of the same top-level module (or one of them is the
+  top-level ancestor of the other)."
+  [declared caller target]
+  (= (top-level-ancestor declared caller) (top-level-ancestor declared target)))
+
+(defn- top-level-oss-module?
+  "True if `m` is a top-level OSS module symbol — no namespace part and a
+  name with no dots. Mirror of `hooks.common.modules/top-level-oss-module?`."
+  [m]
+  (and (nil? (namespace m))
+       (not (str/includes? (name m) "."))))
+
+(defn- open-children*
+  "Mirror of `hooks.common.modules/open-children`. Returns the `:module-exports` set
+  for `parent` including the auto-opened `enterprise/X` counterpart when
+  `parent` is a top-level OSS module with a declared EE counterpart."
+  [config parent]
+  (let [explicit (set (get-in config [parent :module-exports]))
+        ee-child (when (top-level-oss-module? parent)
+                   (let [candidate (symbol "enterprise" (name parent))]
+                     (when (contains? config candidate)
+                       candidate)))]
+    (cond-> explicit
+      ee-child (conj ee-child))))
+
+(defn- externally-referenceable?
+  "True if `target` may be named in the `:uses` of a module outside its
+  top-level subtree. Equivalent to: every ancestor in the chain from
+  target up to top-level is `:module-exports`ed by its parent (and the top-level
+  ancestor is implicitly externally referenceable). Mirror of the
+  `externally-visible?` helper in the kondo hook."
+  [config target]
+  (let [declared (declared-modules-set config)]
+    (loop [m target]
+      (if-let [p (dev.deps-graph/module-parent declared m)]
+        (if (contains? (open-children* config p) m)
+          (recur p)
+          false)
+        true))))
+
+(defn- can-be-named-by?
+  "True if `caller` is permitted to put `target` in its `:uses` declaration
+  under the strict module model. Permitted iff:
+    - they share a top-level subtree (anyone in the same subtree can name
+      anyone else in the subtree), OR
+    - `target` is externally referenceable (top-level OR `:module-exports`ed all the
+      way from the root).
+
+  Uses the declared-modules set (from the config) so that the `enterprise/X`
+  shorthand is honored: `enterprise/X` is treated as a child of the OSS
+  module `X` when `X` is declared."
+  [config caller target]
+  (let [declared (declared-modules-set config)]
+    (or (= caller target)
+        (same-subtree? declared caller target)
+        (externally-referenceable? config target))))
+
+(deftest ^:parallel uses-references-must-be-namable-test
+  (testing (str "Every entry in a module's `:uses` must be a module that the caller is "
+                "allowed to name. Outside-of-subtree callers may only name modules that "
+                "are externally referenceable (top-level OR `:module-exports`ed by every ancestor "
+                "from the root). Same-subtree callers may name any module in the subtree.")
+    (let [config   (dev.deps-graph/kondo-config)
+          declared (declared-modules-set config)]
+      (doseq [[caller cfg] config
+              :let          [uses (:uses cfg)]
+              :when         (set? uses)
+              target        uses
+              ;; Skip references to modules that aren't actually declared
+              ;; (these will be caught by the staleness test as a separate
+              ;; concern; here we only check naming validity for declared
+              ;; targets).
+              :when         (contains? config target)]
+        (testing (format "\n[%s :uses %s]" (pr-str caller) (pr-str target))
+          (is (can-be-named-by? config caller target)
+              (format
+               (str "%s declares :uses #{%s} but cannot name %s under the strict module model. "
+                    "Either: (a) move %s into %s's top-level subtree (currently %s vs %s), or "
+                    "(b) ensure %s is externally referenceable by adding it to its parent's "
+                    ":module-exports set (and recursively up to the top-level).")
+               caller target target
+               target caller
+               (top-level-ancestor declared caller)
+               (top-level-ancestor declared target)
+               target)))))))
+
+(deftest ^:parallel ns-prefix-uniqueness-test
+  (testing (str "Every module has a unique effective :ns-prefix (explicit via :ns-prefix "
+                "config key or derived from the module name). Two modules sharing the same "
+                "prefix would create ambiguity in namespace→module resolution, so this test "
+                "enforces uniqueness across the whole config including implicit defaults.")
+    (let [config           (dev.deps-graph/kondo-config)
+          effective-prefix (fn [m]
+                             (or (get-in config [m :ns-prefix])
+                                 (dev.deps-graph/default-ns-prefix m)))
+          by-prefix        (group-by effective-prefix (keys config))]
+      (doseq [[prefix modules] by-prefix
+              :when            (> (count modules) 1)]
+        (testing (format "\nprefix %s is claimed by multiple modules: %s"
+                         (pr-str prefix)
+                         (pr-str (sort modules)))
+          (is (= 1 (count modules))
+              (format "Modules %s share :ns-prefix %s. Either give them distinct explicit :ns-prefix values, or rename one so its default prefix doesn't collide."
+                      (pr-str (sort modules))
+                      (pr-str prefix))))))))
+
+(deftest ^:parallel nested-modules-have-declared-parents-test
+  (testing "Every syntactically nested module has a declared direct parent"
+    (let [config   (dev.deps-graph/kondo-config)
+          declared (declared-modules-set config)]
+      (doseq [module declared
+              :let   [parent (dev.deps-graph/module-parent declared module)]
+              :when  parent]
+        (testing (format "\n%s is nested under %s" module parent)
+          (is (contains? declared parent)
+              (format "Declare parent module %s before declaring nested module %s."
+                      parent
+                      module)))))))
+
+(deftest ^:parallel module-exports-are-declared-direct-children-test
+  (testing "Every :module-exports entry names a declared direct child"
+    (let [config   (dev.deps-graph/kondo-config)
+          declared (declared-modules-set config)]
+      (doseq [[parent module-config] config
+              child                  (:module-exports module-config)]
+        (testing (format "\n[%s :module-exports %s]" parent child)
+          (is (contains? declared child)
+              (format "Exported child %s is not a declared module." child))
+          (is (= parent (dev.deps-graph/module-parent declared child))
+              (format "%s may only export direct children; %s has parent %s."
+                      parent
+                      child
+                      (dev.deps-graph/module-parent declared child))))))))
+
 (deftest ^:parallel module-boundary-config-values-have-valid-types-test
   (testing "Module boundary keys use the values understood by the linter"
     (doseq [[module config] (dev.deps-graph/kondo-config)]
@@ -190,7 +385,13 @@
             ":uses must be omitted, a set, or :any")
         (is (or (nil? (:friends config))
                 (set? (:friends config)))
-            ":friends must be a set when present")))))
+            ":friends must be a set when present")
+        (is (or (nil? (:module-exports config))
+                (set? (:module-exports config)))
+            ":module-exports must be a set when present")
+        (is (or (nil? (:ns-prefix config))
+                (string? (:ns-prefix config)))
+            ":ns-prefix must be a string when present")))))
 
 (deftest ^:parallel module-boundary-debt-matches-ratchets-test
   (testing "Module boundary anti-pattern counts match their exact ratchets"
@@ -215,7 +416,8 @@
   exactly: PR CI checks out the merge preview with master, so scan-derived keys (SCC sizes, namespace
   counts, test blast) legitimately differ from any branch's committed baseline whenever master moves.
   They are still synced into module-stats.edn for PR-diff visibility."
-  [:largest-api :model-import-bypass-modules :module-count :total-api])
+  [:largest-api :model-import-bypass-modules :module-count :module-exports :ns-prefix-overrides
+   :parent-team-mismatches :total-api])
 
 (deftest ^:parallel module-boundary-stats-match-committed-test
   (testing (str "Config-derived module surface stats match module-stats.edn. Unlike the ratchets these\n"
@@ -236,7 +438,7 @@
                 "must be dropped — the set is a ratchet (:driver-test-exempt-modules) and may only shrink.")
     (let [config    (dev.deps-graph/kondo-config)
           declared  (set (keys config))
-          deps      (dev.deps-graph/dependencies)
+          deps      (dev.deps-graph/dependencies (dev.deps-graph/build-prefix->module config))
           full      (dev.deps-graph/full-dependencies deps)
           ;; A trigger module's own entry is also meaningful: mage strips exemptions from the changed
           ;; set before computing what is affected, so it suppresses self-triggering.
@@ -266,13 +468,13 @@
                         (dev.deps-graph/lowered-module-boundary-ratchets {:debt 2} {:other 1}))))
 
 (deftest ^:parallel standalone-rest-module-debt-test
-  (testing "-rest module symbols are counted, in either the OSS or the enterprise namespace"
+  (testing "Only deprecated -rest module symbols count as debt; hyphenated namespace prefixes remain valid"
     (is (= 2
            (:standalone-rest-modules
             (dev.deps-graph/module-boundary-debt
              []
              {'actions-rest          {}
-              'actions               {}
+              'actions.rest          {:ns-prefix "metabase.actions-rest"}
               'enterprise/users-rest {}}))))))
 
 ;;;; Classpath / namespace convention
@@ -404,14 +606,18 @@
                     ee-namespace-prefix))))))
 
 (defn- rest-module?
-  "True for deprecated `-rest` module symbols."
+  "True for canonical nested `.rest` modules and deprecated `-rest` compatibility symbols."
   [module]
-  (str/ends-with? (str module) "-rest"))
+  (let [module-name (str module)]
+    (or (str/ends-with? module-name "-rest")
+        (str/ends-with? module-name ".rest"))))
 
 (defn- routes-module?
   "True for route aggregators, which are allowed to assemble REST routes."
   [module]
-  (str/ends-with? (str module) "-routes"))
+  (let [module-name (str module)]
+    (or (str/ends-with? module-name "-routes")
+        (str/ends-with? module-name ".routes"))))
 
 (defn- core-module?
   "True for OSS and EE core initializer modules."
@@ -424,9 +630,12 @@
   ((some-fn rest-module? routes-module? core-module?) module))
 
 (deftest ^:parallel rest-module-recognition-test
+  ;; Deprecated symbols must remain recognizable until they are removed, or they would bypass the guard.
   (are [module] (rest-module? module)
     'queries-rest
-    'enterprise/queries-rest)
+    'queries.rest
+    'enterprise/queries-rest
+    'enterprise/queries.rest)
   (is (not (rest-module? 'queries))))
 
 (deftest do-not-use-rest-modules-in-other-modules-test
@@ -439,7 +648,7 @@
                 used-module
                 module
                 used-module
-                (symbol (str/replace (str used-module) #"-rest$" ""))))))
+                (symbol (str/replace (str used-module) #"(?:-rest|\.rest)$" ""))))))
 
 ;;;; Model boundary tests
 

--- a/mage/src/mage/jar_download.clj
+++ b/mage/src/mage/jar_download.clj
@@ -3,8 +3,6 @@
    [babashka.curl :as curl]
    [babashka.fs :as fs]
    [babashka.process :as p]
-   ;; mage runs under babashka, which bundles cheshire; metabase.util.json isn't on its classpath
-   ^{:clj-kondo/ignore [:discouraged-namespace]}
    [cheshire.core :as json]
    [clojure.edn :as edn]
    [clojure.java.io :as io]

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -3,6 +3,7 @@
    ^:clj-kondo/ignore
    [cheshire.core :as json]
    [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.string :as str]
    [mage.be-dev :as be-dev]
@@ -25,12 +26,111 @@
 
 ;;; TODO (Cam 2025-11-07) changes to test files should only cause us to run tests for that module as well, not
 ;;; everything that depends on that module directly or indirectly in `src`
-(defn- file->module [filename]
-  (or
-   (when-let [[_match module] (re-matches #"^(?:(?:src)|(?:test))/metabase/([^/]+)/.*$" filename)]
-     (symbol (str/replace module #"_" "-")))
-   (when-let [[_match module] (re-matches #"^enterprise/backend/(?:(?:src)|(?:test))/metabase_enterprise/([^/]+)/.*$" filename)]
-     (symbol "enterprise" (str/replace module #"_" "-")))))
+;;;
+;;; MIRROR: this is the file-path-based equivalent of the namespace-symbol-based
+;;; module resolution in two other sites:
+;;;
+;;;   - .clj-kondo/src/hooks/common/modules.clj  (canonical)
+;;;   - dev/src/dev/deps_graph.clj               (deps graph mirror)
+;;;
+;;; Invariant: given a file at path P containing namespace ns-symb, this
+;;; function must return the same module symbol that the other two sites
+;;; return when given ns-symb. The test `metabase.core.modules-consistency-test`
+;;; verifies the three sites stay in sync.
+;;;
+;;; If you change the module resolution algorithm (e.g. adding longest-prefix
+;;; matching for nested modules), update ALL THREE sites.
+
+(defn- file->ns-symbol
+  "Derive a namespace symbol from a source file path by stripping the src/test
+  root and converting path segments to dotted namespace form (with underscores
+  replaced by hyphens). Returns `nil` if the file isn't a recognized Metabase
+  source file.
+
+  Examples:
+
+    src/metabase/lib/schema/foo.clj         => metabase.lib.schema.foo
+    enterprise/backend/src/metabase_enterprise/transforms/python/foo.clj
+                                            => metabase-enterprise.transforms.python.foo
+    src/metabase/lib_be/core.clj            => metabase.lib-be.core"
+  [filename]
+  (letfn [(normalize-module-path [module-path]
+            (if (or (str/starts-with? filename "test/")
+                    (str/starts-with? filename "enterprise/backend/test/"))
+              (str/replace module-path #"[_-]test$" "")
+              module-path))]
+    (or
+     (when-let [[_match module-path] (re-matches #"^(?:(?:src)|(?:test))/metabase/([^.]+)\.(?:clj|cljc|cljs|bb)$" filename)]
+       (symbol (str "metabase."
+                    (-> (normalize-module-path module-path)
+                        (str/replace #"/" ".")
+                        (str/replace #"_" "-")))))
+     (when-let [[_match module-path] (re-matches #"^enterprise/backend/(?:(?:src)|(?:test))/metabase_enterprise/([^.]+)\.(?:clj|cljc|cljs|bb)$" filename)]
+       (symbol (str "metabase-enterprise."
+                    (-> (normalize-module-path module-path)
+                        (str/replace #"/" ".")
+                        (str/replace #"_" "-"))))))))
+
+(defn- ns-starts-with-prefix?
+  "True if `ns-str` equals `prefix` or begins with `prefix + \".\"`
+  (segment boundary)."
+  [ns-str prefix]
+  (or (= ns-str prefix)
+      (str/starts-with? ns-str (str prefix "."))))
+
+(defn- default-ns-prefix-for [m]
+  (if (= (namespace m) "enterprise")
+    (str "metabase-enterprise." (name m))
+    (str "metabase." (name m))))
+
+(defn- build-prefix->module
+  "Build the `{ns-prefix-string module-symbol}` map from the `:metabase/modules`
+  map read from the kondo config. Mirror of the same function in the kondo
+  hook and dev.deps-graph."
+  [modules-config]
+  (into {}
+        (map (fn [[m cfg]]
+               [(or (:ns-prefix cfg) (default-ns-prefix-for m)) m]))
+        modules-config))
+
+(defn- longest-matching-prefix [prefix->module ns-str]
+  (second
+   (reduce-kv
+    (fn [[best-prefix :as best] prefix module]
+      (if (and (ns-starts-with-prefix? ns-str prefix)
+               (or (nil? best-prefix)
+                   (> (count prefix) (count best-prefix))))
+        [prefix module]
+        best))
+    nil
+    prefix->module)))
+
+(defn- file->module
+  "Resolve a file path to a module symbol.
+
+  With one arg (legacy / backwards-compat): extracts the single first-path
+  segment after `metabase/` or `metabase_enterprise/`, matching the flat
+  pre-nested-modules behavior.
+
+  With two args, the first being a `prefix->module` map (as produced by
+  `build-prefix->module`), derives the namespace symbol from the file path
+  and does longest-matching-prefix lookup at segment boundaries. Analogous
+  to the namespace-symbol-based resolution in `deps_graph` and the kondo
+  hook."
+  ([filename]
+   (file->module nil filename))
+  ([prefix->module filename]
+   (or
+    ;; Primary: derive ns symbol from file path, do longest-prefix lookup.
+    (when (seq prefix->module)
+      (when-let [ns-sym (file->ns-symbol filename)]
+        (longest-matching-prefix prefix->module (str ns-sym))))
+    ;; Fallback: single-segment extraction. Regex literals preserved
+    ;; byte-for-byte-equivalent to the pre-nesting behavior.
+    (when-let [[_match module] (re-matches #"^(?:(?:src)|(?:test))/metabase/([^/]+)/.*$" filename)]
+      (symbol (str/replace module #"_" "-")))
+    (when-let [[_match module] (re-matches #"^enterprise/backend/(?:(?:src)|(?:test))/metabase_enterprise/([^/]+)/.*$" filename)]
+      (symbol "enterprise" (str/replace module #"_" "-"))))))
 
 (defn- read-modules-config
   []
@@ -38,21 +138,72 @@
         (edn/read r))
       :metabase/modules))
 
-(defn- updated-files->updated-modules [updated-files]
-  (into (sorted-set)
-        (keep file->module)
-        updated-files))
+(defn- read-prefix->module
+  "Read the `:metabase/modules` map from kondo config and build the
+  `{ns-prefix-string module-symbol}` lookup map used for file→module
+  resolution."
+  []
+  (-> (read-modules-config)
+      build-prefix->module))
 
-(defn- updated-modules [git-ref]
+(defn- updated-files->updated-modules
+  ([updated-files]
+   (updated-files->updated-modules (read-prefix->module) updated-files))
+  ([prefix->module updated-files]
+   (into (sorted-set)
+         (keep (partial file->module prefix->module))
+         updated-files)))
+
+(defn- updated-modules [prefix->module git-ref]
   (let [git-ref (or git-ref "master")
         updated-files (u/updated-files git-ref)]
-    (updated-files->updated-modules updated-files)))
+    (updated-files->updated-modules prefix->module updated-files)))
 
-(defn- module->test-directory
-  [module]
-  (case (namespace module)
-    "enterprise" (str "enterprise/backend/test/metabase_enterprise/" (str/replace (name module) #"-" "_"))
-    nil (str "test/metabase/" (str/replace (name module) #"-" "_"))))
+(defn- module-ns-prefix
+  [modules-config module]
+  (or (get-in modules-config [module :ns-prefix])
+      (default-ns-prefix-for module)))
+
+(def ^:private backend-test-source-file-extensions
+  [".clj" ".cljc"])
+
+(defn- ns-prefix->test-path-fragment [ns-prefix]
+  (->> (str/split ns-prefix #"\.")
+       (map #(str/replace % #"-" "_"))
+       (str/join "/")))
+
+(defn- module->test-path-prefix
+  [modules-config module]
+  (let [ns-prefix   (module-ns-prefix modules-config module)
+        [parent-dir ns-fragment]
+        (if (str/starts-with? ns-prefix "metabase-enterprise.")
+          ["enterprise/backend/test/metabase_enterprise/"
+           (subs ns-prefix (count "metabase-enterprise."))]
+          ["test/metabase/"
+           (subs ns-prefix (count "metabase."))])]
+    (str parent-dir
+         (ns-prefix->test-path-fragment ns-fragment))))
+
+(defn- module->test-paths
+  [modules-config module]
+  (let [prefix->module (build-prefix->module modules-config)
+        path-prefix    (module->test-path-prefix modules-config module)
+        test-dir       (io/file path-prefix)
+        test-files     (concat
+                        (for [extension backend-test-source-file-extensions
+                              :let      [file (io/file (str path-prefix "_test" extension))]
+                              :when     (.isFile file)]
+                          file)
+                        (when (.isDirectory test-dir)
+                          (for [file (file-seq test-dir)
+                                :when (and (.isFile ^java.io.File file)
+                                           (some #(str/ends-with? (str file) %)
+                                                 backend-test-source-file-extensions))]
+                            file)))]
+    (into (sorted-set)
+          (comp (filter #(= module (file->module prefix->module (str %))))
+                (map str))
+          test-files)))
 
 (defn- dependencies
   "Read out the Kondo config for the modules linter; return a map of module => set of modules it directly depends on."
@@ -140,9 +291,11 @@
 (defn cli-print-affected-modules
   "CLI entry point: print modules affected by changes since `git-ref`, plus driver-test guidance."
   [[git-ref, :as _command-line-args]]
-  (let [deps (dependencies)
-        updated (updated-modules git-ref)
-        affected (affected-modules deps updated)
+  (let [modules-config         (read-modules-config)
+        prefix->module        (build-prefix->module modules-config)
+        deps                   (dependencies modules-config)
+        updated                (updated-modules prefix->module git-ref)
+        affected               (affected-modules deps updated)
         driver-deps-affected? (not (contains? (unaffected-modules deps updated) 'driver))]
     (print-updated-and-unaffected-modules deps updated driver-deps-affected?)
     (println)
@@ -150,7 +303,8 @@
     (println "You can run tests for these modules and all downstream modules as follows:")
     (println)
     (println)
-    (printf "clojure -X :dev:ee:ee-dev:test :only '%s'\n" (pr-str (mapv module->test-directory affected)))
+    (printf "clojure -X :dev:ee:ee-dev:test :only '%s'\n"
+            (pr-str (into [] (mapcat #(module->test-paths modules-config %)) affected)))
     (flush)
     (u/exit 0)))
 
@@ -166,14 +320,41 @@
         (shell/sh* "./bin/test-agent" ":only" "[metabase.core.modules-test]")]
     (u/exit exit)))
 
+(defn cli-print-expanded-config!
+  "Print the source-aware expanded module config and exit with the command's status."
+  [_cli-args]
+  (let [{:keys [exit], :or {exit -1}}
+        (shell/sh* "clojure" "-X:dev" "dev.deps-graph/print-expanded-kondo-config")]
+    (u/exit exit)))
+
 ;;;; =============================================================================
 ;;;; Module tree
 ;;;; =============================================================================
 
 (defn- module->tree-path
-  "Path segments a module occupies in the display tree. Every module is its own root."
-  [_modules-config module]
-  [(str module)])
+  "Path segments a module occupies in the display tree. An `enterprise/` module nests under its OSS
+  counterpart as a trailing segment — `enterprise/transforms` sits under `transforms` as
+  `transforms.enterprise` — so enterprise extensions group with the module they extend. An enterprise
+  module with no OSS counterpart is its own root, displayed with its full `enterprise/` name."
+  [modules-config module]
+  (let [segments (str/split (name module) #"\.")]
+    (if (= (namespace module) "enterprise")
+      (if (contains? modules-config (symbol (first segments)))
+        ;; nest under the OSS root with "enterprise" as the next segment, so a dotted child like
+        ;; enterprise/transforms.python lands at transforms -> enterprise -> python rather than
+        ;; transforms.python.enterprise.
+        (into [(first segments) "enterprise"] (rest segments))
+        (into [(str "enterprise/" (first segments))] (rest segments)))
+      segments)))
+
+(defn- explicit-ns-prefix
+  "The module's `:ns-prefix` when it differs from the default derived from the module name, i.e. when the
+  namespaces have not (yet) been physically moved to match the module name. The implicit
+  `metabase-enterprise.` prefix of `enterprise/` modules is canonical and does not count."
+  [modules-config module]
+  (let [prefix (get-in modules-config [module :ns-prefix])]
+    (when (and prefix (not= prefix (default-ns-prefix-for module)))
+      prefix)))
 
 (defn- module-display-tree
   "Nest all module names into `{:children {segment {:module sym, :children {...}}}}`. Intermediate nodes
@@ -187,8 +368,7 @@
           (keys modules-config)))
 
 (defn- sorted-children
-  "Child entries of a tree node, alphabetical except `enterprise/` modules always sort last among their
-  siblings."
+  "Child entries of a tree node, alphabetical except `enterprise` always sorts last among its siblings."
   [node]
   (sort-by (fn [[segment _]] [(if (or (= segment "enterprise")
                                       (str/starts-with? segment "enterprise/"))
@@ -199,31 +379,45 @@
 
 (defn- tree-node-lines
   "Render a tree node and its descendants as display lines. Depth 1 gets `- `, each further level one
-  more dash. Nodes that only group children (not modules themselves) print dark."
-  [path node]
+  more dash. Nodes that only group children (not modules themselves) print dark; modules whose
+  namespaces still live at an explicit `:ns-prefix` get a yellow `*`, or the prefix itself in yellow
+  parens when `show-prefixes?`."
+  [modules-config show-prefixes? path node]
   (let [depth   (dec (count path))
         module  (:module node)
         display (str/join "." path)
         line    (str (when (pos? depth)
                        (str (apply str (repeat depth "-")) " "))
-                     (if module display (c/dark display)))]
+                     (if module display (c/dark display))
+                     (when-let [prefix (and module (explicit-ns-prefix modules-config module))]
+                       (if show-prefixes?
+                         (str " " (c/yellow (str "(" prefix ")")))
+                         (str " " (c/yellow "*")))))]
     (into [line]
           (mapcat (fn [[segment child]]
-                    (tree-node-lines (conj path segment) child)))
+                    (tree-node-lines modules-config show-prefixes? (conj path segment) child)))
           (sorted-children node))))
 
 (defn cli-print-module-tree
-  "Print the declared modules, one per line, enterprise modules last."
-  [{:keys [_options] :as _parsed}]
+  "Print the module hierarchy as an indented tree, with enterprise extensions nested under the module
+  they extend and ns-prefixed (not yet moved) modules starred."
+  [{:keys [options] :as _parsed}]
   (let [modules-config (read-modules-config)
-        tree           (module-display-tree modules-config)]
-    (doseq [[segment node] (sorted-children tree)
-            line            (tree-node-lines [segment] node)]
+        tree           (module-display-tree modules-config)
+        roots          (cond->> (sorted-children tree)
+                         (:nested-only options) (filter (fn [[_ node]] (seq (:children node)))))
+        starred        (count (keep #(explicit-ns-prefix modules-config %) (keys modules-config)))]
+    (doseq [[segment node] roots
+            line            (tree-node-lines modules-config (:prefixes options) [segment] node)]
       (println line))
     (println)
     (println (c/dark (str (count modules-config) " modules, "
                           (count (filter #(= (namespace %) "enterprise") (keys modules-config)))
-                          " enterprise")))
+                          " enterprise"
+                          (when (pos? starred)
+                            (str ", " starred " ns-prefixed ("
+                                 (if (:prefixes options) "prefix in parens " "* ")
+                                 "= namespaces not moved to match the module name)")))))
     (u/exit 0)))
 
 (defn- changes-important-file-for-drivers?

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -1,6 +1,7 @@
 (ns mage.modules
   (:require
    [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.string :as str]
    [mage.be-dev :as be-dev]
@@ -31,12 +32,111 @@
 
 ;;; TODO (Cam 2025-11-07) changes to test files should only cause us to run tests for that module as well, not
 ;;; everything that depends on that module directly or indirectly in `src`
-(defn- file->module [filename]
-  (or
-   (when-let [[_match module] (re-matches #"^(?:(?:src)|(?:test))/metabase/([^/]+)/.*$" filename)]
-     (symbol (str/replace module #"_" "-")))
-   (when-let [[_match module] (re-matches #"^enterprise/backend/(?:(?:src)|(?:test))/metabase_enterprise/([^/]+)/.*$" filename)]
-     (symbol "enterprise" (str/replace module #"_" "-")))))
+;;;
+;;; MIRROR: this is the file-path-based equivalent of the namespace-symbol-based
+;;; module resolution in two other sites:
+;;;
+;;;   - .clj-kondo/src/hooks/common/modules.clj  (canonical)
+;;;   - dev/src/dev/deps_graph.clj               (deps graph mirror)
+;;;
+;;; Invariant: given a file at path P containing namespace ns-symb, this
+;;; function must return the same module symbol that the other two sites
+;;; return when given ns-symb. The test `metabase.core.modules-consistency-test`
+;;; verifies the three sites stay in sync.
+;;;
+;;; If you change the module resolution algorithm (e.g. adding longest-prefix
+;;; matching for nested modules), update ALL THREE sites.
+
+(defn- file->ns-symbol
+  "Derive a namespace symbol from a source file path by stripping the src/test
+  root and converting path segments to dotted namespace form (with underscores
+  replaced by hyphens). Returns `nil` if the file isn't a recognized Metabase
+  source file.
+
+  Examples:
+
+    src/metabase/lib/schema/foo.clj         => metabase.lib.schema.foo
+    enterprise/backend/src/metabase_enterprise/transforms/python/foo.clj
+                                            => metabase-enterprise.transforms.python.foo
+    src/metabase/lib_be/core.clj            => metabase.lib-be.core"
+  [filename]
+  (letfn [(normalize-module-path [module-path]
+            (if (or (str/starts-with? filename "test/")
+                    (str/starts-with? filename "enterprise/backend/test/"))
+              (str/replace module-path #"[_-]test$" "")
+              module-path))]
+    (or
+     (when-let [[_match module-path] (re-matches #"^(?:(?:src)|(?:test))/metabase/([^.]+)\.(?:clj|cljc|cljs|bb)$" filename)]
+       (symbol (str "metabase."
+                    (-> (normalize-module-path module-path)
+                        (str/replace #"/" ".")
+                        (str/replace #"_" "-")))))
+     (when-let [[_match module-path] (re-matches #"^enterprise/backend/(?:(?:src)|(?:test))/metabase_enterprise/([^.]+)\.(?:clj|cljc|cljs|bb)$" filename)]
+       (symbol (str "metabase-enterprise."
+                    (-> (normalize-module-path module-path)
+                        (str/replace #"/" ".")
+                        (str/replace #"_" "-"))))))))
+
+(defn- ns-starts-with-prefix?
+  "True if `ns-str` equals `prefix` or begins with `prefix + \".\"`
+  (segment boundary)."
+  [ns-str prefix]
+  (or (= ns-str prefix)
+      (str/starts-with? ns-str (str prefix "."))))
+
+(defn- default-ns-prefix-for [m]
+  (if (= (namespace m) "enterprise")
+    (str "metabase-enterprise." (name m))
+    (str "metabase." (name m))))
+
+(defn- build-prefix->module
+  "Build the `{ns-prefix-string module-symbol}` map from the `:metabase/modules`
+  map read from the kondo config. Mirror of the same function in the kondo
+  hook and dev.deps-graph."
+  [modules-config]
+  (into {}
+        (map (fn [[m cfg]]
+               [(or (:ns-prefix cfg) (default-ns-prefix-for m)) m]))
+        modules-config))
+
+(defn- longest-matching-prefix [prefix->module ns-str]
+  (second
+   (reduce-kv
+    (fn [[best-prefix :as best] prefix module]
+      (if (and (ns-starts-with-prefix? ns-str prefix)
+               (or (nil? best-prefix)
+                   (> (count prefix) (count best-prefix))))
+        [prefix module]
+        best))
+    nil
+    prefix->module)))
+
+(defn- file->module
+  "Resolve a file path to a module symbol.
+
+  With one arg (legacy / backwards-compat): extracts the single first-path
+  segment after `metabase/` or `metabase_enterprise/`, matching the flat
+  pre-nested-modules behavior.
+
+  With two args, the first being a `prefix->module` map (as produced by
+  `build-prefix->module`), derives the namespace symbol from the file path
+  and does longest-matching-prefix lookup at segment boundaries. Analogous
+  to the namespace-symbol-based resolution in `deps_graph` and the kondo
+  hook."
+  ([filename]
+   (file->module nil filename))
+  ([prefix->module filename]
+   (or
+    ;; Primary: derive ns symbol from file path, do longest-prefix lookup.
+    (when (seq prefix->module)
+      (when-let [ns-sym (file->ns-symbol filename)]
+        (longest-matching-prefix prefix->module (str ns-sym))))
+    ;; Fallback: single-segment extraction. Regex literals preserved
+    ;; byte-for-byte-equivalent to the pre-nesting behavior.
+    (when-let [[_match module] (re-matches #"^(?:(?:src)|(?:test))/metabase/([^/]+)/.*$" filename)]
+      (symbol (str/replace module #"_" "-")))
+    (when-let [[_match module] (re-matches #"^enterprise/backend/(?:(?:src)|(?:test))/metabase_enterprise/([^/]+)/.*$" filename)]
+      (symbol "enterprise" (str/replace module #"_" "-"))))))
 
 (defn- read-modules-config
   []
@@ -44,21 +144,72 @@
         (edn/read r))
       :metabase/modules))
 
-(defn- updated-files->updated-modules [updated-files]
-  (into (sorted-set)
-        (keep file->module)
-        updated-files))
+(defn- read-prefix->module
+  "Read the `:metabase/modules` map from kondo config and build the
+  `{ns-prefix-string module-symbol}` lookup map used for file→module
+  resolution."
+  []
+  (-> (read-modules-config)
+      build-prefix->module))
 
-(defn- updated-modules [git-ref]
+(defn- updated-files->updated-modules
+  ([updated-files]
+   (updated-files->updated-modules (read-prefix->module) updated-files))
+  ([prefix->module updated-files]
+   (into (sorted-set)
+         (keep (partial file->module prefix->module))
+         updated-files)))
+
+(defn- updated-modules [prefix->module git-ref]
   (let [git-ref (or git-ref "master")
         updated-files (u/updated-files git-ref)]
-    (updated-files->updated-modules updated-files)))
+    (updated-files->updated-modules prefix->module updated-files)))
 
-(defn- module->test-directory
-  [module]
-  (case (namespace module)
-    "enterprise" (str "enterprise/backend/test/metabase_enterprise/" (str/replace (name module) #"-" "_"))
-    nil (str "test/metabase/" (str/replace (name module) #"-" "_"))))
+(defn- module-ns-prefix
+  [modules-config module]
+  (or (get-in modules-config [module :ns-prefix])
+      (default-ns-prefix-for module)))
+
+(def ^:private backend-test-source-file-extensions
+  [".clj" ".cljc"])
+
+(defn- ns-prefix->test-path-fragment [ns-prefix]
+  (->> (str/split ns-prefix #"\.")
+       (map #(str/replace % #"-" "_"))
+       (str/join "/")))
+
+(defn- module->test-path-prefix
+  [modules-config module]
+  (let [ns-prefix   (module-ns-prefix modules-config module)
+        [parent-dir ns-fragment]
+        (if (str/starts-with? ns-prefix "metabase-enterprise.")
+          ["enterprise/backend/test/metabase_enterprise/"
+           (subs ns-prefix (count "metabase-enterprise."))]
+          ["test/metabase/"
+           (subs ns-prefix (count "metabase."))])]
+    (str parent-dir
+         (ns-prefix->test-path-fragment ns-fragment))))
+
+(defn- module->test-paths
+  [modules-config module]
+  (let [prefix->module (build-prefix->module modules-config)
+        path-prefix    (module->test-path-prefix modules-config module)
+        test-dir       (io/file path-prefix)
+        test-files     (concat
+                        (for [extension backend-test-source-file-extensions
+                              :let      [file (io/file (str path-prefix "_test" extension))]
+                              :when     (.isFile file)]
+                          file)
+                        (when (.isDirectory test-dir)
+                          (for [file (file-seq test-dir)
+                                :when (and (.isFile ^java.io.File file)
+                                           (some #(str/ends-with? (str file) %)
+                                                 backend-test-source-file-extensions))]
+                            file)))]
+    (into (sorted-set)
+          (comp (filter #(= module (file->module prefix->module (str %))))
+                (map str))
+          test-files)))
 
 (defn- dependencies
   "Read out the Kondo config for the modules linter; return a map of module => set of modules it directly depends on."
@@ -141,9 +292,11 @@
 (defn cli-print-affected-modules
   "CLI entry point: print modules affected by changes since `git-ref`, plus driver-test guidance."
   [[git-ref, :as _command-line-args]]
-  (let [deps (dependencies)
-        updated (updated-modules git-ref)
-        affected (affected-modules deps updated)
+  (let [modules-config         (read-modules-config)
+        prefix->module        (build-prefix->module modules-config)
+        deps                   (dependencies modules-config)
+        updated                (updated-modules prefix->module git-ref)
+        affected               (affected-modules deps updated)
         driver-deps-affected? (not (contains? (unaffected-modules deps updated) 'driver))]
     (print-updated-and-unaffected-modules deps updated driver-deps-affected?)
     (println)
@@ -151,7 +304,8 @@
     (println "You can run tests for these modules and all downstream modules as follows:")
     (println)
     (println)
-    (printf "clojure -X :dev:ee:ee-dev:test :only '%s'\n" (pr-str (mapv module->test-directory affected)))
+    (printf "clojure -X :dev:ee:ee-dev:test :only '%s'\n"
+            (pr-str (into [] (mapcat #(module->test-paths modules-config %)) affected)))
     (flush)
     (u/exit 0)))
 
@@ -167,14 +321,41 @@
         (shell/sh* "./bin/test-agent" ":only" "[metabase.core.modules-test]")]
     (u/exit exit)))
 
+(defn cli-print-expanded-config!
+  "Print the source-aware expanded module config and exit with the command's status."
+  [_cli-args]
+  (let [{:keys [exit], :or {exit -1}}
+        (shell/sh* "clojure" "-X:dev" "dev.deps-graph/print-expanded-kondo-config")]
+    (u/exit exit)))
+
 ;;;; =============================================================================
 ;;;; Module tree
 ;;;; =============================================================================
 
 (defn- module->tree-path
-  "Path segments a module occupies in the display tree. Every module is its own root."
-  [_modules-config module]
-  [(str module)])
+  "Path segments a module occupies in the display tree. An `enterprise/` module nests under its OSS
+  counterpart as a trailing segment — `enterprise/transforms` sits under `transforms` as
+  `transforms.enterprise` — so enterprise extensions group with the module they extend. An enterprise
+  module with no OSS counterpart is its own root, displayed with its full `enterprise/` name."
+  [modules-config module]
+  (let [segments (str/split (name module) #"\.")]
+    (if (= (namespace module) "enterprise")
+      (if (contains? modules-config (symbol (first segments)))
+        ;; nest under the OSS root with "enterprise" as the next segment, so a dotted child like
+        ;; enterprise/transforms.python lands at transforms -> enterprise -> python rather than
+        ;; transforms.python.enterprise.
+        (into [(first segments) "enterprise"] (rest segments))
+        (into [(str "enterprise/" (first segments))] (rest segments)))
+      segments)))
+
+(defn- explicit-ns-prefix
+  "The module's `:ns-prefix` when it differs from the default derived from the module name, i.e. when the
+  namespaces have not (yet) been physically moved to match the module name. The implicit
+  `metabase-enterprise.` prefix of `enterprise/` modules is canonical and does not count."
+  [modules-config module]
+  (let [prefix (get-in modules-config [module :ns-prefix])]
+    (when (and prefix (not= prefix (default-ns-prefix-for module)))
+      prefix)))
 
 (defn- module-display-tree
   "Nest all module names into `{:children {segment {:module sym, :children {...}}}}`. Intermediate nodes
@@ -188,8 +369,7 @@
           (keys modules-config)))
 
 (defn- sorted-children
-  "Child entries of a tree node, alphabetical except `enterprise/` modules always sort last among their
-  siblings."
+  "Child entries of a tree node, alphabetical except `enterprise` always sorts last among its siblings."
   [node]
   (sort-by (fn [[segment _]] [(if (or (= segment "enterprise")
                                       (str/starts-with? segment "enterprise/"))
@@ -200,31 +380,45 @@
 
 (defn- tree-node-lines
   "Render a tree node and its descendants as display lines. Depth 1 gets `- `, each further level one
-  more dash. Nodes that only group children (not modules themselves) print dark."
-  [path node]
+  more dash. Nodes that only group children (not modules themselves) print dark; modules whose
+  namespaces still live at an explicit `:ns-prefix` get a yellow `*`, or the prefix itself in yellow
+  parens when `show-prefixes?`."
+  [modules-config show-prefixes? path node]
   (let [depth   (dec (count path))
         module  (:module node)
         display (str/join "." path)
         line    (str (when (pos? depth)
                        (str (apply str (repeat depth "-")) " "))
-                     (if module display (c/dark display)))]
+                     (if module display (c/dark display))
+                     (when-let [prefix (and module (explicit-ns-prefix modules-config module))]
+                       (if show-prefixes?
+                         (str " " (c/yellow (str "(" prefix ")")))
+                         (str " " (c/yellow "*")))))]
     (into [line]
           (mapcat (fn [[segment child]]
-                    (tree-node-lines (conj path segment) child)))
+                    (tree-node-lines modules-config show-prefixes? (conj path segment) child)))
           (sorted-children node))))
 
 (defn cli-print-module-tree
-  "Print the declared modules, one per line, enterprise modules last."
-  [{:keys [_options] :as _parsed}]
+  "Print the module hierarchy as an indented tree, with enterprise extensions nested under the module
+  they extend and ns-prefixed (not yet moved) modules starred."
+  [{:keys [options] :as _parsed}]
   (let [modules-config (read-modules-config)
-        tree           (module-display-tree modules-config)]
-    (doseq [[segment node] (sorted-children tree)
-            line            (tree-node-lines [segment] node)]
+        tree           (module-display-tree modules-config)
+        roots          (cond->> (sorted-children tree)
+                         (:nested-only options) (filter (fn [[_ node]] (seq (:children node)))))
+        starred        (count (keep #(explicit-ns-prefix modules-config %) (keys modules-config)))]
+    (doseq [[segment node] roots
+            line            (tree-node-lines modules-config (:prefixes options) [segment] node)]
       (println line))
     (println)
     (println (c/dark (str (count modules-config) " modules, "
                           (count (filter #(= (namespace %) "enterprise") (keys modules-config)))
-                          " enterprise")))
+                          " enterprise"
+                          (when (pos? starred)
+                            (str ", " starred " ns-prefixed ("
+                                 (if (:prefixes options) "prefix in parens " "* ")
+                                 "= namespaces not moved to match the module name)")))))
     (u/exit 0)))
 
 (defn- changes-important-file-for-drivers?

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -2,7 +2,9 @@
   "Tests for driver decision logic.
    Run `mage -driver-decisions -h` to see the priority order."
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
+   [mage.color]
    [mage.modules]))
 
 ;; Referenced by core_test.clj to ensure namespace is loaded
@@ -343,11 +345,39 @@
         all (keys deps)]
     (filter #(mage.modules/driver-deps-affected? [%]) all)))
 
+(defn- top-level-module
+  [declared-modules module]
+  (loop [module module]
+    (let [parts (str/split (name module) #"\.")]
+      (cond
+        (> (count parts) 1)
+        (recur (if-let [ns-part (namespace module)]
+                 (symbol ns-part (str/join "." (butlast parts)))
+                 (symbol (str/join "." (butlast parts)))))
+
+        (and (= "enterprise" (namespace module))
+             (contains? declared-modules (symbol (name module))))
+        (recur (symbol (name module)))
+
+        :else module))))
+
+(deftest top-level-module-test
+  (let [declared '#{lib lib.schema query-processor query-processor.driver-api workspaces enterprise/workspaces
+                    enterprise/sandbox}]
+    (is (= 'lib (top-level-module declared 'lib.schema)))
+    (is (= 'query-processor (top-level-module declared 'query-processor.driver-api)))
+    (is (= 'workspaces (top-level-module declared 'enterprise/workspaces)))
+    (is (= 'enterprise/sandbox (top-level-module declared 'enterprise/sandbox)))))
+
 (deftest module-graph-may-not-become-more-connected
-  (testing "The number of modules that trigger driver tests should not increase without explicit approval.
+  (testing "The number of top-level modules that trigger driver tests should not increase without explicit approval.
             If this test fails, you've likely connected a module to driver that shouldn't trigger driver tests.
             Add it to driver-affecting-overrides if it shouldn't trigger driver tests."
-    (let [modules-triggering-drivers (modules-affecting-drivers)
+    (let [deps                       (mage.modules/dependencies)
+          modules-triggering-drivers (modules-affecting-drivers)
+          top-level-modules          (into #{}
+                                           (map (partial top-level-module (set (keys deps))))
+                                           modules-triggering-drivers)
           ;; This is a ratchet: it prevents accidental expansion of which modules
           ;; trigger driver tests. When a module transitively depends on driver code,
           ;; changes to that module cause ALL driver tests to run in CI, which is
@@ -364,14 +394,16 @@
           ;; 2026-04-07 Bumped to 41 due to agent-lib addition (Metabot MBQL improvements #71524)
           ;; 2026-06-04 Bumped to 42 due to run-tracking addition (Zombie transform reaper #75194)
           ;; 2026-06-24 Bumped to 44 for indexes + indexes-rest (Index manager #75848)
-          max-allowed-count 44]
-      (is (<= (count modules-triggering-drivers) max-allowed-count)
-          (format "Too many modules trigger driver tests! Expected <= %d, got %d.
+          ;; 2026-07-13 Changed the ratchet to count distinct logical top-level ancestors. Baseline remains 44
+          ;;            before any nested-module config migrations.
+          max-allowed-top-level-count 44]
+      (is (<= (count top-level-modules) max-allowed-top-level-count)
+          (format "Too many top-level modules trigger driver tests! Expected <= %d, got %d.
                    Modules triggering driver tests: %s
-                   If this is intentional, update max-allowed-count.
+                   If this is intentional, update max-allowed-top-level-count.
                    Otherwise, add the new module(s) to driver-affecting-overrides."
-                  max-allowed-count
-                  (count modules-triggering-drivers)
+                  max-allowed-top-level-count
+                  (count top-level-modules)
                   (pr-str (sort modules-triggering-drivers)))))))
 
 (deftest test-files-mark-modules-changes
@@ -439,11 +471,49 @@
       (is (true? (:should-run result)))
       (is (= "master/release branch" (:reason result))))))
 
-(deftest module-tree-sorts-enterprise-last
-  (testing "siblings are alphabetical, except enterprise modules sort after everything else"
-    (let [config {'queries {} 'enterprise/audit {} 'actions {} 'enterprise/sso {} 'util {}}
-          tree   (#'mage.modules/module-display-tree config)
-          lines  (#'mage.modules/tree-node-lines [] tree)]
-      ;; the root node renders an empty line, so drop it
-      (is (= ["actions" "queries" "util" "enterprise/audit" "enterprise/sso"]
-             (rest lines))))))
+(deftest module-tree-lines-test
+  (let [config '{lib                  {}
+                 lib.be               {:ns-prefix "metabase.lib-be"}
+                 transforms           {}
+                 transforms.base      {:ns-prefix "metabase.transforms-base"}
+                 transforms.base.deep {}
+                 transforms.python    {:ns-prefix "metabase.transforms-python"}
+                 enterprise-tools     {}
+                 enterprise/transforms {}
+                 enterprise/transforms.python {:ns-prefix "metabase-enterprise.transforms-python"}
+                 enterprise/billing   {}}
+        tree   (#'mage.modules/module-display-tree config)
+        lines  (binding [mage.color/*disable-colors* true]
+                 (into []
+                       (mapcat (fn [[segment node]]
+                                 (#'mage.modules/tree-node-lines config false [segment] node)))
+                       (#'mage.modules/sorted-children tree)))]
+    (testing "alphabetical roots, enterprise last among siblings, dotted display names, stars on :ns-prefix"
+      (is (= ["enterprise-tools"
+              "lib"
+              "- lib.be *"
+              "transforms"
+              "- transforms.base *"
+              "-- transforms.base.deep"
+              "- transforms.python *"
+              "- transforms.enterprise"
+              "-- transforms.enterprise.python *"
+              "enterprise/billing"]
+             lines)))))
+
+(deftest module-tree-enterprise-default-prefix-not-starred-test
+  (testing "the implicit metabase-enterprise. prefix is canonical, and so is an explicit :ns-prefix equal to the default"
+    (is (nil? (#'mage.modules/explicit-ns-prefix '{enterprise/billing {}} 'enterprise/billing)))
+    (is (nil? (#'mage.modules/explicit-ns-prefix '{enterprise/billing {:ns-prefix "metabase-enterprise.billing"}}
+                                                 'enterprise/billing)))
+    (is (= "metabase.lib-be"
+           (#'mage.modules/explicit-ns-prefix '{lib.be {:ns-prefix "metabase.lib-be"}} 'lib.be)))))
+
+(deftest dotted-module-exact-test-files-mark-correct-module-changes
+  (testing "module-level dotted test files resolve back to the dotted module when a dotted prefix exists"
+    (let [build-prefix->module @#'mage.modules/build-prefix->module
+          file->module         @#'mage.modules/file->module
+          prefix->module       (build-prefix->module {'lib.schema {}})]
+      (is (= 'lib.schema
+             (file->module prefix->module
+                           "test/metabase/lib/schema_test.cljc"))))))

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -2,7 +2,7 @@
   "Tests for driver decision logic.
    Run `mage -driver-decisions -h` to see the priority order."
   (:require
-   [clojure.string :as str]
+   [clojure.edn :as edn]
    [clojure.test :refer [deftest is testing]]
    [mage.color]
    [mage.modules]))
@@ -286,65 +286,33 @@
         all (keys deps)]
     (filter #(mage.modules/driver-deps-affected? [%]) all)))
 
-(defn- top-level-module
-  [declared-modules module]
-  (loop [module module]
-    (let [parts (str/split (name module) #"\.")]
-      (cond
-        (> (count parts) 1)
-        (recur (if-let [ns-part (namespace module)]
-                 (symbol ns-part (str/join "." (butlast parts)))
-                 (symbol (str/join "." (butlast parts)))))
-
-        (and (= "enterprise" (namespace module))
-             (contains? declared-modules (symbol (name module))))
-        (recur (symbol (name module)))
-
-        :else module))))
-
-(deftest top-level-module-test
-  (let [declared '#{lib lib.schema query-processor query-processor.driver-api workspaces enterprise/workspaces
-                    enterprise/sandbox}]
-    (is (= 'lib (top-level-module declared 'lib.schema)))
-    (is (= 'query-processor (top-level-module declared 'query-processor.driver-api)))
-    (is (= 'workspaces (top-level-module declared 'enterprise/workspaces)))
-    (is (= 'enterprise/sandbox (top-level-module declared 'enterprise/sandbox)))))
-
 (deftest module-graph-may-not-become-more-connected
   (testing "The number of top-level modules that trigger driver tests should not increase without explicit approval.
             If this test fails, you've likely connected a module to driver that shouldn't trigger driver tests.
             Add it to driver-affecting-overrides if it shouldn't trigger driver tests."
-    (let [deps                       (mage.modules/dependencies)
-          modules-triggering-drivers (modules-affecting-drivers)
-          top-level-modules          (into #{}
-                                           (map (partial top-level-module (set (keys deps))))
-                                           modules-triggering-drivers)
-          ;; This is a ratchet: it prevents accidental expansion of which modules
-          ;; trigger driver tests. When a module transitively depends on driver code,
-          ;; changes to that module cause ALL driver tests to run in CI, which is
-          ;; expensive. If this test fails, either:
-          ;;   1. Your module legitimately affects drivers -- bump max-allowed-count
-          ;;   2. Your module is infrastructure/gating, not driver logic
-          ;;      -- add it to driver-affecting-overrides in mage.modules
-          ;;
-          ;; History:
-          ;; 2026-02-06 Initial count: 37
-          ;; 2026-02-10 Bumped to 38 for sql-tools + sql-parsing
-          ;; 2026-03-10 Bumped to 40 for lib-metric + metrics (Metrics Explorer #68961)
-          ;;            Added premium-features to driver-affecting-overrides (#69561)
-          ;; 2026-04-07 Bumped to 41 due to agent-lib addition (Metabot MBQL improvements #71524)
-          ;; 2026-06-04 Bumped to 42 due to run-tracking addition (Zombie transform reaper #75194)
-          ;; 2026-06-24 Bumped to 44 for indexes + indexes-rest (Index manager #75848)
-          ;; 2026-07-13 Changed the ratchet to count distinct logical top-level ancestors. Baseline remains 44
-          ;;            before any nested-module config migrations.
-          max-allowed-top-level-count 44]
-      (is (<= (count top-level-modules) max-allowed-top-level-count)
-          (format "Too many top-level modules trigger driver tests! Expected <= %d, got %d.
+    ;; A module that transitively depends on driver code makes a change to it run ALL driver tests, which
+    ;; is expensive. The budget lives in ratchets.edn next to :driver-test-exempt-modules, because the two
+    ;; move against each other: exempting a module lowers this and raises the exemption count, and dropping
+    ;; an exemption does the reverse. Reading either alone is how you talk yourself into paying for CI you
+    ;; did not mean to.
+    ;;
+    ;; Counted per module, not per top-level subtree. Collapsing to top-level ancestors would report
+    ;; nesting the -rest layer as a 46 -> 33 improvement while the same 696 namespaces still trigger, so
+    ;; module-stats.edn carries :driver-test-triggering-namespaces for the number that holds still. The
+    ;; cost of counting modules is that splitting a triggering module needs a hand edit here, with a
+    ;; reason in the commit.
+    (let [modules-triggering-drivers (modules-affecting-drivers)
+          max-allowed-count          (:driver-test-triggering-modules
+                                      (edn/read-string
+                                       (slurp ".clj-kondo/config/modules/ratchets.edn")))]
+      (is (<= (count modules-triggering-drivers) max-allowed-count)
+          (format "Too many modules trigger driver tests! Expected <= %d, got %d.
                    Modules triggering driver tests: %s
-                   If this is intentional, update max-allowed-top-level-count.
-                   Otherwise, add the new module(s) to driver-affecting-overrides."
-                  max-allowed-top-level-count
-                  (count top-level-modules)
+                   If this is intentional, raise :driver-test-triggering-modules in
+                   .clj-kondo/config/modules/ratchets.edn and say why in the commit message.
+                   Otherwise, add the new module(s) to :exempt-modules in driver-test-overrides.edn."
+                  max-allowed-count
+                  (count modules-triggering-drivers)
                   (pr-str (sort modules-triggering-drivers)))))))
 
 (deftest test-files-mark-modules-changes

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -2,8 +2,9 @@
   "Tests for driver decision logic.
    Run `mage -driver-decisions -h` to see the priority order."
   (:require
-   [clojure.edn :as edn]
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
+   [mage.color]
    [mage.modules]))
 
 ;; Referenced by core_test.clj to ensure namespace is loaded
@@ -285,26 +286,65 @@
         all (keys deps)]
     (filter #(mage.modules/driver-deps-affected? [%]) all)))
 
+(defn- top-level-module
+  [declared-modules module]
+  (loop [module module]
+    (let [parts (str/split (name module) #"\.")]
+      (cond
+        (> (count parts) 1)
+        (recur (if-let [ns-part (namespace module)]
+                 (symbol ns-part (str/join "." (butlast parts)))
+                 (symbol (str/join "." (butlast parts)))))
+
+        (and (= "enterprise" (namespace module))
+             (contains? declared-modules (symbol (name module))))
+        (recur (symbol (name module)))
+
+        :else module))))
+
+(deftest top-level-module-test
+  (let [declared '#{lib lib.schema query-processor query-processor.driver-api workspaces enterprise/workspaces
+                    enterprise/sandbox}]
+    (is (= 'lib (top-level-module declared 'lib.schema)))
+    (is (= 'query-processor (top-level-module declared 'query-processor.driver-api)))
+    (is (= 'workspaces (top-level-module declared 'enterprise/workspaces)))
+    (is (= 'enterprise/sandbox (top-level-module declared 'enterprise/sandbox)))))
+
 (deftest module-graph-may-not-become-more-connected
-  (testing "The number of modules that trigger driver tests should not increase without explicit approval.
+  (testing "The number of top-level modules that trigger driver tests should not increase without explicit approval.
             If this test fails, you've likely connected a module to driver that shouldn't trigger driver tests.
-            Add it to :exempt-modules in driver-test-overrides.edn if it shouldn't trigger driver tests."
-    ;; A module that transitively depends on driver code makes a change to it run ALL driver tests, which
-    ;; is expensive. The budget lives in ratchets.edn next to :driver-test-exempt-modules, because the two
-    ;; move against each other: exempting a module lowers this count and raises the exemption count, and
-    ;; dropping an exemption does the reverse. Reading either alone is how you talk yourself into paying
-    ;; for CI you did not mean to. Raising it needs a hand edit there, with the reason in the commit.
-    (let [modules-triggering-drivers (modules-affecting-drivers)
-          max-allowed-count          (:driver-test-triggering-modules
-                                      (edn/read-string (slurp ".clj-kondo/config/modules/ratchets.edn")))]
-      (is (<= (count modules-triggering-drivers) max-allowed-count)
-          (format "Too many modules trigger driver tests! Expected <= %d, got %d.
+            Add it to driver-affecting-overrides if it shouldn't trigger driver tests."
+    (let [deps                       (mage.modules/dependencies)
+          modules-triggering-drivers (modules-affecting-drivers)
+          top-level-modules          (into #{}
+                                           (map (partial top-level-module (set (keys deps))))
+                                           modules-triggering-drivers)
+          ;; This is a ratchet: it prevents accidental expansion of which modules
+          ;; trigger driver tests. When a module transitively depends on driver code,
+          ;; changes to that module cause ALL driver tests to run in CI, which is
+          ;; expensive. If this test fails, either:
+          ;;   1. Your module legitimately affects drivers -- bump max-allowed-count
+          ;;   2. Your module is infrastructure/gating, not driver logic
+          ;;      -- add it to driver-affecting-overrides in mage.modules
+          ;;
+          ;; History:
+          ;; 2026-02-06 Initial count: 37
+          ;; 2026-02-10 Bumped to 38 for sql-tools + sql-parsing
+          ;; 2026-03-10 Bumped to 40 for lib-metric + metrics (Metrics Explorer #68961)
+          ;;            Added premium-features to driver-affecting-overrides (#69561)
+          ;; 2026-04-07 Bumped to 41 due to agent-lib addition (Metabot MBQL improvements #71524)
+          ;; 2026-06-04 Bumped to 42 due to run-tracking addition (Zombie transform reaper #75194)
+          ;; 2026-06-24 Bumped to 44 for indexes + indexes-rest (Index manager #75848)
+          ;; 2026-07-13 Changed the ratchet to count distinct logical top-level ancestors. Baseline remains 44
+          ;;            before any nested-module config migrations.
+          max-allowed-top-level-count 44]
+      (is (<= (count top-level-modules) max-allowed-top-level-count)
+          (format "Too many top-level modules trigger driver tests! Expected <= %d, got %d.
                    Modules triggering driver tests: %s
-                   If this is intentional, raise :driver-test-triggering-modules in
-                   .clj-kondo/config/modules/ratchets.edn and say why in the commit message.
-                   Otherwise, add the new module(s) to :exempt-modules in driver-test-overrides.edn."
-                  max-allowed-count
-                  (count modules-triggering-drivers)
+                   If this is intentional, update max-allowed-top-level-count.
+                   Otherwise, add the new module(s) to driver-affecting-overrides."
+                  max-allowed-top-level-count
+                  (count top-level-modules)
                   (pr-str (sort modules-triggering-drivers)))))))
 
 (deftest test-files-mark-modules-changes
@@ -322,7 +362,57 @@
   (testing "siblings are alphabetical, except enterprise modules sort after everything else"
     (let [config {'queries {} 'enterprise/audit {} 'actions {} 'enterprise/sso {} 'util {}}
           tree   (#'mage.modules/module-display-tree config)
-          lines  (#'mage.modules/tree-node-lines [] tree)]
-      ;; the root node renders an empty line, so drop it
+          lines  (binding [mage.color/*disable-colors* true]
+                   (into []
+                         (mapcat (fn [[segment node]]
+                                   (#'mage.modules/tree-node-lines config false [segment] node)))
+                         (#'mage.modules/sorted-children tree)))]
       (is (= ["actions" "queries" "util" "enterprise/audit" "enterprise/sso"]
-             (rest lines))))))
+             lines)))))
+
+(deftest module-tree-lines-test
+  (let [config '{lib                  {}
+                 lib.be               {:ns-prefix "metabase.lib-be"}
+                 transforms           {}
+                 transforms.base      {:ns-prefix "metabase.transforms-base"}
+                 transforms.base.deep {}
+                 transforms.python    {:ns-prefix "metabase.transforms-python"}
+                 enterprise-tools     {}
+                 enterprise/transforms {}
+                 enterprise/transforms.python {:ns-prefix "metabase-enterprise.transforms-python"}
+                 enterprise/billing   {}}
+        tree   (#'mage.modules/module-display-tree config)
+        lines  (binding [mage.color/*disable-colors* true]
+                 (into []
+                       (mapcat (fn [[segment node]]
+                                 (#'mage.modules/tree-node-lines config false [segment] node)))
+                       (#'mage.modules/sorted-children tree)))]
+    (testing "alphabetical roots, enterprise last among siblings, dotted display names, stars on :ns-prefix"
+      (is (= ["enterprise-tools"
+              "lib"
+              "- lib.be *"
+              "transforms"
+              "- transforms.base *"
+              "-- transforms.base.deep"
+              "- transforms.python *"
+              "- transforms.enterprise"
+              "-- transforms.enterprise.python *"
+              "enterprise/billing"]
+             lines)))))
+
+(deftest module-tree-enterprise-default-prefix-not-starred-test
+  (testing "the implicit metabase-enterprise. prefix is canonical, and so is an explicit :ns-prefix equal to the default"
+    (is (nil? (#'mage.modules/explicit-ns-prefix '{enterprise/billing {}} 'enterprise/billing)))
+    (is (nil? (#'mage.modules/explicit-ns-prefix '{enterprise/billing {:ns-prefix "metabase-enterprise.billing"}}
+                                                 'enterprise/billing)))
+    (is (= "metabase.lib-be"
+           (#'mage.modules/explicit-ns-prefix '{lib.be {:ns-prefix "metabase.lib-be"}} 'lib.be)))))
+
+(deftest dotted-module-exact-test-files-mark-correct-module-changes
+  (testing "module-level dotted test files resolve back to the dotted module when a dotted prefix exists"
+    (let [build-prefix->module @#'mage.modules/build-prefix->module
+          file->module         @#'mage.modules/file->module
+          prefix->module       (build-prefix->module {'lib.schema {}})]
+      (is (= 'lib.schema
+             (file->module prefix->module
+                           "test/metabase/lib/schema_test.cljc"))))))

--- a/src/metabase/util/log.clj
+++ b/src/metabase/util/log.clj
@@ -111,19 +111,51 @@
                    (io/resource "metabase/config/modules.edn")
                    (io/file ".clj-kondo/config/modules/config.edn"))
                  slurp edn/read-string :metabase/modules)
-      first-segment (fn first-segment [ns-sym]
-                      (-> (str/split (name ns-sym) #"\.") second))
-      chop (fn chop [ns-sym]
-             (if (str/starts-with? (name ns-sym) "metabase-enterprise")
-               (symbol "enterprise" (first-segment ns-sym))
-               (symbol (first-segment ns-sym))))]
+      declared-modules (set (keys config))
+      module-prefix (fn module-prefix [module]
+                      (or (get-in config [module :ns-prefix])
+                          (if (= "enterprise" (namespace module))
+                            (str "metabase-enterprise." (name module))
+                            (str "metabase." (name module)))))
+      prefix->module (into {} (map (juxt module-prefix identity)) declared-modules)
+      module-for-ns (fn module-for-ns [ns-sym]
+                      (let [ns-str (str ns-sym)]
+                        (second
+                         (reduce-kv
+                          (fn [[best-prefix :as best] prefix module]
+                            (if (and (or (= ns-str prefix)
+                                         (str/starts-with? ns-str (str prefix ".")))
+                                     (or (nil? best-prefix)
+                                         (> (count prefix) (count best-prefix))))
+                              [prefix module]
+                              best))
+                          nil
+                          prefix->module))))
+      module-parent (fn module-parent [module]
+                      (let [parts (str/split (name module) #"\.")]
+                        (cond
+                          (> (count parts) 1)
+                          (let [parent-name (str/join "." (butlast parts))]
+                            (if-let [ns-part (namespace module)]
+                              (symbol ns-part parent-name)
+                              (symbol parent-name)))
+
+                          (= "enterprise" (namespace module))
+                          (let [oss-module (symbol (name module))]
+                            (when (contains? declared-modules oss-module)
+                              oss-module)))))
+      module-team (fn module-team [module]
+                    (loop [module module]
+                      (when module
+                        (if (contains? (get config module) :team)
+                          (get-in config [module :team])
+                          (recur (module-parent module))))))]
   (defn ns->team*
-    "Chops the namespace symbol to look up which team owns this namespace in the module config. Assumes that the first
-  segment of the namespace is a module. Should be memoized for speed."
+    "Resolve the namespace's owning module and its nearest explicitly configured team. Should be memoized for speed."
     [ns-sym]
     (if ('#{metabase.server.middleware.log} ns-sym)
       ::skip
-      (-> ns-sym chop config :team))))
+      (some-> ns-sym module-for-ns module-team))))
 
 (let [attribution (if (config/config-bool :mb-log-team-attribution)
                     (memoize ns->team*)

--- a/src/metabase/util/log.clj
+++ b/src/metabase/util/log.clj
@@ -113,19 +113,51 @@
                    (io/resource "metabase/config/modules.edn")
                    (io/file ".clj-kondo/config/modules/config.edn"))
                  slurp edn/read-string :metabase/modules)
-      first-segment (fn first-segment [ns-sym]
-                      (-> (str/split (name ns-sym) #"\.") second))
-      chop (fn chop [ns-sym]
-             (if (str/starts-with? (name ns-sym) "metabase-enterprise")
-               (symbol "enterprise" (first-segment ns-sym))
-               (symbol (first-segment ns-sym))))]
+      declared-modules (set (keys config))
+      module-prefix (fn module-prefix [module]
+                      (or (get-in config [module :ns-prefix])
+                          (if (= "enterprise" (namespace module))
+                            (str "metabase-enterprise." (name module))
+                            (str "metabase." (name module)))))
+      prefix->module (into {} (map (juxt module-prefix identity)) declared-modules)
+      module-for-ns (fn module-for-ns [ns-sym]
+                      (let [ns-str (str ns-sym)]
+                        (second
+                         (reduce-kv
+                          (fn [[best-prefix :as best] prefix module]
+                            (if (and (or (= ns-str prefix)
+                                         (str/starts-with? ns-str (str prefix ".")))
+                                     (or (nil? best-prefix)
+                                         (> (count prefix) (count best-prefix))))
+                              [prefix module]
+                              best))
+                          nil
+                          prefix->module))))
+      module-parent (fn module-parent [module]
+                      (let [parts (str/split (name module) #"\.")]
+                        (cond
+                          (> (count parts) 1)
+                          (let [parent-name (str/join "." (butlast parts))]
+                            (if-let [ns-part (namespace module)]
+                              (symbol ns-part parent-name)
+                              (symbol parent-name)))
+
+                          (= "enterprise" (namespace module))
+                          (let [oss-module (symbol (name module))]
+                            (when (contains? declared-modules oss-module)
+                              oss-module)))))
+      module-team (fn module-team [module]
+                    (loop [module module]
+                      (when module
+                        (if (contains? (get config module) :team)
+                          (get-in config [module :team])
+                          (recur (module-parent module))))))]
   (defn ns->team*
-    "Chops the namespace symbol to look up which team owns this namespace in the module config. Assumes that the first
-  segment of the namespace is a module. Should be memoized for speed."
+    "Resolve the namespace's owning module and its nearest explicitly configured team. Should be memoized for speed."
     [ns-sym]
     (if ('#{metabase.server.middleware.log} ns-sym)
       ::skip
-      (-> ns-sym chop config :team))))
+      (some-> ns-sym module-for-ns module-team))))
 
 (let [attribution (if (config/config-bool :mb-log-team-attribution)
                     (memoize ns->team*)

--- a/test/metabase/core/modules_consistency_test.clj
+++ b/test/metabase/core/modules_consistency_test.clj
@@ -1,0 +1,363 @@
+(ns metabase.core.modules-consistency-test
+  "Verifies that the three sites implementing namespace→module resolution stay
+  in sync with each other.
+
+  Metabase's modules-enforcement system resolves a namespace symbol (or file
+  path) to a module symbol. This resolution is implemented in three places:
+
+    1. `.clj-kondo/src/hooks/common/modules.clj`   — CANONICAL
+       Runs inside clj-kondo's isolated classpath; the source-of-truth
+       definition of the algorithm.
+
+    2. `dev/src/dev/deps_graph.clj`                — dev mirror
+       Runs in the dev Clojure classpath; used by the config generator
+       and the staleness test.
+
+    3. `mage/src/mage/modules.clj`                 — mage mirror (file-path based)
+       Runs in the mage Babashka classpath; used by CI to determine
+       affected modules from git-changed file paths.
+
+  These three sites cannot share source code because they live in three
+  different classpath contexts. Instead, they maintain the same algorithm
+  by convention, backed by this test as a tripwire.
+
+  WHY THIS TEST EXISTS
+  --------------------
+  When we extend module resolution — for example, adding longest-prefix
+  matching for nested sub-modules — it is dangerously easy to update only
+  one or two of the three sites and leave the third broken. This test
+  catches such drift by comparing the regex literals used for extraction
+  across the three source files.
+
+  APPROACH
+  --------
+  Because the three sites live in different classpath contexts, we cannot
+  simply call each implementation and diff behavior. Instead we parse each
+  source file as text, extract the regex literals referencing `metabase`,
+  and assert that the kondo hook and `dev.deps-graph` share the same set
+  of namespace-matching patterns.
+
+  The mage site uses a different regex shape (file paths rather than
+  namespace symbols), so we assert its patterns exist and reference the
+  expected path fragments, without requiring byte-equality with the other
+  two.
+
+  IF THIS TEST FAILS
+  ------------------
+  Most likely, you edited one of the three sites without editing the others.
+  Before fixing the test, decide whether the algorithm change is
+  intentional — then apply the equivalent change to the other two sites
+  and re-run the test."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [dev.deps-graph]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private kondo-hook-path ".clj-kondo/src/hooks/common/modules.clj")
+(def ^:private deps-graph-path "dev/src/dev/deps_graph.clj")
+(def ^:private mage-modules-path "mage/src/mage/modules.clj")
+
+;; Mirror sites live in different classpaths in production, but in tests we can
+;; load/resolve them directly and compare behavior on representative fixtures.
+(load-file ".clj-kondo/src/hooks/common/modules.clj")
+
+(defn- private-fn [ns-sym sym]
+  (let [v (ns-resolve (find-ns ns-sym) sym)]
+    (assert v (str ns-sym "/" sym " not found"))
+    v))
+
+(defn- working-executable? [executable]
+  (try
+    (zero? (:exit (shell/sh executable "--version")))
+    (catch java.io.IOException _
+      false)))
+
+(defn- find-babashka-executable []
+  (some #(when (working-executable? %) %)
+        ["./bin/bb" "bb"]))
+
+(def ^:private babashka-executable
+  (delay (find-babashka-executable)))
+
+(defn- babashka-available?
+  []
+  (some? (force babashka-executable)))
+
+(deftest babashka-executable-falls-back-to-path-test
+  (with-redefs [working-executable? #(= % "bb")]
+    (is (= "bb" (find-babashka-executable)))))
+
+(defn- bb-mage-file->module [modules-config filename]
+  (let [expr               (str "(do "
+                                "(require 'mage.modules) "
+                                "(let [build-prefix->module (ns-resolve 'mage.modules 'build-prefix->module) "
+                                "      file->module (ns-resolve 'mage.modules 'file->module)] "
+                                "  (prn ((deref file->module) ((deref build-prefix->module) "
+                                (pr-str (list 'quote modules-config))
+                                ") "
+                                (pr-str filename)
+                                "))))")
+        {:keys [exit out err]} (shell/sh (force babashka-executable) "-e" expr)]
+    (when-not (zero? exit)
+      (throw (ex-info "Babashka mage.modules evaluation failed"
+                      {:exit exit
+                       :stderr err
+                       :expr expr})))
+    (edn/read-string (str/trim out))))
+
+(defn- bb-mage-module->test-paths [modules-config module]
+  (let [expr               (str "(do "
+                                "(require 'mage.modules) "
+                                "(let [module->test-paths (ns-resolve 'mage.modules 'module->test-paths)] "
+                                "  (prn ((deref module->test-paths) "
+                                (pr-str (list 'quote modules-config))
+                                " "
+                                (pr-str (list 'quote module))
+                                "))))")
+        {:keys [exit out err]} (shell/sh (force babashka-executable) "-e" expr)]
+    (when-not (zero? exit)
+      (throw (ex-info "Babashka mage.modules test-path evaluation failed"
+                      {:exit exit
+                       :stderr err
+                       :expr expr})))
+    (edn/read-string (str/trim out))))
+
+(defn- bb-mage-updated-files->updated-modules [modules-config filenames]
+  (let [expr               (str "(do "
+                                "(require 'mage.modules) "
+                                "(let [build-prefix->module (ns-resolve 'mage.modules 'build-prefix->module) "
+                                "      updated-files->updated-modules (ns-resolve 'mage.modules 'updated-files->updated-modules)] "
+                                "  (with-redefs [mage.modules/read-prefix->module (fn [] ((deref build-prefix->module) "
+                                (pr-str (list 'quote modules-config))
+                                "))] "
+                                "    (prn ((deref updated-files->updated-modules) "
+                                (pr-str filenames)
+                                ")))))")
+        {:keys [exit out err]} (shell/sh (force babashka-executable) "-e" expr)]
+    (when-not (zero? exit)
+      (throw (ex-info "Babashka mage.modules updated-files evaluation failed"
+                      {:exit exit
+                       :stderr err
+                       :expr expr})))
+    (edn/read-string (str/trim out))))
+
+(defn- regex-literals-in-file
+  "Parse the file at `path` as text and return the seq of regex literal strings
+  it contains.
+
+  A regex literal here is the body of a `#\"...\"` form, without the enclosing
+  `#\"` and `\"`. This is a deliberately naive lexer that does not handle
+  escaped double-quotes inside a regex literal — none of our three target
+  files use such literals, and if someone introduces one the test will need
+  updating anyway."
+  [path]
+  (let [content (slurp (io/file path))
+        matcher (re-matcher #"#\"([^\"]*)\"" content)]
+    (loop [acc []]
+      (if (.find matcher)
+        (recur (conj acc (.group matcher 1)))
+        acc))))
+
+(defn- metabase-namespace-regexes
+  "The subset of regex literals in `path` that match namespace symbols starting
+  with `metabase` or `metabase-enterprise`. Used for cross-checking the
+  namespace-based mapping sites (kondo hook and deps_graph)."
+  [path]
+  (->> (regex-literals-in-file path)
+       (filter (fn [pat]
+                 (or (str/starts-with? pat "^metabase\\.")
+                     (str/starts-with? pat "^metabase-enterprise\\."))))
+       set))
+
+(deftest ^:parallel kondo-hook-and-deps-graph-regexes-agree-test
+  (testing (str "The namespace→module regex literals in the kondo hook and dev.deps-graph "
+                "must agree byte-for-byte. See this namespace's docstring for background.")
+    (let [kondo-regexes      (metabase-namespace-regexes kondo-hook-path)
+          deps-graph-regexes (metabase-namespace-regexes deps-graph-path)]
+      (testing (format "\nkondo hook (%s) has regexes the deps_graph (%s) lacks:"
+                       kondo-hook-path deps-graph-path)
+        (is (empty? (into (sorted-set) (map str) (remove deps-graph-regexes kondo-regexes)))))
+      (testing (format "\ndeps_graph (%s) has regexes the kondo hook (%s) lacks:"
+                       deps-graph-path kondo-hook-path)
+        (is (empty? (into (sorted-set) (map str) (remove kondo-regexes deps-graph-regexes)))))
+      (testing "\nboth files must actually contain at least one namespace-matching regex"
+        (is (seq kondo-regexes)
+            "kondo hook has no metabase-namespace regexes — was the file moved or rewritten?")
+        (is (seq deps-graph-regexes)
+            "deps_graph has no metabase-namespace regexes — was the file moved or rewritten?")))))
+
+(deftest ^:parallel mage-file-path-regexes-exist-test
+  (testing (str "mage/modules/file->module uses file-path-based module extraction. "
+                "This test ensures the expected path fragments are still referenced in "
+                "the file so that accidental deletion or semantic drift is caught. "
+                "See this namespace's docstring for background.")
+    (let [content     (slurp (io/file mage-modules-path))
+          regexes     (regex-literals-in-file mage-modules-path)
+          joined      (str/join "\n" regexes)]
+      (testing "\nfile path regex for `metabase/<module>/...` is present"
+        (is (str/includes? joined "metabase/([^/]+)")
+            (str "mage.modules/file->module should still reference the file-path pattern "
+                 "`metabase/([^/]+)`. If you removed this pattern, either reintroduce it "
+                 "or update this test to reflect the new extraction approach.")))
+      (testing "\nfile path regex for `metabase_enterprise/<module>/...` is present"
+        (is (str/includes? joined "metabase_enterprise/([^/]+)")
+            (str "mage.modules/file->module should still reference the file-path pattern "
+                 "`metabase_enterprise/([^/]+)`. If you removed this pattern, either "
+                 "reintroduce it or update this test to reflect the new extraction approach.")))
+      (testing "\nfile contains a reminder comment pointing at the canonical site"
+        (is (str/includes? content "hooks/common/modules.clj")
+            (str "mage/src/mage/modules.clj should contain a comment pointing at "
+                 ".clj-kondo/src/hooks/common/modules.clj as the canonical source "
+                 "of the module-resolution algorithm."))))))
+
+(deftest ^:parallel module-resolution-behavior-agrees-test
+  (testing "Representative namespace/file-path cases resolve to the same module across all three sites"
+    (let [hook-module        (private-fn 'hooks.common.modules 'module)
+          dev-module         (private-fn 'dev.deps-graph 'module)
+          config             {:metabase/modules
+                              {'actions               {}
+                               'actions.rest          {:ns-prefix "metabase.actions-rest"}
+                               'queries               {}
+                               'queries.rest          {:ns-prefix "metabase.queries-rest"}
+                               'lib                   {}
+                               'lib.schema            {}
+                               'lib.be                {:ns-prefix "metabase.lib-be"}
+                               'enterprise/transforms {}
+                               'enterprise/transforms.python {}}}
+          modules-config     (:metabase/modules config)
+          dev-prefix->module (dev.deps-graph/build-prefix->module modules-config)
+          cases              [{:ns 'metabase.actions-rest.api
+                               :file "src/metabase/actions_rest/api.clj"
+                               :want 'actions.rest}
+                              {:ns 'metabase.queries-rest.middleware
+                               :file "test/metabase/queries_rest/middleware_test.clj"
+                               :want 'queries.rest}
+                              {:ns 'metabase.lib.schema.util
+                               :file "src/metabase/lib/schema/util.clj"
+                               :want 'lib.schema}
+                              {:ns 'metabase.lib.schema-test
+                               :file "test/metabase/lib/schema_test.cljc"
+                               :want 'lib.schema}
+                              {:ns 'metabase.lib-be.core
+                               :file "src/metabase/lib_be/core.clj"
+                               :want 'lib.be}
+                              {:ns 'metabase-enterprise.transforms.python.runner
+                               :file "enterprise/backend/src/metabase_enterprise/transforms/python/runner.clj"
+                               :want 'enterprise/transforms.python}]]
+      (doseq [{:keys [ns file want]} cases]
+        (testing (str ns " <-> " file)
+          (is (= want (hook-module config ns)))
+          (is (= want (dev-module dev-prefix->module ns)))
+          (if (babashka-available?)
+            (do
+              (is (= want (bb-mage-file->module modules-config file)))
+              (is (= (hook-module config ns)
+                     (dev-module dev-prefix->module ns)
+                     (bb-mage-file->module modules-config file))))
+            (is true "Skipping mage.modules resolution assertions because `bb` is unavailable")))))))
+
+(deftest ^:parallel dotted-module-test-paths-test
+  (testing "Dotted modules resolve to the actual on-disk test paths for both default and explicit prefixes"
+    (let [modules-config {'actions.rest {:ns-prefix "metabase.actions-rest"}
+                          'lib.schema   {}}
+          module->test-files (private-fn 'dev.deps-graph 'module->test-files)]
+      (testing "dev.deps-graph finds both explicit-prefix and default nested-module tests"
+        (is (contains? (module->test-files modules-config 'actions.rest)
+                       "test/metabase/actions_rest/api_test.clj"))
+        (is (contains? (module->test-files modules-config 'lib.schema)
+                       "test/metabase/lib/schema/util_test.cljc"))
+        (is (contains? (module->test-files modules-config 'lib.schema)
+                       "test/metabase/lib/schema_test.cljc")))
+      (if (babashka-available?)
+        (testing "mage.modules emits exact files owned by each module"
+          (is (contains? (set (bb-mage-module->test-paths modules-config 'actions.rest))
+                         "test/metabase/actions_rest/api_test.clj"))
+          (is (contains? (set (bb-mage-module->test-paths modules-config 'lib.schema))
+                         "test/metabase/lib/schema/util_test.cljc"))
+          (is (contains? (set (bb-mage-module->test-paths modules-config 'lib.schema))
+                         "test/metabase/lib/schema_test.cljc")))
+        (is true "Skipping mage.modules path assertions because `bb` is unavailable")))))
+
+(deftest ^:parallel parent-test-discovery-excludes-declared-child-tests-test
+  (let [child-test "test/metabase/query_processor/middleware/cache_backend/db_test.clj"
+        modules-config {'query-processor               {}
+                        'query-processor.cache-backend {:ns-prefix "metabase.query-processor.middleware.cache-backend"}}
+        module->test-files (private-fn 'dev.deps-graph 'module->test-files)]
+    (testing "dev dependency tooling assigns a nested test only to its exact owner"
+      (is (not (contains? (module->test-files modules-config 'query-processor) child-test)))
+      (is (contains? (module->test-files modules-config 'query-processor.cache-backend) child-test)))
+    (if (babashka-available?)
+      (testing "Mage affected-test paths assign a nested test only to its exact owner"
+        (is (not (contains? (set (bb-mage-module->test-paths modules-config 'query-processor)) child-test)))
+        (is (contains? (set (bb-mage-module->test-paths modules-config 'query-processor.cache-backend)) child-test)))
+      (is true "Skipping mage.modules path assertions because `./bin/bb` is unavailable"))))
+
+(deftest ^:parallel mage-affected-tests-are-jvm-loadable-test
+  (if (babashka-available?)
+    (let [paths (set (bb-mage-module->test-paths {'lib {}} 'lib))]
+      (is (not (contains? paths "test/metabase/lib/js_test.cljs"))))
+    (is true "Skipping mage.modules path assertions because Babashka is unavailable")))
+
+(deftest ^:parallel explicit-prefix-map-overloads-remain-pure-test
+  (testing "dev.deps-graph path helpers honor caller-supplied prefix->module maps instead of recomputing live config"
+    (let [deps        [{:module 'lib.schema.util
+                        :deps   []
+                        :filename "src/metabase/lib/schema/util/core.cljc"}]
+          prefix->mod {"metabase.lib.schema.util" 'lib.schema.util}]
+      (is (= #{"src/metabase/lib/schema/util/core.cljc"}
+             (set (dev.deps-graph/test-filenames->relevant-source-filenames
+                   deps
+                   prefix->mod
+                   ["test/metabase/lib/schema/util/core_test.cljc"]))))
+      (is (= #{"test/metabase/lib/schema/util_test.cljc"}
+             (set (dev.deps-graph/source-filenames->relevant-test-filenames
+                   deps
+                   {'lib.schema.util {}}
+                   prefix->mod
+                   ["src/metabase/lib/schema/util/core.cljc"])))))))
+
+(deftest ^:parallel exact-dotted-module-test-files-round-trip-test
+  (testing "Exact-file dotted-module tests resolve back to the dotted module"
+    (let [deps        [{:module   'lib.schema
+                        :deps     []
+                        :filename "src/metabase/lib/schema.cljc"}
+                       {:module   'lib
+                        :deps     []
+                        :filename "src/metabase/lib.clj"}]
+          prefix->mod {"metabase.lib.schema" 'lib.schema}
+          test-file   "test/metabase/lib/schema_test.cljc"]
+      (is (= #{"src/metabase/lib/schema.cljc"}
+             (set (dev.deps-graph/test-filenames->relevant-source-filenames
+                   deps
+                   prefix->mod
+                   [test-file]))))
+      (if (babashka-available?)
+        (do
+          (is (= 'lib.schema
+                 (bb-mage-file->module {'lib.schema {}}
+                                       test-file)))
+          (is (= '#{lib.schema}
+                 (bb-mage-updated-files->updated-modules {'lib.schema {}
+                                                          'lib        {}}
+                                                         [test-file]))))
+        (is true "Skipping mage.modules exact-file assertions because `bb` is unavailable")))))
+
+(deftest ^:parallel canonical-comments-present-test
+  (testing "Each of the three mapping sites must carry a comment pointing at the others"
+    (testing (format "\n%s contains the word CANONICAL" kondo-hook-path)
+      (is (str/includes? (slurp (io/file kondo-hook-path)) "CANONICAL")
+          (str "The kondo hook's `module` function docstring should include the word "
+               "CANONICAL to mark it as the source-of-truth implementation.")))
+    (testing (format "\n%s contains the word MIRROR" deps-graph-path)
+      (is (str/includes? (slurp (io/file deps-graph-path)) "MIRROR")
+          (str "The deps_graph `module` function docstring should include the word "
+               "MIRROR to make its relationship to the kondo hook explicit.")))
+    (testing (format "\n%s contains the word MIRROR" mage-modules-path)
+      (is (str/includes? (slurp (io/file mage-modules-path)) "MIRROR")
+          (str "The mage `file->module` function should include a MIRROR comment "
+               "pointing at the canonical site.")))))

--- a/test/metabase/core/modules_consistency_test.clj
+++ b/test/metabase/core/modules_consistency_test.clj
@@ -331,9 +331,17 @@
         (is (all-under? "test/metabase/actions_rest"
                         (module->test-files modules-config 'actions.rest))
             "an explicit :ns-prefix resolves into the prefix's directory")
-        (is (all-under? "test/metabase/lib/schema"
-                        (module->test-files modules-config 'lib.schema))
-            "a default-derived prefix resolves into the dotted module's directory"))
+        (let [schema-tests (module->test-files modules-config 'lib.schema)]
+          (is (all-under? "test/metabase/lib/schema" schema-tests)
+              "a default-derived prefix resolves into the dotted module's directory")
+          ;; Completeness signal. `all-under?` alone would still pass if discovery silently stopped
+          ;; surfacing nested files and returned only the module's own `schema_test.cljc`, which is
+          ;; the regression the old per-file assertions caught. Checking that both shapes appear
+          ;; keeps that signal without pinning any filename.
+          (is (some #(re-matches #"test/metabase/lib/schema_test\.\w+" %) schema-tests)
+              "the module's own test file is discovered")
+          (is (some #(.startsWith ^String % "test/metabase/lib/schema/") schema-tests)
+              "and so are tests nested beneath it")))
       (if (babashka-available?)
         (testing "mage.modules emits the same directories"
           (is (all-under? "test/metabase/actions_rest"
@@ -365,7 +373,11 @@
 (deftest ^:parallel mage-affected-tests-are-jvm-loadable-test
   (if (babashka-available?)
     (let [paths (set (bb-mage-module->test-paths {'lib {}} 'lib))]
-      (is (not (contains? paths "test/metabase/lib/js_test.cljs"))))
+      ;; Assert the property, not one filename: naming `lib/js_test.cljs` meant the check silently
+      ;; became a no-op the moment that file was renamed or deleted.
+      (is (seq paths) "no paths resolved, so the exclusion below would hold vacuously")
+      (is (empty? (filter #(str/ends-with? ^String % ".cljs") paths))
+          "mage affected-test paths feed a JVM runner, so ClojureScript-only tests must not appear"))
     (is false (missing-babashka-failure))))
 
 (deftest ^:parallel explicit-prefix-map-overloads-remain-pure-test

--- a/test/metabase/core/modules_consistency_test.clj
+++ b/test/metabase/core/modules_consistency_test.clj
@@ -259,7 +259,46 @@
               (is (= (hook-module config ns)
                      (dev-module dev-prefix->module ns)
                      (bb-mage-file->module modules-config file))))
-            (is true "Skipping mage.modules resolution assertions because `bb` is unavailable")))))))
+            (is false (str "Cannot cross-check the mage resolver mirror: no working babashka at "
+                           "./bin/bb or on PATH. Run any ./bin/mage task once to install it. "
+                           "Skipping silently would let the mage mirror drift out of sync "
+                           "unnoticed, which is what this test exists to prevent."))))))))
+
+(deftest ^:parallel visibility-behavior-agrees-test
+  (testing (str "The dev mirror of the namability rule agrees with the canonical hook. This file "
+                "otherwise cross-checks only namespace resolution, leaving "
+                "`dev.deps-graph/module-namable-from?` the one mirror of this rule with no coverage; "
+                "a desync there corrupts `:uses :any` expansion in `expanded-module-uses`.")
+    (let [hook-namable (private-fn 'hooks.common.modules 'namable-from?)
+          dev-namable  (private-fn 'dev.deps-graph 'module-namable-from?)
+          base         {'outer        {}
+                        'outer.a      {}
+                        'outer.a.leaf {}
+                        'outer.a.sib  {}
+                        'outer.b      {}
+                        'outer.b.deep {}
+                        'unrelated    {}}
+          pairs        [['unrelated 'outer]
+                        ['outer.a 'outer.a.leaf]
+                        ['outer.a.sib 'outer.a.leaf]
+                        ['outer 'outer.a.leaf]
+                        ['outer.b 'outer.a.leaf]
+                        ['outer.b.deep 'outer.a.leaf]
+                        ['unrelated 'outer.a.leaf]]]
+      (doseq [[label config] [["unopened" base]
+                              ["leaf exported by its parent"
+                               (assoc-in base ['outer.a :module-exports] #{'outer.a.leaf})]
+                              ["leaf exported all the way to the root"
+                               (-> base
+                                   (assoc-in ['outer.a :module-exports] #{'outer.a.leaf})
+                                   (assoc-in ['outer :module-exports] #{'outer.a}))]]]
+        (testing (str "\n" label)
+          (doseq [[caller target] pairs]
+            (testing (format "\n%s naming %s" caller target)
+              ;; the hook reads modules out of a `:metabase/modules` wrapper; the dev mirror takes
+              ;; the inner map directly.
+              (is (= (boolean (hook-namable {:metabase/modules config} caller target))
+                     (boolean (dev-namable config caller target)))))))))))
 
 (deftest ^:parallel dotted-module-test-paths-test
   (testing "Dotted modules resolve to the actual on-disk test paths for both default and explicit prefixes"

--- a/test/metabase/core/modules_consistency_test.clj
+++ b/test/metabase/core/modules_consistency_test.clj
@@ -88,6 +88,14 @@
   []
   (some? (force babashka-executable)))
 
+(defn- missing-babashka-failure
+  "Message for a cross-check that cannot run because babashka is absent. These assertions are the only
+  thing binding the mage mirror to the other two resolvers, so a missing `bb` fails loudly rather than
+  passing silently: a tripwire that quietly degrades from three-way to two-way is worse than a red test."
+  []
+  (str "Cannot cross-check the mage resolver mirror: no working babashka at ./bin/bb or on PATH. "
+       "Run any ./bin/mage task once to install it."))
+
 (deftest babashka-executable-falls-back-to-path-test
   (with-redefs [working-executable? #(= % "bb")]
     (is (= "bb" (find-babashka-executable)))))
@@ -260,10 +268,7 @@
               (is (= (hook-module config ns)
                      (dev-module dev-prefix->module ns)
                      mage-result)))
-            (is false (str "Cannot cross-check the mage resolver mirror: no working babashka at "
-                           "./bin/bb or on PATH. Run any ./bin/mage task once to install it. "
-                           "Skipping silently would let the mage mirror drift out of sync "
-                           "unnoticed, which is what this test exists to prevent."))))))))
+            (is false (missing-babashka-failure))))))))
 
 (deftest ^:parallel visibility-behavior-agrees-test
   (testing (str "The dev mirror of the namability rule agrees with the canonical hook. This file "
@@ -301,53 +306,67 @@
               (is (= (boolean (hook-namable {:metabase/modules config} caller target))
                      (boolean (dev-namable config caller target)))))))))))
 
-;; The tests below assert against real on-disk test files rather than fixtures, because the point is
-;; that resolution lands on paths that actually exist. That couples them to files they do not own:
-;; `actions_rest/api_test.clj`, `lib/schema/util_test.cljc`, `lib/schema_test.cljc`,
-;; `cache_backend/db_test.clj` and `lib/js_test.cljs`. Renaming or deleting any of those breaks these
-;; tests without the resolution logic having changed. If that happens, repoint the path rather than
-;; assuming a resolver regression.
+;; The path tests below run against the real test tree rather than fixtures, because the property under
+;; test is that resolution lands on paths that actually exist. They assert on the DIRECTORY a module's
+;; tests resolve into, never on individual filenames, so renaming or adding a test file cannot break
+;; them. What does break them is resolution moving a file to the wrong module, which is the point.
+
+(defn- all-under?
+  "True if `paths` is non-empty and every path is the module's own `<dir>_test.<ext>` file or sits
+  under `<dir>/`. Non-emptiness matters: an empty set would satisfy `every?` vacuously and the
+  assertion would prove nothing."
+  [dir paths]
+  (and (seq paths)
+       (every? (fn [^String p]
+                 (or (re-matches (re-pattern (str "\\Q" dir "\\E_test\\.\\w+")) p)
+                     (.startsWith p (str dir "/"))))
+               paths)))
+
 (deftest ^:parallel dotted-module-test-paths-test
   (testing "Dotted modules resolve to the actual on-disk test paths for both default and explicit prefixes"
     (let [modules-config {'actions.rest {:ns-prefix "metabase.actions-rest"}
                           'lib.schema   {}}
           module->test-files (private-fn 'dev.deps-graph 'module->test-files)]
       (testing "dev.deps-graph finds both explicit-prefix and default nested-module tests"
-        (is (contains? (module->test-files modules-config 'actions.rest)
-                       "test/metabase/actions_rest/api_test.clj"))
-        (is (contains? (module->test-files modules-config 'lib.schema)
-                       "test/metabase/lib/schema/util_test.cljc"))
-        (is (contains? (module->test-files modules-config 'lib.schema)
-                       "test/metabase/lib/schema_test.cljc")))
+        (is (all-under? "test/metabase/actions_rest"
+                        (module->test-files modules-config 'actions.rest))
+            "an explicit :ns-prefix resolves into the prefix's directory")
+        (is (all-under? "test/metabase/lib/schema"
+                        (module->test-files modules-config 'lib.schema))
+            "a default-derived prefix resolves into the dotted module's directory"))
       (if (babashka-available?)
-        (testing "mage.modules emits exact files owned by each module"
-          (is (contains? (set (bb-mage-module->test-paths modules-config 'actions.rest))
-                         "test/metabase/actions_rest/api_test.clj"))
-          (is (contains? (set (bb-mage-module->test-paths modules-config 'lib.schema))
-                         "test/metabase/lib/schema/util_test.cljc"))
-          (is (contains? (set (bb-mage-module->test-paths modules-config 'lib.schema))
-                         "test/metabase/lib/schema_test.cljc")))
-        (is true "Skipping mage.modules path assertions because `bb` is unavailable")))))
+        (testing "mage.modules emits the same directories"
+          (is (all-under? "test/metabase/actions_rest"
+                          (bb-mage-module->test-paths modules-config 'actions.rest)))
+          (is (all-under? "test/metabase/lib/schema"
+                          (bb-mage-module->test-paths modules-config 'lib.schema))))
+        (is false (missing-babashka-failure))))))
 
 (deftest ^:parallel parent-test-discovery-excludes-declared-child-tests-test
-  (let [child-test "test/metabase/query_processor/middleware/cache_backend/db_test.clj"
+  (let [child-dir "test/metabase/query_processor/middleware/cache_backend"
         modules-config {'query-processor               {}
                         'query-processor.cache-backend {:ns-prefix "metabase.query-processor.middleware.cache-backend"}}
         module->test-files (private-fn 'dev.deps-graph 'module->test-files)]
     (testing "dev dependency tooling assigns a nested test only to its exact owner"
-      (is (not (contains? (module->test-files modules-config 'query-processor) child-test)))
-      (is (contains? (module->test-files modules-config 'query-processor.cache-backend) child-test)))
+      (let [parent (module->test-files modules-config 'query-processor)
+            child  (module->test-files modules-config 'query-processor.cache-backend)]
+        (is (all-under? child-dir child)
+            "the declared child owns the tests under its own prefix")
+        (is (empty? (filter #(.startsWith ^String % (str child-dir "/")) parent))
+            "and the parent claims none of them")))
     (if (babashka-available?)
       (testing "Mage affected-test paths assign a nested test only to its exact owner"
-        (is (not (contains? (set (bb-mage-module->test-paths modules-config 'query-processor)) child-test)))
-        (is (contains? (set (bb-mage-module->test-paths modules-config 'query-processor.cache-backend)) child-test)))
-      (is true "Skipping mage.modules path assertions because `./bin/bb` is unavailable"))))
+        (let [parent (bb-mage-module->test-paths modules-config 'query-processor)
+              child  (bb-mage-module->test-paths modules-config 'query-processor.cache-backend)]
+          (is (all-under? child-dir child))
+          (is (empty? (filter #(.startsWith ^String % (str child-dir "/")) parent)))))
+      (is false (missing-babashka-failure)))))
 
 (deftest ^:parallel mage-affected-tests-are-jvm-loadable-test
   (if (babashka-available?)
     (let [paths (set (bb-mage-module->test-paths {'lib {}} 'lib))]
       (is (not (contains? paths "test/metabase/lib/js_test.cljs"))))
-    (is true "Skipping mage.modules path assertions because Babashka is unavailable")))
+    (is false (missing-babashka-failure))))
 
 (deftest ^:parallel explicit-prefix-map-overloads-remain-pure-test
   (testing "dev.deps-graph path helpers honor caller-supplied prefix->module maps instead of recomputing live config"
@@ -391,7 +410,7 @@
                  (bb-mage-updated-files->updated-modules {'lib.schema {}
                                                           'lib        {}}
                                                          [test-file]))))
-        (is true "Skipping mage.modules exact-file assertions because `bb` is unavailable")))))
+        (is false (missing-babashka-failure))))))
 
 (deftest ^:parallel canonical-comments-present-test
   (testing "Each of the three mapping sites must carry a comment pointing at the others"

--- a/test/metabase/core/modules_consistency_test.clj
+++ b/test/metabase/core/modules_consistency_test.clj
@@ -254,11 +254,12 @@
           (is (= want (hook-module config ns)))
           (is (= want (dev-module dev-prefix->module ns)))
           (if (babashka-available?)
-            (do
-              (is (= want (bb-mage-file->module modules-config file)))
+            ;; one subprocess per case, not one per assertion
+            (let [mage-result (bb-mage-file->module modules-config file)]
+              (is (= want mage-result))
               (is (= (hook-module config ns)
                      (dev-module dev-prefix->module ns)
-                     (bb-mage-file->module modules-config file))))
+                     mage-result)))
             (is false (str "Cannot cross-check the mage resolver mirror: no working babashka at "
                            "./bin/bb or on PATH. Run any ./bin/mage task once to install it. "
                            "Skipping silently would let the mage mirror drift out of sync "
@@ -300,6 +301,12 @@
               (is (= (boolean (hook-namable {:metabase/modules config} caller target))
                      (boolean (dev-namable config caller target)))))))))))
 
+;; The tests below assert against real on-disk test files rather than fixtures, because the point is
+;; that resolution lands on paths that actually exist. That couples them to files they do not own:
+;; `actions_rest/api_test.clj`, `lib/schema/util_test.cljc`, `lib/schema_test.cljc`,
+;; `cache_backend/db_test.clj` and `lib/js_test.cljs`. Renaming or deleting any of those breaks these
+;; tests without the resolution logic having changed. If that happens, repoint the path rather than
+;; assuming a resolver regression.
 (deftest ^:parallel dotted-module-test-paths-test
   (testing "Dotted modules resolve to the actual on-disk test paths for both default and explicit prefixes"
     (let [modules-config {'actions.rest {:ns-prefix "metabase.actions-rest"}

--- a/test/metabase/core/modules_consistency_test.clj
+++ b/test/metabase/core/modules_consistency_test.clj
@@ -54,7 +54,8 @@
    [clojure.java.shell :as shell]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [dev.deps-graph]))
+   [dev.deps-graph]
+   [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
 
@@ -438,3 +439,24 @@
       (is (str/includes? (slurp (io/file mage-modules-path)) "MIRROR")
           (str "The mage `file->module` function should include a MIRROR comment "
                "pointing at the canonical site.")))))
+
+(deftest ^:parallel log-team-attribution-agrees-with-deps-graph-test
+  (testing (str "`metabase.util.log`'s team attribution is a FOURTH copy of namespace-to-module "
+                "resolution, alongside the kondo hook, `dev.deps-graph` and `mage.modules`. It resolves "
+                "a namespace to its module and then climbs to the nearest ancestor declaring `:team`. "
+                "It cannot take an injected config, so the inheritance climb cannot be exercised on a "
+                "fixture; what can be pinned is that it agrees with `dev.deps-graph` on the real "
+                "config, so this copy cannot drift from the source of truth unnoticed.")
+    (let [config      (dev.deps-graph/kondo-config)
+          prefix->mod (dev.deps-graph/build-prefix->module config)
+          ;; One namespace per module, derived from the config rather than hard-coded, so this cannot
+          ;; rot against a rename and cannot quietly shrink to a handful of modules.
+          samples     (for [m (sort (keys config))]
+                        [m (symbol (dev.deps-graph/module-ns-prefix config m))])]
+      (is (< 100 (count samples))
+          "sampling every declared module, so a shrunken sample would mean the config failed to load")
+      (doseq [[module ns-sym] samples]
+        (testing (format "\n%s (%s)" ns-sym module)
+          ;; log resolves the namespace itself, so compare against deps-graph doing both steps.
+          (is (= (dev.deps-graph/module-team config ((private-fn 'dev.deps-graph 'module) prefix->mod ns-sym))
+                 (log/ns->team* ns-sym))))))))

--- a/test/metabase/core/modules_nesting_test.clj
+++ b/test/metabase/core/modules_nesting_test.clj
@@ -1,0 +1,645 @@
+(ns metabase.core.modules-nesting-test
+  "Tests for the nested-modules mechanism: longest-prefix namespace→module
+  resolution and `:module-exports`-based visibility.
+
+  The kondo hook at `.clj-kondo/src/hooks/common/modules.clj` lives in
+  clj-kondo's isolated classpath and cannot be `require`d from the test
+  classpath directly. To test it, we `load-file` the hook source into the
+  test JVM, creating the `hooks.common.modules` namespace on-the-fly.
+
+  These tests use **fixture configs** — hand-constructed maps shaped like
+  the real `:metabase/modules` config — to exercise the hook's resolution
+  and visibility logic in isolation. No production config is read."
+  (:require
+   [clojure.test :refer :all]
+   [dev.deps-graph]))
+
+(set! *warn-on-reflection* true)
+
+;; Load the kondo hook source into this test JVM so we can call its functions.
+;; The hook only depends on `clojure.string`, so this is safe.
+(load-file ".clj-kondo/src/hooks/common/modules.clj")
+
+;; Resolve hook functions via the namespace (which was just created by
+;; load-file). We use `ns-resolve` rather than direct references because
+;; the namespace isn't required at compile time.
+(def ^:private hook-ns (find-ns 'hooks.common.modules))
+
+(defn- hook-fn [sym]
+  (let [v (ns-resolve hook-ns sym)]
+    (assert v (str "hooks.common.modules/" sym " not found"))
+    v))
+
+;;;; -------------------------------------------------------------------------
+;;;; Longest-prefix module resolution
+;;;; -------------------------------------------------------------------------
+
+(deftest ^:parallel module-resolution-single-arg-is-flat-test
+  (testing "Single-arg `module` uses flat first-segment extraction regardless of config"
+    (let [module (hook-fn 'module)]
+      (is (= 'lib                    (module 'metabase.lib.schema.foo)))
+      (is (= 'lib                    (module 'metabase.lib.core)))
+      (is (= 'query-processor        (module 'metabase.query-processor.middleware.foo)))
+      (is (= 'enterprise/transforms  (module 'metabase-enterprise.transforms.core)))
+      (is (nil? (module 'clojure.core)))
+      (is (nil? (module 'clj-kondo.impl.config))))))
+
+(deftest ^:parallel module-resolution-two-arg-with-empty-config-is-flat-test
+  (testing "Two-arg `module` with empty/nil config degenerates to flat extraction"
+    (let [module (hook-fn 'module)]
+      (is (= 'lib (module nil 'metabase.lib.schema.foo)))
+      (is (= 'lib (module {} 'metabase.lib.schema.foo)))
+      (is (= 'lib (module {:metabase/modules {}} 'metabase.lib.schema.foo))))))
+
+(deftest ^:parallel module-resolution-longest-prefix-test
+  (testing "Two-arg `module` does longest-prefix matching against declared modules"
+    (let [module (hook-fn 'module)
+          config {:metabase/modules {'lib        {}
+                                     'lib.schema {}}}]
+      (testing "resolves to the most-specific declared ancestor"
+        (is (= 'lib.schema (module config 'metabase.lib.schema.foo)))
+        (is (= 'lib.schema (module config 'metabase.lib.schema.nested.deeper))))
+      (testing "falls back to parent when deeper child isn't declared"
+        (is (= 'lib (module config 'metabase.lib.core))))
+      (testing "unrelated namespaces still hit the flat fallback"
+        (is (= 'query-processor (module config 'metabase.query-processor.foo)))))))
+
+(deftest ^:parallel module-resolution-enterprise-dotted-children-test
+  (testing "Enterprise dotted children resolve correctly"
+    (let [module (hook-fn 'module)
+          config {:metabase/modules {'enterprise/transforms         {}
+                                     'enterprise/transforms.python  {}}}]
+      (is (= 'enterprise/transforms.python
+             (module config 'metabase-enterprise.transforms.python.runner)))
+      (is (= 'enterprise/transforms
+             (module config 'metabase-enterprise.transforms.core))))))
+
+(deftest ^:parallel module-resolution-three-level-nesting-test
+  (testing "Three-level nesting: longest-prefix walks down through multiple declared ancestors"
+    (let [module (hook-fn 'module)
+          config {:metabase/modules {'outer                {}
+                                     'outer.middle         {}
+                                     'outer.middle.deepest {}}}]
+      (is (= 'outer.middle.deepest
+             (module config 'metabase.outer.middle.deepest.foo)))
+      (is (= 'outer.middle
+             (module config 'metabase.outer.middle.other)))
+      (is (= 'outer
+             (module config 'metabase.outer.top))))))
+
+(deftest ^:parallel module-resolution-test-namespace-suffix-stripping-test
+  (testing "`-test` suffix on the first segment is stripped (legacy behavior)"
+    (let [module (hook-fn 'module)]
+      (is (= 'driver (module 'metabase.driver-test))))))
+
+;;;; -------------------------------------------------------------------------
+;;;; :ns-prefix — explicit override of the name-derived default
+;;;; -------------------------------------------------------------------------
+
+(deftest ^:parallel default-ns-prefix-test
+  (testing "`default-ns-prefix` derives the prefix string from the module name"
+    (let [default-ns-prefix (hook-fn 'default-ns-prefix)]
+      (is (= "metabase.lib"                         (default-ns-prefix 'lib)))
+      (is (= "metabase.lib.schema"                  (default-ns-prefix 'lib.schema)))
+      (is (= "metabase.query-processor"             (default-ns-prefix 'query-processor)))
+      (is (= "metabase-enterprise.transforms"       (default-ns-prefix 'enterprise/transforms)))
+      (is (= "metabase-enterprise.transforms.python"
+             (default-ns-prefix 'enterprise/transforms.python))))))
+
+(deftest ^:parallel module-ns-prefix-explicit-override-test
+  (testing "`module-ns-prefix` returns explicit `:ns-prefix` when set, else default"
+    (let [module-ns-prefix (hook-fn 'module-ns-prefix)
+          config {:metabase/modules {'lib        {}
+                                     'lib.be     {:ns-prefix "metabase.lib-be"}
+                                     'lib.schema {}}}]
+      (is (= "metabase.lib"         (module-ns-prefix config 'lib)))
+      (is (= "metabase.lib-be"      (module-ns-prefix config 'lib.be)))
+      (is (= "metabase.lib.schema"  (module-ns-prefix config 'lib.schema))))))
+
+(deftest ^:parallel module-resolution-explicit-ns-prefix-test
+  (testing "Namespace resolution respects explicit `:ns-prefix` on a module"
+    (let [module (hook-fn 'module)
+          config {:metabase/modules {'lib        {}
+                                     'lib.schema {}
+                                     'lib.be     {:ns-prefix "metabase.lib-be"}
+                                     'lib.legacy-mbql {:ns-prefix "metabase.legacy-mbql"}}}]
+      (testing "hyphenated source namespace resolves to the nested module"
+        (is (= 'lib.be (module config 'metabase.lib-be.core)))
+        (is (= 'lib.be (module config 'metabase.lib-be.models.query))))
+      (testing "unrelated hyphenated namespace resolves to its own nested module"
+        (is (= 'lib.legacy-mbql (module config 'metabase.legacy-mbql.util)))
+        (is (= 'lib.legacy-mbql (module config 'metabase.legacy-mbql.schema.macros))))
+      (testing "default-prefixed sibling still resolves correctly"
+        (is (= 'lib.schema (module config 'metabase.lib.schema.foo))))
+      (testing "parent resolves to itself for its own namespaces"
+        (is (= 'lib (module config 'metabase.lib.core)))))))
+
+(deftest ^:parallel module-resolution-segment-boundary-test
+  (testing "Longest-prefix matching only accepts matches at segment boundaries"
+    (let [module (hook-fn 'module)
+          config {:metabase/modules {'lib    {}
+                                     'lib.be {:ns-prefix "metabase.lib-be"}}}]
+      (testing "`metabase.lib-be.foo` matches `metabase.lib-be` at segment boundary"
+        (is (= 'lib.be (module config 'metabase.lib-be.foo))))
+      (testing "`metabase.lib-bert.foo` does NOT match `metabase.lib-be` (mid-segment)"
+        ;; No declared prefix matches at a segment boundary, so the primary
+        ;; path returns nil. The fallback single-segment regex returns the
+        ;; first segment after `metabase.` literally — `lib-bert` — which is
+        ;; NOT `lib.be`.
+        (is (not= 'lib.be (module config 'metabase.lib-bert.foo)))
+        (is (= 'lib-bert (module config 'metabase.lib-bert.foo))))
+      (testing "exact match works"
+        (is (= 'lib.be (module config 'metabase.lib-be))))
+      (testing "unrelated namespace outside the declared set falls through to flat fallback"
+        (is (= 'query-processor (module config 'metabase.query-processor.foo)))))))
+
+(deftest ^:parallel build-prefix->module-test
+  (testing "`build-prefix->module` assembles the lookup map from declared modules"
+    (let [build-prefix->module (hook-fn 'build-prefix->module)
+          config {:metabase/modules {'lib    {}
+                                     'lib.be {:ns-prefix "metabase.lib-be"}
+                                     'query-processor {}}}
+          result (build-prefix->module config)]
+      (is (= {"metabase.lib"             'lib
+              "metabase.lib-be"          'lib.be
+              "metabase.query-processor" 'query-processor}
+             result)))))
+
+(deftest ^:parallel descendant-api-generation-is-monotonic-test
+  (let [deps [{:namespace 'metabase.parent.child.core
+               :module 'parent.child
+               :deps [{:namespace 'metabase.parent.internal
+                       :module 'parent}]}]
+        base-config '{parent       {:api #{}}
+                      parent.child {:uses #{parent}}}]
+    (testing "a new descendant-only use does not become public API"
+      (is (= #{}
+             (dev.deps-graph/externally-used-namespaces-ignoring-friends
+              deps base-config 'parent))))
+    (testing "a pre-existing API remains stable while a descendant still uses it"
+      (is (= '#{metabase.parent.internal}
+             (dev.deps-graph/externally-used-namespaces-ignoring-friends
+              deps (assoc-in base-config ['parent :api] '#{metabase.parent.internal}) 'parent))))))
+
+(deftest default-dependency-helpers-use-configured-prefixes-test
+  (let [config '{parent       {}
+                 parent.child {:ns-prefix metabase.special-child}}
+        seen-prefixes (promise)]
+    (with-redefs [dev.deps-graph/kondo-config (constantly config)
+                  dev.deps-graph/dependencies (fn [prefix->module]
+                                                (deliver seen-prefixes prefix->module)
+                                                [])]
+      (is (= [] (dev.deps-graph/external-usages 'parent)))
+      (is (= (dev.deps-graph/build-prefix->module config) @seen-prefixes)))))
+
+(deftest ^:parallel simulate-rename-preserves-nested-module-ownership-test
+  (let [prefix->module {"metabase.parent" 'parent
+                        "metabase.parent.child" 'parent.child}
+        deps [{:namespace 'metabase.consumer.core
+               :module 'consumer
+               :deps [{:namespace 'metabase.old.core
+                       :module 'old}]}]
+        renamed (#'dev.deps-graph/simulate-rename
+                 deps prefix->module {'metabase.old.core 'metabase.parent.child.core})]
+    (is (= 'parent.child (:module (first (:deps (first renamed))))))))
+
+;;;; -------------------------------------------------------------------------
+;;;; Visibility helpers (parent-module, ancestor-chain, etc.)
+;;;; -------------------------------------------------------------------------
+
+(deftest ^:parallel parent-module-test
+  (testing "`parent-module` derives the parent from a dotted name"
+    (let [parent-module (hook-fn 'parent-module)]
+      (is (= 'lib          (parent-module 'lib.schema)))
+      (is (= 'lib.schema   (parent-module 'lib.schema.foo)))
+      (is (nil?            (parent-module 'lib)))
+      (is (= 'enterprise/transforms (parent-module 'enterprise/transforms.python)))
+      (is (nil?            (parent-module 'enterprise/transforms))))))
+
+(deftest ^:parallel ancestor-chain-test
+  (testing "`ancestor-chain` returns the seq of ancestors from direct parent up"
+    (let [ancestor-chain (hook-fn 'ancestor-chain)]
+      (is (= '(lib.schema lib)     (ancestor-chain 'lib.schema.foo)))
+      (is (= '(lib)                (ancestor-chain 'lib.schema)))
+      (is (= ()                    (ancestor-chain 'lib)))
+      (is (= '(enterprise/transforms)
+             (ancestor-chain 'enterprise/transforms.python))))))
+
+;;;; -------------------------------------------------------------------------
+;;;; :module-exports set
+;;;; -------------------------------------------------------------------------
+
+(deftest ^:parallel open-children-test
+  (testing "`open-children` returns the set declared under `:module-exports` on the parent"
+    (let [open-children (hook-fn 'open-children)
+          config {:metabase/modules {'lib {:module-exports #{'lib.schema 'lib.be}}}}]
+      (is (= #{'lib.schema 'lib.be} (open-children config 'lib)))
+      (is (= #{}                     (open-children config 'query-processor)))
+      (is (= #{}                     (open-children {} 'lib))))))
+
+(deftest ^:parallel externally-visible?-test
+  (testing "A module is externally visible iff every ancestor is either top-level or opened by its parent"
+    (let [externally-visible? (hook-fn 'externally-visible?)]
+      (testing "top-level modules are always externally visible"
+        (is (true? (externally-visible? {} 'lib)))
+        (is (true? (externally-visible? {} 'query-processor))))
+      (testing "a nested module whose parent opens it is visible (parent is top-level)"
+        (let [config {:metabase/modules {'lib {:module-exports #{'lib.schema}}}}]
+          (is (true? (externally-visible? config 'lib.schema)))))
+      (testing "a nested module whose parent does NOT open it is NOT visible"
+        (let [config {:metabase/modules {'lib {:module-exports #{}}}}]
+          (is (false? (externally-visible? config 'lib.schema)))))
+      (testing "a grandchild is visible only if both its parent and grandparent open the chain"
+        (let [ok       {:metabase/modules {'outer        {:module-exports #{'outer.middle}}
+                                           'outer.middle {:module-exports #{'outer.middle.deepest}}}}
+              bad-mid  {:metabase/modules {'outer        {:module-exports #{}}
+                                           'outer.middle {:module-exports #{'outer.middle.deepest}}}}
+              bad-deep {:metabase/modules {'outer        {:module-exports #{'outer.middle}}
+                                           'outer.middle {:module-exports #{}}}}]
+          (is (true?  (externally-visible? ok       'outer.middle.deepest)))
+          (is (false? (externally-visible? bad-mid  'outer.middle.deepest)))
+          (is (false? (externally-visible? bad-deep 'outer.middle.deepest))))))))
+
+;;;; -------------------------------------------------------------------------
+;;;; STRICT MODEL: every cross-module access is an explicit :uses + :api
+;;;; check. There is no implicit visibility of any kind. Same-module access
+;;;; is the only thing that bypasses the lint, and that's just because
+;;;; there's no module boundary to cross.
+;;;;
+;;;; The `internally-visible?` helper has been removed entirely; the
+;;;; visibility-question tests below cover the strict model directly.
+;;;; -------------------------------------------------------------------------
+
+;;;; -------------------------------------------------------------------------
+;;;; usage-error behavior under nesting
+;;;; -------------------------------------------------------------------------
+
+(defn- synthesize-ns-for-module
+  "Given a module symbol and its config entry, produce a plausible namespace
+  symbol that resolves to that module. Used in test fixtures where the exact
+  caller namespace doesn't matter — we just need something the module
+  resolver recognizes as belonging to the module."
+  [config module-sym]
+  (let [prefix (or (get-in config [:metabase/modules module-sym :ns-prefix])
+                   (if (= (namespace module-sym) "enterprise")
+                     (str "metabase-enterprise." (name module-sym))
+                     (str "metabase." (name module-sym))))]
+    (symbol (str prefix ".core"))))
+
+(defn- usage-error
+  "Test helper that calls the loaded kondo hook's `usage-error`.
+
+  Three-arg form: pass a module symbol as the caller. The helper synthesizes
+  a plausible namespace for that module (`<ns-prefix>.core`) and passes it
+  as `current-ns` to the real function. Use this when the test doesn't
+  care about the caller's specific namespace.
+
+  Four-arg form: pass both `current-ns` and `current-module` explicitly.
+  Use this when the test specifically exercises behavior that depends on
+  which namespace inside the module is doing the require — e.g., the
+  `:private` rule that allows only `<parent>.init`/`.core` to load
+  private children."
+  ([config current-module required-namespace]
+   (usage-error config
+                (synthesize-ns-for-module config current-module)
+                current-module
+                required-namespace))
+  ([config current-ns current-module required-namespace]
+   ((hook-fn 'usage-error) config current-ns current-module required-namespace)))
+
+(deftest ^:parallel usage-error-parent-needs-explicit-uses-and-api-test
+  (testing "Parent accessing descendant must declare :uses AND obey the child's :api"
+    (let [config-without-uses
+          {:metabase/modules {'lib        {:uses #{}}
+                              'lib.schema {:api  #{'metabase.lib.schema.foo}
+                                           :uses #{}}}}]
+      (is (some? (usage-error config-without-uses 'lib 'metabase.lib.schema.foo))
+          "lib does not declare :uses #{lib.schema} so the access is denied"))
+    (let [config-with-uses
+          {:metabase/modules {'lib        {:uses #{'lib.schema}}
+                              'lib.schema {:api  #{'metabase.lib.schema.foo}
+                                           :uses #{}}}}]
+      (testing "namespace in lib.schema's :api — allowed"
+        (is (nil? (usage-error config-with-uses 'lib 'metabase.lib.schema.foo))))
+      (testing "namespace NOT in lib.schema's :api — denied even though lib is the parent"
+        ;; Subtree trust is UNIDIRECTIONAL: descendants can read their
+        ;; ancestors' internals, but ancestors must respect their
+        ;; descendants' :api. The child's :api is its outward-facing
+        ;; contract, and even its parent must go through it.
+        (is (some? (usage-error config-with-uses 'lib 'metabase.lib.schema.private-ns)))))))
+
+(deftest ^:parallel usage-error-siblings-need-explicit-uses-and-api-test
+  (testing "Siblings must declare :uses and go through each other's :api — no sibling trust"
+    (let [config-without-uses
+          {:metabase/modules {'lib        {}
+                              'lib.schema {:api  #{'metabase.lib.schema.foo}
+                                           :uses #{}}
+                              'lib.be     {:api  :any
+                                           :uses #{}}}}]
+      (is (some? (usage-error config-without-uses 'lib.be 'metabase.lib.schema.foo))
+          "lib.be does not declare :uses #{lib.schema}, so even sibling access is denied"))
+    (let [config-with-uses
+          {:metabase/modules {'lib        {}
+                              'lib.schema {:api  #{'metabase.lib.schema.foo}
+                                           :uses #{}}
+                              'lib.be     {:api  :any
+                                           :uses #{'lib.schema}}}}]
+      (is (nil? (usage-error config-with-uses 'lib.be 'metabase.lib.schema.foo))
+          "with :uses declared and the namespace in lib.schema's :api, the access is allowed")
+      (is (some? (usage-error config-with-uses 'lib.be 'metabase.lib.schema.private-ns))
+          "even with :uses declared, namespaces NOT in lib.schema's :api are denied"))))
+
+(deftest ^:parallel usage-error-child-must-declare-uses-on-parent-test
+  (testing "Child accessing parent must declare :uses, but :api is waived by subtree trust"
+    (let [config-without-uses
+          {:metabase/modules {'lib        {:api  #{'metabase.lib.core}
+                                           :uses #{}}
+                              'lib.schema {:api  :any
+                                           :uses #{}}}}]
+      (is (some? (usage-error config-without-uses 'lib.schema 'metabase.lib.core))
+          "lib.schema does not declare :uses #{lib} so it cannot access lib's namespaces"))
+    (let [config-with-uses
+          {:metabase/modules {'lib        {:api  #{'metabase.lib.core}
+                                           :uses #{}}
+                              'lib.schema {:api  :any
+                                           :uses #{'lib}}}}]
+      (testing "namespace in lib's :api — allowed"
+        (is (nil? (usage-error config-with-uses 'lib.schema 'metabase.lib.core))))
+      (testing "namespace NOT in lib's :api — ALSO allowed (subtree trust)"
+        (is (nil? (usage-error config-with-uses 'lib.schema 'metabase.lib.internal))
+            (str "Under subtree trust, a child reaching into its parent's internals is "
+                 "allowed regardless of :api — this is the ancestor-descendant relaxation."))))))
+
+(deftest ^:parallel usage-error-encapsulated-grandchild-denied-test
+  (testing "Outside module cannot reach into an unopened nested module"
+    ;; `lib.schema` is nested under `lib` but lib does not open it, so
+    ;; lib.schema is encapsulated behind lib. Outside callers see only
+    ;; lib's :api and cannot reach lib.schema's contents — even if
+    ;; lib.schema's own :api declares those namespaces. This is strict
+    ;; encapsulation: :module-exports is the only way to expose a nested child.
+    ;;
+    ;; An explicit empty `:api` exports nothing; only `:api :any` is
+    ;; unrestricted. This fixture uses a non-empty API so it can verify both
+    ;; access to lib's public namespace and denial of its private child.
+    (let [config {:metabase/modules {'lib             {:module-exports #{}
+                                                       :api  #{'metabase.lib.core}
+                                                       :uses #{}}
+                                     'lib.schema      {:api  #{'metabase.lib.schema.public-ns}
+                                                       :uses #{}}
+                                     'query-processor {:uses #{'lib}
+                                                       :api  :any}}}]
+      (testing "access to a private descendant namespace is denied"
+        (is (some? (usage-error config 'query-processor 'metabase.lib.schema.private-ns))))
+      (testing "access to lib's own api is allowed"
+        (is (nil? (usage-error config 'query-processor 'metabase.lib.core))))
+      (testing "access to lib.schema's own :api is ALSO denied — lib.schema is fully encapsulated"
+        ;; lib.schema's :api declares `metabase.lib.schema.public-ns`, but
+        ;; lib does NOT open lib.schema, so lib.schema's API is invisible
+        ;; to outside callers. The only way for query-processor to reach
+        ;; this would be for lib to explicitly `:module-exports #{lib.schema}` or
+        ;; for lib to re-export the namespace in its own :api.
+        (is (some? (usage-error config 'query-processor 'metabase.lib.schema.public-ns)))))))
+
+(deftest ^:parallel usage-error-opened-child-allowed-test
+  (testing "Outside module CAN reach into an opened nested module when listed in :module-exports"
+    (let [config {:metabase/modules {'lib             {:module-exports #{'lib.schema}
+                                                       :api  :any}
+                                     'lib.schema      {:api  :any
+                                                       :uses #{}}
+                                     'query-processor {:uses #{'lib.schema}
+                                                       :api  :any}}}]
+      (is (nil? (usage-error config 'query-processor 'metabase.lib.schema.foo))))))
+
+(deftest ^:parallel usage-error-subtree-trust-is-unidirectional-test
+  (testing "Subtree trust is UNIDIRECTIONAL: descendants can read ancestors' internals, but ancestors must respect descendants' :api"
+    (let [config {:metabase/modules {'outer              {:uses #{'outer.middle.inner}
+                                                          :api  #{'metabase.outer.public}}
+                                     'outer.middle       {:api  #{}}
+                                     'outer.middle.inner {:api  #{'metabase.outer.middle.inner.public}
+                                                          :uses #{'outer}}}}]
+      (testing "grandchild → grandparent bypasses :api (descendant reading ancestor)"
+        (is (nil? (usage-error config 'outer.middle.inner 'metabase.outer.internal))
+            (str "outer.middle.inner declares :uses on outer; the grandparent's :api is "
+                 "waived because descendants can read ancestors' internals.")))
+      (testing "grandparent → grandchild must go through grandchild's :api"
+        (is (some? (usage-error config 'outer 'metabase.outer.middle.inner.internal))
+            (str "outer declares :uses on outer.middle.inner, but the grandchild's "
+                 ":api is enforced — parents (and grandparents) do NOT get free "
+                 "access to their descendants' internals. The :api is the outward "
+                 "contract, and even its ancestors must respect it.")))
+      (testing "grandparent → grandchild CAN access the grandchild's public :api"
+        (is (nil? (usage-error config 'outer 'metabase.outer.middle.inner.public)))))))
+
+(deftest ^:parallel usage-error-subtree-trust-does-not-extend-to-cousins-test
+  (testing "Cousins (same grandparent, different parents) are NOT subtree-trusted — they go through :api"
+    (let [config {:metabase/modules {'outer             {}
+                                     'outer.a           {}
+                                     'outer.a.leaf      {:api  #{'metabase.outer.a.leaf.public}
+                                                         :uses #{}}
+                                     'outer.b           {}
+                                     'outer.b.leaf      {:api  :any
+                                                         :uses #{'outer.a.leaf}}}}]
+      (testing "namespace in cousin's :api — allowed"
+        (is (nil? (usage-error config 'outer.b.leaf 'metabase.outer.a.leaf.public))))
+      (testing "namespace NOT in cousin's :api — denied (no subtree trust between cousins)"
+        (is (some? (usage-error config 'outer.b.leaf 'metabase.outer.a.leaf.internal))
+            "cousins are not in an ancestor-descendant relationship, so :api still applies")))))
+
+(deftest ^:parallel usage-error-uses-must-name-resolved-module-exactly-test
+  (testing "`:uses` is matched exactly against the resolved required module — no walking up the tree"
+    (let [config {:metabase/modules {'lib             {:api  :any
+                                                       :uses #{}}
+                                     'lib.schema      {:api  :any
+                                                       :uses #{}}
+                                     'query-processor {:uses #{'lib}
+                                                       :api  :any}}}]
+      (is (some? (usage-error config 'query-processor 'metabase.lib.schema.foo))
+          (str ":uses #{lib} does NOT cover lib.schema even though lib is its parent. "
+               "The required namespace resolves to lib.schema (via longest-prefix matching) "
+               "and the :uses entry must name lib.schema directly."))
+      (is (nil? (usage-error config 'query-processor 'metabase.lib.core))
+          ":uses #{lib} covers references to namespaces that resolve to lib itself"))
+    (let [config {:metabase/modules {'lib             {:api  :any
+                                                       :uses #{}}
+                                     'lib.schema      {:api  :any
+                                                       :uses #{}}
+                                     'query-processor {:uses #{'lib 'lib.schema}
+                                                       :api  :any}}}]
+      (is (nil? (usage-error config 'query-processor 'metabase.lib.schema.foo))
+          "with both lib and lib.schema in :uses, the access works"))))
+
+(deftest ^:parallel usage-error-explicit-empty-api-denies-external-access-test
+  (let [config {:metabase/modules {'private-module {:api #{}}
+                                   'caller         {:uses #{'private-module}}}}]
+    (testing "an explicit empty API exports no namespaces"
+      (is (some? (usage-error config 'caller 'metabase.private-module.api))))
+    (testing "`:api :any` remains the unrestricted API sentinel"
+      (is (nil? (usage-error (assoc-in config [:metabase/modules 'private-module :api] :any)
+                             'caller
+                             'metabase.private-module.internal))))
+    (testing "friends may still bypass an explicitly empty API"
+      (is (nil? (usage-error (assoc-in config [:metabase/modules 'private-module :friends] #{'caller})
+                             'caller
+                             'metabase.private-module.internal))))))
+
+(deftest ^:parallel usage-error-uses-any-namability-test
+  (testing "`:uses :any` allows any *namable* module reference (subject to :api); namability is enforced
+            at require time for `:any` callers since the config-level test only covers set-valued `:uses`"
+    (let [config {:metabase/modules {'lib        {:api  :any}
+                                     'lib.schema {:api  :any}
+                                     'caller     {:uses :any
+                                                  :api  :any}}}]
+      (testing "top-level modules are always namable"
+        (is (nil? (usage-error config 'caller 'metabase.lib.core))))
+      (testing "a nested child not in its parent's :module-exports is private to its subtree"
+        (is (some? (usage-error config 'caller 'metabase.lib.schema.foo))))
+      (testing "exporting the child makes it namable from anywhere"
+        (is (nil? (usage-error (assoc-in config [:metabase/modules 'lib :module-exports] #{'lib.schema})
+                               'caller
+                               'metabase.lib.schema.foo))))
+      (testing "same-subtree callers may name private children"
+        (is (nil? (usage-error (assoc-in config [:metabase/modules 'lib.other] {:uses :any, :api :any})
+                               'lib.other
+                               'metabase.lib.schema.foo)))))))
+
+(deftest ^:parallel usage-error-uses-any-rest-module-test
+  (testing "`:uses :any` does not allow domain modules to depend on REST modules"
+    (let [config {:metabase/modules {'actions      {:api :any}
+                                     'actions.rest {:ns-prefix "metabase.actions-rest"
+                                                    :api       :any}
+                                     'caller       {:uses :any
+                                                    :api  :any}}}
+          expected (str "Do not use REST modules (actions.rest) in non-REST modules (caller) "
+                        "-- move things from actions.rest to actions if needed")]
+      (is (= expected (usage-error config 'caller 'metabase.actions-rest.api))))))
+
+(deftest ^:parallel usage-error-rest-module-exceptions-test
+  (testing "REST modules, route aggregators, and core initializers may use REST modules"
+    (let [config {:metabase/modules {'actions        {:module-exports #{'actions.rest}
+                                                      :api            :any}
+                                     'actions.rest   {:ns-prefix "metabase.actions-rest"
+                                                      :api       :any}
+                                     'questions.rest {:ns-prefix "metabase.questions-rest"
+                                                      :uses      :any
+                                                      :api       :any}
+                                     'api-routes     {:uses :any
+                                                      :api  :any}
+                                     'core           {:uses :any
+                                                      :api  :any}}}]
+      (are [caller] (nil? (usage-error config caller 'metabase.actions-rest.api))
+        'questions.rest
+        'api-routes
+        'core))))
+
+;;;; -------------------------------------------------------------------------
+;;;; `enterprise/X` shorthand: EE module as a nested child of OSS X
+;;;;
+;;;; When an `enterprise/X` module is declared in config and an OSS module
+;;;; `X` is also declared, the system treats `enterprise/X` as if it were a
+;;;; nested child of `X` — same subtree, auto-opened in `X`'s `:module-exports` set.
+;;;; This lets EE modules be organized as companions to their OSS
+;;;; counterparts without needing to rename anything or declare explicit
+;;;; `:ns-prefix` / `:module-exports` entries.
+;;;;
+;;;; If `X` is NOT declared (e.g. `enterprise/sandbox` with no OSS
+;;;; counterpart), the shorthand falls back: `enterprise/sandbox` stays a
+;;;; top-level module, externally referenceable by anyone.
+;;;; -------------------------------------------------------------------------
+
+(deftest ^:parallel parent-module-shorthand-test
+  (testing "`parent-module` honors the `enterprise/X` shorthand when declared modules are known"
+    (let [parent-module (hook-fn 'parent-module)]
+      (testing "no declared modules: enterprise/X is top-level (pure syntactic)"
+        (is (nil? (parent-module 'enterprise/internal-stats))))
+      (testing "empty declared set: same as no declared — no shorthand activation"
+        (is (nil? (parent-module #{} 'enterprise/internal-stats))))
+      (testing "declared set includes OSS X: enterprise/X's parent is X"
+        (is (= 'internal-stats
+               (parent-module #{'internal-stats} 'enterprise/internal-stats))))
+      (testing "declared set does NOT include OSS X: enterprise/X is still top-level"
+        (is (nil? (parent-module #{'other-module} 'enterprise/internal-stats))))
+      (testing "dotted-name children still work via pure syntactic rule"
+        (is (= 'lib
+               (parent-module #{'lib} 'lib.schema))))
+      (testing "deeply-nested enterprise names fall back to syntactic rule"
+        (is (= 'enterprise/transforms
+               (parent-module #{'transforms} 'enterprise/transforms.python)))))))
+
+(deftest ^:parallel open-children-auto-opens-enterprise-test
+  (testing "`open-children` auto-includes `enterprise/X` when X is a declared OSS top-level"
+    (let [open-children (hook-fn 'open-children)]
+      (testing "no enterprise counterpart declared: only the explicit :module-exports set"
+        (let [config {:metabase/modules {'lib {:module-exports #{'lib.schema}}}}]
+          (is (= #{'lib.schema} (open-children config 'lib)))))
+      (testing "enterprise/X counterpart declared: auto-included in :module-exports"
+        (let [config {:metabase/modules {'cache            {}
+                                         'enterprise/cache {}}}]
+          (is (= #{'enterprise/cache} (open-children config 'cache)))))
+      (testing "combines explicit and auto-opened"
+        (let [config {:metabase/modules {'lib             {:module-exports #{'lib.schema}}
+                                         'enterprise/lib  {}}}]
+          (is (= #{'lib.schema 'enterprise/lib} (open-children config 'lib)))))
+      (testing "nested modules (not top-level) do NOT get auto-opened enterprise counterparts"
+        ;; `foo.bar` is not top-level (has a dot in its name), so
+        ;; `enterprise/foo.bar` is not auto-opened on it even if declared.
+        ;; `foo.bar` has no explicit `:module-exports` set, so open-children should be #{}.
+        (let [config {:metabase/modules {'foo                 {:module-exports #{'foo.bar}}
+                                         'foo.bar             {}
+                                         'enterprise/foo.bar  {}}}]
+          (is (= #{} (open-children config 'foo.bar))))))))
+
+(deftest ^:parallel usage-error-enterprise-shorthand-allows-cross-subtree-access-test
+  (testing (str "Under the shorthand, `enterprise/X` is in the X subtree. Other modules "
+                "can still reach it via the auto-opened `:module-exports` set. `enterprise/core`'s "
+                "init chain, for instance, can statically require `enterprise/cache` "
+                "because `cache` auto-opens `enterprise/cache`.")
+    (let [config {:metabase/modules {'core              {:api :any}
+                                     'cache             {:api :any}
+                                     'enterprise/core   {:api :any
+                                                         :uses #{'enterprise/cache}}
+                                     'enterprise/cache  {:api :any
+                                                         :uses #{}}}}]
+      (testing "enterprise/core can statically require enterprise/cache"
+        (is (nil? (usage-error config 'metabase-enterprise.core.init 'enterprise/core
+                               'metabase-enterprise.cache.core)))))))
+
+(deftest ^:parallel usage-error-enterprise-shorthand-same-subtree-access-test
+  (testing "OSS X and enterprise/X are same-subtree after shorthand — both in X's subtree"
+    (let [config {:metabase/modules {'cache             {:api :any
+                                                         :uses #{'enterprise/cache}}
+                                     'enterprise/cache  {:api :any
+                                                         :uses #{'cache}}}}]
+      (testing "OSS cache → enterprise/cache via :uses is allowed (same subtree)"
+        (is (nil? (usage-error config 'metabase.cache.init 'cache
+                               'metabase-enterprise.cache.core))))
+      (testing "enterprise/cache → OSS cache via :uses is allowed (same subtree, reverse direction)"
+        (is (nil? (usage-error config 'metabase-enterprise.cache.init 'enterprise/cache
+                               'metabase.cache.core)))))))
+
+(deftest ^:parallel usage-error-enterprise-without-oss-counterpart-stays-top-level-test
+  (testing (str "An `enterprise/X` module whose OSS counterpart `X` is NOT declared stays "
+                "top-level — no phantom parent. Anyone can name it directly since top-level "
+                "modules are always externally referenceable.")
+    (let [config {:metabase/modules {'enterprise/sandbox {:api :any
+                                                          :uses #{}}
+                                     'unrelated          {:api :any
+                                                          :uses #{'enterprise/sandbox}}}}]
+      ;; `unrelated` is in a different subtree, but `enterprise/sandbox`
+      ;; has no OSS parent (sandbox isn't declared), so it's top-level
+      ;; and externally referenceable.
+      (testing "unrelated can reach top-level enterprise/sandbox"
+        (is (nil? (usage-error config 'metabase.unrelated.core 'unrelated
+                               'metabase-enterprise.sandbox.core)))))))
+
+(deftest ^:parallel usage-error-backwards-compat-flat-config-test
+  (testing "With no nested modules declared, behavior matches the flat pre-nesting model"
+    (let [config {:metabase/modules {'lib             {:api  #{'metabase.lib.core
+                                                               'metabase.lib.schema.foo}
+                                                       :uses #{}}
+                                     'query-processor {:api  :any
+                                                       :uses #{'lib}}}}]
+      (testing "flat :uses lib is sufficient for namespaces in lib's api"
+        (is (nil? (usage-error config 'query-processor 'metabase.lib.core)))
+        (is (nil? (usage-error config 'query-processor 'metabase.lib.schema.foo))))
+      (testing "namespaces not in :api are denied"
+        (is (some? (usage-error config 'query-processor 'metabase.lib.internal)))))))

--- a/test/metabase/core/modules_nesting_test.clj
+++ b/test/metabase/core/modules_nesting_test.clj
@@ -562,7 +562,11 @@
           (is (nil? (usage-error config 'outer.b.deep 'metabase.outer.a.leaf.foo)))
           (testing "but not to a module outside the `outer` subtree"
             (let [config (assoc-in config [:metabase/modules 'unrelated] {:uses :any, :api :any})]
-              (is (some? (usage-error config 'unrelated 'metabase.outer.a.leaf.foo))))))))))
+              (is (= (str "Module outer.a.leaf is nested and not exported by its ancestors; "
+                          "unrelated may not use it. Add outer.a to outer's :module-exports, "
+                          "or move the caller into the outer subtree. "
+                          "[:metabase/modules outer :module-exports]")
+                     (usage-error config 'unrelated 'metabase.outer.a.leaf.foo))))))))))
 
 (deftest ^:parallel usage-error-uses-any-rest-module-test
   (testing "`:uses :any` does not allow domain modules to depend on REST modules"

--- a/test/metabase/core/modules_nesting_test.clj
+++ b/test/metabase/core/modules_nesting_test.clj
@@ -182,15 +182,32 @@
               deps (assoc-in base-config ['parent :api] '#{metabase.parent.internal}) 'parent))))))
 
 (deftest default-dependency-helpers-use-configured-prefixes-test
-  (let [config '{parent       {}
-                 parent.child {:ns-prefix metabase.special-child}}
-        seen-prefixes (promise)]
-    (with-redefs [dev.deps-graph/kondo-config (constantly config)
-                  dev.deps-graph/dependencies (fn [prefix->module]
-                                                (deliver seen-prefixes prefix->module)
-                                                [])]
-      (is (= [] (dev.deps-graph/external-usages 'parent)))
-      (is (= (dev.deps-graph/build-prefix->module config) @seen-prefixes)))))
+  (testing (str "Helpers reach `dependencies` through the arity that resolves against the current "
+                "module config, not by passing `nil`, which would select the flat pre-nesting "
+                "extraction and silently attribute nested namespaces to their top-level parent.")
+    (let [config '{parent       {}
+                   parent.child {:ns-prefix "metabase.special-child"}}
+          seen-args (promise)]
+      (with-redefs [dev.deps-graph/kondo-config (constantly config)
+                    ;; variadic: the helpers call the no-arg arity, and capturing the argument
+                    ;; vector is what distinguishes it from an explicit `nil` (flat resolution).
+                    dev.deps-graph/dependencies (fn [& args]
+                                                  (deliver seen-args (vec args))
+                                                  [])]
+        (is (= [] (dev.deps-graph/external-usages 'parent)))
+        ;; Timed deref: the promise is delivered only from inside the redef, so if `external-usages`
+        ;; ever stops calling `dependencies` a bare `@` would hang forever instead of failing, which
+        ;; is much harder to diagnose in CI than a red assertion.
+        (let [seen (deref seen-args 5000 ::not-delivered)]
+          (is (not= ::not-delivered seen)
+              "external-usages never called dependencies at all")
+          (is (= [] seen)
+              "external-usages must use the config-resolving no-arg arity, never (dependencies nil)")))))
+  (testing "and that no-arg arity builds its prefix map from the configured modules"
+    (let [config '{parent       {}
+                   parent.child {:ns-prefix "metabase.special-child"}}]
+      (is (= {"metabase.parent" 'parent, "metabase.special-child" 'parent.child}
+             (dev.deps-graph/build-prefix->module config))))))
 
 (deftest ^:parallel simulate-rename-preserves-nested-module-ownership-test
   (let [prefix->module {"metabase.parent" 'parent

--- a/test/metabase/core/modules_nesting_test.clj
+++ b/test/metabase/core/modules_nesting_test.clj
@@ -260,6 +260,29 @@
           (is (false? (externally-visible? bad-mid  'outer.middle.deepest)))
           (is (false? (externally-visible? bad-deep 'outer.middle.deepest))))))))
 
+(deftest ^:parallel visibility-root-test
+  (testing "`visibility-root` is the nearest ancestor that does not export the module below it"
+    (let [visibility-root (hook-fn 'visibility-root)]
+      (testing "top-level modules are visible everywhere, so they have no root"
+        (is (nil? (visibility-root {} 'lib)))
+        (is (nil? (visibility-root {:metabase/modules {'lib {}}} 'lib))))
+      (testing "an unopened child is scoped to its direct parent"
+        (let [config {:metabase/modules {'lib {:module-exports #{}}}}]
+          (is (= 'lib (visibility-root config 'lib.schema)))))
+      (testing "a fully-exported chain reaches top-level, so there is no root"
+        (let [config {:metabase/modules {'lib {:module-exports #{'lib.schema}}}}]
+          (is (nil? (visibility-root config 'lib.schema)))))
+      (testing "each export widens the scope by exactly one level"
+        (let [none  {:metabase/modules {'outer   {:module-exports #{}}
+                                        'outer.a {:module-exports #{}}}}
+              inner {:metabase/modules {'outer   {:module-exports #{}}
+                                        'outer.a {:module-exports #{'outer.a.leaf}}}}
+              both  {:metabase/modules {'outer   {:module-exports #{'outer.a}}
+                                        'outer.a {:module-exports #{'outer.a.leaf}}}}]
+          (is (= 'outer.a (visibility-root none  'outer.a.leaf)))
+          (is (= 'outer   (visibility-root inner 'outer.a.leaf)))
+          (is (nil?       (visibility-root both  'outer.a.leaf))))))))
+
 ;;;; -------------------------------------------------------------------------
 ;;;; STRICT MODEL: every cross-module access is an explicit :uses + :api
 ;;;; check. There is no implicit visibility of any kind. Same-module access
@@ -501,6 +524,45 @@
         (is (nil? (usage-error (assoc-in config [:metabase/modules 'lib.other] {:uses :any, :api :any})
                                'lib.other
                                'metabase.lib.schema.foo)))))))
+
+(deftest ^:parallel usage-error-privacy-scoped-to-nearest-non-opening-ancestor-test
+  (testing (str "An unopened nested child is private to the subtree of the nearest ancestor that "
+                "does NOT export it — not to its whole top-level subtree. `outer.a` keeps "
+                "`outer.a.leaf` private, so only the `outer.a` subtree may name it; a cousin "
+                "under the same top-level `outer` may not.")
+    (let [config {:metabase/modules {'outer        {:module-exports #{}
+                                                    :uses           :any
+                                                    :api            :any}
+                                     'outer.a      {:module-exports #{}
+                                                    :uses           :any
+                                                    :api            :any}
+                                     'outer.a.leaf {:uses :any
+                                                    :api  :any}
+                                     'outer.a.sib  {:uses :any
+                                                    :api  :any}
+                                     'outer.b      {:module-exports #{}
+                                                    :uses           :any
+                                                    :api            :any}
+                                     'outer.b.deep {:uses :any
+                                                    :api  :any}}}]
+      (testing "the nearest non-opening ancestor and its descendants may name it"
+        (is (nil? (usage-error config 'outer.a 'metabase.outer.a.leaf.foo)))
+        (is (nil? (usage-error config 'outer.a.sib 'metabase.outer.a.leaf.foo))))
+      (testing "a cousin sharing only the top-level ancestor may NOT name it"
+        (is (some? (usage-error config 'outer.b 'metabase.outer.a.leaf.foo))
+            (str "outer.b is outside outer.a's subtree; sharing the top-level module `outer` "
+                 "is not enough to see a module outer.a keeps private."))
+        (is (some? (usage-error config 'outer.b.deep 'metabase.outer.a.leaf.foo))))
+      (testing "an ancestor above the nearest non-opening ancestor may NOT name it either"
+        (is (some? (usage-error config 'outer 'metabase.outer.a.leaf.foo))))
+      (testing "exporting the leaf one level up widens the scope to the whole `outer` subtree"
+        (let [config (assoc-in config [:metabase/modules 'outer.a :module-exports] #{'outer.a.leaf})]
+          (is (nil? (usage-error config 'outer 'metabase.outer.a.leaf.foo)))
+          (is (nil? (usage-error config 'outer.b 'metabase.outer.a.leaf.foo)))
+          (is (nil? (usage-error config 'outer.b.deep 'metabase.outer.a.leaf.foo)))
+          (testing "but not to a module outside the `outer` subtree"
+            (let [config (assoc-in config [:metabase/modules 'unrelated] {:uses :any, :api :any})]
+              (is (some? (usage-error config 'unrelated 'metabase.outer.a.leaf.foo))))))))))
 
 (deftest ^:parallel usage-error-uses-any-rest-module-test
   (testing "`:uses :any` does not allow domain modules to depend on REST modules"

--- a/test/metabase/core/modules_nesting_test.clj
+++ b/test/metabase/core/modules_nesting_test.clj
@@ -709,3 +709,30 @@
         (is (nil? (usage-error config 'query-processor 'metabase.lib.schema.foo))))
       (testing "namespaces not in :api are denied"
         (is (some? (usage-error config 'query-processor 'metabase.lib.internal)))))))
+
+(deftest ^:parallel cross-subtree-cycle-pair-count-semantics-test
+  (testing (str "The `:cross-subtree-cycle-pairs` ratchet counts mutual dependencies only when the "
+                "two modules sit in different top-level subtrees, and counts each unordered pair "
+                "once. `module-boundary-debt-matches-ratchets-test` compares this function against "
+                "baselines this same function produced, so it cannot catch a miscount; these "
+                "assertions pin the semantics against a synthetic graph instead.")
+    (let [deps  (fn [pairs]
+                  (for [[m ds] pairs]
+                    {:module m :deps (for [d ds] {:module d})}))
+          count-pairs #'dev.deps-graph/cross-subtree-cycle-pair-count]
+      (testing "a cycle inside one top-level subtree is internal organization and does not count"
+        (is (zero? (count-pairs (deps '{outer       [outer.child]
+                                        outer.child [outer]})
+                                '{outer {} outer.child {}}))))
+      (testing "a mutual dependency across two top-level subtrees counts once, not twice"
+        (is (= 1 (count-pairs (deps '{alpha [beta] beta [alpha]})
+                              '{alpha {} beta {}}))))
+      (testing "nested children in different subtrees still count, and are not collapsed to roots"
+        (is (= 1 (count-pairs (deps '{alpha.leaf [beta.leaf] beta.leaf [alpha.leaf]})
+                              '{alpha {} alpha.leaf {} beta {} beta.leaf {}}))))
+      (testing "a one-way dependency is not a cycle"
+        (is (zero? (count-pairs (deps '{alpha [beta] beta []})
+                                '{alpha {} beta {}}))))
+      (testing "two independent cross-subtree cycles count separately"
+        (is (= 2 (count-pairs (deps '{alpha [beta] beta [alpha] gamma [delta] delta [gamma]})
+                              '{alpha {} beta {} gamma {} delta {}})))))))

--- a/test/metabase/core/modules_nesting_test.clj
+++ b/test/metabase/core/modules_nesting_test.clj
@@ -744,9 +744,15 @@
       (testing "a mutual dependency across two top-level subtrees counts once, not twice"
         (is (= 1 (count-pairs (deps '{alpha [beta] beta [alpha]})
                               '{alpha {} beta {}}))))
-      (testing "nested children in different subtrees still count, and are not collapsed to roots"
+      (testing "nested children in different subtrees still count"
         (is (= 1 (count-pairs (deps '{alpha.leaf [beta.leaf] beta.leaf [alpha.leaf]})
                               '{alpha {} alpha.leaf {} beta {} beta.leaf {}}))))
+      ;; The case above passes under a collapse-to-roots implementation too, since the pair is
+      ;; between the same two leaves. This one does not: there is no mutual pair between any two
+      ;; modules, but collapsing each side to its root would fabricate `alpha` <-> `beta`.
+      (testing "one-way edges between different children of two subtrees are not a root cycle"
+        (is (zero? (count-pairs (deps '{alpha.a [beta] beta [alpha.b] alpha.b []})
+                                '{alpha {} alpha.a {} alpha.b {} beta {}}))))
       (testing "a one-way dependency is not a cycle"
         (is (zero? (count-pairs (deps '{alpha [beta] beta []})
                                 '{alpha {} beta {}}))))

--- a/test/metabase/core/modules_test.clj
+++ b/test/metabase/core/modules_test.clj
@@ -39,13 +39,55 @@
 (def ^:private teams-to-reassign #{"Admin Webapp" "DashViz"})
 
 (deftest all-modules-have-teams-test
-  (testing "All modules should have a valid :team owner"
-    (let [teams (teams)]
-      (doseq [[module config] (modules-config)]
+  (testing "All modules should have a valid effective :team owner"
+    (let [teams  (teams)
+          config (dev.deps-graph/expanded-kondo-config (modules-config))]
+      (doseq [[module config] config]
         (testing (format "\n'%s' module" module)
           (is (or (contains? teams (:team config))
                   (contains? teams-to-reassign (:team config)))
               "Should have a valid :team key"))))))
+
+(deftest ^:parallel expanded-kondo-config-test
+  (let [config {'parent               {:team "Parent"}
+                'parent.child         {:ns-prefix "metabase.legacy-child"}
+                'parent.child.leaf    {:team "Leaf"}
+                'enterprise/parent    {}
+                'enterprise/standalone {:team "Enterprise"}}
+        expanded (dev.deps-graph/expanded-kondo-config config)]
+    (testing "children inherit team ownership from the closest configured ancestor"
+      (is (= "Parent" (get-in expanded ['parent.child :team])))
+      (is (= 'parent (dev.deps-graph/module-team-source config 'parent.child))))
+    (testing "an explicit child team overrides its ancestors"
+      (is (= "Leaf" (get-in expanded ['parent.child.leaf :team])))
+      (is (= 'parent.child.leaf (dev.deps-graph/module-team-source config 'parent.child.leaf))))
+    (testing "declared enterprise companions inherit from their OSS parent"
+      (is (= "Parent" (get-in expanded ['enterprise/parent :team])))
+      (is (= 'parent (dev.deps-graph/module-team-source config 'enterprise/parent))))
+    (testing "standalone enterprise modules keep their own ownership"
+      (is (= "Enterprise" (get-in expanded ['enterprise/standalone :team])))
+      (is (= 'enterprise/standalone
+             (dev.deps-graph/module-team-source config 'enterprise/standalone))))
+    (testing "config-only defaults are materialized"
+      (is (= "metabase.legacy-child" (get-in expanded ['parent.child :ns-prefix])))
+      (is (= '#{metabase.legacy-child.api metabase.legacy-child.core metabase.legacy-child.init}
+             (get-in expanded ['parent.child :api])))
+      (is (= #{} (get-in expanded ['parent.child :uses])))
+      (is (= #{} (get-in expanded ['parent.child :friends])))
+      (is (= '#{enterprise/parent} (get-in expanded ['parent :module-exports])))))
+  (testing "wildcards expand to their effective config and source-aware values"
+    (let [config   {'caller        {:uses :any}
+                    'parent        {:module-exports #{'parent.open}}
+                    'parent.hidden {}
+                    'parent.open   {}
+                    'public        {:api :any}}
+          deps     [{:module 'public :namespace 'metabase.public.alpha}
+                    {:module 'public :namespace 'metabase.public.beta}]
+          expanded (dev.deps-graph/expanded-kondo-config config deps)]
+      (is (= '#{parent parent.open public}
+             (get-in expanded ['caller :uses])))
+      (is (= '#{metabase.public.alpha metabase.public.beta}
+             (get-in expanded ['public :api]))))))
 
 (defn- modules-config-zipper
   "Return a zipper pointing to the modules config map node (the value of the `:metabase/modules` key)."
@@ -147,11 +189,16 @@
 (deftest modules-config-up-to-date-test
   (testing (str "Please update .clj-kondo/config/modules/config.edn 🥰\n"
                 "[Pro Tip: use (dev.deps-graph/print-kondo-config-diff) to see the changes you need to make in a nicer format]\n")
-    (let [deps     (dev.deps-graph/dependencies)
-          actual   (dev.deps-graph/kondo-config)
-          expected (dev.deps-graph/generate-config deps actual)
-          modules  (set/union (set (keys expected))
-                              (set (keys actual)))]
+    ;; Compute dependencies with awareness of the declared modules and their
+    ;; `:ns-prefix`es, so nested modules (e.g. `lib.schema` as a child of
+    ;; `lib`, or `lib.be` with an explicit :ns-prefix "metabase.lib-be")
+    ;; resolve via longest-prefix matching at segment boundaries.
+    (let [actual      (dev.deps-graph/kondo-config)
+          prefix->mod (dev.deps-graph/build-prefix->module actual)
+          deps        (dev.deps-graph/dependencies prefix->mod)
+          expected    (dev.deps-graph/generate-config deps actual)
+          modules     (set/union (set (keys expected))
+                                 (set (keys actual)))]
       (doseq [module modules
               :let   [_ (testing (format "Remove %s" (pr-str module))
                           (is (seq (get expected module))))]
@@ -176,6 +223,154 @@
         (testing (format "Remove %s from %s" (pr-str extraneous) (pr-str ks))
           (is (empty? extraneous)))))))
 
+(defn- declared-modules-set
+  "Set of declared module symbols from the kondo config (the outer keys)."
+  [config]
+  (set (keys config)))
+
+(defn- top-level-ancestor
+  "Return the topmost ancestor of module `m` (or `m` itself if it's already
+  top-level). Used for subtree-membership checks. Honors the `enterprise/X`
+  shorthand when `declared` is provided."
+  [declared m]
+  (or (last (dev.deps-graph/module-ancestor-chain declared m)) m))
+
+(defn- same-subtree?
+  "True if `caller` and `target` share a top-level ancestor — i.e., they're
+  both descendants of the same top-level module (or one of them is the
+  top-level ancestor of the other)."
+  [declared caller target]
+  (= (top-level-ancestor declared caller) (top-level-ancestor declared target)))
+
+(defn- top-level-oss-module?
+  "True if `m` is a top-level OSS module symbol — no namespace part and a
+  name with no dots. Mirror of `hooks.common.modules/top-level-oss-module?`."
+  [m]
+  (and (nil? (namespace m))
+       (not (str/includes? (name m) "."))))
+
+(defn- open-children*
+  "Mirror of `hooks.common.modules/open-children`. Returns the `:module-exports` set
+  for `parent` including the auto-opened `enterprise/X` counterpart when
+  `parent` is a top-level OSS module with a declared EE counterpart."
+  [config parent]
+  (let [explicit (set (get-in config [parent :module-exports]))
+        ee-child (when (top-level-oss-module? parent)
+                   (let [candidate (symbol "enterprise" (name parent))]
+                     (when (contains? config candidate)
+                       candidate)))]
+    (cond-> explicit
+      ee-child (conj ee-child))))
+
+(defn- externally-referenceable?
+  "True if `target` may be named in the `:uses` of a module outside its
+  top-level subtree. Equivalent to: every ancestor in the chain from
+  target up to top-level is `:module-exports`ed by its parent (and the top-level
+  ancestor is implicitly externally referenceable). Mirror of the
+  `externally-visible?` helper in the kondo hook."
+  [config target]
+  (let [declared (declared-modules-set config)]
+    (loop [m target]
+      (if-let [p (dev.deps-graph/module-parent declared m)]
+        (if (contains? (open-children* config p) m)
+          (recur p)
+          false)
+        true))))
+
+(defn- can-be-named-by?
+  "True if `caller` is permitted to put `target` in its `:uses` declaration
+  under the strict module model. Permitted iff:
+    - they share a top-level subtree (anyone in the same subtree can name
+      anyone else in the subtree), OR
+    - `target` is externally referenceable (top-level OR `:module-exports`ed all the
+      way from the root).
+
+  Uses the declared-modules set (from the config) so that the `enterprise/X`
+  shorthand is honored: `enterprise/X` is treated as a child of the OSS
+  module `X` when `X` is declared."
+  [config caller target]
+  (let [declared (declared-modules-set config)]
+    (or (= caller target)
+        (same-subtree? declared caller target)
+        (externally-referenceable? config target))))
+
+(deftest ^:parallel uses-references-must-be-namable-test
+  (testing (str "Every entry in a module's `:uses` must be a module that the caller is "
+                "allowed to name. Outside-of-subtree callers may only name modules that "
+                "are externally referenceable (top-level OR `:module-exports`ed by every ancestor "
+                "from the root). Same-subtree callers may name any module in the subtree.")
+    (let [config   (dev.deps-graph/kondo-config)
+          declared (declared-modules-set config)]
+      (doseq [[caller cfg] config
+              :let          [uses (:uses cfg)]
+              :when         (set? uses)
+              target        uses
+              ;; Skip references to modules that aren't actually declared
+              ;; (these will be caught by the staleness test as a separate
+              ;; concern; here we only check naming validity for declared
+              ;; targets).
+              :when         (contains? config target)]
+        (testing (format "\n[%s :uses %s]" (pr-str caller) (pr-str target))
+          (is (can-be-named-by? config caller target)
+              (format
+               (str "%s declares :uses #{%s} but cannot name %s under the strict module model. "
+                    "Either: (a) move %s into %s's top-level subtree (currently %s vs %s), or "
+                    "(b) ensure %s is externally referenceable by adding it to its parent's "
+                    ":module-exports set (and recursively up to the top-level).")
+               caller target target
+               target caller
+               (top-level-ancestor declared caller)
+               (top-level-ancestor declared target)
+               target)))))))
+
+(deftest ^:parallel ns-prefix-uniqueness-test
+  (testing (str "Every module has a unique effective :ns-prefix (explicit via :ns-prefix "
+                "config key or derived from the module name). Two modules sharing the same "
+                "prefix would create ambiguity in namespace→module resolution, so this test "
+                "enforces uniqueness across the whole config including implicit defaults.")
+    (let [config           (dev.deps-graph/kondo-config)
+          effective-prefix (fn [m]
+                             (or (get-in config [m :ns-prefix])
+                                 (dev.deps-graph/default-ns-prefix m)))
+          by-prefix        (group-by effective-prefix (keys config))]
+      (doseq [[prefix modules] by-prefix
+              :when            (> (count modules) 1)]
+        (testing (format "\nprefix %s is claimed by multiple modules: %s"
+                         (pr-str prefix)
+                         (pr-str (sort modules)))
+          (is (= 1 (count modules))
+              (format "Modules %s share :ns-prefix %s. Either give them distinct explicit :ns-prefix values, or rename one so its default prefix doesn't collide."
+                      (pr-str (sort modules))
+                      (pr-str prefix))))))))
+
+(deftest ^:parallel nested-modules-have-declared-parents-test
+  (testing "Every syntactically nested module has a declared direct parent"
+    (let [config   (dev.deps-graph/kondo-config)
+          declared (declared-modules-set config)]
+      (doseq [module declared
+              :let   [parent (dev.deps-graph/module-parent declared module)]
+              :when  parent]
+        (testing (format "\n%s is nested under %s" module parent)
+          (is (contains? declared parent)
+              (format "Declare parent module %s before declaring nested module %s."
+                      parent
+                      module)))))))
+
+(deftest ^:parallel module-exports-are-declared-direct-children-test
+  (testing "Every :module-exports entry names a declared direct child"
+    (let [config   (dev.deps-graph/kondo-config)
+          declared (declared-modules-set config)]
+      (doseq [[parent module-config] config
+              child                  (:module-exports module-config)]
+        (testing (format "\n[%s :module-exports %s]" parent child)
+          (is (contains? declared child)
+              (format "Exported child %s is not a declared module." child))
+          (is (= parent (dev.deps-graph/module-parent declared child))
+              (format "%s may only export direct children; %s has parent %s."
+                      parent
+                      child
+                      (dev.deps-graph/module-parent declared child))))))))
+
 (deftest ^:parallel module-boundary-config-values-have-valid-types-test
   (testing "Module boundary keys use the values understood by the linter"
     (doseq [[module config] (dev.deps-graph/kondo-config)]
@@ -190,7 +385,13 @@
             ":uses must be omitted, a set, or :any")
         (is (or (nil? (:friends config))
                 (set? (:friends config)))
-            ":friends must be a set when present")))))
+            ":friends must be a set when present")
+        (is (or (nil? (:module-exports config))
+                (set? (:module-exports config)))
+            ":module-exports must be a set when present")
+        (is (or (nil? (:ns-prefix config))
+                (string? (:ns-prefix config)))
+            ":ns-prefix must be a string when present")))))
 
 (deftest ^:parallel module-boundary-debt-matches-ratchets-test
   (testing "Module boundary anti-pattern counts match their exact ratchets"
@@ -215,7 +416,7 @@
   exactly: PR CI checks out the merge preview with master, so scan-derived keys (SCC sizes, namespace
   counts, test blast) legitimately differ from any branch's committed baseline whenever master moves.
   They are still synced into module-stats.edn for PR-diff visibility."
-  [:largest-api :module-count :total-api])
+  [:largest-api :module-count :module-exports :ns-prefix-overrides :parent-team-mismatches :total-api])
 
 (deftest ^:parallel module-boundary-stats-match-committed-test
   (testing (str "Config-derived module surface stats match module-stats.edn. Unlike the ratchets these\n"
@@ -236,7 +437,7 @@
                 "must be dropped — the set is a ratchet (:driver-test-exempt-modules) and may only shrink.")
     (let [config    (dev.deps-graph/kondo-config)
           declared  (set (keys config))
-          deps      (dev.deps-graph/dependencies)
+          deps      (dev.deps-graph/dependencies (dev.deps-graph/build-prefix->module config))
           full      (dev.deps-graph/full-dependencies deps)
           ;; mirrors the trigger set of mage.modules/driver-deps-affected?:
           ;; the union of default-modules-which-trigger-drivers and modules-triggering-cloud-drivers.
@@ -264,13 +465,13 @@
                         (dev.deps-graph/lowered-module-boundary-ratchets {:debt 2} {:other 1}))))
 
 (deftest ^:parallel legacy-rest-module-debt-test
-  (testing "-rest module symbols count as debt"
+  (testing "Only deprecated -rest module symbols count as debt; hyphenated namespace prefixes remain valid"
     (is (= 2
            (:legacy-rest-modules
             (dev.deps-graph/module-boundary-debt
              []
              {'actions-rest          {}
-              'actions               {}
+              'actions.rest          {:ns-prefix "metabase.actions-rest"}
               'enterprise/users-rest {}}))))))
 
 ;;;; Classpath / namespace convention
@@ -402,14 +603,18 @@
                     ee-namespace-prefix))))))
 
 (defn- rest-module?
-  "True for deprecated `-rest` module symbols."
+  "True for canonical nested `.rest` modules and deprecated `-rest` compatibility symbols."
   [module]
-  (str/ends-with? (str module) "-rest"))
+  (let [module-name (str module)]
+    (or (str/ends-with? module-name "-rest")
+        (str/ends-with? module-name ".rest"))))
 
 (defn- routes-module?
   "True for route aggregators, which are allowed to assemble REST routes."
   [module]
-  (str/ends-with? (str module) "-routes"))
+  (let [module-name (str module)]
+    (or (str/ends-with? module-name "-routes")
+        (str/ends-with? module-name ".routes"))))
 
 (defn- core-module?
   "True for OSS and EE core initializer modules."
@@ -422,9 +627,12 @@
   ((some-fn rest-module? routes-module? core-module?) module))
 
 (deftest ^:parallel rest-module-recognition-test
+  ;; Deprecated symbols must remain recognizable until they are removed, or they would bypass the guard.
   (are [module] (rest-module? module)
     'queries-rest
-    'enterprise/queries-rest)
+    'queries.rest
+    'enterprise/queries-rest
+    'enterprise/queries.rest)
   (is (not (rest-module? 'queries))))
 
 (deftest do-not-use-rest-modules-in-other-modules-test
@@ -437,7 +645,7 @@
                 used-module
                 module
                 used-module
-                (symbol (str/replace (str used-module) #"-rest$" ""))))))
+                (symbol (str/replace (str used-module) #"(?:-rest|\.rest)$" ""))))))
 
 ;;;; Model boundary tests
 

--- a/test/metabase/core/modules_test.clj
+++ b/test/metabase/core/modules_test.clj
@@ -228,19 +228,12 @@
   [config]
   (set (keys config)))
 
-(defn- top-level-ancestor
-  "Return the topmost ancestor of module `m` (or `m` itself if it's already
-  top-level). Used for subtree-membership checks. Honors the `enterprise/X`
+(defn- in-subtree?
+  "True if `m` is `root` or one of its descendants. Honors the `enterprise/X`
   shorthand when `declared` is provided."
-  [declared m]
-  (or (last (dev.deps-graph/module-ancestor-chain declared m)) m))
-
-(defn- same-subtree?
-  "True if `caller` and `target` share a top-level ancestor — i.e., they're
-  both descendants of the same top-level module (or one of them is the
-  top-level ancestor of the other)."
-  [declared caller target]
-  (= (top-level-ancestor declared caller) (top-level-ancestor declared target)))
+  [declared root m]
+  (or (= root m)
+      (boolean (some #(= root %) (dev.deps-graph/module-ancestor-chain declared m)))))
 
 (defn- top-level-oss-module?
   "True if `m` is a top-level OSS module symbol — no namespace part and a
@@ -262,45 +255,59 @@
     (cond-> explicit
       ee-child (conj ee-child))))
 
-(defn- externally-referenceable?
-  "True if `target` may be named in the `:uses` of a module outside its
-  top-level subtree. Equivalent to: every ancestor in the chain from
-  target up to top-level is `:module-exports`ed by its parent (and the top-level
-  ancestor is implicitly externally referenceable). Mirror of the
-  `externally-visible?` helper in the kondo hook."
+(defn- visibility-root
+  "The module whose subtree `target` is private to, or `nil` if `target` may be
+  named from anywhere. Walk up from `target` to the nearest ancestor that does
+  NOT `:module-exports` the module below it on the path; `nil` means the chain
+  reached top-level unobstructed. Mirror of the `visibility-root` helper in the
+  kondo hook."
   [config target]
   (let [declared (declared-modules-set config)]
     (loop [m target]
-      (if-let [p (dev.deps-graph/module-parent declared m)]
+      (when-let [p (dev.deps-graph/module-parent declared m)]
         (if (contains? (open-children* config p) m)
           (recur p)
-          false)
-        true))))
+          p)))))
+
+(defn- externally-referenceable?
+  "True if `target` may be named in the `:uses` of any module at all, wherever
+  it sits in the tree. Equivalent to: every ancestor in the chain from target
+  up to top-level is `:module-exports`ed by its parent (and the top-level
+  ancestor is implicitly externally referenceable) — i.e. `target` has no
+  `visibility-root`. Mirror of the `externally-visible?` helper in the kondo
+  hook."
+  [config target]
+  (nil? (visibility-root config target)))
 
 (defn- can-be-named-by?
   "True if `caller` is permitted to put `target` in its `:uses` declaration
   under the strict module model. Permitted iff:
-    - they share a top-level subtree (anyone in the same subtree can name
-      anyone else in the subtree), OR
-    - `target` is externally referenceable (top-level OR `:module-exports`ed all the
-      way from the root).
+    - `target` is externally referenceable (top-level OR `:module-exports`ed all
+      the way from the root), OR
+    - `caller` is inside the subtree of `target`'s `visibility-root` — the
+      nearest ancestor that keeps `target` private. Note this is the *nearest*
+      such ancestor, not the top-level one: sharing a top-level ancestor is not
+      on its own enough to name a deeply-private module.
 
   Uses the declared-modules set (from the config) so that the `enterprise/X`
   shorthand is honored: `enterprise/X` is treated as a child of the OSS
-  module `X` when `X` is declared."
+  module `X` when `X` is declared.
+
+  Mirror of `namable-from?` in `.clj-kondo/src/hooks/common/modules.clj`; the
+  two are meant to agree."
   [config caller target]
   (let [declared (declared-modules-set config)]
     (or (= caller target)
-        (same-subtree? declared caller target)
-        (externally-referenceable? config target))))
+        (externally-referenceable? config target)
+        (in-subtree? declared (visibility-root config target) caller))))
 
 (deftest ^:parallel uses-references-must-be-namable-test
   (testing (str "Every entry in a module's `:uses` must be a module that the caller is "
-                "allowed to name. Outside-of-subtree callers may only name modules that "
-                "are externally referenceable (top-level OR `:module-exports`ed by every ancestor "
-                "from the root). Same-subtree callers may name any module in the subtree.")
-    (let [config   (dev.deps-graph/kondo-config)
-          declared (declared-modules-set config)]
+                "allowed to name. A nested module is namable from the subtree of the nearest "
+                "ancestor that does not `:module-exports` it; outside that subtree it is namable "
+                "only if it is externally referenceable (top-level OR `:module-exports`ed by "
+                "every ancestor from the root).")
+    (let [config (dev.deps-graph/kondo-config)]
       (doseq [[caller cfg] config
               :let          [uses (:uses cfg)]
               :when         (set? uses)
@@ -314,14 +321,44 @@
           (is (can-be-named-by? config caller target)
               (format
                (str "%s declares :uses #{%s} but cannot name %s under the strict module model. "
-                    "Either: (a) move %s into %s's top-level subtree (currently %s vs %s), or "
-                    "(b) ensure %s is externally referenceable by adding it to its parent's "
-                    ":module-exports set (and recursively up to the top-level).")
+                    "%s is private to the %s subtree, and %s is outside it. Either: (a) move %s "
+                    "into that subtree, or (b) widen %s's visibility by adding it to its parent's "
+                    ":module-exports set (and recursively up, as far as it needs to go).")
                caller target target
-               target caller
-               (top-level-ancestor declared caller)
-               (top-level-ancestor declared target)
-               target)))))))
+               target (visibility-root config target) caller
+               caller target)))))))
+
+(deftest ^:parallel can-be-named-by?-test
+  (testing (str "Naming scope is the subtree of the nearest ancestor that does not export the "
+                "module below it on the path — not the whole top-level subtree. Mirrors "
+                "`namable-from?` in the kondo hook; the two must agree.")
+    (let [config {'outer        {}
+                  'outer.a      {}
+                  'outer.a.leaf {}
+                  'outer.a.sib  {}
+                  'outer.b      {}
+                  'outer.b.deep {}
+                  'unrelated    {}}]
+      (testing "top-level modules are namable from anywhere"
+        (is (true? (can-be-named-by? config 'unrelated 'outer))))
+      (testing "an unopened leaf is namable only from its nearest non-exporting ancestor's subtree"
+        (is (true?  (can-be-named-by? config 'outer.a 'outer.a.leaf)))
+        (is (true?  (can-be-named-by? config 'outer.a.sib 'outer.a.leaf)))
+        (is (false? (can-be-named-by? config 'outer 'outer.a.leaf)))
+        (is (false? (can-be-named-by? config 'outer.b 'outer.a.leaf))
+            "sharing the top-level module `outer` is not enough")
+        (is (false? (can-be-named-by? config 'outer.b.deep 'outer.a.leaf)))
+        (is (false? (can-be-named-by? config 'unrelated 'outer.a.leaf))))
+      (testing "exporting the leaf widens the scope to the whole `outer` subtree, but no further"
+        (let [config (assoc-in config ['outer.a :module-exports] #{'outer.a.leaf})]
+          (is (true?  (can-be-named-by? config 'outer 'outer.a.leaf)))
+          (is (true?  (can-be-named-by? config 'outer.b.deep 'outer.a.leaf)))
+          (is (false? (can-be-named-by? config 'unrelated 'outer.a.leaf)))))
+      (testing "exporting the whole chain makes the leaf namable from anywhere"
+        (let [config (-> config
+                         (assoc-in ['outer.a :module-exports] #{'outer.a.leaf})
+                         (assoc-in ['outer :module-exports] #{'outer.a}))]
+          (is (true? (can-be-named-by? config 'unrelated 'outer.a.leaf))))))))
 
 (deftest ^:parallel ns-prefix-uniqueness-test
   (testing (str "Every module has a unique effective :ns-prefix (explicit via :ns-prefix "

--- a/test/metabase/dev/deps_graph_test.clj
+++ b/test/metabase/dev/deps_graph_test.clj
@@ -1,0 +1,25 @@
+(ns metabase.dev.deps-graph-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [dev.deps-graph :as deps-graph]))
+
+(set! *warn-on-reflection* true)
+
+(deftest ^:parallel kondo-config-diff-excludes-human-owned-keys-test
+  (testing "kondo-config-diff does not report human-owned keys as extraneous drift"
+    ;; Two modules whose regenerated :api/:uses reproduce the committed values exactly, so the
+    ;; human-owned keys are the only ones that could show up in the diff. Excluded, the diff is empty.
+    (let [config '{a {:ns-prefix "metabase.a-legacy" :api #{metabase.a-legacy.core} :uses #{}
+                      :module-exports #{a.child}}
+                   b {:ns-prefix "metabase.b-legacy" :api #{}                        :uses #{a}}}
+          deps   '[{:module a :namespace metabase.a-legacy.core
+                    :filename "src/metabase/a_legacy/core.clj" :deps []}
+                   {:module b :namespace metabase.b-legacy.core
+                    :filename "src/metabase/b_legacy/core.clj"
+                    :deps [{:module a :namespace metabase.a-legacy.core}]}]]
+      (with-redefs [deps-graph/kondo-config (constantly config)]
+        (let [diff (pr-str (deps-graph/kondo-config-diff deps))]
+          (is (not (re-find #"ns-prefix" diff))
+              "the :ns-prefix key must not appear in the config diff")
+          (is (not (re-find #"module-exports" diff))
+              "the :module-exports key must not appear in the config diff"))))))

--- a/test/metabase/dev/deps_graph_test.clj
+++ b/test/metabase/dev/deps_graph_test.clj
@@ -5,7 +5,9 @@
 
 (set! *warn-on-reflection* true)
 
-(deftest ^:parallel kondo-config-diff-excludes-human-owned-keys-test
+;; Not ^:parallel: the body rebinds `deps-graph/kondo-config` with `with-redefs`, a global mutation
+;; that is unsafe to run alongside other tests.
+(deftest kondo-config-diff-excludes-human-owned-keys-test
   (testing "kondo-config-diff does not report human-owned keys as extraneous drift"
     ;; Two modules whose regenerated :api/:uses reproduce the committed values exactly, so the
     ;; human-owned keys are the only ones that could show up in the diff. Excluded, the diff is empty.

--- a/test/metabase/dev/module_metrics_test.clj
+++ b/test/metabase/dev/module_metrics_test.clj
@@ -84,7 +84,7 @@
 
 (deftest ^:parallel metrics-test
   (mt/with-dynamic-fn-redefs [dev.deps-graph/source-filenames->relevant-test-filenames
-                              (fn [_deps source-filenames]
+                              (fn [_deps _config _prefix->mod source-filenames]
                                 (relevant-test-files source-filenames))]
     (let [metrics           (module-metrics/metrics deps config)
           metrics-by-module (into {} (map (juxt :module identity)) metrics)]
@@ -102,7 +102,8 @@
                (select-keys (get metrics-by-module 'c)
                             [:dependencies :dependents :cycles :blast-radius]))))
       (testing "config and graph metrics stay available alongside the blast radius counts"
-        (is (= {:dependencies {:direct-count                 2
+        (is (= {:top-level?    true
+                :dependencies {:direct-count                 2
                                :transitive-count             2
                                :reachable-namespace-count    2
                                :max-depth                    1}
@@ -119,7 +120,8 @@
                 :blast-radius {:source-file-count            3
                                :test-file-count              2}}
                (select-keys (get metrics-by-module 'a)
-                            [:dependencies
+                            [:top-level?
+                             :dependencies
                              :dependents
                              :size
                              :api
@@ -128,9 +130,10 @@
 
 (deftest ^:parallel repo-metrics-test
   (mt/with-dynamic-fn-redefs [dev.deps-graph/source-filenames->relevant-test-filenames
-                              (fn [_deps source-filenames]
+                              (fn [_deps _config _prefix->mod source-filenames]
                                 (relevant-test-files source-filenames))]
     (is (= {:graph         {:module-count                            4
+                            :top-level-module-count                  4
                             :edge-count                              5
                             :mean-out-degree                         1.25
                             :max-in-degree                           3
@@ -163,6 +166,7 @@
 (deftest ^:parallel empty-repo-metrics-test
   (let [metrics (module-metrics/repo-metrics [] {})]
     (is (= {:module-count                0
+            :top-level-module-count      0
             :edge-count                  0
             :mean-out-degree             0.0
             :max-in-degree               0
@@ -177,9 +181,25 @@
            (get-in metrics [:size :namespaces-per-module])))
     (is (= 0.0 (get-in metrics [:blast-radius :mean-test-files-per-source-file])))))
 
+(deftest ^:parallel top-level-classification-test
+  (testing "top-level? follows module-parent: dotted children and OSS-parented enterprise modules are
+            nested, but a standalone enterprise module (no OSS counterpart) is top-level"
+    (let [deps   [{:namespace 'metabase.base.core       :filename "src/metabase/base/core.clj"          :module 'base :deps []}
+                  {:namespace 'metabase.base.child.core :filename "src/metabase/base/child/core.clj"    :module 'base.child :deps []}
+                  {:namespace 'metabase-enterprise.base.core :filename "enterprise/backend/src/metabase_enterprise/base/core.clj" :module 'enterprise/base :deps []}
+                  {:namespace 'metabase-enterprise.lonely.core :filename "enterprise/backend/src/metabase_enterprise/lonely/core.clj" :module 'enterprise/lonely :deps []}]
+          config {'base            {:api #{'metabase.base.core} :module-exports #{'base.child}}
+                  'base.child      {:api #{'metabase.base.child.core}}
+                  'enterprise/base {:api #{'metabase-enterprise.base.core}}
+                  'enterprise/lonely {:api #{'metabase-enterprise.lonely.core}}}
+          by-mod (into {} (map (juxt :module :top-level?)) (module-metrics/metrics deps config))]
+      (is (= {'base true, 'base.child false, 'enterprise/base false, 'enterprise/lonely true}
+             by-mod))
+      (is (= 2 (:top-level-module-count (:graph (module-metrics/repo-metrics deps config))))))))
+
 (deftest ^:parallel csv-test
   (mt/with-dynamic-fn-redefs [dev.deps-graph/source-filenames->relevant-test-filenames
-                              (fn [_deps source-filenames]
+                              (fn [_deps _config _prefix->mod source-filenames]
                                 (relevant-test-files source-filenames))]
     (let [header (first (str/split-lines (with-out-str (module-metrics/csv deps config))))]
       (is (str/includes? header "dependencies.direct-count"))

--- a/test/metabase/dev/module_metrics_test.clj
+++ b/test/metabase/dev/module_metrics_test.clj
@@ -90,7 +90,7 @@
 
 (deftest ^:parallel metrics-test
   (mt/with-dynamic-fn-redefs [dev.deps-graph/source-filenames->relevant-test-filenames
-                              (fn [_deps source-filenames]
+                              (fn [_deps _config _prefix->mod source-filenames]
                                 (relevant-test-files source-filenames))]
     (let [metrics           (module-metrics/metrics deps config)
           metrics-by-module (into {} (map (juxt :module identity)) metrics)]
@@ -108,7 +108,8 @@
                (select-keys (get metrics-by-module 'c)
                             [:dependencies :dependents :cycles :blast-radius]))))
       (testing "config and graph metrics stay available alongside the blast radius counts"
-        (is (= {:dependencies {:direct-count                 2
+        (is (= {:top-level?    true
+                :dependencies {:direct-count                 2
                                :transitive-count             2
                                :reachable-namespace-count    2
                                :max-depth                    1}
@@ -125,7 +126,8 @@
                 :blast-radius {:source-file-count            3
                                :test-file-count              2}}
                (select-keys (get metrics-by-module 'a)
-                            [:dependencies
+                            [:top-level?
+                             :dependencies
                              :dependents
                              :size
                              :api
@@ -134,9 +136,10 @@
 
 (deftest ^:parallel repo-metrics-test
   (mt/with-dynamic-fn-redefs [dev.deps-graph/source-filenames->relevant-test-filenames
-                              (fn [_deps source-filenames]
+                              (fn [_deps _config _prefix->mod source-filenames]
                                 (relevant-test-files source-filenames))]
     (is (= {:graph         {:module-count                            4
+                            :top-level-module-count                  4
                             :edge-count                              5
                             :mean-out-degree                         1.25
                             :max-in-degree                           3
@@ -183,6 +186,7 @@
 (deftest ^:parallel empty-repo-metrics-test
   (let [metrics (module-metrics/repo-metrics [] {})]
     (is (= {:module-count                0
+            :top-level-module-count      0
             :edge-count                  0
             :mean-out-degree             0.0
             :max-in-degree               0
@@ -206,9 +210,25 @@
            (get-in metrics [:size :namespaces-per-module])))
     (is (= 0.0 (get-in metrics [:blast-radius :mean-test-files-per-source-file])))))
 
+(deftest ^:parallel top-level-classification-test
+  (testing "top-level? follows module-parent: dotted children and OSS-parented enterprise modules are
+            nested, but a standalone enterprise module (no OSS counterpart) is top-level"
+    (let [deps   [{:namespace 'metabase.base.core       :filename "src/metabase/base/core.clj"          :module 'base :deps []}
+                  {:namespace 'metabase.base.child.core :filename "src/metabase/base/child/core.clj"    :module 'base.child :deps []}
+                  {:namespace 'metabase-enterprise.base.core :filename "enterprise/backend/src/metabase_enterprise/base/core.clj" :module 'enterprise/base :deps []}
+                  {:namespace 'metabase-enterprise.lonely.core :filename "enterprise/backend/src/metabase_enterprise/lonely/core.clj" :module 'enterprise/lonely :deps []}]
+          config {'base            {:api #{'metabase.base.core} :module-exports #{'base.child}}
+                  'base.child      {:api #{'metabase.base.child.core}}
+                  'enterprise/base {:api #{'metabase-enterprise.base.core}}
+                  'enterprise/lonely {:api #{'metabase-enterprise.lonely.core}}}
+          by-mod (into {} (map (juxt :module :top-level?)) (module-metrics/metrics deps config))]
+      (is (= {'base true, 'base.child false, 'enterprise/base false, 'enterprise/lonely true}
+             by-mod))
+      (is (= 2 (:top-level-module-count (:graph (module-metrics/repo-metrics deps config))))))))
+
 (deftest ^:parallel csv-test
   (mt/with-dynamic-fn-redefs [dev.deps-graph/source-filenames->relevant-test-filenames
-                              (fn [_deps source-filenames]
+                              (fn [_deps _config _prefix->mod source-filenames]
                                 (relevant-test-files source-filenames))]
     (let [header (first (str/split-lines (with-out-str (module-metrics/csv deps config))))]
       (is (str/includes? header "dependencies.direct-count"))

--- a/test/metabase/util/log_test.clj
+++ b/test/metabase/util/log_test.clj
@@ -100,3 +100,10 @@
       (is (= [:ok nil]
              (vec (for [_ (range 2)]
                     (log/throttle 60000 :ok))))))))
+
+(deftest ^:parallel nested-module-team-attribution-test
+  (testing "nested modules inherit their nearest configured team"
+    (is (= "Querying Platform" (log/ns->team* 'metabase.lib.schema.expression)))
+    (is (= "UX West" (log/ns->team* 'metabase-enterprise.analytics.stats))))
+  (testing "nested modules can override their ancestor's team"
+    (is (= "Metabot" (log/ns->team* 'metabase.agent-lib.core)))))


### PR DESCRIPTION
## Summary

Today, module ownership is derived from the first namespace segment after `metabase` or `metabase-enterprise`. For example, `metabase.query-processor.middleware.*` belongs to the top-level `query-processor` module.

That makes a top-level namespace the smallest boundary we can express. Logically separate subsystems cannot have their own dependency rules, ownership, or affected-test scope without first becoming new top-level namespaces.

This PR adds the infrastructure needed to model modules hierarchically. It enables boundaries such as `query-processor.middleware`, `transforms.python`, `warehouse.rest`, and `permissions.enterprise` without requiring their source namespaces to move at the same time.

## What changes

- Namespace ownership is resolved by longest-prefix matching at segment boundaries. Each module receives a name-derived prefix by default and may override it with `:ns-prefix` when the source namespace does not match the module hierarchy.
- The clj-kondo hook, `dev.deps-graph`, and `mage.modules` all use the same resolution semantics. A consistency test runs the three implementations against shared fixtures so they cannot drift silently despite living on separate classpaths.
- Nested-module visibility is explicit and asymmetric:
  - every dependency must still be declared in `:uses`;
  - descendants may access their ancestors' internals;
  - ancestors, siblings, and unrelated modules must use the target's API;
  - a nested module may be named outside its private subtree only when the relevant parent exports it through `:module-exports`.
- When both `X` and `enterprise/X` exist, the enterprise module is modeled as an automatically exported child of `X`. This preserves existing cross-tree references while giving EE counterparts the intended relationship to their OSS modules.
- Team attribution in `metabase.util.log` follows the same module hierarchy. A nested module without its own `:team` inherits the nearest configured ancestor's owner.

## Compatibility

This PR does not add any explicitly dotted modules to the production configuration, and no module currently declares `:ns-prefix` or `:module-exports`. Namespace ownership therefore remains unchanged for the current config.

The existing `X` / `enterprise/X` pairs are the one hierarchy already recognized by this change: 25 enterprise modules are modeled as automatically exported children of their OSS counterparts.

## Stack

The measurement tooling that previously lived in this branch—SCC and module-graph metrics, debt ratchets, `modules-validate`, expanded-config output, and ownership-exact affected-test discovery—moved to #79540. That PR sits below this one and can land independently.

## Validation

- `./bin/mage modules-validate`
  - 25 tests
  - 10,550 assertions
  - 0 failures
  - 0 errors
