### PR TITLE
Move index manager driver changelog entry to 0.64.0

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -10,8 +10,6 @@ title: Driver interface changelog
   `GROUP BY GROUPING SETS (...)` statement instead of the legacy multi-query path. Drivers that opt in must also
   derive from `:sql-mbql5` (which provides the `:pivot` clause compiler). Defaults to `false`.
 
-## Metabase 0.63.0
-
 - Index Manager: drivers can now read and create table indexes, in the broad sense (secondary indexes, sort keys,
   distribution keys, clustering, etc.). New driver feature flags:
 
@@ -40,8 +38,10 @@ title: Driver interface changelog
   - `metabase.driver/compile-create-index` `[driver schema table structured]` -- compiles a `:standalone` index into
     the DDL statement(s) that create it.
 
-  - `metabase.driver/refresh-table-stats!` `[driver database schema table transform-type]` -- refreshes table
-    statistics (e.g. `ANALYZE`) after a transform run. Defaults to a no-op.
+## Metabase 0.63.0
+
+- `metabase.driver/refresh-table-stats!` `[driver database schema table transform-type]` -- refreshes table
+  statistics (e.g. `ANALYZE`) after a transform run. Defaults to a no-op.
 
 - `metabase.driver/describe-table-fks`, deprecated in 0.49.0, has been removed. Please implement
   `metabase.driver/describe-fks` instead. This method is now required for drivers that support


### PR DESCRIPTION
the index manager (#75848) merged after the 63 release branch was cut, so it ships in 64 (its app db migration is already under `migrations/064/`). but the driver changelog entry went under 0.63.0. moved it to a new 0.64.0 section.