### PR TITLE
Align transform job header to fix tab layout shift

### DIFF
--- a/frontend/src/metabase/transforms/components/JobEditor/JobEditor.tsx
+++ b/frontend/src/metabase/transforms/components/JobEditor/JobEditor.tsx
@@ -1,21 +1,10 @@
 import type { ReactNode } from "react";
-import { t } from "ttag";
 
-import { DataStudioBreadcrumbs } from "metabase/common/data-studio/components/DataStudioBreadcrumbs";
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
-import {
-  PaneHeader,
-  PaneHeaderInput,
-} from "metabase/common/data-studio/components/PaneHeader";
-import { useSetting } from "metabase/common/hooks";
-import { Link } from "metabase/router";
-import { Group, Stack } from "metabase/ui";
-import * as Urls from "metabase/urls";
+import { Stack } from "metabase/ui";
 import type { ScheduleDisplayType, TransformTagId } from "metabase-types/api";
 
-import { NAME_MAX_LENGTH } from "../../constants";
-import { LockedTransformsHoverCard } from "../LockedTransformsHoverCard/LockedTransformsHoverCard";
-import { TransformBadge } from "../TransformBadge/TransformBadge";
+import { JobHeader } from "../JobHeader";
 
 import { ScheduleSection } from "./ScheduleSection";
 import { TagSection } from "./TagSection";
@@ -29,6 +18,7 @@ type JobEditorProps = {
   tabs?: ReactNode;
   readOnly?: boolean;
   isCheckingPermissions?: boolean;
+  showMetabotButton?: boolean;
   onNameChange: (name: string) => void;
   onScheduleChange: (
     schedule: string,
@@ -44,48 +34,21 @@ export function JobEditor({
   tabs,
   readOnly,
   isCheckingPermissions,
+  showMetabotButton,
   onNameChange,
   onScheduleChange,
   onTagListChange,
 }: JobEditorProps) {
-  const isMeterLocked = useSetting("transforms-meter-locked");
-
   return (
     <PageContainer data-testid="transforms-job-editor" gap="2.5rem">
-      <PaneHeader
-        title={
-          <Group align="center" gap="sm" wrap="nowrap">
-            <PaneHeaderInput
-              initialValue={job.name}
-              maxLength={NAME_MAX_LENGTH}
-              onChange={onNameChange}
-              readOnly={readOnly}
-            />
-            {isMeterLocked && (
-              <LockedTransformsHoverCard>
-                <TransformBadge bg="background_surface-warning-strong">{t`Disabled`}</TransformBadge>
-              </LockedTransformsHoverCard>
-            )}
-            {!isMeterLocked && !job.active && (
-              <TransformBadge bg="background_surface-warning-strong">
-                {t`Disabled`}
-              </TransformBadge>
-            )}
-          </Group>
-        }
-        py={0}
-        breadcrumbs={
-          <DataStudioBreadcrumbs>
-            <Link key="transform-job-list" to={Urls.transformJobList()}>
-              {t`Jobs`}
-            </Link>
-            {job.name}
-          </DataStudioBreadcrumbs>
-        }
+      <JobHeader
+        job={job}
         menu={menu}
         actions={actions}
         tabs={tabs}
-        data-testid="jobs-header"
+        readOnly={readOnly}
+        showMetabotButton={showMetabotButton}
+        onNameChange={onNameChange}
       />
       <Stack gap="3.5rem">
         <ScheduleSection

--- a/frontend/src/metabase/transforms/components/JobHeader/JobHeader.tsx
+++ b/frontend/src/metabase/transforms/components/JobHeader/JobHeader.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from "react";
+import { t } from "ttag";
+
+import { DataStudioBreadcrumbs } from "metabase/common/data-studio/components/DataStudioBreadcrumbs";
+import {
+  PaneHeader,
+  PaneHeaderInput,
+} from "metabase/common/data-studio/components/PaneHeader";
+import { useSetting } from "metabase/common/hooks";
+import { Link } from "metabase/router";
+import { Group } from "metabase/ui";
+import * as Urls from "metabase/urls";
+
+import { NAME_MAX_LENGTH } from "../../constants";
+import type { TransformJobInfo } from "../JobEditor/types";
+import { LockedTransformsHoverCard } from "../LockedTransformsHoverCard/LockedTransformsHoverCard";
+import { TransformBadge } from "../TransformBadge/TransformBadge";
+
+type JobHeaderProps = {
+  job: TransformJobInfo;
+  menu?: ReactNode;
+  actions?: ReactNode;
+  tabs?: ReactNode;
+  readOnly?: boolean;
+  showMetabotButton?: boolean;
+  onNameChange: (name: string) => void;
+};
+
+export function JobHeader({
+  job,
+  menu,
+  actions,
+  tabs,
+  readOnly,
+  showMetabotButton,
+  onNameChange,
+}: JobHeaderProps) {
+  const isMeterLocked = useSetting("transforms-meter-locked");
+
+  return (
+    <PaneHeader
+      title={
+        <Group align="center" gap="sm" wrap="nowrap">
+          <PaneHeaderInput
+            initialValue={job.name}
+            maxLength={NAME_MAX_LENGTH}
+            onChange={onNameChange}
+            readOnly={readOnly}
+          />
+          {isMeterLocked && (
+            <LockedTransformsHoverCard>
+              <TransformBadge bg="background_surface-warning-strong">{t`Disabled`}</TransformBadge>
+            </LockedTransformsHoverCard>
+          )}
+          {!isMeterLocked && !job.active && (
+            <TransformBadge bg="background_surface-warning-strong">
+              {t`Disabled`}
+            </TransformBadge>
+          )}
+        </Group>
+      }
+      py={0}
+      breadcrumbs={
+        <DataStudioBreadcrumbs>
+          <Link key="transform-job-list" to={Urls.transformJobList()}>
+            {t`Jobs`}
+          </Link>
+          {job.name}
+        </DataStudioBreadcrumbs>
+      }
+      menu={menu}
+      actions={actions}
+      tabs={tabs}
+      showMetabotButton={showMetabotButton}
+      data-testid="jobs-header"
+    />
+  );
+}

--- a/frontend/src/metabase/transforms/components/JobHeader/index.ts
+++ b/frontend/src/metabase/transforms/components/JobHeader/index.ts
@@ -1,0 +1,1 @@
+export { JobHeader } from "./JobHeader";

--- a/frontend/src/metabase/transforms/hooks/use-job-header-state.ts
+++ b/frontend/src/metabase/transforms/hooks/use-job-header-state.ts
@@ -31,7 +31,7 @@ export function useJobHeaderState(jobId: TransformJobId | undefined) {
   }, [transforms, transformsDatabases]);
 
   const handleNameChange = async (name: string) => {
-    if (jobId == null) {
+    if (jobId === undefined) {
       return;
     }
     const { error } = await updateJob({ id: jobId, name });

--- a/frontend/src/metabase/transforms/hooks/use-job-header-state.ts
+++ b/frontend/src/metabase/transforms/hooks/use-job-header-state.ts
@@ -1,0 +1,46 @@
+import { useMemo } from "react";
+import { t } from "ttag";
+
+import {
+  skipToken,
+  useListTransformJobTransformsQuery,
+  useUpdateTransformJobMutation,
+} from "metabase/api";
+import { useMetadataToasts } from "metabase/metadata/hooks";
+import type { TransformJobId } from "metabase-types/api";
+
+import {
+  canEditTransform,
+  useTransformPermissions,
+} from "./use-transform-permissions";
+
+export function useJobHeaderState(jobId: TransformJobId | undefined) {
+  const [updateJob] = useUpdateTransformJobMutation();
+  const { sendErrorToast, sendSuccessToast } = useMetadataToasts();
+  const { transformsDatabases } = useTransformPermissions();
+  const { data: transforms, isLoading: isCheckingPermissions } =
+    useListTransformJobTransformsQuery(jobId ?? skipToken);
+
+  const readOnly = useMemo(() => {
+    if (!transformsDatabases || !transforms) {
+      return true;
+    }
+    return !transforms.every((transform) =>
+      canEditTransform(transform, transformsDatabases),
+    );
+  }, [transforms, transformsDatabases]);
+
+  const handleNameChange = async (name: string) => {
+    if (jobId == null) {
+      return;
+    }
+    const { error } = await updateJob({ id: jobId, name });
+    if (error) {
+      sendErrorToast(t`Failed to update job name`);
+    } else {
+      sendSuccessToast(t`Job name updated`);
+    }
+  };
+
+  return { readOnly, isCheckingPermissions, onNameChange: handleNameChange };
+}

--- a/frontend/src/metabase/transforms/pages/JobPage/JobPage.tsx
+++ b/frontend/src/metabase/transforms/pages/JobPage/JobPage.tsx
@@ -1,18 +1,15 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { t } from "ttag";
 
 import {
   skipToken,
   useGetTransformJobQuery,
-  useListTransformJobTransformsQuery,
   useUpdateTransformJobMutation,
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useMetadataToasts } from "metabase/metadata/hooks";
-import {
-  canEditTransform,
-  useTransformPermissions,
-} from "metabase/transforms/hooks/use-transform-permissions";
+import { useJobHeaderState } from "metabase/transforms/hooks/use-job-header-state";
+import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
 import { Center } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type {
@@ -50,16 +47,9 @@ export function JobPage({ params }: JobPageProps) {
     pollingInterval: isPolling ? POLLING_INTERVAL : undefined,
   });
 
-  const { transformsDatabases, isLoadingDatabases, databasesError } =
-    useTransformPermissions();
-  const { data: transforms, isLoading: isLoadingTransforms } =
-    useListTransformJobTransformsQuery(jobId || skipToken);
-  const readOnly = useMemo(() => {
-    if (!transformsDatabases || !transforms) {
-      return true;
-    }
-    return !transforms.every((t) => canEditTransform(t, transformsDatabases));
-  }, [transforms, transformsDatabases]);
+  const { isLoadingDatabases, databasesError } = useTransformPermissions();
+  const { readOnly, isCheckingPermissions, onNameChange } =
+    useJobHeaderState(jobId);
 
   if (isPolling !== isPollingNeeded(job)) {
     setIsPolling(isPollingNeeded(job));
@@ -79,7 +69,8 @@ export function JobPage({ params }: JobPageProps) {
     <JobPageBody
       job={job}
       readOnly={readOnly}
-      isCheckingPermissions={isLoadingTransforms}
+      isCheckingPermissions={isCheckingPermissions}
+      onNameChange={onNameChange}
     />
   );
 }
@@ -88,29 +79,18 @@ type JobPageBodyProps = {
   job: TransformJob;
   readOnly?: boolean;
   isCheckingPermissions?: boolean;
+  onNameChange: (name: string) => void;
 };
 
 function JobPageBody({
   job,
   readOnly,
   isCheckingPermissions,
+  onNameChange,
 }: JobPageBodyProps) {
   const [updateJob] = useUpdateTransformJobMutation();
   const { sendErrorToast, sendSuccessToast, sendUndoToast } =
     useMetadataToasts();
-
-  const handleNameChange = async (name: string) => {
-    const { error } = await updateJob({
-      id: job.id,
-      name,
-    });
-
-    if (error) {
-      sendErrorToast(t`Failed to update job name`);
-    } else {
-      sendSuccessToast(t`Job name updated`);
-    }
-  };
 
   const handleScheduleChange = async (
     schedule: string,
@@ -162,7 +142,7 @@ function JobPageBody({
       readOnly={readOnly}
       isCheckingPermissions={isCheckingPermissions}
       showMetabotButton
-      onNameChange={handleNameChange}
+      onNameChange={onNameChange}
       onScheduleChange={handleScheduleChange}
       onTagListChange={handleTagListChange}
     />

--- a/frontend/src/metabase/transforms/pages/JobPage/JobPage.tsx
+++ b/frontend/src/metabase/transforms/pages/JobPage/JobPage.tsx
@@ -161,6 +161,7 @@ function JobPageBody({
       tabs={<JobTabs jobId={job.id} />}
       readOnly={readOnly}
       isCheckingPermissions={isCheckingPermissions}
+      showMetabotButton
       onNameChange={handleNameChange}
       onScheduleChange={handleScheduleChange}
       onTagListChange={handleTagListChange}

--- a/frontend/src/metabase/transforms/pages/JobPage/JobPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/JobPage/JobPage.unit.spec.tsx
@@ -1,8 +1,10 @@
-import fetchMock from "fetch-mock";
-
-import { setupDatabaseListEndpoint } from "__support__/server-mocks";
+import {
+  setupDatabaseListEndpoint,
+  setupUserMetabotPermissionsEndpoint,
+} from "__support__/server-mocks";
 import {
   setupGetTransformJobEndpoint,
+  setupListTransformJobTransformsEndpoint,
   setupListTransformTagsEndpoint,
 } from "__support__/server-mocks/transform";
 import { act, renderWithProviders, screen, within } from "__support__/ui";
@@ -30,7 +32,8 @@ const setup = ({
   setupGetTransformJobEndpoint(job);
   setupDatabaseListEndpoint([createMockDatabase()]);
   setupListTransformTagsEndpoint([]);
-  fetchMock.get(`path:/api/transform-job/${job.id}/transforms`, [], {
+  setupUserMetabotPermissionsEndpoint();
+  setupListTransformJobTransformsEndpoint(job.id, [], {
     delay: transformsDelay,
   });
 

--- a/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunListPage.tsx
+++ b/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunListPage.tsx
@@ -11,15 +11,11 @@ import {
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PaginationControls } from "metabase/common/components/PaginationControls";
-import { DataStudioBreadcrumbs } from "metabase/common/data-studio/components/DataStudioBreadcrumbs";
-import {
-  PaneHeader,
-  PanelHeaderTitle,
-} from "metabase/common/data-studio/components/PaneHeader";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { useDispatch } from "metabase/redux";
-import { Link, replace } from "metabase/router";
+import { replace } from "metabase/router";
 import { POLLING_INTERVAL } from "metabase/transforms/constants";
+import { useJobHeaderState } from "metabase/transforms/hooks/use-job-header-state";
 import { formatRunMethod, formatStatus } from "metabase/transforms/utils";
 import { Center, Flex, Group, Select, Stack } from "metabase/ui";
 import * as Urls from "metabase/urls";
@@ -32,6 +28,8 @@ import {
   type TransformRunMethod,
 } from "metabase-types/api";
 
+import { JobHeader } from "../../components/JobHeader";
+import { JobMoreMenu } from "../../components/JobMoreMenu";
 import { JobTabs } from "../../components/JobTabs";
 
 import S from "./JobRunListPage.module.css";
@@ -63,6 +61,7 @@ export function JobRunListPage({ params, location }: JobRunListPageProps) {
   const dispatch = useDispatch();
 
   const { data: job } = useGetTransformJobQuery(jobId ?? skipToken);
+  const { readOnly, onNameChange } = useJobHeaderState(jobId);
 
   const { data, isLoading, error } = useListTransformJobRunsQuery(
     jobId != null
@@ -164,18 +163,16 @@ export function JobRunListPage({ params, location }: JobRunListPageProps) {
       data-testid="job-run-list"
     >
       <Stack className={S.main} flex={1} px="3.5rem" pb="md" gap={0}>
-        <PaneHeader
-          title={job != null && <PanelHeaderTitle>{job.name}</PanelHeaderTitle>}
-          tabs={jobId != null && <JobTabs jobId={jobId} />}
-          breadcrumbs={
-            <DataStudioBreadcrumbs>
-              <Link to={Urls.transformJobList()}>{t`Jobs`}</Link>
-              {job?.name ?? t`Run history`}
-            </DataStudioBreadcrumbs>
-          }
-          py={0}
-          showMetabotButton
-        />
+        {job != null && jobId != null && (
+          <JobHeader
+            job={job}
+            menu={!readOnly && <JobMoreMenu job={job} />}
+            tabs={<JobTabs jobId={jobId} />}
+            readOnly={readOnly}
+            showMetabotButton
+            onNameChange={onNameChange}
+          />
+        )}
         {isLoading || error != null ? (
           <Center h="100%">
             <LoadingAndErrorWrapper loading={isLoading} error={error} />

--- a/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunListPage.tsx
+++ b/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunListPage.tsx
@@ -163,11 +163,11 @@ export function JobRunListPage({ params, location }: JobRunListPageProps) {
       data-testid="job-run-list"
     >
       <Stack className={S.main} flex={1} px="3.5rem" pb="md" gap={0}>
-        {job != null && jobId != null && (
+        {job !== undefined && (
           <JobHeader
             job={job}
             menu={!readOnly && <JobMoreMenu job={job} />}
-            tabs={<JobTabs jobId={jobId} />}
+            tabs={<JobTabs jobId={job.id} />}
             readOnly={readOnly}
             showMetabotButton
             onNameChange={onNameChange}

--- a/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunListPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunListPage.unit.spec.tsx
@@ -2,9 +2,11 @@ import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
 import {
+  setupDatabaseListEndpoint,
   setupGetTransformJobEndpoint,
   setupListJobRunTransformRunsEndpoint,
   setupListTransformJobRunsEndpoint,
+  setupListTransformJobTransformsEndpoint,
   setupUserMetabotPermissionsEndpoint,
 } from "__support__/server-mocks";
 import {
@@ -22,6 +24,7 @@ import type {
   TransformRunForJobRun,
 } from "metabase-types/api";
 import {
+  createMockDatabase,
   createMockListTransformJobRunsResponse,
   createMockTransformJob,
   createMockTransformJobRun,
@@ -48,6 +51,8 @@ function setup({
 
   setupUserMetabotPermissionsEndpoint();
   setupGetTransformJobEndpoint(job);
+  setupDatabaseListEndpoint([createMockDatabase()]);
+  setupListTransformJobTransformsEndpoint(JOB_ID, []);
   setupListTransformJobRunsEndpoint(JOB_ID, () =>
     createMockListTransformJobRunsResponse({
       data: currentRuns,

--- a/frontend/test/__support__/server-mocks/transform.ts
+++ b/frontend/test/__support__/server-mocks/transform.ts
@@ -43,8 +43,13 @@ export function setupListTransformJobsEndpoint(jobs: TransformJob[]) {
 export function setupListTransformJobTransformsEndpoint(
   jobId: TransformJobId,
   transforms: Transform[],
+  options?: { delay?: number },
 ) {
-  fetchMock.get(`path:/api/transform-job/${jobId}/transforms`, transforms);
+  fetchMock.get(
+    `path:/api/transform-job/${jobId}/transforms`,
+    transforms,
+    options,
+  );
 }
 
 export function setupListTransformJobTransformsEndpointWithError(


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76993
Closes [GDGT-2758](https://linear.app/metabase/issue/GDGT-2758), #76993

### Description

The job **Overview** and **Run history** pages each rendered their own header — Overview with an editable name input and a `...` menu, Run history with a static title and no menu — so the differing heights shifted the tab row when switching tabs.

Extracted a shared `JobHeader` component (plus a `useJobHeaderState` hook for the `readOnly`/name-change logic) that both pages now render identically, following the existing `MetricHeader` pattern. As a result, Run history also gets the editable name and `...` menu, and Metabot is consistent across both tabs.

### How to verify

1. Go to `/data-studio/transforms/jobs`, open a job
2. Click the **Run history** tab, then back to **Overview**
3. The tab row no longer jumps — the clicked tab stays put
4. Run history now shows the `...` menu and editable job name, matching Overview

### Checklist

- [x] Tests have been added/updated to cover changes in this PR