### PR TITLE
Setup separate entries for client and node dev data app entries

### DIFF
--- a/bin/embedding-sdk/fixup-types-after-compilation.js
+++ b/bin/embedding-sdk/fixup-types-after-compilation.js
@@ -63,6 +63,17 @@ const DTS_ROLLUPS = [
       "../../resources/embedding-sdk/dist/enterprise/frontend/src/embedding-sdk-package/data-app-dev.d.ts",
     ),
   },
+  {
+    name: "data-app-dev-config",
+    configPath: path.join(
+      __dirname,
+      "../../enterprise/frontend/src/embedding-sdk-package/embedding-sdk-data-app-dev-config-api-extractor.json",
+    ),
+    entryPointPath: path.join(
+      __dirname,
+      "../../resources/embedding-sdk/dist/enterprise/frontend/src/embedding-sdk-package/data-app-dev.config.d.ts",
+    ),
+  },
 ];
 
 const getLogger = (prefix) => {

--- a/e2e/support/helpers/build-data-app-fixture.mjs
+++ b/e2e/support/helpers/build-data-app-fixture.mjs
@@ -8,7 +8,7 @@ import { build } from "vite";
 import {
   BUILD_CONFIGS_DIR,
   DATA_APP_FIXTURES_DIR,
-  SDK_DATA_APP_DEV_SOURCE,
+  SDK_DATA_APP_DEV_CONFIG_SOURCE,
 } from "./data-app-fixture-paths.mjs";
 
 const appName = process.argv[2];
@@ -29,7 +29,7 @@ fs.mkdirSync(scratchDir, { recursive: true });
 const dataAppDevEntry = path.join(scratchDir, `${appName}.data-app-dev.mjs`);
 
 await bundle({
-  entryPoints: [SDK_DATA_APP_DEV_SOURCE],
+  entryPoints: [SDK_DATA_APP_DEV_CONFIG_SOURCE],
   outfile: dataAppDevEntry,
   bundle: true,
   platform: "node",

--- a/e2e/support/helpers/data-app-fixture-paths.mjs
+++ b/e2e/support/helpers/data-app-fixture-paths.mjs
@@ -15,9 +15,9 @@ export const DATA_APP_BUILD_SCRIPT = path.join(
   "e2e/support/helpers/build-data-app-fixture.mjs",
 );
 
-export const SDK_DATA_APP_DEV_SOURCE = path.join(
+export const SDK_DATA_APP_DEV_CONFIG_SOURCE = path.join(
   REPO_ROOT,
-  "enterprise/frontend/src/embedding-sdk-package/data-app-dev.ts",
+  "enterprise/frontend/src/embedding-sdk-package/data-app-dev.config.ts",
 );
 
 export const BUILD_CONFIGS_DIR = path.join(REPO_ROOT, "frontend/build");

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev-entry.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev-entry.tsx
@@ -7,15 +7,16 @@ import * as ReactJsxRuntime from "react/jsx-runtime";
 import * as sdkExports from "@metabase/embedding-sdk-react";
 import * as dataAppExports from "@metabase/embedding-sdk-react/data-app";
 import {
+  DevToolbar,
+  createDataAppSandbox,
+  installDevDiagnostics,
+} from "@metabase/embedding-sdk-react/data-app-dev";
+import {
   allowedHosts,
   bundleUrl,
   rebuiltEvent,
 } from "virtual:metabase-data-app-dev-config";
 import { createRoot } from "react-dom/client";
-
-import { createDataAppSandbox } from "metabase-enterprise/data_apps/sandbox/sandbox";
-import { DevToolbar } from "./components/public/debug/DevToolbar/DevToolbar";
-import { installDevDiagnostics } from "./components/public/debug/DevToolbar/diagnostics";
 
 // The same baseline reset the production iframe loads (`iframe-vendors.ts`), so the
 // dev preview matches production. style-loader injects it at runtime.

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev.config.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev.config.ts
@@ -1,0 +1,5 @@
+// Node part of the `@metabase/embedding-sdk-react/data-app-dev` with the Vite app config
+export {
+  dataAppConfig,
+  type DataAppConfigOverrides,
+} from "./data-app-dev/index";

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev.config.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev.config.ts
@@ -1,4 +1,4 @@
-// Node part of the `@metabase/embedding-sdk-react/data-app-dev` with the Vite app config
+// Node subpath `@metabase/embedding-sdk-react/data-app-dev/config` with the Vite app config
 export {
   dataAppConfig,
   type DataAppConfigOverrides,

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev.ts
@@ -1,4 +1,8 @@
+// Browser part of the `@metabase/embedding-sdk-react/data-app-dev` with dev app client exports
 export {
-  dataAppConfig,
-  type DataAppConfigOverrides,
-} from "./data-app-dev/index";
+  DataAppDevProvider,
+  type DataAppDevProviderProps,
+} from "./components/public/DataAppDevProvider/DataAppDevProvider";
+export { DevToolbar } from "./components/public/debug/DevToolbar/DevToolbar";
+export { installDevDiagnostics } from "./components/public/debug/DevToolbar/diagnostics";
+export { createDataAppSandbox } from "metabase-enterprise/data_apps/sandbox";

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev.ts
@@ -1,4 +1,5 @@
-// Browser part of the `@metabase/embedding-sdk-react/data-app-dev` with dev app client exports
+// Browser subpath `@metabase/embedding-sdk-react/data-app-dev` with dev app client exports.
+// The Node Vite config preset lives at `/data-app-dev/config` (data-app-dev.config.ts).
 export { DevToolbar } from "./components/public/debug/DevToolbar/DevToolbar";
 export { installDevDiagnostics } from "./components/public/debug/DevToolbar/diagnostics";
 export { createDataAppSandbox } from "metabase-enterprise/data_apps/sandbox";

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev.ts
@@ -1,8 +1,4 @@
 // Browser part of the `@metabase/embedding-sdk-react/data-app-dev` with dev app client exports
-export {
-  DataAppDevProvider,
-  type DataAppDevProviderProps,
-} from "./components/public/DataAppDevProvider/DataAppDevProvider";
 export { DevToolbar } from "./components/public/debug/DevToolbar/DevToolbar";
 export { installDevDiagnostics } from "./components/public/debug/DevToolbar/diagnostics";
 export { createDataAppSandbox } from "metabase-enterprise/data_apps/sandbox";

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev.ts
@@ -2,4 +2,4 @@
 // The Node Vite config preset lives at `/data-app-dev/config` (data-app-dev.config.ts).
 export { DevToolbar } from "./components/public/debug/DevToolbar/DevToolbar";
 export { installDevDiagnostics } from "./components/public/debug/DevToolbar/diagnostics";
-export { createDataAppSandbox } from "metabase-enterprise/data_apps/sandbox";
+export { createDataAppSandbox } from "metabase-enterprise/data_apps/sandbox/sandbox";

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/index.ts
@@ -78,7 +78,7 @@ export interface DataAppConfigOverrides {
  * `vite.config.ts` needs:
  *
  * ```ts
- * import { dataAppConfig } from "@metabase/embedding-sdk-react/data-app-dev";
+ * import { dataAppConfig } from "@metabase/embedding-sdk-react/data-app-dev/config";
  *
  * export default dataAppConfig();
  * ```

--- a/enterprise/frontend/src/embedding-sdk-package/embedding-sdk-data-app-dev-config-api-extractor.json
+++ b/enterprise/frontend/src/embedding-sdk-package/embedding-sdk-data-app-dev-config-api-extractor.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "mainEntryPointFilePath": "<projectFolder>/resources/embedding-sdk/dist/enterprise/frontend/src/embedding-sdk-package/data-app-dev.config.d.ts",
+  "bundledPackages": [],
+  "apiReport": {
+    "enabled": false
+  },
+  "docModel": {
+    "enabled": false
+  },
+  "dtsRollup": {
+    "enabled": true,
+    "untrimmedFilePath": "<projectFolder>/resources/embedding-sdk/dist/data-app-dev.config.d.ts"
+  },
+  "tsdocMetadata": {
+    "enabled": false
+  },
+  "messages": {
+    "extractorMessageReporting": {
+      "ae-wrong-input-file-type": {
+        "logLevel": "none"
+      }
+    }
+  }
+}

--- a/enterprise/frontend/src/embedding-sdk-package/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk-package/package.template.json
@@ -25,14 +25,12 @@
       "import": "./dist/data-app.js"
     },
     "./data-app-dev": {
-      "node": {
-        "types": "./dist/data-app-dev.config.d.ts",
-        "default": "./dist/data-app-dev.config.js"
-      },
-      "default": {
-        "types": "./dist/data-app-dev.d.ts",
-        "default": "./dist/data-app-dev.js"
-      }
+      "types": "./dist/data-app-dev.d.ts",
+      "import": "./dist/data-app-dev.js"
+    },
+    "./data-app-dev/config": {
+      "types": "./dist/data-app-dev.config.d.ts",
+      "import": "./dist/data-app-dev.config.js"
     },
     "./package.json": "./package.json"
   },

--- a/enterprise/frontend/src/embedding-sdk-package/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk-package/package.template.json
@@ -25,8 +25,14 @@
       "import": "./dist/data-app.js"
     },
     "./data-app-dev": {
-      "types": "./dist/data-app-dev.d.ts",
-      "import": "./dist/data-app-dev.js"
+      "node": {
+        "types": "./dist/data-app-dev.config.d.ts",
+        "default": "./dist/data-app-dev.config.js"
+      },
+      "default": {
+        "types": "./dist/data-app-dev.d.ts",
+        "default": "./dist/data-app-dev.js"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/rspack.embedding-sdk-node.config.js
+++ b/rspack.embedding-sdk-node.config.js
@@ -78,7 +78,7 @@ const cliConfig = {
 /** @type {import('@rspack/cli').Configuration} */
 const dataAppDevConfig = {
   mode: "production",
-  entry: `${SDK_PACKAGE_SRC_PATH}/data-app-dev.ts`,
+  entry: `${SDK_PACKAGE_SRC_PATH}/data-app-dev.config.ts`,
   target: "node",
   context: SDK_PACKAGE_SRC_PATH,
   // The consumer's app provides the Vite toolchain (the same Vite instance runs
@@ -94,7 +94,7 @@ const dataAppDevConfig = {
   externalsType: "module",
   output: {
     path: SDK_DIST_PATH,
-    filename: "data-app-dev.js",
+    filename: "data-app-dev.config.js",
     library: { type: "module" },
   },
   experiments: { outputModule: true },

--- a/rspack.embedding-sdk-node.config.js
+++ b/rspack.embedding-sdk-node.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 /* eslint-disable no-undef */
 // Node-targeted builds for the SDK package: the `npx` CLI and the data-app dev
-// preset (`@metabase/embedding-sdk-react/data-app-dev`). Both run
+// preset (`@metabase/embedding-sdk-react/data-app-dev/config`). Both run
 // in Node (not the browser), so they can't go through the browser rspack bundle.
 const path = require("path");
 
@@ -72,9 +72,11 @@ const cliConfig = {
 };
 
 // ESM-only: this entry is imported from a Vite config (`import { dataAppConfig }
-// from "@metabase/embedding-sdk-react/data-app-dev"`), which Vite loads through the
-// ESM `import` condition. ESM-only lets the dev plugin read its sibling dev-entry
-// bundle via `import.meta.url` natively (no `__dirname` shim needed).
+// from "@metabase/embedding-sdk-react/data-app-dev/config"`), which Vite loads
+// through the ESM `import` condition. ESM-only lets the dev plugin read its
+// sibling dev-entry bundle via `import.meta.url` natively (no `__dirname` shim
+// needed). The browser subpath (`/data-app-dev`) is built from `data-app-dev.ts`
+// by rspack.embedding-sdk-package.config.js.
 /** @type {import('@rspack/cli').Configuration} */
 const dataAppDevConfig = {
   mode: "production",

--- a/rspack.embedding-sdk-package.config.js
+++ b/rspack.embedding-sdk-package.config.js
@@ -111,6 +111,7 @@ const esmConfig = {
   entry: {
     "main.esm": "./index.ts",
     "data-app.esm": "./data-app.ts",
+    "data-app-dev": "./data-app-dev.ts",
   },
 
   output: {
@@ -144,6 +145,7 @@ const dataAppDevEntryConfig = {
     "react/jsx-dev-runtime",
     "@metabase/embedding-sdk-react",
     "@metabase/embedding-sdk-react/data-app",
+    "@metabase/embedding-sdk-react/data-app-dev",
     DATA_APP_DEV_CONFIG_VIRTUAL_ID,
   ],
 

--- a/skills/metabase-data-app-routing/SKILL.md
+++ b/skills/metabase-data-app-routing/SKILL.md
@@ -17,7 +17,7 @@ That's the entire surface. **No `react-router` of any version, no `<BrowserRoute
 
 ## When to use this skill
 
-- The user has a working data-app project — scaffolded from the `data-app-template` repo, so `vite.config.ts` with `name: "__dataAppFactory__"`, an `src/index.tsx` that exports a factory, and an `src/dev.tsx` for the dev preview already exist.
+- The user has a working data-app project — scaffolded from the `data-app-template` repo, so a one-liner `vite.config.ts` (`dataAppConfig()`) and an `src/index.tsx` that exports a factory already exist. The dev preview has no in-project entry: the SDK's dev preset serves it.
 - The user wants the bundle to render different content at different URLs (`/overview`, `/customers/:id`).
 - **Do not use this skill** to scaffold a project from scratch — it only patches an existing data-app project. If there is no project yet, stop and tell the user to start with a new data-app scaffold before adding routing.
 
@@ -27,7 +27,7 @@ The template already externalizes `@metabase/embedding-sdk-react/data-app` in `v
 
 Import the routing primitives normally. `<DataAppRouter>` does NOT take a `basename` prop — it auto-detects the iframe's URL prefix (`/embed/apps/<name>`) in production and resolves to no prefix in the Vite dev preview.
 
-`App.tsx` is pure content — no `<MetabaseProvider>` here. The dev entry (`src/dev.tsx`) and the production host both wrap the tree.
+`App.tsx` is pure content — no `<MetabaseProvider>` here. The SDK's dev preview entry (`DataAppDevProvider`) and the production host (`DataAppProvider`) each wrap the tree in their own realm.
 
 ```tsx
 import { StaticQuestion } from "@metabase/embedding-sdk-react";
@@ -179,7 +179,7 @@ function useCustomerIdFromPath(): number | null {
 
 | Symptom | Fix |
 |---|---|
-| `<DataAppLink>` renders as plain text (no clickable link) on initial load. | The bundle hasn't finished loading and the fallback path is showing. Confirm the tree is wrapped in `<MetabaseProvider authConfig=…>` (dev) or `<DataAppProvider>` (host) so the bundle gets triggered. The fallback resolves to a real link once the bundle is up. |
+| `<DataAppLink>` renders as plain text (no clickable link) on initial load. | The bundle hasn't finished loading and the fallback path is showing. The provider wrap is supplied automatically (the SDK dev preview's `DataAppDevProvider`, or the host's `DataAppProvider`) — don't add `<MetabaseProvider>` inside the app. The fallback resolves to a real link once the bundle is up. |
 | URL changes in dev preview but the production iframe shows the bundle re-render itself on every navigation (or routes don't work in prod at all). | `vite.config.ts` got edited and lost `@metabase/embedding-sdk-react/data-app` from `external` / `output.globals`. Restore from the [template](https://github.com/metabase/data-app-template) — without it, Vite inlines the package's implementation into `dist/index.js`, which runs inside the Near Membrane sandbox and breaks React's state batching. |
 | URL changes but UI doesn't. | A `<BrowserRouter>`/`<HashRouter>` is still in the tree. Strip the router library out and use `<DataAppRouter>` / `<DataAppLink>` instead — the Near Membrane interaction with React-18 batching breaks every router that runs its own `setState` inside the bundle. |
 | Reload at a deep URL in dev (`localhost:5174/customers/42`) shows a blank page. | Vite's dev server is serving the route as a 404 instead of falling back to `index.html`. Set `appType: "spa"` in `vite.config.ts` (it's the default — only an issue if someone overrode it). |

--- a/skills/metabase-data-app-setup/SKILL.md
+++ b/skills/metabase-data-app-setup/SKILL.md
@@ -42,7 +42,7 @@ Data apps live inside the Git repository connected to Metabase via remote-sync. 
 If `<repo>/data_apps/<slug>/` already holds a project, verify it matches the current `data-app-template`. Check **all** of:
 
 1. `vite.config.ts` is a one-liner: `export default dataAppConfig()`
-   (from `@metabase/embedding-sdk-react/data-app-dev`). There is **no**
+   (from `@metabase/embedding-sdk-react/data-app-dev/config`). There is **no**
    local `config/` directory: the whole bundle contract (externals/globals, the
    dev sandbox entry, CSS/SVG handling) lives inside that SDK config, not the
    scaffold. `dataAppConfig` takes only a curated set of overrides (currently just
@@ -81,7 +81,7 @@ Once the template is in `<repo>/data_apps/<slug>/` (run everything below from th
    npm install @metabase/embedding-sdk-react@63-data-apps
    ```
 
-   This resolves to the current internal-testing SDK build with the `@metabase/embedding-sdk-react/data-app` entrypoint (the app's APIs) and the `@metabase/embedding-sdk-react/data-app-dev` entrypoint `vite.config.ts` uses (the dev/build preset, which serves the sandbox entry). Do not use `latest`, `63-stable`, or a generic `^0.63.x` range for data apps until the data-app SDK surface is promoted out of the internal tag.
+   This resolves to the current internal-testing SDK build with the `@metabase/embedding-sdk-react/data-app` entrypoint (the app's APIs) and the `@metabase/embedding-sdk-react/data-app-dev/config` entrypoint `vite.config.ts` uses (the dev/build preset, which serves the sandbox entry). Do not use `latest`, `63-stable`, or a generic `^0.63.x` range for data apps until the data-app SDK surface is promoted out of the internal tag.
 3. **Ensure the repo-root `.gitignore` ignores `.env.local`** — do this *before* creating any credentials file so the secret can never be committed. Create the `.gitignore` if the repo doesn't have one, then add the entry if it's missing:
 
    ```bash
@@ -181,7 +181,7 @@ with data-layer authoring rules.
 **Do not modify `src/index.tsx` or `tsconfig.json` unless the change is genuinely required.** The whole build/dev setup lives in the SDK behind `dataAppConfig()` (which also serves the dev HTML shell — there's no `index.html` to edit), so `vite.config.ts` is just:
 
 ```ts
-import { dataAppConfig } from "@metabase/embedding-sdk-react/data-app-dev";
+import { dataAppConfig } from "@metabase/embedding-sdk-react/data-app-dev/config";
 
 export default dataAppConfig();
 ```

--- a/skills/metabase-data-app-setup/template/vite.config.ts
+++ b/skills/metabase-data-app-setup/template/vite.config.ts
@@ -1,3 +1,3 @@
-import { dataAppConfig } from "@metabase/embedding-sdk-react/data-app-dev";
+import { dataAppConfig } from "@metabase/embedding-sdk-react/data-app-dev/config";
 
 export default dataAppConfig();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,9 @@
       ],
       "@metabase/embedding-sdk-react/data-app-dev": [
         "./enterprise/frontend/src/embedding-sdk-package/data-app-dev.ts"
+      ],
+      "@metabase/embedding-sdk-react/data-app-dev/config": [
+        "./enterprise/frontend/src/embedding-sdk-package/data-app-dev.config.ts"
       ]
     },
     "plugins": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,9 @@
       ],
       "@metabase/embedding-sdk-react/data-app": [
         "./enterprise/frontend/src/embedding-sdk-package/data-app.ts"
+      ],
+      "@metabase/embedding-sdk-react/data-app-dev": [
+        "./enterprise/frontend/src/embedding-sdk-package/data-app-dev.ts"
       ]
     },
     "plugins": [


### PR DESCRIPTION
This PR:
- splits the `@metabase/embedding-sdk-react/data-app-dev` import into client and node resolved, and routes client to `data-app-dev.js` and server to `data-app-dev.config.js`.
- having this setup we can keep a single import,  but 2 different entries for vite app dev data app config and client-side data app dev exports like DevToolbar or (in the separate PR) DataAppDevProvider
- also because of this change, these client dev entries from `@metabase/embedding-sdk-react/data-app-dev` are now properly externalized instead of being bundled

How to test:
- CI should pass
- you can run `bun run build-embedding-sdk-package` and check `resources/embedding-sdk/dist`:
    - resources/embedding-sdk/dist/data-app.esm.js should be a relatively small file
    - resources/embedding-sdk/dist/data-app-dev-entry.js now a relatively small file
    - resources/embedding-sdk/dist/data-app-dev.js - expectedly kind of non-small file as it contains near-membrame + some dev data app components (toolbar, etc)
    - resources/embedding-sdk/dist/data-app-dev.config.js - expectedly kind of non-smal file as it bundles `js-yaml`