### PR TITLE
fix: metabot ai settings

### DIFF
--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
@@ -2420,9 +2420,9 @@ function setupDivergentReadsBackend({
   fetchMock.removeRoutes();
   fetchMock.clearHistory();
 
-  const backend = {
+  const backend: { apiKeySaved: boolean; providerRow: string | null } = {
     apiKeySaved: false,
-    providerRow: null as string | null,
+    providerRow: null,
   };
 
   const providerValue = () => backend.providerRow ?? DEFAULT_PROVIDER_VALUE;
@@ -2476,11 +2476,9 @@ function setupDivergentReadsBackend({
   }));
 
   fetchMock.put("path:/api/metabot/settings", (call) => {
-    const body = JSON.parse(String(call.options?.body ?? "{}")) as {
-      provider: MetabotProvider;
-      model?: string;
-      "api-key"?: string | null;
-    };
+    const body: MetabotSettingsUpdateBody = JSON.parse(
+      String(call.options?.body ?? "{}"),
+    );
     const currentProviderFromGetter = providerValue().split("/")[0];
     const providerChanged = currentProviderFromGetter !== body.provider;
 

--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
@@ -2406,3 +2406,184 @@ describe("AIProviderSettingsSection", () => {
     });
   });
 });
+
+const DEFAULT_PROVIDER_VALUE = "anthropic/claude-sonnet-4-6";
+const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6";
+const DIVERGENT_MODELS = [
+  { id: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6" },
+  { id: "claude-sonnet-5", display_name: "Claude Sonnet 5" },
+];
+
+function setupDivergentReadsBackend({
+  delayAdminSettingDetailsRefetch = false,
+}: { delayAdminSettingDetailsRefetch?: boolean } = {}) {
+  fetchMock.removeRoutes();
+  fetchMock.clearHistory();
+
+  const backend = {
+    apiKeySaved: false,
+    providerRow: null as string | null,
+  };
+
+  const providerValue = () => backend.providerRow ?? DEFAULT_PROVIDER_VALUE;
+  const isConfigured = () => backend.apiKeySaved;
+
+  const sessionPropertiesResponse = () =>
+    createMockSettings({
+      "llm-metabot-provider": providerValue(),
+      "llm-metabot-configured?": isConfigured(),
+    });
+
+  const disconnectedSnapshot = sessionPropertiesResponse();
+  let pendingStaleSessionPropertiesReads = 0;
+
+  fetchMock.get("path:/api/session/properties", () => {
+    if (pendingStaleSessionPropertiesReads > 0) {
+      pendingStaleSessionPropertiesReads -= 1;
+      return disconnectedSnapshot;
+    }
+    return sessionPropertiesResponse();
+  });
+
+  const adminSettingDetailsResponse = () => [
+    createMockSettingDefinition({
+      key: "llm-metabot-provider",
+      value: backend.providerRow ?? undefined,
+    }),
+    createMockSettingDefinition({
+      key: "llm-anthropic-api-key",
+      value: backend.apiKeySaved ? "**********ey" : undefined,
+    }),
+  ];
+
+  const detailsRefetchDeferred = defer<void>();
+  let adminSettingDetailsRequestCount = 0;
+
+  fetchMock.get("path:/api/setting", async () => {
+    adminSettingDetailsRequestCount += 1;
+    if (
+      delayAdminSettingDetailsRefetch &&
+      adminSettingDetailsRequestCount > 1
+    ) {
+      await detailsRefetchDeferred.promise;
+    }
+    return adminSettingDetailsResponse();
+  });
+
+  fetchMock.get("path:/api/metabot/settings", () => ({
+    value: providerValue(),
+    models: backend.apiKeySaved ? DIVERGENT_MODELS : [],
+  }));
+
+  fetchMock.put("path:/api/metabot/settings", (call) => {
+    const body = JSON.parse(String(call.options?.body ?? "{}")) as {
+      provider: MetabotProvider;
+      model?: string;
+      "api-key"?: string | null;
+    };
+    const currentProviderFromGetter = providerValue().split("/")[0];
+    const providerChanged = currentProviderFromGetter !== body.provider;
+
+    if ("api-key" in body) {
+      backend.apiKeySaved = Boolean(body["api-key"]);
+    }
+
+    const model =
+      body.model ?? (providerChanged ? DEFAULT_ANTHROPIC_MODEL : null);
+    if (model) {
+      backend.providerRow = `${body.provider}/${model}`;
+    }
+
+    return { value: providerValue(), models: DIVERGENT_MODELS };
+  });
+
+  renderWithProviders(
+    <Route path="/admin/metabot*" component={AIProviderSettingsSection} />,
+    {
+      withRouter: true,
+      initialRoute: "/admin/metabot",
+      storeInitialState: {
+        settings: mockSettings(disconnectedSnapshot),
+        currentUser: createMockUser({ is_superuser: true }),
+      },
+    },
+  );
+
+  return {
+    backend,
+    releaseAdminSettingDetailsRefetch: () => detailsRefetchDeferred.resolve(),
+    markNextSessionPropertiesReadStale: () => {
+      pendingStaleSessionPropertiesReads += 1;
+    },
+  };
+}
+
+async function connectToAnthropicFromScratch() {
+  await screen.findByText("Connect to an AI provider");
+  await userEvent.click(await screen.findByLabelText("Provider"));
+  await userEvent.click(
+    await screen.findByRole("option", { name: "Anthropic" }),
+  );
+  await userEvent.type(
+    await screen.findByLabelText("API key"),
+    "sk-ant-test-key",
+  );
+  await userEvent.click(screen.getByRole("button", { name: "Connect" }));
+}
+
+describe("AIProviderSettingsSection with divergent settings reads", () => {
+  it("keeps the entered API key and offers the model picker while the setting-details refetch lags behind session-properties", async () => {
+    const { releaseAdminSettingDetailsRefetch } = setupDivergentReadsBackend({
+      delayAdminSettingDetailsRefetch: true,
+    });
+
+    await connectToAnthropicFromScratch();
+
+    expect(await screen.findByLabelText("Model")).toBeInTheDocument();
+    expect(screen.getByLabelText("API key")).toHaveValue("sk-ant-test-key");
+
+    await userEvent.click(screen.getByLabelText("Model"));
+    expect(
+      await screen.findByRole("option", { name: "Claude Sonnet 5" }),
+    ).toBeInTheDocument();
+    await userEvent.keyboard("{Escape}");
+
+    releaseAdminSettingDetailsRefetch();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("API key")).toHaveValue("**********ey");
+    });
+    expect(
+      await screen.findByText("Connected to Anthropic"),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: "Disconnect" }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the provider and model selection when a stale node serves the session-properties refetch after picking a model", async () => {
+    const { backend, markNextSessionPropertiesReadStale } =
+      setupDivergentReadsBackend();
+
+    await connectToAnthropicFromScratch();
+    await screen.findByText("Connected to Anthropic");
+    await waitFor(() => {
+      expect(screen.getByLabelText("Model")).toHaveValue("Claude Sonnet 4.6");
+    });
+
+    markNextSessionPropertiesReadStale();
+
+    await userEvent.click(screen.getByLabelText("Model"));
+    await userEvent.click(
+      await screen.findByRole("option", { name: "Claude Sonnet 5" }),
+    );
+
+    await waitFor(() => {
+      expect(backend.providerRow).toBe("anthropic/claude-sonnet-5");
+    });
+
+    expect(screen.getByLabelText("API key")).toBeInTheDocument();
+    expect(screen.getByLabelText("Model")).toHaveValue("Claude Sonnet 5");
+    expect(screen.getByLabelText("Provider")).toHaveValue("Anthropic");
+  });
+});

--- a/frontend/src/metabase/api/metabot.ts
+++ b/frontend/src/metabase/api/metabot.ts
@@ -40,7 +40,7 @@ export const metabotApi = Api.injectEndpoints({
         url: "/api/metabot/settings",
         params: { provider },
       }),
-      providesTags: () => [listTag("llm-models"), "session-properties"],
+      providesTags: () => [listTag("llm-models")],
     }),
     updateMetabotSettings: builder.mutation<
       MetabotSettingsResponse,
@@ -52,7 +52,7 @@ export const metabotApi = Api.injectEndpoints({
         body,
       }),
       invalidatesTags: (_, error) =>
-        invalidateTags(error, [listTag("llm-models"), "session-properties"]),
+        invalidateTags(error, ["session-properties"]),
     }),
     updateMetabot: builder.mutation<
       MetabotInfo,

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationForm.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationForm.tsx
@@ -64,7 +64,7 @@ export function AIProviderConfigurationForm({
   const isCurrentConfigured = connectedProvider === provider && isConfigured;
 
   useEffect(() => {
-    if (isModal) {
+    if (isModal || !connectedProvider) {
       return;
     }
     setProvider(connectedProvider);
@@ -132,6 +132,8 @@ export function AIProviderConfigurationForm({
           icon: "warning",
           toastColor: "feedback-negative",
         });
+      } else {
+        setProvider(undefined);
       }
     } catch (error) {
       const message = getErrorMessage(

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/ApiKeyProviderFields.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/ApiKeyProviderFields.tsx
@@ -47,10 +47,8 @@ export const ApiKeyProviderFields = ({
   const onConnect = async () => {
     await updateMetabotSettings({
       provider: selectedProvider,
-      "api-key": localApiKey || null,
+      ...(localApiKey !== null && { "api-key": localApiKey || null }),
     }).unwrap();
-
-    setLocalApiKey(null);
   };
 
   const hasDirtyApiKey = localApiKey !== null;
@@ -58,15 +56,23 @@ export const ApiKeyProviderFields = ({
     !isCurrentConfigured || hasDirtyApiKey ? onConnect : null;
   const { isMutating } = useAIProviderConfigurationContext(connectHandler);
 
-  const needsApiKey = !hasConfiguredSettingValue(apiKeySetting);
+  const hasVerifiedApiKey = updateMetabotSettingsResult.isSuccess;
+  const needsApiKey =
+    !hasConfiguredSettingValue(apiKeySetting) && !hasVerifiedApiKey;
   const { modelsQuery, credentialsError: savedCredentialsError } =
     useProviderModelsQuery(selectedProvider, { skip: needsApiKey });
   const credentialsError = hasDirtyApiKey ? undefined : savedCredentialsError;
 
+  const queriedModels = modelsQuery.currentData?.models ?? [];
+  const verifiedModels = updateMetabotSettingsResult.data?.models ?? [];
+  const models = queriedModels.length > 0 ? queriedModels : verifiedModels;
+
   const apiKeySettingValue = apiKeySetting?.value;
 
   useEffect(() => {
-    setLocalApiKey(null);
+    if (apiKeySettingValue) {
+      setLocalApiKey(null);
+    }
   }, [apiKeySettingValue]);
 
   const handleApiKeyChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -102,8 +108,8 @@ export const ApiKeyProviderFields = ({
         <ProviderModelPicker
           provider={selectedProvider}
           connectedModel={connectedModel}
-          models={modelsQuery.currentData?.models ?? []}
-          isLoading={modelsQuery.isLoading}
+          models={models}
+          isLoading={modelsQuery.isLoading && models.length === 0}
           loadError={modelsQuery.error}
           disabled={isEnvSetting || isMutating}
         />

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/ProviderModelPicker.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/ProviderModelPicker.tsx
@@ -52,7 +52,9 @@ export const ProviderModelPicker = ({
   const [sendToast] = useToast();
 
   useEffect(() => {
-    setModel(connectedModel);
+    if (connectedModel) {
+      setModel(connectedModel);
+    }
   }, [connectedModel]);
 
   const modelOptions = useMemo(() => getLlmModelOptions(models), [models]);


### PR DESCRIPTION
Closes [BOT-1837: Bug: not able to select Sonnet 5 in the AI feature connect page](https://linear.app/metabase/issue/BOT-1837/bug-not-able-to-select-sonnet-5-in-the-ai-feature-connect-page)

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
