### PR TITLE
Extract typed schema generator for metrics

### DIFF
--- a/src/metabase/typed_schemas/api.clj
+++ b/src/metabase/typed_schemas/api.clj
@@ -2,23 +2,16 @@
   "/api/typed-schemas endpoints."
   (:require
    [clojure.set :as set]
-   [medley.core :as m]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
-   [metabase.metabot.tools.entity-details :as entity-details]
-   [metabase.metrics.core :as metrics]
-   [metabase.models.interface :as mi]
-   [metabase.typed-schemas.api.common :as common]
    [metabase.typed-schemas.api.render :as render]
    [metabase.typed-schemas.api.schema :as schema]
-   [metabase.typed-schemas.api.schema.common :as schema.common]
+   [metabase.typed-schemas.api.schema.metric :as schema.metric]
    [metabase.typed-schemas.api.schema.model :as schema.model]
    [metabase.typed-schemas.api.schema.question :as schema.question]
    [metabase.typed-schemas.api.schema.table :as schema.table]
    [metabase.typed-schemas.api.scope :as scope]
-   [metabase.util :as u]
-   [metabase.util.malli.schema :as ms]
-   [toucan2.core :as t2]))
+   [metabase.util.malli.schema :as ms]))
 
 (set! *warn-on-reflection* true)
 
@@ -28,196 +21,6 @@
    "Cross-Origin-Resource-Policy" "same-origin"
    "Referrer-Policy"              "no-referrer"
    "Cache-Control"                "no-store"})
-
-(defn- metric-result-column
-  [card]
-  (schema.common/aggregation-result-column (:database_id card) (:dataset_query card)))
-
-(defn- metric-details
-  [card]
-  (-> (entity-details/get-metric-details {:metric-id                       (:id card)
-                                          :with-default-temporal-breakout? true
-                                          :with-field-values?              false
-                                          :with-queryable-dimensions?      true
-                                          :with-segments?                  false})
-      :structured-output))
-
-(defn- persisted-dimension->column
-  [dimension]
-  (let [field-id (some-> dimension :sources first :field-id)]
-    {:name           (:name dimension)
-     :display_name   (:display-name dimension)
-     :base_type      (some-> (:effective-type dimension) u/qualified-name)
-     :effective_type (some-> (:effective-type dimension) u/qualified-name)
-     :semantic_type  (some-> (:semantic-type dimension) u/qualified-name)
-     :field_id       field-id}))
-
-(defn- dimension-table-id
-  [{:keys [field_id] :as dimension}]
-  (let [field-id (or field_id (some-> dimension :sources first :field-id))]
-    (or (:table_id dimension)
-        (:table-id dimension)
-        (schema.table/table-by-field-id field-id))))
-
-(defn- dimension-schema
-  ([dimension metric-id]
-   (dimension-schema dimension metric-id {}))
-  ([dimension metric-id table-key-by-id]
-   (dimension-schema dimension metric-id table-key-by-id {}))
-  ([{:keys [field_id] :as dimension}
-    metric-id
-    table-key-by-id
-    table-source-name-by-id]
-   (let [dimension-id (or (:id dimension) field_id)
-         field-id     (or field_id (some-> dimension :sources first :field-id))
-         table-id     (dimension-table-id dimension)
-         column       (if (:sources dimension)
-                        (persisted-dimension->column dimension)
-                        dimension)]
-     (m/assoc-some
-      (assoc (common/column-schema column)
-             :type "column"
-             :key (common/generated-key (:name column) dimension-id)
-             :id (str dimension-id))
-      :sourceName (when (integer? table-id)
-                    (get table-source-name-by-id table-id))
-      :fieldId (when (integer? field-id) field-id)
-      :tableId (when (integer? table-id) table-id)
-      :sourceFieldId (when (integer? (:source-field-id dimension))
-                       (:source-field-id dimension))
-      :metricId metric-id
-      :keyDisambiguator (when (integer? table-id)
-                          (get table-key-by-id table-id))))))
-
-(defn- mapping-source-field-id
-  [{:keys [target]}]
-  (when (and (vector? target)
-             (= :field (first target))
-             (map? (second target)))
-    (let [source-field-id (:source-field (second target))]
-      (when (integer? source-field-id)
-        source-field-id))))
-
-(defn- enrich-dimensions-with-mappings
-  [dimensions dimension-mappings]
-  (let [mapping-by-dimension-id (into {} (map (juxt :dimension-id identity)) dimension-mappings)]
-    (mapv (fn [{:keys [id] :as dimension}]
-            (m/assoc-some dimension
-                          :source-field-id (some-> (get mapping-by-dimension-id id)
-                                                   mapping-source-field-id)))
-          dimensions)))
-
-(defn- metric-dimensions
-  [{:keys [id]}]
-  (metrics/sync-dimensions! :metadata/metric id)
-  (let [{:keys [dimensions dimension_mappings]} (t2/select-one [:model/Card :dimensions :dimension_mappings] :id id)]
-    (enrich-dimensions-with-mappings dimensions dimension_mappings)))
-
-(defn- readable-table-source-rows
-  [table-ids]
-  (when (seq table-ids)
-    (->> (t2/select [:model/Table :id :name :display_name] :id [:in table-ids])
-         (filter mi/can-read?))))
-
-(defn- table-key-disambiguators
-  ([table-ids]
-   (table-key-disambiguators table-ids (readable-table-source-rows table-ids)))
-  ([_table-ids table-rows]
-   (when (seq table-rows)
-     (->> table-rows
-          (map (fn [{:keys [id name display_name]}]
-                 [id (common/pascal-case (common/generated-key (or display_name name) id))]))
-          (into {})))))
-
-(defn- table-source-names
-  ([table-ids]
-   (table-source-names table-ids (readable-table-source-rows table-ids)))
-  ([_table-ids table-rows]
-   (when (seq table-rows)
-     (->> table-rows
-          (map (juxt :id :name))
-          (into {})))))
-
-(defn- source-table-schema
-  [[database-name schema-name table-name]]
-  (when (and database-name table-name)
-    {:databaseName database-name
-     :schemaName   schema-name
-     :tableName    table-name}))
-
-(defn- source-table-id
-  [card]
-  (let [source-table (or (get-in card [:dataset_query :query :source-table])
-                         (get-in card [:dataset_query :stages 0 :source-table]))]
-    (when (integer? source-table)
-      source-table)))
-
-(defn- source-card-id
-  [card]
-  (or (when-let [source-card (get-in card [:dataset_query :stages 0 :source-card])]
-        (when (integer? source-card)
-          source-card))
-      (let [source-table (or (get-in card [:dataset_query :query :source-table])
-                             (get-in card [:dataset_query :stages 0 :source-table]))]
-        (when (string? source-table)
-          (some->> (re-matches #"card__(\d+)" source-table)
-                   second
-                   parse-long)))))
-
-(defn- fallback-metric-column
-  [{:keys [name]}]
-  {:type          "column"
-   :name          name
-   :displayName   name
-   :jsType        "unknown"})
-
-(defn- metric-schema
-  [{:keys [id name description verified portable_entity_id base_table_portable_fk] :as details}
-   card]
-  (let [result-column (or (some-> (metric-result-column card) common/column-schema)
-                          (fallback-metric-column details))
-        source-card-id-value (source-card-id card)
-        dimensions    (cond->> (or (seq (metric-dimensions details))
-                                   (:queryable-dimensions details))
-                        source-card-id-value (remove (comp integer? dimension-table-id)))
-        table-ids     (->> dimensions
-                           (keep dimension-table-id)
-                           (filter integer?)
-                           distinct)
-        table-rows              (readable-table-source-rows table-ids)
-        table-key-by-id         (table-key-disambiguators table-ids table-rows)
-        table-source-name-by-id (table-source-names table-ids table-rows)
-        dimension-schemas (mapv #(dimension-schema % id table-key-by-id table-source-name-by-id)
-                                dimensions)
-        mapped-table-ids  (->> dimension-schemas
-                               (keep :tableId)
-                               distinct
-                               sort
-                               vec)]
-    (m/assoc-some
-     {:type       "metric"
-      :key        (common/generated-key name id)
-      :id         id
-      :name       name
-      :columns    [result-column]}
-     :databaseId (:database_id card)
-     :sourceTableId (source-table-id card)
-     :sourceCardId source-card-id-value
-     :entityId portable_entity_id
-     :description description
-     :verified (when verified true)
-     :sourceTable (source-table-schema base_table_portable_fk)
-     :mappedTableIds (not-empty mapped-table-ids)
-     :dimensions (not-empty (common/keyed-map dimension-schemas)))))
-
-(defn- metric-schemas
-  ([database-ids]
-   (metric-schemas database-ids nil))
-  ([database-ids collection-ids]
-   (for [card (schema.common/select-schema-cards :metric database-ids collection-ids)
-         :let [details (metric-details card)]
-         :when details]
-     (metric-schema details card))))
 
 (defn- validate-query-params!
   [query-params]
@@ -248,7 +51,7 @@
 (defn- typed-schema-for-library-scope
   [library-scope models]
   (let [{:keys [metric-collection-ids]} library-scope
-        metrics               (metric-schemas nil metric-collection-ids)
+        metrics               (schema.metric/metric-schemas nil metric-collection-ids)
         mapped-table-ids      (->> metrics (mapcat :mappedTableIds) set)
         library-table-ids     (->> (schema.table/select-library-tables library-scope) (map :id) set)
         table-ids             (set/union library-table-ids mapped-table-ids)
@@ -296,7 +99,7 @@
 
       :else
       (let [questions (schema.question/question-schemas database-ids)
-            metrics   (metric-schemas database-ids)
+            metrics   (schema.metric/metric-schemas database-ids)
             tables    (schema.table/table-schemas (schema.table/select-tables database-ids))]
         (schema/base-schema questions models tables metrics)))))
 

--- a/src/metabase/typed_schemas/api/schema/metric.clj
+++ b/src/metabase/typed_schemas/api/schema/metric.clj
@@ -42,27 +42,29 @@
      :semantic_type  (some-> (:semantic-type dimension) u/qualified-name)
      :field_id       field-id}))
 
+(defn- dimension-field-id
+  "Returns the field id backing a metric dimension, including persisted dimension sources."
+  [{:keys [field_id] :as dimension}]
+  (or field_id (some-> dimension :sources first :field-id)))
+
 (defn- dimension-table-id
   "Returns the table id that backs a metric dimension, when known."
-  [{:keys [field_id] :as dimension}]
-  (let [field-id (or field_id (some-> dimension :sources first :field-id))]
-    (or (:table_id dimension)
-        (:table-id dimension)
-        (schema.table/table-by-field-id field-id))))
+  [dimension]
+  (or (:table_id dimension)
+      (:table-id dimension)
+      (schema.table/table-by-field-id (dimension-field-id dimension))))
 
 (defn- dimension-schema
   "Returns the schema for a metric dimension."
   ([dimension metric-id]
-   (dimension-schema dimension metric-id {}))
-  ([dimension metric-id table-key-by-id]
-   (dimension-schema dimension metric-id table-key-by-id {}))
-  ([{:keys [field_id] :as dimension}
+   (dimension-schema dimension metric-id (dimension-table-id dimension) {} {}))
+  ([dimension
     metric-id
+    table-id
     table-key-by-id
     table-source-name-by-id]
-   (let [dimension-id (or (:id dimension) field_id)
-         field-id     (or field_id (some-> dimension :sources first :field-id))
-         table-id     (dimension-table-id dimension)
+   (let [field-id     (dimension-field-id dimension)
+         dimension-id (or (:id dimension) field-id)
          column       (if (:sources dimension)
                         (persisted-dimension->column dimension)
                         dimension)]
@@ -101,7 +103,7 @@
                                                    mapping-source-field-id)))
           dimensions)))
 
-(defn- metric-dimensions
+(defn- sync-and-fetch-metric-dimensions!
   "Syncs and returns persisted metric dimensions with mapping metadata."
   [{:keys [id]}]
   (metrics/sync-dimensions! :metadata/metric id)
@@ -177,6 +179,35 @@
    :displayName name
    :jsType      "unknown"})
 
+(defn- metric-dimensions-with-table-ids
+  "Returns metric dimensions paired with their backing table ids, filtering mapped dimensions for card metrics."
+  [details source-card-id-value]
+  (let [dimensions (or (seq (sync-and-fetch-metric-dimensions! details))
+                       (:queryable-dimensions details))]
+    (cond->> (mapv (fn [dimension]
+                     [dimension (dimension-table-id dimension)])
+                   dimensions)
+      source-card-id-value (remove (fn [[_dimension table-id]]
+                                     (integer? table-id))))))
+
+(defn- metric-dimension-schemas
+  "Returns dimension schemas and mapped table ids for a metric."
+  [metric-id details source-card-id-value]
+  (let [dimension-table-id-pairs (metric-dimensions-with-table-ids details source-card-id-value)
+        table-ids                (->> dimension-table-id-pairs (keep second) (filter integer?) distinct)
+        table-rows               (readable-table-source-rows table-ids)
+        table-key-by-id          (table-key-disambiguators table-ids table-rows)
+        table-source-name-by-id  (table-source-names table-ids table-rows)
+        dimension-schemas        (mapv (fn [[dimension table-id]]
+                                         (dimension-schema dimension
+                                                           metric-id
+                                                           table-id
+                                                           table-key-by-id
+                                                           table-source-name-by-id))
+                                       dimension-table-id-pairs)]
+    {:dimension-schemas dimension-schemas
+     :mapped-table-ids  (->> dimension-schemas (keep :tableId) distinct sort vec)}))
+
 (defn- metric-schema
   "Returns the schema for a metric and its queryable dimensions."
   [{:keys [id name description verified portable_entity_id base_table_portable_fk] :as details}
@@ -184,23 +215,7 @@
   (let [result-column (or (some-> (metric-result-column card) common/column-schema)
                           (fallback-metric-column details))
         source-card-id-value (source-card-id card)
-        dimensions    (cond->> (or (seq (metric-dimensions details))
-                                   (:queryable-dimensions details))
-                        source-card-id-value (remove (comp integer? dimension-table-id)))
-        table-ids     (->> dimensions
-                           (keep dimension-table-id)
-                           (filter integer?)
-                           distinct)
-        table-rows              (readable-table-source-rows table-ids)
-        table-key-by-id         (table-key-disambiguators table-ids table-rows)
-        table-source-name-by-id (table-source-names table-ids table-rows)
-        dimension-schemas (mapv #(dimension-schema % id table-key-by-id table-source-name-by-id)
-                                dimensions)
-        mapped-table-ids  (->> dimension-schemas
-                               (keep :tableId)
-                               distinct
-                               sort
-                               vec)]
+        {:keys [dimension-schemas mapped-table-ids]} (metric-dimension-schemas id details source-card-id-value)]
     (m/assoc-some
      {:type    "metric"
       :key     (common/generated-key name id)

--- a/src/metabase/typed_schemas/api/schema/metric.clj
+++ b/src/metabase/typed_schemas/api/schema/metric.clj
@@ -22,7 +22,8 @@
   "Returns metric details with queryable dimensions for schema generation."
   [card]
   (-> (entity-details/get-metric-details {:metric-id                       (:id card)
-                                          :with-default-temporal-breakout? true
+                                          ;; The typed schema does not use the default temporal dimension.
+                                          :with-default-temporal-breakout? false
                                           :with-field-values?              false
                                           :with-queryable-dimensions?      true
                                           :with-segments?                  false})

--- a/src/metabase/typed_schemas/api/schema/metric.clj
+++ b/src/metabase/typed_schemas/api/schema/metric.clj
@@ -49,10 +49,26 @@
 
 (defn- dimension-table-id
   "Returns the table id that backs a metric dimension, when known."
-  [dimension]
-  (or (:table_id dimension)
-      (:table-id dimension)
-      (schema.table/table-by-field-id (dimension-field-id dimension))))
+  ([dimension]
+   (dimension-table-id dimension nil))
+  ([dimension field-table-ids]
+   (or (:table_id dimension)
+       (:table-id dimension)
+       (if field-table-ids
+         (get field-table-ids (dimension-field-id dimension))
+         (schema.table/table-by-field-id (dimension-field-id dimension))))))
+
+(defn- field-table-ids
+  "Returns backing table ids for dimensions that need field-based resolution."
+  [dimensions]
+  (let [field-ids (into #{}
+                        (comp (remove #(or (:table_id %) (:table-id %)))
+                              (keep dimension-field-id))
+                        dimensions)]
+    (when (seq field-ids)
+      (into {}
+            (map (juxt :id :table_id))
+            (t2/select [:model/Field :id :table_id] :id [:in field-ids])))))
 
 (defn- dimension-schema
   "Returns the schema for a metric dimension."
@@ -183,9 +199,10 @@
   "Returns metric dimensions paired with their backing table ids, filtering mapped dimensions for card metrics."
   [details source-card-id-value]
   (let [dimensions (or (seq (sync-and-fetch-metric-dimensions! details))
-                       (:queryable-dimensions details))]
+                       (:queryable-dimensions details))
+        field-table-ids (field-table-ids dimensions)]
     (cond->> (mapv (fn [dimension]
-                     [dimension (dimension-table-id dimension)])
+                     [dimension (dimension-table-id dimension field-table-ids)])
                    dimensions)
       source-card-id-value (remove (fn [[_dimension table-id]]
                                      (integer? table-id))))))

--- a/src/metabase/typed_schemas/api/schema/metric.clj
+++ b/src/metabase/typed_schemas/api/schema/metric.clj
@@ -1,0 +1,228 @@
+(ns metabase.typed-schemas.api.schema.metric
+  "Typed schema generation for metrics and metric dimensions."
+  (:require
+   [medley.core :as m]
+   [metabase.metabot.tools.entity-details :as entity-details]
+   [metabase.metrics.core :as metrics]
+   [metabase.models.interface :as mi]
+   [metabase.typed-schemas.api.common :as common]
+   [metabase.typed-schemas.api.schema.common :as schema.common]
+   [metabase.typed-schemas.api.schema.table :as schema.table]
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- metric-result-column
+  "Returns the metric aggregation result column inferred by Lib."
+  [card]
+  (schema.common/aggregation-result-column (:database_id card) (:dataset_query card)))
+
+(defn- metric-details
+  "Returns metric details with queryable dimensions for schema generation."
+  [card]
+  (-> (entity-details/get-metric-details {:metric-id                       (:id card)
+                                          :with-default-temporal-breakout? true
+                                          :with-field-values?              false
+                                          :with-queryable-dimensions?      true
+                                          :with-segments?                  false})
+      :structured-output))
+
+(defn- persisted-dimension->column
+  "Converts persisted metric dimensions to column-shaped maps.
+
+  Persisted metric dimensions use kebab-case field/type keys, while [[common/column-schema]] expects
+  result-column-style snake_case keys."
+  [dimension]
+  (let [field-id (some-> dimension :sources first :field-id)]
+    {:name           (:name dimension)
+     :display_name   (:display-name dimension)
+     :base_type      (some-> (:effective-type dimension) u/qualified-name)
+     :effective_type (some-> (:effective-type dimension) u/qualified-name)
+     :semantic_type  (some-> (:semantic-type dimension) u/qualified-name)
+     :field_id       field-id}))
+
+(defn- dimension-table-id
+  "Returns the table id that backs a metric dimension, when known."
+  [{:keys [field_id] :as dimension}]
+  (let [field-id (or field_id (some-> dimension :sources first :field-id))]
+    (or (:table_id dimension)
+        (:table-id dimension)
+        (schema.table/table-by-field-id field-id))))
+
+(defn- dimension-schema
+  "Returns the schema for a metric dimension."
+  ([dimension metric-id]
+   (dimension-schema dimension metric-id {}))
+  ([dimension metric-id table-key-by-id]
+   (dimension-schema dimension metric-id table-key-by-id {}))
+  ([{:keys [field_id] :as dimension}
+    metric-id
+    table-key-by-id
+    table-source-name-by-id]
+   (let [dimension-id (or (:id dimension) field_id)
+         field-id     (or field_id (some-> dimension :sources first :field-id))
+         table-id     (dimension-table-id dimension)
+         column       (if (:sources dimension)
+                        (persisted-dimension->column dimension)
+                        dimension)]
+     (m/assoc-some
+      (assoc (common/column-schema column)
+             :type "column"
+             :key (common/generated-key (:name column) dimension-id)
+             :id (str dimension-id))
+      :sourceName (when (integer? table-id)
+                    (get table-source-name-by-id table-id))
+      :fieldId (when (integer? field-id) field-id)
+      :tableId (when (integer? table-id) table-id)
+      :sourceFieldId (when (integer? (:source-field-id dimension))
+                       (:source-field-id dimension))
+      :metricId metric-id
+      :keyDisambiguator (when (integer? table-id)
+                          (get table-key-by-id table-id))))))
+
+(defn- mapping-source-field-id
+  "Returns the mapped source field id for a metric dimension mapping."
+  [{:keys [target]}]
+  (when (and (vector? target)
+             (= :field (first target))
+             (map? (second target)))
+    (let [source-field-id (:source-field (second target))]
+      (when (integer? source-field-id)
+        source-field-id))))
+
+(defn- enrich-dimensions-with-mappings
+  "Adds mapped source field ids to persisted metric dimensions."
+  [dimensions dimension-mappings]
+  (let [mapping-by-dimension-id (into {} (map (juxt :dimension-id identity)) dimension-mappings)]
+    (mapv (fn [{:keys [id] :as dimension}]
+            (m/assoc-some dimension
+                          :source-field-id (some-> (get mapping-by-dimension-id id)
+                                                   mapping-source-field-id)))
+          dimensions)))
+
+(defn- metric-dimensions
+  "Syncs and returns persisted metric dimensions with mapping metadata."
+  [{:keys [id]}]
+  (metrics/sync-dimensions! :metadata/metric id)
+  (let [{:keys [dimensions dimension_mappings]} (t2/select-one [:model/Card :dimensions :dimension_mappings] :id id)]
+    (enrich-dimensions-with-mappings dimensions dimension_mappings)))
+
+(defn- readable-table-source-rows
+  "Returns readable table rows for table-backed metric dimensions."
+  [table-ids]
+  (when (seq table-ids)
+    (->> (t2/select [:model/Table :id :name :display_name] :id [:in table-ids])
+         (filter mi/can-read?))))
+
+(defn- table-key-disambiguators
+  "Returns table display keys used to disambiguate compacted metric dimensions."
+  ([table-ids]
+   (table-key-disambiguators table-ids (readable-table-source-rows table-ids)))
+  ([_dimension-table-ids table-rows]
+   (when (seq table-rows)
+     (->> table-rows
+          (map (fn [{:keys [id name display_name]}]
+                 [id (common/pascal-case (common/generated-key (or display_name name) id))]))
+          (into {})))))
+
+(defn- table-source-names
+  "Returns table names emitted as metric dimension source names."
+  ([table-ids]
+   (table-source-names table-ids (readable-table-source-rows table-ids)))
+  ([_dimension-table-ids table-rows]
+   (when (seq table-rows)
+     (->> table-rows
+          (map (juxt :id :name))
+          (into {})))))
+
+(defn- source-table-schema
+  "Returns the metric source table identity from portable table metadata."
+  [[database-name schema-name table-name]]
+  (when (and database-name table-name)
+    {:databaseName database-name
+     :schemaName   schema-name
+     :tableName    table-name}))
+
+(defn- source-table-reference
+  "Returns the metric query source-table reference from either query shape."
+  [card]
+  (or (get-in card [:dataset_query :query :source-table])
+      (get-in card [:dataset_query :stages 0 :source-table])))
+
+(defn- source-table-id
+  "Returns the source table id for table-backed metrics."
+  [card]
+  (let [source-table (source-table-reference card)]
+    (when (integer? source-table)
+      source-table)))
+
+(defn- source-card-id
+  "Returns the source card id for metrics that are based on saved questions."
+  [card]
+  (or (when-let [source-card (get-in card [:dataset_query :stages 0 :source-card])]
+        (when (integer? source-card)
+          source-card))
+      (let [source-table (source-table-reference card)]
+        (when (string? source-table)
+          (some->> (re-matches #"card__(\d+)" source-table)
+                   second
+                   parse-long)))))
+
+(defn- fallback-metric-column
+  "Returns a stable fallback column when metric result-column inference fails."
+  [{:keys [name]}]
+  {:type        "column"
+   :name        name
+   :displayName name
+   :jsType      "unknown"})
+
+(defn- metric-schema
+  "Returns the schema for a metric and its queryable dimensions."
+  [{:keys [id name description verified portable_entity_id base_table_portable_fk] :as details}
+   card]
+  (let [result-column (or (some-> (metric-result-column card) common/column-schema)
+                          (fallback-metric-column details))
+        source-card-id-value (source-card-id card)
+        dimensions    (cond->> (or (seq (metric-dimensions details))
+                                   (:queryable-dimensions details))
+                        source-card-id-value (remove (comp integer? dimension-table-id)))
+        table-ids     (->> dimensions
+                           (keep dimension-table-id)
+                           (filter integer?)
+                           distinct)
+        table-rows              (readable-table-source-rows table-ids)
+        table-key-by-id         (table-key-disambiguators table-ids table-rows)
+        table-source-name-by-id (table-source-names table-ids table-rows)
+        dimension-schemas (mapv #(dimension-schema % id table-key-by-id table-source-name-by-id)
+                                dimensions)
+        mapped-table-ids  (->> dimension-schemas
+                               (keep :tableId)
+                               distinct
+                               sort
+                               vec)]
+    (m/assoc-some
+     {:type    "metric"
+      :key     (common/generated-key name id)
+      :id      id
+      :name    name
+      :columns [result-column]}
+     :databaseId (:database_id card)
+     :sourceTableId (source-table-id card)
+     :sourceCardId source-card-id-value
+     :entityId portable_entity_id
+     :description description
+     :verified (when verified true)
+     :sourceTable (source-table-schema base_table_portable_fk)
+     :mappedTableIds (not-empty mapped-table-ids)
+     :dimensions (not-empty (common/keyed-map dimension-schemas)))))
+
+(defn metric-schemas
+  "Returns metric schemas, with optional database and collection scopes."
+  ([database-ids]
+   (metric-schemas database-ids nil))
+  ([database-ids collection-ids]
+   (for [card (schema.common/select-schema-cards :metric database-ids collection-ids)
+         :let [details (metric-details card)]
+         :when details]
+     (metric-schema details card))))

--- a/src/metabase/typed_schemas/api/schema/metric.clj
+++ b/src/metabase/typed_schemas/api/schema/metric.clj
@@ -18,16 +18,35 @@
   [card]
   (schema.common/aggregation-result-column (:database_id card) (:dataset_query card)))
 
+(defn- metric-details-error-message
+  [card error-message]
+  (format "Failed to build schema details for metric \"%s\" (card %s): %s"
+          (or (:name card) "Untitled")
+          (:id card)
+          (or error-message "unknown error")))
+
+(defn- metric-details-error-data
+  [card error-data]
+  (m/assoc-some
+   {:card-id   (:id card)
+    :card-name (:name card)
+    :card-type (:type card)}
+   :status-code (:status-code error-data)))
+
 (defn- metric-details
   "Returns metric details with queryable dimensions for schema generation."
   [card]
-  (-> (entity-details/get-metric-details {:metric-id                       (:id card)
-                                          ;; The typed schema does not use the default temporal dimension.
-                                          :with-default-temporal-breakout? false
-                                          :with-field-values?              false
-                                          :with-queryable-dimensions?      true
-                                          :with-segments?                  false})
-      :structured-output))
+  (let [response (entity-details/get-metric-details {:metric-id                       (:id card)
+                                                     ;; The typed schema does not use the default temporal dimension.
+                                                     :with-default-temporal-breakout? false
+                                                     :with-field-values?              false
+                                                     :with-queryable-dimensions?      true
+                                                     :with-segments?                  false})]
+    (or (:structured-output response)
+        (let [error-message (:output response)]
+          (throw (ex-info (metric-details-error-message card error-message)
+                          (assoc (metric-details-error-data card response)
+                                 :error-message error-message)))))))
 
 (defn- persisted-dimension->column
   "Converts persisted metric dimensions to column-shaped maps.

--- a/test/metabase/typed_schemas/api/schema/metric_test.clj
+++ b/test/metabase/typed_schemas/api/schema/metric_test.clj
@@ -5,7 +5,7 @@
    [metabase.typed-schemas.api.schema.metric :as schema.metric]
    [toucan2.core :as t2]))
 
-(deftest metric-dimension-schema-uses-dimension-id-test
+(deftest ^:parallel metric-dimension-schema-uses-dimension-id-test
   (is (= {:type        "column"
           :name        "category"
           :displayName "Category"
@@ -25,7 +25,7 @@
            :sources        [{:type :field, :field-id 3815}]}
           247))))
 
-(deftest metric-dimension-schema-preserves-source-field-id-test
+(deftest ^:parallel metric-dimension-schema-preserves-source-field-id-test
   (is (= 102
          (:sourceFieldId
           (#'schema.metric/dimension-schema
@@ -34,7 +34,7 @@
             :source-field-id 102}
            247)))))
 
-(deftest metric-source-id-test
+(deftest ^:parallel metric-source-id-test
   (testing "integer source-table emits sourceTableId but not sourceCardId"
     (let [card {:dataset_query {:query {:source-table 10}}}]
       (is (= 10 (#'schema.metric/source-table-id card)))
@@ -60,7 +60,7 @@
   (with-redefs [schema.metric/metric-result-column (constantly nil)
                 schema.metric/readable-table-source-rows
                 (constantly [{:id 10 :name "orders" :display_name "Orders"}])
-                schema.metric/metric-dimensions
+                schema.metric/sync-and-fetch-metric-dimensions!
                 (constantly [{:id             "550e8400-e29b-41d4-a716-446655440001"
                               :name           "orders"
                               :display-name   "Orders"
@@ -95,7 +95,7 @@
 (deftest metric-schema-reuses-table-source-rows-test
   (let [table-select-count (atom 0)]
     (with-redefs [schema.metric/metric-result-column (constantly nil)
-                  schema.metric/metric-dimensions
+                  schema.metric/sync-and-fetch-metric-dimensions!
                   (constantly [{:id       "orders-dimension"
                                 :name     "orders"
                                 :table-id 10}])
@@ -112,7 +112,7 @@
 
 (deftest source-card-metric-schema-omits-mapped-table-dimensions-test
   (with-redefs [schema.metric/metric-result-column (constantly nil)
-                schema.metric/metric-dimensions
+                schema.metric/sync-and-fetch-metric-dimensions!
                 (constantly [{:id   "count-dimension-uuid"
                               :name "count"}
                              {:id             "store-name-dimension-uuid"

--- a/test/metabase/typed_schemas/api/schema/metric_test.clj
+++ b/test/metabase/typed_schemas/api/schema/metric_test.clj
@@ -1,0 +1,152 @@
+(ns metabase.typed-schemas.api.schema.metric-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.models.interface :as mi]
+   [metabase.typed-schemas.api.schema.metric :as schema.metric]
+   [toucan2.core :as t2]))
+
+(deftest metric-dimension-schema-uses-dimension-id-test
+  (is (= {:type        "column"
+          :name        "category"
+          :displayName "Category"
+          :baseType    "type/Text"
+          :jsType      "string"
+          :key         "category"
+          :id          "550e8400-e29b-41d4-a716-446655440001"
+          :fieldId     3815
+          :tableId     12
+          :metricId    247}
+         (#'schema.metric/dimension-schema
+          {:id             "550e8400-e29b-41d4-a716-446655440001"
+           :name           "category"
+           :display-name   "Category"
+           :effective-type :type/Text
+           :table-id       12
+           :sources        [{:type :field, :field-id 3815}]}
+          247))))
+
+(deftest metric-dimension-schema-preserves-source-field-id-test
+  (is (= 102
+         (:sourceFieldId
+          (#'schema.metric/dimension-schema
+           {:id              "550e8400-e29b-41d4-a716-446655440001"
+            :name            "category"
+            :display-name    "Category"
+            :effective-type  :type/Text
+            :table-id        12
+            :source-field-id 102
+            :sources         [{:type :field, :field-id 3815}]}
+           247)))))
+
+(deftest metric-source-id-test
+  (testing "integer source-table emits sourceTableId but not sourceCardId"
+    (let [card {:dataset_query {:query {:source-table 10}}}]
+      (is (= 10 (#'schema.metric/source-table-id card)))
+      (is (nil? (#'schema.metric/source-card-id card)))))
+  (testing "card source-table emits sourceCardId but not sourceTableId"
+    (let [card {:dataset_query {:query {:source-table "card__42"}}}]
+      (is (nil? (#'schema.metric/source-table-id card)))
+      (is (= 42 (#'schema.metric/source-card-id card)))))
+  (testing "stage source-card emits sourceCardId"
+    (is (= 42 (#'schema.metric/source-card-id
+               {:dataset_query {:stages [{:source-card 42}]}})))))
+
+(deftest table-source-names-filters-unreadable-tables-test
+  (with-redefs [t2/select (constantly [{:id 10 :name "orders" :display_name "Orders"}
+                                       {:id 20 :name "franchises" :display_name "Franchises"}])
+                mi/can-read? (fn [{:keys [id]}] (= id 10))]
+    (is (= {10 "orders"}
+           (#'schema.metric/table-source-names [10 20])))
+    (is (= {10 "Orders"}
+           (#'schema.metric/table-key-disambiguators [10 20])))))
+
+(deftest metric-schema-keys-dimensions-test
+  (with-redefs [schema.metric/metric-result-column (constantly nil)
+                schema.metric/readable-table-source-rows
+                (constantly [{:id 10 :name "orders" :display_name "Orders"}])
+                schema.metric/metric-dimensions
+                (constantly [{:id             "550e8400-e29b-41d4-a716-446655440001"
+                              :name           "orders"
+                              :display-name   "Orders"
+                              :effective-type :type/Integer
+                              :table-id       10
+                              :sources        [{:type :field, :field-id 42}]}])]
+    (is (= {:type           "metric"
+            :key            "customerLifetimeValue"
+            :id             247
+            :name           "Customer Lifetime Value"
+            :columns        [{:type        "column"
+                              :name        "Customer Lifetime Value"
+                              :displayName "Customer Lifetime Value"
+                              :jsType      "unknown"}]
+            :mappedTableIds [10]
+            :dimensions     {"orders" {:type        "column"
+                                       :name        "orders"
+                                       :sourceName  "orders"
+                                       :displayName "Orders"
+                                       :baseType    "type/Integer"
+                                       :jsType      "number"
+                                       :key         "orders"
+                                       :id          "550e8400-e29b-41d4-a716-446655440001"
+                                       :fieldId     42
+                                       :tableId     10
+                                       :metricId    247}}}
+           (#'schema.metric/metric-schema
+            {:id   247
+             :name "Customer Lifetime Value"}
+            {:id 247})))))
+
+(deftest metric-schema-reuses-table-source-rows-test
+  (let [table-select-count (atom 0)]
+    (with-redefs [schema.metric/metric-result-column (constantly nil)
+                  schema.metric/metric-dimensions
+                  (constantly [{:id             "550e8400-e29b-41d4-a716-446655440001"
+                                :name           "orders"
+                                :display-name   "Orders"
+                                :effective-type :type/Integer
+                                :table-id       10
+                                :sources        [{:type :field, :field-id 42}]}])
+                  mi/can-read? (constantly true)
+                  t2/select (fn [columns & _args]
+                              (when (= columns [:model/Table :id :name :display_name])
+                                (swap! table-select-count inc)
+                                [{:id 10 :name "orders" :display_name "Orders"}]))]
+      (#'schema.metric/metric-schema
+       {:id   247
+        :name "Customer Lifetime Value"}
+       {:id 247})
+      (is (= 1 @table-select-count)))))
+
+(deftest source-card-metric-schema-omits-mapped-table-dimensions-test
+  (with-redefs [schema.metric/metric-result-column (constantly nil)
+                schema.metric/table-source-names (constantly {10 "employee_store_roster"})
+                schema.metric/metric-dimensions
+                (constantly [{:id   "count-dimension-uuid"
+                              :name "count"}
+                             {:id             "store-name-dimension-uuid"
+                              :name           "store_name"
+                              :display-name   "Store Name"
+                              :effective-type :type/Text
+                              :table-id       10
+                              :sources        [{:type :field, :field-id 42}]}])]
+    (is (= {:type         "metric"
+            :key          "storesWithOver5Employees"
+            :id           259
+            :name         "Stores with Over 5 Employees"
+            :columns      [{:type        "column"
+                            :name        "Stores with Over 5 Employees"
+                            :displayName "Stores with Over 5 Employees"
+                            :jsType      "unknown"}]
+            :sourceCardId 258
+            :dimensions   {"count" {:type        "column"
+                                    :name        "count"
+                                    :displayName "count"
+                                    :jsType      "unknown"
+                                    :key         "count"
+                                    :id          "count-dimension-uuid"
+                                    :metricId    259}}}
+           (#'schema.metric/metric-schema
+            {:id   259
+             :name "Stores with Over 5 Employees"}
+            {:id            259
+             :dataset_query {:stages [{:source-card 258}]}})))))

--- a/test/metabase/typed_schemas/api/schema/metric_test.clj
+++ b/test/metabase/typed_schemas/api/schema/metric_test.clj
@@ -29,13 +29,9 @@
   (is (= 102
          (:sourceFieldId
           (#'schema.metric/dimension-schema
-           {:id              "550e8400-e29b-41d4-a716-446655440001"
+           {:id              "category-dimension"
             :name            "category"
-            :display-name    "Category"
-            :effective-type  :type/Text
-            :table-id        12
-            :source-field-id 102
-            :sources         [{:type :field, :field-id 3815}]}
+            :source-field-id 102}
            247)))))
 
 (deftest metric-source-id-test
@@ -100,12 +96,9 @@
   (let [table-select-count (atom 0)]
     (with-redefs [schema.metric/metric-result-column (constantly nil)
                   schema.metric/metric-dimensions
-                  (constantly [{:id             "550e8400-e29b-41d4-a716-446655440001"
-                                :name           "orders"
-                                :display-name   "Orders"
-                                :effective-type :type/Integer
-                                :table-id       10
-                                :sources        [{:type :field, :field-id 42}]}])
+                  (constantly [{:id       "orders-dimension"
+                                :name     "orders"
+                                :table-id 10}])
                   mi/can-read? (constantly true)
                   t2/select (fn [columns & _args]
                               (when (= columns [:model/Table :id :name :display_name])
@@ -119,16 +112,12 @@
 
 (deftest source-card-metric-schema-omits-mapped-table-dimensions-test
   (with-redefs [schema.metric/metric-result-column (constantly nil)
-                schema.metric/table-source-names (constantly {10 "employee_store_roster"})
                 schema.metric/metric-dimensions
                 (constantly [{:id   "count-dimension-uuid"
                               :name "count"}
                              {:id             "store-name-dimension-uuid"
                               :name           "store_name"
-                              :display-name   "Store Name"
-                              :effective-type :type/Text
-                              :table-id       10
-                              :sources        [{:type :field, :field-id 42}]}])]
+                              :table-id       10}])]
     (is (= {:type         "metric"
             :key          "storesWithOver5Employees"
             :id           259

--- a/test/metabase/typed_schemas/api/schema/metric_test.clj
+++ b/test/metabase/typed_schemas/api/schema/metric_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.typed-schemas.api.schema.metric-test
   (:require
    [clojure.test :refer :all]
+   [metabase.metabot.tools.entity-details :as entity-details]
    [metabase.models.interface :as mi]
    [metabase.test :as mt]
    [metabase.typed-schemas.api.schema.metric :as schema.metric]
@@ -48,6 +49,14 @@
   (testing "stage source-card emits sourceCardId"
     (is (= 42 (#'schema.metric/source-card-id
                {:dataset_query {:stages [{:source-card 42}]}})))))
+
+(deftest metric-details-skips-default-temporal-breakout-test
+  (mt/with-dynamic-fn-redefs [entity-details/get-metric-details
+                              (fn [options]
+                                (is (false? (:with-default-temporal-breakout? options)))
+                                {:structured-output {:id 247}})]
+    (is (= {:id 247}
+           (#'schema.metric/metric-details {:id 247})))))
 
 (deftest table-source-names-filters-unreadable-tables-test
   (with-redefs [t2/select (constantly [{:id 10 :name "orders" :display_name "Orders"}

--- a/test/metabase/typed_schemas/api/schema/metric_test.clj
+++ b/test/metabase/typed_schemas/api/schema/metric_test.clj
@@ -2,7 +2,9 @@
   (:require
    [clojure.test :refer :all]
    [metabase.models.interface :as mi]
+   [metabase.test :as mt]
    [metabase.typed-schemas.api.schema.metric :as schema.metric]
+   [metabase.typed-schemas.api.schema.table :as schema.table]
    [toucan2.core :as t2]))
 
 (deftest ^:parallel metric-dimension-schema-uses-dimension-id-test
@@ -109,6 +111,27 @@
         :name "Customer Lifetime Value"}
        {:id 247})
       (is (= 1 @table-select-count)))))
+
+(deftest metric-dimensions-bulk-load-table-ids-test
+  (let [field-select-count   (atom 0)
+        field-lookup-attempts (atom [])
+        dimensions           [{:id "orders-dimension"
+                               :sources [{:type :field, :field-id 42}]}
+                              {:id "people-dimension"
+                               :sources [{:type :field, :field-id 84}]}]]
+    (mt/with-dynamic-fn-redefs [schema.metric/sync-and-fetch-metric-dimensions! (constantly dimensions)
+                                schema.table/table-by-field-id (fn [field-id]
+                                                                 (swap! field-lookup-attempts conj field-id)
+                                                                 ({42 10, 84 20} field-id))
+                                t2/select (fn [columns & _args]
+                                            (when (= columns [:model/Field :id :table_id])
+                                              (swap! field-select-count inc)
+                                              [{:id 42 :table_id 10}
+                                               {:id 84 :table_id 20}]))]
+      (is (= (mapv vector dimensions [10 20])
+             (#'schema.metric/metric-dimensions-with-table-ids {:id 247} nil)))
+      (is (= 1 @field-select-count))
+      (is (empty? @field-lookup-attempts)))))
 
 (deftest source-card-metric-schema-omits-mapped-table-dimensions-test
   (with-redefs [schema.metric/metric-result-column (constantly nil)

--- a/test/metabase/typed_schemas/api/schema/metric_test.clj
+++ b/test/metabase/typed_schemas/api/schema/metric_test.clj
@@ -58,6 +58,24 @@
     (is (= {:id 247}
            (#'schema.metric/metric-details {:id 247})))))
 
+(deftest metric-details-surfaces-error-responses-test
+  (mt/with-dynamic-fn-redefs [entity-details/get-metric-details
+                              (constantly {:output "Not found."
+                                           :status-code 404})]
+    (let [exception (try
+                      (#'schema.metric/metric-details {:id 247
+                                                       :name "Customer Lifetime Value"
+                                                       :type :metric})
+                      (catch clojure.lang.ExceptionInfo exception
+                        exception))]
+      (is (instance? clojure.lang.ExceptionInfo exception))
+      (is (= {:card-id     247
+              :card-name   "Customer Lifetime Value"
+              :card-type   :metric
+              :status-code 404
+              :error-message "Not found."}
+             (ex-data exception))))))
+
 (deftest table-source-names-filters-unreadable-tables-test
   (with-redefs [t2/select (constantly [{:id 10 :name "orders" :display_name "Orders"}
                                        {:id 20 :name "franchises" :display_name "Franchises"}])

--- a/test/metabase/typed_schemas/api_test.clj
+++ b/test/metabase/typed_schemas/api_test.clj
@@ -2,164 +2,17 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase.models.interface :as mi]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.typed-schemas.api :as typed-schemas.api]
    [metabase.typed-schemas.api.render :as typed-schemas.api.render]
+   [metabase.typed-schemas.api.schema.metric :as typed-schemas.api.schema.metric]
    [metabase.typed-schemas.api.schema.model :as typed-schemas.api.schema.model]
    [metabase.typed-schemas.api.schema.question :as typed-schemas.api.schema.question]
    [metabase.typed-schemas.api.schema.table :as typed-schemas.api.schema.table]
-   [metabase.typed-schemas.api.scope :as typed-schemas.api.scope]
-   [toucan2.core :as t2]))
+   [metabase.typed-schemas.api.scope :as typed-schemas.api.scope]))
 
 (use-fixtures :once (fixtures/initialize :db :web-server :test-users))
-
-(deftest metric-dimension-schema-uses-dimension-id-test
-  (is (= {:type          "column"
-          :name          "category"
-          :displayName   "Category"
-          :baseType      "type/Text"
-          :jsType        "string"
-          :key           "category"
-          :id            "550e8400-e29b-41d4-a716-446655440001"
-          :fieldId       3815
-          :tableId       12
-          :metricId      247}
-         (#'typed-schemas.api/dimension-schema
-          {:id             "550e8400-e29b-41d4-a716-446655440001"
-           :name           "category"
-           :display-name   "Category"
-           :effective-type :type/Text
-           :table-id       12
-           :sources        [{:type :field, :field-id 3815}]}
-          247))))
-
-(deftest metric-dimension-schema-preserves-source-field-id-test
-  (is (= 102
-         (:sourceFieldId
-          (#'typed-schemas.api/dimension-schema
-           {:id              "550e8400-e29b-41d4-a716-446655440001"
-            :name            "category"
-            :display-name    "Category"
-            :effective-type  :type/Text
-            :table-id        12
-            :source-field-id 102
-            :sources         [{:type :field, :field-id 3815}]}
-           247)))))
-
-(deftest metric-source-id-test
-  (testing "integer source-table emits sourceTableId but not sourceCardId"
-    (let [card {:dataset_query {:query {:source-table 10}}}]
-      (is (= 10 (#'typed-schemas.api/source-table-id card)))
-      (is (nil? (#'typed-schemas.api/source-card-id card)))))
-  (testing "card source-table emits sourceCardId but not sourceTableId"
-    (let [card {:dataset_query {:query {:source-table "card__42"}}}]
-      (is (nil? (#'typed-schemas.api/source-table-id card)))
-      (is (= 42 (#'typed-schemas.api/source-card-id card)))))
-  (testing "stage source-card emits sourceCardId"
-    (is (= 42 (#'typed-schemas.api/source-card-id
-               {:dataset_query {:stages [{:source-card 42}]}})))))
-
-(deftest table-source-names-filters-unreadable-tables-test
-  (with-redefs [t2/select (constantly [{:id 10 :name "orders" :display_name "Orders"}
-                                       {:id 20 :name "franchises" :display_name "Franchises"}])
-                mi/can-read? (fn [{:keys [id]}] (= id 10))]
-    (is (= {10 "orders"}
-           (#'typed-schemas.api/table-source-names [10 20])))
-    (is (= {10 "Orders"}
-           (#'typed-schemas.api/table-key-disambiguators [10 20])))))
-
-(deftest metric-schema-keys-dimensions-test
-  (with-redefs [typed-schemas.api/metric-result-column (constantly nil)
-                typed-schemas.api/readable-table-source-rows
-                (constantly [{:id 10 :name "orders" :display_name "Orders"}])
-                typed-schemas.api/metric-dimensions
-                (constantly [{:id             "550e8400-e29b-41d4-a716-446655440001"
-                              :name           "orders"
-                              :display-name   "Orders"
-                              :effective-type :type/Integer
-                              :table-id       10
-                              :sources        [{:type :field, :field-id 42}]}])]
-    (is (= {:type           "metric"
-            :key            "customerLifetimeValue"
-            :id             247
-            :name           "Customer Lifetime Value"
-            :columns        [{:type        "column"
-                              :name        "Customer Lifetime Value"
-                              :displayName "Customer Lifetime Value"
-                              :jsType      "unknown"}]
-            :mappedTableIds [10]
-            :dimensions     {"orders" {:type        "column"
-                                       :name        "orders"
-                                       :sourceName "orders"
-                                       :displayName "Orders"
-                                       :baseType    "type/Integer"
-                                       :jsType      "number"
-                                       :key         "orders"
-                                       :id          "550e8400-e29b-41d4-a716-446655440001"
-                                       :fieldId     42
-                                       :tableId     10
-                                       :metricId    247}}}
-           (#'typed-schemas.api/metric-schema
-            {:id   247
-             :name "Customer Lifetime Value"}
-            {:id 247})))))
-
-(deftest metric-schema-reuses-table-source-rows-test
-  (let [table-select-count (atom 0)]
-    (with-redefs [typed-schemas.api/metric-result-column (constantly nil)
-                  typed-schemas.api/metric-dimensions
-                  (constantly [{:id             "550e8400-e29b-41d4-a716-446655440001"
-                                :name           "orders"
-                                :display-name   "Orders"
-                                :effective-type :type/Integer
-                                :table-id       10
-                                :sources        [{:type :field, :field-id 42}]}])
-                  mi/can-read? (constantly true)
-                  t2/select (fn [columns & _args]
-                              (when (= columns [:model/Table :id :name :display_name])
-                                (swap! table-select-count inc)
-                                [{:id 10 :name "orders" :display_name "Orders"}]))]
-      (#'typed-schemas.api/metric-schema
-       {:id   247
-        :name "Customer Lifetime Value"}
-       {:id 247})
-      (is (= 1 @table-select-count)))))
-
-(deftest source-card-metric-schema-omits-mapped-table-dimensions-test
-  (with-redefs [typed-schemas.api/metric-result-column (constantly nil)
-                typed-schemas.api/table-source-names (constantly {10 "employee_store_roster"})
-                typed-schemas.api/metric-dimensions
-                (constantly [{:id   "count-dimension-uuid"
-                              :name "count"}
-                             {:id             "store-name-dimension-uuid"
-                              :name           "store_name"
-                              :display-name   "Store Name"
-                              :effective-type :type/Text
-                              :table-id       10
-                              :sources        [{:type :field, :field-id 42}]}])]
-    (is (= {:type         "metric"
-            :key          "storesWithOver5Employees"
-            :id           259
-            :name         "Stores with Over 5 Employees"
-            :columns      [{:type "column"
-                            :name "Stores with Over 5 Employees"
-                            :displayName "Stores with Over 5 Employees"
-                            :jsType "unknown"}]
-            :sourceCardId 258
-            :dimensions   {"count" {:type        "column"
-                                    :name        "count"
-                                    :displayName "count"
-                                    :jsType      "unknown"
-                                    :key         "count"
-                                    :id          "count-dimension-uuid"
-                                    :metricId    259}}}
-           (#'typed-schemas.api/metric-schema
-            {:id   259
-             :name "Stores with Over 5 Employees"}
-            {:id            259
-             :dataset_query {:stages [{:source-card 258}]}})))))
 
 (deftest typescript-endpoint-test
   (let [response (mt/user-http-request-full-response :crowberto :get 200 "typed-schemas/v1/typescript")]
@@ -221,9 +74,9 @@
                   typed-schemas.api.schema.question/question-schemas (fn
                                                                        ([_database-ids] [])
                                                                        ([_database-ids _collection-ids] []))
-                  typed-schemas.api/metric-schemas (fn
-                                                     ([_database-ids] [])
-                                                     ([_database-ids _collection-ids] []))
+                  typed-schemas.api.schema.metric/metric-schemas (fn
+                                                                   ([_database-ids] [])
+                                                                   ([_database-ids _collection-ids] []))
                   typed-schemas.api.schema.table/select-tables (fn
                                                                  ([_database-ids] [])
                                                                  ([_database-ids _table-ids] []))
@@ -277,7 +130,7 @@
                      (is false "library-only schemas should not load models"))
                     ([_database-ids _collection-ids]
                      (is false "library-only schemas should not load models")))
-                  typed-schemas.api/metric-schemas
+                  typed-schemas.api.schema.metric/metric-schemas
                   (fn [_database-ids collection-ids]
                     (is (= #{20} collection-ids))
                     [{:type           "metric"
@@ -315,7 +168,7 @@
                      (is false "library-only schemas should not load models"))
                     ([_database-ids _collection-ids]
                      (is false "library-only schemas should not load models")))
-                  typed-schemas.api/metric-schemas
+                  typed-schemas.api.schema.metric/metric-schemas
                   (fn [_database-ids collection-ids]
                     (is (= #{20} collection-ids))
                     [{:type           "metric"
@@ -354,7 +207,7 @@
                    (is false "include-models-only schemas should not load questions"))
                   ([_database-ids _collection-ids]
                    (is false "include-models-only schemas should not load questions")))
-                typed-schemas.api/metric-schemas
+                typed-schemas.api.schema.metric/metric-schemas
                 (fn
                   ([_database-ids]
                    (is false "include-models-only schemas should not load metrics"))
@@ -383,9 +236,9 @@
                   typed-schemas.api.schema.question/question-schemas (fn
                                                                        ([_database-ids] [])
                                                                        ([_database-ids _collection-ids] []))
-                  typed-schemas.api/metric-schemas (fn
-                                                     ([_database-ids] [])
-                                                     ([_database-ids _collection-ids] []))
+                  typed-schemas.api.schema.metric/metric-schemas (fn
+                                                                   ([_database-ids] [])
+                                                                   ([_database-ids _collection-ids] []))
                   typed-schemas.api.schema.table/select-tables (fn
                                                                  ([_database-ids] [])
                                                                  ([_database-ids _table-ids] []))
@@ -438,7 +291,7 @@
                    (is false "question collection schemas should not load models"))
                   ([_database-ids _collection-ids]
                    (is false "question collection schemas should not load models")))
-                typed-schemas.api/metric-schemas
+                typed-schemas.api.schema.metric/metric-schemas
                 (constantly [{:type "metric", :key "revenue", :id 2}])
                 typed-schemas.api.schema.table/select-library-tables
                 (constantly [{:id 3}])
@@ -473,7 +326,7 @@
                   (is (nil? database-ids))
                   [{:key     "selectedQuestionCollectionModel"
                     :actions {"create" {:kind "action", :key "create", :id 1}}}])
-                typed-schemas.api/metric-schemas
+                typed-schemas.api.schema.metric/metric-schemas
                 (constantly [{:type "metric", :key "revenue", :id 2}])
                 typed-schemas.api.schema.table/select-library-tables
                 (constantly [{:id 3}])


### PR DESCRIPTION
Closes [EMB-2079: Extract metric schema generator](https://linear.app/metabase/issue/EMB-2079/extract-metric-schema-generator)

PR 5/5 of [EMB-2062: Code cleanup: split `src/metabase/typed_schemas/api.clj` to multiple files](https://linear.app/metabase/issue/EMB-2062/code-cleanup-split-srcmetabasetyped-schemasapiclj-to-multiple-files)

### Description

Extracts metric and metric-dimension typed schema generation from `metabase.typed-schemas.api` into `metabase.typed-schemas.api.schema.metric`.

This keeps the API namespace focused on the endpoint while moving metric details lookup, dimension handling, source table/source card handling and metric schema rendering into a dedicated schema generator namespace.

Also moves the focused metric tests out of the main API test namespace into `metabase.typed-schemas.api.schema.metric-test`, while keeping API tests in `metabase.typed-schemas.api-test`.

### How to verify

Existing backend tests should continue to pass. Schema generation via `/api/typed-schemas/v1/typescript` endpoint should continue to work.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR