### PR TITLE
Backport ci conductor wiring to v61

### DIFF
--- a/.github/actions/prepare-ci-conductor/action.yml
+++ b/.github/actions/prepare-ci-conductor/action.yml
@@ -1,0 +1,52 @@
+name: Prepare CI Conductor
+description: >-
+  Make the ci-conductor sources runnable in the workspace.
+  Unless the checkout is headed for master, they are overlaid from master, so every
+  branch runs the latest scripts while its workflow wiring stays branch-historical.
+
+runs:
+  using: composite
+  steps:
+    - name: Detect bun
+      id: bun
+      shell: bash
+      run: |
+        if command -v bun >/dev/null; then
+          echo "present=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "present=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Install bun
+      if: steps.bun.outputs.present != 'true'
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      with:
+        bun-version-file: "package.json"
+        token: ${{ github.token }}
+
+    # Anything headed for master runs master's own sources, so a PR can test its own changes.
+    - name: Fetch ci-conductor sources from master
+      if: ${{ github.base_ref != 'master' && github.ref_name != 'master' }}
+      uses: actions/checkout@v6
+      with:
+        repository: metabase/metabase
+        ref: master
+        path: .ci-conductor-master
+        persist-credentials: false
+        sparse-checkout-cone-mode: false
+        sparse-checkout: |
+          release/ci-conductor
+          e2e/support/ci_conductor.ts
+
+    # e2e/support/config.js and e2e/support/ci_conductor.ts resolve these by relative
+    # path at bundle time, so the sources have to land where the branch expects them.
+    - name: Overlay ci-conductor sources from master
+      if: ${{ github.base_ref != 'master' && github.ref_name != 'master' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        rm -rf release/ci-conductor
+        mv .ci-conductor-master/release/ci-conductor release/ci-conductor
+        mv .ci-conductor-master/e2e/support/ci_conductor.ts e2e/support/ci_conductor.ts
+        rm -rf .ci-conductor-master
+        echo "Overlaid ci-conductor sources from master."

--- a/.github/actions/prepare-cypress/action.yml
+++ b/.github/actions/prepare-cypress/action.yml
@@ -15,6 +15,10 @@ outputs:
 runs:
   using: "composite"
   steps:
+    # e2e/support/config.js imports the reporter, so it has to be in place before Cypress bundles.
+    - name: Prepare CI Conductor
+      uses: ./.github/actions/prepare-ci-conductor
+
     - name: Install Chrome v144
       uses: browser-actions/setup-chrome@v2
       with:

--- a/.github/actions/quarantine-gate/action.yml
+++ b/.github/actions/quarantine-gate/action.yml
@@ -1,0 +1,38 @@
+name: CI Conductor quarantine gate
+description: >-
+  Check this job's test failures against ci-conductor's quarantine list.
+  Either enforces the quarantine or only prints a verdict (dry run).
+  Fails closed when enforcing but the `CI_CONDUCTOR_BASE_URL` is missing or unreachable.
+
+inputs:
+  adapter:
+    description: Which gate to run — one of `backend`, `frontend`, `e2e`.
+    required: true
+  test-suite:
+    description: >-
+      Suite label to gate (CI_CONDUCTOR_TEST_SUITE). MUST match the label this
+      job reports under, or the gate checks the wrong quarantine list.
+    required: true
+  enforce-quarantine:
+    description: >-
+      Whether the gate actually gates the job. When "false", it only prints a verdict.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Prepare CI Conductor
+      uses: ./.github/actions/prepare-ci-conductor
+    - name: Check failures against the quarantine list
+      shell: bash
+      env:
+        CI_CONDUCTOR_TEST_SUITE: ${{ inputs.test-suite }}
+        ADAPTER: ${{ inputs.adapter }}
+        QUARANTINE_DRY_RUN: ${{ inputs.enforce-quarantine != 'true' }}
+      run: |
+        case "$ADAPTER" in
+          backend|frontend|e2e) ;;
+          *) echo "::error::quarantine-gate: unknown adapter '$ADAPTER' (expected backend|frontend|e2e)"; exit 1 ;;
+        esac
+        bun "release/ci-conductor/src/check-${ADAPTER}-quarantine.ts"

--- a/.github/actions/report-failures-to-ci-conductor/action.yml
+++ b/.github/actions/report-failures-to-ci-conductor/action.yml
@@ -1,0 +1,34 @@
+name: Report failures to CI Conductor
+description: >-
+  Report this job's test failures to ci-conductor. Best-effort; no-ops unless
+  CI_CONDUCTOR_BASE_URL is set. Gate it at the call site with continue-on-error
+  and an `if:` on the test step's outcome.
+
+inputs:
+  test-suite:
+    description: Per-job identity label (CI_CONDUCTOR_TEST_SUITE); unique per job/leg.
+    required: true
+  adapter:
+    description: Which reporter to run; resolves to report-<adapter>.ts. backend or frontend.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Prepare CI Conductor
+      uses: ./.github/actions/prepare-ci-conductor
+    - name: Report failed tests to ci-conductor
+      shell: bash
+      env:
+        REPO_ID: ${{ github.event.repository.id }}
+        COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
+        CI_CONDUCTOR_TEST_SUITE: ${{ inputs.test-suite }}
+        ADAPTER: ${{ inputs.adapter }}
+      # Keep the path constrained to known entrypoints.
+      run: |
+        case "$ADAPTER" in
+          backend|frontend) ;;
+          *) echo "::error::Unknown ci-conductor adapter '$ADAPTER'"; exit 1 ;;
+        esac
+        bun "release/ci-conductor/src/report-${ADAPTER}.ts"

--- a/.github/actions/resolve-job-id/action.yml
+++ b/.github/actions/resolve-job-id/action.yml
@@ -1,0 +1,66 @@
+name: Resolve current job id
+description: >
+  Resolve this job's GitHub workflow_jobs.id via the Actions API and export it
+  as JOB_ID (and JOB_HTML_URL) to $GITHUB_ENV, so any later step can read the
+  numeric job id without making its own API call. Best-effort: warns and
+  proceeds on failure so it can never break the run.
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve JOB_ID
+      shell: bash
+      env:
+        # Use the built-in per-job token, not a PAT: this lookup is best-effort
+        # (a miss just leaves JOB_ID unset, never breaks the run) and other jobs
+        # depend on the automation PAT's rate-limit budget — we don't want ~70
+        # e2e shards drawing it down. Worst case under heavy CI load is the
+        # occasional unresolved job_id, which is acceptable. DEV-2117.
+        GH_TOKEN: ${{ github.token }}
+        RUNNER_NAME: ${{ runner.name }}
+      run: |
+        # GitHub doesn't expose the current job's numeric id, so we look it up
+        # from the Actions API. A runner runs exactly one job at a time, so the
+        # in-progress job with this runner_name within (run_id, run_attempt) is
+        # unique. We require status == in_progress and no completed_at so a
+        # reused runner can't match a job it already finished this attempt, with
+        # max_by(.started_at) as a final tiebreaker.
+        #
+        # $GITHUB_RUN_ID is the whole CI run, whose total job count exceeds the
+        # 100-per-page cap (~185 jobs), so this shard's job is frequently NOT on
+        # the first page. --paginate --slurp pulls every page and slurps them
+        # into one array so the filter sees all jobs, not just the first 100 —
+        # without it the lookup returned null whenever this job sorted past
+        # position 100 (DEV-2117).
+        #
+        # gh rejects `--slurp` together with `--jq` ("the --slurp option is not
+        # supported with --jq"), so we slurp with gh and run the filter through a
+        # standalone `jq`. The earlier `--slurp --jq` form errored on every
+        # attempt — swallowed by 2>/dev/null — leaving JOB_ID permanently unset.
+        set +e
+        api_url="/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT/jobs?per_page=100"
+        jq_filter="[.[].jobs[] | select(.runner_name == \"$RUNNER_NAME\" and .status == \"in_progress\" and .completed_at == null)] | max_by(.started_at) | \"\(.id) \(.html_url)\""
+
+        # The Actions jobs API is eventually consistent: after a runner picks
+        # up a job, it can take a few seconds for runner_name to appear in the
+        # response. Retry briefly to absorb that.
+        out=""
+        for attempt in 1 2 3 4 5; do
+          out=$(gh api --paginate --slurp "$api_url" 2>/dev/null | jq -r "$jq_filter" 2>/dev/null)
+          if [ -n "$out" ] && [ "$out" != "null null" ]; then
+            break
+          fi
+          out=""
+          echo "Attempt $attempt: job not yet visible in Actions API; retrying..."
+          sleep 3
+        done
+
+        if [ -n "$out" ]; then
+          read -r job_id job_url <<<"$out"
+          echo "JOB_ID=$job_id" >> "$GITHUB_ENV"
+          echo "JOB_HTML_URL=$job_url" >> "$GITHUB_ENV"
+          echo "Resolved JOB_ID=$job_id (runner=$RUNNER_NAME)"
+        else
+          echo "::warning::Could not resolve current job id after 5 attempts (runner=$RUNNER_NAME)"
+        fi
+        exit 0

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -14,8 +14,10 @@ inputs:
     description: Suffix to append to the test logs artifact name to avoid conflicts in matrix jobs
   edition:
     required: false
-    default: 'ee'
+    default: "ee"
     description: Edition to test (oss or ee)
+  quarantine-engine:
+    required: false
 
 outputs:
   test-outcome:
@@ -27,6 +29,10 @@ runs:
   steps:
     - name: Prepare back-end environment
       uses: ./.github/actions/prepare-backend
+    - name: Resolve current job id
+      # Resolve JOB_ID early (before the long test step) so the ci-conductor
+      # reporter below can link failures to this exact job. Best-effort.
+      uses: ./.github/actions/resolve-job-id
     - name: Prepare front-end environment
       if: ${{ inputs.build-static-viz == 'true' }}
       uses: ./.github/actions/prepare-frontend
@@ -36,14 +42,23 @@ runs:
       shell: bash
       env:
         MB_EDITION: ee
+
     - name: Test database driver
       run: clojure -X:dev:ci:${{ inputs.edition }}:${{ inputs.edition }}-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
       shell: bash
       id: run-test
-      # Trunk Quarantine controls the final state of the run in the CI!
-      # Even if this step fails we let it pass, and then `trunk-io/analytics-uploader` determines
-      # whether to fail or to pass the whole job, based on the quarantine list.
+      # Keep this step continue-on-error because the quarantine logic controls whether it ultimately fails.
       continue-on-error: true
+
+    - name: Report failed tests to ci-conductor
+      if: ${{ !cancelled() && steps.run-test.outcome == 'failure' }}
+      # This step should NEVER fail the job!
+      continue-on-error: true
+      uses: ./.github/actions/report-failures-to-ci-conductor
+      with:
+        test-suite: ${{ inputs.junit-name }}
+        adapter: backend
+
     - name: Publish Test Report (JUnit)
       uses: dorny/test-reporter@v1
       # As per the documentation: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#steps-context
@@ -57,6 +72,7 @@ runs:
         list-suites: failed
         list-tests: failed
         fail-on-error: false
+
     - name: Upload Logs on Failure
       if: always() && steps.run-test.outcome != 'success'
       uses: actions/upload-artifact@v4
@@ -66,3 +82,14 @@ runs:
         retention-days: 1
       # Failing to upload the artifact should never affect the outcome of the whole test run.
       continue-on-error: true
+
+    # Last, because this is the only step allowed to fail the job: everything above it reports the
+    # failure (JUnit report, logs, ci-conductor) and must run regardless of the verdict below.
+    - name: Quarantine gate
+      if: ${{ !cancelled() && steps.run-test.outcome == 'failure' }}
+      continue-on-error: ${{ inputs.quarantine-engine != 'ci-conductor' }}
+      uses: ./.github/actions/quarantine-gate
+      with:
+        adapter: backend
+        test-suite: ${{ inputs.junit-name }}
+        enforce-quarantine: ${{ inputs.quarantine-engine == 'ci-conductor' }}

--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -21,6 +21,10 @@ inputs:
     default: ""
   previous-step-outcome:
     required: true
+  run-trunk:
+    required: false
+    default: "true"
+    description: Whether to run the Trunk step at all.
 
 runs:
   using: "composite"
@@ -47,10 +51,10 @@ runs:
         aws s3 cp ${OUTPUT_FILE}.zip s3://$BUCKET/$DATE/$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT/
 
     - name: Upload results to Trunk
+      if: ${{ always() && github.repository_owner == 'metabase' && inputs.run-trunk == 'true' }}
       # Important!
       # 1. This step must always run because it controls job's exit code.
       # 2. There's no point in running this outside the organization
-      if: always() && github.repository_owner == 'metabase'
       uses: trunk-io/analytics-uploader@main
       env:
         TRUNK_REPO_URL: git@github.com:metabase/metabase.git

--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -11,6 +11,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}-app-db
   cancel-in-progress: true
 
+# Exposed to every job so the test-driver action can report failures to
+# ci-conductor (secrets: inherit is already set on the app-db call in
+# run-tests.yml). See DEV-2224.
+env:
+  CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+  CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
+
 jobs:
   be-tests-mariadb:
     if: ${{ !inputs.skip }}
@@ -69,7 +76,7 @@ jobs:
             github.event_name == 'push' &&
             (
               github.ref_name == 'master' ||
-              startsWith(github.ref_name, 'release-')
+              startsWith(github.ref_name, 'release-x')
             ) &&
             ''
           ) ||
@@ -113,6 +120,7 @@ jobs:
           test-args: >-
             ${{ matrix.job.test-args }}
             :exclude-tags '[ ${{ matrix.job.exclude-tag }} ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
+          quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always()
@@ -124,6 +132,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+          run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-mysql:
     if: ${{ !inputs.skip }}
@@ -184,7 +193,7 @@ jobs:
             github.event_name == 'push' &&
             (
               github.ref_name == 'master' ||
-              startsWith(github.ref_name, 'release-')
+              startsWith(github.ref_name, 'release-x')
             ) &&
             ''
           ) ||
@@ -236,6 +245,7 @@ jobs:
           test-args: >-
             ${{ matrix.job.test-args }}
             :exclude-tags '[ ${{ matrix.job.exclude-tag }} ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
+          quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always()
@@ -247,6 +257,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+          run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-postgres:
     if: ${{ !inputs.skip }}
@@ -300,7 +311,7 @@ jobs:
             github.event_name == 'push' &&
             (
               github.ref_name == 'master' ||
-              startsWith(github.ref_name, 'release-')
+              startsWith(github.ref_name, 'release-x')
             ) &&
             ''
           ) ||
@@ -346,6 +357,7 @@ jobs:
           test-args: >-
             ${{ matrix.job.test-args }}
             :exclude-tags '[ ${{ matrix.job.exclude-tag }} ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
+          quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always()
@@ -357,6 +369,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+          run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   app-db-tests-result:
     needs:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -11,6 +11,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}-backend
   cancel-in-progress: true
 
+# Exposed to the test jobs so they can report failures to ci-conductor
+# (secrets: inherit is already set on the backend call in run-tests.yml).
+# See DEV-2224.
+env:
+  CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+  CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
+
 jobs:
   be-linter-clj-kondo:
     if: ${{ !inputs.skip }}
@@ -38,7 +45,7 @@ jobs:
 
   be-linter-eastwood-test:
     # Master / release safety net: lint every backend test namespace.
-    if: ${{ !inputs.skip && github.event_name == 'push' && (github.ref_name == 'master' || startsWith(github.ref_name, 'release-')) }}
+    if: ${{ !inputs.skip && github.event_name == 'push' && (github.ref_name == 'master' || startsWith(github.ref_name, 'release-x')) }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 45
     name: Eastwood (tests only)
@@ -160,7 +167,7 @@ jobs:
             github.event_name == 'push' &&
             (
               github.ref_name == 'master' ||
-              startsWith(github.ref_name, 'release-')
+              startsWith(github.ref_name, 'release-x')
             ) &&
             ''
           ) ||
@@ -179,16 +186,38 @@ jobs:
         env:
           MB_EDITION: ${{ matrix.job.edition }}
 
+      - name: Resolve current job id
+        # Resolve JOB_ID before the long test step so the ci-conductor reporter
+        # below can link failures to this exact job. Best-effort.
+        uses: ./.github/actions/resolve-job-id
+
       - name: "Test Java ${{ matrix.java-version }} ${{ matrix.job.name }}"
         id: run-java-tests
         run: >-
           clojure -X:dev:ci:test:${{ matrix.job.edition }}:${{ matrix.job.edition }}-dev
           :exclude-tags '[:mb/driver-tests ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
           ${{ matrix.job.test-args }}
-        # Trunk Quarantine controls the final state of the run in the CI!
-        # Even if this step fails we let it pass, and then `trunk-io/analytics-uploader` determines
-        # whether to fail or to pass the whole job, based on the quarantine list.
+        # Keep this step continue-on-error because the quarantine logic controls whether it ultimately fails.
         continue-on-error: true
+
+      - name: Report failed tests to ci-conductor
+        if: ${{ !cancelled() && steps.run-java-tests.outcome == 'failure' }}
+        # This step should NEVER fail the job!
+        continue-on-error: true
+        uses: ./.github/actions/report-failures-to-ci-conductor
+        with:
+          test-suite: be-tests-java-${{ matrix.java-version }}-${{ matrix.job.test-group-name }}
+          adapter: backend
+
+      - name: Quarantine gate
+        if: ${{ !cancelled() && steps.run-java-tests.outcome == 'failure' }}
+        continue-on-error: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
+        timeout-minutes: 3
+        uses: ./.github/actions/quarantine-gate
+        with:
+          adapter: backend
+          test-suite: be-tests-java-${{ matrix.java-version }}-${{ matrix.job.test-group-name }}
+          enforce-quarantine: ${{ vars.QUARANTINE_ENGINE == 'ci-conductor' }}
 
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
@@ -201,6 +230,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.run-java-tests.outcome }}
+          run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
       - name: Publish Test Report (JUnit)
         uses: dorny/test-reporter@3eeb9fc888e82e8be2fb356bbeec2750231672bc # v1

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -11,6 +11,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}-drivers
   cancel-in-progress: true
 
+# Exposed to every driver job so the test-driver action can report failures to
+# ci-conductor (secrets: inherit is already set on the drivers call in
+# run-tests.yml). See DEV-2224.
+env:
+  CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+  CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
+
 jobs:
   # This job determines which driver tests should run based on PR context.
   # All decision logic is consolidated in mage driver-decisions.
@@ -130,6 +137,7 @@ jobs:
         test-args: >-
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -141,6 +149,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-bigquery-cloud-sdk-ee:
     needs: determine-driver-skips
@@ -195,6 +204,7 @@ jobs:
         junit-name: 'be-tests-bigquery-cloud-sdk-ee'
         test-args: ${{ matrix.job.test-args }}
         logs-artifact-suffix: ${{ matrix.job.name }}
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -206,6 +216,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
       uses: ./.github/actions/cleanup-python-runner
@@ -277,6 +288,7 @@ jobs:
         junit-name: 'be-tests-clickhouse-ee'
         test-args: ${{ matrix.job.test-args }}
         logs-artifact-suffix: ${{ matrix.job.name }}
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -288,6 +300,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
       uses: ./.github/actions/cleanup-python-runner
@@ -331,6 +344,7 @@ jobs:
         test-args: >-
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -342,6 +356,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-druid-jdbc-ee:
     needs: determine-driver-skips
@@ -379,6 +394,7 @@ jobs:
         test-args: >-
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -390,6 +406,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-databricks-ee:
     needs: determine-driver-skips
@@ -450,6 +467,7 @@ jobs:
       with:
         junit-name: 'be-tests-databricks-ee'
         test-args: ${{ matrix.job.test-args }}
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -461,6 +479,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-databricks-multi-catalog-ee:
     needs: determine-driver-skips
@@ -522,6 +541,7 @@ jobs:
       with:
         junit-name: 'be-tests-databricks-multi-catalog-ee'
         test-args: ${{ matrix.job.test-args }}
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -533,6 +553,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-h2:
     needs: determine-driver-skips
@@ -552,6 +573,7 @@ jobs:
         test-args: >-
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -563,6 +585,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-h2-oss:
     needs: determine-driver-skips
@@ -583,6 +606,7 @@ jobs:
         test-args: >-
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -594,6 +618,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-mysql-mariadb:
     needs: determine-driver-skips
@@ -713,6 +738,7 @@ jobs:
           test-args: >-
             ${{ matrix.job.test-args }}
             :exclude-tags '[ ${{ matrix.job.exclude-tag }} ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
+          quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always()
@@ -724,6 +750,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+          run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
       - name: Cleanup python-runner
         if: always()
         uses: ./.github/actions/cleanup-python-runner
@@ -793,6 +820,7 @@ jobs:
         junit-name: ${{ matrix.version.junit-name }}
         test-args: ${{ matrix.job.test-args }}
         logs-artifact-suffix: ${{ matrix.job.name }}
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -804,6 +832,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
       uses: ./.github/actions/cleanup-python-runner
@@ -875,6 +904,7 @@ jobs:
           test-args: >-
             :exclude-tags '[:mongo-sharded-cluster-tests :mb/transforms-python-test]'
             :only-tags [:mb/driver-tests]
+          quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always()
@@ -886,6 +916,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+          run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-mongo-sharded-cluster-ee:
     needs: determine-driver-skips
@@ -920,6 +951,7 @@ jobs:
         junit-name: 'be-tests-mongo-sharded-cluster-ee'
         test-args: >-
           :only metabase.driver.mongo.sharded-cluster-test
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -931,6 +963,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-oracle:
     needs: determine-driver-skips
@@ -1005,6 +1038,7 @@ jobs:
         test-args: >-
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -1016,6 +1050,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-postgres:
     needs: determine-driver-skips
@@ -1109,6 +1144,7 @@ jobs:
           test-args: >-
             ${{ matrix.job.test-args }}
             :exclude-tags '[ ${{ matrix.job.exclude-tag }} ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
+          quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always()
@@ -1120,6 +1156,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+          run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
       - name: Cleanup python-runner
         if: always()
         uses: ./.github/actions/cleanup-python-runner
@@ -1196,6 +1233,7 @@ jobs:
         test-args: >-
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -1207,6 +1245,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-redshift-ee:
     needs: determine-driver-skips
@@ -1280,6 +1319,7 @@ jobs:
         test-args: >-
           ${{ matrix.job.test-args }}
         logs-artifact-suffix: ${{ matrix.job.name }}
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: ${{ !matrix.job.skip && !cancelled() }}
@@ -1291,6 +1331,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
       uses: ./.github/actions/cleanup-python-runner
@@ -1360,6 +1401,7 @@ jobs:
         junit-name: 'be-tests-snowflake-ee'
         test-args: ${{ matrix.job.test-args }}
         logs-artifact-suffix: ${{ matrix.job.name }}
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -1371,6 +1413,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
       uses: ./.github/actions/cleanup-python-runner
@@ -1412,6 +1455,7 @@ jobs:
         test-args: >-
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -1423,6 +1467,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-sqlite-ee:
     needs: determine-driver-skips
@@ -1453,6 +1498,7 @@ jobs:
         test-args: >-
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -1464,6 +1510,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   be-tests-sqlserver:
     needs: determine-driver-skips
@@ -1529,6 +1576,7 @@ jobs:
         junit-name: ${{ matrix.version.junit-name }}
         test-args: ${{ matrix.job.test-args }}
         logs-artifact-suffix: ${{ matrix.version.name }}
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -1540,6 +1588,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
     - name: Cleanup python-runner
       if: ${{ always() && matrix.job.needs-python-runner == true }}
       uses: ./.github/actions/cleanup-python-runner
@@ -1654,6 +1703,7 @@ jobs:
         test-args: >-
           :only-tags [:mb/driver-tests]
           :exclude-tags [:mb/transforms-python-test]
+        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -1665,6 +1715,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+        run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   drivers-tests-result:
     needs:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,6 +37,20 @@ env:
   HASH: ${{ github.event.pull_request.head.sha || github.sha }}-${{ github.run_attempt }}
   PR_NUMBER: ${{ github.event.pull_request.number || '' }}
   JOB_NAME: ${{ inputs.name }}
+  # ci-conductor reporting (DEV-1999). Secret holds the base origin
+  # (e.g. "https://conductor.<host>"); each consumer appends the path it needs
+  # (the reporter POSTs to "/webhooks/failed-tests"). Callers pass
+  # `secrets: inherit`; reporting no-ops when it's unset.
+  CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+  # Shared secret sent as the `x-internal-secret` header to authenticate.
+  CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
+  REPO_ID: ${{ github.event.repository.id }}
+  # Commit + PR target branch under test, so conductor can tie failures to the
+  # right code. On PRs the ambient GITHUB_SHA is the synthetic merge commit and
+  # GITHUB_BASE_REF the target, so we pass the PR head sha / base ref explicitly
+  # (falling back to push-event values). The reporter reads these. DEV-1999.
+  COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
 
 jobs:
   e2e-tests:
@@ -45,6 +59,11 @@ jobs:
     name: e2e-tests-${{ inputs.name }}-${{ inputs.edition }}
     env:
       MB_EDITION: ${{ inputs.edition }}
+      # Absolute path for the quarantine failures file (DEV-2082). The after:spec
+      # recorder runs in Cypress' plugins process, whose cwd differs from the
+      # workspace where the gate step runs; an absolute path anchored to the
+      # workspace makes both agree regardless of cwd.
+      QUARANTINE_FAILURES_FILE: ${{ github.workspace }}/target/quarantine-failures.jsonl
       # Sensitive env vars (tokens, secrets) starting with `CYPRESS_` are accessed via async `cy.env()`
       # Example: `cy.env(["FOO"]).then(({ FOO }) => ...)`
       # For non-sensitive config, use `Cypress.expose()` in cypress config instead (synchronous)
@@ -112,6 +131,15 @@ jobs:
       - name: Run Metabase
         run: node e2e/runner/run_cypress_ci.js start
 
+      # Export this job's numeric GitHub job id as $JOB_ID for the Cypress runs
+      # below (ci-conductor failed-tests reporting reads it in after:spec).
+      # Snapshot generation is itself a Cypress run that fires after:spec, so
+      # this must precede it. Placed late, not after checkout: the Actions jobs
+      # API is eventually consistent, so the longer the job has been alive the
+      # more reliably the lookup resolves. JOB_ID exported here persists to the
+      # steps below. DEV-1999.
+      - uses: ./.github/actions/resolve-job-id
+
       - name: Generate database snapshots
         env:
           CYPRESS_BROWSER: ${{ steps.cypress-prep.outputs.chrome-path }}
@@ -136,9 +164,7 @@ jobs:
           node e2e/runner/run_cypress_ci.js e2e \
             --expose grepTags="-@mongo+-@python+-@OSS+-@skip" \
             --spec "$SPEC_PATH"
-        # Trunk Quarantine controls the final state of the run in the CI!
-        # Even if this step fails we let it pass, and then `trunk-io/analytics-uploader` determines
-        # whether to fail or to pass the whole job, based on the quarantine list.
+        # Keep this step continue-on-error because the quarantine logic controls whether it ultimately fails.
         continue-on-error: true
 
       - name: Run Tagged EE Cypress tests on ${{ inputs.name }}
@@ -153,9 +179,7 @@ jobs:
           node e2e/runner/run_cypress_ci.js e2e \
           --expose grepTags="${{inputs.tags && format('{0}+-@skip', inputs.tags) || '-@skip'}}" \
           --spec "$SPEC_PATH"
-        # Trunk Quarantine controls the final state of the run in the CI!
-        # Even if this step fails we let it pass, and then `trunk-io/analytics-uploader` determines
-        # whether to fail or to pass the whole job, based on the quarantine list.
+        # Keep this step continue-on-error because the quarantine logic controls whether it ultimately fails.
         continue-on-error: true
 
       - name: Upload Test Results
@@ -172,6 +196,18 @@ jobs:
           variant: e2e-tests
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ inputs.specs && steps.tagged-e2e.outcome || steps.split-e2e.outcome }}
+          run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
+
+      - name: Quarantine gate
+        # Only one of the two run steps executes; the other reports `skipped`. Only gate on actual failure.
+        if: ${{ !cancelled() && (steps.split-e2e.outcome == 'failure' || steps.tagged-e2e.outcome == 'failure') }}
+        continue-on-error: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
+        timeout-minutes: 3
+        uses: ./.github/actions/quarantine-gate
+        with:
+          adapter: e2e
+          test-suite: e2e
+          enforce-quarantine: ${{ vars.QUARANTINE_ENGINE == 'ci-conductor' }}
 
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v4

--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -8,6 +8,12 @@ env:
   TERM: xterm
   TZ: US/Pacific # to make Node match the instance tz
   MB_EDITION: "ee"
+  CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+  CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
+  REPO_ID: ${{ github.event.repository.id }}
+  COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
+  QUARANTINE_FAILURES_FILE: ${{ github.workspace }}/target/quarantine-failures.jsonl
 
 jobs:
   sdk-component-tests:
@@ -19,6 +25,7 @@ jobs:
         react-version: [18, 19]
       fail-fast: false
     env:
+      CI_CONDUCTOR_TEST_SUITE: embedding-sdk-component-react-${{ matrix.react-version }}
       # Sensitive env vars (tokens, secrets) starting with `CYPRESS_` are accessed via async `cy.env()`
       # Example: `cy.env(["FOO"]).then(({ FOO }) => ...)`
       # For non-sensitive config, use `Cypress.expose()` in cypress config instead (synchronous)
@@ -69,6 +76,8 @@ jobs:
       - name: Run Metabase
         run: node e2e/runner/run_cypress_ci.js start
 
+      - uses: ./.github/actions/resolve-job-id
+
       - name: Make app db snapshot
         env:
           CYPRESS_BROWSER: ${{ steps.cypress-prep.outputs.chrome-path }}
@@ -86,6 +95,8 @@ jobs:
         env:
           CYPRESS_BROWSER: ${{ steps.cypress-prep.outputs.chrome-path }}
         run: node e2e/runner/run_cypress_ci.js component
+        # Keep this step continue-on-error because the quarantine logic controls whether it ultimately fails.
+        continue-on-error: true
 
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
@@ -98,10 +109,21 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.run-tests.outcome }}
+          run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
+
+      - name: Quarantine gate
+        if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' }}
+        continue-on-error: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
+        timeout-minutes: 3
+        uses: ./.github/actions/quarantine-gate
+        with:
+          adapter: e2e
+          test-suite: ${{ env.CI_CONDUCTOR_TEST_SUITE }}
+          enforce-quarantine: ${{ vars.QUARANTINE_ENGINE == 'ci-conductor' }}
 
       - name: "SDK component tests > Upload Cypress Artifacts upon failure"
         uses: actions/upload-artifact@v4
-        if: failure()
+        if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' }}
         with:
           name: cypress-recording-embedding-sdk-react-${{ matrix.react-version }}
           path: |
@@ -110,7 +132,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: "SDK component tests > Publish Summary"
-        if: failure()
+        if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' }}
         uses: actions/github-script@v7
         with:
           script: | #js
@@ -155,6 +177,7 @@ jobs:
     env:
       MB_RUN_MODE: "e2e"
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
+      CI_CONDUCTOR_TEST_SUITE: embedding-sdk-component-backward-compatibility
       # Sensitive env vars (tokens, secrets) starting with `CYPRESS_` are accessed via async `cy.env()`
       # Example: `cy.env(["FOO"]).then(({ FOO }) => ...)`
       # For non-sensitive config, use `Cypress.expose()` in cypress config instead (synchronous)
@@ -224,6 +247,8 @@ jobs:
       - name: Run Metabase
         run: node e2e/runner/run_cypress_ci.js start
 
+      - uses: ./.github/actions/resolve-job-id
+
       - name: Make app db snapshot
         env:
           CYPRESS_BROWSER: ${{ steps.cypress-prep.outputs.chrome-path }}
@@ -239,6 +264,8 @@ jobs:
         run: |
           node e2e/runner/run_cypress_ci.js component \
             --expose grepTags="-@skip-backward-compatibility"
+        # Keep this step continue-on-error because the quarantine logic controls whether it ultimately fails.
+        continue-on-error: true
 
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
@@ -251,10 +278,21 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.run-tests.outcome }}
+          run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
+
+      - name: Quarantine gate
+        if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' }}
+        continue-on-error: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
+        timeout-minutes: 3
+        uses: ./.github/actions/quarantine-gate
+        with:
+          adapter: e2e
+          test-suite: ${{ env.CI_CONDUCTOR_TEST_SUITE }}
+          enforce-quarantine: ${{ vars.QUARANTINE_ENGINE == 'ci-conductor' }}
 
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v4
-        if: failure()
+        if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' }}
         with:
           name: cypress-recording-embedding-sdk-cross-version
           path: |
@@ -263,7 +301,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish Summary
-        if: failure()
+        if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' }}
         uses: actions/github-script@v7
         with:
           script: | #js

--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -171,6 +171,8 @@ jobs:
       - name: Log free disk space
         run: df -h /
 
+      - uses: ./.github/actions/resolve-job-id
+
       - name: Run e2e tests for Sample App
         id: run-e2e-tests
         if: ${{ steps.check-sample-app-branch.outputs.sample_app_branch_exists == 'true' }}
@@ -237,6 +239,8 @@ jobs:
           metastore-dev-server-url: ${{ secrets.METASTORE_DEV_SERVER_URL }}
           shoppy-datadog-application-id: ${{ secrets.SHOPPY_METABASE_APP_DATADOG_APPLICATION_ID }}
           shoppy-datadog-client-token: ${{ secrets.SHOPPY_METABASE_APP_DATADOG_CLIENT_TOKEN }}
+
+      - uses: ./.github/actions/resolve-job-id
 
       - name: Run e2e tests for Shoppy
         id: run-e2e-tests
@@ -316,6 +320,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: ./.github/actions/resolve-job-id
+
       - name: Run synthetic monitoring tests
         id: run-e2e-tests
         if: ${{ steps.shoppy-prep.outputs.sample_app_branch_exists == 'true' }}
@@ -363,6 +369,19 @@ jobs:
     timeout-minutes: 45
     name: e2e-host-app-${{ matrix.test_suite }}-tests-${{ matrix.environment }}-bundle
     env:
+      # Host apps are the only suite here running through Metabase's Cypress config,
+      # whose `after:spec` hook reports failures and writes QUARANTINE_FAILURES_FILE.
+      # Sample-app suites load their own config (no-op), so ci-conductor is scoped to this job.
+      CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+      CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
+      CI_CONDUCTOR_TEST_SUITE: embedding-sdk-host-app
+      REPO_ID: ${{ github.event.repository.id }}
+      COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
+      QUARANTINE_FAILURES_FILE: ${{ github.workspace }}/target/quarantine-failures.jsonl
+      # `Fail job if tests failed` is the arbiter until ci-conductor takes over.
+      # Exactly one of the two gates the job.
+      CI_CONDUCTOR_QUARANTINE_ACTIVE: ${{ vars.QUARANTINE_ENGINE == 'ci-conductor' }}
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
       HOST_APP_ENVIRONMENT: ${{ matrix.environment }}
     permissions:
@@ -399,6 +418,8 @@ jobs:
       - name: Run Metabase
         run: node e2e/runner/run_cypress_ci.js start
 
+      - uses: ./.github/actions/resolve-job-id
+
       - name: Generate database snapshots
         run: |
           node e2e/runner/run_cypress_ci.js snapshot \
@@ -416,14 +437,24 @@ jobs:
 
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v4
-        if: ${{ steps.run-e2e-tests.outcome != 'success' }}
+        if: ${{ !cancelled() && steps.run-e2e-tests.outcome == 'failure' }}
         with:
           name: cypress-recording-host-app-${{ matrix.test_suite }}-${{ matrix.environment }}-latest
           path: |
             ./cypress
           if-no-files-found: ignore
 
+      - name: Quarantine gate
+        if: ${{ !cancelled() && steps.run-e2e-tests.outcome == 'failure' }}
+        continue-on-error: ${{ env.CI_CONDUCTOR_QUARANTINE_ACTIVE != 'true' }}
+        timeout-minutes: 3
+        uses: ./.github/actions/quarantine-gate
+        with:
+          adapter: e2e
+          test-suite: ${{ env.CI_CONDUCTOR_TEST_SUITE }}
+          enforce-quarantine: ${{ env.CI_CONDUCTOR_QUARANTINE_ACTIVE }}
+
       - name: Fail job if tests failed
-        if: ${{ steps.run-e2e-tests.outcome != 'success' }}
+        if: ${{ !cancelled() && steps.run-e2e-tests.outcome == 'failure' && env.CI_CONDUCTOR_QUARANTINE_ACTIVE != 'true' }}
         run: |
           exit 1

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -24,6 +24,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}-frontend
   cancel-in-progress: true
 
+env:
+  # Consumed by the report-failures-to-ci-conductor step in fe-tests-unit. Absent
+  # (e.g. fork PRs without secret access) the reporter no-ops. Matches the other
+  # suite workflows (backend, drivers, e2e, app-db, semantic-search).
+  CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+  CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
+
 jobs:
   fe-lint:
     if: ${{ !inputs.skip-lint }}
@@ -89,13 +96,32 @@ jobs:
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
+      - name: Resolve current job id
+        # Resolve JOB_ID before the long test step so the ci-conductor reporter
+        # below can link failures to this exact job. Best-effort.
+        uses: ./.github/actions/resolve-job-id
       - name: Run frontend unit tests
         id: fe-tests
         run: bun run test-unit --silent --shard=${{ matrix.shard }}/${{ env.SHARDS }}
-        # Trunk Quarantine controls the final state of the run in the CI!
-        # Even if this step fails we let it pass, and then `trunk-io/analytics-uploader` determines
-        # whether to fail or to pass the whole job, based on the quarantine list.
+        # Keep this step continue-on-error because the quarantine logic controls whether it ultimately fails.
         continue-on-error: true
+      - name: Report failed tests to ci-conductor
+        if: ${{ !cancelled() && steps.fe-tests.outcome == 'failure' }}
+        # This step should NEVER fail the job!
+        continue-on-error: true
+        uses: ./.github/actions/report-failures-to-ci-conductor
+        with:
+          test-suite: fe-tests-unit
+          adapter: frontend
+      - name: Quarantine gate
+        if: ${{ !cancelled() && steps.fe-tests.outcome == 'failure' }}
+        continue-on-error: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
+        timeout-minutes: 3
+        uses: ./.github/actions/quarantine-gate
+        with:
+          adapter: frontend
+          test-suite: fe-tests-unit
+          enforce-quarantine: ${{ vars.QUARANTINE_ENGINE == 'ci-conductor' }}
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always() && github.event_name != 'workflow_dispatch'
@@ -107,6 +133,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.fe-tests.outcome }}
+          run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   fe-tests-timezones:
     if: ${{ !inputs.skip }}

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -65,6 +65,27 @@ jobs:
       - name: Run release unit tests
         run: bun run --cwd release test:unit
 
+  ci-conductor-tests:
+    needs: files-changed
+    if: needs.files-changed.outputs.release_source == 'true'
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: "release/ci-conductor"
+      - name: Install bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.14"
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install ci-conductor dependencies
+        run: bun install --cwd release/ci-conductor --frozen-lockfile
+      - name: Type-check ci-conductor
+        run: bun run --cwd release/ci-conductor type-check
+      - name: Run ci-conductor unit tests
+        run: bun run --cwd release/ci-conductor test
+
   release-test-build:
     needs: files-changed
     if: needs.files-changed.outputs.release_source == 'true'

--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -11,6 +11,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}-semantic-search
   cancel-in-progress: true
 
+# Exposed to every job so the test-driver action can report failures to
+# ci-conductor (secrets: inherit is already set on the semantic-search call in
+# run-tests.yml). See DEV-2224.
+env:
+  CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+  CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
+
 jobs:
   semantic-search-tests-h2:
     if: ${{ !inputs.skip }}
@@ -54,6 +61,7 @@ jobs:
           test-args: >-
             ${{ matrix.job.test-args }}
             :exclude-tags '[${{ matrix.job.exclude-tag }}]'
+          quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always()
@@ -65,6 +73,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+          run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   semantic-search-tests-mariadb:
     if: ${{ !inputs.skip }}
@@ -127,6 +136,7 @@ jobs:
           test-args: >-
             ${{ matrix.job.test-args }}
             :exclude-tags '[${{ matrix.job.exclude-tag }}]'
+          quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always()
@@ -138,6 +148,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+          run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   semantic-search-tests-mysql:
     if: ${{ !inputs.skip }}
@@ -200,6 +211,7 @@ jobs:
           test-args: >-
             ${{ matrix.job.test-args }}
             :exclude-tags '[${{ matrix.job.exclude-tag }}]'
+          quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always()
@@ -211,6 +223,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+          run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   semantic-search-tests-postgres:
     if: ${{ !inputs.skip }}
@@ -274,6 +287,7 @@ jobs:
           test-args: >-
             ${{ matrix.job.test-args }}
             :exclude-tags '[${{ matrix.job.exclude-tag }}]'
+          quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always()
@@ -285,6 +299,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
           previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+          run-trunk: ${{ vars.QUARANTINE_ENGINE != 'ci-conductor' }}
 
   semantic-search-tests-result:
     needs:

--- a/e2e/support/ci_conductor.ts
+++ b/e2e/support/ci_conductor.ts
@@ -1,0 +1,405 @@
+import { appendFileSync, mkdirSync, readFileSync, statSync } from "node:fs";
+import { dirname } from "node:path";
+
+import fetch from "node-fetch"; // must be node-fetch v2 because it's non-esm
+
+// The canonical wire shape and the numeric-env parser live once in the
+// ci-conductor module (release/ci-conductor), shared by the backend and
+// frontend reporters. e2e reuses them so the report path and the quarantine
+// path can't drift on a test's identity (see contract.ts). The transport stays
+// forked here: e2e posts mid-run from inside Cypress's `after:spec` hook on
+// node-fetch, with screenshots and a dry-run mode — none of which the module's
+// bun-native, post-run transport covers.
+import type {
+  FailedTestsBody,
+  NormalizedTest,
+} from "../../release/ci-conductor/src/contract";
+import { toNumber } from "../../release/ci-conductor/src/util";
+
+// `Cypress` and `CypressCommandLine` are global namespaces provided by the
+// "cypress" types (see e2e/tsconfig.json), so they're referenced without import.
+
+/**
+ * Reports Cypress test failures to the ci-conductor service, mid-run, from the
+ * `after:spec` Node hook (see e2e/support/config.js). Sending per-spec — rather
+ * than waiting for the whole job to finish — lets failures be tied back to the
+ * CI run (and through it the PR / release branch) before the job completes.
+ *
+ * The base URL is only supplied via env in CI, so local runs no-op.
+ *
+ * See DEV-1999.
+ */
+
+const {
+  CI_CONDUCTOR_BASE_URL,
+  CI_CONDUCTOR_WEBHOOK_SECRET,
+  CI_CONDUCTOR_DRY_RUN,
+  CI_CONDUCTOR_TEST_SUITE,
+  REPO_ID,
+  GITHUB_RUN_ID,
+  GITHUB_RUN_ATTEMPT,
+  JOB_ID,
+  // The commit and PR target branch under test. On PRs the ambient GITHUB_SHA is
+  // a synthetic merge commit and GITHUB_BASE_REF the target, so e2e-test.yml sets
+  // COMMIT_SHA/TARGET_BRANCH to the PR's head sha / base ref; we fall back to the
+  // ambient vars (push runs, local) when they're unset. See DEV-1999.
+  COMMIT_SHA,
+  GITHUB_SHA,
+  TARGET_BRANCH,
+  GITHUB_BASE_REF,
+} = process.env;
+
+// When set, the payload is logged instead of POSTed — used to validate env
+// resolution and payload shape in CI before sending real data. See DEV-1999.
+const isDryRun = CI_CONDUCTOR_DRY_RUN === "true";
+
+/**
+ * One reportable e2e test: the shared `NormalizedTest` wire shape (defined once
+ * in the ci-conductor module, so the report path and the quarantine path can't
+ * drift on a test's identity) plus a transient, never-sent `screenshotPath`.
+ *
+ * The Cypress-specific field semantics live at `extractFailedTests`: `message`
+ * is null for flakes (Cypress drops `displayError` once the final attempt
+ * passes), passing tests are only reported on re-runs, and `status` is derived
+ * from `attempts` by `classifyStatus`.
+ */
+type E2ETest = NormalizedTest & {
+  /**
+   * Transient (never sent on the wire): absolute path to the resolved first
+   * failure screenshot, set by `extractFailedTests`. It's read and encoded into
+   * `failure_screenshot` just before the POST, then dropped. See DEV-2000.
+   */
+  screenshotPath?: string;
+};
+
+/**
+ * Classify a test from its attempts: "passed" if every attempt passed,
+ * "failure" if every attempt failed, "flake" if it failed at least once but
+ * ultimately passed on retry. Callers only pass tests that ran (a non-empty
+ * attempts array of passes and/or fails), never pending/skipped.
+ */
+function classifyStatus(
+  attempts: { state: string }[],
+): "failure" | "flake" | "passed" {
+  if (attempts.every((attempt) => attempt.state === "passed")) {
+    return "passed";
+  }
+  const allFailed = attempts.every((attempt) => attempt.state === "failed");
+  return allFailed ? "failure" : "flake";
+}
+
+/**
+ * GitHub doesn't expose the current job's numeric `workflow_jobs.id` to a
+ * running job, so the `./.github/actions/resolve-job-id` composite action
+ * resolves it once at job start and exports it as `JOB_ID`. We just read that
+ * env here. Falls back to null when the env isn't set (the column is
+ * nullable). See DEV-1999.
+ */
+function getJobId(): number | null {
+  return toNumber(JOB_ID);
+}
+
+/** Normalize a string to just [a-z0-9] for sanitization-proof matching. */
+function normalizeForMatch(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/** Basename of a path, tolerant of both POSIX and Windows separators. */
+function baseName(p: string): string {
+  return p.split(/[\\/]/).pop() ?? "";
+}
+
+/**
+ * Match a failed test to its first-failure screenshot from after:spec's
+ * `results.screenshots` — a flat, spec-level list with no link back to the test.
+ * Cypress derives each screenshot filename from the test's full title (joined
+ * with " -- ", sanitized) followed by " (failed)" (plus "(attempt N)" for
+ * retries). We normalize the title and each basename down to [a-z0-9] — which
+ * cancels every sanitization rule (">", " -- ", "/", ":", ...) on both sides, so
+ * we never reconstruct the filename — and anchor on the title immediately
+ * followed by "failed":
+ *
+ *   normalize(basename) === normalize(title.join("")) + "failed" + [attempt…] + ext
+ *
+ * Anchoring on "failed" (a) excludes manual cy.screenshot() shots, which have no
+ * "(failed)" suffix, and (b) is collision-proof: a title that's a prefix of
+ * another's won't match, because "failed" must follow the key exactly. The first
+ * shot and its retries both anchor-match, so we take the shortest basename — the
+ * one without an "(attempt N)" suffix, i.e. the first attempt.
+ *
+ * Pure and defensive: returns undefined on any missing/odd input, never throws.
+ * See DEV-2000.
+ */
+export function resolveScreenshotPath(
+  titlePath: string[] | undefined,
+  screenshots: Array<{ path?: string }> | undefined,
+): string | undefined {
+  try {
+    const key = normalizeForMatch((titlePath ?? []).join(""));
+    if (!key || !Array.isArray(screenshots)) {
+      return undefined;
+    }
+
+    const anchor = `${key}failed`;
+    return (
+      screenshots
+        .map((shot) => (typeof shot?.path === "string" ? shot.path : ""))
+        .filter((path) => path !== "")
+        .filter((path) => normalizeForMatch(baseName(path)).startsWith(anchor))
+        // Shortest basename = the first attempt (no "(attempt N)" suffix).
+        .sort((a, b) => baseName(a).length - baseName(b).length)[0]
+    );
+  } catch (error) {
+    console.error("[ci-conductor] failed to resolve screenshot path", error);
+    return undefined;
+  }
+}
+
+// ci-conductor rejects screenshots over 10 MB decoded; base64 inflates ~33%, so
+// we cap the raw file well under that (see its lib/screenshots MAX_SCREENSHOT_BYTES).
+const MAX_SCREENSHOT_RAW_BYTES = 7 * 1024 * 1024;
+
+/**
+ * Read a screenshot file and return it as a base64 PNG data URI, or undefined if
+ * the file is missing, empty, too large, or unreadable. Best-effort and never
+ * throws — a screenshot problem must not break reporting. See DEV-2000.
+ */
+function encodeScreenshot(filePath: string): string | undefined {
+  try {
+    const stat = statSync(filePath);
+    if (
+      !stat.isFile() ||
+      stat.size === 0 ||
+      stat.size > MAX_SCREENSHOT_RAW_BYTES
+    ) {
+      return undefined;
+    }
+    const b64 = readFileSync(filePath).toString("base64");
+    return b64 ? `data:image/png;base64,${b64}` : undefined;
+  } catch (error) {
+    console.error("[ci-conductor] failed to read screenshot", filePath, error);
+    return undefined;
+  }
+}
+
+/**
+ * Pull the reportable tests out of a single spec's run results. We always
+ * include any test that had at least one failed attempt — so both "broken"
+ * (every attempt failed) and "flaky" (failed at least once, passed on retry)
+ * are reported. On a re-run (GITHUB_RUN_ATTEMPT > 1) we additionally include
+ * tests that passed, so conductor can see a previously-failing test recover.
+ * Pending/skipped tests are never reported. Each row carries a derived `status`
+ * ("failure" | "flake" | "passed"); see `classifyStatus`.
+ *
+ * Cypress only populates `displayError` for the *final* state, so flaky tests
+ * arrive with `message: null` — we know *that* they flaked from `attempts`,
+ * but not *why*. Broken tests carry the full error blob.
+ *
+ * If the spec crashed before any tests ran (e.g. a compile/import error),
+ * Cypress reports no tests but sets `results.error`; we surface that as a
+ * single synthetic entry so the failure isn't lost.
+ */
+export function extractFailedTests(
+  spec: Cypress.Spec,
+  results: CypressCommandLine.RunResult,
+): E2ETest[] {
+  const file = spec?.relative;
+
+  // On a re-run we also report passing tests (not just failures) so conductor
+  // can see a previously-failing test recover. Read at call time rather than the
+  // module-level destructure so it's controllable per-call in tests.
+  const isRerun = (toNumber(process.env.GITHUB_RUN_ATTEMPT) ?? 0) > 1;
+
+  const tests = (results?.tests ?? [])
+    .filter((test) => {
+      const attempts = test.attempts ?? [];
+      const failed = attempts.some((attempt) => attempt.state === "failed");
+      // A test "passed" only if it ran and every attempt passed — this excludes
+      // pending/skipped tests, which we never report.
+      const passed =
+        attempts.length > 0 &&
+        attempts.every((attempt) => attempt.state === "passed");
+      return failed || (isRerun && passed);
+    })
+    .map((test) => {
+      const titlePath = test.title ?? [];
+      const name = titlePath[titlePath.length - 1] ?? "(unknown test)";
+      const suite = titlePath.slice(0, -1).join(" > ");
+      const attempts = test.attempts ?? [];
+      // Resolve (but don't yet read) the test's first failure screenshot from
+      // this spec's `results.screenshots`. The file is encoded into
+      // `failure_screenshot` at send time so the matching logic here stays pure.
+      // Returns undefined on any miss — best-effort.
+      const screenshotPath = resolveScreenshotPath(
+        titlePath,
+        results?.screenshots,
+      );
+      return {
+        name,
+        path: suite || undefined,
+        file,
+        duration: test.duration,
+        attempts,
+        status: classifyStatus(attempts),
+        message: test.displayError ?? null,
+        ...(screenshotPath ? { screenshotPath } : {}),
+      };
+    });
+
+  if (tests.length === 0 && results?.error) {
+    return [
+      {
+        name: spec?.name ?? "(spec failed to run)",
+        file,
+        attempts: [{ state: "failed" }],
+        status: "failure",
+        message: results.error,
+      },
+    ];
+  }
+
+  return tests;
+}
+
+/**
+ * Where after:spec records this run's ultimate test failures for the post-run
+ * quarantine gate (DEV-2082). One JSON object per line
+ * (`{test_name, test_path, file_path}`), appended per spec, so the gate step
+ * can read the whole job's failures from a single file. Override with
+ * QUARANTINE_FAILURES_FILE. Note these are the SAME fields ci-conductor stores
+ * in its quarantine list (both derived from the same Cypress title array), so
+ * the gate can compare them exactly. See
+ * `release/ci-conductor/src/check-e2e-quarantine.ts`.
+ */
+const QUARANTINE_FAILURES_FILE =
+  process.env.QUARANTINE_FAILURES_FILE ?? "./target/quarantine-failures.jsonl";
+
+/**
+ * Persist the tests that ultimately failed (status "failure") so the post-run
+ * quarantine gate can decide whether the job passes. Flaky tests that recovered
+ * on retry and passing tests don't gate the build, so they're filtered out.
+ * Best-effort and never throws — recording must not break the test run.
+ */
+export function recordFailedTestsForQuarantine(tests: E2ETest[]): void {
+  try {
+    const broken = tests.filter((test) => test.status === "failure");
+    if (broken.length === 0) {
+      return;
+    }
+    const lines =
+      broken
+        .map((test) =>
+          JSON.stringify({
+            test_name: test.name,
+            test_path: test.path ?? null,
+            file_path: test.file ?? null,
+          }),
+        )
+        .join("\n") + "\n";
+    mkdirSync(dirname(QUARANTINE_FAILURES_FILE), { recursive: true });
+    appendFileSync(QUARANTINE_FAILURES_FILE, lines);
+  } catch (error) {
+    console.error("[quarantine] failed to record failures", error);
+  }
+}
+
+/**
+ * Report the given failures to ci-conductor. In dry-run mode the payload is
+ * logged and nothing is sent. Otherwise it's POSTed, no-opping when the webhook
+ * URL isn't configured (local runs, PRs without the secret). Never throws —
+ * reporting must not break a test run — so all errors are logged and swallowed.
+ */
+export async function reportFailedTestsToConductor(
+  tests: E2ETest[],
+): Promise<void> {
+  if (tests.length === 0 || (!CI_CONDUCTOR_BASE_URL && !isDryRun)) {
+    return;
+  }
+
+  // Everything below is wrapped so the reporter can never throw into the test
+  // run, regardless of payload contents or network behavior.
+  try {
+    // Best-effort: read each resolved screenshot and inline it as base64 for
+    // ci-conductor to upload. encodeScreenshot never throws — a test simply goes
+    // without a screenshot if it can't be read. The transient `screenshotPath`
+    // is dropped here so it never reaches the wire.
+    const outgoing = tests.map(({ screenshotPath, ...rest }) => {
+      const failure_screenshot = screenshotPath
+        ? encodeScreenshot(screenshotPath)
+        : undefined;
+      return failure_screenshot ? { ...rest, failure_screenshot } : rest;
+    });
+
+    // Typed against the shared contract so the run-level identity stays in
+    // lockstep with the backend/frontend reporters; `retries` is the one e2e-only
+    // field (Cypress has a retry ceiling; the JUnit producers don't).
+    const body: FailedTestsBody & { retries: number | null } = {
+      repo_id: toNumber(REPO_ID),
+      run_id: toNumber(GITHUB_RUN_ID),
+      attempt: toNumber(GITHUB_RUN_ATTEMPT),
+      job_id: getJobId(),
+      test_suite: CI_CONDUCTOR_TEST_SUITE || "e2e",
+      // PR head sha / target branch when set by e2e-test.yml, else the ambient
+      // (push/local) values. Empty strings collapse to null.
+      sha: COMMIT_SHA || GITHUB_SHA || null,
+      target_branch: TARGET_BRANCH || GITHUB_BASE_REF || null,
+      // The retry ceiling so conductor can interpret per-test `attempts`.
+      // CYPRESS_RETRIES isn't set in CI by default; e2e/support/config.js
+      // surfaces the resolved Cypress config value into this env at startup.
+      retries: toNumber(process.env.CYPRESS_RETRIES),
+      tests: outgoing,
+    };
+
+    if (isDryRun) {
+      // Don't dump base64 blobs into the log — replace each with a size marker.
+      const screenshotCount = outgoing.filter(
+        (t) => t.failure_screenshot,
+      ).length;
+      const redactedTests = outgoing.map((t) =>
+        t.failure_screenshot
+          ? {
+              ...t,
+              failure_screenshot: `<base64 ${t.failure_screenshot.length} chars>`,
+            }
+          : t,
+      );
+      console.log(
+        `[ci-conductor] (dry run) would POST ${outgoing.length} failure(s), ${screenshotCount} with screenshot(s):`,
+        JSON.stringify({ ...body, tests: redactedTests }),
+      );
+      return;
+    }
+
+    if (!CI_CONDUCTOR_BASE_URL) {
+      // already excluded by the guard above; this also narrows the type
+      return;
+    }
+
+    // CI_CONDUCTOR_BASE_URL holds the ci-conductor base origin (e.g.
+    // "https://conductor.<host>"); we append this endpoint's path. Other
+    // consumers (e.g. the quarantine gate's /api/quarantine) build their own.
+    const endpoint = `${CI_CONDUCTOR_BASE_URL.replace(/\/+$/, "")}/webhooks/failed-tests`;
+
+    // ci-conductor authenticates this endpoint via the x-internal-secret header.
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (CI_CONDUCTOR_WEBHOOK_SECRET) {
+      headers["x-internal-secret"] = CI_CONDUCTOR_WEBHOOK_SECRET;
+    }
+
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      console.error(
+        `[ci-conductor] failed-tests POST returned ${response.status} ${response.statusText}`,
+      );
+    }
+  } catch (error) {
+    console.error("[ci-conductor] failed to POST failed-tests", error);
+  }
+}

--- a/e2e/support/ci_conductor.unit.spec.ts
+++ b/e2e/support/ci_conductor.unit.spec.ts
@@ -1,0 +1,754 @@
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { extractFailedTests, resolveScreenshotPath } from "./ci_conductor";
+
+// jest.mock is hoisted; the mocked default must be referenced via a `mock`-
+// prefixed variable. node-fetch is unused by extractFailedTests, so mocking it
+// here is harmless for those tests.
+const mockFetch = jest.fn();
+jest.mock("node-fetch", () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockFetch(...args),
+}));
+
+// ci_conductor reads some env at import time (top-level destructure) and some
+// at call time (e.g. CYPRESS_RETRIES), so loadConductor applies the env BEFORE
+// re-importing and leaves it applied until afterEach restores it.
+const envBackups: Array<{ key: string; previous: string | undefined }> = [];
+
+afterEach(() => {
+  while (envBackups.length) {
+    const { key, previous } = envBackups.pop()!;
+    if (previous === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = previous;
+    }
+  }
+});
+
+const loadConductor = async (env: Record<string, string | undefined>) => {
+  jest.resetModules();
+  for (const [key, value] of Object.entries(env)) {
+    envBackups.push({ key, previous: process.env[key] });
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  return await import("./ci_conductor");
+};
+
+// Minimal builders for the bits of Cypress' after:spec payload we read.
+const spec = {
+  name: "foo.cy.spec.ts",
+  relative: "e2e/test/scenarios/foo/foo.cy.spec.ts",
+} as Cypress.Spec;
+
+const makeResults = (
+  overrides: Partial<CypressCommandLine.RunResult>,
+): CypressCommandLine.RunResult =>
+  ({
+    error: null,
+    tests: [],
+    stats: { failures: 0 },
+    ...overrides,
+  }) as unknown as CypressCommandLine.RunResult;
+
+// Builds a TestResult-shaped object. The final `state` is derived from
+// `attemptStates` so callers can describe healthy/flaky/broken naturally.
+const test = (
+  title: string[],
+  attemptStates: string[],
+  displayError: string | null = null,
+  duration: number = 100,
+) => ({
+  title,
+  state: attemptStates[attemptStates.length - 1],
+  displayError,
+  duration,
+  attempts: attemptStates.map((state) => ({ state })),
+});
+
+// Build a `results.screenshots`-shaped array from bare paths (the only field we
+// read). Cypress leaves `name` null for automatic failure shots.
+const screenshotsFromPaths = (...paths: string[]) =>
+  paths.map((path) => ({
+    path,
+  })) as unknown as CypressCommandLine.RunResult["screenshots"];
+
+describe("extractFailedTests", () => {
+  // Pin the default to "first attempt" so these tests are deterministic even
+  // when the CI job running them is itself a re-run (GITHUB_RUN_ATTEMPT > 1).
+  // The global afterEach restores the original via envBackups. Re-run cases
+  // override process.env.GITHUB_RUN_ATTEMPT in the test body.
+  beforeEach(() => {
+    envBackups.push({
+      key: "GITHUB_RUN_ATTEMPT",
+      previous: process.env.GITHUB_RUN_ATTEMPT,
+    });
+    delete process.env.GITHUB_RUN_ATTEMPT;
+  });
+
+  it("reports broken tests with the full displayError as message", () => {
+    const displayError =
+      "AssertionError: expected true to be false\n    at Context.eval (foo.cy.spec.ts:42)";
+
+    const results = makeResults({
+      tests: [
+        test(["Dashboard", "filters", "applies a filter"], ["passed"]),
+        test(
+          ["Dashboard", "filters", "shows an error"],
+          ["failed", "failed"],
+          displayError,
+        ),
+      ],
+    });
+
+    expect(extractFailedTests(spec, results)).toEqual([
+      {
+        name: "shows an error",
+        path: "Dashboard > filters",
+        file: "e2e/test/scenarios/foo/foo.cy.spec.ts",
+        duration: 100,
+        attempts: [{ state: "failed" }, { state: "failed" }],
+        status: "failure",
+        message: displayError,
+      },
+    ]);
+  });
+
+  it("includes flaky tests too (final passed but ≥1 failed attempt), with null message", () => {
+    const results = makeResults({
+      tests: [
+        test(["a", "healthy"], ["passed"]),
+        test(["a", "flaky"], ["failed", "passed"]),
+      ],
+    });
+
+    const failures = extractFailedTests(spec, results);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({
+      name: "flaky",
+      attempts: [{ state: "failed" }, { state: "passed" }],
+      status: "flake",
+      message: null,
+    });
+  });
+
+  it("excludes healthy, pending, and skipped tests", () => {
+    const results = makeResults({
+      tests: [
+        test(["a", "passed test"], ["passed"]),
+        test(["a", "pending test"], ["pending"]),
+        test(["a", "skipped test"], ["skipped"]),
+      ],
+    });
+
+    expect(extractFailedTests(spec, results)).toEqual([]);
+  });
+
+  it("returns an empty array when nothing has a failed attempt", () => {
+    expect(extractFailedTests(spec, makeResults({}))).toEqual([]);
+  });
+
+  it("omits `path` for a top-level test with no suite", () => {
+    const results = makeResults({
+      tests: [test(["lonely test"], ["failed"], "boom")],
+    });
+
+    const [failure] = extractFailedTests(spec, results);
+    expect(failure).toMatchObject({ name: "lonely test", status: "failure" });
+    expect(failure.path).toBeUndefined();
+  });
+
+  it("sends message: null when a failed test has no displayError", () => {
+    const results = makeResults({
+      tests: [test(["a", "no error string"], ["failed"], null)],
+    });
+
+    expect(extractFailedTests(spec, results)[0]).toMatchObject({
+      name: "no error string",
+      path: "a",
+      message: null,
+    });
+  });
+
+  it("falls back to a synthetic entry when the spec crashes before any test runs", () => {
+    const results = makeResults({
+      error: "SyntaxError: Unexpected token\n  at compile",
+      tests: [],
+    });
+
+    expect(extractFailedTests(spec, results)).toEqual([
+      {
+        name: "foo.cy.spec.ts",
+        file: "e2e/test/scenarios/foo/foo.cy.spec.ts",
+        attempts: [{ state: "failed" }],
+        status: "failure",
+        message: "SyntaxError: Unexpected token\n  at compile",
+      },
+    ]);
+  });
+
+  it("prefers real failed tests over the spec-level error fallback", () => {
+    const results = makeResults({
+      error: "some run-level error",
+      tests: [test(["a", "real failure"], ["failed"], "boom")],
+    });
+
+    const failures = extractFailedTests(spec, results);
+    expect(failures).toHaveLength(1);
+    expect(failures[0].name).toBe("real failure");
+  });
+
+  it("tolerates a missing tests array", () => {
+    expect(extractFailedTests(spec, makeResults({ tests: undefined }))).toEqual(
+      [],
+    );
+  });
+
+  it("does not report passing tests on the first attempt", () => {
+    process.env.GITHUB_RUN_ATTEMPT = "1";
+    const results = makeResults({
+      tests: [test(["a", "passing"], ["passed"])],
+    });
+
+    expect(extractFailedTests(spec, results)).toEqual([]);
+  });
+
+  it("on a re-run (attempt > 1) also reports passing tests with status passed", () => {
+    process.env.GITHUB_RUN_ATTEMPT = "2";
+    const results = makeResults({
+      tests: [
+        test(["a", "now passing"], ["passed"]),
+        test(["a", "still broken"], ["failed", "failed"], "boom"),
+      ],
+    });
+
+    const reported = extractFailedTests(spec, results);
+    expect(reported).toHaveLength(2);
+    expect(reported).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "now passing",
+          status: "passed",
+          message: null,
+        }),
+        expect.objectContaining({ name: "still broken", status: "failure" }),
+      ]),
+    );
+  });
+
+  it("still excludes pending and skipped tests on a re-run", () => {
+    process.env.GITHUB_RUN_ATTEMPT = "3";
+    const results = makeResults({
+      tests: [
+        test(["a", "pending test"], ["pending"]),
+        test(["a", "skipped test"], ["skipped"]),
+      ],
+    });
+
+    expect(extractFailedTests(spec, results)).toEqual([]);
+  });
+
+  it("attaches screenshotPath for a failed test with a matching screenshot", () => {
+    const path =
+      "/cy/screenshots/foo.cy.spec.js/a -- shows an error (failed).png";
+    const results = makeResults({
+      tests: [test(["a", "shows an error"], ["failed"], "boom")],
+      screenshots: screenshotsFromPaths(path),
+    });
+
+    expect(extractFailedTests(spec, results)[0]).toMatchObject({
+      name: "shows an error",
+      screenshotPath: path,
+    });
+  });
+
+  it("omits screenshotPath when no screenshot matches the test", () => {
+    const unrelated =
+      "/cy/screenshots/foo/a -- a totally different test (failed).png";
+    const results = makeResults({
+      tests: [test(["a", "shows an error"], ["failed"], "boom")],
+      screenshots: screenshotsFromPaths(unrelated),
+    });
+
+    expect(extractFailedTests(spec, results)[0]).not.toHaveProperty(
+      "screenshotPath",
+    );
+  });
+
+  it("omits screenshotPath when the spec produced no screenshots", () => {
+    const results = makeResults({
+      tests: [test(["a", "shows an error"], ["failed"], "boom")],
+    });
+
+    expect(extractFailedTests(spec, results)[0]).not.toHaveProperty(
+      "screenshotPath",
+    );
+  });
+});
+
+describe("resolveScreenshotPath", () => {
+  const shots = (...paths: string[]) => paths.map((path) => ({ path }));
+
+  it("returns undefined with no screenshots, no title, or no match", () => {
+    expect(resolveScreenshotPath(["a", "b"], undefined)).toBeUndefined();
+    expect(resolveScreenshotPath(["a", "b"], [])).toBeUndefined();
+    expect(
+      resolveScreenshotPath(undefined, shots("/x/a (failed).png")),
+    ).toBeUndefined();
+    expect(
+      resolveScreenshotPath(["a", "b"], shots("/x/unrelated (failed).png")),
+    ).toBeUndefined();
+  });
+
+  it("matches the real on-disk basename despite spaces, ` -- ` and `>` stripping", () => {
+    // Verbatim from a local run: describe("scenarios > models > create") →
+    // Cypress writes "scenarios  models  create -- <test> (failed).png".
+    const path =
+      "/home/dev/code/metabase/cypress/screenshots/create.cy.spec.js/scenarios  models  create -- user without a collection access should still be able to create and save a model in his own personal collection (failed).png";
+    expect(
+      resolveScreenshotPath(
+        [
+          "scenarios > models > create",
+          "user without a collection access should still be able to create and save a model in his own personal collection",
+        ],
+        shots(path),
+      ),
+    ).toBe(path);
+  });
+
+  it("excludes manual screenshots (no `(failed)` anchor)", () => {
+    // A manual cy.screenshot() is named "<title>.png" — no "(failed)".
+    const manual = "/x/a -- renders the chart.png";
+    expect(
+      resolveScreenshotPath(["a", "renders the chart"], shots(manual)),
+    ).toBeUndefined();
+  });
+
+  it("picks the first attempt over its retry", () => {
+    const first = "/x/a -- flaky (failed).png";
+    const retry = "/x/a -- flaky (failed) (attempt 2).png";
+    expect(resolveScreenshotPath(["a", "flaky"], shots(retry, first))).toBe(
+      first,
+    );
+  });
+
+  it("anchors on `(failed)`, so a prefix title can't steal a longer test's shot", () => {
+    const shortShot = "/x/a -- loads (failed).png";
+    const longShot = "/x/a -- loads quickly (failed).png";
+    // "loads" anchors on "loadsfailed"; "loadsquickly…" can't match it.
+    expect(
+      resolveScreenshotPath(["a", "loads"], shots(longShot, shortShot)),
+    ).toBe(shortShot);
+    expect(
+      resolveScreenshotPath(["a", "loads quickly"], shots(longShot, shortShot)),
+    ).toBe(longShot);
+  });
+});
+
+describe("reportFailedTestsToConductor", () => {
+  const url = "https://conductor.example";
+  const endpoint = "https://conductor.example/webhooks/failed-tests";
+  const oneTest = [{ name: "a test", file: "foo.cy.spec.ts" }];
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({ ok: true, status: 200, statusText: "OK" });
+  });
+
+  it("no-ops when the base URL is not configured", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_BASE_URL: undefined,
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when there are no failures to report", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_BASE_URL: url,
+    });
+
+    await reportFailedTestsToConductor([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("POSTs the failures with parsed numeric ids and forwarded tests", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_BASE_URL: url,
+      REPO_ID: "123",
+      GITHUB_RUN_ID: "456",
+      GITHUB_RUN_ATTEMPT: "2",
+      // Cleared explicitly: the resolve-job-id action exports a real JOB_ID to
+      // $GITHUB_ENV, so on CI this var is present in the ambient process env.
+      // This case asserts the null-job_id path, so it must not inherit it.
+      JOB_ID: undefined,
+      CYPRESS_RETRIES: "1",
+      COMMIT_SHA: "abc123",
+      TARGET_BRANCH: "master",
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [calledUrl, options] = mockFetch.mock.calls[0];
+    expect(calledUrl).toBe(endpoint);
+    expect(options.method).toBe("POST");
+    expect(options.headers).toMatchObject({
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(options.body)).toEqual({
+      repo_id: 123,
+      run_id: 456,
+      attempt: 2,
+      job_id: null,
+      test_suite: "e2e",
+      sha: "abc123",
+      target_branch: "master",
+      retries: 1,
+      tests: oneTest,
+    });
+  });
+
+  it("prefers COMMIT_SHA/TARGET_BRANCH but falls back to the ambient GITHUB_* vars", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_BASE_URL: url,
+      COMMIT_SHA: undefined,
+      GITHUB_SHA: "ambient-sha",
+      TARGET_BRANCH: undefined,
+      GITHUB_BASE_REF: "ambient-branch",
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.sha).toBe("ambient-sha");
+    expect(body.target_branch).toBe("ambient-branch");
+  });
+
+  it("sends null attempt, sha, target_branch, and retries when their envs are missing", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_BASE_URL: url,
+      GITHUB_RUN_ATTEMPT: undefined,
+      CYPRESS_RETRIES: undefined,
+      COMMIT_SHA: undefined,
+      GITHUB_SHA: undefined,
+      TARGET_BRANCH: undefined,
+      GITHUB_BASE_REF: undefined,
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.attempt).toBeNull();
+    expect(body.retries).toBeNull();
+    expect(body.sha).toBeNull();
+    expect(body.target_branch).toBeNull();
+  });
+
+  it("sends the x-internal-secret header when the secret is configured", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_BASE_URL: url,
+      CI_CONDUCTOR_WEBHOOK_SECRET: "s3cr3t",
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+
+    expect(mockFetch.mock.calls[0][1].headers).toMatchObject({
+      "x-internal-secret": "s3cr3t",
+    });
+  });
+
+  it("omits the secret header when no secret is configured", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_BASE_URL: url,
+      CI_CONDUCTOR_WEBHOOK_SECRET: undefined,
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+
+    expect(mockFetch.mock.calls[0][1].headers).not.toHaveProperty(
+      "x-internal-secret",
+    );
+  });
+
+  it("appends the endpoint regardless of a trailing slash on the base URL", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_BASE_URL: `${url}/`,
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+    expect(mockFetch.mock.calls[0][0]).toBe(endpoint);
+  });
+
+  it("uses JOB_ID env when set (populated by the resolve-job-id action)", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_BASE_URL: url,
+      JOB_ID: "789",
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body).job_id).toBe(789);
+  });
+
+  it("sends a null job_id when JOB_ID is missing or non-numeric", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_BASE_URL: url,
+      JOB_ID: "not-a-number",
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body).job_id).toBeNull();
+  });
+
+  it("sends null ids when the env vars are missing or non-numeric", async () => {
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_BASE_URL: url,
+      REPO_ID: undefined,
+      GITHUB_RUN_ID: "not-a-number",
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.repo_id).toBeNull();
+    expect(body.run_id).toBeNull();
+  });
+
+  it("never throws when the request fails", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch.mockRejectedValue(new Error("network down"));
+
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_BASE_URL: url,
+    });
+
+    await expect(
+      reportFailedTestsToConductor(oneTest),
+    ).resolves.toBeUndefined();
+    expect(console.error).toHaveBeenCalled();
+    (console.error as jest.Mock).mockRestore();
+  });
+
+  it("logs the payload and does not POST in dry-run mode", async () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_DRY_RUN: "true",
+      CI_CONDUCTOR_BASE_URL: url,
+      REPO_ID: "123",
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("dry run"),
+      expect.stringContaining('"repo_id":123'),
+    );
+    logSpy.mockRestore();
+  });
+
+  it("logs in dry-run mode even when no base URL is configured", async () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_DRY_RUN: "true",
+      CI_CONDUCTOR_BASE_URL: undefined,
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
+  it("logs but does not throw on a non-ok response", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_BASE_URL: url,
+    });
+
+    await reportFailedTestsToConductor(oneTest);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("500"));
+    (console.error as jest.Mock).mockRestore();
+  });
+
+  it("inlines a resolved screenshot as base64 and drops screenshotPath", async () => {
+    const fs = await import("node:fs");
+    const os = await import("node:os");
+    const pathMod = await import("node:path");
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]); // PNG magic
+    const file = pathMod.join(os.tmpdir(), "ci-conductor-shot.png");
+    fs.writeFileSync(file, bytes);
+    try {
+      const { reportFailedTestsToConductor } = await loadConductor({
+        CI_CONDUCTOR_BASE_URL: url,
+      });
+      await reportFailedTestsToConductor([
+        { name: "t", file: "f.cy.spec.ts", screenshotPath: file },
+      ]);
+      const sent = JSON.parse(mockFetch.mock.calls[0][1].body).tests[0];
+      expect(sent.failure_screenshot).toBe(
+        `data:image/png;base64,${bytes.toString("base64")}`,
+      );
+      expect(sent).not.toHaveProperty("screenshotPath");
+    } finally {
+      fs.unlinkSync(file);
+    }
+  });
+
+  it("omits the screenshot (and screenshotPath) when the file can't be read", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_BASE_URL: url,
+    });
+
+    await reportFailedTestsToConductor([
+      { name: "t", file: "f.cy.spec.ts", screenshotPath: "/no/such/file.png" },
+    ]);
+
+    const sent = JSON.parse(mockFetch.mock.calls[0][1].body).tests[0];
+    expect(sent).not.toHaveProperty("failure_screenshot");
+    expect(sent).not.toHaveProperty("screenshotPath");
+    // The read failure is logged (best-effort), not thrown.
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("failed to read screenshot"),
+      "/no/such/file.png",
+      expect.anything(),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("never throws even when fetch throws synchronously", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch.mockImplementation(() => {
+      throw new Error("synchronous boom");
+    });
+
+    const { reportFailedTestsToConductor } = await loadConductor({
+      CI_CONDUCTOR_BASE_URL: url,
+    });
+
+    await expect(
+      reportFailedTestsToConductor(oneTest),
+    ).resolves.toBeUndefined();
+    expect(console.error).toHaveBeenCalled();
+    (console.error as jest.Mock).mockRestore();
+  });
+});
+
+describe("recordFailedTestsForQuarantine", () => {
+  const failuresFile = join(tmpdir(), `q-failures-${process.pid}.jsonl`);
+
+  afterEach(() => {
+    if (existsSync(failuresFile)) {
+      rmSync(failuresFile);
+    }
+  });
+
+  // The recorder reads QUARANTINE_FAILURES_FILE at import time, so point it at
+  // a temp file by re-importing the module with that env applied.
+  const load = () => loadConductor({ QUARANTINE_FAILURES_FILE: failuresFile });
+
+  const readLines = () =>
+    readFileSync(failuresFile, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+
+  it("records only ultimate failures (not flakes or passes), one per line", async () => {
+    const { recordFailedTestsForQuarantine } = await load();
+
+    const results = makeResults({
+      tests: [
+        test(["scenarios > foo", "passes"], ["passed"]),
+        test(["scenarios > foo", "flakes then passes"], ["failed", "passed"]),
+        test(["scenarios > foo", "stays broken"], ["failed", "failed"], "boom"),
+      ],
+    });
+
+    recordFailedTestsForQuarantine(extractFailedTests(spec, results));
+
+    expect(readLines()).toEqual([
+      {
+        test_name: "stays broken",
+        test_path: "scenarios > foo",
+        file_path: "e2e/test/scenarios/foo/foo.cy.spec.ts",
+      },
+    ]);
+  });
+
+  it("appends across calls so the whole job's failures accumulate", async () => {
+    const { recordFailedTestsForQuarantine } = await load();
+
+    recordFailedTestsForQuarantine(
+      extractFailedTests(
+        spec,
+        makeResults({ tests: [test(["A", "one"], ["failed", "failed"], "x")] }),
+      ),
+    );
+    recordFailedTestsForQuarantine(
+      extractFailedTests(
+        spec,
+        makeResults({ tests: [test(["B", "two"], ["failed", "failed"], "y")] }),
+      ),
+    );
+
+    expect(readLines().map((t) => t.test_name)).toEqual(["one", "two"]);
+  });
+
+  it("writes nothing when there are no ultimate failures", async () => {
+    const { recordFailedTestsForQuarantine } = await load();
+
+    recordFailedTestsForQuarantine(
+      extractFailedTests(
+        spec,
+        makeResults({
+          tests: [
+            test(["A", "ok"], ["passed"]),
+            test(["A", "flaky"], ["failed", "passed"]),
+          ],
+        }),
+      ),
+    );
+
+    expect(existsSync(failuresFile)).toBe(false);
+  });
+
+  it("never throws when the file can't be written", async () => {
+    // A NUL byte in the path makes the fs calls throw; the recorder must swallow it.
+    const { recordFailedTestsForQuarantine } = await loadConductor({
+      QUARANTINE_FAILURES_FILE: "/tmp/\0/nope.jsonl",
+    });
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() =>
+      recordFailedTestsForQuarantine([
+        {
+          name: "n",
+          path: "p",
+          file: "f",
+          status: "failure",
+          attempts: [{ state: "failed" }],
+        },
+      ] as Parameters<typeof recordFailedTestsForQuarantine>[0]),
+    ).not.toThrow();
+
+    (console.error as jest.Mock).mockRestore();
+  });
+});

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -7,6 +7,11 @@ import installLogsPrinter from "cypress-terminal-report/src/installLogsPrinter";
 
 import { BACKEND_HOST, BACKEND_PORT } from "../runner/constants/backend-port";
 
+import {
+  extractFailedTests,
+  recordFailedTestsForQuarantine,
+  reportFailedTestsToConductor,
+} from "./ci_conductor";
 import * as ciTasks from "./ci_tasks";
 import { collectFailingTests } from "./collectFailedTests";
 import {
@@ -159,9 +164,33 @@ const defaultConfig = {
       collectFailingTests(on, config);
     }
 
-    // this is an official workaround to keep recordings of the failed specs only
-    // https://docs.cypress.io/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests
-    on("after:spec", (spec, results) => {
+    // Surface the resolved Cypress retry ceiling so the ci-conductor reporter
+    // can include it in the payload (CYPRESS_RETRIES isn't otherwise set in CI;
+    // the value lives in mainConfig.retries.runMode). DEV-1999.
+    const resolvedRetries =
+      typeof config.retries === "number"
+        ? config.retries
+        : (config.retries?.runMode ?? 0);
+    process.env.CYPRESS_RETRIES = String(resolvedRetries);
+
+    on("after:spec", async (spec, results) => {
+      // Report failures to ci-conductor mid-run (no-ops unless configured).
+      if (isCI) {
+        // Reporting to ci-conductor must NEVER break the test run, so this is
+        // a hard backstop around everything — extraction, payload build, and
+        // the request. The reporter also handles its own errors internally.
+        try {
+          const failedTests = extractFailedTests(spec, results);
+          // Persist ultimate failures for the post-run quarantine gate (DEV-2082).
+          recordFailedTestsForQuarantine(failedTests);
+          await reportFailedTestsToConductor(failedTests);
+        } catch (error) {
+          console.error("[ci-conductor] reporting failed (ignored)", error);
+        }
+      }
+
+      // this is an official workaround to keep recordings of the failed specs only
+      // https://docs.cypress.io/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests
       if (results && results.video) {
         // Do we have test failures?
         if (results && results.video && results.stats.failures === 0) {

--- a/jest.config.js
+++ b/jest.config.js
@@ -101,7 +101,12 @@ const baseConfig = {
 
 /** @type {import('jest').Config} */
 const config = {
-  reporters: ["default", "jest-junit"],
+  // `addFileAttribute` makes jest-junit emit the source path as a `file`
+  // attribute on each <testcase>. Additive — it leaves classname/name untouched,
+  // so Trunk's existing test identity is preserved — and it lets both Trunk
+  // (codeowners/file attribution) and the ci-conductor reporter resolve a real
+  // source file. Output dir/name come from the JEST_JUNIT_OUTPUT_* env vars.
+  reporters: ["default", ["jest-junit", { addFileAttribute: "true" }]],
   coverageReporters: ["html", "lcov"],
   watchPlugins: [
     "jest-watch-typeahead/filename",

--- a/release/ci-conductor/bun.lock
+++ b/release/ci-conductor/bun.lock
@@ -1,0 +1,25 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "ci-conductor",
+      "devDependencies": {
+        "@types/bun": "^1.3.14",
+        "@types/node": "^22.10.0",
+        "typescript": "^5.9.3",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@22.20.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+  }
+}

--- a/release/ci-conductor/package.json
+++ b/release/ci-conductor/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "ci-conductor",
+  "version": "1.0.0",
+  "description": "Shared CI Conductor test-failure reporting. Adapter pattern: each test suite (be/fe/e2e) transforms its source data into one canonical shape, and the shared core posts it to ci-conductor. This round ships the backend (JUnit) adapter + the /webhooks/failed-tests transport.",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "bun test",
+    "type-check": "tsc --noEmit"
+  },
+  "author": "Metabase",
+  "license": "AGPL-3.0-or-later",
+  "devDependencies": {
+    "@types/bun": "^1.3.14",
+    "@types/node": "^22.10.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/release/ci-conductor/src/adapters/backend.ts
+++ b/release/ci-conductor/src/adapters/backend.ts
@@ -1,0 +1,45 @@
+// Backend (Clojure/hawk) adapter: hawk's JUnit XML → NormalizedTest[].
+//
+// hawk always writes JUnit XML to `target/junit/`, so the backend "collector"
+// is a post-run scan of that artifact (one runner, one artifact, covering both
+// the backend and driver CI paths). The XML parsing itself is shared
+// (`../junit.ts`); this owns the backend-specific parts — hawk's `*_test.xml`
+// file layout — while the suite label is supplied by the entrypoint.
+
+import { readFileSync } from "node:fs";
+
+import type { NormalizedTest } from "../contract.ts";
+import { findJunitFiles, parseJunit } from "../junit.ts";
+import { log } from "../util.ts";
+
+const JUNIT_DIR = process.env.JUNIT_DIR || "target/junit";
+
+/** hawk always names its JUnit files `*_test.xml`. */
+const selectHawkJunit = (entries: string[]): string[] =>
+  entries.filter((entry) => entry.endsWith("_test.xml"));
+
+/**
+ * Normalize every JUnit file hawk wrote under `dir` into `NormalizedTest[]` —
+ * the source-specific half of the adapter pattern (hawk XML → the shared
+ * normalized shape).
+ */
+export function normalizeBackendJunit(
+  dir: string = JUNIT_DIR,
+): NormalizedTest[] {
+  const files = findJunitFiles(dir, selectHawkJunit);
+  const failures = files.flatMap((file) => {
+    try {
+      return parseJunit(readFileSync(file, "utf8"));
+    } catch (error) {
+      console.error(`[ci-conductor] failed to read ${file}`, error);
+      return [];
+    }
+  });
+  log(
+    `scanned ${dir}: ${files.length} JUnit file(s), ${failures.length} failing test(s)`,
+  );
+  for (const test of failures) {
+    log(`  failing: ${test.path || "(no namespace)"} / ${test.name}`);
+  }
+  return failures;
+}

--- a/release/ci-conductor/src/adapters/frontend.ts
+++ b/release/ci-conductor/src/adapters/frontend.ts
@@ -1,0 +1,68 @@
+// Frontend (jest) adapter: jest-junit's JUnit XML → NormalizedTest[].
+//
+// jest-junit writes a single JUnit file per job, its location given by jest's
+// own `JEST_JUNIT_OUTPUT_DIR` / `JEST_JUNIT_OUTPUT_NAME` env contract (the
+// `frontend.yml` job sets both). So the frontend "collector" is a post-run read
+// of that one file. The XML parsing itself is shared (`../junit.ts`); this owns
+// the frontend-specific parts — where jest-junit drops its file — while the
+// suite label is supplied by the entrypoint.
+//
+// Two jest-junit details that mean there's nothing to massage here:
+//   - it already strips ANSI colour codes from failure bodies, so messages
+//     arrive plain (unlike a raw jest console dump);
+//   - it entity-escapes (rather than CDATA-wraps) those bodies, which
+//     `parseJunit`'s `elementBody` already decodes.
+//
+// FILE / IDENTITY NOTE: `jest.config.js` sets jest-junit's `addFileAttribute`,
+// so each <testcase> carries the source path as a `file` attribute, which the
+// shared parser surfaces as `file_path`. We deliberately leave jest-junit's
+// `classname`/`name` on their defaults (the same `{ancestors} {title}` blob in
+// both) rather than re-template them: that artifact is also what Trunk ingests,
+// and changing those fields would re-baseline its test identity. So `test_path`
+// and `test_name` carry that blob (redundant but a stable, unique key) and
+// identity is (test_suite, test_path, test_name, file_path).
+
+import { readFileSync } from "node:fs";
+
+import type { NormalizedTest } from "../contract.ts";
+import { findJunitFiles, parseJunit } from "../junit.ts";
+import { log } from "../util.ts";
+
+const JUNIT_DIR = process.env.JEST_JUNIT_OUTPUT_DIR || "target/junit";
+const JUNIT_NAME = process.env.JEST_JUNIT_OUTPUT_NAME || "junit.xml";
+
+/**
+ * Pick jest-junit's output from a directory listing by the exact name its env
+ * contract sets (`JEST_JUNIT_OUTPUT_NAME`). An empty match means nothing to
+ * report.
+ */
+function selectJestJunit(name: string): (entries: string[]) => string[] {
+  return (entries) => entries.filter((entry) => entry.endsWith(name));
+}
+
+/**
+ * Normalize the JUnit file(s) jest-junit wrote under `dir` into
+ * `NormalizedTest[]` — the source-specific half of the adapter pattern
+ * (jest-junit XML → the shared normalized shape).
+ */
+export function normalizeFrontendJunit(
+  dir: string = JUNIT_DIR,
+  name: string = JUNIT_NAME,
+): NormalizedTest[] {
+  const files = findJunitFiles(dir, selectJestJunit(name));
+  const failures = files.flatMap((file) => {
+    try {
+      return parseJunit(readFileSync(file, "utf8"));
+    } catch (error) {
+      console.error(`[ci-conductor] failed to read ${file}`, error);
+      return [];
+    }
+  });
+  log(
+    `scanned ${dir}: ${files.length} JUnit file(s), ${failures.length} failing test(s)`,
+  );
+  for (const test of failures) {
+    log(`  failing: ${test.path || "(no describe path)"} / ${test.name}`);
+  }
+  return failures;
+}

--- a/release/ci-conductor/src/check-backend-quarantine.ts
+++ b/release/ci-conductor/src/check-backend-quarantine.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env bun
+
+import { normalizeBackendJunit } from "./adapters/backend.ts";
+import {
+  applyQuarantineGate,
+  junitFailuresToFailedTests,
+} from "./quarantine.ts";
+import { log } from "./util.ts";
+
+async function main(): Promise<void> {
+  log("backend quarantine gate starting");
+  const env = process.env;
+  const suite =
+    env.CI_CONDUCTOR_TEST_SUITE ||
+    (env.DRIVERS ? `driver-${env.DRIVERS}` : "backend");
+  await applyQuarantineGate({
+    suite,
+    failures: junitFailuresToFailedTests(normalizeBackendJunit()),
+    baseUrl: env.CI_CONDUCTOR_BASE_URL,
+    secret: env.CI_CONDUCTOR_WEBHOOK_SECRET,
+    dryRun: env.QUARANTINE_DRY_RUN !== "false",
+  });
+}
+
+main().catch((error) => {
+  // Last line of defense: the gate must never throw into the job.
+  console.error(
+    "[ci-conductor] backend quarantine gate failed (ignored)",
+    error,
+  );
+});

--- a/release/ci-conductor/src/check-e2e-quarantine.ts
+++ b/release/ci-conductor/src/check-e2e-quarantine.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env bun
+
+import { readFileSync } from "node:fs";
+
+import { type FailedTest, applyQuarantineGate } from "./quarantine.ts";
+import { log } from "./util.ts";
+
+const {
+  CI_CONDUCTOR_BASE_URL,
+  CI_CONDUCTOR_WEBHOOK_SECRET,
+  CI_CONDUCTOR_TEST_SUITE,
+  // Default to a dry run: compute and print the verdict, but never fail the job.
+  QUARANTINE_DRY_RUN,
+  QUARANTINE_FAILURES_FILE,
+} = process.env;
+
+const isDryRun = QUARANTINE_DRY_RUN !== "false";
+
+// ci-conductor keys its quarantine list by suite; e2e reports under "e2e".
+const TEST_SUITE = CI_CONDUCTOR_TEST_SUITE || "e2e";
+
+const failuresFile =
+  QUARANTINE_FAILURES_FILE ?? "./target/quarantine-failures.jsonl";
+
+/** Read the run's ultimate failures from the JSONL file after:spec appended. */
+function readFailedTests(file: string): FailedTest[] {
+  let raw: string;
+  try {
+    raw = readFileSync(file, "utf8");
+  } catch {
+    log(`no failures file at ${file}; nothing to gate.`);
+    return [];
+  }
+
+  return raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "")
+    .map((line): FailedTest | null => {
+      try {
+        return JSON.parse(line) as FailedTest;
+      } catch {
+        log(`skipping unparseable line: ${line}`);
+        return null;
+      }
+    })
+    .filter((test): test is FailedTest => test !== null);
+}
+
+async function main(): Promise<void> {
+  await applyQuarantineGate({
+    suite: TEST_SUITE,
+    failures: readFailedTests(failuresFile),
+    baseUrl: CI_CONDUCTOR_BASE_URL,
+    secret: CI_CONDUCTOR_WEBHOOK_SECRET,
+    dryRun: isDryRun,
+  });
+}
+
+// Only run when invoked directly (`bun src/check-e2e-quarantine.ts`), not on import.
+if (import.meta.main) {
+  main().catch((error) => {
+    // Last line of defense: the gate must never throw into the job.
+    console.error("[ci-conductor] e2e quarantine gate failed (ignored)", error);
+  });
+}

--- a/release/ci-conductor/src/check-frontend-quarantine.ts
+++ b/release/ci-conductor/src/check-frontend-quarantine.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env bun
+
+import { normalizeFrontendJunit } from "./adapters/frontend.ts";
+import {
+  applyQuarantineGate,
+  junitFailuresToFailedTests,
+} from "./quarantine.ts";
+import { log } from "./util.ts";
+
+async function main(): Promise<void> {
+  log("frontend quarantine gate starting");
+  const env = process.env;
+  const suite = env.CI_CONDUCTOR_TEST_SUITE || "frontend";
+  await applyQuarantineGate({
+    suite,
+    failures: junitFailuresToFailedTests(normalizeFrontendJunit()),
+    baseUrl: env.CI_CONDUCTOR_BASE_URL,
+    secret: env.CI_CONDUCTOR_WEBHOOK_SECRET,
+    dryRun: env.QUARANTINE_DRY_RUN !== "false",
+  });
+}
+
+main().catch((error) => {
+  // Last line of defense: the gate must never throw into the job.
+  console.error(
+    "[ci-conductor] frontend quarantine gate failed (ignored)",
+    error,
+  );
+});

--- a/release/ci-conductor/src/contract.ts
+++ b/release/ci-conductor/src/contract.ts
@@ -1,0 +1,68 @@
+// The normalized shape every adapter produces and every consumer reads.
+//
+// THE AGREEMENT of the adapter pattern: each suite's normalizer
+// (`normalizeBackendJunit` / `normalizeFrontendJunit` / `normalizeCypressFailure`)
+// turns its source-specific data into `NormalizedTest[]`, and BOTH downstream
+// consumers — `reportTestFailures` (the POST) and, later,
+// `checkFailuresAgainstQuarantine` (the gate) — read that exact shape. They MUST
+// agree on it: if a test's normalized identity differs between the report path
+// and the quarantine path, a failure reported under one name won't match its
+// quarantine entry under another. Keeping the shape here, in one place, is what
+// prevents that drift.
+//
+// This mirrors ci-conductor's own contract (server repo `origin/dev`:
+// `server/src/webhookTypes.ts` `FailedTestsBody` + `lib/failedTests.ts`
+// `resolveTestRow`) — a *superset of mostly-optional* fields, resolved
+// server-side per-test → body → column default. So each adapter emits only what
+// it truthfully observes (the backend has no per-attempt data; it leaves
+// `attempts` absent) and the server fills the rest.
+//
+// NOTE: runtime validation (zod/valibot) is a deliberate, close follow-up. For
+// now the shape is enforced by these types only.
+
+/**
+ * One reportable test. The backend (JUnit) normalizer only ever emits
+ * `name`/`path`/`file`/`message`/`stack`/`status`; the richer fields
+ * (`duration`/`attempts`/`failure_screenshot`) exist for the e2e and fe
+ * normalizers that land in later rounds. Field names match the wire contract
+ * consumed by ci-conductor's `ingestFailedTests` (`path` → test_path, `file` →
+ * file_path, `stack` → stack_trace).
+ */
+export type NormalizedTest = {
+  name: string;
+  /** Joined suite/`describe` path. Maps to the server's `test_path`. */
+  path?: string | null;
+  /** Source file. Maps to the server's `file_path`. */
+  file?: string | null;
+  message?: string | null;
+  stack?: string | null;
+  /** Defaults to "failure" server-side when absent. */
+  status?: "failure" | "flake" | "passed";
+  duration?: number;
+  /** Raw per-attempt states, e.g. `[{state:"failed"},{state:"passed"}]`. */
+  attempts?: { state: string }[];
+  /** Base64 PNG data URI; ci-conductor uploads it and stores the URL. */
+  failure_screenshot?: string;
+};
+
+/**
+ * Run-level context shared by every test in a post, resolved once from the CI
+ * environment (see `resolveRunContext` in `transport.ts`). `test_suite` is the
+ * per-job identity discriminator. `repo_id`/`run_id`/`job_id` are GitHub
+ * *numeric* IDs (FKs in ci-conductor), null when unresolved (all nullable
+ * server-side).
+ */
+export type RunContext = {
+  repo_id: number | null;
+  run_id: number | null;
+  job_id: number | null;
+  attempt: number | null;
+  test_suite: string;
+  sha: string | null;
+  target_branch: string | null;
+};
+
+/** The full request body: run-level context plus the batch of tests. */
+export type FailedTestsBody = RunContext & {
+  tests: NormalizedTest[];
+};

--- a/release/ci-conductor/src/junit.test.ts
+++ b/release/ci-conductor/src/junit.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "bun:test";
+
+import { parseJunit } from "./junit.ts";
+
+// A real hawk failure body: first line is `file.clj:line`, then context, then
+// the expected/actual assertion. Two <failure>s under one <testcase>.
+const TWO_FAILURES = `<?xml version='1.0' encoding='UTF-8'?>
+<testsuite name="metabase.agent-lib.representations.repair-test" time="0.039" tests="2" errors="0" failures="2">
+<testcase classname="metabase.agent-lib.representations.repair-test" name="idempotency-unwrapped-boolean-wrapper-test" time="0.033" assertions="2">
+<failure>
+<![CDATA[
+repair_test.clj:1184
+unwrapping a boolean wrapper stays idempotent
+expected: (= [["x" {}]] once)
+  actual: (not (= [["x" {}]] ["x"]))
+]]>
+</failure>
+<failure>
+<![CDATA[
+repair_test.clj:1186
+and the result is a fixed point
+expected: (= once (repair/repair trivial-mp once))
+  actual: (not (= ["x"] ["x" {}]))
+]]>
+</failure>
+</testcase>
+</testsuite>`;
+
+// Test names routinely contain unescaped `>`/`<` (Clojure thread arrows `->`,
+// comparison preds `>=`; a JS title like "renders > when open"). A JUnit
+// producer emits them verbatim in the `name` attribute, and XML allows an
+// unescaped `>` inside an attribute value. The parser must not let that `>`
+// terminate the tag. Regression for DEV-2224 (these were silently dropped: the
+// testcase parsed with an empty name and got skipped).
+const ANGLE_BRACKET_NAMES = `<?xml version='1.0' encoding='UTF-8'?>
+<testsuite name="metabase.util.cron-test" time="0.063" tests="2" errors="0" failures="2">
+<testcase classname="metabase.util.cron-test" name="cron-string->schedule-map-test" time="0.03" assertions="1">
+<failure>
+<![CDATA[
+cron_test.clj:65
+nope
+]]>
+</failure>
+</testcase>
+<testcase classname="metabase.util.cron-test" name="schedule-map->cron-string-test" time="0.03" assertions="1">
+<failure>
+<![CDATA[
+cron_test.clj:12
+also nope
+]]>
+</failure>
+</testcase>
+</testsuite>`;
+
+// A passing testcase (self-closing) mixed with an errored one in the same suite.
+const PASS_AND_ERROR = `<?xml version='1.0' encoding='UTF-8'?>
+<testsuite name="metabase.foo-test" tests="2" errors="1" failures="0">
+<testcase classname="metabase.foo-test" name="passing-test" time="0.01" assertions="1"/>
+<testcase classname="metabase.foo-test" name="erroring-test" time="0.02">
+<error>
+<![CDATA[
+foo_test.clj:42
+boom
+java.lang.RuntimeException: boom
+]]>
+</error>
+</testcase>
+</testsuite>`;
+
+// Two suites in one document (defensive: also covers a <testsuites> wrapper,
+// since we scan testcases regardless of nesting).
+const TWO_SUITES = `<?xml version='1.0' encoding='UTF-8'?>
+<testsuites>
+<testsuite name="metabase.a-test" tests="1" failures="1">
+<testcase classname="metabase.a-test" name="a" time="0.01">
+<failure><![CDATA[a_test.clj:1
+nope
+]]></failure>
+</testcase>
+</testsuite>
+<testsuite name="metabase.b-test" tests="1" failures="1">
+<testcase classname="metabase.b-test" name="b" time="0.01">
+<failure><![CDATA[b_test.clj:2
+also nope
+]]></failure>
+</testcase>
+</testsuite>
+</testsuites>`;
+
+// hawk with the `message` attribute (https://github.com/metabase/hawk/pull/49):
+// the failure carries a first-class `message`, and the body still holds the
+// file:line locator + full assertion. The parser must prefer the attribute.
+const FAILURE_WITH_MESSAGE = `<?xml version='1.0' encoding='UTF-8'?>
+<testsuite name="metabase.foo-test" tests="1" errors="0" failures="1">
+<testcase classname="metabase.foo-test" name="bar-test" time="0.01" assertions="1">
+<failure message="expected: (= 1 2)">
+<![CDATA[
+foo_test.clj:42
+expected: (= 1 2)
+  actual: (not (= 1 2))
+]]>
+</failure>
+</testcase>
+</testsuite>`;
+
+// hawk emits `message` on <error> too, alongside the `type` attribute (the
+// :error branch of write-assertion-result!* in hawk PR #49). The parser must
+// read the message off an <error> the same as a <failure>, ignoring `type`.
+const ERROR_WITH_MESSAGE = `<?xml version='1.0' encoding='UTF-8'?>
+<testsuite name="metabase.foo-test" tests="1" errors="1" failures="0">
+<testcase classname="metabase.foo-test" name="boom-test" time="0.01">
+<error type="clojure.lang.ExceptionInfo" message="boom">
+<![CDATA[
+foo_test.clj:99
+java.lang.RuntimeException: boom
+]]>
+</error>
+</testcase>
+</testsuite>`;
+
+// jest-junit with `addFileAttribute: "true"` emits a `file` attribute holding
+// the source path, plus an entity-escaped (non-CDATA) failure body. The parser
+// must surface that path as `file` and decode the body.
+const JEST_WITH_FILE = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="jest tests" tests="1" failures="1">
+<testsuite name="Button" failures="1" tests="1">
+<testcase classname="Button when open renders &gt; the label" name="Button when open renders &gt; the label" time="0.012" file="frontend/src/metabase/components/Button/Button.unit.spec.tsx">
+<failure>Error: expect(received).toBe(expected)
+
+    at Button.unit.spec.tsx:42:18</failure>
+</testcase>
+</testsuite>
+</testsuites>`;
+
+describe("parseJunit", () => {
+  it("prefers the failure `message` attribute over the body", () => {
+    const [test] = parseJunit(FAILURE_WITH_MESSAGE);
+    expect(test.message).toBe("expected: (= 1 2)");
+    // The full trace, including the locator, stays in the stack.
+    expect(test.stack).toContain("foo_test.clj:42");
+  });
+
+  it("reads the `message` attribute off an <error>, ignoring `type`", () => {
+    const [test] = parseJunit(ERROR_WITH_MESSAGE);
+    expect(test.message).toBe("boom");
+    expect(test.status).toBe("failure");
+    expect(test.stack).toContain("java.lang.RuntimeException: boom");
+  });
+
+  it("collapses multiple <failure>s in one testcase into a single entry", () => {
+    const tests = parseJunit(TWO_FAILURES);
+    expect(tests).toHaveLength(1);
+    const [test] = tests;
+    expect(test.name).toBe("idempotency-unwrapped-boolean-wrapper-test");
+    expect(test.path).toBe("metabase.agent-lib.representations.repair-test");
+    // file_path is intentionally null — backend identity is (suite, path, name).
+    expect(test.file).toBeNull();
+    expect(test.status).toBe("failure");
+    // No `message` attribute on the <failure> => null (we don't guess from the
+    // body; its first line is the file:line locator, not a message).
+    expect(test.message).toBeNull();
+    // The stack carries both failures.
+    expect(test.stack).toContain("repair_test.clj:1184");
+    expect(test.stack).toContain("repair_test.clj:1186");
+  });
+
+  it("parses test names containing unescaped angle brackets (Clojure `->`)", () => {
+    const tests = parseJunit(ANGLE_BRACKET_NAMES);
+    expect(tests.map((t) => t.name).sort()).toEqual([
+      "cron-string->schedule-map-test",
+      "schedule-map->cron-string-test",
+    ]);
+    expect(tests.every((t) => t.path === "metabase.util.cron-test")).toBe(true);
+    expect(tests.every((t) => t.status === "failure")).toBe(true);
+  });
+
+  it("reports errored tests as failures and skips passing tests", () => {
+    const tests = parseJunit(PASS_AND_ERROR);
+    expect(tests).toHaveLength(1);
+    expect(tests[0].name).toBe("erroring-test");
+    expect(tests[0].file).toBeNull();
+    expect(tests[0].status).toBe("failure");
+    expect(tests[0].stack).toContain("java.lang.RuntimeException: boom");
+  });
+
+  it("handles multiple suites / a <testsuites> wrapper", () => {
+    const tests = parseJunit(TWO_SUITES);
+    expect(tests.map((t) => t.name).sort()).toEqual(["a", "b"]);
+    expect(tests.map((t) => t.path).sort()).toEqual([
+      "metabase.a-test",
+      "metabase.b-test",
+    ]);
+  });
+
+  it("surfaces the testcase `file` attribute as file_path (frontend/jest)", () => {
+    const tests = parseJunit(JEST_WITH_FILE);
+    expect(tests).toHaveLength(1);
+    const [test] = tests;
+    expect(test.file).toBe(
+      "frontend/src/metabase/components/Button/Button.unit.spec.tsx",
+    );
+    // The unescaped `>` in the title survives decoding.
+    expect(test.name).toBe("Button when open renders > the label");
+    // The <failure> has no `message` attribute, so message is null; the body
+    // text lands in `stack`.
+    expect(test.message).toBeNull();
+    expect(test.stack).toContain("Error: expect(received).toBe(expected)");
+    expect(test.status).toBe("failure");
+  });
+
+  it("returns [] for malformed XML without throwing", () => {
+    expect(parseJunit("<not-valid")).toEqual([]);
+  });
+
+  it("returns [] for a suite with only passing tests", () => {
+    const xml = `<testsuite name="metabase.ok-test" tests="1" failures="0">
+<testcase classname="metabase.ok-test" name="ok" time="0.01"/>
+</testsuite>`;
+    expect(parseJunit(xml)).toEqual([]);
+  });
+});

--- a/release/ci-conductor/src/junit.ts
+++ b/release/ci-conductor/src/junit.ts
@@ -1,0 +1,140 @@
+// The shared JUnit utilities: discover a producer's JUnit files in a directory
+// (`findJunitFiles`) and turn one file's `<testcase>`/`<failure>` document into
+// NormalizedTest[] (`parseJunit`). Format-level and producer-agnostic — both
+// the backend (hawk) and the frontend (jest-junit) adapters build on these. The
+// per-suite parts (which entries are this producer's files, how fields map, the
+// suite label) stay in `adapters/`. JUnit XML is simple, machine-generated
+// markup, so we parse it ourselves rather than pull in a dependency.
+
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import type { NormalizedTest } from "./contract.ts";
+
+/**
+ * List files under `dir` (recursively), keeping those `select` returns, as
+ * paths joined to `dir`. Each adapter passes the topical part — which entries
+ * are *its* JUnit files (hawk's `*_test.xml`, jest-junit's configured output
+ * name, ...). Returns [] on any IO error — a missing artifact directory is a
+ * no-op, not a failure (reporting is best-effort).
+ */
+export function findJunitFiles(
+  dir: string,
+  select: (entries: string[]) => string[],
+): string[] {
+  try {
+    const entries = readdirSync(dir, { recursive: true }).map(String);
+    return select(entries).map((entry) => join(dir, entry));
+  } catch {
+    return [];
+  }
+}
+
+/** Decode the XML entities a JUnit producer can emit in attribute values. */
+function decodeEntities(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+/** Read an attribute off an XML open-tag's attribute string. */
+function attr(attrs: string, name: string): string | undefined {
+  const match = attrs.match(new RegExp(`\\b${name}\\s*=\\s*"([^"]*)"`));
+  return match ? decodeEntities(match[1]) : undefined;
+}
+
+/** Unwrap CDATA / decode plain text from a failure/error body. */
+function elementBody(inner: string): string {
+  const cdata = [...inner.matchAll(/<!\[CDATA\[([\s\S]*?)\]\]>/g)].map((m) =>
+    m[1].trim(),
+  );
+  const text = cdata.length > 0 ? cdata.join("\n") : decodeEntities(inner);
+  return text.trim();
+}
+
+/**
+ * Parse one JUnit XML document into normalized entries — one per `<testcase>`
+ * that carries a `<failure>` or `<error>`. Multiple problems in a single
+ * testcase are joined into one `stack`. Passing (self-closing or problem-free)
+ * testcases are skipped. Never throws.
+ *
+ * Pure (string → normalized), so it's the unit-tested core that each suite's
+ * adapter wraps with its own file discovery / labeling.
+ */
+export function parseJunit(xml: string): NormalizedTest[] {
+  try {
+    const tests: NormalizedTest[] = [];
+    // <testcase ...>...</testcase> (failing) or <testcase .../> (passing,
+    // skipped). classname carries the namespace.
+    //
+    // Attribute blobs are matched as a run of quoted strings or non-quote chars
+    // (`ATTRS`) rather than `[^>]*`, because test names routinely contain an
+    // unescaped `>` (Clojure thread arrows `cron-string->schedule-map-test`,
+    // `>=`; a JS title like "renders > when open"), and XML doesn't require
+    // escaping `>` inside an attribute value. A naive `[^>]` stops at that `>`
+    // and silently drops the testcase (it parses with an empty name).
+    const ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+    const testcaseRe = new RegExp(
+      `<testcase\\b(${ATTRS}?)(?:/>|>([\\s\\S]*?)</testcase>)`,
+      "g",
+    );
+    const problemRe = new RegExp(
+      `<(failure|error)\\b(${ATTRS})>([\\s\\S]*?)</\\1>`,
+      "g",
+    );
+    for (const match of xml.matchAll(testcaseRe)) {
+      const attrs = match[1];
+      const inner = match[2];
+      if (!inner) {
+        continue; // self-closing => passed
+      }
+
+      const problems = [...inner.matchAll(problemRe)];
+      if (problems.length === 0) {
+        continue;
+      }
+
+      const name = (attr(attrs, "name") || "").trim();
+      if (name === "") {
+        continue;
+      }
+      const namespace = (attr(attrs, "classname") || "").trim();
+      // `file` is a standard (optional) JUnit testcase attribute. jest-junit
+      // emits it as the source path when `addFileAttribute: "true"` is set
+      // (the frontend path); hawk never writes one, so backend testcases parse
+      // to null — backend identity stays (test_suite, test_path, test_name).
+      const file = (attr(attrs, "file") || "").trim();
+
+      const stack = problems
+        .map((p) => elementBody(p[3]))
+        .filter((body) => body !== "")
+        .join("\n\n");
+      // The `message` attribute on the failure/error is the first-class source
+      // of the human-readable message. When it's absent we send null rather
+      // than guessing from the body — the body's first line is the `file:line`
+      // locator, not a message. The full trace stays in `stack`.
+      const message =
+        problems
+          .map((p) => attr(p[2], "message"))
+          .find((m) => m != null && m !== "") ?? null;
+
+      tests.push({
+        name,
+        path: namespace || undefined,
+        file: file || null,
+        message,
+        stack: stack || undefined,
+        // JUnit only tells us a test failed/errored, never that it recovered,
+        // so everything is "failure".
+        status: "failure",
+      });
+    }
+    return tests;
+  } catch (error) {
+    console.error("[ci-conductor] failed to parse JUnit XML", error);
+    return [];
+  }
+}

--- a/release/ci-conductor/src/quarantine.test.ts
+++ b/release/ci-conductor/src/quarantine.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "bun:test";
+
+import type { NormalizedTest } from "./contract.ts";
+import {
+  type FailedTest,
+  type GateResult,
+  type QuarantineEntry,
+  checkQuarantineGate,
+  compareFailedToQuarantine,
+  junitFailuresToFailedTests,
+  matchKey,
+} from "./quarantine.ts";
+
+const failed = (
+  test_name: string,
+  test_path: string | null = "Suite",
+  file_path: string | null = "e2e/test/foo.cy.spec.ts",
+): FailedTest => ({ test_name, test_path, file_path });
+
+const quarantined = (
+  test_name: string,
+  test_path = "Suite",
+  file_path = "e2e/test/foo.cy.spec.ts",
+): QuarantineEntry => ({ test_name, test_path, file_path, test_suite: "e2e" });
+
+describe("compareFailedToQuarantine", () => {
+  it("puts every failure in `unquarantined` when nothing is quarantined", () => {
+    const failures = [failed("a"), failed("b")];
+
+    const { quarantined: q, unquarantined } = compareFailedToQuarantine(
+      failures,
+      [],
+    );
+
+    expect(q).toEqual([]);
+    expect(unquarantined).toEqual(failures);
+  });
+
+  it("puts every failure in `quarantined` when all are listed", () => {
+    const failures = [failed("a"), failed("b")];
+
+    const { quarantined: q, unquarantined } = compareFailedToQuarantine(
+      failures,
+      [quarantined("a"), quarantined("b")],
+    );
+
+    expect(q).toEqual(failures);
+    expect(unquarantined).toEqual([]);
+  });
+
+  it("partitions a mixed set", () => {
+    const a = failed("a");
+    const b = failed("b");
+    const c = failed("c");
+
+    const { quarantined: q, unquarantined } = compareFailedToQuarantine(
+      [a, b, c],
+      [quarantined("a"), quarantined("c")],
+    );
+
+    expect(q).toEqual([a, c]);
+    expect(unquarantined).toEqual([b]);
+  });
+
+  it("returns two empty buckets for no failures", () => {
+    expect(compareFailedToQuarantine([], [quarantined("a")])).toEqual({
+      quarantined: [],
+      unquarantined: [],
+    });
+  });
+
+  it("matches on all three fields — same name, different file is not a match", () => {
+    const failure = failed("a", "Suite", "e2e/test/foo.cy.spec.ts");
+
+    const { unquarantined } = compareFailedToQuarantine(
+      [failure],
+      [quarantined("a", "Suite", "e2e/test/bar.cy.spec.ts")],
+    );
+
+    expect(unquarantined).toEqual([failure]);
+  });
+
+  it("matches on all three fields — same name/file, different describe path is not a match", () => {
+    const failure = failed("a", "Suite > inner");
+
+    const { unquarantined } = compareFailedToQuarantine(
+      [failure],
+      [quarantined("a", "Suite > other")],
+    );
+
+    expect(unquarantined).toEqual([failure]);
+  });
+
+  it("treats a null path on the failure as an empty string for matching", () => {
+    const failure = failed("a", null, null);
+
+    const { quarantined: q } = compareFailedToQuarantine(
+      [failure],
+      [quarantined("a", "", "")],
+    );
+
+    expect(q).toEqual([failure]);
+  });
+});
+
+describe("matchKey", () => {
+  it("normalizes null/undefined paths to empty strings", () => {
+    expect(
+      matchKey({ filePath: null, testPath: undefined, testName: "a" }),
+    ).toBe(matchKey({ filePath: "", testPath: "", testName: "a" }));
+  });
+
+  it("does not collide when a boundary between fields shifts", () => {
+    // ["a", "b", "c"] vs ["ab", "", "c"] must stay distinct.
+    expect(
+      matchKey({ filePath: "a", testPath: "b", testName: "c" }),
+    ).not.toBe(matchKey({ filePath: "ab", testPath: "", testName: "c" }));
+  });
+});
+
+describe("junitFailuresToFailedTests", () => {
+  it("renames name/path/file to the gate's identity fields", () => {
+    const tests: NormalizedTest[] = [
+      {
+        name: "renders the table",
+        path: "metabase.viz-test",
+        file: "viz_test.clj",
+        status: "failure",
+      },
+    ];
+
+    expect(junitFailuresToFailedTests(tests)).toEqual([
+      {
+        test_name: "renders the table",
+        test_path: "metabase.viz-test",
+        file_path: "viz_test.clj",
+      },
+    ]);
+  });
+
+  it("defaults a missing path/file to null", () => {
+    const tests: NormalizedTest[] = [{ name: "a", status: "failure" }];
+
+    expect(junitFailuresToFailedTests(tests)).toEqual([
+      { test_name: "a", test_path: null, file_path: null },
+    ]);
+  });
+
+  it("treats an absent status as a failure (JUnit only emits failures)", () => {
+    const tests: NormalizedTest[] = [{ name: "a" }];
+
+    expect(junitFailuresToFailedTests(tests)).toHaveLength(1);
+  });
+
+  it("drops a non-failure row defensively", () => {
+    const tests: NormalizedTest[] = [
+      { name: "broke", status: "failure" },
+      { name: "recovered", status: "passed" },
+    ];
+
+    expect(junitFailuresToFailedTests(tests)).toEqual([
+      { test_name: "broke", test_path: null, file_path: null },
+    ]);
+  });
+});
+
+describe("checkQuarantineGate", () => {
+  const failure: FailedTest = {
+    test_name: "renders",
+    test_path: "Suite",
+    file_path: "foo.spec.ts",
+  };
+
+  // Both branches under test return before any fetch, so no network is touched.
+  // Capture the gate's log lines so we can assert on the printed verdict.
+  async function runCapturingLogs(
+    opts: Parameters<typeof checkQuarantineGate>[0],
+  ): Promise<{ result: GateResult; verdict: string | undefined }> {
+    const lines: string[] = [];
+    const original = console.log;
+    console.log = (...args: unknown[]) => {
+      lines.push(args.map(String).join(" "));
+    };
+    try {
+      const result = await checkQuarantineGate(opts);
+      return { result, verdict: lines.find((l) => l.includes("VERDICT:")) };
+    } finally {
+      console.log = original;
+    }
+  }
+
+  it("passes without a verdict line when there are no failures to gate", async () => {
+    const { result, verdict } = await runCapturingLogs({
+      suite: "e2e",
+      failures: [],
+      baseUrl: undefined,
+      secret: undefined,
+      dryRun: true,
+    });
+    expect(result).toEqual({
+      shouldFail: false,
+      enforced: false,
+      reason: "no failures to gate",
+    });
+    expect(verdict).toBeUndefined();
+  });
+
+  it("reports COULD NOT CHECK — not FAIL — when the base URL is unset", async () => {
+    const { result, verdict } = await runCapturingLogs({
+      suite: "e2e",
+      failures: [failure],
+      baseUrl: undefined,
+      secret: undefined,
+      dryRun: true,
+    });
+    expect(result.reason).toBe("could not fetch the quarantine list");
+    expect(verdict).toContain("COULD NOT CHECK");
+    expect(verdict).not.toContain("FAIL");
+  });
+
+  it("fails closed but stays unenforced under dry run when it can't check", async () => {
+    const { result } = await runCapturingLogs({
+      suite: "e2e",
+      failures: [failure],
+      baseUrl: undefined,
+      secret: undefined,
+      dryRun: true,
+    });
+    expect(result.shouldFail).toBe(true);
+    expect(result.enforced).toBe(false);
+  });
+
+  it("fails closed AND enforces when it can't check outside dry run", async () => {
+    const { result } = await runCapturingLogs({
+      suite: "e2e",
+      failures: [failure],
+      baseUrl: undefined,
+      secret: undefined,
+      dryRun: false,
+    });
+    expect(result.shouldFail).toBe(true);
+    expect(result.enforced).toBe(true);
+  });
+});

--- a/release/ci-conductor/src/quarantine.ts
+++ b/release/ci-conductor/src/quarantine.ts
@@ -1,0 +1,265 @@
+// Shared quarantine gate for all three suites: given a run's failed tests, pass
+// iff every failure is on ci-conductor's quarantine list.
+
+import type { NormalizedTest } from "./contract.ts";
+import { log } from "./util.ts";
+
+// The list endpoint can be slow, but the gate must never hang a CI job.
+const REQUEST_TIMEOUT_MS = 15_000;
+
+/** One quarantined test as served by ci-conductor's `/api/quarantine`. */
+export type QuarantineEntry = {
+  test_name: string;
+  test_suite: string;
+  test_path: string;
+  file_path: string;
+};
+
+/**
+ * A test that ultimately failed in this run. The three identity fields mirror
+ * ci-conductor's wire/storage names (`NormalizedTest`'s `name`/`path`/`file`
+ * map to `test_name`/`test_path`/`file_path`); `junitFailuresToFailedTests`
+ * does that rename for the JUnit suites.
+ */
+export type FailedTest = {
+  test_name: string;
+  test_path: string | null;
+  file_path: string | null;
+};
+
+/** The gate's outcome. `enforced` is the raw verdict gated by dry-run. */
+export type GateResult = {
+  /** True when any failure isn't quarantined (or the list couldn't be read). */
+  shouldFail: boolean;
+  /** `shouldFail` AND not a dry run — i.e. the entrypoint should exit non-zero. */
+  enforced: boolean;
+  reason: string;
+};
+
+/**
+ * Identity key for a test: the spec/source file, the describe/namespace path,
+ * and the leaf test name as a JSON tuple. JSON-encoding keeps the parts
+ * distinct, so tuples that differ only in where a boundary falls (`["a","b"]`
+ * vs `["ab",""]`) can't collide.
+ */
+export function matchKey(opts: {
+  filePath: string | null | undefined;
+  testPath: string | null | undefined;
+  testName: string;
+}): string {
+  const { filePath, testPath, testName } = opts;
+  return JSON.stringify([filePath ?? "", testPath ?? "", testName]);
+}
+
+/**
+ * Partition the run's failed tests into those that are quarantined and those
+ * that are not, matching on exact {file_path, test_path, test_name} identity.
+ * A single pass over the failures.
+ */
+export function compareFailedToQuarantine(
+  failedTests: FailedTest[],
+  quarantineEntries: QuarantineEntry[],
+): { quarantined: FailedTest[]; unquarantined: FailedTest[] } {
+  const quarantinedKeys = new Set(
+    quarantineEntries.map((q) =>
+      matchKey({
+        filePath: q.file_path,
+        testPath: q.test_path,
+        testName: q.test_name,
+      }),
+    ),
+  );
+  const quarantined: FailedTest[] = [];
+  const unquarantined: FailedTest[] = [];
+  for (const test of failedTests) {
+    const isQuarantined = quarantinedKeys.has(
+      matchKey({
+        filePath: test.file_path,
+        testPath: test.test_path,
+        testName: test.test_name,
+      }),
+    );
+    (isQuarantined ? quarantined : unquarantined).push(test);
+  }
+  return { quarantined, unquarantined };
+}
+
+/**
+ * Adapt the JUnit suites' normalized failures to the gate's `FailedTest` shape.
+ * `parseJunit` only emits failing/erroring testcases, but we filter on `status`
+ * defensively so a future "passed" row can't leak into the gate.
+ */
+export function junitFailuresToFailedTests(
+  tests: NormalizedTest[],
+): FailedTest[] {
+  return tests
+    .filter((test) => (test.status ?? "failure") === "failure")
+    .map((test) => ({
+      test_name: test.name,
+      test_path: test.path ?? null,
+      file_path: test.file ?? null,
+    }));
+}
+
+/**
+ * Fetch the quarantine list for `suite` from ci-conductor. The reporter POSTs to
+ * `.../webhooks/failed-tests`; the list lives at `.../api/quarantine` on the same
+ * host. Returns null (not []) when it can't be retrieved, so the caller can tell
+ * "nothing quarantined" from "couldn't check". Never throws. Logs the path and
+ * suite only — never the host (public repo) or the secret.
+ */
+export async function fetchQuarantineList(opts: {
+  baseUrl: string;
+  suite: string;
+  secret?: string;
+}): Promise<QuarantineEntry[] | null> {
+  const base = opts.baseUrl.replace(/\/+$/, "");
+  const url = `${base}/api/quarantine?suite=${encodeURIComponent(opts.suite)}`;
+  try {
+    const headers: Record<string, string> = {};
+    if (opts.secret) {
+      headers["x-internal-secret"] = opts.secret;
+    }
+    const response = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      log(
+        `🛑 GET /api/quarantine?suite=${opts.suite} → ${response.status} ${response.statusText}`,
+      );
+      return null;
+    }
+    const body = (await response.json()) as { tests?: QuarantineEntry[] };
+    return body.tests ?? [];
+  } catch (error) {
+    console.error(
+      "[ci-conductor] failed to fetch the quarantine list",
+      error,
+    );
+    return null;
+  }
+}
+
+const RULE = "─".repeat(60);
+
+/** `test_path › test_name`, or just the name when there's no path. */
+function title(test: FailedTest): string {
+  return test.test_path ? `${test.test_path} › ${test.test_name}` : test.test_name;
+}
+
+/** Print the verdict (+ dry-run footer) and return the gate result. */
+function finish(opts: {
+  shouldFail: boolean;
+  reason: string;
+  dryRun: boolean;
+  // When the gate couldn't reach a real pass/fail decision — e.g. the quarantine
+  // list was unreachable — show a distinct "couldn't check" verdict rather than a
+  // red FAIL. It still fails closed (shouldFail stays true), but it isn't a real
+  // gate failure, so it shouldn't read as one in the logs.
+  inconclusive?: boolean;
+}): GateResult {
+  const { shouldFail, reason, dryRun, inconclusive = false } = opts;
+  if (inconclusive) {
+    log(`⚠️  VERDICT: COULD NOT CHECK — ${reason}.`);
+  } else if (shouldFail) {
+    log(`🔴 VERDICT: FAIL — ${reason}.`);
+  } else {
+    log(`🟢 VERDICT: PASS — ${reason}.`);
+  }
+  if (dryRun && shouldFail) {
+    log("🌥️  dry run: not enforced — exiting 0.");
+  }
+  log(RULE);
+  return { shouldFail, enforced: shouldFail && !dryRun, reason };
+}
+
+/**
+ * Check one suite's failures against the quarantine gate: print a readable,
+ * dry-run-aware report of which failures are quarantined and return the verdict.
+ * Pure w.r.t. process state — it computes and returns a `GateResult` but never
+ * touches the exit code; `applyQuarantineGate` is the adapter that enacts it.
+ * Source-agnostic — each suite's entrypoint resolves its own `failures` and
+ * `suite`. Never throws.
+ */
+export async function checkQuarantineGate(opts: {
+  suite: string;
+  failures: FailedTest[];
+  baseUrl: string | undefined;
+  secret: string | undefined;
+  dryRun: boolean;
+}): Promise<GateResult> {
+  const { suite, failures, baseUrl, secret, dryRun } = opts;
+
+  log(RULE);
+  log(`🛡️  CI Conductor quarantine gate · suite "${suite}"`);
+  log(
+    dryRun
+      ? "🌥️  DRY RUN — observing only; this gate never fails the job."
+      : "⚔️  ENFORCING — an unquarantined failure will fail this job.",
+  );
+  log(RULE);
+
+  if (failures.length === 0) {
+    log("✅ no failures this run — nothing to gate.");
+    log(RULE);
+    return { shouldFail: false, enforced: false, reason: "no failures to gate" };
+  }
+
+  if (!baseUrl) {
+    log("⚠️  CI_CONDUCTOR_BASE_URL not set — can't fetch the quarantine list (local run or missing secret).");
+    return finish({
+      shouldFail: true,
+      reason: "could not fetch the quarantine list",
+      dryRun,
+      inconclusive: true,
+    });
+  }
+
+  const list = await fetchQuarantineList({ baseUrl, suite, secret });
+  if (list === null) {
+    // Couldn't read the list ⇒ can't confirm everything is quarantined.
+    return finish({
+      shouldFail: true,
+      reason: "could not fetch the quarantine list",
+      dryRun,
+      inconclusive: true,
+    });
+  }
+
+  const { quarantined, unquarantined } = compareFailedToQuarantine(failures, list);
+
+  log(`📋 quarantine list: ${list.length} test(s) registered for "${suite}"`);
+  log(`💥 this run: ${failures.length} failure(s) to evaluate`);
+  for (const test of quarantined) {
+    log(`  🔒 quarantined      ${title(test)}`);
+    log(`                      ↳ ${test.file_path ?? "(no file)"}`);
+  }
+  for (const test of unquarantined) {
+    log(`  🚨 NOT quarantined  ${title(test)}`);
+    log(`                      ↳ ${test.file_path ?? "(no file)"}`);
+  }
+
+  return finish({
+    shouldFail: unquarantined.length > 0,
+    reason:
+      unquarantined.length > 0
+        ? `${unquarantined.length} of ${failures.length} failure(s) are NOT quarantined`
+        : `all ${failures.length} failure(s) are quarantined`,
+    dryRun,
+  });
+}
+
+/**
+ * Impure adapter over `checkQuarantineGate`: run the check, then apply the
+ * verdict to the process exit code (non-zero only when `enforced`). This is the
+ * one place the gate touches process state, so the engine stays testable.
+ */
+export async function applyQuarantineGate(
+  opts: Parameters<typeof checkQuarantineGate>[0],
+): Promise<void> {
+  const result = await checkQuarantineGate(opts);
+  if (result.enforced) {
+    process.exitCode = 1;
+  }
+}

--- a/release/ci-conductor/src/report-backend.ts
+++ b/release/ci-conductor/src/report-backend.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env bun
+
+// Backend test-failure reporter entrypoint. Runs as a post-test CI step on the
+// backend and driver paths: normalize the raw JUnit hawk just wrote and report
+// the failures to ci-conductor. Best-effort — reporting must never break a test
+// run.
+//
+// Run directly with bun (no build step):  bun src/report-backend.ts
+
+import { normalizeBackendJunit } from "./adapters/backend.ts";
+import { reportTestFailures } from "./transport.ts";
+import { log } from "./util.ts";
+
+async function main(): Promise<void> {
+  log("backend test-failure reporter starting");
+  const env = process.env;
+  // `test_suite` is the per-job identity discriminator: each driver / backend
+  // job exports its unique label as `CI_CONDUCTOR_TEST_SUITE` (e.g.
+  // `be-tests-java-21-ee`, `driver-postgres-ee`) so the same namespace run on
+  // different drivers or legs stays distinct in ci-conductor's identity key.
+  // Falls back to the driver keyword, then a generic `backend`.
+  const testSuite =
+    env.CI_CONDUCTOR_TEST_SUITE ||
+    (env.DRIVERS ? `driver-${env.DRIVERS}` : "backend");
+  await reportTestFailures(normalizeBackendJunit(), testSuite);
+}
+
+main().catch((error) => {
+  // Last line of defense: reporting must never fail the job.
+  console.error("[ci-conductor] backend reporting failed (ignored)", error);
+});

--- a/release/ci-conductor/src/report-frontend.ts
+++ b/release/ci-conductor/src/report-frontend.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env bun
+
+// Frontend test-failure reporter entrypoint. Runs as a post-test CI step on the
+// frontend (jest) path: normalize the JUnit jest-junit just wrote and report the
+// failures to ci-conductor. Best-effort — reporting must never break a test run.
+//
+// Run directly with bun (no build step):  bun src/report-frontend.ts
+
+import { normalizeFrontendJunit } from "./adapters/frontend.ts";
+import { reportTestFailures } from "./transport.ts";
+import { log } from "./util.ts";
+
+async function main(): Promise<void> {
+  log("frontend test-failure reporter starting");
+  const env = process.env;
+  // `test_suite` is the suite-level identity discriminator. Frontend unit tests
+  // are jest-sharded across parallel jobs, but each test file runs on exactly
+  // one shard, so every shard reports a disjoint subset under the SAME stable
+  // suite (`fe-tests-unit`, the job name, set via `CI_CONDUCTOR_TEST_SUITE`) —
+  // the shard number is deliberately NOT part of the suite, or a test would re-key in
+  // ci-conductor whenever sharding changes. Falls back to a generic `frontend`.
+  const testSuite = env.CI_CONDUCTOR_TEST_SUITE || "frontend";
+  await reportTestFailures(normalizeFrontendJunit(), testSuite);
+}
+
+main().catch((error) => {
+  // Last line of defense: reporting must never fail the job.
+  console.error("[ci-conductor] frontend reporting failed (ignored)", error);
+});

--- a/release/ci-conductor/src/transport.ts
+++ b/release/ci-conductor/src/transport.ts
@@ -1,0 +1,108 @@
+// Shared transport: POST a batch of normalized failures to ci-conductor's
+// `/webhooks/failed-tests`. Call-site-agnostic — the backend posts once
+// post-run; e2e posts per-spec mid-run (later round). Best-effort and never
+// throws: reporting must not break a test run.
+//
+// The quarantine side of the conversation (fetch the list + check failures
+// against it) lands here too in a later round — same host, same transport,
+// reading the same `NormalizedTest[]` this reports.
+
+import type { NormalizedTest, RunContext } from "./contract.ts";
+import { log, toNumber } from "./util.ts";
+
+// The endpoint can be slow, but the reporter must never hang a CI job.
+const REQUEST_TIMEOUT_MS = 15_000;
+
+/**
+ * Resolve the run-level half of the body from the CI environment. This is the
+ * payload's identity, not just log decoration: `repo_id`/`run_id`/`job_id` are
+ * GitHub numeric IDs (foreign keys in ci-conductor), `sha`/`target_branch` tie
+ * the failures to a commit/PR, and `test_suite` is the per-job dedup
+ * discriminator. On PRs the ambient `GITHUB_SHA` is a synthetic merge commit
+ * and `GITHUB_BASE_REF` the target, so the workflow sets `COMMIT_SHA`/
+ * `TARGET_BRANCH` to the PR's head sha / base ref; we fall back to the ambient
+ * vars (push runs, local). `JOB_ID` is exported by the `resolve-job-id`
+ * composite action (null when unresolved — the column is nullable).
+ */
+function resolveRunContext(testSuite: string): RunContext {
+  const env = process.env;
+  return {
+    repo_id: toNumber(env.REPO_ID ?? env.GITHUB_REPOSITORY_ID),
+    run_id: toNumber(env.GITHUB_RUN_ID),
+    attempt: toNumber(env.GITHUB_RUN_ATTEMPT),
+    job_id: toNumber(env.JOB_ID),
+    test_suite: testSuite,
+    sha: env.COMMIT_SHA || env.GITHUB_SHA || null,
+    target_branch: env.TARGET_BRANCH || env.GITHUB_BASE_REF || null,
+  };
+}
+
+/**
+ * Report the given normalized failures to ci-conductor by POSTing them to the
+ * webhook under `testSuite`'s run-level context, no-opping when the webhook URL
+ * isn't configured (local runs, PRs without the secret). Logs the resolved
+ * identity (no secrets, no host) up front so a missing row in ci-conductor can
+ * be correlated with — or ruled out against — this exact post. Never throws.
+ */
+export async function reportTestFailures(
+  tests: NormalizedTest[],
+  testSuite: string,
+): Promise<void> {
+  const baseUrl = process.env.CI_CONDUCTOR_BASE_URL;
+  const context = resolveRunContext(testSuite);
+
+  log(
+    `run context: test_suite=${context.test_suite} sha=${context.sha} ` +
+      `run_id=${context.run_id} attempt=${context.attempt} job_id=${context.job_id} ` +
+      `repo_id=${context.repo_id} target_branch=${context.target_branch}`,
+  );
+
+  if (tests.length === 0) {
+    log("no failing tests to report — skipping POST");
+    return;
+  }
+  if (!baseUrl) {
+    log(
+      "CI_CONDUCTOR_BASE_URL not set — skipping POST (local run or missing secret)",
+    );
+    return;
+  }
+
+  try {
+    const body = { ...context, tests };
+
+    const endpoint = `${baseUrl.replace(/\/+$/, "")}/webhooks/failed-tests`;
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (process.env.CI_CONDUCTOR_WEBHOOK_SECRET) {
+      // ci-conductor authenticates this endpoint via the x-internal-secret header.
+      headers["x-internal-secret"] = process.env.CI_CONDUCTOR_WEBHOOK_SECRET;
+    }
+
+    // Path only — never the host (public repo). The secret is never logged.
+    log(
+      `POSTing ${tests.length} failure(s) to /webhooks/failed-tests ` +
+        `(${headers["x-internal-secret"] ? "authenticated" : "no secret header"})`,
+    );
+
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      console.error(
+        `[ci-conductor] failed-tests POST returned ${response.status} ${response.statusText}`,
+      );
+    } else {
+      log(
+        `ci-conductor accepted the report (${response.status} ${response.statusText})`,
+      );
+    }
+  } catch (error) {
+    console.error("[ci-conductor] failed to POST failed-tests", error);
+  }
+}

--- a/release/ci-conductor/src/util.ts
+++ b/release/ci-conductor/src/util.ts
@@ -1,0 +1,21 @@
+// Small shared utilities, kept out of the domain modules (identity / transport /
+// adapters) so they don't reach across each other just to borrow a helper.
+
+/** Parse a numeric env var, treating missing/blank/non-numeric as null. */
+export function toNumber(value: string | undefined | null): number | null {
+  if (value == null || value === "") {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Progress line for the CI step log. The reporting step exists largely for
+ * visibility, so it narrates what it's doing — but NEVER the webhook secret or
+ * the base URL/host (metabase/metabase is a public repo). Only non-sensitive
+ * identity fields and the request path are ever logged.
+ */
+export function log(message: string): void {
+  console.log(`[ci-conductor] ${message}`);
+}

--- a/release/ci-conductor/tsconfig.json
+++ b/release/ci-conductor/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    // The source uses explicit `.ts` import specifiers (run directly with bun,
+    // never compiled), so tell tsc to accept them. We type-check only — bun is
+    // the runtime, so there's no emit.
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["bun", "node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/release/jest.config.cjs
+++ b/release/jest.config.cjs
@@ -2,4 +2,8 @@ module.exports = {
   testEnvironment: "node",
   extensionsToTreatAsEsm: [".ts"],
   transformIgnorePatterns: [],
+  // ci-conductor is a separate bun package with its own `bun test`; keep
+  // release's jest out of it (its bun:test files can't load under jest, and
+  // junit.test.ts otherwise matches `--testPathPattern unit`).
+  testPathIgnorePatterns: ["/node_modules/", "<rootDir>/ci-conductor/"],
 };


### PR DESCRIPTION
Backport of the ci-conductor reporting and quarantine work from master.

The ci-conductor scripts themselves are shared CI infrastructure: the prepare-ci-conductor action overlays release/ci-conductor and e2e/support/ci_conductor.ts from master at run time, so this branch always runs the current scripts while its workflow wiring stays branch-historical.

The info-driver mechanism (driver-status / report-variant) does not exist on this branch, so the quarantine wiring is backported without it.
