### PR TITLE
Bump Docker runtime images to Temurin 25 JRE

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/java:21
+FROM mcr.microsoft.com/vscode/devcontainers/java:25
 
 # Set up nodesource, install node, bun, fontconfig for static viz, rlwrap for dev ergonomics
 

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -4,7 +4,7 @@ description: |
 inputs:
   java-version:
     required: true
-    default: "21"
+    default: "25"
   clojure-version:
     required: true
     default: "1.12.0.1488"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -121,7 +121,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [21]
+        java-version: [25]
         job:
           - name: Enterprise Tests
             edition: ee
@@ -259,7 +259,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        java-version: [21]
+        java-version: [25]
     name: "Check Java ${{ matrix.java-version }}"
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -122,7 +122,7 @@ jobs:
     strategy:
       matrix:
         edition: [oss, ee]
-        java-version: [21]
+        java-version: [25]
     steps:
       - name: Prepare JRE (Java Run-time Environment)
         uses: actions/setup-java@v5.2.0

--- a/.github/workflows/snowplow.yml
+++ b/.github/workflows/snowplow.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
       - name: Set up Babashka
         uses: turtlequeue/setup-babashka@d78ec6570aea3b614bc695cafcceb82eb45c2af9 # v1.8.0
         with:

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -201,7 +201,7 @@ jobs:
       uses: actions/setup-java@v5.2.0
       with:
         distribution: 'temurin'
-        java-version: 21
+        java-version: 25
 
     - name: Retrieve test build uberjar artifact for ${{ matrix.edition }}
       uses: ./.github/actions/fetch-artifact

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:
-          java-version: "${{ needs.get-build-requirements.outputs.java_version || 21 }}"
+          java-version: "${{ needs.get-build-requirements.outputs.java_version || 25 }}"
       - name: Build
         run: ./bin/build.sh
       - name: Upload bundle stats
@@ -174,7 +174,7 @@ jobs:
     strategy:
       matrix:
         edition: ["ee", "oss"]
-        java-version: [21]
+        java-version: [25]
     steps:
       - name: Check out the code
         uses: actions/checkout@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN INTERACTIVE=false CI=true MB_EDITION=$MB_EDITION bin/build.sh :version ${VER
 ## Remember that this runner image needs to be the same as bin/docker/Dockerfile with the exception that this one grabs the
 ## jar from the previous stage rather than the local build
 
-FROM eclipse-temurin:21-jre-alpine AS runner
+FROM eclipse-temurin:25-jre-alpine AS runner
 
 ENV FC_LANG=en-US LC_CTYPE=en_US.UTF-8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install wget apt-transport-h
     && wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null \
     && echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
     && apt-get update \
-    && apt install temurin-21-jdk -y \
+    && apt install temurin-25-jdk -y \
     && curl -O https://download.clojure.org/install/linux-install-1.12.0.1488.sh \
     && chmod +x linux-install-1.12.0.1488.sh \
     && ./linux-install-1.12.0.1488.sh \

--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 
 ENV FC_LANG=en-US LC_CTYPE=en_US.UTF-8
 

--- a/bin/docker/Dockerfile_ubuntu
+++ b/bin/docker/Dockerfile_ubuntu
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre-noble as runner
+FROM eclipse-temurin:25-jre-noble as runner
 
 ENV FC_LANG=en-US LC_CTYPE=en_US.UTF-8
 

--- a/bin/docker/run_metabase.sh
+++ b/bin/docker/run_metabase.sh
@@ -11,6 +11,9 @@ JAVA_OPTS="${JAVA_OPTS} -Dlogfile.path=target/log"
 JAVA_OPTS="${JAVA_OPTS} -XX:+CrashOnOutOfMemoryError"
 JAVA_OPTS="${JAVA_OPTS} -server"
 JAVA_OPTS="${JAVA_OPTS} --add-opens java.base/java.nio=ALL-UNNAMED"
+# Truffle (GraalJS/GraalPy) loads a native library; JDK 25+ warns and future JDKs
+# will block it unless native access is enabled
+JAVA_OPTS="${JAVA_OPTS} --enable-native-access=ALL-UNNAMED"
 
 if [ ! -z "$JAVA_TIMEZONE" ]; then
     JAVA_OPTS="${JAVA_OPTS} -Duser.timezone=${JAVA_TIMEZONE}"

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -254,6 +254,7 @@ export const versionRequirements: Record<
   61: { java: 21, node: 22, platforms: "linux/amd64,linux/arm64" },
   62: { java: 21, node: 22, platforms: "linux/amd64,linux/arm64" },
   63: { java: 21, node: 22, platforms: "linux/amd64,linux/arm64" },
+  64: { java: 25, node: 22, platforms: "linux/amd64,linux/arm64" },
 };
 
 export const getBuildRequirements = (version: string) => {

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -251,9 +251,9 @@ export const versionRequirements: Record<
   58: { java: 21, node: 22, platforms: "linux/amd64,linux/arm64" },
   59: { java: 21, node: 22, platforms: "linux/amd64,linux/arm64" },
   60: { java: 25, node: 22, platforms: "linux/amd64,linux/arm64" },
-  61: { java: 21, node: 22, platforms: "linux/amd64,linux/arm64" },
-  62: { java: 21, node: 22, platforms: "linux/amd64,linux/arm64" },
-  63: { java: 21, node: 22, platforms: "linux/amd64,linux/arm64" },
+  61: { java: 25, node: 22, platforms: "linux/amd64,linux/arm64" },
+  62: { java: 25, node: 22, platforms: "linux/amd64,linux/arm64" },
+  63: { java: 25, node: 22, platforms: "linux/amd64,linux/arm64" },
   64: { java: 25, node: 22, platforms: "linux/amd64,linux/arm64" },
 };
 

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -250,7 +250,7 @@ export const versionRequirements: Record<
   57: { java: 21, node: 22, platforms: "linux/amd64,linux/arm64" },
   58: { java: 21, node: 22, platforms: "linux/amd64,linux/arm64" },
   59: { java: 21, node: 22, platforms: "linux/amd64,linux/arm64" },
-  60: { java: 21, node: 22, platforms: "linux/amd64,linux/arm64" },
+  60: { java: 25, node: 22, platforms: "linux/amd64,linux/arm64" },
   61: { java: 21, node: 22, platforms: "linux/amd64,linux/arm64" },
   62: { java: 21, node: 22, platforms: "linux/amd64,linux/arm64" },
   63: { java: 21, node: 22, platforms: "linux/amd64,linux/arm64" },

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -304,7 +304,7 @@ describe("version-helpers", () => {
     it("should use the latest build requirements for a version that has not been released", () => {
       expect(getBuildRequirements("v0.99.0")).toEqual({
         node: 22,
-        java: 21,
+        java: 25,
         platforms: "linux/amd64,linux/arm64",
       });
     });

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -178,19 +178,22 @@
                          :es-MX #{"2 de abril de 2021 02:42:09 PM (Hora de verano del Pacífico)"
                                   "2 de abril de 2021 14:42:09 (Hora de verano del Pacífico)"
                                   "2 de abril de 2021 14:42:09 (hora de verano del Pacífico)"
-                                  "2 de abril de 2021, 14:42:09 (Hora de verano del Pacífico)"}}
+                                  "2 de abril de 2021, 14:42:09 (Hora de verano del Pacífico)"
+                                  "2 de abril de 2021, 2:42:09 p.m. (hora de verano del Pacífico)"}}
 
                         #t "2021-04-02T14:42:09.524392-07:00" ; OffsetDateTime
                         {:en-US #{"April 2, 2021 2:42:09 PM (GMT-07:00)"
                                   "April 2, 2021, 2:42:09 PM (GMT-07:00)"}
                          :es-MX #{"2 de abril de 2021 02:42:09 PM (GMT-07:00)"
-                                  "2 de abril de 2021 14:42:09 (GMT-07:00)"}}
+                                  "2 de abril de 2021 14:42:09 (GMT-07:00)"
+                                  "2 de abril de 2021, 2:42:09 p.m. (GMT-07:00)"}}
 
                         #t "2021-04-02T14:42:09.524392" ; LocalDateTime
                         {:en-US #{"April 2, 2021 2:42:09 PM"
                                   "April 2, 2021, 2:42:09 PM"}
                          :es-MX #{"2 de abril de 2021 02:42:09 PM"
-                                  "2 de abril de 2021 14:42:09"}}
+                                  "2 de abril de 2021 14:42:09"
+                                  "2 de abril de 2021, 2:42:09 p.m."}}
 
                         #t "2021-04-02" ; LocalDate
                         {:en-US "April 2, 2021"
@@ -199,12 +202,14 @@
                         #t "14:42:09.524392-07:00" ; OffsetTime
                         {:en-US "2:42:09 PM (GMT-07:00)"
                          :es-MX #{"02:42:09 PM (GMT-07:00)"
-                                  "14:42:09 (GMT-07:00)"}}
+                                  "14:42:09 (GMT-07:00)"
+                                  "2:42:09 p.m. (GMT-07:00)"}}
 
                         #t "14:42:09.524392" ; LocalTime
                         {:en-US "2:42:09 PM"
                          :es-MX #{"02:42:09 PM"
-                                  "14:42:09"}}}
+                                  "14:42:09"
+                                  "2:42:09 p.m."}}}
           [locale expected] expected]
     (mt/with-user-locale locale
       (testing (format "%s %s" (.getCanonicalName (class t)) (pr-str t))


### PR DESCRIPTION
JDK 24+ removed the G1 GCLocker (JDK-8318706), which eliminates GCLocker-starvation OutOfMemoryErrors seen on busy hosted instances: under heavy concurrent query load (gzip cache writes + gzip responses + SSL reads all holding JNI critical sections), an allocating thread can exceed GCLockerRetryAllocationCount and throw 'Java heap space' while most of the heap is reclaimable.

The build stage stays on JDK 21; jars built on 21 run unchanged on 25.