### PR TITLE
Extract typed schema generators for models and actions

### DIFF
--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -2,9 +2,7 @@
   "/api/typed-schemas endpoints."
   (:require
    [clojure.set :as set]
-   [clojure.string :as str]
    [medley.core :as m]
-   [metabase.actions.core :as actions]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.metabot.tools.entity-details :as entity-details]
@@ -14,6 +12,7 @@
    [metabase.typed-schemas.api.render :as render]
    [metabase.typed-schemas.api.schema :as schema]
    [metabase.typed-schemas.api.schema.common :as schema.common]
+   [metabase.typed-schemas.api.schema.model :as schema.model]
    [metabase.typed-schemas.api.schema.question :as schema.question]
    [metabase.typed-schemas.api.schema.table :as schema.table]
    [metabase.typed-schemas.api.scope :as scope]
@@ -30,65 +29,6 @@
    "Referrer-Policy"              "no-referrer"
    "Cache-Control"                "no-store"})
 
-(defn- model-action-error-message
-  ([model error-message]
-   (format "Failed to build action schemas for model \"%s\" (card %s): %s"
-           (or (:name model) "Untitled")
-           (:id model)
-           (or error-message "unknown error")))
-  ([model action error-message]
-   (format "Failed to build action schema for action \"%s\" (action %s, type %s) on model \"%s\" (card %s): %s"
-           (or (:name action) "Untitled")
-           (:id action)
-           (or (some-> (:type action) name) "unknown")
-           (or (:name model) "Untitled")
-           (:id model)
-           (or error-message "unknown error"))))
-
-(defn- model-action-error-data
-  ([model error-data]
-   (m/assoc-some
-    {:model-id   (:id model)
-     :model-name (:name model)}
-    :status-code (:status-code error-data)))
-  ([model action error-data]
-   (m/assoc-some
-    (assoc (model-action-error-data model error-data)
-           :action-id   (:id action)
-           :action-name (:name action)
-           :action-type (:type action))
-    :status-code (:status-code error-data))))
-
-(defn- raw-model-actions
-  [model-id]
-  (t2/select :model/Action
-             :model_id model-id
-             :archived false
-             :type [:not= "http"]))
-
-(defn- dropped-actions
-  [raw-actions actions]
-  (let [action-ids (set (map :id actions))]
-    (not-empty
-     (remove #(contains? action-ids (:id %)) raw-actions))))
-
-(defn- dropped-actions-message
-  [model dropped-actions]
-  (format "Failed to build action schemas for model \"%s\" (card %s): selected actions were dropped while normalizing action details: %s"
-          (or (:name model) "Untitled")
-          (:id model)
-          (str/join ", "
-                    (for [action dropped-actions]
-                      (format "%s (action %s, type %s)"
-                              (or (:name action) "Untitled")
-                              (:id action)
-                              (or (some-> (:type action) name) "unknown"))))))
-
-(defn- dropped-actions-data
-  [model dropped-actions]
-  (assoc (model-action-error-data model nil)
-         :dropped-actions (mapv #(select-keys % [:id :name :type]) dropped-actions)))
-
 (defn- metric-result-column
   [card]
   (schema.common/aggregation-result-column (:database_id card) (:dataset_query card)))
@@ -101,143 +41,6 @@
                                           :with-queryable-dimensions?      true
                                           :with-segments?                  false})
       :structured-output))
-
-(defn- ->keyword
-  "Coerces strings or keywords into a keyword for uniform type inspection."
-  [value]
-  (cond
-    (keyword? value) value
-    (string? value)  (keyword value)
-    :else            nil))
-
-(defn- param-type->js-type
-  "Maps a Metabase parameter type (`:number`, `:string/=`, `:date/single`,
-  `:=`, `:id`, …) to a JS-level type matching [[js-type]]'s convention.
-  Returns nil for ambiguous types (`:=`, `:id`, `:category`, …) so the
-  caller can fall back to other type sources like a backing template-tag."
-  [param-type]
-  (when-let [param-type-keyword (->keyword param-type)]
-    (let [prefix (or (namespace param-type-keyword) (name param-type-keyword))]
-      (case prefix
-        ("number" "numeric") "number"
-        ("text" "string")    "string"
-        "date"               "Date"
-        "boolean"            "boolean"
-        nil))))
-
-(defn- template-tag-name-from-target
-  "Extracts the template-tag name from a parameter's `:target`.
-  Target shape: `[:variable [:template-tag <name>]]` (with keywords or strings
-  at any position depending on serialization)."
-  [target]
-  (when (sequential? target)
-    (let [[op inner] target]
-      (when (and (or (= op :variable) (= op "variable"))
-                 (sequential? inner))
-        (let [[tag-op tag-name] inner]
-          (when (or (= tag-op :template-tag) (= tag-op "template-tag"))
-            (cond
-              (string? tag-name)  tag-name
-              (keyword? tag-name) (clojure.core/name tag-name)
-              :else               nil)))))))
-
-(defn- query-action-template-tag-types
-  "For a query action, builds `{template-tag-name → tag-type}` from the
-  saved `dataset_query`. Empty for non-query actions and for actions
-  without a native query stage."
-  [{:keys [type dataset_query]}]
-  (when (and (= (->keyword type) :query) dataset_query)
-    (let [stage-tags (some-> dataset_query :stages first :template-tags)
-          native-tags (some-> dataset_query :native :template-tags)
-          tags (or stage-tags native-tags)]
-      (into {}
-            (for [[tag-key tag] tags]
-              [(or (:name tag)
-                   (cond
-                     (string? tag-key)  tag-key
-                     (keyword? tag-key) (clojure.core/name tag-key)
-                     :else              nil))
-               (:type tag)])))))
-
-(defn- action-parameter-schema
-  "Each parameter on an Action. The `:slug` is the key the bundle uses in the
-  execute payload (`execute({ <slug>: value, … })`). For implicit actions the
-  slug is `(slugify column-name)`; for custom (query) actions it's whatever
-  the user assigned."
-  [tag-types
-   {:keys [id slug name display-name type target required]}]
-  (let [resolved-slug (or slug
-                          (some-> id clojure.core/name)
-                          (some-> name u/slugify))
-        resolved-type (or (param-type->js-type type)
-                          (param-type->js-type
-                           (get tag-types
-                                (template-tag-name-from-target target)))
-                          "unknown")]
-    (m/assoc-some
-     {:slug resolved-slug
-      :displayName (or display-name name resolved-slug)
-      :jsType resolved-type}
-     :required (when required true))))
-
-(defn- action-schema
-  "A pre-existing Metabase action. HTTP actions are filtered upstream because
-  the execute endpoint refuses to run them."
-  [{:keys [id name description type kind parameters entity_id] :as action}]
-  (let [tag-types (query-action-template-tag-types action)
-        implicit? (= (->keyword type) :implicit)]
-    (m/assoc-some
-     {:kind       "action"
-      :key        (common/generated-key name id)
-      :id         id
-      :name       name
-      :type       (some-> type clojure.core/name)
-      :parameters (mapv #(action-parameter-schema tag-types %) parameters)}
-     :description description
-     :entityId entity_id
-     :implicitKind (when implicit?
-                     (some-> kind ->keyword u/qualified-name)))))
-
-(defn- model-actions
-  "Fetches non-archived, non-HTTP actions for a single model and emits each
-  in schema form. Returns nil when the model has no executable actions."
-  [model]
-  (let [raw-actions (raw-model-actions (:id model))
-        actions (try
-                  (actions/select-actions
-                   nil
-                   :model_id (:id model)
-                   :archived false
-                   :type [:not= "http"])
-                  (catch Exception exception
-                    (throw (ex-info (model-action-error-message model (ex-message exception))
-                                    (assoc (model-action-error-data model (ex-data exception))
-                                           :cause-message (ex-message exception))
-                                    exception))))
-        dropped (dropped-actions raw-actions actions)]
-    (when dropped
-      (throw (ex-info (dropped-actions-message model dropped)
-                      (dropped-actions-data model dropped))))
-    (when (seq actions)
-      (mapv (fn [action]
-              (try
-                (action-schema action)
-                (catch Exception exception
-                  (throw (ex-info (model-action-error-message model action (ex-message exception))
-                                  (assoc (model-action-error-data model action (ex-data exception))
-                                         :cause-message (ex-message exception))
-                                  exception)))))
-            actions))))
-
-(defn- model-schema
-  "A Metabase model (curated dataset) as an action namespace. Returns nil when
-  the model has no executable actions."
-  [{:keys [id name] :as model}]
-  (let [action-schemas (model-actions model)]
-    (when (seq action-schemas)
-      {:key              (common/generated-key name id)
-       :keyDisambiguator id
-       :actions          (common/keyed-map action-schemas)})))
 
 (defn- persisted-dimension->column
   [dimension]
@@ -407,15 +210,6 @@
      :mappedTableIds (not-empty mapped-table-ids)
      :dimensions (not-empty (common/keyed-map dimension-schemas)))))
 
-(defn- model-schemas
-  ([database-ids]
-   (model-schemas database-ids nil))
-  ([database-ids collection-ids]
-   (for [card (schema.common/select-schema-cards :model database-ids collection-ids)
-         :let [schema (model-schema card)]
-         :when schema]
-     schema)))
-
 (defn- metric-schemas
   ([database-ids]
    (metric-schemas database-ids nil))
@@ -473,10 +267,10 @@
         include-models?            (scope/query-include-models? query-params)
         models                     (cond
                                      database-ids
-                                     (model-schemas database-ids)
+                                     (schema.model/model-schemas database-ids)
 
                                      include-models?
-                                     (model-schemas nil)
+                                     (schema.model/model-schemas nil)
 
                                      :else
                                      [])

--- a/src/metabase/typed_schemas/api/schema/model.clj
+++ b/src/metabase/typed_schemas/api/schema/model.clj
@@ -45,9 +45,9 @@
 
 (defn- action-rows
   "Returns raw rows so we can detect actions that cannot be resolved to action details."
-  [model-id]
-  (t2/select [:model/Action :id :name :type]
-             :model_id model-id
+  [model-ids]
+  (t2/select [:model/Action :id :model_id :name :type]
+             :model_id [:in model-ids]
              :archived false
              :type [:not= "http"]))
 
@@ -198,6 +198,24 @@
                        exception)
                       exception)))))
 
+(defn- resolved-action-details-for-models
+  "Returns resolved action details for selected models."
+  [models]
+  (let [model-ids (set (map :id models))]
+    (try
+      (actions/select-actions
+       models
+       :model_id [:in model-ids]
+       :archived false
+       :type [:not= "http"])
+      (catch Exception exception
+        (throw (ex-info (format "Failed to build action schemas for selected models: %s" (ex-message exception))
+                        (error-data-with-cause-message
+                         {:model-ids   model-ids
+                          :status-code (:status-code (ex-data exception))}
+                         exception)
+                        exception))))))
+
 (defn- model-action-schema
   "Returns an action schema, preserving which model/action failed to render."
   [model action]
@@ -212,28 +230,40 @@
 
 (defn- model-action-schemas
   "Returns action schemas for a model, preserving action lookup error context."
-  [model]
-  (let [action-rows    (action-rows (:id model))
-        action-details (resolved-action-details model)]
-    (throw-if-unresolved-action-rows! model action-rows action-details)
-    (not-empty
-     (mapv #(model-action-schema model %) action-details))))
+  ([model]
+   (model-action-schemas model
+                         (action-rows #{(:id model)})
+                         (resolved-action-details model)))
+  ([model action-rows action-details]
+   (throw-if-unresolved-action-rows! model action-rows action-details)
+   (not-empty
+    (mapv #(model-action-schema model %) action-details))))
 
 (defn model-schema
   "Returns the model schema with actions, or nil when the model has no executable actions."
-  [{:keys [id name] :as model}]
-  (let [action-schemas (model-action-schemas model)]
-    (when (seq action-schemas)
-      {:key              (common/generated-key name id)
-       :keyDisambiguator id
-       :actions          (common/keyed-map action-schemas)})))
+  ([model]
+   (model-schema model (model-action-schemas model)))
+  ([{:keys [id name]} action-schemas]
+   (when (seq action-schemas)
+     {:key              (common/generated-key name id)
+      :keyDisambiguator id
+      :actions          (common/keyed-map action-schemas)})))
 
 (defn model-schemas
   "Returns model schemas, with optional database and collection scopes."
   ([database-ids]
    (model-schemas database-ids nil))
   ([database-ids collection-ids]
-   (for [card (schema.common/select-schema-cards :model database-ids collection-ids)
-         :let [schema (model-schema card)]
-         :when schema]
-     schema)))
+   (let [models (schema.common/select-schema-cards :model database-ids collection-ids)]
+     (if (seq models)
+       (let [model-ids                  (set (map :id models))
+             action-rows-by-model-id    (group-by :model_id (action-rows model-ids))
+             action-details-by-model-id (group-by :model_id (resolved-action-details-for-models models))]
+         (for [model models
+               :let [action-schemas (model-action-schemas model
+                                                          (get action-rows-by-model-id (:id model))
+                                                          (get action-details-by-model-id (:id model)))
+                     schema         (model-schema model action-schemas)]
+               :when schema]
+           schema))
+       []))))

--- a/src/metabase/typed_schemas/api/schema/model.clj
+++ b/src/metabase/typed_schemas/api/schema/model.clj
@@ -1,0 +1,239 @@
+(ns metabase.typed-schemas.api.schema.model
+  "Typed schema generation for models and actions."
+  (:require
+   [clojure.string :as str]
+   [medley.core :as m]
+   [metabase.actions.core :as actions]
+   [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.typed-schemas.api.common :as common]
+   [metabase.typed-schemas.api.schema.common :as schema.common]
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- keyword-or-string?
+  "Returns true for values that can be normalized to keywords."
+  [value]
+  ((some-fn keyword? string?) value))
+
+(defn- keyword-name
+  "Returns a display string for Toucan-normalized action type/kind keywords."
+  [value]
+  (when (keyword? value)
+    (u/qualified-name value)))
+
+(defn- action-type-name
+  "Returns a display-safe action type name."
+  [action]
+  (or (keyword-name (:type action)) "unknown"))
+
+(defn- model-action-error-data
+  "Returns structured error data for model action schema failures."
+  ([model error-data]
+   (m/assoc-some
+    {:model-id   (:id model)
+     :model-name (:name model)}
+    :status-code (:status-code error-data)))
+  ([model action error-data]
+   (m/assoc-some
+    (assoc (model-action-error-data model error-data)
+           :action-id   (:id action)
+           :action-name (:name action)
+           :action-type (:type action))
+    :status-code (:status-code error-data))))
+
+(defn- action-rows
+  "Returns raw rows so we can detect actions that cannot be resolved to action details."
+  [model-id]
+  (t2/select [:model/Action :id :name :type]
+             :model_id model-id
+             :archived false
+             :type [:not= "http"]))
+
+(defn- unresolved-action-rows
+  "Returns action rows missing from resolved action details."
+  [action-rows action-details]
+  (let [action-ids (set (map :id action-details))]
+    (not-empty
+     (remove #(contains? action-ids (:id %)) action-rows))))
+
+(defn- unresolved-action-rows-message
+  "Returns the error message for action rows that cannot be resolved."
+  [model unresolved-action-rows]
+  (format "Failed to build action schemas for model \"%s\" (card %s): action rows could not be resolved: %s"
+          (or (:name model) "Untitled")
+          (:id model)
+          (str/join ", "
+                    (for [action unresolved-action-rows]
+                      (format "%s (action %s, type %s)"
+                              (or (:name action) "Untitled")
+                              (:id action)
+                              (action-type-name action))))))
+
+(defn- unresolved-action-rows-data
+  "Returns structured error data for action rows that cannot be resolved."
+  [model unresolved-action-rows]
+  (assoc (model-action-error-data model nil)
+         :unresolved-action-rows (mapv #(select-keys % [:id :name :type]) unresolved-action-rows)))
+
+(defn- throw-if-unresolved-action-rows!
+  "Surfaces action rows that cannot be resolved into action details."
+  [model action-rows action-details]
+  (when-let [unresolved-rows (unresolved-action-rows action-rows action-details)]
+    (throw (ex-info (unresolved-action-rows-message model unresolved-rows)
+                    (unresolved-action-rows-data model unresolved-rows)))))
+
+(defn- param-type->js-type
+  "Returns the JS type for a Metabase action parameter type."
+  [param-type]
+  (when (keyword-or-string? param-type)
+    (let [param-type-keyword (lib.schema.common/normalize-keyword param-type)
+          prefix             (or (namespace param-type-keyword) (name param-type-keyword))]
+      (case prefix
+        ("number" "numeric") "number"
+        ("text" "string")    "string"
+        "date"               "Date"
+        "boolean"            "boolean"
+        nil))))
+
+(defn- template-tag-name-from-target
+  "Returns the template-tag name referenced by an action parameter target."
+  [target]
+  (when (sequential? target)
+    (let [[op inner] target]
+      (when (and (or (= op :variable) (= op "variable"))
+                 (sequential? inner))
+        (let [[tag-op tag-name] inner]
+          (when (or (= tag-op :template-tag) (= tag-op "template-tag"))
+            (cond
+              (string? tag-name)  tag-name
+              (keyword? tag-name) (clojure.core/name tag-name)
+              :else               nil)))))))
+
+(defn- query-action-template-tag-types
+  "Returns template-tag types for query action parameters."
+  [{:keys [type dataset_query]}]
+  (when (and (= (lib.schema.common/normalize-keyword type) :query) dataset_query)
+    (let [stage-tags (some-> dataset_query :stages first :template-tags)
+          native-tags (some-> dataset_query :native :template-tags)
+          tags (or stage-tags native-tags)]
+      (into {}
+            (for [[tag-key tag] tags]
+              [(or (:name tag)
+                   (cond
+                     (string? tag-key)  tag-key
+                     (keyword? tag-key) (clojure.core/name tag-key)
+                     :else              nil))
+               (:type tag)])))))
+
+(defn- model-action-error-message
+  "Returns the error message for model action schema failures."
+  ([model error-message]
+   (format "Failed to build action schemas for model \"%s\" (card %s): %s"
+           (or (:name model) "Untitled")
+           (:id model)
+           (or error-message "unknown error")))
+  ([model action error-message]
+   (format "Failed to build action schema for action \"%s\" (action %s, type %s) on model \"%s\" (card %s): %s"
+           (or (:name action) "Untitled")
+           (:id action)
+           (action-type-name action)
+           (or (:name model) "Untitled")
+           (:id model)
+           (or error-message "unknown error"))))
+
+(defn- error-data-with-cause-message
+  "Adds the original exception message to structured error data."
+  [error-data exception]
+  (assoc error-data :cause-message (ex-message exception)))
+
+(defn- action-parameter-schema
+  "Returns the schema for an action execute parameter."
+  [tag-types
+   {:keys [id slug name display-name type target required]}]
+  (let [resolved-slug (or slug
+                          (some-> id clojure.core/name)
+                          (some-> name u/slugify))
+        resolved-type (or (param-type->js-type type)
+                          (param-type->js-type
+                           (get tag-types
+                                (template-tag-name-from-target target)))
+                          "unknown")]
+    (m/assoc-some
+     {:slug resolved-slug
+      :displayName (or display-name name resolved-slug)
+      :jsType resolved-type}
+     :required (when required true))))
+
+(defn- action-detail-schema
+  "Returns the typed schema entry for resolved action details."
+  [{:keys [id name description type kind parameters entity_id] :as action}]
+  (let [tag-types (query-action-template-tag-types action)
+        implicit? (= (lib.schema.common/normalize-keyword type) :implicit)]
+    (m/assoc-some
+     {:kind       "action"
+      :key        (common/generated-key name id)
+      :id         id
+      :name       name
+      :type       (keyword-name type)
+      :parameters (mapv #(action-parameter-schema tag-types %) parameters)}
+     :description description
+     :entityId entity_id
+     :implicitKind (when implicit? (keyword-name kind)))))
+
+(defn- resolved-action-details
+  "Returns action details from the actions module, preserving lookup error context."
+  [model]
+  (try
+    (actions/select-actions
+     nil
+     :model_id (:id model)
+     :archived false
+     :type [:not= "http"])
+    (catch Exception exception
+      (throw (ex-info (model-action-error-message model (ex-message exception))
+                      (error-data-with-cause-message
+                       (model-action-error-data model (ex-data exception))
+                       exception)
+                      exception)))))
+
+(defn- model-action-schema
+  "Returns an action schema, preserving which model/action failed to render."
+  [model action]
+  (try
+    (action-detail-schema action)
+    (catch Exception exception
+      (throw (ex-info (model-action-error-message model action (ex-message exception))
+                      (error-data-with-cause-message
+                       (model-action-error-data model action (ex-data exception))
+                       exception)
+                      exception)))))
+
+(defn- model-action-schemas
+  "Returns action schemas for a model, preserving action lookup error context."
+  [model]
+  (let [action-rows    (action-rows (:id model))
+        action-details (resolved-action-details model)]
+    (throw-if-unresolved-action-rows! model action-rows action-details)
+    (not-empty
+     (mapv #(model-action-schema model %) action-details))))
+
+(defn model-schema
+  "Returns the model schema with actions, or nil when the model has no executable actions."
+  [{:keys [id name] :as model}]
+  (let [action-schemas (model-action-schemas model)]
+    (when (seq action-schemas)
+      {:key              (common/generated-key name id)
+       :keyDisambiguator id
+       :actions          (common/keyed-map action-schemas)})))
+
+(defn model-schemas
+  "Returns model schemas, with optional database and collection scopes."
+  ([database-ids]
+   (model-schemas database-ids nil))
+  ([database-ids collection-ids]
+   (for [card (schema.common/select-schema-cards :model database-ids collection-ids)
+         :let [schema (model-schema card)]
+         :when schema]
+     schema)))

--- a/test/metabase/typed_schemas/api/schema/model_test.clj
+++ b/test/metabase/typed_schemas/api/schema/model_test.clj
@@ -1,0 +1,91 @@
+(ns metabase.typed-schemas.api.schema.model-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.actions.core :as actions]
+   [metabase.typed-schemas.api.schema.common :as schema.common]
+   [metabase.typed-schemas.api.schema.model :as schema.model]))
+
+(deftest model-schema-includes-actions-test
+  (with-redefs [schema.model/model-action-schemas
+                (fn [model]
+                  (is (= 42 (:id model)))
+                  [{:kind "action", :key "create", :id 5}])]
+    (is (= {:key              "ordersModel"
+            :keyDisambiguator 42
+            :actions          {"create" {:kind "action", :key "create", :id 5}}}
+           (schema.model/model-schema
+            {:id   42
+             :name "Orders model"})))))
+
+(deftest model-schemas-includes-actionable-models-test
+  (with-redefs [schema.common/select-schema-cards
+                (fn [card-type database-ids collection-ids]
+                  (is (= :model card-type))
+                  (is (= #{1} database-ids))
+                  (is (nil? collection-ids))
+                  [{:id 42 :name "Model 42"}
+                   {:id 43 :name "Model 43"}])
+                schema.model/model-action-schemas
+                (fn [model]
+                  (when (= (:id model) 42)
+                    [{:kind "action", :key "create", :id 5}]))]
+    (is (= #{"model42"}
+           (->> (schema.model/model-schemas #{1})
+                (map :key)
+                set)))))
+
+(deftest model-schema-surfaces-action-selection-errors-test
+  (with-redefs [schema.model/action-rows (constantly [])
+                actions/select-actions (fn [& _]
+                                         (throw (ex-info "action lookup failed"
+                                                         {:status-code 500})))]
+    (let [exception (is (thrown? clojure.lang.ExceptionInfo
+                                 (schema.model/model-schema {:id   100
+                                                             :name "Broken model"})))]
+      (is (= "Failed to build action schemas for model \"Broken model\" (card 100): action lookup failed"
+             (ex-message exception)))
+      (is (= {:model-id      100
+              :model-name    "Broken model"
+              :status-code   500
+              :cause-message "action lookup failed"}
+             (select-keys (ex-data exception) [:model-id :model-name :status-code :cause-message]))))))
+
+(deftest model-schema-surfaces-action-rendering-errors-test
+  (with-redefs [actions/select-actions (constantly [{:id   200
+                                                     :name "Broken action"
+                                                     :type :query}])
+                schema.model/action-rows (constantly [{:id   200
+                                                       :name "Broken action"
+                                                       :type :query}])
+                schema.model/action-detail-schema (fn [& _]
+                                                    (throw (ex-info "action parameters are invalid"
+                                                                    {:status-code 500})))]
+    (let [exception (is (thrown? clojure.lang.ExceptionInfo
+                                 (schema.model/model-schema {:id   100
+                                                             :name "Broken model"})))]
+      (is (= "Failed to build action schema for action \"Broken action\" (action 200, type query) on model \"Broken model\" (card 100): action parameters are invalid"
+             (ex-message exception)))
+      (is (= {:model-id      100
+              :model-name    "Broken model"
+              :action-id     200
+              :action-name   "Broken action"
+              :action-type   :query
+              :status-code   500
+              :cause-message "action parameters are invalid"}
+             (select-keys (ex-data exception)
+                          [:model-id :model-name :action-id :action-name :action-type :status-code :cause-message]))))))
+
+(deftest model-schema-surfaces-unresolved-action-row-errors-test
+  (with-redefs [schema.model/action-rows (constantly [{:id   200
+                                                       :name "Broken action"
+                                                       :type :broken}])
+                actions/select-actions (constantly [])]
+    (let [exception (is (thrown? clojure.lang.ExceptionInfo
+                                 (schema.model/model-schema {:id   100
+                                                             :name "Broken model"})))]
+      (is (= "Failed to build action schemas for model \"Broken model\" (card 100): action rows could not be resolved: Broken action (action 200, type broken)"
+             (ex-message exception)))
+      (is (= {:model-id               100
+              :model-name             "Broken model"
+              :unresolved-action-rows [{:id 200, :name "Broken action", :type :broken}]}
+             (select-keys (ex-data exception) [:model-id :model-name :unresolved-action-rows]))))))

--- a/test/metabase/typed_schemas/api/schema/model_test.clj
+++ b/test/metabase/typed_schemas/api/schema/model_test.clj
@@ -34,6 +34,26 @@
                 (map :key)
                 set)))))
 
+; Ensures we are not doing N+1 queries for action rows and details
+(deftest model-schemas-bulk-loads-actions-test
+  (let [models               [{:id 42 :name "Model 42"}
+                              {:id 43 :name "Model 43"}]
+        action-rows-calls    (atom [])
+        action-details-calls (atom [])]
+    (with-redefs [schema.common/select-schema-cards (constantly models)
+                  schema.model/action-rows (fn [model-ids]
+                                             (swap! action-rows-calls conj model-ids)
+                                             [])
+                  actions/select-actions (fn [known-models & options]
+                                           (swap! action-details-calls conj [known-models options])
+                                           [])]
+      (is (= [] (vec (schema.model/model-schemas #{1}))))
+      (is (= [#{42 43}] @action-rows-calls))
+      (is (= [[models [:model_id [:in #{42 43}]
+                       :archived false
+                       :type [:not= "http"]]]]
+             @action-details-calls)))))
+
 (deftest model-schema-surfaces-action-selection-errors-test
   (with-redefs [schema.model/action-rows (constantly [])
                 actions/select-actions (fn [& _]

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -2,13 +2,12 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase.actions.core :as actions]
    [metabase.models.interface :as mi]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.typed-schemas.api :as typed-schemas.api]
    [metabase.typed-schemas.api.render :as typed-schemas.api.render]
-   [metabase.typed-schemas.api.schema.common :as typed-schemas.api.schema.common]
+   [metabase.typed-schemas.api.schema.model :as typed-schemas.api.schema.model]
    [metabase.typed-schemas.api.schema.question :as typed-schemas.api.schema.question]
    [metabase.typed-schemas.api.schema.table :as typed-schemas.api.schema.table]
    [metabase.typed-schemas.api.scope :as typed-schemas.api.scope]
@@ -48,35 +47,6 @@
             :source-field-id 102
             :sources         [{:type :field, :field-id 3815}]}
            247)))))
-
-(deftest model-schema-includes-actions-test
-  (with-redefs [typed-schemas.api/model-actions
-                (fn [model]
-                  (is (= 42 (:id model)))
-                  [{:kind "action", :key "create", :id 5}])]
-    (is (= {:key              "ordersModel"
-            :keyDisambiguator 42
-            :actions          {"create" {:kind "action", :key "create", :id 5}}}
-           (#'typed-schemas.api/model-schema
-            {:id             42
-             :name           "Orders model"})))))
-
-(deftest model-schemas-includes-actionable-models-test
-  (with-redefs [typed-schemas.api.schema.common/select-schema-cards
-                (fn [card-type database-ids collection-ids]
-                  (is (= :model card-type))
-                  (is (= #{1} database-ids))
-                  (is (nil? collection-ids))
-                  [{:id 42 :name "Model 42"}
-                   {:id 43 :name "Model 43"}])
-                typed-schemas.api/model-actions
-                (fn [model]
-                  (when (= (:id model) 42)
-                    [{:kind "action", :key "create", :id 5}]))]
-    (is (= #{"model42"}
-           (->> (#'typed-schemas.api/model-schemas #{1})
-                (map :key)
-                set)))))
 
 (deftest metric-source-id-test
   (testing "integer source-table emits sourceTableId but not sourceCardId"
@@ -245,9 +215,9 @@
 (deftest database-filter-scopes-models-test
   (let [model-database-ids (atom [])]
     (with-redefs [typed-schemas.api.scope/database-ids-for-value (constantly #{42})
-                  typed-schemas.api/model-schemas (fn [database-ids]
-                                                    (swap! model-database-ids conj database-ids)
-                                                    [])
+                  typed-schemas.api.schema.model/model-schemas (fn [database-ids]
+                                                                 (swap! model-database-ids conj database-ids)
+                                                                 [])
                   typed-schemas.api.schema.question/question-schemas (fn
                                                                        ([_database-ids] [])
                                                                        ([_database-ids _collection-ids] []))
@@ -261,64 +231,6 @@
       (#'typed-schemas.api/typed-schema {:database "Boba"})
       (#'typed-schemas.api/typed-schema {:database "Boba" :questions "true"})
       (is (= [#{42} #{42}] @model-database-ids)))))
-
-(deftest model-schema-surfaces-action-selection-errors-test
-  (with-redefs [typed-schemas.api/raw-model-actions (constantly [])
-                actions/select-actions (fn [& _]
-                                         (throw (ex-info "action lookup failed"
-                                                         {:status-code 500})))]
-    (let [exception (is (thrown? clojure.lang.ExceptionInfo
-                                 (#'typed-schemas.api/model-schema {:id             100
-                                                                    :name           "Broken model"
-                                                                    :result-columns []})))]
-      (is (= "Failed to build action schemas for model \"Broken model\" (card 100): action lookup failed"
-             (ex-message exception)))
-      (is (= {:model-id      100
-              :model-name    "Broken model"
-              :status-code   500
-              :cause-message "action lookup failed"}
-             (select-keys (ex-data exception) [:model-id :model-name :status-code :cause-message]))))))
-
-(deftest model-schema-surfaces-action-rendering-errors-test
-  (with-redefs [actions/select-actions (constantly [{:id   200
-                                                     :name "Broken action"
-                                                     :type :query}])
-                typed-schemas.api/raw-model-actions (constantly [{:id   200
-                                                                  :name "Broken action"
-                                                                  :type :query}])
-                typed-schemas.api/action-schema (fn [& _]
-                                                  (throw (ex-info "action parameters are invalid"
-                                                                  {:status-code 500})))]
-    (let [exception (is (thrown? clojure.lang.ExceptionInfo
-                                 (#'typed-schemas.api/model-schema {:id             100
-                                                                    :name           "Broken model"
-                                                                    :result-columns []})))]
-      (is (= "Failed to build action schema for action \"Broken action\" (action 200, type query) on model \"Broken model\" (card 100): action parameters are invalid"
-             (ex-message exception)))
-      (is (= {:model-id      100
-              :model-name    "Broken model"
-              :action-id     200
-              :action-name   "Broken action"
-              :action-type   :query
-              :status-code   500
-              :cause-message "action parameters are invalid"}
-             (select-keys (ex-data exception) [:model-id :model-name :action-id :action-name :action-type :status-code :cause-message]))))))
-
-(deftest model-schema-surfaces-dropped-action-errors-test
-  (with-redefs [typed-schemas.api/raw-model-actions (constantly [{:id   200
-                                                                  :name "Broken action"
-                                                                  :type :broken}])
-                actions/select-actions (constantly [])]
-    (let [exception (is (thrown? clojure.lang.ExceptionInfo
-                                 (#'typed-schemas.api/model-schema {:id             100
-                                                                    :name           "Broken model"
-                                                                    :result-columns []})))]
-      (is (= "Failed to build action schemas for model \"Broken model\" (card 100): selected actions were dropped while normalizing action details: Broken action (action 200, type broken)"
-             (ex-message exception)))
-      (is (= {:model-id        100
-              :model-name      "Broken model"
-              :dropped-actions [{:id 200, :name "Broken action", :type :broken}]}
-             (select-keys (ex-data exception) [:model-id :model-name :dropped-actions]))))))
 
 (deftest library-and-database-are-mutually-exclusive-test
   (mt/user-http-request-full-response
@@ -359,7 +271,7 @@
     (with-redefs [typed-schemas.api.scope/library-collection-scope
                   (constantly {:metric-collection-ids #{20}
                                :data-collection-ids   #{10}})
-                  typed-schemas.api/model-schemas
+                  typed-schemas.api.schema.model/model-schemas
                   (fn
                     ([_database-ids]
                      (is false "library-only schemas should not load models"))
@@ -397,7 +309,7 @@
                     (is (= ["10" "20"] collection-values))
                     {:metric-collection-ids #{20}
                      :data-collection-ids   #{10}})
-                  typed-schemas.api/model-schemas
+                  typed-schemas.api.schema.model/model-schemas
                   (fn
                     ([_database-ids]
                      (is false "library-only schemas should not load models"))
@@ -431,7 +343,7 @@
         (is (= #{1} (->> (:metrics schema) vals (map :id) set)))))))
 
 (deftest include-models-schema-includes-actionable-models-test
-  (with-redefs [typed-schemas.api/model-schemas
+  (with-redefs [typed-schemas.api.schema.model/model-schemas
                 (fn [database-ids]
                   (is (nil? database-ids))
                   [{:key     "actionableModel"
@@ -464,10 +376,10 @@
 (deftest include-models-with-database-scopes-models-test
   (let [model-database-ids (atom [])]
     (with-redefs [typed-schemas.api.scope/database-ids-for-value (constantly #{42})
-                  typed-schemas.api/model-schemas (fn [database-ids]
-                                                    (swap! model-database-ids conj database-ids)
-                                                    [{:key     "databaseModel"
-                                                      :actions {"create" {:kind "action", :key "create", :id 1}}}])
+                  typed-schemas.api.schema.model/model-schemas (fn [database-ids]
+                                                                 (swap! model-database-ids conj database-ids)
+                                                                 [{:key     "databaseModel"
+                                                                   :actions {"create" {:kind "action", :key "create", :id 1}}}])
                   typed-schemas.api.schema.question/question-schemas (fn
                                                                        ([_database-ids] [])
                                                                        ([_database-ids _collection-ids] []))
@@ -493,7 +405,7 @@
                   (is (nil? database-ids))
                   (is (= #{30 40} collection-ids))
                   [{:type "card", :key "ordersByMonth", :id 1}])
-                typed-schemas.api/model-schemas
+                typed-schemas.api.schema.model/model-schemas
                 (fn
                   ([_database-ids]
                    (is false "question collection schemas should not load models"))
@@ -520,7 +432,7 @@
                   (is (nil? database-ids))
                   (is (= #{30} collection-ids))
                   [{:type "card", :key "ordersByMonth", :id 1}])
-                typed-schemas.api/model-schemas
+                typed-schemas.api.schema.model/model-schemas
                 (fn
                   ([_database-ids]
                    (is false "question collection schemas should not load models"))
@@ -556,7 +468,7 @@
                   (is (nil? database-ids))
                   (is (= #{30} collection-ids))
                   [{:type "card", :key "ordersByMonth", :id 1}])
-                typed-schemas.api/model-schemas
+                typed-schemas.api.schema.model/model-schemas
                 (fn [database-ids]
                   (is (nil? database-ids))
                   [{:key     "selectedQuestionCollectionModel"


### PR DESCRIPTION
Closes [EMB-2078: Extract model and action schema generator](https://linear.app/metabase/issue/EMB-2078/extract-model-and-action-schema-generator)

PR 4/5 of [EMB-2062: Code cleanup: split `src/metabase/typed_schemas/api.clj` to multiple files](https://linear.app/metabase/issue/EMB-2062/code-cleanup-split-srcmetabasetyped-schemasapiclj-to-multiple-files)

### Description

Extracts model and action schema generation from `metabase.typed-schemas.api` into `metabase.typed-schemas.api.schema.model` to keep it in its own modules.

This keeps the top-level API namespace focused on endpoint, while moving model action lookup, action detail rendering, and [EMB-2066: Surface model, action and question typed schema generation errors](https://linear.app/metabase/issue/EMB-2066/surface-model-action-and-question-typed-schema-generation-errors) error surfacing into a dedicated schema generator namespace.

The extracted module preserves error context for:

- Action detail lookup errors
- Action rows that cannot be resolved into action details
- Action schema rendering errors

Also moves the corresponding model and action tests out of the main API test namespace into `metabase.typed-schemas.api.schema.model-test`.

### How to verify

Existing backend tests should continue to pass. Schema generation via `/api/typed-schemas/v1/typescript` endpoint should continue to work.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR