### PR TITLE
feat(workspaces): user-named target_branch at create + 409 collision guard

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/workspaces/api/workspace_manager.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api/workspace_manager.clj
@@ -33,6 +33,9 @@
   [:map {:closed true}
    [:name         ms/NonBlankString]
    [:database_ids [:sequential {:min 1} ::lib.schema.id/database]]
+   ;; export branch; omitted = auto-named ws-<slug>-<id>. 409 when another
+   ;; workspace already exports to the same branch.
+   [:target_branch {:optional true} ms/NonBlankString]
    ;; when true, also mint the agent api-key, build config.yml, and spawn the child
    ;; instance via Harbormaster (blocking). Off by default so the config-download flow
    ;; and local rigs keep working without HM.

--- a/enterprise/backend/src/metabase_enterprise/workspaces/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/core.clj
@@ -188,6 +188,11 @@
     (throw (ex-info "Workspaces are not enabled for this database"
                     {:status-code 400 :database_id (:id database)}))))
 
+(defn- assert-target-branch-available [target-branch]
+  (when (t2/exists? :model/Workspace :target_branch target-branch)
+    (throw (ex-info "Another workspace already exports to this branch"
+                    {:status-code 409 :target_branch target-branch}))))
+
 ;;; ------------------------------------- Manager-side reads --------------------------------------------------
 
 (defn get-workspace
@@ -212,29 +217,35 @@
    single transaction, so a provisioning failure rolls back the workspace and its
    database rows. Returns the created workspace, hydrated.
 
-   Git binding: the export branch (`:target_branch`) is named `ws-<slug>-<id>` here
-   at create — the id suffix keeps branches distinct when two workspace names
-   slugify to the same string (names are not unique). `:base_branch` (what the
-   child's initial import will read from, once wired — GHY-4121) records the
-   parent's `remote-sync-branch` at create; deliberately not caller-supplied, so a
+   Git binding: the export branch (`:target_branch`) defaults to `ws-<slug>-<id>` —
+   the id suffix keeps branches distinct when two workspace names slugify to the
+   same string (names are not unique). A caller-supplied `:target_branch` is used
+   verbatim; it 409s when another workspace already exports to that branch (the
+   suffix can't protect user-chosen names). `:base_branch` (what the child's
+   initial import will read from, once wired — GHY-4121) records the parent's
+   `remote-sync-branch` at create; deliberately not caller-supplied, so a
    workspace can never be based on another workspace's target branch (no stacked
    PRs — GHY-4121 has the reasoning). Snapshot semantics: changing the parent
    setting later never affects existing workspaces. Nil when the parent has no
    git remote configured."
-  [{:keys [name creator_id database_ids]}]
+  [{:keys [name creator_id database_ids target_branch]}]
   (let [databases (mapv (fn [db-id]
                           (let [database (assert-database-exists db-id)]
                             (assert-database-eligible-for-workspaces database)
                             {:database_id   db-id
                              :input_schemas (workspace-database/database-input-schemas database)}))
                         database_ids)]
+    (when target_branch
+      (assert-target-branch-available target_branch))
     (t2/with-transaction [_conn]
-      (let [ws (workspace/create-workspace! {:name        name
-                                             :creator_id  creator_id
-                                             :databases   databases
-                                             :base_branch (remote-sync/remote-sync-branch)})]
-        (t2/update! :model/Workspace :id (:id ws)
-                    {:target_branch (str "ws-" (u/slugify name) "-" (:id ws))})
+      (let [ws (workspace/create-workspace! {:name          name
+                                             :creator_id    creator_id
+                                             :databases     databases
+                                             :base_branch   (remote-sync/remote-sync-branch)
+                                             :target_branch target_branch})]
+        (when-not target_branch
+          (t2/update! :model/Workspace :id (:id ws)
+                      {:target_branch (str "ws-" (u/slugify name) "-" (:id ws))}))
         (doseq [{wsd-id :id} (:databases ws)]
           (provisioning/provision-single! wsd-id))
         (workspace/get-workspace (:id ws))))))

--- a/enterprise/backend/test/metabase_enterprise/workspaces/api/workspace_manager_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api/workspace_manager_test.clj
@@ -97,6 +97,31 @@
             (mt/user-http-request :crowberto :post 400 "ee/workspace-manager/"
                                   {:name "Nope" :database_ids []})))))))
 
+(deftest create-workspace-user-named-target-branch-test
+  (testing "POST / with target_branch uses it verbatim; a second workspace targeting the same branch 409s"
+    (mt/with-temp [:model/Database {db-id :id} {:engine   :postgres
+                                                :details  {}
+                                                :settings {:database-enable-workspaces true}}]
+      (mt/with-model-cleanup [:model/Workspace]
+        (with-redefs [provisioning/dispatching-provisioner (stub-provisioner)]
+          (is (=? {:target_branch "my-feature-branch"}
+                  (mt/user-http-request :crowberto :post 200 "ee/workspace-manager/"
+                                        {:name          "Named Branch"
+                                         :database_ids  [db-id]
+                                         :target_branch "my-feature-branch"})))
+          (testing "same branch again -> 409"
+            (mt/user-http-request :crowberto :post 409 "ee/workspace-manager/"
+                                  {:name          "Named Branch Two"
+                                   :database_ids  [db-id]
+                                   :target_branch "my-feature-branch"}))
+          (testing "collision with an auto-named branch also 409s"
+            (let [{:keys [target_branch]} (mt/user-http-request :crowberto :post 200 "ee/workspace-manager/"
+                                                                {:name "Auto Named" :database_ids [db-id]})]
+              (mt/user-http-request :crowberto :post 409 "ee/workspace-manager/"
+                                    {:name          "Squatter"
+                                     :database_ids  [db-id]
+                                     :target_branch target_branch}))))))))
+
 (deftest metadata-export-test
   (testing "GET /:id/metadata/export streams metadata scoped to the workspace's databases + input"
     (mt/with-temp [:model/Database {db-id :id db-name :name} {:engine :postgres :details {}}


### PR DESCRIPTION
## What this does

Resolves GHY-4122. Stacked on #77118 — targets that branch, rebase onto master after it merges.

Users want `target: "my-feature-branch"` at workspace create instead of the auto-generated name. This adds an optional `target_branch` param to `POST /api/ee/workspace-manager`:

- **Supplied**: used verbatim. A user-chosen name loses the `ws-<slug>-<id>` suffix's built-in uniqueness, so create **409s** when any other workspace already exports to that branch — two workspaces pushing one branch clobber each other's exports. The guard also catches squatting on an existing auto-named branch.
- **Omitted**: unchanged — auto-named `ws-<slug>-<id>` post-insert.

One `t2/exists?` check, no migration. Race window between check and insert is accepted for v0 (no unique index; same exposure as workspace names today).

## Validation

API-level tests: verbatim use, duplicate 409, auto-name collision 409. Full `workspace-manager` + `config` test namespaces green.