### PR TITLE
Make getState generic for createThunkAction

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.ts
@@ -79,12 +79,9 @@ const SAVE_APPLICATION_PERMISSIONS =
   "metabase-enterprise/general-permissions/data/SAVE_APPLICATION_PERMISSIONS";
 export const saveApplicationPermissions = createThunkAction(
   SAVE_APPLICATION_PERMISSIONS,
-  () => async (dispatch, getState) => {
-    // getState() is typed as the base State, which doesn't include the
-    // enterprise plugin slice this reducer registers at runtime.
-    const { applicationPermissions, applicationPermissionsRevision } = (
-      getState() as ApplicationPermissionsState
-    ).plugins.applicationPermissionsPlugin;
+  () => async (dispatch, getState: () => ApplicationPermissionsState) => {
+    const { applicationPermissions, applicationPermissionsRevision } =
+      getState().plugins.applicationPermissionsPlugin;
 
     const result = await runRtkEndpoint(
       {

--- a/frontend/src/metabase/redux/utils.ts
+++ b/frontend/src/metabase/redux/utils.ts
@@ -21,11 +21,15 @@ export function createThunkAction<
   TArgs extends any[],
   TResult,
   TActionType extends string,
+  TState = State,
 >(
   actionType: TActionType,
   thunkCreator: (
     ...args: TArgs
-  ) => (dispatch: ThunkDispatch<any, any, any>, getState: GetState) => TResult,
+  ) => (
+    dispatch: ThunkDispatch<any, any, any>,
+    getState: () => TState,
+  ) => TResult,
 ): (
   ...args: TArgs
 ) => (


### PR DESCRIPTION
### Description

Allows us to define the type for getState() when creating thunk actions. This means in the enterprise folder we can tell TS to expect a state with enterprise properties, removing the need to cast.  Should purely be linter based, no UX changes

### How to verify

Green CI

