### PR TITLE
GDGT-2832: Group Monitor navbar items into sub-menus

### DIFF
--- a/e2e/test/scenarios/monitor/tools/tools.cy.spec.ts
+++ b/e2e/test/scenarios/monitor/tools/tools.cy.spec.ts
@@ -84,8 +84,7 @@ describe("issue 14636", () => {
 
     cy.location("search").should("eq", "");
 
-    // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Troubleshooting logs");
+    cy.findByRole("heading", { name: "Background tasks" }).should("be.visible");
 
     cy.findByLabelText("pagination").findByText("1 - 50").should("be.visible");
     // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
@@ -521,12 +520,12 @@ describe("monitor > tools", () => {
     cy.visit("/monitor/errors");
 
     cy.findByRole("heading", {
-      name: "Questions that errored when last run",
+      name: "Erroring questions",
     }).should("be.visible");
 
     cy.log("We should be able to switch to the model caching page");
 
-    cy.findByTestId("monitor-nav").findByText("Model cache log").click();
+    cy.findByTestId("monitor-nav").findByText("Model caching log").click();
     cy.location("pathname").should("eq", "/monitor/model-caching");
 
     cy.log(

--- a/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/components/DiagnosticsHeader/DiagnosticsHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/components/DiagnosticsHeader/DiagnosticsHeader.tsx
@@ -24,7 +24,7 @@ export const DiagnosticsHeader = memo(function DiagnosticsHeader() {
   ];
 
   return (
-    <Stack gap="md">
+    <Stack gap="lg">
       <MonitorHeaderTitle>{t`Dependency diagnostics`}</MonitorHeaderTitle>
       <MonitorHeaderTabs tabs={tabs} />
     </Stack>

--- a/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErrorOverview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErrorOverview.tsx
@@ -116,7 +116,7 @@ const ErrorOverviewBase = ({ location }: WithRouterProps) => {
     <>
       <Flex h="100%" wrap="nowrap">
         <Stack className={S.main} flex={1} gap="md">
-          <MonitorHeaderTitle>{t`Questions that errored when last run`}</MonitorHeaderTitle>
+          <MonitorHeaderTitle mb="sm">{t`Questions that errored when last run`}</MonitorHeaderTitle>
 
           {pageError != null ? (
             <Center flex={1}>

--- a/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErrorOverview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErrorOverview.tsx
@@ -116,7 +116,7 @@ const ErrorOverviewBase = ({ location }: WithRouterProps) => {
     <>
       <Flex h="100%" wrap="nowrap">
         <Stack className={S.main} flex={1} gap="md">
-          <MonitorHeaderTitle mb="sm">{t`Questions that errored when last run`}</MonitorHeaderTitle>
+          <MonitorHeaderTitle mb="sm">{t`Erroring questions`}</MonitorHeaderTitle>
 
           {pageError != null ? (
             <Center flex={1}>

--- a/frontend/src/metabase/monitor/components/MonitorLayout/MonitorContent.tsx
+++ b/frontend/src/metabase/monitor/components/MonitorLayout/MonitorContent.tsx
@@ -7,9 +7,11 @@ import {
 } from "react";
 
 import { AppSwitcher } from "metabase/nav/components/AppSwitcher";
+import {
+  AreaContent,
+  CONTENT_PADDING_X,
+} from "metabase/nav/components/AreaLayout";
 import { Box } from "metabase/ui";
-
-import { AreaContent, CONTENT_PADDING_X } from "./AreaContent";
 
 type MonitorContentProps = {
   children?: ReactNode;

--- a/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.tsx
+++ b/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { P, match } from "ts-pattern";
 import { t } from "ttag";
 
 import { useHasTokenFeature } from "metabase/common/hooks";
@@ -8,7 +9,11 @@ import {
   canAccessMonitorDiagnostics,
   canAccessMonitoringTools,
 } from "metabase/common/monitor/selectors";
-import { AreaLayout, AreaTab } from "metabase/nav/components/AreaLayout";
+import {
+  AreaLayout,
+  AreaTab,
+  AreaTabGroup,
+} from "metabase/nav/components/AreaLayout";
 import { useSelector } from "metabase/redux";
 import { getLocation } from "metabase/selectors/routing";
 import { FixedSizeIcon } from "metabase/ui";
@@ -19,6 +24,50 @@ import { MonitorContent } from "./MonitorContent";
 type MonitorLayoutProps = {
   children?: ReactNode;
 };
+
+type MonitorSection =
+  | "diagnostics"
+  | "erroring-questions"
+  | "alerts"
+  | "tasks"
+  | "jobs"
+  | "logs"
+  | "model-caching";
+
+const CONTENT_MANAGEMENT_SECTIONS: readonly MonitorSection[] = [
+  "diagnostics",
+  "erroring-questions",
+  "alerts",
+];
+
+const LOGS_AND_ACTIVITY_SECTIONS: readonly MonitorSection[] = [
+  "tasks",
+  "jobs",
+  "logs",
+  "model-caching",
+];
+
+function getActiveSection(pathname: string): MonitorSection | null {
+  return match(pathname)
+    .returnType<MonitorSection | null>()
+    .with(
+      P.string.startsWith(Urls.dependencyDiagnostics()),
+      () => "diagnostics",
+    )
+    .with(
+      P.string.startsWith(Urls.monitorErroringQuestions()),
+      () => "erroring-questions",
+    )
+    .with(P.string.startsWith(Urls.monitorNotifications()), () => "alerts")
+    .with(P.string.startsWith(Urls.monitorTasks()), () => "tasks")
+    .with(P.string.startsWith(Urls.monitorJobs()), () => "jobs")
+    .with(P.string.startsWith(Urls.monitorLogs()), () => "logs")
+    .with(
+      P.string.startsWith(Urls.monitorModelCaching()),
+      () => "model-caching",
+    )
+    .otherwise(() => null);
+}
 
 export function MonitorLayout({ children }: MonitorLayoutProps) {
   const {
@@ -38,66 +87,94 @@ export function MonitorLayout({ children }: MonitorLayoutProps) {
   const canAccessTools = useSelector(canAccessMonitoringTools);
   const canAccessAlerts = useSelector(canAccessAlertsManagement);
 
+  const activeSection = getActiveSection(pathname);
+
+  const hasContentManagement =
+    canAccessDiagnostics || canAccessTools || canAccessAlerts;
+  const hasLogsAndActivity = canAccessTools;
+
   const upperNav = (
     <>
-      {canAccessDiagnostics && (
-        <AreaTab
-          label={t`Dependency diagnostics`}
-          icon="search_check"
-          to={Urls.dependencyDiagnostics()}
-          isSelected={pathname.startsWith(Urls.dependencyDiagnostics())}
+      {hasContentManagement && (
+        <AreaTabGroup
+          label={t`Content management`}
+          icon="folder"
           showLabel={isNavbarOpened}
-          isGated={!hasDependenciesFeature}
-        />
+          isActive={
+            activeSection != null &&
+            CONTENT_MANAGEMENT_SECTIONS.includes(activeSection)
+          }
+        >
+          {canAccessDiagnostics && (
+            <AreaTab
+              label={t`Dependency diagnostics`}
+              icon="search_check"
+              to={Urls.dependencyDiagnostics()}
+              isSelected={activeSection === "diagnostics"}
+              showLabel={isNavbarOpened}
+              isGated={!hasDependenciesFeature}
+            />
+          )}
+          {canAccessTools && (
+            <AreaTab
+              label={t`Erroring questions`}
+              icon="warning_round_filled"
+              to={Urls.monitorErroringQuestions()}
+              isSelected={activeSection === "erroring-questions"}
+              showLabel={isNavbarOpened}
+              isGated={!hasAuditAppFeature}
+            />
+          )}
+          {canAccessAlerts && (
+            <AreaTab
+              label={t`Alerts management`}
+              icon="bell"
+              to={Urls.monitorNotifications()}
+              isSelected={activeSection === "alerts"}
+              showLabel={isNavbarOpened}
+            />
+          )}
+        </AreaTabGroup>
       )}
-      {canAccessTools && (
-        <>
+      {hasLogsAndActivity && (
+        <AreaTabGroup
+          label={t`Logs and activity`}
+          icon="list"
+          showLabel={isNavbarOpened}
+          isActive={
+            activeSection != null &&
+            LOGS_AND_ACTIVITY_SECTIONS.includes(activeSection)
+          }
+        >
           <AreaTab
-            label={t`Tasks`}
+            label={t`Background tasks`}
             icon="clipboard"
             to={Urls.monitorTasks()}
-            isSelected={pathname.startsWith(Urls.monitorTasks())}
+            isSelected={activeSection === "tasks"}
             showLabel={isNavbarOpened}
           />
           <AreaTab
-            label={t`Jobs`}
+            label={t`Scheduled jobs`}
             icon="clock"
             to={Urls.monitorJobs()}
-            isSelected={pathname.startsWith(Urls.monitorJobs())}
+            isSelected={activeSection === "jobs"}
             showLabel={isNavbarOpened}
           />
           <AreaTab
-            label={t`Logs`}
+            label={t`Application logs`}
             icon="audit"
             to={Urls.monitorLogs()}
-            isSelected={pathname.startsWith(Urls.monitorLogs())}
+            isSelected={activeSection === "logs"}
             showLabel={isNavbarOpened}
           />
           <AreaTab
-            label={t`Erroring questions`}
-            icon="warning_round_filled"
-            to={Urls.monitorErroringQuestions()}
-            isSelected={pathname.startsWith(Urls.monitorErroringQuestions())}
-            showLabel={isNavbarOpened}
-            isGated={!hasAuditAppFeature}
-          />
-          <AreaTab
-            label={t`Model cache log`}
+            label={t`Model caching log`}
             icon="database"
             to={Urls.monitorModelCaching()}
-            isSelected={pathname.startsWith(Urls.monitorModelCaching())}
+            isSelected={activeSection === "model-caching"}
             showLabel={isNavbarOpened}
           />
-        </>
-      )}
-      {canAccessAlerts && (
-        <AreaTab
-          label={t`Alerts management`}
-          icon="bell"
-          to={Urls.monitorNotifications()}
-          isSelected={pathname.startsWith(Urls.monitorNotifications())}
-          showLabel={isNavbarOpened}
-        />
+        </AreaTabGroup>
       )}
     </>
   );

--- a/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.tsx
+++ b/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.tsx
@@ -34,19 +34,6 @@ type MonitorSection =
   | "logs"
   | "model-caching";
 
-const CONTENT_MANAGEMENT_SECTIONS: readonly MonitorSection[] = [
-  "diagnostics",
-  "erroring-questions",
-  "alerts",
-];
-
-const LOGS_AND_ACTIVITY_SECTIONS: readonly MonitorSection[] = [
-  "tasks",
-  "jobs",
-  "logs",
-  "model-caching",
-];
-
 function getActiveSection(pathname: string): MonitorSection | null {
   return match(pathname)
     .returnType<MonitorSection | null>()
@@ -96,15 +83,7 @@ export function MonitorLayout({ children }: MonitorLayoutProps) {
   const upperNav = (
     <>
       {hasContentManagement && (
-        <AreaTabGroup
-          label={t`Content management`}
-          icon="folder"
-          showLabel={isNavbarOpened}
-          isActive={
-            activeSection != null &&
-            CONTENT_MANAGEMENT_SECTIONS.includes(activeSection)
-          }
-        >
+        <AreaTabGroup label={t`Content management`} showLabel={isNavbarOpened}>
           {canAccessDiagnostics && (
             <AreaTab
               label={t`Dependency diagnostics`}
@@ -137,15 +116,7 @@ export function MonitorLayout({ children }: MonitorLayoutProps) {
         </AreaTabGroup>
       )}
       {hasLogsAndActivity && (
-        <AreaTabGroup
-          label={t`Logs and activity`}
-          icon="list"
-          showLabel={isNavbarOpened}
-          isActive={
-            activeSection != null &&
-            LOGS_AND_ACTIVITY_SECTIONS.includes(activeSection)
-          }
-        >
+        <AreaTabGroup label={t`Logs and activity`} showLabel={isNavbarOpened}>
           <AreaTab
             label={t`Background tasks`}
             icon="clipboard"

--- a/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.unit.spec.tsx
@@ -117,18 +117,8 @@ const setup = ({
 const CONTENT_MANAGEMENT_GROUP = "Content management";
 const LOGS_AND_ACTIVITY_GROUP = "Logs and activity";
 
-const expandGroup = async (name: string) => {
-  const linkCountBefore = screen.queryAllByRole("link").length;
-  await userEvent.click(screen.getByRole("button", { name }));
-  await waitFor(() => {
-    expect(screen.queryAllByRole("link").length).toBeGreaterThan(
-      linkCountBefore,
-    );
-  });
-};
-
 describe("MonitorLayout", () => {
-  it("groups the sections into collapsible menus that start collapsed", async () => {
+  it("groups the sections under static headings with a link for each Monitor section", async () => {
     setup();
 
     await waitFor(() => {
@@ -136,34 +126,11 @@ describe("MonitorLayout", () => {
     });
 
     expect(
-      screen.getByRole("button", { name: CONTENT_MANAGEMENT_GROUP }),
-    ).toHaveAttribute("aria-expanded", "false");
+      screen.getByRole("heading", { name: CONTENT_MANAGEMENT_GROUP }),
+    ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: LOGS_AND_ACTIVITY_GROUP }),
-    ).toHaveAttribute("aria-expanded", "false");
-
-    [
-      "Dependency diagnostics",
-      "Erroring questions",
-      "Alerts management",
-      "Background tasks",
-      "Scheduled jobs",
-      "Application logs",
-      "Model caching log",
-    ].forEach((name) => {
-      expect(screen.queryByRole("link", { name })).not.toBeInTheDocument();
-    });
-  });
-
-  it("renders a link for each Monitor section once its group is expanded", async () => {
-    setup();
-
-    await waitFor(() => {
-      expect(screen.getByTestId("monitor-nav")).toBeInTheDocument();
-    });
-
-    await expandGroup(CONTENT_MANAGEMENT_GROUP);
-    await expandGroup(LOGS_AND_ACTIVITY_GROUP);
+      screen.getByRole("heading", { name: LOGS_AND_ACTIVITY_GROUP }),
+    ).toBeInTheDocument();
 
     const expectedTabs: [string, string][] = [
       ["Dependency diagnostics", Urls.dependencyDiagnostics()],
@@ -180,96 +147,26 @@ describe("MonitorLayout", () => {
     });
   });
 
-  it("opens the group containing the active route on mount", async () => {
-    setup({ initialRoute: Urls.monitorTasks() });
-
-    await waitFor(() => {
-      expect(screen.getByTestId("monitor-nav")).toBeInTheDocument();
-    });
-
-    expect(
-      screen.getByRole("button", { name: LOGS_AND_ACTIVITY_GROUP }),
-    ).toHaveAttribute("aria-expanded", "true");
-    expect(
-      await screen.findByRole("link", { name: "Background tasks" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: CONTENT_MANAGEMENT_GROUP }),
-    ).toHaveAttribute("aria-expanded", "false");
-    expect(
-      screen.queryByRole("link", { name: "Dependency diagnostics" }),
-    ).not.toBeInTheDocument();
-  });
-
-  const SECTION_CASES: {
-    label: string;
-    route: string;
-    group: string;
-    otherGroup: string;
-  }[] = [
-    {
-      label: "Dependency diagnostics",
-      route: Urls.dependencyDiagnostics(),
-      group: CONTENT_MANAGEMENT_GROUP,
-      otherGroup: LOGS_AND_ACTIVITY_GROUP,
-    },
-    {
-      label: "Erroring questions",
-      route: Urls.monitorErroringQuestions(),
-      group: CONTENT_MANAGEMENT_GROUP,
-      otherGroup: LOGS_AND_ACTIVITY_GROUP,
-    },
-    {
-      label: "Alerts management",
-      route: Urls.monitorNotifications(),
-      group: CONTENT_MANAGEMENT_GROUP,
-      otherGroup: LOGS_AND_ACTIVITY_GROUP,
-    },
-    {
-      label: "Background tasks",
-      route: Urls.monitorTasks(),
-      group: LOGS_AND_ACTIVITY_GROUP,
-      otherGroup: CONTENT_MANAGEMENT_GROUP,
-    },
-    {
-      label: "Scheduled jobs",
-      route: Urls.monitorJobs(),
-      group: LOGS_AND_ACTIVITY_GROUP,
-      otherGroup: CONTENT_MANAGEMENT_GROUP,
-    },
-    {
-      label: "Application logs",
-      route: Urls.monitorLogs(),
-      group: LOGS_AND_ACTIVITY_GROUP,
-      otherGroup: CONTENT_MANAGEMENT_GROUP,
-    },
-    {
-      label: "Model caching log",
-      route: Urls.monitorModelCaching(),
-      group: LOGS_AND_ACTIVITY_GROUP,
-      otherGroup: CONTENT_MANAGEMENT_GROUP,
-    },
+  const SECTION_CASES: { label: string; route: string }[] = [
+    { label: "Dependency diagnostics", route: Urls.dependencyDiagnostics() },
+    { label: "Erroring questions", route: Urls.monitorErroringQuestions() },
+    { label: "Alerts management", route: Urls.monitorNotifications() },
+    { label: "Background tasks", route: Urls.monitorTasks() },
+    { label: "Scheduled jobs", route: Urls.monitorJobs() },
+    { label: "Application logs", route: Urls.monitorLogs() },
+    { label: "Model caching log", route: Urls.monitorModelCaching() },
   ];
 
   it.each(SECTION_CASES)(
-    "opens the owning group and marks $label as the current page for its route",
-    async ({ label, route, group, otherGroup }) => {
+    "marks $label as the current page for its route",
+    async ({ label, route }) => {
       setup({ initialRoute: route });
 
       await waitFor(() => {
         expect(screen.getByTestId("monitor-nav")).toBeInTheDocument();
       });
 
-      expect(screen.getByRole("button", { name: group })).toHaveAttribute(
-        "aria-expanded",
-        "true",
-      );
-      expect(screen.getByRole("button", { name: otherGroup })).toHaveAttribute(
-        "aria-expanded",
-        "false",
-      );
-
-      const activeLink = await screen.findByRole("link", { name: label });
+      const activeLink = screen.getByRole("link", { name: label });
       expect(activeLink).toHaveAttribute("aria-current", "page");
       expect(screen.getAllByRole("link", { current: "page" })).toEqual([
         activeLink,
@@ -291,10 +188,8 @@ describe("MonitorLayout", () => {
     });
 
     expect(
-      screen.queryByRole("button", { name: LOGS_AND_ACTIVITY_GROUP }),
+      screen.queryByRole("heading", { name: LOGS_AND_ACTIVITY_GROUP }),
     ).not.toBeInTheDocument();
-
-    await expandGroup(CONTENT_MANAGEMENT_GROUP);
 
     expect(
       screen.getByRole("link", { name: "Dependency diagnostics" }),
@@ -323,9 +218,6 @@ describe("MonitorLayout", () => {
     await waitFor(() => {
       expect(screen.getByTestId("monitor-nav")).toBeInTheDocument();
     });
-
-    await expandGroup(CONTENT_MANAGEMENT_GROUP);
-    await expandGroup(LOGS_AND_ACTIVITY_GROUP);
 
     expect(
       screen.queryByRole("link", { name: "Dependency diagnostics" }),
@@ -356,8 +248,9 @@ describe("MonitorLayout", () => {
       expect(screen.getByTestId("monitor-nav")).toBeInTheDocument();
     });
 
-    await expandGroup(CONTENT_MANAGEMENT_GROUP);
-
+    expect(
+      screen.getByRole("link", { name: "Erroring questions" }),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: "Alerts management" }),
     ).not.toBeInTheDocument();
@@ -427,7 +320,6 @@ describe("MonitorLayout", () => {
     await waitFor(() => {
       expect(screen.getByTestId("monitor-nav")).toBeInTheDocument();
     });
-    await expandGroup(CONTENT_MANAGEMENT_GROUP);
 
     expect(getTabGem("Erroring questions")).toBeInTheDocument();
     expect(getTabGem("Dependency diagnostics")).not.toBeInTheDocument();
@@ -439,7 +331,6 @@ describe("MonitorLayout", () => {
     await waitFor(() => {
       expect(screen.getByTestId("monitor-nav")).toBeInTheDocument();
     });
-    await expandGroup(CONTENT_MANAGEMENT_GROUP);
 
     expect(getTabGem("Dependency diagnostics")).toBeInTheDocument();
     expect(getTabGem("Erroring questions")).not.toBeInTheDocument();
@@ -451,7 +342,6 @@ describe("MonitorLayout", () => {
     await waitFor(() => {
       expect(screen.getByTestId("monitor-nav")).toBeInTheDocument();
     });
-    await expandGroup(CONTENT_MANAGEMENT_GROUP);
 
     expect(getTabGem("Dependency diagnostics")).not.toBeInTheDocument();
     expect(getTabGem("Erroring questions")).not.toBeInTheDocument();

--- a/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.unit.spec.tsx
@@ -8,7 +8,11 @@ import {
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
-import { createMockState } from "metabase/redux/store/mocks";
+import {
+  createMockLocation,
+  createMockRoutingState,
+  createMockState,
+} from "metabase/redux/store/mocks";
 import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { TokenFeatures } from "metabase-types/api";
@@ -91,12 +95,15 @@ const setup = ({
 
   const state = createMockState({
     currentUser: user,
+    routing: createMockRoutingState({
+      locationBeforeTransitions: createMockLocation({ pathname: initialRoute }),
+    }),
     settings,
   });
 
   renderWithProviders(
     <Route
-      path="/monitor"
+      path="*"
       component={() => <MonitorLayout>{children}</MonitorLayout>}
     />,
     {
@@ -107,28 +114,168 @@ const setup = ({
   );
 };
 
+const CONTENT_MANAGEMENT_GROUP = "Content management";
+const LOGS_AND_ACTIVITY_GROUP = "Logs and activity";
+
+const expandGroup = async (name: string) => {
+  const linkCountBefore = screen.queryAllByRole("link").length;
+  await userEvent.click(screen.getByRole("button", { name }));
+  await waitFor(() => {
+    expect(screen.queryAllByRole("link").length).toBeGreaterThan(
+      linkCountBefore,
+    );
+  });
+};
+
 describe("MonitorLayout", () => {
-  it("renders a navbar with tabs for each Monitor section", async () => {
+  it("groups the sections into collapsible menus that start collapsed", async () => {
     setup();
 
     await waitFor(() => {
       expect(screen.getByTestId("monitor-nav")).toBeInTheDocument();
     });
 
+    expect(
+      screen.getByRole("button", { name: CONTENT_MANAGEMENT_GROUP }),
+    ).toHaveAttribute("aria-expanded", "false");
+    expect(
+      screen.getByRole("button", { name: LOGS_AND_ACTIVITY_GROUP }),
+    ).toHaveAttribute("aria-expanded", "false");
+
+    [
+      "Dependency diagnostics",
+      "Erroring questions",
+      "Alerts management",
+      "Background tasks",
+      "Scheduled jobs",
+      "Application logs",
+      "Model caching log",
+    ].forEach((name) => {
+      expect(screen.queryByRole("link", { name })).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders a link for each Monitor section once its group is expanded", async () => {
+    setup();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("monitor-nav")).toBeInTheDocument();
+    });
+
+    await expandGroup(CONTENT_MANAGEMENT_GROUP);
+    await expandGroup(LOGS_AND_ACTIVITY_GROUP);
+
     const expectedTabs: [string, string][] = [
       ["Dependency diagnostics", Urls.dependencyDiagnostics()],
-      ["Tasks", Urls.monitorTasks()],
-      ["Jobs", Urls.monitorJobs()],
-      ["Logs", Urls.monitorLogs()],
       ["Erroring questions", Urls.monitorErroringQuestions()],
-      ["Model cache log", Urls.monitorModelCaching()],
       ["Alerts management", Urls.monitorNotifications()],
+      ["Background tasks", Urls.monitorTasks()],
+      ["Scheduled jobs", Urls.monitorJobs()],
+      ["Application logs", Urls.monitorLogs()],
+      ["Model caching log", Urls.monitorModelCaching()],
     ];
 
     expectedTabs.forEach(([name, href]) => {
       expect(screen.getByRole("link", { name })).toHaveAttribute("href", href);
     });
   });
+
+  it("opens the group containing the active route on mount", async () => {
+    setup({ initialRoute: Urls.monitorTasks() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("monitor-nav")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("button", { name: LOGS_AND_ACTIVITY_GROUP }),
+    ).toHaveAttribute("aria-expanded", "true");
+    expect(
+      await screen.findByRole("link", { name: "Background tasks" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: CONTENT_MANAGEMENT_GROUP }),
+    ).toHaveAttribute("aria-expanded", "false");
+    expect(
+      screen.queryByRole("link", { name: "Dependency diagnostics" }),
+    ).not.toBeInTheDocument();
+  });
+
+  const SECTION_CASES: {
+    label: string;
+    route: string;
+    group: string;
+    otherGroup: string;
+  }[] = [
+    {
+      label: "Dependency diagnostics",
+      route: Urls.dependencyDiagnostics(),
+      group: CONTENT_MANAGEMENT_GROUP,
+      otherGroup: LOGS_AND_ACTIVITY_GROUP,
+    },
+    {
+      label: "Erroring questions",
+      route: Urls.monitorErroringQuestions(),
+      group: CONTENT_MANAGEMENT_GROUP,
+      otherGroup: LOGS_AND_ACTIVITY_GROUP,
+    },
+    {
+      label: "Alerts management",
+      route: Urls.monitorNotifications(),
+      group: CONTENT_MANAGEMENT_GROUP,
+      otherGroup: LOGS_AND_ACTIVITY_GROUP,
+    },
+    {
+      label: "Background tasks",
+      route: Urls.monitorTasks(),
+      group: LOGS_AND_ACTIVITY_GROUP,
+      otherGroup: CONTENT_MANAGEMENT_GROUP,
+    },
+    {
+      label: "Scheduled jobs",
+      route: Urls.monitorJobs(),
+      group: LOGS_AND_ACTIVITY_GROUP,
+      otherGroup: CONTENT_MANAGEMENT_GROUP,
+    },
+    {
+      label: "Application logs",
+      route: Urls.monitorLogs(),
+      group: LOGS_AND_ACTIVITY_GROUP,
+      otherGroup: CONTENT_MANAGEMENT_GROUP,
+    },
+    {
+      label: "Model caching log",
+      route: Urls.monitorModelCaching(),
+      group: LOGS_AND_ACTIVITY_GROUP,
+      otherGroup: CONTENT_MANAGEMENT_GROUP,
+    },
+  ];
+
+  it.each(SECTION_CASES)(
+    "opens the owning group and marks $label as the current page for its route",
+    async ({ label, route, group, otherGroup }) => {
+      setup({ initialRoute: route });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("monitor-nav")).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole("button", { name: group })).toHaveAttribute(
+        "aria-expanded",
+        "true",
+      );
+      expect(screen.getByRole("button", { name: otherGroup })).toHaveAttribute(
+        "aria-expanded",
+        "false",
+      );
+
+      const activeLink = await screen.findByRole("link", { name: label });
+      expect(activeLink).toHaveAttribute("aria-current", "page");
+      expect(screen.getAllByRole("link", { current: "page" })).toEqual([
+        activeLink,
+      ]);
+    },
+  );
 
   it("hides the migrated Tools tabs for an analyst without the monitoring permission", async () => {
     setup({
@@ -144,14 +291,20 @@ describe("MonitorLayout", () => {
     });
 
     expect(
+      screen.queryByRole("button", { name: LOGS_AND_ACTIVITY_GROUP }),
+    ).not.toBeInTheDocument();
+
+    await expandGroup(CONTENT_MANAGEMENT_GROUP);
+
+    expect(
       screen.getByRole("link", { name: "Dependency diagnostics" }),
     ).toBeInTheDocument();
     [
-      "Tasks",
-      "Jobs",
-      "Logs",
+      "Background tasks",
+      "Scheduled jobs",
+      "Application logs",
       "Erroring questions",
-      "Model cache log",
+      "Model caching log",
       "Alerts management",
     ].forEach((name) => {
       expect(screen.queryByRole("link", { name })).not.toBeInTheDocument();
@@ -171,10 +324,18 @@ describe("MonitorLayout", () => {
       expect(screen.getByTestId("monitor-nav")).toBeInTheDocument();
     });
 
+    await expandGroup(CONTENT_MANAGEMENT_GROUP);
+    await expandGroup(LOGS_AND_ACTIVITY_GROUP);
+
     expect(
       screen.queryByRole("link", { name: "Dependency diagnostics" }),
     ).not.toBeInTheDocument();
-    ["Tasks", "Jobs", "Logs", "Model cache log"].forEach((name) => {
+    [
+      "Background tasks",
+      "Scheduled jobs",
+      "Application logs",
+      "Model caching log",
+    ].forEach((name) => {
       expect(screen.getByRole("link", { name })).toBeInTheDocument();
     });
     expect(
@@ -194,6 +355,8 @@ describe("MonitorLayout", () => {
     await waitFor(() => {
       expect(screen.getByTestId("monitor-nav")).toBeInTheDocument();
     });
+
+    await expandGroup(CONTENT_MANAGEMENT_GROUP);
 
     expect(
       screen.queryByRole("link", { name: "Alerts management" }),
@@ -259,12 +422,12 @@ describe("MonitorLayout", () => {
     within(screen.getByRole("link", { name })).queryByTestId("upsell-gem");
 
   it("gates only Erroring questions when audit_app is unavailable", async () => {
-    // dependencies present (Dependency diagnostics ungated), audit_app absent.
     setup({ tokenFeatures: { dependencies: true, audit_app: false } });
 
     await waitFor(() => {
       expect(screen.getByTestId("monitor-nav")).toBeInTheDocument();
     });
+    await expandGroup(CONTENT_MANAGEMENT_GROUP);
 
     expect(getTabGem("Erroring questions")).toBeInTheDocument();
     expect(getTabGem("Dependency diagnostics")).not.toBeInTheDocument();
@@ -276,6 +439,7 @@ describe("MonitorLayout", () => {
     await waitFor(() => {
       expect(screen.getByTestId("monitor-nav")).toBeInTheDocument();
     });
+    await expandGroup(CONTENT_MANAGEMENT_GROUP);
 
     expect(getTabGem("Dependency diagnostics")).toBeInTheDocument();
     expect(getTabGem("Erroring questions")).not.toBeInTheDocument();
@@ -287,6 +451,7 @@ describe("MonitorLayout", () => {
     await waitFor(() => {
       expect(screen.getByTestId("monitor-nav")).toBeInTheDocument();
     });
+    await expandGroup(CONTENT_MANAGEMENT_GROUP);
 
     expect(getTabGem("Dependency diagnostics")).not.toBeInTheDocument();
     expect(getTabGem("Erroring questions")).not.toBeInTheDocument();

--- a/frontend/src/metabase/monitor/routes.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/routes.unit.spec.tsx
@@ -45,7 +45,7 @@ jest.mock("metabase/monitor/tools/components/JobInfoApp", () => ({
 }));
 jest.mock("metabase/monitor/tools/components/ModelCacheRefreshJobs", () => ({
   ModelCachePage: () => (
-    <div data-testid="model-caching-page">{"Model cache log"}</div>
+    <div data-testid="model-caching-page">{"Model caching log"}</div>
   ),
   ModelCacheRefreshJobModal: () => null,
 }));
@@ -309,7 +309,7 @@ describe("monitor routes", () => {
       expect(await screen.findByTestId("jobs-page")).toBeInTheDocument();
     });
 
-    it("renders the Model cache log section at /monitor/model-caching", async () => {
+    it("renders the Model caching log section at /monitor/model-caching", async () => {
       setup({ initialRoute: "/monitor/model-caching" });
 
       expect(

--- a/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobInfoApp.tsx
+++ b/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobInfoApp.tsx
@@ -24,7 +24,7 @@ export const JobInfoApp = ({ params }: WithRouterProps<RouteParams>) => {
   return (
     <Flex ref={containerRef} h="100%" wrap="nowrap">
       <Stack className={S.main} flex={1} gap="md">
-        <MonitorHeaderTitle mb="sm">{t`Scheduler Info`}</MonitorHeaderTitle>
+        <MonitorHeaderTitle mb="sm">{t`Scheduled jobs`}</MonitorHeaderTitle>
         {error != null ? (
           <Center flex={1}>
             <DelayedLoadingAndErrorWrapper loading={isFetching} error={error} />

--- a/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobInfoApp.tsx
+++ b/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobInfoApp.tsx
@@ -24,7 +24,7 @@ export const JobInfoApp = ({ params }: WithRouterProps<RouteParams>) => {
   return (
     <Flex ref={containerRef} h="100%" wrap="nowrap">
       <Stack className={S.main} flex={1} gap="md">
-        <MonitorHeaderTitle>{t`Scheduler Info`}</MonitorHeaderTitle>
+        <MonitorHeaderTitle mb="sm">{t`Scheduler Info`}</MonitorHeaderTitle>
         {error != null ? (
           <Center flex={1}>
             <DelayedLoadingAndErrorWrapper loading={isFetching} error={error} />

--- a/frontend/src/metabase/monitor/tools/components/Logs/Logs.tsx
+++ b/frontend/src/metabase/monitor/tools/components/Logs/Logs.tsx
@@ -71,7 +71,7 @@ const LogsBase = ({
     <>
       <Flex h="100%" wrap="nowrap">
         <Stack className={S.main} flex={1} gap="md">
-          <MonitorHeaderTitle>{t`Logs`}</MonitorHeaderTitle>
+          <MonitorHeaderTitle mb="sm">{t`Logs`}</MonitorHeaderTitle>
 
           {!loaded || error != null ? (
             <Center flex={1}>

--- a/frontend/src/metabase/monitor/tools/components/Logs/Logs.tsx
+++ b/frontend/src/metabase/monitor/tools/components/Logs/Logs.tsx
@@ -71,7 +71,7 @@ const LogsBase = ({
     <>
       <Flex h="100%" wrap="nowrap">
         <Stack className={S.main} flex={1} gap="md">
-          <MonitorHeaderTitle mb="sm">{t`Logs`}</MonitorHeaderTitle>
+          <MonitorHeaderTitle mb="sm">{t`Application logs`}</MonitorHeaderTitle>
 
           {!loaded || error != null ? (
             <Center flex={1}>

--- a/frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
+++ b/frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
@@ -106,7 +106,7 @@ export function ModelCacheRefreshJobs() {
           <TreeTable
             instance={treeTableInstance}
             hierarchical={false}
-            ariaLabel={t`Model cache log`}
+            ariaLabel={t`Model caching log`}
             emptyState={
               <Stack p="xl" align="center">
                 <Text c="text-disabled">{t`No results`}</Text>
@@ -139,7 +139,7 @@ export function ModelCachePage({ children }: { children?: ReactNode }) {
   return (
     <Flex h="100%" wrap="nowrap">
       <Stack className={S.main} flex={1} gap="md">
-        <MonitorHeaderTitle mb="sm">{t`Model cache log`}</MonitorHeaderTitle>
+        <MonitorHeaderTitle mb="sm">{t`Model caching log`}</MonitorHeaderTitle>
         <ModelCacheRefreshJobs />
       </Stack>
       {children /* refresh modal */}

--- a/frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
+++ b/frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
@@ -139,7 +139,7 @@ export function ModelCachePage({ children }: { children?: ReactNode }) {
   return (
     <Flex h="100%" wrap="nowrap">
       <Stack className={S.main} flex={1} gap="md">
-        <MonitorHeaderTitle>{t`Model cache log`}</MonitorHeaderTitle>
+        <MonitorHeaderTitle mb="sm">{t`Model cache log`}</MonitorHeaderTitle>
         <ModelCacheRefreshJobs />
       </Stack>
       {children /* refresh modal */}

--- a/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
@@ -62,7 +62,7 @@ export const TaskDetailsPage = ({ params }: TaskDetailsPageProps) => {
 
   return (
     <Flex h="100%" wrap="nowrap">
-      <Stack className={S.main} flex={1} gap="md">
+      <Stack className={S.main} flex={1} gap="lg">
         <MonitorBackLink
           to={Urls.monitorTasksList()}
           label={t`Back to Tasks`}

--- a/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.tsx
@@ -46,7 +46,7 @@ export const TaskRunDetailsPage = ({ params }: TaskRunDetailsPageProps) => {
 
   return (
     <Flex h="100%" wrap="nowrap">
-      <Stack className={S.main} flex={1} gap="md">
+      <Stack className={S.main} flex={1} gap="lg">
         <MonitorBackLink to={Urls.monitorTasksRuns()} label={t`Back to Runs`} />
 
         <MonitorPageContent className={S.content}>

--- a/frontend/src/metabase/monitor/tools/components/TasksTabs/TasksTabs.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TasksTabs/TasksTabs.tsx
@@ -24,7 +24,7 @@ export const TasksTabs = ({ children }: TasksTabsProps) => {
   return (
     <Flex h="100%" wrap="nowrap">
       <Stack className={S.main} flex={1} gap="md">
-        <Stack gap="md">
+        <Stack gap="lg">
           <Flex align="center" gap="xs">
             <MonitorHeaderTitle>{t`Troubleshooting logs`}</MonitorHeaderTitle>
             <Tooltip

--- a/frontend/src/metabase/monitor/tools/components/TasksTabs/TasksTabs.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TasksTabs/TasksTabs.tsx
@@ -26,7 +26,7 @@ export const TasksTabs = ({ children }: TasksTabsProps) => {
       <Stack className={S.main} flex={1} gap="md">
         <Stack gap="lg">
           <Flex align="center" gap="xs">
-            <MonitorHeaderTitle>{t`Troubleshooting logs`}</MonitorHeaderTitle>
+            <MonitorHeaderTitle>{t`Background tasks`}</MonitorHeaderTitle>
             <Tooltip
               label={t`Trying to get to the bottom of something? This section shows logs of Metabase's background tasks, which can help shed light on what's going on.`}
               events={{ hover: true, focus: true, touch: false }}

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.tsx
@@ -314,7 +314,7 @@ export const NotificationsAdminPage = ({
     <>
       <Flex ref={containerRef} h="100%" wrap="nowrap">
         <Stack className={S.main} flex={1} gap="md">
-          <MonitorHeaderTitle>{t`Alerts management`}</MonitorHeaderTitle>
+          <MonitorHeaderTitle mb="sm">{t`Alerts management`}</MonitorHeaderTitle>
 
           <NotificationsTabs
             tab={urlState.tab}

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsTabs/NotificationsTabs.module.css
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsTabs/NotificationsTabs.module.css
@@ -1,6 +1,5 @@
 .list {
   padding: 0;
-  gap: var(--mantine-spacing-md);
 }
 
 .tab.tab {

--- a/frontend/src/metabase/nav/components/AreaLayout/AreaContent.tsx
+++ b/frontend/src/metabase/nav/components/AreaLayout/AreaContent.tsx
@@ -4,7 +4,6 @@ import ErrorBoundary from "metabase/ErrorBoundary";
 import { Box } from "metabase/ui";
 
 export const CONTENT_PADDING_X = "3.5rem";
-const CONTENT_PADDING_RIGHT_WITH_APP_SWITCHER = "7rem";
 
 type AreaContentProps = {
   children?: ReactNode;
@@ -16,8 +15,7 @@ export const AreaContent = memo(function AreaContent({
   return (
     <Box
       h="100%"
-      pl={CONTENT_PADDING_X}
-      pr={CONTENT_PADDING_RIGHT_WITH_APP_SWITCHER}
+      px={CONTENT_PADDING_X}
       py="1.5rem"
       style={{ overflowY: "auto" }}
     >

--- a/frontend/src/metabase/nav/components/AreaLayout/AreaLayout.module.css
+++ b/frontend/src/metabase/nav/components/AreaLayout/AreaLayout.module.css
@@ -76,6 +76,19 @@
   }
 }
 
+.chevron {
+  color: var(--mb-color-text-secondary);
+  transition: transform 200ms ease;
+
+  @media (prefers-reduced-motion) {
+    transition: none;
+  }
+}
+
+.chevronOpen {
+  transform: rotate(180deg);
+}
+
 .badgeOverlay {
   position: absolute;
   top: 0.25rem;

--- a/frontend/src/metabase/nav/components/AreaLayout/AreaLayout.module.css
+++ b/frontend/src/metabase/nav/components/AreaLayout/AreaLayout.module.css
@@ -97,4 +97,8 @@
 
 .upperGroup {
   overflow-y: auto;
+
+  /* keep the 4px focus ring (2px outline + 2px offset) inside the scrollport */
+  padding: 4px;
+  margin: -4px;
 }

--- a/frontend/src/metabase/nav/components/AreaLayout/AreaLayout.module.css
+++ b/frontend/src/metabase/nav/components/AreaLayout/AreaLayout.module.css
@@ -76,17 +76,12 @@
   }
 }
 
-.chevron {
+.groupHeading {
   color: var(--mb-color-text-secondary);
-  transition: transform 200ms ease;
-
-  @media (prefers-reduced-motion) {
-    transition: none;
-  }
-}
-
-.chevronOpen {
-  transform: rotate(180deg);
+  font-weight: 700;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.45px;
 }
 
 .badgeOverlay {

--- a/frontend/src/metabase/nav/components/AreaLayout/AreaLayout.tsx
+++ b/frontend/src/metabase/nav/components/AreaLayout/AreaLayout.tsx
@@ -59,7 +59,7 @@ export function AreaLayout({
         justify="space-between"
         data-testid={testId}
       >
-        <Stack gap="0.75rem" flex={1} mih={0} className={S.upperGroup}>
+        <Stack gap="md" flex={1} mih={0} className={S.upperGroup}>
           <AreaNavbarHeader
             logo={logo}
             headerControls={headerControls}

--- a/frontend/src/metabase/nav/components/AreaLayout/AreaTabGroup.tsx
+++ b/frontend/src/metabase/nav/components/AreaLayout/AreaTabGroup.tsx
@@ -1,83 +1,28 @@
-import { useDisclosure } from "@mantine/hooks";
-import cx from "classnames";
-import { type ReactNode, useEffect } from "react";
+import type { ReactNode } from "react";
 
-import {
-  Box,
-  Collapse,
-  FixedSizeIcon,
-  Stack,
-  Text,
-  Tooltip,
-  UnstyledButton,
-} from "metabase/ui";
-import type { IconName } from "metabase-types/api";
+import { Stack, Text } from "metabase/ui";
 
 import S from "./AreaLayout.module.css";
-import { TOOLTIP_OPEN_DELAY } from "./constants";
 
 type AreaTabGroupProps = {
   label: string;
-  icon: IconName;
-  isActive?: boolean;
   showLabel: boolean;
   children: ReactNode;
 };
 
 export function AreaTabGroup({
   label,
-  icon,
-  isActive,
   showLabel,
   children,
 }: AreaTabGroupProps) {
-  const [isOpen, { toggle, open }] = useDisclosure(false);
-
-  useEffect(() => {
-    if (isActive) {
-      open();
-    }
-  }, [isActive, open]);
-
   return (
-    <Box>
-      <Tooltip
-        label={label}
-        position="right"
-        openDelay={TOOLTIP_OPEN_DELAY}
-        disabled={showLabel}
-      >
-        <UnstyledButton
-          className={cx(S.tab, { [S.selected]: isActive && !isOpen })}
-          onClick={toggle}
-          p="sm"
-          bdrs="md"
-          w="100%"
-          aria-label={label}
-          aria-expanded={isOpen}
-          aria-current={isActive && !isOpen ? "location" : undefined}
-        >
-          <FixedSizeIcon name={icon} display="block" className={S.icon} />
-          {showLabel && (
-            <>
-              <Text lh="sm" ml="sm">
-                {label}
-              </Text>
-              <FixedSizeIcon
-                name="chevrondown"
-                display="block"
-                className={cx(S.chevron, { [S.chevronOpen]: isOpen })}
-                ml="auto"
-              />
-            </>
-          )}
-        </UnstyledButton>
-      </Tooltip>
-      <Collapse in={isOpen}>
-        <Stack gap="0.75rem" pt="0.75rem" pl={showLabel ? "md" : undefined}>
-          {children}
-        </Stack>
-      </Collapse>
-    </Box>
+    <Stack component="section" gap="0.75rem" aria-label={label}>
+      {showLabel && (
+        <Text component="h4" className={S.groupHeading} px="sm">
+          {label}
+        </Text>
+      )}
+      {children}
+    </Stack>
   );
 }

--- a/frontend/src/metabase/nav/components/AreaLayout/AreaTabGroup.tsx
+++ b/frontend/src/metabase/nav/components/AreaLayout/AreaTabGroup.tsx
@@ -1,0 +1,83 @@
+import { useDisclosure } from "@mantine/hooks";
+import cx from "classnames";
+import { type ReactNode, useEffect } from "react";
+
+import {
+  Box,
+  Collapse,
+  FixedSizeIcon,
+  Stack,
+  Text,
+  Tooltip,
+  UnstyledButton,
+} from "metabase/ui";
+import type { IconName } from "metabase-types/api";
+
+import S from "./AreaLayout.module.css";
+import { TOOLTIP_OPEN_DELAY } from "./constants";
+
+type AreaTabGroupProps = {
+  label: string;
+  icon: IconName;
+  isActive?: boolean;
+  showLabel: boolean;
+  children: ReactNode;
+};
+
+export function AreaTabGroup({
+  label,
+  icon,
+  isActive,
+  showLabel,
+  children,
+}: AreaTabGroupProps) {
+  const [isOpen, { toggle, open }] = useDisclosure(false);
+
+  useEffect(() => {
+    if (isActive) {
+      open();
+    }
+  }, [isActive, open]);
+
+  return (
+    <Box>
+      <Tooltip
+        label={label}
+        position="right"
+        openDelay={TOOLTIP_OPEN_DELAY}
+        disabled={showLabel}
+      >
+        <UnstyledButton
+          className={cx(S.tab, { [S.selected]: isActive && !isOpen })}
+          onClick={toggle}
+          p="sm"
+          bdrs="md"
+          w="100%"
+          aria-label={label}
+          aria-expanded={isOpen}
+          aria-current={isActive && !isOpen ? "location" : undefined}
+        >
+          <FixedSizeIcon name={icon} display="block" className={S.icon} />
+          {showLabel && (
+            <>
+              <Text lh="sm" ml="sm">
+                {label}
+              </Text>
+              <FixedSizeIcon
+                name="chevrondown"
+                display="block"
+                className={cx(S.chevron, { [S.chevronOpen]: isOpen })}
+                ml="auto"
+              />
+            </>
+          )}
+        </UnstyledButton>
+      </Tooltip>
+      <Collapse in={isOpen}>
+        <Stack gap="0.75rem" pt="0.75rem" pl={showLabel ? "md" : undefined}>
+          {children}
+        </Stack>
+      </Collapse>
+    </Box>
+  );
+}

--- a/frontend/src/metabase/nav/components/AreaLayout/AreaTabGroup.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/AreaLayout/AreaTabGroup.unit.spec.tsx
@@ -1,0 +1,137 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+
+import { AreaTabGroup } from "./AreaTabGroup";
+
+interface SetupOpts {
+  isActive?: boolean;
+  showLabel?: boolean;
+}
+
+const setup = ({ isActive = false, showLabel = true }: SetupOpts = {}) => {
+  const { rerender } = renderWithProviders(
+    <AreaTabGroup
+      label="Content management"
+      icon="folder"
+      isActive={isActive}
+      showLabel={showLabel}
+    >
+      <div data-testid="child">{"Child item"}</div>
+    </AreaTabGroup>,
+  );
+
+  const rerenderWith = (opts: SetupOpts) =>
+    rerender(
+      <AreaTabGroup
+        label="Content management"
+        icon="folder"
+        isActive={opts.isActive ?? isActive}
+        showLabel={opts.showLabel ?? showLabel}
+      >
+        <div data-testid="child">{"Child item"}</div>
+      </AreaTabGroup>,
+    );
+
+  return { rerenderWith };
+};
+
+const getHeader = () =>
+  screen.getByRole("button", { name: "Content management" });
+
+describe("AreaTabGroup", () => {
+  it("is collapsed by default, hiding its children", () => {
+    setup();
+
+    expect(getHeader()).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByTestId("child")).not.toBeVisible();
+  });
+
+  it("is open on mount when active", async () => {
+    setup({ isActive: true });
+
+    expect(getHeader()).toHaveAttribute("aria-expanded", "true");
+    await waitFor(() => expect(screen.getByTestId("child")).toBeVisible());
+  });
+
+  it("toggles open and closed on header click", async () => {
+    setup();
+
+    await userEvent.click(getHeader());
+    expect(getHeader()).toHaveAttribute("aria-expanded", "true");
+    await waitFor(() => expect(screen.getByTestId("child")).toBeVisible());
+
+    await userEvent.click(getHeader());
+    expect(getHeader()).toHaveAttribute("aria-expanded", "false");
+    await waitFor(() => expect(screen.getByTestId("child")).not.toBeVisible());
+  });
+
+  it("opens when it becomes active (navigation into the group)", async () => {
+    const { rerenderWith } = setup({ isActive: false });
+
+    expect(screen.getByTestId("child")).not.toBeVisible();
+
+    rerenderWith({ isActive: true });
+
+    expect(getHeader()).toHaveAttribute("aria-expanded", "true");
+    await waitFor(() => expect(screen.getByTestId("child")).toBeVisible());
+  });
+
+  it("allows manual collapse of the active group and does not force it back open", async () => {
+    setup({ isActive: true });
+
+    expect(getHeader()).toHaveAttribute("aria-expanded", "true");
+
+    await userEvent.click(getHeader());
+
+    expect(getHeader()).toHaveAttribute("aria-expanded", "false");
+    await waitFor(() => expect(screen.getByTestId("child")).not.toBeVisible());
+  });
+
+  it("never auto-closes when the group stops being active", async () => {
+    const { rerenderWith } = setup({ isActive: true });
+
+    expect(getHeader()).toHaveAttribute("aria-expanded", "true");
+    await waitFor(() => expect(screen.getByTestId("child")).toBeVisible());
+
+    rerenderWith({ isActive: false });
+
+    expect(getHeader()).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("child")).toBeVisible();
+  });
+
+  it("marks the header as the current location only while an active group is collapsed", async () => {
+    setup({ isActive: true });
+
+    expect(getHeader()).not.toHaveAttribute("aria-current");
+
+    await userEvent.click(getHeader());
+
+    expect(getHeader()).toHaveAttribute("aria-expanded", "false");
+    expect(getHeader()).toHaveAttribute("aria-current", "location");
+  });
+
+  it("does not mark an inactive collapsed group as the current location", () => {
+    setup({ isActive: false });
+
+    expect(getHeader()).toHaveAttribute("aria-expanded", "false");
+    expect(getHeader()).not.toHaveAttribute("aria-current");
+  });
+
+  it("stays reachable and toggleable in icon-only mode without label/chevron UI", async () => {
+    setup({ showLabel: false });
+
+    const header = getHeader();
+    expect(header).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Content management")).not.toBeInTheDocument();
+    expect(screen.getByTestId("child")).not.toBeVisible();
+
+    await userEvent.click(header);
+    expect(header).toHaveAttribute("aria-expanded", "true");
+    await waitFor(() => expect(screen.getByTestId("child")).toBeVisible());
+
+    await userEvent.click(header);
+    expect(header).toHaveAttribute("aria-expanded", "false");
+    await waitFor(() => expect(screen.getByTestId("child")).not.toBeVisible());
+  });
+});

--- a/frontend/src/metabase/nav/components/AreaLayout/AreaTabGroup.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/AreaLayout/AreaTabGroup.unit.spec.tsx
@@ -1,126 +1,38 @@
-import userEvent from "@testing-library/user-event";
-
-import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 
 import { AreaTabGroup } from "./AreaTabGroup";
 
-interface SetupOpts {
-  isActive?: boolean;
-  showLabel?: boolean;
-}
-
-const setup = ({ isActive = false, showLabel = true }: SetupOpts = {}) => {
-  const { rerender } = renderWithProviders(
-    <AreaTabGroup
-      label="Content management"
-      icon="folder"
-      isActive={isActive}
-      showLabel={showLabel}
-    >
+const setup = ({ showLabel = true }: { showLabel?: boolean } = {}) => {
+  renderWithProviders(
+    <AreaTabGroup label="Content management" showLabel={showLabel}>
       <div data-testid="child">{"Child item"}</div>
     </AreaTabGroup>,
   );
-
-  const rerenderWith = (opts: SetupOpts) =>
-    rerender(
-      <AreaTabGroup
-        label="Content management"
-        icon="folder"
-        isActive={opts.isActive ?? isActive}
-        showLabel={opts.showLabel ?? showLabel}
-      >
-        <div data-testid="child">{"Child item"}</div>
-      </AreaTabGroup>,
-    );
-
-  return { rerenderWith };
 };
 
-const getHeader = () =>
-  screen.getByRole("button", { name: "Content management" });
-
 describe("AreaTabGroup", () => {
-  it("is collapsed by default, hiding its children", () => {
+  it("renders a static heading with its children always visible", () => {
     setup();
 
-    expect(getHeader()).toHaveAttribute("aria-expanded", "false");
-    expect(screen.getByTestId("child")).not.toBeVisible();
-  });
-
-  it("is open on mount when active", async () => {
-    setup({ isActive: true });
-
-    expect(getHeader()).toHaveAttribute("aria-expanded", "true");
-    await waitFor(() => expect(screen.getByTestId("child")).toBeVisible());
-  });
-
-  it("toggles open and closed on header click", async () => {
-    setup();
-
-    await userEvent.click(getHeader());
-    expect(getHeader()).toHaveAttribute("aria-expanded", "true");
-    await waitFor(() => expect(screen.getByTestId("child")).toBeVisible());
-
-    await userEvent.click(getHeader());
-    expect(getHeader()).toHaveAttribute("aria-expanded", "false");
-    await waitFor(() => expect(screen.getByTestId("child")).not.toBeVisible());
-  });
-
-  it("opens when it becomes active (navigation into the group)", async () => {
-    const { rerenderWith } = setup({ isActive: false });
-
-    expect(screen.getByTestId("child")).not.toBeVisible();
-
-    rerenderWith({ isActive: true });
-
-    expect(getHeader()).toHaveAttribute("aria-expanded", "true");
-    await waitFor(() => expect(screen.getByTestId("child")).toBeVisible());
-  });
-
-  it("never auto-closes when the group stops being active", async () => {
-    const { rerenderWith } = setup({ isActive: true });
-
-    expect(getHeader()).toHaveAttribute("aria-expanded", "true");
-    await waitFor(() => expect(screen.getByTestId("child")).toBeVisible());
-
-    rerenderWith({ isActive: false });
-
-    expect(getHeader()).toHaveAttribute("aria-expanded", "true");
+    expect(
+      screen.getByRole("heading", { name: "Content management" }),
+    ).toBeInTheDocument();
     expect(screen.getByTestId("child")).toBeVisible();
   });
 
-  it("marks the header as the current location when an active group is collapsed", async () => {
-    setup({ isActive: true });
+  it("is not interactive", () => {
+    setup();
 
-    expect(getHeader()).not.toHaveAttribute("aria-current");
-
-    await userEvent.click(getHeader());
-
-    expect(getHeader()).toHaveAttribute("aria-expanded", "false");
-    expect(getHeader()).toHaveAttribute("aria-current", "location");
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
-  it("does not mark an inactive collapsed group as the current location", () => {
-    setup({ isActive: false });
-
-    expect(getHeader()).toHaveAttribute("aria-expanded", "false");
-    expect(getHeader()).not.toHaveAttribute("aria-current");
-  });
-
-  it("stays reachable and toggleable in icon-only mode without label/chevron UI", async () => {
+  it("hides the heading in icon-only mode while keeping children visible and the section labelled", () => {
     setup({ showLabel: false });
 
-    const header = getHeader();
-    expect(header).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByText("Content management")).not.toBeInTheDocument();
-    expect(screen.getByTestId("child")).not.toBeVisible();
-
-    await userEvent.click(header);
-    expect(header).toHaveAttribute("aria-expanded", "true");
-    await waitFor(() => expect(screen.getByTestId("child")).toBeVisible());
-
-    await userEvent.click(header);
-    expect(header).toHaveAttribute("aria-expanded", "false");
-    await waitFor(() => expect(screen.getByTestId("child")).not.toBeVisible());
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+    expect(screen.getByTestId("child")).toBeVisible();
+    expect(
+      screen.getByRole("region", { name: "Content management" }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/nav/components/AreaLayout/AreaTabGroup.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/AreaLayout/AreaTabGroup.unit.spec.tsx
@@ -77,17 +77,6 @@ describe("AreaTabGroup", () => {
     await waitFor(() => expect(screen.getByTestId("child")).toBeVisible());
   });
 
-  it("allows manual collapse of the active group and does not force it back open", async () => {
-    setup({ isActive: true });
-
-    expect(getHeader()).toHaveAttribute("aria-expanded", "true");
-
-    await userEvent.click(getHeader());
-
-    expect(getHeader()).toHaveAttribute("aria-expanded", "false");
-    await waitFor(() => expect(screen.getByTestId("child")).not.toBeVisible());
-  });
-
   it("never auto-closes when the group stops being active", async () => {
     const { rerenderWith } = setup({ isActive: true });
 
@@ -100,7 +89,7 @@ describe("AreaTabGroup", () => {
     expect(screen.getByTestId("child")).toBeVisible();
   });
 
-  it("marks the header as the current location only while an active group is collapsed", async () => {
+  it("marks the header as the current location when an active group is collapsed", async () => {
     setup({ isActive: true });
 
     expect(getHeader()).not.toHaveAttribute("aria-current");

--- a/frontend/src/metabase/nav/components/AreaLayout/index.ts
+++ b/frontend/src/metabase/nav/components/AreaLayout/index.ts
@@ -1,3 +1,4 @@
 export * from "./AreaContent";
 export * from "./AreaLayout";
 export * from "./AreaTab";
+export * from "./AreaTabGroup";

--- a/frontend/src/metabase/nav/components/AreaLayout/index.ts
+++ b/frontend/src/metabase/nav/components/AreaLayout/index.ts
@@ -1,2 +1,3 @@
+export * from "./AreaContent";
 export * from "./AreaLayout";
 export * from "./AreaTab";


### PR DESCRIPTION
Closes [GDGT-2832](https://linear.app/metabase/issue/GDGT-2832/implement-sub-menus-support-in-navbar)

## Description

Groups the Monitor navbar items into two sub-menus (introduced new `AreaTabGroup` component):

- **Content management** — Dependency diagnostics, Erroring questions, Alerts management
- **Logs and activity** — Background tasks, Scheduled jobs, Application logs, Model caching log (items renamed per ticket)

**Also**, fixes Monitor pages layout – removes additional padding on the right + increases gap between AppSwitcher and page content.

## Demo
**Before**
<img width="3840" height="1868" alt="image" src="https://github.com/user-attachments/assets/63b59b14-5a18-4b88-bf78-1a8e883250d4" />

**After**
<img width="2726" height="1936" alt="image" src="https://github.com/user-attachments/assets/e01aafef-adf3-4c3c-a008-3bf1f18caefa" />
