### PR TITLE
Bundle-size stats: lower record threshold to 0.5%

### DIFF
--- a/.github/workflows/bundle-size-stats.yml
+++ b/.github/workflows/bundle-size-stats.yml
@@ -26,7 +26,7 @@ jobs:
       # Only record a data point when a bundle's as-served size (brotli where the
       # build ships .br, else gzip) moved by at least this percent vs the last
       # plotted point, keeping the chart to real changes.
-      MIN_DELTA_PERCENT: "1"
+      MIN_DELTA_PERCENT: "0.5"
     steps:
       - name: Check out the code
         uses: actions/checkout@v6


### PR DESCRIPTION
## What

Lowers `MIN_DELTA_PERCENT` from `1` to `0.5` in the Bundle Size Stats workflow.

## Why

The as-served bundle size has been drifting up gradually since the last plotted point, sitting at ~0.83% for many builds without ever tripping the 1% gate. So the chart hasn't recorded a point in a while even though the bundle did grow.

The growth is death-by-a-thousand-cuts: no single merge moved it by a meaningful amount, each contributed a fraction of a percent. Dropping the gate to 0.5% captures this class of slow drift instead of letting it hide under the threshold.

Side effect (intended): the next master merge will now record a point, since the current ~0.83% cumulative drift exceeds 0.5%. That plots the accumulated growth and re-baselines the rolling comparison.