### PR TITLE
Fix type casts lint errors

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/components/public/debug/DevToolbar/diagnostics.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/debug/DevToolbar/diagnostics.unit.spec.ts
@@ -60,32 +60,30 @@ describe("dev diagnostics store", () => {
   });
 
   it("captures uncaught window errors", () => {
-    const event = new Event("error") as Event & { message: string };
-    event.message = "window blew up";
+    const event = Object.assign(new Event("error"), {
+      message: "window blew up",
+    });
     window.dispatchEvent(event);
 
     expect(last(getDevDiagnostics()).message).toContain("window blew up");
   });
 
   it("captures unhandled promise rejections", () => {
-    const event = new Event("unhandledrejection") as Event & {
-      reason: unknown;
-    };
-    event.reason = "nope";
+    const event = Object.assign(new Event("unhandledrejection"), {
+      reason: "nope",
+    });
     window.dispatchEvent(event);
 
     expect(last(getDevDiagnostics()).message).toBe("Unhandled rejection: nope");
   });
 
   it("captures CSP form-action violations (e.g. a blocked native form submit)", () => {
-    const event = new Event("securitypolicyviolation") as Event &
-      Partial<SecurityPolicyViolationEvent>;
-    Object.assign(event, {
+    const event = Object.assign(new Event("securitypolicyviolation"), {
       effectiveDirective: "form-action",
       violatedDirective: "form-action",
       blockedURI: "https://example.com/",
       originalPolicy: "connect-src 'self'; form-action 'none'",
-    });
+    } satisfies Partial<SecurityPolicyViolationEvent>);
     window.dispatchEvent(event);
 
     expect(last(getDevDiagnostics()).message).toBe(
@@ -94,14 +92,12 @@ describe("dev diagnostics store", () => {
   });
 
   it("formats other CSP violations generically (e.g. connect-src)", () => {
-    const event = new Event("securitypolicyviolation") as Event &
-      Partial<SecurityPolicyViolationEvent>;
-    Object.assign(event, {
+    const event = Object.assign(new Event("securitypolicyviolation"), {
       effectiveDirective: "connect-src",
       violatedDirective: "connect-src",
       blockedURI: "https://evil.test/",
       originalPolicy: "connect-src 'self'; form-action 'none'",
-    });
+    } satisfies Partial<SecurityPolicyViolationEvent>);
     window.dispatchEvent(event);
 
     expect(last(getDevDiagnostics()).message).toBe(

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/config/build-config.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/config/build-config.ts
@@ -25,7 +25,7 @@ export function dataAppLibBuild(fileName: string) {
     assetsInlineLimit: () => true,
     lib: {
       entry: DATA_APP_ENTRY,
-      formats: ["iife"] as LibraryFormats[],
+      formats: ["iife"] satisfies LibraryFormats[],
       name: DATA_APP_FACTORY_GLOBAL,
       fileName: () => fileName,
     },

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/config/dev-connect-src.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/config/dev-connect-src.ts
@@ -38,11 +38,11 @@ export function readAllowedHosts(appRoot: string): string[] {
   }
 
   if (!hosts.every(isString)) {
-    const nonString = hosts.filter((host) => !isString(host));
+    const nonString = hosts.find((host) => !isString(host));
 
     throw new Error(
       `${manifestPath}: every "allowed_hosts" entry must be a string, got ${JSON.stringify(
-        nonString[0],
+        nonString,
       )}.`,
     );
   }

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/config/dev-connect-src.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/config/dev-connect-src.ts
@@ -25,8 +25,8 @@ export function readAllowedHosts(appRoot: string): string[] {
   }
 
   const hosts =
-    typeof parsed === "object" && parsed !== null
-      ? (parsed as { allowed_hosts?: unknown }).allowed_hosts
+    typeof parsed === "object" && parsed !== null && "allowed_hosts" in parsed
+      ? parsed.allowed_hosts
       : undefined;
 
   if (hosts == null) {
@@ -37,9 +37,9 @@ export function readAllowedHosts(appRoot: string): string[] {
     throw new Error(`${manifestPath}: "allowed_hosts" must be a list.`);
   }
 
-  const nonString = hosts.filter((host) => typeof host !== "string");
+  if (!hosts.every(isString)) {
+    const nonString = hosts.filter((host) => !isString(host));
 
-  if (nonString.length > 0) {
     throw new Error(
       `${manifestPath}: every "allowed_hosts" entry must be a string, got ${JSON.stringify(
         nonString[0],
@@ -47,8 +47,10 @@ export function readAllowedHosts(appRoot: string): string[] {
     );
   }
 
-  return hosts as string[];
+  return hosts;
 }
+
+const isString = (value: unknown): value is string => typeof value === "string";
 
 function toOrigin(url: string | undefined): string | undefined {
   try {

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/dev-plugin/plugin.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/dev-plugin/plugin.unit.spec.ts
@@ -49,6 +49,9 @@ type TestPlugin = {
 };
 
 function makePlugin(allowedHosts: string[] = []): TestPlugin {
+  // Vite declares every hook on `Plugin` as an `ObjectHook` union (a function or
+  // a `{ handler }` object) bound to Rollup's plugin context. The tests call the
+  // hooks we return as plain functions, which no assignable type expresses.
   return dataAppSandboxDevPlugin(allowedHosts) as unknown as TestPlugin;
 }
 
@@ -134,6 +137,8 @@ describe("dataAppSandboxDevPlugin", () => {
     }
 
     async function setup(bundleCode = "BUNDLE_CODE") {
+      // Rollup's `OutputChunk` declares ~20 required fields; the plugin only
+      // reads `type` and `code`, so the stub deliberately omits the rest.
       mockedBuild.mockResolvedValue({
         output: [{ type: "chunk", code: bundleCode }],
       } as unknown as Awaited<ReturnType<typeof build>>);

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/data-schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/data-schema.ts
@@ -73,9 +73,13 @@ export function getSchemaId<TEntity extends { id: unknown }>(
   }
 
   if (typeof entity === "object" && "id" in entity) {
+    // `TEntity["id"]` is unconstrained, so it may itself be an object with an
+    // `id`: the guard cannot narrow the `TEntity | TEntity["id"]` union for TS.
     return entity.id as TEntity["id"];
   }
 
+  // Not an entity object, so it is already the id — but TS still cannot rule
+  // `TEntity` out of the union at the type level.
   return entity as TEntity["id"];
 }
 
@@ -84,6 +88,8 @@ export function mapRowsToObjects<TRow>(
   rows: RowValues[],
 ): TRow[] {
   return rows.map((row) => {
+    // Rows are keyed by column names known only at runtime; `TRow` is the
+    // schema-derived shape the caller expects, so the two can't be tied in TS.
     return columns.reduce<Record<string, RowValue>>((acc, column, index) => {
       const key = column.name || column.display_name || `column_${index}`;
       acc[key] = row[index];

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/aggregation-helpers.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/aggregation-helpers.ts
@@ -53,6 +53,9 @@ const fieldAggregation = <
   displayName: string,
   dimension: TDimension,
 ): FieldAggregationSchema<TOperator, TDimension> =>
+  // The column's `name`/`jsType` are computed at runtime (`string` /
+  // `SchemaJavaScriptType`), while the schema type states them as the conditional
+  // literals derived from `TOperator` — TS can't connect the two.
   ({
     type: "operator",
     operator: type,
@@ -78,11 +81,15 @@ function getFieldAggregationColumnJavaScriptType(
     return "number";
   }
 
-  if (dimension == null || typeof dimension !== "object") {
+  if (
+    dimension == null ||
+    typeof dimension !== "object" ||
+    !("jsType" in dimension)
+  ) {
     return "number";
   }
 
-  const jsType = (dimension as { jsType?: unknown }).jsType;
+  const { jsType } = dimension;
 
   if (isOrderableJavaScriptType(jsType)) {
     return jsType;

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/query-helpers.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/query-helpers.ts
@@ -68,14 +68,16 @@ export function filter(
   };
 }
 
-export function breakout<TDimension>(dimension: TDimension): TDimension;
+export function breakout<TDimension extends object>(
+  dimension: TDimension,
+): TDimension;
 
-export function breakout<TDimension>(
+export function breakout<TDimension extends object>(
   dimension: TDimension,
   options: BreakoutOptionsArgument<TDimension>,
 ): TDimension & BreakoutOptionsArgument<TDimension>;
 
-export function breakout<TDimension>(
+export function breakout<TDimension extends object>(
   dimension: TDimension,
   options?: BreakoutOptionsArgument<TDimension>,
 ) {

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/query-helpers.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/query-helpers.ts
@@ -46,16 +46,14 @@ export function filter(
   value?: unknown,
 ): MetabaseDimensionFilterForOperator<unknown, FilterOperator> {
   if (operator === "between") {
-    const [min, max] = value as readonly unknown[];
+    // The `between` overload takes a `[min, max]` tuple, but the implementation
+    // signature shared by all overloads widens `value` to `unknown`.
+    const [min, max] = value as readonly [unknown, unknown];
 
     return {
       type: "operator",
       operator,
-      args: [
-        dimension,
-        { type: "literal", value: min as FilterLiteralValue },
-        { type: "literal", value: max as FilterLiteralValue },
-      ],
+      args: [dimension, toFilterLiteral(min), toFilterLiteral(max)],
     };
   }
 
@@ -66,7 +64,7 @@ export function filter(
   return {
     type: "operator",
     operator,
-    args: [dimension, { type: "literal", value: value as FilterLiteralValue }],
+    args: [dimension, toFilterLiteral(value)],
   };
 }
 
@@ -82,7 +80,7 @@ export function breakout<TDimension>(
   options?: BreakoutOptionsArgument<TDimension>,
 ) {
   return {
-    ...(dimension as object),
+    ...dimension,
     unit: options && "unit" in options ? options.unit : undefined,
     ...getBinningOptions(options),
   };
@@ -138,11 +136,11 @@ export function orderBy<TDimension>(
 }
 
 function getAggregationResultColumn(value: unknown): SchemaColumn | undefined {
-  if (value == null || typeof value !== "object") {
+  if (value == null || typeof value !== "object" || !("columns" in value)) {
     return undefined;
   }
 
-  const columns = (value as { columns?: unknown }).columns;
+  const { columns } = value;
 
   if (!Array.isArray(columns)) {
     return undefined;
@@ -150,15 +148,16 @@ function getAggregationResultColumn(value: unknown): SchemaColumn | undefined {
 
   const [column] = columns;
 
-  if (
-    column == null ||
-    typeof column !== "object" ||
-    typeof (column as { name?: unknown }).name !== "string"
-  ) {
-    return undefined;
-  }
+  return isSchemaColumn(column) ? column : undefined;
+}
 
-  return column as SchemaColumn;
+function isSchemaColumn(value: unknown): value is SchemaColumn {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    "name" in value &&
+    typeof value.name === "string"
+  );
 }
 
 function getBinningOptions(
@@ -195,4 +194,16 @@ function getBinningOptions(
   }
 
   return undefined;
+}
+
+function toFilterLiteral(value: unknown): {
+  type: "literal";
+  value: FilterLiteralValue;
+} {
+  return {
+    type: "literal",
+    // The overloads accept the filter value as `unknown` (it is only constrained
+    // by the operator), while the emitted filter types it as a literal value.
+    value: value as FilterLiteralValue,
+  };
 }

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppSkillsSection/DataAppSkillsSection.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppSkillsSection/DataAppSkillsSection.unit.spec.tsx
@@ -20,13 +20,13 @@ const setup = (tag?: string) => {
 };
 
 const copyCommand = async () => {
-  const writeText = jest.fn().mockResolvedValue(undefined);
+  const writeText = jest.fn((_text: string) => Promise.resolve());
   Object.assign(navigator, { clipboard: { writeText } });
 
   await userEvent.click(screen.getByTestId("copy-button"));
 
   await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
-  return writeText.mock.calls[0][0] as string;
+  return writeText.mock.calls[0][0];
 };
 
 const DATA_APP_SKILLS = [

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/components/DataAppView/DataAppView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/components/DataAppView/DataAppView.tsx
@@ -25,6 +25,18 @@ interface AppViewProps {
   params: { name: string };
 }
 
+/** The iframe can post anything; only trust objects tagged with our error type. */
+function isBundleErrorMessage(
+  data: unknown,
+): data is Partial<DataAppBundleErrorMessage> {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "type" in data &&
+    data.type === DATA_APP_ERROR_MESSAGE_TYPE
+  );
+}
+
 /**
  * /apps/:name(/*) — renders the requested data-app inside an isolated
  * iframe, mirroring the iframe's internal route into the parent's URL.
@@ -136,9 +148,9 @@ export function DataAppView({ params }: AppViewProps) {
         return;
       }
 
-      const data = event.data as Partial<DataAppBundleErrorMessage> | null;
+      const data: unknown = event.data;
 
-      if (data?.type === DATA_APP_ERROR_MESSAGE_TYPE) {
+      if (isBundleErrorMessage(data)) {
         setBundleError({
           type: DATA_APP_ERROR_MESSAGE_TYPE,
           notReady: Boolean(data.notReady),
@@ -171,7 +183,7 @@ export function DataAppView({ params }: AppViewProps) {
     // else is an unexpected failure.
     const status =
       metaError && typeof metaError === "object" && "status" in metaError
-        ? (metaError as { status?: unknown }).status
+        ? metaError.status
         : undefined;
 
     if (!metaError || status === 404) {

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/components/DataAppView/DataAppView.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/components/DataAppView/DataAppView.unit.spec.tsx
@@ -28,6 +28,8 @@ function setup({
   isLoading = false,
   error,
 }: SetupOpts = {}) {
+  // RTK Query's hook result is a wide discriminated union (refetch, status,
+  // isFetching, …); the component reads only these three fields.
   mockedGetApp.mockReturnValue({
     data,
     isLoading,

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/runtime/lib/describe-error.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/runtime/lib/describe-error.ts
@@ -3,9 +3,6 @@ import { t } from "ttag";
 /** The actual error message + stack pulled out of a thrown value. */
 export type ErrorDetail = { message: string; stack?: string };
 
-/** Loose shape we defensively read off a thrown value (or membrane proxy). */
-type MaybeError = { message?: unknown; stack?: unknown };
-
 /**
  * Pull a human-readable message + stack out of a thrown value.
  *
@@ -22,17 +19,16 @@ export function describeError(
   const fallback = fallbackMessage || t`An unexpected error occurred.`;
 
   try {
-    const normalizedValue = value as MaybeError | null;
+    const errorLike =
+      typeof value === "object" && value !== null ? value : null;
+    const rawMessage =
+      errorLike && "message" in errorLike ? errorLike.message : undefined;
+    const rawStack =
+      errorLike && "stack" in errorLike ? errorLike.stack : undefined;
+
     const message =
-      normalizedValue &&
-      typeof normalizedValue.message === "string" &&
-      normalizedValue.message
-        ? normalizedValue.message
-        : fallback;
-    const stack =
-      normalizedValue && typeof normalizedValue.stack === "string"
-        ? normalizedValue.stack
-        : undefined;
+      typeof rawMessage === "string" && rawMessage ? rawMessage : fallback;
+    const stack = typeof rawStack === "string" ? rawStack : undefined;
 
     return { message, stack };
   } catch {

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/runtime/lib/use-host-sdk-store.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/runtime/lib/use-host-sdk-store.unit.spec.ts
@@ -30,6 +30,8 @@ const mockedEnsurePropsStore = jest.mocked(ensureMetabaseProviderPropsStore);
 
 const setup = (initialProps: Record<string, unknown> = {}) => {
   const dispatch = jest.fn();
+  // The hook only ever dispatches; faking the rest of the Redux store contract
+  // (getState over the whole SDK state tree, subscribe, replaceReducer) is dead weight.
   const store = { dispatch } as unknown as ReturnType<typeof getSdkStore>;
   mockedGetSdkStore.mockReturnValue(store);
 
@@ -38,7 +40,10 @@ const setup = (initialProps: Record<string, unknown> = {}) => {
   mockedEnsurePropsStore.mockReturnValue({
     setProps,
     updateInternalProps,
-  } as unknown as ReturnType<typeof ensureMetabaseProviderPropsStore>);
+    getState: () => ({ props: null, internalProps: {} }),
+    subscribe: () => () => undefined,
+    cleanup: () => undefined,
+  });
 
   const utils = renderHook(({ props }) => useHostSdkStore(props), {
     initialProps: { props: initialProps },

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/runtime/loader.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/runtime/loader.ts
@@ -110,7 +110,7 @@ export const fetchDataAppBundleCode = async (
 export const instantiateDataAppBundle = (
   code: string,
   label: string,
-  targetWindow: Window,
+  targetWindow: Window & typeof globalThis,
   allowedHosts: string[] = [],
 ): LoadedDataApp => {
   const sandbox = createDataAppSandbox({

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/runtime/loader.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/runtime/loader.unit.spec.ts
@@ -26,7 +26,7 @@ describe("fetchDataAppBundleCode", () => {
           : Promise.resolve(response),
     );
 
-    global.fetch = fetchMock as unknown as typeof fetch;
+    global.fetch = fetchMock;
 
     return { fetchMock };
   };
@@ -102,8 +102,10 @@ describe("fetchDataAppBundleCode", () => {
 describe("instantiateDataAppBundle", () => {
   const setup = (factoryResult: unknown) => {
     mockedCreateSandbox.mockReturnValue({
+      // @ts-expect-error - the factory result is deliberately untyped: these tests
+      // feed the loader malformed values (`null`, a non-function `component`).
       evaluate: () => () => factoryResult,
-    } as unknown as ReturnType<typeof createDataAppSandbox>);
+    });
 
     return {
       instantiate: () => instantiateDataAppBundle("code", "demo", window, []),

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/allowed-hosts.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/allowed-hosts.ts
@@ -16,6 +16,17 @@
  * sandboxed browser realm — so keep the two in sync if either changes.
  */
 
+/**
+ * The slice of the sandbox's realm the network wrappers touch: the native
+ * `fetch`/`XMLHttpRequest` they wrap, and the location a relative request URL
+ * resolves against. A real `Window & typeof globalThis` satisfies it.
+ */
+export interface SandboxRealm {
+  fetch: typeof fetch;
+  XMLHttpRequest: typeof XMLHttpRequest;
+  location: { href: string; origin: string };
+}
+
 interface AllowedOrigin {
   protocol: string; // "https:" | "http:"
   wildcard: boolean; // entry was "*.host"
@@ -135,7 +146,7 @@ function blockedReason(
  * the caller keeps the sandbox's default hard block.
  */
 export function makeSandboxFetch(
-  targetWindow: Window & typeof globalThis,
+  targetWindow: SandboxRealm,
   allowedHosts: string[],
   label: string,
 ): typeof fetch | null {
@@ -162,7 +173,7 @@ export function makeSandboxFetch(
  * (keeps the default hard block).
  */
 export function makeSandboxXhr(
-  targetWindow: Window & typeof globalThis,
+  targetWindow: SandboxRealm,
   allowedHosts: string[],
   label: string,
 ): typeof XMLHttpRequest | null {

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/allowed-hosts.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/allowed-hosts.unit.spec.ts
@@ -1,4 +1,5 @@
 import {
+  type SandboxRealm,
   isHostAllowed,
   makeSandboxFetch,
   makeSandboxXhr,
@@ -81,9 +82,11 @@ describe("makeSandboxFetch", () => {
   const base = "https://mb.example.com/embed/apps/sales";
   const origin = "https://mb.example.com";
 
-  const fakeWindow = (fetch: jest.Mock) =>
-    ({ fetch, location: { href: base, origin } }) as unknown as Window &
-      typeof globalThis;
+  const fakeWindow = (fetch: typeof global.fetch): SandboxRealm => ({
+    fetch,
+    XMLHttpRequest,
+    location: { href: base, origin },
+  });
 
   it("returns null for an empty allowlist (keeps the sandbox hard block)", () => {
     expect(makeSandboxFetch(window, [], "sales")).toBeNull();

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/create-element.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/create-element.ts
@@ -13,11 +13,28 @@ function isStyleQualifiedName(qualifiedName: string) {
   return isStyleTag(localName);
 }
 
+/** The shared sandbox distortion callback, as the membrane types it. */
+type SharedDistortion = (value: object) => object;
+
+export function makeCreateElementDistortion(
+  value: typeof CREATE_ELEMENT,
+  shared: SharedDistortion,
+): typeof CREATE_ELEMENT;
+export function makeCreateElementDistortion(
+  value: typeof CREATE_ELEMENT_NS,
+  shared: SharedDistortion,
+): typeof CREATE_ELEMENT_NS;
 export function makeCreateElementDistortion(
   value: object,
-  shared: (value: object) => object,
-) {
+  shared: SharedDistortion,
+): object | null;
+export function makeCreateElementDistortion(
+  value: object,
+  shared: SharedDistortion,
+): object | null {
   if (value === CREATE_ELEMENT) {
+    // A distortion callback is typed `object -> object` (the membrane erases the
+    // call signature), so restore the signature of the ref it stands in for.
     const sharedCreateElement = shared(value) as typeof CREATE_ELEMENT;
 
     return function createElement(
@@ -38,6 +55,8 @@ export function makeCreateElementDistortion(
   }
 
   if (value === CREATE_ELEMENT_NS) {
+    // Same signature restoration as above: `shared` hands back a drop-in
+    // replacement for `createElementNS`, typed only as `object`.
     const sharedCreateElementNS = shared(value) as typeof CREATE_ELEMENT_NS;
 
     return function createElementNS(
@@ -53,7 +72,7 @@ export function makeCreateElementDistortion(
           this,
           namespaceURI,
           qualifiedName,
-          options as ElementCreationOptions,
+          options,
         );
       }
 
@@ -61,7 +80,7 @@ export function makeCreateElementDistortion(
         this,
         namespaceURI,
         qualifiedName,
-        options as ElementCreationOptions,
+        options,
       );
     };
   }

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/create-element.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/create-element.unit.spec.ts
@@ -11,30 +11,27 @@ import { makeCreateElementDistortion } from "./create-element";
 // assert the delegation contract (non-<style> tags fall back to `shared`, with
 // the tag/options forwarded and its result returned); the blocklist behaviour
 // itself is covered by scripts-sandbox's own tests.
-const setup = (target: object, sentinel?: unknown) => {
+const setup = (sentinel?: unknown) => {
   const sharedImpl = jest.fn(() => sentinel);
   const shared = jest.fn(() => sharedImpl);
-  const distorted = makeCreateElementDistortion(target, shared);
 
-  return { distorted, shared, sharedImpl };
+  return { shared, sharedImpl };
 };
 
 describe("makeCreateElementDistortion", () => {
   it("returns null for values that aren't createElement / createElementNS", () => {
-    const { distorted, shared } = setup({});
+    const { shared } = setup();
 
-    expect(distorted).toBeNull();
+    expect(makeCreateElementDistortion({}, shared)).toBeNull();
     expect(shared).not.toHaveBeenCalled();
   });
 
   describe("createElement", () => {
     it("allows <style> through the native creator (bundled CSS injection)", () => {
-      const { distorted, sharedImpl } = setup(CREATE_ELEMENT);
-      const create = distorted as
-        | typeof Document.prototype.createElement
-        | null;
+      const { shared, sharedImpl } = setup();
+      const create = makeCreateElementDistortion(CREATE_ELEMENT, shared);
 
-      const el = create?.call(document, "style");
+      const el = create.call(document, "style");
 
       expect(el).toBeInstanceOf(HTMLStyleElement);
       expect(sharedImpl).not.toHaveBeenCalled();
@@ -42,13 +39,11 @@ describe("makeCreateElementDistortion", () => {
 
     it("delegates non-style tags to the shared (blocklisted) creator", () => {
       const sentinel = document.createElement("div");
-      const { distorted, shared, sharedImpl } = setup(CREATE_ELEMENT, sentinel);
-      const create = distorted as
-        | typeof Document.prototype.createElement
-        | null;
+      const { shared, sharedImpl } = setup(sentinel);
+      const create = makeCreateElementDistortion(CREATE_ELEMENT, shared);
 
       const options = { is: "custom-el" };
-      const el = create?.call(document, "script", options);
+      const el = create.call(document, "script", options);
 
       expect(shared).toHaveBeenCalledWith(CREATE_ELEMENT);
       expect(sharedImpl).toHaveBeenCalledWith("script", options);
@@ -58,12 +53,10 @@ describe("makeCreateElementDistortion", () => {
 
   describe("createElementNS", () => {
     it("allows namespaced <style> through the native creator", () => {
-      const { distorted, sharedImpl } = setup(CREATE_ELEMENT_NS);
-      const create = distorted as
-        | typeof Document.prototype.createElementNS
-        | null;
+      const { shared, sharedImpl } = setup();
+      const create = makeCreateElementDistortion(CREATE_ELEMENT_NS, shared);
 
-      const el = create?.call(
+      const el = create.call(
         document,
         "http://www.w3.org/1999/xhtml",
         "html:style",
@@ -78,15 +71,10 @@ describe("makeCreateElementDistortion", () => {
         "http://www.w3.org/2000/svg",
         "svg",
       );
-      const { distorted, shared, sharedImpl } = setup(
-        CREATE_ELEMENT_NS,
-        sentinel,
-      );
-      const create = distorted as
-        | typeof Document.prototype.createElementNS
-        | null;
+      const { shared, sharedImpl } = setup(sentinel);
+      const create = makeCreateElementDistortion(CREATE_ELEMENT_NS, shared);
 
-      const el = create?.call(
+      const el = create.call(
         document,
         "http://www.w3.org/2000/svg",
         "svg:script",

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.ts
@@ -1,6 +1,10 @@
 import { makeSandboxDistortionCallback } from "metabase/utils/scripts-sandbox";
 
-import { makeSandboxFetch, makeSandboxXhr } from "./allowed-hosts";
+import {
+  type SandboxRealm,
+  makeSandboxFetch,
+  makeSandboxXhr,
+} from "./allowed-hosts";
 import { makeCreateElementDistortion } from "./create-element";
 
 /**
@@ -21,7 +25,7 @@ import { makeCreateElementDistortion } from "./create-element";
  */
 export function makeDistortionCallback(
   label: string,
-  targetWindow: Window & typeof globalThis,
+  targetWindow: SandboxRealm,
   allowedHosts: string[],
 ) {
   const shared = makeSandboxDistortionCallback(

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.unit.spec.ts
@@ -1,23 +1,25 @@
+import type { SandboxRealm } from "./allowed-hosts";
 import { makeDistortionCallback } from "./distortions";
 
 // A minimal stand-in for the iframe window the data-app sandbox is built on.
 // `fetch`/`XMLHttpRequest` are the native refs the membrane passes to the
 // distortion callback; `makeDistortionCallback` should route those to the
 // allowlist wrappers and delegate everything else to the shared callback.
-const fakeWindow = () =>
-  ({
-    fetch: function nativeFetch() {},
-    XMLHttpRequest: class NativeXHR {},
-    location: {
-      href: "https://mb.example.com/embed/apps/sales",
-      origin: "https://mb.example.com",
-    },
-  }) as unknown as Window & typeof globalThis;
+const fakeWindow = (): SandboxRealm => ({
+  fetch: async () => new Response("native"),
+  XMLHttpRequest: class NativeXHR extends XMLHttpRequest {},
+  location: {
+    href: "https://mb.example.com/embed/apps/sales",
+    origin: "https://mb.example.com",
+  },
+});
 
 describe("makeDistortionCallback", () => {
   it("allows style elements for bundled CSS injection", () => {
     const win = fakeWindow();
     const callback = makeDistortionCallback("sales", win, []);
+    // The membrane types a distortion as `object -> object`, erasing the call
+    // signature of the native ref it replaces — restore it to invoke it.
     const createElement = callback(
       Document.prototype.createElement,
     ) as typeof Document.prototype.createElement;
@@ -31,6 +33,7 @@ describe("makeDistortionCallback", () => {
       .mockImplementation(() => {});
     const win = fakeWindow();
     const callback = makeDistortionCallback("sales", win, []);
+    // Same signature erasure as above.
     const createElement = callback(
       Document.prototype.createElement,
     ) as typeof Document.prototype.createElement;
@@ -44,11 +47,12 @@ describe("makeDistortionCallback", () => {
   it("routes window.fetch to the allowlisted wrapper when allowed_hosts is set", async () => {
     const win = fakeWindow();
     const realFetch = jest.fn(() => Promise.resolve(new Response("ok")));
-    win.fetch = realFetch as unknown as typeof fetch;
+    win.fetch = realFetch;
 
     const callback = makeDistortionCallback("sales", win, [
       "https://api.example.com",
     ]);
+    // Same signature erasure as above.
     const distorted = callback(win.fetch) as typeof fetch;
 
     // Not the native fetch — a wrapper that enforces the allowlist.
@@ -65,6 +69,8 @@ describe("makeDistortionCallback", () => {
     const callback = makeDistortionCallback("sales", win, [
       "https://api.example.com",
     ]);
+    // Same signature erasure as above: the membrane hands the constructor back
+    // as a bare `object`.
     const Distorted = callback(win.XMLHttpRequest) as typeof XMLHttpRequest;
 
     expect(Distorted).not.toBe(win.XMLHttpRequest);

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/sandbox.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/sandbox.ts
@@ -41,7 +41,7 @@ export interface CreateDataAppSandboxOptions {
   /** Human-readable label used in sandbox diagnostics, e.g. the app slug. */
   label?: string;
   /** Realm the membrane binds to. Defaults to the current `window`. */
-  targetWindow?: Window;
+  targetWindow?: Window & typeof globalThis;
   /** Origins the bundle may fetch/XHR; empty keeps the default hard block. */
   allowedHosts?: string[];
   /** The realm's React/SDK exposed to the bundle. See [[DataAppSandboxEndowments]]. */
@@ -52,6 +52,10 @@ function isLiveTarget(target: object): boolean {
   return target instanceof CSSStyleDeclaration;
 }
 
+function isDataAppFactory(value: unknown): value is DataAppFactory {
+  return typeof value === "function";
+}
+
 export function createDataAppSandbox({
   label = "",
   targetWindow = window,
@@ -60,44 +64,41 @@ export function createDataAppSandbox({
 }: CreateDataAppSandboxOptions) {
   let captured: unknown;
 
-  const env = createVirtualEnvironment(
-    targetWindow as Window & typeof globalThis,
-    {
-      distortionCallback: makeDistortionCallback(
-        label,
-        targetWindow as Window & typeof globalThis,
-        allowedHosts,
-      ),
-      liveTargetCallback: isLiveTarget,
-      // Global names come from the shared `DATA_APP_GLOBAL_NAMES`, so the bundle's
-      // externals (defined by the SDK build) and these endowments can't drift.
-      endowments: Object.getOwnPropertyDescriptors({
-        [DATA_APP_GLOBAL_NAMES.react]: endowments.React,
-        [DATA_APP_GLOBAL_NAMES.reactDom]: endowments.reactDom,
-        [DATA_APP_GLOBAL_NAMES.reactDomClient]: endowments.reactDomClient,
-        [DATA_APP_GLOBAL_NAMES.reactDomServer]: endowments.reactDomServer,
-        [DATA_APP_GLOBAL_NAMES.reactJsxRuntime]: endowments.reactJsxRuntime,
-        ...(!!endowments.reactJsxDevRuntime && {
-          [DATA_APP_GLOBAL_NAMES.reactJsxDevRuntime]:
-            endowments.reactJsxDevRuntime,
-        }),
-        [DATA_APP_GLOBAL_NAMES.sdk]: {
-          ...endowments.sdkExports,
-          // Below we can set fallbacks to `sdkExports` exports that were renamed/removed to prevent breaking changes
-        },
-        [DATA_APP_GLOBAL_NAMES.dataApp]: {
-          ...endowments.dataAppExports,
-          // Below we can set fallbacks to `dataAppExports` exports that were renamed/removed to prevent breaking changes
-        },
-        get [DATA_APP_GLOBAL_NAMES.factory]() {
-          return captured;
-        },
-        set [DATA_APP_GLOBAL_NAMES.factory](value: unknown) {
-          captured = value;
-        },
+  const env = createVirtualEnvironment(targetWindow, {
+    distortionCallback: makeDistortionCallback(
+      label,
+      targetWindow,
+      allowedHosts,
+    ),
+    liveTargetCallback: isLiveTarget,
+    // Global names come from the shared `DATA_APP_GLOBAL_NAMES`, so the bundle's
+    // externals (defined by the SDK build) and these endowments can't drift.
+    endowments: Object.getOwnPropertyDescriptors({
+      [DATA_APP_GLOBAL_NAMES.react]: endowments.React,
+      [DATA_APP_GLOBAL_NAMES.reactDom]: endowments.reactDom,
+      [DATA_APP_GLOBAL_NAMES.reactDomClient]: endowments.reactDomClient,
+      [DATA_APP_GLOBAL_NAMES.reactDomServer]: endowments.reactDomServer,
+      [DATA_APP_GLOBAL_NAMES.reactJsxRuntime]: endowments.reactJsxRuntime,
+      ...(!!endowments.reactJsxDevRuntime && {
+        [DATA_APP_GLOBAL_NAMES.reactJsxDevRuntime]:
+          endowments.reactJsxDevRuntime,
       }),
-    },
-  );
+      [DATA_APP_GLOBAL_NAMES.sdk]: {
+        ...endowments.sdkExports,
+        // Below we can set fallbacks to `sdkExports` exports that were renamed/removed to prevent breaking changes
+      },
+      [DATA_APP_GLOBAL_NAMES.dataApp]: {
+        ...endowments.dataAppExports,
+        // Below we can set fallbacks to `dataAppExports` exports that were renamed/removed to prevent breaking changes
+      },
+      get [DATA_APP_GLOBAL_NAMES.factory]() {
+        return captured;
+      },
+      set [DATA_APP_GLOBAL_NAMES.factory](value: unknown) {
+        captured = value;
+      },
+    }),
+  });
 
   return {
     evaluate(code: string): DataAppFactory {
@@ -107,7 +108,13 @@ export function createDataAppSandbox({
         let message: string;
 
         try {
-          message = String((error as { message?: unknown })?.message ?? error);
+          // Reading `message` off a membrane-opaque throw can itself throw, so
+          // the read stays inside this try.
+          message = String(
+            typeof error === "object" && error !== null && "message" in error
+              ? (error.message ?? error)
+              : error,
+          );
         } catch {
           message = "Unknown error inside data-app sandbox";
         }
@@ -115,13 +122,13 @@ export function createDataAppSandbox({
         throw new Error(message);
       }
 
-      if (typeof captured !== "function") {
+      if (!isDataAppFactory(captured)) {
         throw new Error(
           "Bundle did not assign a function to __dataAppFactory__",
         );
       }
 
-      return captured as DataAppFactory;
+      return captured;
     },
   };
 }

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/sandbox.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/sandbox.unit.spec.ts
@@ -33,7 +33,9 @@ function setup({ overrides, runBundle = () => {} }: SetupOpts = {}) {
 
   mockedCreateEnv.mockReset();
   mockedCreateEnv.mockImplementation((_targetWindow, options) => {
-    endowments = (options as { endowments: EnvEndowments }).endowments;
+    endowments = options?.endowments;
+    // `VirtualEnvironment` is a class with a large internal surface (link,
+    // remap, lazyRemapProperties, …); the sandbox only ever calls `evaluate`.
     return {
       evaluate: () => runBundle(),
     } as unknown as ReturnType<typeof createVirtualEnvironment>;
@@ -43,9 +45,12 @@ function setup({ overrides, runBundle = () => {} }: SetupOpts = {}) {
     endowments: baseEndowments(overrides),
   });
 
-  const descriptors = endowments as EnvEndowments;
+  if (!endowments) {
+    throw new Error("createVirtualEnvironment was called without endowments");
+  }
+
   const endowed = Object.fromEntries(
-    Object.entries(descriptors).map(([name, descriptor]) => [
+    Object.entries(endowments).map(([name, descriptor]) => [
       name,
       descriptor.value,
     ]),

--- a/enterprise/frontend/src/metabase-enterprise/user_provisioning/components/ScimInputs.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/user_provisioning/components/ScimInputs.tsx
@@ -1,7 +1,7 @@
 import { match } from "ts-pattern";
 
+import type { CopyTextInputProps } from "metabase/common/components/CopyTextInput";
 import { CopyTextInput } from "metabase/common/components/CopyTextInput";
-import type { TextInputProps } from "metabase/ui";
 import { getThemeOverrides } from "metabase/ui/theme";
 
 // Unjustified type cast. FIXME
@@ -30,7 +30,7 @@ export const getTextInputStyles = (params: {
 export const CopyScimInput = ({
   disabled = true,
   ...props
-}: TextInputProps & {
+}: CopyTextInputProps & {
   label: string;
   value: string;
   disabled?: boolean;

--- a/frontend/src/embedding-sdk-bundle/lib/execute-action.unit.spec.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/execute-action.unit.spec.ts
@@ -18,6 +18,9 @@ function setup() {
     Api.middleware,
   ]);
   activeStore = store;
+  // The test store is built from the main-app `State`, so it does not carry the
+  // SDK-only slices of `SdkStoreState`. `executeAction` only ever touches
+  // `dispatch`, which is compatible.
   return store as unknown as SdkStore;
 }
 
@@ -44,7 +47,7 @@ describe("executeAction", () => {
       `path:/api/action/${NUMERIC_ID}/execute`,
     );
     expect(calls).toHaveLength(1);
-    const body = JSON.parse(calls[0].options.body as string);
+    const body = JSON.parse(String(calls[0].options.body));
     expect(body).toEqual({ parameters: { id: 1, name: "European" } });
   });
 
@@ -60,7 +63,7 @@ describe("executeAction", () => {
       `path:/api/action/${NUMERIC_ID}/execute`,
     );
     expect(calls).toHaveLength(1);
-    expect(JSON.parse(calls[0].options.body as string)).toEqual({
+    expect(JSON.parse(String(calls[0].options.body))).toEqual({
       parameters: {},
     });
   });

--- a/frontend/src/embedding-sdk-bundle/lib/query-dataset.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/query-dataset.ts
@@ -20,6 +20,8 @@ export type QueryDatasetResult = {
 export const queryDataset =
   () =>
   async ({ datasetQuery }: QueryDatasetParams): Promise<QueryDatasetResult> => {
+    // `api.request` resolves to `unknown` (it does not take a response type
+    // parameter), so the /api/dataset body has to be named here.
     const response = (await api.request({
       method: "POST",
       url: "/api/dataset",

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question-query.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question-query.ts
@@ -1,8 +1,9 @@
+import type { MetabaseQueryObject } from "embedding-sdk-bundle/types/question";
 import { deserializeCardFromQuery } from "metabase/common/utils/card";
 import type { DatasetQuery, UnsavedCard } from "metabase-types/api";
 
 export function getCardFromSdkQuestionQuery(
-  query: unknown | null | undefined,
+  query: string | MetabaseQueryObject | null | undefined,
 ): UnsavedCard | undefined {
   if (query == null) {
     return undefined;
@@ -13,6 +14,9 @@ export function getCardFromSdkQuestionQuery(
   }
 
   return {
+    // `MetabaseQueryObject` is the public structural mirror of `DatasetQuery`
+    // and deliberately omits its opaque marker, so it cannot be assigned to the
+    // internal type without an assertion.
     dataset_query: query as DatasetQuery,
     display: "table",
     visualization_settings: {},

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/resolve-card-prop.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/resolve-card-prop.ts
@@ -26,6 +26,9 @@ export function resolveCardProp(
     input.visualization != null || input.displayIsLocked != null;
 
   return {
+    // `MetabaseQueryObject` is the public structural mirror of `DatasetQuery`
+    // and deliberately omits its opaque marker, so it cannot be assigned to the
+    // internal type without an assertion.
     dataset_query: input.query as DatasetQuery,
     // Public-facing `visualization` maps to the internal card `display`. When
     // omitted, let query results pick a better unlocked display later.

--- a/frontend/src/embedding-sdk-bundle/lib/validate-function-schema.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/validate-function-schema.ts
@@ -1,48 +1,43 @@
-import type * as Yup from "yup";
+import { ValidationError } from "yup";
 
 import type { FunctionSchema } from "embedding-sdk-bundle/types/schema";
 import type {
-  FunctionParametersSchemaValidationErrorMetadata,
   FunctionSchemaValidationResult,
   SchemaValidationErrorMetadata,
 } from "embedding-sdk-shared/types/validation";
 
-const getErrorMetadata = <
-  TMetadata extends
-    | SchemaValidationErrorMetadata
-    | FunctionParametersSchemaValidationErrorMetadata,
->({
-  error,
-  parameterIndex,
-}: {
-  error: Yup.ValidationError;
-  parameterIndex?: number;
-}): TMetadata | null => {
+const getErrorMetadata = (
+  error: ValidationError,
+): SchemaValidationErrorMetadata | null => {
   switch (error.type) {
     case "required":
-      // Unjustified type cast. FIXME
       return {
         errorCode: "missing_required_property",
-        data: error.params?.path ?? "",
-        parameterIndex,
-      } as TMetadata;
+        data: String(error.params?.path ?? ""),
+      };
     case "has-entity-prop":
       return {
         errorCode: "missing_required_property",
         data: "questionId, token, or query",
-        parameterIndex,
-      } as TMetadata;
+      };
     case "noUnknown":
-      // Unjustified type cast. FIXME
       return {
         errorCode: "unrecognized_keys",
-        data: error.params?.unknown ?? "",
-        parameterIndex,
-      } as TMetadata;
+        data: String(error.params?.unknown ?? ""),
+      };
   }
 
   return null;
 };
+
+/**
+ * Schema violations surface as `ValidationError`; anything else thrown by
+ * `validateSync` is not a schema problem and carries no metadata.
+ */
+const getThrownErrorMetadata = (
+  error: unknown,
+): SchemaValidationErrorMetadata | null =>
+  ValidationError.isError(error) ? getErrorMetadata(error) : null;
 
 export const validateFunctionSchema = <
   TSchema extends FunctionSchema,
@@ -65,19 +60,13 @@ export const validateFunctionSchema = <
         });
 
         return { success: true };
-      } catch (_error: unknown) {
-        // Unjustified type cast. FIXME
-        const error = _error as Yup.ValidationError;
-        const errorMetadata =
-          getErrorMetadata<FunctionParametersSchemaValidationErrorMetadata>({
-            error,
-            parameterIndex: i,
-          });
+      } catch (error: unknown) {
+        const errorMetadata = getThrownErrorMetadata(error);
 
         if (errorMetadata) {
           return {
             success: false,
-            errorMetadata,
+            errorMetadata: { ...errorMetadata, parameterIndex: i },
           };
         }
       }
@@ -96,12 +85,8 @@ export const validateFunctionSchema = <
       });
 
       return { success: true };
-    } catch (_error: unknown) {
-      // Unjustified type cast. FIXME
-      const error = _error as Yup.ValidationError;
-      const errorMetadata = getErrorMetadata<SchemaValidationErrorMetadata>({
-        error,
-      });
+    } catch (error: unknown) {
+      const errorMetadata = getThrownErrorMetadata(error);
 
       if (errorMetadata) {
         return {

--- a/frontend/src/metabase-lib/query/query.unit.spec.ts
+++ b/frontend/src/metabase-lib/query/query.unit.spec.ts
@@ -515,13 +515,9 @@ describe("createTestQuery", () => {
         ],
       });
 
-      expect(
-        (
-          Lib.toLegacyQuery(query) as DatasetQuery & {
-            query: { filter: unknown };
-          }
-        ).query.filter,
-      ).toEqual(["segment", SEGMENT_ID]);
+      expect(Lib.toLegacyQuery(query)).toMatchObject({
+        query: { filter: ["segment", SEGMENT_ID] },
+      });
     });
 
     it("should create a query with filters", () => {
@@ -567,12 +563,14 @@ describe("createTestQuery", () => {
             createMockMeasure({
               id: MEASURE_ID,
               table_id: PRODUCTS_ID,
-              definition: createMockStructuredDatasetQuery({
-                query: {
-                  "source-table": PRODUCTS_ID,
-                  aggregation: [["count"]],
-                },
-              }) as never,
+              definition: Lib.createTestJsQuery(SAMPLE_PROVIDER, {
+                stages: [
+                  {
+                    source: { type: "table", id: PRODUCTS_ID },
+                    aggregations: [{ type: "operator", operator: "count" }],
+                  },
+                ],
+              }),
             }),
           ],
         }),
@@ -590,19 +588,17 @@ describe("createTestQuery", () => {
         ],
       });
 
-      expect(
-        (
-          Lib.toLegacyQuery(query) as DatasetQuery & {
-            query: { aggregation: unknown };
-          }
-        ).query.aggregation,
-      ).toEqual([
-        [
-          "aggregation-options",
-          expect.anything(),
-          { "display-name": "Measure" },
-        ],
-      ]);
+      expect(Lib.toLegacyQuery(query)).toMatchObject({
+        query: {
+          aggregation: [
+            [
+              "aggregation-options",
+              expect.anything(),
+              { "display-name": "Measure" },
+            ],
+          ],
+        },
+      });
     });
 
     it("should create a query with aggregations", () => {

--- a/frontend/src/metabase/common/components/CopyTextArea/CopyTextArea.tsx
+++ b/frontend/src/metabase/common/components/CopyTextArea/CopyTextArea.tsx
@@ -5,9 +5,16 @@ import { forwardRef } from "react";
 import type { TextareaProps } from "metabase/ui";
 import { Textarea } from "metabase/ui";
 
+import type { CopyTextFieldClassNames } from "../CopyTextField/copy-text-field-props";
 import { getCopyTextFieldProps } from "../CopyTextField/copy-text-field-props";
 
 import S from "./CopyTextArea.module.css";
+
+type CopyTextAreaProps = Omit<TextareaProps, "classNames"> & {
+  value: string;
+  onCopied?: () => void;
+  classNames?: CopyTextFieldClassNames<TextareaProps>;
+};
 
 /**
  * The multi-line sibling of `CopyTextInput`: a read-only `Textarea` with the same
@@ -15,13 +22,7 @@ import S from "./CopyTextArea.module.css";
  * value stays exactly what was passed.
  */
 export const CopyTextArea = forwardRef(function CopyTextArea(
-  {
-    classNames,
-    onClick,
-    onCopied,
-    readOnly,
-    ...props
-  }: TextareaProps & { value: string; onCopied?: () => void },
+  { classNames, onClick, onCopied, readOnly, ...props }: CopyTextAreaProps,
   ref: Ref<HTMLTextAreaElement>,
 ) {
   return (
@@ -36,8 +37,8 @@ export const CopyTextArea = forwardRef(function CopyTextArea(
       })}
       classNames={{
         ...classNames,
-        input: cx(S.input, (classNames as Record<string, string>)?.input),
-        section: cx(S.section, (classNames as Record<string, string>)?.section),
+        input: cx(S.input, classNames?.input),
+        section: cx(S.section, classNames?.section),
       }}
     />
   );

--- a/frontend/src/metabase/common/components/CopyTextField/copy-text-field-props.tsx
+++ b/frontend/src/metabase/common/components/CopyTextField/copy-text-field-props.tsx
@@ -5,6 +5,14 @@ import { ActionIcon, CopyButton, Icon, Tooltip } from "metabase/ui";
 
 type CopyableElement = HTMLInputElement | HTMLTextAreaElement;
 
+/**
+ * The record form of a Mantine field's `classNames`. `CopyText*` fields merge
+ * their own module classes into the caller's, which the function form (the
+ * other half of Mantine's union) cannot express.
+ */
+export type CopyTextFieldClassNames<Props extends { classNames?: unknown }> =
+  Exclude<Props["classNames"], (...args: never[]) => unknown>;
+
 export type CopyTextFieldOptions<E extends CopyableElement> = {
   value: string;
   readOnly?: boolean;

--- a/frontend/src/metabase/common/components/CopyTextInput/CopyTextInput.tsx
+++ b/frontend/src/metabase/common/components/CopyTextInput/CopyTextInput.tsx
@@ -5,18 +5,19 @@ import { forwardRef } from "react";
 import type { TextInputProps } from "metabase/ui";
 import { TextInput } from "metabase/ui";
 
+import type { CopyTextFieldClassNames } from "../CopyTextField/copy-text-field-props";
 import { getCopyTextFieldProps } from "../CopyTextField/copy-text-field-props";
 
 import S from "./CopyTextInput.module.css";
 
+export type CopyTextInputProps = Omit<TextInputProps, "classNames"> & {
+  value: string;
+  onCopied?: () => void;
+  classNames?: CopyTextFieldClassNames<TextInputProps>;
+};
+
 export const CopyTextInput = forwardRef(function CopyTextInput(
-  {
-    classNames,
-    onClick,
-    onCopied,
-    readOnly,
-    ...props
-  }: TextInputProps & { value: string; onCopied?: () => void },
+  { classNames, onClick, onCopied, readOnly, ...props }: CopyTextInputProps,
   ref: Ref<HTMLInputElement>,
 ) {
   return (
@@ -31,8 +32,7 @@ export const CopyTextInput = forwardRef(function CopyTextInput(
       })}
       classNames={{
         ...classNames,
-        // Unjustified type cast. FIXME
-        input: cx(S.input, (classNames as Record<string, string>)?.input),
+        input: cx(S.input, classNames?.input),
       }}
     />
   );

--- a/frontend/src/metabase/plugins/oss/data-apps.ts
+++ b/frontend/src/metabase/plugins/oss/data-apps.ts
@@ -2,17 +2,19 @@ import type { ComponentType, ReactNode } from "react";
 
 import { PluginPlaceholder } from "metabase/plugins/components/PluginPlaceholder";
 
-const getDefaultPluginDataApps = () => ({
-  isEnabled: false,
-  getRoutes: () => null as ReactNode | null,
-  ManageDataAppsPage: PluginPlaceholder as ComponentType,
-});
-
-export const PLUGIN_DATA_APPS: {
+export type DataAppsPlugin = {
   isEnabled: boolean;
   getRoutes: () => ReactNode | null;
   ManageDataAppsPage: ComponentType;
-} = getDefaultPluginDataApps();
+};
+
+const getDefaultPluginDataApps = (): DataAppsPlugin => ({
+  isEnabled: false,
+  getRoutes: () => null,
+  ManageDataAppsPage: PluginPlaceholder,
+});
+
+export const PLUGIN_DATA_APPS: DataAppsPlugin = getDefaultPluginDataApps();
 
 /**
  * @internal Do not call directly. Use the main reinitialize function from metabase/plugins instead.


### PR DESCRIPTION
Fix type casts lint errors

How to verify:
- CI should still have failed Lint job, but only with `import boundary` errors