### PR TITLE
Compose route guards as element wrappers

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/routes.tsx
@@ -24,7 +24,7 @@ export function getDataStudioTableRoutes(IsAdmin: ComponentType) {
       <Route path=":tableId/fields" component={TableFieldsPage} />
       <Route path=":tableId/fields/:fieldId" component={TableFieldsPage} />
       <Route path=":tableId/segments" component={TableSegmentsPage} />
-      <Route path=":tableId/segments/new" component={IsAdmin}>
+      <Route path=":tableId/segments/new" element={<IsAdmin />}>
         <Route index component={PublishedTableNewSegmentPage} />
       </Route>
       <Route
@@ -44,7 +44,7 @@ export function getDataStudioTableRoutes(IsAdmin: ComponentType) {
         </Route>
       )}
       <Route path=":tableId/measures" component={TableMeasuresPage} />
-      <Route path=":tableId/measures/new" component={IsAdmin}>
+      <Route path=":tableId/measures/new" element={<IsAdmin />}>
         <Route index component={PublishedTableNewMeasurePage} />
       </Route>
       <Route

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/index.tsx
@@ -39,12 +39,12 @@ export function initializePlugin() {
     PLUGIN_DB_ROUTING.getDestinationDatabaseRoutes = (IsAdmin: any) => (
       <Route path="destination-databases">
         <Route index component={DestinationDatabasesModal} />
-        <Route component={IsAdmin}>
+        <Route element={<IsAdmin />}>
           <Route path="create" component={DestinationDatabaseConnectionModal} />
         </Route>
         <Route path=":destinationDatabaseId">
           <Route index component={DestinationDatabaseConnectionModal} />
-          <Route component={IsAdmin}>
+          <Route element={<IsAdmin />}>
             <Route path="remove" component={RemoveDestinationDatabaseModal} />
           </Route>
         </Route>

--- a/enterprise/frontend/src/metabase-enterprise/workspaces/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/workspaces/routes.tsx
@@ -13,7 +13,7 @@ export function getDataStudioRoutes() {
 
 export function getWorkspaceDatabaseRoutes(IsAdmin: RouteComponent) {
   return (
-    <Route component={IsAdmin}>
+    <Route element={<IsAdmin />}>
       <Route path=":databaseId/admin" component={AdminConnectionInfoPage} />
     </Route>
   );

--- a/frontend/src/metabase/account/routes.tsx
+++ b/frontend/src/metabase/account/routes.tsx
@@ -15,7 +15,7 @@ export const getAccountRoutes = (
   IsAuthenticated: RouteComponent,
 ) => {
   return (
-    <Route path="/account" component={IsAuthenticated}>
+    <Route path="/account" element={<IsAuthenticated />}>
       <Route component={AccountApp}>
         <Route index component={redirect("profile")} />
         <Route path="profile" component={UserProfileApp} />

--- a/frontend/src/metabase/admin/routes.tsx
+++ b/frontend/src/metabase/admin/routes.tsx
@@ -90,12 +90,12 @@ export const getRoutes = (
   const hasSimpleEmbedding = getTokenFeature(state, "embedding_simple");
 
   return (
-    <Route path="/admin" component={CanAccessSettings}>
+    <Route path="/admin" element={<CanAccessSettings />}>
       <Route component={AdminApp}>
         <Route index component={RedirectToAllowedSettings} />
         <Route path="databases" component={createAdminRouteGuard("databases")}>
           <Route index component={DatabaseListApp} />
-          <Route component={IsAdmin}>
+          <Route element={<IsAdmin />}>
             <Route path="create" component={DatabasePage} />
           </Route>
           <Route path=":databaseId/edit" component={DatabasePage} />
@@ -124,10 +124,10 @@ export const getRoutes = (
             />
             <Route component={DataModelV1}>
               <Route path="segments" component={SegmentListApp} />
-              <Route path="segment/create" component={IsAdmin}>
+              <Route path="segment/create" element={<IsAdmin />}>
                 <Route index component={SegmentApp} />
               </Route>
-              <Route path="segment/:id" component={IsAdmin}>
+              <Route path="segment/:id" element={<IsAdmin />}>
                 <Route index component={SegmentApp} />
               </Route>
               <Route
@@ -256,7 +256,7 @@ export const getRoutes = (
           {getSettingsRoutes(store, IsAdmin)}
         </Route>
         {/* PERMISSIONS */}
-        <Route path="permissions" component={IsAdmin}>
+        <Route path="permissions" element={<IsAdmin />}>
           {getAdminPermissionsRoutes()}
         </Route>
 

--- a/frontend/src/metabase/admin/settings/tests/setup.tsx
+++ b/frontend/src/metabase/admin/settings/tests/setup.tsx
@@ -1,6 +1,5 @@
 import { render as testingLibraryRender } from "@testing-library/react";
 import fetchMock from "fetch-mock";
-import type { ReactNode } from "react";
 
 import {
   setupEnterpriseOnlyPlugin,
@@ -26,7 +25,7 @@ import { mockSettings } from "__support__/settings";
 import { getTestStoreAndWrapper, screen } from "__support__/ui";
 import { getSettingsRoutes } from "metabase/admin/settingsRoutes";
 import { createMockState } from "metabase/redux/store/mocks";
-import { Route } from "metabase/router";
+import { Outlet, Route } from "metabase/router";
 import type { TokenFeature, TokenFeatures } from "metabase-types/api";
 import {
   createMockSettings,
@@ -206,9 +205,7 @@ export const setup = async ({
     initialRoute: `/admin/settings${initialRoute}`,
   });
 
-  const PassThroughGuard = ({ children }: { children: ReactNode }) => (
-    <>{children}</>
-  );
+  const PassThroughGuard = () => <Outlet />;
 
   testingLibraryRender(
     <Route path="admin/settings">

--- a/frontend/src/metabase/admin/settingsRoutes.tsx
+++ b/frontend/src/metabase/admin/settingsRoutes.tsx
@@ -88,7 +88,7 @@ export const getSettingsRoutes = (
       <Route
         path="custom-visualizations"
         /* do not allow users with "Settings access" permissions to access custom viz pages */
-        component={IsAdmin}
+        element={<IsAdmin />}
       >
         <Route index component={CustomVisualizationsManagePage} />
         <Route path="new" component={CustomVisualizationsFormPage} />

--- a/frontend/src/metabase/data-studio/data-model/routes.tsx
+++ b/frontend/src/metabase/data-studio/data-model/routes.tsx
@@ -29,7 +29,7 @@ export function getDataStudioMetadataRoutes(IsAdmin: ComponentType) {
       />
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/segments/new"
-        component={IsAdmin}
+        element={<IsAdmin />}
       >
         <Route index component={DataModelNewSegmentPage} />
       </Route>
@@ -51,7 +51,7 @@ export function getDataStudioMetadataRoutes(IsAdmin: ComponentType) {
       )}
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/measures/new"
-        component={IsAdmin}
+        element={<IsAdmin />}
       >
         <Route index component={DataModelNewMeasurePage} />
       </Route>

--- a/frontend/src/metabase/data-studio/routes.tsx
+++ b/frontend/src/metabase/data-studio/routes.tsx
@@ -35,10 +35,10 @@ export function getDataStudioRoutes(
   IsAdmin: RouteComponent,
 ) {
   return (
-    <Route component={CanAccessDataStudio}>
+    <Route element={<CanAccessDataStudio />}>
       <Route path="data-studio" component={DataStudioLayout}>
         <Route index component={DataStudioIndexRedirect} />
-        <Route path="data" component={CanAccessDataModel}>
+        <Route path="data" element={<CanAccessDataModel />}>
           <Route component={DataSectionLayout}>
             {getDataStudioMetadataRoutes(IsAdmin)}
           </Route>

--- a/frontend/src/metabase/router/Outlet.tsx
+++ b/frontend/src/metabase/router/Outlet.tsx
@@ -1,6 +1,8 @@
 import type { ComponentType, ReactNode } from "react";
 import { createContext, useContext } from "react";
 
+import type { Route } from "./route";
+
 const OutletContext = createContext<ReactNode>(null);
 
 /**
@@ -15,18 +17,64 @@ export function Outlet(): JSX.Element {
   return <>{child}</>;
 }
 
+type RouteWithElement = Route & { element?: ReactNode };
+
+type RouteElementComponent = ComponentType<{
+  children?: ReactNode;
+  route?: RouteWithElement;
+}>;
+
+// The generated route `component` is keyed by the element's component *type*, not
+// by element identity, and it renders the element off the v3-injected `route`.
+// Two sibling routes that render the same component (`element={<X/>}` at
+// `foo/:a` and `foo/:a/:b`) therefore share one `component`, so React reconciles
+// `X` across a navigation between them instead of remounting it — matching v3's
+// `component={X}` behaviour and preserving `X`'s state. It also keeps the
+// component stable across v3's config rebuilds, so a `redirect()` element does
+// not remount and re-fire its navigation in a loop.
+const componentByType = new WeakMap<object, RouteElementComponent>();
+
 /**
- * Turns a v7-style route `element` into a react-router v3 route `component`. The
- * child route that v3 injects as `props.children` is exposed through context, so
- * the element can render it with `<Outlet/>`.
+ * Turns a v7-style `element` into a react-router v3 route `component`. The child
+ * route that v3 injects as `props.children` is exposed through context, letting
+ * the element render it with `<Outlet/>`. This is how `<Route element={<X/>}>`
+ * runs on v3.
  */
-export function routeElement(
+export function routeElementToComponent(
   element: ReactNode,
-): ComponentType<{ children?: ReactNode }> {
-  return function RouteElement({ children }) {
+): RouteElementComponent {
+  const type = elementType(element);
+  if (type != null) {
+    let cached = componentByType.get(type);
+    if (!cached) {
+      cached = makeRouteElementComponent();
+      componentByType.set(type, cached);
+    }
+    return cached;
+  }
+  return makeRouteElementComponent();
+}
+
+// The component type of an element, usable as a WeakMap key (a component function
+// or a `React.memo`/`forwardRef` object). Host tags (strings) and fragments
+// (symbols) aren't keyable, so those fall back to a fresh, unmemoized component.
+function elementType(element: ReactNode): object | null {
+  if (element != null && typeof element === "object" && "type" in element) {
+    // Narrowed to an object with a `type` key just above; read it as `unknown`
+    // to classify the element's component type without assuming a React shape.
+    const type = (element as { type: unknown }).type;
+    if (typeof type === "function" || (typeof type === "object" && type)) {
+      return type;
+    }
+  }
+  return null;
+}
+
+function makeRouteElementComponent(): RouteElementComponent {
+  return function RouteElement({ children, route }) {
     return (
       <OutletContext.Provider value={children}>
-        {element}
+        {route?.element}
       </OutletContext.Provider>
     );
   };
@@ -40,5 +88,11 @@ export function routeElement(
 export function withOutlet(
   Component: ComponentType,
 ): ComponentType<{ children?: ReactNode }> {
-  return routeElement(<Component />);
+  return function RoutedComponent({ children }) {
+    return (
+      <OutletContext.Provider value={children}>
+        <Component />
+      </OutletContext.Provider>
+    );
+  };
 }

--- a/frontend/src/metabase/router/Outlet.tsx
+++ b/frontend/src/metabase/router/Outlet.tsx
@@ -16,6 +16,23 @@ export function Outlet(): JSX.Element {
 }
 
 /**
+ * Turns a v7-style route `element` into a react-router v3 route `component`. The
+ * child route that v3 injects as `props.children` is exposed through context, so
+ * the element can render it with `<Outlet/>`.
+ */
+export function routeElement(
+  element: ReactNode,
+): ComponentType<{ children?: ReactNode }> {
+  return function RouteElement({ children }) {
+    return (
+      <OutletContext.Provider value={children}>
+        {element}
+      </OutletContext.Provider>
+    );
+  };
+}
+
+/**
  * Wraps a v7-style component so it can be used as a react-router v3 route
  * `component`. The child route that v3 injects as `props.children` is exposed
  * through context, letting the wrapped component render it with `<Outlet/>`.
@@ -23,11 +40,5 @@ export function Outlet(): JSX.Element {
 export function withOutlet(
   Component: ComponentType,
 ): ComponentType<{ children?: ReactNode }> {
-  return function RouteWithOutlet({ children }) {
-    return (
-      <OutletContext.Provider value={children}>
-        <Component />
-      </OutletContext.Provider>
-    );
-  };
+  return routeElement(<Component />);
 }

--- a/frontend/src/metabase/router/guards.tsx
+++ b/frontend/src/metabase/router/guards.tsx
@@ -11,6 +11,7 @@ import { getSetting } from "metabase/selectors/settings";
 import { isSameOrSiteUrlOrigin, replaceLocation } from "metabase/utils/dom";
 
 import { Navigate } from "./Navigate";
+import { Outlet } from "./Outlet";
 import type { Location } from "./types";
 import { useLocation } from "./use-location";
 
@@ -167,49 +168,63 @@ const UserCanAccessDataStudio = createRedirectGuard(
   "/unauthorized",
 );
 
-export const IsAuthenticated = ({ children }: Props) => (
-  <MetabaseIsSetup>
-    <UserIsAuthenticated>{children}</UserIsAuthenticated>
-  </MetabaseIsSetup>
-);
-
-export const IsAdmin = ({ children }: Props) => (
+export const IsAuthenticated = () => (
   <MetabaseIsSetup>
     <UserIsAuthenticated>
-      <UserIsAdmin>{children}</UserIsAdmin>
+      <Outlet />
     </UserIsAuthenticated>
   </MetabaseIsSetup>
 );
 
-export const IsNotAuthenticated = ({ children }: Props) => (
-  <MetabaseIsSetup>
-    <UserIsNotAuthenticated>{children}</UserIsNotAuthenticated>
-  </MetabaseIsSetup>
-);
-
-export const CanAccessSettings = ({ children }: Props) => (
+export const IsAdmin = () => (
   <MetabaseIsSetup>
     <UserIsAuthenticated>
-      <UserCanAccessSettings>{children}</UserCanAccessSettings>
+      <UserIsAdmin>
+        <Outlet />
+      </UserIsAdmin>
     </UserIsAuthenticated>
   </MetabaseIsSetup>
 );
 
-export const CanAccessOnboarding = ({ children }: Props) => (
-  <UserCanAccessOnboarding>{children}</UserCanAccessOnboarding>
+export const IsNotAuthenticated = () => (
+  <MetabaseIsSetup>
+    <UserIsNotAuthenticated>
+      <Outlet />
+    </UserIsNotAuthenticated>
+  </MetabaseIsSetup>
+);
+
+export const CanAccessSettings = () => (
+  <MetabaseIsSetup>
+    <UserIsAuthenticated>
+      <UserCanAccessSettings>
+        <Outlet />
+      </UserCanAccessSettings>
+    </UserIsAuthenticated>
+  </MetabaseIsSetup>
+);
+
+export const CanAccessOnboarding = () => (
+  <UserCanAccessOnboarding>
+    <Outlet />
+  </UserCanAccessOnboarding>
 );
 
 // Must be in sync with canAccessDataStudio in frontend/src/metabase/data-studio/selectors.ts
-export const CanAccessDataStudio = ({ children }: Props) => (
+export const CanAccessDataStudio = () => (
   <MetabaseIsSetup>
     <UserIsAuthenticated>
       <UserCanAccessDataStudio>
-        <AvailableInEmbedding>{children}</AvailableInEmbedding>
+        <AvailableInEmbedding>
+          <Outlet />
+        </AvailableInEmbedding>
       </UserCanAccessDataStudio>
     </UserIsAuthenticated>
   </MetabaseIsSetup>
 );
 
-export const CanAccessDataModel = ({ children }: Props) => (
-  <UserCanAccessDataModel>{children}</UserCanAccessDataModel>
+export const CanAccessDataModel = () => (
+  <UserCanAccessDataModel>
+    <Outlet />
+  </UserCanAccessDataModel>
 );

--- a/frontend/src/metabase/router/guards.unit.spec.tsx
+++ b/frontend/src/metabase/router/guards.unit.spec.tsx
@@ -37,10 +37,10 @@ describe("route-guards", () => {
 
       const { history } = renderWithProviders(
         <>
-          <Route component={IsAuthenticated}>
+          <Route element={<IsAuthenticated />}>
             <Route path="/dashboard/:slug" component={Dashboard} />
           </Route>
-          <Route component={IsNotAuthenticated}>
+          <Route element={<IsNotAuthenticated />}>
             <Route path="/auth/login" component={LoginPage} />
           </Route>
         </>,
@@ -72,7 +72,7 @@ describe("route-guards", () => {
 
       const { history } = renderWithProviders(
         <>
-          <Route component={IsAdmin}>
+          <Route element={<IsAdmin />}>
             <Route path="/admin/settings" component={Protected} />
           </Route>
           <Route path="/unauthorized" component={Unauthorized} />
@@ -100,7 +100,7 @@ describe("route-guards", () => {
 
       const { history } = renderWithProviders(
         <>
-          <Route component={IsNotAuthenticated}>
+          <Route element={<IsNotAuthenticated />}>
             <Route path="/auth/login" component={LoginPage} />
           </Route>
           <Route path="/" component={Home} />
@@ -136,7 +136,7 @@ describe("route-guards", () => {
       });
 
       const { history } = renderWithProviders(
-        <Route component={IsNotAuthenticated}>
+        <Route element={<IsNotAuthenticated />}>
           <Route path="/auth/login" component={LoginPage} />
         </Route>,
         {

--- a/frontend/src/metabase/router/route.tsx
+++ b/frontend/src/metabase/router/route.tsx
@@ -5,7 +5,7 @@ import {
   createElement,
 } from "react";
 
-import { routeElement } from "./Outlet";
+import { routeElementToComponent } from "./Outlet";
 import {
   type PlainRoute,
   ReactRouterRoute,
@@ -14,16 +14,14 @@ import {
 } from "./react-router";
 
 /**
- * Props accepted by the `<Route>` element. Adds react-router v7's `index` on top
- * of v3's route props, so an index route is written `<Route index component={X}/>`
- * instead of the v3 `<IndexRoute>`.
+ * Props accepted by the `<Route>` element. Adds react-router v7's `index` and
+ * `element` on top of v3's route props: an index route is written
+ * `<Route index element={<X/>}/>` instead of the v3 `<IndexRoute>`, and `element`
+ * is bridged to a v3 `component` that renders it and exposes the matched child
+ * through `<Outlet/>`.
  */
 export type RouteElementProps = RouteProps & {
   index?: boolean;
-  /**
-   * v7-style wrapper element. Rendered in place of `component`, with the matched
-   * child route exposed through `<Outlet/>`.
-   */
   element?: ReactNode;
 };
 
@@ -45,9 +43,7 @@ export type Route = ComponentClass<RouteProps>;
  * react-router v7's `<Route>` shape running on the v3 engine. Like v3's `Route` it
  * is route configuration and never renders. It adds support for the v7 `index`
  * prop by registering the element as its parent's index route (what v3's
- * `<IndexRoute>` did), and for the v7 `element` prop by mapping it onto v3's
- * `component` with the matched child wired through `<Outlet/>`; every other prop
- * behaves exactly as v3's `<Route>`.
+ * `<IndexRoute>` did); every other prop behaves exactly as v3's `<Route>`.
  *
  * @see https://reactrouter.com/7.18.1/api/components/Route
  */
@@ -62,16 +58,23 @@ export const Route: RouteConfigElement = Object.assign(
       element: ReactElement<RouteElementProps>,
       parentRoute?: PlainRoute,
     ): PlainRoute | undefined {
-      const { index, element: wrapper, ...props } = element.props;
-      // A v7 `element` becomes a v3 `component` that exposes the matched child
-      // route through `<Outlet/>`. Routes without `element` pass straight through.
-      const routeProps =
-        wrapper == null
-          ? props
-          : { ...props, component: routeElement(wrapper) };
       // Rebuild the element as a raw v3 `<Route>` so v3's own builder turns it (and
       // its children) into a route object without dispatching back into this static.
-      const [route] = createRoutes(createElement(ReactRouterRoute, routeProps));
+      const { index, ...props } = element.props;
+      // v3 copies our `element` prop onto the route config but `PlainRoute` does
+      // not type it, so widen the result to read it below.
+      const [route] = createRoutes(createElement(ReactRouterRoute, props)) as [
+        (PlainRoute & { element?: ReactNode }) | undefined,
+      ];
+
+      // Bridge `element` onto v3: render it through a `component` that publishes
+      // the matched child on `<Outlet/>`'s context. The `element` stays on the
+      // route config so the bridge component can render it off the injected
+      // `route` prop, letting sibling routes that share a component reconcile
+      // instead of remounting. Goes away at the engine swap.
+      if (route?.element != null) {
+        route.component = routeElementToComponent(route.element);
+      }
 
       if (index) {
         if (parentRoute && route) {

--- a/frontend/src/metabase/router/route.tsx
+++ b/frontend/src/metabase/router/route.tsx
@@ -1,5 +1,11 @@
-import { type ComponentClass, type ReactElement, createElement } from "react";
+import {
+  type ComponentClass,
+  type ReactElement,
+  type ReactNode,
+  createElement,
+} from "react";
 
+import { routeElement } from "./Outlet";
 import {
   type PlainRoute,
   ReactRouterRoute,
@@ -12,7 +18,14 @@ import {
  * of v3's route props, so an index route is written `<Route index component={X}/>`
  * instead of the v3 `<IndexRoute>`.
  */
-export type RouteElementProps = RouteProps & { index?: boolean };
+export type RouteElementProps = RouteProps & {
+  index?: boolean;
+  /**
+   * v7-style wrapper element. Rendered in place of `component`, with the matched
+   * child route exposed through `<Outlet/>`.
+   */
+  element?: ReactNode;
+};
 
 interface RouteConfigElement {
   (props: RouteElementProps): null;
@@ -32,7 +45,9 @@ export type Route = ComponentClass<RouteProps>;
  * react-router v7's `<Route>` shape running on the v3 engine. Like v3's `Route` it
  * is route configuration and never renders. It adds support for the v7 `index`
  * prop by registering the element as its parent's index route (what v3's
- * `<IndexRoute>` did); every other prop behaves exactly as v3's `<Route>`.
+ * `<IndexRoute>` did), and for the v7 `element` prop by mapping it onto v3's
+ * `component` with the matched child wired through `<Outlet/>`; every other prop
+ * behaves exactly as v3's `<Route>`.
  *
  * @see https://reactrouter.com/7.18.1/api/components/Route
  */
@@ -47,10 +62,16 @@ export const Route: RouteConfigElement = Object.assign(
       element: ReactElement<RouteElementProps>,
       parentRoute?: PlainRoute,
     ): PlainRoute | undefined {
+      const { index, element: wrapper, ...props } = element.props;
+      // A v7 `element` becomes a v3 `component` that exposes the matched child
+      // route through `<Outlet/>`. Routes without `element` pass straight through.
+      const routeProps =
+        wrapper == null
+          ? props
+          : { ...props, component: routeElement(wrapper) };
       // Rebuild the element as a raw v3 `<Route>` so v3's own builder turns it (and
       // its children) into a route object without dispatching back into this static.
-      const { index, ...props } = element.props;
-      const [route] = createRoutes(createElement(ReactRouterRoute, props));
+      const [route] = createRoutes(createElement(ReactRouterRoute, routeProps));
 
       if (index) {
         if (parentRoute && route) {

--- a/frontend/src/metabase/router/route.tsx
+++ b/frontend/src/metabase/router/route.tsx
@@ -15,10 +15,10 @@ import {
 
 /**
  * Props accepted by the `<Route>` element. Adds react-router v7's `index` and
- * `element` on top of v3's route props: an index route is written
- * `<Route index element={<X/>}/>` instead of the v3 `<IndexRoute>`, and `element`
- * is bridged to a v3 `component` that renders it and exposes the matched child
- * through `<Outlet/>`.
+ * `element` on top of v3's route props. `index` registers the route as its
+ * parent's index route (what v3's `<IndexRoute>` did) and works with either
+ * `component` or `element`. `element` is bridged to a v3 `component` that renders
+ * it and exposes the matched child through `<Outlet/>`.
  */
 export type RouteElementProps = RouteProps & {
   index?: boolean;

--- a/frontend/src/metabase/router/route.unit.spec.tsx
+++ b/frontend/src/metabase/router/route.unit.spec.tsx
@@ -2,6 +2,7 @@ import type { PropsWithChildren } from "react";
 
 import { renderWithProviders, screen } from "__support__/ui";
 
+import { Outlet } from "./Outlet";
 import { Route } from "./route";
 
 const Parent = ({ children }: PropsWithChildren) => <div>{children}</div>;
@@ -37,6 +38,58 @@ describe("router/Route", () => {
     renderWithProviders(<Route path="solo" component={ChildPage} />, {
       withRouter: true,
       initialRoute: "/solo",
+    });
+
+    expect(await screen.findByText("child-page")).toBeInTheDocument();
+  });
+});
+
+const Wrapper = () => (
+  <div>
+    <span>wrapper chrome</span>
+    <Outlet />
+  </div>
+);
+
+const Inner = () => (
+  <div>
+    <span>inner chrome</span>
+    <Outlet />
+  </div>
+);
+
+describe("router/Route element adapter", () => {
+  it("renders an `element` wrapper with the matched child exposed via <Outlet/>", async () => {
+    renderWithProviders(
+      <Route element={<Wrapper />}>
+        <Route path="/nested" component={ChildPage} />
+      </Route>,
+      { withRouter: true, initialRoute: "/nested" },
+    );
+
+    expect(await screen.findByText("child-page")).toBeInTheDocument();
+    expect(screen.getByText("wrapper chrome")).toBeInTheDocument();
+  });
+
+  it("composes nested `element` wrappers", async () => {
+    renderWithProviders(
+      <Route element={<Wrapper />}>
+        <Route element={<Inner />}>
+          <Route path="/deep" component={ChildPage} />
+        </Route>
+      </Route>,
+      { withRouter: true, initialRoute: "/deep" },
+    );
+
+    expect(await screen.findByText("child-page")).toBeInTheDocument();
+    expect(screen.getByText("wrapper chrome")).toBeInTheDocument();
+    expect(screen.getByText("inner chrome")).toBeInTheDocument();
+  });
+
+  it("still passes `component` routes straight through to v3", async () => {
+    renderWithProviders(<Route path="/plain" component={ChildPage} />, {
+      withRouter: true,
+      initialRoute: "/plain",
     });
 
     expect(await screen.findByText("child-page")).toBeInTheDocument();

--- a/frontend/src/metabase/router/route.unit.spec.tsx
+++ b/frontend/src/metabase/router/route.unit.spec.tsx
@@ -1,6 +1,7 @@
-import type { PropsWithChildren } from "react";
+import { type PropsWithChildren, useEffect } from "react";
 
-import { renderWithProviders, screen } from "__support__/ui";
+import { act, renderWithProviders, screen } from "__support__/ui";
+import { checkNotNull } from "metabase/utils/types";
 
 import { Outlet } from "./Outlet";
 import { Route } from "./route";
@@ -93,5 +94,48 @@ describe("router/Route element adapter", () => {
     });
 
     expect(await screen.findByText("child-page")).toBeInTheDocument();
+  });
+});
+
+describe("router/Route element memoization", () => {
+  it("reuses a shared element component across sibling routes instead of remounting it", async () => {
+    let mounts = 0;
+    const Shared = () => {
+      useEffect(() => {
+        mounts += 1;
+      }, []);
+      return (
+        <div>
+          <span>shared-chrome</span>
+          <Outlet />
+        </div>
+      );
+    };
+    const PageA = () => <div>page-a</div>;
+    const PageB = () => <div>page-b</div>;
+
+    const { history } = renderWithProviders(
+      <Route path="shared">
+        <Route path=":a" element={<Shared />}>
+          <Route index element={<PageA />} />
+        </Route>
+        <Route path=":a/:b" element={<Shared />}>
+          <Route index element={<PageB />} />
+        </Route>
+      </Route>,
+      { withRouter: true, initialRoute: "/shared/1" },
+    );
+
+    expect(await screen.findByText("page-a")).toBeInTheDocument();
+    expect(mounts).toBe(1);
+
+    act(() => {
+      checkNotNull(history).push("/shared/1/2");
+    });
+
+    // The sibling route renders the same `Shared` component, so it reconciles
+    // across the navigation instead of remounting: `mounts` stays at 1.
+    expect(await screen.findByText("page-b")).toBeInTheDocument();
+    expect(mounts).toBe(1);
   });
 });

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -107,7 +107,7 @@ export const getRoutes = (store: AppStore) => {
         {/* AUTH */}
         <Route path="/auth">
           <Route index component={redirect("/auth/login")} />
-          <Route component={IsNotAuthenticated}>
+          <Route element={<IsNotAuthenticated />}>
             <Route path="login" component={Login} />
             <Route path="login/:provider" component={Login} />
           </Route>
@@ -121,13 +121,13 @@ export const getRoutes = (store: AppStore) => {
         </Route>
 
         {/* MAIN */}
-        <Route component={IsAuthenticated}>
+        <Route element={<IsAuthenticated />}>
           {getMetabotRoutes()}
 
           {/* The global all hands routes, things in here are for all the folks */}
           <Route path="/" component={LandingPageRedirect} />
 
-          <Route path="getting-started" component={CanAccessOnboarding}>
+          <Route path="getting-started" element={<CanAccessOnboarding />}>
             <Route index component={Onboarding} />
           </Route>
 
@@ -155,7 +155,7 @@ export const getRoutes = (store: AppStore) => {
             })}
           />
 
-          <Route path="collection/users" component={IsAdmin}>
+          <Route path="collection/users" element={<IsAdmin />}>
             <Route index component={UserCollectionList} />
           </Route>
 
@@ -166,7 +166,7 @@ export const getRoutes = (store: AppStore) => {
             <Route index component={PLUGIN_TENANTS.TenantCollectionList} />
           </Route>
 
-          <Route path="collection/tenant-users" component={IsAdmin}>
+          <Route path="collection/tenant-users" element={<IsAdmin />}>
             <Route index component={PLUGIN_TENANTS.TenantUsersList} />
             <Route
               path=":tenantId"


### PR DESCRIPTION
Closes DEV-2284

Composes the guard components from 1.1 as `element` wrappers so the route tree takes its v7 shape while still running on v3. Behavior is unchanged.


**1. Add `element` support to the facade `Route`.**

- v3 builds its route config by calling `type.createRouteFromReactElement` on each route element and never renders `<Route>` itself. The facade `Route` now overrides that static to translate a v7 `element` prop into v3's `component`, exposing the matched child through `<Outlet/>`. Routes without `element` pass straight through, so every existing `component=` route and `ModalRoute extends Route` are untouched.
- `Outlet.tsx` gains a `routeElementToComponent(element)` helper that builds the bridge `component`. The `element` stays on the built v3 route config, and the bridge renders it off the v3-injected `route`.
- The bridge is memoized by the element's component *type* (not by element identity). Two sibling routes rendering the same component share one bridge `component`, so React reconciles it across a navigation between them instead of remounting and losing state, matching v3's `component={X}` behavior. It also keeps the component stable across v3's config rebuilds, so a `redirect()` element does not re-fire in a loop.

This is the general element-on-v3 mechanism that Phase 2.1 needs, brought in here because the guards cannot become `element` wrappers without it. 2.1 becomes the remaining non-guard `component` to `element` sweep.

**2. Compose the guards as element wrappers.**

- The 7 composed guard exports (`IsAuthenticated`, `IsAdmin`, `IsNotAuthenticated`, `CanAccessSettings`, `CanAccessOnboarding`, `CanAccessDataStudio`, `CanAccessDataModel`) render `<Outlet/>` at the leaf instead of `children`. The primitive guards are unchanged.
- All 21 guard applications across 9 files (OSS and enterprise) move from `component={Guard}` to `element={<Guard/>}`, including guards threaded through the `getAccountRoutes` / `getAdminRoutes` / `getSettingsRoutes` / `getDataStudioRoutes` / plugin route factories.
