### PR TITLE
Disable unsupported actions on driver change

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1995,7 +1995,8 @@
   {:team "UX West"
    :api  #{metabase.sample-data.core
            metabase.sample-data.init}
-   :uses #{plugins
+   :uses #{driver
+           plugins
            settings
            sync
            util}

--- a/src/metabase/sample_data/impl.clj
+++ b/src/metabase/sample_data/impl.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
+   [metabase.driver.util :as driver.u]
    [metabase.plugins.core :as plugins]
    [metabase.sync.core :as sync]
    [metabase.util.files :as u.files]
@@ -117,6 +118,23 @@
     :h2     "PUBLIC"
     :sqlite nil))
 
+(defn- settings-sans-unsupported-features
+  "The database's settings with feature-gated toggles the new `engine` can't support turned off, or nil when
+  nothing needs to change. Leaving one enabled would make the Database model's before-update reject the
+  engine change (e.g. `:database-enable-actions` when migrating to SQLite, which doesn't support actions)."
+  [engine database]
+  (let [disabled (into {}
+                       (keep (fn [[setting feature]]
+                               (when (and (get-in database [:settings setting])
+                                          (not (driver.u/supports? engine feature database)))
+                                 [setting false])))
+                       {:database-enable-actions       :actions
+                        :database-enable-table-editing :actions/data-editing})]
+    (when (seq disabled)
+      (log/warnf "Disabling %s on the sample database: not supported by engine %s"
+                 (str/join ", " (map name (keys disabled))) engine)
+      (merge (:settings database) disabled))))
+
 (defn- migrate-sample-database-engine-in-place!
   "The only app-db differences between the H2 and
   SQLite sample databases are the Database record's engine/details and the tables' schema (H2 = \"PUBLIC\",
@@ -126,9 +144,12 @@
   remapping, deletion, or re-seeding."
   [engine old-sample-db]
   (log/infof "Migrating sample database engine from %s to %s in place" (:engine old-sample-db) engine)
-  (let [details (try-to-extract-sample-database! engine)]
+  (let [details  (try-to-extract-sample-database! engine)
+        settings (settings-sans-unsupported-features engine old-sample-db)]
     (t2/with-transaction [_conn]
-      (t2/update! :model/Database (:id old-sample-db) {:engine engine, :details details})
+      (t2/update! :model/Database (:id old-sample-db)
+                  (cond-> {:engine engine, :details details}
+                    settings (assoc :settings settings)))
       (t2/update! :model/Table :db_id (:id old-sample-db) {:schema (table-schema-for-engine engine)}))
     (sync/sync-database! (t2/select-one :model/Database :id (:id old-sample-db)))))
 

--- a/test/metabase/sample_data/impl_test.clj
+++ b/test/metabase/sample_data/impl_test.clj
@@ -126,6 +126,24 @@
               (is (= :completed (:status result)))
               (is (pos? (count (mt/rows result)))))))))))
 
+(deftest migrate-sample-database-engine-in-place-disables-actions-test
+  (testing "Migrating the sample DB to an engine that doesn't support actions disables the actions settings
+           instead of failing the update (GHY-4133: actions enabled on the H2 sample DB blocked the v62->v63
+           upgrade because SQLite doesn't support actions)."
+    (mt/with-model-cleanup [:model/Database]
+      (let [h2-db (t2/insert-returning-instance! :model/Database
+                                                 {:name "Sample Database" :engine :h2 :is_sample true
+                                                  :settings {:database-enable-actions       true
+                                                             :database-enable-table-editing true}
+                                                  :details (#'sample-data/try-to-extract-sample-database! :h2)})]
+        (#'sample-data/migrate-sample-database-engine-in-place! :sqlite (t2/select-one :model/Database :id (:id h2-db)))
+        (let [db (t2/select-one :model/Database :id (:id h2-db))]
+          (testing "the migration succeeds"
+            (is (= :sqlite (:engine db))))
+          (testing "the unsupported feature settings are disabled"
+            (is (false? (get-in db [:settings :database-enable-actions])))
+            (is (false? (get-in db [:settings :database-enable-table-editing])))))))))
+
 (def ^:private extracted-db-path-regex #".*plugins/sample-database\.sqlite$")
 
 (deftest extract-sample-database-test


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/77818

### Description

In v63, on startup the instance will modify the existing H2 sample DB to have the SQLite driver instead. In the `before-update` hook on the database record, we validate that the database driver supports all the features that are toggled on for the database. SQLite does not support actions (and some other features), so if an H2 sample DB with actions toggled on is migrated, the database update will fail because the database settings still have actions toggled on.

Now, when the sample DB is updated to SQLite, the update will also modify the toggled settings to disable any settings that are not supported on the target driver.