### PR TITLE
Fix leaking plural template

### DIFF
--- a/frontend/src/metabase/common/components/Schedule/Schedule.tsx
+++ b/frontend/src/metabase/common/components/Schedule/Schedule.tsx
@@ -1,7 +1,7 @@
 import cx from "classnames";
 import { type HTMLAttributes, useCallback, useMemo, useState } from "react";
 import { match } from "ts-pattern";
-import { c, t } from "ttag";
+import { c } from "ttag";
 import _ from "underscore";
 
 import { CronExpressionInput } from "metabase/common/components/CronExpressioInput";
@@ -211,7 +211,9 @@ export const Schedule = ({
           schedule_minute === 1
             ? c("Time unit in the schedule builder, e.g. 'every 1 minute'")
                 .t`Minute`
-            : t`Minutes`
+            : c(
+                "Plural time unit in the schedule builder, e.g. 'every 10 minutes'",
+              ).t`Minutes`
         ).toLocaleLowerCase();
         return c(
           "{0} is a verb like 'Check', {1} is an adverb like 'by the minute', {2} is a number of minutes.",

--- a/frontend/src/metabase/common/components/Schedule/Schedule.tsx
+++ b/frontend/src/metabase/common/components/Schedule/Schedule.tsx
@@ -1,7 +1,7 @@
 import cx from "classnames";
 import { type HTMLAttributes, useCallback, useMemo, useState } from "react";
 import { match } from "ts-pattern";
-import { c, msgid, ngettext } from "ttag";
+import { c, t } from "ttag";
 import _ from "underscore";
 
 import { CronExpressionInput } from "metabase/common/components/CronExpressioInput";
@@ -204,17 +204,20 @@ export const Schedule = ({
     );
 
     return match(schedule_type)
-      .with(
-        "every_n_minutes",
-        () =>
-          // Converting to lowercase here, because 'minute` is used without pluralization on the backend,
-          // and it's impossible to have both pluralized and single form for the same string.
-          c(
-            "{0} is a verb like 'Check', {1} is an adverb like 'by the minute', {2} is a number of minutes.",
-          )
-            // Unjustified type cast. FIXME
-            .jt`${verb} ${selectFrequency} every ${selectEveryMinute} ${ngettext(msgid`Minute`, "Minutes", schedule_minute as number).toLocaleLowerCase()}`,
-      )
+      .with("every_n_minutes", () => {
+        // "Minute" is registered as a plural msgid elsewhere; give this row's
+        // singular its own context so it's a distinct key (no extraction clash).
+        const minuteUnit = (
+          schedule_minute === 1
+            ? c("Time unit in the schedule builder, e.g. 'every 1 minute'")
+                .t`Minute`
+            : t`Minutes`
+        ).toLocaleLowerCase();
+        return c(
+          "{0} is a verb like 'Check', {1} is an adverb like 'by the minute', {2} is a number of minutes.",
+        )
+          .jt`${verb} ${selectFrequency} every ${selectEveryMinute} ${minuteUnit}`;
+      })
       .with("hourly", () => {
         return minutesOnHourPicker ? (
           // For example, "Send hourly at 15 minutes past the hour"

--- a/frontend/src/metabase/common/components/Schedule/Schedule.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Schedule/Schedule.unit.spec.tsx
@@ -7,6 +7,7 @@ import {
   setup,
   setupHarness,
 } from "metabase/common/components/Schedule/test-utils";
+import { setLocalization } from "metabase/utils/i18n";
 
 const getInputValues = () => {
   const inputs = screen.getAllByRole("textbox");
@@ -374,5 +375,51 @@ describe("Schedule", () => {
         expect(onScheduleChange.mock.calls.at(-1)?.[0]).toBe(expectedCron);
       },
     );
+  });
+});
+
+describe("Schedule i18n (metabase#77265)", () => {
+  // Mirrors the real hu.po: "Minute" is only a {0}-carrying plural entry, plus a
+  // clean standalone "Minutes". A bare ngettext plural here would render "{0} perc".
+  const HU_LOCALE = {
+    headers: {
+      language: "hu",
+      "plural-forms": "nplurals=2; plural=(n != 1);",
+    },
+    translations: {
+      "": {
+        Minute: {
+          msgid_plural: "{0} Minutes",
+          msgstr: ["Perc", "{0} perc"],
+        },
+        Minutes: {
+          msgstr: ["Percek"],
+        },
+      },
+    },
+  };
+
+  afterEach(() => {
+    setLocalization({
+      headers: {
+        language: "en",
+        "plural-forms": "nplurals=2; plural=(n != 1);",
+      },
+      translations: { "": {} },
+    });
+  });
+
+  it("renders the plural unit without leaking a {0} placeholder", () => {
+    setLocalization(HU_LOCALE);
+    const { container } = setup({ cronString: "0 0/5 * * * ? *" });
+    expect(container).not.toHaveTextContent(/\{\s*0\s*\}/);
+    expect(screen.getByText("percek")).toBeInTheDocument();
+  });
+
+  it("renders the singular unit without leaking a {0} placeholder", () => {
+    setLocalization(HU_LOCALE);
+    const { container } = setup({ cronString: "0 0/1 * * * ? *" });
+    expect(container).not.toHaveTextContent(/\{\s*0\s*\}/);
+    expect(screen.getByText("perc")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #77265
### Description

This issue stems from the fact that the plural `Minutes` tag is expecting a number to go in front of it. This PR manually adjusts the singular / plural version of `Minute` / `Minutes` so that we can side step `ngetnext`s existing template for 'Minutes' .

A unit test was added more as a regression guard than anything else

### How to verify

1. Change your language to Hungarian
2. Go to set up an alert, change the check interval to minute
3. We should see the translated `Perc` change to a plural, with no `{0}` in the template

### Demo


https://github.com/user-attachments/assets/5889dda5-b36e-4c4a-b514-5197bdb7574d



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
