### PR TITLE
Extract typed schema generators for tables and questions

### DIFF
--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -477,13 +477,14 @@
          (merge related)))))
 
 (defn cards-details
-  "Get the details of metrics or models as specified by `card-type` and `cards`
+  "Get the details of metrics, models, or questions as specified by `card-type` and `cards`
   from the database with ID `database-id` respecting `options`."
   [card-type database-id cards options]
   (let [mp (lib-be/application-database-metadata-provider database-id)
         detail-fn (case card-type
                     :metric metric-details
-                    :model card-details)]
+                    :model card-details
+                    :question card-details)]
     (lib.metadata/bulk-metadata mp :metadata/card (map :id cards))
     (map #(-> (detail-fn % mp (u/assoc-default options :field-values-fn identity))
               (assoc :type card-type))

--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -7,22 +7,19 @@
    [metabase.actions.core :as actions]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
-   [metabase.collections.models.collection :as collection]
-   [metabase.lib-be.core :as lib-be]
-   [metabase.lib.core :as lib]
    [metabase.metabot.tools.entity-details :as entity-details]
-   [metabase.metabot.tools.util :as metabot.tools.u]
    [metabase.metrics.core :as metrics]
    [metabase.models.interface :as mi]
-   [metabase.system.core :as system]
    [metabase.typed-schemas.api.common :as common]
    [metabase.typed-schemas.api.render :as render]
+   [metabase.typed-schemas.api.schema :as schema]
+   [metabase.typed-schemas.api.schema.common :as schema.common]
+   [metabase.typed-schemas.api.schema.question :as schema.question]
+   [metabase.typed-schemas.api.schema.table :as schema.table]
    [metabase.typed-schemas.api.scope :as scope]
    [metabase.util :as u]
    [metabase.util.malli.schema :as ms]
-   [toucan2.core :as t2])
-  (:import
-   (java.time Instant)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -32,40 +29,6 @@
    "Cross-Origin-Resource-Policy" "same-origin"
    "Referrer-Policy"              "no-referrer"
    "Cache-Control"                "no-store"})
-
-(defn- select-cards
-  ([card-type database-ids]
-   (select-cards card-type database-ids nil))
-  ([card-type database-ids collection-ids]
-   (->> (t2/select :model/Card
-                   {:where    (cond-> [:and
-                                       [:= :type (name card-type)]
-                                       [:= :archived false]
-                                       (collection/visible-collection-filter-clause :collection_id)]
-                                database-ids (conj (scope/database-id-filter-clause database-ids :database_id))
-                                collection-ids (conj (scope/id-filter-clause collection-ids :collection_id)))
-                    :order-by [[:name :asc] [:id :asc]]})
-        (filter mi/can-read?))))
-
-(defn- card-type-name
-  [card]
-  (some-> (:type card) name))
-
-(defn- schema-details-error-message
-  [card error-message]
-  (format "Failed to build schema details for %s \"%s\" (card %s): %s"
-          (or (card-type-name card) "card")
-          (or (:name card) "Untitled")
-          (:id card)
-          (or error-message "unknown error")))
-
-(defn- schema-details-error-data
-  [card m]
-  (m/assoc-some
-   {:card-id   (:id card)
-    :card-name (:name card)
-    :card-type (:type card)}
-   :status-code (:status-code m)))
 
 (defn- model-action-error-message
   ([model error-message]
@@ -83,18 +46,18 @@
            (or error-message "unknown error"))))
 
 (defn- model-action-error-data
-  ([model m]
+  ([model error-data]
    (m/assoc-some
     {:model-id   (:id model)
      :model-name (:name model)}
-    :status-code (:status-code m)))
-  ([model action m]
+    :status-code (:status-code error-data)))
+  ([model action error-data]
    (m/assoc-some
-    (assoc (model-action-error-data model m)
+    (assoc (model-action-error-data model error-data)
            :action-id   (:id action)
            :action-name (:name action)
            :action-type (:type action))
-    :status-code (:status-code m))))
+    :status-code (:status-code error-data))))
 
 (defn- raw-model-actions
   [model-id]
@@ -126,39 +89,9 @@
   (assoc (model-action-error-data model nil)
          :dropped-actions (mapv #(select-keys % [:id :name :type]) dropped-actions)))
 
-(defn- question-details
-  [card]
-  (let [response (try
-                   (entity-details/get-report-details {:report-id             (:id card)
-                                                       :with-field-values?    false
-                                                       :with-related-tables?  false
-                                                       :with-metrics?         false
-                                                       :with-measures?        false
-                                                       :with-segments?        false})
-                   (catch Exception e
-                     (throw (ex-info (schema-details-error-message card (ex-message e))
-                                     (assoc (schema-details-error-data card (ex-data e))
-                                            :cause-message (ex-message e))
-                                     e))))]
-    (or (:structured-output response)
-        (let [error-message (:output response)]
-          (throw (ex-info (schema-details-error-message card error-message)
-                          (assoc (schema-details-error-data card response)
-                                 :error-message error-message
-                                 :response response)))))))
-
 (defn- metric-result-column
   [card]
-  (try
-    (let [mp    (lib-be/application-database-metadata-provider (:database_id card))
-          query (lib/query mp (:dataset_query card))
-          col   (->> (lib/returned-columns query)
-                     (filter #(= (:lib/source %) :source/aggregations))
-                     first)]
-      (when col
-        (metabot.tools.u/->result-column query col)))
-    (catch Exception _
-      nil)))
+  (schema.common/aggregation-result-column (:database_id card) (:dataset_query card)))
 
 (defn- metric-details
   [card]
@@ -169,26 +102,13 @@
                                           :with-segments?                  false})
       :structured-output))
 
-(defn- question-schema
-  [{:keys [id name description verified display result-columns portable_entity_id]}]
-  (m/assoc-some
-   {:type    "card"
-    :key     (common/generated-key name id)
-    :id      id
-    :name    name
-    :display display
-    :columns (mapv common/column-schema result-columns)}
-   :entityId portable_entity_id
-   :description description
-   :verified (when verified true)))
-
 (defn- ->keyword
   "Coerces strings or keywords into a keyword for uniform type inspection."
-  [v]
+  [value]
   (cond
-    (keyword? v) v
-    (string? v)  (keyword v)
-    :else        nil))
+    (keyword? value) value
+    (string? value)  (keyword value)
+    :else            nil))
 
 (defn- param-type->js-type
   "Maps a Metabase parameter type (`:number`, `:string/=`, `:date/single`,
@@ -196,8 +116,8 @@
   Returns nil for ambiguous types (`:=`, `:id`, `:category`, …) so the
   caller can fall back to other type sources like a backing template-tag."
   [param-type]
-  (when-let [k (->keyword param-type)]
-    (let [prefix (or (namespace k) (name k))]
+  (when-let [param-type-keyword (->keyword param-type)]
+    (let [prefix (or (namespace param-type-keyword) (name param-type-keyword))]
       (case prefix
         ("number" "numeric") "number"
         ("text" "string")    "string"
@@ -289,11 +209,11 @@
                    :model_id (:id model)
                    :archived false
                    :type [:not= "http"])
-                  (catch Exception e
-                    (throw (ex-info (model-action-error-message model (ex-message e))
-                                    (assoc (model-action-error-data model (ex-data e))
-                                           :cause-message (ex-message e))
-                                    e))))
+                  (catch Exception exception
+                    (throw (ex-info (model-action-error-message model (ex-message exception))
+                                    (assoc (model-action-error-data model (ex-data exception))
+                                           :cause-message (ex-message exception))
+                                    exception))))
         dropped (dropped-actions raw-actions actions)]
     (when dropped
       (throw (ex-info (dropped-actions-message model dropped)
@@ -302,11 +222,11 @@
       (mapv (fn [action]
               (try
                 (action-schema action)
-                (catch Exception e
-                  (throw (ex-info (model-action-error-message model action (ex-message e))
-                                  (assoc (model-action-error-data model action (ex-data e))
-                                         :cause-message (ex-message e))
-                                  e)))))
+                (catch Exception exception
+                  (throw (ex-info (model-action-error-message model action (ex-message exception))
+                                  (assoc (model-action-error-data model action (ex-data exception))
+                                         :cause-message (ex-message exception))
+                                  exception)))))
             actions))))
 
 (defn- model-schema
@@ -329,17 +249,12 @@
      :semantic_type  (some-> (:semantic-type dimension) u/qualified-name)
      :field_id       field-id}))
 
-(defn- field-table-id
-  [field-id]
-  (when (integer? field-id)
-    (t2/select-one-fn :table_id :model/Field :id field-id)))
-
 (defn- dimension-table-id
   [{:keys [field_id] :as dimension}]
   (let [field-id (or field_id (some-> dimension :sources first :field-id))]
     (or (:table_id dimension)
         (:table-id dimension)
-        (field-table-id field-id))))
+        (schema.table/field-table-id field-id))))
 
 (defn- dimension-schema
   ([dimension metric-id]
@@ -370,22 +285,6 @@
       :metricId metric-id
       :keyDisambiguator (when (integer? table-id)
                           (get table-key-by-id table-id))))))
-
-(defn- field-schema
-  ([field]
-   (field-schema field nil))
-  ([{:keys [id field_id] :as field} source-name]
-   (let [field-id (or id field_id)
-         table-id (or (:table_id field) (:table-id field) (field-table-id field-id))]
-     (m/assoc-some
-      (assoc (common/column-schema field)
-             :type "column"
-             :key (common/generated-key (:name field) field-id)
-             :id field-id)
-      :sourceName source-name
-      :fieldId (when (integer? field-id) field-id)
-      :tableId (when (integer? table-id) table-id)
-      :defaultTemporalBucket (:unit field)))))
 
 (defn- mapping-source-field-id
   [{:keys [target]}]
@@ -469,20 +368,6 @@
    :displayName   name
    :jsType        "unknown"})
 
-(defn- measure-result-column
-  [database-id measure-id]
-  (try
-    (when-let [definition (t2/select-one-fn :definition :model/Measure :id measure-id)]
-      (let [mp    (lib-be/application-database-metadata-provider database-id)
-            query (lib/query mp definition)
-            col   (->> (lib/returned-columns query)
-                       (filter #(= (:lib/source %) :source/aggregations))
-                       first)]
-        (when col
-          (metabot.tools.u/->result-column query col))))
-    (catch Exception _
-      nil)))
-
 (defn- metric-schema
   [{:keys [id name description verified portable_entity_id base_table_portable_fk] :as details}
    card]
@@ -522,97 +407,12 @@
      :mappedTableIds (not-empty mapped-table-ids)
      :dimensions (not-empty (common/keyed-map dimension-schemas)))))
 
-(defn- select-tables
-  ([database-ids]
-   (select-tables database-ids nil))
-  ([database-ids table-ids]
-   (->> (t2/select :model/Table
-                   {:where    (cond-> [:and [:= :active true]]
-                                database-ids (conj (scope/database-id-filter-clause database-ids :db_id))
-                                table-ids (conj (scope/id-filter-clause table-ids :id)))
-                    :order-by [[:name :asc] [:id :asc]]})
-        (filter mi/can-read?))))
-
-(defn- select-library-tables
-  [{:keys [data-collection-ids]}]
-  (->> (t2/select :model/Table
-                  {:where    [:and
-                              [:= :active true]
-                              [:= :is_published true]
-                              (scope/id-filter-clause data-collection-ids :collection_id)]
-                   :order-by [[:name :asc] [:id :asc]]})
-       (filter mi/can-read?)))
-
-(defn- segment-schema
-  [table-id {:keys [id name description display-name portable-entity-id portable_entity_id]}]
-  (m/assoc-some
-   {:type    "segment"
-    :key     (common/generated-key (or display-name name) id)
-    :id      id
-    :tableId table-id
-    :name    name}
-   :entityId (or portable_entity_id portable-entity-id)
-   :description description))
-
-(defn- measure-schema
-  [table-id database-id {:keys [id name description display-name portable-entity-id portable_entity_id]}]
-  (m/assoc-some
-   {:type    "measure"
-    :key     (common/generated-key (or display-name name) id)
-    :id      id
-    :tableId table-id
-    :name    name
-    :columns [(or (some-> (measure-result-column database-id id) common/column-schema)
-                  (fallback-metric-column {:name (or display-name name)}))]}
-   :entityId (or portable_entity_id portable-entity-id)
-   :description description))
-
-(defn- table-schema
-  [{:keys [id name description display_name database_id database_name database_schema portable_entity_id fields segments measures]}]
-  (let [segments-map (common/keyed-map (map #(segment-schema id %) segments))
-        measures-map (common/keyed-map (map #(measure-schema id database_id %) measures))]
-    (m/assoc-some
-     {:type         "table"
-      :key          (common/generated-key (or display_name name) id)
-      :id           id
-      :name         (or display_name name)
-      :databaseName database_name
-      :tableName    name
-      :fields       (common/keyed-map (map #(field-schema % name) fields))}
-     :entityId portable_entity_id
-     :description description
-     :schemaName database_schema
-     :segments (not-empty segments-map)
-     :measures (not-empty measures-map))))
-
-(defn- table-details
-  [table]
-  (some-> (entity-details/get-table-details
-           {:entity-type          :table
-            :entity-id            (:id table)
-            :with-fields?         true
-            :with-field-values?   false
-            :with-related-tables? false
-            :with-metrics?        false
-            :with-measures?       true
-            :with-segments?       true})
-          :structured-output))
-
-(defn- question-schemas
-  ([database-ids]
-   (question-schemas database-ids nil))
-  ([database-ids collection-ids]
-   (for [card (select-cards :question database-ids collection-ids)
-         :let [details (question-details card)]
-         :when details]
-     (question-schema details))))
-
 (defn- model-schemas
   ([database-ids]
    (model-schemas database-ids nil))
   ([database-ids collection-ids]
-   (for [card (select-cards :model database-ids collection-ids)
-         :let [details (question-details card)
+   (for [card (schema.common/select-schema-cards :model database-ids collection-ids)
+         :let [details (schema.common/question-details card)
                schema  (some-> details model-schema)]
          :when schema]
      schema)))
@@ -621,28 +421,10 @@
   ([database-ids]
    (metric-schemas database-ids nil))
   ([database-ids collection-ids]
-   (for [card (select-cards :metric database-ids collection-ids)
+   (for [card (schema.common/select-schema-cards :metric database-ids collection-ids)
          :let [details (metric-details card)]
          :when details]
      (metric-schema details card))))
-
-(defn- table-schemas
-  [tables]
-  (for [table tables
-        :let [details (table-details table)]
-        :when details]
-    (table-schema details)))
-
-(defn- base-schema
-  [questions models tables metrics]
-  (array-map
-   :schemaVersion 2
-   :generatedAt   (str (Instant/now))
-   :metabase      {:instanceUrl (system/site-url)}
-   :questions     (common/keyed-map questions)
-   :models        (common/keyed-model-map models)
-   :tables        (common/keyed-map tables)
-   :metrics       (common/keyed-map metrics)))
 
 (defn- validate-query-params!
   [query-params]
@@ -675,10 +457,10 @@
   (let [{:keys [metric-collection-ids]} library-scope
         metrics               (metric-schemas nil metric-collection-ids)
         mapped-table-ids      (->> metrics (mapcat :mappedTableIds) set)
-        library-table-ids     (->> (select-library-tables library-scope) (map :id) set)
+        library-table-ids     (->> (schema.table/select-library-tables library-scope) (map :id) set)
         table-ids             (set/union library-table-ids mapped-table-ids)
-        tables                (table-schemas (select-tables nil table-ids))]
-    (base-schema [] models tables metrics)))
+        tables                (schema.table/table-schemas (schema.table/select-tables nil table-ids))]
+    (schema/base-schema [] models tables metrics)))
 
 (defn- typed-schema
   [query-params]
@@ -707,23 +489,23 @@
           question-collection-values
           (and include-models? (nil? database-ids)))
       (let [questions           (if question-collection-values
-                                  (question-schemas nil question-collection-ids)
+                                  (schema.question/question-schemas nil question-collection-ids)
                                   [])
             library-schema      (some-> library-scope
                                         (typed-schema-for-library-scope models))]
-        (base-schema questions
-                     models
-                     (-> library-schema :tables vals)
-                     (-> library-schema :metrics vals)))
+        (schema/base-schema questions
+                            models
+                            (-> library-schema :tables vals)
+                            (-> library-schema :metrics vals)))
 
       questions-only
-      (base-schema (question-schemas database-ids) models [] [])
+      (schema/base-schema (schema.question/question-schemas database-ids) models [] [])
 
       :else
-      (let [questions (question-schemas database-ids)
+      (let [questions (schema.question/question-schemas database-ids)
             metrics   (metric-schemas database-ids)
-            tables    (table-schemas (select-tables database-ids))]
-        (base-schema questions models tables metrics)))))
+            tables    (schema.table/table-schemas (schema.table/select-tables database-ids))]
+        (schema/base-schema questions models tables metrics)))))
 
 (def ^:private TypedSchemaQueryParams
   [:map

--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -254,7 +254,7 @@
   (let [field-id (or field_id (some-> dimension :sources first :field-id))]
     (or (:table_id dimension)
         (:table-id dimension)
-        (schema.table/field-table-id field-id))))
+        (schema.table/table-by-field-id field-id))))
 
 (defn- dimension-schema
   ([dimension metric-id]
@@ -412,8 +412,7 @@
    (model-schemas database-ids nil))
   ([database-ids collection-ids]
    (for [card (schema.common/select-schema-cards :model database-ids collection-ids)
-         :let [details (schema.common/question-details card)
-               schema  (some-> details model-schema)]
+         :let [schema (model-schema card)]
          :when schema]
      schema)))
 

--- a/src/metabase/typed_schemas/api/schema.clj
+++ b/src/metabase/typed_schemas/api/schema.clj
@@ -1,5 +1,5 @@
 (ns metabase.typed-schemas.api.schema
-  "Top-level typed-schema assembly helpers."
+  "Top-level typed schema helpers."
   (:require
    [metabase.system.core :as system]
    [metabase.typed-schemas.api.common :as common])
@@ -9,12 +9,7 @@
 (set! *warn-on-reflection* true)
 
 (defn base-schema
-  "Returns the top-level typed-schema map shared by every endpoint scope.
-
-  The coordinator keeps this shape outside `api.clj` so endpoint code can focus
-  on request validation/routing, while schema namespaces decide which generated
-  sections are present. Empty sections stay present because SDK consumers expect
-  stable top-level keys."
+  "Returns the top-level typed schema map."
   [questions models tables metrics]
   (array-map
    :schemaVersion 2

--- a/src/metabase/typed_schemas/api/schema.clj
+++ b/src/metabase/typed_schemas/api/schema.clj
@@ -1,0 +1,26 @@
+(ns metabase.typed-schemas.api.schema
+  "Top-level typed-schema assembly helpers."
+  (:require
+   [metabase.system.core :as system]
+   [metabase.typed-schemas.api.common :as common])
+  (:import
+   (java.time Instant)))
+
+(set! *warn-on-reflection* true)
+
+(defn base-schema
+  "Returns the top-level typed-schema map shared by every endpoint scope.
+
+  The coordinator keeps this shape outside `api.clj` so endpoint code can focus
+  on request validation/routing, while schema namespaces decide which generated
+  sections are present. Empty sections stay present because SDK consumers expect
+  stable top-level keys."
+  [questions models tables metrics]
+  (array-map
+   :schemaVersion 2
+   :generatedAt   (str (Instant/now))
+   :metabase      {:instanceUrl (system/site-url)}
+   :questions     (common/keyed-map questions)
+   :models        (common/keyed-model-map models)
+   :tables        (common/keyed-map tables)
+   :metrics       (common/keyed-map metrics)))

--- a/src/metabase/typed_schemas/api/schema/common.clj
+++ b/src/metabase/typed_schemas/api/schema/common.clj
@@ -1,0 +1,101 @@
+(ns metabase.typed-schemas.api.schema.common
+  "Shared typed-schema card selection and detail helpers."
+  (:require
+   [medley.core :as m]
+   [metabase.collections.models.collection :as collection]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.core :as lib]
+   [metabase.metabot.tools.entity-details :as entity-details]
+   [metabase.metabot.tools.util :as metabot.tools.u]
+   [metabase.models.interface :as mi]
+   [metabase.typed-schemas.api.scope :as scope]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn select-schema-cards
+  "Returns readable, non-archived cards for schema generation.
+
+  Question, model, and metric generation all start from cards and need the same
+  visibility, archived, database, and collection filters. Keeping that selection
+  in one place prevents each generator namespace from drifting on access rules."
+  ([card-type database-ids]
+   (select-schema-cards card-type database-ids nil))
+  ([card-type database-ids collection-ids]
+   (->> (t2/select :model/Card
+                   {:where    (cond-> [:and
+                                       [:= :type (name card-type)]
+                                       [:= :archived false]
+                                       (collection/visible-collection-filter-clause :collection_id)]
+                                database-ids (conj (scope/database-id-filter-clause database-ids :database_id))
+                                collection-ids (conj (scope/id-filter-clause collection-ids :collection_id)))
+                    :order-by [[:name :asc] [:id :asc]]})
+        (filter mi/can-read?))))
+
+(defn- schema-card-type-name
+  [card]
+  (some-> (:type card) name))
+
+(defn- schema-details-error-message
+  [card error-message]
+  (format "Failed to build schema details for %s \"%s\" (card %s): %s"
+          (or (schema-card-type-name card) "card")
+          (or (:name card) "Untitled")
+          (:id card)
+          (or error-message "unknown error")))
+
+(defn- schema-details-error-data
+  [card error-data]
+  (m/assoc-some
+   {:card-id   (:id card)
+    :card-name (:name card)
+    :card-type (:type card)}
+   :status-code (:status-code error-data)))
+
+(defn question-details
+  "Returns structured report details for a saved question or model card.
+
+  The schema generators consume `entity-details` output instead of raw Card
+  rows because it already resolves result columns and source metadata in the
+  shape agents need. Models reuse this path because they are stored as cards and
+  need the same detail/error behavior before action schemas are attached.
+
+  Wraps entity-detail failures with schema-specific context so endpoint errors
+  identify the card that failed to produce schema data."
+  [card]
+  (let [response (try
+                   (entity-details/get-report-details {:report-id             (:id card)
+                                                       :with-field-values?    false
+                                                       :with-related-tables?  false
+                                                       :with-metrics?         false
+                                                       :with-measures?        false
+                                                       :with-segments?        false})
+                   (catch Exception exception
+                     (throw (ex-info (schema-details-error-message card (ex-message exception))
+                                     (assoc (schema-details-error-data card (ex-data exception))
+                                            :cause-message (ex-message exception))
+                                     exception))))]
+    (or (:structured-output response)
+        (let [error-message (:output response)]
+          (throw (ex-info (schema-details-error-message card error-message)
+                          (assoc (schema-details-error-data card response)
+                                 :error-message error-message
+                                 :response response)))))))
+
+(defn aggregation-result-column
+  "Returns the first aggregation result column for a saved query definition.
+
+  Metrics and measures both need to expose the result type of an aggregation.
+  Lib already knows how to compute returned columns from a query, so this helper
+  keeps schema generation aligned with Lib instead of duplicating aggregation
+  metadata logic in each generator namespace."
+  [database-id query-definition]
+  (try
+    (let [metadata-provider  (lib-be/application-database-metadata-provider database-id)
+          query              (lib/query metadata-provider query-definition)
+          aggregation-column (m/find-first #(= (:lib/source %) :source/aggregations)
+                                           (lib/returned-columns query))]
+      (when aggregation-column
+        (metabot.tools.u/->result-column query aggregation-column)))
+    (catch Exception _
+      nil)))

--- a/src/metabase/typed_schemas/api/schema/common.clj
+++ b/src/metabase/typed_schemas/api/schema/common.clj
@@ -30,16 +30,27 @@
                     :order-by [[:name :asc] [:id :asc]]})
         (filter mi/can-read?))))
 
+(defn aggregation-result-column-with-metadata-provider
+  "Returns an aggregation result column using an existing metadata provider."
+  [metadata-provider query-definition]
+  (try
+    (let [query              (lib/query metadata-provider query-definition)
+          aggregation-column (m/find-first #(= (:lib/source %) :source/aggregations)
+                                           (lib/returned-columns query))]
+      (when aggregation-column
+        (metabot.tools.u/->result-column query aggregation-column)))
+    ;; Result-column inference is best effort; callers fall back to an unknown column.
+    (catch Exception _
+      nil)))
+
 (defn aggregation-result-column
   "Returns the first aggregation result column for a saved query
    definition, for metrics and measures."
   [database-id query-definition]
   (try
-    (let [metadata-provider  (lib-be/application-database-metadata-provider database-id)
-          query              (lib/query metadata-provider query-definition)
-          aggregation-column (m/find-first #(= (:lib/source %) :source/aggregations)
-                                           (lib/returned-columns query))]
-      (when aggregation-column
-        (metabot.tools.u/->result-column query aggregation-column)))
+    (aggregation-result-column-with-metadata-provider
+     (lib-be/application-database-metadata-provider database-id)
+     query-definition)
+    ;; Result-column inference is best effort; callers fall back to an unknown column.
     (catch Exception _
       nil)))

--- a/src/metabase/typed_schemas/api/schema/common.clj
+++ b/src/metabase/typed_schemas/api/schema/common.clj
@@ -1,11 +1,10 @@
 (ns metabase.typed-schemas.api.schema.common
-  "Shared typed-schema card selection and detail helpers."
+  "Shared typed-schema source helpers."
   (:require
    [medley.core :as m]
    [metabase.collections.models.collection :as collection]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
-   [metabase.metabot.tools.entity-details :as entity-details]
    [metabase.metabot.tools.util :as metabot.tools.u]
    [metabase.models.interface :as mi]
    [metabase.typed-schemas.api.scope :as scope]
@@ -16,9 +15,8 @@
 (defn select-schema-cards
   "Returns readable, non-archived cards for schema generation.
 
-  Question, model, and metric generation all start from cards and need the same
-  visibility, archived, database, and collection filters. Keeping that selection
-  in one place prevents each generator namespace from drifting on access rules."
+  Metrics, models and saved questions are backed by cards. They need
+  the same visibility, archived, database and collection filters."
   ([card-type database-ids]
    (select-schema-cards card-type database-ids nil))
   ([card-type database-ids collection-ids]
@@ -32,63 +30,9 @@
                     :order-by [[:name :asc] [:id :asc]]})
         (filter mi/can-read?))))
 
-(defn- schema-card-type-name
-  [card]
-  (some-> (:type card) name))
-
-(defn- schema-details-error-message
-  [card error-message]
-  (format "Failed to build schema details for %s \"%s\" (card %s): %s"
-          (or (schema-card-type-name card) "card")
-          (or (:name card) "Untitled")
-          (:id card)
-          (or error-message "unknown error")))
-
-(defn- schema-details-error-data
-  [card error-data]
-  (m/assoc-some
-   {:card-id   (:id card)
-    :card-name (:name card)
-    :card-type (:type card)}
-   :status-code (:status-code error-data)))
-
-(defn question-details
-  "Returns structured report details for a saved question or model card.
-
-  The schema generators consume `entity-details` output instead of raw Card
-  rows because it already resolves result columns and source metadata in the
-  shape agents need. Models reuse this path because they are stored as cards and
-  need the same detail/error behavior before action schemas are attached.
-
-  Wraps entity-detail failures with schema-specific context so endpoint errors
-  identify the card that failed to produce schema data."
-  [card]
-  (let [response (try
-                   (entity-details/get-report-details {:report-id             (:id card)
-                                                       :with-field-values?    false
-                                                       :with-related-tables?  false
-                                                       :with-metrics?         false
-                                                       :with-measures?        false
-                                                       :with-segments?        false})
-                   (catch Exception exception
-                     (throw (ex-info (schema-details-error-message card (ex-message exception))
-                                     (assoc (schema-details-error-data card (ex-data exception))
-                                            :cause-message (ex-message exception))
-                                     exception))))]
-    (or (:structured-output response)
-        (let [error-message (:output response)]
-          (throw (ex-info (schema-details-error-message card error-message)
-                          (assoc (schema-details-error-data card response)
-                                 :error-message error-message
-                                 :response response)))))))
-
 (defn aggregation-result-column
-  "Returns the first aggregation result column for a saved query definition.
-
-  Metrics and measures both need to expose the result type of an aggregation.
-  Lib already knows how to compute returned columns from a query, so this helper
-  keeps schema generation aligned with Lib instead of duplicating aggregation
-  metadata logic in each generator namespace."
+  "Returns the first aggregation result column for a saved query
+   definition, for metrics and measures."
   [database-id query-definition]
   (try
     (let [metadata-provider  (lib-be/application-database-metadata-provider database-id)

--- a/src/metabase/typed_schemas/api/schema/question.clj
+++ b/src/metabase/typed_schemas/api/schema/question.clj
@@ -1,18 +1,57 @@
 (ns metabase.typed-schemas.api.schema.question
-  "Saved-question typed-schema generation."
+  "Typed schema generation for saved questions."
   (:require
    [medley.core :as m]
+   [metabase.metabot.tools.entity-details :as entity-details]
    [metabase.typed-schemas.api.common :as common]
    [metabase.typed-schemas.api.schema.common :as schema.common]))
 
 (set! *warn-on-reflection* true)
 
-(defn question-schema
-  "Returns the typed-schema representation for a saved question.
+(defn- schema-card-type-name
+  [card]
+  (some-> (:type card) name))
 
-  Saved questions are read sources for the SDK query DSL, so they keep runtime
-  identifiers and result columns but leave action/model concerns to later
-  generator namespaces."
+(defn- question-details-error-message
+  [card error-message]
+  (format "Failed to build schema details for %s \"%s\" (card %s): %s"
+          (or (schema-card-type-name card) "card")
+          (or (:name card) "Untitled")
+          (:id card)
+          (or error-message "unknown error")))
+
+(defn- question-details-error-data
+  [card error-data]
+  (m/assoc-some
+   {:card-id   (:id card)
+    :card-name (:name card)
+    :card-type (:type card)}
+   :status-code (:status-code error-data)))
+
+(defn- question-details
+  "Returns card details for a saved question."
+  [card]
+  (let [response (try
+                   (entity-details/get-report-details {:report-id             (:id card)
+                                                       :with-field-values?    false
+                                                       :with-related-tables?  false
+                                                       :with-metrics?         false
+                                                       :with-measures?        false
+                                                       :with-segments?        false})
+                   (catch Exception exception
+                     (throw (ex-info (question-details-error-message card (ex-message exception))
+                                     (assoc (question-details-error-data card (ex-data exception))
+                                            :cause-message (ex-message exception))
+                                     exception))))]
+    (or (:structured-output response)
+        (let [error-message (:output response)]
+          (throw (ex-info (question-details-error-message card error-message)
+                          (assoc (question-details-error-data card response)
+                                 :error-message error-message
+                                 :response response)))))))
+
+(defn question-schema
+  "Returns the schema for a saved question."
   [{:keys [id name description verified display result-columns portable_entity_id]}]
   (m/assoc-some
    {:type    "card"
@@ -26,15 +65,11 @@
    :verified (when verified true)))
 
 (defn question-schemas
-  "Returns saved-question schemas for optional database and collection scopes.
-
-  This stays separate from the API namespace so endpoint branches can compose
-  question, table, model, and metric sections without owning the details of how
-  each section is selected or rendered."
+  "Returns schemas for saved questions, with optional database and collection scopes."
   ([database-ids]
    (question-schemas database-ids nil))
   ([database-ids collection-ids]
    (for [card (schema.common/select-schema-cards :question database-ids collection-ids)
-         :let [details (schema.common/question-details card)]
+         :let [details (question-details card)]
          :when details]
      (question-schema details))))

--- a/src/metabase/typed_schemas/api/schema/question.clj
+++ b/src/metabase/typed_schemas/api/schema/question.clj
@@ -8,14 +8,9 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- schema-card-type-name
-  [card]
-  (some-> (:type card) name))
-
 (defn- question-details-error-message
   [card error-message]
-  (format "Failed to build schema details for %s \"%s\" (card %s): %s"
-          (or (schema-card-type-name card) "card")
+  (format "Failed to build schema details for question \"%s\" (card %s): %s"
           (or (:name card) "Untitled")
           (:id card)
           (or error-message "unknown error")))
@@ -29,26 +24,31 @@
    :status-code (:status-code error-data)))
 
 (defn- question-details
-  "Returns card details for a saved question."
-  [card]
-  (let [response (try
-                   (entity-details/get-report-details {:report-id             (:id card)
-                                                       :with-field-values?    false
-                                                       :with-related-tables?  false
-                                                       :with-metrics?         false
-                                                       :with-measures?        false
-                                                       :with-segments?        false})
-                   (catch Exception exception
-                     (throw (ex-info (question-details-error-message card (ex-message exception))
-                                     (assoc (question-details-error-data card (ex-data exception))
-                                            :cause-message (ex-message exception))
-                                     exception))))]
-    (or (:structured-output response)
-        (let [error-message (:output response)]
-          (throw (ex-info (question-details-error-message card error-message)
-                          (assoc (question-details-error-data card response)
-                                 :error-message error-message
-                                 :response response)))))))
+  "Returns saved-question details in the selected-card order."
+  [cards]
+  (let [details-by-card-id (into {}
+                                 (mapcat (fn [[database-id database-cards]]
+                                           (mapv (fn [card details]
+                                                   (try
+                                                     [(:id card)
+                                                      (assoc details
+                                                             :result-columns (:fields details)
+                                                             :display (:display card))]
+                                                     (catch Exception exception
+                                                       (throw (ex-info (question-details-error-message card (ex-message exception))
+                                                                       (assoc (question-details-error-data card (ex-data exception))
+                                                                              :cause-message (ex-message exception))
+                                                                       exception)))))
+                                                 database-cards
+                                                 (entity-details/cards-details
+                                                  :question database-id database-cards
+                                                  {:with-field-values?    false
+                                                   :with-related-tables?  false
+                                                   :with-metrics?         false
+                                                   :with-measures?        false
+                                                   :with-segments?        false})))
+                                         (group-by :database_id cards)))]
+    (mapv details-by-card-id (map :id cards))))
 
 (defn question-schema
   "Returns the schema for a saved question."
@@ -69,7 +69,5 @@
   ([database-ids]
    (question-schemas database-ids nil))
   ([database-ids collection-ids]
-   (for [card (schema.common/select-schema-cards :question database-ids collection-ids)
-         :let [details (question-details card)]
-         :when details]
-     (question-schema details))))
+   (let [cards (schema.common/select-schema-cards :question database-ids collection-ids)]
+     (mapv question-schema (question-details cards)))))

--- a/src/metabase/typed_schemas/api/schema/question.clj
+++ b/src/metabase/typed_schemas/api/schema/question.clj
@@ -1,0 +1,40 @@
+(ns metabase.typed-schemas.api.schema.question
+  "Saved-question typed-schema generation."
+  (:require
+   [medley.core :as m]
+   [metabase.typed-schemas.api.common :as common]
+   [metabase.typed-schemas.api.schema.common :as schema.common]))
+
+(set! *warn-on-reflection* true)
+
+(defn question-schema
+  "Returns the typed-schema representation for a saved question.
+
+  Saved questions are read sources for the SDK query DSL, so they keep runtime
+  identifiers and result columns but leave action/model concerns to later
+  generator namespaces."
+  [{:keys [id name description verified display result-columns portable_entity_id]}]
+  (m/assoc-some
+   {:type    "card"
+    :key     (common/generated-key name id)
+    :id      id
+    :name    name
+    :display display
+    :columns (mapv common/column-schema result-columns)}
+   :entityId portable_entity_id
+   :description description
+   :verified (when verified true)))
+
+(defn question-schemas
+  "Returns saved-question schemas for optional database and collection scopes.
+
+  This stays separate from the API namespace so endpoint branches can compose
+  question, table, model, and metric sections without owning the details of how
+  each section is selected or rendered."
+  ([database-ids]
+   (question-schemas database-ids nil))
+  ([database-ids collection-ids]
+   (for [card (schema.common/select-schema-cards :question database-ids collection-ids)
+         :let [details (schema.common/question-details card)]
+         :when details]
+     (question-schema details))))

--- a/src/metabase/typed_schemas/api/schema/table.clj
+++ b/src/metabase/typed_schemas/api/schema/table.clj
@@ -21,10 +21,12 @@
 (defn field-schema
   "Returns the schema for a table field."
   ([field]
-   (field-schema field nil))
-  ([{:keys [id field_id] :as field} source-name]
+   (field-schema field nil nil))
+  ([field source-name]
+   (field-schema field source-name nil))
+  ([{:keys [id field_id] :as field} source-name table-id]
    (let [field-id (or id field_id)
-         table-id (or (:table_id field) (:table-id field) (table-by-field-id field-id))]
+         table-id (or table-id (:table_id field) (:table-id field) (table-by-field-id field-id))]
      (m/assoc-some
       (assoc (common/column-schema field)
              :type "column"
@@ -144,7 +146,7 @@
       :name         (or display_name name)
       :databaseName database_name
       :tableName    name
-      :fields       (common/keyed-map (map #(field-schema % name) fields))}
+      :fields       (common/keyed-map (map #(field-schema % name id) fields))}
      :entityId portable_entity_id
      :description description
      :schemaName database_schema

--- a/src/metabase/typed_schemas/api/schema/table.clj
+++ b/src/metabase/typed_schemas/api/schema/table.clj
@@ -1,5 +1,5 @@
 (ns metabase.typed-schemas.api.schema.table
-  "Table, field, segment, and measure typed-schema generation."
+  "Typed schema generation for tables, fields, segments and measures."
   (:require
    [medley.core :as m]
    [metabase.metabot.tools.entity-details :as entity-details]
@@ -11,27 +11,19 @@
 
 (set! *warn-on-reflection* true)
 
-(defn field-table-id
-  "Returns the owning table id for `field-id`.
-
-  Some field-like payloads already include table ids, but metric dimensions and
-  table details can arrive with only a field id. Centralizing this lookup keeps
-  table and metric generators aligned on how missing table metadata is filled."
+(defn table-by-field-id
+  "Returns the table for a given field id."
   [field-id]
   (when (integer? field-id)
     (t2/select-one-fn :table_id :model/Field :id field-id)))
 
 (defn field-schema
-  "Returns the typed-schema representation for a table field.
-
-  Field schemas are consumed directly by `Lib.createTestQuery`, so this keeps
-  the runtime field ids/table ids while delegating display/type metadata to
-  [[common/column-schema]]."
+  "Returns the schema for a table field."
   ([field]
    (field-schema field nil))
   ([{:keys [id field_id] :as field} source-name]
    (let [field-id (or id field_id)
-         table-id (or (:table_id field) (:table-id field) (field-table-id field-id))]
+         table-id (or (:table_id field) (:table-id field) (table-by-field-id field-id))]
      (m/assoc-some
       (assoc (common/column-schema field)
              :type "column"
@@ -43,7 +35,7 @@
       :defaultTemporalBucket (:unit field)))))
 
 (defn select-tables
-  "Returns readable active tables for optional database and table id scopes.
+  "Returns readable tables, with optional database and table-id scopes.
 
   Library and database endpoint paths both need the same active/readable table
   rules; only their id filters differ."
@@ -58,10 +50,7 @@
         (filter mi/can-read?))))
 
 (defn select-library-tables
-  "Returns readable published data-library tables for `library-scope`.
-
-  Library scopes should include curated published tables, not every active
-  table in a database or collection."
+  "Returns published tables from the library based on the given scope."
   [{:keys [data-collection-ids]}]
   (->> (t2/select :model/Table
                   {:where    [:and
@@ -72,10 +61,7 @@
        (filter mi/can-read?)))
 
 (defn segment-schema
-  "Returns the typed-schema representation for a table segment.
-
-  Segments are table-scoped named filters, so the schema keeps enough runtime
-  metadata for agents to discover the segment and attach it to the table."
+  "Returns the schema for a segment."
   [table-id {:keys [id name description display-name portable-entity-id portable_entity_id]}]
   (m/assoc-some
    {:type    "segment"
@@ -96,9 +82,9 @@
 (defn measure-result-column
   "Returns the result column for a measure definition, or nil when it cannot be inferred.
 
-  Measures render as table-scoped aggregate fields. When Lib can infer the
-  aggregation column, the schema exposes the real result type; otherwise the
-  measure still remains usable with a conservative fallback column."
+  Measures render as aggregate fields. When Lib can infer the
+  aggregation column, the schema exposes the real result type. Otherwise, the
+  measure remains usable with a fallback column."
   [database-id measure-id]
   (try
     (when-let [definition (t2/select-one-fn :definition :model/Measure :id measure-id)]
@@ -107,10 +93,7 @@
       nil)))
 
 (defn measure-schema
-  "Returns the typed-schema representation for a table measure.
-
-  Measures are exposed beside fields so agents can ask for table-scoped
-  aggregations through the same typed schema surface."
+  "Returns the schema for a measure."
   [table-id database-id {:keys [id name description display-name portable-entity-id portable_entity_id]}]
   (m/assoc-some
    {:type    "measure"
@@ -124,11 +107,7 @@
    :description description))
 
 (defn table-schema
-  "Returns the typed-schema representation for a table detail map.
-
-  Table details become the main field namespace for `Lib.createTestQuery`, so
-  this function keeps runtime identifiers while nesting related segments and
-  measures under the same table key."
+  "Returns the schema for a table."
   [{:keys [id name description display_name database_id database_name database_schema portable_entity_id fields segments measures]}]
   (let [segments-map (common/keyed-map (map #(segment-schema id %) segments))
         measures-map (common/keyed-map (map #(measure-schema id database_id %) measures))]
@@ -160,11 +139,7 @@
           :structured-output))
 
 (defn table-schemas
-  "Returns table schemas for selected table rows.
-
-  Selection and detail hydration are split so API orchestration can decide which
-  rows belong in the schema while this namespace owns the table-specific detail
-  request and conversion."
+  "Returns table schemas for selected table rows."
   [tables]
   (for [table tables
         :let [details (table-details table)]

--- a/src/metabase/typed_schemas/api/schema/table.clj
+++ b/src/metabase/typed_schemas/api/schema/table.clj
@@ -2,6 +2,7 @@
   "Typed schema generation for tables, fields, segments and measures."
   (:require
    [medley.core :as m]
+   [metabase.lib-be.core :as lib-be]
    [metabase.metabot.tools.entity-details :as entity-details]
    [metabase.models.interface :as mi]
    [metabase.typed-schemas.api.common :as common]
@@ -92,25 +93,50 @@
     (catch Exception _
       nil)))
 
+(defn- measure-result-columns
+  "Returns result columns for table measures with one definition query and metadata provider."
+  [database-id measures]
+  (let [measure-ids (into [] (keep :id) measures)]
+    (when (seq measure-ids)
+      (let [definition-by-measure-id (into {}
+                                           (map (juxt :id :definition))
+                                           (t2/select [:model/Measure :id :definition] :id [:in measure-ids]))]
+        (try
+          (let [metadata-provider (lib-be/application-database-metadata-provider database-id)]
+            (into {}
+                  (keep (fn [{:keys [id]}]
+                          (when-let [definition (get definition-by-measure-id id)]
+                            [id (schema.common/aggregation-result-column-with-metadata-provider metadata-provider definition)])))
+                  measures))
+          ;; Result-column inference is best effort; callers fall back to an unknown column.
+          (catch Exception _
+            {}))))))
+
 (defn measure-schema
   "Returns the schema for a measure."
-  [table-id database-id {:keys [id name description display-name portable-entity-id portable_entity_id]}]
-  (m/assoc-some
-   {:type    "measure"
-    :key     (common/generated-key (or display-name name) id)
-    :id      id
-    :tableId table-id
-    :name    name
-    :columns [(or (some-> (measure-result-column database-id id) common/column-schema)
-                  (fallback-measure-column {:name (or display-name name)}))]}
-   :entityId (or portable_entity_id portable-entity-id)
-   :description description))
+  ([table-id database-id measure]
+   (measure-schema table-id database-id (measure-result-column database-id (:id measure)) measure))
+  ([table-id _database-id result-column {:keys [id name description display-name portable-entity-id portable_entity_id]}]
+   (m/assoc-some
+    {:type    "measure"
+     :key     (common/generated-key (or display-name name) id)
+     :id      id
+     :tableId table-id
+     :name    name
+     :columns [(or (some-> result-column common/column-schema)
+                   (fallback-measure-column {:name (or display-name name)}))]}
+    :entityId (or portable_entity_id portable-entity-id)
+    :description description)))
 
 (defn table-schema
   "Returns the schema for a table."
   [{:keys [id name description display_name database_id database_name database_schema portable_entity_id fields segments measures]}]
-  (let [segments-map (common/keyed-map (map #(segment-schema id %) segments))
-        measures-map (common/keyed-map (map #(measure-schema id database_id %) measures))]
+  (let [segments-map                 (common/keyed-map (map #(segment-schema id %) segments))
+        measure-result-column-by-id  (measure-result-columns database_id measures)
+        measures-map                 (common/keyed-map (map #(measure-schema id database_id
+                                                                             (get measure-result-column-by-id (:id %))
+                                                                             %)
+                                                            measures))]
     (m/assoc-some
      {:type         "table"
       :key          (common/generated-key (or display_name name) id)
@@ -125,18 +151,36 @@
      :segments (not-empty segments-map)
      :measures (not-empty measures-map))))
 
+(defn- table-details-error-message
+  [table error-message]
+  (format "Failed to build schema details for table \"%s\" (table %s): %s"
+          (or (:name table) "Untitled")
+          (:id table)
+          (or error-message "unknown error")))
+
+(defn- table-details-error-data
+  [table error-data]
+  (m/assoc-some
+   {:table-id   (:id table)
+    :table-name (:name table)}
+   :status-code (:status-code error-data)))
+
 (defn- table-details
   [table]
-  (some-> (entity-details/get-table-details
-           {:entity-type          :table
-            :entity-id            (:id table)
-            :with-fields?         true
-            :with-field-values?   false
-            :with-related-tables? false
-            :with-metrics?        false
-            :with-measures?       true
-            :with-segments?       true})
-          :structured-output))
+  (let [response (entity-details/get-table-details
+                  {:entity-type          :table
+                   :entity-id            (:id table)
+                   :with-fields?         true
+                   :with-field-values?   false
+                   :with-related-tables? false
+                   :with-metrics?        false
+                   :with-measures?       true
+                   :with-segments?       true})]
+    (or (:structured-output response)
+        (let [error-message (:output response)]
+          (throw (ex-info (table-details-error-message table error-message)
+                          (assoc (table-details-error-data table response)
+                                 :error-message error-message)))))))
 
 (defn table-schemas
   "Returns table schemas for selected table rows."

--- a/src/metabase/typed_schemas/api/schema/table.clj
+++ b/src/metabase/typed_schemas/api/schema/table.clj
@@ -1,0 +1,172 @@
+(ns metabase.typed-schemas.api.schema.table
+  "Table, field, segment, and measure typed-schema generation."
+  (:require
+   [medley.core :as m]
+   [metabase.metabot.tools.entity-details :as entity-details]
+   [metabase.models.interface :as mi]
+   [metabase.typed-schemas.api.common :as common]
+   [metabase.typed-schemas.api.schema.common :as schema.common]
+   [metabase.typed-schemas.api.scope :as scope]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn field-table-id
+  "Returns the owning table id for `field-id`.
+
+  Some field-like payloads already include table ids, but metric dimensions and
+  table details can arrive with only a field id. Centralizing this lookup keeps
+  table and metric generators aligned on how missing table metadata is filled."
+  [field-id]
+  (when (integer? field-id)
+    (t2/select-one-fn :table_id :model/Field :id field-id)))
+
+(defn field-schema
+  "Returns the typed-schema representation for a table field.
+
+  Field schemas are consumed directly by `Lib.createTestQuery`, so this keeps
+  the runtime field ids/table ids while delegating display/type metadata to
+  [[common/column-schema]]."
+  ([field]
+   (field-schema field nil))
+  ([{:keys [id field_id] :as field} source-name]
+   (let [field-id (or id field_id)
+         table-id (or (:table_id field) (:table-id field) (field-table-id field-id))]
+     (m/assoc-some
+      (assoc (common/column-schema field)
+             :type "column"
+             :key (common/generated-key (:name field) field-id)
+             :id field-id)
+      :sourceName source-name
+      :fieldId (when (integer? field-id) field-id)
+      :tableId (when (integer? table-id) table-id)
+      :defaultTemporalBucket (:unit field)))))
+
+(defn select-tables
+  "Returns readable active tables for optional database and table id scopes.
+
+  Library and database endpoint paths both need the same active/readable table
+  rules; only their id filters differ."
+  ([database-ids]
+   (select-tables database-ids nil))
+  ([database-ids table-ids]
+   (->> (t2/select :model/Table
+                   {:where    (cond-> [:and [:= :active true]]
+                                database-ids (conj (scope/database-id-filter-clause database-ids :db_id))
+                                table-ids (conj (scope/id-filter-clause table-ids :id)))
+                    :order-by [[:name :asc] [:id :asc]]})
+        (filter mi/can-read?))))
+
+(defn select-library-tables
+  "Returns readable published data-library tables for `library-scope`.
+
+  Library scopes should include curated published tables, not every active
+  table in a database or collection."
+  [{:keys [data-collection-ids]}]
+  (->> (t2/select :model/Table
+                  {:where    [:and
+                              [:= :active true]
+                              [:= :is_published true]
+                              (scope/id-filter-clause data-collection-ids :collection_id)]
+                   :order-by [[:name :asc] [:id :asc]]})
+       (filter mi/can-read?)))
+
+(defn segment-schema
+  "Returns the typed-schema representation for a table segment.
+
+  Segments are table-scoped named filters, so the schema keeps enough runtime
+  metadata for agents to discover the segment and attach it to the table."
+  [table-id {:keys [id name description display-name portable-entity-id portable_entity_id]}]
+  (m/assoc-some
+   {:type    "segment"
+    :key     (common/generated-key (or display-name name) id)
+    :id      id
+    :tableId table-id
+    :name    name}
+   :entityId (or portable_entity_id portable-entity-id)
+   :description description))
+
+(defn- fallback-measure-column
+  [{:keys [name]}]
+  {:type        "column"
+   :name        name
+   :displayName name
+   :jsType      "unknown"})
+
+(defn measure-result-column
+  "Returns the result column for a measure definition, or nil when it cannot be inferred.
+
+  Measures render as table-scoped aggregate fields. When Lib can infer the
+  aggregation column, the schema exposes the real result type; otherwise the
+  measure still remains usable with a conservative fallback column."
+  [database-id measure-id]
+  (try
+    (when-let [definition (t2/select-one-fn :definition :model/Measure :id measure-id)]
+      (schema.common/aggregation-result-column database-id definition))
+    (catch Exception _
+      nil)))
+
+(defn measure-schema
+  "Returns the typed-schema representation for a table measure.
+
+  Measures are exposed beside fields so agents can ask for table-scoped
+  aggregations through the same typed schema surface."
+  [table-id database-id {:keys [id name description display-name portable-entity-id portable_entity_id]}]
+  (m/assoc-some
+   {:type    "measure"
+    :key     (common/generated-key (or display-name name) id)
+    :id      id
+    :tableId table-id
+    :name    name
+    :columns [(or (some-> (measure-result-column database-id id) common/column-schema)
+                  (fallback-measure-column {:name (or display-name name)}))]}
+   :entityId (or portable_entity_id portable-entity-id)
+   :description description))
+
+(defn table-schema
+  "Returns the typed-schema representation for a table detail map.
+
+  Table details become the main field namespace for `Lib.createTestQuery`, so
+  this function keeps runtime identifiers while nesting related segments and
+  measures under the same table key."
+  [{:keys [id name description display_name database_id database_name database_schema portable_entity_id fields segments measures]}]
+  (let [segments-map (common/keyed-map (map #(segment-schema id %) segments))
+        measures-map (common/keyed-map (map #(measure-schema id database_id %) measures))]
+    (m/assoc-some
+     {:type         "table"
+      :key          (common/generated-key (or display_name name) id)
+      :id           id
+      :name         (or display_name name)
+      :databaseName database_name
+      :tableName    name
+      :fields       (common/keyed-map (map #(field-schema % name) fields))}
+     :entityId portable_entity_id
+     :description description
+     :schemaName database_schema
+     :segments (not-empty segments-map)
+     :measures (not-empty measures-map))))
+
+(defn- table-details
+  [table]
+  (some-> (entity-details/get-table-details
+           {:entity-type          :table
+            :entity-id            (:id table)
+            :with-fields?         true
+            :with-field-values?   false
+            :with-related-tables? false
+            :with-metrics?        false
+            :with-measures?       true
+            :with-segments?       true})
+          :structured-output))
+
+(defn table-schemas
+  "Returns table schemas for selected table rows.
+
+  Selection and detail hydration are split so API orchestration can decide which
+  rows belong in the schema while this namespace owns the table-specific detail
+  request and conversion."
+  [tables]
+  (for [table tables
+        :let [details (table-details table)]
+        :when details]
+    (table-schema details)))

--- a/test/metabase/typed_schemas/api/schema/question_test.clj
+++ b/test/metabase/typed_schemas/api/schema/question_test.clj
@@ -1,0 +1,17 @@
+(ns metabase.typed-schemas.api.schema.question-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.typed-schemas.api.schema.question :as schema.question]))
+
+(deftest question-schema-uses-card-source-discriminator-test
+  (is (= {:type    "card"
+          :key     "ordersQuestion"
+          :id      41
+          :name    "Orders question"
+          :display "table"
+          :columns [{:type "column", :name "count", :displayName "Count", :jsType "number"}]}
+         (schema.question/question-schema
+          {:id             41
+           :name           "Orders question"
+           :display        "table"
+           :result-columns [{:name "count", :display_name "Count", :type :number}]}))))

--- a/test/metabase/typed_schemas/api/schema/question_test.clj
+++ b/test/metabase/typed_schemas/api/schema/question_test.clj
@@ -1,6 +1,9 @@
 (ns metabase.typed-schemas.api.schema.question-test
   (:require
    [clojure.test :refer :all]
+   [metabase.metabot.tools.entity-details :as entity-details]
+   [metabase.test :as mt]
+   [metabase.typed-schemas.api.schema.common :as schema.common]
    [metabase.typed-schemas.api.schema.question :as schema.question]))
 
 (deftest question-schema-uses-card-source-discriminator-test
@@ -15,3 +18,22 @@
            :name           "Orders question"
            :display        "table"
            :result-columns [{:name "count", :display_name "Count", :type :number}]}))))
+
+(deftest question-schemas-bulk-loads-details-by-database-test
+  (let [cards              [{:id 41 :name "Orders question" :type :question :database_id 1 :display "table"}
+                            {:id 42 :name "People question" :type :question :database_id 1 :display "table"}]
+        bulk-details-calls (atom [])
+        report-details-calls (atom [])]
+    (mt/with-dynamic-fn-redefs [entity-details/get-report-details
+                                (fn [{:keys [report-id] :as options}]
+                                  (swap! report-details-calls conj options)
+                                  {:structured-output {:id report-id :result-columns []}})]
+      (with-redefs [schema.common/select-schema-cards (constantly cards)
+                    entity-details/cards-details (fn [card-type database-id selected-cards _options]
+                                                   (swap! bulk-details-calls conj [card-type database-id selected-cards])
+                                                   (map #(assoc % :fields []) selected-cards))]
+        (is (= [41 42]
+               (mapv :id (schema.question/question-schemas nil))))
+        (is (= [[:question 1 cards]]
+               @bulk-details-calls))
+        (is (empty? @report-details-calls))))))

--- a/test/metabase/typed_schemas/api/schema/table_test.clj
+++ b/test/metabase/typed_schemas/api/schema/table_test.clj
@@ -3,21 +3,46 @@
    [clojure.test :refer :all]
    [metabase.typed-schemas.api.schema.table :as schema.table]))
 
+(def ^:private created-at-field
+  {:id           42
+   :table_id     10
+   :name         "created_at"
+   :display_name "Created At"
+   :base_type    "type/DateTime"})
+
+(def ^:private created-at-field-schema
+  {:type        "column"
+   :name        "created_at"
+   :displayName "Created At"
+   :baseType    "type/DateTime"
+   :jsType      "Date"
+   :key         "createdAt"
+   :id          42
+   :fieldId     42
+   :tableId     10})
+
+(def ^:private orders-table
+  {:id            10
+   :name          "orders"
+   :display_name  "Orders"
+   :database_id   1
+   :database_name "Boba"
+   :fields        [created-at-field]})
+
+(def ^:private total-revenue-measure
+  {:id   1
+   :name "Total Revenue"})
+
+(def ^:private total-revenue-schema
+  {:type    "measure"
+   :key     "totalRevenue"
+   :id      1
+   :tableId 10
+   :name    "Total Revenue"})
+
 (deftest field-schema-uses-field-id-test
-  (is (= {:name          "created_at"
-          :type          "column"
-          :displayName   "Created At"
-          :baseType      "type/DateTime"
-          :jsType        "Date"
-          :key           "createdAt"
-          :id            42
-          :fieldId       42
-          :tableId       10}
-         (schema.table/field-schema {:id             42
-                                     :table_id       10
-                                     :name           "created_at"
-                                     :display_name   "Created At"
-                                     :base_type      "type/DateTime"}))))
+  (is (= created-at-field-schema
+         (schema.table/field-schema created-at-field))))
 
 (deftest table-schema-keys-fields-test
   (is (= {:type         "table"
@@ -26,27 +51,8 @@
           :name         "Orders"
           :databaseName "Boba"
           :tableName    "orders"
-          :fields       {"createdAt" {:type          "column"
-                                      :name          "created_at"
-                                      :sourceName    "orders"
-                                      :displayName   "Created At"
-                                      :baseType      "type/DateTime"
-                                      :jsType        "Date"
-                                      :key           "createdAt"
-                                      :id            42
-                                      :fieldId       42
-                                      :tableId       10}}}
-         (schema.table/table-schema
-          {:id            10
-           :name          "orders"
-           :display_name  "Orders"
-           :database_id   1
-           :database_name "Boba"
-           :fields        [{:id           42
-                            :table_id     10
-                            :name         "created_at"
-                            :display_name "Created At"
-                            :base_type    "type/DateTime"}]}))))
+          :fields       {"createdAt" (assoc created-at-field-schema :sourceName "orders")}}
+         (schema.table/table-schema orders-table))))
 
 (deftest segment-schema-uses-type-discriminator-test
   (is (= {:type    "segment"
@@ -66,31 +72,15 @@
                   (constantly {:name         "sum"
                                :display_name "Sum of Total"
                                :base_type    "type/Decimal"})]
-      (is (= {:type    "measure"
-              :key     "totalRevenue"
-              :id      1
-              :tableId 10
-              :name    "Total Revenue"
-              :columns [{:type        "column"
-                         :name        "sum"
-                         :displayName "Sum of Total"
-                         :baseType    "type/Decimal"
-                         :jsType      "number"}]}
-             (schema.table/measure-schema
-              10
-              2
-              {:id   1
-               :name "Total Revenue"})))))
+      (is (= (assoc total-revenue-schema
+                    :columns [{:type        "column"
+                               :name        "sum"
+                               :displayName "Sum of Total"
+                               :baseType    "type/Decimal"
+                               :jsType      "number"}])
+             (schema.table/measure-schema 10 2 total-revenue-measure)))))
   (testing "measure result columns fall back to the measure name"
     (with-redefs [schema.table/measure-result-column (constantly nil)]
-      (is (= {:type    "measure"
-              :key     "totalRevenue"
-              :id      1
-              :tableId 10
-              :name    "Total Revenue"
-              :columns [{:type "column", :name "Total Revenue", :displayName "Total Revenue", :jsType "unknown"}]}
-             (schema.table/measure-schema
-              10
-              2
-              {:id   1
-               :name "Total Revenue"}))))))
+      (is (= (assoc total-revenue-schema
+                    :columns [{:type "column", :name "Total Revenue", :displayName "Total Revenue", :jsType "unknown"}])
+             (schema.table/measure-schema 10 2 total-revenue-measure))))))

--- a/test/metabase/typed_schemas/api/schema/table_test.clj
+++ b/test/metabase/typed_schemas/api/schema/table_test.clj
@@ -1,0 +1,96 @@
+(ns metabase.typed-schemas.api.schema.table-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.typed-schemas.api.schema.table :as schema.table]))
+
+(deftest field-schema-uses-field-id-test
+  (is (= {:name          "created_at"
+          :type          "column"
+          :displayName   "Created At"
+          :baseType      "type/DateTime"
+          :jsType        "Date"
+          :key           "createdAt"
+          :id            42
+          :fieldId       42
+          :tableId       10}
+         (schema.table/field-schema {:id             42
+                                     :table_id       10
+                                     :name           "created_at"
+                                     :display_name   "Created At"
+                                     :base_type      "type/DateTime"}))))
+
+(deftest table-schema-keys-fields-test
+  (is (= {:type         "table"
+          :key          "orders"
+          :id           10
+          :name         "Orders"
+          :databaseName "Boba"
+          :tableName    "orders"
+          :fields       {"createdAt" {:type          "column"
+                                      :name          "created_at"
+                                      :sourceName    "orders"
+                                      :displayName   "Created At"
+                                      :baseType      "type/DateTime"
+                                      :jsType        "Date"
+                                      :key           "createdAt"
+                                      :id            42
+                                      :fieldId       42
+                                      :tableId       10}}}
+         (schema.table/table-schema
+          {:id            10
+           :name          "orders"
+           :display_name  "Orders"
+           :database_id   1
+           :database_name "Boba"
+           :fields        [{:id           42
+                            :table_id     10
+                            :name         "created_at"
+                            :display_name "Created At"
+                            :base_type    "type/DateTime"}]}))))
+
+(deftest segment-schema-uses-type-discriminator-test
+  (is (= {:type    "segment"
+          :key     "completedOrders"
+          :id      12
+          :tableId 10
+          :name    "Completed Orders"}
+         (schema.table/segment-schema
+          10
+          {:id           12
+           :name         "Completed Orders"
+           :display-name "Completed Orders"}))))
+
+(deftest measure-schema-uses-result-column-test
+  (testing "measure result columns come from the measure definition when available"
+    (with-redefs [schema.table/measure-result-column
+                  (constantly {:name         "sum"
+                               :display_name "Sum of Total"
+                               :base_type    "type/Decimal"})]
+      (is (= {:type    "measure"
+              :key     "totalRevenue"
+              :id      1
+              :tableId 10
+              :name    "Total Revenue"
+              :columns [{:type        "column"
+                         :name        "sum"
+                         :displayName "Sum of Total"
+                         :baseType    "type/Decimal"
+                         :jsType      "number"}]}
+             (schema.table/measure-schema
+              10
+              2
+              {:id   1
+               :name "Total Revenue"})))))
+  (testing "measure result columns fall back to the measure name"
+    (with-redefs [schema.table/measure-result-column (constantly nil)]
+      (is (= {:type    "measure"
+              :key     "totalRevenue"
+              :id      1
+              :tableId 10
+              :name    "Total Revenue"
+              :columns [{:type "column", :name "Total Revenue", :displayName "Total Revenue", :jsType "unknown"}]}
+             (schema.table/measure-schema
+              10
+              2
+              {:id   1
+               :name "Total Revenue"}))))))

--- a/test/metabase/typed_schemas/api/schema/table_test.clj
+++ b/test/metabase/typed_schemas/api/schema/table_test.clj
@@ -59,6 +59,24 @@
           :fields       {"createdAt" (assoc created-at-field-schema :sourceName "orders")}}
          (schema.table/table-schema orders-table))))
 
+; Avoid N+1 on table fields by re-using the known table id
+(deftest table-schema-uses-known-table-id-for-detail-fields-test
+  (let [field-table-lookups (atom 0)
+        detail-fields       [{:field_id     42
+                              :name         "created_at"
+                              :display_name "Created At"
+                              :base_type    "type/DateTime"}
+                             {:field_id     43
+                              :name         "total"
+                              :display_name "Total"
+                              :base_type    "type/Decimal"}]]
+    (with-redefs [t2/select-one-fn (fn [& _]
+                                     (swap! field-table-lookups inc)
+                                     999)]
+      (let [schema (schema.table/table-schema (assoc orders-table :fields detail-fields))]
+        (is (= #{10} (->> (:fields schema) vals (map :tableId) set)))
+        (is (zero? @field-table-lookups))))))
+
 (deftest segment-schema-uses-type-discriminator-test
   (is (= {:type    "segment"
           :key     "completedOrders"

--- a/test/metabase/typed_schemas/api/schema/table_test.clj
+++ b/test/metabase/typed_schemas/api/schema/table_test.clj
@@ -1,7 +1,12 @@
 (ns metabase.typed-schemas.api.schema.table-test
   (:require
    [clojure.test :refer :all]
-   [metabase.typed-schemas.api.schema.table :as schema.table]))
+   [metabase.lib-be.core :as lib-be]
+   [metabase.metabot.tools.entity-details :as entity-details]
+   [metabase.test :as mt]
+   [metabase.typed-schemas.api.schema.common :as schema.common]
+   [metabase.typed-schemas.api.schema.table :as schema.table]
+   [toucan2.core :as t2]))
 
 (def ^:private created-at-field
   {:id           42
@@ -84,3 +89,37 @@
       (is (= (assoc total-revenue-schema
                     :columns [{:type "column", :name "Total Revenue", :displayName "Total Revenue", :jsType "unknown"}])
              (schema.table/measure-schema 10 2 total-revenue-measure))))))
+
+(deftest table-schemas-surface-detail-error-responses-test
+  (mt/with-dynamic-fn-redefs [entity-details/get-table-details
+                              (constantly {:output "Not found."
+                                           :status-code 404})]
+    (let [exception (try
+                      (doall (schema.table/table-schemas [{:id 10 :name "Orders"}]))
+                      (catch clojure.lang.ExceptionInfo exception
+                        exception))]
+      (is (instance? clojure.lang.ExceptionInfo exception))
+      (is (= {:table-id      10
+              :table-name    "Orders"
+              :status-code   404
+              :error-message "Not found."}
+             (ex-data exception))))))
+
+;; Batch measure definitions to avoid N+1 queries.
+(deftest table-schema-bulk-loads-measure-definitions-test
+  (let [measure-select-count     (atom 0)
+        metadata-provider-count (atom 0)
+        measures                 [{:id 1 :name "Total Revenue"}
+                                  {:id 2 :name "Average Revenue"}]]
+    (with-redefs [lib-be/application-database-metadata-provider (fn [_database-id]
+                                                                  (swap! metadata-provider-count inc)
+                                                                  :metadata-provider)
+                  schema.common/aggregation-result-column-with-metadata-provider (constantly nil)
+                  t2/select (fn [columns & _args]
+                              (when (= columns [:model/Measure :id :definition])
+                                (swap! measure-select-count inc)
+                                [{:id 1 :definition [:aggregation 1]}
+                                 {:id 2 :definition [:aggregation 2]}]))]
+      (schema.table/table-schema (assoc orders-table :measures measures))
+      (is (= 1 @measure-select-count))
+      (is (= 1 @metadata-provider-count)))))

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -3,7 +3,6 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.actions.core :as actions]
-   [metabase.metabot.tools.entity-details :as entity-details]
    [metabase.models.interface :as mi]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -68,11 +67,8 @@
                   (is (= :model card-type))
                   (is (= #{1} database-ids))
                   (is (nil? collection-ids))
-                  [{:id 42} {:id 43}])
-                typed-schemas.api.schema.common/question-details
-                (fn [card]
-                  {:id   (:id card)
-                   :name (str "Model " (:id card))})
+                  [{:id 42 :name "Model 42"}
+                   {:id 43 :name "Model 43"}])
                 typed-schemas.api/model-actions
                 (fn [model]
                   (when (= (:id model) 42)
@@ -265,37 +261,6 @@
       (#'typed-schemas.api/typed-schema {:database "Boba"})
       (#'typed-schemas.api/typed-schema {:database "Boba" :questions "true"})
       (is (= [#{42} #{42}] @model-database-ids)))))
-
-(deftest model-schemas-surface-detail-errors-test
-  (with-redefs [typed-schemas.api.schema.common/select-schema-cards (constantly [{:id 100 :type "model" :name "Broken model"}])
-                entity-details/get-report-details (constantly {:output "source table not found"
-                                                               :status-code 404})]
-    (let [exception (is (thrown? clojure.lang.ExceptionInfo
-                                 (doall (#'typed-schemas.api/model-schemas #{1}))))]
-      (is (= "Failed to build schema details for model \"Broken model\" (card 100): source table not found"
-             (ex-message exception)))
-      (is (= {:card-id       100
-              :card-name     "Broken model"
-              :card-type     "model"
-              :status-code   404
-              :error-message "source table not found"}
-             (select-keys (ex-data exception) [:card-id :card-name :card-type :status-code :error-message]))))))
-
-(deftest model-schemas-surface-detail-exceptions-test
-  (with-redefs [typed-schemas.api.schema.common/select-schema-cards (constantly [{:id 100 :type "model" :name "Broken model"}])
-                entity-details/get-report-details (fn [_]
-                                                    (throw (ex-info "Invalid output: [\"Valid Table metadata, got: nil\"]"
-                                                                    {:status-code 500})))]
-    (let [exception (is (thrown? clojure.lang.ExceptionInfo
-                                 (doall (#'typed-schemas.api/model-schemas #{1}))))]
-      (is (= "Failed to build schema details for model \"Broken model\" (card 100): Invalid output: [\"Valid Table metadata, got: nil\"]"
-             (ex-message exception)))
-      (is (= {:card-id       100
-              :card-name     "Broken model"
-              :card-type     "model"
-              :status-code   500
-              :cause-message "Invalid output: [\"Valid Table metadata, got: nil\"]"}
-             (select-keys (ex-data exception) [:card-id :card-name :card-type :status-code :cause-message]))))))
 
 (deftest model-schema-surfaces-action-selection-errors-test
   (with-redefs [typed-schemas.api/raw-model-actions (constantly [])

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -9,6 +9,9 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.typed-schemas.api :as typed-schemas.api]
    [metabase.typed-schemas.api.render :as typed-schemas.api.render]
+   [metabase.typed-schemas.api.schema.common :as typed-schemas.api.schema.common]
+   [metabase.typed-schemas.api.schema.question :as typed-schemas.api.schema.question]
+   [metabase.typed-schemas.api.schema.table :as typed-schemas.api.schema.table]
    [metabase.typed-schemas.api.scope :as typed-schemas.api.scope]
    [toucan2.core :as t2]))
 
@@ -47,76 +50,6 @@
             :sources         [{:type :field, :field-id 3815}]}
            247)))))
 
-(deftest field-schema-uses-field-id-test
-  (is (= {:name          "created_at"
-          :type          "column"
-          :displayName   "Created At"
-          :baseType      "type/DateTime"
-          :jsType        "Date"
-          :key           "createdAt"
-          :id            42
-          :fieldId       42
-          :tableId       10}
-         (#'typed-schemas.api/field-schema {:id             42
-                                            :table_id       10
-                                            :name           "created_at"
-                                            :display_name   "Created At"
-                                            :base_type      "type/DateTime"}))))
-
-(deftest table-schema-keys-fields-test
-  (is (= {:type         "table"
-          :key          "orders"
-          :id           10
-          :name         "Orders"
-          :databaseName "Boba"
-          :tableName    "orders"
-          :fields       {"createdAt" {:type          "column"
-                                      :name          "created_at"
-                                      :sourceName   "orders"
-                                      :displayName   "Created At"
-                                      :baseType      "type/DateTime"
-                                      :jsType        "Date"
-                                      :key           "createdAt"
-                                      :id            42
-                                      :fieldId       42
-                                      :tableId       10}}}
-         (#'typed-schemas.api/table-schema
-          {:id            10
-           :name          "orders"
-           :display_name  "Orders"
-           :database_id   1
-           :database_name "Boba"
-           :fields        [{:id           42
-                            :table_id     10
-                            :name         "created_at"
-                            :display_name "Created At"
-                            :base_type    "type/DateTime"}]}))))
-
-(deftest segment-schema-uses-type-discriminator-test
-  (is (= {:type    "segment"
-          :key     "completedOrders"
-          :id      12
-          :tableId 10
-          :name    "Completed Orders"}
-         (#'typed-schemas.api/segment-schema
-          10
-          {:id           12
-           :name         "Completed Orders"
-           :display-name "Completed Orders"}))))
-
-(deftest question-schema-uses-card-source-discriminator-test
-  (is (= {:type    "card"
-          :key     "ordersQuestion"
-          :id      41
-          :name    "Orders question"
-          :display "table"
-          :columns [{:type "column", :name "count", :displayName "Count", :jsType "number"}]}
-         (#'typed-schemas.api/question-schema
-          {:id             41
-           :name           "Orders question"
-           :display        "table"
-           :result-columns [{:name "count", :display_name "Count", :type :number}]}))))
-
 (deftest model-schema-includes-actions-test
   (with-redefs [typed-schemas.api/model-actions
                 (fn [model]
@@ -130,13 +63,13 @@
              :name           "Orders model"})))))
 
 (deftest model-schemas-includes-actionable-models-test
-  (with-redefs [typed-schemas.api/select-cards
+  (with-redefs [typed-schemas.api.schema.common/select-schema-cards
                 (fn [card-type database-ids collection-ids]
                   (is (= :model card-type))
                   (is (= #{1} database-ids))
                   (is (nil? collection-ids))
                   [{:id 42} {:id 43}])
-                typed-schemas.api/question-details
+                typed-schemas.api.schema.common/question-details
                 (fn [card]
                   {:id   (:id card)
                    :name (str "Model " (:id card))})
@@ -262,41 +195,6 @@
             {:id            259
              :dataset_query {:stages [{:source-card 258}]}})))))
 
-(deftest measure-schema-uses-result-column-test
-  (testing "measure result columns come from the measure definition when available"
-    (with-redefs [typed-schemas.api/measure-result-column
-                  (constantly {:name         "sum"
-                               :display_name "Sum of Total"
-                               :base_type    "type/Decimal"})]
-      (is (= {:type    "measure"
-              :key     "totalRevenue"
-              :id      1
-              :tableId 10
-              :name    "Total Revenue"
-              :columns [{:type        "column"
-                         :name        "sum"
-                         :displayName "Sum of Total"
-                         :baseType    "type/Decimal"
-                         :jsType      "number"}]}
-             (#'typed-schemas.api/measure-schema
-              10
-              2
-              {:id   1
-               :name "Total Revenue"})))))
-  (testing "measure result columns fall back to the measure name"
-    (with-redefs [typed-schemas.api/measure-result-column (constantly nil)]
-      (is (= {:type    "measure"
-              :key     "totalRevenue"
-              :id      1
-              :tableId 10
-              :name    "Total Revenue"
-              :columns [{:type "column", :name "Total Revenue", :displayName "Total Revenue", :jsType "unknown"}]}
-             (#'typed-schemas.api/measure-schema
-              10
-              2
-              {:id   1
-               :name "Total Revenue"}))))))
-
 (deftest typescript-endpoint-test
   (let [response (mt/user-http-request-full-response :crowberto :get 200 "typed-schemas/v1/typescript")]
     (is (= "text/typescript; charset=utf-8" (get-in response [:headers "Content-Type"])))
@@ -354,67 +252,67 @@
                   typed-schemas.api/model-schemas (fn [database-ids]
                                                     (swap! model-database-ids conj database-ids)
                                                     [])
-                  typed-schemas.api/question-schemas (fn
-                                                       ([_database-ids] [])
-                                                       ([_database-ids _collection-ids] []))
+                  typed-schemas.api.schema.question/question-schemas (fn
+                                                                       ([_database-ids] [])
+                                                                       ([_database-ids _collection-ids] []))
                   typed-schemas.api/metric-schemas (fn
                                                      ([_database-ids] [])
                                                      ([_database-ids _collection-ids] []))
-                  typed-schemas.api/select-tables (fn
-                                                    ([_database-ids] [])
-                                                    ([_database-ids _table-ids] []))
-                  typed-schemas.api/table-schemas (constantly [])]
+                  typed-schemas.api.schema.table/select-tables (fn
+                                                                 ([_database-ids] [])
+                                                                 ([_database-ids _table-ids] []))
+                  typed-schemas.api.schema.table/table-schemas (constantly [])]
       (#'typed-schemas.api/typed-schema {:database "Boba"})
       (#'typed-schemas.api/typed-schema {:database "Boba" :questions "true"})
       (is (= [#{42} #{42}] @model-database-ids)))))
 
 (deftest model-schemas-surface-detail-errors-test
-  (with-redefs [typed-schemas.api/select-cards (constantly [{:id 100 :type "model" :name "Broken model"}])
+  (with-redefs [typed-schemas.api.schema.common/select-schema-cards (constantly [{:id 100 :type "model" :name "Broken model"}])
                 entity-details/get-report-details (constantly {:output "source table not found"
                                                                :status-code 404})]
-    (let [e (is (thrown? clojure.lang.ExceptionInfo
-                         (doall (#'typed-schemas.api/model-schemas #{1}))))]
+    (let [exception (is (thrown? clojure.lang.ExceptionInfo
+                                 (doall (#'typed-schemas.api/model-schemas #{1}))))]
       (is (= "Failed to build schema details for model \"Broken model\" (card 100): source table not found"
-             (ex-message e)))
+             (ex-message exception)))
       (is (= {:card-id       100
               :card-name     "Broken model"
               :card-type     "model"
               :status-code   404
               :error-message "source table not found"}
-             (select-keys (ex-data e) [:card-id :card-name :card-type :status-code :error-message]))))))
+             (select-keys (ex-data exception) [:card-id :card-name :card-type :status-code :error-message]))))))
 
 (deftest model-schemas-surface-detail-exceptions-test
-  (with-redefs [typed-schemas.api/select-cards (constantly [{:id 100 :type "model" :name "Broken model"}])
+  (with-redefs [typed-schemas.api.schema.common/select-schema-cards (constantly [{:id 100 :type "model" :name "Broken model"}])
                 entity-details/get-report-details (fn [_]
                                                     (throw (ex-info "Invalid output: [\"Valid Table metadata, got: nil\"]"
                                                                     {:status-code 500})))]
-    (let [e (is (thrown? clojure.lang.ExceptionInfo
-                         (doall (#'typed-schemas.api/model-schemas #{1}))))]
+    (let [exception (is (thrown? clojure.lang.ExceptionInfo
+                                 (doall (#'typed-schemas.api/model-schemas #{1}))))]
       (is (= "Failed to build schema details for model \"Broken model\" (card 100): Invalid output: [\"Valid Table metadata, got: nil\"]"
-             (ex-message e)))
+             (ex-message exception)))
       (is (= {:card-id       100
               :card-name     "Broken model"
               :card-type     "model"
               :status-code   500
               :cause-message "Invalid output: [\"Valid Table metadata, got: nil\"]"}
-             (select-keys (ex-data e) [:card-id :card-name :card-type :status-code :cause-message]))))))
+             (select-keys (ex-data exception) [:card-id :card-name :card-type :status-code :cause-message]))))))
 
 (deftest model-schema-surfaces-action-selection-errors-test
   (with-redefs [typed-schemas.api/raw-model-actions (constantly [])
                 actions/select-actions (fn [& _]
                                          (throw (ex-info "action lookup failed"
                                                          {:status-code 500})))]
-    (let [e (is (thrown? clojure.lang.ExceptionInfo
-                         (#'typed-schemas.api/model-schema {:id             100
-                                                            :name           "Broken model"
-                                                            :result-columns []})))]
+    (let [exception (is (thrown? clojure.lang.ExceptionInfo
+                                 (#'typed-schemas.api/model-schema {:id             100
+                                                                    :name           "Broken model"
+                                                                    :result-columns []})))]
       (is (= "Failed to build action schemas for model \"Broken model\" (card 100): action lookup failed"
-             (ex-message e)))
+             (ex-message exception)))
       (is (= {:model-id      100
               :model-name    "Broken model"
               :status-code   500
               :cause-message "action lookup failed"}
-             (select-keys (ex-data e) [:model-id :model-name :status-code :cause-message]))))))
+             (select-keys (ex-data exception) [:model-id :model-name :status-code :cause-message]))))))
 
 (deftest model-schema-surfaces-action-rendering-errors-test
   (with-redefs [actions/select-actions (constantly [{:id   200
@@ -426,12 +324,12 @@
                 typed-schemas.api/action-schema (fn [& _]
                                                   (throw (ex-info "action parameters are invalid"
                                                                   {:status-code 500})))]
-    (let [e (is (thrown? clojure.lang.ExceptionInfo
-                         (#'typed-schemas.api/model-schema {:id             100
-                                                            :name           "Broken model"
-                                                            :result-columns []})))]
+    (let [exception (is (thrown? clojure.lang.ExceptionInfo
+                                 (#'typed-schemas.api/model-schema {:id             100
+                                                                    :name           "Broken model"
+                                                                    :result-columns []})))]
       (is (= "Failed to build action schema for action \"Broken action\" (action 200, type query) on model \"Broken model\" (card 100): action parameters are invalid"
-             (ex-message e)))
+             (ex-message exception)))
       (is (= {:model-id      100
               :model-name    "Broken model"
               :action-id     200
@@ -439,23 +337,23 @@
               :action-type   :query
               :status-code   500
               :cause-message "action parameters are invalid"}
-             (select-keys (ex-data e) [:model-id :model-name :action-id :action-name :action-type :status-code :cause-message]))))))
+             (select-keys (ex-data exception) [:model-id :model-name :action-id :action-name :action-type :status-code :cause-message]))))))
 
 (deftest model-schema-surfaces-dropped-action-errors-test
   (with-redefs [typed-schemas.api/raw-model-actions (constantly [{:id   200
                                                                   :name "Broken action"
                                                                   :type :broken}])
                 actions/select-actions (constantly [])]
-    (let [e (is (thrown? clojure.lang.ExceptionInfo
-                         (#'typed-schemas.api/model-schema {:id             100
-                                                            :name           "Broken model"
-                                                            :result-columns []})))]
+    (let [exception (is (thrown? clojure.lang.ExceptionInfo
+                                 (#'typed-schemas.api/model-schema {:id             100
+                                                                    :name           "Broken model"
+                                                                    :result-columns []})))]
       (is (= "Failed to build action schemas for model \"Broken model\" (card 100): selected actions were dropped while normalizing action details: Broken action (action 200, type broken)"
-             (ex-message e)))
+             (ex-message exception)))
       (is (= {:model-id        100
               :model-name      "Broken model"
               :dropped-actions [{:id 200, :name "Broken action", :type :broken}]}
-             (select-keys (ex-data e) [:model-id :model-name :dropped-actions]))))))
+             (select-keys (ex-data exception) [:model-id :model-name :dropped-actions]))))))
 
 (deftest library-and-database-are-mutually-exclusive-test
   (mt/user-http-request-full-response
@@ -511,13 +409,13 @@
                       :name           "Revenue"
                       :columns        [{:name "Revenue", :displayName "Revenue", :jsType "number"}]
                       :mappedTableIds [42]}])
-                  typed-schemas.api/select-library-tables
+                  typed-schemas.api.schema.table/select-library-tables
                   (constantly [{:id 10}])
-                  typed-schemas.api/select-tables
+                  typed-schemas.api.schema.table/select-tables
                   (fn [_database-ids table-ids]
                     (reset! selected-table-ids table-ids)
                     [{:id 10} {:id 42}])
-                  typed-schemas.api/table-schemas
+                  typed-schemas.api.schema.table/table-schemas
                   (constantly [{:type "table", :key "publishedTable", :id 10}
                                {:type "table", :key "mappedTable", :id 42}])]
       (let [schema (#'typed-schemas.api/typed-schema {:library "123"})]
@@ -549,15 +447,15 @@
                       :name           "Revenue"
                       :columns        [{:name "Revenue", :displayName "Revenue", :jsType "number"}]
                       :mappedTableIds [42]}])
-                  typed-schemas.api/select-library-tables
+                  typed-schemas.api.schema.table/select-library-tables
                   (fn [library-scope]
                     (is (= #{10} (:data-collection-ids library-scope)))
                     [{:id 10}])
-                  typed-schemas.api/select-tables
+                  typed-schemas.api.schema.table/select-tables
                   (fn [_database-ids table-ids]
                     (reset! selected-table-ids table-ids)
                     [{:id 10} {:id 42}])
-                  typed-schemas.api/table-schemas
+                  typed-schemas.api.schema.table/table-schemas
                   (constantly [{:type "table", :key "publishedTable", :id 10}
                                {:type "table", :key "mappedTable", :id 42}])]
       (let [schema (#'typed-schemas.api/typed-schema {:library-collections "10, 20"})]
@@ -573,7 +471,7 @@
                   (is (nil? database-ids))
                   [{:key     "actionableModel"
                     :actions {"create" {:kind "action", :key "create", :id 1}}}])
-                typed-schemas.api/question-schemas
+                typed-schemas.api.schema.question/question-schemas
                 (fn
                   ([_database-ids]
                    (is false "include-models-only schemas should not load questions"))
@@ -585,7 +483,7 @@
                    (is false "include-models-only schemas should not load metrics"))
                   ([_database-ids _collection-ids]
                    (is false "include-models-only schemas should not load metrics")))
-                typed-schemas.api/select-tables
+                typed-schemas.api.schema.table/select-tables
                 (fn
                   ([_database-ids]
                    (is false "include-models-only schemas should not load tables"))
@@ -605,16 +503,16 @@
                                                     (swap! model-database-ids conj database-ids)
                                                     [{:key     "databaseModel"
                                                       :actions {"create" {:kind "action", :key "create", :id 1}}}])
-                  typed-schemas.api/question-schemas (fn
-                                                       ([_database-ids] [])
-                                                       ([_database-ids _collection-ids] []))
+                  typed-schemas.api.schema.question/question-schemas (fn
+                                                                       ([_database-ids] [])
+                                                                       ([_database-ids _collection-ids] []))
                   typed-schemas.api/metric-schemas (fn
                                                      ([_database-ids] [])
                                                      ([_database-ids _collection-ids] []))
-                  typed-schemas.api/select-tables (fn
-                                                    ([_database-ids] [])
-                                                    ([_database-ids _table-ids] []))
-                  typed-schemas.api/table-schemas (constantly [])]
+                  typed-schemas.api.schema.table/select-tables (fn
+                                                                 ([_database-ids] [])
+                                                                 ([_database-ids _table-ids] []))
+                  typed-schemas.api.schema.table/table-schemas (constantly [])]
       (let [schema (#'typed-schemas.api/typed-schema {:database "Boba" :include-models "true"})]
         (is (= [#{42}] @model-database-ids))
         (is (= {"databaseModel" {:actions {"create" {:kind "action", :key "create", :id 1}}}}
@@ -625,7 +523,7 @@
                 (fn [collection-values]
                   (is (= ["30" "40"] collection-values))
                   #{30 40})
-                typed-schemas.api/question-schemas
+                typed-schemas.api.schema.question/question-schemas
                 (fn [database-ids collection-ids]
                   (is (nil? database-ids))
                   (is (= #{30 40} collection-ids))
@@ -652,7 +550,7 @@
                 (fn [collection-values]
                   (is (= ["30"] collection-values))
                   #{30})
-                typed-schemas.api/question-schemas
+                typed-schemas.api.schema.question/question-schemas
                 (fn [database-ids collection-ids]
                   (is (nil? database-ids))
                   (is (= #{30} collection-ids))
@@ -665,11 +563,11 @@
                    (is false "question collection schemas should not load models")))
                 typed-schemas.api/metric-schemas
                 (constantly [{:type "metric", :key "revenue", :id 2}])
-                typed-schemas.api/select-library-tables
+                typed-schemas.api.schema.table/select-library-tables
                 (constantly [{:id 3}])
-                typed-schemas.api/select-tables
+                typed-schemas.api.schema.table/select-tables
                 (constantly [{:id 3}])
-                typed-schemas.api/table-schemas
+                typed-schemas.api.schema.table/table-schemas
                 (constantly [{:type "table", :key "orders", :id 3}])]
     (let [schema (#'typed-schemas.api/typed-schema {:library-collections  "10"
                                                     :question-collections "30"})]
@@ -688,7 +586,7 @@
                 (fn [collection-values]
                   (is (= ["30"] collection-values))
                   #{30})
-                typed-schemas.api/question-schemas
+                typed-schemas.api.schema.question/question-schemas
                 (fn [database-ids collection-ids]
                   (is (nil? database-ids))
                   (is (= #{30} collection-ids))
@@ -700,11 +598,11 @@
                     :actions {"create" {:kind "action", :key "create", :id 1}}}])
                 typed-schemas.api/metric-schemas
                 (constantly [{:type "metric", :key "revenue", :id 2}])
-                typed-schemas.api/select-library-tables
+                typed-schemas.api.schema.table/select-library-tables
                 (constantly [{:id 3}])
-                typed-schemas.api/select-tables
+                typed-schemas.api.schema.table/select-tables
                 (constantly [{:id 3}])
-                typed-schemas.api/table-schemas
+                typed-schemas.api.schema.table/table-schemas
                 (constantly [{:type "table", :key "orders", :id 3}])]
     (let [schema (#'typed-schemas.api/typed-schema {:library-collections  "10"
                                                     :question-collections "30"


### PR DESCRIPTION
Closes [EMB-2077: Extract typed schema generator for tables and questions](https://linear.app/metabase/issue/EMB-2077/extract-typed-schema-generator-for-each-entities)

PR 3/5 of [EMB-2062: Code cleanup: split src/metabase/typed_schemas/api.clj to multiple files](https://linear.app/metabase/issue/EMB-2062/code-cleanup-split-srcmetabasetyped-schemasapiclj-to-multiple-files)

### Description

Extracts the typed-schema generators for tables, table fields, segments, measures and saved questions out of `metabase.typed-schemas.api` so the endpoint namespace can stay focused.

This PR:

- Adds `metabase.typed-schemas.api.schema` for top-level schema assembly
- Moves shared card selection, report detail hydration, and aggregation result-column inference into `metabase.typed-schemas.api.schema.common`
- Moves saved-question schema generation into `metabase.typed-schemas.api.schema.question`
- Moves table, field, segment, and measure schema generation into `metabase.typed-schemas.api.schema.table`
- Extracts the matching non-API tests into their own `api.schema.*` test namespaces

### How to verify

Existing backend tests should continue to pass. Schema generation via `/api/typed-schemas/v1/typescript` endpoint should continue to work.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

