### PR TITLE
Manual backport of driver/refresh-table-stats! from  Index Manager

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -6,6 +6,9 @@ title: Driver interface changelog
 
 ## Metabase 0.63.0
 
+- New driver method `metabase.driver/refresh-table-stats!` `[driver database schema table transform-type]` --
+  refreshes table statistics (e.g. `ANALYZE`) after a transform run. Defaults to a no-op.
+
 - `metabase.driver/describe-table-fks`, deprecated in 0.49.0, has been removed. Please implement
   `metabase.driver/describe-fks` instead. This method is now required for drivers that support
   `:metadata/key-constraints`.

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1368,6 +1368,17 @@
   [driver database target]
   ((get-method drop-transform-target! [driver :table]) driver database target))
 
+(defmulti refresh-table-stats!
+  "Refresh the database's table statistics (e.g. `ANALYZE`) for `table` after a transform run materializes it, so
+  query planners see fresh stats. Defaults to a no-op."
+  {:added "0.63.0", :arglists '([driver database schema table transform-type])}
+  dispatch-on-initialized-driver
+  :hierarchy #'hierarchy)
+
+(defmethod refresh-table-stats! :default
+  [_driver _database _schema _table _transform-type]
+  nil)
+
 (mr/def ::native-query-deps.table-dep
   [:map
    {:closed true}

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -1334,6 +1334,13 @@
     (let [sql [[(format "CREATE SCHEMA IF NOT EXISTS %s;" (quote-schema schema))]]]
       (driver/execute-raw-queries! driver conn-spec sql))))
 
+(defmethod driver/refresh-table-stats! :postgres
+  [driver database schema table _transform-type]
+  (let [qtable (apply sql.u/quote-name driver :table (if (not-empty schema) [schema table] [table]))]
+    (driver/execute-raw-queries! driver
+                                 (driver/connection-spec driver database)
+                                 [[(format "ANALYZE %s" qtable)]])))
+
 (defmethod driver/extra-info :postgres
   [_driver]
   {:providers [{:name "Aiven" :pattern "\\.aivencloud\\.com$"}

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -623,6 +623,13 @@
     (when-let [table (sync-target! target database)]
       (t2/update! :model/Transform (:id transform) {:target_table_id (:id table)})
       (t2/update! :model/Table (:id table) {:transform_id (:id transform)}))
+    ;; ANALYZE the target before the run is observable, so dependents don't plan on stale stats.
+    ;; Best-effort: a stats failure shouldn't fail an otherwise-successful run.
+    (try
+      (driver/refresh-table-stats! (:engine database) database (:schema target) (:name target)
+                                   (keyword (:type target)))
+      (catch Throwable t
+        (log/warnf t "refresh-table-stats! failed for %s.%s" (:schema target) (:name target))))
     ;; Publish event after sync so the table exists in AppDB.
     (when publish-events?
       (events/publish-event! :event/transform-run-complete

--- a/test/metabase/transforms/execute_test.clj
+++ b/test/metabase/transforms/execute_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.transforms.execute-test
   (:require
+   [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.config.core :as config]
@@ -542,3 +543,41 @@
               (finally
                 (t2/update! :model/Database db-id {:write_data_details old-write-details})
                 (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))))))))))
+
+(deftest transform-run-refreshes-target-stats-test
+  (testing "completing a transform run leaves its target table analyzed, so a dependent transform plans
+            against real stats instead of the empty estimate a freshly CTAS'd table starts with"
+    ;; The ANALYZE effect is observable on Postgres (Redshift inherits the same impl); assert it here.
+    (mt/test-driver :postgres
+      (mt/dataset transforms-dataset/transforms-test
+        (let [schema      (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))
+              source-name (t2/select-one-fn :name :model/Table (mt/id :transforms_products))
+              admin-spec  (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
+              ;; A table has one pg_statistic row per analyzed column; a never-analyzed CTAS table has none.
+              analyzed-column-count
+              (fn [table-name]
+                (-> (jdbc/query admin-spec
+                                ["SELECT count(*) AS n FROM pg_stats WHERE schemaname = ? AND tablename = ?"
+                                 schema table-name])
+                    first :n))
+              run-and-wait! (fn [transform]
+                              (transforms.execute/execute! transform {:run-method :manual})
+                              (transforms.tu/wait-for-table (-> transform :target :name) 10000))]
+          (testing "real lifecycle: the target ends up with planner stats"
+            (with-transform-cleanup! [target {:type "table" :schema schema :name "products_analyzed"}]
+              (mt/with-temp [:model/Transform t {:name   "analyzed"
+                                                 :source {:type :query :query (make-query source-name)}
+                                                 :target target}]
+                (run-and-wait! t)
+                (is (pos? (analyzed-column-count (:name target)))
+                    "complete-execution! should have run ANALYZE, populating pg_statistic for the target"))))
+          (testing "control: with the refresh hook stubbed out, the same run leaves no stats — so the rows
+                    above come from our refresh, not from Postgres analyzing on its own"
+            (with-transform-cleanup! [target {:type "table" :schema schema :name "products_unanalyzed"}]
+              (mt/with-temp [:model/Transform t {:name   "unanalyzed"
+                                                 :source {:type :query :query (make-query source-name)}
+                                                 :target target}]
+                (with-redefs [driver/refresh-table-stats! (fn [& _] nil)]
+                  (run-and-wait! t))
+                (is (zero? (analyzed-column-count (:name target)))
+                    "a freshly materialized table has no planner stats until something analyzes it")))))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #74478
Closes https://linear.app/metabase/issue/GDGT-2450/dependent-transforms-can-run-before-upstream-table-stats-are-ready

Backports just the table-stats piece of 32a869b1e6a:

- new driver multimethod `metabase.driver/refresh-table-stats!` (default no-op) with a Postgres `ANALYZE` implementation
- `complete-execution!` refreshes the target table's stats (best-effort) after a transform run, before events are published
- lifecycle test asserting the target ends up analyzed on Postgres

