### PR TITLE
GDGT-2833 Add per-version download link to Security Center advisories

### DIFF
--- a/e2e/support/helpers/api/seedSecurityAdvisories.ts
+++ b/e2e/support/helpers/api/seedSecurityAdvisories.ts
@@ -6,6 +6,7 @@ export type SecurityAdvisorySpec = {
   remediation: string;
   advisory_url?: string | null;
   affected_versions: { min: string; fixed: string }[];
+  download_jar_urls?: { version: string; url: string }[];
   matching_query?: Record<string, string> | null;
   match_status: "unknown" | "active" | "resolved" | "not_affected" | "error";
   published_at: string;

--- a/e2e/test/scenarios/admin-2/security-center.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/security-center.cy.spec.ts
@@ -218,4 +218,50 @@ describe("scenarios > admin > security center", { tags: "@EE" }, () => {
     cy.findByTestId("sync-advisories").click();
     cy.wait("@sync");
   });
+
+  describe("per-version download link", () => {
+    const DOWNLOADABLE_ADVISORY = {
+      advisory_id: "TEST-DL",
+      severity: "critical",
+      title: "Critical bug with a downloadable fix",
+      description: "A critical issue shipping a per-version JAR fix.",
+      remediation: "Upgrade to the patched release",
+      affected_versions: [{ min: "0.58.0", fixed: "0.59.11" }],
+      download_jar_urls: [
+        { version: "0.58.11", url: "https://downloads.example.com/58.jar" },
+        { version: "0.59.11", url: "https://downloads.example.com/59.jar" },
+      ],
+      match_status: "active",
+      published_at: "2026-03-24T00:00:00Z",
+      updated_at: "2026-03-24T00:00:00Z",
+    } as const;
+
+    it("stores and returns download_jar_urls through the real backend", () => {
+      H.seedSecurityAdvisories([DOWNLOADABLE_ADVISORY]);
+      cy.request("GET", "/api/ee/security-center").then(({ body }) => {
+        const advisory = body.advisories.find(
+          (a: { advisory_id: string }) => a.advisory_id === "TEST-DL",
+        );
+        expect(advisory.download_jar_urls).to.deep.equal([
+          { version: "0.58.11", url: "https://downloads.example.com/58.jar" },
+          { version: "0.59.11", url: "https://downloads.example.com/59.jar" },
+        ]);
+      });
+    });
+
+    it("shows a single download button for the fix matching the instance major version", () => {
+      H.mockSessionProperty("version", { tag: "v0.59.3" });
+      H.seedSecurityAdvisories([DOWNLOADABLE_ADVISORY]);
+      cy.visit("/admin/security-center");
+
+      cy.findAllByTestId("advisory-card")
+        .first()
+        .within(() => {
+          cy.findByRole("link", { name: /Download v0\.59\.11/ })
+            .should("have.attr", "href", "https://downloads.example.com/59.jar")
+            .and("have.attr", "target", "_blank");
+          cy.findByText("Download v0.58.11").should("not.exist");
+        });
+    });
+  });
 });

--- a/enterprise/backend/src/metabase_enterprise/security_center/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/api.clj
@@ -28,7 +28,7 @@
   (-> (select-keys advisory [:advisory_id :title :severity :description :advisory_url :remediation
                              :published_at :match_status :last_evaluated_at
                              :acknowledged_by_user :acknowledged_at :affected_versions :download_jar_urls])
-      (update :download_jar_urls #(or % []))
+      (update :download_jar_urls sequence)
       (set/rename-keys {:acknowledged_by_user :acknowledged_by})))
 
 (def ^:private AcknowledgedByUser

--- a/enterprise/backend/src/metabase_enterprise/security_center/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/api.clj
@@ -27,7 +27,8 @@
   [advisory]
   (-> (select-keys advisory [:advisory_id :title :severity :description :advisory_url :remediation
                              :published_at :match_status :last_evaluated_at
-                             :acknowledged_by_user :acknowledged_at :affected_versions])
+                             :acknowledged_by_user :acknowledged_at :affected_versions :download_jar_urls])
+      (update :download_jar_urls #(or % []))
       (set/rename-keys {:acknowledged_by_user :acknowledged_by})))
 
 (def ^:private AcknowledgedByUser
@@ -51,7 +52,8 @@
    [:last_evaluated_at [:maybe ms/TemporalInstant]]
    [:acknowledged_by   [:maybe AcknowledgedByUser]]
    [:acknowledged_at   [:maybe ms/TemporalInstant]]
-   [:affected_versions ::security-center.schema/affected-versions]])
+   [:affected_versions ::security-center.schema/affected-versions]
+   [:download_jar_urls ::security-center.schema/download-jar-urls]])
 
 (def ^:private AcknowledgeResponse
   "Schema for the acknowledge endpoint response."

--- a/enterprise/backend/src/metabase_enterprise/security_center/fetch.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/fetch.clj
@@ -25,7 +25,8 @@
 (mr/def ::affected-version
   [:map {:closed true}
    [:min ::security-center.schema/semver]
-   [:fixed ::security-center.schema/semver]])
+   [:fixed ::security-center.schema/semver]
+   [:download_jar_url {:optional true} [:maybe :string]]])
 
 (mr/def ::driver
   [:enum :default :postgres :mysql :h2])

--- a/enterprise/backend/src/metabase_enterprise/security_center/fetch.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/fetch.clj
@@ -23,10 +23,9 @@
   [:enum "critical" "high" "medium" "low"])
 
 (mr/def ::affected-version
-  [:map {:closed true}
+  [:map
    [:min ::security-center.schema/semver]
-   [:fixed ::security-center.schema/semver]
-   [:download_jar_url {:optional true} [:maybe :string]]])
+   [:fixed ::security-center.schema/semver]])
 
 (mr/def ::driver
   [:enum :default :postgres :mysql :h2])
@@ -45,6 +44,7 @@
    [:updated_at ms/TemporalString]
    [:advisory_url [:maybe :string]]
    [:affected_versions [:vector {:min 1} ::affected-version]]
+   [:download_jar_urls {:optional true} [:maybe ::security-center.schema/download-jar-urls]]
    [:matching_query [:maybe ::matching-query]]
    [:remediation [:string {:min 1}]]])
 
@@ -100,6 +100,7 @@
    :advisory_url      (:advisory_url advisory)
    :remediation       (:remediation advisory)
    :affected_versions (:affected_versions advisory)
+   :download_jar_urls (:download_jar_urls advisory)
    :matching_query    (parse-matching-query (:matching_query advisory))
    :published_at      (t/offset-date-time (:published_at advisory))
    :updated_at        (t/offset-date-time (:updated_at advisory))})

--- a/enterprise/backend/src/metabase_enterprise/security_center/models/security_advisory.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/models/security_advisory.clj
@@ -15,6 +15,7 @@
   {:severity          mi/transform-keyword
    :match_status      mi/transform-keyword
    :affected_versions mi/transform-json
+   :download_jar_urls mi/transform-json
    ;; EDN because HoneySQL treats keywords as identifiers and strings as values.
    :matching_query    mi/transform-edn})
 

--- a/enterprise/backend/src/metabase_enterprise/security_center/schema.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/schema.clj
@@ -19,11 +19,19 @@
   "A single affected version range with inclusive min and exclusive fixed."
   [:map
    [:min   ::semver]
-   [:fixed ::semver]
-   [:download_jar_url {:optional true} [:maybe :string]]])
+   [:fixed ::semver]])
 
 (mr/def ::affected-versions
   [:sequential ::version-range])
+
+(mr/def ::download-jar-url
+  "A downloadable JAR for a given fixed version."
+  [:map
+   [:version ::semver]
+   [:url     :string]])
+
+(mr/def ::download-jar-urls
+  [:sequential ::download-jar-url])
 
 (mr/def ::matching-query
   "HoneySQL query keyed by dialect. nil means affects all instances.

--- a/enterprise/backend/src/metabase_enterprise/security_center/schema.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/schema.clj
@@ -19,7 +19,8 @@
   "A single affected version range with inclusive min and exclusive fixed."
   [:map
    [:min   ::semver]
-   [:fixed ::semver]])
+   [:fixed ::semver]
+   [:download_jar_url {:optional true} [:maybe :string]]])
 
 (mr/def ::affected-versions
   [:sequential ::version-range])

--- a/enterprise/backend/test/metabase_enterprise/security_center/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/security_center/api_test.clj
@@ -69,8 +69,8 @@
         (testing "non-superuser gets 403"
           (mt/user-http-request :rasta :get 403 "ee/security-center"))))))
 
-(deftest list-advisories-returns-download-jar-url-test
-  (testing "GET /api/ee/security-center returns affected_versions download_jar_url"
+(deftest list-advisories-returns-download-jar-urls-test
+  (testing "GET /api/ee/security-center returns download_jar_urls"
     (mt/with-premium-features #{:admin-security-center}
       (mt/with-temp [:model/SecurityAdvisory _
                      {:advisory_id       "SC-DL-001"
@@ -78,16 +78,18 @@
                       :title             "Advisory with download link"
                       :description       "Test"
                       :remediation       "Upgrade"
-                      :affected_versions [{"min" "1.58.0" "fixed" "1.58.11"
-                                           "download_jar_url" "https://downloads.example.com/metabase.jar"}]
+                      :affected_versions [{"min" "1.58.0" "fixed" "1.58.11"}]
+                      :download_jar_urls [{"version" "1.58.11"
+                                           "url" "https://downloads.example.com/metabase.jar"}]
                       :match_status      "active"
                       :published_at      #t "2026-03-24T00:00:00Z"
                       :updated_at        #t "2026-03-24T00:00:00Z"}]
         (let [response  (mt/user-http-request :crowberto :get 200 "ee/security-center")
               advisory  (->> response :advisories (some #(when (= "SC-DL-001" (:advisory_id %)) %)))]
-          (is (= [{:min "1.58.0" :fixed "1.58.11"
-                   :download_jar_url "https://downloads.example.com/metabase.jar"}]
-                 (:affected_versions advisory))))))))
+          (is (= [{:min "1.58.0" :fixed "1.58.11"}]
+                 (:affected_versions advisory)))
+          (is (= [{:version "1.58.11" :url "https://downloads.example.com/metabase.jar"}]
+                 (:download_jar_urls advisory))))))))
 
 (deftest trial-subscription-gate-test
   (testing "Security Center is not available on trial subscriptions"

--- a/enterprise/backend/test/metabase_enterprise/security_center/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/security_center/api_test.clj
@@ -69,6 +69,26 @@
         (testing "non-superuser gets 403"
           (mt/user-http-request :rasta :get 403 "ee/security-center"))))))
 
+(deftest list-advisories-returns-download-jar-url-test
+  (testing "GET /api/ee/security-center returns affected_versions download_jar_url"
+    (mt/with-premium-features #{:admin-security-center}
+      (mt/with-temp [:model/SecurityAdvisory _
+                     {:advisory_id       "SC-DL-001"
+                      :severity          "high"
+                      :title             "Advisory with download link"
+                      :description       "Test"
+                      :remediation       "Upgrade"
+                      :affected_versions [{"min" "1.58.0" "fixed" "1.58.11"
+                                           "download_jar_url" "https://downloads.example.com/metabase.jar"}]
+                      :match_status      "active"
+                      :published_at      #t "2026-03-24T00:00:00Z"
+                      :updated_at        #t "2026-03-24T00:00:00Z"}]
+        (let [response  (mt/user-http-request :crowberto :get 200 "ee/security-center")
+              advisory  (->> response :advisories (some #(when (= "SC-DL-001" (:advisory_id %)) %)))]
+          (is (= [{:min "1.58.0" :fixed "1.58.11"
+                   :download_jar_url "https://downloads.example.com/metabase.jar"}]
+                 (:affected_versions advisory))))))))
+
 (deftest trial-subscription-gate-test
   (testing "Security Center is not available on trial subscriptions"
     (mt/with-premium-features #{:admin-security-center}

--- a/enterprise/backend/test/metabase_enterprise/security_center/fetch_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/security_center/fetch_test.clj
@@ -106,6 +106,24 @@
                      :title       "Advisory SC-2026-001"}
                     row))))))))
 
+(deftest fetch-advisory-with-download-jar-url-test
+  (testing "affected_versions download_jar_url passes validation and is stored"
+    (let [advisory (make-json-advisory "SC-DL-001"
+                                       "affected_versions" [{"min" "0.58.0" "fixed" "0.58.11"
+                                                             "download_jar_url" "https://downloads.example.com/metabase.jar"}
+                                                            {"min" "0.59.0" "fixed" "0.59.6"}])]
+      (mt/with-model-cleanup [:model/SecurityAdvisory]
+        (with-redefs [http/get                                                    (constantly (fake-store-response [advisory]))
+                      premium-features/premium-embedding-token                    (constantly "fake-token")
+                      premium-features/site-uuid-for-premium-features-token-checks (constantly "fake-uuid")]
+          (fetch/sync-advisories!)
+          (let [row (t2/select-one :model/SecurityAdvisory :advisory_id "SC-DL-001")]
+            (is (some? row))
+            (is (= [{:min "0.58.0" :fixed "0.58.11"
+                     :download_jar_url "https://downloads.example.com/metabase.jar"}
+                    {:min "0.59.0" :fixed "0.59.6"}]
+                   (:affected_versions row)))))))))
+
 (deftest sync-advisories-stores-updated-at-test
   (mt/with-model-cleanup [:model/SecurityAdvisory]
     (mt/with-dynamic-fn-redefs [fetch/fetch-advisories-from-store

--- a/enterprise/backend/test/metabase_enterprise/security_center/fetch_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/security_center/fetch_test.clj
@@ -106,12 +106,13 @@
                      :title       "Advisory SC-2026-001"}
                     row))))))))
 
-(deftest fetch-advisory-with-download-jar-url-test
-  (testing "affected_versions download_jar_url passes validation and is stored"
+(deftest fetch-advisory-with-download-jar-urls-test
+  (testing "download_jar_urls side field passes validation and is stored"
     (let [advisory (make-json-advisory "SC-DL-001"
-                                       "affected_versions" [{"min" "0.58.0" "fixed" "0.58.11"
-                                                             "download_jar_url" "https://downloads.example.com/metabase.jar"}
-                                                            {"min" "0.59.0" "fixed" "0.59.6"}])]
+                                       "affected_versions" [{"min" "0.58.0" "fixed" "0.58.11"}
+                                                            {"min" "0.59.0" "fixed" "0.59.6"}]
+                                       "download_jar_urls" [{"version" "0.58.11"
+                                                             "url" "https://downloads.example.com/metabase.jar"}])]
       (mt/with-model-cleanup [:model/SecurityAdvisory]
         (with-redefs [http/get                                                    (constantly (fake-store-response [advisory]))
                       premium-features/premium-embedding-token                    (constantly "fake-token")
@@ -119,10 +120,10 @@
           (fetch/sync-advisories!)
           (let [row (t2/select-one :model/SecurityAdvisory :advisory_id "SC-DL-001")]
             (is (some? row))
-            (is (= [{:min "0.58.0" :fixed "0.58.11"
-                     :download_jar_url "https://downloads.example.com/metabase.jar"}
-                    {:min "0.59.0" :fixed "0.59.6"}]
-                   (:affected_versions row)))))))))
+            (is (= [{:min "0.58.0" :fixed "0.58.11"} {:min "0.59.0" :fixed "0.59.6"}]
+                   (:affected_versions row)))
+            (is (= [{:version "0.58.11" :url "https://downloads.example.com/metabase.jar"}]
+                   (:download_jar_urls row)))))))))
 
 (deftest sync-advisories-stores-updated-at-test
   (mt/with-model-cleanup [:model/SecurityAdvisory]

--- a/enterprise/frontend/src/metabase-enterprise/security_center/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/analytics.ts
@@ -5,3 +5,9 @@ export const trackSecurityCenterPageViewed = () => {
     event: "security_center_page_viewed",
   });
 };
+
+export const trackSecurityAdvisoryDownloadClicked = () => {
+  trackSimpleEvent({
+    event: "security_advisory_download_clicked",
+  });
+};

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -36,7 +36,7 @@ export function AdvisoryCard({
   isAffecting,
   onAcknowledge,
 }: AdvisoryCardProps) {
-  const currentVersion = useSetting("version")?.tag ?? "";
+  const currentVersion = useSetting("version").tag ?? "";
   const acknowledged = isAcknowledged(advisory);
   const downloadJar = isAffecting
     ? getDownloadJarForInstance(advisory, currentVersion)

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -23,6 +23,7 @@ import type {
   AdvisorySeverity,
 } from "metabase-types/api";
 
+import { trackSecurityAdvisoryDownloadClicked } from "../../analytics";
 import { getDownloadJarForInstance, isAcknowledged } from "../../utils";
 
 interface AdvisoryCardProps {
@@ -101,6 +102,7 @@ export function AdvisoryCard({
               target="_blank"
               rel="noopener noreferrer"
               leftSection={<Icon name="download" />}
+              onClick={trackSecurityAdvisoryDownloadClicked}
             >
               {t`Download v${downloadJar.version}`}
             </Button>

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -79,9 +79,9 @@ export function AdvisoryCard({
             <Text fw={700} mb="xs">{t`Affected versions`}</Text>
             <List size="sm">
               {advisory.affected_versions.map((v) => (
-                <List.Item key={`${v.min}-${v.fixed}`}>
-                  <Text span>{`${v.min} - ${v.fixed}`}</Text>
-                </List.Item>
+                <List.Item
+                  key={`${v.min}-${v.fixed}`}
+                >{`${v.min} - ${v.fixed}`}</List.Item>
               ))}
             </List>
           </Box>

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -23,7 +23,7 @@ import type {
   AdvisorySeverity,
 } from "metabase-types/api";
 
-import { getAffectedVersionForInstance, isAcknowledged } from "../../utils";
+import { getDownloadJarForInstance, isAcknowledged } from "../../utils";
 
 interface AdvisoryCardProps {
   advisory: Advisory;
@@ -38,8 +38,8 @@ export function AdvisoryCard({
 }: AdvisoryCardProps) {
   const currentVersion = useSetting("version")?.tag ?? "";
   const acknowledged = isAcknowledged(advisory);
-  const affectedVersion = isAffecting
-    ? getAffectedVersionForInstance(advisory, currentVersion)
+  const downloadJar = isAffecting
+    ? getDownloadJarForInstance(advisory, currentVersion)
     : null;
 
   return (
@@ -93,16 +93,16 @@ export function AdvisoryCard({
         </Box>
 
         <Group gap="md" mt="sm">
-          {affectedVersion?.download_jar_url && (
+          {downloadJar && (
             <Button
               variant="outline"
               component="a"
-              href={affectedVersion.download_jar_url}
+              href={downloadJar.url}
               target="_blank"
               rel="noopener noreferrer"
               leftSection={<Icon name="download" />}
             >
-              {t`Download v${affectedVersion.fixed}`}
+              {t`Download v${downloadJar.version}`}
             </Button>
           )}
           {!acknowledged && onAcknowledge && (

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -74,9 +74,21 @@ export function AdvisoryCard({
             <Text fw={700} mb="xs">{t`Affected versions`}</Text>
             <List size="sm">
               {advisory.affected_versions.map((v) => (
-                <List.Item
-                  key={`${v.min}-${v.fixed}`}
-                >{`${v.min} - ${v.fixed}`}</List.Item>
+                <List.Item key={`${v.min}-${v.fixed}`}>
+                  <Group gap="xs">
+                    <Text span>{`${v.min} - ${v.fixed}`}</Text>
+                    {v.download_jar_url && (
+                      <Anchor
+                        href={v.download_jar_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        size="sm"
+                      >
+                        {t`Download ${v.fixed}`}
+                      </Anchor>
+                    )}
+                  </Group>
+                </List.Item>
               ))}
             </List>
           </Box>

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -75,7 +75,7 @@ export function AdvisoryCard({
             <List size="sm">
               {advisory.affected_versions.map((v) => (
                 <List.Item key={`${v.min}-${v.fixed}`}>
-                  <Group gap="xs">
+                  <Group gap="xs" align="baseline">
                     <Text span>{`${v.min} - ${v.fixed}`}</Text>
                     {v.download_jar_url && (
                       <Anchor

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -1,6 +1,7 @@
 import { match } from "ts-pattern";
 import { t } from "ttag";
 
+import { useSetting } from "metabase/common/hooks";
 import {
   Anchor,
   Badge,
@@ -22,7 +23,7 @@ import type {
   AdvisorySeverity,
 } from "metabase-types/api";
 
-import { isAcknowledged } from "../../utils";
+import { getAffectedVersionForInstance, isAcknowledged } from "../../utils";
 
 interface AdvisoryCardProps {
   advisory: Advisory;
@@ -35,7 +36,11 @@ export function AdvisoryCard({
   isAffecting,
   onAcknowledge,
 }: AdvisoryCardProps) {
+  const currentVersion = useSetting("version")?.tag ?? "";
   const acknowledged = isAcknowledged(advisory);
+  const affectedVersion = isAffecting
+    ? getAffectedVersionForInstance(advisory, currentVersion)
+    : null;
 
   return (
     <Card p="xl" withBorder data-testid="advisory-card">
@@ -75,19 +80,7 @@ export function AdvisoryCard({
             <List size="sm">
               {advisory.affected_versions.map((v) => (
                 <List.Item key={`${v.min}-${v.fixed}`}>
-                  <Group gap="xs" align="baseline">
-                    <Text span>{`${v.min} - ${v.fixed}`}</Text>
-                    {v.download_jar_url && (
-                      <Anchor
-                        href={v.download_jar_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        size="sm"
-                      >
-                        {t`Download ${v.fixed}`}
-                      </Anchor>
-                    )}
-                  </Group>
+                  <Text span>{`${v.min} - ${v.fixed}`}</Text>
                 </List.Item>
               ))}
             </List>
@@ -100,6 +93,18 @@ export function AdvisoryCard({
         </Box>
 
         <Group gap="md" mt="sm">
+          {affectedVersion?.download_jar_url && (
+            <Button
+              variant="outline"
+              component="a"
+              href={affectedVersion.download_jar_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              leftSection={<Icon name="download" />}
+            >
+              {t`Download v${affectedVersion.fixed}`}
+            </Button>
+          )}
           {!acknowledged && onAcknowledge && (
             <Tooltip
               label={t`Clicking on Dismiss just hides the notification and you can view this later by toggling 'Show dismissed'`}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
@@ -160,6 +160,45 @@ describe("SecurityCenterPage", () => {
     expect(advisoryLink).toHaveAttribute("target", "_blank");
   });
 
+  it("renders a download link when a fix version has a download_jar_url", async () => {
+    const advisories = [
+      createAdvisory({
+        advisory_id: "1",
+        affected_versions: [
+          {
+            min: "0.58.0",
+            fixed: "0.58.11",
+            download_jar_url: "https://downloads.example.com/metabase.jar",
+          },
+        ],
+      }),
+    ];
+
+    setup(advisories);
+
+    const downloadLink = screen.getByText("Download 0.58.11");
+    expect(downloadLink).toHaveAttribute(
+      "href",
+      "https://downloads.example.com/metabase.jar",
+    );
+    expect(downloadLink).toHaveAttribute("target", "_blank");
+  });
+
+  it("does not render a download link when download_jar_url is null", async () => {
+    const advisories = [
+      createAdvisory({
+        advisory_id: "1",
+        affected_versions: [
+          { min: "0.58.0", fixed: "0.58.11", download_jar_url: null },
+        ],
+      }),
+    ];
+
+    setup(advisories);
+
+    expect(screen.queryByText("Download 0.58.11")).not.toBeInTheDocument();
+  });
+
   it("calls acknowledgeAdvisory when dismiss button is clicked", async () => {
     const advisories = [
       createAdvisory({ advisory_id: "SA-001", acknowledged_at: null }),

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
@@ -166,16 +166,12 @@ describe("SecurityCenterPage", () => {
         advisory_id: "1",
         match_status: "active",
         affected_versions: [
-          {
-            min: "0.58.0",
-            fixed: "0.58.11",
-            download_jar_url: "https://downloads.example.com/58.jar",
-          },
-          {
-            min: "0.59.0",
-            fixed: "0.59.11",
-            download_jar_url: "https://downloads.example.com/59.jar",
-          },
+          { min: "0.58.0", fixed: "0.58.11" },
+          { min: "0.59.0", fixed: "0.59.11" },
+        ],
+        download_jar_urls: [
+          { version: "0.58.11", url: "https://downloads.example.com/58.jar" },
+          { version: "0.59.11", url: "https://downloads.example.com/59.jar" },
         ],
       }),
     ];
@@ -193,14 +189,13 @@ describe("SecurityCenterPage", () => {
     expect(downloadButton).toHaveAttribute("target", "_blank");
   });
 
-  it("does not render a download button when download_jar_url is null", async () => {
+  it("does not render a download button when there is no matching download url", async () => {
     const advisories = [
       createAdvisory({
         advisory_id: "1",
         match_status: "active",
-        affected_versions: [
-          { min: "0.59.0", fixed: "0.59.11", download_jar_url: null },
-        ],
+        affected_versions: [{ min: "0.59.0", fixed: "0.59.11" }],
+        download_jar_urls: [],
       }),
     ];
 
@@ -214,12 +209,9 @@ describe("SecurityCenterPage", () => {
       createAdvisory({
         advisory_id: "1",
         match_status: "not_affected",
-        affected_versions: [
-          {
-            min: "0.59.0",
-            fixed: "0.59.11",
-            download_jar_url: "https://downloads.example.com/59.jar",
-          },
+        affected_versions: [{ min: "0.59.0", fixed: "0.59.11" }],
+        download_jar_urls: [
+          { version: "0.59.11", url: "https://downloads.example.com/59.jar" },
         ],
       }),
     ];

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
@@ -160,15 +160,21 @@ describe("SecurityCenterPage", () => {
     expect(advisoryLink).toHaveAttribute("target", "_blank");
   });
 
-  it("renders a download link when a fix version has a download_jar_url", async () => {
+  it("renders a single download button for the fix matching the instance's major version", async () => {
     const advisories = [
       createAdvisory({
         advisory_id: "1",
+        match_status: "active",
         affected_versions: [
           {
             min: "0.58.0",
             fixed: "0.58.11",
-            download_jar_url: "https://downloads.example.com/metabase.jar",
+            download_jar_url: "https://downloads.example.com/58.jar",
+          },
+          {
+            min: "0.59.0",
+            fixed: "0.59.11",
+            download_jar_url: "https://downloads.example.com/59.jar",
           },
         ],
       }),
@@ -176,27 +182,51 @@ describe("SecurityCenterPage", () => {
 
     setup(advisories);
 
-    const downloadLink = screen.getByText("Download 0.58.11");
-    expect(downloadLink).toHaveAttribute(
+    expect(screen.queryByText("Download v0.58.11")).not.toBeInTheDocument();
+    const downloadButton = screen.getByRole("link", {
+      name: /Download v0.59.11/,
+    });
+    expect(downloadButton).toHaveAttribute(
       "href",
-      "https://downloads.example.com/metabase.jar",
+      "https://downloads.example.com/59.jar",
     );
-    expect(downloadLink).toHaveAttribute("target", "_blank");
+    expect(downloadButton).toHaveAttribute("target", "_blank");
   });
 
-  it("does not render a download link when download_jar_url is null", async () => {
+  it("does not render a download button when download_jar_url is null", async () => {
     const advisories = [
       createAdvisory({
         advisory_id: "1",
+        match_status: "active",
         affected_versions: [
-          { min: "0.58.0", fixed: "0.58.11", download_jar_url: null },
+          { min: "0.59.0", fixed: "0.59.11", download_jar_url: null },
         ],
       }),
     ];
 
     setup(advisories);
 
-    expect(screen.queryByText("Download 0.58.11")).not.toBeInTheDocument();
+    expect(screen.queryByText("Download v0.59.11")).not.toBeInTheDocument();
+  });
+
+  it("does not render a download button when the instance is not affected", async () => {
+    const advisories = [
+      createAdvisory({
+        advisory_id: "1",
+        match_status: "not_affected",
+        affected_versions: [
+          {
+            min: "0.59.0",
+            fixed: "0.59.11",
+            download_jar_url: "https://downloads.example.com/59.jar",
+          },
+        ],
+      }),
+    ];
+
+    setup(advisories);
+
+    expect(screen.queryByText("Download v0.59.11")).not.toBeInTheDocument();
   });
 
   it("calls acknowledgeAdvisory when dismiss button is clicked", async () => {

--- a/enterprise/frontend/src/metabase-enterprise/security_center/hooks/use-security-advisories.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/hooks/use-security-advisories.ts
@@ -1,11 +1,8 @@
-import { useMemo } from "react";
-
 import {
   useAcknowledgeAdvisoriesMutation,
   useAcknowledgeAdvisoryMutation,
   useListSecurityAdvisoriesQuery,
 } from "metabase/api";
-import type { Advisory } from "metabase-types/api";
 
 const POLLING_INTERVAL = 2000;
 
@@ -21,13 +18,8 @@ export function useSecurityAdvisories(isPolling = false) {
   const [acknowledgeAdvisory] = useAcknowledgeAdvisoryMutation();
   const [acknowledgeAdvisories] = useAcknowledgeAdvisoriesMutation();
 
-  const advisories: Advisory[] = useMemo(
-    () => response?.advisories ?? [],
-    [response?.advisories],
-  );
-
   return {
-    data: advisories,
+    data: response?.advisories ?? [],
     lastCheckedAt: response?.last_checked_at ?? null,
     isLoading,
     isError,

--- a/enterprise/frontend/src/metabase-enterprise/security_center/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/utils.ts
@@ -1,7 +1,4 @@
-import {
-  compareVersions,
-  versionToNumericComponents,
-} from "metabase/utils/version";
+import { compareVersions, getMajorVersion } from "metabase/utils/version";
 import type {
   Advisory,
   AdvisoryDownloadJarUrl,
@@ -14,13 +11,13 @@ export const getDownloadJarForInstance = (
   advisory: Advisory,
   currentVersion: string,
 ): AdvisoryDownloadJarUrl | null => {
-  const currentMajor = versionToNumericComponents(currentVersion)?.[1];
+  const currentMajor = getMajorVersion(currentVersion);
   if (currentMajor == null) {
     return null;
   }
   return (
     advisory.download_jar_urls.find(
-      (jar) => versionToNumericComponents(jar.version)?.[1] === currentMajor,
+      (jar) => getMajorVersion(jar.version) === currentMajor,
     ) ?? null
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/security_center/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/utils.ts
@@ -1,7 +1,29 @@
-import { compareVersions } from "metabase/utils/version";
-import type { Advisory, AdvisorySeverity } from "metabase-types/api";
+import {
+  compareVersions,
+  versionToNumericComponents,
+} from "metabase/utils/version";
+import type {
+  Advisory,
+  AdvisoryAffectedVersion,
+  AdvisorySeverity,
+} from "metabase-types/api";
 
 import type { AdvisoryFilter } from "./types";
+
+export const getAffectedVersionForInstance = (
+  advisory: Advisory,
+  currentVersion: string,
+): AdvisoryAffectedVersion | null => {
+  const currentMajor = versionToNumericComponents(currentVersion)?.[1];
+  if (currentMajor == null) {
+    return null;
+  }
+  const match = advisory.affected_versions.find(
+    (affectedVersion) =>
+      versionToNumericComponents(affectedVersion.fixed)?.[1] === currentMajor,
+  );
+  return match ?? null;
+};
 
 const SEVERITY_ORDER: Record<AdvisorySeverity, number> = {
   critical: 0,

--- a/enterprise/frontend/src/metabase-enterprise/security_center/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/utils.ts
@@ -4,25 +4,25 @@ import {
 } from "metabase/utils/version";
 import type {
   Advisory,
-  AdvisoryAffectedVersion,
+  AdvisoryDownloadJarUrl,
   AdvisorySeverity,
 } from "metabase-types/api";
 
 import type { AdvisoryFilter } from "./types";
 
-export const getAffectedVersionForInstance = (
+export const getDownloadJarForInstance = (
   advisory: Advisory,
   currentVersion: string,
-): AdvisoryAffectedVersion | null => {
+): AdvisoryDownloadJarUrl | null => {
   const currentMajor = versionToNumericComponents(currentVersion)?.[1];
   if (currentMajor == null) {
     return null;
   }
-  const match = advisory.affected_versions.find(
-    (affectedVersion) =>
-      versionToNumericComponents(affectedVersion.fixed)?.[1] === currentMajor,
+  return (
+    advisory.download_jar_urls.find(
+      (jar) => versionToNumericComponents(jar.version)?.[1] === currentMajor,
+    ) ?? null
   );
-  return match ?? null;
 };
 
 const SEVERITY_ORDER: Record<AdvisorySeverity, number> = {

--- a/enterprise/frontend/src/metabase-enterprise/security_center/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/utils.unit.spec.ts
@@ -16,6 +16,7 @@ const makeAdvisory = (overrides: Partial<Advisory>): Advisory => ({
   acknowledged_by: null,
   acknowledged_at: null,
   affected_versions: [{ min: "0.45.0", fixed: "0.59.0" }],
+  download_jar_urls: [],
   ...overrides,
 });
 

--- a/frontend/src/metabase-types/api/mocks/security-center.ts
+++ b/frontend/src/metabase-types/api/mocks/security-center.ts
@@ -57,7 +57,9 @@ export function createAdvisory(overrides: Partial<Advisory> = {}): Advisory {
     last_evaluated_at: null,
     acknowledged_by: null,
     acknowledged_at: null,
-    affected_versions: [{ min: "0.45.0", fixed: "0.59.0" }],
+    affected_versions: [
+      { min: "0.45.0", fixed: "0.59.0", download_jar_url: null },
+    ],
     ...overrides,
   };
 }

--- a/frontend/src/metabase-types/api/mocks/security-center.ts
+++ b/frontend/src/metabase-types/api/mocks/security-center.ts
@@ -57,9 +57,8 @@ export function createAdvisory(overrides: Partial<Advisory> = {}): Advisory {
     last_evaluated_at: null,
     acknowledged_by: null,
     acknowledged_at: null,
-    affected_versions: [
-      { min: "0.45.0", fixed: "0.59.0", download_jar_url: null },
-    ],
+    affected_versions: [{ min: "0.45.0", fixed: "0.59.0" }],
+    download_jar_urls: [],
     ...overrides,
   };
 }

--- a/frontend/src/metabase-types/api/security-center.ts
+++ b/frontend/src/metabase-types/api/security-center.ts
@@ -6,7 +6,7 @@ export type AdvisoryMatchStatus =
   | "not_affected"
   | "error";
 
-export type AdvisoryVersion = {
+export type AdvisoryVersionRange = {
   min: string;
   fixed: string;
 };
@@ -32,7 +32,7 @@ export type Advisory = {
   last_evaluated_at: string | null;
   acknowledged_by: { id: number; common_name: string; email: string } | null;
   acknowledged_at: string | null;
-  affected_versions: AdvisoryVersion[];
+  affected_versions: AdvisoryVersionRange[];
   download_jar_urls: AdvisoryDownloadJarUrl[];
 };
 

--- a/frontend/src/metabase-types/api/security-center.ts
+++ b/frontend/src/metabase-types/api/security-center.ts
@@ -9,7 +9,11 @@ export type AdvisoryMatchStatus =
 export type AdvisoryVersion = {
   min: string;
   fixed: string;
-  download_jar_url?: string | null;
+};
+
+export type AdvisoryDownloadJarUrl = {
+  version: string;
+  url: string;
 };
 
 export type AdvisorySeverity = "critical" | "high" | "medium" | "low";
@@ -29,6 +33,7 @@ export type Advisory = {
   acknowledged_by: { id: number; common_name: string; email: string } | null;
   acknowledged_at: string | null;
   affected_versions: AdvisoryVersion[];
+  download_jar_urls: AdvisoryDownloadJarUrl[];
 };
 
 export type ListAdvisoriesResponse = {

--- a/frontend/src/metabase-types/api/security-center.ts
+++ b/frontend/src/metabase-types/api/security-center.ts
@@ -6,7 +6,7 @@ export type AdvisoryMatchStatus =
   | "not_affected"
   | "error";
 
-export type AdvisoryVersionRange = {
+export type AdvisoryVersion = {
   min: string;
   fixed: string;
   download_jar_url?: string | null;
@@ -28,7 +28,7 @@ export type Advisory = {
   last_evaluated_at: string | null;
   acknowledged_by: { id: number; common_name: string; email: string } | null;
   acknowledged_at: string | null;
-  affected_versions: AdvisoryVersionRange[];
+  affected_versions: AdvisoryVersion[];
 };
 
 export type ListAdvisoriesResponse = {

--- a/frontend/src/metabase-types/api/security-center.ts
+++ b/frontend/src/metabase-types/api/security-center.ts
@@ -9,6 +9,7 @@ export type AdvisoryMatchStatus =
 export type AdvisoryVersionRange = {
   min: string;
   fixed: string;
+  download_jar_url?: string | null;
 };
 
 export type AdvisorySeverity = "critical" | "high" | "medium" | "low";

--- a/frontend/src/metabase/utils/version.ts
+++ b/frontend/src/metabase/utils/version.ts
@@ -38,6 +38,10 @@ export function versionToNumericComponents(version: string): number[] | null {
   ].map((part) => (typeof part === "string" ? parseInt(part, 10) : part));
 }
 
+export function getMajorVersion(version: string): number | null {
+  return versionToNumericComponents(version)?.[1] ?? null;
+}
+
 /**
  * this should correctly compare all version formats Metabase uses, e.g.
  * 0.0.9, 0.0.10-snapshot, 0.0.10-alpha1, 0.0.10-rc1, 0.0.10-rc2, 0.0.10-rc10

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11776,6 +11776,27 @@ databaseChangeLog:
               - column:
                   name: match_status
 
+  - changeSet:
+      id: v55.2026-03-30T00:00:05
+      author: egorgrushin
+      comment: Add security_advisory.download_jar_urls for per-version download links
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: security_advisory
+                columnName: download_jar_urls
+      changes:
+        - addColumn:
+            tableName: security_advisory
+            columns:
+              - column:
+                  name: download_jar_urls
+                  type: ${text.type}
+                  remarks: "JSON array of {version, url} downloadable JARs"
+                  constraints:
+                    nullable: true
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/testing_api/api.clj
+++ b/src/metabase/testing_api/api.clj
@@ -274,6 +274,7 @@
    [:advisory_url      {:optional true} [:maybe ms/NonBlankString]]
    [:remediation       ms/NonBlankString]
    [:affected_versions [:sequential [:map [:min :string] [:fixed :string]]]]
+   [:download_jar_urls {:optional true} [:maybe [:sequential [:map [:version :string] [:url :string]]]]]
    [:matching_query    {:optional true} [:maybe [:map-of :keyword :string]]]
    [:match_status      [:enum "unknown" "active" "resolved" "not_affected" "error"]]
    [:published_at      :any]


### PR DESCRIPTION
Closes [GDGT-2833: Security center: Add explicit downloadable link to the fix version](https://linear.app/metabase/issue/GDGT-2833/security-center-add-explicit-downloadable-link-to-the-fix-version)
Related PRs: https://github.com/metabase/harbormaster/pull/7453 and https://github.com/metabase/security-advisories-registry/pull/32

### Description
Adds a download link for each affected version if there is one. Renders it in `/admin/security-center`.

### How to verify
1. Create an advisory using `/create-advisory` skill from https://github.com/metabase/security-advisories-registry/pull/32
2. Skill will ask to provide a downloadable jar url for each affected version.
3. Publish advisory
4. Go to `/admin/security-center`
5. See a link next to affected version

### Demo

Before
<img width="1728" height="1001" alt="SCR-20260714-dolg" src="https://github.com/user-attachments/assets/58f64e73-ace1-40a3-a294-504c621ef41f" />

After:

<img width="1728" height="1001" alt="image" src="https://github.com/user-attachments/assets/94af9778-fd7c-48fb-bbcc-7ce62379b64b" />
