### PR TITLE
Clean up stale step condition in backend.yml

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -221,7 +221,7 @@ jobs:
 
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
-        if: always() && (steps.run-java-tests.conclusion != 'skipped' || steps.run-java-tests-21.conclusion != 'skipped')
+        if: ${{ !cancelled() && steps.run-java-tests.conclusion != 'skipped' }}
         with:
           input-path: ./target/junit/
           output-name: be-tests-java-${{ matrix.java-version }}-${{ matrix.job.edition }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -221,7 +221,7 @@ jobs:
 
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
-        if: ${{ !cancelled() && steps.run-java-tests.conclusion != 'skipped' }}
+        if: always()
         with:
           input-path: ./target/junit/
           output-name: be-tests-java-${{ matrix.java-version }}-${{ matrix.job.edition }}


### PR DESCRIPTION
issue: [DEV-2352: Clean up a stale step condition in backend.yml](https://linear.app/metabase/issue/DEV-2352/clean-up-a-stale-step-condition-in-backendyml)

- remove check for step that no longer exists
- also updated from `always()` to `!cancelled()` to match the surrounding blocks: the check will still run on test success/failure, but **won't** run if the job gets cancelled (ex. someone pushes a new commit). I think this makes sense since a cancelled run likely means partial test reporting/coverage anyways so it doesn't have much value to upload.
