### PR TITLE
update the backport announcement

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -250,8 +250,7 @@ jobs:
 
             const message = [
               `:announcement-animated: ${eng} The v${next} release branch has been cut.`,
-              `- \`backport\`s will go to v${next} now`,
-              `- If you want to go back to v${current}, you'll need to add the double-backport tag`,
+              `Add the \`backport\` label to backport changes to all supported release branches.`,
             ].join('\n');
 
             await sendSlackMessage({


### PR DESCRIPTION
issue: [DEV-2335: Update release branch cut announcement to remove mention of backports going to v63](https://linear.app/metabase/issue/DEV-2335/update-release-branch-cut-announcement-to-remove-mention-of-backports)

Small update to the backport announcement so that it reflects the fact that backporting is an automated process and engineers don't generally need to make manual judgements about which versions a change should be backported to, adding the `backport` label is sufficient.