### PR TITLE
Search MB documentation link incorrectly has underline on hover

### DIFF
--- a/frontend/src/metabase/palette/components/PaletteResultItem.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultItem.tsx
@@ -1,6 +1,7 @@
 import { EntityIcon } from "metabase/common/components/EntityIcon";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { Link } from "metabase/common/components/Link";
+import CS from "metabase/css/core/index.css";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import { Box, Flex, Group, Stack, Text } from "metabase/ui";
 
@@ -117,6 +118,7 @@ export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
           role="link"
           w="100%"
           lh={1}
+          className={CS.noDecoration}
         >
           {content}
         </Box>


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #77645
Closes https://linear.app/metabase/issue/GRO-691/search-metabase-documentation-link-incorrectly-has-underline-on-hover.

### Description

The `search documentation` link has an unwanted underline.

<img width="650" height="200" alt="image" src="https://github.com/user-attachments/assets/782fc2f5-db9d-40a7-b9ef-86b51130977b" />

### What's in

- [x] UI updates
- [x] e2e tests updated

### How to verify

1. Open/click on the search
2. Type `something`
3. Hover over the "Search Metabase's docs for x" link
4. The underline is gone

<img width="2022" height="1670" alt="image" src="https://github.com/user-attachments/assets/931959c9-fc8b-42ab-9b99-6f064eba6929" />

### Demo

https://www.loom.com/share/6688ee2204a04862918c01ec1a88dd48

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
