### PR TITLE
Fix lost plural translations for strings that also have a msgctxt

### DIFF
--- a/bin/build/src/i18n/common.clj
+++ b/bin/build/src/i18n/common.clj
@@ -55,7 +55,9 @@
      :fuzzy?            (.isFuzzy message)
      :plural?           (.isPlural message)
      :source-references (seq (remove str/blank? (.getSourceReferences message)))
-     :comment           (.getMsgctxt message)}))
+     ;; the `msgctxt` a message was extracted with (nil when it declares none). Part of a
+     ;; message's identity: the same `msgid` can appear under several contexts.
+     :context           (.getMsgctxt message)}))
 
 (defn po-contents
   "Contents of the PO file for a `locale`."

--- a/bin/build/src/i18n/create_artifacts/frontend.clj
+++ b/bin/build/src/i18n/create_artifacts/frontend.clj
@@ -22,20 +22,34 @@
   [message-id]
   (str/replace message-id #"\{\s*(\d+)\s*\}" "\\${ $1 }"))
 
-(defn- ->translations-map [messages drop-msgids]
-  {"" (into {}
-            (comp
-             ;; filter out i18n messages that aren't used on the FE client
-             (filter frontend-message?)
-             (remove (fn [{:keys [id]}] (contains? drop-msgids id)))
-             i18n/print-message-count-xform
-             (map (fn [message]
-                    [(->ttag-reference (:id message))
-                     (if (:plural? message)
-                       {:msgid_plural (:id-plural message)
-                        :msgstr       (map ->ttag-reference (:str-plural message))}
-                       {:msgstr [(->ttag-reference (:str message))]})])))
-            messages)})
+(defn- ->translation-entry [message]
+  [(->ttag-reference (:id message))
+   (if (:plural? message)
+     {:msgid_plural (:id-plural message)
+      :msgstr       (map ->ttag-reference (:str-plural message))}
+     {:msgstr [(->ttag-reference (:str message))]})])
+
+(defn- ->translations-map
+  "ttag looks a translation up by (context, msgid), so the top level of the map is keyed by the
+  message's `msgctxt` — `\"\"` for the messages that declare none.
+
+  Two messages may share a `msgid` as long as their contexts differ, e.g. `Year` exists both as a
+  pluralized unit (`ngettext(\"Year\", \"Years\", n)`) and as a granularity option
+  (``c(\"Date granularity option\").t`Year` ``). Keying by `msgid` alone collapsed them onto one
+  entry, so the last one won and the other's translation was lost — including, for the pair above,
+  the plural form that `ngettext` then failed to find."
+  [messages drop-msgids]
+  (let [frontend-messages (into []
+                                (comp
+                                 ;; filter out i18n messages that aren't used on the FE client
+                                 (filter frontend-message?)
+                                 (remove (fn [{:keys [id]}] (contains? drop-msgids id)))
+                                 i18n/print-message-count-xform)
+                                messages)]
+    (into {}
+          (map (fn [[context messages]]
+                 [context (into {} (map ->translation-entry) messages)]))
+          (group-by #(or (:context %) "") frontend-messages))))
 
 (defn- ->i18n-map
   "Convert the contents of a `.po` file to map format used in the frontend client."

--- a/bin/build/test/i18n/create_artifacts/frontend_test.clj
+++ b/bin/build/test/i18n/create_artifacts/frontend_test.clj
@@ -36,5 +36,21 @@
                           {:msgstr ["Average of ${ 0 }"]}
 
                           "Median of ${ 0 }"
-                          {:msgstr ["Median of ${ 0 }"]}}}}
-         (#'frontend/->i18n-map test-common/po-contents #{}))))
+                          {:msgstr ["Median of ${ 0 }"]}
+
+                          "Year"
+                          {:msgid_plural "Years"
+                           :msgstr       ["Año" "Años"]}}
+
+                         "Date granularity option, distinct from the pluralized unit"
+                         {"Year"
+                          {:msgstr ["Año"]}}}}
+         (#'frontend/->i18n-map test-common/po-contents #{})))
+  (testing "a msgid that exists under several contexts keeps one entry per context, so neither
+  translation (nor a plural form) is lost"
+    (let [{translations :translations} (#'frontend/->i18n-map test-common/po-contents #{})]
+      (is (= {:msgid_plural "Years", :msgstr ["Año" "Años"]}
+             (get-in translations ["" "Year"])))
+      (is (= {:msgstr ["Año"]}
+             (get-in translations ["Date granularity option, distinct from the pluralized unit"
+                                   "Year"]))))))

--- a/bin/build/test/i18n/create_artifacts/test_common.clj
+++ b/bin/build/test/i18n/create_artifacts/test_common.clj
@@ -8,7 +8,7 @@
    :fuzzy?            false
    :plural?           false
    :source-references ["frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136"]
-   :comment           nil})
+   :context           nil})
 
 (def ^:private singular-message-backend
   {:id                "No table description yet"
@@ -18,7 +18,7 @@
    :fuzzy?            false
    :plural?           false
    :source-references ["metabase/warehouse_schema/models/table.clj"]
-   :comment           nil})
+   :context           nil})
 
 (def ^:private singular-template-message-frontend
   {:id                "Count of {0}"
@@ -28,7 +28,7 @@
    :fuzzy?            false
    :plural?           false
    :source-references ["frontend/src/metabase/reference/databases/TableDetail.jsx:38"]
-   :comment           nil})
+   :context           nil})
 
 (def ^:private singular-template-message-backend
   {:id                "Count of {0}"
@@ -38,7 +38,7 @@
    :fuzzy?            false
    :plural?           false
    :source-references ["src/metabase/warehouse_schema/models/table.clj:80"]
-   :comment           nil})
+   :context           nil})
 
 (def ^:private plural-message-frontend
   {:id                "{0} Queryable Table"
@@ -48,7 +48,7 @@
    :fuzzy?            false
    :plural?           true
    :source-references ["frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77"]
-   :comment           nil})
+   :context           nil})
 
 (def ^:private plural-message-backend
   {:id               "{0} table"
@@ -58,7 +58,7 @@
    :fuzzy?            false
    :plural?           true
    :source-references ["src/metabase/automagic_dashboards/core.clj"]
-   :comment           nil})
+   :context           nil})
 
 (def ^:private plural-message-frontend-with-empty
   {:id                "{0} metric"
@@ -68,7 +68,7 @@
    :fuzzy?            false
    :plural?           true
    :source-references ["frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:20"]
-   :comment           nil})
+   :context           nil})
 
 (def ^:private plural-message-backend-with-empty
   {:id                "{0} metric"
@@ -78,7 +78,7 @@
    :fuzzy?            false
    :plural?           true
    :source-references ["src/metabase/automagic_dashboards/core.clj"]
-   :comment           nil})
+   :context           nil})
 
 (def ^:private cljc-message
   {:id                "Average of {0}"
@@ -88,7 +88,7 @@
    :fuzzy?            false
    :plural?           false
    :source-references ["src/metabase/utils/aggregation.cljc"]
-   :comment           nil})
+   :context           nil})
 
 (def ^:private cljs-message
   {:id                "Median of {0}"
@@ -98,7 +98,29 @@
    :fuzzy?            false
    :plural?           false
    :source-references ["src/metabase/utils/aggregation.cljs"]
-   :comment           nil})
+   :context           nil})
+
+;; The same `msgid` under two different contexts — a pluralized unit and a granularity option.
+;; They are separate messages, and collapsing them onto one entry loses a translation.
+(def ^:private plural-message-frontend-no-context
+  {:id                "Year"
+   :id-plural         "Years"
+   :str               nil
+   :str-plural        ["Año" "Años"]
+   :fuzzy?            false
+   :plural?           true
+   :source-references ["frontend/src/metabase/querying/utils.ts:41"]
+   :context           nil})
+
+(def ^:private singular-message-frontend-with-context
+  {:id                "Year"
+   :id-plural         nil
+   :str               "Año"
+   :str-plural        nil
+   :fuzzy?            false
+   :plural?           false
+   :source-references ["frontend/src/metabase/visualizations/SmartScalar/definition.ts:127"]
+   :context           "Date granularity option, distinct from the pluralized unit"})
 
 (def ^:private messages
   [singular-message-frontend
@@ -110,7 +132,9 @@
    plural-message-backend
    plural-message-backend-with-empty
    cljc-message
-   cljs-message])
+   cljs-message
+   plural-message-frontend-no-context
+   singular-message-frontend-with-context])
 
 (def po-contents
   "Contents of a `.po` file."

--- a/frontend/src/metabase/utils/i18n.ts
+++ b/frontend/src/metabase/utils/i18n.ts
@@ -109,17 +109,21 @@ function getStartOfWeekDay(
   return startOfWeekDayNumber;
 }
 
-// we delete msgid property since it's redundant, but have to add it back in to
-// make ttag happy
+// The artifact drops each entry's `msgid` field as redundant (it's already the key), but ttag
+// wants it back. Every context has to be walked, not just the default one: a string extracted
+// with a `msgctxt` (`c("…").t`) lives under that context, and leaving it without a `msgid` breaks
+// the locale for every string, not just that one.
+type TtagMessage = { msgid?: string; msgstr: string[] };
+
+const isTtagMessage = (value: unknown): value is TtagMessage =>
+  typeof value === "object" && value !== null && "msgstr" in value;
+
 function addMsgIds(translationsObject: LocaleDataWithLanguage): void {
-  // Unjustified type cast. FIXME
-  const msgs = translationsObject.translations[""] as Record<
-    string,
-    { msgid?: string; msgstr: string[] }
-  >;
-  for (const msgid in msgs) {
-    if (msgs[msgid].msgid === undefined) {
-      msgs[msgid].msgid = msgid;
+  for (const context of Object.values(translationsObject.translations)) {
+    for (const [msgid, message] of Object.entries(context)) {
+      if (isTtagMessage(message) && message.msgid === undefined) {
+        message.msgid = msgid;
+      }
     }
   }
 }

--- a/frontend/src/metabase/utils/i18n.ts
+++ b/frontend/src/metabase/utils/i18n.ts
@@ -113,10 +113,10 @@ function getStartOfWeekDay(
 // wants it back. Every context has to be walked, not just the default one: a string extracted
 // with a `msgctxt` (`c("…").t`) lives under that context, and leaving it without a `msgid` breaks
 // the locale for every string, not just that one.
-type TtagMessage = { msgid?: string; msgstr: string[] };
+type TtagMessage = { msgid?: string };
 
 const isTtagMessage = (value: unknown): value is TtagMessage =>
-  typeof value === "object" && value !== null && "msgstr" in value;
+  typeof value === "object" && value !== null;
 
 function addMsgIds(translationsObject: LocaleDataWithLanguage): void {
   for (const context of Object.values(translationsObject.translations)) {

--- a/frontend/src/metabase/utils/i18n.unit.spec.ts
+++ b/frontend/src/metabase/utils/i18n.unit.spec.ts
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
 
-import { setLocalization } from "./i18n";
+import { type LocaleDataWithLanguage, setLocalization } from "./i18n";
 
 function setup(language: string) {
   setLocalization({
@@ -31,5 +31,33 @@ describe("setLocalization", () => {
     expect(date.format("MMMM D, YYYY, h:mm A")).toBe(
       "October 12, 2023, 9:07 PM",
     );
+  });
+
+  it("should restore msgids in every context, not just the default one (metabase#77700)", () => {
+    // Entries in the locale artifact carry no `msgid`, but ttag's addLocale requires one on every
+    // entry in every context — a single entry without it throws and breaks the whole locale.
+    const context =
+      "Date granularity option, distinct from the pluralized unit";
+    const translations: Record<
+      string,
+      Record<
+        string,
+        { msgid?: string; msgid_plural?: string; msgstr: string[] }
+      >
+    > = {
+      "": { Year: { msgid_plural: "Years", msgstr: ["Año", "Años"] } },
+      [context]: { Year: { msgstr: ["Año"] } },
+    };
+    const localeData: LocaleDataWithLanguage = {
+      headers: {
+        language: "es",
+        "plural-forms": "nplurals=2; plural=(n != 1);",
+      },
+      translations,
+    };
+
+    expect(() => setLocalization(localeData)).not.toThrow();
+    expect(translations[""].Year.msgid).toBe("Year");
+    expect(translations[context].Year.msgid).toBe("Year");
   });
 });


### PR DESCRIPTION
The fix is vibe-coded and may be totally invalid. Please adjust PR or close it in favor of a proper fix.|

Context:
https://metaboat.slack.com/archives/C5XHN8GLW/p1784019295843839

Cause from Claude:

> What's broken: Lib.describeTemporalUnit("year", n) returns undefined on any non-English locale (I checked es, fr, de — all the same).
> 
>   Why:
> 
>   1. The latest translation update added a second Year entry to the .po files — a singular one, distinguished by msgctxt "Date granularity option, distinct from the pluralized unit". The .po itself is fine: two entries, same msgid, different context.
>   2. But the frontend locale compiler (->translations-map in bin/build/src/i18n/create_artifacts/frontend.clj) drops msgctxt — it puts everything under a single "" context and keys only by msgid.
>   3. So both Year entries collapse onto one key. The last one wins — the new singular. The plural form (Year/Years → Año/Años) is gone from the compiled JSON:
> 
>   'Year'  -> {'msgstr': ['Año']}                                    ← no msgid_plural, no [1]
>   'Month' -> {'msgid_plural': 'Months', 'msgstr': ['Mes','Meses']}  ← intact
> 
>   4. ngettext("Year", "Years", n) then reaches for msgstr[1], which no longer exists → undefined.
> 
>   In one line: a translated string with a msgctxt collides with its plural twin because the locale compiler ignores contexts, and the singular overwrites the plural.
> 
>   Any string that gains a msgctxt while a same-msgid plural exists will break the same way — Year is just the first to get translated.