### PR TITLE
Take a data app's slug from its directory name

### DIFF
--- a/e2e/support/assets/data-apps/.gitignore
+++ b/e2e/support/assets/data-apps/.gitignore
@@ -1,6 +1,6 @@
-# Each test app under this directory commits ONLY its `src/`. At test setup we
-# copy the `skills/metabase-data-app-setup/template` base (everything except its `src/`)
-# into the app dir and build the bundle with the Vite API — all of that is
-# generated, so it's ignored here.
+# Each test app under this directory commits its `src/` and its `data_app.yaml`
+# manifest. Everything else — the SDK/template base pulled in at test setup and
+# the built `dist/` bundle (Vite API) — is generated, so it's ignored here.
 /*/*
 !/*/src
+!/*/data_app.yaml

--- a/e2e/support/assets/data-apps/custom-error-component/data_app.yaml
+++ b/e2e/support/assets/data-apps/custom-error-component/data_app.yaml
@@ -1,0 +1,2 @@
+name: Custom Error Component
+path: ./dist/index.js

--- a/e2e/support/assets/data-apps/kitchen-sink/data_app.yaml
+++ b/e2e/support/assets/data-apps/kitchen-sink/data_app.yaml
@@ -1,0 +1,2 @@
+name: Kitchen Sink
+path: ./dist/index.js

--- a/e2e/support/assets/example_synced_data_apps/data_apps/bad-config/data_app.yaml
+++ b/e2e/support/assets/example_synced_data_apps/data_apps/bad-config/data_app.yaml
@@ -1,0 +1,1 @@
+name: [unterminated

--- a/e2e/support/assets/example_synced_data_apps/data_apps/bad-config/index.js
+++ b/e2e/support/assets/example_synced_data_apps/data_apps/bad-config/index.js
@@ -1,0 +1,2 @@
+// Present, but unreachable: its data_app.yaml can't be parsed, so the app is skipped.
+export default () => ({ component: null });

--- a/e2e/support/assets/example_synced_data_apps/data_apps/broken-bundle/data_app.yaml
+++ b/e2e/support/assets/example_synced_data_apps/data_apps/broken-bundle/data_app.yaml
@@ -1,0 +1,3 @@
+name: Broken Bundle
+# Points at a file that isn't in the repo — a valid config, an un-loadable app.
+path: ./missing.js

--- a/e2e/support/assets/example_synced_data_apps/data_apps/good/data_app.yaml
+++ b/e2e/support/assets/example_synced_data_apps/data_apps/good/data_app.yaml
@@ -1,0 +1,2 @@
+name: Good App
+path: ./index.js

--- a/e2e/support/assets/example_synced_data_apps/data_apps/good/index.js
+++ b/e2e/support/assets/example_synced_data_apps/data_apps/good/index.js
@@ -1,0 +1,3 @@
+// A placeholder bundle — this fixture exercises sync/materialization + the admin
+// listing + the bundle endpoint, not rendering, so the bytes are served opaquely.
+export default () => ({ component: null });

--- a/e2e/support/assets/example_synced_data_apps/data_apps/no-config/index.js
+++ b/e2e/support/assets/example_synced_data_apps/data_apps/no-config/index.js
@@ -1,0 +1,3 @@
+// A bundle with no data_app.yaml beside it — nothing declares this directory an
+// app, so sync doesn't discover it.
+export default () => ({ component: null });

--- a/e2e/support/helpers/build-data-app-fixture.mjs
+++ b/e2e/support/helpers/build-data-app-fixture.mjs
@@ -41,6 +41,8 @@ await bundle({
 
 const { dataAppConfig } = await import(pathToFileURL(dataAppDevEntry).href);
 
+process.chdir(appDir);
+
 await build({
   root: appDir,
   configFile: false,

--- a/e2e/support/helpers/e2e-data-app-helpers.ts
+++ b/e2e/support/helpers/e2e-data-app-helpers.ts
@@ -3,6 +3,24 @@ import type { DataApp } from "metabase-types/api";
 
 import type { DataAppTestEnv } from "./data-app-test-env";
 import { getIframeBody } from "./e2e-embedding-helpers";
+import { LOCAL_GIT_PATH } from "./e2e-remote-sync-helpers";
+
+export const SYNCED_DATA_APPS_FIXTURE_PATH =
+  Cypress.config("projectRoot") +
+  "/e2e/support/assets/example_synced_data_apps";
+
+/**
+ * Copy the example data-app repo into the working directory of the local git repo
+ * `setupGitSync` created, so a `commitToRepo` + a real pull materialize its apps.
+ * The repo holds one directory per materialization outcome (a good app, an app
+ * whose bundle is missing, a malformed config, and a directory with no config) —
+ * see the fixture and the sync spec that drives it.
+ */
+export const copySyncedDataAppsFixture = () =>
+  cy.task("copyDirectory", {
+    source: SYNCED_DATA_APPS_FIXTURE_PATH,
+    destination: LOCAL_GIT_PATH,
+  });
 
 /**
  * The e2e data-app fixture that `mockDataApp` builds and serves — its directory

--- a/e2e/test/scenarios/data-apps/sync.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/sync.cy.spec.ts
@@ -1,0 +1,95 @@
+const { H } = cy;
+
+/**
+ * Drives a real remote-sync pull of a repo whose `data_apps/` covers every
+ * materialization outcome, and asserts each is handled the way the backend
+ * intends (see `data-apps.sync` / `data-apps.config`):
+ *
+ *   good/          valid config + bundle        -> materialized, served
+ *   broken-bundle/ valid config, missing bundle -> row with "Sync failed", not served
+ *   bad-config/    malformed data_app.yaml       -> skipped, no row
+ *   no-config/     a bundle but no data_app.yaml -> not discovered, no row
+ *
+ * A bad app never blocks a good one, and neither a bad config nor a missing
+ * bundle removes an app that isn't theirs.
+ */
+describe("scenarios > data apps > repo sync", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.activateToken("bleeding-edge");
+    H.setupGitSync();
+  });
+
+  it("materializes each app per its config/bundle, isolating the broken ones", () => {
+    H.copySyncedCollectionFixture();
+    H.copySyncedDataAppsFixture();
+    H.commitToRepo("Add data apps with mixed config/bundle states");
+
+    H.configureGitAndPullChanges("read-write");
+
+    cy.visit("/admin/settings/apps");
+    cy.findByTestId("admin-layout-content").within(() => {
+      // The good app is materialized and shown as synced. Scope to its own row so
+      // its status can't be satisfied by another app's — a "Sync failed" leaking
+      // onto the good app (or "Synced" onto the broken one) must fail the test.
+      cy.findByTestId("data-app-list-item-good")
+        .scrollIntoView()
+        .within(() => {
+          cy.findByRole("link", { name: "Good App" }).should("be.visible");
+          cy.findByText(/^Synced/).should("be.visible");
+        });
+
+      // The app whose bundle is missing still appears — with its failure, not hidden.
+      // Its name is plain text, not a link: a sync-failed app can't be opened.
+      cy.findByTestId("data-app-list-item-broken-bundle")
+        .scrollIntoView()
+        .within(() => {
+          cy.findByText("Broken Bundle").should("be.visible");
+          cy.findByRole("link", { name: "Broken Bundle" }).should("not.exist");
+          cy.findByText("Sync failed").should("be.visible");
+        });
+
+      // The malformed config and the config-less directory produced no app at all.
+      cy.findByText("/apps/bad-config").should("not.exist");
+      cy.findByText("/apps/no-config").should("not.exist");
+    });
+
+    // The API tells the same story: exactly the two apps, and only the good one serves a bundle.
+    cy.request("GET", "/api/apps").then(({ body: apps }) => {
+      expect(apps.map((app: { name: string }) => app.name).sort()).to.deep.eq([
+        "broken-bundle",
+        "good",
+      ]);
+    });
+
+    cy.request("/api/apps/good/bundle").its("status").should("eq", 200);
+
+    cy.request({
+      url: "/api/apps/broken-bundle/bundle",
+      failOnStatusCode: false,
+    }).then(({ status, body }) => {
+      expect(status).to.eq(404);
+      expect(body).to.deep.eq({ error: "Bundle not synced yet" });
+    });
+
+    for (const slug of ["bad-config", "no-config"]) {
+      cy.request({
+        url: `/api/apps/${slug}/bundle`,
+        failOnStatusCode: false,
+      }).then(({ status, body }) => {
+        expect(status).to.eq(404);
+        expect(body).to.eq("Not found.");
+      });
+    }
+
+    // And what a user opening the broken app sees: its metadata loads (the app
+    // exists), the host frames it, and the bundle 404 surfaces from inside the
+    // iframe as the "isn't ready yet" screen — driven by the real pull, no mocks.
+    // (The not-found screen for a missing app is covered in viewing.cy.spec.ts.)
+    cy.visit("/apps/broken-bundle");
+    H.main()
+      .findByText(/isn.t ready yet/i, { timeout: 30000 })
+      .should("be.visible");
+  });
+});

--- a/e2e/test/scenarios/data-apps/viewing.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/viewing.cy.spec.ts
@@ -1,7 +1,6 @@
 import {
   DATA_APP_DISPLAY_NAME as APP_DISPLAY_NAME,
   DATA_APP_NAME as APP_NAME,
-  fakeDataApp as fakeApp,
   visitDataAppRoute as visitAppRoute,
 } from "e2e/support/helpers";
 
@@ -61,15 +60,9 @@ describe("scenarios > data apps > viewing & routing", () => {
     });
 
     it("shows a not-found state for a disabled or missing app", () => {
-      // A disabled or non-existent app 404s from the metadata endpoint; the host
-      // renders a not-found state rather than a broken iframe.
-      cy.intercept("GET", `/api/apps/${APP_NAME}`, {
-        statusCode: 404,
-        body: {},
-      }).as("meta");
-
-      H.openDataApp(APP_NAME);
-      cy.wait("@meta");
+      // No app with this slug exists, so the metadata endpoint really 404s and the
+      // host renders a not-found state rather than a broken iframe — no mock needed.
+      H.openDataApp("does-not-exist");
       H.main().findByText("Data app not found").should("be.visible");
     });
   });
@@ -148,20 +141,6 @@ describe("scenarios > data apps > viewing & routing", () => {
       // renders its themed failure screen in the host realm.
       H.main()
         .findByText(/couldn.t be loaded/i, { timeout: 30000 })
-        .should("be.visible");
-    });
-
-    it("shows a not-ready screen when the bundle hasn't synced (404)", () => {
-      cy.intercept("GET", "/api/apps/repo-status", { configured: true });
-      cy.intercept("GET", `/api/apps/${APP_NAME}`, fakeApp());
-      cy.intercept("GET", `/api/apps/${APP_NAME}/bundle*`, {
-        statusCode: 404,
-        body: { error: "Bundle not synced yet" },
-      });
-
-      cy.visit(`/apps/${APP_NAME}`);
-      H.main()
-        .findByText(/isn.t ready yet/i, { timeout: 30000 })
         .should("be.visible");
     });
   });

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -2,7 +2,7 @@
   "Data-app endpoints, mounted at `/api/apps`.
 
    Data apps come from the repository connected via the remote-sync feature. The
-   repo's `data_apps/<dir>/data_app.yml` files are discovered on sync and each is
+   repo's `data_apps/<dir>/data_app.yaml` files are discovered on sync and each is
    materialized as one `data_app` row, caching the app's bundle. Users navigate to
    `/apps/:slug`, which fetches `/api/apps/:slug/bundle` and evaluates the
    bytes inside a Near Membrane sandbox.

--- a/enterprise/backend/src/metabase_enterprise/data_apps/config.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/config.clj
@@ -1,16 +1,15 @@
 (ns metabase-enterprise.data-apps.config
-  "Parsing + validation of a per-app `data_app.yml`. Each data app lives in its
+  "Parsing + validation of a per-app `data_app.yaml`. Each data app lives in its
    own directory under `data_apps/` at the repo root, alongside its built bundle:
 
      data_apps/
-       sales/
-         data_app.yml
+       sales/                   # the directory name is the slug: /apps/sales
+         data_app.yaml
          dist/index.js
 
-   where `data_app.yml` is:
+   where `data_app.yaml` is:
 
      name: Sales dashboard      # display name
-     slug: sales                # URL identity (/apps/:slug)
      path: dist/index.js        # bundle path, relative to this app's directory
      allowed_hosts:             # optional — origins the sandboxed bundle may fetch/XHR
        - https://api.example.com
@@ -27,20 +26,18 @@
 (set! *warn-on-reflection* true)
 
 (def config-file-name
-  "Canonical name of the per-app config file (used in error messages). Both
-   `data_app.yml` and `data_app.yaml` are accepted on disk — see [[config-file-re]]."
-  "data_app.yml")
-
-(def config-file-re
-  "Matches the per-app config filename, either extension."
-  #"data_app\.ya?ml")
+  "Name of the per-app config file (used in error messages)."
+  "data_app.yaml")
 
 (def apps-dir
   "Directory at the repo root that holds one subdirectory per data app."
   "data_apps")
 
 (def ^:private slug-pattern
-  "Lowercase letters/numbers separated by single dashes."
+  "Lowercase letters/numbers separated by single dashes. An app *directory* must
+   match this: the name is used verbatim as the slug, never normalized. Folding
+   case here would reintroduce the collisions the directory naming rules out —
+   git happily holds both `data_apps/Sales` and `data_apps/sales`."
   #"[a-z0-9]+(?:-[a-z0-9]+)*")
 
 (def ^:private reserved-slugs
@@ -106,24 +103,30 @@
       (throw (ex-info (tru "Could not parse {0}/{1}: {2}" dir config-file-name (ex-message e))
                       {:status-code 400})))))
 
+(defn- dir-slug
+  "The app's slug: the name of its directory (`data_apps/sales` -> `sales`)."
+  [^String dir]
+  (subs dir (inc (str/last-index-of dir "/"))))
+
 (defn parse-app-config
-  "Parse the bytes of one `data_app.yml` (from directory `dir`, used only for
-   error messages) into `{:slug ..., :display_name ..., :path ...,
-   :allowed_hosts [...]}`. `path` is relative to the app's directory;
-   `:allowed_hosts` is a (possibly empty) vector of origins the sandboxed bundle
-   may reach. Throws an `ex-info` with `:status-code` 400 on malformed or
-   incomplete content."
+  "Parse the bytes of one `data_app.yaml` from the app directory `dir` (e.g.
+   `data_apps/sales`) into `{:slug ..., :display_name ..., :path ...,
+   :allowed_hosts [...]}`. The slug is the directory's name; `path` is relative to
+   the directory; `:allowed_hosts` is a (possibly empty) vector of origins the
+   sandboxed bundle may reach. Throws an `ex-info` with `:status-code` 400 on
+   malformed or incomplete content — including a directory whose name isn't a
+   usable slug, since that app has no URL to be served at."
   [^bytes bytes ^String dir]
   (let [parsed        (parse-yaml bytes dir)
-        slug          (some-> (:slug parsed) str str/trim not-empty)
+        slug          (dir-slug dir)
         name          (some-> (:name parsed) str str/trim not-empty)
         path          (some-> (:path parsed) normalize-path not-empty)
         allowed-hosts (parse-allowed-hosts parsed dir)]
-    (when-not (and slug (re-matches slug-pattern slug))
-      (throw (ex-info (tru "{0}/{1}: \"slug\" must be lowercase letters, numbers, and dashes." dir config-file-name)
+    (when-not (re-matches slug-pattern slug)
+      (throw (ex-info (tru "{0}: the app directory''s name is its slug, so it must be lowercase letters, numbers, and dashes." dir)
                       {:status-code 400})))
     (when (contains? reserved-slugs slug)
-      (throw (ex-info (tru "{0}/{1}: \"{2}\" is a reserved slug." dir config-file-name slug)
+      (throw (ex-info (tru "{0}: \"{1}\" is a reserved slug — rename the directory." dir slug)
                       {:status-code 400})))
     (when-not name
       (throw (ex-info (tru "{0}/{1}: \"name\" is required." dir config-file-name)

--- a/enterprise/backend/src/metabase_enterprise/data_apps/sync.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/sync.clj
@@ -4,8 +4,9 @@
    Data apps ride the remote-sync import pipeline: whenever remote-sync pulls the
    connected repository (manual \"Pull changes\", auto-import poll, or startup),
    it calls [[sync-from-snapshot!]] with the just-imported snapshot. We discover
-   every `data_apps/<dir>/data_app.yml`, materialize one `data_app` row per app
-   (caching the built bundle), and prune rows whose app directory is gone.
+   every `data_apps/<dir>/data_app.yaml` and materialize one `data_app` row per app
+   (caching the built bundle). A sync only upserts — it never deletes, so an app
+   whose directory is gone from the repo is kept until an admin removes it.
 
    This namespace does no Git access of its own — the snapshot's `read-file` /
    `list-files` come from remote-sync. The cached `bundle` blob is what serving
@@ -48,28 +49,31 @@
 
 ;;; ----------------------------------------------------- Discovery -----------------------------------------------------
 
-(def ^:private config-path-regex
-  ;; data_apps/<dir>/data_app.{yml,yaml}, where <dir> is a single path segment
-  (re-pattern (format "%s/[^/]+/%s"
-                      (Pattern/quote data-app.config/apps-dir)
-                      (.pattern ^Pattern data-app.config/config-file-re))))
+(def ^:private app-dir-regex
+  ;; the data_apps/<dir> folder a repo path sits in (dir = a single path segment)
+  (re-pattern (format "(%s/[^/]+)/.*" (Pattern/quote data-app.config/apps-dir))))
 
 (defn- discover-app-configs
   "Given the snapshot's `list-files` and `read-file` fns (where `read-file`
-   returns file text or nil), return one entry per `data_apps/<dir>/data_app.yml`,
-   each either a parsed app `{:slug :display_name :bundle :allowed_hosts}` (with
-   `:bundle` the repo-root relative bundle path) or `{:config-error <message>}`. Parse/read
-   failures are isolated per app so one bad config can't abort the whole sync."
+   returns file text or nil), iterate the folders under `data_apps/` and return one
+   entry per folder that is an app — it holds a `data_app.yaml`; a folder without
+   one is skipped. Each entry is a parsed app
+   `{:slug :display_name :bundle :allowed_hosts}` (with `:bundle` the repo-root
+   relative bundle path) or `{:config-error <message>}`. Parse/read failures are
+   isolated per app so one bad config can't abort the sync."
   [list-files read-file]
-  (for [config-path (filter #(re-matches config-path-regex %) (list-files))
-        :let [dir (subs config-path 0 (str/last-index-of config-path "/"))]]
-    (try
-      (if-let [content (read-file config-path)]
-        (let [{:keys [slug display_name path allowed_hosts]} (data-app.config/parse-app-config (->bytes content) dir)]
-          {:slug slug, :display_name display_name, :bundle (str dir "/" path), :allowed_hosts allowed_hosts})
-        {:config-error (tru "Could not read {0}." config-path)})
-      (catch Throwable e
-        {:config-error (ex-message e)}))))
+  (let [files    (set (list-files))
+        app-dirs (distinct (keep #(second (re-matches app-dir-regex %)) files))]
+    (for [dir  app-dirs
+          :let [config-path (files (str dir "/data_app.yaml"))]
+          :when config-path]
+      (try
+        (if-let [content (read-file config-path)]
+          (let [{:keys [slug display_name path allowed_hosts]} (data-app.config/parse-app-config (->bytes content) dir)]
+            {:slug slug, :display_name display_name, :bundle (str dir "/" path), :allowed_hosts allowed_hosts})
+          {:config-error (tru "Could not read {0}." config-path)})
+        (catch Throwable e
+          {:config-error (ex-message e)})))))
 
 ;;; ----------------------------------------------------- Materialize -----------------------------------------------------
 
@@ -138,57 +142,58 @@
       :list-files (fn [] -> [<path-string> ...])
       :sha        <commit-sha-string>}
 
-   Discovers every `data_apps/<dir>/data_app.yml` and upserts a row per app in a
+   Discovers every `data_apps/<dir>/data_app.yaml` and upserts a row per app in a
    single transaction. Apps not present in the snapshot are left untouched (a
    sync never deletes — removal is an explicit admin action). Returns
    `{:synced <n>, :changed <n>, :sha <sha>, :config-errors [<message> ...]}`,
    where `:changed` is how many apps this sync actually created/updated
    (a `last_synced_sha` bump on an unchanged app does not count). A malformed
-   `data_app.yml` is isolated (collected into `:config-errors`, that app skipped)
+   `data_app.yaml` is isolated (collected into `:config-errors`, that app skipped)
    rather than aborting the others; per-app bundle failures are recorded on the
-   row. Throws only on duplicate slugs, which make app identity ambiguous."
+   row.
+
+   Two apps can't collide on a slug here: a slug *is* an app's directory name (see
+   the config namespace), a repo can't hold two `data_apps/<slug>` directories, and
+   discovery takes one config per directory (see [[discover-app-configs]])."
   [{:keys [read-file list-files sha]}]
   ;; realize discovery once (it calls read-file/parse per config); `results` is
   ;; then walked several times below
   (let [results  (vec (discover-app-configs list-files read-file))
         good     (filter :slug results)
         errors   (vec (keep :config-error results))
-        slugs    (map :slug good)
         ;; pre-sync rows, so we can tell a real change from a sha/timestamp bump
         existing (into {} (map (juxt :name identity))
                        (t2/select [:model/DataApp :name :display_name :allowed_hosts
-                                   :bundle_path :bundle_hash :sync_error]))]
-    (when (not= (count slugs) (count (distinct slugs)))
-      (throw (ex-info (tru "Two data apps in the repository share a slug.")
-                      {:status-code 400})))
-    (let [changed
-          ;; Upsert-only: a sync never deletes. Apps materialized from a previous
-          ;; repo are kept (they survive unlinking, and switching repos), and an
-          ;; app sharing a slug is overridden in place by `upsert-by-name!`. Rows
-          ;; are removed only by an explicit admin action (see the API's DELETE).
-          (t2/with-transaction [_conn]
-            (reduce (fn [n cfg]
-                      (cond-> n
-                        (sync-app! (get existing (:slug cfg))
-                                   (assoc cfg :sha sha :read-file read-file))
-                        inc))
-                    0 good))]
-      (log/infof "[data-app] synced sha=%s apps=%d changed=%d errors=%d"
-                 sha (count good) changed (count errors))
-      {:synced (count good), :changed changed, :sha sha, :config-errors errors})))
+                                   :bundle_path :bundle_hash :sync_error]))
+        changed
+        ;; Upsert-only: a sync never deletes. Apps materialized from a previous
+        ;; repo are kept (they survive unlinking, and switching repos), and an
+        ;; app whose directory name matches an existing app's is overridden in
+        ;; place by `upsert-by-name!`. Rows are removed only by an explicit admin
+        ;; action (see the API's DELETE).
+        (t2/with-transaction [_conn]
+          (reduce (fn [n cfg]
+                    (cond-> n
+                      (sync-app! (get existing (:slug cfg))
+                                 (assoc cfg :sha sha :read-file read-file))
+                      inc))
+                  0 good))]
+    (log/infof "[data-app] synced sha=%s apps=%d changed=%d errors=%d"
+               sha (count good) changed (count errors))
+    {:synced (count good), :changed changed, :sha sha, :config-errors errors}))
 
 (defn sync-from-snapshot!
   "Entry point for the remote-sync import pipeline. Materializes data apps from
    the just-imported `snapshot` (see [[import-from-snapshot!]] for its shape).
    Never throws, so it can't break the surrounding remote-sync import: a thrown
-   failure is logged and swallowed, and a malformed `data_app.yml` is logged and
+   failure is logged and swallowed, and a malformed `data_app.yaml` is logged and
    its app simply doesn't appear. Returns the [[import-from-snapshot!]] result, or
    nil if the sync threw."
   [snapshot]
   (try
     (let [{:keys [config-errors] :as result} (import-from-snapshot! snapshot)]
       (when (seq config-errors)
-        (log/warnf "[data-app] %d data_app.yml config(s) skipped: %s"
+        (log/warnf "[data-app] %d data_app.yaml config(s) skipped: %s"
                    (count config-errors) (str/join "; " config-errors)))
       result)
     (catch Throwable e

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -29,19 +29,20 @@
    :read-file  (fn [p] (get path->content p))})
 
 (defn- app-config
-  "Render a per-app data_app.yml from `{:name :slug :path :allowed_hosts}`."
-  [{:keys [name slug path allowed_hosts]}]
-  (str (format "name: %s\nslug: %s\npath: %s\n" name slug path)
+  "Render a per-app data_app.yaml from `{:name :path :allowed_hosts}`. No slug: an
+   app's slug is the name of the directory the config sits in."
+  [{:keys [name path allowed_hosts]}]
+  (str (format "name: %s\npath: %s\n" name path)
        (when (seq allowed_hosts)
          (apply str "allowed_hosts:\n"
                 (map #(format "  - %s\n" %) allowed_hosts)))))
 
 (defn- app-files
-  "Repo files for one data app under `data_apps/<dir>/`: its data_app.yml plus a
+  "Repo files for one data app under `data_apps/<dir>/`: its data_app.yaml plus a
    bundle at `path` with `bundle` content."
   [dir {:keys [path bundle] :as cfg}]
-  {(format "data_apps/%s/data_app.yml" dir) (app-config cfg)
-   (format "data_apps/%s/%s" dir path)      bundle})
+  {(format "data_apps/%s/data_app.yaml" dir) (app-config cfg)
+   (format "data_apps/%s/%s" dir path)       bundle})
 
 ;;; ---------------------------------------------- Permissions ----------------------------------------------
 
@@ -124,8 +125,8 @@
 (deftest import-materializes-apps-test
   (mt/with-model-cleanup [:model/DataApp]
     (let [result (data-app.sync/import-from-snapshot!
-                  (snapshot (merge (app-files "sales" {:name "Sales" :slug "sales" :path "dist/index.js" :bundle "SALES-BUNDLE"})
-                                   (app-files "ops"   {:name "Ops"   :slug "ops"   :path "dist/app.js"   :bundle "OPS-BUNDLE"}))))]
+                  (snapshot (merge (app-files "sales" {:name "Sales" :path "dist/index.js" :bundle "SALES-BUNDLE"})
+                                   (app-files "ops"   {:name "Ops"   :path "dist/app.js"   :bundle "OPS-BUNDLE"}))))]
       (is (=? {:synced 2} result))
       (is (= #{"sales" "ops"} (t2/select-fn-set :name :model/DataApp)))
       (let [sales (t2/select-one :model/DataApp :name "sales")]
@@ -138,27 +139,27 @@
 
 (deftest import-stores-allowed-hosts-test
   (mt/with-model-cleanup [:model/DataApp]
-    (testing "allowed_hosts from data_app.yml are persisted on the row"
+    (testing "allowed_hosts from data_app.yaml are persisted on the row"
       (data-app.sync/import-from-snapshot!
-       (snapshot (app-files "sales" {:name "Sales" :slug "sales" :path "dist/index.js" :bundle "B"
+       (snapshot (app-files "sales" {:name "Sales" :path "dist/index.js" :bundle "B"
                                      :allowed_hosts ["https://api.example.com" "https://*.acme.com"]})))
       (is (= ["https://api.example.com" "https://*.acme.com"]
              (:allowed_hosts (t2/select-one :model/DataApp :name "sales")))))
     (testing "re-syncing without allowed_hosts clears them to an empty list"
       (data-app.sync/import-from-snapshot!
-       (snapshot (app-files "sales" {:name "Sales" :slug "sales" :path "dist/index.js" :bundle "B"})))
+       (snapshot (app-files "sales" {:name "Sales" :path "dist/index.js" :bundle "B"})))
       (is (= [] (:allowed_hosts (t2/select-one :model/DataApp :name "sales")))))))
 
 (deftest import-keeps-apps-absent-from-snapshot-test
   (mt/with-model-cleanup [:model/DataApp]
     (data-app.sync/import-from-snapshot!
-     (snapshot (merge (app-files "keep" {:name "Keep" :slug "keep" :path "index.js" :bundle "KEEP"})
-                      (app-files "gone" {:name "Gone" :slug "gone" :path "index.js" :bundle "GONE"}))))
+     (snapshot (merge (app-files "keep" {:name "Keep" :path "index.js" :bundle "KEEP"})
+                      (app-files "gone" {:name "Gone" :path "index.js" :bundle "GONE"}))))
     (is (= #{"keep" "gone"} (t2/select-fn-set :name :model/DataApp)))
     ;; A sync never deletes: an app missing from a later snapshot is kept, not
     ;; pruned. Removal is an explicit admin action (DELETE /api/apps/:slug).
     (data-app.sync/import-from-snapshot!
-     (snapshot (app-files "keep" {:name "Keep" :slug "keep" :path "index.js" :bundle "KEEP"})))
+     (snapshot (app-files "keep" {:name "Keep" :path "index.js" :bundle "KEEP"})))
     (is (= #{"keep" "gone"} (t2/select-fn-set :name :model/DataApp))
         "the app absent from the later snapshot is kept")))
 
@@ -180,11 +181,11 @@
 (deftest import-preserves-enabled-across-syncs-test
   (mt/with-model-cleanup [:model/DataApp]
     (data-app.sync/import-from-snapshot!
-     (snapshot (app-files "a" {:name "A" :slug "a" :path "index.js" :bundle "V1"})))
+     (snapshot (app-files "a" {:name "A" :path "index.js" :bundle "V1"})))
     (t2/update! :model/DataApp :name "a" {:enabled false})
     ;; a new bundle must not flip the admin's enabled toggle back on
     (data-app.sync/import-from-snapshot!
-     (snapshot (app-files "a" {:name "A" :slug "a" :path "index.js" :bundle "V2"})))
+     (snapshot (app-files "a" {:name "A" :path "index.js" :bundle "V2"})))
     (let [a (t2/select-one :model/DataApp :name "a")]
       (is (false? (:enabled a)) "the disabled toggle is preserved")
       (is (= "V2" (String. ^bytes (:bundle a) "UTF-8")) "the bundle is still updated"))))
@@ -193,9 +194,9 @@
   (testing "a missing bundle file fails just that app, not the whole import"
     (mt/with-model-cleanup [:model/DataApp]
       (data-app.sync/import-from-snapshot!
-       (snapshot (merge (app-files "good" {:name "Good" :slug "good" :path "index.js" :bundle "GOOD"})
+       (snapshot (merge (app-files "good" {:name "Good" :path "index.js" :bundle "GOOD"})
                         ;; "bad" declares a path that doesn't exist
-                        {"data_apps/bad/data_app.yml" (app-config {:name "Bad" :slug "bad" :path "missing.js"})})))
+                        {"data_apps/bad/data_app.yaml" (app-config {:name "Bad" :path "missing.js"})})))
       (is (= #{"good" "bad"} (t2/select-fn-set :name :model/DataApp)))
       (let [good (t2/select-one :model/DataApp :name "good")
             bad  (t2/select-one :model/DataApp :name "bad")]
@@ -204,49 +205,41 @@
         (is (nil? (:bundle bad)))
         (is (str/includes? (:sync_error bad) "missing.js"))))))
 
-(deftest import-duplicate-slugs-test
-  (mt/with-model-cleanup [:model/DataApp]
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo #"share a slug"
-         (data-app.sync/import-from-snapshot!
-          (snapshot (merge (app-files "one" {:name "One" :slug "dup" :path "a.js" :bundle "A"})
-                           (app-files "two" {:name "Two" :slug "dup" :path "b.js" :bundle "B"}))))))))
+(deftest import-serves-each-app-from-its-directory-test
+  (testing "the directory an app lives in is the slug it's served at — two apps can't collide on one"
+    (mt/with-model-cleanup [:model/DataApp]
+      (data-app.sync/import-from-snapshot!
+       (snapshot (merge (app-files "one" {:name "One" :path "a.js" :bundle "A"})
+                        (app-files "two" {:name "Two" :path "b.js" :bundle "B"}))))
+      (is (= #{"one" "two"} (t2/select-fn-set :name :model/DataApp))))))
 
 (deftest import-isolates-bad-config-test
-  (testing "a malformed data_app.yml is isolated: other apps still sync, the bad one is reported, nothing is pruned"
+  (testing "a malformed data_app.yaml is isolated: other apps still sync, the bad one is reported, nothing is pruned"
     (mt/with-model-cleanup [:model/DataApp]
       ;; pre-existing app that must survive a sync where another config is broken
       (data-app.sync/import-from-snapshot!
-       (snapshot (app-files "existing" {:name "Existing" :slug "existing" :path "i.js" :bundle "E"})))
+       (snapshot (app-files "existing" {:name "Existing" :path "i.js" :bundle "E"})))
       (let [result (data-app.sync/import-from-snapshot!
-                    (snapshot (merge (app-files "good" {:name "Good" :slug "good" :path "i.js" :bundle "GOOD"})
-                                     {"data_apps/bad/data_app.yml" "name: [unterminated"})))]
+                    (snapshot (merge (app-files "good" {:name "Good" :path "i.js" :bundle "GOOD"})
+                                     {"data_apps/bad/data_app.yaml" "name: [unterminated"})))]
         (is (=? {:synced 1} result))
         (is (= 1 (count (:config-errors result))))
         (is (= #{"existing" "good"} (t2/select-fn-set :name :model/DataApp))
             "the good app is added and the pre-existing app is NOT pruned despite the bad config")))))
 
 (deftest sync-from-snapshot!-never-throws-test
-  (testing "a malformed data_app.yml is isolated into :config-errors; the app just doesn't appear, the sync doesn't throw"
+  (testing "a malformed data_app.yaml is isolated into :config-errors; the app just doesn't appear, the sync doesn't throw"
     (mt/with-model-cleanup [:model/DataApp]
       (let [result (data-app.sync/sync-from-snapshot!
-                    (snapshot {"data_apps/x/data_app.yml" "name: [unterminated"}))]
+                    (snapshot {"data_apps/x/data_app.yaml" "name: [unterminated"}))]
         (is (seq (:config-errors result)))
         (is (empty? (t2/select-fn-set :name :model/DataApp))))))
   (testing "a clean sync materializes the app with no config errors"
     (mt/with-model-cleanup [:model/DataApp]
       (let [result (data-app.sync/sync-from-snapshot!
-                    (snapshot (app-files "a" {:name "A" :slug "a" :path "index.js" :bundle "A"})))]
+                    (snapshot (app-files "a" {:name "A" :path "index.js" :bundle "A"})))]
         (is (empty? (:config-errors result)))
         (is (= #{"a"} (t2/select-fn-set :name :model/DataApp)))))))
-
-(deftest import-accepts-yaml-extension-test
-  (testing "data_app.yaml (not just .yml) is discovered"
-    (mt/with-model-cleanup [:model/DataApp]
-      (data-app.sync/import-from-snapshot!
-       (snapshot {"data_apps/y/data_app.yaml" (app-config {:name "Y" :slug "y" :path "i.js"})
-                  "data_apps/y/i.js"          "YBUNDLE"}))
-      (is (= #{"y"} (t2/select-fn-set :name :model/DataApp))))))
 
 ;;; ----------------------------------------------------- API -----------------------------------------------------
 
@@ -255,7 +248,7 @@
     (mt/with-premium-features #{:data-apps}
       (mt/with-model-cleanup [:model/DataApp]
         (data-app.sync/import-from-snapshot!
-         (snapshot (app-files "demo" {:name "Demo app" :slug "demo" :path "dist/index.js" :bundle "DEMOBUNDLE"})))
+         (snapshot (app-files "demo" {:name "Demo app" :path "dist/index.js" :bundle "DEMOBUNDLE"})))
         (testing "GET / lists the synced apps"
           (is (=? [{:name "demo" :display_name "Demo app"
                     :bundle_path "data_apps/demo/dist/index.js" :enabled true}]
@@ -281,7 +274,7 @@
     (mt/with-premium-features #{:data-apps}
       (mt/with-model-cleanup [:model/DataApp]
         (data-app.sync/import-from-snapshot!
-         (snapshot (app-files "demo" {:name "Demo" :slug "demo" :path "index.js" :bundle "BUNDLE"})))
+         (snapshot (app-files "demo" {:name "Demo" :path "index.js" :bundle "BUNDLE"})))
         (testing "PUT /:slug can disable an app"
           (is (=? {:name "demo" :enabled false}
                   (mt/user-http-request :crowberto :put 200 "apps/demo" {:enabled false}))))

--- a/enterprise/backend/test/metabase_enterprise/data_apps/config_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/config_test.clj
@@ -8,60 +8,73 @@
 (defn- ->bytes ^bytes [^String s]
   (.getBytes s "UTF-8"))
 
-(defn- parse [s]
-  (data-app.config/parse-app-config (->bytes s) "data_apps/sales"))
+(defn- parse
+  "Parse a `data_app.yaml` as if it sat in `dir` (default `data_apps/sales`, so the
+   parsed slug is `sales` — the slug is the directory's name, never a config key)."
+  ([s] (parse s "data_apps/sales"))
+  ([s dir] (data-app.config/parse-app-config (->bytes s) dir)))
 
 (deftest parse-valid-config-test
   (is (= {:slug "sales" :display_name "Sales dashboard" :path "dist/index.js" :allowed_hosts []}
          (parse "name: Sales dashboard
-slug: sales
 path: ./dist/index.js"))))
+
+(deftest slug-comes-from-the-directory-test
+  (testing "the app's slug is the name of the directory it lives in"
+    (is (= "inventory" (:slug (parse "name: X\npath: dist/index.js" "data_apps/inventory")))))
+  (testing "a directory name that isn't a usable slug is rejected — the app would have no URL to be served at"
+    (doseq [bad ["Sales" "my_app" "sales app" "-sales" "sales-"]]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"lowercase letters, numbers, and dashes"
+                            (parse "name: X\npath: dist/index.js" (str "data_apps/" bad)))
+          (str "should reject the directory: " bad)))))
 
 (deftest parse-allowed-hosts-test
   (testing "valid entries are lowercased, trailing-slash-stripped, and de-duplicated"
     (is (= ["https://api.example.com" "https://*.internal.acme.com"]
            (:allowed_hosts
-            (parse "name: X\nslug: x\npath: dist/index.js\nallowed_hosts:\n  - https://API.example.com/\n  - https://*.internal.acme.com\n  - https://api.example.com")))))
+            (parse "name: X\npath: dist/index.js\nallowed_hosts:\n  - https://API.example.com/\n  - https://*.internal.acme.com\n  - https://api.example.com")))))
   (testing "absent → empty vector"
-    (is (= [] (:allowed_hosts (parse "name: X\nslug: x\npath: dist/index.js")))))
+    (is (= [] (:allowed_hosts (parse "name: X\npath: dist/index.js")))))
   (testing "a non-list value is rejected"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"allowed_hosts.*must be a list"
-                          (parse "name: X\nslug: x\npath: dist/index.js\nallowed_hosts: https://api.example.com"))))
+                          (parse "name: X\npath: dist/index.js\nallowed_hosts: https://api.example.com"))))
   (testing "invalid entries (bare *, path, non-http scheme, no scheme) are rejected"
     (doseq [bad ["*" "https://example.com/path" "ftp://example.com" "example.com"]]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not a valid allowed_hosts entry"
-                            (parse (str "name: X\nslug: x\npath: dist/index.js\nallowed_hosts:\n  - \"" bad "\"")))
+                            (parse (str "name: X\npath: dist/index.js\nallowed_hosts:\n  - \"" bad "\"")))
           (str "should reject: " bad)))))
 
 (deftest parse-strips-leading-dot-slash-test
   (is (= "dist/app.js"
-         (:path (parse "name: X\nslug: x\npath: ./dist/app.js")))))
+         (:path (parse "name: X\npath: ./dist/app.js")))))
+
+(deftest unknown-fields-are-ignored-test
+  (testing "unknown keys don't fail the parse — including a stray `slug`, which the directory name overrides"
+    (is (= {:slug "sales" :display_name "X" :path "dist/index.js" :allowed_hosts []}
+           (parse "name: X\nslug: elsewhere\nfuture_option: 1\npath: dist/index.js")))))
 
 (deftest parse-errors-test
-  (testing "invalid slug"
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"slug"
-                          (parse "name: X\nslug: Not A Slug\npath: dist/index.js"))))
   (testing "missing name"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"name"
-                          (parse "slug: x\npath: dist/index.js"))))
+                          (parse "path: dist/index.js"))))
   (testing "missing path"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"path"
-                          (parse "name: X\nslug: x"))))
+                          (parse "name: X"))))
   (testing "malformed yaml"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Could not parse"
                           (parse "name: [unterminated"))))
   (testing "path traversal is rejected"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must not contain"
-                          (parse "name: X\nslug: x\npath: ../other/dist/index.js")))
+                          (parse "name: X\npath: ../other/dist/index.js")))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must not contain"
-                          (parse "name: X\nslug: x\npath: dist/../../escape.js"))))
-  (testing "a reserved slug that collides with an API sub-route is rejected"
+                          (parse "name: X\npath: dist/../../escape.js"))))
+  (testing "a directory whose name collides with an API sub-route is rejected"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"reserved slug"
-                          (parse "name: X\nslug: repo-status\npath: dist/index.js")))))
+                          (parse "name: X\npath: dist/index.js" "data_apps/repo-status")))))
 
 (deftest parse-errors-carry-400-test
   (try
-    (parse "name: X\nslug: x")
+    (parse "name: X")
     (is false "should have thrown")
     (catch clojure.lang.ExceptionInfo e
       (is (= 400 (:status-code (ex-data e)))))))

--- a/enterprise/backend/test/metabase_enterprise/data_apps/sync_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/sync_test.clj
@@ -21,14 +21,16 @@
    :read-file  (fn [p] (get path->content p))})
 
 (defn- app-files
-  [dir {:keys [name slug path bundle]}]
-  {(format "data_apps/%s/data_app.yml" dir)
-   (format "name: %s\nslug: %s\npath: %s\n" name slug path)
+  "The repo files for one app in `data_apps/<dir>`. `dir` is the app's slug — the
+   config declares no slug, it is the directory's name."
+  [dir {:keys [name path bundle]}]
+  {(format "data_apps/%s/data_app.yaml" dir)
+   (format "name: %s\npath: %s\n" name path)
    (format "data_apps/%s/%s" dir path) bundle})
 
 (deftest changed-count-tracks-content-not-sha-bumps-test
   (mt/with-model-cleanup [:model/DataApp]
-    (let [files (app-files "a" {:name "A" :slug "a" :path "index.js" :bundle "V1"})]
+    (let [files (app-files "a" {:name "A" :path "index.js" :bundle "V1"})]
       (testing "the first sync counts the new app"
         (is (=? {:synced 1 :changed 1}
                 (data-app.sync/import-from-snapshot! (snapshot files)))))
@@ -39,25 +41,25 @@
       (testing "a metadata-only change counts"
         (is (=? {:changed 1}
                 (data-app.sync/import-from-snapshot!
-                 (snapshot (app-files "a" {:name "A renamed" :slug "a" :path "index.js" :bundle "V1"}))))))
+                 (snapshot (app-files "a" {:name "A renamed" :path "index.js" :bundle "V1"}))))))
       (testing "a bundle content change counts"
         (is (=? {:changed 1}
                 (data-app.sync/import-from-snapshot!
-                 (snapshot (app-files "a" {:name "A renamed" :slug "a" :path "index.js" :bundle "V2"})))))))))
+                 (snapshot (app-files "a" {:name "A renamed" :path "index.js" :bundle "V2"})))))))))
 
 (deftest sync-across-repos-keeps-overrides-and-adds-test
   (testing "linking repo A, unlinking, then linking repo B: keep A-only apps, override shared slugs with B, add B-only apps"
     (mt/with-model-cleanup [:model/DataApp]
       ;; Repo A: Foo + Bar
       (data-app.sync/import-from-snapshot!
-       (snapshot (merge (app-files "foo" {:name "Foo" :slug "foo" :path "index.js" :bundle "FOO"})
-                        (app-files "bar" {:name "Bar A" :slug "bar" :path "index.js" :bundle "BAR-A"}))))
+       (snapshot (merge (app-files "foo" {:name "Foo" :path "index.js" :bundle "FOO"})
+                        (app-files "bar" {:name "Bar A" :path "index.js" :bundle "BAR-A"}))))
       (is (= #{"foo" "bar"} (t2/select-fn-set :name :model/DataApp)))
       ;; Unlinking A doesn't sync (nothing prunes). Linking repo B (Bar + Baz)
       ;; and importing it keeps Foo, overrides Bar by slug, and adds Baz.
       (data-app.sync/import-from-snapshot!
-       (snapshot (merge (app-files "bar" {:name "Bar B" :slug "bar" :path "index.js" :bundle "BAR-B"})
-                        (app-files "baz" {:name "Baz" :slug "baz" :path "index.js" :bundle "BAZ"}))))
+       (snapshot (merge (app-files "bar" {:name "Bar B" :path "index.js" :bundle "BAR-B"})
+                        (app-files "baz" {:name "Baz" :path "index.js" :bundle "BAZ"}))))
       (is (= #{"foo" "bar" "baz"} (t2/select-fn-set :name :model/DataApp))
           "Foo (from repo A) is kept and Baz (from repo B) is added")
       (is (= "Foo" (:display_name (t2/select-one :model/DataApp :name "foo")))
@@ -75,7 +77,7 @@
   (testing "a bundle over the size cap is rejected with a sync_error, no bundle cached"
     (mt/with-model-cleanup [:model/DataApp]
       (data-app.sync/import-from-snapshot!
-       (snapshot (app-files "big" {:name "Big" :slug "big" :path "index.js"
+       (snapshot (app-files "big" {:name "Big" :path "index.js"
                                    :bundle (oversized-bundle)})))
       (let [app (t2/select-one :model/DataApp :name "big")]
         (is (some? app) "the app still appears in the list")
@@ -86,11 +88,30 @@
   (testing "an oversized re-sync sets sync_error but keeps the last good bundle"
     (mt/with-model-cleanup [:model/DataApp]
       (data-app.sync/import-from-snapshot!
-       (snapshot (app-files "app" {:name "App" :slug "app" :path "index.js" :bundle "GOOD"})))
+       (snapshot (app-files "app" {:name "App" :path "index.js" :bundle "GOOD"})))
       (data-app.sync/import-from-snapshot!
-       (snapshot (app-files "app" {:name "App" :slug "app" :path "index.js"
+       (snapshot (app-files "app" {:name "App" :path "index.js"
                                    :bundle (oversized-bundle)})))
       (let [app (t2/select-one :model/DataApp :name "app")]
         (is (= "GOOD" (String. ^bytes (:bundle app) "UTF-8"))
             "the previously cached bundle is retained")
         (is (str/includes? (:sync_error app) "MiB"))))))
+
+(deftest a-directory-without-a-config-is-not-an-app-test
+  (testing "a data_apps/<dir> that ships a bundle but no data_app.yaml is not discovered — no app, no error"
+    (mt/with-model-cleanup [:model/DataApp]
+      (let [result (data-app.sync/import-from-snapshot!
+                    (snapshot {"data_apps/orphan/index.js" "BUNDLE"}))]
+        (is (=? {:synced 0 :changed 0 :config-errors []} result))
+        (is (empty? (t2/select-fn-set :name :model/DataApp)))))))
+
+(deftest an-unreadable-config-is-a-config-error-test
+  (testing "a data_app.yaml the snapshot lists but can't read is isolated as a config-error, not a crash"
+    (mt/with-model-cleanup [:model/DataApp]
+      (let [result (data-app.sync/import-from-snapshot!
+                    {:sha        fake-sha
+                     :list-files (fn [] ["data_apps/ghost/data_app.yaml"])
+                     :read-file  (fn [_] nil)})]
+        (is (= 1 (count (:config-errors result))))
+        (is (str/includes? (first (:config-errors result)) "data_apps/ghost/data_app.yaml"))
+        (is (empty? (t2/select-fn-set :name :model/DataApp)))))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/data_app_pull_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/data_app_pull_test.clj
@@ -31,9 +31,9 @@
     result))
 
 (defn- app-tree
-  "Repo files for one data app: its `data_app.yml` + a bundle at `dist/index.js`."
+  "Repo files for one data app: its `data_app.yaml` + a bundle at `dist/index.js`."
   [slug bundle]
-  {(str "data_apps/" slug "/data_app.yml")  (str "name: " slug "\nslug: " slug "\npath: dist/index.js\n")
+  {(str "data_apps/" slug "/data_app.yaml")  (str "name: " slug "\npath: dist/index.js\n")
    (str "data_apps/" slug "/dist/index.js") bundle})
 
 ;; One self-contained serdes entity (a bare collection — no DB deps), used as the

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/data_apps_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/data_apps_test.clj
@@ -33,7 +33,7 @@
     (mt/with-model-cleanup [:model/DataApp]
       (let [files  {"main" {"collections/c/c.yaml"
                             (test-helpers/generate-collection-yaml "data-apps-test-collx" "DA Coll")
-                            "data_apps/sales/data_app.yml"  "name: Sales\nslug: sales\npath: ./dist/index.js\n"
+                            "data_apps/sales/data_app.yaml"  "name: Sales\npath: ./dist/index.js\n"
                             "data_apps/sales/dist/index.js" "SALESBUNDLE"}}
             result (import! files)]
         (is (= :success (:status result)))
@@ -47,12 +47,12 @@
 (deftest import-keeps-data-apps-absent-from-repo-test
   (testing "an import whose repo no longer has an app dir keeps that app (a sync never deletes)"
     (mt/with-model-cleanup [:model/DataApp]
-      (import! {"main" {"data_apps/gone/data_app.yml" "name: Gone\nslug: gone\npath: ./i.js\n"
+      (import! {"main" {"data_apps/gone/data_app.yaml" "name: Gone\npath: ./i.js\n"
                         "data_apps/gone/i.js"         "X"
-                        "data_apps/kept/data_app.yml" "name: Kept\nslug: kept\npath: ./i.js\n"
+                        "data_apps/kept/data_app.yaml" "name: Kept\npath: ./i.js\n"
                         "data_apps/kept/i.js"         "K"}})
       (is (= #{"gone" "kept"} (t2/select-fn-set :name :model/DataApp)))
-      (import! {"main" {"data_apps/kept/data_app.yml" "name: Kept\nslug: kept\npath: ./i.js\n"
+      (import! {"main" {"data_apps/kept/data_app.yaml" "name: Kept\npath: ./i.js\n"
                         "data_apps/kept/i.js"         "K"}})
       (is (some? (t2/select-one :model/DataApp :name "gone"))
           "the app absent from the later import is kept, not pruned")

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/config/read-manifest.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/config/read-manifest.ts
@@ -4,11 +4,10 @@ import path from "node:path";
 import { load as parseYaml } from "js-yaml";
 
 /**
- * The app's parsed `data_app.yml` manifest, validated and normalized:
- * `slug` is trimmed, `allowed_hosts` is guaranteed to be a list of strings.
+ * The app's parsed `data_app.yaml` manifest, validated and normalized:
+ * `allowed_hosts` is guaranteed to be a list of strings.
  */
 export type DataAppManifest = {
-  slug?: string;
   allowed_hosts?: string[];
 };
 
@@ -40,16 +39,15 @@ const parseAllowedHosts = (
 };
 
 /**
- * Read, parse, and normalize the app's `data_app.yml`/`.yaml` manifest.
+ * Read, parse, and normalize the app's `data_app.yaml` manifest.
  * Returns null when the app has no manifest.
  */
 export const readManifest = (
   appRoot: string,
 ): { manifestPath: string; manifest: DataAppManifest } | null => {
-  const manifestPath = [
-    path.join(appRoot, "data_app.yaml"),
-    path.join(appRoot, "data_app.yml"),
-  ].find((candidate) => fs.existsSync(candidate));
+  const manifestPath = [path.join(appRoot, "data_app.yaml")].find((candidate) =>
+    fs.existsSync(candidate),
+  );
 
   if (!manifestPath) {
     return null;
@@ -67,13 +65,12 @@ export const readManifest = (
     );
   }
 
-  const raw: { slug?: unknown; allowed_hosts?: unknown } =
+  const raw: { allowed_hosts?: unknown } =
     typeof parsed === "object" && parsed !== null ? parsed : {};
 
   return {
     manifestPath,
     manifest: {
-      slug: isString(raw.slug) ? raw.slug.trim() : undefined,
       allowed_hosts: parseAllowedHosts(raw.allowed_hosts, manifestPath),
     },
   };

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/config/read-manifest.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/config/read-manifest.unit.spec.ts
@@ -9,7 +9,6 @@ const mockedFs = jest.mocked(fs);
 
 const APP_ROOT = "/app";
 const YAML_PATH = path.join(APP_ROOT, "data_app.yaml");
-const YML_PATH = path.join(APP_ROOT, "data_app.yml");
 
 const setup = (files: Record<string, string>) => {
   mockedFs.existsSync.mockImplementation((p) => p.toString() in files);
@@ -33,41 +32,16 @@ describe("readManifest", () => {
     expect(readManifest(APP_ROOT)).toBeNull();
   });
 
-  it("prefers data_app.yaml over data_app.yml", () => {
-    setup({ [YAML_PATH]: "slug: yaml-app\n", [YML_PATH]: "slug: yml-app\n" });
-
-    expect(readManifest(APP_ROOT)).toEqual({
-      manifestPath: YAML_PATH,
-      manifest: { slug: "yaml-app" },
-    });
-  });
-
   it("returns an empty manifest for non-object yaml", () => {
-    setup({ [YML_PATH]: "just a string\n" });
+    setup({ [YAML_PATH]: "just a string\n" });
 
     expect(readManifest(APP_ROOT)?.manifest).toEqual({});
   });
 
   it("throws on unparseable yaml", () => {
-    setup({ [YML_PATH]: "slug: [unclosed\n" });
+    setup({ [YAML_PATH]: "allowed_hosts: [unclosed\n" });
 
     expect(() => readManifest(APP_ROOT)).toThrow(/Could not parse/);
-  });
-
-  describe("slug", () => {
-    it("trims the slug", () => {
-      setup({ [YML_PATH]: "slug: ' sales '\n" });
-
-      expect(readManifest(APP_ROOT)?.manifest.slug).toBe("sales");
-    });
-
-    it("is undefined when the slug is absent or not a string", () => {
-      setup({ [YML_PATH]: "name: Sales dashboard\n" });
-      expect(readManifest(APP_ROOT)?.manifest.slug).toBeUndefined();
-
-      setup({ [YML_PATH]: "slug: 123\n" });
-      expect(readManifest(APP_ROOT)?.manifest.slug).toBeUndefined();
-    });
   });
 
   describe("allowed_hosts", () => {

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/index.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import react from "@vitejs/plugin-react";
 import {
   type ConfigEnv,
@@ -27,9 +29,18 @@ import { dataAppSandboxDevPlugin } from "./dev-plugin/plugin";
 function dataAppVitePlugin(): PluginOption[] {
   const appRoot = process.cwd();
   const envDir = findEnvRoot(appRoot);
-  const { manifest } = readManifest(appRoot) ?? {};
-  const appSlug = manifest?.slug ?? "";
-  const allowedHosts = manifest?.allowed_hosts ?? [];
+
+  const manifestResult = readManifest(appRoot);
+
+  if (!manifestResult) {
+    throw new Error(
+      `No data_app.yaml found in ${appRoot}. Run vite from the data app's own ` +
+        `directory (data_apps/<slug>/).`,
+    );
+  }
+
+  const appSlug = path.basename(appRoot);
+  const allowedHosts = manifestResult.manifest.allowed_hosts ?? [];
 
   return [
     react(),

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/index.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/index.unit.spec.ts
@@ -1,0 +1,53 @@
+import { readManifest } from "./config/read-manifest";
+
+import { dataAppConfig } from "./index";
+
+jest.mock("vite", () => ({ loadEnv: jest.fn(() => ({})) }));
+jest.mock("@vitejs/plugin-react", () => ({
+  __esModule: true,
+  default: () => ({ name: "mock-react" }),
+}));
+jest.mock("./config/build-config", () => ({
+  dataAppBuildPlugins: () => [],
+  dataAppLibBuild: () => ({}),
+}));
+jest.mock("./config/find-env-root", () => ({
+  findEnvRoot: (appRoot: string) => appRoot,
+}));
+jest.mock("./dev-plugin/plugin", () => ({
+  dataAppSandboxDevPlugin: () => ({ name: "mock-sandbox-dev" }),
+}));
+jest.mock("./config/read-manifest");
+
+const mockedReadManifest = jest.mocked(readManifest);
+
+afterEach(() => jest.resetAllMocks());
+
+describe("dataAppConfig", () => {
+  it("throws when the cwd has no data_app.yaml (run from the wrong directory)", () => {
+    mockedReadManifest.mockReturnValue(null);
+
+    expect(() => dataAppConfig()).toThrow(/No data_app\.yaml found/);
+  });
+
+  it("builds the config when a manifest is present", () => {
+    mockedReadManifest.mockReturnValue({
+      manifestPath: "/app/data_app.yaml",
+      manifest: { allowed_hosts: [] },
+    });
+
+    const config = dataAppConfig();
+
+    expect(config.server?.port).toBe(5174);
+    expect(config.plugins).toBeDefined();
+  });
+
+  it("uses the port override", () => {
+    mockedReadManifest.mockReturnValue({
+      manifestPath: "/app/data_app.yaml",
+      manifest: {},
+    });
+
+    expect(dataAppConfig({ port: 4000 }).server?.port).toBe(4000);
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppAllowedHosts/DataAppAllowedHosts.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppAllowedHosts/DataAppAllowedHosts.tsx
@@ -3,7 +3,7 @@ import { msgid, ngettext } from "ttag";
 import { HoverCard, Stack, Text } from "metabase/ui";
 
 type Props = {
-  /** External origins the app may fetch/XHR (from `data_app.yml`). */
+  /** External origins the app may fetch/XHR (from `data_app.yaml`). */
   hosts: string[];
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppListItem/DataAppListItem.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppListItem/DataAppListItem.tsx
@@ -11,7 +11,13 @@ type Props = {
 };
 
 export const DataAppListItem = ({ app, canRemove = false }: Props) => (
-  <Flex justify="space-between" align="center" gap="md" p="md">
+  <Flex
+    data-testid={`data-app-list-item-${app.name}`}
+    justify="space-between"
+    align="center"
+    gap="md"
+    p="md"
+  >
     <DataAppSummary app={app} />
 
     <Group flex="0 0 auto" gap="md" wrap="nowrap" align="center">

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppSummary/DataAppSummary.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppSummary/DataAppSummary.tsx
@@ -47,54 +47,58 @@ const SyncStatus = ({ app }: Props) => {
   );
 };
 
-export const DataAppSummary = ({ app }: Props) => (
-  <Group align="center" flex="1" wrap="nowrap" miw={0}>
-    <DataAppIcon />
+export const DataAppSummary = ({ app }: Props) => {
+  const isOpenable = app.enabled && !app.sync_error;
 
-    <Stack flex="1" gap={2} miw={0}>
-      {app.enabled ? (
-        <Text
-          component="a"
-          href={Urls.getSubpathSafeUrl(Urls.dataApp(app.name))}
-          target="_blank"
-          rel="noreferrer"
-          fw={700}
-          lh="1.4"
-          c="brand"
-          truncate
-        >
-          {app.display_name}
-        </Text>
-      ) : (
-        <Text fw={700} lh="1.4" c="text-secondary" truncate>
-          {app.display_name}
-        </Text>
-      )}
+  return (
+    <Group align="center" flex="1" wrap="nowrap" miw={0}>
+      <DataAppIcon />
 
-      <Group gap="xs" align="center" wrap="wrap">
-        <Text
-          size="sm"
-          c="text-secondary"
-          ff="monospace"
-          lh="1.4"
-          truncate
-          maw="100%"
-        >
-          {Urls.dataApp(app.name)}
-        </Text>
-
-        <Bullet />
-
-        <SyncStatus app={app} />
-
-        {app.allowed_hosts.length > 0 && (
-          <>
-            <Bullet />
-
-            <DataAppAllowedHosts hosts={app.allowed_hosts} />
-          </>
+      <Stack flex="1" gap={2} miw={0}>
+        {isOpenable ? (
+          <Text
+            component="a"
+            href={Urls.getSubpathSafeUrl(Urls.dataApp(app.name))}
+            target="_blank"
+            rel="noreferrer"
+            fw={700}
+            lh="1.4"
+            c="brand"
+            truncate
+          >
+            {app.display_name}
+          </Text>
+        ) : (
+          <Text fw={700} lh="1.4" c="text-secondary" truncate>
+            {app.display_name}
+          </Text>
         )}
-      </Group>
-    </Stack>
-  </Group>
-);
+
+        <Group gap="xs" align="center" wrap="wrap">
+          <Text
+            size="sm"
+            c="text-secondary"
+            ff="monospace"
+            lh="1.4"
+            truncate
+            maw="100%"
+          >
+            {Urls.dataApp(app.name)}
+          </Text>
+
+          <Bullet />
+
+          <SyncStatus app={app} />
+
+          {app.allowed_hosts.length > 0 && (
+            <>
+              <Bullet />
+
+              <DataAppAllowedHosts hosts={app.allowed_hosts} />
+            </>
+          )}
+        </Group>
+      </Stack>
+    </Group>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppSummary/DataAppSummary.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppSummary/DataAppSummary.unit.spec.tsx
@@ -31,6 +31,23 @@ describe("DataAppSummary", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders a sync-failed app's name as plain text (the link would lead to a dead end)", () => {
+    renderWithProviders(
+      <DataAppSummary
+        app={createMockDataApp({
+          display_name: "Sales",
+          enabled: true,
+          sync_error: "Bundle file not found",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Sales")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Sales" }),
+    ).not.toBeInTheDocument();
+  });
+
   describe("sync status", () => {
     it("shows the short synced SHA when the app has synced", () => {
       renderWithProviders(

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/runtime/loader.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/runtime/loader.ts
@@ -22,7 +22,7 @@ export interface LoadedDataApp {
 /** Response carrying the bundle source plus the app's fetch/XHR allowlist. */
 export interface FetchedDataAppBundle {
   code: string;
-  /** Origins the sandboxed bundle may fetch/XHR (from `data_app.yml`). */
+  /** Origins the sandboxed bundle may fetch/XHR (from `data_app.yaml`). */
   allowedHosts: string[];
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/allowed-hosts.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/allowed-hosts.ts
@@ -3,7 +3,7 @@
  *
  * By default the sandbox hard-blocks all network egress (see
  * `metabase/utils/scripts-sandbox/distortions-blocked-apis`). When an app
- * declares `allowed_hosts` in its `data_app.yml`, those origins — and ONLY
+ * declares `allowed_hosts` in its `data_app.yaml`, those origins — and ONLY
  * those, never the Metabase origin, which stays reachable only via sanctioned
  * SDK calls — become reachable through `fetch`/`XMLHttpRequest`. Host matching
  * mirrors the CSP `connect-src` the backend emits for the same hosts, so the JS

--- a/frontend/src/metabase-types/api/data-app.ts
+++ b/frontend/src/metabase-types/api/data-app.ts
@@ -2,13 +2,13 @@ export type DataAppId = number;
 
 /**
  * A data app materialized from the connected repository. The repo's
- * `data_apps/<dir>/data_app.yml` files are discovered on sync; one row exists
+ * `data_apps/<dir>/data_app.yaml` files are discovered on sync; one row exists
  * per app and the bundle is cached in the app DB and served at `/apps/:name`.
  * The repository itself is configured via the remote-sync settings.
  */
 export interface DataApp {
   id: DataAppId;
-  /** Stable slug from the app's `data_app.yml`; also the URL segment. */
+  /** The app's slug. */
   name: string;
   display_name: string;
   /** Path within the repo to the built bundle. */
@@ -17,7 +17,7 @@ export interface DataApp {
   enabled: boolean;
   /**
    * External origins the app's sandboxed bundle may `fetch`/XHR, from its
-   * `data_app.yml`. Empty means none (Metabase data still flows through the
+   * `data_app.yaml`. Empty means none (Metabase data still flows through the
    * SDK). Each entry is an origin, optionally with a `*.` wildcard.
    */
   allowed_hosts: string[];

--- a/resources/migrations/064/20260528_data_app.yaml
+++ b/resources/migrations/064/20260528_data_app.yaml
@@ -2,7 +2,7 @@
 ##
 ## Data apps come from the repository connected via the remote-sync feature. The
 ## repo root has a `data_apps/` directory; each subdirectory is one app and
-## contains a `data_app.yml` (name/slug/path) plus its built bundle. Each app dir
+## contains a `data_app.yaml` (name/path) plus its built bundle. Each app dir
 ## is materialized as one row in this table on sync. The `bundle` / `bundle_hash`
 ## columns cache the last successfully synced bytes (nullable until first sync).
 
@@ -31,7 +31,7 @@ databaseChangeLog:
               - column:
                   name: name
                   type: varchar(254)
-                  remarks: Slug from the app's data_app.yml; unique, used in the URL /data-app/:name
+                  remarks: Slug, used in the URL /apps/:name
                   constraints:
                     nullable: false
                     unique: true

--- a/skills/metabase-data-app-actions/SKILL.md
+++ b/skills/metabase-data-app-actions/SKILL.md
@@ -219,4 +219,4 @@ When an action appears to succeed but the screen doesn't update, or a call fails
 - Letting the trigger fire while a previous request is in flight. Drive `disabled={isExecuting}` from the hook.
 - Prepending the action's `result` directly to a local list to skip the refresh. Server-filled defaults (auto-IDs, timestamps, computed columns, derived join columns) diverge from any client-side guess.
 - Inventing an action because the user asked for behavior the instance doesn't expose. The schema is the catalog of what exists; surface the gap, don't fake the call.
-- Reaching for `fetch("/api/action/...")` directly. The sandbox blocks raw network calls to the Metabase origin (raw `fetch`/XHR work only for external `allowed_hosts` declared in `data_app.yml`); the only path to actions is `useAction`.
+- Reaching for `fetch("/api/action/...")` directly. The sandbox blocks raw network calls to the Metabase origin (raw `fetch`/XHR work only for external `allowed_hosts` declared in `data_app.yaml`); the only path to actions is `useAction`.

--- a/skills/metabase-data-app-semantic-layer/SKILL.md
+++ b/skills/metabase-data-app-semantic-layer/SKILL.md
@@ -652,7 +652,7 @@ If no curated schema entry supports the intended UI, leave the section out or as
 - Verify every rendered value can be traced to a returned row property, schema field, measure, or deterministic transform.
 - Search touched files for `row[0]`, `row[1]`, `row.orderedAt`, `row.orderDate`, `as unknown as`, `DisplayRow`, `<select`, `margin`, `rate`, `score`, `percent`, `%`, `* 100`, and `.toFixed`; fix positional rows, result-key guesses, entity `<select>` filters, and unsupported business-field interpretations.
 - Verify every date preset bar includes Custom last unless explicitly omitted, every visible date filter affects the current page, and no page shows duplicate date filters for one scope.
-- Verify `data_app.yml` / `data_app.yaml` points at the built bundle path and that the bundle path is tracked by git.
+- Verify `data_app.yaml` points at the built bundle path and that the bundle path is tracked by git.
 - For every visible filter, verify "All" maps to no filter, selected values come from runtime query results, and each non-All option changes every card it claims to affect.
 
 ## Common Mistakes

--- a/skills/metabase-data-app-setup/SKILL.md
+++ b/skills/metabase-data-app-setup/SKILL.md
@@ -7,7 +7,7 @@ description: Scaffold a new Metabase data-app into the connected remote-sync rep
 
 A Metabase **data-app** is a single JS bundle that the host loads inside a Near Membrane sandbox and renders inside its own React tree. The scaffold is a Vite + React + TypeScript project: source under `src/`, a dev server that previews the app against a real Metabase **through the same Near Membrane sandbox + distortion rules Metabase uses in production** — so `npm run dev` behaves like production, including for third-party libraries the app bundles — and `npm run build` producing a single `dist/index.js`. (Because the sandbox runs a built bundle, a change rebuilds it and does a *soft reload* — re-evaluates the bundle in the sandbox and remounts the app, keeping auth/SDK loaded — rather than hot-swapping modules; component state resets, but there's no full browser refresh.) The dev preview also shows a corner **⚠ Diagnostics** toolbar that captures runtime errors — including the sandbox's otherwise-opaque blocked-API messages — so failures surface instead of being swallowed.
 
-**Data apps are served from Git, not uploaded.** A single repository is connected to Metabase via remote-sync (Admin → Settings → Remote sync). Each app lives in its own directory `data_apps/<app>/` inside that repo — its source, a `data_app.yml` (name/slug/path), and the committed built bundle at the `path` its `data_app.yml` declares (`dist/index.js` by default). On each remote-sync import Metabase materializes one app per directory and serves it at `/apps/<slug>`. So this skill always scaffolds **into the connected repo's `data_apps/<app>/` directory**, never as a standalone project.
+**Data apps are served from Git, not uploaded.** A single repository is connected to Metabase via remote-sync (Admin → Settings → Remote sync). Each app lives in its own directory `data_apps/<app>/` inside that repo — its source, a `data_app.yaml` (name/path), and the committed built bundle at the `path` its `data_app.yaml` declares (`dist/index.js` by default). On each remote-sync import Metabase materializes one app per directory and serves it at `/apps/<slug>` url, where the slug **is** the directory's name. So this skill always scaffolds **into the connected repo's `data_apps/<app>/` directory**, never as a standalone project.
 
 **The scaffold ships inside this skill at `./template/`** — a Vite + React + TypeScript project that was installed alongside the skill. Step 3 just copies it into the app directory; the skill then guides you through the customization + first-app-content steps — it never generates project files from scratch. If you find yourself writing `package.json`, `vite.config.ts`, `tsconfig.json`, or `src/index.tsx` by hand, stop — copy the template instead.
 
@@ -33,7 +33,7 @@ Data apps live inside the Git repository connected to Metabase via remote-sync. 
 
 ## Step 2 — Name the app and create its directory
 
-1. Settle on the app's **slug** before scaffolding — it's the directory name *and* the `/apps/<slug>` URL. Lowercase letters, numbers, and single dashes (`[a-z0-9]+(?:-[a-z0-9]+)*`). If the purpose isn't clear yet, ask a one-line "what's this app for?" and propose a slug; confirm it.
+1. Settle on the app's **directory name** before scaffolding — it is used verbatim as the slug (the `/apps/<slug>` URL), so it **must be dash-cased**: lowercase letters, numbers, and single dashes (`[a-z0-9]+(?:-[a-z0-9]+)*`), e.g. `sales-overview`. Anything else (uppercase, spaces, underscores) is rejected on sync. If the purpose isn't clear yet, ask a one-line "what's this app for?" and propose a name; confirm it.
 2. Ensure `<repo>/data_apps/` exists; create it if missing.
 3. Create `<repo>/data_apps/<slug>/`. **If it already exists**, treat it as an existing project (see below) — never overwrite without confirmation.
 
@@ -123,15 +123,14 @@ Once the template is in `<repo>/data_apps/<slug>/` (run everything below from th
 5. `npm install` (or whichever package manager the user prefers — the template ships with no lockfile, so `npm` / `yarn` / `pnpm` / `bun` all work; use the project's existing lockfile if one appears post-clone).
 6. **Fix the app's `.gitignore` so the lockfile *and* the built bundle get committed.** Two things must end up tracked in the remote-sync repo:
    - **Lockfile** — strip the lockfile-ignoring block (the chunk between `# Lockfiles —` and `bun.lockb`, covering `package-lock.json` / `yarn.lock` / `pnpm-lock.yaml` / `bun.lock` / `bun.lockb`) so the project commits its lockfile for reproducible installs.
-   - **The built bundle** — Metabase serves the file at the `path` declared in `data_app.yml` (the template builds to `dist/index.js`, the default `path`) straight from the committed Git tree, so **that file must be committed**. If the template's `.gitignore` ignores `dist/` (or wherever your build outputs), remove that line.
+   - **The built bundle** — Metabase serves the file at the `path` declared in `data_app.yaml` (the template builds to `dist/index.js`, the default `path`) straight from the committed Git tree, so **that file must be committed**. If the template's `.gitignore` ignores `dist/` (or wherever your build outputs), remove that line.
    **Verify with `git status`** — after `npm install` + a build, both the generated lockfile and the built bundle (the file `path` points at) must appear as untracked/committable files. If either doesn't, the relevant `.gitignore` line is still there; remove it and re-check. Do **not** skip this — agents have repeatedly shipped projects with no committed lockfile or an un-synced bundle.
 7. `npm run dev` and confirm the preview at http://localhost:5174 renders the starter "Hello, data app" message.
 8. If the preview hits CORS, add `http://localhost:5174` under Admin → Embedding → Embedded analytics SDK → CORS.
-9. **Edit `data_app.yml`** (it ships with the template, in the app directory). This is the per-app config Metabase reads on sync — one file per app. Fill in its fields for this app:
+9. **Edit `data_app.yaml`** (it ships with the template, in the app directory). This is the per-app config Metabase reads on sync — one file per app. Fill in its fields for this app:
 
    ```yaml
    name: Sales App        # display name shown in the admin UI
-   slug: sales            # URL identity → /apps/sales (match the directory name)
    path: ./dist/index.js  # bundle path, relative to this app's directory — leave as-is unless you change the build output
    # allowed_hosts:       # optional — external origins the app may fetch/XHR (see below)
    #   - https://api.example.com
@@ -164,7 +163,7 @@ project scaffold and proving the starter bundle works.
 
 1. Run `npm run typecheck`.
 2. Run `npm run build`.
-3. Confirm `git status` shows the app source, lockfile, `data_app.yml`, and the
+3. Confirm `git status` shows the app source, lockfile, `data_app.yaml`, and the
    built bundle (`dist/index.js` by default) as committable files.
 4. If the user asked for a live preview, run `npm run dev` and confirm the
    starter "Hello, data app" screen renders through the sandbox preview.
@@ -366,15 +365,15 @@ The bundle imports React hooks/JSX, SDK components from `@metabase/embedding-sdk
 
 The Near Membrane sandbox throws at runtime on these globals. Use the endowed replacement instead:
 
-| Blocked | Use instead |
-|---|---|
-| **Network** — `fetch`, `XMLHttpRequest`, `WebSocket` | Use the SDK/data-app APIs for Metabase reads and writes — never raw `fetch`. Raw `fetch`/`XHR` reach **only** the external origins listed in `data_app.yml`'s `allowed_hosts` (Step 4); everything else (including the Metabase origin) throws. `WebSocket` is always blocked. |
-| **UI dialogs** — `alert`, `confirm`, `prompt` | Render a React modal in your own tree. |
-| **Storage** — `localStorage`, `sessionStorage`, `indexedDB`, `document.cookie` | Treat the data app as stateless across reloads; persist via a Metabase action. |
-| **Window / history navigation** — `window.open`, `history.pushState`, `history.replaceState` | `useDataAppLocation().navigate` for in-app; `<a target="_blank" rel="noopener">` for external. |
-| **Clipboard** — `document.execCommand("copy")`, `navigator.clipboard` | `copy` (write-only): `import { copy } from "@metabase/embedding-sdk-react/data-app"`, then `await copy(text)` from a user event. There is **no** read/paste API — that would let a bundle exfiltrate whatever the user copied. |
-| **Other `navigator.*` device APIs** — `geolocation`, etc. | Not available. |
-| **Global `document`/`window` listeners** for typing/clipboard events — `keydown`, `keyup`, `keypress`, `beforeinput`, `input`, `paste`, `copy`, `cut`, `before*paste/copy/cut`, `compositionstart/update/end`, `storage` | Attach the listener to your own element, or use the React handler (`onKeyDown`, `onPaste`, …) on the specific input/container. The same listener on a script-owned element still works. |
+| Blocked | Use instead                                                                                                                                                                                                                                                                     |
+|---|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Network** — `fetch`, `XMLHttpRequest`, `WebSocket` | Use the SDK/data-app APIs for Metabase reads and writes — never raw `fetch`. Raw `fetch`/`XHR` reach **only** the external origins listed in `data_app.yaml`'s `allowed_hosts` (Step 4); everything else (including the Metabase origin) throws. `WebSocket` is always blocked. |
+| **UI dialogs** — `alert`, `confirm`, `prompt` | Render a React modal in your own tree.                                                                                                                                                                                                                                          |
+| **Storage** — `localStorage`, `sessionStorage`, `indexedDB`, `document.cookie` | Treat the data app as stateless across reloads; persist via a Metabase action.                                                                                                                                                                                                  |
+| **Window / history navigation** — `window.open`, `history.pushState`, `history.replaceState` | `useDataAppLocation().navigate` for in-app; `<a target="_blank" rel="noopener">` for external.                                                                                                                                                                                  |
+| **Clipboard** — `document.execCommand("copy")`, `navigator.clipboard` | `copy` (write-only): `import { copy } from "@metabase/embedding-sdk-react/data-app"`, then `await copy(text)` from a user event. There is **no** read/paste API — that would let a bundle exfiltrate whatever the user copied.                                                  |
+| **Other `navigator.*` device APIs** — `geolocation`, etc. | Not available.                                                                                                                                                                                                                                                                  |
+| **Global `document`/`window` listeners** for typing/clipboard events — `keydown`, `keyup`, `keypress`, `beforeinput`, `input`, `paste`, `copy`, `cut`, `before*paste/copy/cut`, `compositionstart/update/end`, `storage` | Attach the listener to your own element, or use the React handler (`onKeyDown`, `onPaste`, …) on the specific input/container. The same listener on a script-owned element still works.                                                                                         |
 
 **Rule of thumb:** if you're about to touch `window.X`, `document.X`, `navigator.X`, `history.X`, or any storage global, stop and pick the endowed replacement above. The endowed surface (React + React DOM + SDK components + data hooks + `useAction` + DataAppRouter + `copy`) covers every routine need; anything outside it is intentionally unreachable.
 
@@ -414,8 +413,8 @@ Without `height`/`width`, the SDK component renders at its intrinsic size and ov
 
 Data apps are delivered by Git, not uploaded — you commit the app directory and Metabase pulls it on its next remote-sync import.
 
-1. `npm run build` → produces the bundle at your `data_app.yml` `path` (the template builds to `dist/index.js`).
-2. From the **repo root**, commit the app directory — its `data_app.yml`, the built bundle (the file `path` points at), the source, and the lockfile — and **push**:
+1. `npm run build` → produces the bundle at your `data_app.yaml` `path` (the template builds to `dist/index.js`).
+2. From the **repo root**, commit the app directory — its `data_app.yaml`, the built bundle (the file `path` points at), the source, and the lockfile — and **push**:
    ```bash
    git add data_apps/<slug>
    git commit -m "Add <slug> data app"
@@ -423,7 +422,7 @@ Data apps are delivered by Git, not uploaded — you commit the app directory an
    ```
 3. The app appears in Metabase on the next remote-sync import — a manual **Pull changes** (Admin → Data apps / Remote sync), the auto-import poll, or a restart — reachable at `/apps/<slug>`.
 
-**To update:** commit a new build and pull again. **To remove:** delete `data_apps/<slug>/`, commit, and pull — Metabase prunes apps whose directory is gone from the repo.
+**To update:** commit a new build and pull again. **To remove:** a sync never deletes, so removing the app's directory from the repo does *not* remove the app — an admin removes it in Metabase (Admin → Data apps).
 
 ## Common pitfalls
 

--- a/skills/metabase-data-app-setup/template/README.md
+++ b/skills/metabase-data-app-setup/template/README.md
@@ -38,7 +38,7 @@ import (manual "Pull changes", auto-import, or startup).
 
 ```
 .
-├── data_app.yaml           ← manifest: name, slug, bundle path, allowed_hosts
+├── data_app.yaml           ← manifest: name, bundle path, allowed_hosts
 ├── package.json            ← @metabase/embedding-sdk-react + react/react-dom + Vite toolchain
 ├── vite.config.ts          ← one-liner: `export default dataAppConfig()`
 ├── tsconfig.json

--- a/skills/metabase-data-app-setup/template/data_app.yaml
+++ b/skills/metabase-data-app-setup/template/data_app.yaml
@@ -1,5 +1,4 @@
 name: Data App Template
-slug: data-app-template
 path: ./dist/index.js
 
 # Origins this app may call with fetch/XHR. Everything else is blocked — both in


### PR DESCRIPTION
Take a data app's slug from its directory name.

To avoid the case when there are 2 different data app directories, but they both have the same slug in their data_app.yaml file, we decided to remove the `slug` field from config, and use the directory name of the app as a slug.

Also the PR adjusts the config validation logic, it does not fail on unexpected fields.
It still:
- silently ignores app if data_app.yaml is missing at all (this can be discussed, but i am worry about cases when for some reason there's an empty app directory that may trigger errors)
- fails on invalid config: error is logged

How to verify:
- there are new e2e added, so CI should be green
- review the SKILL.md so it mentions new approach
- you can also setup a data app for this branch using skill to ensure it is properly generated
- or you can for existing data apps in repo remove the `slug` field in the `data_app.yaml` file, commit them - they still must be synced properly
