### PR TITLE
Force a full rebuild when a transform index request is :failed

### DIFF
--- a/src/metabase/indexes/models/table_index.clj
+++ b/src/metabase/indexes/models/table_index.clj
@@ -36,8 +36,16 @@
    :status     (mi/transform-validator mi/transform-keyword (partial mi/assert-enum schema/statuses))})
 
 (def pending-statuses
-  "Statuses that require a full incremental rebuild before an index request's physical state can be trusted."
+  "In-flight lifecycle statuses whose physical index state hasn't settled yet.
+  Writing one of these clears any stale `:error_message` (see [[pending-status-for-changes]])."
   #{:create-pending :update-pending :delete-pending :running})
+
+(def ^:private rebuild-forcing-statuses
+  "Statuses whose physical index state can't be trusted, so the transform's next run must be a full rebuild.
+  Includes `:failed`: a failed index DDL runs before the watermark is saved, so the table was already
+  materialized; only a full rebuild re-attempts the index instead of appending duplicate rows from the stale
+  checkpoint (and leaving the index stuck `:failed`)."
+  (conj pending-statuses :failed))
 
 (def ^:private runnable-statuses
   #{:create-pending :update-pending :running :failed})
@@ -112,7 +120,7 @@
   [transform-id]
   (boolean
    (when transform-id
-     (t2/exists? :model/TableIndex :transform_id transform-id :status [:in pending-statuses]))))
+     (t2/exists? :model/TableIndex :transform_id transform-id :status [:in rebuild-forcing-statuses]))))
 
 (defn mark-runnable-indexes-running!
   "Mark hydrated index requests that this run will apply as running.

--- a/test/metabase/indexes/models/table_index_test.clj
+++ b/test/metabase/indexes/models/table_index_test.clj
@@ -121,6 +121,25 @@
   (testing "a nil transform-id is a no-op"
     (is (nil? (table-index/mark-for-revalidation! nil)))))
 
+(deftest pending-changes-for-transform?-test
+  (testing "any unsettled request forces the transform's next run to be a full rebuild"
+    (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)
+                   :model/TableIndex {index-id :id} {:transform_id transform-id
+                                                     :index_name   "idx"
+                                                     :status       :succeeded
+                                                     :structured   {:kind :btree :name "idx"
+                                                                    :columns [{:name "a"}]}}]
+      (is (false? (table-index/pending-changes-for-transform? transform-id))
+          "a settled (:succeeded) request needs no rebuild")
+      ;; :failed is included: its index DDL already ran against a materialized table, so only a full rebuild
+      ;; safely re-attempts it instead of appending duplicate rows from the stale checkpoint.
+      (doseq [status [:create-pending :update-pending :delete-pending :running :failed]]
+        (t2/update! :model/TableIndex index-id {:status status})
+        (is (true? (table-index/pending-changes-for-transform? transform-id))
+            (str status " forces a full rebuild")))))
+  (testing "a nil transform-id is not pending"
+    (is (false? (table-index/pending-changes-for-transform? nil)))))
+
 (deftest select-for-verification-test
   (mt/with-temp [:model/Transform {transform-id :id} (temp-transform-spec)
                  :model/TableIndex {running-id :id} {:transform_id transform-id


### PR DESCRIPTION
A `:failed` index request was retryable but wasn't counted as a pending change, so it never forced the transform's next run to be a full rebuild. Index DDL runs after the table is materialized but before the watermark is saved, so a failure leaves the table rebuilt with the watermark unchanged. The next run appends from the stale checkpoint onto the already-materialized table (duplicate rows) and never re-attempts the index, so it stays stuck `:failed`. Triggers when you add an index to an already-incrementing transform; a first-ever run is safe, since a nil checkpoint keeps that run a full rebuild anyway.

Fix: split `rebuild-forcing-statuses` (`pending-statuses` + `:failed`) and use it in `pending-changes-for-transform?`, keeping `:failed` out of the before-update error-clearing path.

**Draft — not mergeable as-is.** Forcing a rebuild on `:failed` trades the duplicate-row corruption for an unbounded retry: a permanently-invalid index definition (unsupported for the warehouse, a typo'd column) now re-materializes the whole target table on every run, forever, with no attempt counter or circuit breaker. Strictly better than the corruption, but for a large incremental transform it's a real cost and the broken index is silently masked. Needs a product call before merge — attempt counter with a give-up state, surface stuck `:failed` to the user, or accept and document — and whatever we pick has to keep the append-duplicates hazard closed.

Test: `pending-changes-for-transform?-test`.
