### PR TITLE
Always include inactive tables in dependencies API responses

### DIFF
--- a/e2e/test/scenarios/data-studio/data-model/source-replacement.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/source-replacement.cy.spec.ts
@@ -404,6 +404,11 @@ describe(
         createTestTables();
         createSourceQuestion("Graph question").as("question");
 
+        // The replacement modal fetches the dependents of the source table
+        // exactly once when it opens; wait for the async dependency backfill
+        // so the question's dependency row exists by then.
+        H.waitForBackfillComplete();
+
         getTableId(SOURCE_TABLE).then((sourceTableId) => {
           cy.visit(`/data-studio/dependencies?id=${sourceTableId}&type=table`);
         });
@@ -821,6 +826,12 @@ function getTableId(tableName: string) {
 }
 
 function openReplacementModal(sourceTableLabel: string) {
+  // The modal fetches the dependents of the source table exactly once when it
+  // opens, and the card -> table dependency rows are written by an async
+  // backfill job. Wait for the backfill so the modal doesn't race it and show
+  // "Nothing uses this data source" for a table that does have dependents.
+  H.waitForBackfillComplete();
+
   H.DataModel.visitDataStudio();
 
   H.DataModel.TablePicker.getDatabase("Writable Postgres12").click();

--- a/e2e/test/scenarios/dependencies/dependency-unreferenced-list.cy.spec.ts
+++ b/e2e/test/scenarios/dependencies/dependency-unreferenced-list.cy.spec.ts
@@ -83,6 +83,19 @@ const ENTITY_NAMES = [
   ...SNIPPET_NAMES,
 ];
 
+// The unreferenced list also contains inactive tables of the shared writable DB
+// (tables dropped by other specs stay visible on purpose — see #77714), so the
+// full list can exceed one page. Tests that need to see all of the entities
+// created by this spec at once narrow the list down with this search term,
+// which matches every entity name above except the table's.
+const ENTITY_SEARCH_TERM = "for";
+const SEARCHABLE_ENTITY_NAMES = [
+  ...MODEL_NAMES,
+  ...SEGMENT_NAMES,
+  ...METRIC_NAMES,
+  ...SNIPPET_NAMES,
+];
+
 const MODELS_SORTED_BY_NAME = [
   MODEL_FOR_DASHBOARD_CARD,
   MODEL_FOR_DASHBOARD_PARAMETER_SOURCE,
@@ -124,11 +137,9 @@ describe("scenarios > dependencies > unreferenced list", () => {
       setupEntities();
       waitForUnreferencedAnalysis();
       H.DependencyDiagnostics.visitUnreferencedEntities();
-      H.DependencyDiagnostics.list().within(() => {
-        ENTITY_NAMES.forEach((name) => {
-          cy.findByText(name).should("be.visible");
-        });
-      });
+      checkList({ visibleEntities: [TABLE_DISPLAY_NAME] });
+      H.DependencyDiagnostics.searchInput().type(ENTITY_SEARCH_TERM);
+      checkList({ visibleEntities: SEARCHABLE_ENTITY_NAMES });
     });
 
     it("should not show referenced entities", () => {
@@ -187,7 +198,8 @@ describe("scenarios > dependencies > unreferenced list", () => {
       setupEntities();
       waitForUnreferencedAnalysis();
       H.DependencyDiagnostics.visitUnreferencedEntities();
-      checkList({ visibleEntities: ENTITY_NAMES });
+      H.DependencyDiagnostics.searchInput().type(ENTITY_SEARCH_TERM);
+      checkList({ visibleEntities: SEARCHABLE_ENTITY_NAMES });
 
       H.DependencyDiagnostics.filterButton().click();
       H.popover().findByText("Model").click();
@@ -232,6 +244,7 @@ describe("scenarios > dependencies > unreferenced list", () => {
       setupEntities();
       waitForUnreferencedAnalysis();
       H.DependencyDiagnostics.visitUnreferencedEntities();
+      H.DependencyDiagnostics.searchInput().type(ENTITY_SEARCH_TERM);
       checkList({
         visibleEntities: [
           MODEL_FOR_MODEL_DATA_SOURCE,
@@ -340,6 +353,7 @@ describe("scenarios > dependencies > unreferenced list", () => {
         fields: ["ID", "UUID"],
       });
 
+      H.DependencyDiagnostics.searchInput().type(ENTITY_SEARCH_TERM);
       H.DependencyDiagnostics.list()
         .findByText(MODEL_FOR_QUESTION_DATA_SOURCE)
         .click();

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -194,7 +194,7 @@
   - `entity-type-field`: Database column name for entity type (e.g., :to_entity_type)
   - `entity-id-field`: Database column name for entity ID (e.g., :to_entity_id)
   - `include-archived-items`: How to handle archived items (:exclude, :all, :only). Defaults to :exclude.
-    This applies to both archived collections AND archived entities (cards/dashboards/documents/snippets/tables).
+    This applies to both archived collections AND archived entities (cards/dashboards/documents/snippets).
 
   Returns a compound [:or ...] clause checking whether entities at those columns are readable.
 
@@ -203,9 +203,9 @@
   - Collection-based (:model/Card, :model/Dashboard, :model/Document, :model/NativeQuerySnippet):
     Uses collection/visible-collection-filter-clause for collection filtering and adds archived entity filtering.
     Native query snippets have additional restrictions for sandboxed users.
-  - Table: Uses perms/visible-table-filter-select with appropriate permissions and filters by active/visibility_type.
-    Follows search API conventions: active=true AND visibility_type=nil for non-archived tables.
-    Note: archived_at is not checked separately as archived tables always have active=false.
+  - Table: Uses perms/visible-table-filter-select with appropriate permissions. Tables are NOT filtered by
+    active/visibility_type regardless of `include-archived-items`, so dependencies broken by dropped or
+    hidden tables stay visible.
   - Transform: Analysts can view any transform they have source view permission to."
   ([entity-type-field entity-id-field]
    (visible-entities-filter-clause entity-type-field entity-id-field nil))
@@ -266,27 +266,20 @@
                                                            :only [:= archived-column true]
                                                            :all nil)]}]]))
 
-                     ;; Table with visible-filter-clause and active/visibility_type filtering
+                     ;; Table with visible-filter-clause; inactive/hidden tables are always included
+                     ;; so that dependencies broken by dropped tables stay visible
                      :model/Table
-                     (let [active-column          (keyword (name table-name) "active")
-                           visibility-type-column (keyword (name table-name) "visibility_type")]
-                       [:and
-                        [:= entity-type-field (name entity-type)]
-                        [:in entity-id-field {:select [:id]
-                                              :from   [table-name]
-                                              :where  [:and
-                                                       [:in id-column
-                                                        (perms/visible-table-filter-select
-                                                         :id
-                                                         {:user-id       api/*current-user-id*
-                                                          :is-superuser? api/*is-superuser?*}
-                                                         {:perms/view-data      :unrestricted
-                                                          :perms/create-queries :query-builder})]
-                                                       (case include-archived-items
-                                                         :exclude [:and
-                                                                   [:= active-column true]
-                                                                   [:= visibility-type-column nil]]
-                                                         (:only :all) nil)]}]])
+                     [:and
+                      [:= entity-type-field (name entity-type)]
+                      [:in entity-id-field {:select [:id]
+                                            :from   [table-name]
+                                            :where  [:in id-column
+                                                     (perms/visible-table-filter-select
+                                                      :id
+                                                      {:user-id       api/*current-user-id*
+                                                       :is-superuser? api/*is-superuser?*}
+                                                      {:perms/view-data      :unrestricted
+                                                       :perms/create-queries :query-builder})]}]]
 
                      ;; Segment/Measure with table permissions and archived filtering
                      (:model/Segment :model/Measure)
@@ -727,14 +720,12 @@
                                                         nil))]
                                   {:filter (mi/exclude-internal-content-hsql model :table-alias :entity)
                                    :filter-joins #{}})
+        ;; note that tables are not filtered by active/visibility_type, so that dependencies
+        ;; broken by dropped tables stay visible
         archived-filter (when-not (= query-type :breaking)
                           {:filter (case entity-type
                                      (:card :dashboard :document :snippet :segment :measure)
                                      [:= :entity.archived false]
-                                     :table
-                                     [:and
-                                      [:= :entity.active true]
-                                      [:= :entity.visibility_type nil]]
                                      nil)
                            :filter-joins #{}})
         personal-filter (when-not include-personal-collections

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -448,6 +448,42 @@
                                                  :dependent-types "card")]
               (is (empty? response)))))))))
 
+(deftest ^:sequential dependents-inactive-table-test
+  (testing "inactive tables are always included as dependents and in node counts"
+    (mt/with-premium-features #{:dependencies :transforms-basic :hosting}
+      (let [mp (mt/metadata-provider)
+            products (lib.metadata/table mp (mt/id :products))]
+        (mt/with-temp [:model/Table {table-id :id} {:db_id (mt/id)
+                                                    :schema "PUBLIC"
+                                                    :name "inactive_transform_table"
+                                                    :active false}
+                       :model/Transform {transform-id :id} {:name "Transform - inactivetabletest"
+                                                            :source {:type :query
+                                                                     :query (lib/query mp products)}
+                                                            :target {:schema "PUBLIC"
+                                                                     :name "inactive_transform_table"}}]
+          ;; Simulate the transform having been run: link it to its (now inactive) target table
+          (t2/update! :model/Transform transform-id {:target_table_id table-id})
+          (events/publish-event! :event/transform-run-complete
+                                 {:object {:db-id (mt/id)
+                                           :output-schema "PUBLIC"
+                                           :output-table "inactive_transform_table"
+                                           :transform-id transform-id}})
+          (deps.test/synchronously-run-backfill!)
+          (testing "GET /graph/dependents returns the inactive table as a child"
+            (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/dependents"
+                                                 :id transform-id
+                                                 :type "transform")]
+              (is (contains? (set (map :id response)) table-id))))
+          (testing "GET /graph counts the inactive table in the transform's dependents_count"
+            (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph"
+                                                 :id transform-id
+                                                 :type "transform")
+                  transform-node (m/find-first #(and (= (:type %) "transform")
+                                                     (= (:id %) transform-id))
+                                               (:nodes response))]
+              (is (= 1 (get-in transform-node [:dependents_count :table]))))))))))
+
 (deftest ^:sequential dependents-broken-parameter-test
   (testing "GET /api/ee/dependencies/graph/dependents?broken=true - only returns entities that are broken"
     (mt/with-premium-features #{:dependencies}
@@ -1118,7 +1154,7 @@
                                                                        :target {:schema "PUBLIC"
                                                                                 :name "referenced_transform_table"}}]
           ;; Simulate the referenced transform having been run: link it to its target table
-          ;; so the table→transform dep is visible in the dependency graph (which filters active=true).
+          ;; so the table→transform dep is visible in the dependency graph.
           (t2/update! :model/Transform referenced-transform-id {:target_table_id referenced-table-id})
           (events/publish-event! :event/transform-run-complete
                                  {:object {:db-id (mt/id)
@@ -1382,7 +1418,7 @@
             (is (not (contains? segment-ids archived-segment-id)))))))))
 
 (deftest ^:sequential unreferenced-archived-table-test
-  (testing "GET /api/ee/dependencies/graph/unreferenced with archived parameter for tables"
+  (testing "GET /api/ee/dependencies/graph/unreferenced includes inactive and hidden tables"
     (mt/with-premium-features #{:dependencies}
       (mt/with-temp [:model/Table {active-table-id :id} {:name "Active Unreferenced Table - archivedtest"
                                                          :db_id (mt/id)
@@ -1398,8 +1434,10 @@
         (let [response (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=table&query=archivedtest")
               table-ids (set (map :id (:data response)))]
           (is (contains? table-ids active-table-id))
-          (is (not (contains? table-ids inactive-table-id)))
-          (is (not (contains? table-ids hidden-table-id))))))))
+          (testing "inactive tables are always included"
+            (is (contains? table-ids inactive-table-id)))
+          (testing "hidden tables are always included"
+            (is (contains? table-ids hidden-table-id))))))))
 
 (deftest ^:sequential unreferenced-pagination-test
   (testing "GET /api/ee/dependencies/unreferenced - should paginate results"

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -4636,11 +4636,12 @@
                                       :type  "string/="
                                       :value ["LinkedIn"]}],
                       :dashboard_id dash-id}]
-                    (#'api.dashboard/broken-pulses dash-id {param-id param}))))
+                    ;; `broken-pulses` doesn't order its results, so sort them for a stable comparison
+                    (sort-by :id (#'api.dashboard/broken-pulses dash-id {param-id param})))))
           (testing "We can gather all needed data regarding broken params"
             (let [bad-pulses    (mapv
                                  #(update % :affected-users (partial sort-by :email))
-                                 (#'api.dashboard/broken-subscription-data dash-id {param-id param}))
+                                 (sort-by :pulse-id (#'api.dashboard/broken-subscription-data dash-id {param-id param})))
                   bad-pulse-ids (set (map :pulse-id bad-pulses))]
               (testing "We only detect the bad pulse and not the good one"
                 (is (true? (contains? bad-pulse-ids bad-pulse-id)))


### PR DESCRIPTION
Inactive and hidden tables are no longer filtered out of /api/ee/dependencies responses - they now appear as graph nodes, dependents, and in node counts, so dependencies broken by dropped tables stay visible.
