### PR TITLE
Add row count to explorations API

### DIFF
--- a/resources/migrations/063/20260428_explorations.yaml
+++ b/resources/migrations/063/20260428_explorations.yaml
@@ -1609,6 +1609,21 @@ databaseChangeLog:
                     nullable: true
 
   - changeSet:
+      id: v63.srrowcount
+      author: johnswanson
+      comment: Add stored_result.row_count
+      changes:
+        - addColumn:
+            tableName: stored_result
+            columns:
+              - column:
+                  name: row_count
+                  type: int
+                  remarks: Number of rows in the snapshot
+                  constraints:
+                    nullable: true
+
+  - changeSet:
       id: v63.storedresultdataaccesstokenbf
       author: johnswanson
       comment: Backfill data_access_token to the empty-map EDN sentinel '{}' for pre-token stored_result rows so legacy snapshots stay viewable by anyone with sufficient data perms (the nil-token read gate is creator+admin-only).

--- a/src/metabase/explorations/api.clj
+++ b/src/metabase/explorations/api.clj
@@ -275,10 +275,11 @@
 
 (mr/def ::ExplorationQuerySummary
   "Schema for a query row in API responses. The result blob and `dataset_query` aren't
-   asserted here; `interestingness_score` and `contextual_interestingness_score` are
-   left-joined (in `/:id/queries`) or batched-hydrated (in `/:id`) from
-   `exploration_query_result` and may be nil for pending/errored queries or — for the
-   contextual score — when the LLM is unconfigured or the thread had no prompt."
+   asserted here; `interestingness_score`, `contextual_interestingness_score`, and
+   `row_count` are left-joined (in `/:id/queries`) or batched-hydrated (in `/:id`) — the
+   scores from `exploration_query_result`, `row_count` from the linked `stored_result` —
+   and may be nil for pending/errored queries or — for the contextual score — when the LLM
+   is unconfigured or the thread had no prompt."
   [:map
    [:id                               ms/PositiveInt]
    [:exploration_thread_id            ms/PositiveInt]
@@ -298,6 +299,7 @@
    [:entity_id                        {:optional true} [:maybe :string]]
    [:interestingness_score            {:optional true} [:maybe number?]]
    [:contextual_interestingness_score {:optional true} [:maybe number?]]
+   [:row_count                        {:optional true} [:maybe ms/IntGreaterThanOrEqualToZero]]
    [:timeline_interestingness         {:optional true} [:maybe [:sequential
                                                                 [:map
                                                                  [:timeline_id           ms/PositiveInt]
@@ -671,7 +673,9 @@
 
 (def ^:private query-summary-columns
   "Column projection for `::ExplorationQuerySummary` rows — excludes `dataset_query` and the
-  result blob, joins both interestingness scores from `exploration_query_result`."
+  result blob, joins both interestingness scores from `exploration_query_result` and the
+  snapshot `row_count` from `stored_result` (reached through the EQR FK — callers must
+  left-join both tables)."
   [:exploration_query.id :exploration_query.exploration_thread_id
    :exploration_query.card_id :exploration_query.segment_id
    :exploration_query.dimension_id :exploration_query.query_type
@@ -680,7 +684,8 @@
    :exploration_query.started_at :exploration_query.finished_at
    :exploration_query.entity_id
    [:exploration_query_result.interestingness_score            :interestingness_score]
-   [:exploration_query_result.contextual_interestingness_score :contextual_interestingness_score]])
+   [:exploration_query_result.contextual_interestingness_score :contextual_interestingness_score]
+   [:stored_result.row_count                                    :row_count]])
 
 (defn- get-exploration-page-or-404
   [page-id]
@@ -890,7 +895,9 @@
               {:left-join [:exploration_thread
                            [:= :exploration_query.exploration_thread_id :exploration_thread.id]
                            :exploration_query_result
-                           [:= :exploration_query_result.exploration_query_id :exploration_query.id]]
+                           [:= :exploration_query_result.exploration_query_id :exploration_query.id]
+                           :stored_result
+                           [:= :stored_result.id :exploration_query_result.stored_result_id]]
                :where     [:= :exploration_thread.exploration_id id]
                :order-by  [[:exploration_query.position :asc]
                            [:exploration_query.id :asc]]})

--- a/src/metabase/explorations/models/exploration_query.clj
+++ b/src/metabase/explorations/models/exploration_query.clj
@@ -47,6 +47,20 @@
   [_model k queries]
   (hydrate-score-from-result k queries))
 
+(methodical/defmethod t2/batched-hydrate [:model/ExplorationQuery :row_count]
+  [_model k queries]
+  (mi/instances-with-hydrated-data
+   queries k
+   #(u/index-by :exploration_query_id :row_count
+                (t2/select [:model/ExplorationQueryResult
+                            :exploration_query_result.exploration_query_id
+                            [:stored_result.row_count :row_count]]
+                           {:join  [:stored_result
+                                    [:= :stored_result.id :exploration_query_result.stored_result_id]]
+                            :where [:in :exploration_query_result.exploration_query_id
+                                    (map :id queries)]}))
+   :id))
+
 (defn- ->timeline-score [row]
   (select-keys row [:timeline_id :interestingness_score]))
 

--- a/src/metabase/explorations/models/exploration_query_result.clj
+++ b/src/metabase/explorations/models/exploration_query_result.clj
@@ -217,7 +217,10 @@
                                           :creator_id    creator-id
                                           :database_id   (or (:database_id first-sr)
                                                              (-> dataset-query :database))
-                                          :dataset_query dataset-query})))
+                                          :dataset_query dataset-query
+                                          ;; `composite/combine` refreshed :row_count to the
+                                          ;; combined row set's size.
+                                          :row_count     (:row_count composite-qp)})))
               card-id          (:id (queries/create-card!
                                      {:name                   (or (not-empty (:name first-eq))
                                                                   (not-empty (:name src-card))

--- a/src/metabase/explorations/models/exploration_thread.clj
+++ b/src/metabase/explorations/models/exploration_thread.clj
@@ -76,6 +76,7 @@
                           {:order-by [[:position :asc] [:id :asc]]})
                :interestingness_score
                :contextual_interestingness_score
+               :row_count
                :segment_name
                :timeline_interestingness))
    :id

--- a/src/metabase/explorations/task/runner.clj
+++ b/src/metabase/explorations/task/runner.clj
@@ -450,6 +450,7 @@
                         :creator_id        creator-id
                         :database_id       db-id
                         :dataset_query     (:dataset_query row)
+                        :row_count         (:row_count qp-result)
                         :data_access_token token}))]
     (t2/insert! :model/ExplorationQueryResult
                 {:exploration_query_id             (:id row)

--- a/test/metabase/explorations/api_test.clj
+++ b/test/metabase/explorations/api_test.clj
@@ -1105,7 +1105,9 @@
           (is (contains? s :contextual_interestingness_score)
               "contextual score is included via the result-table left-join")
           (is (nil? (:contextual_interestingness_score s))
-              "pending queries have no result row, hence nil contextual score"))))))
+              "pending queries have no result row, hence nil contextual score")
+          (is (contains? s :row_count) "row_count is included via the result-table left-join")
+          (is (nil? (:row_count s)) "pending queries have no result row, hence nil row_count"))))))
 
 (deftest exploration-list-queries-includes-score-from-result-test
   (testing "GET /:id/queries surfaces both interestingness scores via the result-table left-join"
@@ -1119,7 +1121,8 @@
             eid (:id resp)
             qid (-> resp :threads first :queries first :id)]
         (let [sr-id (first (t2/insert-returning-pks! :model/StoredResult
-                                                     {:result_data (byte-array [0])}))]
+                                                     {:result_data (byte-array [0])
+                                                      :row_count   37}))]
           (t2/insert! :model/ExplorationQueryResult
                       {:exploration_query_id             qid
                        :stored_result_id                 sr-id
@@ -1127,7 +1130,8 @@
                        :contextual_interestingness_score 0.83}))
         (let [s (-> (mt/user-http-request u :get 200 (format "exploration/%d/queries" eid)) first)]
           (is (= 0.42 (:interestingness_score s)))
-          (is (= 0.83 (:contextual_interestingness_score s))))))))
+          (is (= 0.83 (:contextual_interestingness_score s)))
+          (is (= 37 (:row_count s)) "row_count surfaces from the linked stored_result"))))))
 
 (deftest exploration-get-includes-interestingness-on-queries-test
   (testing "GET /:id hydrates both interestingness scores on each nested query"
@@ -1148,10 +1152,13 @@
             (is (contains? q :interestingness_score))
             (is (nil? (:interestingness_score q)))
             (is (contains? q :contextual_interestingness_score))
-            (is (nil? (:contextual_interestingness_score q)))))
+            (is (nil? (:contextual_interestingness_score q)))
+            (is (contains? q :row_count))
+            (is (nil? (:row_count q)))))
         (testing "after a result row is inserted, both scores surface via hydration"
           (let [sr-id (first (t2/insert-returning-pks! :model/StoredResult
-                                                       {:result_data (byte-array [0])}))]
+                                                       {:result_data (byte-array [0])
+                                                        :row_count   37}))]
             (t2/insert! :model/ExplorationQueryResult
                         {:exploration_query_id             qid
                          :stored_result_id                 sr-id
@@ -1159,7 +1166,8 @@
                          :contextual_interestingness_score 0.83}))
           (let [q (fetch-query)]
             (is (= 0.42 (:interestingness_score q)))
-            (is (= 0.83 (:contextual_interestingness_score q)))))))))
+            (is (= 0.83 (:contextual_interestingness_score q)))
+            (is (= 37 (:row_count q)) "row_count hydrates from the linked stored_result")))))))
 
 (deftest exploration-list-queries-permissions-test
   (testing "GET /:id/queries enforces the same read-check as the parent exploration"

--- a/test/metabase/explorations/task/runner_test.clj
+++ b/test/metabase/explorations/task/runner_test.clj
@@ -96,7 +96,9 @@
         (is (some? result))
         (is (some? (:stored_result_id result)))
         (is (some? sr))
-        (is (pos? (count (:result_data sr))))))))
+        (is (pos? (count (:result_data sr))))
+        (is (= 1 (:row_count sr))
+            "the QP's top-level :row_count (1 row for an unbucketed count) is persisted on the snapshot")))))
 
 (deftest run-one-iteration-records-stored-result-use-test
   (testing "Running a query records a stored_result_use row tying the snapshot to the exploration"


### PR DESCRIPTION
Already available, we just need to persist it and thread it through the API.