### PR TITLE
Bound concurrent query-cache writes

### DIFF
--- a/src/metabase/cache/core.clj
+++ b/src/metabase/cache/core.clj
@@ -16,5 +16,6 @@
   root-strategy]
  [metabase.cache.settings
   enable-query-caching
+  query-caching-max-concurrent-writes
   query-caching-max-kb
   query-caching-max-ttl])

--- a/src/metabase/cache/settings.clj
+++ b/src/metabase/cache/settings.clj
@@ -50,17 +50,17 @@
 
 (defsetting query-caching-max-concurrent-writes
   (deferred-tru
-   (str "Maximum number of queries that can write their results to the query cache at the same time. "
-        "Queries over the limit run normally but skip caching that run, bounding the CPU and memory spent "
+   (str "Maximum number of queries that can write their results to the query cache at the same time; 0 means no "
+        "limit. Queries over the limit run normally but skip caching that run, bounding the CPU and memory spent "
         "storing results during a burst of cache misses. Each concurrent write buffers a result capped by "
-        "query-caching-max-kb (2 MB by default), so the default of 32 bounds the worst-case burst cost at "
-        "roughly 200 MB including growth transients -- affordable on a 2 GB heap, invisible on bigger ones."))
+        "query-caching-max-kb (2 MB by default), so e.g. a limit of 32 bounds the worst-case burst cost at "
+        "roughly 200 MB including growth transients."))
   :type       :integer
-  :default    32
+  :default    0
   :visibility :internal
   :export?    false
   :setter     :none
-  :doc        (str "Maximum number of queries that can write their results to the query cache at the same time. "
-                   "Queries over the limit run normally but skip caching that run, bounding the CPU and memory "
-                   "spent storing results during a burst of cache misses. The default of 32 bounds the worst-case "
-                   "burst cost at roughly 200 MB."))
+  :doc        (str "Maximum number of queries that can write their results to the query cache at the same time; "
+                   "0 (the default) means no limit. Queries over the limit run normally but skip caching that run, "
+                   "bounding the CPU and memory spent storing results during a burst of cache misses. E.g. a limit "
+                   "of 32 bounds the worst-case burst cost at roughly 200 MB."))

--- a/src/metabase/cache/settings.clj
+++ b/src/metabase/cache/settings.clj
@@ -47,3 +47,14 @@
   :type    :double
   :default (* 60.0 60.0 24.0 35.0) ; 35 days
   :audit   :getter)
+
+(defsetting query-caching-max-concurrent-writes
+  (deferred-tru
+   (str "Maximum number of queries that can write their results to the query cache at the same time. "
+        "Queries over the limit run normally but skip caching that run, bounding the CPU and memory spent "
+        "compressing results during a burst of cache misses."))
+  :type       :integer
+  :default    16
+  :visibility :internal
+  :export?    false
+  :setter     :none)

--- a/src/metabase/cache/settings.clj
+++ b/src/metabase/cache/settings.clj
@@ -52,11 +52,15 @@
   (deferred-tru
    (str "Maximum number of queries that can write their results to the query cache at the same time. "
         "Queries over the limit run normally but skip caching that run, bounding the CPU and memory spent "
-        "compressing results during a burst of cache misses."))
+        "storing results during a burst of cache misses. Each concurrent write buffers a result capped by "
+        "query-caching-max-kb (2 MB by default), so the default of 32 bounds the worst-case burst cost at "
+        "roughly 200 MB including growth transients -- affordable on a 2 GB heap, invisible on bigger ones."))
   :type       :integer
-  ;; worst case per write is a buffered compressed result (query-caching-max-kb, ~2 MB) plus growth transients, so 32
-  ;; concurrent writes bound the burst cost to ~200 MB -- affordable on a 2 GB heap, invisible on bigger ones
   :default    32
   :visibility :internal
   :export?    false
-  :setter     :none)
+  :setter     :none
+  :doc        (str "Maximum number of queries that can write their results to the query cache at the same time. "
+                   "Queries over the limit run normally but skip caching that run, bounding the CPU and memory "
+                   "spent storing results during a burst of cache misses. The default of 32 bounds the worst-case "
+                   "burst cost at roughly 200 MB."))

--- a/src/metabase/cache/settings.clj
+++ b/src/metabase/cache/settings.clj
@@ -54,7 +54,9 @@
         "Queries over the limit run normally but skip caching that run, bounding the CPU and memory spent "
         "compressing results during a burst of cache misses."))
   :type       :integer
-  :default    16
+  ;; worst case per write is a buffered compressed result (query-caching-max-kb, ~2 MB) plus growth transients, so 32
+  ;; concurrent writes bound the burst cost to ~200 MB -- affordable on a 2 GB heap, invisible on bigger ones
+  :default    32
   :visibility :internal
   :export?    false
   :setter     :none)

--- a/src/metabase/cmd/resources/other-env-vars.md
+++ b/src/metabase/cmd/resources/other-env-vars.md
@@ -494,6 +494,13 @@ Default: `"db"`
 
 Current cache backend. Dynamically rebindable primarily for test purposes.
 
+### `MB_QP_CACHE_MAX_CONCURRENT_WRITES`
+
+Type: integer<br>
+Default: twice the number of CPU cores, with a minimum of 8
+
+Maximum number of queries that may serialize their results into the query cache at the same time. When the limit is reached, additional queries still run and return results normally; their results just aren't cached that time. Bounding concurrent cache writes prevents a burst of cache misses (for example, many uniquely parameterized embedded dashboard requests) from causing a CPU and memory spike while every query compresses its results for the cache.
+
 ### `MB_SETUP_TOKEN`
 
 Type: string<br>

--- a/src/metabase/cmd/resources/other-env-vars.md
+++ b/src/metabase/cmd/resources/other-env-vars.md
@@ -494,13 +494,6 @@ Default: `"db"`
 
 Current cache backend. Dynamically rebindable primarily for test purposes.
 
-### `MB_QP_CACHE_MAX_CONCURRENT_WRITES`
-
-Type: integer<br>
-Default: twice the number of CPU cores, with a minimum of 8
-
-Maximum number of queries that may serialize their results into the query cache at the same time. When the limit is reached, additional queries still run and return results normally; their results just aren't cached that time. Bounding concurrent cache writes prevents a burst of cache misses (for example, many uniquely parameterized embedded dashboard requests) from causing a CPU and memory spike while every query compresses its results for the cache.
-
 ### `MB_SETUP_TOKEN`
 
 Type: string<br>

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -50,9 +50,11 @@
 (def ^:dynamic *write-permits*
   "Semaphore capping concurrent cache writes ([[cache/query-caching-max-concurrent-writes]]) so a burst of cache misses
   can't spike CPU/memory with unbounded concurrent result serialization. When exhausted, queries run normally but skip
-  caching that run. The root value is a delay so the setting isn't read at namespace load (AOT-safe) -- deref with
-  `force`. Bind a bare `Semaphore` in tests."
-  (delay (Semaphore. (max 1 (cache/query-caching-max-concurrent-writes)))))
+  caching that run. nil (the setting is unset or not a positive integer) means no limit. The root value is a delay so
+  the setting isn't read at namespace load (AOT-safe) -- deref with `force`. Bind a bare `Semaphore` in tests."
+  (delay (let [n (cache/query-caching-max-concurrent-writes)]
+           (when (pos-int? n)
+             (Semaphore. n)))))
 
 (def ^:private purge-interval-seconds
   "How often, at most, to purge cache entries older than [[cache/query-caching-max-ttl]]. Purging on every save is
@@ -268,12 +270,12 @@
 ;;; --------------------------------------------------- Middleware ---------------------------------------------------
 
 (defn- reduce-with-serialization!
-  "Reduce with `orig-reduce`, serializing every reduced object into the current cache entry -- if a [[*write-permits*]]
-  permit is available. Otherwise reduce without serializing: this run just isn't cached ([[*result-fn*]] stays nil, so
-  [[save-results-xform]] reports `:stored false` and skips the save)."
+  "Reduce with `orig-reduce`, serializing every reduced object into the current cache entry -- unless the concurrent
+  cache-write limit ([[*write-permits*]]) is reached, in which case reduce without serializing: that run just isn't
+  cached ([[*result-fn*]] stays nil, so [[save-results-xform]] reports `:stored false` and skips the save)."
   [orig-reduce rff metadata rows]
   (let [^Semaphore permits (force *write-permits*)]
-    (if-not (.tryAcquire permits)
+    (if (and permits (not (.tryAcquire permits)))
       (do (log/throttle (u/minutes->ms 1)
                         (log/warn "Not caching results: the concurrent cache-write limit was reached"))
           (orig-reduce rff metadata rows))
@@ -284,7 +286,7 @@
                      *result-fn* result-fn]
              (orig-reduce rff metadata rows))))
         (finally
-          (.release permits))))))
+          (some-> permits .release))))))
 
 (defn- run-and-cache!
   "Run `query` through `qp` and save the results to the cache (if eligible). Used on a cache miss, or when this process

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -47,21 +47,19 @@
 
 ;;; ------------------------------------------------------ Save ------------------------------------------------------
 
-(def ^:private default-max-concurrent-writes
-  "Default cap on queries concurrently serializing their results into the cache. Serializing a result stream costs a
-  gzip `Deflater` (CPU + native memory + JNI critical sections) and buffers up to [[cache/query-caching-max-kb]] per
-  query, so a burst of cache misses -- e.g. hundreds of parameterized embed requests, each a unique query hash -- can
-  multiply into a CPU/memory spike big enough to take the instance down. Twice the core count keeps the cache busy
-  without letting serialization monopolize the machine."
-  (max 8 (* 2 (.availableProcessors (Runtime/getRuntime)))))
+(defonce ^:private ^{:doc "Delay so the setting isn't read at namespace load (AOT-safe)."}
+  default-write-permits
+  (delay (Semaphore. (cache/query-caching-max-concurrent-writes))))
 
 (def ^:dynamic ^Semaphore *write-permits*
-  "Semaphore bounding how many queries may serialize results into the cache at once. When no permit is available the
-  query still runs and returns results normally -- it just isn't cached this time (the cache is an optimization;
-  skipping writes under load is graceful degradation). Override the cap with `MB_QP_CACHE_MAX_CONCURRENT_WRITES`.
-  Dynamically rebindable for tests."
-  (Semaphore. (or (config/config-int :mb-qp-cache-max-concurrent-writes)
-                  default-max-concurrent-writes)))
+  "Semaphore capping concurrent cache writes ([[cache/query-caching-max-concurrent-writes]]) so a burst of cache misses
+  can't spike CPU/memory with unbounded concurrent result serialization. When exhausted, queries run normally but skip
+  caching. Bind to a `Semaphore` in tests; nil means use the process-wide default."
+  nil)
+
+(defn- write-permits
+  ^Semaphore []
+  (or *write-permits* @default-write-permits))
 
 (def ^:private purge-interval-seconds
   "How often, at most, to purge cache entries older than [[cache/query-caching-max-ttl]]. Purging on every save is
@@ -278,31 +276,31 @@
   "Run `query` through `qp` and save the results to the cache (if eligible). Used on a cache miss, or when this process
   holds the stale-while-revalidate refresh lease.
 
-  Requires a [[*write-permits*]] permit for the duration of the run; when none is available (too many queries are
-  already serializing into the cache) the query runs normally but is not cached this time. If this process held the
-  refresh lease, the entry simply stays stale until the lease expires and another run refreshes it."
+  Holds a [[*write-permits*]] permit for the run; when none is available the query runs uncached (a held refresh lease
+  then just expires and a later run refreshes the entry)."
   [qp query query-hash cache-strategy rff]
-  (if-not (.tryAcquire *write-permits*)
-    (do (log/infof "Not caching results for query %s: the concurrent cache-write limit was reached"
-                   (i/short-hex-hash query-hash))
-        (qp query rff))
-    (try
-      (let [start-time-ns (System/nanoTime)
-            orig-reduce   qp.pipeline/*reduce*]
-        (log/trace "Running query and saving cached results (if eligible)...")
-        (binding [qp.pipeline/*reduce* (fn reduce'
-                                         [rff metadata rows]
-                                         {:post [(some? %)]}
-                                         (impl/do-with-serialization
-                                          (fn [in-fn result-fn]
-                                            (binding [*in-fn*     in-fn
-                                                      *result-fn* result-fn]
-                                              (orig-reduce rff metadata rows)))))]
-          (qp query
-              (fn [metadata]
-                (save-results-xform start-time-ns metadata query-hash cache-strategy (rff metadata))))))
-      (finally
-        (.release *write-permits*)))))
+  (let [permits (write-permits)]
+    (if-not (.tryAcquire permits)
+      (do (log/infof "Not caching results for query %s: the concurrent cache-write limit was reached"
+                     (i/short-hex-hash query-hash))
+          (qp query rff))
+      (try
+        (let [start-time-ns (System/nanoTime)
+              orig-reduce   qp.pipeline/*reduce*]
+          (log/trace "Running query and saving cached results (if eligible)...")
+          (binding [qp.pipeline/*reduce* (fn reduce'
+                                           [rff metadata rows]
+                                           {:post [(some? %)]}
+                                           (impl/do-with-serialization
+                                            (fn [in-fn result-fn]
+                                              (binding [*in-fn*     in-fn
+                                                        *result-fn* result-fn]
+                                                (orig-reduce rff metadata rows)))))]
+            (qp query
+                (fn [metadata]
+                  (save-results-xform start-time-ns metadata query-hash cache-strategy (rff metadata))))))
+        (finally
+          (.release permits))))))
 
 (mu/defn- run-query-with-cache :- :some
   [qp {:keys [cache-strategy middleware], :as query} :- ::qp.schema/any-query

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -47,19 +47,12 @@
 
 ;;; ------------------------------------------------------ Save ------------------------------------------------------
 
-(defonce ^:private ^{:doc "Delay so the setting isn't read at namespace load (AOT-safe)."}
-  default-write-permits
-  (delay (Semaphore. (cache/query-caching-max-concurrent-writes))))
-
-(def ^:dynamic ^Semaphore *write-permits*
+(def ^:dynamic *write-permits*
   "Semaphore capping concurrent cache writes ([[cache/query-caching-max-concurrent-writes]]) so a burst of cache misses
   can't spike CPU/memory with unbounded concurrent result serialization. When exhausted, queries run normally but skip
-  caching. Bind to a `Semaphore` in tests; nil means use the process-wide default."
-  nil)
-
-(defn- write-permits
-  ^Semaphore []
-  (or *write-permits* @default-write-permits))
+  caching that run. The root value is a delay so the setting isn't read at namespace load (AOT-safe) -- deref with
+  `force`. Bind a bare `Semaphore` in tests."
+  (delay (Semaphore. (max 1 (cache/query-caching-max-concurrent-writes)))))
 
 (def ^:private purge-interval-seconds
   "How often, at most, to purge cache entries older than [[cache/query-caching-max-ttl]]. Purging on every save is
@@ -141,17 +134,19 @@
      (let [duration-ms     (/ (- (System/nanoTime) start-time-ns) 1e6)
            min-duration-ms (:min-duration-ms strategy 0)
            ;; cache any query that ran long enough -- including ones that returned no rows, so a slow empty result
-           ;; doesn't get re-run at full cost on every request
-           eligible?       (> duration-ms min-duration-ms)]
+           ;; doesn't get re-run at full cost on every request. *result-fn* is nil when the run skipped serialization
+           ;; because the concurrent cache-write limit was reached.
+           eligible?       (> duration-ms min-duration-ms)
+           stored?         (boolean (and eligible? *result-fn*))]
        (log/infof "Query %s took %s to run; minimum for cache eligibility is %s; %s"
                   (i/short-hex-hash query-hash)
                   (u/format-milliseconds duration-ms)
                   (u/format-milliseconds min-duration-ms)
                   (if eligible? "eligible" "not eligible"))
-       (when eligible?
+       (when stored?
          (cache-results! query-hash))
        (rf (cond-> result
-             (map? result) (update :cache/details assoc :hash query-hash :stored (boolean eligible?))))))
+             (map? result) (update :cache/details assoc :hash query-hash :stored stored?)))))
 
     ([acc row]
      (add-object-to-cache! row)
@@ -276,31 +271,32 @@
   "Run `query` through `qp` and save the results to the cache (if eligible). Used on a cache miss, or when this process
   holds the stale-while-revalidate refresh lease.
 
-  Holds a [[*write-permits*]] permit for the run; when none is available the query runs uncached (a held refresh lease
-  then just expires and a later run refreshes the entry)."
+  Serialization holds a [[*write-permits*]] permit, scoped to the reduce so warehouse wait time doesn't consume the
+  budget. When none is available the query still runs and returns results, they just aren't written to the cache (a
+  refresh lease this process holds then just expires and a later run refreshes the entry)."
   [qp query query-hash cache-strategy rff]
-  (let [permits (write-permits)]
-    (if-not (.tryAcquire permits)
-      (do (log/infof "Not caching results for query %s: the concurrent cache-write limit was reached"
-                     (i/short-hex-hash query-hash))
-          (qp query rff))
-      (try
-        (let [start-time-ns (System/nanoTime)
-              orig-reduce   qp.pipeline/*reduce*]
-          (log/trace "Running query and saving cached results (if eligible)...")
-          (binding [qp.pipeline/*reduce* (fn reduce'
-                                           [rff metadata rows]
-                                           {:post [(some? %)]}
+  (let [start-time-ns (System/nanoTime)
+        orig-reduce   qp.pipeline/*reduce*]
+    (log/trace "Running query and saving cached results (if eligible)...")
+    (binding [qp.pipeline/*reduce* (fn reduce'
+                                     [rff metadata rows]
+                                     {:post [(some? %)]}
+                                     (let [^Semaphore permits (force *write-permits*)]
+                                       (if-not (.tryAcquire permits)
+                                         (do (log/throttle (u/minutes->ms 1)
+                                                           (log/warn "Not caching results: the concurrent cache-write limit was reached"))
+                                             (orig-reduce rff metadata rows))
+                                         (try
                                            (impl/do-with-serialization
                                             (fn [in-fn result-fn]
                                               (binding [*in-fn*     in-fn
                                                         *result-fn* result-fn]
-                                                (orig-reduce rff metadata rows)))))]
-            (qp query
-                (fn [metadata]
-                  (save-results-xform start-time-ns metadata query-hash cache-strategy (rff metadata))))))
-        (finally
-          (.release permits))))))
+                                                (orig-reduce rff metadata rows))))
+                                           (finally
+                                             (.release permits))))))]
+      (qp query
+          (fn [metadata]
+            (save-results-xform start-time-ns metadata query-hash cache-strategy (rff metadata)))))))
 
 (mu/defn- run-query-with-cache :- :some
   [qp {:keys [cache-strategy middleware], :as query} :- ::qp.schema/any-query

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -267,6 +267,25 @@
 
 ;;; --------------------------------------------------- Middleware ---------------------------------------------------
 
+(defn- reduce-with-serialization!
+  "Reduce with `orig-reduce`, serializing every reduced object into the current cache entry -- if a [[*write-permits*]]
+  permit is available. Otherwise reduce without serializing: this run just isn't cached ([[*result-fn*]] stays nil, so
+  [[save-results-xform]] reports `:stored false` and skips the save)."
+  [orig-reduce rff metadata rows]
+  (let [^Semaphore permits (force *write-permits*)]
+    (if-not (.tryAcquire permits)
+      (do (log/throttle (u/minutes->ms 1)
+                        (log/warn "Not caching results: the concurrent cache-write limit was reached"))
+          (orig-reduce rff metadata rows))
+      (try
+        (impl/do-with-serialization
+         (fn [in-fn result-fn]
+           (binding [*in-fn*     in-fn
+                     *result-fn* result-fn]
+             (orig-reduce rff metadata rows))))
+        (finally
+          (.release permits))))))
+
 (defn- run-and-cache!
   "Run `query` through `qp` and save the results to the cache (if eligible). Used on a cache miss, or when this process
   holds the stale-while-revalidate refresh lease.
@@ -281,19 +300,7 @@
     (binding [qp.pipeline/*reduce* (fn reduce'
                                      [rff metadata rows]
                                      {:post [(some? %)]}
-                                     (let [^Semaphore permits (force *write-permits*)]
-                                       (if-not (.tryAcquire permits)
-                                         (do (log/throttle (u/minutes->ms 1)
-                                                           (log/warn "Not caching results: the concurrent cache-write limit was reached"))
-                                             (orig-reduce rff metadata rows))
-                                         (try
-                                           (impl/do-with-serialization
-                                            (fn [in-fn result-fn]
-                                              (binding [*in-fn*     in-fn
-                                                        *result-fn* result-fn]
-                                                (orig-reduce rff metadata rows))))
-                                           (finally
-                                             (.release permits))))))]
+                                     (reduce-with-serialization! orig-reduce rff metadata rows))]
       (qp query
           (fn [metadata]
             (save-results-xform start-time-ns metadata query-hash cache-strategy (rff metadata)))))))

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -28,6 +28,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.performance :refer [get-in]])
   (:import
+   (java.util.concurrent Semaphore)
    (org.eclipse.jetty.io EofException)))
 
 (set! *warn-on-reflection* true)
@@ -45,6 +46,22 @@
   (i/cache-backend (config/config-kw :mb-qp-cache-backend)))
 
 ;;; ------------------------------------------------------ Save ------------------------------------------------------
+
+(def ^:private default-max-concurrent-writes
+  "Default cap on queries concurrently serializing their results into the cache. Serializing a result stream costs a
+  gzip `Deflater` (CPU + native memory + JNI critical sections) and buffers up to [[cache/query-caching-max-kb]] per
+  query, so a burst of cache misses -- e.g. hundreds of parameterized embed requests, each a unique query hash -- can
+  multiply into a CPU/memory spike big enough to take the instance down. Twice the core count keeps the cache busy
+  without letting serialization monopolize the machine."
+  (max 8 (* 2 (.availableProcessors (Runtime/getRuntime)))))
+
+(def ^:dynamic ^Semaphore *write-permits*
+  "Semaphore bounding how many queries may serialize results into the cache at once. When no permit is available the
+  query still runs and returns results normally -- it just isn't cached this time (the cache is an optimization;
+  skipping writes under load is graceful degradation). Override the cap with `MB_QP_CACHE_MAX_CONCURRENT_WRITES`.
+  Dynamically rebindable for tests."
+  (Semaphore. (or (config/config-int :mb-qp-cache-max-concurrent-writes)
+                  default-max-concurrent-writes)))
 
 (def ^:private purge-interval-seconds
   "How often, at most, to purge cache entries older than [[cache/query-caching-max-ttl]]. Purging on every save is
@@ -259,22 +276,33 @@
 
 (defn- run-and-cache!
   "Run `query` through `qp` and save the results to the cache (if eligible). Used on a cache miss, or when this process
-  holds the stale-while-revalidate refresh lease."
+  holds the stale-while-revalidate refresh lease.
+
+  Requires a [[*write-permits*]] permit for the duration of the run; when none is available (too many queries are
+  already serializing into the cache) the query runs normally but is not cached this time. If this process held the
+  refresh lease, the entry simply stays stale until the lease expires and another run refreshes it."
   [qp query query-hash cache-strategy rff]
-  (let [start-time-ns (System/nanoTime)
-        orig-reduce   qp.pipeline/*reduce*]
-    (log/trace "Running query and saving cached results (if eligible)...")
-    (binding [qp.pipeline/*reduce* (fn reduce'
-                                     [rff metadata rows]
-                                     {:post [(some? %)]}
-                                     (impl/do-with-serialization
-                                      (fn [in-fn result-fn]
-                                        (binding [*in-fn*     in-fn
-                                                  *result-fn* result-fn]
-                                          (orig-reduce rff metadata rows)))))]
-      (qp query
-          (fn [metadata]
-            (save-results-xform start-time-ns metadata query-hash cache-strategy (rff metadata)))))))
+  (if-not (.tryAcquire *write-permits*)
+    (do (log/infof "Not caching results for query %s: the concurrent cache-write limit was reached"
+                   (i/short-hex-hash query-hash))
+        (qp query rff))
+    (try
+      (let [start-time-ns (System/nanoTime)
+            orig-reduce   qp.pipeline/*reduce*]
+        (log/trace "Running query and saving cached results (if eligible)...")
+        (binding [qp.pipeline/*reduce* (fn reduce'
+                                         [rff metadata rows]
+                                         {:post [(some? %)]}
+                                         (impl/do-with-serialization
+                                          (fn [in-fn result-fn]
+                                            (binding [*in-fn*     in-fn
+                                                      *result-fn* result-fn]
+                                              (orig-reduce rff metadata rows)))))]
+          (qp query
+              (fn [metadata]
+                (save-results-xform start-time-ns metadata query-hash cache-strategy (rff metadata))))))
+      (finally
+        (.release *write-permits*)))))
 
 (mu/defn- run-query-with-cache :- :some
   [qp {:keys [cache-strategy middleware], :as query} :- ::qp.schema/any-query

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -315,6 +315,27 @@
         (is (= :not-cached
                (run-query)))))))
 
+(deftest concurrent-write-limit-test
+  (testing "when no cache-write permits are available, the query still runs but its results are not cached"
+    (with-mock-cache! [save-chan]
+      (binding [cache/*write-permits* (java.util.concurrent.Semaphore. 0)]
+        (is (= :not-cached
+               (run-query)))
+        (is (= :metabase.test.util.async/timed-out
+               (mt/wait-for-result save-chan 100))
+            "nothing should have been written to the cache backend")
+        ;; the second run also runs uncached: nothing was stored the first time
+        (is (= :not-cached
+               (run-query))))))
+  (testing "permits are released after each run, so sequential queries all get cached"
+    (with-mock-cache! [save-chan]
+      (binding [cache/*write-permits* (java.util.concurrent.Semaphore. 1)]
+        (run-query)
+        (mt/wait-for-result save-chan)
+        (is (= :cached
+               (run-query)))
+        (is (= 1 (.availablePermits cache/*write-permits*)))))))
+
 (deftest ignore-cached-results-test
   (testing "check that :ignore-cached-results? in middleware is respected when returning results..."
     (with-mock-cache! [save-chan]

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -39,7 +39,8 @@
    [pretty.core :as pretty]
    [toucan2.core :as t2])
   (:import
-   (java.time ZonedDateTime)))
+   (java.time ZonedDateTime)
+   (java.util.concurrent Semaphore)))
 
 (set! *warn-on-reflection* true)
 
@@ -318,7 +319,7 @@
 (deftest concurrent-write-limit-test
   (testing "when no cache-write permits are available, the query still runs but its results are not cached"
     (with-mock-cache! [save-chan]
-      (binding [cache/*write-permits* (java.util.concurrent.Semaphore. 0)]
+      (binding [cache/*write-permits* (Semaphore. 0)]
         (is (= :not-cached
                (run-query)))
         (is (= :metabase.test.util.async/timed-out
@@ -326,15 +327,17 @@
             "nothing should have been written to the cache backend")
         ;; the second run also runs uncached: nothing was stored the first time
         (is (= :not-cached
-               (run-query))))))
+               (run-query)))))))
+
+(deftest concurrent-write-limit-release-test
   (testing "permits are released after each run, so sequential queries all get cached"
     (with-mock-cache! [save-chan]
-      (binding [cache/*write-permits* (java.util.concurrent.Semaphore. 1)]
+      (binding [cache/*write-permits* (Semaphore. 1)]
         (run-query)
         (mt/wait-for-result save-chan)
         (is (= :cached
                (run-query)))
-        (is (= 1 (.availablePermits cache/*write-permits*)))))))
+        (is (= 1 (.availablePermits ^Semaphore cache/*write-permits*)))))))
 
 (deftest ignore-cached-results-test
   (testing "check that :ignore-cached-results? in middleware is respected when returning results..."


### PR DESCRIPTION
Max concurrent query_cache writes avoid high CPU and memory (secondary) costs, preventing crashes on the initial burst.