### PR TITLE
Omit empty optional fields when serializing a transform index request

### DIFF
--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.ts
@@ -96,9 +96,9 @@ export function toStructured(
           }))
         : value.map((column) => ({ name: column.name }));
     } else {
-      // Omit an optional scalar left blank (e.g. a ClickHouse skip-index granularity): the backend rejects
-      // null but accepts the key being absent.
-      if (!field.required && value == null) {
+      // Omit an optional scalar left blank -- null (e.g. a ClickHouse skip-index granularity) or "" (a blank
+      // string or empty-option select): the backend rejects those but accepts the key being absent.
+      if (!field.required && (value == null || value === "")) {
         continue;
       }
       structured[field.name] = value;

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.ts
@@ -84,6 +84,11 @@ export function toStructured(
   for (const field of fields) {
     const value = values[field.name];
     if (field.type === "columns" && Array.isArray(value)) {
+      // Omit an optional column list left empty (e.g. a Redshift DISTSTYLE ALL/EVEN distkey): the backend
+      // rejects [] but accepts the key being absent.
+      if (!field.required && value.length === 0) {
+        continue;
+      }
       structured[field.name] = field.directions
         ? value.map((column) => ({
             name: column.name,
@@ -91,6 +96,11 @@ export function toStructured(
           }))
         : value.map((column) => ({ name: column.name }));
     } else {
+      // Omit an optional scalar left blank (e.g. a ClickHouse skip-index granularity): the backend rejects
+      // null but accepts the key being absent.
+      if (!field.required && value == null) {
+        continue;
+      }
       structured[field.name] = value;
     }
   }

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.unit.spec.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.unit.spec.ts
@@ -1,0 +1,81 @@
+import type { IndexField } from "metabase-types/api";
+
+import { toStructured } from "./utils";
+
+function field(overrides: Partial<IndexField> & { name: string }): IndexField {
+  return {
+    "display-name": overrides.name,
+    type: "string",
+    ...overrides,
+  };
+}
+
+describe("toStructured", () => {
+  it("omits an optional scalar left blank instead of sending null", () => {
+    const fields = [
+      field({ name: "type", type: "select" }),
+      field({ name: "granularity", type: "integer" }),
+    ];
+
+    const structured = toStructured("skip-index", fields, {
+      type: "minmax",
+      granularity: null,
+    });
+
+    expect(structured).toEqual({ kind: "skip-index", type: "minmax" });
+    expect("granularity" in structured).toBe(false);
+  });
+
+  it("omits an optional column list left empty instead of sending []", () => {
+    const fields = [
+      field({ name: "style", type: "select" }),
+      field({ name: "columns", type: "columns" }),
+    ];
+
+    const structured = toStructured("distkey", fields, {
+      style: "all",
+      columns: [],
+    });
+
+    expect(structured).toEqual({ kind: "distkey", style: "all" });
+    expect("columns" in structured).toBe(false);
+  });
+
+  it("keeps a required field even when empty so validation can flag it", () => {
+    const fields = [
+      field({ name: "granularity", type: "integer", required: true }),
+    ];
+
+    const structured = toStructured("skip-index", fields, {
+      granularity: null,
+    });
+
+    expect(structured).toEqual({ kind: "skip-index", granularity: null });
+  });
+
+  it("keeps falsy-but-present values like a boolean false", () => {
+    const fields = [field({ name: "unique", type: "boolean" })];
+
+    const structured = toStructured("btree", fields, { unique: false });
+
+    expect(structured).toEqual({ kind: "btree", unique: false });
+  });
+
+  it("maps a populated column list, defaulting direction when the kind supports it", () => {
+    const fields = [
+      field({ name: "columns", type: "columns", directions: true }),
+    ];
+
+    const structured = toStructured("btree", fields, {
+      columns: [{ name: "city" }, { name: "country", direction: "desc" }],
+    });
+
+    expect(structured).toEqual({
+      kind: "btree",
+      columns: [
+        { name: "city", direction: "asc" },
+        { name: "country", direction: "desc" },
+      ],
+    });
+  });
+});

--- a/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.unit.spec.ts
+++ b/frontend/src/metabase/transforms/pages/TransformIndexesPage/IndexEditorModal/utils.unit.spec.ts
@@ -26,6 +26,21 @@ describe("toStructured", () => {
     expect("granularity" in structured).toBe(false);
   });
 
+  it("omits an optional string/select left blank instead of sending an empty string", () => {
+    const fields = [
+      field({ name: "name", type: "string" }),
+      field({ name: "collation", type: "select" }),
+    ];
+
+    const structured = toStructured("btree", fields, {
+      name: "idx",
+      collation: "",
+    });
+
+    expect(structured).toEqual({ kind: "btree", name: "idx" });
+    expect("collation" in structured).toBe(false);
+  });
+
   it("omits an optional column list left empty instead of sending []", () => {
     const fields = [
       field({ name: "style", type: "select" }),


### PR DESCRIPTION
`toStructured` serialized every declared field, so a valid choice that left an optional field blank sent a value the backend schema rejects: a ClickHouse skip-index with no granularity sent `granularity: null`, a Redshift `DISTSTYLE ALL`/`EVEN` distkey sent `columns: []`. Both are accepted when the key is absent but 400 when present as null or an empty array, so you got a 400 for an otherwise valid index.

Fix: omit an optional field left null/undefined, an empty array, or a blank string (`""` seeded by `defaultFieldValue`); required and populated fields go through as before.
