### PR TITLE
Treat a blank MB_CONFIG_FILE_PATH as unset

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file.clj
@@ -159,10 +159,16 @@
   env/env)
 
 (defn- path
-  "Path for the YAML config file Metabase should use for initialization and Settings values."
+  "Path for the YAML config file Metabase should use for initialization and Settings values.
+
+  A blank `MB_CONFIG_FILE_PATH` counts as unset, consistent with [[metabase.config.core/config-str]]. (On JDK 25+ an
+  empty path \"exists\" — it resolves to the current directory — so without this we would try to parse the current
+  directory as YAML and fail to boot.)"
   ^java.nio.file.Path []
-  (let [path* (or (some-> (get *env* :mb-config-file-path) u.files/get-path)
-                  (u.files/get-path (System/getProperty "user.dir") "config.yml"))]
+  (let [env-path (get *env* :mb-config-file-path)
+        path*    (or (when-not (str/blank? env-path)
+                       (u.files/get-path env-path))
+                     (u.files/get-path (System/getProperty "user.dir") "config.yml"))]
     (if (u.files/exists? path*)
       (log/info (u/format-color :magenta
                                 "Found config file at path %s; Metabase will be initialized with values from this file"

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file_test.clj
@@ -7,6 +7,7 @@
    [metabase-enterprise.advanced-config.file.interface :as advanced-config.file.i]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.files :as u.files]
    [metabase.util.yaml :as yaml]))
 
 (set! *warn-on-reflection* true)
@@ -30,6 +31,13 @@
       (binding [advanced-config.file/*env* (assoc @#'advanced-config.file/*env* :mb-config-file-path filename)]
         (is (= mock-yaml
                (#'advanced-config.file/config-from-disk)))))))
+
+(deftest ^:parallel blank-config-file-path-test
+  (testing "A blank MB_CONFIG_FILE_PATH counts as unset (on JDK 25+ the empty path 'exists' as the current directory)"
+    (doseq [blank ["" "   "]]
+      (binding [advanced-config.file/*env* (assoc @#'advanced-config.file/*env* :mb-config-file-path blank)]
+        (is (= (str (u.files/get-path (System/getProperty "user.dir") "config.yml"))
+               (str (#'advanced-config.file/path))))))))
 
 (deftest ^:parallel validate-config-test
   (testing "Config should throw an error"

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -885,7 +885,7 @@
                  false)}
    {:name      :config-text-file
     :available (premium-features/enable-config-text-file?)
-    :enabled   (some? (get env/env :mb-config-file-path))}
+    :enabled   (not (str/blank? (get env/env :mb-config-file-path)))}
    {:name      :content-translation
     :available (premium-features/enable-content-translation?)
     :enabled   (premium-features/enable-content-translation?)}


### PR DESCRIPTION
context: https://stackoverflow.com/questions/79886234/why-does-java-25s-file-exists-method-return-true-for-an-empty-string-while-fi