### PR TITLE
Better validate-setting logging and test handling

### DIFF
--- a/e2e/support/helpers/e2e-token-helpers.ts
+++ b/e2e/support/helpers/e2e-token-helpers.ts
@@ -42,7 +42,7 @@ export const activateToken = (
     return cy.request({
       method: "PUT",
       url: "/api/setting/premium-embedding-token",
-      retryOnStatusCodeFailure: true,
+      failOnStatusCode: false,
       body: {
         value: token,
       },

--- a/e2e/support/helpers/e2e-token-helpers.ts
+++ b/e2e/support/helpers/e2e-token-helpers.ts
@@ -42,7 +42,7 @@ export const activateToken = (
     return cy.request({
       method: "PUT",
       url: "/api/setting/premium-embedding-token",
-      failOnStatusCode: false,
+      retryOnStatusCodeFailure: true,
       body: {
         value: token,
       },

--- a/enterprise/backend/test/metabase_enterprise/security_center/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/security_center/settings_test.clj
@@ -47,7 +47,7 @@
                               {:value [{:type "notification-recipient/user" :user_id (mt/user->id :crowberto) :details nil}]}))))
   (testing "requires premium feature"
     (mt/with-premium-features #{}
-      (mt/user-http-request :crowberto :put 500 "setting/security-center-email-recipients"
+      (mt/user-http-request :crowberto :put 402 "setting/security-center-email-recipients"
                             {:value [{:type "notification-recipient/user" :user_id (mt/user->id :crowberto) :details nil}]}))))
 
 (deftest security-center-slack-channel-test
@@ -73,5 +73,5 @@
                                 {:value "#security"})))))
   (testing "requires premium feature"
     (mt/with-premium-features #{}
-      (mt/user-http-request :crowberto :put 500 "setting/security-center-slack-channel"
+      (mt/user-http-request :crowberto :put 402 "setting/security-center-slack-channel"
                             {:value "#security"}))))

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -993,11 +993,19 @@
    (let [{:keys [setter enabled? feature] :as setting} (resolve-setting setting-definition-or-name)
          s-name (setting-name setting)]
      (when (and feature (not (has-feature? feature)))
-       (throw (ex-info (tru "Setting {0} is not enabled because feature {1} is not available" s-name feature) setting)))
+       (throw (ex-info (tru "Setting {0} is not enabled because feature {1} is not available" s-name feature)
+                       {:status-code 402
+                        :status      "error-premium-feature-not-available"
+                        :setting     s-name
+                        :feature     feature})))
      (when (and enabled? (not (enabled?)))
-       (throw (ex-info (tru "Setting {0} is not enabled" s-name) setting)))
+       (throw (ex-info (tru "Setting {0} is not enabled" s-name)
+                       {:status-code 400
+                        :setting     s-name})))
      (when-not (current-user-can-access-setting? setting)
-       (throw (ex-info (tru "You do not have access to the setting {0}" s-name) setting)))
+       (throw (ex-info (tru "You do not have access to the setting {0}" s-name)
+                       {:status-code 400
+                        :setting     s-name})))
      (when-not bypass-read-only?
        (when (= setter :none)
          (throw (UnsupportedOperationException. (tru "You cannot set {0}; it is a read-only setting." s-name))))))))

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -1223,6 +1223,22 @@
            :feature    :test-feature
            :encryption :when-encryption-key-set)))))
 
+(deftest validate-settable!-ex-data-test
+  (testing "Settings that can't be written report a status code, so the API doesn't surface them as a 500"
+    (testing "premium feature not available"
+      (mt/with-premium-features #{}
+        (is (= {:status-code 402
+                :status      "error-premium-feature-not-available"
+                :setting     "test-feature-setting"
+                :feature     :test-feature}
+               (try (test-feature-setting! "custom")
+                    (catch ExceptionInfo e (ex-data e)))))))
+    (testing ":enabled? returns false"
+      (is (= {:status-code 400
+              :setting     "test-enabled-setting-default"}
+             (try (test-enabled-setting-default! "custom")
+                  (catch ExceptionInfo e (ex-data e))))))))
+
 ;;; ------------------------------------------------- Misc tests -------------------------------------------------------
 
 (defsetting ^:private test-no-default-setting

--- a/test/metabase/settings_rest/api_test.clj
+++ b/test/metabase/settings_rest/api_test.clj
@@ -37,6 +37,13 @@
   :visibility :settings-manager
   :encryption :when-encryption-key-set)
 
+(defsetting test-api-setting-premium-feature
+  (deferred-tru "Setting gated behind a premium feature. This only shows up in dev.")
+  :visibility :admin
+  :type       :boolean
+  :default    false
+  :feature    :test-feature)
+
 (defsetting test-admin-write-authed-read-visibility
   (deferred-tru "Setting to test the `:admin-write-authed-read` visibility level. This only shows up in dev.")
   :visibility :admin-write-authed-read
@@ -198,6 +205,21 @@
     (testing "Check that a generic 403 error is returned if a non-superuser tries to set a Setting that doesn't exist"
       (is (= "You don't have permissions to do that."
              (mt/user-http-request :rasta :put 403 "setting/bad-setting" {:value "NICE!"}))))))
+
+(deftest update-setting-without-premium-feature-test
+  (testing "PUT /api/setting/:key for a setting whose premium feature is unavailable returns a 402, not a 500"
+    (mt/with-premium-features #{}
+      (doseq [[endpoint body] [["setting/test-api-setting-premium-feature" {:value true}]
+                               ["setting"                                  {:test-api-setting-premium-feature true}]]]
+        (testing (str "PUT /api/" endpoint)
+          (let [response (mt/user-http-request :crowberto :put 402 endpoint body)]
+            (is (= "Setting test-api-setting-premium-feature is not enabled because feature :test-feature is not available"
+                   (:message response)))
+            (testing "the setting definition is not leaked into the response body"
+              (is (not-any? (set (keys response)) [:description :getter :setter :default])))))))
+    (testing "turning the setting off is rejected the same way, rather than 500ing"
+      (mt/with-premium-features #{}
+        (mt/user-http-request :crowberto :put 402 "setting/test-api-setting-premium-feature" {:value false})))))
 
 (deftest fetch-sensitive-setting-test
   (testing "Sensitive settings should always come back obfuscated"


### PR DESCRIPTION
### Description

We have tests failing with `Setting use-tenants is not enabled because feature :tenants is not available` as a 500 error, and not helpful error messages.

This PR provides a better status code in the error, and a map of the setting info instead of the non-printable settings object itself.

Also, the tests that are failing seem like they should have `use-tenants` which makes me think the token-setting is hitting a network flake. So I changed cypress to use `retryOnStatusCodeFailure`

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
