### PR TITLE
GDGT-2748 Broken Security Center layout in error state

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
@@ -126,18 +126,20 @@ export function SecurityCenterPage({ location }: SecurityCenterPageProps = {}) {
 
   if (isError) {
     return (
-      <Box className={S.root}>
-        <Stack gap="lg" className={S.header}>
-          <Title order={1}>{t`Security Center`}</Title>
-        </Stack>
-        <Stack gap="xl" className={S.content}>
-          <EmptyState
-            className={S.emptyState}
-            icon="warning_triangle_filled"
-            message={t`Something went wrong loading security advisories.`}
-          />
-        </Stack>
-      </Box>
+      <AdminSettingsLayout>
+        <Box className={S.root}>
+          <Stack gap="lg" className={S.header}>
+            <Title order={1}>{t`Security Center`}</Title>
+          </Stack>
+          <Stack gap="xl" className={S.content}>
+            <EmptyState
+              className={S.emptyState}
+              icon="warning_triangle_filled"
+              message={t`Something went wrong loading security advisories.`}
+            />
+          </Stack>
+        </Box>
+      </AdminSettingsLayout>
     );
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
@@ -16,7 +16,7 @@ import { SecurityCenterPage } from "./SecurityCenterPage";
 
 jest.mock("metabase/admin/components/AdminLayout/AdminSettingsLayout", () => ({
   AdminSettingsLayout: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
+    <div data-testid="admin-settings-layout">{children}</div>
   ),
 }));
 
@@ -28,16 +28,18 @@ function setup(
   {
     lastCheckedAt = null,
     location,
+    isError = false,
   }: {
     lastCheckedAt?: string | null;
     location?: Location<{ open?: string }>;
+    isError?: boolean;
   } = {},
 ) {
   jest.spyOn(advisoriesHook, "useSecurityAdvisories").mockReturnValue({
     data: advisories,
     lastCheckedAt,
     isLoading: false,
-    isError: false,
+    isError,
     acknowledgeAdvisory: mockAcknowledge,
     acknowledgeAdvisories: mockAcknowledgeAll,
   });
@@ -85,6 +87,15 @@ describe("SecurityCenterPage", () => {
 
     expect(screen.getByText("Security Center")).toBeInTheDocument();
     expect(screen.getByTestId("current-version")).toHaveTextContent("v0.59.3");
+  });
+
+  it("renders the error state within the admin settings layout (GDGT-2748)", async () => {
+    setup([], { isError: true });
+
+    expect(
+      screen.getByText("Something went wrong loading security advisories."),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("admin-settings-layout")).toBeInTheDocument();
   });
 
   it("renders the empty state when there are no advisories", async () => {


### PR DESCRIPTION
Closes #76888
Closes [GDGT-2748](https://linear.app/metabase/issue/GDGT-2748/broken-security-center-layout-in-error-state)

### Description

Hiding whitespace changes recommended.

### How to verify

1. Use pro self-hosted license
2. Open Admin
3. Disable network
4. Open Security tab

Page layout should not be broken.

### Demo

[Before](https://github.com/user-attachments/assets/1b6bd0a1-efc5-4d0c-9666-83072c785ad8) vs [after](https://github.com/user-attachments/assets/d1b29259-2812-4be3-8f4a-0c69d00443f8)



