### PR TITLE
Require justifications for linter ignores

### DIFF
--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -1,50 +1,89 @@
 ;; Per-linter budgets for inline `:clj-kondo/ignore` forms.
-;; metabase.core.kondo-ratchet-test fails when the budgets drift from the actual counts.
-;; `./bin/mage fix-kondo-ratchets` lowers budgets to match the tree; local test runs do it
-;; automatically. Raising a budget, or adding one for a new linter (`--seed`), is a hand edit
-;; to defend in your PR.
+;; metabase.core.kondo-ratchet-test fails when the budgets drift from the actual counts, or when an
+;; ignore outside :comment-exempt lacks an explanatory comment directly above or trailing on its line.
+;; `./bin/mage fix-kondo-ratchets` lowers budgets and drops stale exemptions; local test runs do it
+;; automatically. Raising a budget, adding one for a new linter (`--seed`), or widening the
+;; exemptions is a hand edit to defend in your PR.
 ;; :all is the vector-less ignore form, which suppresses every linter on the next form.
-{:ignore-counts {:aliased-namespace-symbol                                            5
-                 :case-symbol-test                                                    1
-                 :clojure-lsp/unused-public-var                                       9
-                 :consistent-alias                                                    2
-                 :def-fn                                                              1
-                 :deprecated-namespace                                                95
-                 :deprecated-var                                                      86
-                 :discouraged-java-method                                             4
-                 :discouraged-namespace                                               81
-                 :discouraged-var                                                     134
-                 :duplicate-require                                                   1
-                 :equals-true                                                         1
-                 :main-without-gen-class                                              1
-                 :metabase/defsetting-namespace                                       2
-                 :metabase/disallow-hardcoded-driver-names-in-tests                   34
-                 :metabase/discourage-millis-duration                                 1
-                 :metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests 13
-                 :metabase/modules                                                    9
-                 :metabase/namespace-name                                             4
-                 :metabase/prefer-with-dynamic-fn-redefs                              28
-                 :metabase/test-helpers-use-non-thread-safe-functions                 18
-                 :metabase/validate-defendpoint-has-response-schema                   440
-                 :metabase/validate-defendpoint-query-params-use-kebab-case           50
-                 :metabase/validate-defendpoint-route-uses-kebab-case                 44
-                 :metabase/validate-deftest                                           10
-                 :missing-docstring                                                   12
-                 :missing-protocol-method                                             3
-                 :non-arg-vec-return-type-hint                                        1
-                 :reduce-without-init                                                 3
-                 :redundant-do                                                        1
-                 :syntax                                                              2
-                 :type-mismatch                                                       6
-                 :uninitialized-var                                                   1
-                 :unquote-not-syntax-quoted                                           1
-                 :unresolved-namespace                                                8
-                 :unresolved-require                                                  1
-                 :unresolved-symbol                                                   9
-                 :unsorted-required-namespaces                                        1
-                 :unused-alias                                                        2
-                 :unused-binding                                                      9
-                 :unused-excluded-var                                                 2
-                 :unused-namespace                                                    2
-                 :unused-private-var                                                  9
-                 :unused-value                                                        1}}
+{:ignore-counts  {:aliased-namespace-symbol                                            5
+                  :case-symbol-test                                                    1
+                  :clojure-lsp/unused-public-var                                       9
+                  :consistent-alias                                                    2
+                  :def-fn                                                              1
+                  :deprecated-namespace                                                95
+                  :deprecated-var                                                      86
+                  :discouraged-java-method                                             4
+                  :discouraged-namespace                                               81
+                  :discouraged-var                                                     134
+                  :duplicate-require                                                   1
+                  :equals-true                                                         1
+                  :main-without-gen-class                                              1
+                  :metabase/defsetting-namespace                                       2
+                  :metabase/disallow-hardcoded-driver-names-in-tests                   34
+                  :metabase/discourage-millis-duration                                 1
+                  :metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests 13
+                  :metabase/modules                                                    9
+                  :metabase/namespace-name                                             4
+                  :metabase/prefer-with-dynamic-fn-redefs                              28
+                  :metabase/test-helpers-use-non-thread-safe-functions                 18
+                  :metabase/validate-defendpoint-has-response-schema                   440
+                  :metabase/validate-defendpoint-query-params-use-kebab-case           50
+                  :metabase/validate-defendpoint-route-uses-kebab-case                 44
+                  :metabase/validate-deftest                                           10
+                  :missing-docstring                                                   12
+                  :missing-protocol-method                                             3
+                  :non-arg-vec-return-type-hint                                        1
+                  :reduce-without-init                                                 3
+                  :redundant-do                                                        1
+                  :syntax                                                              2
+                  :type-mismatch                                                       8
+                  :uninitialized-var                                                   1
+                  :unquote-not-syntax-quoted                                           1
+                  :unresolved-namespace                                                8
+                  :unresolved-require                                                  1
+                  :unresolved-symbol                                                   11
+                  :unsorted-required-namespaces                                        1
+                  :unused-alias                                                        2
+                  :unused-binding                                                      9
+                  :unused-excluded-var                                                 2
+                  :unused-namespace                                                    2
+                  :unused-private-var                                                  9
+                  :unused-value                                                        1}
+ :comment-exempt #{:aliased-namespace-symbol
+                   :case-symbol-test
+                   :clojure-lsp/unused-public-var
+                   :def-fn
+                   :deprecated-namespace
+                   :deprecated-var
+                   :discouraged-java-method
+                   :discouraged-namespace
+                   :discouraged-var
+                   :duplicate-require
+                   :equals-true
+                   :metabase/defsetting-namespace
+                   :metabase/discourage-millis-duration
+                   :metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests
+                   :metabase/modules
+                   :metabase/namespace-name
+                   :metabase/prefer-with-dynamic-fn-redefs
+                   :metabase/test-helpers-use-non-thread-safe-functions
+                   :metabase/validate-defendpoint-has-response-schema
+                   :metabase/validate-defendpoint-query-params-use-kebab-case
+                   :metabase/validate-defendpoint-route-uses-kebab-case
+                   :metabase/validate-deftest
+                   :missing-docstring
+                   :missing-protocol-method
+                   :reduce-without-init
+                   :redundant-do
+                   :syntax
+                   :type-mismatch
+                   :unquote-not-syntax-quoted
+                   :unresolved-namespace
+                   :unresolved-require
+                   :unresolved-symbol
+                   :unused-alias
+                   :unused-binding
+                   :unused-excluded-var
+                   :unused-namespace
+                   :unused-private-var
+                   :unused-value}}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,8 @@ Budget too low (you added an ignore): the task only raises a budget when told to
 genuinely required, run `./bin/mage fix-kondo-ratchets --seed :the-linter` and defend the increase in the
 PR.
 
-Ignores of linters outside the file's `:comment-exempt` set need an explanatory `;;` comment on the line
+The ignore must be the first key in its map; noncanonical forms fail the ratchet instead of being guessed
+at. Ignores of linters outside the file's `:comment-exempt` set need an explanatory `;;` comment directly
 above (or trailing on the same line). The set only shrinks: once a linter's last uncommented ignore gains
 a comment, the fixer drops its exemption.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,10 @@ Budget too low (you added an ignore): the task only raises a budget when told to
 genuinely required, run `./bin/mage fix-kondo-ratchets --seed :the-linter` and defend the increase in the
 PR.
 
+Ignores of linters outside the file's `:comment-exempt` set need an explanatory `;;` comment on the line
+above (or trailing on the same line). The set only shrinks: once a linter's last uncommented ignore gains
+a comment, the fixer drops its exemption.
+
 Introducing a new linter: `./bin/mage kondo-insert-ignores :the-linter` inserts an ignore at every site it
 flags, then `./bin/mage fix-kondo-ratchets --seed :the-linter` records the budget — no big-bang cleanup.
 To burn debt down, `./bin/mage kondo-redundant-ignores` lists ignores that are no longer needed (slow:

--- a/dev/src/dev/kondo_ratchet.clj
+++ b/dev/src/dev/kondo_ratchet.clj
@@ -1,9 +1,10 @@
 (ns dev.kondo-ratchet
   "Ratchet on inline kondo ignore forms.
 
-  Per-linter budgets live in `.clj-kondo/ratchets.edn`.
-  `metabase.core.kondo-ratchet-test` fails when they drift from the tree;
-  `./bin/mage fix-kondo-ratchets` lowers budgets, never raises them.
+  Per-linter budgets live in `.clj-kondo/ratchets.edn`, along with the set of linters whose ignores don't
+  need a justification comment.
+  `metabase.core.kondo-ratchet-test` fails when either drifts from the tree;
+  `./bin/mage fix-kondo-ratchets` lowers budgets and drops stale exemptions, never the reverse.
   Loaded by both the bb task and the JVM test, so keep it dependency-free."
   {:clj-kondo/config '{:linters {:discouraged-var {clojure.core/println {:level :off}}}}}
   (:require
@@ -102,6 +103,26 @@
                           :linters (if bare? [:all] (vec (linter-keywords (.group m 1))))}))
         acc))))
 
+;; A justifying comment has words in it; a bare `;;` section divider does not.
+(def ^:private substantive-comment-re
+  #";+\s*\S*[A-Za-z].*")
+
+(defn- justified?
+  "Does the ignore starting at `start`/ending at `end` in `content` have an explanatory comment?
+  Counts a substantive trailing comment on the same line, or one on the nearest preceding non-blank line."
+  [content start end]
+  (let [line-num   (offset->line content start)
+        lines      (str/split-lines content)
+        after      (let [line-end (str/index-of content "\n" end)]
+                     (subs content end (or line-end (count content))))
+        prev-lines (->> (take (dec line-num) lines)
+                        reverse
+                        (drop-while str/blank?))]
+    (boolean (or (when-let [i (str/index-of after ";")]
+                   (re-matches substantive-comment-re (str/trim (subs after i))))
+                 (when-let [prev (first prev-lines)]
+                   (re-matches substantive-comment-re (str/trim prev)))))))
+
 (defn ignore-matches
   "Inline ignore matches in `content`, in file order:
   `{:start _, :end _, :line _, :linters [...]}` with character offsets and a 1-based line.
@@ -115,7 +136,7 @@
 
 (defn scan
   "Occurrences of inline ignore forms under `roots` (relative to the repo root).
-  Returns `{:file \"src/...\", :line 42, :linters [...]}` maps.
+  Returns `{:file \"src/...\", :line 42, :linters [...], :justified? true}` maps.
   Forms inside string literals or line comments don't count."
   ([]
    (scan source-roots))
@@ -127,9 +148,10 @@
          :let  [content (slurp f)]
          :when (str/includes? content ignore-marker)
          m     (ignore-matches content)]
-     {:file    (.getPath f)
-      :line    (:line m)
-      :linters (:linters m)})))
+     {:file       (.getPath f)
+      :line       (:line m)
+      :linters    (:linters m)
+      :justified? (justified? content (:start m) (:end m))})))
 
 (defn actual-counts
   "Per-linter occurrence counts for `occurrences`, as returned by [[scan]]."
@@ -158,28 +180,47 @@
                                        (take 5)
                                        vec)))]))))
 
+(defn unjustified
+  "Occurrences that need a justification comment but lack one: not [[justified?]], and suppressing at
+  least one linter outside the `exempt` set."
+  [exempt occurrences]
+  (for [{:keys [linters justified?] :as occurrence} occurrences
+        :when (and (not justified?)
+                   (seq (remove exempt linters)))]
+    occurrence))
+
+(defn stale-exemptions
+  "Linters in `exempt` that no longer have any unjustified ignore, so the exemption can go."
+  [exempt occurrences]
+  (let [still-needed (set (mapcat :linters (unjustified #{} occurrences)))]
+    (into (sorted-set-by #(compare (str %1) (str %2)))
+          (remove still-needed)
+          exempt)))
+
 (defn read-ratchets
   "Parsed contents of [[ratchets-file]], with empty defaults when the file doesn't exist."
   []
-  (merge {:ignore-counts {}}
+  (merge {:ignore-counts {}, :comment-exempt #{}}
          (when (.exists (io/file ratchets-file))
            (edn/read-string (slurp ratchets-file)))))
 
 (def ^:private header
   (str ";; Per-linter budgets for inline `" ignore-marker "` forms.\n"
-       ";; metabase.core.kondo-ratchet-test fails when the budgets drift from the actual counts.\n"
-       ";; `./bin/mage fix-kondo-ratchets` lowers budgets to match the tree; local test runs do it\n"
-       ";; automatically. Raising a budget, or adding one for a new linter (`--seed`), is a hand edit\n"
-       ";; to defend in your PR.\n"
+       ";; metabase.core.kondo-ratchet-test fails when the budgets drift from the actual counts, or when a\n"
+       ";; linter outside :comment-exempt has an ignore with no explanatory comment above (or trailing) it.\n"
+       ";; `./bin/mage fix-kondo-ratchets` lowers budgets and drops stale exemptions; local test runs do it\n"
+       ";; automatically. Raising a budget, adding one for a new linter (`--seed`), or widening the\n"
+       ";; exemptions is a hand edit to defend in your PR.\n"
        ";; :all is the vector-less ignore form, which suppresses every linter on the next form.\n"))
 
 (defn render
-  "Text of the ratchets file for the `{:ignore-counts _}` map `ratchets`.
+  "Text of the ratchets file for the `{:ignore-counts _, :comment-exempt _}` map `ratchets`.
   Byte-stable: [[fix!]] idempotency and the file-hygiene test depend on it."
-  [{:keys [ignore-counts]}]
-  (let [counts-indent (apply str (repeat (count "{:ignore-counts {") \space))]
+  [{:keys [ignore-counts comment-exempt]}]
+  (let [counts-indent (apply str (repeat (count "{:ignore-counts  {") \space))
+        exempt-indent (apply str (repeat (count " :comment-exempt #{") \space))]
     (str header
-         "{:ignore-counts "
+         "{:ignore-counts  "
          (if (empty? ignore-counts)
            "{}"
            (let [entries (sort-by (comp str first) ignore-counts)
@@ -189,6 +230,13 @@
                             (for [[linter n] entries]
                               (format (str "%-" width "s %d") (str linter) n)))
                   "}")))
+         "\n :comment-exempt "
+         (if (empty? comment-exempt)
+           "#{}"
+           (str "#{"
+                (str/join (str "\n" exempt-indent)
+                          (sort-by str comment-exempt))
+                "}"))
          "}\n")))
 
 (defn lowered-counts
@@ -210,8 +258,9 @@
         recorded))
 
 (defn change-report
-  "The lines [[fix!]] prints: lowered/dropped/seeded budgets, plus warnings for anything over budget."
-  [{:keys [ignore-counts]} occurrences seeded]
+  "The lines [[fix!]] prints: lowered/dropped/seeded budgets, dropped exemptions, plus warnings for
+  anything over budget."
+  [{:keys [ignore-counts comment-exempt]} occurrences seeded]
   (let [actual (actual-counts occurrences)]
     (concat
      (for [linter seeded
@@ -229,20 +278,23 @@
                               linter budget n linter)))
      (for [[linter n] (sort-by (comp str first) (apply dissoc actual (concat seeded (keys ignore-counts))))]
        (format "WARNING: %s has %d ignores but no budget entry -- seed one with `./bin/mage fix-kondo-ratchets --seed %s`"
-               linter n linter)))))
+               linter n linter))
+     (for [linter (stale-exemptions comment-exempt occurrences)]
+       (format "unexempted %s (all its ignores are justified now)" linter)))))
 
 (defn fix!
-  "Rewrite [[ratchets-file]]: lower budgets and normalize formatting.
+  "Rewrite [[ratchets-file]]: lower budgets, drop stale comment exemptions, normalize formatting.
   `--seed LINTER` (`{:seed \"...\"}` here) sets that budget to the actual count, adding or raising it.
   Prints the [[change-report]], or `unchanged` on a no-op."
   ([]
    (fix! nil))
   ([{:keys [seed]}]
-   (let [{:keys [ignore-counts] :as ratchets} (read-ratchets)
+   (let [{:keys [ignore-counts comment-exempt] :as ratchets} (read-ratchets)
          occurrences (scan)
          seeded      (if seed [(keyword (str/replace-first seed #"^:" ""))] [])
          actual      (actual-counts occurrences)
-         text        (render {:ignore-counts (lowered-counts ignore-counts actual seeded)})
+         text        (render {:ignore-counts  (lowered-counts ignore-counts actual seeded)
+                              :comment-exempt (reduce disj comment-exempt (stale-exemptions comment-exempt occurrences))})
          file        (io/file ratchets-file)
          old         (when (.exists file) (slurp file))]
      (run! println (change-report ratchets occurrences seeded))

--- a/dev/src/dev/kondo_ratchet.clj
+++ b/dev/src/dev/kondo_ratchet.clj
@@ -28,10 +28,12 @@
 (def ^:private ignore-marker
   (str ":clj-kondo" "/ignore"))
 
-;; `#_{... [:some-linter]}`, `^{... [:some-linter]}`, and the prefix-less attr-map form
-;; `(ns foo {... [:some-linter]})`; the vector may span lines. The lazy tail after the vector runs to the
-;; map's own closing brace, so extra keys still count and removal spans the whole form; a nested-brace
-;; value stops the match at the vector instead.
+;; Canonical map form: the ignore must be the first key. This covers reader-discard maps, metadata maps,
+;; and prefix-less attr maps such as `(ns foo {...})`. Keeping one deliberately narrow spelling lets the
+;; scanner fail closed instead of growing a partial Clojure reader; [[ignore-matches]] rejects any real
+;; ignore marker not covered by this pattern. The vector may span lines. The lazy tail after the vector
+;; runs to the map's own closing brace, so extra keys still count and removal spans the whole form; a
+;; nested-brace value stops the match at the vector instead.
 (def ^:private vector-form-re
   (re-pattern (str "(?:(?:#_|\\^)\\s*)?\\{\\s*" ignore-marker "\\s*\\[([^\\]]*)\\](?:[^{}]*?\\})?")))
 
@@ -39,12 +41,15 @@
 (def ^:private bare-form-re
   (re-pattern (str "(?:#_\\s*|\\^)" ignore-marker "(?![\\w./-])")))
 
+(def ^:private ignore-marker-re
+  (re-pattern (str ignore-marker "(?![\\w./-])")))
+
 (defn mask-strings-and-comments
   "`content` with string-literal and line-comment interiors replaced by spaces, newlines kept.
   Same length as the input, so offsets and line numbers carry over.
   Ignore forms inside strings (test fixtures) or commented-out code must not count.
-  The `;` that starts a comment survives, and no other `;` does, so [[justified?]] can locate real
-  trailing comments."
+  The `;` that starts a comment survives, and no other `;` does, so
+  [[has-justification-comment?]] can locate real trailing comments."
   [content]
   (let [sb (StringBuilder. ^String content)
         n  (count content)]
@@ -82,15 +87,6 @@
   (map (comp keyword #(subs % 1))
        (re-seq #":[A-Za-z][A-Za-z0-9*+!?<>=._/-]*" vector-contents)))
 
-(defn line-linters
-  "Linter keywords suppressed by inline ignore forms on `line`.
-  The bare vector-less form counts as `:all`.
-  Like [[scan]], ignore forms inside string literals or line comments don't count."
-  [line]
-  (let [masked (mask-strings-and-comments line)]
-    (concat (mapcat (comp linter-keywords second) (re-seq vector-form-re masked))
-            (repeat (count (re-seq bare-form-re masked)) :all))))
-
 (defn- offset->line
   "1-based line number of character offset `i` in `content`."
   [content i]
@@ -107,39 +103,74 @@
                           :linters (if bare? [:all] (vec (linter-keywords (.group m 1))))}))
         acc))))
 
-;; A justifying comment has words in it; a bare `;;` section divider does not.
+;; A justifying comment has a letter somewhere in it; a bare `;;` or `;; ----` section divider does not.
 (def ^:private substantive-comment-re
-  #";+\s*\S*[A-Za-z].*")
+  #";+.*[A-Za-z].*")
 
-(defn- justified?
+(defn- has-justification-comment?
   "Does the ignore starting at `start`/ending at `end` in `content` have an explanatory comment?
-  Counts a substantive trailing comment on the same line, or one on the nearest preceding non-blank line.
-  The trailing comment is located in `masked`, where a `;` inside a string literal is blanked out."
+  Counts a substantive trailing comment on the same line, or a comment-only line directly above.
+
+  Comment openers are authenticated in `masked`, where a real opener survives but semicolons inside
+  strings do not; their text is then read from `content`, since masking blanks comment interiors."
   [content masked start end]
   (let [line-num   (offset->line content start)
-        lines      (str/split-lines content)
         line-end   (or (str/index-of content "\n" end) (count content))
-        prev-lines (->> (take (dec line-num) lines)
-                        reverse
-                        (drop-while str/blank?))]
+        raw-lines  (vec (str/split-lines content))
+        mask-lines (vec (str/split-lines masked))
+        above-idx  (- line-num 2)]
     (boolean (or (when-let [i (str/index-of masked ";" end)]
                    (when (< i line-end)
                      (re-matches substantive-comment-re (str/trim (subs content i line-end)))))
-                 (when-let [prev (first prev-lines)]
-                   (re-matches substantive-comment-re (str/trim prev)))))))
+                 (when-let [raw (get raw-lines above-idx)]
+                   (when-let [i (str/index-of (get mask-lines above-idx "") ";")]
+                     (and (str/blank? (subs raw 0 i))
+                          (re-matches substantive-comment-re (str/trim (subs raw i))))))))))
+
+(defn- marker-offsets
+  "Offsets of real ignore markers in `masked`; strings and comments have already been blanked."
+  [masked]
+  (let [m (re-matcher ignore-marker-re masked)]
+    (loop [acc []]
+      (if (.find m)
+        (recur (conj acc (.start m)))
+        acc))))
+
+(defn- unsupported-ignore-lines
+  "Lines containing an ignore marker outside one of `matches`' canonical spans."
+  [masked matches]
+  (for [offset (marker-offsets masked)
+        :when  (not-any? #(<= (:start %) offset (dec (:end %))) matches)]
+    (offset->line masked offset)))
 
 (defn ignore-matches
   "Inline ignore matches in `content`, in file order:
   `{:start _, :end _, :line _, :linters [...], :justified? _}` with character offsets and a 1-based line.
-  Matches inside string literals or line comments are excluded."
+  The ignore must be the first key of its map. Any other spelling is rejected rather than guessed at,
+  so a suppression cannot silently bypass the ratchet. Matches inside strings and comments are excluded."
   [content]
-  (let [masked (mask-strings-and-comments content)]
-    (->> (concat (matches-with-offsets vector-form-re masked false)
-                 (matches-with-offsets bare-form-re masked true))
+  (let [masked      (mask-strings-and-comments content)
+        matches     (vec (concat (matches-with-offsets vector-form-re masked false)
+                                 (matches-with-offsets bare-form-re masked true)))
+        unsupported (vec (unsupported-ignore-lines masked matches))]
+    (when (seq unsupported)
+      (throw (ex-info (format "Unsupported %s syntax on line%s %s; put the ignore first in its map"
+                              ignore-marker
+                              (if (= 1 (count unsupported)) "" "s")
+                              (str/join ", " unsupported))
+                      {:lines unsupported})))
+    (->> matches
          (sort-by :start)
          (map #(assoc %
                       :line       (offset->line masked (:start %))
-                      :justified? (justified? content masked (:start %) (:end %)))))))
+                      :justified? (has-justification-comment? content masked (:start %) (:end %)))))))
+
+(defn line-linters
+  "Linter keywords suppressed by inline ignore forms on `line`.
+  The bare vector-less form counts as `:all`.
+  Like [[scan]], ignore forms inside string literals or line comments don't count."
+  [line]
+  (mapcat :linters (ignore-matches line)))
 
 (defn scan
   "Occurrences of inline ignore forms under `roots` (relative to the repo root).
@@ -188,8 +219,8 @@
                                        vec)))]))))
 
 (defn unjustified
-  "Occurrences that need a justification comment but lack one: not [[justified?]], and suppressing at
-  least one linter outside the `exempt` set."
+  "Occurrences that need a justification comment but lack one, and suppress at least one linter outside
+  the `exempt` set."
   [exempt occurrences]
   (for [{:keys [linters justified?] :as occurrence} occurrences
         :when (and (not justified?)
@@ -213,8 +244,8 @@
 
 (def ^:private header
   (str ";; Per-linter budgets for inline `" ignore-marker "` forms.\n"
-       ";; metabase.core.kondo-ratchet-test fails when the budgets drift from the actual counts, or when a\n"
-       ";; linter outside :comment-exempt has an ignore with no explanatory comment above (or trailing) it.\n"
+       ";; metabase.core.kondo-ratchet-test fails when the budgets drift from the actual counts, or when an\n"
+       ";; ignore outside :comment-exempt lacks an explanatory comment directly above or trailing on its line.\n"
        ";; `./bin/mage fix-kondo-ratchets` lowers budgets and drops stale exemptions; local test runs do it\n"
        ";; automatically. Raising a budget, adding one for a new linter (`--seed`), or widening the\n"
        ";; exemptions is a hand edit to defend in your PR.\n"

--- a/dev/src/dev/kondo_ratchet.clj
+++ b/dev/src/dev/kondo_ratchet.clj
@@ -42,7 +42,9 @@
 (defn mask-strings-and-comments
   "`content` with string-literal and line-comment interiors replaced by spaces, newlines kept.
   Same length as the input, so offsets and line numbers carry over.
-  Ignore forms inside strings (test fixtures) or commented-out code must not count."
+  Ignore forms inside strings (test fixtures) or commented-out code must not count.
+  The `;` that starts a comment survives, and no other `;` does, so [[justified?]] can locate real
+  trailing comments."
   [content]
   (let [sb (StringBuilder. ^String content)
         n  (count content)]
@@ -53,10 +55,12 @@
           (case state
             :code    (case c
                        \" (recur (inc i) :string)
-                       \; (do (.setCharAt sb i \space)
-                              (recur (inc i) :comment))
-                       ;; char literal: never treat the next char as a delimiter
-                       \\ (recur (+ i 2) :code)
+                       \; (recur (inc i) :comment)
+                       ;; char literal: mask the next char so it can't open a string or start a comment
+                       \\ (do (when (< (inc i) n)
+                                (when-not (= (.charAt sb (inc i)) \newline)
+                                  (.setCharAt sb (inc i) \space)))
+                              (recur (+ i 2) :code))
                        (recur (inc i) :code))
             :string  (case c
                        \" (recur (inc i) :code)
@@ -109,34 +113,37 @@
 
 (defn- justified?
   "Does the ignore starting at `start`/ending at `end` in `content` have an explanatory comment?
-  Counts a substantive trailing comment on the same line, or one on the nearest preceding non-blank line."
-  [content start end]
+  Counts a substantive trailing comment on the same line, or one on the nearest preceding non-blank line.
+  The trailing comment is located in `masked`, where a `;` inside a string literal is blanked out."
+  [content masked start end]
   (let [line-num   (offset->line content start)
         lines      (str/split-lines content)
-        after      (let [line-end (str/index-of content "\n" end)]
-                     (subs content end (or line-end (count content))))
+        line-end   (or (str/index-of content "\n" end) (count content))
         prev-lines (->> (take (dec line-num) lines)
                         reverse
                         (drop-while str/blank?))]
-    (boolean (or (when-let [i (str/index-of after ";")]
-                   (re-matches substantive-comment-re (str/trim (subs after i))))
+    (boolean (or (when-let [i (str/index-of masked ";" end)]
+                   (when (< i line-end)
+                     (re-matches substantive-comment-re (str/trim (subs content i line-end)))))
                  (when-let [prev (first prev-lines)]
                    (re-matches substantive-comment-re (str/trim prev)))))))
 
 (defn ignore-matches
   "Inline ignore matches in `content`, in file order:
-  `{:start _, :end _, :line _, :linters [...]}` with character offsets and a 1-based line.
+  `{:start _, :end _, :line _, :linters [...], :justified? _}` with character offsets and a 1-based line.
   Matches inside string literals or line comments are excluded."
   [content]
   (let [masked (mask-strings-and-comments content)]
     (->> (concat (matches-with-offsets vector-form-re masked false)
                  (matches-with-offsets bare-form-re masked true))
          (sort-by :start)
-         (map #(assoc % :line (offset->line masked (:start %)))))))
+         (map #(assoc %
+                      :line       (offset->line masked (:start %))
+                      :justified? (justified? content masked (:start %) (:end %)))))))
 
 (defn scan
   "Occurrences of inline ignore forms under `roots` (relative to the repo root).
-  Returns `{:file \"src/...\", :line 42, :linters [...], :justified? true}` maps.
+  Returns `{:file \"src/...\", :line 42, :linters [...], :justified? boolean}` maps.
   Forms inside string literals or line comments don't count."
   ([]
    (scan source-roots))
@@ -151,7 +158,7 @@
      {:file       (.getPath f)
       :line       (:line m)
       :linters    (:linters m)
-      :justified? (justified? content (:start m) (:end m))})))
+      :justified? (:justified? m)})))
 
 (defn actual-counts
   "Per-linter occurrence counts for `occurrences`, as returned by [[scan]]."

--- a/dev/src/dev/kondo_ratchet.clj
+++ b/dev/src/dev/kondo_ratchet.clj
@@ -32,7 +32,7 @@
 ;; Defining the boundary by delimiters keeps every other character -- including Unicode -- in a
 ;; lookalike keyword such as `:clj-kondo/ignoreλ` rather than mistaking its prefix for the marker.
 (def ^:private ignore-marker-boundary
-  "(?=$|[\\s,()\\[\\]{}\";@^`~\\\\])")
+  "(?=$|[\\p{javaWhitespace},()\\[\\]{}\";@^`~\\\\])")
 
 ;; Canonical map form: the ignore must be the first key. This covers reader-discard maps, metadata maps,
 ;; and prefix-less attr maps such as `(ns foo {...})`. Keeping one deliberately narrow spelling lets the
@@ -53,7 +53,7 @@
 ;; Any explicit `#:clj-kondo{...}` map can spell the real ignore key as `:ignore`, including after
 ;; arbitrary values or comments. Reserve the whole spelling rather than parsing inside the map.
 (def ^:private namespaced-ignore-map-re
-  #"#:clj-kondo\s*\{")
+  #"#:clj-kondo[\p{javaWhitespace},]*\{")
 
 (defn mask-strings-and-comments
   "`content` with string-literal and line-comment interiors replaced by spaces, newlines kept.

--- a/dev/src/dev/kondo_ratchet.clj
+++ b/dev/src/dev/kondo_ratchet.clj
@@ -28,13 +28,11 @@
 (def ^:private ignore-marker
   (str ":clj-kondo" "/ignore"))
 
-;; Keep marker boundaries aligned with [[linter-keywords]] so lookalike keywords such as
-;; `:clj-kondo/ignore?` remain ordinary data rather than being mistaken for the ignore marker.
-(def ^:private keyword-token-char-class
-  "[A-Za-z0-9*+!?<>=._/-]")
-
+;; A keyword ends only at EOF, whitespace/comma, or one of Clojure's terminating reader macros.
+;; Defining the boundary by delimiters keeps every other character -- including Unicode -- in a
+;; lookalike keyword such as `:clj-kondo/ignoreλ` rather than mistaking its prefix for the marker.
 (def ^:private ignore-marker-boundary
-  (str "(?!" keyword-token-char-class ")"))
+  "(?=$|[\\s,()\\[\\]{}\";@^`~\\\\])")
 
 ;; Canonical map form: the ignore must be the first key. This covers reader-discard maps, metadata maps,
 ;; and prefix-less attr maps such as `(ns foo {...})`. Keeping one deliberately narrow spelling lets the
@@ -52,10 +50,10 @@
 (def ^:private ignore-marker-re
   (re-pattern (str ignore-marker ignore-marker-boundary)))
 
-;; `#:clj-kondo{:ignore [...]}` reads as a map containing the real ignore key without spelling that key
-;; literally. Reject this narrow alternate spelling so it cannot bypass the lexical scanner.
-(def ^:private namespaced-ignore-marker-re
-  (re-pattern (str "#:clj-kondo\\s*\\{\\s*:ignore" ignore-marker-boundary)))
+;; Any explicit `#:clj-kondo{...}` map can spell the real ignore key as `:ignore`, including after
+;; arbitrary values or comments. Reserve the whole spelling rather than parsing inside the map.
+(def ^:private namespaced-ignore-map-re
+  #"#:clj-kondo\s*\{")
 
 (defn mask-strings-and-comments
   "`content` with string-literal and line-comment interiors replaced by spaces, newlines kept.
@@ -149,7 +147,7 @@
                 (if (.find m)
                   (recur (conj acc (.start m)))
                   acc))))
-          [ignore-marker-re namespaced-ignore-marker-re]))
+          [ignore-marker-re namespaced-ignore-map-re]))
 
 (defn- unsupported-ignore-lines
   "Lines containing an ignore marker outside one of `matches`' canonical spans."
@@ -200,7 +198,7 @@
                     (some #(str/ends-with? (.getPath f) %) source-extensions))
          :let  [content (slurp f)]
          :when (or (str/includes? content ignore-marker)
-                   (re-find namespaced-ignore-marker-re content))
+                   (re-find namespaced-ignore-map-re content))
          m     (ignore-matches content)]
      {:file       (.getPath f)
       :line       (:line m)

--- a/dev/src/dev/kondo_ratchet.clj
+++ b/dev/src/dev/kondo_ratchet.clj
@@ -31,8 +31,16 @@
 ;; A keyword ends only at EOF, whitespace/comma, or one of Clojure's terminating reader macros.
 ;; Defining the boundary by delimiters keeps every other character -- including Unicode -- in a
 ;; lookalike keyword such as `:clj-kondo/ignoreλ` rather than mistaking its prefix for the marker.
+(def ^:private reader-delimiter-char-class
+  "[\\p{javaWhitespace},()\\[\\]{}\";@^`~\\\\]")
+
 (def ^:private ignore-marker-boundary
-  "(?=$|[\\p{javaWhitespace},()\\[\\]{}\";@^`~\\\\])")
+  (str "(?=$|" reader-delimiter-char-class ")"))
+
+;; A namespaced-map prefix (and its optional clj-kondo reader discard) must start a reader form,
+;; not merely occur inside a symbol such as `foo#:clj-kondo` or `foo#_#:clj-kondo`.
+(def ^:private reader-form-start
+  (str "(?:^|(?<=" reader-delimiter-char-class "))(?:#_)*"))
 
 ;; Canonical map form: the ignore must be the first key. This covers reader-discard maps, metadata maps,
 ;; and prefix-less attr maps such as `(ns foo {...})`. Keeping one deliberately narrow spelling lets the
@@ -53,7 +61,7 @@
 ;; Any explicit `#:clj-kondo` map can spell the real ignore key as `:ignore`, including after arbitrary
 ;; values or comments. Reserve the namespace prefix itself rather than parsing what separates it from the map.
 (def ^:private namespaced-ignore-prefix-re
-  (re-pattern (str "#:clj-kondo" ignore-marker-boundary)))
+  (re-pattern (str reader-form-start "#:clj-kondo" ignore-marker-boundary)))
 
 (defn mask-strings-and-comments
   "`content` with string-literal and line-comment interiors replaced by spaces, newlines kept.
@@ -199,7 +207,13 @@
          :let  [content (slurp f)]
          :when (or (str/includes? content ignore-marker)
                    (re-find namespaced-ignore-prefix-re content))
-         m     (ignore-matches content)]
+         m     (try
+                 (ignore-matches content)
+                 (catch clojure.lang.ExceptionInfo e
+                   (let [file (.getPath f)]
+                     (throw (ex-info (format "%s in %s" (.getMessage e) file)
+                                     (assoc (ex-data e) :file file)
+                                     e)))))]
      {:file       (.getPath f)
       :line       (:line m)
       :linters    (:linters m)

--- a/dev/src/dev/kondo_ratchet.clj
+++ b/dev/src/dev/kondo_ratchet.clj
@@ -50,10 +50,10 @@
 (def ^:private ignore-marker-re
   (re-pattern (str ignore-marker ignore-marker-boundary)))
 
-;; Any explicit `#:clj-kondo{...}` map can spell the real ignore key as `:ignore`, including after
-;; arbitrary values or comments. Reserve the whole spelling rather than parsing inside the map.
-(def ^:private namespaced-ignore-map-re
-  #"#:clj-kondo[\p{javaWhitespace},]*\{")
+;; Any explicit `#:clj-kondo` map can spell the real ignore key as `:ignore`, including after arbitrary
+;; values or comments. Reserve the namespace prefix itself rather than parsing what separates it from the map.
+(def ^:private namespaced-ignore-prefix-re
+  (re-pattern (str "#:clj-kondo" ignore-marker-boundary)))
 
 (defn mask-strings-and-comments
   "`content` with string-literal and line-comment interiors replaced by spaces, newlines kept.
@@ -147,7 +147,7 @@
                 (if (.find m)
                   (recur (conj acc (.start m)))
                   acc))))
-          [ignore-marker-re namespaced-ignore-map-re]))
+          [ignore-marker-re namespaced-ignore-prefix-re]))
 
 (defn- unsupported-ignore-lines
   "Lines containing an ignore marker outside one of `matches`' canonical spans."
@@ -198,7 +198,7 @@
                     (some #(str/ends-with? (.getPath f) %) source-extensions))
          :let  [content (slurp f)]
          :when (or (str/includes? content ignore-marker)
-                   (re-find namespaced-ignore-map-re content))
+                   (re-find namespaced-ignore-prefix-re content))
          m     (ignore-matches content)]
      {:file       (.getPath f)
       :line       (:line m)

--- a/dev/src/dev/kondo_ratchet.clj
+++ b/dev/src/dev/kondo_ratchet.clj
@@ -28,6 +28,14 @@
 (def ^:private ignore-marker
   (str ":clj-kondo" "/ignore"))
 
+;; Keep marker boundaries aligned with [[linter-keywords]] so lookalike keywords such as
+;; `:clj-kondo/ignore?` remain ordinary data rather than being mistaken for the ignore marker.
+(def ^:private keyword-token-char-class
+  "[A-Za-z0-9*+!?<>=._/-]")
+
+(def ^:private ignore-marker-boundary
+  (str "(?!" keyword-token-char-class ")"))
+
 ;; Canonical map form: the ignore must be the first key. This covers reader-discard maps, metadata maps,
 ;; and prefix-less attr maps such as `(ns foo {...})`. Keeping one deliberately narrow spelling lets the
 ;; scanner fail closed instead of growing a partial Clojure reader; [[ignore-matches]] rejects any real
@@ -39,10 +47,15 @@
 
 ;; Bare `#_kw` / `^kw` with no linter vector: suppresses every linter on the next form.
 (def ^:private bare-form-re
-  (re-pattern (str "(?:#_\\s*|\\^)" ignore-marker "(?![\\w./-])")))
+  (re-pattern (str "(?:#_\\s*|\\^)" ignore-marker ignore-marker-boundary)))
 
 (def ^:private ignore-marker-re
-  (re-pattern (str ignore-marker "(?![\\w./-])")))
+  (re-pattern (str ignore-marker ignore-marker-boundary)))
+
+;; `#:clj-kondo{:ignore [...]}` reads as a map containing the real ignore key without spelling that key
+;; literally. Reject this narrow alternate spelling so it cannot bypass the lexical scanner.
+(def ^:private namespaced-ignore-marker-re
+  (re-pattern (str "#:clj-kondo\\s*\\{\\s*:ignore" ignore-marker-boundary)))
 
 (defn mask-strings-and-comments
   "`content` with string-literal and line-comment interiors replaced by spaces, newlines kept.
@@ -128,13 +141,15 @@
                           (re-matches substantive-comment-re (str/trim (subs raw i))))))))))
 
 (defn- marker-offsets
-  "Offsets of real ignore markers in `masked`; strings and comments have already been blanked."
+  "Offsets of real or namespaced-map ignore markers in `masked`; strings and comments are blanked."
   [masked]
-  (let [m (re-matcher ignore-marker-re masked)]
-    (loop [acc []]
-      (if (.find m)
-        (recur (conj acc (.start m)))
-        acc))))
+  (mapcat (fn [re]
+            (let [m (re-matcher re masked)]
+              (loop [acc []]
+                (if (.find m)
+                  (recur (conj acc (.start m)))
+                  acc))))
+          [ignore-marker-re namespaced-ignore-marker-re]))
 
 (defn- unsupported-ignore-lines
   "Lines containing an ignore marker outside one of `matches`' canonical spans."
@@ -154,7 +169,7 @@
                                  (matches-with-offsets bare-form-re masked true)))
         unsupported (vec (unsupported-ignore-lines masked matches))]
     (when (seq unsupported)
-      (throw (ex-info (format "Unsupported %s syntax on line%s %s; put the ignore first in its map"
+      (throw (ex-info (format "Unsupported %s syntax on line%s %s; use the literal ignore key first in its map"
                               ignore-marker
                               (if (= 1 (count unsupported)) "" "s")
                               (str/join ", " unsupported))
@@ -184,7 +199,8 @@
          :when (and (.isFile f)
                     (some #(str/ends-with? (.getPath f) %) source-extensions))
          :let  [content (slurp f)]
-         :when (str/includes? content ignore-marker)
+         :when (or (str/includes? content ignore-marker)
+                   (re-find namespaced-ignore-marker-re content))
          m     (ignore-matches content)]
      {:file       (.getPath f)
       :line       (:line m)

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
@@ -67,7 +67,6 @@
 ;;
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
-
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
                       :metabase/validate-defendpoint-query-params-use-kebab-case
                       :metabase/validate-defendpoint-has-response-schema]}

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -366,7 +366,7 @@
                                        (remove-ignores-at (slurp file) (map :row file-candidates))]
                                    (spit file text)
                                    (doseq [row skipped]
-                                     (println (format "WARNING: %s:%d skipped -- the ignore form's braces don't balance within the match; remove it by hand"
+                                     (println (format "WARNING: %s:%d skipped -- can't be excised cleanly (unbalanced braces); remove it by hand"
                                                       file row)))
                                    ;; whether the removed site carried a marker decides where its marker
                                    ;; goes on restore ([[site-restore-plan]]) -- record it, don't infer it

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -244,8 +244,9 @@
 (defn- remove-ignores-at
   "The inline ignore forms that start on the 1-based `rows` of `text`, removed.
   Forms that name any clojure-lsp/* linter survive ([[names-lsp?]]): the verify pass could never restore
-  that half of the suppression. Prefixless maps and forms whose matched span has unbalanced braces
-  (nested maps the regex can't span) are skipped and reported under `:skipped` rather than corrupted.
+  that half of the suppression. Prefixless maps, forms preceded by a `#` (legacy `#^` metadata vs a gensym's `#` -- telling
+  them apart needs a reader), and forms whose matched span has unbalanced braces (nested maps the
+  regex can't span) are skipped and reported under `:skipped` rather than corrupted.
   A line left whitespace-only by a removal is deleted; an inline removal also swallows the spaces
   separating it from the following form when the preceding text already ends in a space.
   Returns `{:text _, :sites [{:row _, :linters _, :original _} ...], :skipped [rows...]}`.
@@ -254,17 +255,26 @@
   [text rows]
   (let [rowset (set rows)
         masked (kondo-ratchet/mask-strings-and-comments text)
+        ;; A `#` right before the match is ambiguous without a reader: in `#^{...}` it is legacy
+        ;; metadata and removal must take it too, in `x#^{...}` it closes a syntax-quote gensym and
+        ;; removal must leave it. Both are rare; skip them rather than grow a partial reader here.
+        hash-caret? (fn [{:keys [start]}]
+                      (and (pos? start)
+                           (= \^ (.charAt ^String masked start))
+                           (= \# (.charAt ^String masked (dec start)))))
         prefixed? (fn [{:keys [start]}]
                     (contains? #{\# \^} (.charAt ^String masked start)))
         balanced? (fn [{:keys [start end]}]
                     (let [span (subs masked start end)]
                       (= (count (filter #{\{} span))
                          (count (filter #{\}} span)))))
-        {prefixed true, prefixless false}
-        (group-by prefixed?
+        {hash-caret true, plain false}
+        (group-by hash-caret?
                   (->> (kondo-ratchet/ignore-matches text)
                        (filter (comp rowset :line))
                        (remove (comp names-lsp? :linters))))
+        {prefixed true, prefixless false}
+        (group-by prefixed? plain)
         {removable true, unbalanced false}
         (group-by balanced? prefixed)
         result (reduce (fn [{:keys [text] :as acc} {:keys [start end line linters]}]
@@ -312,7 +322,7 @@
                  :linters      linters
                  :original     original})
      ;; adjusted like :sites, so warnings point at the rewritten file
-     :skipped (map (comp post-removal-row :line) (concat prefixless unbalanced))}))
+     :skipped (map (comp post-removal-row :line) (concat hash-caret prefixless unbalanced))}))
 
 (defn redundant-ignores
   "Report inline ignores kondo flags as redundant, dropping its two known false-positive classes:
@@ -370,7 +380,7 @@
                                        (remove-ignores-at (slurp file) (map :row file-candidates))]
                                    (spit file text)
                                    (doseq [row skipped]
-                                     (println (format "WARNING: %s:%d skipped -- can't be excised safely (prefixless map or unbalanced braces); remove it by hand"
+                                     (println (format "WARNING: %s:%d skipped -- can't be excised safely (prefixless map, a `#` before the form, or unbalanced braces); remove it by hand"
                                                       file row)))
                                    ;; whether the removed site carried a marker decides where its marker
                                    ;; goes on restore ([[site-restore-plan]]) -- record it, don't infer it
@@ -478,8 +488,12 @@
                            (count (distinct (map (juxt :filename :row) findings)))
                            (count by-file)
                            linter))
-          ;; the inserted ignores carry no justification comments, so the justification ratchet
-          ;; fails unless the linter is grandfathered
+          ;; Inserted ignores carry no justification comment of their own, so the justification ratchet
+          ;; fails unless the linter is grandfathered -- but an insert lands under whatever comment was
+          ;; already above the flagged form, which justifies it. Advising an exemption none of the sites
+          ;; need would just fail no-stale-exemptions-test instead, so ask the scanner first.
           (when-not (contains? (:comment-exempt (kondo-ratchet/read-ratchets)) linter)
-            (println (format "Also add %s to :comment-exempt in %s -- the inserted ignores have no comments."
-                             linter kondo-ratchet/ratchets-file)))))))
+            (when (seq (kondo-ratchet/unjustified #{} (filter #(some #{linter} (:linters %))
+                                                              (kondo-ratchet/scan roots))))
+              (println (format "Also add %s to :comment-exempt in %s -- the inserted ignores have no comments."
+                               linter kondo-ratchet/ratchets-file))))))))

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -474,7 +474,12 @@
     (println)
     (if (empty? by-file)
       (println "No findings; nothing inserted.")
-      (println (format "Inserted %d ignores across %d files. Now seed the budget:\n  ./bin/mage fix-kondo-ratchets --seed %s"
-                       (count (distinct (map (juxt :filename :row) findings)))
-                       (count by-file)
-                       linter)))))
+      (do (println (format "Inserted %d ignores across %d files. Now seed the budget:\n  ./bin/mage fix-kondo-ratchets --seed %s"
+                           (count (distinct (map (juxt :filename :row) findings)))
+                           (count by-file)
+                           linter))
+          ;; the inserted ignores carry no justification comments, so the justification ratchet
+          ;; fails unless the linter is grandfathered
+          (when-not (contains? (:comment-exempt (kondo-ratchet/read-ratchets)) linter)
+            (println (format "Also add %s to :comment-exempt in %s -- the inserted ignores have no comments."
+                             linter kondo-ratchet/ratchets-file)))))))

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -224,11 +224,11 @@
 ;;;; ---------------------------------------------------------------------------
 
 (defn- ignored-linters-at
-  "Linter keywords named by the ignore form at `row` of `lines`; reads a couple of extra lines since
-  the vector may wrap."
+  "Linter keywords named by the ignore form starting at `row` of `lines`."
   [lines row]
-  (kondo-ratchet/line-linters
-   (str/join "\n" (subvec lines (dec row) (min (count lines) (+ row 2))))))
+  (->> (kondo-ratchet/ignore-matches (str/join "\n" lines))
+       (filter #(= row (:line %)))
+       (mapcat :linters)))
 
 (defn- lsp-only?
   "Does the ignore form suppress only linters kondo doesn't run, so a re-lint could never restore it?"
@@ -244,8 +244,8 @@
 (defn- remove-ignores-at
   "The inline ignore forms that start on the 1-based `rows` of `text`, removed.
   Forms that name any clojure-lsp/* linter survive ([[names-lsp?]]): the verify pass could never restore
-  that half of the suppression. Forms whose matched span has unbalanced braces (nested maps the regex
-  can't span) are skipped and reported under `:skipped` rather than corrupted.
+  that half of the suppression. Prefixless maps and forms whose matched span has unbalanced braces
+  (nested maps the regex can't span) are skipped and reported under `:skipped` rather than corrupted.
   A line left whitespace-only by a removal is deleted; an inline removal also swallows the spaces
   separating it from the following form when the preceding text already ends in a space.
   Returns `{:text _, :sites [{:row _, :linters _, :original _} ...], :skipped [rows...]}`.
@@ -254,15 +254,19 @@
   [text rows]
   (let [rowset (set rows)
         masked (kondo-ratchet/mask-strings-and-comments text)
+        prefixed? (fn [{:keys [start]}]
+                    (contains? #{\# \^} (.charAt ^String masked start)))
         balanced? (fn [{:keys [start end]}]
                     (let [span (subs masked start end)]
                       (= (count (filter #{\{} span))
                          (count (filter #{\}} span)))))
-        {removable true, unbalanced false}
-        (group-by balanced?
+        {prefixed true, prefixless false}
+        (group-by prefixed?
                   (->> (kondo-ratchet/ignore-matches text)
                        (filter (comp rowset :line))
                        (remove (comp names-lsp? :linters))))
+        {removable true, unbalanced false}
+        (group-by balanced? prefixed)
         result (reduce (fn [{:keys [text] :as acc} {:keys [start end line linters]}]
                          (let [before     (subs text 0 start)
                                after      (subs text end)
@@ -308,7 +312,7 @@
                  :linters      linters
                  :original     original})
      ;; adjusted like :sites, so warnings point at the rewritten file
-     :skipped (map (comp post-removal-row :line) unbalanced)}))
+     :skipped (map (comp post-removal-row :line) (concat prefixless unbalanced))}))
 
 (defn redundant-ignores
   "Report inline ignores kondo flags as redundant, dropping its two known false-positive classes:
@@ -366,7 +370,7 @@
                                        (remove-ignores-at (slurp file) (map :row file-candidates))]
                                    (spit file text)
                                    (doseq [row skipped]
-                                     (println (format "WARNING: %s:%d skipped -- can't be excised cleanly (unbalanced braces); remove it by hand"
+                                     (println (format "WARNING: %s:%d skipped -- can't be excised safely (prefixless map or unbalanced braces); remove it by hand"
                                                       file row)))
                                    ;; whether the removed site carried a marker decides where its marker
                                    ;; goes on restore ([[site-restore-plan]]) -- record it, don't infer it

--- a/mage/test/mage/kondo_ratchet_test.clj
+++ b/mage/test/mage/kondo_ratchet_test.clj
@@ -287,7 +287,16 @@
            (map :original
                 (:sites (#'kondo-ratchet/remove-ignores-at
                          "(a)\n#_{:clj-kondo/ignore [:x\n                      :y]}\n(b)\n"
-                         [2])))))))
+                         [2]))))))
+  (testing "a `#` before the form is left for a human -- `#^` metadata and a gensym's `#` need a reader to tell apart"
+    (doseq [[description text] [["legacy #^ metadata"        "(def #^{:clj-kondo/ignore [:x]} y 1)\n"]
+                                ["a syntax-quote gensym"     "`(m x#^{:clj-kondo/ignore [:x]} y)\n"]
+                                ["a quote macro before it"   "(def x '#^{:clj-kondo/ignore [:z]} y)\n"]]]
+      (testing description
+        (let [{removed :text, :keys [sites skipped]} (#'kondo-ratchet/remove-ignores-at text [1])]
+          (is (= text removed) "the source is left exactly as it was")
+          (is (= [] sites) "nothing is excised")
+          (is (= [1] skipped) "the row is reported instead"))))))
 
 (deftest inline-ignore-separator-round-trip-test
   (doseq [[description separator text]

--- a/mage/test/mage/kondo_ratchet_test.clj
+++ b/mage/test/mage/kondo_ratchet_test.clj
@@ -265,6 +265,14 @@
   (update (#'kondo-ratchet/remove-ignores-at text rows)
           :sites (partial mapv #(dissoc % :original :removed-line))))
 
+(deftest ignored-linters-at-test
+  (testing "reads the complete file when an ignore vector spans more than three lines"
+    (is (= [:a :b :c :d]
+           (#'kondo-ratchet/ignored-linters-at
+            (vec (str/split-lines
+                  "#_{:clj-kondo/ignore [:a\n                      :b\n                      :c\n                      :d]}\n(foo)"))
+            1)))))
+
 (deftest remove-ignores-at-originals-test
   (testing "each site captures its removed form verbatim, so a restore puts back exactly what was cut"
     (is (= [{:whole-line? true, :text "  #_{:clj-kondo/ignore [:equals-true]}"}]
@@ -321,6 +329,10 @@
            (remove-ignores-at'
             "#_{:clj-kondo/ignore [:x] :reason {:ticket \"ABC-1\"}}\n(a)\n"
             [1]))))
+  (testing "a prefixless match is left for manual removal rather than risking a dangling reader discard"
+    (let [text "#_ ;; rationale\n{:clj-kondo/ignore [:x]}\n(a)\n"]
+      (is (= {:text text, :sites [], :skipped [2]}
+             (remove-ignores-at' text [2])))))
   (testing "a skipped row is reported in post-removal coordinates when removals above it delete lines"
     (is (= {:text      "(a)\n#_{:clj-kondo/ignore [:y] :reason {:nested 1}}\n(b)\n"
             :sites     [{:row 1, :linters [:x]}]

--- a/modules/drivers/mongo/src/metabase/driver/mongo/connection.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/connection.clj
@@ -127,8 +127,8 @@
   "Create instance of `MongoClient` for `database` and bind it to [[*mongo-client*]]. `database` can be anything
    digestable by [[mongo.db/details-normalized]]. Call of this macro in its body will reuse existing
    [[*mongo-client*]]."
-  {:clj-kondo/lint-as 'clojure.core/let
-   :clj-kondo/ignore [:unresolved-symbol :type-mismatch]}
+  {:clj-kondo/ignore  [:unresolved-symbol :type-mismatch]
+   :clj-kondo/lint-as 'clojure.core/let} ;; kondo can't follow the syntax-quoted fn indirection under lint-as let
   [[client-sym database] & body]
   `(let [f# (fn [~client-sym] ~@body)]
      (if (nil? *mongo-client*)
@@ -144,8 +144,8 @@
 
 (defmacro with-mongo-database
   "Utility for accessing database directly instead of a client. For more info see [[with-mongo-client]]."
-  {:clj-kondo/lint-as 'clojure.core/let
-   :clj-kondo/ignore [:unresolved-symbol :type-mismatch]}
+  {:clj-kondo/ignore  [:unresolved-symbol :type-mismatch]
+   :clj-kondo/lint-as 'clojure.core/let} ;; kondo can't follow the syntax-quoted fn indirection under lint-as let
   [[db-sym database] & body]
   `(let [f# (fn [~db-sym] ~@body)]
      (do-with-mongo-database f# ~database)))

--- a/src/metabase/models/humanization.clj
+++ b/src/metabase/models/humanization.clj
@@ -77,7 +77,6 @@
 
 ;;; these kondo warnings are ignored for now because I'm planning on moving this namespace out of `util` to eliminate
 ;;; the dependency of `util` of `settings` -- will fix them after this namespace gets moved. -- Cam
-
 #_{:clj-kondo/ignore [:metabase/defsetting-namespace]}
 (defsetting ^{:added "0.28.0"} humanization-strategy
   (deferred-tru

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -316,7 +316,6 @@
 ;;
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
-
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-route-uses-kebab-case
                       :metabase/validate-defendpoint-query-params-use-kebab-case
                       :metabase/validate-defendpoint-has-response-schema]}

--- a/test/metabase/core/kondo_ratchet_test.clj
+++ b/test/metabase/core/kondo_ratchet_test.clj
@@ -113,6 +113,15 @@
     []                  "(def s \"#_{:clj-kondo/ignore [:in-a-string]}\")"
     []                  ";; #_{:clj-kondo/ignore [:commented-out]}"))
 
+(deftest ^:parallel noncanonical-ignore-test
+  (testing "an ignore behind another map key fails closed instead of asking a partial reader to classify it"
+    (are [line] (thrown-with-msg? clojure.lang.ExceptionInfo
+                                  #"put the ignore first in its map"
+                                  (kondo-ratchet/line-linters line))
+      "(def ^{:added \"0.1\" :clj-kondo/ignore [:buried]} x 1)"
+      "(ns b {:doc \"d\" :clj-kondo/ignore [:buried]})"
+      "{:label :clj-kondo/ignore [:data]}")))
+
 (deftest ^:parallel scan-test
   (let [dir (.toFile (java.nio.file.Files/createTempDirectory
                       "kondo-ratchet-test"
@@ -128,8 +137,15 @@
                "#_{:clj-kondo/ignore [:multi\n"
                "                      :line]}\n"
                "(defn i [] 4) #_{:clj-kondo/ignore [:trailing]} ;; trailing needs suppressing here\n"
+               "(f) ;; this describes f, not the ignore below\n"
+               "#_{:clj-kondo/ignore [:after-code-comment]}\n"
+               "(defn after-code-comment [] 5)\n"
+               ";; a real comment, but separated from the ignore\n"
+               "\n"
+               "#_{:clj-kondo/ignore [:after-blank]}\n"
+               "(defn after-blank [] 5)\n"
                ";; #_{:clj-kondo/ignore [:commented-out]}\n"
-               "(defn j [] 5)\n"
+               "(defn j [] 6)\n"
                "#_{:clj-kondo/ignore [:sneaky]} (def s \"a ; b\")\n"))
     (spit (io/file dir "b.clj")
           (str "(ns b {:clj-kondo/ignore [:attr-map]})\n"
@@ -140,13 +156,16 @@
               {:file (.getPath (io/file dir "a.clj")), :line 5,  :linters [:all],         :justified? true}
               {:file (.getPath (io/file dir "a.clj")), :line 8,  :linters [:multi :line], :justified? false}
               {:file (.getPath (io/file dir "a.clj")), :line 10, :linters [:trailing],    :justified? true}
-              {:file (.getPath (io/file dir "a.clj")), :line 13, :linters [:sneaky],      :justified? false}
+              {:file (.getPath (io/file dir "a.clj")), :line 12, :linters [:after-code-comment], :justified? false}
+              {:file (.getPath (io/file dir "a.clj")), :line 16, :linters [:after-blank], :justified? false}
+              {:file (.getPath (io/file dir "a.clj")), :line 20, :linters [:sneaky],      :justified? false}
               {:file (.getPath (io/file dir "b.clj")), :line 1,  :linters [:attr-map],    :justified? false}
               {:file (.getPath (io/file dir "b.clj")), :line 2,  :linters [:extra],       :justified? false}]
              occurrences)
           "strings and commented-out forms don't count; multi-line vectors, attr-maps, and extra keys do;
            a semicolon inside a trailing string is not a justification")
-      (is (= {:x 1, :y 1, :all 1, :multi 1, :line 1, :trailing 1, :sneaky 1, :attr-map 1, :extra 1}
+      (is (= {:x 1, :y 1, :all 1, :multi 1, :line 1, :trailing 1, :after-code-comment 1,
+              :after-blank 1, :sneaky 1, :attr-map 1, :extra 1}
              (kondo-ratchet/actual-counts occurrences))))))
 
 ;;;; ---------------------------------------------------------------------------

--- a/test/metabase/core/kondo_ratchet_test.clj
+++ b/test/metabase/core/kondo_ratchet_test.clj
@@ -11,20 +11,26 @@
 
 (set! *warn-on-reflection* true)
 
+;; Scanning walks the whole tree, so the ratchet tests share one pass per run; the fixture invalidates
+;; the cache so a long-lived REPL doesn't compare fresh ratchet-file contents with stale counts.
+(def ^:private tree-scan-cache
+  (atom nil))
+
+(defn- tree-scan []
+  (or @tree-scan-cache
+      (reset! tree-scan-cache (kondo-ratchet/scan))))
+
 ;; Outside CI, tighten the ratchets before asserting — the fix rides along in your next commit.
 ;; The self-heal workflow does the same for labelled PRs.
 (use-fixtures :once (fn [thunk]
                       (when-not (System/getenv "CI")
                         (kondo-ratchet/fix!))
+                      (reset! tree-scan-cache nil)
                       (thunk)))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; The ratchets themselves
 ;;;; ---------------------------------------------------------------------------
-
-;; Scanning walks the whole tree, so the ratchet tests share one pass.
-(def ^:private tree-scan
-  (delay (kondo-ratchet/scan)))
 
 (deftest ^:parallel budgets-match-actual-counts-test
   (testing (str "\nBudgets in " kondo-ratchet/ratchets-file " must match the actual inline ignore counts.\n"
@@ -35,7 +41,7 @@
                 "run means `fix!` itself is broken, since the test fixture just ran it.")
     (is (= {}
            (kondo-ratchet/drift (:ignore-counts (kondo-ratchet/read-ratchets))
-                                @tree-scan)))))
+                                (tree-scan))))))
 
 (deftest ^:parallel ignores-are-justified-test
   (testing (str "\nInline ignores of these linters need an explanatory `;;` comment on the line above\n"
@@ -45,7 +51,7 @@
     (let [exempt (:comment-exempt (kondo-ratchet/read-ratchets))]
       (is (= []
              (map #(dissoc % :justified?)
-                  (kondo-ratchet/unjustified exempt @tree-scan)))))))
+                  (kondo-ratchet/unjustified exempt (tree-scan))))))))
 
 (deftest ^:parallel no-stale-exemptions-test
   (testing (str "\nEvery linter in :comment-exempt still has at least one unjustified ignore; once the last\n"
@@ -53,7 +59,7 @@
                 "the PR kondo-ratchets-self-healing.")
     (let [{:keys [comment-exempt]} (kondo-ratchet/read-ratchets)]
       (is (= #{}
-             (kondo-ratchet/stale-exemptions comment-exempt @tree-scan))))))
+             (kondo-ratchet/stale-exemptions comment-exempt (tree-scan)))))))
 
 (deftest ^:parallel ratchets-file-normalized-test
   (testing (str "\n" kondo-ratchet/ratchets-file " should be sorted and aligned exactly as the generator"

--- a/test/metabase/core/kondo_ratchet_test.clj
+++ b/test/metabase/core/kondo_ratchet_test.clj
@@ -11,22 +11,27 @@
 
 (set! *warn-on-reflection* true)
 
-;; Scanning walks the whole tree, so the ratchet tests share one pass per run; the fixture invalidates
-;; the cache so a long-lived REPL doesn't compare fresh ratchet-file contents with stale counts.
+;; Scanning walks the whole tree, so the ratchet tests share one pass per run. The cache only exists
+;; while the :once fixture is live; a directly-run test var (no fixture) always scans fresh, so a
+;; long-lived REPL never compares fresh ratchet-file contents with stale counts.
 (def ^:private tree-scan-cache
   (atom nil))
 
 (defn- tree-scan []
-  (or @tree-scan-cache
-      (reset! tree-scan-cache (kondo-ratchet/scan))))
+  (if-let [scan @tree-scan-cache]
+    @scan
+    (kondo-ratchet/scan)))
 
 ;; Outside CI, tighten the ratchets before asserting — the fix rides along in your next commit.
 ;; The self-heal workflow does the same for labelled PRs.
 (use-fixtures :once (fn [thunk]
                       (when-not (System/getenv "CI")
                         (kondo-ratchet/fix!))
-                      (reset! tree-scan-cache nil)
-                      (thunk)))
+                      (reset! tree-scan-cache (delay (kondo-ratchet/scan)))
+                      (try
+                        (thunk)
+                        (finally
+                          (reset! tree-scan-cache nil)))))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; The ratchets themselves

--- a/test/metabase/core/kondo_ratchet_test.clj
+++ b/test/metabase/core/kondo_ratchet_test.clj
@@ -64,11 +64,14 @@
 (deftest ^:parallel mask-strings-and-comments-test
   (are [expected content] (= expected (kondo-ratchet/mask-strings-and-comments content))
     "(f \"     \" x)"        "(f \"a ; b\" x)"
-    "(f)      \n(g)"         "(f) ; hey\n(g)"
+    ;; the comment-start `;` survives; the interior does not
+    "(f) ;    \n(g)"         "(f) ; hey\n(g)"
     "(f \"   \n  \")"        "(f \"a b\nc \")"
-    ;; escaped quote stays inside the string; char literals never open one
+    ;; escaped quote stays inside the string; char literals are masked so they can't open a string or
+    ;; start a comment
     "(f \"      \")"         "(f \"a\\\"b c\")"
-    "[\\\" \"   \"]"         "[\\\" \"abc\"]")
+    "[\\  \"   \"]"          "[\\\" \"abc\"]"
+    "(f \\  \"   \")"        "(f \\; \"a;b\")")
   (testing "masking preserves length and newline positions"
     (let [content "(f \"a\nb\") ; c\n(g)"
           masked  (kondo-ratchet/mask-strings-and-comments content)]
@@ -111,7 +114,8 @@
                "                      :line]}\n"
                "(defn i [] 4) #_{:clj-kondo/ignore [:trailing]} ;; trailing needs suppressing here\n"
                ";; #_{:clj-kondo/ignore [:commented-out]}\n"
-               "(defn j [] 5)\n"))
+               "(defn j [] 5)\n"
+               "#_{:clj-kondo/ignore [:sneaky]} (def s \"a ; b\")\n"))
     (spit (io/file dir "b.clj")
           (str "(ns b {:clj-kondo/ignore [:attr-map]})\n"
                "#_{:clj-kondo/ignore [:extra] :reason \"legacy\"}\n"
@@ -121,11 +125,13 @@
               {:file (.getPath (io/file dir "a.clj")), :line 5,  :linters [:all],         :justified? true}
               {:file (.getPath (io/file dir "a.clj")), :line 8,  :linters [:multi :line], :justified? false}
               {:file (.getPath (io/file dir "a.clj")), :line 10, :linters [:trailing],    :justified? true}
+              {:file (.getPath (io/file dir "a.clj")), :line 13, :linters [:sneaky],      :justified? false}
               {:file (.getPath (io/file dir "b.clj")), :line 1,  :linters [:attr-map],    :justified? false}
               {:file (.getPath (io/file dir "b.clj")), :line 2,  :linters [:extra],       :justified? false}]
              occurrences)
-          "strings and commented-out forms don't count; multi-line vectors, attr-maps, and extra keys do")
-      (is (= {:x 1, :y 1, :all 1, :multi 1, :line 1, :trailing 1, :attr-map 1, :extra 1}
+          "strings and commented-out forms don't count; multi-line vectors, attr-maps, and extra keys do;
+           a semicolon inside a trailing string is not a justification")
+      (is (= {:x 1, :y 1, :all 1, :multi 1, :line 1, :trailing 1, :sneaky 1, :attr-map 1, :extra 1}
              (kondo-ratchet/actual-counts occurrences))))))
 
 ;;;; ---------------------------------------------------------------------------

--- a/test/metabase/core/kondo_ratchet_test.clj
+++ b/test/metabase/core/kondo_ratchet_test.clj
@@ -22,6 +22,10 @@
 ;;;; The ratchets themselves
 ;;;; ---------------------------------------------------------------------------
 
+;; Scanning walks the whole tree, so the ratchet tests share one pass.
+(def ^:private tree-scan
+  (delay (kondo-ratchet/scan)))
+
 (deftest ^:parallel budgets-match-actual-counts-test
   (testing (str "\nBudgets in " kondo-ratchet/ratchets-file " must match the actual inline ignore counts.\n"
                 "Budget too low: remove an ignore, or seed the budget with\n"
@@ -31,7 +35,7 @@
                 "run means `fix!` itself is broken, since the test fixture just ran it.")
     (is (= {}
            (kondo-ratchet/drift (:ignore-counts (kondo-ratchet/read-ratchets))
-                                (kondo-ratchet/scan))))))
+                                @tree-scan)))))
 
 (deftest ^:parallel ignores-are-justified-test
   (testing (str "\nInline ignores of these linters need an explanatory `;;` comment on the line above\n"
@@ -41,7 +45,7 @@
     (let [exempt (:comment-exempt (kondo-ratchet/read-ratchets))]
       (is (= []
              (map #(dissoc % :justified?)
-                  (kondo-ratchet/unjustified exempt (kondo-ratchet/scan))))))))
+                  (kondo-ratchet/unjustified exempt @tree-scan)))))))
 
 (deftest ^:parallel no-stale-exemptions-test
   (testing (str "\nEvery linter in :comment-exempt still has at least one unjustified ignore; once the last\n"
@@ -49,7 +53,7 @@
                 "the PR kondo-ratchets-self-healing.")
     (let [{:keys [comment-exempt]} (kondo-ratchet/read-ratchets)]
       (is (= #{}
-             (kondo-ratchet/stale-exemptions comment-exempt (kondo-ratchet/scan)))))))
+             (kondo-ratchet/stale-exemptions comment-exempt @tree-scan))))))
 
 (deftest ^:parallel ratchets-file-normalized-test
   (testing (str "\n" kondo-ratchet/ratchets-file " should be sorted and aligned exactly as the generator"

--- a/test/metabase/core/kondo_ratchet_test.clj
+++ b/test/metabase/core/kondo_ratchet_test.clj
@@ -33,6 +33,24 @@
            (kondo-ratchet/drift (:ignore-counts (kondo-ratchet/read-ratchets))
                                 (kondo-ratchet/scan))))))
 
+(deftest ^:parallel ignores-are-justified-test
+  (testing (str "\nInline ignores of these linters need an explanatory `;;` comment on the line above\n"
+                "(or trailing on the same line) saying why the suppression is warranted.\n"
+                "Linters in :comment-exempt in " kondo-ratchet/ratchets-file " are grandfathered;\n"
+                "widening that set is a hand edit to defend in the PR.")
+    (let [exempt (:comment-exempt (kondo-ratchet/read-ratchets))]
+      (is (= []
+             (map #(dissoc % :justified?)
+                  (kondo-ratchet/unjustified exempt (kondo-ratchet/scan))))))))
+
+(deftest ^:parallel no-stale-exemptions-test
+  (testing (str "\nEvery linter in :comment-exempt still has at least one unjustified ignore; once the last\n"
+                "one gains a comment, the exemption goes. Run `./bin/mage fix-kondo-ratchets`, or label\n"
+                "the PR kondo-ratchets-self-healing.")
+    (let [{:keys [comment-exempt]} (kondo-ratchet/read-ratchets)]
+      (is (= #{}
+             (kondo-ratchet/stale-exemptions comment-exempt (kondo-ratchet/scan)))))))
+
 (deftest ^:parallel ratchets-file-normalized-test
   (testing (str "\n" kondo-ratchet/ratchets-file " should be sorted and aligned exactly as the generator"
                 " writes it.\nAfter a hand edit, run `./bin/mage fix-kondo-ratchets` to normalize the formatting.")
@@ -99,12 +117,12 @@
                "#_{:clj-kondo/ignore [:extra] :reason \"legacy\"}\n"
                "(defn k [] 6)\n"))
     (let [occurrences (sort-by (juxt :file :line) (kondo-ratchet/scan [(.getPath dir)]))]
-      (is (= [{:file (.getPath (io/file dir "a.clj")), :line 2,  :linters [:x :y]}
-              {:file (.getPath (io/file dir "a.clj")), :line 5,  :linters [:all]}
-              {:file (.getPath (io/file dir "a.clj")), :line 8,  :linters [:multi :line]}
-              {:file (.getPath (io/file dir "a.clj")), :line 10, :linters [:trailing]}
-              {:file (.getPath (io/file dir "b.clj")), :line 1,  :linters [:attr-map]}
-              {:file (.getPath (io/file dir "b.clj")), :line 2,  :linters [:extra]}]
+      (is (= [{:file (.getPath (io/file dir "a.clj")), :line 2,  :linters [:x :y],        :justified? false}
+              {:file (.getPath (io/file dir "a.clj")), :line 5,  :linters [:all],         :justified? true}
+              {:file (.getPath (io/file dir "a.clj")), :line 8,  :linters [:multi :line], :justified? false}
+              {:file (.getPath (io/file dir "a.clj")), :line 10, :linters [:trailing],    :justified? true}
+              {:file (.getPath (io/file dir "b.clj")), :line 1,  :linters [:attr-map],    :justified? false}
+              {:file (.getPath (io/file dir "b.clj")), :line 2,  :linters [:extra],       :justified? false}]
              occurrences)
           "strings and commented-out forms don't count; multi-line vectors, attr-maps, and extra keys do")
       (is (= {:x 1, :y 1, :all 1, :multi 1, :line 1, :trailing 1, :attr-map 1, :extra 1}
@@ -116,16 +134,19 @@
 
 (deftest ^:parallel render-test
   (testing "keys come out sorted, values aligned, and the text round-trips losslessly"
-    (let [ratchets {:ignore-counts {:discouraged-var 3, :all 1, :metabase/modules 2}}
+    (let [ratchets {:ignore-counts  {:discouraged-var 3, :all 1, :metabase/modules 2}
+                    :comment-exempt #{:metabase/modules :discouraged-var}}
           text     (kondo-ratchet/render ratchets)]
-      (is (str/ends-with? text (str "{:ignore-counts {:all              1\n"
-                                    "                 :discouraged-var  3\n"
-                                    "                 :metabase/modules 2}}\n")))
+      (is (str/ends-with? text (str "{:ignore-counts  {:all              1\n"
+                                    "                  :discouraged-var  3\n"
+                                    "                  :metabase/modules 2}\n"
+                                    " :comment-exempt #{:discouraged-var\n"
+                                    "                   :metabase/modules}}\n")))
       (is (= ratchets (edn/read-string text)))
       (is (= text (kondo-ratchet/render (edn/read-string text))))))
   (testing "empty ratchets"
-    (is (str/ends-with? (kondo-ratchet/render {:ignore-counts {}})
-                        "{:ignore-counts {}}\n"))))
+    (is (str/ends-with? (kondo-ratchet/render {:ignore-counts {}, :comment-exempt #{}})
+                        "{:ignore-counts  {}\n :comment-exempt #{}}\n"))))
 
 (deftest ^:parallel lowered-counts-test
   (is (= {:lower 3, :over-budget 5}
@@ -160,16 +181,40 @@
                         {:file "f.clj", :line line, :linters [:a]})]
       (is (= 5 (count (:examples (:a (kondo-ratchet/drift {} occurrences)))))))))
 
+;;;; ---------------------------------------------------------------------------
+;;;; Justification bookkeeping unit tests
+;;;; ---------------------------------------------------------------------------
+
+(deftest ^:parallel unjustified-test
+  (let [occurrences [{:file "f.clj", :line 1, :linters [:a],    :justified? false}
+                     {:file "f.clj", :line 2, :linters [:a :b], :justified? false}
+                     {:file "f.clj", :line 3, :linters [:a],    :justified? true}
+                     {:file "f.clj", :line 4, :linters [:all],  :justified? false}]]
+    (is (= [2 4]
+           (map :line (kondo-ratchet/unjustified #{:a} occurrences)))
+        "line 1 is fully exempt, line 2 still owes :b a comment, line 3 is justified,
+         line 4's :all is not exempt")))
+
+(deftest ^:parallel stale-exemptions-test
+  (let [occurrences [{:file "f.clj", :line 1, :linters [:a], :justified? false}
+                     {:file "f.clj", :line 2, :linters [:b], :justified? true}]]
+    (is (= #{:b}
+           (kondo-ratchet/stale-exemptions #{:a :b} occurrences))
+        ":a still has an unjustified ignore; :b's are all justified so its exemption is stale")))
+
 (deftest ^:parallel change-report-test
-  (let [occurrences (for [[linter n] {:lower 3, :over 7, :new 9, :same 4}
-                          i          (range n)]
-                      {:file "f.clj", :line (inc i), :linters [linter]})]
+  (let [occurrences (concat (for [[linter n] {:lower 3, :over 7, :new 9, :same 4}
+                                  i          (range n)]
+                              {:file "f.clj", :line (inc i), :linters [linter], :justified? false})
+                            [{:file "g.clj", :line 1, :linters [:polite], :justified? true}])]
     (is (= ["seeded :new at 9"
             "WARNING: :void has no inline ignores -- nothing to seed"
             "dropped :gone (no ignores left)"
             "lowered :lower 5 -> 3"
-            "WARNING: :over is over budget (5 recorded, 7 actual) -- remove ignores, or accept them all with `--seed :over`"]
-           (kondo-ratchet/change-report {:ignore-counts {:lower 5, :over 5, :gone 5, :same 4}}
+            "WARNING: :over is over budget (5 recorded, 7 actual) -- remove ignores, or accept them all with `--seed :over`"
+            "unexempted :polite (all its ignores are justified now)"]
+           (kondo-ratchet/change-report {:ignore-counts  {:lower 5, :over 5, :gone 5, :same 4, :polite 1}
+                                         :comment-exempt #{:lower :polite}}
                                         occurrences
                                         [:new :void]))
-        "an untouched budget (:same) earns no line")))
+        "an untouched budget (:same) and a still-needed exemption (:lower) earn no line")))

--- a/test/metabase/core/kondo_ratchet_test.clj
+++ b/test/metabase/core/kondo_ratchet_test.clj
@@ -169,20 +169,29 @@
                "#_{:clj-kondo/ignore [:extra] :reason \"legacy\"}\n"
                "(defn k [] 6)\n"))
     (let [occurrences (sort-by (juxt :file :line) (kondo-ratchet/scan [(.getPath dir)]))]
-      (is (= [{:file (.getPath (io/file dir "a.clj")), :line 2,  :linters [:x :y],        :justified? false}
-              {:file (.getPath (io/file dir "a.clj")), :line 5,  :linters [:all],         :justified? true}
-              {:file (.getPath (io/file dir "a.clj")), :line 8,  :linters [:multi :line], :justified? false}
-              {:file (.getPath (io/file dir "a.clj")), :line 10, :linters [:trailing],    :justified? true}
+      (is (= [{:file (.getPath (io/file dir "a.clj")), :line 2,  :linters [:x :y],               :justified? false}
+              {:file (.getPath (io/file dir "a.clj")), :line 5,  :linters [:all],                :justified? true}
+              {:file (.getPath (io/file dir "a.clj")), :line 8,  :linters [:multi :line],        :justified? false}
+              {:file (.getPath (io/file dir "a.clj")), :line 10, :linters [:trailing],           :justified? true}
               {:file (.getPath (io/file dir "a.clj")), :line 12, :linters [:after-code-comment], :justified? false}
-              {:file (.getPath (io/file dir "a.clj")), :line 16, :linters [:after-blank], :justified? false}
-              {:file (.getPath (io/file dir "a.clj")), :line 20, :linters [:sneaky],      :justified? false}
-              {:file (.getPath (io/file dir "b.clj")), :line 1,  :linters [:attr-map],    :justified? false}
-              {:file (.getPath (io/file dir "b.clj")), :line 2,  :linters [:extra],       :justified? false}]
+              {:file (.getPath (io/file dir "a.clj")), :line 16, :linters [:after-blank],        :justified? false}
+              {:file (.getPath (io/file dir "a.clj")), :line 20, :linters [:sneaky],             :justified? false}
+              {:file (.getPath (io/file dir "b.clj")), :line 1,  :linters [:attr-map],           :justified? false}
+              {:file (.getPath (io/file dir "b.clj")), :line 2,  :linters [:extra],              :justified? false}]
              occurrences)
           "strings and commented-out forms don't count; multi-line vectors, attr-maps, and extra keys do;
            a semicolon inside a trailing string is not a justification")
-      (is (= {:x 1, :y 1, :all 1, :multi 1, :line 1, :trailing 1, :after-code-comment 1,
-              :after-blank 1, :sneaky 1, :attr-map 1, :extra 1}
+      (is (= {:x                  1
+              :y                  1
+              :all                1
+              :multi              1
+              :line               1
+              :trailing           1
+              :after-code-comment 1
+              :after-blank        1
+              :sneaky             1
+              :attr-map           1
+              :extra              1}
              (kondo-ratchet/actual-counts occurrences))))))
 
 (deftest ^:parallel scan-error-identifies-file-test

--- a/test/metabase/core/kondo_ratchet_test.clj
+++ b/test/metabase/core/kondo_ratchet_test.clj
@@ -112,6 +112,9 @@
     []                  "#_:clj-kondo/ignore!"
     []                  "#_:clj-kondo/ignore+"
     []                  "#_:clj-kondo/ignore*"
+    []                  "#_:clj-kondo/ignore'"
+    []                  "#_:clj-kondo/ignore$"
+    []                  "#_:clj-kondo/ignoreλ"
     []                  "(defn foo [x] (inc x))"
     ;; ignore forms inside strings and comments don't count either
     []                  "(def s \"#_{:clj-kondo/ignore [:in-a-string]}\")"
@@ -125,7 +128,9 @@
       "(def ^{:added \"0.1\" :clj-kondo/ignore [:buried]} x 1)"
       "(ns b {:doc \"d\" :clj-kondo/ignore [:buried]})"
       "{:label :clj-kondo/ignore [:data]}"
-      "(def ^#:clj-kondo{:ignore [:namespaced-map]} x 1)")))
+      "(def ^#:clj-kondo{:ignore [:namespaced-map]} x 1)"
+      "(def ^#:clj-kondo{:doc \"x\", :ignore [:namespaced-map]} x 1)"
+      "(def ^#:clj-kondo{;; why\n :ignore [:namespaced-map]} x 1)")))
 
 (deftest ^:parallel scan-test
   (let [dir (.toFile (java.nio.file.Files/createTempDirectory

--- a/test/metabase/core/kondo_ratchet_test.clj
+++ b/test/metabase/core/kondo_ratchet_test.clj
@@ -116,6 +116,8 @@
     []                  "#_:clj-kondo/ignore'"
     []                  "#_:clj-kondo/ignore$"
     []                  "#_:clj-kondo/ignoreλ"
+    []                  "(def foo#:clj-kondo 1)"
+    []                  "(def foo#_#:clj-kondo 1)"
     []                  "(defn foo [x] (inc x))"
     ;; ignore forms inside strings and comments don't count either
     []                  "(def s \"#_{:clj-kondo/ignore [:in-a-string]}\")"
@@ -133,7 +135,9 @@
       "(def ^#:clj-kondo{:doc \"x\", :ignore [:namespaced-map]} x 1)"
       "(def ^#:clj-kondo,{:ignore [:namespaced-map]} x 1)"
       "(def ^#:clj-kondo ;; why\n {:ignore [:namespaced-map]} x 1)"
-      "(def ^#:clj-kondo{;; why\n :ignore [:namespaced-map]} x 1)")))
+      "(def ^#:clj-kondo{;; why\n :ignore [:namespaced-map]} x 1)"
+      "#_#:clj-kondo{:ignore [:namespaced-map]} (foo)"
+      "#_#_#:clj-kondo{:ignore [:namespaced-map]} (foo)")))
 
 (deftest ^:parallel scan-test
   (let [dir (.toFile (java.nio.file.Files/createTempDirectory
@@ -180,6 +184,19 @@
       (is (= {:x 1, :y 1, :all 1, :multi 1, :line 1, :trailing 1, :after-code-comment 1,
               :after-blank 1, :sneaky 1, :attr-map 1, :extra 1}
              (kondo-ratchet/actual-counts occurrences))))))
+
+(deftest ^:parallel scan-error-identifies-file-test
+  (let [dir  (.toFile (java.nio.file.Files/createTempDirectory
+                       "kondo-ratchet-error-test"
+                       (make-array java.nio.file.attribute.FileAttribute 0)))
+        file (io/file dir "unsupported.clj")]
+    (spit file "(def ^{:doc \"x\" :clj-kondo/ignore [:buried]} x 1)")
+    (try
+      (doall (kondo-ratchet/scan [(.getPath dir)]))
+      (is false "unsupported syntax should fail closed")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= (.getPath file) (:file (ex-data e))))
+        (is (str/includes? (.getMessage e) (.getPath file)))))))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; Budget bookkeeping unit tests

--- a/test/metabase/core/kondo_ratchet_test.clj
+++ b/test/metabase/core/kondo_ratchet_test.clj
@@ -108,19 +108,24 @@
     [:all]              "  ^:clj-kondo/ignore (foo)"
     ;; lookalikes that must NOT count
     []                  "#_:clj-kondo/ignore-my-advice"
+    []                  "#_:clj-kondo/ignore?"
+    []                  "#_:clj-kondo/ignore!"
+    []                  "#_:clj-kondo/ignore+"
+    []                  "#_:clj-kondo/ignore*"
     []                  "(defn foo [x] (inc x))"
     ;; ignore forms inside strings and comments don't count either
     []                  "(def s \"#_{:clj-kondo/ignore [:in-a-string]}\")"
     []                  ";; #_{:clj-kondo/ignore [:commented-out]}"))
 
 (deftest ^:parallel noncanonical-ignore-test
-  (testing "an ignore behind another map key fails closed instead of asking a partial reader to classify it"
+  (testing "alternate ignore spellings fail closed instead of asking a partial reader to classify them"
     (are [line] (thrown-with-msg? clojure.lang.ExceptionInfo
-                                  #"put the ignore first in its map"
+                                  #"literal ignore key first"
                                   (kondo-ratchet/line-linters line))
       "(def ^{:added \"0.1\" :clj-kondo/ignore [:buried]} x 1)"
       "(ns b {:doc \"d\" :clj-kondo/ignore [:buried]})"
-      "{:label :clj-kondo/ignore [:data]}")))
+      "{:label :clj-kondo/ignore [:data]}"
+      "(def ^#:clj-kondo{:ignore [:namespaced-map]} x 1)")))
 
 (deftest ^:parallel scan-test
   (let [dir (.toFile (java.nio.file.Files/createTempDirectory

--- a/test/metabase/core/kondo_ratchet_test.clj
+++ b/test/metabase/core/kondo_ratchet_test.clj
@@ -105,6 +105,7 @@
     ;; vector-less forms suppress everything -> :all
     [:all]              "  #_:clj-kondo/ignore"
     [:all]              "  #_ :clj-kondo/ignore (foo)"
+    [:all]              "  #_:clj-kondo/ignore\u2003(foo)"
     [:all]              "  ^:clj-kondo/ignore (foo)"
     ;; lookalikes that must NOT count
     []                  "#_:clj-kondo/ignore-my-advice"
@@ -130,6 +131,7 @@
       "{:label :clj-kondo/ignore [:data]}"
       "(def ^#:clj-kondo{:ignore [:namespaced-map]} x 1)"
       "(def ^#:clj-kondo{:doc \"x\", :ignore [:namespaced-map]} x 1)"
+      "(def ^#:clj-kondo,{:ignore [:namespaced-map]} x 1)"
       "(def ^#:clj-kondo{;; why\n :ignore [:namespaced-map]} x 1)")))
 
 (deftest ^:parallel scan-test

--- a/test/metabase/core/kondo_ratchet_test.clj
+++ b/test/metabase/core/kondo_ratchet_test.clj
@@ -132,6 +132,7 @@
       "(def ^#:clj-kondo{:ignore [:namespaced-map]} x 1)"
       "(def ^#:clj-kondo{:doc \"x\", :ignore [:namespaced-map]} x 1)"
       "(def ^#:clj-kondo,{:ignore [:namespaced-map]} x 1)"
+      "(def ^#:clj-kondo ;; why\n {:ignore [:namespaced-map]} x 1)"
       "(def ^#:clj-kondo{;; why\n :ignore [:namespaced-map]} x 1)")))
 
 (deftest ^:parallel scan-test

--- a/test/metabase/test/sync.clj
+++ b/test/metabase/test/sync.clj
@@ -5,6 +5,7 @@
    [metabase.test.data :as data]
    [toucan2.core :as t2]))
 
+;; deliberately has no root value: the reader below checks `bound?` to tell a live cache from no cache at all
 #_{:clj-kondo/ignore [:uninitialized-var]}
 (def ^:private ^:dynamic *sync-steps-run-to-completion-cache*)
 


### PR DESCRIPTION
An ignore should say why. From here on, an ignore of a linter outside `:comment-exempt` needs a substantive `;;` comment directly above it or trailing on its line, and `metabase.core.kondo-ratchet-test` fails on any that doesn't.

Nothing checks that the comment is *about* the lint. Reviewers catch that, and a future linter could do better.

| | Today |
|---|---|
| Ignore sites | 1022 |
| Carrying a justification | 203 (20%) |
| Sitting under a bare `;;` divider[^1] | 427 (42%) |
| Linters with a budget | 45 |
| Starting exempt | 38 |

Bare dividers don't count as justification. They sit above 42% of ignores, mostly the `defendpoint` groupings, so accepting them would make the requirement mean nothing.

The exemption set only shrinks. Once a linter's last uncommented ignore gains a comment or is removed, `fix-kondo-ratchets` drops the exemption, and the ratchet test keeps it dropped.

Five sites in the tree move to meet the rule rather than dodge it: three lose a blank line so the comment already above them counts, and the two mongo `with-mongo-*` macros get `:clj-kondo/ignore` into first position with a note on why kondo can't follow them through `lint-as`.

[^1]: A comment line with no letters in it, so `;;` and `;; ----` and friends.
