### PR TITLE
Add missing monthsListControl style to DateInput

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/DateInput/DateInput.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/DateInput/DateInput.config.tsx
@@ -18,6 +18,7 @@ export const dateInputOverrides = {
       monthsList: Styles.monthsList,
       monthsListRow: Styles.row,
       monthsListCell: Styles.cell,
+      monthsListControl: Styles.monthsListControl,
       yearsList: Styles.yearsList,
       yearsListRow: Styles.row,
       yearsListCell: Styles.cell,


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #77094
### Description

Small PR to add a missing class to the DateInput component

### How to verify

1. Go to a collection and create an event
2. switch to dark mode, open the date picker, click on the month
3. You should still see things

### Demo


https://github.com/user-attachments/assets/a555c5e6-85d0-48ca-b235-8310c774a6df



### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
