### PR TITLE
Make default-source-table-entry deterministic and field-safe

### DIFF
--- a/test/metabase/transforms/test_util.clj
+++ b/test/metabase/transforms/test_util.clj
@@ -43,7 +43,13 @@
                                          :active true
                                          :id     [:in {:select [:table_id]
                                                        :from   [(t2/table-name :model/Field)]
-                                                       :where  [:= :active true]}]
+                                                       ;; Mirror the QP's queryable-column filter (active-column-pred):
+                                                       ;; active, and visibility not sensitive/retired, else the picked
+                                                       ;; table still yields no implicit fields.
+                                                       :where  [:and
+                                                                [:= :active true]
+                                                                [:or [:= :visibility_type nil]
+                                                                 [:not-in :visibility_type ["sensitive" "retired"]]]]}]
                                          {:order-by [[:id :asc]]}))))
 
 (defn drop-target!

--- a/test/metabase/transforms/test_util.clj
+++ b/test/metabase/transforms/test_util.clj
@@ -30,11 +30,21 @@
     {:alias alias :table_id table-id :database_id db_id :schema schema}))
 
 (defn default-source-table-entry
-  "Build a source-table-entry for the first active table in the current test database."
+  "Build a source-table-entry for an active, field-synced table in the current test database.
+  Deterministic: orders by id and requires a synced field."
   ([]
    (default-source-table-entry "test"))
   ([alias]
-   (source-table-entry alias (t2/select-one-pk :model/Table :db_id (mt/id) :active true))))
+   ;; Requiring a field skips field-less leftovers (un-synced transform targets, or Snowflake tables whose
+   ;; columns haven't propagated yet) that would make the QP throw "Table has no Fields associated with it".
+   (source-table-entry alias
+                       (t2/select-one-pk :model/Table
+                                         :db_id  (mt/id)
+                                         :active true
+                                         :id     [:in {:select [:table_id]
+                                                       :from   [(t2/table-name :model/Field)]
+                                                       :where  [:= :active true]}]
+                                         {:order-by [[:id :asc]]}))))
 
 (defn drop-target!
   "Drop transform target `target` and clean up its metadata.


### PR DESCRIPTION
I think this will fix flakes like [this](https://app.mendral.com/insights/01KXGDF7TVJ3NZ4WPQHM86VJ0V).

Our tests were picking an arbitrary active table to work with, but there was no guarantee it would pick one with usable fields. On Snowflake we're intermittently picking tables that seem empty, blowing up QP via `add-implicit-clauses`, causing flakes for tests like `transforms-python.api-test/test-run-permissions-test`.

Sync creates the `Table` row (already active) and inserts `Field` rows in a later step, so there's a window where the this metadata exists, even without empty tables in the database. See the `wait-for-table` docstring. 

On Snowflake the gap is wider because metadata has a propagation lag, and the whole `:mb/transforms-python-test` set runs in parallel against one shared test-data database. This means that the mid-sync table from any namespace is visible to every other's `default-source-table-entry`.

This filters things down to only tables with an active `Field`. It also orders by id to make things more deterministic.

Test-only change; every `default-source-table-entry` caller benefits, not just the permissions test.
