### PR TITLE
Keep dominant treemap share honest instead of rounding to 100%

### DIFF
--- a/frontend/src/metabase/static-viz/components/TreemapChart/TreemapChart.tsx
+++ b/frontend/src/metabase/static-viz/components/TreemapChart/TreemapChart.tsx
@@ -60,7 +60,7 @@ export function TreemapChart({
     settings,
   );
   const colors = getTreemapColors(tree, treemapRows);
-  const formatters = getTreemapFormatters(treemapColumns, settings);
+  const formatters = getTreemapFormatters(treemapColumns, settings, tree);
 
   const config: TreemapChartOptionConfig = {
     tree,

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/model/formatters.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/model/formatters.ts
@@ -1,5 +1,6 @@
 import { NULL_DISPLAY_VALUE } from "metabase/utils/constants";
 import { formatValue } from "metabase/visualizations/lib/formatting";
+import { computeMaxDecimalsForValues } from "metabase/visualizations/lib/utils";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 import type { DatasetColumn, RowValue } from "metabase-types/api";
 
@@ -11,11 +12,38 @@ export interface TreemapFormatters {
   percent: (ratio: number) => string;
 }
 
+const DEFAULT_PERCENT_DECIMALS = 2;
+const PERCENT_SIGNIFICANT_DIGITS = 2;
+
+function getPercentDecimals(tree: TreemapTree): number {
+  const total = getTreemapTotal(tree);
+  if (total === 0) {
+    return DEFAULT_PERCENT_DECIMALS;
+  }
+
+  const shares = tree.flatMap((root) => [
+    root.value / total,
+    ...(root.children ?? []).map((leaf) => leaf.value / total),
+  ]);
+
+  const decimals = computeMaxDecimalsForValues(shares, {
+    style: "percent",
+    maximumSignificantDigits: PERCENT_SIGNIFICANT_DIGITS,
+  });
+
+  return Math.max(
+    DEFAULT_PERCENT_DECIMALS,
+    decimals ?? DEFAULT_PERCENT_DECIMALS,
+  );
+}
+
 export function getTreemapFormatters(
   columns: TreemapChartColumns,
   settings: ComputedVisualizationSettings,
+  tree: TreemapTree,
 ): TreemapFormatters {
   const valueColumn = columns.value.column;
+  const percentDecimals = getPercentDecimals(tree);
   return {
     value: getTreemapColumnFormatter(valueColumn, settings),
     percent: (ratio: number) =>
@@ -23,7 +51,7 @@ export function getTreemapFormatters(
         formatValue(ratio, {
           column: valueColumn,
           number_style: "percent",
-          decimals: Math.abs(ratio) === 1 ? 0 : 2,
+          decimals: Math.abs(ratio) === 1 ? 0 : percentDecimals,
         }),
       ),
   };

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/model/formatters.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/model/formatters.unit.spec.ts
@@ -27,27 +27,31 @@ function makeTree(...values: number[]): TreemapTree {
   }));
 }
 
-function setup(tree: TreemapTree) {
+type SetupOpts = {
+  tree: TreemapTree;
+};
+
+function setup({ tree }: SetupOpts) {
   return getTreemapFormatters(columns, { column: () => ({}) }, tree);
 }
 
 describe("getTreemapFormatters percent", () => {
   it("keeps a dominant share honest instead of rounding it to 100%", () => {
     const total = 100001;
-    const { percent } = setup(makeTree(100000, 1));
+    const { percent } = setup({ tree: makeTree(100000, 1) });
 
     expect(percent(100000 / total)).toBe("99.999%");
     expect(percent(1 / total)).toBe("0.001%");
   });
 
   it("uses two decimals by default for evenly split values", () => {
-    const { percent } = setup(makeTree(1, 1, 1));
+    const { percent } = setup({ tree: makeTree(1, 1, 1) });
 
     expect(percent(1 / 3)).toBe("33.33%");
   });
 
   it("renders an exact whole share without decimals", () => {
-    const { percent } = setup(makeTree(10));
+    const { percent } = setup({ tree: makeTree(10) });
 
     expect(percent(1)).toBe("100%");
   });
@@ -63,7 +67,7 @@ describe("getTreemapFormatters percent", () => {
         children: makeTree(100000, 1),
       },
     ];
-    const { percent } = setup(tree);
+    const { percent } = setup({ tree });
 
     expect(percent(100000 / total)).toBe("99.999%");
   });

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/model/formatters.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/model/formatters.unit.spec.ts
@@ -1,0 +1,70 @@
+import { createMockColumn } from "metabase-types/api/mocks/dataset";
+
+import { getTreemapFormatters } from "./formatters";
+import type { TreemapChartColumns, TreemapTree } from "./types";
+
+const valueColumn = createMockColumn({
+  name: "Amount",
+  display_name: "Amount",
+  base_type: "type/Number",
+  semantic_type: "type/Number",
+});
+
+const columns: TreemapChartColumns = {
+  grouping: {
+    index: 0,
+    column: createMockColumn({ name: "Category", base_type: "type/Text" }),
+  },
+  value: { index: 1, column: valueColumn },
+};
+
+function makeTree(...values: number[]): TreemapTree {
+  return values.map((value, index) => ({
+    rawName: `n${index}`,
+    displayName: `n${index}`,
+    value,
+    rowIndices: [index],
+  }));
+}
+
+function setup(tree: TreemapTree) {
+  return getTreemapFormatters(columns, { column: () => ({}) }, tree);
+}
+
+describe("getTreemapFormatters percent", () => {
+  it("keeps a dominant share honest instead of rounding it to 100%", () => {
+    const total = 100001;
+    const { percent } = setup(makeTree(100000, 1));
+
+    expect(percent(100000 / total)).toBe("99.999%");
+    expect(percent(1 / total)).toBe("0.001%");
+  });
+
+  it("uses two decimals by default for evenly split values", () => {
+    const { percent } = setup(makeTree(1, 1, 1));
+
+    expect(percent(1 / 3)).toBe("33.33%");
+  });
+
+  it("renders an exact whole share without decimals", () => {
+    const { percent } = setup(makeTree(10));
+
+    expect(percent(1)).toBe("100%");
+  });
+
+  it("considers leaf shares when picking the decimal count", () => {
+    const total = 100001;
+    const tree: TreemapTree = [
+      {
+        rawName: "root",
+        displayName: "root",
+        value: total,
+        rowIndices: [0, 1],
+        children: makeTree(100000, 1),
+      },
+    ];
+    const { percent } = setup(tree);
+
+    expect(percent(100000 / total)).toBe("99.999%");
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/TreemapChart/TreemapChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/TreemapChart/TreemapChart.tsx
@@ -86,7 +86,11 @@ export const TreemapChart = ({
   const formatters = useMemo(
     () =>
       chartData
-        ? getTreemapFormatters(chartData.treemapColumns, settings)
+        ? getTreemapFormatters(
+            chartData.treemapColumns,
+            settings,
+            chartData.tree,
+          )
         : null,
     [chartData, settings],
   );


### PR DESCRIPTION
Closes [GDGT-2761](https://linear.app/metabase/issue/GDGT-2761)

### Description

Previously, the treemap formatted every share with a fixed two decimal places, so when one leaf vastly outweighed the rest its share rounded up to a misleading `100.00%`. With values of `100000` and `1`, the total was correct (`100001`) but the dominant leaf rendered as `100.00%` instead of its true `99.999%` — visually erasing the tiny sibling's contribution.

`getTreemapFormatters` now derives the decimal count from every node share (roots and leaves) via `computeMaxDecimalsForValues` — the same helper the pie chart uses. The formatter always uses at least two decimals to match the current treemap look, so ordinary treemaps are visually unchanged (`33.33%`, `50.00%`), and a genuine whole still shows a clean `100%`.

**Note** that this only fixes the *label*. The tiny tile itself still isn't drawn — a `0.001%` share is sub-pixel area and ECharts filters it via `visibleMin`.

### How to verify

1. Create a native question with one dominant value and one tiny one, e.g.:
   ```sql
   SELECT 'Widget' AS category, 'Huge Vendor' AS vendor, 100000 AS num_orders
   UNION ALL SELECT 'Gadget', 'Tiny Vendor', 1
   ```
2. Switch the visualization to Treemap (Grouping: `category`, Value: `num_orders`).
3. The dominant tile's label should read `99.999%`, not `100.00%`.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR