### PR TITLE
Burn down redundant kondo ignores and stamp the false positives

### DIFF
--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -13,7 +13,7 @@
                  :deprecated-var                                                      81
                  :discouraged-java-method                                             3
                  :discouraged-namespace                                               81
-                 :discouraged-var                                                     107
+                 :discouraged-var                                                     108
                  :equals-true                                                         1
                  :main-without-gen-class                                              1
                  :metabase/defsetting-namespace                                       7

--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -17,7 +17,7 @@
                  :equals-true                                                         1
                  :main-without-gen-class                                              1
                  :metabase/defsetting-namespace                                       7
-                 :metabase/disallow-hardcoded-driver-names-in-tests                   50
+                 :metabase/disallow-hardcoded-driver-names-in-tests                   34
                  :metabase/discourage-millis-duration                                 1
                  :metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests 14
                  :metabase/modules                                                    8

--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -17,7 +17,7 @@
                  :equals-true                                                         1
                  :main-without-gen-class                                              1
                  :metabase/defsetting-namespace                                       7
-                 :metabase/disallow-hardcoded-driver-names-in-tests                   39
+                 :metabase/disallow-hardcoded-driver-names-in-tests                   50
                  :metabase/discourage-millis-duration                                 1
                  :metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests 14
                  :metabase/modules                                                    8

--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -34,12 +34,14 @@
                  :reduce-without-init                                                 3
                  :redundant-fn-wrapper                                                1
                  :syntax                                                              2
+                 :unquote-not-syntax-quoted                                           1
                  :unresolved-namespace                                                3
                  :unresolved-require                                                  1
                  :unresolved-symbol                                                   4
                  :unsorted-required-namespaces                                        1
                  :unused-alias                                                        1
                  :unused-binding                                                      9
+                 :unused-excluded-var                                                 2
                  :unused-namespace                                                    1
                  :unused-private-var                                                  8
                  :unused-value                                                        1}}

--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -5,47 +5,41 @@
 ;; to defend in your PR.
 ;; :all is the vector-less ignore form, which suppresses every linter on the next form.
 {:ignore-counts {:aliased-namespace-symbol                                            3
-                 :all                                                                 61
+                 :all                                                                 50
                  :case-symbol-test                                                    2
                  :clojure-lsp/unused-public-var                                       9
-                 :consistent-alias                                                    1
                  :def-fn                                                              1
                  :deprecated-namespace                                                97
-                 :deprecated-var                                                      91
-                 :discouraged-java-method                                             4
+                 :deprecated-var                                                      81
+                 :discouraged-java-method                                             3
                  :discouraged-namespace                                               81
-                 :discouraged-var                                                     144
-                 :equals-true                                                         28
-                 :invalid-arity                                                       1
+                 :discouraged-var                                                     107
+                 :equals-true                                                         1
                  :main-without-gen-class                                              1
                  :metabase/defsetting-namespace                                       7
-                 :metabase/disallow-hardcoded-driver-names-in-tests                   34
+                 :metabase/disallow-hardcoded-driver-names-in-tests                   39
                  :metabase/discourage-millis-duration                                 1
-                 :metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests 19
-                 :metabase/modules                                                    12
+                 :metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests 14
+                 :metabase/modules                                                    8
                  :metabase/namespace-name                                             4
-                 :metabase/prefer-with-dynamic-fn-redefs                              35
-                 :metabase/test-helpers-use-non-thread-safe-functions                 40
-                 :metabase/validate-defendpoint-has-response-schema                   462
+                 :metabase/prefer-with-dynamic-fn-redefs                              25
+                 :metabase/test-helpers-use-non-thread-safe-functions                 17
+                 :metabase/validate-defendpoint-has-response-schema                   444
                  :metabase/validate-defendpoint-query-params-use-kebab-case           40
                  :metabase/validate-defendpoint-route-uses-kebab-case                 44
-                 :metabase/validate-deftest                                           19
+                 :metabase/validate-deftest                                           10
                  :missing-docstring                                                   10
-                 :missing-protocol-method                                             4
+                 :missing-protocol-method                                             3
                  :non-arg-vec-return-type-hint                                        1
                  :reduce-without-init                                                 3
                  :redundant-fn-wrapper                                                1
-                 :redundant-nested-call                                               1
                  :syntax                                                              2
-                 :unquote-not-syntax-quoted                                           1
-                 :unresolved-namespace                                                5
+                 :unresolved-namespace                                                3
                  :unresolved-require                                                  1
                  :unresolved-symbol                                                   4
-                 :unresolved-var                                                      1
                  :unsorted-required-namespaces                                        1
                  :unused-alias                                                        1
                  :unused-binding                                                      9
-                 :unused-excluded-var                                                 2
                  :unused-namespace                                                    1
-                 :unused-private-var                                                  9
+                 :unused-private-var                                                  8
                  :unused-value                                                        1}}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,9 +98,10 @@ PR.
 Introducing a new linter: `./bin/mage kondo-insert-ignores :the-linter` inserts an ignore at every site it
 flags, then `./bin/mage fix-kondo-ratchets --seed :the-linter` records the budget — no big-bang cleanup.
 To burn debt down, `./bin/mage kondo-redundant-ignores` lists ignores that are no longer needed (slow:
-full kondo run). Kondo's redundancy report can't see hook-linter warnings, so `--fix` verifies each
-removal against a pre-removal baseline lint, restores ignores that were still working, and stamps them
-with a `[kondo-keep]` comment; marked sites are skipped on later runs. `--fix --audit` rechecks the
+full kondo run). Kondo's redundancy report can't see hook-linter warnings, so `--fix` re-lints after
+removing, puts any still-working ignore back exactly as it was, and stamps it with a `[kondo-keep]`
+comment; marked sites are skipped on later runs. That verification needs a clean starting point, so
+files with pre-existing lint findings are excluded from the sweep and reported. `--fix --audit` rechecks the
 marked sites too, removing any that have become truly redundant along with their stamped marker
 comments (a marker trailing on a code line is left for a hand fix). `[kondo-keep]` can also be added
 by hand to protect an ignore whose exact form matters — it only counts on the line directly above the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,13 @@ PR.
 Introducing a new linter: `./bin/mage kondo-insert-ignores :the-linter` inserts an ignore at every site it
 flags, then `./bin/mage fix-kondo-ratchets --seed :the-linter` records the budget — no big-bang cleanup.
 To burn debt down, `./bin/mage kondo-redundant-ignores` lists ignores that are no longer needed (slow:
-full kondo run).
+full kondo run). Kondo's redundancy report can't see hook-linter warnings, so `--fix` verifies each
+removal against a pre-removal baseline lint, restores ignores that were still working, and stamps them
+with a `[kondo-keep]` comment; marked sites are skipped on later runs. `--fix --audit` rechecks the
+marked sites too, removing any that have become truly redundant along with their stamped marker
+comments (a marker trailing on a code line is left for a hand fix). `[kondo-keep]` can also be added
+by hand to protect an ignore whose exact form matters — it only counts on the line directly above the
+ignore, or trailing on the ignore's own line.
 
 ## Tool Preferences
 

--- a/bb.edn
+++ b/bb.edn
@@ -286,8 +286,10 @@
   kondo-redundant-ignores
   {:doc "Report inline kondo ignores that are no longer necessary (slow: full kondo run)."
    :examples [["./bin/mage kondo-redundant-ignores" "Scan the backend tree for removable ignores"]
-              ["./bin/mage kondo-redundant-ignores --fix" "Also remove them from source"]]
-   :options [["-f" "--fix" "Remove the candidate ignores from source"]]
+              ["./bin/mage kondo-redundant-ignores --fix" "Also remove them from source (restores + marks [kondo-keep] any that re-trigger)"]
+              ["./bin/mage kondo-redundant-ignores --fix --audit" "Recheck [kondo-keep] sites too, unmarking any now truly redundant"]]
+   :options [["-f" "--fix" "Remove the candidate ignores from source"]
+             ["-a" "--audit" "Include sites marked [kondo-keep] instead of skipping them"]]
    :requires [[mage.kondo-ratchet]]
    :task (task! (mage.kondo-ratchet/redundant-ignores parsed))}
 

--- a/bin/build/src/metabuild_common/files.clj
+++ b/bin/build/src/metabuild_common/files.clj
@@ -169,7 +169,6 @@
        (doseq [^File file (file-seq source-path)
                :when (not (directory? file))
                :when
-               #_{:clj-kondo/ignore [:discouraged-var]}
                (or (str/ends-with? (str/lower-case file) "yaml")
                    (str/ends-with? (str/lower-case file) "yml"))]
          (when verbose (out/safe-println "Zipping file:" file))

--- a/bin/build/test/i18n/create_artifacts/backend_test.clj
+++ b/bin/build/test/i18n/create_artifacts/backend_test.clj
@@ -27,7 +27,6 @@
 
 (deftest ^:parallel backend-message?
   (testing "messages present in any .clj and .cljc files are detected as backend messages"
-    #_{:clj-kondo/ignore [:equals-true]}
     (are [source-references expected] (= expected
                                          (i18n/backend-message? {:source-references source-references}))
       ;; Simple .clj and .cljc files with and without line numbers

--- a/bin/lint-migrations-file/src/lint_migrations_file.cljc
+++ b/bin/lint-migrations-file/src/lint_migrations_file.cljc
@@ -368,17 +368,14 @@
           (println)
           #_:clj-kondo/ignore
           (printf "Error in %s:\t%s\n" (:file (ex-data e)) (.getMessage e))
-          #_:clj-kondo/ignore
           (printf "Details:\n\n %s" (with-out-str (pprint/pprint (dissoc (ex-data e) ::validation-error))))
           (println))
         (do
           (pprint/pprint (Throwable->map e))
           (println (.getMessage e))))
-      #_:clj-kondo/ignore
       (System/exit 1))
     (catch #_:clj-kondo/ignore
      Throwable e
            (pprint/pprint (Throwable->map e))
            (println (.getMessage e))
-           #_:clj-kondo/ignore
            (System/exit 1))))

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -158,7 +158,6 @@
   (let [h2-dbs (t2/select :model/Database :engine :h2)
         in-memory? (fn [db] (some-> db :details :db (str/starts-with? "mem:")))
         can-connect? (fn [db]
-                       #_:clj-kondo/ignore
                        (binding [driver.settings/*allow-testing-h2-connections* true]
                          (try
                            (driver/can-connect? :h2 (:details db))

--- a/enterprise/backend/src/metabase_enterprise/library/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/library/api.clj
@@ -42,7 +42,6 @@
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/" :- [:or ::collections.schema/CollectionItem [:map [:data nil?]]]
   "Get the Library. If no library exists, it doesn't fail but returns an empty response"
   [_route

--- a/enterprise/backend/src/metabase_enterprise/library/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/library/api.clj
@@ -39,9 +39,6 @@
                     true sort
                     true ((partial map name))))))
 
-;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
-;; use our API + we will need it when we make auto-TypeScript-signature generation happen
-;;
 (api.macros/defendpoint :get "/" :- [:or ::collections.schema/CollectionItem [:map [:data nil?]]]
   "Get the Library. If no library exists, it doesn't fail but returns an empty response"
   [_route

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/pgvector_api.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/pgvector_api.clj
@@ -22,7 +22,6 @@
 
 (set! *warn-on-reflection* true)
 
-#_{:clj-kondo/ignore [unresolved-require]}
 (comment
   (require '[metabase-enterprise.semantic-search.db.datasource :as semantic.db])
   (def pgvector (or @semantic.db/data-source (semantic.db/init-db!)))

--- a/enterprise/backend/src/metabase_enterprise/support_access_grants/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/support_access_grants/api.clj
@@ -12,7 +12,6 @@
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/"
   :- ::grants.schema/grant-response
   "Create a new support access grant.
@@ -31,7 +30,6 @@
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :put "/:id/revoke"
   :- ::grants.schema/grant-response
   "Revoke an existing support access grant.
@@ -45,7 +43,6 @@
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/"
   :- ::grants.schema/list-grants-response
   "List support access grants with optional filtering and pagination.
@@ -73,7 +70,6 @@
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/current"
   :- ::grants.schema/current-grant-response
   "Get the currently active support access grant, if one exists.

--- a/enterprise/backend/src/metabase_enterprise/support_access_grants/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/support_access_grants/api.clj
@@ -9,9 +9,6 @@
    [metabase.request.core :as request]
    [metabase.util.malli.schema :as ms]))
 
-;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
-;; use our API + we will need it when we make auto-TypeScript-signature generation happen
-;;
 (api.macros/defendpoint :post "/"
   :- ::grants.schema/grant-response
   "Create a new support access grant.
@@ -27,9 +24,6 @@
                         (:ticket_number body)
                         (:notes body)))
 
-;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
-;; use our API + we will need it when we make auto-TypeScript-signature generation happen
-;;
 (api.macros/defendpoint :put "/:id/revoke"
   :- ::grants.schema/grant-response
   "Revoke an existing support access grant.
@@ -40,9 +34,6 @@
   (api/write-check :model/SupportAccessGrantLog id)
   (grants/revoke-grant! api/*current-user-id* id))
 
-;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
-;; use our API + we will need it when we make auto-TypeScript-signature generation happen
-;;
 (api.macros/defendpoint :get "/"
   :- ::grants.schema/list-grants-response
   "List support access grants with optional filtering and pagination.
@@ -67,9 +58,6 @@
                        :user-id user-id
                        :include-revoked include-revoked}))
 
-;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
-;; use our API + we will need it when we make auto-TypeScript-signature generation happen
-;;
 (api.macros/defendpoint :get "/current"
   :- ::grants.schema/current-grant-response
   "Get the currently active support access grant, if one exists.

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/impl.clj
@@ -3,7 +3,6 @@
    [metabase-enterprise.transforms-python.execute :as transforms-python.execute]
    [metabase.transforms.interface :as transforms.i]))
 
-#_{:clj-kondo/ignore [:discouraged-var]}
 (defmethod transforms.i/execute! :python
   [transform options]
   (transforms-python.execute/execute-python-transform! transform options))

--- a/enterprise/backend/test/metabase_enterprise/action_v2/models/undo_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/models/undo_test.clj
@@ -61,7 +61,6 @@
 
 ;; I'm OK reducing this scenario's scope once we have e2e tests.
 ;; Until then, I think this is ideal.
-#_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest undo-redo-single-user-single-table-single-record-integration-test
   (mt/with-empty-h2-app-db!
     (mt/with-premium-features #{:table-data-editing}
@@ -121,7 +120,6 @@
 
 ;; I'm OK reducing this scenario's scope once we have e2e tests.
 ;; Until then, I think this is ideal.
-#_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest undo-redo-multi-user-single-table-single-record-integration-test
   (mt/with-empty-h2-app-db!
     (mt/with-premium-features #{:table-data-editing}

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -23,7 +23,6 @@
 (use-fixtures :once (fixtures/initialize :db))
 
 ;; `reindex!` below is ok in a parallel test since it's not actually executing anything
-#_{:clj-kondo/ignore [:metabase/validate-deftest]}
 (use-fixtures :each (fn [f]
                       (mt/with-dynamic-fn-redefs [search/reindex! (constantly nil)]
                         (test-helpers/clean-remote-sync-state f))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/snippets_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/snippets_test.clj
@@ -39,7 +39,6 @@
     (finally
       (t2/delete! :model/RemoteSyncObject))))
 
-#_{:clj-kondo/ignore [:metabase/validate-deftest]}
 (use-fixtures :each (fn [f]
                       (mt/with-dynamic-fn-redefs [search/reindex! (constantly nil)]
                         (clean-remote-sync-state f))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/transforms_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/transforms_test.clj
@@ -21,7 +21,6 @@
 
 (use-fixtures :once (fixtures/initialize :db))
 
-#_{:clj-kondo/ignore [:metabase/validate-deftest]}
 (use-fixtures :each test-helpers/commit-with-temp
   (fn [f]
     (mt/with-dynamic-fn-redefs [search/reindex! (constantly nil)]

--- a/enterprise/backend/test/metabase_enterprise/replacement/runner_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/replacement/runner_test.clj
@@ -205,7 +205,6 @@
                                    (start-run! [_])
                                    (succeed-run! [_])
                                    (fail-run! [_ _]))]
-                #_{:clj-kondo/ignore [:unresolved-var]}
                 (replacement.runner/run-swap-source! [:card old-id] [:card new-id] progress)
                 (testing "child card's source-card is updated to new model"
                   (is (= new-id (get-in (t2/select-one-fn :dataset_query :model/Card :id child-id)

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
@@ -1032,7 +1032,6 @@
                                        (get-in (-> drill-thru-query
                                                    qp.preprocess/preprocess
                                                    ;; legacy usage -- don't do things like this going forward
-                                                   #_{:clj-kondo/ignore [:discouraged-var]}
                                                    lib/->legacy-MBQL)
                                                [:query :filter])))))]
                         (testing "As an admin"

--- a/enterprise/backend/test/metabase_enterprise/security_center/matching_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/security_center/matching_test.clj
@@ -31,7 +31,6 @@
       nil
       "")))
 
-#_:clj-kondo/ignore
 (deftest ^:parallel affected-by-version?-test
   (let [v            matching/parse-version
         in-range?    @#'matching/affected-by-version?

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/repair_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/repair_test.clj
@@ -96,7 +96,6 @@
       (semantic.tu/with-test-db! {:mode :blank}
         ;; with-redefs mirrors the :mock-initialized bindings, which include non-fn values that
         ;; with-dynamic-fn-redefs cannot proxy.
-        #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
         (with-redefs [semantic.embedding/get-configured-model        (fn [] semantic.tu/mock-embedding-model)
                       semantic.index-metadata/default-index-metadata semantic.tu/mock-index-metadata
                       semantic.index/model-table-suffix              semantic.tu/mock-table-suffix]

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -49,7 +49,6 @@
   "Wraps with-temp*, but binding `*allow-deleting-personal-collections*` to true so that temporary personal collections
   can still be deleted."
   [model-bindings & body]
-  #_{:clj-kondo/ignore [:discouraged-var]}
   `(binding [collection/*allow-deleting-personal-collections* true]
      (mt/with-temp ~model-bindings ~@body)))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -35,7 +35,6 @@
 ;; `reindex!` below is ok in a parallel test since it's not actually executing anything.
 ;; Many tests here rely on the H2 test-data database via Card defaults, so we keep the H2 guard
 ;; off and re-enable the H2 path in the extract (production keeps it filtered).
-#_{:clj-kondo/ignore [:metabase/validate-deftest]}
 (use-fixtures :each (fn [thunk]
                       (mt/with-dynamic-fn-redefs [search/reindex! (constantly nil)
                                                   models.database/assert-not-h2! (constantly nil)]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -25,7 +25,6 @@
 ;; `reindex!` below is ok in a parallel test since it's not actually executing anything.
 ;; Many tests here use the H2 test-data database (Card defaults), so we keep the H2 guard off
 ;; and re-enable H2 in the extract (production keeps it filtered).
-#_{:clj-kondo/ignore [:metabase/validate-deftest]}
 (use-fixtures :each (fn [thunk]
                       (mt/with-dynamic-fn-redefs [search/reindex! (constantly nil)
                                                   models.database/assert-not-h2! (constantly nil)]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/osi_ai_context_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/osi_ai_context_test.clj
@@ -20,7 +20,6 @@
 (set! *warn-on-reflection* true)
 
 ;; The references point at the H2 test-data Table, so keep the H2 guard off and re-enable H2 in extract.
-#_{:clj-kondo/ignore [:metabase/validate-deftest]}
 (use-fixtures :each (fn [thunk]
                       (mt/with-dynamic-fn-redefs [search/reindex! (constantly nil)
                                                   models.database/assert-not-h2! (constantly nil)]

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -630,6 +630,7 @@
         (t2/update! :model/User :email "newuser@metabase.com" {:is_active false})
         (is (not (t2/select-one-fn :is_active :model/User :email "newuser@metabase.com")))
         ;; with-redefs (cross-thread): /auth/sso runs on Jetty workers that don't inherit *local-redefs*
+        ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
         #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
         (with-redefs [sso-settings/jwt-user-provisioning-enabled? (constantly false)
                       appearance.settings/site-name               (constantly "test")]
@@ -822,6 +823,7 @@
                                                       :is_active false}
                        :model/User {existing-email :email} {:tenant_id tenant-id}]
           ;; with-redefs (cross-thread): /auth/sso runs on Jetty workers that don't inherit *local-redefs*
+          ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
           #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
           (with-redefs [sso-settings/jwt-user-provisioning-enabled? (constantly false)]
             (testing "with user provisioning turned off"
@@ -969,6 +971,7 @@
   (testing "When user provisioning is disabled, throw an error if we attempt to create a new user."
     (with-jwt-default-setup!
       ;; with-redefs (cross-thread): /auth/sso runs on Jetty workers that don't inherit *local-redefs*
+      ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
       #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
       (with-redefs [sso-settings/jwt-user-provisioning-enabled? (constantly false)
                     appearance.settings/site-name               (constantly "test")]

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/ldap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/ldap_test.clj
@@ -288,6 +288,7 @@
       (ldap.test/with-ldap-server!
         (testing "an error is thrown when a new user attempts to login via provider/login! and user provisioning is not enabled"
           ;; with-redefs (cross-thread): /auth/sso runs on Jetty workers that don't inherit *local-redefs*
+          ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
           #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
           (with-redefs [sso-settings/ldap-user-provisioning-enabled? (constantly false)
                         appearance.settings/site-name                (constantly "test")]

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/oidc_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/oidc_test.clj
@@ -237,6 +237,7 @@
                           *group-sync-email*  email]
                   (with-group-sync-oidc!
                     ;; with-redefs (cross-thread): /auth/sso runs on Jetty workers that don't inherit *local-redefs*
+                    ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
                     #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
                     (with-redefs [oidc.state/validate-oidc-callback
                                   (fn [_request _state _provider & _opts]

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -1126,7 +1126,6 @@
                        (is (not (successful-login? response))))))
                  (testing "an existing user also fails to log in"
                    ;; with-redefs (cross-thread): /auth/sso runs on Jetty workers that don't inherit *local-redefs*
-                   #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
                    (with-redefs [saml.p/saml-response->attributes
                                  (fn [_]
                                    {"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" existing-email

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -614,6 +614,7 @@
              (t2/update! :model/User :%lower.email "newuser@metabase.com" {:is_active false})
              (testing "We can't reactivate the user if user provisioning is disabled."
                ;; with-redefs (cross-thread): /auth/sso runs on Jetty workers that don't inherit *local-redefs*
+               ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
                #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
                (with-redefs [sso-settings/saml-user-provisioning-enabled? (constantly false)
                              appearance.settings/site-name (constantly "test")]
@@ -765,6 +766,7 @@
     (with-other-sso-types-disabled!
       (with-saml-default-setup!
         ;; with-redefs (cross-thread): /auth/sso runs on Jetty workers that don't inherit *local-redefs*
+        ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
         #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
         (with-redefs [sso-settings/saml-user-provisioning-enabled? (constantly false)
                       appearance.settings/site-name (constantly "test")]
@@ -972,6 +974,7 @@
          (fn []
            ;; Mock the saml-response->attributes function to return mixed attribute types.
            ;; with-redefs (cross-thread): /auth/sso runs on Jetty workers that don't inherit *local-redefs*
+           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
            #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
            (with-redefs [saml.p/saml-response->attributes
                          (fn [_]
@@ -1093,6 +1096,7 @@
                      (is (successful-login? response)))))
                (testing "an existing user also fails to log in"
                  ;; with-redefs (cross-thread): /auth/sso runs on Jetty workers that don't inherit *local-redefs*
+                 ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
                  #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
                  (with-redefs [saml.p/saml-response->attributes
                                (fn [_]
@@ -1114,6 +1118,7 @@
                                                         :is_active false}
                          :model/User {existing-email :email} {:tenant_id tenant-id}]
             ;; with-redefs (cross-thread): /auth/sso runs on Jetty workers that don't inherit *local-redefs*
+            ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
             #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
             (with-redefs [sso-settings/saml-user-provisioning-enabled? (constantly false)]
               (do-with-some-validators-disabled!
@@ -1150,6 +1155,7 @@
              (fn []
                (testing "tenant -> other tenant fails with correct error message"
                  ;; with-redefs (cross-thread): /auth/sso runs on Jetty workers that don't inherit *local-redefs*
+                 ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
                  #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
                  (with-redefs [saml.p/saml-response->attributes
                                (fn [_]
@@ -1174,6 +1180,7 @@
                (fn []
                  ;; Use the regular new-user response which doesn't have tenant attribute.
                  ;; with-redefs (cross-thread): /auth/sso runs on Jetty workers that don't inherit *local-redefs*
+                 ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
                  #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
                  (with-redefs [saml.p/saml-response->attributes
                                (fn [_]
@@ -1196,6 +1203,7 @@
               (do-with-some-validators-disabled!
                (fn []
                  ;; with-redefs (cross-thread): /auth/sso runs on Jetty workers that don't inherit *local-redefs*
+                 ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
                  #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
                  (with-redefs [saml.p/saml-response->attributes
                                (fn [_]

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/drivers_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/drivers_test.clj
@@ -191,7 +191,6 @@
        :rows rows
        :metadata metadata})))
 
-#_:clj-kondo/ignore
 (defmacro with-test-table
   [[table-id table-name] [schema data] & body]
   `(let [table-name# (if (= :redshift driver/*driver*)

--- a/enterprise/backend/test/metabase_enterprise/workspaces/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/e2e_test.clj
@@ -277,7 +277,6 @@
 ;; `^:synchronized` because the `instance-workspace` setting is process-wide state
 ;; backed by the shared test app DB; running concurrently with other workspace-mode
 ;; tests would cross-pollute.
-#_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (defn- with-redshift-describe-filter-disabled
   "Redshift test infra normally filters describe-database to only return tables
    prefixed by dataset name (`<dataset>_<name>`). Workspace e2e creates tables

--- a/enterprise/backend/test/metabase_enterprise/workspaces/transform_hooks_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/transform_hooks_test.clj
@@ -93,7 +93,6 @@
   (wired in `transforms.execute/execute!`), so the captured target reflects the post-rewrite
   state — the question this helper answers is 'what does the per-type method actually see?'."
   [captured-atom body-fn]
-  #_{:clj-kondo/ignore [:discouraged-var]}
   (with-redefs [transforms.i/execute! (fn [transform _opts]
                                         (reset! captured-atom transform)
                                         {:status :succeeded})]

--- a/mage/src/mage/cli.clj
+++ b/mage/src/mage/cli.clj
@@ -86,14 +86,12 @@
       (if (mc/validate arg-schema decoded-args)
         decoded-args
         (do (doseq [{:keys [path schema value]} (:errors
-                                                 #_:clj-kondo/ignore
                                                  (mc/explain arg-schema decoded-args))]
               (println (c/red "Invalid Argument at " path
                               ". It should match: " (mc/form schema)
                               " got: " (pr-str value))))
             (binding [*command-line-args* ["-h"]]
               (check-print-help current-task))
-            #_{:clj-kondo/ignore [:discouraged-java-method]}
             (System/exit 0))))))
 
 (defn- check-option-errors [option-errors *error-hit? summary]

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -99,7 +99,9 @@
                                  #(compare %2 %1)
                                  sites))
         ;; phase 2: line insertions (comments, whole-line originals), bottom-up; splicing first means
-        ;; a comment inserted above a row can no longer displace a same-row splice target
+        ;; a comment inserted above a row can no longer displace a same-row splice target. Within a
+        ;; row, inline comments insert first so they end up directly above the code line, below any
+        ;; whole-line block that lands on the same row -- each ignore keeps its own marker adjacent.
         result  (reduce
                  (fn [{:keys [lines] :as acc} {:keys [row original comment]}]
                    (let [original-lines (str/split-lines (:text original))
@@ -116,7 +118,10 @@
                                       (subvec lines (dec row)))
                       :inserted (into (:inserted acc) (repeat n-added row))}))
                  {:lines spliced, :inserted []}
-                 (sort-by :row > sites))]
+                 (sort-by (fn [{:keys [row original]}]
+                            [row (if (:whole-line? original) 0 1)])
+                          #(compare %2 %1)
+                          sites))]
     {:text          (str (str/join "\n" (:lines result)) ending)
      :inserted-rows (:inserted result)}))
 
@@ -304,12 +309,16 @@
                                        (for [[file sites] (sort-by key file->sites)]
                                          (let [text  (slurp file)
                                                lines (vec (str/split-lines text))
-                                               ;; one comment per row, however many sites restore onto it
+                                               ;; every whole-line restore gets its own marker; a row's
+                                               ;; inline restores share one, directly above the code line
                                                sites (mapcat (fn [[row row-sites]]
-                                                               (let [comment (when-not (marked-row? lines row)
-                                                                               keep-comment)]
-                                                                 (cons (assoc (first row-sites) :comment comment)
-                                                                       (map #(assoc % :comment nil) (rest row-sites)))))
+                                                               (if (marked-row? lines row)
+                                                                 (map #(assoc % :comment nil) row-sites)
+                                                                 (let [{wl true, inl false} (group-by (comp boolean :whole-line? :original) row-sites)]
+                                                                   (concat (map #(assoc % :comment keep-comment) wl)
+                                                                           (when (seq inl)
+                                                                             (cons (assoc (first inl) :comment keep-comment)
+                                                                                   (map #(assoc % :comment nil) (rest inl))))))))
                                                              (group-by :row sites))
                                                {:keys [text inserted-rows]} (reinsert-ignores text sites)]
                                            (spit file text)

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -24,20 +24,90 @@
     (cond->> findings
       linter (filter #(= (:type %) linter)))))
 
+(def keep-marker
+  "Comment token marking an ignore as a verified `:redundant-ignore` false positive.
+  Sites carrying it are skipped by [[redundant-ignores]] unless `--audit` rechecks them."
+  "[kondo-keep]")
+
+(def ^:private keep-comment
+  (str ";; " keep-marker " suppresses a warning :redundant-ignore can't see; --audit rechecks"))
+
+(defn- marker-on-line?
+  "Is [[keep-marker]] on `line` as (part of) a comment? A `;` must precede it, so the marker occurring
+  inside a plain string literal doesn't count."
+  [line]
+  (boolean (when-let [i (str/index-of (str line) keep-marker)]
+             (str/includes? (subs (str line) 0 i) ";"))))
+
+(defn- marked-row?
+  "Does the ignore starting on 1-based `row` of `lines` carry [[keep-marker]] -- on the line directly
+  above, or trailing on the ignore's own line?"
+  [lines row]
+  (boolean (some marker-on-line? [(get lines (- row 2)) (get lines (dec row))])))
+
 (defn- insert-ignore-lines
-  "`text` with an ignore inserted above each 1-based row of `row->linters`, at matching indentation."
-  [text row->linters]
-  (let [ending (if (str/ends-with? text "\n") "\n" "")]
-    (str (str/join "\n"
-                   (reduce (fn [lines [row linters]]
-                             (let [indent (re-find #"^\s*" (nth lines (dec row)))]
-                               (into (conj (subvec lines 0 (dec row))
-                                           (str indent "#_{:clj-kondo/ignore ["
-                                                (str/join " " (sort-by str (distinct linters)))
-                                                "]}"))
-                                     (subvec lines (dec row)))))
-                           (vec (str/split-lines text))
-                           (sort-by key > row->linters)))
+  "`text` with an ignore inserted above each 1-based row of `row->linters`, at matching indentation.
+  A row in `row->comment` gets that comment line inserted above its ignore."
+  ([text row->linters]
+   (insert-ignore-lines text row->linters {}))
+  ([text row->linters row->comment]
+   (let [ending (if (str/ends-with? text "\n") "\n" "")]
+     (str (str/join "\n"
+                    (reduce (fn [lines [row linters]]
+                              (let [indent (re-find #"^\s*" (nth lines (dec row)))
+                                    added  (cond->> [(str indent "#_{:clj-kondo/ignore ["
+                                                          (str/join " " (sort-by str (distinct linters)))
+                                                          "]}")]
+                                             (row->comment row) (cons (str indent (row->comment row))))]
+                                (into (into (subvec lines 0 (dec row)) added)
+                                      (subvec lines (dec row)))))
+                            (vec (str/split-lines text))
+                            (sort-by key > row->linters)))
+          ending))))
+
+(defn- insert-inline-ignores
+  "`text` with an ignore spliced directly before the token at each 1-based `[row col]` of `sites`
+  (`{[row col] linters}`), plus `row->comment` lines inserted above rows at matching indentation.
+  Kondo reports a finding at its token, which may be a map value or a later form on its line; a
+  line-above ignore only covers the line's first form, so restores must splice inline to be precise."
+  [text sites row->comment]
+  (let [lines    (vec (str/split-lines text))
+        ending   (if (str/ends-with? text "\n") "\n" "")
+        ;; right-to-left within a row so earlier cols stay valid; rows are independent
+        spliced  (reduce (fn [lines [[row col] linters]]
+                           (update lines (dec row)
+                                   (fn [line]
+                                     (str (subs line 0 (dec col))
+                                          "#_{:clj-kondo/ignore ["
+                                          (str/join " " (sort-by str (distinct linters)))
+                                          "]} "
+                                          (subs line (dec col))))))
+                         lines
+                         (sort-by (comp second key) > sites))
+        ;; bottom-up so earlier rows stay valid; splicing above never changed row numbers
+        commented (reduce (fn [lines [row comment]]
+                            (let [indent (re-find #"^\s*" (nth lines (dec row)))]
+                              (into (conj (subvec lines 0 (dec row)) (str indent comment))
+                                    (subvec lines (dec row)))))
+                          spliced
+                          (sort-by key > row->comment))]
+    (str (str/join "\n" commented) ending)))
+
+(defn- strip-orphan-keep-comments
+  "`text` minus whole-line [[keep-marker]] comments no longer attached to an ignore form -- what an
+  `--audit` removal that stuck leaves behind. Attachment looks past further comment lines, and only
+  needs the ignore's first line (the linter vector may wrap). Trailing markers on code lines are left
+  alone."
+  [text]
+  (let [lines    (vec (str/split-lines text))
+        ending   (if (str/ends-with? text "\n") "\n" "")
+        ignored? (fn [line] (str/includes? (str line) ":clj-kondo/ignore"))
+        orphan?  (fn [i line]
+                   (and (marker-on-line? line)
+                        (re-matches #"\s*;.*" line)
+                        (let [below (drop-while #(re-matches #"\s*;.*" %) (subvec lines (inc i)))]
+                          (not (ignored? (first below))))))]
+    (str (str/join "\n" (keep-indexed (fn [i line] (when-not (orphan? i line) line)) lines))
          ending)))
 
 ;;;; ---------------------------------------------------------------------------
@@ -69,9 +139,11 @@
   that half of the suppression. Forms whose matched span has unbalanced braces (nested maps the regex
   can't span) are skipped and reported under `:skipped` rather than corrupted.
   A line left whitespace-only by a removal is deleted; an inline removal also swallows one space.
-  Returns `{:text _, :sites [{:row _, :linters _} ...], :skipped [rows...]}` — `:sites` carries the
-  post-removal row of the form each ignore covered and the linters it named, so a verifying re-lint can
-  tell exposed findings apart from unrelated pre-existing ones."
+  Returns `{:text _, :sites [{:row _, :linters _} ...], :deletions [[line rows-deleted] ...],
+  :skipped [rows...]}`.
+  `:sites` carries the post-removal row of the form each ignore covered and the linters it named;
+  `:deletions` maps each removal's original line to how many lines it deleted, so a verifying re-lint
+  can shift pre-removal finding rows into post-removal coordinates."
   [text rows]
   (let [rowset (set rows)
         masked (kondo-ratchet/mask-strings-and-comments text)
@@ -99,77 +171,144 @@
                                               (str (subs before 0 line-start)
                                                    (subs after (min (count after) (inc line-end))))
                                               (str before after)))
+                               ;; an inline removal still deletes the newlines inside a wrapped span;
+                               ;; a blank-line removal deletes the remaining physical line on top
                                (update :deletions conj [line
-                                                        (if blank?
-                                                          (inc (count (filter #(= % \newline) (subs text start end))))
-                                                          0)
+                                                        (cond-> (count (filter #(= % \newline) (subs text start end)))
+                                                          blank? inc)
                                                         linters]))))
                        {:text text, :deletions []}
                        ;; bottom-up so earlier offsets stay valid
                        (sort-by :start > removable))
         post-removal-row (fn [line]
                            (- line (transduce (keep (fn [[l k]] (when (< l line) k))) + (:deletions result))))]
-    {:text    (:text result)
-     :sites   (for [[line _ linters] (:deletions result)]
-                {:row     (post-removal-row line)
-                 :linters linters})
+    {:text      (:text result)
+     :sites     (for [[line _ linters] (:deletions result)]
+                  {:row     (post-removal-row line)
+                   :linters linters})
+     :deletions (mapv (fn [[line k _]] [line k]) (:deletions result))
      ;; adjusted like :sites, so warnings point at the rewritten file
-     :skipped (map (comp post-removal-row :line) unbalanced)}))
+     :skipped   (map (comp post-removal-row :line) unbalanced)}))
 
 (defn redundant-ignores
   "Report inline ignores kondo flags as redundant, dropping its two known false-positive classes:
   findings with no location, and ignores that only name linters kondo doesn't run (clojure-lsp/*).
-  With `--fix`, remove the candidates from source."
+  Sites whose comment (directly above, or trailing on the ignore's line) carries [[keep-marker]] are
+  proven false positives and are skipped too, unless `--audit` rechecks them.
+  With `--fix`, remove the candidates, then verify against a pre-removal baseline lint of the touched
+  files: any finding not in the baseline was exposed by a removal, and gets its ignore restored with
+  the marker stamped. An `--audit` removal that sticks takes its stale marker comment with it.
+  Restores are per site, so a broad ignore can come back as several; `fix-kondo-ratchets` flags any
+  budget that ends up exceeded."
   [parsed]
   (println "Running kondo with :redundant-ignore enabled (full lint, takes a minute or two)...")
-  (let [findings (kondo-findings! :redundant-ignore lint-roots)
+  (let [audit?   (get-in parsed [:options :audit])
+        findings (kondo-findings! :redundant-ignore lint-roots)
         {located true, homeless false} (group-by #(some? (:row %)) findings)
-        {lsp-only true, candidates false}
+        {lsp-only true, verifiable false}
         (group-by (fn [{:keys [filename row]}]
                     (lsp-only? (ignored-linters-at filename row)))
-                  located)]
+                  located)
+        file-lines (memoize (fn [file] (vec (str/split-lines (slurp file)))))
+        {marked true, candidates false}
+        (group-by (fn [{:keys [filename row]}]
+                    (marked-row? (file-lines filename) row))
+                  verifiable)
+        candidates (if audit? (concat candidates marked) candidates)]
     (doseq [{:keys [filename row]} (sort-by (juxt :filename :row) candidates)]
       (println (format "%s:%d %s" filename row (str/join " " (ignored-linters-at filename row)))))
     (println)
     (println (format "%d candidate redundant ignores (dropped as false positives: %d location-less, %d lsp-only)"
                      (count candidates) (count homeless) (count lsp-only)))
+    (when (seq marked)
+      (println (if audit?
+                 (format "Including %d %s sites in the audit." (count marked) keep-marker)
+                 (format "Skipped %d sites marked %s; recheck them with --audit." (count marked) keep-marker))))
     (when (and (get-in parsed [:options :fix]) (seq candidates))
-      (let [files       (vec (sort (distinct (map :filename candidates))))
-            sites       (into {}
-                              (for [[file file-candidates] (group-by :filename candidates)]
-                                (let [{:keys [text sites skipped]} (remove-ignores-at (slurp file)
-                                                                                      (map :row file-candidates))]
-                                  (spit file text)
-                                  (doseq [row skipped]
-                                    (println (format "WARNING: %s:%d skipped -- the ignore form's braces don't balance within the match; remove it by hand"
-                                                     file row)))
-                                  [file sites])))
-            near-sites  (fn [{:keys [filename row]}]
-                          (filter #(<= (abs (- row (:row %))) 5) (sites filename)))
-            ;; a finding near a removed site, of a type the removed ignore named, was exposed by the
-            ;; removal; anything further away is a pre-existing finding in a file the usual
-            ;; `mage kondo` roots don't cover
-            exposed?    (fn [{:keys [type] :as finding}]
-                          (boolean (some #(some #{:all type} (:linters %)) (near-sites finding))))]
-        (println (format "Removed them across %d files; re-linting those files to verify..." (count files)))
-        ;; redundant-ignore can't see findings from hook-based linters, so some ignores it called
-        ;; redundant were still doing work; restore those.
-        (let [{regressions true, others false} (group-by exposed? (filter :row (kondo-findings! nil files)))
-              mismatched (filter (comp seq near-sites) others)]
-          (doseq [[file file-regressions] (sort-by key (group-by :filename regressions))]
-            (spit file (insert-ignore-lines (slurp file)
-                                            (-> (group-by :row file-regressions)
-                                                (update-vals #(map :type %))))))
-          (doseq [{:keys [filename row type]} (sort-by (juxt :filename :row) mismatched)]
-            (println (format "WARNING: %s:%d has a new %s finding near a removed ignore that named other linters -- fix or re-ignore by hand"
-                             filename row type)))
-          (if (empty? regressions)
-            (println "Verified: the removals exposed no findings.")
-            (println (format "Restored ignores at %d sites where a finding reappeared (%s)."
-                             (count (distinct (map (juxt :filename :row) regressions)))
-                             (str/join ", " (sort (distinct (map :type regressions))))))))
-        (println "Now run `./bin/mage fix-kondo-ratchets` to update the budgets, and `./bin/mage kondo`
-for the final word (a finding deep inside a large ignored form can escape the nearby-site check).")))))
+      (let [files    (vec (sort (distinct (map :filename candidates))))
+            _        (println (format "Baseline-linting %d files before removal..." (count files)))
+            baseline (filter :row (kondo-findings! nil files))
+            removals (into {}
+                           (for [[file file-candidates] (group-by :filename candidates)]
+                             (let [{:keys [text sites deletions skipped]}
+                                   (remove-ignores-at (slurp file) (map :row file-candidates))]
+                               (spit file text)
+                               (doseq [row skipped]
+                                 (println (format "WARNING: %s:%d skipped -- the ignore form's braces don't balance within the match; remove it by hand"
+                                                  file row)))
+                               [file {:sites sites, :deletions deletions}])))
+            adjusted-row (fn [file row]
+                           (- row (transduce (keep (fn [[l k]] (when (< l row) k)))
+                                             + (:deletions (removals file)))))
+            named        (fn [file] (into #{} (mapcat :linters) (:sites (removals file))))
+            restore!     (fn [exposed]
+                           ;; returns {file [comment-rows...]} so baseline rows can shift past the inserts
+                           (into {}
+                                 (for [[file file-exposed] (sort-by key (group-by :filename exposed))]
+                                   (let [text  (slurp file)
+                                         lines (vec (str/split-lines text))
+                                         sites (update-vals (group-by (juxt :row :col) file-exposed) #(map :type %))
+                                         ;; the site keeps any marker it already has
+                                         row->comment (into {}
+                                                            (for [row   (distinct (map :row file-exposed))
+                                                                  :when (not (marked-row? lines row))]
+                                                              [row keep-comment]))]
+                                     (spit file (insert-inline-ignores text sites row->comment))
+                                     [file (sort (keys row->comment))]))))
+            _            (println (format "Removed them across %d files; re-linting to verify..." (count files)))]
+        ;; A finding beyond the (row-shifted) baseline was exposed by a removal; restore it when some
+        ;; removed ignore in the file named its type. The baseline is a frequency map so an exposed
+        ;; finding sharing row and type with a pre-existing one still counts as new. Hook linters can
+        ;; report only the first occurrence per form, so each restore round may surface the next one --
+        ;; iterate to a fixpoint.
+        (loop [round         1
+               baseline-freq (frequencies
+                              (map (fn [{:keys [filename row type]}]
+                                     [filename (adjusted-row filename row) type])
+                                   baseline))
+               restored      []]
+          (let [{exposed true, mismatched false}
+                (group-by (fn [{:keys [filename type]}]
+                            (boolean (some #{:all type} (named filename))))
+                          (mapcat (fn [[key key-findings]]
+                                    (drop (get baseline-freq key 0) (sort-by :col key-findings)))
+                                  (group-by (fn [{:keys [filename row type]}] [filename row type])
+                                            (filter :row (kondo-findings! nil files)))))]
+            (cond
+              (and (seq exposed) (< round 5))
+              (let [inserted (restore! exposed)]
+                (println (format "Round %d: restored %d sites; re-linting for occurrences the first report shadowed..."
+                                 round (count (distinct (map (juxt :filename :row) exposed)))))
+                (recur (inc round)
+                       ;; a comment line inserted above row r pushes baseline rows at or below r down one
+                       (into {}
+                             (map (fn [[[file row type] n]]
+                                    [[file
+                                      (reduce (fn [r ins] (if (<= ins r) (inc r) r))
+                                              row (sort (get inserted file [])))
+                                      type]
+                                     n]))
+                             baseline-freq)
+                       (into restored exposed)))
+
+              :else
+              (do (when (seq exposed)
+                    (doseq [{:keys [filename row type]} (sort-by (juxt :filename :row) exposed)]
+                      (println (format "WARNING: %s:%d still exposes %s after %d restore rounds -- re-ignore by hand"
+                                       filename row type round))))
+                  (doseq [{:keys [filename row type]} (sort-by (juxt :filename :row) mismatched)]
+                    (println (format "WARNING: %s:%d has a new %s finding no removed ignore in the file named -- fix or re-ignore by hand"
+                                     filename row type)))
+                  (when audit?
+                    (doseq [file files]
+                      (spit file (strip-orphan-keep-comments (slurp file)))))
+                  (if (empty? restored)
+                    (println "Verified: the removals exposed no findings.")
+                    (println (format "Restored ignores at %d sites where a finding reappeared (%s), stamped %s."
+                                     (count (distinct (map (juxt :filename :row) restored)))
+                                     (str/join ", " (sort (distinct (map :type restored))))
+                                     keep-marker)))))))
+        (println "Now run `./bin/mage fix-kondo-ratchets` to update the budgets, and `./bin/mage kondo` for the final word.")))))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; kondo-insert-ignores

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -134,21 +134,20 @@
 (defn- site-restore-plan
   "Restore sites annotated with `:comment` (and sometimes an adjusted `:row`), so every restored
   ignore ends up with its own marker adjacent and no insert splits an existing marker from the line
-  it marks. Whole-line restores each carry a marker; when the line above already holds one that marks
-  the code line's own ignore, the whole-line block moves above that marker instead of splitting the
-  pair -- unless the code line has no ignore, in which case the marker marked the removed site itself
-  (an --audit re-restore) and no new marker is needed. A row's inline restores share one marker,
-  directly above the code line, unless the row already carries one."
+  it marks. A whole-line site that was itself marked before removal (`:was-marked?`, an --audit
+  re-restore) returns beneath its still-present marker, unstamped; any other marker above the row
+  marks that row's own ignore, so an unmarked whole-line site moves above it with its own stamp.
+  A row's inline restores share one marker, directly above the code line, unless the row already
+  carries one."
   [lines sites]
   (mapcat (fn [[row row-sites]]
             (let [{wl true, inl false} (group-by (comp boolean :whole-line? :original) row-sites)
-                  above-marker? (marker-on-line? (get lines (- row 2)))
-                  code-ignored? (seq (kondo-ratchet/line-linters (str (get lines (dec row)))))]
+                  above-marker? (marker-on-line? (get lines (- row 2)))]
               (concat (for [s wl]
                         (cond
-                          (and above-marker? code-ignored?) (assoc s :row (dec row), :comment keep-comment)
-                          above-marker?                     (assoc s :comment nil)
-                          :else                             (assoc s :comment keep-comment)))
+                          (and above-marker? (:was-marked? s)) (assoc s :comment nil)
+                          above-marker?                        (assoc s :row (dec row), :comment keep-comment)
+                          :else                                (assoc s :comment keep-comment)))
                       (when (seq inl)
                         (if (marked-row? lines row)
                           (map #(assoc % :comment nil) inl)
@@ -264,9 +263,10 @@
                                               + deletions)))]
     {:text    (:text result)
      :sites   (for [{:keys [line linters original]} deletions]
-                {:row      (post-removal-row line)
-                 :linters  linters
-                 :original original})
+                {:row          (post-removal-row line)
+                 :removed-line line
+                 :linters      linters
+                 :original     original})
      ;; adjusted like :sites, so warnings point at the rewritten file
      :skipped (map (comp post-removal-row :line) unbalanced)}))
 
@@ -317,7 +317,10 @@
           (println (format "WARNING: %s has pre-existing findings; its candidates are excluded this run -- clean it up or mark them by hand"
                            file)))
         (when (seq candidates)
-          (let [removals (into {}
+          (let [marked-rows (into {}
+                                  (map (fn [[file ms]] [file (into #{} (map :row) ms)]))
+                                  (group-by :filename marked))
+                removals (into {}
                                (for [[file file-candidates] (group-by :filename candidates)]
                                  (let [{:keys [text sites skipped]}
                                        (remove-ignores-at (slurp file) (map :row file-candidates))]
@@ -325,7 +328,11 @@
                                    (doseq [row skipped]
                                      (println (format "WARNING: %s:%d skipped -- the ignore form's braces don't balance within the match; remove it by hand"
                                                       file row)))
-                                   [file sites])))
+                                   ;; whether the removed site carried a marker decides where its marker
+                                   ;; goes on restore ([[site-restore-plan]]) -- record it, don't infer it
+                                   [file (mapv #(assoc % :was-marked?
+                                                       (contains? (get marked-rows file #{}) (:removed-line %)))
+                                               sites)])))
                 named    (fn [file] (into #{} (mapcat :linters) (removals file)))
                 restore-sites! (fn [file->sites]
                                  ;; puts each removed ignore back exactly as it was; returns

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -131,6 +131,15 @@
   [row inserted-rows]
   (+ row (count (filter #(<= % row) inserted-rows))))
 
+(defn- shift-site-past-inserts
+  "Move a pending site's restore anchor past inserted lines. A marked whole-line site's anchor stays
+  immediately below its reserved marker when another restore inserts at that same anchor; inserts
+  strictly above it still move the marker and anchor together."
+  [site inserted-rows]
+  (if (and (:was-marked? site) (get-in site [:original :whole-line?]))
+    (update site :row (fn [row] (+ row (count (filter #(< % row) inserted-rows)))))
+    (update site :row shift-past-inserts inserted-rows)))
+
 (defn- site-restore-plan
   "Restore sites annotated with `:comment` (and sometimes an adjusted `:row`), so every restored
   ignore ends up with its own marker adjacent and no insert splits an existing marker from the line
@@ -138,22 +147,31 @@
   re-restore) returns beneath its still-present marker, unstamped; any other marker above the row
   marks that row's own ignore, so an unmarked whole-line site moves above it with its own stamp.
   A row's inline restores share one marker, directly above the code line, unless the row already
-  carries one."
-  [lines sites]
-  (mapcat (fn [[row row-sites]]
-            (let [{wl true, inl false} (group-by (comp boolean :whole-line? :original) row-sites)
-                  above-marker? (marker-on-line? (get lines (- row 2)))]
-              (concat (for [s wl]
-                        (cond
-                          (and above-marker? (:was-marked? s)) (assoc s :comment nil)
-                          above-marker?                        (assoc s :row (dec row), :comment keep-comment)
-                          :else                                (assoc s :comment keep-comment)))
-                      (when (seq inl)
-                        (if (marked-row? lines row)
-                          (map #(assoc % :comment nil) inl)
-                          (cons (assoc (first inl) :comment keep-comment)
-                                (map #(assoc % :comment nil) (rest inl))))))))
-          (group-by :row sites)))
+  carries one. `pending-sites` preserves ownership of markers belonging to marked whole-line sites
+  that may restore in a later round; an inline restore at such a row gets a separate marker."
+  ([lines sites]
+   (site-restore-plan lines sites sites))
+  ([lines sites pending-sites]
+   (let [reserved-rows (into #{}
+                             (comp (filter :was-marked?)
+                                   (filter #(get-in % [:original :whole-line?]))
+                                   (map :row))
+                             pending-sites)]
+     (mapcat (fn [[row row-sites]]
+               (let [{wl true, inl false} (group-by (comp boolean :whole-line? :original) row-sites)
+                     above-marker? (marker-on-line? (get lines (- row 2)))
+                     reserved?     (and above-marker? (contains? reserved-rows row))]
+                 (concat (for [s wl]
+                           (cond
+                             (and above-marker? (:was-marked? s)) (assoc s :comment nil)
+                             above-marker?                        (assoc s :row (dec row), :comment keep-comment)
+                             :else                                (assoc s :comment keep-comment)))
+                         (when (seq inl)
+                           (if (and (marked-row? lines row) (not reserved?))
+                             (map #(assoc % :comment nil) inl)
+                             (cons (assoc (first inl) :comment keep-comment)
+                                   (map #(assoc % :comment nil) (rest inl))))))))
+             (group-by :row sites)))))
 
 (defn- strip-orphan-keep-comments
   "`text` minus [[keep-marker]] markers no longer attached to an ignore form -- what an `--audit`
@@ -334,7 +352,7 @@
                                                        (contains? (get marked-rows file #{}) (:removed-line %)))
                                                sites)])))
                 named    (fn [file] (into #{} (mapcat :linters) (removals file)))
-                restore-sites! (fn [file->sites]
+                restore-sites! (fn [file->sites pending]
                                  ;; puts each removed ignore back exactly as it was; returns
                                  ;; {file [inserted-anchor-rows...]} for shifting row bookkeeping
                                  (into {}
@@ -342,7 +360,7 @@
                                          (let [text  (slurp file)
                                                lines (vec (str/split-lines text))
                                                {:keys [text inserted-rows]}
-                                               (reinsert-ignores text (site-restore-plan lines sites))]
+                                               (reinsert-ignores text (site-restore-plan lines sites (get pending file)))]
                                            (spit file text)
                                            [file inserted-rows]))))
                 finish!  (fn [exposed mismatched restored covered rounds-run]
@@ -392,8 +410,8 @@
                   (let [file->sites (into {}
                                           (for [[file fps] (group-by (comp :filename first) attributable)]
                                             [file (vec (distinct (map second fps)))]))
-                        inserted    (restore-sites! file->sites)
-                        shift-site  (fn [file s] (update s :row #(shift-past-inserts % (get inserted file []))))]
+                        inserted    (restore-sites! file->sites pending)
+                        shift-site  (fn [file s] (shift-site-past-inserts s (get inserted file [])))]
                     (println (format "Round %d: put back %d removed ignores covering %d findings; re-linting..."
                                      round
                                      (reduce + (map count (vals file->sites)))

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -113,7 +113,12 @@
                                      (subvec lines (dec row)))
                      :inserted (into (:inserted acc) (repeat n-added row))}))
                 {:lines (vec (str/split-lines text)), :inserted []}
-                (sort-by :row > sites))]
+                ;; bottom-up; within a row, inline splices right-to-left so earlier columns stay
+                ;; valid, and any whole-line insert last so it can't displace the line being spliced
+                (sort-by (fn [{:keys [row original]}]
+                           [row (if (:whole-line? original) -1 (:col original))])
+                         #(compare %2 %1)
+                         sites))]
     {:text          (str (str/join "\n" (:lines result)) ending)
      :inserted-rows (:inserted result)}))
 
@@ -346,8 +351,9 @@
                                            (str/join ", " (sort (distinct (map :type covered))))
                                            keep-marker)))
                         (println "Now run `./bin/mage fix-kondo-ratchets` to update the budgets, and `./bin/mage kondo` for the final word.")
-                        (when (seq exposed)
-                          (throw (ex-info "the removals left warnings exposed; re-ignore them by hand and re-run" {:exit-code 1}))))]
+                        (when (or (seq exposed) (seq mismatched))
+                          (throw (ex-info "the removals left warnings in the tree; fix or re-ignore them by hand and re-run"
+                                          {:exit-code 1}))))]
           (loop [round         1
                  pending       (update-vals removals :sites)
                  baseline-freq (frequencies
@@ -373,6 +379,9 @@
                                         (for [[file fps] (group-by (comp :filename first) attributable)]
                                           [file (vec (distinct (map second fps)))]))
                       collisions  (into #{} (map second) (filter (comp :collision? first) attributable))
+                      collision-keys (into #{}
+                                           (map (fn [{:keys [filename row type]}] [filename row type]))
+                                           (filter :collision? (map first attributable)))
                       inserted    (restore-sites! file->sites collisions)
                       shift-site  (fn [file s] (update s :row #(shift-past-inserts % (get inserted file []))))]
                   (println (format "Round %d: put back %d removed ignores covering %d findings; re-linting..."
@@ -385,9 +394,12 @@
                                      :let [gone (set (get file->sites file))]]
                                  [file (vec (for [s sites :when (not (gone s))]
                                               (shift-site file s)))]))
+                         ;; a collision restore also suppresses the pre-existing finding its baseline
+                         ;; slot counted, so drop those slots before shifting the rest
                          (into {}
-                               (map (fn [[[file row type] n]]
-                                      [[file (shift-past-inserts row (get inserted file [])) type] n]))
+                               (comp (remove (fn [[key _]] (contains? collision-keys key)))
+                                     (map (fn [[[file row type] n]]
+                                            [[file (shift-past-inserts row (get inserted file [])) type] n])))
                                baseline-freq)
                          (into restored (for [[file sites] file->sites, s sites]
                                           {:file file, :row (:row s), :collision? (contains? collisions s)}))

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -91,9 +91,13 @@
                             lines
                             (update lines (dec row)
                                     (fn [line]
-                                      (str (subs line 0 (dec (:col original)))
-                                           (:text original) " "
-                                           (subs line (dec (:col original))))))))
+                                      (let [rest-of-line (subs line (dec (:col original)))]
+                                        (str (subs line 0 (dec (:col original)))
+                                             (:text original)
+                                             ;; removal swallowed the separating space unless the
+                                             ;; remnant kept one; mirror it so restores are verbatim
+                                             (when-not (str/starts-with? rest-of-line " ") " ")
+                                             rest-of-line))))))
                         (vec (str/split-lines text))
                         (sort-by (fn [{:keys [row original]}] [row (:col original -1)])
                                  #(compare %2 %1)

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -32,9 +32,6 @@
 (def ^:private keep-comment
   (str ";; " keep-marker " suppresses a warning :redundant-ignore can't see; --audit rechecks"))
 
-(def ^:private collision-comment
-  (str ";; " keep-marker " same-row collision; one of these may be pre-existing debt -- verify by hand"))
-
 (defn- comment-start
   "Index of the `;` starting `line`'s comment, skipping semicolons inside string literals and after a
   backslash (char literals, string escapes). Line-local: a string opened on an earlier line isn't
@@ -123,34 +120,11 @@
     {:text          (str (str/join "\n" (:lines result)) ending)
      :inserted-rows (:inserted result)}))
 
-(defn- beyond-baseline
-  "Findings beyond the per-`[filename row type]` counts of `baseline-freq`.
-  A group holding more findings than its non-zero baseline count returns ALL of them, tagged
-  `:collision? true`: an exposed finding can't be told apart from a pre-existing one on the same row,
-  and an extra restore is visible in the diff where a silently dropped one is not. Callers stamp
-  collision restores with [[collision-comment]] instead of claiming verified provenance."
-  [baseline-freq findings]
-  (mapcat (fn [[key key-findings]]
-            (let [n (get baseline-freq key 0)]
-              (cond
-                (zero? n)                  key-findings
-                (> (count key-findings) n) (map #(assoc % :collision? true) key-findings)
-                :else                      ())))
-          (group-by (fn [{:keys [filename row type]}] [filename row type]) findings)))
-
 (defn- shift-past-inserts
   "`row` moved down one for each line inserted at or above it, `inserted-rows` being in the same
   pre-insertion coordinates as `row`."
   [row inserted-rows]
   (+ row (count (filter #(<= % row) inserted-rows))))
-
-(defn- surviving-slots
-  "New baseline slot count for a collision key after a restore round: of the `a` attributed findings,
-  `c - n` were genuinely new (`c` observed against `n` slots), so the rest must have been pre-existing
-  findings the restore suppressed -- their slots go. Slots for findings left unattributed stay, so a
-  pre-existing warning outside the restored ignore's scope isn't misread as new next round."
-  [n c a]
-  (max 0 (- n (max 0 (- a (- c n))))))
 
 (defn- strip-orphan-keep-comments
   "`text` minus [[keep-marker]] markers no longer attached to an ignore form -- what an `--audit`
@@ -162,7 +136,7 @@
   (let [lines    (vec (str/split-lines text))
         ending   (if (str/ends-with? text "\n") "\n" "")
         ignored? (fn [line] (str/includes? (str line) ":clj-kondo/ignore"))
-        stamped? #{keep-comment collision-comment}
+        stamped? #{keep-comment}
         orphan?  (fn [i line]
                    (and (marker-on-line? line)
                         (re-matches #"\s*;.*" line)
@@ -207,11 +181,9 @@
   that half of the suppression. Forms whose matched span has unbalanced braces (nested maps the regex
   can't span) are skipped and reported under `:skipped` rather than corrupted.
   A line left whitespace-only by a removal is deleted; an inline removal also swallows one space.
-  Returns `{:text _, :sites [{:row _, :linters _} ...], :deletions [[line rows-deleted] ...],
-  :skipped [rows...]}`.
-  `:sites` carries the post-removal row of the form each ignore covered and the linters it named;
-  `:deletions` maps each removal's original line to how many lines it deleted, so a verifying re-lint
-  can shift pre-removal finding rows into post-removal coordinates."
+  Returns `{:text _, :sites [{:row _, :linters _, :original _} ...], :skipped [rows...]}`.
+  `:sites` carries the post-removal row of the form each ignore covered, the linters it named, and
+  `:original` -- the removed form's exact text and placement, so a restore can put it back verbatim."
   [text rows]
   (let [rowset (set rows)
         masked (kondo-ratchet/mask-strings-and-comments text)
@@ -260,24 +232,24 @@
         post-removal-row (fn [line]
                            (- line (transduce (keep (fn [{l :line, k :rows-deleted}] (when (< l line) k)))
                                               + deletions)))]
-    {:text      (:text result)
-     :sites     (for [{:keys [line linters original]} deletions]
-                  {:row      (post-removal-row line)
-                   :linters  linters
-                   :original original})
-     :deletions (mapv (fn [{:keys [line rows-deleted]}] [line rows-deleted]) deletions)
+    {:text    (:text result)
+     :sites   (for [{:keys [line linters original]} deletions]
+                {:row      (post-removal-row line)
+                 :linters  linters
+                 :original original})
      ;; adjusted like :sites, so warnings point at the rewritten file
-     :skipped   (map (comp post-removal-row :line) unbalanced)}))
+     :skipped (map (comp post-removal-row :line) unbalanced)}))
 
 (defn redundant-ignores
   "Report inline ignores kondo flags as redundant, dropping its two known false-positive classes:
   findings with no location, and ignores that only name linters kondo doesn't run (clojure-lsp/*).
   Sites whose comment (directly above, or trailing on the ignore's line) carries [[keep-marker]] are
   proven false positives and are skipped too, unless `--audit` rechecks them.
-  With `--fix`, remove the candidates, then verify against a pre-removal baseline lint of the touched
-  files: any finding not in the baseline was exposed by a removal, whose ignore is put back exactly as
-  it was -- a coarse form-level ignore returns as the same single form-level ignore -- with the marker
-  stamped above it. An `--audit` removal that sticks takes its stale marker comment with it."
+  With `--fix`, remove the candidates and re-lint the touched files: every finding was exposed by a
+  removal, whose ignore is put back exactly as it was -- a coarse form-level ignore returns as the
+  same single form-level ignore -- with the marker stamped above it. That inference requires a clean
+  pre-removal baseline, so files with pre-existing findings are excluded from the sweep and reported.
+  An `--audit` removal that sticks takes its stale marker comment with it."
   [parsed]
   (println "Running kondo with :redundant-ignore enabled (full lint, takes a minute or two)...")
   (let [audit?     (get-in parsed [:options :audit])
@@ -303,126 +275,108 @@
                  (format "Including %d %s sites in the audit." (count marked) keep-marker)
                  (format "Skipped %d sites marked %s; recheck them with --audit." (count marked) keep-marker))))
     (when (and (get-in parsed [:options :fix]) (seq candidates))
-      (let [files    (vec (sort (distinct (map :filename candidates))))
-            _        (println (format "Baseline-linting %d files before removal..." (count files)))
-            baseline (filter :row (kondo-findings! nil files))
-            removals (into {}
-                           (for [[file file-candidates] (group-by :filename candidates)]
-                             (let [{:keys [text sites deletions skipped]}
-                                   (remove-ignores-at (slurp file) (map :row file-candidates))]
-                               (spit file text)
-                               (doseq [row skipped]
-                                 (println (format "WARNING: %s:%d skipped -- the ignore form's braces don't balance within the match; remove it by hand"
-                                                  file row)))
-                               [file {:sites sites, :deletions deletions}])))
-            adjusted-row (fn [file row]
-                           (- row (transduce (keep (fn [[l k]] (when (< l row) k)))
-                                             + (:deletions (removals file)))))
-            named        (fn [file] (into #{} (mapcat :linters) (:sites (removals file))))
-            restore-sites! (fn [file->sites collision-site?]
-                             ;; puts each removed ignore back exactly as it was; returns
-                             ;; {file [inserted-anchor-rows...]} for shifting row bookkeeping
-                             (into {}
-                                   (for [[file sites] (sort-by key file->sites)]
-                                     (let [text  (slurp file)
-                                           lines (vec (str/split-lines text))
-                                           ;; one comment per row, however many sites restore onto it
-                                           sites (mapcat (fn [[row row-sites]]
-                                                           (let [comment (when-not (marked-row? lines row)
-                                                                           (if (some collision-site? row-sites)
-                                                                             collision-comment
-                                                                             keep-comment))]
-                                                             (cons (assoc (first row-sites) :comment comment)
-                                                                   (map #(assoc % :comment nil) (rest row-sites)))))
-                                                         (group-by :row sites))
-                                           {:keys [text inserted-rows]} (reinsert-ignores text sites)]
-                                       (spit file text)
-                                       [file inserted-rows]))))
-            _              (println (format "Removed them across %d files; re-linting to verify..." (count files)))]
-        ;; A finding beyond the (row-shifted) baseline was exposed by a removal. Attribute it to the
-        ;; nearest preceding removed site naming its type and put that ignore back verbatim -- a coarse
-        ;; ignore returns as the same coarse ignore, never as several narrow ones. Hook linters can
-        ;; report only the first occurrence per form, so a round may surface findings a restored form
-        ;; already covers; iterate until the lint comes back clean.
-        (let [finish! (fn [exposed mismatched restored covered rounds-run]
-                        (doseq [{:keys [filename row type]} (sort-by (juxt :filename :row) exposed)]
-                          (println (format "WARNING: %s:%d still exposes %s after %d restore rounds -- re-ignore by hand"
-                                           filename row type rounds-run)))
-                        (doseq [{:keys [filename row type]} (sort-by (juxt :filename :row) mismatched)]
-                          (println (format "WARNING: %s:%d has a new %s finding no removed ignore in the file named -- fix or re-ignore by hand"
-                                           filename row type)))
-                        (when audit?
-                          (doseq [file files]
-                            (spit file (strip-orphan-keep-comments (slurp file)))))
-                        (doseq [[file row] (sort (distinct (map (juxt :file :row) (filter :collision? restored))))]
-                          (println (format "NOTE: %s:%d restored over a same-row collision -- it may cover pre-existing debt; verify by hand"
-                                           file row)))
-                        (if (empty? restored)
-                          (println "Verified: the removals exposed no findings.")
-                          (println (format "Restored %d removed ignores covering %d findings (%s), stamped %s."
-                                           (count restored)
-                                           (count covered)
-                                           (str/join ", " (sort (distinct (map :type covered))))
-                                           keep-marker)))
-                        (println "Now run `./bin/mage fix-kondo-ratchets` to update the budgets, and `./bin/mage kondo` for the final word.")
-                        (when (or (seq exposed) (seq mismatched))
-                          (throw (ex-info "the removals left warnings in the tree; fix or re-ignore them by hand and re-run"
-                                          {:exit-code 1}))))]
-          (loop [round         1
-                 pending       (update-vals removals :sites)
-                 baseline-freq (frequencies
-                                (map (fn [{:keys [filename row type]}]
-                                       [filename (adjusted-row filename row) type])
-                                     baseline))
-                 restored      []
-                 covered       []]
-            (let [{exposed true, mismatched false}
-                  (group-by (fn [{:keys [filename type]}]
-                              (boolean (some #{:all type} (named filename))))
-                            (beyond-baseline baseline-freq (filter :row (kondo-findings! nil files))))
-                  ;; nearest preceding pending site naming the finding's type; else nearest overall
-                  pick (fn [{:keys [filename row type]}]
-                         (let [match? (fn [s] (boolean (some #{:all type} (:linters s))))
-                               sites  (filter match? (get pending filename))]
-                           (or (last (sort-by :row (filter #(<= (:row %) row) sites)))
-                               (first (sort-by #(abs (- (:row %) row)) sites)))))
-                  picks (map (juxt identity pick) exposed)
-                  attributable (filter second picks)]
-              (if (and (seq attributable) (< round 6))
-                (let [file->sites (into {}
-                                        (for [[file fps] (group-by (comp :filename first) attributable)]
-                                          [file (vec (distinct (map second fps)))]))
-                      collisions  (into #{} (map second) (filter (comp :collision? first) attributable))
-                      key-of      (fn [{:keys [filename row type]}] [filename row type])
-                      observed    (frequencies (map key-of (filter :collision? exposed)))
-                      attributed  (frequencies (map key-of (filter :collision? (map first attributable))))
-                      inserted    (restore-sites! file->sites collisions)
-                      shift-site  (fn [file s] (update s :row #(shift-past-inserts % (get inserted file []))))]
-                  (println (format "Round %d: put back %d removed ignores covering %d findings; re-linting..."
-                                   round
-                                   (reduce + (map count (vals file->sites)))
-                                   (count attributable)))
-                  (recur (inc round)
-                         (into {}
-                               (for [[file sites] pending
-                                     :let [gone (set (get file->sites file))]]
-                                 [file (vec (for [s sites :when (not (gone s))]
-                                              (shift-site file s)))]))
-                         ;; a collision restore suppresses pre-existing findings too, so shrink those
-                         ;; keys' slots ([[surviving-slots]]) before shifting the rest
-                         (into {}
-                               (comp (keep (fn [[key n]]
-                                             (let [n' (if (contains? observed key)
-                                                        (surviving-slots n (observed key) (get attributed key 0))
-                                                        n)]
-                                               (when (pos? n') [key n']))))
-                                     (map (fn [[[file row type] n]]
-                                            [[file (shift-past-inserts row (get inserted file [])) type] n])))
-                               baseline-freq)
-                         (into restored (for [[file sites] file->sites, s sites]
-                                          {:file file, :row (:row s), :collision? (contains? collisions s)}))
-                         (into covered (map first attributable))))
-                (finish! exposed mismatched restored covered (dec round))))))))))
+      ;; Precondition: swept files must baseline-lint clean, so that afterwards EVERY finding the
+      ;; verify lint reports was exposed by our removal. Files with pre-existing findings are excluded
+      ;; -- there is no way to tell their old warnings from newly exposed ones.
+      (let [all-files  (vec (sort (distinct (map :filename candidates))))
+            _          (println (format "Baseline-linting %d files before removal..." (count all-files)))
+            dirty      (into #{} (map :filename) (filter :row (kondo-findings! nil all-files)))
+            candidates (remove (comp dirty :filename) candidates)
+            files      (vec (sort (distinct (map :filename candidates))))]
+        (doseq [file (sort dirty)]
+          (println (format "WARNING: %s has pre-existing findings; its candidates are excluded this run -- clean it up or mark them by hand"
+                           file)))
+        (when (seq candidates)
+          (let [removals (into {}
+                               (for [[file file-candidates] (group-by :filename candidates)]
+                                 (let [{:keys [text sites skipped]}
+                                       (remove-ignores-at (slurp file) (map :row file-candidates))]
+                                   (spit file text)
+                                   (doseq [row skipped]
+                                     (println (format "WARNING: %s:%d skipped -- the ignore form's braces don't balance within the match; remove it by hand"
+                                                      file row)))
+                                   [file sites])))
+                named    (fn [file] (into #{} (mapcat :linters) (removals file)))
+                restore-sites! (fn [file->sites]
+                                 ;; puts each removed ignore back exactly as it was; returns
+                                 ;; {file [inserted-anchor-rows...]} for shifting row bookkeeping
+                                 (into {}
+                                       (for [[file sites] (sort-by key file->sites)]
+                                         (let [text  (slurp file)
+                                               lines (vec (str/split-lines text))
+                                               ;; one comment per row, however many sites restore onto it
+                                               sites (mapcat (fn [[row row-sites]]
+                                                               (let [comment (when-not (marked-row? lines row)
+                                                                               keep-comment)]
+                                                                 (cons (assoc (first row-sites) :comment comment)
+                                                                       (map #(assoc % :comment nil) (rest row-sites)))))
+                                                             (group-by :row sites))
+                                               {:keys [text inserted-rows]} (reinsert-ignores text sites)]
+                                           (spit file text)
+                                           [file inserted-rows]))))
+                finish!  (fn [exposed mismatched restored covered rounds-run]
+                           (doseq [{:keys [filename row type]} (sort-by (juxt :filename :row) exposed)]
+                             (println (format "WARNING: %s:%d still exposes %s after %d restore rounds -- re-ignore by hand"
+                                              filename row type rounds-run)))
+                           (doseq [{:keys [filename row type]} (sort-by (juxt :filename :row) mismatched)]
+                             (println (format "WARNING: %s:%d has a new %s finding no removed ignore in the file named -- fix or re-ignore by hand"
+                                              filename row type)))
+                           (when audit?
+                             (doseq [file files]
+                               (spit file (strip-orphan-keep-comments (slurp file)))))
+                           (if (empty? restored)
+                             (println "Verified: the removals exposed no findings.")
+                             (println (format "Restored %d removed ignores covering %d findings (%s), stamped %s."
+                                              (count restored)
+                                              (count covered)
+                                              (str/join ", " (sort (distinct (map :type covered))))
+                                              keep-marker)))
+                           (println "Now run `./bin/mage fix-kondo-ratchets` to update the budgets, and `./bin/mage kondo` for the final word.")
+                           (when (or (seq exposed) (seq mismatched))
+                             (throw (ex-info "the removals left warnings in the tree; fix or re-ignore them by hand and re-run"
+                                             {:exit-code 1}))))
+                _        (println (format "Removed them across %d files; re-linting to verify..." (count files)))]
+            ;; The baseline was clean, so every finding here was exposed by a removal. Attribute it to
+            ;; the nearest preceding removed site naming its type and put that ignore back verbatim --
+            ;; a coarse ignore returns as the same coarse ignore, never as several narrow ones. Hook
+            ;; linters can report only the first occurrence per form, so a round may surface findings
+            ;; a restored form already covers; iterate until the lint comes back clean.
+            (loop [round    1
+                   pending  removals
+                   restored []
+                   covered  []]
+              (let [{exposed true, mismatched false}
+                    (group-by (fn [{:keys [filename type]}]
+                                (boolean (some #{:all type} (named filename))))
+                              (filter :row (kondo-findings! nil files)))
+                    ;; nearest preceding pending site naming the finding's type; else nearest overall
+                    pick (fn [{:keys [filename row type]}]
+                           (let [match? (fn [s] (boolean (some #{:all type} (:linters s))))
+                                 sites  (filter match? (get pending filename))]
+                             (or (last (sort-by :row (filter #(<= (:row %) row) sites)))
+                                 (first (sort-by #(abs (- (:row %) row)) sites)))))
+                    picks (map (juxt identity pick) exposed)
+                    attributable (filter second picks)]
+                (if (and (seq attributable) (< round 6))
+                  (let [file->sites (into {}
+                                          (for [[file fps] (group-by (comp :filename first) attributable)]
+                                            [file (vec (distinct (map second fps)))]))
+                        inserted    (restore-sites! file->sites)
+                        shift-site  (fn [file s] (update s :row #(shift-past-inserts % (get inserted file []))))]
+                    (println (format "Round %d: put back %d removed ignores covering %d findings; re-linting..."
+                                     round
+                                     (reduce + (map count (vals file->sites)))
+                                     (count attributable)))
+                    (recur (inc round)
+                           (into {}
+                                 (for [[file sites] pending
+                                       :let [gone (set (get file->sites file))]]
+                                   [file (vec (for [s sites :when (not (gone s))]
+                                                (shift-site file s)))]))
+                           (into restored (for [[file sites] file->sites, s sites]
+                                            {:file file, :row (:row s)}))
+                           (into covered (map first attributable))))
+                  (finish! exposed mismatched restored covered (dec round)))))))))))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; kondo-insert-ignores

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -149,8 +149,9 @@
   re-restore) returns beneath its still-present marker, unstamped; any other marker above the row
   marks that row's own ignore, so an unmarked whole-line site moves above it with its own stamp.
   A row's inline restores share one marker, directly above the code line, unless the row already
-  carries one. `pending-sites` preserves ownership of markers belonging to marked whole-line sites
-  that may restore in a later round; an inline restore at such a row gets a separate marker."
+  carries one, including a trailing marker on the row itself. `pending-sites` preserves ownership
+  of markers belonging to marked whole-line sites that may restore in a later round; an inline
+  restore at such a row gets a separate marker only when it does not retain its own trailing marker."
   ([lines sites]
    (site-restore-plan lines sites sites))
   ([lines sites pending-sites]
@@ -161,15 +162,17 @@
                              pending-sites)]
      (mapcat (fn [[row row-sites]]
                (let [{wl true, inl false} (group-by (comp boolean :whole-line? :original) row-sites)
-                     above-marker? (marker-on-line? (get lines (- row 2)))
-                     reserved?     (and above-marker? (contains? reserved-rows row))]
+                     above-marker?  (marker-on-line? (get lines (- row 2)))
+                     on-row-marker? (marker-on-line? (get lines (dec row)))
+                     reserved?      (and above-marker? (contains? reserved-rows row))]
                  (concat (for [s wl]
                            (cond
                              (and above-marker? (:was-marked? s)) (assoc s :comment nil)
                              above-marker?                        (assoc s :row (dec row), :comment keep-comment)
                              :else                                (assoc s :comment keep-comment)))
                          (when (seq inl)
-                           (if (and (marked-row? lines row) (not reserved?))
+                           (if (or on-row-marker?
+                                   (and above-marker? (not reserved?)))
                              (map #(assoc % :comment nil) inl)
                              (cons (assoc (first inl) :comment keep-comment)
                                    (map #(assoc % :comment nil) (rest inl))))))))

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -86,39 +86,40 @@
   spliced back at its original column. Returns `{:text _, :inserted-rows [...]}` with one entry per
   physical line added, for shifting other row bookkeeping past the inserts."
   [text sites]
-  (let [ending (if (str/ends-with? text "\n") "\n" "")
-        ;; bottom-up so earlier rows stay valid
-        result (reduce
-                (fn [{:keys [lines] :as acc} {:keys [row original comment]}]
-                  (let [{:keys [whole-line? col]} original
-                        original-lines (str/split-lines (:text original))
-                        indent         (if whole-line?
-                                         (re-find #"^\s*" (or (first original-lines) ""))
-                                         (re-find #"^\s*" (get lines (dec row) "")))
-                        comment-lines  (when comment [(str indent comment)])
-                        added          (if whole-line?
-                                         (concat comment-lines original-lines)
-                                         comment-lines)
-                        lines          (cond-> lines
-                                         (not whole-line?)
-                                         (update (dec row)
-                                                 (fn [line]
-                                                   (str (subs line 0 (dec col))
-                                                        (:text original) " "
-                                                        (subs line (dec col))))))
-                        ;; an inline splice adds span-internal newlines as extra physical lines
-                        n-added        (+ (count added)
-                                          (if whole-line? 0 (dec (count original-lines))))]
-                    {:lines    (into (into (subvec lines 0 (dec row)) added)
-                                     (subvec lines (dec row)))
-                     :inserted (into (:inserted acc) (repeat n-added row))}))
-                {:lines (vec (str/split-lines text)), :inserted []}
-                ;; bottom-up; within a row, inline splices right-to-left so earlier columns stay
-                ;; valid, and any whole-line insert last so it can't displace the line being spliced
-                (sort-by (fn [{:keys [row original]}]
-                           [row (if (:whole-line? original) -1 (:col original))])
-                         #(compare %2 %1)
-                         sites))]
+  (let [ending  (if (str/ends-with? text "\n") "\n" "")
+        ;; phase 1: all inline splices, right-to-left within a row so earlier columns stay valid;
+        ;; nothing is added or removed as a line, so every :row still indexes the original vector
+        spliced (reduce (fn [lines {:keys [row original]}]
+                          (if (:whole-line? original)
+                            lines
+                            (update lines (dec row)
+                                    (fn [line]
+                                      (str (subs line 0 (dec (:col original)))
+                                           (:text original) " "
+                                           (subs line (dec (:col original))))))))
+                        (vec (str/split-lines text))
+                        (sort-by (fn [{:keys [row original]}] [row (:col original -1)])
+                                 #(compare %2 %1)
+                                 sites))
+        ;; phase 2: line insertions (comments, whole-line originals), bottom-up; splicing first means
+        ;; a comment inserted above a row can no longer displace a same-row splice target
+        result  (reduce
+                 (fn [{:keys [lines] :as acc} {:keys [row original comment]}]
+                   (let [original-lines (str/split-lines (:text original))
+                         whole-line?    (:whole-line? original)
+                         indent         (if whole-line?
+                                          (re-find #"^\s*" (or (first original-lines) ""))
+                                          (re-find #"^\s*" (get lines (dec row) "")))
+                         added          (concat (when comment [(str indent comment)])
+                                                (when whole-line? original-lines))
+                         ;; an inline splice added its span-internal newlines in phase 1
+                         n-added        (+ (count added)
+                                           (if whole-line? 0 (dec (count original-lines))))]
+                     {:lines    (into (into (subvec lines 0 (dec row)) added)
+                                      (subvec lines (dec row)))
+                      :inserted (into (:inserted acc) (repeat n-added row))}))
+                 {:lines spliced, :inserted []}
+                 (sort-by :row > sites))]
     {:text          (str (str/join "\n" (:lines result)) ending)
      :inserted-rows (:inserted result)}))
 
@@ -142,6 +143,14 @@
   pre-insertion coordinates as `row`."
   [row inserted-rows]
   (+ row (count (filter #(<= % row) inserted-rows))))
+
+(defn- surviving-slots
+  "New baseline slot count for a collision key after a restore round: of the `a` attributed findings,
+  `c - n` were genuinely new (`c` observed against `n` slots), so the rest must have been pre-existing
+  findings the restore suppressed -- their slots go. Slots for findings left unattributed stay, so a
+  pre-existing warning outside the restored ignore's scope isn't misread as new next round."
+  [n c a]
+  (max 0 (- n (max 0 (- a (- c n))))))
 
 (defn- strip-orphan-keep-comments
   "`text` minus [[keep-marker]] markers no longer attached to an ignore form -- what an `--audit`
@@ -317,10 +326,15 @@
                                    (for [[file sites] (sort-by key file->sites)]
                                      (let [text  (slurp file)
                                            lines (vec (str/split-lines text))
-                                           sites (for [s sites]
-                                                   (assoc s :comment
-                                                          (when-not (marked-row? lines (:row s))
-                                                            (if (collision-site? s) collision-comment keep-comment))))
+                                           ;; one comment per row, however many sites restore onto it
+                                           sites (mapcat (fn [[row row-sites]]
+                                                           (let [comment (when-not (marked-row? lines row)
+                                                                           (if (some collision-site? row-sites)
+                                                                             collision-comment
+                                                                             keep-comment))]
+                                                             (cons (assoc (first row-sites) :comment comment)
+                                                                   (map #(assoc % :comment nil) (rest row-sites)))))
+                                                         (group-by :row sites))
                                            {:keys [text inserted-rows]} (reinsert-ignores text sites)]
                                        (spit file text)
                                        [file inserted-rows]))))
@@ -379,9 +393,9 @@
                                         (for [[file fps] (group-by (comp :filename first) attributable)]
                                           [file (vec (distinct (map second fps)))]))
                       collisions  (into #{} (map second) (filter (comp :collision? first) attributable))
-                      collision-keys (into #{}
-                                           (map (fn [{:keys [filename row type]}] [filename row type]))
-                                           (filter :collision? (map first attributable)))
+                      key-of      (fn [{:keys [filename row type]}] [filename row type])
+                      observed    (frequencies (map key-of (filter :collision? exposed)))
+                      attributed  (frequencies (map key-of (filter :collision? (map first attributable))))
                       inserted    (restore-sites! file->sites collisions)
                       shift-site  (fn [file s] (update s :row #(shift-past-inserts % (get inserted file []))))]
                   (println (format "Round %d: put back %d removed ignores covering %d findings; re-linting..."
@@ -394,10 +408,14 @@
                                      :let [gone (set (get file->sites file))]]
                                  [file (vec (for [s sites :when (not (gone s))]
                                               (shift-site file s)))]))
-                         ;; a collision restore also suppresses the pre-existing finding its baseline
-                         ;; slot counted, so drop those slots before shifting the rest
+                         ;; a collision restore suppresses pre-existing findings too, so shrink those
+                         ;; keys' slots ([[surviving-slots]]) before shifting the rest
                          (into {}
-                               (comp (remove (fn [[key _]] (contains? collision-keys key)))
+                               (comp (keep (fn [[key n]]
+                                             (let [n' (if (contains? observed key)
+                                                        (surviving-slots n (observed key) (get attributed key 0))
+                                                        n)]
+                                               (when (pos? n') [key n']))))
                                      (map (fn [[[file row type] n]]
                                             [[file (shift-past-inserts row (get inserted file [])) type] n])))
                                baseline-freq)

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -93,6 +93,26 @@
                           (sort-by key > row->comment))]
     (str (str/join "\n" commented) ending)))
 
+(defn- beyond-baseline
+  "Findings beyond the per-`[filename row type]` counts of `baseline-freq`.
+  A group holding more findings than its baseline count returns ALL of them: an exposed finding can't
+  be told apart from a pre-existing one on the same row, and an extra restore is visible in the diff
+  where a silently dropped one is not."
+  [baseline-freq findings]
+  (mapcat (fn [[key key-findings]]
+            (let [n (get baseline-freq key 0)]
+              (cond
+                (zero? n)                    key-findings
+                (> (count key-findings) n)   key-findings
+                :else                        ())))
+          (group-by (fn [{:keys [filename row type]}] [filename row type]) findings)))
+
+(defn- shift-past-inserts
+  "`row` moved down one for each line inserted at or above it, `inserted-rows` being in the same
+  pre-insertion coordinates as `row`."
+  [row inserted-rows]
+  (+ row (count (filter #(<= % row) inserted-rows))))
+
 (defn- strip-orphan-keep-comments
   "`text` minus whole-line [[keep-marker]] comments no longer attached to an ignore form -- what an
   `--audit` removal that stuck leaves behind. Attachment looks past further comment lines, and only
@@ -270,24 +290,16 @@
           (let [{exposed true, mismatched false}
                 (group-by (fn [{:keys [filename type]}]
                             (boolean (some #{:all type} (named filename))))
-                          (mapcat (fn [[key key-findings]]
-                                    (drop (get baseline-freq key 0) (sort-by :col key-findings)))
-                                  (group-by (fn [{:keys [filename row type]}] [filename row type])
-                                            (filter :row (kondo-findings! nil files)))))]
+                          (beyond-baseline baseline-freq (filter :row (kondo-findings! nil files))))]
             (cond
               (and (seq exposed) (< round 5))
               (let [inserted (restore! exposed)]
                 (println (format "Round %d: restored %d sites; re-linting for occurrences the first report shadowed..."
                                  round (count (distinct (map (juxt :filename :row) exposed)))))
                 (recur (inc round)
-                       ;; a comment line inserted above row r pushes baseline rows at or below r down one
                        (into {}
                              (map (fn [[[file row type] n]]
-                                    [[file
-                                      (reduce (fn [r ins] (if (<= ins r) (inc r) r))
-                                              row (sort (get inserted file [])))
-                                      type]
-                                     n]))
+                                    [[file (shift-past-inserts row (get inserted file [])) type] n]))
                              baseline-freq)
                        (into restored exposed)))
 

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -32,12 +32,30 @@
 (def ^:private keep-comment
   (str ";; " keep-marker " suppresses a warning :redundant-ignore can't see; --audit rechecks"))
 
-(defn- marker-on-line?
-  "Is [[keep-marker]] on `line` as (part of) a comment? A `;` must precede it, so the marker occurring
-  inside a plain string literal doesn't count."
+(def ^:private collision-comment
+  (str ";; " keep-marker " same-row collision; one of these may be pre-existing debt -- verify by hand"))
+
+(defn- comment-start
+  "Index of the `;` starting `line`'s comment, skipping semicolons inside string literals and after a
+  backslash (char literals, string escapes). Line-local: a string opened on an earlier line isn't
+  visible, which is fine for locating marker comments. Nil when the line has no comment."
   [line]
-  (boolean (when-let [i (str/index-of (str line) keep-marker)]
-             (str/includes? (subs (str line) 0 i) ";"))))
+  (let [line (str line)
+        n    (count line)]
+    (loop [i 0, in-string? false]
+      (when (< i n)
+        (let [c (.charAt ^String line i)]
+          (cond
+            (= c \\)                        (recur (+ i 2) in-string?)
+            (= c \")                        (recur (inc i) (not in-string?))
+            (and (= c \;) (not in-string?)) i
+            :else                           (recur (inc i) in-string?)))))))
+
+(defn- marker-on-line?
+  "Is [[keep-marker]] in `line`'s comment? The marker inside a string literal doesn't count."
+  [line]
+  (boolean (when-let [i (comment-start line)]
+             (str/includes? (subs (str line) i) keep-marker))))
 
 (defn- marked-row?
   "Does the ignore starting on 1-based `row` of `lines` carry [[keep-marker]] -- on the line directly
@@ -46,24 +64,20 @@
   (boolean (some marker-on-line? [(get lines (- row 2)) (get lines (dec row))])))
 
 (defn- insert-ignore-lines
-  "`text` with an ignore inserted above each 1-based row of `row->linters`, at matching indentation.
-  A row in `row->comment` gets that comment line inserted above its ignore."
-  ([text row->linters]
-   (insert-ignore-lines text row->linters {}))
-  ([text row->linters row->comment]
-   (let [ending (if (str/ends-with? text "\n") "\n" "")]
-     (str (str/join "\n"
-                    (reduce (fn [lines [row linters]]
-                              (let [indent (re-find #"^\s*" (nth lines (dec row)))
-                                    added  (cond->> [(str indent "#_{:clj-kondo/ignore ["
-                                                          (str/join " " (sort-by str (distinct linters)))
-                                                          "]}")]
-                                             (row->comment row) (cons (str indent (row->comment row))))]
-                                (into (into (subvec lines 0 (dec row)) added)
-                                      (subvec lines (dec row)))))
-                            (vec (str/split-lines text))
-                            (sort-by key > row->linters)))
-          ending))))
+  "`text` with an ignore inserted above each 1-based row of `row->linters`, at matching indentation."
+  [text row->linters]
+  (let [ending (if (str/ends-with? text "\n") "\n" "")]
+    (str (str/join "\n"
+                   (reduce (fn [lines [row linters]]
+                             (let [indent (re-find #"^\s*" (nth lines (dec row)))]
+                               (into (conj (subvec lines 0 (dec row))
+                                           (str indent "#_{:clj-kondo/ignore ["
+                                                (str/join " " (sort-by str (distinct linters)))
+                                                "]}"))
+                                     (subvec lines (dec row)))))
+                           (vec (str/split-lines text))
+                           (sort-by key > row->linters)))
+         ending)))
 
 (defn- insert-inline-ignores
   "`text` with an ignore spliced directly before the token at each 1-based `[row col]` of `sites`
@@ -95,16 +109,17 @@
 
 (defn- beyond-baseline
   "Findings beyond the per-`[filename row type]` counts of `baseline-freq`.
-  A group holding more findings than its baseline count returns ALL of them: an exposed finding can't
-  be told apart from a pre-existing one on the same row, and an extra restore is visible in the diff
-  where a silently dropped one is not."
+  A group holding more findings than its non-zero baseline count returns ALL of them, tagged
+  `:collision? true`: an exposed finding can't be told apart from a pre-existing one on the same row,
+  and an extra restore is visible in the diff where a silently dropped one is not. Callers stamp
+  collision restores with [[collision-comment]] instead of claiming verified provenance."
   [baseline-freq findings]
   (mapcat (fn [[key key-findings]]
             (let [n (get baseline-freq key 0)]
               (cond
-                (zero? n)                    key-findings
-                (> (count key-findings) n)   key-findings
-                :else                        ())))
+                (zero? n)                  key-findings
+                (> (count key-findings) n) (map #(assoc % :collision? true) key-findings)
+                :else                      ())))
           (group-by (fn [{:keys [filename row type]}] [filename row type]) findings)))
 
 (defn- shift-past-inserts
@@ -114,20 +129,30 @@
   (+ row (count (filter #(<= % row) inserted-rows))))
 
 (defn- strip-orphan-keep-comments
-  "`text` minus whole-line [[keep-marker]] comments no longer attached to an ignore form -- what an
-  `--audit` removal that stuck leaves behind. Attachment looks past further comment lines, and only
-  needs the ignore's first line (the linter vector may wrap). Trailing markers on code lines are left
-  alone."
+  "`text` minus [[keep-marker]] markers no longer attached to an ignore form -- what an `--audit`
+  removal that stuck leaves behind. A stamped whole-line marker comment is deleted; a hand-written
+  comment that merely carries the token keeps its prose and loses only the token. Attachment looks
+  past further comment lines, and only needs the ignore's first line (the linter vector may wrap).
+  Trailing markers on code lines are left alone."
   [text]
   (let [lines    (vec (str/split-lines text))
         ending   (if (str/ends-with? text "\n") "\n" "")
         ignored? (fn [line] (str/includes? (str line) ":clj-kondo/ignore"))
+        stamped? #{keep-comment collision-comment}
         orphan?  (fn [i line]
                    (and (marker-on-line? line)
                         (re-matches #"\s*;.*" line)
                         (let [below (drop-while #(re-matches #"\s*;.*" %) (subvec lines (inc i)))]
                           (not (ignored? (first below))))))]
-    (str (str/join "\n" (keep-indexed (fn [i line] (when-not (orphan? i line) line)) lines))
+    (str (str/join "\n"
+                   (keep-indexed (fn [i line]
+                                   (cond
+                                     (not (orphan? i line))       line
+                                     (stamped? (str/trim line))   nil
+                                     :else                        (-> line
+                                                                      (str/replace (str " " keep-marker) "")
+                                                                      (str/replace keep-marker ""))))
+                                 lines))
          ending)))
 
 ;;;; ---------------------------------------------------------------------------
@@ -135,12 +160,11 @@
 ;;;; ---------------------------------------------------------------------------
 
 (defn- ignored-linters-at
-  "Linter keywords named by the ignore form at `row` of `file`; reads a couple of extra lines since the
-  vector may wrap."
-  [file row]
-  (let [lines (vec (str/split-lines (slurp file)))]
-    (kondo-ratchet/line-linters
-     (str/join "\n" (subvec lines (dec row) (min (count lines) (+ row 2)))))))
+  "Linter keywords named by the ignore form at `row` of `lines`; reads a couple of extra lines since
+  the vector may wrap."
+  [lines row]
+  (kondo-ratchet/line-linters
+   (str/join "\n" (subvec lines (dec row) (min (count lines) (+ row 2))))))
 
 (defn- lsp-only?
   "Does the ignore form suppress only linters kondo doesn't run, so a re-lint could never restore it?"
@@ -222,21 +246,21 @@
   budget that ends up exceeded."
   [parsed]
   (println "Running kondo with :redundant-ignore enabled (full lint, takes a minute or two)...")
-  (let [audit?   (get-in parsed [:options :audit])
-        findings (kondo-findings! :redundant-ignore lint-roots)
+  (let [audit?     (get-in parsed [:options :audit])
+        findings   (kondo-findings! :redundant-ignore lint-roots)
         {located true, homeless false} (group-by #(some? (:row %)) findings)
+        file-lines (memoize (fn [file] (vec (str/split-lines (slurp file)))))
         {lsp-only true, verifiable false}
         (group-by (fn [{:keys [filename row]}]
-                    (lsp-only? (ignored-linters-at filename row)))
+                    (lsp-only? (ignored-linters-at (file-lines filename) row)))
                   located)
-        file-lines (memoize (fn [file] (vec (str/split-lines (slurp file)))))
         {marked true, candidates false}
         (group-by (fn [{:keys [filename row]}]
                     (marked-row? (file-lines filename) row))
                   verifiable)
         candidates (if audit? (concat candidates marked) candidates)]
     (doseq [{:keys [filename row]} (sort-by (juxt :filename :row) candidates)]
-      (println (format "%s:%d %s" filename row (str/join " " (ignored-linters-at filename row)))))
+      (println (format "%s:%d %s" filename row (str/join " " (ignored-linters-at (file-lines filename) row)))))
     (println)
     (println (format "%d candidate redundant ignores (dropped as false positives: %d location-less, %d lsp-only)"
                      (count candidates) (count homeless) (count lsp-only)))
@@ -262,65 +286,91 @@
                                              + (:deletions (removals file)))))
             named        (fn [file] (into #{} (mapcat :linters) (:sites (removals file))))
             restore!     (fn [exposed]
-                           ;; returns {file [comment-rows...]} so baseline rows can shift past the inserts
-                           (into {}
-                                 (for [[file file-exposed] (sort-by key (group-by :filename exposed))]
-                                   (let [text  (slurp file)
-                                         lines (vec (str/split-lines text))
-                                         sites (update-vals (group-by (juxt :row :col) file-exposed) #(map :type %))
-                                         ;; the site keeps any marker it already has
-                                         row->comment (into {}
-                                                            (for [row   (distinct (map :row file-exposed))
-                                                                  :when (not (marked-row? lines row))]
-                                                              [row keep-comment]))]
-                                     (spit file (insert-inline-ignores text sites row->comment))
-                                     [file (sort (keys row->comment))]))))
+                           ;; returns {:inserted {file [comment-rows...]}, :restored [findings...]};
+                           ;; :inserted lets baseline rows shift past the inserts, :restored is what
+                           ;; actually got a splice
+                           (reduce
+                            (fn [acc [file file-exposed]]
+                              (let [text  (slurp file)
+                                    lines (vec (str/split-lines text))
+                                    ;; a site already carrying a spliced ignore wasn't suppressed by
+                                    ;; it; splicing again would stack garbage forms -- leave it for
+                                    ;; the final warning pass
+                                    {stuck true, spliceable false}
+                                    (group-by (fn [{:keys [row col]}]
+                                                (boolean
+                                                 (some->> (get lines (dec row))
+                                                          (#(subs % 0 (min (dec col) (count %))))
+                                                          (re-find #":clj-kondo/ignore\s+\[[^\]]*\]\}\s*$"))))
+                                              file-exposed)
+                                    sites (update-vals (group-by (juxt :row :col) spliceable) #(map :type %))
+                                    ;; the site keeps any marker it already has
+                                    row->comment (into {}
+                                                       (for [row   (distinct (map :row spliceable))
+                                                             :when (not (marked-row? lines row))]
+                                                         [row (if (some :collision? (get (group-by :row spliceable) row))
+                                                                collision-comment
+                                                                keep-comment)]))]
+                                (when (seq spliceable)
+                                  (spit file (insert-inline-ignores text sites row->comment)))
+                                (-> acc
+                                    (assoc-in [:inserted file] (vec (sort (keys row->comment))))
+                                    (update :restored into spliceable)
+                                    (update :stuck into stuck))))
+                            {:inserted {}, :restored [], :stuck []}
+                            (sort-by key (group-by :filename exposed))))
             _            (println (format "Removed them across %d files; re-linting to verify..." (count files)))]
         ;; A finding beyond the (row-shifted) baseline was exposed by a removal; restore it when some
         ;; removed ignore in the file named its type. The baseline is a frequency map so an exposed
         ;; finding sharing row and type with a pre-existing one still counts as new. Hook linters can
         ;; report only the first occurrence per form, so each restore round may surface the next one --
         ;; iterate to a fixpoint.
-        (loop [round         1
-               baseline-freq (frequencies
-                              (map (fn [{:keys [filename row type]}]
-                                     [filename (adjusted-row filename row) type])
-                                   baseline))
-               restored      []]
-          (let [{exposed true, mismatched false}
-                (group-by (fn [{:keys [filename type]}]
-                            (boolean (some #{:all type} (named filename))))
-                          (beyond-baseline baseline-freq (filter :row (kondo-findings! nil files))))]
-            (cond
-              (and (seq exposed) (< round 5))
-              (let [inserted (restore! exposed)]
-                (println (format "Round %d: restored %d sites; re-linting for occurrences the first report shadowed..."
-                                 round (count (distinct (map (juxt :filename :row) exposed)))))
-                (recur (inc round)
-                       (into {}
-                             (map (fn [[[file row type] n]]
-                                    [[file (shift-past-inserts row (get inserted file [])) type] n]))
-                             baseline-freq)
-                       (into restored exposed)))
-
-              :else
-              (do (when (seq exposed)
-                    (doseq [{:keys [filename row type]} (sort-by (juxt :filename :row) exposed)]
-                      (println (format "WARNING: %s:%d still exposes %s after %d restore rounds -- re-ignore by hand"
-                                       filename row type round))))
-                  (doseq [{:keys [filename row type]} (sort-by (juxt :filename :row) mismatched)]
-                    (println (format "WARNING: %s:%d has a new %s finding no removed ignore in the file named -- fix or re-ignore by hand"
-                                     filename row type)))
-                  (when audit?
-                    (doseq [file files]
-                      (spit file (strip-orphan-keep-comments (slurp file)))))
-                  (if (empty? restored)
-                    (println "Verified: the removals exposed no findings.")
-                    (println (format "Restored ignores at %d sites where a finding reappeared (%s), stamped %s."
-                                     (count (distinct (map (juxt :filename :row) restored)))
-                                     (str/join ", " (sort (distinct (map :type restored))))
-                                     keep-marker)))))))
-        (println "Now run `./bin/mage fix-kondo-ratchets` to update the budgets, and `./bin/mage kondo` for the final word.")))))
+        (let [finish! (fn [exposed mismatched restored rounds-run]
+                        (doseq [{:keys [filename row type]} (sort-by (juxt :filename :row) exposed)]
+                          (println (format "WARNING: %s:%d still exposes %s after %d restore rounds -- re-ignore by hand"
+                                           filename row type rounds-run)))
+                        (doseq [{:keys [filename row type]} (sort-by (juxt :filename :row) mismatched)]
+                          (println (format "WARNING: %s:%d has a new %s finding no removed ignore in the file named -- fix or re-ignore by hand"
+                                           filename row type)))
+                        (when audit?
+                          (doseq [file files]
+                            (spit file (strip-orphan-keep-comments (slurp file)))))
+                        (doseq [{:keys [filename row]} (distinct (map #(select-keys % [:filename :row]) (filter :collision? restored)))]
+                          (println (format "NOTE: %s:%d restored a same-row collision -- one ignore there may cover pre-existing debt; verify by hand"
+                                           filename row)))
+                        (if (empty? restored)
+                          (println "Verified: the removals exposed no findings.")
+                          (println (format "Restored ignores at %d sites where a finding reappeared (%s), stamped %s."
+                                           (count (distinct (map (juxt :filename :row) restored)))
+                                           (str/join ", " (sort (distinct (map :type restored))))
+                                           keep-marker)))
+                        (println "Now run `./bin/mage fix-kondo-ratchets` to update the budgets, and `./bin/mage kondo` for the final word.")
+                        (when (seq exposed)
+                          (throw (ex-info "the removals left warnings exposed; re-ignore them by hand and re-run" {:exit-code 1}))))]
+          (loop [round         1
+                 baseline-freq (frequencies
+                                (map (fn [{:keys [filename row type]}]
+                                       [filename (adjusted-row filename row) type])
+                                     baseline))
+                 restored      []]
+            (let [{exposed true, mismatched false}
+                  (group-by (fn [{:keys [filename type]}]
+                              (boolean (some #{:all type} (named filename))))
+                            (beyond-baseline baseline-freq (filter :row (kondo-findings! nil files))))]
+              (if (and (seq exposed) (< round 10))
+                (let [{:keys [inserted] :as results} (restore! exposed)]
+                  (if (empty? (:restored results))
+                    ;; every remaining site resists splicing; another lint would change nothing
+                    (finish! exposed mismatched restored (dec round))
+                    (do (println (format "Round %d: restored %d sites; re-linting for occurrences the first report shadowed..."
+                                         round (count (distinct (map (juxt :filename :row) (:restored results))))))
+                        (recur (inc round)
+                               (into {}
+                                     (map (fn [[[file row type] n]]
+                                            [[file (shift-past-inserts row (get inserted file [])) type] n]))
+                                     baseline-freq)
+                               (into restored (:restored results))))))
+                (finish! exposed mismatched restored (dec round))))))))))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; kondo-insert-ignores

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -94,9 +94,7 @@
                                       (let [rest-of-line (subs line (dec (:col original)))]
                                         (str (subs line 0 (dec (:col original)))
                                              (:text original)
-                                             ;; removal swallowed the separating space unless the
-                                             ;; remnant kept one; mirror it so restores are verbatim
-                                             (when-not (str/starts-with? rest-of-line " ") " ")
+                                             (:separator original)
                                              rest-of-line))))))
                         (vec (str/split-lines text))
                         (sort-by (fn [{:keys [row original]}] [row (:col original -1)])
@@ -245,7 +243,8 @@
   Forms that name any clojure-lsp/* linter survive ([[names-lsp?]]): the verify pass could never restore
   that half of the suppression. Forms whose matched span has unbalanced braces (nested maps the regex
   can't span) are skipped and reported under `:skipped` rather than corrupted.
-  A line left whitespace-only by a removal is deleted; an inline removal also swallows one space.
+  A line left whitespace-only by a removal is deleted; an inline removal also swallows the spaces
+  separating it from the following form when the preceding text already ends in a space.
   Returns `{:text _, :sites [{:row _, :linters _, :original _} ...], :skipped [rows...]}`.
   `:sites` carries the post-removal row of the form each ignore covered, the linters it named, and
   `:original` -- the removed form's exact text and placement, so a restore can put it back verbatim."
@@ -264,9 +263,10 @@
         result (reduce (fn [{:keys [text] :as acc} {:keys [start end line linters]}]
                          (let [before     (subs text 0 start)
                                after      (subs text end)
-                               after      (if (and (str/ends-with? before " ") (str/starts-with? after " "))
-                                            (str/replace-first after #" +" "")
-                                            after)
+                               separator  (if (str/ends-with? before " ")
+                                            (or (re-find #"^ +" after) "")
+                                            "")
+                               after      (subs after (count separator))
                                line-start (inc (or (str/last-index-of before "\n") -1))
                                line-end   (or (str/index-of after "\n") (count after))
                                remnant    (str (subs before line-start) (subs after 0 line-end))
@@ -289,7 +289,8 @@
                                                          :text        (subs text line-start (+ end line-end))}
                                                         {:whole-line? false
                                                          :col         (inc (- start line-start))
-                                                         :text        (subs text start end)})}))))
+                                                         :text        (subs text start end)
+                                                         :separator   separator})}))))
                        {:text text, :deletions []}
                        ;; bottom-up so earlier offsets stay valid
                        (sort-by :start > removable))

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -79,33 +79,43 @@
                            (sort-by key > row->linters)))
          ending)))
 
-(defn- insert-inline-ignores
-  "`text` with an ignore spliced directly before the token at each 1-based `[row col]` of `sites`
-  (`{[row col] linters}`), plus `row->comment` lines inserted above rows at matching indentation.
-  Kondo reports a finding at its token, which may be a map value or a later form on its line; a
-  line-above ignore only covers the line's first form, so restores must splice inline to be precise."
-  [text sites row->comment]
-  (let [lines    (vec (str/split-lines text))
-        ending   (if (str/ends-with? text "\n") "\n" "")
-        ;; right-to-left within a row so earlier cols stay valid; rows are independent
-        spliced  (reduce (fn [lines [[row col] linters]]
-                           (update lines (dec row)
-                                   (fn [line]
-                                     (str (subs line 0 (dec col))
-                                          "#_{:clj-kondo/ignore ["
-                                          (str/join " " (sort-by str (distinct linters)))
-                                          "]} "
-                                          (subs line (dec col))))))
-                         lines
-                         (sort-by (comp second key) > sites))
-        ;; bottom-up so earlier rows stay valid; splicing above never changed row numbers
-        commented (reduce (fn [lines [row comment]]
-                            (let [indent (re-find #"^\s*" (nth lines (dec row)))]
-                              (into (conj (subvec lines 0 (dec row)) (str indent comment))
-                                    (subvec lines (dec row)))))
-                          spliced
-                          (sort-by key > row->comment))]
-    (str (str/join "\n" commented) ending)))
+(defn- reinsert-ignores
+  "`text` with removed ignore forms put back exactly as they were: each site is a
+  [[remove-ignores-at]] `:sites` entry (`:row` in current coordinates) plus optional `:comment` to
+  stamp above it. A whole-line original returns as its original line(s); an inline original is
+  spliced back at its original column. Returns `{:text _, :inserted-rows [...]}` with one entry per
+  physical line added, for shifting other row bookkeeping past the inserts."
+  [text sites]
+  (let [ending (if (str/ends-with? text "\n") "\n" "")
+        ;; bottom-up so earlier rows stay valid
+        result (reduce
+                (fn [{:keys [lines] :as acc} {:keys [row original comment]}]
+                  (let [{:keys [whole-line? col]} original
+                        original-lines (str/split-lines (:text original))
+                        indent         (if whole-line?
+                                         (re-find #"^\s*" (or (first original-lines) ""))
+                                         (re-find #"^\s*" (get lines (dec row) "")))
+                        comment-lines  (when comment [(str indent comment)])
+                        added          (if whole-line?
+                                         (concat comment-lines original-lines)
+                                         comment-lines)
+                        lines          (cond-> lines
+                                         (not whole-line?)
+                                         (update (dec row)
+                                                 (fn [line]
+                                                   (str (subs line 0 (dec col))
+                                                        (:text original) " "
+                                                        (subs line (dec col))))))
+                        ;; an inline splice adds span-internal newlines as extra physical lines
+                        n-added        (+ (count added)
+                                          (if whole-line? 0 (dec (count original-lines))))]
+                    {:lines    (into (into (subvec lines 0 (dec row)) added)
+                                     (subvec lines (dec row)))
+                     :inserted (into (:inserted acc) (repeat n-added row))}))
+                {:lines (vec (str/split-lines text)), :inserted []}
+                (sort-by :row > sites))]
+    {:text          (str (str/join "\n" (:lines result)) ending)
+     :inserted-rows (:inserted result)}))
 
 (defn- beyond-baseline
   "Findings beyond the per-`[filename row type]` counts of `baseline-freq`.
@@ -217,20 +227,31 @@
                                               (str before after)))
                                ;; an inline removal still deletes the newlines inside a wrapped span;
                                ;; a blank-line removal deletes the remaining physical line on top
-                               (update :deletions conj [line
-                                                        (cond-> (count (filter #(= % \newline) (subs text start end)))
-                                                          blank? inc)
-                                                        linters]))))
+                               (update :deletions conj
+                                       {:line         line
+                                        :rows-deleted (cond-> (count (filter #(= % \newline) (subs text start end)))
+                                                        blank? inc)
+                                        :linters      linters
+                                        ;; enough to put the removal back exactly as it was
+                                        :original     (if blank?
+                                                        {:whole-line? true
+                                                         :text        (subs text line-start (+ end line-end))}
+                                                        {:whole-line? false
+                                                         :col         (inc (- start line-start))
+                                                         :text        (subs text start end)})}))))
                        {:text text, :deletions []}
                        ;; bottom-up so earlier offsets stay valid
                        (sort-by :start > removable))
+        deletions        (:deletions result)
         post-removal-row (fn [line]
-                           (- line (transduce (keep (fn [[l k]] (when (< l line) k))) + (:deletions result))))]
+                           (- line (transduce (keep (fn [{l :line, k :rows-deleted}] (when (< l line) k)))
+                                              + deletions)))]
     {:text      (:text result)
-     :sites     (for [[line _ linters] (:deletions result)]
-                  {:row     (post-removal-row line)
-                   :linters linters})
-     :deletions (mapv (fn [[line k _]] [line k]) (:deletions result))
+     :sites     (for [{:keys [line linters original]} deletions]
+                  {:row      (post-removal-row line)
+                   :linters  linters
+                   :original original})
+     :deletions (mapv (fn [{:keys [line rows-deleted]}] [line rows-deleted]) deletions)
      ;; adjusted like :sites, so warnings point at the rewritten file
      :skipped   (map (comp post-removal-row :line) unbalanced)}))
 
@@ -240,10 +261,9 @@
   Sites whose comment (directly above, or trailing on the ignore's line) carries [[keep-marker]] are
   proven false positives and are skipped too, unless `--audit` rechecks them.
   With `--fix`, remove the candidates, then verify against a pre-removal baseline lint of the touched
-  files: any finding not in the baseline was exposed by a removal, and gets its ignore restored with
-  the marker stamped. An `--audit` removal that sticks takes its stale marker comment with it.
-  Restores are per site, so a broad ignore can come back as several; `fix-kondo-ratchets` flags any
-  budget that ends up exceeded."
+  files: any finding not in the baseline was exposed by a removal, whose ignore is put back exactly as
+  it was -- a coarse form-level ignore returns as the same single form-level ignore -- with the marker
+  stamped above it. An `--audit` removal that sticks takes its stale marker comment with it."
   [parsed]
   (println "Running kondo with :redundant-ignore enabled (full lint, takes a minute or two)...")
   (let [audit?     (get-in parsed [:options :audit])
@@ -285,47 +305,27 @@
                            (- row (transduce (keep (fn [[l k]] (when (< l row) k)))
                                              + (:deletions (removals file)))))
             named        (fn [file] (into #{} (mapcat :linters) (:sites (removals file))))
-            restore!     (fn [exposed]
-                           ;; returns {:inserted {file [comment-rows...]}, :restored [findings...]};
-                           ;; :inserted lets baseline rows shift past the inserts, :restored is what
-                           ;; actually got a splice
-                           (reduce
-                            (fn [acc [file file-exposed]]
-                              (let [text  (slurp file)
-                                    lines (vec (str/split-lines text))
-                                    ;; a site already carrying a spliced ignore wasn't suppressed by
-                                    ;; it; splicing again would stack garbage forms -- leave it for
-                                    ;; the final warning pass
-                                    {stuck true, spliceable false}
-                                    (group-by (fn [{:keys [row col]}]
-                                                (boolean
-                                                 (some->> (get lines (dec row))
-                                                          (#(subs % 0 (min (dec col) (count %))))
-                                                          (re-find #":clj-kondo/ignore\s+\[[^\]]*\]\}\s*$"))))
-                                              file-exposed)
-                                    sites (update-vals (group-by (juxt :row :col) spliceable) #(map :type %))
-                                    ;; the site keeps any marker it already has
-                                    row->comment (into {}
-                                                       (for [row   (distinct (map :row spliceable))
-                                                             :when (not (marked-row? lines row))]
-                                                         [row (if (some :collision? (get (group-by :row spliceable) row))
-                                                                collision-comment
-                                                                keep-comment)]))]
-                                (when (seq spliceable)
-                                  (spit file (insert-inline-ignores text sites row->comment)))
-                                (-> acc
-                                    (assoc-in [:inserted file] (vec (sort (keys row->comment))))
-                                    (update :restored into spliceable)
-                                    (update :stuck into stuck))))
-                            {:inserted {}, :restored [], :stuck []}
-                            (sort-by key (group-by :filename exposed))))
-            _            (println (format "Removed them across %d files; re-linting to verify..." (count files)))]
-        ;; A finding beyond the (row-shifted) baseline was exposed by a removal; restore it when some
-        ;; removed ignore in the file named its type. The baseline is a frequency map so an exposed
-        ;; finding sharing row and type with a pre-existing one still counts as new. Hook linters can
-        ;; report only the first occurrence per form, so each restore round may surface the next one --
-        ;; iterate to a fixpoint.
-        (let [finish! (fn [exposed mismatched restored rounds-run]
+            restore-sites! (fn [file->sites collision-site?]
+                             ;; puts each removed ignore back exactly as it was; returns
+                             ;; {file [inserted-anchor-rows...]} for shifting row bookkeeping
+                             (into {}
+                                   (for [[file sites] (sort-by key file->sites)]
+                                     (let [text  (slurp file)
+                                           lines (vec (str/split-lines text))
+                                           sites (for [s sites]
+                                                   (assoc s :comment
+                                                          (when-not (marked-row? lines (:row s))
+                                                            (if (collision-site? s) collision-comment keep-comment))))
+                                           {:keys [text inserted-rows]} (reinsert-ignores text sites)]
+                                       (spit file text)
+                                       [file inserted-rows]))))
+            _              (println (format "Removed them across %d files; re-linting to verify..." (count files)))]
+        ;; A finding beyond the (row-shifted) baseline was exposed by a removal. Attribute it to the
+        ;; nearest preceding removed site naming its type and put that ignore back verbatim -- a coarse
+        ;; ignore returns as the same coarse ignore, never as several narrow ones. Hook linters can
+        ;; report only the first occurrence per form, so a round may surface findings a restored form
+        ;; already covers; iterate until the lint comes back clean.
+        (let [finish! (fn [exposed mismatched restored covered rounds-run]
                         (doseq [{:keys [filename row type]} (sort-by (juxt :filename :row) exposed)]
                           (println (format "WARNING: %s:%d still exposes %s after %d restore rounds -- re-ignore by hand"
                                            filename row type rounds-run)))
@@ -335,42 +335,64 @@
                         (when audit?
                           (doseq [file files]
                             (spit file (strip-orphan-keep-comments (slurp file)))))
-                        (doseq [{:keys [filename row]} (distinct (map #(select-keys % [:filename :row]) (filter :collision? restored)))]
-                          (println (format "NOTE: %s:%d restored a same-row collision -- one ignore there may cover pre-existing debt; verify by hand"
-                                           filename row)))
+                        (doseq [[file row] (sort (distinct (map (juxt :file :row) (filter :collision? restored))))]
+                          (println (format "NOTE: %s:%d restored over a same-row collision -- it may cover pre-existing debt; verify by hand"
+                                           file row)))
                         (if (empty? restored)
                           (println "Verified: the removals exposed no findings.")
-                          (println (format "Restored ignores at %d sites where a finding reappeared (%s), stamped %s."
-                                           (count (distinct (map (juxt :filename :row) restored)))
-                                           (str/join ", " (sort (distinct (map :type restored))))
+                          (println (format "Restored %d removed ignores covering %d findings (%s), stamped %s."
+                                           (count restored)
+                                           (count covered)
+                                           (str/join ", " (sort (distinct (map :type covered))))
                                            keep-marker)))
                         (println "Now run `./bin/mage fix-kondo-ratchets` to update the budgets, and `./bin/mage kondo` for the final word.")
                         (when (seq exposed)
                           (throw (ex-info "the removals left warnings exposed; re-ignore them by hand and re-run" {:exit-code 1}))))]
           (loop [round         1
+                 pending       (update-vals removals :sites)
                  baseline-freq (frequencies
                                 (map (fn [{:keys [filename row type]}]
                                        [filename (adjusted-row filename row) type])
                                      baseline))
-                 restored      []]
+                 restored      []
+                 covered       []]
             (let [{exposed true, mismatched false}
                   (group-by (fn [{:keys [filename type]}]
                               (boolean (some #{:all type} (named filename))))
-                            (beyond-baseline baseline-freq (filter :row (kondo-findings! nil files))))]
-              (if (and (seq exposed) (< round 10))
-                (let [{:keys [inserted] :as results} (restore! exposed)]
-                  (if (empty? (:restored results))
-                    ;; every remaining site resists splicing; another lint would change nothing
-                    (finish! exposed mismatched restored (dec round))
-                    (do (println (format "Round %d: restored %d sites; re-linting for occurrences the first report shadowed..."
-                                         round (count (distinct (map (juxt :filename :row) (:restored results))))))
-                        (recur (inc round)
-                               (into {}
-                                     (map (fn [[[file row type] n]]
-                                            [[file (shift-past-inserts row (get inserted file [])) type] n]))
-                                     baseline-freq)
-                               (into restored (:restored results))))))
-                (finish! exposed mismatched restored (dec round))))))))))
+                            (beyond-baseline baseline-freq (filter :row (kondo-findings! nil files))))
+                  ;; nearest preceding pending site naming the finding's type; else nearest overall
+                  pick (fn [{:keys [filename row type]}]
+                         (let [match? (fn [s] (boolean (some #{:all type} (:linters s))))
+                               sites  (filter match? (get pending filename))]
+                           (or (last (sort-by :row (filter #(<= (:row %) row) sites)))
+                               (first (sort-by #(abs (- (:row %) row)) sites)))))
+                  picks (map (juxt identity pick) exposed)
+                  attributable (filter second picks)]
+              (if (and (seq attributable) (< round 6))
+                (let [file->sites (into {}
+                                        (for [[file fps] (group-by (comp :filename first) attributable)]
+                                          [file (vec (distinct (map second fps)))]))
+                      collisions  (into #{} (map second) (filter (comp :collision? first) attributable))
+                      inserted    (restore-sites! file->sites collisions)
+                      shift-site  (fn [file s] (update s :row #(shift-past-inserts % (get inserted file []))))]
+                  (println (format "Round %d: put back %d removed ignores covering %d findings; re-linting..."
+                                   round
+                                   (reduce + (map count (vals file->sites)))
+                                   (count attributable)))
+                  (recur (inc round)
+                         (into {}
+                               (for [[file sites] pending
+                                     :let [gone (set (get file->sites file))]]
+                                 [file (vec (for [s sites :when (not (gone s))]
+                                              (shift-site file s)))]))
+                         (into {}
+                               (map (fn [[[file row type] n]]
+                                      [[file (shift-past-inserts row (get inserted file [])) type] n]))
+                               baseline-freq)
+                         (into restored (for [[file sites] file->sites, s sites]
+                                          {:file file, :row (:row s), :collision? (contains? collisions s)}))
+                         (into covered (map first attributable))))
+                (finish! exposed mismatched restored covered (dec round))))))))))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; kondo-insert-ignores

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -182,27 +182,41 @@
   removal that stuck leaves behind. A stamped whole-line marker comment is deleted; a hand-written
   comment that merely carries the token keeps its prose and loses only the token. Attachment looks
   past further comment lines, and only needs the ignore's first line (the linter vector may wrap).
-  Trailing markers on code lines are left alone."
-  [text]
-  (let [lines    (vec (str/split-lines text))
-        ending   (if (str/ends-with? text "\n") "\n" "")
-        ignored? (fn [line] (str/includes? (str line) ":clj-kondo/ignore"))
-        stamped? #{keep-comment}
-        orphan?  (fn [i line]
-                   (and (marker-on-line? line)
-                        (re-matches #"\s*;.*" line)
-                        (let [below (drop-while #(re-matches #"\s*;.*" %) (subvec lines (inc i)))]
-                          (not (ignored? (first below))))))]
-    (str (str/join "\n"
-                   (keep-indexed (fn [i line]
-                                   (cond
-                                     (not (orphan? i line))       line
-                                     (stamped? (str/trim line))   nil
-                                     :else                        (-> line
-                                                                      (str/replace (str " " keep-marker) "")
-                                                                      (str/replace keep-marker ""))))
-                                 lines))
-         ending)))
+  Trailing markers on code lines are left alone. `pending-sites` identifies markers reserved for
+  marked whole-line sites that never restored; those are removed by ownership rather than adjacency,
+  since another restored ignore may now sit below them."
+  ([text]
+   (strip-orphan-keep-comments text nil))
+  ([text pending-sites]
+   (let [lines      (vec (str/split-lines text))
+         ending     (if (str/ends-with? text "\n") "\n" "")
+         ignored?   (fn [line] (str/includes? (str line) ":clj-kondo/ignore"))
+         stamped?   #{keep-comment}
+         owned-rows (into #{}
+                          (comp (filter :was-marked?)
+                                (filter #(get-in % [:original :whole-line?]))
+                                (map (comp dec :row)))
+                          pending-sites)
+         orphan?    (fn [i line]
+                      (and (marker-on-line? line)
+                           (re-matches #"\s*;.*" line)
+                           (let [below (drop-while #(re-matches #"\s*;.*" %) (subvec lines (inc i)))]
+                             (not (ignored? (first below))))))
+         strip?     (fn [i line]
+                      (and (marker-on-line? line)
+                           (re-matches #"\s*;.*" line)
+                           (or (contains? owned-rows (inc i))
+                               (orphan? i line))))]
+     (str (str/join "\n"
+                    (keep-indexed (fn [i line]
+                                    (cond
+                                      (not (strip? i line))        line
+                                      (stamped? (str/trim line))   nil
+                                      :else                         (-> line
+                                                                        (str/replace (str " " keep-marker) "")
+                                                                        (str/replace keep-marker ""))))
+                                  lines))
+          ending))))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; kondo-redundant-ignores
@@ -367,7 +381,7 @@
                                                (reinsert-ignores text (site-restore-plan lines sites (get pending file)))]
                                            (spit file text)
                                            [file inserted-rows]))))
-                finish!  (fn [exposed mismatched restored covered rounds-run]
+                finish!  (fn [exposed mismatched restored covered rounds-run pending]
                            (doseq [{:keys [filename row type]} (sort-by (juxt :filename :row) exposed)]
                              (println (format "WARNING: %s:%d still exposes %s after %d restore rounds -- re-ignore by hand"
                                               filename row type rounds-run)))
@@ -376,7 +390,7 @@
                                               filename row type)))
                            (when audit?
                              (doseq [file files]
-                               (spit file (strip-orphan-keep-comments (slurp file)))))
+                               (spit file (strip-orphan-keep-comments (slurp file) (get pending file)))))
                            (if (empty? restored)
                              (println "Verified: the removals exposed no findings.")
                              (println (format "Restored %d removed ignores covering %d findings (%s), stamped %s."
@@ -429,7 +443,7 @@
                            (into restored (for [[file sites] file->sites, s sites]
                                             {:file file, :row (:row s)}))
                            (into covered (map first attributable))))
-                  (finish! exposed mismatched restored covered (dec round)))))))))))
+                  (finish! exposed mismatched restored covered (dec round) pending))))))))))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; kondo-insert-ignores

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -131,6 +131,31 @@
   [row inserted-rows]
   (+ row (count (filter #(<= % row) inserted-rows))))
 
+(defn- site-restore-plan
+  "Restore sites annotated with `:comment` (and sometimes an adjusted `:row`), so every restored
+  ignore ends up with its own marker adjacent and no insert splits an existing marker from the line
+  it marks. Whole-line restores each carry a marker; when the line above already holds one that marks
+  the code line's own ignore, the whole-line block moves above that marker instead of splitting the
+  pair -- unless the code line has no ignore, in which case the marker marked the removed site itself
+  (an --audit re-restore) and no new marker is needed. A row's inline restores share one marker,
+  directly above the code line, unless the row already carries one."
+  [lines sites]
+  (mapcat (fn [[row row-sites]]
+            (let [{wl true, inl false} (group-by (comp boolean :whole-line? :original) row-sites)
+                  above-marker? (marker-on-line? (get lines (- row 2)))
+                  code-ignored? (seq (kondo-ratchet/line-linters (str (get lines (dec row)))))]
+              (concat (for [s wl]
+                        (cond
+                          (and above-marker? code-ignored?) (assoc s :row (dec row), :comment keep-comment)
+                          above-marker?                     (assoc s :comment nil)
+                          :else                             (assoc s :comment keep-comment)))
+                      (when (seq inl)
+                        (if (marked-row? lines row)
+                          (map #(assoc % :comment nil) inl)
+                          (cons (assoc (first inl) :comment keep-comment)
+                                (map #(assoc % :comment nil) (rest inl))))))))
+          (group-by :row sites)))
+
 (defn- strip-orphan-keep-comments
   "`text` minus [[keep-marker]] markers no longer attached to an ignore form -- what an `--audit`
   removal that stuck leaves behind. A stamped whole-line marker comment is deleted; a hand-written
@@ -309,18 +334,8 @@
                                        (for [[file sites] (sort-by key file->sites)]
                                          (let [text  (slurp file)
                                                lines (vec (str/split-lines text))
-                                               ;; every whole-line restore gets its own marker; a row's
-                                               ;; inline restores share one, directly above the code line
-                                               sites (mapcat (fn [[row row-sites]]
-                                                               (if (marked-row? lines row)
-                                                                 (map #(assoc % :comment nil) row-sites)
-                                                                 (let [{wl true, inl false} (group-by (comp boolean :whole-line? :original) row-sites)]
-                                                                   (concat (map #(assoc % :comment keep-comment) wl)
-                                                                           (when (seq inl)
-                                                                             (cons (assoc (first inl) :comment keep-comment)
-                                                                                   (map #(assoc % :comment nil) (rest inl))))))))
-                                                             (group-by :row sites))
-                                               {:keys [text inserted-rows]} (reinsert-ignores text sites)]
+                                               {:keys [text inserted-rows]}
+                                               (reinsert-ignores text (site-restore-plan lines sites))]
                                            (spit file text)
                                            [file inserted-rows]))))
                 finish!  (fn [exposed mismatched restored covered rounds-run]

--- a/mage/src/mage/readability_check.clj
+++ b/mage/src/mage/readability_check.clj
@@ -70,10 +70,10 @@
                       ])
            %))
    [1 3 4 5])
-;; => [[1 {:start 1, :end 2}]
-;;     [3 {:start 2, :end 4}]
-;;     [4 {:start 4, :end 7}]
-;;     [5 {:start 4, :end 7}]]
+  ;; => [[1 {:start 1, :end 2}]
+  ;;     [3 {:start 2, :end 4}]
+  ;;     [4 {:start 4, :end 7}]
+  ;;     [5 {:start 4, :end 7}]]
   )
 
 (defn- read-check-problem [reason]
@@ -124,7 +124,6 @@
                                                               corpus)))
                            :starting-at (nth lines (dec start))
                            :ending-at (nth lines (dec (dec end))))]
-               #_:clj-kondo/ignore
                (pprint/pprint result)
                result))
            (catch Exception e

--- a/mage/test/mage/kondo_ratchet_test.clj
+++ b/mage/test/mage/kondo_ratchet_test.clj
@@ -156,16 +156,19 @@
 (deftest marker-lifecycle-edge-test
   (let [stamp @#'kondo-ratchet/keep-comment
         plan  (fn [text sites] (#'kondo-ratchet/site-restore-plan (vec (str/split-lines text)) sites))]
-    (testing "a reserved marker whose owner never restores survives the orphan strip"
+    (testing "a reserved marker is removed when only the inline site restores"
       (let [inl  {:row 2, :linters [:y], :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:y]}"}}
             wl   {:row 2, :was-marked? true, :linters [:x], :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:x]}"}}
             text (str stamp "\n(do (f))\n")
-            {restored :text} (#'kondo-ratchet/reinsert-ignores
-                              text
-                              (#'kondo-ratchet/site-restore-plan
-                               (vec (str/split-lines text)) [inl] [wl inl]))]
+            {restored :text, inserted :inserted-rows}
+            (#'kondo-ratchet/reinsert-ignores
+             text
+             (#'kondo-ratchet/site-restore-plan
+              (vec (str/split-lines text)) [inl] [wl inl]))
+            pending [(#'kondo-ratchet/shift-site-past-inserts wl inserted)]]
         (is (= (str stamp "\n" stamp "\n(do #_{:clj-kondo/ignore [:y]} (f))\n") restored))
-        (is (= restored (#'kondo-ratchet/strip-orphan-keep-comments restored)))))
+        (is (= (str stamp "\n(do #_{:clj-kondo/ignore [:y]} (f))\n")
+               (#'kondo-ratchet/strip-orphan-keep-comments restored pending)))))
     (testing "a whole-line ignore with a trailing marker removes and restores through the inline path, marker never leaving"
       (let [text (str "#_{:clj-kondo/ignore [:x]} ;; " kondo-ratchet/keep-marker " why\n(f)\n")
             {:keys [text sites]} (#'kondo-ratchet/remove-ignores-at text [1])]

--- a/mage/test/mage/kondo_ratchet_test.clj
+++ b/mage/test/mage/kondo_ratchet_test.clj
@@ -56,6 +56,13 @@
             "(do (f) (g))\n"
             [{:row 1, :comment nil, :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:x]}"}}
              {:row 1, :comment nil, :original {:whole-line? false, :col 9, :text "#_{:clj-kondo/ignore [:y]}"}}]))))
+  (testing "a same-row restore with a comment splices first, so the comment can't displace the splice target"
+    (is (= {:text          ";; why\n(do #_{:clj-kondo/ignore [:x]} (f) #_{:clj-kondo/ignore [:y]} (g))\n"
+            :inserted-rows [1]}
+           (#'kondo-ratchet/reinsert-ignores
+            "(do (f) (g))\n"
+            [{:row 1, :comment ";; why", :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:x]}"}}
+             {:row 1, :comment nil, :original {:whole-line? false, :col 9, :text "#_{:clj-kondo/ignore [:y]}"}}]))))
   (testing "multiple sites in one file restore bottom-up"
     (is (= {:text          "#_{:clj-kondo/ignore [:x]}\n(a)\n#_{:clj-kondo/ignore [:y]}\n(b)\n"
             :inserted-rows [2 1]}
@@ -63,6 +70,14 @@
             "(a)\n(b)\n"
             [{:row 1, :comment nil, :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:x]}"}}
              {:row 2, :comment nil, :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:y]}"}}])))))
+
+(deftest surviving-slots-test
+  (testing "slots shrink by the attributed findings that must have been pre-existing, floored at zero"
+    (is (= 0 (#'kondo-ratchet/surviving-slots 1 2 2)))
+    (is (= 1 (#'kondo-ratchet/surviving-slots 1 2 1)))
+    (is (= 2 (#'kondo-ratchet/surviving-slots 2 3 1)))
+    (is (= 0 (#'kondo-ratchet/surviving-slots 2 3 3)))
+    (is (= 1 (#'kondo-ratchet/surviving-slots 2 3 2)))))
 
 (deftest strip-orphan-keep-comments-test
   (let [stamp-line @#'kondo-ratchet/keep-comment

--- a/mage/test/mage/kondo_ratchet_test.clj
+++ b/mage/test/mage/kondo_ratchet_test.clj
@@ -71,14 +71,6 @@
             [{:row 1, :comment nil, :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:x]}"}}
              {:row 2, :comment nil, :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:y]}"}}])))))
 
-(deftest surviving-slots-test
-  (testing "slots shrink by the attributed findings that must have been pre-existing, floored at zero"
-    (is (= 0 (#'kondo-ratchet/surviving-slots 1 2 2)))
-    (is (= 1 (#'kondo-ratchet/surviving-slots 1 2 1)))
-    (is (= 2 (#'kondo-ratchet/surviving-slots 2 3 1)))
-    (is (= 0 (#'kondo-ratchet/surviving-slots 2 3 3)))
-    (is (= 1 (#'kondo-ratchet/surviving-slots 2 3 2)))))
-
 (deftest strip-orphan-keep-comments-test
   (let [stamp-line @#'kondo-ratchet/keep-comment
         hand-line  (str ";; real explanation. " kondo-ratchet/keep-marker)]
@@ -106,23 +98,6 @@
     (testing "a marker separated from its ignore by another comment line survives"
       (let [text (str stamp-line "\n;; more context\n#_{:clj-kondo/ignore [:x]}\n(a)\n")]
         (is (= text (#'kondo-ratchet/strip-orphan-keep-comments text)))))))
-
-(deftest beyond-baseline-test
-  (let [f (fn [filename row type col] {:filename filename, :row row, :type type, :col col})]
-    (testing "findings with no baseline entry are all beyond it"
-      (is (= [(f "a.clj" 3 :x 1)]
-             (#'kondo-ratchet/beyond-baseline {} [(f "a.clj" 3 :x 1)]))))
-    (testing "a group matching its baseline count is fully absorbed"
-      (is (= []
-             (#'kondo-ratchet/beyond-baseline {["a.clj" 3 :x] 1} [(f "a.clj" 3 :x 1)]))))
-    (testing "a group over its baseline count returns ALL its findings tagged :collision? -- an exposed
-              finding can't be told apart from a pre-existing same-row one, so restore conservatively
-              but say so"
-      (is (= [(assoc (f "a.clj" 3 :x 1) :collision? true)
-              (assoc (f "a.clj" 3 :x 20) :collision? true)]
-             (sort-by :col
-                      (#'kondo-ratchet/beyond-baseline {["a.clj" 3 :x] 1}
-                                                       [(f "a.clj" 3 :x 20) (f "a.clj" 3 :x 1)])))))))
 
 (deftest shift-past-inserts-test
   (testing "each insertion at or above the row pushes it down one, measured against the original row"
@@ -171,24 +146,22 @@
   (testing "a standalone ignore line disappears entirely; :sites points at the uncovered form"
     (is (= {:text      "(defn f [x]\n  (= true x))\n"
             :sites     [{:row 2, :linters [:equals-true]}]
-            :deletions [[2 1]]
             :skipped   []}
            (remove-ignores-at'
             "(defn f [x]\n  #_{:clj-kondo/ignore [:equals-true]}\n  (= true x))\n"
             [2]))))
   (testing "an inline ignore is cut out of its line, swallowing a doubled space"
-    (is (= {:text "(do (foo))\n", :sites [{:row 1, :linters [:x]}], :deletions [[1 0]], :skipped []}
+    (is (= {:text "(do (foo))\n", :sites [{:row 1, :linters [:x]}], :skipped []}
            (remove-ignores-at' "(do #_{:clj-kondo/ignore [:x]} (foo))\n" [1]))))
   (testing "a multi-line ignore vector goes too"
-    (is (= {:text "(a)\n(b)\n", :sites [{:row 2, :linters [:x :y]}], :deletions [[2 2]], :skipped []}
+    (is (= {:text "(a)\n(b)\n", :sites [{:row 2, :linters [:x :y]}], :skipped []}
            (remove-ignores-at' "(a)\n#_{:clj-kondo/ignore [:x\n                      :y]}\n(b)\n" [2]))))
   (testing "an ignore map with extra keys is removed whole, not truncated at the vector"
-    (is (= {:text "(a)\n", :sites [{:row 1, :linters [:x]}], :deletions [[1 1]], :skipped []}
+    (is (= {:text "(a)\n", :sites [{:row 1, :linters [:x]}], :skipped []}
            (remove-ignores-at' "#_{:clj-kondo/ignore [:x] :reason \"legacy\"}\n(a)\n" [1]))))
   (testing "an extra-key map with NESTED braces would be truncated by the regex, so it is skipped whole"
     (is (= {:text      "#_{:clj-kondo/ignore [:x] :reason {:ticket \"ABC-1\"}}\n(a)\n"
             :sites     []
-            :deletions []
             :skipped   [1]}
            (remove-ignores-at'
             "#_{:clj-kondo/ignore [:x] :reason {:ticket \"ABC-1\"}}\n(a)\n"
@@ -196,7 +169,6 @@
   (testing "a skipped row is reported in post-removal coordinates when removals above it delete lines"
     (is (= {:text      "(a)\n#_{:clj-kondo/ignore [:y] :reason {:nested 1}}\n(b)\n"
             :sites     [{:row 1, :linters [:x]}]
-            :deletions [[1 1]]
             :skipped   [2]}
            (remove-ignores-at'
             "#_{:clj-kondo/ignore [:x]}\n(a)\n#_{:clj-kondo/ignore [:y] :reason {:nested 1}}\n(b)\n"
@@ -206,7 +178,6 @@
                             "#_{:clj-kondo/ignore [:x :clojure-lsp/unused-public-var]}\n"
                             "(bar)\n")
             :sites     [{:row 1, :linters [:x]}]
-            :deletions [[1 0]]
             :skipped   []}
            (remove-ignores-at'
             (str "(do #_{:clj-kondo/ignore [:x]} #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]} (foo))\n"
@@ -216,7 +187,6 @@
   (testing "an inline removal of a wrapped ignore still counts its deleted newlines, shifting later rows"
     (is (= {:text      "(do (foo))\n(a)\n(b)\n"
             :sites     [{:row 3, :linters [:z]} {:row 1, :linters [:x :y]}]
-            :deletions [[4 1] [1 1]]
             :skipped   []}
            (remove-ignores-at'
             "(do #_{:clj-kondo/ignore [:x\n                          :y]} (foo))\n(a)\n#_{:clj-kondo/ignore [:z]}\n(b)\n"
@@ -224,7 +194,6 @@
   (testing "rows without an ignore are left alone; multiple removals shift later :sites rows up"
     (is (= {:text      "(a)\n(b)\n"
             :sites     [{:row 2, :linters [:y]} {:row 1, :linters [:x]}]
-            :deletions [[3 1] [1 1]]
             :skipped   []}
            (remove-ignores-at'
             "#_{:clj-kondo/ignore [:x]}\n(a)\n#_{:clj-kondo/ignore [:y]}\n(b)\n"

--- a/mage/test/mage/kondo_ratchet_test.clj
+++ b/mage/test/mage/kondo_ratchet_test.clj
@@ -63,6 +63,18 @@
             "(do (f) (g))\n"
             [{:row 1, :comment ";; why", :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:x]}"}}
              {:row 1, :comment nil, :original {:whole-line? false, :col 9, :text "#_{:clj-kondo/ignore [:y]}"}}]))))
+  (testing "a whole-line and an inline restore sharing a row each keep their marker adjacent"
+    (is (= {:text          (str ";; kept A\n"
+                                "#_{:clj-kondo/ignore [:x]}\n"
+                                ";; kept B\n"
+                                "(do #_{:clj-kondo/ignore [:y]} (f))\n")
+            :inserted-rows [1 1 1]}
+           (#'kondo-ratchet/reinsert-ignores
+            "(do (f))\n"
+            [{:row 1, :comment ";; kept A"
+              :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:x]}"}}
+             {:row 1, :comment ";; kept B"
+              :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:y]}"}}]))))
   (testing "multiple sites in one file restore bottom-up"
     (is (= {:text          "#_{:clj-kondo/ignore [:x]}\n(a)\n#_{:clj-kondo/ignore [:y]}\n(b)\n"
             :inserted-rows [2 1]}

--- a/mage/test/mage/kondo_ratchet_test.clj
+++ b/mage/test/mage/kondo_ratchet_test.clj
@@ -153,6 +153,34 @@
                 :inserted-rows [1 1]}
                (#'kondo-ratchet/reinsert-ignores round1 (plan round1 [(wl 2)]))))))))
 
+(deftest marker-lifecycle-edge-test
+  (let [stamp @#'kondo-ratchet/keep-comment
+        plan  (fn [text sites] (#'kondo-ratchet/site-restore-plan (vec (str/split-lines text)) sites))]
+    (testing "a reserved marker whose owner never restores survives the orphan strip"
+      (let [inl  {:row 2, :linters [:y], :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:y]}"}}
+            wl   {:row 2, :was-marked? true, :linters [:x], :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:x]}"}}
+            text (str stamp "\n(do (f))\n")
+            {restored :text} (#'kondo-ratchet/reinsert-ignores
+                              text
+                              (#'kondo-ratchet/site-restore-plan
+                               (vec (str/split-lines text)) [inl] [wl inl]))]
+        (is (= (str stamp "\n" stamp "\n(do #_{:clj-kondo/ignore [:y]} (f))\n") restored))
+        (is (= restored (#'kondo-ratchet/strip-orphan-keep-comments restored)))))
+    (testing "a whole-line ignore with a trailing marker removes and restores through the inline path, marker never leaving"
+      (let [text (str "#_{:clj-kondo/ignore [:x]} ;; " kondo-ratchet/keep-marker " why\n(f)\n")
+            {:keys [text sites]} (#'kondo-ratchet/remove-ignores-at text [1])]
+        (is (= (str " ;; " kondo-ratchet/keep-marker " why\n(f)\n") text))
+        (is (= [{:whole-line? false, :col 1, :text "#_{:clj-kondo/ignore [:x]}"}] (map :original sites)))
+        (let [planned (plan text (map #(assoc % :was-marked? true) sites))]
+          (is (= [nil] (map :comment planned)))
+          (is (= (str "#_{:clj-kondo/ignore [:x]} ;; " kondo-ratchet/keep-marker " why\n(f)\n")
+                 (:text (#'kondo-ratchet/reinsert-ignores text planned)))))))
+    (testing "an unmarked whole-line block climbs above a marker owned by the row's inline ignore"
+      (let [text (str stamp "\n(do #_{:clj-kondo/ignore [:y]} (f))\n")
+            wl   {:row 2, :linters [:x], :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:x]}"}}]
+        (is (= (str stamp "\n#_{:clj-kondo/ignore [:x]}\n" text)
+               (:text (#'kondo-ratchet/reinsert-ignores text (plan text [wl])))))))))
+
 (deftest strip-orphan-keep-comments-test
   (let [stamp-line @#'kondo-ratchet/keep-comment
         hand-line  (str ";; real explanation. " kondo-ratchet/keep-marker)]

--- a/mage/test/mage/kondo_ratchet_test.clj
+++ b/mage/test/mage/kondo_ratchet_test.clj
@@ -108,10 +108,15 @@
       (is (= [[1 stamp]]
              (map (juxt :row :comment)
                   (plan (str stamp "\n(do #_{:clj-kondo/ignore [:y]} (f))\n") [(wl 2)])))))
-    (testing "a marker above a plain code line marked the removed site itself; re-restore under it, no new marker"
+    (testing "a site that was itself marked before removal re-restores under its marker, no new marker"
       (is (= [[2 nil]]
              (map (juxt :row :comment)
-                  (plan (str stamp "\n(f)\n") [(wl 2)])))))
+                  (plan (str stamp "\n(f)\n") [(assoc (wl 2) :was-marked? true)])))))
+    (testing "a marked whole-line site over an unrelated inline ignore doesn't donate its marker to it"
+      (is (= [[2 nil]]
+             (map (juxt :row :comment)
+                  (plan (str stamp "\n(do #_{:clj-kondo/ignore [:y]} (f))\n")
+                        [(assoc (wl 2) :was-marked? true)])))))
     (testing "cross-round end to end: the round-two whole-line block lands above the round-one marker"
       (let [round1 (str stamp "\n(do #_{:clj-kondo/ignore [:y]} (f))\n")]
         (is (= {:text          (str stamp "\n#_{:clj-kondo/ignore [:x]}\n" round1)
@@ -171,7 +176,7 @@
   covers the originals."
   [text rows]
   (update (#'kondo-ratchet/remove-ignores-at text rows)
-          :sites (partial mapv #(dissoc % :original))))
+          :sites (partial mapv #(dissoc % :original :removed-line))))
 
 (deftest remove-ignores-at-originals-test
   (testing "each site captures its removed form verbatim, so a restore puts back exactly what was cut"

--- a/mage/test/mage/kondo_ratchet_test.clj
+++ b/mage/test/mage/kondo_ratchet_test.clj
@@ -18,18 +18,7 @@
            (#'kondo-ratchet/insert-ignore-lines "(a)\n(b)\n" {1 [:x], 2 [:y :x :y]}))))
   (testing "a file without a trailing newline doesn't gain one"
     (is (= "#_{:clj-kondo/ignore [:x]}\n(a)"
-           (#'kondo-ratchet/insert-ignore-lines "(a)" {1 [:x]}))))
-  (testing "a row in row->comment gets its comment above the ignore, at the same indentation"
-    (is (= (str "(defn f [x]\n"
-                "  ;; why\n"
-                "  #_{:clj-kondo/ignore [:equals-true]}\n"
-                "  (= true x))\n")
-           (#'kondo-ratchet/insert-ignore-lines "(defn f [x]\n  (= true x))\n"
-                                                {2 [:equals-true]}
-                                                {2 ";; why"}))))
-  (testing "rows absent from row->comment get no comment"
-    (is (= "#_{:clj-kondo/ignore [:x]}\n(a)\n;; why\n#_{:clj-kondo/ignore [:y]}\n(b)\n"
-           (#'kondo-ratchet/insert-ignore-lines "(a)\n(b)\n" {1 [:x], 2 [:y]} {2 ";; why"})))))
+           (#'kondo-ratchet/insert-ignore-lines "(a)" {1 [:x]})))))
 
 (deftest insert-inline-ignores-test
   (testing "splices directly before the flagged token, wherever it sits on the line"
@@ -48,27 +37,31 @@
            (#'kondo-ratchet/insert-inline-ignores "(a)" {[1 1] [:x]} {})))))
 
 (deftest strip-orphan-keep-comments-test
-  (let [keep-line (str ";; " kondo-ratchet/keep-marker " suppresses a warning")]
-    (testing "a whole-line marker comment with no ignore below it is dropped"
+  (let [stamp-line @#'kondo-ratchet/keep-comment
+        hand-line  (str ";; real explanation. " kondo-ratchet/keep-marker)]
+    (testing "a stamped whole-line marker comment with no ignore below it is dropped"
       (is (= "(a)\n(b)\n"
-             (#'kondo-ratchet/strip-orphan-keep-comments (str "(a)\n" keep-line "\n(b)\n")))))
+             (#'kondo-ratchet/strip-orphan-keep-comments (str "(a)\n" stamp-line "\n(b)\n")))))
+    (testing "an orphaned hand-written comment keeps its prose and loses only the token"
+      (is (= "(a)\n;; real explanation.\n(b)\n"
+             (#'kondo-ratchet/strip-orphan-keep-comments (str "(a)\n" hand-line "\n(b)\n")))))
     (testing "a marker comment still above an ignore survives"
-      (let [text (str keep-line "\n#_{:clj-kondo/ignore [:x]}\n(a)\n")]
+      (let [text (str stamp-line "\n#_{:clj-kondo/ignore [:x]}\n(a)\n")]
         (is (= text (#'kondo-ratchet/strip-orphan-keep-comments text)))))
     (testing "comments without the marker survive, orphaned or not"
       (let [text ";; plain comment\n(a)\n"]
         (is (= text (#'kondo-ratchet/strip-orphan-keep-comments text)))))
     (testing "a trailing marker on a code line is left for a hand fix"
-      (let [text (str "(foo) " keep-line "\n")]
+      (let [text (str "(foo) " stamp-line "\n")]
         (is (= text (#'kondo-ratchet/strip-orphan-keep-comments text)))))
-    (testing "a marker orphaned at the last line of the file is dropped"
+    (testing "a stamped marker orphaned at the last line of the file is dropped"
       (is (= "(a)\n"
-             (#'kondo-ratchet/strip-orphan-keep-comments (str "(a)\n" keep-line "\n")))))
+             (#'kondo-ratchet/strip-orphan-keep-comments (str "(a)\n" stamp-line "\n")))))
     (testing "a marker above an ignore whose linter vector wraps to the next line survives"
-      (let [text (str keep-line "\n#_{:clj-kondo/ignore [:x\n                      :y]}\n(a)\n")]
+      (let [text (str stamp-line "\n#_{:clj-kondo/ignore [:x\n                      :y]}\n(a)\n")]
         (is (= text (#'kondo-ratchet/strip-orphan-keep-comments text)))))
     (testing "a marker separated from its ignore by another comment line survives"
-      (let [text (str keep-line "\n;; more context\n#_{:clj-kondo/ignore [:x]}\n(a)\n")]
+      (let [text (str stamp-line "\n;; more context\n#_{:clj-kondo/ignore [:x]}\n(a)\n")]
         (is (= text (#'kondo-ratchet/strip-orphan-keep-comments text)))))))
 
 (deftest beyond-baseline-test
@@ -79,9 +72,11 @@
     (testing "a group matching its baseline count is fully absorbed"
       (is (= []
              (#'kondo-ratchet/beyond-baseline {["a.clj" 3 :x] 1} [(f "a.clj" 3 :x 1)]))))
-    (testing "a group over its baseline count returns ALL its findings -- an exposed finding can't be
-              told apart from a pre-existing same-row one, so restore conservatively"
-      (is (= [(f "a.clj" 3 :x 1) (f "a.clj" 3 :x 20)]
+    (testing "a group over its baseline count returns ALL its findings tagged :collision? -- an exposed
+              finding can't be told apart from a pre-existing same-row one, so restore conservatively
+              but say so"
+      (is (= [(assoc (f "a.clj" 3 :x 1) :collision? true)
+              (assoc (f "a.clj" 3 :x 20) :collision? true)]
              (sort-by :col
                       (#'kondo-ratchet/beyond-baseline {["a.clj" 3 :x] 1}
                                                        [(f "a.clj" 3 :x 20) (f "a.clj" 3 :x 1)])))))))
@@ -94,11 +89,17 @@
     (is (= 5 (#'kondo-ratchet/shift-past-inserts 5 [6 7])))))
 
 (deftest marker-on-line-test
-  (testing "the marker counts only after a semicolon, so a string literal containing it doesn't mark"
+  (testing "the marker counts only inside the line's comment, not in string literals"
     (is (true? (#'kondo-ratchet/marker-on-line? (str ";; " kondo-ratchet/keep-marker " because"))))
     (is (true? (#'kondo-ratchet/marker-on-line? (str "(foo) ;; " kondo-ratchet/keep-marker))))
     (is (false? (#'kondo-ratchet/marker-on-line? (str "(def marker \"" kondo-ratchet/keep-marker "\")"))))
-    (is (false? (#'kondo-ratchet/marker-on-line? nil)))))
+    (is (false? (#'kondo-ratchet/marker-on-line? nil))))
+  (testing "a semicolon inside a string doesn't open a comment"
+    (is (false? (#'kondo-ratchet/marker-on-line? (str "(def s \"a;b " kondo-ratchet/keep-marker "\")"))))
+    (is (true? (#'kondo-ratchet/marker-on-line? (str "(def s \"a;b\") ;; " kondo-ratchet/keep-marker)))))
+  (testing "char-literal semicolons and string escapes don't open or close early"
+    (is (false? (#'kondo-ratchet/marker-on-line? (str "(= c \\;) (def s \"" kondo-ratchet/keep-marker "\")"))))
+    (is (false? (#'kondo-ratchet/marker-on-line? (str "(def s \"a\\\";b " kondo-ratchet/keep-marker "\")"))))))
 
 (deftest remove-ignores-at-test
   (testing "a standalone ignore line disappears entirely; :sites points at the uncovered form"

--- a/mage/test/mage/kondo_ratchet_test.clj
+++ b/mage/test/mage/kondo_ratchet_test.clj
@@ -18,48 +18,125 @@
            (#'kondo-ratchet/insert-ignore-lines "(a)\n(b)\n" {1 [:x], 2 [:y :x :y]}))))
   (testing "a file without a trailing newline doesn't gain one"
     (is (= "#_{:clj-kondo/ignore [:x]}\n(a)"
-           (#'kondo-ratchet/insert-ignore-lines "(a)" {1 [:x]})))))
+           (#'kondo-ratchet/insert-ignore-lines "(a)" {1 [:x]}))))
+  (testing "a row in row->comment gets its comment above the ignore, at the same indentation"
+    (is (= (str "(defn f [x]\n"
+                "  ;; why\n"
+                "  #_{:clj-kondo/ignore [:equals-true]}\n"
+                "  (= true x))\n")
+           (#'kondo-ratchet/insert-ignore-lines "(defn f [x]\n  (= true x))\n"
+                                                {2 [:equals-true]}
+                                                {2 ";; why"}))))
+  (testing "rows absent from row->comment get no comment"
+    (is (= "#_{:clj-kondo/ignore [:x]}\n(a)\n;; why\n#_{:clj-kondo/ignore [:y]}\n(b)\n"
+           (#'kondo-ratchet/insert-ignore-lines "(a)\n(b)\n" {1 [:x], 2 [:y]} {2 ";; why"})))))
+
+(deftest insert-inline-ignores-test
+  (testing "splices directly before the flagged token, wherever it sits on the line"
+    (is (= "{:engine #_{:clj-kondo/ignore [:x]} :postgres}\n"
+           (#'kondo-ratchet/insert-inline-ignores "{:engine :postgres}\n" {[1 10] [:x]} {}))))
+  (testing "multiple tokens on one line each get their own splice, right-to-left"
+    (is (= "(disj drivers #_{:clj-kondo/ignore [:x]} :presto #_{:clj-kondo/ignore [:x]} :databricks)\n"
+           (#'kondo-ratchet/insert-inline-ignores "(disj drivers :presto :databricks)\n"
+                                                  {[1 15] [:x], [1 23] [:x]}
+                                                  {}))))
+  (testing "a comment goes above the row at its indentation; same-site linters merge sorted"
+    (is (= "(f\n  ;; why\n  #_{:clj-kondo/ignore [:x :y]} :mysql)\n"
+           (#'kondo-ratchet/insert-inline-ignores "(f\n  :mysql)\n" {[2 3] [:y :x :y]} {2 ";; why"}))))
+  (testing "a file without a trailing newline doesn't gain one"
+    (is (= "#_{:clj-kondo/ignore [:x]} (a)"
+           (#'kondo-ratchet/insert-inline-ignores "(a)" {[1 1] [:x]} {})))))
+
+(deftest strip-orphan-keep-comments-test
+  (let [keep-line (str ";; " kondo-ratchet/keep-marker " suppresses a warning")]
+    (testing "a whole-line marker comment with no ignore below it is dropped"
+      (is (= "(a)\n(b)\n"
+             (#'kondo-ratchet/strip-orphan-keep-comments (str "(a)\n" keep-line "\n(b)\n")))))
+    (testing "a marker comment still above an ignore survives"
+      (let [text (str keep-line "\n#_{:clj-kondo/ignore [:x]}\n(a)\n")]
+        (is (= text (#'kondo-ratchet/strip-orphan-keep-comments text)))))
+    (testing "comments without the marker survive, orphaned or not"
+      (let [text ";; plain comment\n(a)\n"]
+        (is (= text (#'kondo-ratchet/strip-orphan-keep-comments text)))))
+    (testing "a trailing marker on a code line is left for a hand fix"
+      (let [text (str "(foo) " keep-line "\n")]
+        (is (= text (#'kondo-ratchet/strip-orphan-keep-comments text)))))
+    (testing "a marker orphaned at the last line of the file is dropped"
+      (is (= "(a)\n"
+             (#'kondo-ratchet/strip-orphan-keep-comments (str "(a)\n" keep-line "\n")))))
+    (testing "a marker above an ignore whose linter vector wraps to the next line survives"
+      (let [text (str keep-line "\n#_{:clj-kondo/ignore [:x\n                      :y]}\n(a)\n")]
+        (is (= text (#'kondo-ratchet/strip-orphan-keep-comments text)))))
+    (testing "a marker separated from its ignore by another comment line survives"
+      (let [text (str keep-line "\n;; more context\n#_{:clj-kondo/ignore [:x]}\n(a)\n")]
+        (is (= text (#'kondo-ratchet/strip-orphan-keep-comments text)))))))
+
+(deftest marker-on-line-test
+  (testing "the marker counts only after a semicolon, so a string literal containing it doesn't mark"
+    (is (true? (#'kondo-ratchet/marker-on-line? (str ";; " kondo-ratchet/keep-marker " because"))))
+    (is (true? (#'kondo-ratchet/marker-on-line? (str "(foo) ;; " kondo-ratchet/keep-marker))))
+    (is (false? (#'kondo-ratchet/marker-on-line? (str "(def marker \"" kondo-ratchet/keep-marker "\")"))))
+    (is (false? (#'kondo-ratchet/marker-on-line? nil)))))
 
 (deftest remove-ignores-at-test
   (testing "a standalone ignore line disappears entirely; :sites points at the uncovered form"
-    (is (= {:text "(defn f [x]\n  (= true x))\n", :sites [{:row 2, :linters [:equals-true]}], :skipped []}
+    (is (= {:text      "(defn f [x]\n  (= true x))\n"
+            :sites     [{:row 2, :linters [:equals-true]}]
+            :deletions [[2 1]]
+            :skipped   []}
            (#'kondo-ratchet/remove-ignores-at
             "(defn f [x]\n  #_{:clj-kondo/ignore [:equals-true]}\n  (= true x))\n"
             [2]))))
   (testing "an inline ignore is cut out of its line, swallowing a doubled space"
-    (is (= {:text "(do (foo))\n", :sites [{:row 1, :linters [:x]}], :skipped []}
+    (is (= {:text "(do (foo))\n", :sites [{:row 1, :linters [:x]}], :deletions [[1 0]], :skipped []}
            (#'kondo-ratchet/remove-ignores-at "(do #_{:clj-kondo/ignore [:x]} (foo))\n" [1]))))
   (testing "a multi-line ignore vector goes too"
-    (is (= {:text "(a)\n(b)\n", :sites [{:row 2, :linters [:x :y]}], :skipped []}
+    (is (= {:text "(a)\n(b)\n", :sites [{:row 2, :linters [:x :y]}], :deletions [[2 2]], :skipped []}
            (#'kondo-ratchet/remove-ignores-at "(a)\n#_{:clj-kondo/ignore [:x\n                      :y]}\n(b)\n" [2]))))
   (testing "an ignore map with extra keys is removed whole, not truncated at the vector"
-    (is (= {:text "(a)\n", :sites [{:row 1, :linters [:x]}], :skipped []}
+    (is (= {:text "(a)\n", :sites [{:row 1, :linters [:x]}], :deletions [[1 1]], :skipped []}
            (#'kondo-ratchet/remove-ignores-at "#_{:clj-kondo/ignore [:x] :reason \"legacy\"}\n(a)\n" [1]))))
   (testing "an extra-key map with NESTED braces would be truncated by the regex, so it is skipped whole"
-    (is (= {:text "#_{:clj-kondo/ignore [:x] :reason {:ticket \"ABC-1\"}}\n(a)\n", :sites [], :skipped [1]}
+    (is (= {:text      "#_{:clj-kondo/ignore [:x] :reason {:ticket \"ABC-1\"}}\n(a)\n"
+            :sites     []
+            :deletions []
+            :skipped   [1]}
            (#'kondo-ratchet/remove-ignores-at
             "#_{:clj-kondo/ignore [:x] :reason {:ticket \"ABC-1\"}}\n(a)\n"
             [1]))))
   (testing "a skipped row is reported in post-removal coordinates when removals above it delete lines"
-    (is (= {:text    "(a)\n#_{:clj-kondo/ignore [:y] :reason {:nested 1}}\n(b)\n"
-            :sites   [{:row 1, :linters [:x]}]
-            :skipped [2]}
+    (is (= {:text      "(a)\n#_{:clj-kondo/ignore [:y] :reason {:nested 1}}\n(b)\n"
+            :sites     [{:row 1, :linters [:x]}]
+            :deletions [[1 1]]
+            :skipped   [2]}
            (#'kondo-ratchet/remove-ignores-at
             "#_{:clj-kondo/ignore [:x]}\n(a)\n#_{:clj-kondo/ignore [:y] :reason {:nested 1}}\n(b)\n"
             [1 3]))))
   (testing "any form naming a clojure-lsp/* linter survives — a re-lint could never restore that half"
-    (is (= {:text  (str "(do #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]} (foo))\n"
-                        "#_{:clj-kondo/ignore [:x :clojure-lsp/unused-public-var]}\n"
-                        "(bar)\n")
-            :sites [{:row 1, :linters [:x]}]
-            :skipped []}
+    (is (= {:text      (str "(do #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]} (foo))\n"
+                            "#_{:clj-kondo/ignore [:x :clojure-lsp/unused-public-var]}\n"
+                            "(bar)\n")
+            :sites     [{:row 1, :linters [:x]}]
+            :deletions [[1 0]]
+            :skipped   []}
            (#'kondo-ratchet/remove-ignores-at
             (str "(do #_{:clj-kondo/ignore [:x]} #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]} (foo))\n"
                  "#_{:clj-kondo/ignore [:x :clojure-lsp/unused-public-var]}\n"
                  "(bar)\n")
             [1 2]))))
+  (testing "an inline removal of a wrapped ignore still counts its deleted newlines, shifting later rows"
+    (is (= {:text      "(do (foo))\n(a)\n(b)\n"
+            :sites     [{:row 3, :linters [:z]} {:row 1, :linters [:x :y]}]
+            :deletions [[4 1] [1 1]]
+            :skipped   []}
+           (#'kondo-ratchet/remove-ignores-at
+            "(do #_{:clj-kondo/ignore [:x\n                          :y]} (foo))\n(a)\n#_{:clj-kondo/ignore [:z]}\n(b)\n"
+            [1 4]))))
   (testing "rows without an ignore are left alone; multiple removals shift later :sites rows up"
-    (is (= {:text "(a)\n(b)\n", :sites [{:row 2, :linters [:y]} {:row 1, :linters [:x]}], :skipped []}
+    (is (= {:text      "(a)\n(b)\n"
+            :sites     [{:row 2, :linters [:y]} {:row 1, :linters [:x]}]
+            :deletions [[3 1] [1 1]]
+            :skipped   []}
            (#'kondo-ratchet/remove-ignores-at
             "#_{:clj-kondo/ignore [:x]}\n(a)\n#_{:clj-kondo/ignore [:y]}\n(b)\n"
             [1 2 3])))))

--- a/mage/test/mage/kondo_ratchet_test.clj
+++ b/mage/test/mage/kondo_ratchet_test.clj
@@ -100,6 +100,7 @@
 (deftest site-restore-plan-test
   (let [stamp @#'kondo-ratchet/keep-comment
         wl    (fn [row] {:row row, :linters [:x], :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:x]}"}})
+        inl   (fn [row] {:row row, :linters [:y], :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:y]}"}})
         plan  (fn [text sites] (#'kondo-ratchet/site-restore-plan (vec (str/split-lines text)) sites))]
     (testing "a whole-line restore onto an unmarked row gets its own marker"
       (is (= [[1 stamp]]
@@ -117,6 +118,35 @@
              (map (juxt :row :comment)
                   (plan (str stamp "\n(do #_{:clj-kondo/ignore [:y]} (f))\n")
                         [(assoc (wl 2) :was-marked? true)])))))
+    (testing "same-round marked whole-line and inline restores each get their own marker"
+      (let [sites [(assoc (wl 2) :was-marked? true) (inl 2)]
+            text  (str stamp "\n(do (f))\n")]
+        (is (= {:text          (str stamp "\n"
+                                    "#_{:clj-kondo/ignore [:x]}\n"
+                                    stamp "\n"
+                                    "(do #_{:clj-kondo/ignore [:y]} (f))\n")
+                :inserted-rows [2 2]}
+               (#'kondo-ratchet/reinsert-ignores text (plan text sites))))))
+    (testing "an inline restore preserves a pending whole-line site's marker for the next round"
+      (let [owner    (assoc (wl 2) :was-marked? true)
+            inline   (inl 2)
+            pending  [owner inline]
+            text     (str stamp "\n(do (f))\n")
+            round1   (#'kondo-ratchet/reinsert-ignores
+                      text
+                      (#'kondo-ratchet/site-restore-plan
+                       (vec (str/split-lines text)) [inline] pending))
+            owner'   (#'kondo-ratchet/shift-site-past-inserts owner (:inserted-rows round1))
+            round2   (#'kondo-ratchet/reinsert-ignores
+                      (:text round1)
+                      (#'kondo-ratchet/site-restore-plan
+                       (vec (str/split-lines (:text round1))) [owner'] [owner']))]
+        (is (= 2 (:row owner')))
+        (is (= (str stamp "\n"
+                    "#_{:clj-kondo/ignore [:x]}\n"
+                    stamp "\n"
+                    "(do #_{:clj-kondo/ignore [:y]} (f))\n")
+               (:text round2)))))
     (testing "cross-round end to end: the round-two whole-line block lands above the round-one marker"
       (let [round1 (str stamp "\n(do #_{:clj-kondo/ignore [:y]} (f))\n")]
         (is (= {:text          (str stamp "\n#_{:clj-kondo/ignore [:x]}\n" round1)
@@ -157,6 +187,14 @@
     (is (= 6 (#'kondo-ratchet/shift-past-inserts 5 [5 6])))
     (is (= 9 (#'kondo-ratchet/shift-past-inserts 7 [5 6])))
     (is (= 5 (#'kondo-ratchet/shift-past-inserts 5 [6 7])))))
+
+(deftest shift-site-past-inserts-test
+  (testing "a marked whole-line owner stays beneath its marker when a same-row stamp is inserted"
+    (let [site {:row 5, :was-marked? true, :original {:whole-line? true}}]
+      (is (= 6 (:row (#'kondo-ratchet/shift-site-past-inserts site [4 5]))))))
+  (testing "ordinary pending sites shift past same-row inserts"
+    (let [site {:row 5, :original {:whole-line? false}}]
+      (is (= 7 (:row (#'kondo-ratchet/shift-site-past-inserts site [4 5])))))))
 
 (deftest marker-on-line-test
   (testing "the marker counts only inside the line's comment, not in string literals"

--- a/mage/test/mage/kondo_ratchet_test.clj
+++ b/mage/test/mage/kondo_ratchet_test.clj
@@ -49,6 +49,13 @@
             "(f\n  :mysql)\n"
             [{:row 2, :comment ";; why"
               :original {:whole-line? false, :col 3, :text "#_{:clj-kondo/ignore [:x]}"}}]))))
+  (testing "two inline removals on one row restore right-to-left, so the left splice can't shift the right column"
+    (is (= {:text          "(do #_{:clj-kondo/ignore [:x]} (f) #_{:clj-kondo/ignore [:y]} (g))\n"
+            :inserted-rows []}
+           (#'kondo-ratchet/reinsert-ignores
+            "(do (f) (g))\n"
+            [{:row 1, :comment nil, :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:x]}"}}
+             {:row 1, :comment nil, :original {:whole-line? false, :col 9, :text "#_{:clj-kondo/ignore [:y]}"}}]))))
   (testing "multiple sites in one file restore bottom-up"
     (is (= {:text          "#_{:clj-kondo/ignore [:x]}\n(a)\n#_{:clj-kondo/ignore [:y]}\n(b)\n"
             :inserted-rows [2 1]}

--- a/mage/test/mage/kondo_ratchet_test.clj
+++ b/mage/test/mage/kondo_ratchet_test.clj
@@ -20,21 +20,42 @@
     (is (= "#_{:clj-kondo/ignore [:x]}\n(a)"
            (#'kondo-ratchet/insert-ignore-lines "(a)" {1 [:x]})))))
 
-(deftest insert-inline-ignores-test
-  (testing "splices directly before the flagged token, wherever it sits on the line"
-    (is (= "{:engine #_{:clj-kondo/ignore [:x]} :postgres}\n"
-           (#'kondo-ratchet/insert-inline-ignores "{:engine :postgres}\n" {[1 10] [:x]} {}))))
-  (testing "multiple tokens on one line each get their own splice, right-to-left"
-    (is (= "(disj drivers #_{:clj-kondo/ignore [:x]} :presto #_{:clj-kondo/ignore [:x]} :databricks)\n"
-           (#'kondo-ratchet/insert-inline-ignores "(disj drivers :presto :databricks)\n"
-                                                  {[1 15] [:x], [1 23] [:x]}
-                                                  {}))))
-  (testing "a comment goes above the row at its indentation; same-site linters merge sorted"
-    (is (= "(f\n  ;; why\n  #_{:clj-kondo/ignore [:x :y]} :mysql)\n"
-           (#'kondo-ratchet/insert-inline-ignores "(f\n  :mysql)\n" {[2 3] [:y :x :y]} {2 ";; why"}))))
-  (testing "a file without a trailing newline doesn't gain one"
-    (is (= "#_{:clj-kondo/ignore [:x]} (a)"
-           (#'kondo-ratchet/insert-inline-ignores "(a)" {[1 1] [:x]} {})))))
+(deftest reinsert-ignores-test
+  (testing "a whole-line removal returns as its original line(s), comment above at its indentation"
+    (is (= {:text          "(defn f [x]\n  ;; why\n  #_{:clj-kondo/ignore [:equals-true]}\n  (= true x))\n"
+            :inserted-rows [2 2]}
+           (#'kondo-ratchet/reinsert-ignores
+            "(defn f [x]\n  (= true x))\n"
+            [{:row 2, :comment ";; why"
+              :original {:whole-line? true, :text "  #_{:clj-kondo/ignore [:equals-true]}"}}]))))
+  (testing "a multi-line whole-line removal returns verbatim, one coarse form -- never several narrow ones"
+    (is (= {:text          ";; why\n#_{:clj-kondo/ignore [:x\n                      :y]}\n(a)\n"
+            :inserted-rows [1 1 1]}
+           (#'kondo-ratchet/reinsert-ignores
+            "(a)\n"
+            [{:row 1, :comment ";; why"
+              :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:x\n                      :y]}"}}]))))
+  (testing "an inline removal splices back at its original column"
+    (is (= {:text          "(do #_{:clj-kondo/ignore [:x]} (foo))\n"
+            :inserted-rows []}
+           (#'kondo-ratchet/reinsert-ignores
+            "(do (foo))\n"
+            [{:row 1, :comment nil
+              :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:x]}"}}]))))
+  (testing "an inline restore's comment sits above at the target line's indentation"
+    (is (= {:text          "(f\n  ;; why\n  #_{:clj-kondo/ignore [:x]} :mysql)\n"
+            :inserted-rows [2]}
+           (#'kondo-ratchet/reinsert-ignores
+            "(f\n  :mysql)\n"
+            [{:row 2, :comment ";; why"
+              :original {:whole-line? false, :col 3, :text "#_{:clj-kondo/ignore [:x]}"}}]))))
+  (testing "multiple sites in one file restore bottom-up"
+    (is (= {:text          "#_{:clj-kondo/ignore [:x]}\n(a)\n#_{:clj-kondo/ignore [:y]}\n(b)\n"
+            :inserted-rows [2 1]}
+           (#'kondo-ratchet/reinsert-ignores
+            "(a)\n(b)\n"
+            [{:row 1, :comment nil, :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:x]}"}}
+             {:row 2, :comment nil, :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:y]}"}}])))))
 
 (deftest strip-orphan-keep-comments-test
   (let [stamp-line @#'kondo-ratchet/keep-comment
@@ -101,30 +122,53 @@
     (is (false? (#'kondo-ratchet/marker-on-line? (str "(= c \\;) (def s \"" kondo-ratchet/keep-marker "\")"))))
     (is (false? (#'kondo-ratchet/marker-on-line? (str "(def s \"a\\\";b " kondo-ratchet/keep-marker "\")"))))))
 
+(defn- remove-ignores-at'
+  "[[remove-ignores-at]] with `:original` stripped from `:sites`; [[remove-ignores-at-originals-test]]
+  covers the originals."
+  [text rows]
+  (update (#'kondo-ratchet/remove-ignores-at text rows)
+          :sites (partial mapv #(dissoc % :original))))
+
+(deftest remove-ignores-at-originals-test
+  (testing "each site captures its removed form verbatim, so a restore puts back exactly what was cut"
+    (is (= [{:whole-line? true, :text "  #_{:clj-kondo/ignore [:equals-true]}"}]
+           (map :original
+                (:sites (#'kondo-ratchet/remove-ignores-at
+                         "(defn f [x]\n  #_{:clj-kondo/ignore [:equals-true]}\n  (= true x))\n"
+                         [2])))))
+    (is (= [{:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:x]}"}]
+           (map :original
+                (:sites (#'kondo-ratchet/remove-ignores-at "(do #_{:clj-kondo/ignore [:x]} (foo))\n" [1])))))
+    (is (= [{:whole-line? true, :text "#_{:clj-kondo/ignore [:x\n                      :y]}"}]
+           (map :original
+                (:sites (#'kondo-ratchet/remove-ignores-at
+                         "(a)\n#_{:clj-kondo/ignore [:x\n                      :y]}\n(b)\n"
+                         [2])))))))
+
 (deftest remove-ignores-at-test
   (testing "a standalone ignore line disappears entirely; :sites points at the uncovered form"
     (is (= {:text      "(defn f [x]\n  (= true x))\n"
             :sites     [{:row 2, :linters [:equals-true]}]
             :deletions [[2 1]]
             :skipped   []}
-           (#'kondo-ratchet/remove-ignores-at
+           (remove-ignores-at'
             "(defn f [x]\n  #_{:clj-kondo/ignore [:equals-true]}\n  (= true x))\n"
             [2]))))
   (testing "an inline ignore is cut out of its line, swallowing a doubled space"
     (is (= {:text "(do (foo))\n", :sites [{:row 1, :linters [:x]}], :deletions [[1 0]], :skipped []}
-           (#'kondo-ratchet/remove-ignores-at "(do #_{:clj-kondo/ignore [:x]} (foo))\n" [1]))))
+           (remove-ignores-at' "(do #_{:clj-kondo/ignore [:x]} (foo))\n" [1]))))
   (testing "a multi-line ignore vector goes too"
     (is (= {:text "(a)\n(b)\n", :sites [{:row 2, :linters [:x :y]}], :deletions [[2 2]], :skipped []}
-           (#'kondo-ratchet/remove-ignores-at "(a)\n#_{:clj-kondo/ignore [:x\n                      :y]}\n(b)\n" [2]))))
+           (remove-ignores-at' "(a)\n#_{:clj-kondo/ignore [:x\n                      :y]}\n(b)\n" [2]))))
   (testing "an ignore map with extra keys is removed whole, not truncated at the vector"
     (is (= {:text "(a)\n", :sites [{:row 1, :linters [:x]}], :deletions [[1 1]], :skipped []}
-           (#'kondo-ratchet/remove-ignores-at "#_{:clj-kondo/ignore [:x] :reason \"legacy\"}\n(a)\n" [1]))))
+           (remove-ignores-at' "#_{:clj-kondo/ignore [:x] :reason \"legacy\"}\n(a)\n" [1]))))
   (testing "an extra-key map with NESTED braces would be truncated by the regex, so it is skipped whole"
     (is (= {:text      "#_{:clj-kondo/ignore [:x] :reason {:ticket \"ABC-1\"}}\n(a)\n"
             :sites     []
             :deletions []
             :skipped   [1]}
-           (#'kondo-ratchet/remove-ignores-at
+           (remove-ignores-at'
             "#_{:clj-kondo/ignore [:x] :reason {:ticket \"ABC-1\"}}\n(a)\n"
             [1]))))
   (testing "a skipped row is reported in post-removal coordinates when removals above it delete lines"
@@ -132,7 +176,7 @@
             :sites     [{:row 1, :linters [:x]}]
             :deletions [[1 1]]
             :skipped   [2]}
-           (#'kondo-ratchet/remove-ignores-at
+           (remove-ignores-at'
             "#_{:clj-kondo/ignore [:x]}\n(a)\n#_{:clj-kondo/ignore [:y] :reason {:nested 1}}\n(b)\n"
             [1 3]))))
   (testing "any form naming a clojure-lsp/* linter survives — a re-lint could never restore that half"
@@ -142,7 +186,7 @@
             :sites     [{:row 1, :linters [:x]}]
             :deletions [[1 0]]
             :skipped   []}
-           (#'kondo-ratchet/remove-ignores-at
+           (remove-ignores-at'
             (str "(do #_{:clj-kondo/ignore [:x]} #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]} (foo))\n"
                  "#_{:clj-kondo/ignore [:x :clojure-lsp/unused-public-var]}\n"
                  "(bar)\n")
@@ -152,7 +196,7 @@
             :sites     [{:row 3, :linters [:z]} {:row 1, :linters [:x :y]}]
             :deletions [[4 1] [1 1]]
             :skipped   []}
-           (#'kondo-ratchet/remove-ignores-at
+           (remove-ignores-at'
             "(do #_{:clj-kondo/ignore [:x\n                          :y]} (foo))\n(a)\n#_{:clj-kondo/ignore [:z]}\n(b)\n"
             [1 4]))))
   (testing "rows without an ignore are left alone; multiple removals shift later :sites rows up"
@@ -160,6 +204,6 @@
             :sites     [{:row 2, :linters [:y]} {:row 1, :linters [:x]}]
             :deletions [[3 1] [1 1]]
             :skipped   []}
-           (#'kondo-ratchet/remove-ignores-at
+           (remove-ignores-at'
             "#_{:clj-kondo/ignore [:x]}\n(a)\n#_{:clj-kondo/ignore [:y]}\n(b)\n"
             [1 2 3])))))

--- a/mage/test/mage/kondo_ratchet_test.clj
+++ b/mage/test/mage/kondo_ratchet_test.clj
@@ -1,5 +1,6 @@
 (ns mage.kondo-ratchet-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [mage.kondo-ratchet :as kondo-ratchet]))
 
@@ -75,6 +76,19 @@
               :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:x]}"}}
              {:row 1, :comment ";; kept B"
               :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:y]}"}}]))))
+  (testing "consecutive whole-line restores on one row each keep their own marker adjacent"
+    (is (= {:text          (str ";; kept B\n"
+                                "#_{:clj-kondo/ignore [:y]}\n"
+                                ";; kept A\n"
+                                "#_{:clj-kondo/ignore [:x]}\n"
+                                "(f)\n")
+            :inserted-rows [1 1 1 1]}
+           (#'kondo-ratchet/reinsert-ignores
+            "(f)\n"
+            [{:row 1, :comment ";; kept A"
+              :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:x]}"}}
+             {:row 1, :comment ";; kept B"
+              :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:y]}"}}]))))
   (testing "multiple sites in one file restore bottom-up"
     (is (= {:text          "#_{:clj-kondo/ignore [:x]}\n(a)\n#_{:clj-kondo/ignore [:y]}\n(b)\n"
             :inserted-rows [2 1]}
@@ -82,6 +96,27 @@
             "(a)\n(b)\n"
             [{:row 1, :comment nil, :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:x]}"}}
              {:row 2, :comment nil, :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:y]}"}}])))))
+
+(deftest site-restore-plan-test
+  (let [stamp @#'kondo-ratchet/keep-comment
+        wl    (fn [row] {:row row, :linters [:x], :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:x]}"}})
+        plan  (fn [text sites] (#'kondo-ratchet/site-restore-plan (vec (str/split-lines text)) sites))]
+    (testing "a whole-line restore onto an unmarked row gets its own marker"
+      (is (= [[1 stamp]]
+             (map (juxt :row :comment) (plan "(f)\n" [(wl 1)])))))
+    (testing "a marker above a still-ignored code line belongs to that line; the block moves above it"
+      (is (= [[1 stamp]]
+             (map (juxt :row :comment)
+                  (plan (str stamp "\n(do #_{:clj-kondo/ignore [:y]} (f))\n") [(wl 2)])))))
+    (testing "a marker above a plain code line marked the removed site itself; re-restore under it, no new marker"
+      (is (= [[2 nil]]
+             (map (juxt :row :comment)
+                  (plan (str stamp "\n(f)\n") [(wl 2)])))))
+    (testing "cross-round end to end: the round-two whole-line block lands above the round-one marker"
+      (let [round1 (str stamp "\n(do #_{:clj-kondo/ignore [:y]} (f))\n")]
+        (is (= {:text          (str stamp "\n#_{:clj-kondo/ignore [:x]}\n" round1)
+                :inserted-rows [1 1]}
+               (#'kondo-ratchet/reinsert-ignores round1 (plan round1 [(wl 2)]))))))))
 
 (deftest strip-orphan-keep-comments-test
   (let [stamp-line @#'kondo-ratchet/keep-comment

--- a/mage/test/mage/kondo_ratchet_test.clj
+++ b/mage/test/mage/kondo_ratchet_test.clj
@@ -71,6 +71,28 @@
       (let [text (str keep-line "\n;; more context\n#_{:clj-kondo/ignore [:x]}\n(a)\n")]
         (is (= text (#'kondo-ratchet/strip-orphan-keep-comments text)))))))
 
+(deftest beyond-baseline-test
+  (let [f (fn [filename row type col] {:filename filename, :row row, :type type, :col col})]
+    (testing "findings with no baseline entry are all beyond it"
+      (is (= [(f "a.clj" 3 :x 1)]
+             (#'kondo-ratchet/beyond-baseline {} [(f "a.clj" 3 :x 1)]))))
+    (testing "a group matching its baseline count is fully absorbed"
+      (is (= []
+             (#'kondo-ratchet/beyond-baseline {["a.clj" 3 :x] 1} [(f "a.clj" 3 :x 1)]))))
+    (testing "a group over its baseline count returns ALL its findings -- an exposed finding can't be
+              told apart from a pre-existing same-row one, so restore conservatively"
+      (is (= [(f "a.clj" 3 :x 1) (f "a.clj" 3 :x 20)]
+             (sort-by :col
+                      (#'kondo-ratchet/beyond-baseline {["a.clj" 3 :x] 1}
+                                                       [(f "a.clj" 3 :x 20) (f "a.clj" 3 :x 1)])))))))
+
+(deftest shift-past-inserts-test
+  (testing "each insertion at or above the row pushes it down one, measured against the original row"
+    (is (= 5 (#'kondo-ratchet/shift-past-inserts 5 [])))
+    (is (= 6 (#'kondo-ratchet/shift-past-inserts 5 [5 6])))
+    (is (= 9 (#'kondo-ratchet/shift-past-inserts 7 [5 6])))
+    (is (= 5 (#'kondo-ratchet/shift-past-inserts 5 [6 7])))))
+
 (deftest marker-on-line-test
   (testing "the marker counts only after a semicolon, so a string literal containing it doesn't mark"
     (is (true? (#'kondo-ratchet/marker-on-line? (str ";; " kondo-ratchet/keep-marker " because"))))

--- a/mage/test/mage/kondo_ratchet_test.clj
+++ b/mage/test/mage/kondo_ratchet_test.clj
@@ -42,28 +42,28 @@
            (#'kondo-ratchet/reinsert-ignores
             "(do (foo))\n"
             [{:row 1, :comment nil
-              :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:x]}"}}]))))
+              :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:x]}", :separator " "}}]))))
   (testing "an inline restore's comment sits above at the target line's indentation"
     (is (= {:text          "(f\n  ;; why\n  #_{:clj-kondo/ignore [:x]} :mysql)\n"
             :inserted-rows [2]}
            (#'kondo-ratchet/reinsert-ignores
             "(f\n  :mysql)\n"
             [{:row 2, :comment ";; why"
-              :original {:whole-line? false, :col 3, :text "#_{:clj-kondo/ignore [:x]}"}}]))))
+              :original {:whole-line? false, :col 3, :text "#_{:clj-kondo/ignore [:x]}", :separator " "}}]))))
   (testing "two inline removals on one row restore right-to-left, so the left splice can't shift the right column"
     (is (= {:text          "(do #_{:clj-kondo/ignore [:x]} (f) #_{:clj-kondo/ignore [:y]} (g))\n"
             :inserted-rows []}
            (#'kondo-ratchet/reinsert-ignores
             "(do (f) (g))\n"
-            [{:row 1, :comment nil, :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:x]}"}}
-             {:row 1, :comment nil, :original {:whole-line? false, :col 9, :text "#_{:clj-kondo/ignore [:y]}"}}]))))
+            [{:row 1, :comment nil, :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:x]}", :separator " "}}
+             {:row 1, :comment nil, :original {:whole-line? false, :col 9, :text "#_{:clj-kondo/ignore [:y]}", :separator " "}}]))))
   (testing "a same-row restore with a comment splices first, so the comment can't displace the splice target"
     (is (= {:text          ";; why\n(do #_{:clj-kondo/ignore [:x]} (f) #_{:clj-kondo/ignore [:y]} (g))\n"
             :inserted-rows [1]}
            (#'kondo-ratchet/reinsert-ignores
             "(do (f) (g))\n"
-            [{:row 1, :comment ";; why", :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:x]}"}}
-             {:row 1, :comment nil, :original {:whole-line? false, :col 9, :text "#_{:clj-kondo/ignore [:y]}"}}]))))
+            [{:row 1, :comment ";; why", :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:x]}", :separator " "}}
+             {:row 1, :comment nil, :original {:whole-line? false, :col 9, :text "#_{:clj-kondo/ignore [:y]}", :separator " "}}]))))
   (testing "a whole-line and an inline restore sharing a row each keep their marker adjacent"
     (is (= {:text          (str ";; kept A\n"
                                 "#_{:clj-kondo/ignore [:x]}\n"
@@ -75,7 +75,7 @@
             [{:row 1, :comment ";; kept A"
               :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:x]}"}}
              {:row 1, :comment ";; kept B"
-              :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:y]}"}}]))))
+              :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:y]}", :separator " "}}]))))
   (testing "consecutive whole-line restores on one row each keep their own marker adjacent"
     (is (= {:text          (str ";; kept B\n"
                                 "#_{:clj-kondo/ignore [:y]}\n"
@@ -100,7 +100,7 @@
 (deftest site-restore-plan-test
   (let [stamp @#'kondo-ratchet/keep-comment
         wl    (fn [row] {:row row, :linters [:x], :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:x]}"}})
-        inl   (fn [row] {:row row, :linters [:y], :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:y]}"}})
+        inl   (fn [row] {:row row, :linters [:y], :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:y]}", :separator " "}})
         plan  (fn [text sites] (#'kondo-ratchet/site-restore-plan (vec (str/split-lines text)) sites))]
     (testing "a whole-line restore onto an unmarked row gets its own marker"
       (is (= [[1 stamp]]
@@ -157,7 +157,7 @@
   (let [stamp @#'kondo-ratchet/keep-comment
         plan  (fn [text sites] (#'kondo-ratchet/site-restore-plan (vec (str/split-lines text)) sites))]
     (testing "a reserved marker is removed when only the inline site restores"
-      (let [inl  {:row 2, :linters [:y], :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:y]}"}}
+      (let [inl  {:row 2, :linters [:y], :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:y]}", :separator " "}}
             wl   {:row 2, :was-marked? true, :linters [:x], :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:x]}"}}
             text (str stamp "\n(do (f))\n")
             {restored :text, inserted :inserted-rows}
@@ -173,7 +173,8 @@
       (let [text (str "#_{:clj-kondo/ignore [:x]} ;; " kondo-ratchet/keep-marker " why\n(f)\n")
             {:keys [text sites]} (#'kondo-ratchet/remove-ignores-at text [1])]
         (is (= (str " ;; " kondo-ratchet/keep-marker " why\n(f)\n") text))
-        (is (= [{:whole-line? false, :col 1, :text "#_{:clj-kondo/ignore [:x]}"}] (map :original sites)))
+        (is (= [{:whole-line? false, :col 1, :text "#_{:clj-kondo/ignore [:x]}", :separator ""}]
+               (map :original sites)))
         (let [planned (plan text (map #(assoc % :was-marked? true) sites))]
           (is (= [nil] (map :comment planned)))
           (is (= (str "#_{:clj-kondo/ignore [:x]} ;; " kondo-ratchet/keep-marker " why\n(f)\n")
@@ -254,7 +255,7 @@
                 (:sites (#'kondo-ratchet/remove-ignores-at
                          "(defn f [x]\n  #_{:clj-kondo/ignore [:equals-true]}\n  (= true x))\n"
                          [2])))))
-    (is (= [{:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:x]}"}]
+    (is (= [{:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:x]}", :separator " "}]
            (map :original
                 (:sites (#'kondo-ratchet/remove-ignores-at "(do #_{:clj-kondo/ignore [:x]} (foo))\n" [1])))))
     (is (= [{:whole-line? true, :text "#_{:clj-kondo/ignore [:x\n                      :y]}"}]
@@ -262,6 +263,22 @@
                 (:sites (#'kondo-ratchet/remove-ignores-at
                          "(a)\n#_{:clj-kondo/ignore [:x\n                      :y]}\n(b)\n"
                          [2])))))))
+
+(deftest inline-ignore-separator-round-trip-test
+  (doseq [[description separator text]
+          [["no space after the ignore" ""
+            "(do #_{:clj-kondo/ignore [:x]}(foo))\n"]
+           ["multiple spaces after the ignore" "   "
+            "(do #_{:clj-kondo/ignore [:x]}   (foo))\n"]
+           ["an ignore ending a line" ""
+            "(do (foo) #_{:clj-kondo/ignore [:x]}\n(bar))\n"]]]
+    (testing description
+      (let [{removed :text, :keys [sites]} (#'kondo-ratchet/remove-ignores-at text [1])]
+        (is (= [separator] (map (comp :separator :original) sites)))
+        (is (= text
+               (:text (#'kondo-ratchet/reinsert-ignores
+                       removed
+                       (map #(assoc % :comment nil) sites)))))))))
 
 (deftest remove-ignores-at-test
   (testing "a standalone ignore line disappears entirely; :sites points at the uncovered form"

--- a/mage/test/mage/kondo_ratchet_test.clj
+++ b/mage/test/mage/kondo_ratchet_test.clj
@@ -169,6 +169,23 @@
         (is (= (str stamp "\n" stamp "\n(do #_{:clj-kondo/ignore [:y]} (f))\n") restored))
         (is (= (str stamp "\n(do #_{:clj-kondo/ignore [:y]} (f))\n")
                (#'kondo-ratchet/strip-orphan-keep-comments restored pending)))))
+    (testing "a restored inline site's trailing marker is not duplicated beside a pending reserved marker"
+      (let [inl     {:row 2, :was-marked? true, :linters [:y],
+                     :original {:whole-line? false, :col 5, :text "#_{:clj-kondo/ignore [:y]}", :separator " "}}
+            wl      {:row 2, :was-marked? true, :linters [:x],
+                     :original {:whole-line? true, :text "#_{:clj-kondo/ignore [:x]}"}}
+            text    (str stamp "\n(do (f)) ;; " kondo-ratchet/keep-marker " inline\n")
+            result  (#'kondo-ratchet/reinsert-ignores
+                     text
+                     (#'kondo-ratchet/site-restore-plan
+                      (vec (str/split-lines text)) [inl] [wl inl]))
+            pending [(#'kondo-ratchet/shift-site-past-inserts wl (:inserted-rows result))]]
+        (is (= (str stamp "\n(do #_{:clj-kondo/ignore [:y]} (f)) ;; "
+                    kondo-ratchet/keep-marker " inline\n")
+               (:text result)))
+        (is (= (str "(do #_{:clj-kondo/ignore [:y]} (f)) ;; "
+                    kondo-ratchet/keep-marker " inline\n")
+               (#'kondo-ratchet/strip-orphan-keep-comments (:text result) pending)))))
     (testing "a whole-line ignore with a trailing marker removes and restores through the inline path, marker never leaving"
       (let [text (str "#_{:clj-kondo/ignore [:x]} ;; " kondo-ratchet/keep-marker " why\n(f)\n")
             {:keys [text sites]} (#'kondo-ratchet/remove-ignores-at text [1])]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -227,7 +227,6 @@
                   "raw values being used to calculate the formulas below, so we can tell at a glance if they're right "
                   "without referring to the EDN def)")
       (is (= [[nil] [0.0] [0.0] [10.0] [8.0] [5.0] [5.0] [nil] [0.0] [0.0]]
-             #_:clj-kondo/ignore
              (calculate-bird-scarcity $count))))))
 
 (deftest ^:parallel nulls-and-zeroes-test-2

--- a/modules/drivers/starburst/src/metabase/driver/starburst.clj
+++ b/modules/drivers/starburst/src/metabase/driver/starburst.clj
@@ -109,7 +109,6 @@
 
 ;;; The Starburst JDBC driver DOES NOT support the `.getImportedKeys` method so just return `nil` here so the
 ;;; implementation doesn't try to use it.
-#_{:clj-kondo/ignore [:deprecated-var]}
 (defmethod driver/describe-fks :starburst
   [_driver _database & {:as _options}]
   ;; starburst does not support finding foreign key metadata tables, but some connectors support foreign keys.

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -133,13 +133,12 @@
    :sso_configured                       (setting/get :google-auth-enabled)
    :instance_started                     (analytics.settings/instance-creation)
    :has_sample_data                      (t2/exists? :model/Database, :is_sample true)
-   :enable_embedding                     #_{:clj-kondo/ignore [:deprecated-var]} (setting/get :enable-embedding)
+   :enable_embedding                     (setting/get :enable-embedding)
    :enable_embedding_sdk                 (setting/get :enable-embedding-sdk)
    :enable_embedding_simple              (setting/get :enable-embedding-simple)
    :enable_embedding_interactive         (setting/get :enable-embedding-interactive)
    :enable_embedding_static              (setting/get :enable-embedding-static)
    :embedding_app_origin_set             (boolean
-                                          #_{:clj-kondo/ignore [:deprecated-var]}
                                           (setting/get :embedding-app-origin))
    ;; We no longer add "localhost:*" as a default origin as of Metabase 56, as it is always allowed,
    ;; but we still filter it out in stats for compatibility with migrated instances.

--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -36,8 +36,8 @@
   [schema]
   (let [schema      (try #_:clj-kondo/ignore
                      (eval schema)
-                         (catch Exception _ #_:clj-kondo/ignore
-                                (requiring-resolve-form schema)))
+                         (catch Exception _
+                           (requiring-resolve-form schema)))
         schema-type (mc/type schema)
         {regex :api/regex} (mc/properties schema)]
     [schema-type

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -411,7 +411,6 @@
 ;; Update the sequence nextvals.
 (defmethod update-sequence-values! :postgres
   [_db-type data-source]
-  #_{:clj-kondo/ignore [:discouraged-var]}
   (jdbc/with-db-transaction [target-db-conn {:datasource data-source}]
     (step (trs "Setting Postgres sequence ids to proper values...")
       (doseq [model entities
@@ -429,7 +428,6 @@
 
 (defmethod update-sequence-values! :h2
   [_db-type data-source]
-  #_{:clj-kondo/ignore [:discouraged-var]}
   (jdbc/with-db-transaction [target-db-conn {:datasource data-source}]
     (step (trs "Setting H2 sequence ids to proper values...")
       (doseq [e     entities
@@ -465,7 +463,6 @@
   (step (trs "Clearing default entries created by Liquibase migrations...")
     (clear-existing-rows! target-db-type target-data-source))
   ;; create a transaction and load the data.
-  #_{:clj-kondo/ignore [:discouraged-var]}
   (jdbc/with-db-transaction [target-conn-spec {:datasource target-data-source}]
     ;; transaction should be set as rollback-only until it completes. Only then should we disable rollback-only so the
     ;; transaction will commit (i.e., only commit if the whole thing succeeds)

--- a/src/metabase/config/core.clj
+++ b/src/metabase/config/core.clj
@@ -21,7 +21,6 @@
 
 (def ^{:doc "Indicates whether Dev extensions are available" :added "0.56.0"} dev-available?
   (try
-    #_{:clj-kondo/ignore [:metabase/modules]}
     (require 'dev.dummy-namespace)
     true
     (catch Throwable _

--- a/src/metabase/core/init.clj
+++ b/src/metabase/core/init.clj
@@ -90,5 +90,4 @@
 ;; load EE init code on system launch if it exists.
 (when (and (not *compile-files*)
            config/ee-available?)
-  #_{:clj-kondo/ignore [:discouraged-var]}
   (require 'metabase-enterprise.core.init))

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -645,7 +645,6 @@
       (u/prog1 (first (revisions/with-last-edit-info [dashboard] :dashboard))
         (events/publish-event! :event/dashboard-read {:object-id (:id dashboard) :user-id api/*current-user-id*})))))
 
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/:id/pdf" :- :any
   "Render Dashboard with ID to a PDF (server-side, the same way dashboard subscriptions render charts) and stream it
   back as a file download.

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -1,6 +1,5 @@
 (ns metabase.driver.common
   "Shared definitions and helper functions for use across different drivers."
-  #_{:clj-kondo/ignore [:metabase/modules]}
   (:require
    [clojure.string :as str]
    [metabase.driver :as driver]

--- a/src/metabase/driver/ddl/interface.clj
+++ b/src/metabase/driver/ddl/interface.clj
@@ -1,5 +1,4 @@
 (ns metabase.driver.ddl.interface
-  #_{:clj-kondo/ignore [:metabase/modules]}
   (:require
    [clojure.string :as str]
    [metabase.appearance.core :as appearance]

--- a/src/metabase/driver/postgres/ddl.clj
+++ b/src/metabase/driver/postgres/ddl.clj
@@ -19,15 +19,15 @@
 
    This helps to address unexpectedly large/long running queries."
   [tx]
-  (let [existing-timeout (->> #_{:clj-kondo/ignore [:discouraged-var]}
+  (let [existing-timeout (->>
                           (sql/format {:select [:setting]
                                        :from   [:pg_settings]
                                        :where  [:= :name "statement_timeout"]}
                                       {:quoted false})
-                              (sql.ddl/jdbc-query tx)
-                              first
-                              :setting
-                              parse-long)
+                          (sql.ddl/jdbc-query tx)
+                          first
+                          :setting
+                          parse-long)
         ten-minutes      (.toMillis (t/minutes 10))
         new-timeout      (if (zero? existing-timeout)
                            ten-minutes

--- a/src/metabase/driver/postgres/ddl.clj
+++ b/src/metabase/driver/postgres/ddl.clj
@@ -19,15 +19,14 @@
 
    This helps to address unexpectedly large/long running queries."
   [tx]
-  (let [existing-timeout (->>
-                          (sql/format {:select [:setting]
-                                       :from   [:pg_settings]
-                                       :where  [:= :name "statement_timeout"]}
-                                      {:quoted false})
-                          (sql.ddl/jdbc-query tx)
-                          first
-                          :setting
-                          parse-long)
+  (let [existing-timeout (->> (sql/format {:select [:setting]
+                                           :from   [:pg_settings]
+                                           :where  [:= :name "statement_timeout"]}
+                                          {:quoted false})
+                              (sql.ddl/jdbc-query tx)
+                              first
+                              :setting
+                              parse-long)
         ten-minutes      (.toMillis (t/minutes 10))
         new-timeout      (if (zero? existing-timeout)
                            ten-minutes

--- a/src/metabase/driver/settings.clj
+++ b/src/metabase/driver/settings.clj
@@ -1,5 +1,4 @@
 (ns metabase.driver.settings
-  #_{:clj-kondo/ignore [:metabase/modules]}
   (:require
    [java-time.api :as t]
    [metabase.config.core :as config]

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -310,7 +310,6 @@
             (->honeysql driver form))]
     (cond
       (params.ops/operator? param-type)
-      #_{:clj-kondo/ignore [:deprecated-var]}
       (->> (assoc params :target [:dimension (field->field-ref driver field param-type value)])
            params.ops/to-clause
            lib/desugar-filter-clause
@@ -320,7 +319,6 @@
 
       (params.dates/exclusion-date-type param-type value)
       (let [field-ref (field->field-ref driver field param-type value)]
-        #_{:clj-kondo/ignore [:deprecated-var]}
         (->> (params.dates/date-string->filter value field-ref)
              lib/desugar-filter-clause
              driver-api/wrap-value-literals-in-mbql5

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -2043,7 +2043,6 @@
 
 (defmethod apply-top-level-clause [:sql :joins]
   [driver _ honeysql-form {:keys [joins]}]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (let [f apply-joins-honey-sql-2]
     (f driver honeysql-form joins)))
 

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -290,7 +290,6 @@
       ;; use the deprecated impl for `connection-with-timezone` if one exists.
       (do
         (log/warnf "%s is deprecated in Metabase 0.47.0. Implement %s instead."
-                   #_{:clj-kondo/ignore [:deprecated-var]}
                    'connection-with-timezone
                    'do-with-connection-with-options)
         ;; for compatibility, make sure we pass it an actual Database instance.

--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -15,7 +15,6 @@
   (or (mr/registered-schema topic)
       :map))
 
-#_{:clj-kondo/ignore [:unused-private-var]}
 (defn- with-hydrate
   "Given a malli entry schema of a map, return a new entry schema with an additional option
   to hydrate information when sending system event notifications.

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -475,7 +475,6 @@
     (when (or force-reset? (not (exists? (active-table))))
       (reset-index!))))
 
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-temp-index-table
   "Create a temporary index table for the duration of the body. Uses the existing index if we're already mocking."
   [& body]

--- a/src/metabase/testing_api/api.clj
+++ b/src/metabase/testing_api/api.clj
@@ -59,7 +59,6 @@
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/snapshot/:name"
   "Snapshot the database for testing purposes."
   [{snapshot-name :name} :- [:map
@@ -135,7 +134,6 @@
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/restore/:name"
   "Restore a database snapshot for testing purposes."
   [{snapshot-name :name} :- [:map
@@ -150,7 +148,6 @@
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/echo"
   "Simple echo handler. Fails when you POST with `?fail=true`."
   [_route-params
@@ -166,7 +163,6 @@
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/set-time"
   "Make java-time see world at exact time."
   [_route-params
@@ -187,7 +183,6 @@
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/echo"
   "Simple echo handler. Fails when you GET with `?fail=true`."
   [_route-params
@@ -203,7 +198,6 @@
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/mark-stale"
   "Mark the card or dashboard as stale"
   [_route-params
@@ -227,7 +221,6 @@
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/stats"
   "Triggers a send of instance usage stats"
   []
@@ -264,7 +257,6 @@
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/refresh-caches"
   "Manually triggers the cache refresh task, if Enterprise code is available."
   []
@@ -297,7 +289,6 @@
    [:published_at      :any]
    [:updated_at        :any]])
 
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/security-advisories"
   "Nuke all existing security advisories and insert the provided ones."
   [_route-params

--- a/src/metabase/timeline/api/timeline.clj
+++ b/src/metabase/timeline/api/timeline.clj
@@ -23,9 +23,6 @@
   [:map
    [:id pos-int?]])
 
-;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
-;; use our API + we will need it when we make auto-TypeScript-signature generation happen
-;;
 (api.macros/defendpoint :post "/" :- ::Timeline
   "Create a new [[Timeline]]."
   [_route-params
@@ -46,9 +43,6 @@
     (u/prog1 (first (t2/insert-returning-instances! :model/Timeline tl))
       (events/publish-event! :event/timeline-create {:object <> :user-id api/*current-user-id*}))))
 
-;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
-;; use our API + we will need it when we make auto-TypeScript-signature generation happen
-;;
 (api.macros/defendpoint :get "/" :- [:sequential ::Timeline]
   "Fetch a list of `Timeline`s. Can include `archived=true` to return archived timelines."
   [_route-params
@@ -65,9 +59,6 @@
       (= include :events)
       (map #(timeline-event/include-events-singular % {:events/all? archived?})))))
 
-;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
-;; use our API + we will need it when we make auto-TypeScript-signature generation happen
-;;
 (api.macros/defendpoint :get "/:id" :- ::Timeline
   "Fetch the `Timeline` with `id`. Include `include=events` to unarchived events included on the timeline. Add
   `archived=true` to return all events on the timeline, both archived and unarchived."

--- a/src/metabase/timeline/api/timeline.clj
+++ b/src/metabase/timeline/api/timeline.clj
@@ -26,7 +26,6 @@
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/" :- ::Timeline
   "Create a new [[Timeline]]."
   [_route-params
@@ -50,7 +49,6 @@
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/" :- [:sequential ::Timeline]
   "Fetch a list of `Timeline`s. Can include `archived=true` to return archived timelines."
   [_route-params
@@ -70,7 +68,6 @@
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/:id" :- ::Timeline
   "Fetch the `Timeline` with `id`. Include `include=events` to unarchived events included on the timeline. Add
   `archived=true` to return all events on the timeline, both archived and unarchived."

--- a/src/metabase/transforms/execute.clj
+++ b/src/metabase/transforms/execute.clj
@@ -53,7 +53,6 @@
                                   (when on-start
                                     (on-start run-id)))})]
      (try
-       #_{:clj-kondo/ignore [:discouraged-var]}
        (transforms.i/execute! (resolve-target transform) opts)
        (catch Throwable t
          ;; so a caller awaiting the start isn't left hanging on a pre-start failure;

--- a/src/metabase/transforms/query_impl.clj
+++ b/src/metabase/transforms/query_impl.clj
@@ -82,6 +82,5 @@
          (log/error t "Error executing transform"))
        (throw t)))))
 
-#_{:clj-kondo/ignore [:discouraged-var]}
 (defmethod transforms.i/execute! :query [transform opts]
   (run-mbql-transform! transform opts))

--- a/src/metabase/util/log/capture.cljc
+++ b/src/metabase/util/log/capture.cljc
@@ -187,7 +187,6 @@
   "Impl for log message capturing for [[metabase.util.log/logf]]."
   [f & args]
   (let [{e :e, [format-string & args] :args} (parse-args args)]
-    #_{:clj-kondo/ignore [:unresolved-namespace]}
     (f e (apply #?(:clj format
                    :cljs gstring/format)
                 format-string args))))

--- a/src/metabase/util/performance.cljc
+++ b/src/metabase/util/performance.cljc
@@ -367,7 +367,6 @@
   (cond (nil? m) {}
         ;; Fallback for non-editable collections where transients aren't supported.
         (not (editable? m))
-        #_{:clj-kondo/ignore [:discouraged-var]}
         (clojure.core/update-keys m f)
         :else (-> (reduce-kv (fn [acc k v]
                                (let [k' (f k)]
@@ -388,7 +387,6 @@
   (cond (nil? coll) {}
         ;; Fallback for non-editable collections where transients aren't supported.
         (not (editable? coll))
-        #_{:clj-kondo/ignore [:discouraged-var]}
         (clojure.core/update-vals coll f)
         :else (-> (reduce-kv (fn [acc k v]
                                (let [v' (f v)]

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -264,7 +264,7 @@
     (tu/with-model-cleanup [:model/Action]
       (f model))))
 
-;;; TODO FIXME -- rename this to [[with-actions!]] and then remove the Kondo ignore comment below
+;;; TODO FIXME -- rename this to [[with-actions!]]
 (defmacro with-actions
   "Execute `body` with newly created Actions.
   `binding-forms-and-options-maps` is a vector of even number of elements, binding and options-map,
@@ -325,21 +325,21 @@
   (tu/with-temp-vals-in-db :model/Database db-id {:settings {:database-enable-actions enable?}}
     (thunk)))
 
-;;; TODO -- FIXME, rename this to `with-actions-enabled!` and remove the `:clj-kondo/ignore`
+;;; TODO -- FIXME, rename this to `with-actions-enabled!`
 (defmacro with-actions-enabled
   "Execute `body` with Actions enabled for the current test Database."
   {:style/indent 0}
   [& body]
   `(do-with-actions-set! (data/id) true (fn [] ~@body)))
 
-;;; TODO -- FIXME, rename this to `with-actions-disabled!` and remove the `:clj-kondo/ignore`
+;;; TODO -- FIXME, rename this to `with-actions-disabled!`
 (defmacro with-actions-disabled
   "Execute `body` with Actions disabled for the current test Database."
   {:style/indent 0}
   [& body]
   `(do-with-actions-set! (data/id) false (fn [] ~@body)))
 
-;;; TODO FIXME -- rename this to [[with-actions!]] and then remove the Kondo ignore comment below
+;;; TODO FIXME -- rename this to [[with-actions-test-data-and-actions-enabled!]]
 (defmacro with-actions-test-data-and-actions-enabled
   "Combines [[with-actions-test-data]] and [[with-actions-enabled]]."
   {:style/indent 0}

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -265,7 +265,6 @@
       (f model))))
 
 ;;; TODO FIXME -- rename this to [[with-actions!]] and then remove the Kondo ignore comment below
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-actions
   "Execute `body` with newly created Actions.
   `binding-forms-and-options-maps` is a vector of even number of elements, binding and options-map,
@@ -327,7 +326,6 @@
     (thunk)))
 
 ;;; TODO -- FIXME, rename this to `with-actions-enabled!` and remove the `:clj-kondo/ignore`
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-actions-enabled
   "Execute `body` with Actions enabled for the current test Database."
   {:style/indent 0}
@@ -335,7 +333,6 @@
   `(do-with-actions-set! (data/id) true (fn [] ~@body)))
 
 ;;; TODO -- FIXME, rename this to `with-actions-disabled!` and remove the `:clj-kondo/ignore`
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-actions-disabled
   "Execute `body` with Actions disabled for the current test Database."
   {:style/indent 0}
@@ -343,7 +340,6 @@
   `(do-with-actions-set! (data/id) false (fn [] ~@body)))
 
 ;;; TODO FIXME -- rename this to [[with-actions!]] and then remove the Kondo ignore comment below
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-actions-test-data-and-actions-enabled
   "Combines [[with-actions-test-data]] and [[with-actions-enabled]]."
   {:style/indent 0}

--- a/test/metabase/ai_tracing/log_test.clj
+++ b/test/metabase/ai_tracing/log_test.clj
@@ -133,7 +133,6 @@
         (is (= :ok (ait/with-eval-session nil (ait/with-llm-call {} :ok))))
         (is (= [] (entries messages)))))))
 
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn- recording-logger-factory
   "A tools.logging factory that records the Log4j2 ThreadContext present at each write."
   [sink]

--- a/test/metabase/analytics/snowplow_test.clj
+++ b/test/metabase/analytics/snowplow_test.clj
@@ -57,7 +57,6 @@
           (f))))))
 
 ;;; TODO -- rename to `with-fake-snowplow-collector!` because this is not thread-safe and remove the Kondo ignore rule below
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-fake-snowplow-collector
   "Creates a new fake snowplow collector in a dynamic scope, and redefines the track-event! function so that analytics
   events are parsed and added to the fake collector.

--- a/test/metabase/analytics/snowplow_test.clj
+++ b/test/metabase/analytics/snowplow_test.clj
@@ -56,7 +56,7 @@
         (mt/with-dynamic-fn-redefs [snowplow/track-event-impl! (partial fake-track-event-impl! collector)]
           (f))))))
 
-;;; TODO -- rename to `with-fake-snowplow-collector!` because this is not thread-safe and remove the Kondo ignore rule below
+;;; TODO -- rename to `with-fake-snowplow-collector!` because this is not thread-safe
 (defmacro with-fake-snowplow-collector
   "Creates a new fake snowplow collector in a dynamic scope, and redefines the track-event! function so that analytics
   events are parsed and added to the fake collector.

--- a/test/metabase/app_db/schema_migrations_test.clj
+++ b/test/metabase/app_db/schema_migrations_test.clj
@@ -1631,7 +1631,6 @@
         (migrate!)
         (is (= users-before (get-users)))))))
 
-#_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest ^:mb/old-migrations-test data-permissions-migration-rollback-test
   (testing "Data permissions are correctly rolled back from `data_permissions` to `permissions`"
     (impl/test-migrations ["v50.2024-01-04T13:52:51" "v50.2024-02-19T21:32:04"] [migrate!]

--- a/test/metabase/app_db/schema_migrations_test/impl.clj
+++ b/test/metabase/app_db/schema_migrations_test/impl.clj
@@ -198,7 +198,6 @@
       (datasets/test-drivers #{:h2 :mysql :postgres}
         (test-migrations-for-driver! driver/*driver* [start-id end-id] f)))))
 
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro test-migrations
   "Util macro for running tests for a set of Liquibase schema migration(s).
 

--- a/test/metabase/app_db/setup_test.clj
+++ b/test/metabase/app_db/setup_test.clj
@@ -199,7 +199,6 @@
                           :where     [:= :table.db_id [:inline 0]]}))))))
 
 ;; `delete!` below is ok in a parallel test since it's not actually executing anything
-#_{:clj-kondo/ignore [:metabase/validate-deftest]}
 (deftest ^:parallel build-before-delete-query-test
   (testing "before-delete's select query should remove `:delete`/`:delete-from` (workaround for https://github.com/camsaul/toucan2/issues/203)"
     (is (= {:select [:*], :from [[:metabase_field :field]], :where [:= :field.id 0]}

--- a/test/metabase/channel/email_test.clj
+++ b/test/metabase/channel/email_test.clj
@@ -81,7 +81,6 @@
         (f)))))
 
 ;;; TODO -- rename to `with-fake-inbox!` since it's not thread-safe and remove the Kondo ignore below.
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-fake-inbox
   "Clear `inbox`, bind `send-email!` to `fake-inbox-email-fn`, set temporary settings for `email-smtp-username` and
   `email-smtp-password` (which will cause [[metabase.channel.settings/email-configured?]] to return `true`, and execute
@@ -96,7 +95,6 @@
   {:style/indent 0}
   `(do-with-fake-inbox! (fn [] ~@body)))
 
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-expected-messages
   "Invokes `body`, waiting until `n` messages are found in the inbox before returning. This is useful if the code you
   are testing sends emails via a future or background thread. Using this will block the test, waiting for the messages

--- a/test/metabase/channel/email_test.clj
+++ b/test/metabase/channel/email_test.clj
@@ -80,7 +80,7 @@
                                                            :notification/sync? true)]
         (f)))))
 
-;;; TODO -- rename to `with-fake-inbox!` since it's not thread-safe and remove the Kondo ignore below.
+;;; TODO -- rename to `with-fake-inbox!` since it's not thread-safe.
 (defmacro with-fake-inbox
   "Clear `inbox`, bind `send-email!` to `fake-inbox-email-fn`, set temporary settings for `email-smtp-username` and
   `email-smtp-password` (which will cause [[metabase.channel.settings/email-configured?]] to return `true`, and execute

--- a/test/metabase/channel/slack_test.clj
+++ b/test/metabase/channel/slack_test.clj
@@ -323,7 +323,7 @@
   (notification.tu/with-send-notification-sync
     (mt/with-temporary-setting-values [slack-app-token    "test-token"
                                        admin-email         nil
-                                       #_:clj-kondo/ignore slack-token-valid? true]
+                                       slack-token-valid? true]
       (mt/with-fake-inbox
         (http-fake/with-fake-routes {#"^https://slack.com/api/chat\.postMessage.*"
                                      (fn [_] (mock-200-response {:ok false, :error "account_inactive"}))}

--- a/test/metabase/channel/slack_test.clj
+++ b/test/metabase/channel/slack_test.clj
@@ -322,7 +322,7 @@
 (deftest slack-token-error-test
   (notification.tu/with-send-notification-sync
     (mt/with-temporary-setting-values [slack-app-token    "test-token"
-                                       admin-email         nil
+                                       admin-email        nil
                                        slack-token-valid? true]
       (mt/with-fake-inbox
         (http-fake/with-fake-routes {#"^https://slack.com/api/chat\.postMessage.*"

--- a/test/metabase/collections/models/collection_test.clj
+++ b/test/metabase/collections/models/collection_test.clj
@@ -1441,7 +1441,6 @@
              (group->perms [a b c] group))))))
 
 (deftest ^:parallel valid-location-path?-test
-  #_{:clj-kondo/ignore [:equals-true]}
   (are [path expected] (= expected
                           (#'collection/valid-location-path? path))
     nil       false

--- a/test/metabase/driver/common_test.clj
+++ b/test/metabase/driver/common_test.clj
@@ -73,7 +73,6 @@
 
 (deftest ^:parallel json-unfolding-default-test
   (testing "JSON Unfolding database support details behave as they're supposed to"
-    #_{:clj-kondo/ignore [:equals-true]}
     (are [details expected] (= expected
                                (driver.common/json-unfolding-default
                                 {:lib/type :metadata/database

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -229,7 +229,6 @@
 
 (deftest ^:parallel check-action-commands-test
   (mt/test-driver :h2
-    #_{:clj-kondo/ignore [:equals-true]}
     (are [query] (= true (#'h2/every-command-allowed-for-actions? (#'h2/classify-query (mt/id) query)))
       "select 1"
       "update venues set name = 'bill'"

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -275,7 +275,7 @@
         (sql.qp/format-honeysql driver {:join join})))))
 
 ;;; Ok to hardcode driver names here because it's for general HoneySQL compilation behavior and not something that needs
-;;; to be run against all supported drivers
+;;; to be run against all supported drivers [kondo-keep]
 #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel compile-honeysql-test
   (testing "make sure the generated HoneySQL will compile to the correct SQL"

--- a/test/metabase/driver/sql/transforms_test.clj
+++ b/test/metabase/driver/sql/transforms_test.clj
@@ -228,7 +228,7 @@
   ;; Characterizes the CTAS row count per driver. BigQuery, Snowflake, and Redshift are excluded; they
   ;; declare `:transforms/accurate-rows-affected false`, so the transforms layer skips emitting
   ;; efficiency metrics for their full-rebuild runs rather than trust the bogus count. New failing
-  ;; driver → add the feature override + add it to this exclusion.
+  ;; driver → add the feature override + add it to this exclusion. [kondo-keep]
   #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :transforms/table)
                          :bigquery-cloud-sdk :redshift :snowflake)

--- a/test/metabase/driver/sql/util_test.clj
+++ b/test/metabase/driver/sql/util_test.clj
@@ -7,15 +7,14 @@
    [metabase.util.honey-sql-2 :as h2x]))
 
 ;;; Ok to hardcode driver names here because it's for a general util function and not something that needs to be run
-;;; against all supported drivers
+;;; against all supported drivers [kondo-keep]
+#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel quote-name-test
   (are [driver expected] (= expected
                             (sql.u/quote-name driver :field "wow"))
-    ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mysql    "`wow`"
+    :mysql    "`wow`"
     :h2       "\"wow\""
-    ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres "\"wow\""))
+    :postgres "\"wow\""))
 
 (deftest ^:parallel select-clause-alias-everything-test
   (testing "first column is just <identifer>, wrap it like [<identifier> <alias>]"
@@ -92,41 +91,41 @@
 ;;; Ok to hardcode driver names in the tests below because they're for general util functions and not something that
 ;;; needs to be run against all supported drivers
 
+;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel format-sql-with-params-test
   (testing "Baseline: format-sql expands metabase params, which is not desired."
     (is (= "SELECT\n  *\nFROM\n  { { # 1234 } }"
-           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-           (sql.u/format-sql #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres "SELECT * FROM {{#1234}}")))
+           (sql.u/format-sql :postgres "SELECT * FROM {{#1234}}")))
     (is (= "SELECT\n  *\nFROM\n  { { #1234}}"
-           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-           (sql.u/format-sql #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mysql "SELECT * FROM {{#1234}}")))))
+           (sql.u/format-sql :mysql "SELECT * FROM {{#1234}}")))))
 
+;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel format-sql-with-params-test-2
   (testing "A compact representation should remain compact (and inner spaces removed, if any)."
     (is (= "SELECT\n  *\nFROM\n  {{#1234}}"
-           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-           (sql.u/format-sql-and-fix-params #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres "SELECT * FROM {{ #1234 }}")))
+           (sql.u/format-sql-and-fix-params :postgres "SELECT * FROM {{ #1234 }}")))
     (is (= "SELECT\n  *\nFROM\n  {{#1234}}"
-           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-           (sql.u/format-sql-and-fix-params #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres "SELECT * FROM {{#1234}}")))))
+           (sql.u/format-sql-and-fix-params :postgres "SELECT * FROM {{#1234}}")))))
 
+;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel format-sql-with-params-test-3
   (testing "Symbolic params should also have spaces removed."
     (is (= "SELECT\n  *\nFROM\n  {{FOO_BAR}}"
-           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-           (sql.u/format-sql-and-fix-params #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres "SELECT * FROM {{FOO_BAR}}")))
+           (sql.u/format-sql-and-fix-params :postgres "SELECT * FROM {{FOO_BAR}}")))
     (is (= "SELECT\n  *\nFROM\n  {{FOO_BAR}}"
-           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-           (sql.u/format-sql-and-fix-params #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres "SELECT * FROM {{ FOO_BAR }}")))))
+           (sql.u/format-sql-and-fix-params :postgres "SELECT * FROM {{ FOO_BAR }}")))))
 
+;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel format-sql-with-params-test-4
   (testing "Dialect-specific versions should work"
     (is (= "SELECT\n  A\nFROM\n  {{#1234}} WHERE {{STATE}}"
-           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-           (sql.u/format-sql-and-fix-params #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mysql "SELECT A FROM { { #1234}} WHERE {{ STATE}  }")))
+           (sql.u/format-sql-and-fix-params :mysql "SELECT A FROM { { #1234}} WHERE {{ STATE}  }")))
     (is (= "SELECT\n  A\nFROM\n  {{#1234}}\nWHERE\n  {{STATE}}"
-           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-           (sql.u/format-sql-and-fix-params #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres "SELECT A FROM { { #1234}} WHERE {{ STATE}  }")))))
+           (sql.u/format-sql-and-fix-params :postgres "SELECT A FROM { { #1234}} WHERE {{ STATE}  }")))))
 
 (defmulti pound-sign-is-special-word-char?
   {:arglists '([driver-or-dialect])}

--- a/test/metabase/driver/sql/util_test.clj
+++ b/test/metabase/driver/sql/util_test.clj
@@ -8,12 +8,13 @@
 
 ;;; Ok to hardcode driver names here because it's for a general util function and not something that needs to be run
 ;;; against all supported drivers
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel quote-name-test
   (are [driver expected] (= expected
                             (sql.u/quote-name driver :field "wow"))
+    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
     :mysql    "`wow`"
     :h2       "\"wow\""
+    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
     :postgres "\"wow\""))
 
 (deftest ^:parallel select-clause-alias-everything-test
@@ -91,36 +92,40 @@
 ;;; Ok to hardcode driver names in the tests below because they're for general util functions and not something that
 ;;; needs to be run against all supported drivers
 
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel format-sql-with-params-test
   (testing "Baseline: format-sql expands metabase params, which is not desired."
     (is (= "SELECT\n  *\nFROM\n  { { # 1234 } }"
+           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
            (sql.u/format-sql :postgres "SELECT * FROM {{#1234}}")))
     (is (= "SELECT\n  *\nFROM\n  { { #1234}}"
+           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
            (sql.u/format-sql :mysql "SELECT * FROM {{#1234}}")))))
 
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel format-sql-with-params-test-2
   (testing "A compact representation should remain compact (and inner spaces removed, if any)."
     (is (= "SELECT\n  *\nFROM\n  {{#1234}}"
+           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
            (sql.u/format-sql-and-fix-params :postgres "SELECT * FROM {{ #1234 }}")))
     (is (= "SELECT\n  *\nFROM\n  {{#1234}}"
+           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
            (sql.u/format-sql-and-fix-params :postgres "SELECT * FROM {{#1234}}")))))
 
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel format-sql-with-params-test-3
   (testing "Symbolic params should also have spaces removed."
     (is (= "SELECT\n  *\nFROM\n  {{FOO_BAR}}"
+           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
            (sql.u/format-sql-and-fix-params :postgres "SELECT * FROM {{FOO_BAR}}")))
     (is (= "SELECT\n  *\nFROM\n  {{FOO_BAR}}"
+           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
            (sql.u/format-sql-and-fix-params :postgres "SELECT * FROM {{ FOO_BAR }}")))))
 
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel format-sql-with-params-test-4
   (testing "Dialect-specific versions should work"
     (is (= "SELECT\n  A\nFROM\n  {{#1234}} WHERE {{STATE}}"
+           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
            (sql.u/format-sql-and-fix-params :mysql "SELECT A FROM { { #1234}} WHERE {{ STATE}  }")))
     (is (= "SELECT\n  A\nFROM\n  {{#1234}}\nWHERE\n  {{STATE}}"
+           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
            (sql.u/format-sql-and-fix-params :postgres "SELECT A FROM { { #1234}} WHERE {{ STATE}  }")))))
 
 (defmulti pound-sign-is-special-word-char?

--- a/test/metabase/driver/sql/util_test.clj
+++ b/test/metabase/driver/sql/util_test.clj
@@ -11,11 +11,11 @@
 (deftest ^:parallel quote-name-test
   (are [driver expected] (= expected
                             (sql.u/quote-name driver :field "wow"))
-    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-    :mysql    "`wow`"
+    ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mysql    "`wow`"
     :h2       "\"wow\""
-    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-    :postgres "\"wow\""))
+    ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres "\"wow\""))
 
 (deftest ^:parallel select-clause-alias-everything-test
   (testing "first column is just <identifer>, wrap it like [<identifier> <alias>]"
@@ -95,38 +95,38 @@
 (deftest ^:parallel format-sql-with-params-test
   (testing "Baseline: format-sql expands metabase params, which is not desired."
     (is (= "SELECT\n  *\nFROM\n  { { # 1234 } }"
-           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-           (sql.u/format-sql :postgres "SELECT * FROM {{#1234}}")))
+           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+           (sql.u/format-sql #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres "SELECT * FROM {{#1234}}")))
     (is (= "SELECT\n  *\nFROM\n  { { #1234}}"
-           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-           (sql.u/format-sql :mysql "SELECT * FROM {{#1234}}")))))
+           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+           (sql.u/format-sql #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mysql "SELECT * FROM {{#1234}}")))))
 
 (deftest ^:parallel format-sql-with-params-test-2
   (testing "A compact representation should remain compact (and inner spaces removed, if any)."
     (is (= "SELECT\n  *\nFROM\n  {{#1234}}"
-           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-           (sql.u/format-sql-and-fix-params :postgres "SELECT * FROM {{ #1234 }}")))
+           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+           (sql.u/format-sql-and-fix-params #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres "SELECT * FROM {{ #1234 }}")))
     (is (= "SELECT\n  *\nFROM\n  {{#1234}}"
-           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-           (sql.u/format-sql-and-fix-params :postgres "SELECT * FROM {{#1234}}")))))
+           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+           (sql.u/format-sql-and-fix-params #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres "SELECT * FROM {{#1234}}")))))
 
 (deftest ^:parallel format-sql-with-params-test-3
   (testing "Symbolic params should also have spaces removed."
     (is (= "SELECT\n  *\nFROM\n  {{FOO_BAR}}"
-           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-           (sql.u/format-sql-and-fix-params :postgres "SELECT * FROM {{FOO_BAR}}")))
+           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+           (sql.u/format-sql-and-fix-params #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres "SELECT * FROM {{FOO_BAR}}")))
     (is (= "SELECT\n  *\nFROM\n  {{FOO_BAR}}"
-           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-           (sql.u/format-sql-and-fix-params :postgres "SELECT * FROM {{ FOO_BAR }}")))))
+           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+           (sql.u/format-sql-and-fix-params #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres "SELECT * FROM {{ FOO_BAR }}")))))
 
 (deftest ^:parallel format-sql-with-params-test-4
   (testing "Dialect-specific versions should work"
     (is (= "SELECT\n  A\nFROM\n  {{#1234}} WHERE {{STATE}}"
-           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-           (sql.u/format-sql-and-fix-params :mysql "SELECT A FROM { { #1234}} WHERE {{ STATE}  }")))
+           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+           (sql.u/format-sql-and-fix-params #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mysql "SELECT A FROM { { #1234}} WHERE {{ STATE}  }")))
     (is (= "SELECT\n  A\nFROM\n  {{#1234}}\nWHERE\n  {{STATE}}"
-           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-           (sql.u/format-sql-and-fix-params :postgres "SELECT A FROM { { #1234}} WHERE {{ STATE}  }")))))
+           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+           (sql.u/format-sql-and-fix-params #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres "SELECT A FROM { { #1234}} WHERE {{ STATE}  }")))))
 
 (defmulti pound-sign-is-special-word-char?
   {:arglists '([driver-or-dialect])}

--- a/test/metabase/driver/sql_jdbc/actions_test.clj
+++ b/test/metabase/driver/sql_jdbc/actions_test.clj
@@ -378,7 +378,7 @@
 (deftest create-all-nil-test
   (testing "table.row/create with no optional fields provided"
     ;; This has been broken since Basic Actions were first built.
-    ;; It was recently fixed for postgres, but we still need to fix the other drivers.
+    ;; It was recently fixed for postgres, but we still need to fix the other drivers. [kondo-keep]
     #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
     (mt/test-drivers #{:postgres} #_(mt/normal-drivers-with-feature :actions)
       (actions.tu/with-actions-temp-db action-nullable

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -46,7 +46,7 @@
 (use-fixtures :once (fixtures/initialize :db))
 (use-fixtures :once ssh-test/do-with-mock-servers)
 
-;;; this is mostly testing [[h2/*allow-testing-h2-connections*]] so it's ok to hardcode driver names below.
+;;; this is mostly testing [[h2/*allow-testing-h2-connections*]] so it's ok to hardcode driver names below. [kondo-keep]
 #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel can-connect-with-details?-test
   (testing "Should not be able to connect without setting h2/*allow-testing-h2-connections*"
@@ -291,9 +291,10 @@
             ;; to [[driver.u/supports?]].
             original-supports?       driver.u/supports?
             supports?-fn             (fn [driver feature database]
-                                       (if (and #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-                                            (= driver :clickhouse)
-                                                (= feature :connection-impersonation))
+                                       (if (and
+                                            ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+                                            (= driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :clickhouse)
+                                            (= feature :connection-impersonation))
                                          true
                                          (original-supports? driver feature database)))]
         (try
@@ -339,7 +340,6 @@
             (t2/update! :model/Database (mt/id) {:details (:details db)})))))))
 
 ;;; Postgres-specific, so ok to hardcode driver names below.
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest connection-pool-invalidated-on-details-change-postgres-secrets-are-stable-test
   (testing "postgres secrets are stable (#23034)"
     (mt/with-temp [:model/Secret secret {:name       "file based secret"
@@ -348,7 +348,8 @@
                                          :value      (.getBytes "super secret")
                                          :creator_id (mt/user->id :crowberto)}]
       (let [db {:lib/type :metadata/database
-                :engine   :postgres
+                ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+                :engine   #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
                 :details  {:ssl                      true
                            :ssl-mode                 "verify-ca"
                            :ssl-root-cert-options    "uploaded"
@@ -357,7 +358,8 @@
                            :ssl-root-cert-id         (:id secret)
                            :ssl-root-cert-created-at "2022-07-25T15:57:51.556-05:00"}}]
         (is (instance? java.io.File
-                       (:sslrootcert (#'sql-jdbc.conn/connection-details->spec :postgres
+                       ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+                       (:sslrootcert (#'sql-jdbc.conn/connection-details->spec #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
                                                                                (:details db))))
             "Secrets not loaded for db connections")
         (is (= (#'sql-jdbc.conn/jdbc-spec-hash db)
@@ -485,10 +487,10 @@
 
 ;;; TODO Not clear why we're only testing Postgres here, do we support Azure Managed Identity for any other app DB type?
 ;;; Needs a comment please.
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest test-auth-provider-connection
   (mt/with-premium-features #{:database-auth-providers}
-    (mt/test-driver :postgres
+    ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+    (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
       (testing "Azure Managed Identity connections can be created and expired passwords get renewed"
         (let [db-details (:details (mt/db))
               oauth-db-details (-> db-details
@@ -520,11 +522,11 @@
                 ;; we must have created more than one connection
                 (is (> @connection-creations 1))))))))))
 
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest test-aws-iam-auth-provider-connection
   (mt/with-premium-features #{:database-auth-providers}
     (testing "AWS IAM authentication for Postgres"
-      (mt/test-driver :postgres
+      ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+      (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
         (let [db-details (:details (mt/db))
               iam-db-details (-> db-details
                                  (dissoc :password)
@@ -532,12 +534,14 @@
                                         :auth-provider :aws-iam
                                         :ssl true))]
           (testing "Connection spec is configured with AWS wrapper"
-            (let [spec (sql-jdbc.conn/connection-details->spec :postgres iam-db-details)]
+            ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+            (let [spec (sql-jdbc.conn/connection-details->spec #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres iam-db-details)]
               (is (= "aws-wrapper:postgresql" (:subprotocol spec)))
               (is (= "software.amazon.jdbc.ds.AwsWrapperDataSource" (:classname spec)))
               (is (= "iam" (:wrapperPlugins spec))))))))
     (testing "AWS IAM authentication for MySQL"
-      (mt/test-driver :mysql
+      ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+      (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mysql
         (let [db-details (:details (mt/db))
               iam-db-details (-> db-details
                                  (dissoc :password)
@@ -545,20 +549,21 @@
                                         :auth-provider :aws-iam
                                         :ssl true))]
           (testing "Connection spec is configured with AWS wrapper"
-            (let [spec (sql-jdbc.conn/connection-details->spec :mysql iam-db-details)]
+            ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+            (let [spec (sql-jdbc.conn/connection-details->spec #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mysql iam-db-details)]
               (is (= "aws-wrapper:mysql" (:subprotocol spec)))
               (is (= "software.amazon.jdbc.ds.AwsWrapperDataSource" (:classname spec)))
               (is (= "iam" (:wrapperPlugins spec)))
               (is (= "VERIFY_CA" (:sslMode spec))))))))))
 
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel test-aws-iam-requires-ssl
   (testing "AWS IAM authentication requires SSL to be enabled"
     (testing "Postgres throws error when SSL is disabled"
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"You must enable SSL in order to use AWS IAM authentication"
-           (sql-jdbc.conn/connection-details->spec :postgres
+           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+           (sql-jdbc.conn/connection-details->spec #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
                                                    {:host "localhost"
                                                     :port 5432
                                                     :user "cam"
@@ -569,7 +574,8 @@
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"You must enable SSL in order to use AWS IAM authentication"
-           (sql-jdbc.conn/connection-details->spec :mysql
+           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+           (sql-jdbc.conn/connection-details->spec #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mysql
                                                    {:host "localhost"
                                                     :port 3306
                                                     :user "root"
@@ -579,7 +585,8 @@
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"sslMode must be VERIFY_CA in order to use AWS IAM authentication"
-           (sql-jdbc.conn/connection-details->spec :mysql
+           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+           (sql-jdbc.conn/connection-details->spec #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mysql
                                                    {:host "localhost"
                                                     :port 3306
                                                     :user "root"
@@ -739,7 +746,6 @@
                   (check-data))))
             (finally (.stop ^Server server))))))))
 
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest postgres-aws-iam-can-connect
   (if (config/config-bool :mb-postgres-aws-iam-test)
     (let [host   (config/config-str :mb-postgres-aws-iam-test-host)
@@ -754,16 +760,16 @@
           (is (string? dbname)))
         (mt/with-temporary-setting-values [db-connection-timeout-ms 10000]
           (is
-           (driver.u/can-connect-with-details? :postgres {:host   host
-                                                          :port   port
-                                                          :dbname dbname
-                                                          :user   user
-                                                          :use-auth-provider true
-                                                          :auth-provider :aws-iam
-                                                          :ssl true})))))
+           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+           (driver.u/can-connect-with-details? #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres {:host   host
+                                                                                                                                     :port   port
+                                                                                                                                     :dbname dbname
+                                                                                                                                     :user   user
+                                                                                                                                     :use-auth-provider true
+                                                                                                                                     :auth-provider :aws-iam
+                                                                                                                                     :ssl true})))))
     (log/info "Skipping test: MB_POSTGRES_AWS_IAM_TEST not set")))
 
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest mysql-aws-iam-can-connect
   (if (config/config-bool :mb-mysql-aws-iam-test)
     (let [host   (config/config-str :mb-mysql-aws-iam-test-host)
@@ -780,16 +786,17 @@
           (is (string? ssl-cert)))
         (mt/with-temporary-setting-values [db-connection-timeout-ms 10000]
           (is
-           (driver.u/can-connect-with-details? :mysql {:host   host
-                                                       :port   port
-                                                       :dbname dbname
-                                                       :user   user
-                                                       :additional-options (if (= ssl-cert "trust")
-                                                                             "trustServerCertificate=true"
-                                                                             (str "serverSslCert=" ssl-cert))
-                                                       :use-auth-provider true
-                                                       :auth-provider :aws-iam
-                                                       :ssl true})))))
+           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+           (driver.u/can-connect-with-details? #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mysql {:host   host
+                                                                                                                                  :port   port
+                                                                                                                                  :dbname dbname
+                                                                                                                                  :user   user
+                                                                                                                                  :additional-options (if (= ssl-cert "trust")
+                                                                                                                                                        "trustServerCertificate=true"
+                                                                                                                                                        (str "serverSslCert=" ssl-cert))
+                                                                                                                                  :use-auth-provider true
+                                                                                                                                  :auth-provider :aws-iam
+                                                                                                                                  :ssl true})))))
     (log/info "Skipping test: MB_MYSQL_AWS_IAM_TEST not set")))
 
 (defn- count-swapped-pools-for-db

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -291,10 +291,10 @@
             ;; to [[driver.u/supports?]].
             original-supports?       driver.u/supports?
             supports?-fn             (fn [driver feature database]
-                                       (if (and
-                                            ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-                                            (= driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :clickhouse)
-                                            (= feature :connection-impersonation))
+                                       ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+                                       (if (and #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+                                            (= driver :clickhouse)
+                                                (= feature :connection-impersonation))
                                          true
                                          (original-supports? driver feature database)))]
         (try
@@ -340,6 +340,8 @@
             (t2/update! :model/Database (mt/id) {:details (:details db)})))))))
 
 ;;; Postgres-specific, so ok to hardcode driver names below.
+;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest connection-pool-invalidated-on-details-change-postgres-secrets-are-stable-test
   (testing "postgres secrets are stable (#23034)"
     (mt/with-temp [:model/Secret secret {:name       "file based secret"
@@ -348,8 +350,7 @@
                                          :value      (.getBytes "super secret")
                                          :creator_id (mt/user->id :crowberto)}]
       (let [db {:lib/type :metadata/database
-                ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-                :engine   #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
+                :engine   :postgres
                 :details  {:ssl                      true
                            :ssl-mode                 "verify-ca"
                            :ssl-root-cert-options    "uploaded"
@@ -358,8 +359,7 @@
                            :ssl-root-cert-id         (:id secret)
                            :ssl-root-cert-created-at "2022-07-25T15:57:51.556-05:00"}}]
         (is (instance? java.io.File
-                       ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-                       (:sslrootcert (#'sql-jdbc.conn/connection-details->spec #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
+                       (:sslrootcert (#'sql-jdbc.conn/connection-details->spec :postgres
                                                                                (:details db))))
             "Secrets not loaded for db connections")
         (is (= (#'sql-jdbc.conn/jdbc-spec-hash db)
@@ -487,10 +487,11 @@
 
 ;;; TODO Not clear why we're only testing Postgres here, do we support Azure Managed Identity for any other app DB type?
 ;;; Needs a comment please.
+;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest test-auth-provider-connection
   (mt/with-premium-features #{:database-auth-providers}
-    ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-    (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
+    (mt/test-driver :postgres
       (testing "Azure Managed Identity connections can be created and expired passwords get renewed"
         (let [db-details (:details (mt/db))
               oauth-db-details (-> db-details
@@ -522,11 +523,12 @@
                 ;; we must have created more than one connection
                 (is (> @connection-creations 1))))))))))
 
+;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest test-aws-iam-auth-provider-connection
   (mt/with-premium-features #{:database-auth-providers}
     (testing "AWS IAM authentication for Postgres"
-      ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-      (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
+      (mt/test-driver :postgres
         (let [db-details (:details (mt/db))
               iam-db-details (-> db-details
                                  (dissoc :password)
@@ -534,14 +536,12 @@
                                         :auth-provider :aws-iam
                                         :ssl true))]
           (testing "Connection spec is configured with AWS wrapper"
-            ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-            (let [spec (sql-jdbc.conn/connection-details->spec #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres iam-db-details)]
+            (let [spec (sql-jdbc.conn/connection-details->spec :postgres iam-db-details)]
               (is (= "aws-wrapper:postgresql" (:subprotocol spec)))
               (is (= "software.amazon.jdbc.ds.AwsWrapperDataSource" (:classname spec)))
               (is (= "iam" (:wrapperPlugins spec))))))))
     (testing "AWS IAM authentication for MySQL"
-      ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-      (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mysql
+      (mt/test-driver :mysql
         (let [db-details (:details (mt/db))
               iam-db-details (-> db-details
                                  (dissoc :password)
@@ -549,21 +549,21 @@
                                         :auth-provider :aws-iam
                                         :ssl true))]
           (testing "Connection spec is configured with AWS wrapper"
-            ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-            (let [spec (sql-jdbc.conn/connection-details->spec #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mysql iam-db-details)]
+            (let [spec (sql-jdbc.conn/connection-details->spec :mysql iam-db-details)]
               (is (= "aws-wrapper:mysql" (:subprotocol spec)))
               (is (= "software.amazon.jdbc.ds.AwsWrapperDataSource" (:classname spec)))
               (is (= "iam" (:wrapperPlugins spec)))
               (is (= "VERIFY_CA" (:sslMode spec))))))))))
 
+;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel test-aws-iam-requires-ssl
   (testing "AWS IAM authentication requires SSL to be enabled"
     (testing "Postgres throws error when SSL is disabled"
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"You must enable SSL in order to use AWS IAM authentication"
-           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-           (sql-jdbc.conn/connection-details->spec #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
+           (sql-jdbc.conn/connection-details->spec :postgres
                                                    {:host "localhost"
                                                     :port 5432
                                                     :user "cam"
@@ -574,8 +574,7 @@
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"You must enable SSL in order to use AWS IAM authentication"
-           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-           (sql-jdbc.conn/connection-details->spec #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mysql
+           (sql-jdbc.conn/connection-details->spec :mysql
                                                    {:host "localhost"
                                                     :port 3306
                                                     :user "root"
@@ -585,8 +584,7 @@
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"sslMode must be VERIFY_CA in order to use AWS IAM authentication"
-           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-           (sql-jdbc.conn/connection-details->spec #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mysql
+           (sql-jdbc.conn/connection-details->spec :mysql
                                                    {:host "localhost"
                                                     :port 3306
                                                     :user "root"
@@ -746,6 +744,8 @@
                   (check-data))))
             (finally (.stop ^Server server))))))))
 
+;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest postgres-aws-iam-can-connect
   (if (config/config-bool :mb-postgres-aws-iam-test)
     (let [host   (config/config-str :mb-postgres-aws-iam-test-host)
@@ -760,16 +760,17 @@
           (is (string? dbname)))
         (mt/with-temporary-setting-values [db-connection-timeout-ms 10000]
           (is
-           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-           (driver.u/can-connect-with-details? #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres {:host   host
-                                                                                                                                     :port   port
-                                                                                                                                     :dbname dbname
-                                                                                                                                     :user   user
-                                                                                                                                     :use-auth-provider true
-                                                                                                                                     :auth-provider :aws-iam
-                                                                                                                                     :ssl true})))))
+           (driver.u/can-connect-with-details? :postgres {:host   host
+                                                          :port   port
+                                                          :dbname dbname
+                                                          :user   user
+                                                          :use-auth-provider true
+                                                          :auth-provider :aws-iam
+                                                          :ssl true})))))
     (log/info "Skipping test: MB_POSTGRES_AWS_IAM_TEST not set")))
 
+;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest mysql-aws-iam-can-connect
   (if (config/config-bool :mb-mysql-aws-iam-test)
     (let [host   (config/config-str :mb-mysql-aws-iam-test-host)
@@ -786,17 +787,16 @@
           (is (string? ssl-cert)))
         (mt/with-temporary-setting-values [db-connection-timeout-ms 10000]
           (is
-           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-           (driver.u/can-connect-with-details? #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mysql {:host   host
-                                                                                                                                  :port   port
-                                                                                                                                  :dbname dbname
-                                                                                                                                  :user   user
-                                                                                                                                  :additional-options (if (= ssl-cert "trust")
-                                                                                                                                                        "trustServerCertificate=true"
-                                                                                                                                                        (str "serverSslCert=" ssl-cert))
-                                                                                                                                  :use-auth-provider true
-                                                                                                                                  :auth-provider :aws-iam
-                                                                                                                                  :ssl true})))))
+           (driver.u/can-connect-with-details? :mysql {:host   host
+                                                       :port   port
+                                                       :dbname dbname
+                                                       :user   user
+                                                       :additional-options (if (= ssl-cert "trust")
+                                                                             "trustServerCertificate=true"
+                                                                             (str "serverSslCert=" ssl-cert))
+                                                       :use-auth-provider true
+                                                       :auth-provider :aws-iam
+                                                       :ssl true})))))
     (log/info "Skipping test: MB_MYSQL_AWS_IAM_TEST not set")))
 
 (defn- count-swapped-pools-for-db

--- a/test/metabase/driver/sql_jdbc/execute_test.clj
+++ b/test/metabase/driver/sql_jdbc/execute_test.clj
@@ -85,10 +85,10 @@
 
 (deftest try-ensure-open-conn-sets-non-recursive-options-test
   (testing "try-ensure-open-conn! sets connection options as non-recursive"
-    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
     (mt/test-drivers (disj (descendants driver/hierarchy :sql-jdbc)
                            ;; too tricky to stub the connection
-                           :presto-jdbc :databricks :starburst)
+                           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+                           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :presto-jdbc #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :databricks #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :starburst)
       (let [connection-option-calls (volatile! [])
             is-default-options
             (identical? (get-method sql-jdbc.execute/do-with-connection-with-options :sql-jdbc)

--- a/test/metabase/driver/sql_jdbc/execute_test.clj
+++ b/test/metabase/driver/sql_jdbc/execute_test.clj
@@ -85,10 +85,11 @@
 
 (deftest try-ensure-open-conn-sets-non-recursive-options-test
   (testing "try-ensure-open-conn! sets connection options as non-recursive"
+    ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
     (mt/test-drivers (disj (descendants driver/hierarchy :sql-jdbc)
                            ;; too tricky to stub the connection
-                           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-                           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :presto-jdbc #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :databricks #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :starburst)
+                           :presto-jdbc :databricks :starburst)
       (let [connection-option-calls (volatile! [])
             is-default-options
             (identical? (get-method sql-jdbc.execute/do-with-connection-with-options :sql-jdbc)

--- a/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
@@ -41,7 +41,8 @@
                      (sql-jdbc.describe-database/simple-select-probe-query driver "schema" "wow"))
       :h2
       ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-      #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres)))
+      #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+      :postgres)))
 
 (deftest ^:parallel simple-select-probe-query-test-3
   (testing "simple-select-probe-query shouldn't actually return any rows"
@@ -264,7 +265,8 @@
 ;;; TODO: fix and change this to test on (mt/sql-jdbc-drivers)
 (deftest sync-table-with-backslash-test
   ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-  (mt/test-drivers #{#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres}
+  #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+  (mt/test-drivers #{:postgres}
     (testing "table with backslash in name, PKs, FKS are correctly synced"
       (mt/with-temp-test-data [["human\\race"
                                 [{:field-name "humanraceid" :base-type :type/Integer :pk? true}

--- a/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
@@ -40,8 +40,8 @@
     (are [driver] (= ["SELECT TRUE AS \"_\" FROM \"schema\".\"wow\" WHERE 1 <> 1 LIMIT 0"]
                      (sql-jdbc.describe-database/simple-select-probe-query driver "schema" "wow"))
       :h2
-      #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-      :postgres)))
+      ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+      #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres)))
 
 (deftest ^:parallel simple-select-probe-query-test-3
   (testing "simple-select-probe-query shouldn't actually return any rows"
@@ -263,8 +263,8 @@
 
 ;;; TODO: fix and change this to test on (mt/sql-jdbc-drivers)
 (deftest sync-table-with-backslash-test
-  #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-  (mt/test-drivers #{:postgres}
+  ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+  (mt/test-drivers #{#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres}
     (testing "table with backslash in name, PKs, FKS are correctly synced"
       (mt/with-temp-test-data [["human\\race"
                                 [{:field-name "humanraceid" :base-type :type/Integer :pk? true}

--- a/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
@@ -36,11 +36,11 @@
 
 (deftest ^:parallel simple-select-probe-query-test-2
   ;; this is mostly a sanity check against some of our known drivers so ok to hardcode driver names.
-  #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
   (testing "real drivers produce correct query"
     (are [driver] (= ["SELECT TRUE AS \"_\" FROM \"schema\".\"wow\" WHERE 1 <> 1 LIMIT 0"]
                      (sql-jdbc.describe-database/simple-select-probe-query driver "schema" "wow"))
       :h2
+      #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
       :postgres)))
 
 (deftest ^:parallel simple-select-probe-query-test-3
@@ -262,8 +262,8 @@
                                  driver/*driver* conn schema table-name))))))))))))))
 
 ;;; TODO: fix and change this to test on (mt/sql-jdbc-drivers)
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest sync-table-with-backslash-test
+  #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
   (mt/test-drivers #{:postgres}
     (testing "table with backslash in name, PKs, FKS are correctly synced"
       (mt/with-temp-test-data [["human\\race"

--- a/test/metabase/driver/sql_jdbc_test.clj
+++ b/test/metabase/driver/sql_jdbc_test.clj
@@ -74,8 +74,8 @@
                  (update :category_id int)
                  (update :id int)))))))
 
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel invalid-ssh-credentials-test
+  #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
   (mt/test-driver :postgres
     (testing "Make sure invalid ssh credentials are detected if a direct connection is possible"
       (is (thrown?

--- a/test/metabase/driver/sql_jdbc_test.clj
+++ b/test/metabase/driver/sql_jdbc_test.clj
@@ -76,15 +76,15 @@
 
 (deftest ^:parallel invalid-ssh-credentials-test
   ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-  (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
+  #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+  (mt/test-driver :postgres
     (testing "Make sure invalid ssh credentials are detected if a direct connection is possible"
       (is (thrown?
            java.net.ConnectException
            ;; this test works if sshd is running or not
            (try
              (let [details {:dbname         "test"
-                            ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-                            :engine         #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
+                            :engine         :postgres
                             :host           "localhost"
                             :password       "changeme"
                             :port           5432
@@ -99,8 +99,7 @@
                             :tunnel-port    21212
                             :tunnel-user    "example"
                             :user           "postgres"}]
-               ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-               (driver.u/can-connect-with-details? #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres details :throw-exceptions))
+               (driver.u/can-connect-with-details? :postgres details :throw-exceptions))
              (catch Throwable e
                (loop [^Throwable e e]
                  (or (when (instance? java.net.ConnectException e)

--- a/test/metabase/driver/sql_jdbc_test.clj
+++ b/test/metabase/driver/sql_jdbc_test.clj
@@ -75,15 +75,16 @@
                  (update :id int)))))))
 
 (deftest ^:parallel invalid-ssh-credentials-test
-  #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-  (mt/test-driver :postgres
+  ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+  (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
     (testing "Make sure invalid ssh credentials are detected if a direct connection is possible"
       (is (thrown?
            java.net.ConnectException
            ;; this test works if sshd is running or not
            (try
              (let [details {:dbname         "test"
-                            :engine         :postgres
+                            ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+                            :engine         #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
                             :host           "localhost"
                             :password       "changeme"
                             :port           5432
@@ -98,7 +99,8 @@
                             :tunnel-port    21212
                             :tunnel-user    "example"
                             :user           "postgres"}]
-               (driver.u/can-connect-with-details? :postgres details :throw-exceptions))
+               ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+               (driver.u/can-connect-with-details? #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres details :throw-exceptions))
              (catch Throwable e
                (loop [^Throwable e e]
                  (or (when (instance? java.net.ConnectException e)

--- a/test/metabase/legacy_mbql/util_test.cljc
+++ b/test/metabase/legacy_mbql/util_test.cljc
@@ -33,7 +33,6 @@
 
 ;;; --------------------------------------------- query->max-rows-limit ----------------------------------------------
 
-#_{:clj-kondo/ignore [:deprecated-var]}
 (t/deftest ^:parallel query->max-rows-limit-test
   (doseq [[group query->expected]
           {"should return `:limit` if set"

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -415,7 +415,6 @@
 (deftest ^:parallel js=-metatest
   (testing "check js= works correctly (who tests the tests?)"
     (testing "should be true"
-      #_{:clj-kondo/ignore [:equals-true]}
       (are [a b] (= true (js= a b))
         7 7
         0 0

--- a/test/metabase/lib/query/test_spec_test.cljc
+++ b/test/metabase/lib/query/test_spec_test.cljc
@@ -848,7 +848,6 @@
       (is (empty? (lib/fields query 2)))
       (is (= 25 (lib/current-limit query 2))))))
 
-#_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest ^:parallel test-query-comprehensive-all-features-test-with-fields
   (testing "test-query exercises all functionality in a comprehensive multi-stage query, with fields clause"
     (let [query (lib.query.test-spec/test-query

--- a/test/metabase/lib/query_test.cljc
+++ b/test/metabase/lib/query_test.cljc
@@ -29,11 +29,11 @@
                   (lib/aggregate (lib/sum (meta/field-metadata :venues :price))))
         ;; wrong arity: there's a bug in our Kondo config, see
         ;; https://metaboat.slack.com/archives/C04DN5VRQM6/p1679022185079739?thread_ts=1679022025.317059&cid=C04DN5VRQM6
-        query (-> #_{:clj-kondo/ignore [:invalid-arity]}
+        query (->
                (lib/filter query (lib/= (meta/field-metadata :venues :name) "Toucannery"))
-                  (lib/breakout (meta/field-metadata :venues :category-id))
-                  (lib/order-by (meta/field-metadata :venues :id))
-                  (lib/limit 100))]
+               (lib/breakout (meta/field-metadata :venues :category-id))
+               (lib/order-by (meta/field-metadata :venues :id))
+               (lib/limit 100))]
     (is (= (str "Venues,"
                 " Sum of Price,"
                 " Grouped by Category ID,"
@@ -195,7 +195,6 @@
 
 (deftest ^:parallel can-run-test
   (mu/disable-enforcement
-    #_{:clj-kondo/ignore [:equals-true]}
     (are [can-run? card-type query]
          (if (= card-type :question)
            (= can-run? (lib.query/can-run query card-type) (lib.query/can-preview query))
@@ -236,7 +235,6 @@
 
 (deftest ^:parallel can-save?-test
   (mu/disable-enforcement
-    #_{:clj-kondo/ignore [:equals-true]}
     (are [can-save? card-type query]
          (= can-save? (lib.query/can-save? query card-type))
       true  :question (lib.tu/venues-query)

--- a/test/metabase/lib/query_test.cljc
+++ b/test/metabase/lib/query_test.cljc
@@ -27,13 +27,10 @@
 (deftest ^:parallel describe-query-test
   (let [query (-> (lib.tu/venues-query)
                   (lib/aggregate (lib/sum (meta/field-metadata :venues :price))))
-        ;; wrong arity: there's a bug in our Kondo config, see
-        ;; https://metaboat.slack.com/archives/C04DN5VRQM6/p1679022185079739?thread_ts=1679022025.317059&cid=C04DN5VRQM6
-        query (->
-               (lib/filter query (lib/= (meta/field-metadata :venues :name) "Toucannery"))
-               (lib/breakout (meta/field-metadata :venues :category-id))
-               (lib/order-by (meta/field-metadata :venues :id))
-               (lib/limit 100))]
+        query (-> (lib/filter query (lib/= (meta/field-metadata :venues :name) "Toucannery"))
+                  (lib/breakout (meta/field-metadata :venues :category-id))
+                  (lib/order-by (meta/field-metadata :venues :id))
+                  (lib/limit 100))]
     (is (= (str "Venues,"
                 " Sum of Price,"
                 " Grouped by Category ID,"

--- a/test/metabase/lib/table_test.cljc
+++ b/test/metabase/lib/table_test.cljc
@@ -33,7 +33,6 @@
 (deftest ^:parallel nil-column-test
   (testing "Fields with missing names shouldn't blow up visible-columns"
     (let [metadata-provider
-          #_{:clj-kondo/ignore [:missing-protocol-method]}
           (reify
             metadata.protocols/MetadataProvider
             (database [_this]

--- a/test/metabase/lib/types/isa_test.cljc
+++ b/test/metabase/lib/types/isa_test.cljc
@@ -147,7 +147,6 @@
   (is (false? (lib.types.isa/numeric? {:effective-type :type/Text :semantic-type :type/Price}))))
 
 (deftest ^:parallel compatible-type?-test
-  #_{:clj-kondo/ignore [:equals-true]}
   (are [exp base-lhs eff-lhs base-rhs eff-rhs] (= exp (lib.types.isa/compatible-type?
                                                        {:base-type      base-lhs
                                                         :effective-type eff-lhs}

--- a/test/metabase/lib_be/metadata/jvm_test.clj
+++ b/test/metabase/lib_be/metadata/jvm_test.clj
@@ -93,7 +93,6 @@
               (lib.metadata.calculation/returned-columns mbql5-query))))))
 
 (deftest ^:synchronized with-temp-source-question-metadata-test
-  #_{:clj-kondo/ignore [:discouraged-var]}
   (mt/with-temp [:model/Card card {:dataset_query
                                    (mt/mbql-query venues
                                      {:joins
@@ -184,7 +183,6 @@
              (mt/id :venues :id))))))
 
 (deftest ^:synchronized persisted-info-metadata-test
-  #_{:clj-kondo/ignore [:discouraged-var]}
   (mt/with-temp [:model/Card          {card-id :id} {:dataset_query {:database (mt/id)
                                                                      :type     :query
                                                                      :query    {:source-table (mt/id :venues)}}}

--- a/test/metabase/lib_metric/metadata/jvm_test.clj
+++ b/test/metabase/lib_metric/metadata/jvm_test.clj
@@ -13,7 +13,6 @@
 
 (deftest ^:synchronized metadatas-fetches-metrics-test
   (testing "metadatas should fetch metrics from the database"
-    #_{:clj-kondo/ignore [:discouraged-var]}
     (mt/with-temp [:model/Card metric {:type         :metric
                                        :name         "Test Metric"
                                        :database_id  (mt/id)
@@ -30,7 +29,6 @@
 
 (deftest ^:synchronized metadatas-fetches-metrics-by-table-id-test
   (testing "metadatas should fetch metrics by table-id"
-    #_{:clj-kondo/ignore [:discouraged-var]}
     (mt/with-temp [:model/Card metric {:type         :metric
                                        :name         "Table Metric"
                                        :database_id  (mt/id)
@@ -46,7 +44,6 @@
 
 (deftest ^:synchronized metadatas-excludes-archived-metrics-test
   (testing "metadatas should exclude archived metrics when not filtering by ID"
-    #_{:clj-kondo/ignore [:discouraged-var]}
     (mt/with-temp [:model/Card active-metric   {:type         :metric
                                                 :name         "Active Metric"
                                                 :archived     false
@@ -72,7 +69,6 @@
 
 (deftest ^:synchronized metadatas-includes-archived-when-filtering-by-id-test
   (testing "metadatas should include archived metrics when filtering by ID"
-    #_{:clj-kondo/ignore [:discouraged-var]}
     (mt/with-temp [:model/Card archived-metric {:type         :metric
                                                 :name         "Archived Metric"
                                                 :archived     true

--- a/test/metabase/logger/core_test.clj
+++ b/test/metabase/logger/core_test.clj
@@ -92,7 +92,6 @@
                 (line-seq (io/reader f))))))))
 
 (deftest level-enabled?-test
-  #_{:clj-kondo/ignore [:equals-true]}
   (are [set-level check-level expected-value] (= expected-value
                                                  (mt/with-log-level [metabase.logger.core-test set-level]
                                                    (logger/level-enabled? 'metabase.logger.core-test check-level)))

--- a/test/metabase/metabot/tools/construct_representations_test.clj
+++ b/test/metabase/metabot/tools/construct_representations_test.clj
@@ -287,7 +287,7 @@
             (when-not (instance? clojure.lang.ExceptionInfo result)
               (let [q          (get-in result [:structured-output :query])
                     ;; Round-trip through legacy is the gate the production failure hit.
-                    legacy     #_{:clj-kondo/ignore [:discouraged-var]}
+                    legacy
                     (lib/->legacy-MBQL q)
                     rebuilt    (try (lib/query mp legacy)
                                     (catch clojure.lang.ExceptionInfo e e))]

--- a/test/metabase/metabot/tools/construct_representations_test.clj
+++ b/test/metabase/metabot/tools/construct_representations_test.clj
@@ -287,8 +287,7 @@
             (when-not (instance? clojure.lang.ExceptionInfo result)
               (let [q          (get-in result [:structured-output :query])
                     ;; Round-trip through legacy is the gate the production failure hit.
-                    legacy
-                    (lib/->legacy-MBQL q)
+                    legacy     (lib/->legacy-MBQL q)
                     rebuilt    (try (lib/query mp legacy)
                                     (catch clojure.lang.ExceptionInfo e e))]
                 (testing "order-by uses an aggregation reference, not an inline aggregation"

--- a/test/metabase/model_persistence/api_test.clj
+++ b/test/metabase/model_persistence/api_test.clj
@@ -103,6 +103,7 @@
                                        (.setProperty "org.quartz.threadPool.threadCount" "6")
                                        (.setProperty "org.quartz.threadPool.class" "org.quartz.simpl.SimpleThreadPool"))))]
     ;; a binding won't work since we need to cross thread boundaries
+    ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
     #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
     (with-redefs [task/scheduler (constantly sched)]
       (try

--- a/test/metabase/notification/condition_test.clj
+++ b/test/metabase/notification/condition_test.clj
@@ -8,7 +8,6 @@
    [metabase.query-processor.test :as qp]
    [metabase.test :as mt]))
 
-#_{:clj-kondo/ignore [:equals-true]}
 (deftest evaluate-literal-values-test
   (testing "literal values"
     (are [expected expression context] (= expected (evaluate-expression expression context))
@@ -17,7 +16,6 @@
       true true {}
       false false {})))
 
-#_{:clj-kondo/ignore [:equals-true]}
 (deftest evaluate-logical-operators-test
   (testing "logical operators"
     (are [expected expression context] (= expected (evaluate-expression expression context))
@@ -39,7 +37,6 @@
       true ["not" false] {}
       false ["not" ["not" false]] {})))
 
-#_{:clj-kondo/ignore [:equals-true]}
 (deftest evaluate-comparison-operators-test
   (testing "comparison operators"
     (are [expected expression context] (= expected (evaluate-expression expression context))
@@ -87,7 +84,6 @@
       true ["<=" 1 2 2] {}
       false ["<=" 2 1 1] {})))
 
-#_{:clj-kondo/ignore [:equals-true]}
 (deftest evaluate-context-access-test
   (testing "context access"
     (are [expected expression context] (= expected (evaluate-expression expression context))
@@ -116,7 +112,6 @@
       3 ["max" 3 2 1] {}
       6 ["max" ["context" "a"] ["context" "b"]] {:a 4, :b 6})))
 
-#_{:clj-kondo/ignore [:equals-true]}
 (deftest evaluate-nested-expressions-test
   (testing "nested expressions"
     (are [expected expression context] (= expected (evaluate-expression expression context))

--- a/test/metabase/notification/send_test.clj
+++ b/test/metabase/notification/send_test.clj
@@ -529,7 +529,6 @@
             (reset! sent-notifications [])
             (let [error-thrown (atom false)]
               ;; dispatcher worker thread — see note above
-              #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
               (with-redefs [notification.send/send-notification-sync!
                             (fn [notification]
                               (if (= "F" (:test-value notification))

--- a/test/metabase/notification/send_test.clj
+++ b/test/metabase/notification/send_test.clj
@@ -492,6 +492,7 @@
                                         :timeout-ms  1000})]
       ;; dispatcher spawns its own worker threads that don't inherit *local-redefs* —
       ;; use with-redefs to swap the root so worker threads see the replacement.
+      ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
       #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
       (with-redefs [notification.send/send-notification-sync! (fn [notification]
                                                                 ;; fake latency
@@ -682,6 +683,7 @@
           queue-size (notification.settings/notification-thread-pool-size)]
       ;; notification thread pool workers don't inherit *local-redefs* — the root swap from
       ;; with-redefs is required so the patched fns are visible to the worker threads.
+      ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
       #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
       (with-redefs [notification.payload/notification-payload (fn [& _]
                                                                 (assert false))
@@ -738,6 +740,7 @@
           dispatch-fn             (:dispatch-fn dispatcher)
           shutdown-fn             (:shutdown-fn dispatcher)]
       ;; dispatcher spawns worker threads without our dynamic binding
+      ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
       #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
       (with-redefs [notification.send/send-notification-sync!
                     (fn [notification]

--- a/test/metabase/notification/test_util.clj
+++ b/test/metabase/notification/test_util.clj
@@ -62,7 +62,6 @@
                 :content "<svg width=\"300\" height=\"130\" xmlns=\"http://www.w3.org/2000/svg\">\n  <rect width=\"200\" height=\"100\" x=\"10\" y=\"10\" rx=\"20\" ry=\"20\" fill=\"blue\" />\n</svg>"})]
      ~@body))
 
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn do-with-captured-channel-send!
   [thunk]
   (with-javascript-visualization-stub

--- a/test/metabase/oauth_server/api_test.clj
+++ b/test/metabase/oauth_server/api_test.clj
@@ -14,7 +14,6 @@
    (java.util Base64)))
 
 ;; reset-provider! is safe here — it resets a local atom, no global side effects.
-;; kondo flags it because of the `!` suffix in a fixture.
 (use-fixtures :each (fn [thunk]
                       (oauth-server/reset-provider!)
                       (binding [client/*url-prefix* ""]

--- a/test/metabase/oauth_server/api_test.clj
+++ b/test/metabase/oauth_server/api_test.clj
@@ -15,7 +15,6 @@
 
 ;; reset-provider! is safe here — it resets a local atom, no global side effects.
 ;; kondo flags it because of the `!` suffix in a fixture.
-#_{:clj-kondo/ignore [:metabase/validate-deftest]}
 (use-fixtures :each (fn [thunk]
                       (oauth-server/reset-provider!)
                       (binding [client/*url-prefix* ""]

--- a/test/metabase/oauth_server/core_test.clj
+++ b/test/metabase/oauth_server/core_test.clj
@@ -5,7 +5,6 @@
    [metabase.test :as mt]))
 
 ;; TODO (Chris 2026-03-24) — remove kondo ignore once linter respects the thread-safe list in use-fixtures
-#_{:clj-kondo/ignore [:metabase/validate-deftest]}
 (use-fixtures :each (fn [thunk]
                       (oauth-server/reset-provider!)
                       (thunk)

--- a/test/metabase/oauth_server/core_test.clj
+++ b/test/metabase/oauth_server/core_test.clj
@@ -4,7 +4,6 @@
    [metabase.oauth-server.core :as oauth-server]
    [metabase.test :as mt]))
 
-;; TODO (Chris 2026-03-24) — remove kondo ignore once linter respects the thread-safe list in use-fixtures
 (use-fixtures :each (fn [thunk]
                       (oauth-server/reset-provider!)
                       (thunk)

--- a/test/metabase/premium_features/api_test.clj
+++ b/test/metabase/premium_features/api_test.clj
@@ -76,7 +76,6 @@
 (deftest token-refresh-sets-premium-features-cookie-test
   (testing "POST /api/premium-features/token/refresh sets the premium-features-last-updated cookie"
     ;; user-real-request hits a real Jetty server; handler thread doesn't inherit *local-redefs*.
-    #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
     (with-redefs [premium-features/token-status            (constantly fake-token-status)
                   premium-features/premium-embedding-token (constantly nil)]
       (let [cs (cookies/cookie-store)]

--- a/test/metabase/premium_features/test_util.clj
+++ b/test/metabase/premium_features/test_util.clj
@@ -23,6 +23,7 @@
           (thunk)
           ;; global mode — must use with-redefs so Jetty handler threads (which don't inherit *local-redefs*)
           ;; see the updated premium features.
+          ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
           #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
           (with-redefs [token-check/*token-features* (constantly features)]
             (thunk)))))))

--- a/test/metabase/pulse/task/send_pulses_test.clj
+++ b/test/metabase/pulse/task/send_pulses_test.clj
@@ -205,6 +205,7 @@
       (mt/with-model-cleanup [:model/Pulse]
         (let [sent-channel-ids (atom #{})]
           ;; with-redefs (cross-thread): quartz scheduler threads don't inherit *local-redefs*
+          ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
           #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
           (with-redefs [;; run the job every second
                         u.cron/schedule-map->cron-string (constantly "* * * 1/1 * ? *")
@@ -241,6 +242,7 @@
                   original-send-pulse!* (mt/original-fn #'task.send-pulses/send-pulse!*)]
               ;; quartz scheduler threads don't inherit *local-redefs*, so we have to swap the
               ;; root — see dynamic-redefs.clj docstring
+              ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
               #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
               (with-redefs [;; run the job every second - must be before creating PulseChannel
                             u.cron/schedule-map->cron-string (constantly "* * * 1/1 * ? *")

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -676,7 +676,8 @@
     (testing "\nCan we fetch a native version of an MBQL query?"
       (testing "`:now` is usable inside `:case` with mongo (#32216)"
         ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-        (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mongo
+        #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+        (mt/test-driver :mongo
           (is (= {"$switch"
                   {"branches"
                    [{"case" {"$eq" [{"$dayOfMonth" {"date" "$$NOW", "timezone" "UTC"}}
@@ -694,7 +695,8 @@
 ;; historical test: don't do this going forward
 (deftest report-timezone-test
   ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-  (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
+  #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+  (mt/test-driver :postgres
     (testing "expected (desired) and actual timezone should be returned as part of query results"
       (mt/with-temporary-setting-values [report-timezone "US/Pacific"]
         (let [results (mt/user-http-request :rasta :post 202 "dataset" (mt/mbql-query checkins
@@ -709,7 +711,8 @@
 (deftest databricks-stack-trace-test
   (testing "exceptions with stacktraces should have the stacktrace removed"
     ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-    (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :databricks
+    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+    (mt/test-driver :databricks
       (let [res (mt/user-http-request :rasta :post 400 "dataset"
                                       (lib/native-query (mt/metadata-provider)
                                                         "asdf;"))]

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -671,11 +671,11 @@
                                      (mt/mbql-query venues {:fields [$id $name]}))))))))
 
 ;; historical test: don't do this going forward
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel compile-test-6
   (testing "POST /api/dataset/native"
     (testing "\nCan we fetch a native version of an MBQL query?"
       (testing "`:now` is usable inside `:case` with mongo (#32216)"
+        #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
         (mt/test-driver :mongo
           (is (= {"$switch"
                   {"branches"
@@ -692,8 +692,8 @@
                      :query json/decode first (get-in ["$project" "E"])))))))))
 
 ;; historical test: don't do this going forward
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest report-timezone-test
+  #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
   (mt/test-driver :postgres
     (testing "expected (desired) and actual timezone should be returned as part of query results"
       (mt/with-temporary-setting-values [report-timezone "US/Pacific"]
@@ -706,9 +706,9 @@
                      (select-keys [:requested_timezone :results_timezone])))))))))
 
 ;; historical test: don't do this going forward
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest databricks-stack-trace-test
   (testing "exceptions with stacktraces should have the stacktrace removed"
+    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
     (mt/test-driver :databricks
       (let [res (mt/user-http-request :rasta :post 400 "dataset"
                                       (lib/native-query (mt/metadata-provider)

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -675,8 +675,8 @@
   (testing "POST /api/dataset/native"
     (testing "\nCan we fetch a native version of an MBQL query?"
       (testing "`:now` is usable inside `:case` with mongo (#32216)"
-        #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-        (mt/test-driver :mongo
+        ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+        (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mongo
           (is (= {"$switch"
                   {"branches"
                    [{"case" {"$eq" [{"$dayOfMonth" {"date" "$$NOW", "timezone" "UTC"}}
@@ -693,8 +693,8 @@
 
 ;; historical test: don't do this going forward
 (deftest report-timezone-test
-  #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-  (mt/test-driver :postgres
+  ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+  (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
     (testing "expected (desired) and actual timezone should be returned as part of query results"
       (mt/with-temporary-setting-values [report-timezone "US/Pacific"]
         (let [results (mt/user-http-request :rasta :post 202 "dataset" (mt/mbql-query checkins
@@ -708,8 +708,8 @@
 ;; historical test: don't do this going forward
 (deftest databricks-stack-trace-test
   (testing "exceptions with stacktraces should have the stacktrace removed"
-    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-    (mt/test-driver :databricks
+    ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+    (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :databricks
       (let [res (mt/user-http-request :rasta :post 400 "dataset"
                                       (lib/native-query (mt/metadata-provider)
                                                         "asdf;"))]

--- a/test/metabase/query_processor/explicit_joins_test.clj
+++ b/test/metabase/query_processor/explicit_joins_test.clj
@@ -879,7 +879,8 @@
                   ;; differences, this is just a sanity check for a few known drivers. So it's okay to hardcode driver
                   ;; names here.
                   ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-                  (when (#{#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres :h2} driver/*driver*)
+                  #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+                  (when (#{:postgres :h2} driver/*driver*)
                     (is (= ["Category" "Count" "Q2 → Category" "Q2 → Sum of Price" "Q3 → Category" "Q3 → Average of Rating"]
                            (map :display_name (get-in results [:data :results_metadata :columns])))))
                   (is (= [["Doohickey" 42 "Doohickey" 2185.89 "Doohickey" 3.73]
@@ -912,7 +913,8 @@
               ;; any differences, this is just a sanity check for a few known drivers. So it's okay to hardcode
               ;; driver names here.
               ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-              (when (#{:h2 #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres} driver/*driver*)
+              #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+              (when (#{:h2 :postgres} driver/*driver*)
                 (is (= ["ID"
                         "User ID"
                         "Product ID"

--- a/test/metabase/query_processor/explicit_joins_test.clj
+++ b/test/metabase/query_processor/explicit_joins_test.clj
@@ -878,8 +878,8 @@
                   ;; the display names can differ a little between drivers, we don't actually care about any
                   ;; differences, this is just a sanity check for a few known drivers. So it's okay to hardcode driver
                   ;; names here.
-                  #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-                  (when (#{:postgres :h2} driver/*driver*)
+                  ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+                  (when (#{#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres :h2} driver/*driver*)
                     (is (= ["Category" "Count" "Q2 → Category" "Q2 → Sum of Price" "Q3 → Category" "Q3 → Average of Rating"]
                            (map :display_name (get-in results [:data :results_metadata :columns])))))
                   (is (= [["Doohickey" 42 "Doohickey" 2185.89 "Doohickey" 3.73]
@@ -911,8 +911,8 @@
               ;; the display names can differ a little between drivers, we don't actually care about
               ;; any differences, this is just a sanity check for a few known drivers. So it's okay to hardcode
               ;; driver names here.
-              #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-              (when (#{:h2 :postgres} driver/*driver*)
+              ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+              (when (#{:h2 #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres} driver/*driver*)
                 (is (= ["ID"
                         "User ID"
                         "Product ID"

--- a/test/metabase/query_processor/filter_test.clj
+++ b/test/metabase/query_processor/filter_test.clj
@@ -178,8 +178,8 @@
     (testing ":between with dates"
       ;; Prevent an issue with Snowflake were a previous connection's report-timezone setting can affect this
       ;; test's results
-      #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-      (when (= driver/*driver* :snowflake)
+      ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+      (when (= driver/*driver* #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :snowflake)
         (driver/notify-database-updated driver/*driver* (mt/id)))
       (is (=? {:rows [[29]]
                :cols [(qp.test-util/aggregate-col :count)]}

--- a/test/metabase/query_processor/filter_test.clj
+++ b/test/metabase/query_processor/filter_test.clj
@@ -179,7 +179,8 @@
       ;; Prevent an issue with Snowflake were a previous connection's report-timezone setting can affect this
       ;; test's results
       ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-      (when (= driver/*driver* #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :snowflake)
+      #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+      (when (= driver/*driver* :snowflake)
         (driver/notify-database-updated driver/*driver* (mt/id)))
       (is (=? {:rows [[29]]
                :cols [(qp.test-util/aggregate-col :count)]}

--- a/test/metabase/query_processor/middleware/cache_backend/db_test.clj
+++ b/test/metabase/query_processor/middleware/cache_backend/db_test.clj
@@ -69,7 +69,6 @@
                                    (await-race! (first args))
                                    (apply orig-ins-instances args))
             cache-backend        (i/cache-backend :db)]
-        #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
         (with-redefs-fn {ins-pks-var       coordinated-ins-pks
                          ins-instances-var coordinated-ins-inst}
           (fn []

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -443,8 +443,8 @@
                   result)))))))
 
 (deftest array-query-can-be-cached-test
-  #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :test/arrays)
+                         #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
                          :sqlite) ;; Disabling until issue #57301 is resolved
     (with-mock-cache! [save-chan]
       (mt/with-temporary-setting-values [enable-query-caching true]

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -445,7 +445,8 @@
 (deftest array-query-can-be-cached-test
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :test/arrays)
                          ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-                         #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :sqlite) ;; Disabling until issue #57301 is resolved
+                         #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+                         :sqlite) ;; Disabling until issue #57301 is resolved
     (with-mock-cache! [save-chan]
       (mt/with-temporary-setting-values [enable-query-caching true]
         (mt/with-clock #t "2025-02-06T00:00:00.000Z[UTC]"
@@ -474,14 +475,14 @@
 
 (deftest postgres-domain-can-be-cached-test
   ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-  (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
+  #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+  (mt/test-driver :postgres
     (mt/dataset (mt/dataset-definition
                  "domain_dataset"
                  [["placeholder"
                    [{:field-name "foo", :base-type :type/Integer}]
                    [[1]]]])
-      ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-      (let [spec (sql-jdbc.conn/connection-details->spec #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres (:details (mt/db)))
+      (let [spec (sql-jdbc.conn/connection-details->spec :postgres (:details (mt/db)))
             dom-name (str "dom_" (mt/random-name))]
         (jdbc/execute! spec [(format "CREATE DOMAIN %s AS text CHECK (VALUE <> '')" dom-name)])
         (with-mock-cache! [save-chan]
@@ -554,6 +555,7 @@
           save-query-update-avg-time-original (mt/original-fn #'query/save-queries-and-update-average-execution-times!)]
       ;; save-execution-metadata!* and save-queries-and-update-average-execution-times! are invoked from
       ;; the QP pipeline on worker threads that don't inherit *local-redefs* — use with-redefs.
+      ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
       #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
       (with-redefs [process-userland-query/save-execution-metadata!*          (fn [& args]
                                                                                 (swap! save-execution-metadata-count inc)

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -444,8 +444,8 @@
 
 (deftest array-query-can-be-cached-test
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :test/arrays)
-                         #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-                         :sqlite) ;; Disabling until issue #57301 is resolved
+                         ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+                         #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :sqlite) ;; Disabling until issue #57301 is resolved
     (with-mock-cache! [save-chan]
       (mt/with-temporary-setting-values [enable-query-caching true]
         (mt/with-clock #t "2025-02-06T00:00:00.000Z[UTC]"
@@ -473,14 +473,15 @@
                    (dissoc cached-result :cache/details)))))))))
 
 (deftest postgres-domain-can-be-cached-test
-  #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-  (mt/test-driver :postgres
+  ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+  (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
     (mt/dataset (mt/dataset-definition
                  "domain_dataset"
                  [["placeholder"
                    [{:field-name "foo", :base-type :type/Integer}]
                    [[1]]]])
-      (let [spec (sql-jdbc.conn/connection-details->spec :postgres (:details (mt/db)))
+      ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+      (let [spec (sql-jdbc.conn/connection-details->spec #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres (:details (mt/db)))
             dom-name (str "dom_" (mt/random-name))]
         (jdbc/execute! spec [(format "CREATE DOMAIN %s AS text CHECK (VALUE <> '')" dom-name)])
         (with-mock-cache! [save-chan]

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -400,7 +400,8 @@
       ;; in [[metabase.query-processor.middleware.fetch-source-query/source-query]]
       (qp.store/with-metadata-provider (-> meta/metadata-provider
                                            ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-                                           (lib.tu/merged-mock-metadata-provider {:database {:engine #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mongo}})
+                                           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+                                           (lib.tu/merged-mock-metadata-provider {:database {:engine :mongo}})
                                            (lib.tu/metadata-provider-with-cards-for-queries [query]))
         (is (=? {:stages            [{:lib/type                     :mbql.stage/native
                                       :projections                  ["_id" "user_id" "venue_id"]
@@ -429,7 +430,8 @@
                      :database (meta/id)}]
       (qp.store/with-metadata-provider (-> meta/metadata-provider
                                            ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-                                           (lib.tu/merged-mock-metadata-provider {:database {:engine #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mongo}})
+                                           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+                                           (lib.tu/merged-mock-metadata-provider {:database {:engine :mongo}})
                                            (lib.tu/metadata-provider-with-cards-for-queries [query]))
         (is (=? {:stages [{:lib/type   :mbql.stage/native
                            :collection "checkins"

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -399,8 +399,8 @@
       ;; this doesn't actually need to load Mongo code, there is special casing for `:mongo`
       ;; in [[metabase.query-processor.middleware.fetch-source-query/source-query]]
       (qp.store/with-metadata-provider (-> meta/metadata-provider
-                                           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-                                           (lib.tu/merged-mock-metadata-provider {:database {:engine :mongo}})
+                                           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+                                           (lib.tu/merged-mock-metadata-provider {:database {:engine #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mongo}})
                                            (lib.tu/metadata-provider-with-cards-for-queries [query]))
         (is (=? {:stages            [{:lib/type                     :mbql.stage/native
                                       :projections                  ["_id" "user_id" "venue_id"]
@@ -428,8 +428,8 @@
                                 :collection "checkins"}
                      :database (meta/id)}]
       (qp.store/with-metadata-provider (-> meta/metadata-provider
-                                           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-                                           (lib.tu/merged-mock-metadata-provider {:database {:engine :mongo}})
+                                           ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+                                           (lib.tu/merged-mock-metadata-provider {:database {:engine #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :mongo}})
                                            (lib.tu/metadata-provider-with-cards-for-queries [query]))
         (is (=? {:stages [{:lib/type   :mbql.stage/native
                            :collection "checkins"

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -387,7 +387,6 @@
 
 ;;; this is a proof-of-concept to make sure this stuff works for non-SQL drivers, that's why we're hardcoding `:mongo`
 ;;; below.
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel card-id->source-query-and-metadata-test
   (testing "card-id->source-query-and-metadata-test should preserve non-SQL native queries"
     (let [query {:type     :native
@@ -400,6 +399,7 @@
       ;; this doesn't actually need to load Mongo code, there is special casing for `:mongo`
       ;; in [[metabase.query-processor.middleware.fetch-source-query/source-query]]
       (qp.store/with-metadata-provider (-> meta/metadata-provider
+                                           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
                                            (lib.tu/merged-mock-metadata-provider {:database {:engine :mongo}})
                                            (lib.tu/metadata-provider-with-cards-for-queries [query]))
         (is (=? {:stages            [{:lib/type                     :mbql.stage/native
@@ -416,7 +416,6 @@
 
 ;;; this is a proof-of-concept to make sure this stuff works for non-SQL drivers, that's why we're hardcoding `:mongo`
 ;;; below.
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel card-id->source-query-and-metadata-test-2
   (testing "card-id->source-query-and-metadata-test should preserve mongodb native queries in string format (#30112)"
     (let [query-str (str "[{\"$project\":\n"
@@ -429,6 +428,7 @@
                                 :collection "checkins"}
                      :database (meta/id)}]
       (qp.store/with-metadata-provider (-> meta/metadata-provider
+                                           #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
                                            (lib.tu/merged-mock-metadata-provider {:database {:engine :mongo}})
                                            (lib.tu/metadata-provider-with-cards-for-queries [query]))
         (is (=? {:stages [{:lib/type   :mbql.stage/native

--- a/test/metabase/query_processor/middleware/parameters/mbql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/mbql_test.clj
@@ -196,8 +196,8 @@
       ;; Prevent an issue with Snowflake were a previous connection's report-timezone setting can affect this test's
       ;; results
       ;; TODO: Verify we still need the following expression in place. PR #36858 may have addressed that.
-      #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-      (when (= :snowflake driver/*driver*)
+      ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+      (when (= #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :snowflake driver/*driver*)
         (driver/notify-database-updated driver/*driver* (mt/id)))
       (is (=? [[29]]
               (mt/formatted-rows

--- a/test/metabase/query_processor/middleware/parameters/mbql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/mbql_test.clj
@@ -197,7 +197,8 @@
       ;; results
       ;; TODO: Verify we still need the following expression in place. PR #36858 may have addressed that.
       ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-      (when (= #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :snowflake driver/*driver*)
+      #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+      (when (= :snowflake driver/*driver*)
         (driver/notify-database-updated driver/*driver* (mt/id)))
       (is (=? [[29]]
               (mt/formatted-rows

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -29,6 +29,7 @@
       (mt/with-temporary-setting-values [synchronous-batch-updates true]
         ;; save-execution-metadata!* is invoked from the QP pipeline transducer, which runs on a thread
         ;; that doesn't inherit *local-redefs* — use with-redefs so worker threads see the replacement.
+        ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
         #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
         (with-redefs [process-userland-query/save-execution-metadata!*
                       (fn [query-executions]

--- a/test/metabase/query_processor/native_test.clj
+++ b/test/metabase/query_processor/native_test.clj
@@ -50,7 +50,8 @@
     ;; this test but because of a coding error it only ever ran against H2. I updated it to run against PG as well
     ;; until we can verify it works on other drivers without issue.
     ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-    (mt/test-drivers #{:h2 #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres}
+    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+    (mt/test-drivers #{:h2 :postgres}
       (let [mp (lib.tu/mock-metadata-provider
                 (mt/metadata-provider)
                 {:cards [{:id              1

--- a/test/metabase/query_processor/native_test.clj
+++ b/test/metabase/query_processor/native_test.clj
@@ -49,8 +49,8 @@
     ;; allow duplicate column names in the `SELECT` list (all of them, I think?). That was the original intention of
     ;; this test but because of a coding error it only ever ran against H2. I updated it to run against PG as well
     ;; until we can verify it works on other drivers without issue.
-    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-    (mt/test-drivers #{:h2 :postgres}
+    ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+    (mt/test-drivers #{:h2 #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres}
       (let [mp (lib.tu/mock-metadata-provider
                 (mt/metadata-provider)
                 {:cards [{:id              1

--- a/test/metabase/query_processor/parameters/values_test.clj
+++ b/test/metabase/query_processor/parameters/values_test.clj
@@ -432,7 +432,8 @@
     (testing "Persisted Models are substituted"
       ;; legacy test -- don't hardcode driver names in new tests going forward.
       ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-      (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
+      #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+      (mt/test-driver :postgres
         ;; TODO (Cam 7/16/25) -- rework this to use metadata providers -- we support model persisted info directly from
         ;; the metadata provider
         (mt/with-persistence-enabled! [persist-models!]

--- a/test/metabase/query_processor/parameters/values_test.clj
+++ b/test/metabase/query_processor/parameters/values_test.clj
@@ -431,8 +431,8 @@
   (mt/with-test-user :rasta
     (testing "Persisted Models are substituted"
       ;; legacy test -- don't hardcode driver names in new tests going forward.
-      #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-      (mt/test-driver :postgres
+      ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+      (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
         ;; TODO (Cam 7/16/25) -- rework this to use metadata providers -- we support model persisted info directly from
         ;; the metadata provider
         (mt/with-persistence-enabled! [persist-models!]

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -219,9 +219,9 @@
 ;;; EXIST ANYMORE, BUT MAYBE YOU CAN GO LOOKING FOR IT IF YOU NEED TO?)
 ;;;
 ;;; This is only running against Postgres since we're just testing general behavior for formatting different types
-#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest report-timezone-test
   (testing "Export downloads should format stuff with the report timezone rather than UTC (#13677)"
+    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
     (mt/test-driver :postgres
       (let [query     (mt/dataset attempted-murders
                         (mt/mbql-query attempts

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -222,7 +222,8 @@
 (deftest report-timezone-test
   (testing "Export downloads should format stuff with the report timezone rather than UTC (#13677)"
     ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
-    (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
+    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+    (mt/test-driver :postgres
       (let [query     (mt/dataset attempted-murders
                         (mt/mbql-query attempts
                           {:fields   [$date $datetime $datetime_ltz $datetime_tz $datetime_tz_id $time $time_ltz $time_tz]

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -221,8 +221,8 @@
 ;;; This is only running against Postgres since we're just testing general behavior for formatting different types
 (deftest report-timezone-test
   (testing "Export downloads should format stuff with the report timezone rather than UTC (#13677)"
-    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
-    (mt/test-driver :postgres
+    ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
+    (mt/test-driver #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]} :postgres
       (let [query     (mt/dataset attempted-murders
                         (mt/mbql-query attempts
                           {:fields   [$date $datetime $datetime_ltz $datetime_tz $datetime_tz_id $time $time_ltz $time_tz]

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -43,7 +43,6 @@
      nil))
 
 ;; These helpers only mutate the temp local AppDb.
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 ;; TODO make this a :once fixture so that we avoid so much setup and tear down
 (defmacro with-index
   "Ensure a clean, small index."

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -23,7 +23,6 @@
 (set! *warn-on-reflection* true)
 
 ;; We act on a random localized table, making this thread-safe.
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-index-contents
   "Populate the index with the given appdb agnostic entity shapes."
   {:style/indent :defn}

--- a/test/metabase/search/engine_test.clj
+++ b/test/metabase/search/engine_test.clj
@@ -22,7 +22,6 @@
   the additional-search-engines setting value."
   [{:keys [supported configured additional]} & body]
   ;; with-redefs is required: supported-engine? is a multimethod, which with-dynamic-fn-redefs cannot proxy.
-  #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
   `(with-redefs [search.engine/supported-engine?            ~supported
                  search.engine/known-engine?                all-engines
                  search.settings/configured-search-engine   (constantly ~configured)

--- a/test/metabase/search/in_place/filter_test.clj
+++ b/test/metabase/search/in_place/filter_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.search.in-place.filter-test
   ;; Left renaming search.filter out of this PR to save a ton of noise.
   ;; This comment is way up here, because cljfmt doesn't like it in the middle of the :require.
-  #_{:clj-kondo/ignore [:consistent-alias]}
   (:require
    [clojure.test :refer :all]
    [metabase.audit-app.core :as audit]
@@ -122,7 +121,6 @@
                       :models #{"dashboard" "card" "transform"}})))))))
 
 (deftest joined-with-table?-test
-  #_{:clj-kondo/ignore [:equals-true]}
   (are [expected args]
        (= expected (apply #'search.filter/joined-with-table? args))
 

--- a/test/metabase/search/in_place/filter_test.clj
+++ b/test/metabase/search/in_place/filter_test.clj
@@ -1,6 +1,4 @@
 (ns metabase.search.in-place.filter-test
-  ;; Left renaming search.filter out of this PR to save a ton of noise.
-  ;; This comment is way up here, because cljfmt doesn't like it in the middle of the :require.
   (:require
    [clojure.test :refer :all]
    [metabase.audit-app.core :as audit]

--- a/test/metabase/search/test_util.clj
+++ b/test/metabase/search/test_util.clj
@@ -13,14 +13,12 @@
 
 (def ^:dynamic *user-ctx* nil)
 
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-sync-search-indexing
   "Perform all search indexing synchronously."
   [& body]
   `(binding [metabase.search.ingestion/*force-sync* true]
      ~@body))
 
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-temp-index-table
   "Create a temporary index table for the duration of the body."
   [& body]
@@ -30,7 +28,6 @@
        (with-sync-search-indexing
          ~@body))))
 
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-appdb-search-if-available*
   "Create a temporary index table for the duration of the body."
   [& body]
@@ -45,7 +42,6 @@
        (search/reindex! {:async? false :in-place? true})
        ~@body)))
 
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-appdb-search-if-available-otherwise-legacy
   "Create a temporary index table for the duration of the body."
   [& body]

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -199,7 +199,6 @@
     (let [nonceJSON (atom nil)
           render-file (mt/original-fn #'stencil/render-file)]
       ;; http/get hits a real Jetty server; handler thread doesn't inherit *local-redefs*.
-      #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
       (with-redefs [stencil/render-file (fn [path variables]
                                           (reset! nonceJSON (:nonceJSON variables))
                                           ;; Use index_template.html instead of index.html so the frontend doesn't

--- a/test/metabase/server/middleware/settings_cache_test.clj
+++ b/test/metabase/server/middleware/settings_cache_test.clj
@@ -48,7 +48,6 @@
           ;; value in 2042 to simulate client has more recent settings
           (update-cookie cs cookie-name "2042-12-02+19%3A57%3A49.775909%2B00")
           ;; user-real-request hits a real Jetty server; handler thread doesn't inherit *local-redefs*.
-          #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
           (with-redefs [setting/restore-cache! (fn [] (swap! calls inc))]
             (mt/user-real-request :crowberto :get 200 "user/current"
                                   {:request-options {:cookie-store cs}})

--- a/test/metabase/server/statistics_handler_test.clj
+++ b/test/metabase/server/statistics_handler_test.clj
@@ -3,7 +3,7 @@
    [clj-http.client :as http]
    [clojure.core.async :as a]
    [clojure.test :refer [deftest is]]
-   [compojure.core :as compojure :refer #_{:clj-kondo/ignore [:discouraged-var]} [GET]]
+   [compojure.core :as compojure :refer [GET]]
    [compojure.route :as route]
    [metabase.analytics.prometheus-test :as prometheus-test]
    [metabase.server.instance :as server.instance]

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -592,7 +592,6 @@
         (t2/insert! :model/User (merge  (mt/with-temp-defaults :model/User) {:email "test@metabase.com" :is_active true}))
         (testing "Google auth works with remember me and rasta"
           ;; client-real-response hits a real Jetty server; handler thread doesn't inherit *local-redefs*.
-          #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
           (with-redefs [http/post (constantly
                                    {:status 200
                                     :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","

--- a/test/metabase/slackbot/uploads_test.clj
+++ b/test/metabase/slackbot/uploads_test.clj
@@ -178,7 +178,6 @@
                   (testing "no upload was attempted"
                     (is (= 0 (count @upload-calls))))
                   (testing "responds directly with skip message"
-                    #_{:clj-kondo/ignore [:unresolved-namespace]}
                     (let [message-text (:text (first @post-calls))]
                       (is (str/includes? message-text "can only process CSV and TSV"))
                       (is (str/includes? message-text "query_result.xlsx")))))))))))))

--- a/test/metabase/sql_tools/macaw/references_test.clj
+++ b/test/metabase/sql_tools/macaw/references_test.clj
@@ -6,7 +6,6 @@
    [metabase.sql-tools.macaw.references :as sql-tools.macaw]))
 
 ;; TODO (Chris 2026-01-22) -- Refactor to use driver.u/parsed-query instead of macaw/parsed-query
-#_{:clj-kondo/ignore [:discouraged-var]}
 (defn- ->references [query]
   (->> query macaw/parsed-query macaw/->ast (sql-tools.macaw/field-references :sql)))
 

--- a/test/metabase/sso/google_test.clj
+++ b/test/metabase/sso/google_test.clj
@@ -38,7 +38,6 @@
 (deftest allow-autocreation-test
   (with-no-sso-google-token!
     (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "metabase.com"]
-      #_{:clj-kondo/ignore [:equals-true]}
       (are [allowed? email] (= allowed?
                                (#'google/autocreate-user-allowed-for-email? email))
         true  "cam@metabase.com"

--- a/test/metabase/sso/integrations/slack_connect_test.clj
+++ b/test/metabase/sso/integrations/slack_connect_test.clj
@@ -298,7 +298,6 @@
                                            site-name "test"]
           (with-successful-oidc!
             ;; client-real-response hits a real Jetty server; handler thread doesn't inherit *local-redefs*.
-            #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
             (with-redefs [auth-identity/login!
                           (fn [_provider _request]
                             {:success? false

--- a/test/metabase/sync/sync_metadata/fields/common_test.clj
+++ b/test/metabase/sync/sync_metadata/fields/common_test.clj
@@ -4,7 +4,6 @@
    [metabase.sync.sync-metadata.fields.common :as common]))
 
 (deftest canonical-names-equal?-test
-  #_{:clj-kondo/ignore [:equals-true]}
   (are [s1 s2 result] (= result (#'common/canonical-names-equal? {:name s1} {:name s2}))
     "id"     "ID"     true
     "Id"     "id"     true

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -190,7 +190,6 @@
   Like `mbql-query`, but for native queries."
   [inner-native-query :- :map]
   {:deprecated "0.61.0"}
-  #_{:clj-kondo/ignore [:deprecated-var]}
   {:database (id)
    :type     :native
    :native   (mbql.normalize/normalize ::mbql.s/TopLevelNativeInnerQuery inner-native-query)})

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -217,7 +217,6 @@
           session-key (session/generate-session-key)]
       (when-not (t2/exists? :model/User :id user-id)
         (throw (ex-info "User does not exist" {:user user})))
-      #_{:clj-kondo/ignore [:discouraged-var]}
       (t2.with-temp/with-temp [:model/Session _ {:id (session/generate-session-id)
                                                  :key_hashed (session/hash-session-key session-key)
                                                  :user_id user-id}]
@@ -272,7 +271,6 @@
     (u/the-id test-user-name-or-user-id)))
 
 (defn do-with-group-for-user [group test-user-name-or-user-id f]
-  #_{:clj-kondo/ignore [:discouraged-var]}
   (t2.with-temp/with-temp [:model/PermissionsGroup           group group
                            :model/PermissionsGroupMembership _     {:group_id (u/the-id group)
                                                                     :user_id  (test-user-name-or-user-id->user-id test-user-name-or-user-id)}]

--- a/test/metabase/test/generate.clj
+++ b/test/metabase/test/generate.clj
@@ -395,7 +395,6 @@
        :insert! (fn [sm-db {:keys [schema-opts attrs] :as visit-opts}]
                   (try
                     (first (t2/insert-returning-instances! (:model schema-opts)
-                                                           #_{:clj-kondo/ignore [:deprecated-var]}
                                                            (rsg/spec-gen-assoc-relations
                                                             sm-db
                                                             (assoc visit-opts :visit-val (:spec-gen attrs)))))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -590,7 +590,6 @@
                                 e))))))))))
 
 ;;; TODO FIXME -- either rename this to `with-temporary-setting-values!` or fix it and make it thread-safe
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-temporary-setting-values
   "Temporarily bind the site-wide values of one or more `Settings`, execute body, and re-establish the original values.
   This works much the same way as `binding`.
@@ -611,7 +610,6 @@
           ~@body)))))
 
 ;;; TODO FIXME -- either rename this to `with-temporary-raw-setting-values!` or fix it and make it thread-safe
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-temporary-raw-setting-values
   "Like [[with-temporary-setting-values]] but works with raw value and it allows settings that are not defined
   using [[metabase.settings.models.setting/defsetting]]."
@@ -637,7 +635,6 @@
     settings)))
 
 ;;; TODO FIXME -- either rename this to `with-discarded-setting-changes!` or fix it and make it thread-safe
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro discard-setting-changes
   "Execute `body` in a try-finally block, restoring any changes to listed `settings` to their original values at its
   conclusion.
@@ -953,7 +950,6 @@
 
 (deftest with-model-cleanup-test
   (testing "Make sure the with-model-cleanup macro actually works as expected"
-    #_{:clj-kondo/ignore [:discouraged-var]}
     (t2.with-temp/with-temp [:model/Card other-card]
       (let [card-count-before (t2/count :model/Card)
             card-name (u.random/random-name)]
@@ -1120,7 +1116,6 @@
     `(do-with-discard-model-updates! ~models (fn [] ~@body))))
 
 (deftest with-discard-model-changes-test
-  #_{:clj-kondo/ignore [:discouraged-var]}
   (t2.with-temp/with-temp
     [:model/Card {card-id :id :as card} {:name "A Card"}
      :model/Dashboard {dash-id :id :as dash} {:name "A Dashboard"}]
@@ -1202,7 +1197,6 @@
 
   For most use cases see the macro [[with-all-users-permission]]."
   [permission-path thunk]
-  #_{:clj-kondo/ignore [:discouraged-var]}
   (t2.with-temp/with-temp [:model/Permissions _ {:group_id (:id (perms/all-users-group))
                                                  :object permission-path}]
     (thunk)))
@@ -1280,7 +1274,6 @@
           ;; remap is integer => fk remap
           (let [remapped (t2/select-one :model/Field :id (u/the-id remap))]
             (fn []
-              #_{:clj-kondo/ignore [:discouraged-var]}
               (t2.with-temp/with-temp [:model/Dimension _ {:field_id (:id original)
                                                            :name (format "%s [external remap]" (:display_name original))
                                                            :type :external
@@ -1300,7 +1293,6 @@
                                     (testing (format "With human readable values remapping %s -> %s\n"
                                                      (describe-field original) (pr-str values-map))
                                       (thunk)))]
-                #_{:clj-kondo/ignore [:discouraged-var]}
                 (t2.with-temp/with-temp [:model/Dimension _ {:field_id (:id original)
                                                              :name (format "%s [internal remap]" (:display_name original))
                                                              :type :internal}]
@@ -1308,7 +1300,6 @@
                     (with-temp-vals-in-db :model/FieldValues preexisting-id {:values (keys values-map)
                                                                              :human_readable_values (vals values-map)}
                       (testing-thunk))
-                    #_{:clj-kondo/ignore [:discouraged-var]}
                     (t2.with-temp/with-temp [:model/FieldValues _ {:field_id (:id original)
                                                                    :values (keys values-map)
                                                                    :human_readable_values (vals values-map)}]
@@ -1334,7 +1325,6 @@
     x))
 
 ;;; TODO FIXME -- either rename this to `with-column-remappings!` or fix it and make it thread-safe.
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-column-remappings
   "Execute `body` with column remappings in place. Can create either FK \"external\" or human-readable-values
   \"internal\" remappings:
@@ -1399,7 +1389,6 @@
         (thunk)))))
 
 ;;; TODO FIXME -- either rename this to `with-env-keys-renamed-by!` or fix it and make it thread-safe
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-env-keys-renamed-by
   "Evaluates body with the current core.environ/env being redefined, its keys having been renamed by the given
   rename-fn."
@@ -1505,12 +1494,10 @@
 
 (defn do-with-user-in-groups
   ([f groups-or-ids]
-   #_{:clj-kondo/ignore [:discouraged-var]}
    (t2.with-temp/with-temp [:model/User user]
      (do-with-user-in-groups f user groups-or-ids)))
   ([f user [group-or-id & more]]
    (if group-or-id
-     #_{:clj-kondo/ignore [:discouraged-var]}
      (t2.with-temp/with-temp [:model/PermissionsGroupMembership _ {:group_id (u/the-id group-or-id), :user_id (u/the-id user)}]
        (do-with-user-in-groups f user more))
      (f user))))
@@ -1530,7 +1517,6 @@
   [[& bindings] & body]
   (if (> (count bindings) 2)
     (let [[group-binding group-definition & more] bindings]
-      #_{:clj-kondo/ignore [:discouraged-var]}
       `(t2.with-temp/with-temp [:model/PermissionsGroup ~group-binding ~group-definition]
          (with-user-in-groups ~more ~@body)))
     (let [[user-binding groups-or-ids-to-put-user-in] bindings]

--- a/test/metabase/test/util/misc.clj
+++ b/test/metabase/test/util/misc.clj
@@ -22,7 +22,6 @@
                   :else                      (throw (Exception. (format "Invalid clock: ^%s %s"
                                                                         (.getName (class clock))
                                                                         (pr-str clock)))))]
-      #_{:clj-kondo/ignore [:discouraged-var]}
       (t/with-clock clock
         (thunk)))))
 
@@ -83,7 +82,6 @@
   (comp
    (memoize
     (fn [toucan-model]
-      #_{:clj-kondo/ignore [:discouraged-var]}
       (t2.with-temp/with-temp [toucan-model x {}
                                toucan-model y {}]
         (let [[_ _ things-in-both] (data/diff x y)]

--- a/test/metabase/transforms/jobs_test.clj
+++ b/test/metabase/transforms/jobs_test.clj
@@ -584,6 +584,7 @@
                       ;; ExecutorService worker (transforms-sql-worker), which doesn't convey dynamic bindings, so a
                       ;; proxy-based redef is invisible there and the barrier choreography silently no-ops. A global
                       ;; root swap is seen by every thread.
+                      ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks
                       #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
                       (with-redefs [transforms.u/try-start-unless-already-running
                                     (fn [transform-id run-method user-id & kwargs]

--- a/test/metabase/util/encryption_test.clj
+++ b/test/metabase/util/encryption_test.clj
@@ -26,7 +26,6 @@
       ;; reset the cache again so nothing that happened during the test is persisted.
       (setting.cache/restore-cache!))))
 
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-secret-key
   "Run `body` with the encryption secret key temporarily bound to `secret-key`. Useful for testing how functions behave
   with and without encryption disabled. A nil secret key disables encryption."

--- a/test/metabase/util/honey_sql_2_test.clj
+++ b/test/metabase/util/honey_sql_2_test.clj
@@ -229,7 +229,6 @@
              (h2x/with-database-type-info (h2x/with-database-type-info :field "date") nil))))))
 
 (deftest ^:parallel is-of-type?-test
-  #_{:clj-kondo/ignore [:equals-true]}
   (are [expr tyype expected] (= expected (h2x/is-of-type? expr tyype))
     typed-form     "text"   true
     typed-form     "TEXT"   true

--- a/test/metabase/util/jvm_test.clj
+++ b/test/metabase/util/jvm_test.clj
@@ -8,7 +8,6 @@
 
 (deftest ^:parallel host-up?-test
   (testing "host-up?"
-    #_{:clj-kondo/ignore [:equals-true]}
     (are [s expected] (= expected
                          (u/host-up? s))
       "localhost"  true
@@ -18,7 +17,6 @@
            (u/host-port-up? "nosuchhost" 8005)))))
 
 (deftest ^:parallel ip-address?-test
-  #_{:clj-kondo/ignore [:equals-true]}
   (are [x expected] (= expected
                        (u/ip-address? x))
     "8.8.8.8"              true

--- a/test/metabase/util/number_test.cljc
+++ b/test/metabase/util/number_test.cljc
@@ -12,7 +12,6 @@
 
 (deftest bigint?-test
   (testing "should check if the value is a bigint"
-    #_{:clj-kondo/ignore [:equals-true]}
     (are [exp value] (= exp (u.number/bigint? value))
       true  (u.number/bigint 10)
       true  (u.number/bigint "9007199254740993")
@@ -21,7 +20,6 @@
 
 (deftest integer?-test
   (testing "should check if the value is an integer"
-    #_{:clj-kondo/ignore [:equals-true]}
     (are [exp value] (= exp (u.number/integer? value))
       true  0
       true  10

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -26,7 +26,6 @@
          (u/add-period "   "))))
 
 (deftest ^:parallel url?-test
-  #_{:clj-kondo/ignore [:equals-true]}
   (are [s expected] (= expected
                        (u/url? s))
     "http://google.com"                                                                      true
@@ -72,7 +71,6 @@
        "email@metabase.com"   false)))
 
 (deftest ^:parallel state?-test
-  #_{:clj-kondo/ignore [:equals-true]}
   (are [x expected] (= expected
                        (u/state? x))
     "louisiana"            true
@@ -173,7 +171,6 @@
     {}                                         [:c]              {}))
 
 (deftest ^:parallel base64-string?-test
-  #_{:clj-kondo/ignore [:equals-true]}
   (are [s expected]    (= expected
                           (u/base64-string? s))
     "ABc="         true
@@ -385,7 +382,6 @@
     "metabase.com"   "cam.saul+1@metabase.com"))
 
 (deftest ^:parallel email-in-domain-test
-  #_{:clj-kondo/ignore [:equals-true]}
   (are [in-domain? email domain] (= in-domain?
                                     (u/email-in-domain? email domain))
     true  "cam@metabase.com"          "metabase.com"
@@ -528,7 +524,6 @@
                         :to-compare #(dissoc % :id :god_id)})))))
 
 (deftest ^:parallel empty-or-distinct?-test
-  #_{:clj-kondo/ignore [:equals-true]}
   (are [xs expected] (= expected
                         (u/empty-or-distinct? xs))
     nil     true

--- a/test/metabase/warehouses/models/database_test.clj
+++ b/test/metabase/warehouses/models/database_test.clj
@@ -529,7 +529,6 @@
                                        :name "Secret Test"
                                        :details base-details}]
       (mt/with-current-user (mt/user->id :crowberto)
-        #_{:clj-kondo/ignore [:redundant-nested-call]}
         (are [expected extra-details] (= (merge
                                           base-details
                                           expected)


### PR DESCRIPTION
The burndown: ~190 dead inline ignores deleted across 109 files, verified with a full `./bin/mage kondo` — the same run CI does — at zero findings. `:redundant-nested-call` and `:unresolved-var` budgets emptied out entirely; `:metabase/disallow-hardcoded-driver-names-in-tests` dropped 39 → 34.

kondo's `:redundant-ignore` can't see findings from our hook-based `:metabase/*` linters, so every sweep re-flags ~60 ignores that are still doing work. `--fix` now deals with that itself:

- After removing the candidates it re-lints the touched files. Any warning that comes back gets its ignore put back, exactly as it was written — a form-level ignore stays form-level.
- Restored ignores are stamped with a `;; [kondo-keep]` comment, and marked sites are skipped by future sweeps.
- `--fix --audit` rechecks the marked sites and unmarks any that have become truly redundant.
- `[kondo-keep]` can also be added by hand to protect an ignore (done for the four driver-test files whose ignores carry real explanations).
- A sweep that can't make every warning go away fails with exit 1.

Every restored ignore on the branch is stamped, so the next run should report nothing but genuinely dead ignores.
