### PR TITLE
Run master's ci-conductor sources on release branches

### DIFF
--- a/.github/actions/prepare-ci-conductor/action.yml
+++ b/.github/actions/prepare-ci-conductor/action.yml
@@ -1,0 +1,52 @@
+name: Prepare CI Conductor
+description: >-
+  Make the ci-conductor sources runnable in the workspace.
+  Unless the checkout is headed for master, they are overlaid from master, so every
+  branch runs the latest scripts while its workflow wiring stays branch-historical.
+
+runs:
+  using: composite
+  steps:
+    - name: Detect bun
+      id: bun
+      shell: bash
+      run: |
+        if command -v bun >/dev/null; then
+          echo "present=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "present=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Install bun
+      if: steps.bun.outputs.present != 'true'
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      with:
+        bun-version-file: "package.json"
+        token: ${{ github.token }}
+
+    # Anything headed for master runs master's own sources, so a PR can test its own changes.
+    - name: Fetch ci-conductor sources from master
+      if: ${{ github.base_ref != 'master' && github.ref_name != 'master' }}
+      uses: actions/checkout@v6
+      with:
+        repository: metabase/metabase
+        ref: master
+        path: .ci-conductor-master
+        persist-credentials: false
+        sparse-checkout-cone-mode: false
+        sparse-checkout: |
+          release/ci-conductor
+          e2e/support/ci_conductor.ts
+
+    # e2e/support/config.js and e2e/support/ci_conductor.ts resolve these by relative
+    # path at bundle time, so the sources have to land where the branch expects them.
+    - name: Overlay ci-conductor sources from master
+      if: ${{ github.base_ref != 'master' && github.ref_name != 'master' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        rm -rf release/ci-conductor
+        mv .ci-conductor-master/release/ci-conductor release/ci-conductor
+        mv .ci-conductor-master/e2e/support/ci_conductor.ts e2e/support/ci_conductor.ts
+        rm -rf .ci-conductor-master
+        echo "Overlaid ci-conductor sources from master."

--- a/.github/actions/prepare-cypress/action.yml
+++ b/.github/actions/prepare-cypress/action.yml
@@ -15,6 +15,10 @@ outputs:
 runs:
   using: "composite"
   steps:
+    # e2e/support/config.js imports the reporter, so it has to be in place before Cypress bundles.
+    - name: Prepare CI Conductor
+      uses: ./.github/actions/prepare-ci-conductor
+
     - name: Install Chrome v144
       uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
       with:

--- a/.github/actions/quarantine-gate/action.yml
+++ b/.github/actions/quarantine-gate/action.yml
@@ -22,21 +22,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Detect bun
-      id: bun
-      shell: bash
-      run: |
-        if command -v bun >/dev/null; then
-          echo "present=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "present=false" >> "$GITHUB_OUTPUT"
-        fi
-    - name: Install bun
-      if: steps.bun.outputs.present != 'true'
-      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-      with:
-        bun-version-file: "package.json"
-        token: ${{ github.token }}
+    - name: Prepare CI Conductor
+      uses: ./.github/actions/prepare-ci-conductor
     - name: Check failures against the quarantine list
       shell: bash
       env:

--- a/.github/actions/report-failures-to-ci-conductor/action.yml
+++ b/.github/actions/report-failures-to-ci-conductor/action.yml
@@ -15,21 +15,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Detect bun
-      id: bun
-      shell: bash
-      run: |
-        if command -v bun >/dev/null; then
-          echo "present=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "present=false" >> "$GITHUB_OUTPUT"
-        fi
-    - name: Install bun
-      if: steps.bun.outputs.present != 'true'
-      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-      with:
-        bun-version-file: 'package.json'
-        token: ${{ github.token }}
+    - name: Prepare CI Conductor
+      uses: ./.github/actions/prepare-ci-conductor
     - name: Report failed tests to ci-conductor
       shell: bash
       env:


### PR DESCRIPTION
Resolves DEV-2362

## Summary

The ci-conductor scripts are shared CI infrastructure: every supported release branch runs them, and they keep evolving on master. A copy committed to a branch goes stale, and syncing six branches by hand on every change does not scale.

Add a prepare-ci-conductor action that overlays release/ci-conductor and e2e/support/ci_conductor.ts from master, so a release branch runs the current scripts while its workflow wiring stays branch-historical. Anything headed for master uses its own sources, so a PR can still test its own changes.

quarantine-gate and report-failures-to-ci-conductor delegate their bun setup to it. prepare-cypress calls it too, because e2e/support/config.js imports the reporter at Cypress bundle time and it has to be in place before the run starts.

