### PR TITLE
Float the action toolbar pinned to the bottom of the chart canvas

### DIFF
--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/ActionToolbar.module.css
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/ActionToolbar.module.css
@@ -1,4 +1,8 @@
 .toolbar {
+  /* float above the charts, pinned to the bottom of the chart canvas */
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
   align-self: center;
   box-shadow: var(--mantine-shadow-xs);
 }

--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/ActionToolbar.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/ActionToolbar.tsx
@@ -209,6 +209,7 @@ export function ActionToolbar({
   return (
     <Group
       gap="xs"
+      bg="background-primary"
       bd="1px solid border"
       bdrs="lg"
       px="sm"

--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.module.css
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.module.css
@@ -17,6 +17,8 @@
   grid-auto-rows: minmax(10rem, auto);
   /* never let the grid itself be widened past its container */
   min-width: 0;
+  /* contain leaflet pane z-indexes (up to ~700) so the sticky toolbar floats above maps */
+  isolation: isolate;
 }
 
 /*


### PR DESCRIPTION
### Description

Fixes [UXW-4759](https://linear.app/metabase/issue/UXW-4759/make-the-toolbar-fixed-and-float-on-top-of-the-visualizations)

The star/comment/hide pill now floats pinned to the bottom of the chart canvas, so it stays visible while tall chart stacks scroll beneath it. Pages that fit the canvas look the same as before.

- Leaflet map panes paint above ordinary content, so the chart grid now contains their stacking to keep the pill on top of maps.

### How to verify

- [ ] Open a research page whose charts overflow the canvas (e.g. stacked map small multiples, which appear when the metric's table has segments) and scroll: the pill stays pinned at the canvas bottom, floating above the charts.
- [ ] Open a page that fits the canvas: the pill sits below the charts as before.

### Demo


https://github.com/user-attachments/assets/f2a031f5-8620-461f-94d9-b964b40a5ab5

