### PR TITLE
Omit negative values from treemap instead of producing wrong percentages

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/model/data.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/model/data.ts
@@ -112,8 +112,12 @@ export function getTreemapData(
       return;
     }
 
+    // Filter negatives per-row (before summing) so a parent's value always
+    // equals the sum of its surviving leaves — required for treemap area
+    // containment. This differs from the pie chart, which drops whole negative
+    // groups but still sums negative rows into the aggregate.
     const numericValue = getNumberOr(metricValue, null);
-    if (numericValue != null && numericValue < 0) {
+    if (numericValue !== null && numericValue < 0) {
       if (areAllNegative) {
         metricValue = Math.abs(numericValue);
       } else {

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/model/data.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/model/data.ts
@@ -1,6 +1,8 @@
 import { NULL_DISPLAY_VALUE } from "metabase/utils/constants";
 import { sumMetric } from "metabase/visualizations/lib/dataset";
 import { getColumnDescriptors } from "metabase/visualizations/lib/graph/columns";
+import { getNumberOr } from "metabase/visualizations/lib/settings/row-values";
+import { treemapNegativesWarning } from "metabase/visualizations/lib/warnings";
 import { getKeyFromDimensionValue } from "metabase/visualizations/shared/settings/pie";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 import type {
@@ -64,6 +66,7 @@ export function getTreemapData(
   treemapColumns: TreemapChartColumns,
   treemapRows?: TreemapRow[],
   settings?: Pick<ComputedVisualizationSettings, "column">,
+  showWarning?: (warning: string) => void,
 ): TreemapTree {
   const [
     {
@@ -90,15 +93,33 @@ export function getTreemapData(
       .map((row) => row.key),
   );
 
+  const isRowEnabled = (row: RowValue[]) =>
+    !userDisabledRows.has(getKeyFromDimensionValue(row[grouping.index]));
+
+  const enabledRows = rows.filter(isRowEnabled);
+  const areAllNegative =
+    enabledRows.length > 0 &&
+    enabledRows.every((row) => getNumberOr(row[value.index], 0) < 0);
+
   const rootByKey = new Map<RowValue, TreemapNode>();
   const leafMapByRoot = new Map<TreemapNode, Map<RowValue, TreemapNode>>();
 
   rows.forEach((row, rowIndex) => {
     const groupingValue = row[grouping.index];
-    const metricValue = row[value.index];
+    let metricValue = row[value.index];
 
-    if (userDisabledRows.has(getKeyFromDimensionValue(groupingValue))) {
+    if (!isRowEnabled(row)) {
       return;
+    }
+
+    const numericValue = getNumberOr(metricValue, null);
+    if (numericValue != null && numericValue < 0) {
+      if (areAllNegative) {
+        metricValue = Math.abs(numericValue);
+      } else {
+        showWarning?.(treemapNegativesWarning().text);
+        return;
+      }
     }
 
     const { node: rootNode } = getOrCreateNode({

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/model/data.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/model/data.unit.spec.ts
@@ -290,6 +290,84 @@ describe("treemap data model", () => {
       },
     ]);
   });
+
+  it("omits negative values and warns when values are mixed sign", () => {
+    const showWarning = jest.fn();
+    const result = getTreemapData(
+      makeRawSeries2Level([
+        ["A", "x", 30],
+        ["A", "x", -50],
+        ["B", "x", 10],
+      ]),
+      treemapColumnsWithSub,
+      undefined,
+      undefined,
+      showWarning,
+    );
+
+    expect(result).toEqual([
+      {
+        rawName: "A",
+        displayName: "A",
+        value: 30,
+        rowIndices: [0],
+        children: [
+          { rawName: "x", displayName: "x", value: 30, rowIndices: [0] },
+        ],
+      },
+      {
+        rawName: "B",
+        displayName: "B",
+        value: 10,
+        rowIndices: [2],
+        children: [
+          { rawName: "x", displayName: "x", value: 10, rowIndices: [2] },
+        ],
+      },
+    ]);
+    expect(showWarning).toHaveBeenCalledWith(
+      "Negative values in measure column have been omitted from treemap chart.",
+    );
+  });
+
+  it("drops a group entirely when all of its rows are negative in mixed data", () => {
+    const showWarning = jest.fn();
+    const result = getTreemapData(
+      makeRawSeries1Level([
+        ["A", 30],
+        ["B", -50],
+      ]),
+      treemapColumns,
+      undefined,
+      undefined,
+      showWarning,
+    );
+
+    expect(result).toEqual([
+      { rawName: "A", displayName: "A", value: 30, rowIndices: [0] },
+    ]);
+    expect(showWarning).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to absolute values when every value is negative", () => {
+    const showWarning = jest.fn();
+    const result = getTreemapData(
+      makeRawSeries1Level([
+        ["A", -30],
+        ["B", -50],
+      ]),
+      treemapColumns,
+      undefined,
+      undefined,
+      showWarning,
+    );
+
+    expect(result).toEqual([
+      { rawName: "A", displayName: "A", value: 30, rowIndices: [0] },
+      { rawName: "B", displayName: "B", value: 50, rowIndices: [1] },
+    ]);
+    expect(showWarning).not.toHaveBeenCalled();
+  });
 });
 
 describe("getNodesFromPath", () => {

--- a/frontend/src/metabase/visualizations/lib/warnings.ts
+++ b/frontend/src/metabase/visualizations/lib/warnings.ts
@@ -9,6 +9,7 @@ const UNAGGREGATED_DATA_WARNING_PIE = "UNAGGREGATED_DATA_WARNING_PIE";
 const UNEXPECTED_QUERY_TIMEZONE = "UNEXPECTED_QUERY_TIMEZONE";
 const MULTIPLE_TIMEZONES = "MULTIPLE_TIMEZONES";
 const PIE_NEGATIVES = "PIE_NEGATIVES";
+const TREEMAP_NEGATIVES = "TREEMAP_NEGATIVES";
 
 type VisualizationWarningKey =
   | typeof NULL_DIMENSION_WARNING
@@ -17,7 +18,8 @@ type VisualizationWarningKey =
   | typeof UNAGGREGATED_DATA_WARNING_PIE
   | typeof UNEXPECTED_QUERY_TIMEZONE
   | typeof MULTIPLE_TIMEZONES
-  | typeof PIE_NEGATIVES;
+  | typeof PIE_NEGATIVES
+  | typeof TREEMAP_NEGATIVES;
 
 export type VisualizationWarning = {
   key: VisualizationWarningKey;
@@ -88,5 +90,12 @@ export function pieNegativesWarning(): VisualizationWarning {
   return {
     key: PIE_NEGATIVES,
     text: t`Negative values in measure column have been omitted from pie chart.`,
+  };
+}
+
+export function treemapNegativesWarning(): VisualizationWarning {
+  return {
+    key: TREEMAP_NEGATIVES,
+    text: t`Negative values in measure column have been omitted from treemap chart.`,
   };
 }

--- a/frontend/src/metabase/visualizations/visualizations/TreemapChart/TreemapChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/TreemapChart/TreemapChart.tsx
@@ -42,6 +42,7 @@ export const TreemapChart = ({
   settings,
   fontFamily,
   onVisualizationClick,
+  onRender,
   clicked,
   isDashboard,
   isDocument,
@@ -50,6 +51,11 @@ export const TreemapChart = ({
   const rawSeriesWithRemappings = useMemo(
     () => extractRemappings(rawSeries),
     [rawSeries],
+  );
+
+  const showWarning = useCallback(
+    (warning: string) => onRender({ warnings: [warning] }),
+    [onRender],
   );
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -72,10 +78,11 @@ export const TreemapChart = ({
       treemapColumns,
       treemapRows,
       settings,
+      showWarning,
     );
     const colors = getTreemapColors(tree, treemapRows);
     return { tree, colors, treemapColumns };
-  }, [rawSeriesWithRemappings, settings]);
+  }, [rawSeriesWithRemappings, settings, showWarning]);
 
   const { viewRootId, viewRootIdRef, setViewRoot } = useTreemapNavigation(
     chartData?.tree ?? null,


### PR DESCRIPTION
Closes [GDGT-2760](https://linear.app/metabase/issue/GDGT-2760)

### Description

Previously, the treemap aggregated metric values as signed sums and used that signed total as the denominator when computing percentages. When the data mixed positive and negative values, this produced nonsense: rows of `30` and `-50` summed to `-20`, and a surviving leaf of `30` rendered as `30 / -20 = -150%`. On top of that, negative values have no positive tile area, so ECharts silently dropped those tiles with no warning to the user.

The treemap is a part-to-whole visualization, so it now handles negatives the same way the pie chart already does. In `getTreemapData`, negative values are **omitted** from aggregation (with a warning surfaced through the standard viz-warning mechanism), unless *every* value is negative — in which case it falls back to **absolute values** so the chart still renders something meaningful. Because all node values are non-negative after this, the downstream percentage math (`getTreemapTotal`, the leaf / percent-of-total formatters, and the tooltip) is correct with no further changes.

### How to verify

1. Create a native question with mixed positive and negative values in the metric column, e.g.:
   ```sql
   SELECT 'Widget' AS category, 'Vendor A' AS vendor, 30 AS num_orders
   UNION ALL SELECT 'Widget', 'Vendor A', -50
   UNION ALL SELECT 'Gadget', 'Vendor B', 10
   ```
2. Switch the visualization to Treemap (Grouping: `category`, Sub-grouping: `vendor`, Value: `num_orders`).
3. The negative value should be omitted rather than skewing the math — percentages should be sane (`75%` / `25%`), never a negative percentage like `-150%`.
4. A warning ("Negative values in measure column have been omitted from treemap chart.") should appear on the viz.
5. Change every value to negative — the treemap should still render using their absolute values, with no warning.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR