### PR TITLE
onboarding: add Github username to team, add Github -> Slack ID mapping

### DIFF
--- a/.github/team.json
+++ b/.github/team.json
@@ -93,7 +93,8 @@
         "deniskaber",
         "andsalves",
         "kevinkelleher12",
-        "AndreyChernykh"
+        "AndreyChernykh",
+        "bowbahdoe"
       ]
     },
     {

--- a/release/github-slack-map.json
+++ b/release/github-slack-map.json
@@ -11,6 +11,7 @@
   "AndreyChernykh": "U0AS0TCU56H",
   "andsalves": "U099KKH8KT7",
   "appleby": "U07GRL255JL",
+  "bowbahdoe": "U0BGPEUHQ8L",
   "bgrabow": "U0AHED0A92P",
   "bpander": "U08TFFZGD16",
   "bronsa": "U08RLB9R6RK",


### PR DESCRIPTION
### Description

Updates team.json with my Github username under the DevEx team, adds my Github username to Slack ID mapping in github-slack-map.json.
