### PR TITLE
Show all connected parameters when setting up a subscription

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/AddEditSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/AddEditSidebar.tsx
@@ -1,7 +1,7 @@
 import { connect } from "metabase/redux";
 import type { State } from "metabase/redux/store";
 
-import { getParameters, getTabHiddenParameterSlugs } from "../../../selectors";
+import { getHiddenParameterSlugs, getParameters } from "../../../selectors";
 
 import { AddEditEmailSidebar as AddEditEmailSidebarComponent } from "./AddEditEmailSidebar";
 import { AddEditSlackSidebar as AddEditSlackSidebarComponent } from "./AddEditSlackSidebar";
@@ -9,7 +9,7 @@ import { AddEditSlackSidebar as AddEditSlackSidebarComponent } from "./AddEditSl
 const mapStateToProps = (state: State) => {
   return {
     parameters: getParameters(state),
-    hiddenParameters: getTabHiddenParameterSlugs(state),
+    hiddenParameters: getHiddenParameterSlugs(state),
   };
 };
 

--- a/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/tests/premium.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/tests/premium.unit.spec.ts
@@ -4,6 +4,7 @@ import { screen, within } from "__support__/ui";
 import {
   createMockCard,
   createMockDashboardCard,
+  createMockDashboardTab,
   createMockParameter,
 } from "metabase-types/api/mocks";
 
@@ -197,6 +198,95 @@ describe("DashboardSubscriptionsSidebar Premium Features", () => {
       expect(
         within(subscriptionParametersSection).queryByLabelText("Title"),
       ).not.toBeInTheDocument();
+    });
+
+    it(`${channel} channel: should show parameters connected on other tabs, since a subscription renders every tab`, async () => {
+      const firstTab = createMockDashboardTab({ id: 1, name: "Tab 1" });
+      const secondTab = createMockDashboardTab({ id: 2, name: "Tab 2" });
+
+      const totalParameter = createMockParameter({
+        id: "1",
+        type: "number/=",
+        slug: "total",
+        name: "Total",
+      });
+      const titleParameter = createMockParameter({
+        id: "2",
+        type: "string/contains",
+        slug: "title",
+        name: "Title",
+      });
+      const mockCardNumeric = createMockCard({
+        id: 1,
+        name: "Numeric Question",
+        display: "table",
+        parameters: [totalParameter],
+      });
+      const mockCardString = createMockCard({
+        id: 2,
+        name: "String Question",
+        display: "pie",
+        parameters: [titleParameter],
+      });
+
+      setup({
+        isAdmin: true,
+        [channel]: true,
+        tokenFeatures,
+        enterprisePlugins: ["sharing"],
+        parameters: [totalParameter, titleParameter],
+        tabs: [firstTab, secondTab],
+        // Viewing the first tab, while "Title" is only wired to a card on the second tab.
+        selectedTabId: firstTab.id,
+        dashcards: [
+          createMockDashboardCard({
+            id: mockCardNumeric.id,
+            dashboard_tab_id: firstTab.id,
+            card: mockCardNumeric,
+            card_id: mockCardNumeric.id,
+            parameter_mappings: [
+              {
+                card_id: mockCardNumeric.id,
+                parameter_id: totalParameter.id,
+                target: ["variable", ["template-tag", totalParameter.slug]],
+              },
+            ],
+          }),
+          createMockDashboardCard({
+            id: mockCardString.id,
+            dashboard_tab_id: secondTab.id,
+            card: mockCardString,
+            card_id: mockCardString.id,
+            parameter_mappings: [
+              {
+                card_id: mockCardString.id,
+                parameter_id: titleParameter.id,
+                target: [
+                  "dimension",
+                  ["field", titleParameter.slug, { "base-type": "type/Text" }],
+                ],
+              },
+            ],
+          }),
+        ],
+      });
+
+      await userEvent.click(await screen.findByText(buttonText));
+
+      screen.getByText(headerText);
+
+      const subscriptionParametersSection = screen.getByTestId(
+        "subscription-parameters-section",
+      );
+
+      expect(subscriptionParametersSection).toBeInTheDocument();
+
+      expect(
+        await within(subscriptionParametersSection).findByLabelText("Total"),
+      ).toBeInTheDocument();
+      expect(
+        await within(subscriptionParametersSection).findByLabelText("Title"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/tests/setup.tsx
@@ -10,6 +10,7 @@ import { renderWithProviders } from "__support__/ui";
 import { getNextId } from "__support__/utils";
 import { MockDashboardContext } from "metabase/dashboard/context/mock-context";
 import { isEmbeddingSdk as mockIsEmbeddingSdk } from "metabase/embedding-sdk/config";
+import type { SelectedTabId } from "metabase/redux/store";
 import {
   createMockDashboardState,
   createMockState,
@@ -19,6 +20,7 @@ import type {
   Dashboard,
   DashboardCard,
   DashboardSubscription,
+  DashboardTab,
   TokenFeatures,
 } from "metabase-types/api";
 import {
@@ -62,9 +64,11 @@ const defaultParameters = [
 function createDashboardState(
   dashboard: Dashboard,
   dashcards: DashboardCard[],
+  selectedTabId: SelectedTabId = null,
 ) {
   return createMockDashboardState({
     dashboardId: dashboard.id,
+    selectedTabId,
     dashcards: dashcards.reduce(
       (acc, card) => {
         acc[card.id] = card;
@@ -89,6 +93,8 @@ type SetupOpts = {
   isAdmin?: boolean;
   dashcards?: DashboardCard[];
   parameters?: UiParameter[];
+  tabs?: DashboardTab[];
+  selectedTabId?: SelectedTabId;
   isEmbeddingSdk?: boolean;
   setSharing?: (sharing: boolean) => void;
   pulses?: (Partial<DashboardSubscription> & { id: number })[];
@@ -107,6 +113,8 @@ export function setup({
   isAdmin = false,
   dashcards = defaultDashcards,
   parameters = defaultParameters,
+  tabs,
+  selectedTabId = null,
   isEmbeddingSdk = false,
   setSharing,
   pulses = [],
@@ -116,6 +124,7 @@ export function setup({
   const dashboard = createMockDashboard({
     dashcards,
     parameters,
+    tabs,
   });
 
   const channelData: {
@@ -206,7 +215,7 @@ export function setup({
           last_name: currentUser?.lastName,
           is_superuser: isAdmin,
         }),
-        dashboard: createDashboardState(dashboard, dashcards),
+        dashboard: createDashboardState(dashboard, dashcards, selectedTabId),
       }),
     },
   );

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -638,21 +638,6 @@ function getSdkInitialDashboardTabId(
   return dashboard.tabs?.[0]?.id ?? null;
 }
 
-export const getCurrentTabDashcards = createSelector(
-  [getDashboardComplete, getSelectedTabId],
-  (dashboard, selectedTabId) => {
-    if (!dashboard || !Array.isArray(dashboard?.dashcards)) {
-      return [];
-    }
-    if (!selectedTabId) {
-      return dashboard.dashcards;
-    }
-    return dashboard.dashcards.filter(
-      (dc: DashboardCard) => dc.dashboard_tab_id === selectedTabId,
-    );
-  },
-);
-
 export const getHiddenParameterSlugs = createSelector(
   [getDashboardComplete, getParameters, getIsEditing],
   (dashboard, parameters, isEditing) => {
@@ -667,23 +652,6 @@ export const getHiddenParameterSlugs = createSelector(
     );
 
     return hiddenParameters.map((parameter) => parameter.slug).join(",");
-  },
-);
-
-export const getTabHiddenParameterSlugs = createSelector(
-  [getParameters, getCurrentTabDashcards, getIsEditing],
-  (parameters, currentTabDashcards, isEditing) => {
-    if (isEditing) {
-      // All filters should be visible in edit mode
-      return undefined;
-    }
-
-    const currentTabParameterIds = getMappedParametersIds(currentTabDashcards);
-    const hiddenParameters = parameters.filter(
-      (parameter) => !currentTabParameterIds.includes(parameter.id),
-    );
-
-    return hiddenParameters.map((p) => p.slug).join(",");
   },
 );
 


### PR DESCRIPTION
### Description

Updates The Email and Slack subscription sidebars to show all connected parameters for a dashboard, rather than just the parameters that are connected to cards on the tab that is currently being displayed. This change also produced some dead code that was cleaned up

### How to verify

1. Set up a dashboard with a couple of different parameters, connected to one card each
2. move one of the cards to another tab
3. in the dashboard header, you should see that one of the parameters is not there anymore
4. Go to create a subscription
5. It should show you all dashboard parameters

### Demo


https://github.com/user-attachments/assets/f181247d-27ac-4f09-ac9d-018d86d60c7f



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
