### PR TITLE
Set enablePutGet as a Snowflake connection property

### DIFF
--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -233,12 +233,11 @@
         (and (not use-password) password-details)
         (conj password-details)))))
 
-(defn- set-put-get [additional-options]
-  (cond (empty? additional-options) "enablePutGet=false"
-        (re-find #"(?i)enablePutGet=" additional-options) (str/replace additional-options
-                                                                       #"enablePutGet=[^&]+"
-                                                                       "enablePutGet=false")
-        :else (str additional-options "&enablePutGet=false")))
+(defn- normalize-additional-options [additional-options]
+  (when-not (str/blank? additional-options)
+    (not-empty
+     (str/join "&" (remove #(re-matches #"(?i)enablePutGet(=.*)?" %)
+                           (str/split additional-options #"&"))))))
 
 (defmethod sql-jdbc.conn/connection-details->spec :snowflake
   [_ {:keys [account additional-options host use-hostname password use-password], :as details}]
@@ -292,10 +291,11 @@
                    resolve-private-key
                    (dissoc :host :port :timezone)))
         (sql-jdbc.common/handle-additional-options (update details
-                                                           :additional-options set-put-get))
+                                                           :additional-options normalize-additional-options))
         ;; Role is not respected when used as connection property if connection string is present with private key
         ;; file. Hence it is moved to connection url. https://github.com/metabase/metabase/issues/43600
-        (maybe-add-role-to-spec-url details))))
+        (maybe-add-role-to-spec-url details)
+        (assoc :enablePutGet "false"))))
 
 (mu/defn- database-type->base-type
   [database-type :- string?
@@ -424,8 +424,8 @@
 
 (defmethod driver/insert-into! :snowflake
   [driver db-id table-name column-names values]
-  ;; Snowflake's fast bulk path (`PUT` + `COPY INTO` from a stage) is unavailable because [[set-put-get]]
-  ;; enforces `enablePutGet=false` on every connection (#73578), so use the generic multi-row `INSERT`.
+  ;; Snowflake's fast bulk path (`PUT` + `COPY INTO` from a stage) is unavailable because Metabase's
+  ;; Snowflake connections set `enablePutGet=false`, so use the generic multi-row `INSERT`.
   ((get-method driver/insert-into! :sql-jdbc)
    driver db-id table-name column-names
    (map #(mapv temporal-bind->string %) values)))

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.snowflake
   "Snowflake Driver."
-  (:refer-clojure :exclude [select-keys empty? not-empty mapv])
+  (:refer-clojure :exclude [select-keys not-empty mapv])
   (:require
    [buddy.core.codecs :as codecs]
    [clojure.java.jdbc :as jdbc]
@@ -38,7 +38,7 @@
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [empty? mapv not-empty select-keys]]
+   [metabase.util.performance :refer [mapv not-empty select-keys]]
    [ring.util.codec :as codec])
   (:import
    (java.io File)

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -170,19 +170,20 @@
                                                                                             (assoc :host alternative-host)
                                                                                             (assoc :use-hostname use-hostname))]
                                                                             (sql-jdbc.conn/connection-details->spec :snowflake details))))
-        true nil "//ls10467.us-east-2.aws.snowflakecomputing.com/?enablePutGet=false"
-        true "" "//ls10467.us-east-2.aws.snowflakecomputing.com/?enablePutGet=false"
-        true "  " "//ls10467.us-east-2.aws.snowflakecomputing.com/?enablePutGet=false"
-        true "snowflake.example.com/" "//snowflake.example.com/?enablePutGet=false"
-        true "snowflake.example.com" "//snowflake.example.com/?enablePutGet=false"
-        false nil "//ls10467.us-east-2.aws.snowflakecomputing.com/?enablePutGet=false"
-        false "" "//ls10467.us-east-2.aws.snowflakecomputing.com/?enablePutGet=false"
-        false "snowflake.example.com/" "//ls10467.us-east-2.aws.snowflakecomputing.com/?enablePutGet=false"
-        false "snowflake.example.com" "//ls10467.us-east-2.aws.snowflakecomputing.com/?enablePutGet=false"))
+        true nil "//ls10467.us-east-2.aws.snowflakecomputing.com/"
+        true "" "//ls10467.us-east-2.aws.snowflakecomputing.com/"
+        true "  " "//ls10467.us-east-2.aws.snowflakecomputing.com/"
+        true "snowflake.example.com/" "//snowflake.example.com/"
+        true "snowflake.example.com" "//snowflake.example.com/"
+        false nil "//ls10467.us-east-2.aws.snowflakecomputing.com/"
+        false "" "//ls10467.us-east-2.aws.snowflakecomputing.com/"
+        false "snowflake.example.com/" "//ls10467.us-east-2.aws.snowflakecomputing.com/"
+        false "snowflake.example.com" "//ls10467.us-east-2.aws.snowflakecomputing.com/"))
     (testing "Unsafe options are removed"
-      (let [details (assoc details :additional-options "enablePutGet=true")
-            spec (sql-jdbc.conn/connection-details->spec :snowflake details)]
-        (is (re-find #"enablePutGet=false" (:subname spec)))))
+      (doseq [opts [nil "enablePutGet=true"]]
+        (let [spec (sql-jdbc.conn/connection-details->spec :snowflake (assoc details :additional-options opts))]
+          (is (= "false" (:enablePutGet spec)))
+          (is (not (re-find #"(?i)enablePutGet" (str (:subname spec))))))))
     (testing "Application parameter is set to identify Metabase connections"
       (is (= "Metabase_Metabase"
              (:application (sql-jdbc.conn/connection-details->spec :snowflake details)))))))

--- a/src/metabase/permissions_rest/api.clj
+++ b/src/metabase/permissions_rest/api.clj
@@ -212,7 +212,7 @@
   "Fetch the details for a certain permissions group."
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
-  (perms/check-group-manager id)
+  (perms/check-manager-of-group id)
   (api/check-404
    (some-> (t2/select-one :model/PermissionsGroup :id id)
            (t2/hydrate :members)


### PR DESCRIPTION
### Description

This sets `enablePutGet=false` as a connection property in `connection-details->spec` instead of appending it to the `additional-options` connection string, and removes any copy from `additional-options` so the property is the single source of truth. No user-facing behavior change.

PR Includes a micro fix in check-manager-of-group function call. Unrelated opportunistic mix-in.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/77731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

