### PR TITLE
GDGT-2810: Enable sorting in all Monitor views

### DIFF
--- a/e2e/test/scenarios/monitor/tools/tools.cy.spec.ts
+++ b/e2e/test/scenarios/monitor/tools/tools.cy.spec.ts
@@ -724,7 +724,7 @@ describe("scenarios > monitor > tools > task runs pagination", () => {
   }) {
     const offset = page * limit;
 
-    cy.intercept("GET", `/api/task/runs?limit=${limit}&offset=${offset}`, {
+    cy.intercept("GET", `/api/task/runs?limit=${limit}&offset=${offset}*`, {
       status: 200,
       body: {
         data: stubRunsPageRows(page),

--- a/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
@@ -132,14 +132,12 @@ describe("scenarios > admin > permissions > application", () => {
         cy.log("Monitor tools smoke test");
         cy.location("pathname").should("contain", "/monitor/tasks");
         cy.findByRole("heading", {
-          name: "Troubleshooting logs",
+          name: "Background tasks",
         });
 
         cy.findByTestId("monitor-nav").findByText("Erroring questions").click();
         cy.location("pathname").should("eq", "/monitor/errors");
-        cy.findByTestId("monitor-main").findByText(
-          "Questions that errored when last run",
-        );
+        cy.findByTestId("monitor-main").findByText("Erroring questions");
       });
     });
 

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationsPage/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationsPage/utils.ts
@@ -1,7 +1,8 @@
 import {
-  type QueryParam,
   type UrlStateConfig,
-  getFirstParamValue,
+  parsePage,
+  parseSortColumn,
+  parseSortDirection,
 } from "metabase/common/hooks/use-url-state";
 import type { SortDirection } from "metabase-types/api";
 
@@ -31,8 +32,15 @@ export type UrlState = FilterUrlState & PageUrlState;
 const pageUrlStateConfig: UrlStateConfig<PageUrlState> = {
   parse: (query) => ({
     page: parsePage(query.page),
-    sort_column: parseSortColumn(query.sort_column),
-    sort_direction: parseSortDirection(query.sort_direction),
+    sort_column: parseSortColumn(
+      query.sort_column,
+      CONVERSATION_SORT_COLUMNS,
+      DEFAULT_SORT_COLUMN,
+    ),
+    sort_direction: parseSortDirection(
+      query.sort_direction,
+      DEFAULT_SORT_DIRECTION,
+    ),
   }),
   serialize: ({ page, sort_column, sort_direction }) => ({
     page: page === 0 ? undefined : String(page),
@@ -46,23 +54,3 @@ export const urlStateConfig: UrlStateConfig<UrlState> = mergeUrlStateConfig(
   filterUrlStateConfig,
   pageUrlStateConfig,
 );
-
-function parsePage(param: QueryParam): number {
-  const value = getFirstParamValue(param);
-  const parsed = parseInt(value || "0", 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
-}
-
-function parseSortColumn(param: QueryParam): ConversationSortColumn {
-  const value = getFirstParamValue(param);
-  return value && isSortColumn(value) ? value : DEFAULT_SORT_COLUMN;
-}
-
-function isSortColumn(value: string): value is ConversationSortColumn {
-  return CONVERSATION_SORT_COLUMNS.some((col) => col === value);
-}
-
-function parseSortDirection(param: QueryParam): SortDirection {
-  const value = getFirstParamValue(param);
-  return value === "asc" ? "asc" : DEFAULT_SORT_DIRECTION;
-}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErroringQuestionsTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErroringQuestionsTable.tsx
@@ -163,9 +163,7 @@ function getColumns(): TreeTableColumnDef<ErroringCard>[] {
       enableSorting: true,
       sortDescFirst: false,
       accessorFn: (card) => card.card_name,
-      cell: ({ row }) => (
-        <Ellipsified fw="bold">{row.original.card_name}</Ellipsified>
-      ),
+      cell: ({ row }) => <Ellipsified>{row.original.card_name}</Ellipsified>,
     },
     {
       id: "error_substr",

--- a/frontend/src/metabase-types/api/task.ts
+++ b/frontend/src/metabase-types/api/task.ts
@@ -2,7 +2,7 @@ import type { Log } from "metabase-types/api/util";
 
 import type { DatabaseId } from "./database";
 import type { PaginationRequest, PaginationResponse } from "./pagination";
-import type { SortingOptions } from "./sorting";
+import type { SortDirection, SortingOptions } from "./sorting";
 
 // "unknown" status is only expected for historical tasks (before Task['status'] was introduced)
 export type TaskStatus = "success" | "started" | "failed" | "unknown";
@@ -126,8 +126,9 @@ export type ListTaskRunsRequest = {
   "entity-id"?: number;
   status?: TaskRunStatus;
   "started-at"?: TaskRunStartedAtParam;
-} & PaginationRequest &
-  Partial<SortingOptions<ListTaskRunsSortColumn>>;
+  "sort-column"?: ListTaskRunsSortColumn;
+  "sort-direction"?: SortDirection;
+} & PaginationRequest;
 
 export type ListTaskRunsResponse = {
   data: TaskRun[];

--- a/frontend/src/metabase-types/api/task.ts
+++ b/frontend/src/metabase-types/api/task.ts
@@ -20,7 +20,14 @@ export interface Task {
   run_id: number | null;
 }
 
-export type ListTasksSortColumn = "started_at" | "ended_at" | "duration";
+export type ListTasksSortColumn =
+  | "started_at"
+  | "ended_at"
+  | "duration"
+  | "task"
+  | "status"
+  | "db_name"
+  | "db_engine";
 
 export type ListTasksRequest = {
   status?: TaskStatus;
@@ -105,13 +112,22 @@ export type TaskRunStartedAtParam =
   | TaskRunDateFilterOption
   | `${TaskRunDateFilterOption}~`;
 
+export type ListTaskRunsSortColumn =
+  | "started_at"
+  | "ended_at"
+  | "run_type"
+  | "status"
+  | "entity_name"
+  | "task_count";
+
 export type ListTaskRunsRequest = {
   "run-type"?: TaskRunType;
   "entity-type"?: TaskRunEntityType;
   "entity-id"?: number;
   status?: TaskRunStatus;
   "started-at"?: TaskRunStartedAtParam;
-} & PaginationRequest;
+} & PaginationRequest &
+  Partial<SortingOptions<ListTaskRunsSortColumn>>;
 
 export type ListTaskRunsResponse = {
   data: TaskRun[];

--- a/frontend/src/metabase/common/hooks/index.ts
+++ b/frontend/src/metabase/common/hooks/index.ts
@@ -9,6 +9,7 @@ export * from "./use-locale";
 export * from "./use-notification-channels";
 export * from "./use-set-collection-preview";
 export * from "./use-setting";
+export * from "./use-sorting-state-change";
 export * from "./use-temp-storage";
 export * from "./use-temporary-state";
 export * from "./use-toast";

--- a/frontend/src/metabase/common/hooks/use-sorting-state-change.ts
+++ b/frontend/src/metabase/common/hooks/use-sorting-state-change.ts
@@ -1,0 +1,51 @@
+import type { SortingState, Updater } from "@tanstack/react-table";
+import { useCallback, useMemo } from "react";
+
+import {
+  getNextOptionalSorting,
+  getSortingState,
+  toSorting,
+  toSortingOptions,
+} from "metabase/utils/sorting";
+import type { SortingOptions } from "metabase-types/api";
+
+type UseSortingStateChangeProps<TColumn extends string> = {
+  sortingOptions: SortingOptions<TColumn>;
+  columns: readonly TColumn[];
+  defaultSorting: SortingOptions<TColumn>;
+  onSortingOptionsChange: (sortingOptions: SortingOptions<TColumn>) => void;
+};
+
+/**
+ * Bridges TanStack Table sorting state and API-style `SortingOptions` for
+ * manually-sorted tables: converts the current options to a `SortingState`
+ * and turns TanStack sorting updates back into `SortingOptions`, falling back
+ * to `defaultSorting` when TanStack cycles to the unsorted state.
+ */
+export function useSortingStateChange<TColumn extends string>({
+  sortingOptions,
+  columns,
+  defaultSorting,
+  onSortingOptionsChange,
+}: UseSortingStateChangeProps<TColumn>) {
+  const sortingState = useMemo(
+    () => getSortingState(toSorting(sortingOptions)),
+    [sortingOptions],
+  );
+
+  const onSortingChange = useCallback(
+    (updater: Updater<SortingState>) => {
+      const newSortingState =
+        typeof updater === "function" ? updater(sortingState) : updater;
+      onSortingOptionsChange(
+        toSortingOptions(
+          getNextOptionalSorting(newSortingState, columns) ??
+            toSorting(defaultSorting),
+        ),
+      );
+    },
+    [sortingState, columns, defaultSorting, onSortingOptionsChange],
+  );
+
+  return { sortingState, onSortingChange };
+}

--- a/frontend/src/metabase/common/hooks/use-sorting-state-change.ts
+++ b/frontend/src/metabase/common/hooks/use-sorting-state-change.ts
@@ -17,10 +17,9 @@ type UseSortingStateChangeProps<TColumn extends string> = {
 };
 
 /**
- * Bridges TanStack Table sorting state and API-style `SortingOptions` for
- * manually-sorted tables: converts the current options to a `SortingState`
- * and turns TanStack sorting updates back into `SortingOptions`, falling back
- * to `defaultSorting` when TanStack cycles to the unsorted state.
+ * Adapter between TanStack Table sorting state and API's `SortingOptions` for
+ * manually-sorted tables.
+ * Falls back to `defaultSorting` when TanStack cycles to the unsorted state.
  */
 export function useSortingStateChange<TColumn extends string>({
   sortingOptions,
@@ -37,12 +36,12 @@ export function useSortingStateChange<TColumn extends string>({
     (updater: Updater<SortingState>) => {
       const newSortingState =
         typeof updater === "function" ? updater(sortingState) : updater;
-      onSortingOptionsChange(
-        toSortingOptions(
-          getNextOptionalSorting(newSortingState, columns) ??
-            toSorting(defaultSorting),
-        ),
-      );
+
+      const nextOptionalSorting =
+        getNextOptionalSorting(newSortingState, columns) ??
+        toSorting(defaultSorting);
+
+      onSortingOptionsChange(toSortingOptions(nextOptionalSorting));
     },
     [sortingState, columns, defaultSorting, onSortingOptionsChange],
   );

--- a/frontend/src/metabase/common/hooks/use-url-state/utils.ts
+++ b/frontend/src/metabase/common/hooks/use-url-state/utils.ts
@@ -1,3 +1,6 @@
+import { isSortColumn } from "metabase/utils/sorting";
+import type { SortDirection } from "metabase-types/api";
+
 import type { QueryParam } from "./types";
 
 export function getFirstParamValue(param: QueryParam) {
@@ -10,3 +13,26 @@ export const getAllParamValues = (param: QueryParam): string[] => {
   }
   return typeof param === "string" ? [param] : [];
 };
+
+export function parsePage(param: QueryParam): number {
+  const value = getFirstParamValue(param);
+  const parsed = parseInt(value || "0", 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+export function parseSortColumn<TColumn extends string>(
+  param: QueryParam,
+  columns: readonly TColumn[],
+  defaultColumn: TColumn,
+): TColumn {
+  const value = getFirstParamValue(param);
+  return value && isSortColumn(value, columns) ? value : defaultColumn;
+}
+
+export function parseSortDirection(
+  param: QueryParam,
+  defaultDirection: SortDirection,
+): SortDirection {
+  const value = getFirstParamValue(param);
+  return value === "asc" || value === "desc" ? value : defaultDirection;
+}

--- a/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobsTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobsTable.tsx
@@ -82,9 +82,7 @@ function getColumns(): TreeTableColumnDef<JobRow>[] {
       enableSorting: true,
       sortDescFirst: false,
       accessorFn: (job) => job.key,
-      cell: ({ row }) => (
-        <Ellipsified fw="bold">{row.original.key}</Ellipsified>
-      ),
+      cell: ({ row }) => <Ellipsified>{row.original.key}</Ellipsified>,
     },
     {
       id: "class",

--- a/frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
+++ b/frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
@@ -156,9 +156,7 @@ function getColumns(
       enableSorting: true,
       sortDescFirst: false,
       accessorFn: (job) => job.card_name,
-      cell: ({ row }) => (
-        <Ellipsified fw="bold">{row.original.card_name}</Ellipsified>
-      ),
+      cell: ({ row }) => <Ellipsified>{row.original.card_name}</Ellipsified>,
     },
     {
       id: "collection",

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
@@ -485,31 +485,20 @@ describe("TaskListPage", () => {
     await waitFor(() => {
       expect(fetchMock.callHistory.calls("path:/api/task")).toHaveLength(1);
     });
-
-    expect(
-      fetchMock.callHistory.calls("path:/api/task").map((call) => call.url),
-    ).toEqual([
+    expect(getLastTaskCallUrl()).toEqual(
       "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=desc",
-    ]);
+    );
     const startedAtHeader = await screen.findByRole("columnheader", {
       name: /Started at/,
     });
-
-    expect(startedAtHeader).toBeInTheDocument();
-    expect(
-      screen.getByRole("columnheader", { name: /Ended at/ }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("columnheader", { name: /Duration/ }),
-    ).toBeInTheDocument();
     expect(startedAtHeader).toHaveAttribute("aria-sort", "descending");
     expect(
       within(startedAtHeader).getByRole("img", { name: "chevrondown icon" }),
     ).toBeInTheDocument();
     expect(history?.getCurrentLocation().search).toEqual("");
 
+    // clicking the active sorted column toggles its direction
     await userEvent.click(startedAtHeader);
-
     await waitFor(() => {
       expect(
         screen.getByRole("columnheader", { name: /Started at/ }),
@@ -520,96 +509,13 @@ describe("TaskListPage", () => {
         screen.getByRole("columnheader", { name: /Started at/ }),
       ).getByRole("img", { name: "chevronup icon" }),
     ).toBeInTheDocument();
-    expect(
-      fetchMock.callHistory.calls("path:/api/task").map((call) => call.url),
-    ).toEqual([
-      "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=desc",
+    expect(getLastTaskCallUrl()).toEqual(
       "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=asc",
-    ]);
+    );
     act(() => {
       jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
     });
     expect(history?.getCurrentLocation().search).toEqual("?sort_direction=asc");
-
-    await userEvent.click(
-      screen.getByRole("columnheader", { name: /Ended at/ }),
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole("columnheader", { name: /Ended at/ }),
-      ).toHaveAttribute("aria-sort", "ascending");
-    });
-    expect(
-      within(screen.getByRole("columnheader", { name: /Ended at/ })).getByRole(
-        "img",
-        { name: "chevronup icon" },
-      ),
-    ).toBeInTheDocument();
-    expect(
-      fetchMock.callHistory.calls("path:/api/task").map((call) => call.url),
-    ).toEqual([
-      "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=desc",
-      "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=asc",
-      "http://localhost/api/task?limit=50&offset=0&sort_column=ended_at&sort_direction=asc",
-    ]);
-    act(() => {
-      jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
-    });
-    expect(history?.getCurrentLocation().search).toEqual(
-      "?sort_column=ended_at&sort_direction=asc",
-    );
-
-    await userEvent.click(
-      screen.getByRole("columnheader", { name: /Duration/ }),
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole("columnheader", { name: /Duration/ }),
-      ).toHaveAttribute("aria-sort", "ascending");
-    });
-    expect(
-      within(screen.getByRole("columnheader", { name: /Duration/ })).getByRole(
-        "img",
-        { name: "chevronup icon" },
-      ),
-    ).toBeInTheDocument();
-    expect(
-      fetchMock.callHistory.calls("path:/api/task").map((call) => call.url),
-    ).toEqual([
-      "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=desc",
-      "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=asc",
-      "http://localhost/api/task?limit=50&offset=0&sort_column=ended_at&sort_direction=asc",
-      "http://localhost/api/task?limit=50&offset=0&sort_column=duration&sort_direction=asc",
-    ]);
-    act(() => {
-      jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
-    });
-    expect(history?.getCurrentLocation().search).toEqual(
-      "?sort_column=duration&sort_direction=asc",
-    );
-  });
-
-  it("should toggle sort direction when clicking the active sorted column", async () => {
-    const { history } = setup({
-      tasksResponse: createMockTasksResponse({ data: [createMockTask()] }),
-    });
-
-    const startedAtHeader = await screen.findByRole("columnheader", {
-      name: /Started at/,
-    });
-    expect(startedAtHeader).toHaveAttribute("aria-sort", "descending");
-
-    await userEvent.click(startedAtHeader);
-    await waitFor(() => {
-      expect(
-        screen.getByRole("columnheader", { name: /Started at/ }),
-      ).toHaveAttribute("aria-sort", "ascending");
-    });
-    expect(getLastTaskCallUrl()).toEqual(
-      "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=asc",
-    );
 
     await userEvent.click(
       screen.getByRole("columnheader", { name: /Started at/ }),
@@ -619,11 +525,6 @@ describe("TaskListPage", () => {
         screen.getByRole("columnheader", { name: /Started at/ }),
       ).toHaveAttribute("aria-sort", "descending");
     });
-    expect(
-      within(
-        screen.getByRole("columnheader", { name: /Started at/ }),
-      ).getByRole("img", { name: "chevrondown icon" }),
-    ).toBeInTheDocument();
     expect(getLastTaskCallUrl()).toEqual(
       "http://localhost/api/task?limit=50&offset=0&sort_column=started_at&sort_direction=desc",
     );
@@ -631,6 +532,41 @@ describe("TaskListPage", () => {
       jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
     });
     expect(history?.getCurrentLocation().search).toEqual("");
+
+    // every sortable column drives the request and URL state
+    const cases: { header: RegExp; column: string }[] = [
+      { header: /Ended at/, column: "ended_at" },
+      { header: /Duration/, column: "duration" },
+      { header: /Task/, column: "task" },
+      { header: /DB Name/, column: "db_name" },
+      { header: /DB Engine/, column: "db_engine" },
+      { header: /Status/, column: "status" },
+    ];
+
+    for (const { header, column } of cases) {
+      await userEvent.click(screen.getByRole("columnheader", { name: header }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("columnheader", { name: header }),
+        ).toHaveAttribute("aria-sort", "ascending");
+      });
+      expect(
+        within(screen.getByRole("columnheader", { name: header })).getByRole(
+          "img",
+          { name: "chevronup icon" },
+        ),
+      ).toBeInTheDocument();
+      expect(getLastTaskCallUrl()).toEqual(
+        `http://localhost/api/task?limit=50&offset=0&sort_column=${column}&sort_direction=asc`,
+      );
+      act(() => {
+        jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
+      });
+      expect(history?.getCurrentLocation().search).toEqual(
+        `?sort_column=${column}&sort_direction=asc`,
+      );
+    }
   });
 
   it("should navigate to task details when a row is clicked", async () => {

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
@@ -497,7 +497,6 @@ describe("TaskListPage", () => {
     ).toBeInTheDocument();
     expect(history?.getCurrentLocation().search).toEqual("");
 
-    // clicking the active sorted column toggles its direction
     await userEvent.click(startedAtHeader);
     await waitFor(() => {
       expect(

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TasksTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TasksTable.tsx
@@ -147,7 +147,7 @@ function getColumns(
       enableSorting: true,
       sortDescFirst: false,
       accessorFn: (task) => task.task,
-      cell: ({ row }) => <Text fw="bold">{row.original.task}</Text>,
+      cell: ({ row }) => <Text>{row.original.task}</Text>,
     },
     {
       id: "db_name",

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TasksTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TasksTable.tsx
@@ -1,9 +1,10 @@
-import type { Row, SortingState, Updater } from "@tanstack/react-table";
+import type { Row } from "@tanstack/react-table";
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
 import { DateTime } from "metabase/common/components/DateTime";
+import { useSortingStateChange } from "metabase/common/hooks";
 import { TaskStatusBadge } from "metabase/monitor/tools/components/TaskStatusBadge";
 import { useDispatch } from "metabase/redux";
 import { push } from "metabase/router";
@@ -19,11 +20,6 @@ import {
 } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
-import {
-  type Sorting,
-  getNextOptionalSorting,
-  getSortingState,
-} from "metabase/utils/sorting";
 import type {
   Database,
   ListTasksSortColumn,
@@ -34,22 +30,6 @@ import type {
 import { DEFAULT_SORTING, TASK_SORT_COLUMNS } from "./utils";
 
 const COLUMN_WIDTHS = [0.25, 0.15, 0.12, 0.16, 0.16, 0.1, 0.06];
-
-const toSorting = ({
-  sort_column,
-  sort_direction,
-}: SortingOptions<ListTasksSortColumn>): Sorting<ListTasksSortColumn> => ({
-  column: sort_column,
-  direction: sort_direction,
-});
-
-const toSortingOptions = ({
-  column,
-  direction,
-}: Sorting<ListTasksSortColumn>): SortingOptions<ListTasksSortColumn> => ({
-  sort_column: column,
-  sort_direction: direction,
-});
 
 interface Props {
   databases: Database[];
@@ -76,30 +56,18 @@ export const TasksTable = ({
   );
 
   const columns = useMemo(() => getColumns(databaseByID), [databaseByID]);
-  const sortingState = useMemo(
-    () => getSortingState(toSorting(sortingOptions)),
-    [sortingOptions],
-  );
+  const { sortingState, onSortingChange } = useSortingStateChange({
+    sortingOptions,
+    columns: TASK_SORT_COLUMNS,
+    defaultSorting: DEFAULT_SORTING,
+    onSortingOptionsChange,
+  });
 
   const handleRowActivate = useCallback(
     (row: Row<Task>) => {
       dispatch(push(Urls.monitorTaskDetails(row.original.id)));
     },
     [dispatch],
-  );
-
-  const handleSortingChange = useCallback(
-    (updater: Updater<SortingState>) => {
-      const newSortingState =
-        typeof updater === "function" ? updater(sortingState) : updater;
-      onSortingOptionsChange(
-        toSortingOptions(
-          getNextOptionalSorting(newSortingState, TASK_SORT_COLUMNS) ??
-            toSorting(DEFAULT_SORTING),
-        ),
-      );
-    },
-    [sortingState, onSortingOptionsChange],
   );
 
   const treeTableInstance = useTreeTableInstance<Task>({
@@ -109,7 +77,7 @@ export const TasksTable = ({
     manualSorting: true,
     getNodeId: (task) => String(task.id),
     onRowActivate: handleRowActivate,
-    onSortingChange: handleSortingChange,
+    onSortingChange,
   });
 
   return (

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TasksTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TasksTable.tsx
@@ -144,7 +144,8 @@ function getColumns(
       width: "auto",
       minWidth: 200,
       maxAutoWidth: 230,
-      enableSorting: false,
+      enableSorting: true,
+      sortDescFirst: false,
       accessorFn: (task) => task.task,
       cell: ({ row }) => <Text fw="bold">{row.original.task}</Text>,
     },
@@ -154,7 +155,8 @@ function getColumns(
       width: "auto",
       minWidth: 120,
       maxAutoWidth: 240,
-      enableSorting: false,
+      enableSorting: true,
+      sortDescFirst: false,
       accessorFn: (task) =>
         task.db_id !== null ? (databaseByID[task.db_id]?.name ?? "") : "",
       cell: ({ row }) => {
@@ -172,7 +174,8 @@ function getColumns(
       width: "auto",
       minWidth: 120,
       maxAutoWidth: 240,
-      enableSorting: false,
+      enableSorting: true,
+      sortDescFirst: false,
       accessorFn: (task) =>
         task.db_id !== null ? (databaseByID[task.db_id]?.engine ?? "") : "",
       cell: ({ row }) => {
@@ -246,7 +249,8 @@ function getColumns(
       header: t`Status`,
       width: "auto",
       minWidth: 100,
-      enableSorting: false,
+      enableSorting: true,
+      sortDescFirst: false,
       accessorFn: (task) => task.status,
       cell: ({ row }) => <TaskStatusBadge task={row.original} />,
     },

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/utils.ts
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/utils.ts
@@ -2,8 +2,10 @@ import {
   type QueryParam,
   type UrlStateConfig,
   getFirstParamValue,
+  parsePage,
+  parseSortColumn,
+  parseSortDirection,
 } from "metabase/common/hooks/use-url-state";
-import { isSortColumn } from "metabase/utils/sorting";
 import type {
   ListTasksSortColumn,
   SortDirection,
@@ -40,8 +42,15 @@ type UrlState = {
 export const urlStateConfig: UrlStateConfig<UrlState> = {
   parse: (query) => ({
     page: parsePage(query.page),
-    sort_column: parseSortColumn(query.sort_column),
-    sort_direction: parseSortDirection(query.sort_direction),
+    sort_column: parseSortColumn(
+      query.sort_column,
+      TASK_SORT_COLUMNS,
+      DEFAULT_SORT_COLUMN,
+    ),
+    sort_direction: parseSortDirection(
+      query.sort_direction,
+      DEFAULT_SORT_DIRECTION,
+    ),
     status: parseStatus(query.status),
     task: parseTask(query.task),
   }),
@@ -54,24 +63,6 @@ export const urlStateConfig: UrlStateConfig<UrlState> = {
     task: task === null ? undefined : task,
   }),
 };
-
-function parsePage(param: QueryParam): UrlState["page"] {
-  const value = getFirstParamValue(param);
-  const parsed = parseInt(value || "0", 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
-}
-
-function parseSortColumn(param: QueryParam): UrlState["sort_column"] {
-  const value = getFirstParamValue(param);
-  return value && isSortColumn(value, TASK_SORT_COLUMNS)
-    ? value
-    : DEFAULT_SORT_COLUMN;
-}
-
-function parseSortDirection(param: QueryParam): UrlState["sort_direction"] {
-  const value = getFirstParamValue(param);
-  return value === "asc" ? "asc" : DEFAULT_SORT_DIRECTION;
-}
 
 function parseStatus(param: QueryParam): UrlState["status"] {
   const value = getFirstParamValue(param);

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/utils.ts
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/utils.ts
@@ -15,6 +15,10 @@ export const TASK_SORT_COLUMNS = [
   "started_at",
   "ended_at",
   "duration",
+  "task",
+  "status",
+  "db_name",
+  "db_engine",
 ] satisfies readonly ListTasksSortColumn[];
 
 const DEFAULT_SORT_COLUMN: ListTasksSortColumn = "started_at";

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.tsx
@@ -23,6 +23,8 @@ const TaskRunsPageBase = ({ location }: WithRouterProps) => {
   const [
     {
       page,
+      sort_column,
+      sort_direction,
       "run-type": runType,
       "entity-type": entityType,
       "entity-id": entityId,
@@ -32,6 +34,7 @@ const TaskRunsPageBase = ({ location }: WithRouterProps) => {
     },
     { patchUrlState },
   ] = useUrlState(location, urlStateConfig);
+  const sortingOptions = { sort_column, sort_direction };
 
   const {
     data: taskRunsData,
@@ -42,6 +45,8 @@ const TaskRunsPageBase = ({ location }: WithRouterProps) => {
     {
       limit: PAGE_SIZE,
       offset: page * PAGE_SIZE,
+      sort_column,
+      sort_direction,
       "run-type": runType ?? undefined,
       "entity-type": entityType ?? undefined,
       "entity-id": entityId ?? undefined,
@@ -115,7 +120,14 @@ const TaskRunsPageBase = ({ location }: WithRouterProps) => {
           <DelayedLoadingAndErrorWrapper loading={isLoading} error={error} />
         </Center>
       ) : (
-        <TaskRunsTable taskRuns={taskRuns} isLoading={isLoading} />
+        <TaskRunsTable
+          taskRuns={taskRuns}
+          isLoading={isLoading}
+          sortingOptions={sortingOptions}
+          onSortingOptionsChange={(sortingOptions) =>
+            patchUrlState({ ...sortingOptions, page: 0 })
+          }
+        />
       )}
 
       {!isLoading && error === undefined && (

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.tsx
@@ -45,8 +45,8 @@ const TaskRunsPageBase = ({ location }: WithRouterProps) => {
     {
       limit: PAGE_SIZE,
       offset: page * PAGE_SIZE,
-      sort_column,
-      sort_direction,
+      "sort-column": sort_column,
+      "sort-direction": sort_direction,
       "run-type": runType ?? undefined,
       "entity-type": entityType ?? undefined,
       "entity-id": entityId ?? undefined,

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.unit.spec.tsx
@@ -3,6 +3,7 @@ import fetchMock from "fetch-mock";
 
 import { setupTaskRunsEndpoints } from "__support__/server-mocks";
 import {
+  act,
   mockGetBoundingClientRect,
   renderWithProviders,
   screen,
@@ -10,6 +11,7 @@ import {
   waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
+import { URL_UPDATE_DEBOUNCE_DELAY } from "metabase/common/hooks/use-url-state";
 import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { ListTaskRunsResponse } from "metabase-types/api";
@@ -133,6 +135,172 @@ describe("TaskRunsPage", () => {
     expect(history?.getCurrentLocation().pathname).toBe(
       Urls.monitorTaskRunDetails(55),
     );
+  });
+
+  describe("sorting", () => {
+    beforeEach(() => {
+      jest.useFakeTimers({ advanceTimers: true });
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("requests the default sorting", async () => {
+      setup();
+
+      await waitFor(() => {
+        expect(fetchMock.callHistory.calls("path:/api/task/runs")).toHaveLength(
+          1,
+        );
+      });
+
+      const params = getLastRunsParams();
+      expect(params.get("sort_column")).toBe("started_at");
+      expect(params.get("sort_direction")).toBe("desc");
+    });
+
+    it("accepts sorting query params", async () => {
+      setup({
+        initialRoute: `${PATHNAME}?sort_column=task_count&sort_direction=asc`,
+      });
+
+      await waitFor(() => {
+        expect(fetchMock.callHistory.calls("path:/api/task/runs")).toHaveLength(
+          1,
+        );
+      });
+
+      const params = getLastRunsParams();
+      expect(params.get("sort_column")).toBe("task_count");
+      expect(params.get("sort_direction")).toBe("asc");
+    });
+
+    it("sorts by each sortable column", async () => {
+      const { history } = setup({
+        taskRunsResponse: createMockTaskRunsResponse({
+          data: [createMockTaskRun()],
+        }),
+      });
+
+      await waitFor(() => {
+        expect(fetchMock.callHistory.calls("path:/api/task/runs")).toHaveLength(
+          1,
+        );
+      });
+
+      const cases: { header: RegExp; column: string }[] = [
+        { header: /Run Type/, column: "run_type" },
+        { header: /Entity/, column: "entity_name" },
+        { header: /Ended at/, column: "ended_at" },
+        { header: /Status/, column: "status" },
+        { header: /Task Count/, column: "task_count" },
+      ];
+
+      for (const { header, column } of cases) {
+        const columnHeader = screen.getByRole("columnheader", { name: header });
+        await userEvent.click(columnHeader);
+
+        await waitFor(() => {
+          expect(
+            screen.getByRole("columnheader", { name: header }),
+          ).toHaveAttribute("aria-sort", "ascending");
+        });
+        const params = getLastRunsParams();
+        expect(params.get("sort_column")).toBe(column);
+        expect(params.get("sort_direction")).toBe("asc");
+        act(() => {
+          jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
+        });
+        expect(history?.getCurrentLocation().search).toEqual(
+          `?sort_column=${column}&sort_direction=asc`,
+        );
+      }
+    });
+
+    it("toggles sort direction when clicking the active sorted column", async () => {
+      const { history } = setup({
+        taskRunsResponse: createMockTaskRunsResponse({
+          data: [createMockTaskRun()],
+        }),
+      });
+
+      const startedAtHeader = await screen.findByRole("columnheader", {
+        name: /Started at/,
+      });
+      expect(startedAtHeader).toHaveAttribute("aria-sort", "descending");
+
+      await userEvent.click(startedAtHeader);
+      await waitFor(() => {
+        expect(
+          screen.getByRole("columnheader", { name: /Started at/ }),
+        ).toHaveAttribute("aria-sort", "ascending");
+      });
+      expect(getLastRunsParams().get("sort_direction")).toBe("asc");
+      act(() => {
+        jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
+      });
+      expect(history?.getCurrentLocation().search).toEqual(
+        "?sort_direction=asc",
+      );
+
+      await userEvent.click(
+        screen.getByRole("columnheader", { name: /Started at/ }),
+      );
+      await waitFor(() => {
+        expect(
+          screen.getByRole("columnheader", { name: /Started at/ }),
+        ).toHaveAttribute("aria-sort", "descending");
+      });
+      expect(getLastRunsParams().get("sort_direction")).toBe("desc");
+      act(() => {
+        jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
+      });
+      expect(history?.getCurrentLocation().search).toEqual("");
+    });
+
+    it("resets pagination on sorting change", async () => {
+      const { history } = setup({
+        taskRunsResponse: createMockTaskRunsResponse({
+          data: [createMockTaskRun()],
+          total: 75,
+          limit: 50,
+          offset: 0,
+        }),
+      });
+
+      await waitFor(() => {
+        expect(fetchMock.callHistory.calls("path:/api/task/runs")).toHaveLength(
+          1,
+        );
+      });
+
+      const nextPage = await screen.findByRole("button", { name: "Next page" });
+      await userEvent.click(nextPage);
+
+      await waitFor(() => {
+        expect(getLastRunsParams().get("offset")).toBe("50");
+      });
+      act(() => {
+        jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
+      });
+      expect(history?.getCurrentLocation().search).toEqual("?page=1");
+
+      await userEvent.click(
+        screen.getByRole("columnheader", { name: /Run Type/ }),
+      );
+
+      await waitFor(() => {
+        expect(getLastRunsParams().get("offset")).toBe("0");
+      });
+      expect(getLastRunsParams().get("sort_column")).toBe("run_type");
+      act(() => {
+        jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
+      });
+      expect(history?.getCurrentLocation().search).toEqual(
+        "?sort_column=run_type&sort_direction=asc",
+      );
+    });
   });
 
   describe("started-at filter with include-today", () => {

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.unit.spec.tsx
@@ -156,8 +156,8 @@ describe("TaskRunsPage", () => {
       });
 
       const params = getLastRunsParams();
-      expect(params.get("sort_column")).toBe("started_at");
-      expect(params.get("sort_direction")).toBe("desc");
+      expect(params.get("sort-column")).toBe("started_at");
+      expect(params.get("sort-direction")).toBe("desc");
     });
 
     it("accepts sorting query params", async () => {
@@ -172,8 +172,8 @@ describe("TaskRunsPage", () => {
       });
 
       const params = getLastRunsParams();
-      expect(params.get("sort_column")).toBe("task_count");
-      expect(params.get("sort_direction")).toBe("asc");
+      expect(params.get("sort-column")).toBe("task_count");
+      expect(params.get("sort-direction")).toBe("asc");
     });
 
     it("sorts by each sortable column", async () => {
@@ -207,8 +207,8 @@ describe("TaskRunsPage", () => {
           ).toHaveAttribute("aria-sort", "ascending");
         });
         const params = getLastRunsParams();
-        expect(params.get("sort_column")).toBe(column);
-        expect(params.get("sort_direction")).toBe("asc");
+        expect(params.get("sort-column")).toBe(column);
+        expect(params.get("sort-direction")).toBe("asc");
         act(() => {
           jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
         });
@@ -236,7 +236,7 @@ describe("TaskRunsPage", () => {
           screen.getByRole("columnheader", { name: /Started at/ }),
         ).toHaveAttribute("aria-sort", "ascending");
       });
-      expect(getLastRunsParams().get("sort_direction")).toBe("asc");
+      expect(getLastRunsParams().get("sort-direction")).toBe("asc");
       act(() => {
         jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
       });
@@ -252,7 +252,7 @@ describe("TaskRunsPage", () => {
           screen.getByRole("columnheader", { name: /Started at/ }),
         ).toHaveAttribute("aria-sort", "descending");
       });
-      expect(getLastRunsParams().get("sort_direction")).toBe("desc");
+      expect(getLastRunsParams().get("sort-direction")).toBe("desc");
       act(() => {
         jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
       });
@@ -293,7 +293,7 @@ describe("TaskRunsPage", () => {
       await waitFor(() => {
         expect(getLastRunsParams().get("offset")).toBe("0");
       });
-      expect(getLastRunsParams().get("sort_column")).toBe("run_type");
+      expect(getLastRunsParams().get("sort-column")).toBe("run_type");
       act(() => {
         jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY);
       });

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsTable.tsx
@@ -1,4 +1,4 @@
-import type { Row } from "@tanstack/react-table";
+import type { Row, SortingState, Updater } from "@tanstack/react-table";
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
@@ -17,22 +17,62 @@ import {
 } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
-import type { TaskRun } from "metabase-types/api";
+import {
+  type Sorting,
+  getNextOptionalSorting,
+  getSortingState,
+} from "metabase/utils/sorting";
+import type {
+  ListTaskRunsSortColumn,
+  SortingOptions,
+  TaskRun,
+} from "metabase-types/api";
 
 import { formatTaskRunType, renderTaskRunCounters } from "../../utils";
 import { TaskRunStatusBadge } from "../TaskRunStatusBadge";
 
+import { DEFAULT_SORTING, TASK_RUN_SORT_COLUMNS } from "./utils";
+
 const COLUMN_WIDTHS = [0.2, 0.2, 0.17, 0.17, 0.13, 0.13];
+
+const toSorting = ({
+  sort_column,
+  sort_direction,
+}: SortingOptions<ListTaskRunsSortColumn>): Sorting<ListTaskRunsSortColumn> => ({
+  column: sort_column,
+  direction: sort_direction,
+});
+
+const toSortingOptions = ({
+  column,
+  direction,
+}: Sorting<ListTaskRunsSortColumn>): SortingOptions<ListTaskRunsSortColumn> => ({
+  sort_column: column,
+  sort_direction: direction,
+});
 
 type TaskRunsTableProps = {
   isLoading: boolean;
+  sortingOptions: SortingOptions<ListTaskRunsSortColumn>;
   taskRuns: TaskRun[];
+  onSortingOptionsChange: (
+    sortingOptions: SortingOptions<ListTaskRunsSortColumn>,
+  ) => void;
 };
 
-export const TaskRunsTable = ({ isLoading, taskRuns }: TaskRunsTableProps) => {
+export const TaskRunsTable = ({
+  isLoading,
+  sortingOptions,
+  taskRuns,
+  onSortingOptionsChange,
+}: TaskRunsTableProps) => {
   const dispatch = useDispatch();
 
   const columns = useMemo(() => getColumns(), []);
+  const sortingState = useMemo(
+    () => getSortingState(toSorting(sortingOptions)),
+    [sortingOptions],
+  );
 
   const handleRowActivate = useCallback(
     (row: Row<TaskRun>) => {
@@ -41,11 +81,28 @@ export const TaskRunsTable = ({ isLoading, taskRuns }: TaskRunsTableProps) => {
     [dispatch],
   );
 
+  const handleSortingChange = useCallback(
+    (updater: Updater<SortingState>) => {
+      const newSortingState =
+        typeof updater === "function" ? updater(sortingState) : updater;
+      onSortingOptionsChange(
+        toSortingOptions(
+          getNextOptionalSorting(newSortingState, TASK_RUN_SORT_COLUMNS) ??
+            toSorting(DEFAULT_SORTING),
+        ),
+      );
+    },
+    [sortingState, onSortingOptionsChange],
+  );
+
   const treeTableInstance = useTreeTableInstance<TaskRun>({
     data: taskRuns,
     columns,
+    sorting: sortingState,
+    manualSorting: true,
     getNodeId: (taskRun) => String(taskRun.id),
     onRowActivate: handleRowActivate,
+    onSortingChange: handleSortingChange,
   });
 
   return (
@@ -84,19 +141,21 @@ function getColumns(): TreeTableColumnDef<TaskRun>[] {
       width: "auto",
       minWidth: 150,
       maxAutoWidth: 240,
-      enableSorting: false,
+      enableSorting: true,
+      sortDescFirst: false,
       accessorFn: (taskRun) => taskRun.run_type,
       cell: ({ row }) => (
         <Text fw="bold">{formatTaskRunType(row.original.run_type)}</Text>
       ),
     },
     {
-      id: "entity",
+      id: "entity_name",
       header: t`Entity`,
       width: "auto",
       minWidth: 150,
       maxAutoWidth: 300,
-      enableSorting: false,
+      enableSorting: true,
+      sortDescFirst: false,
       accessorFn: (taskRun) => taskRun.entity_name ?? "",
       cell: ({ row }) => (
         <Ellipsified style={{ maxWidth: 200 }}>
@@ -109,7 +168,8 @@ function getColumns(): TreeTableColumnDef<TaskRun>[] {
       header: t`Started at`,
       width: "auto",
       minWidth: 150,
-      enableSorting: false,
+      enableSorting: true,
+      sortDescFirst: true,
       accessorFn: (taskRun) => taskRun.started_at,
       cell: ({ row }) => (
         <Ellipsified
@@ -130,7 +190,8 @@ function getColumns(): TreeTableColumnDef<TaskRun>[] {
       header: t`Ended at`,
       width: "auto",
       minWidth: 150,
-      enableSorting: false,
+      enableSorting: true,
+      sortDescFirst: false,
       accessorFn: (taskRun) => taskRun.ended_at,
       cell: ({ row }) =>
         row.original.ended_at ? (
@@ -153,7 +214,8 @@ function getColumns(): TreeTableColumnDef<TaskRun>[] {
       header: t`Status`,
       width: "auto",
       minWidth: 100,
-      enableSorting: false,
+      enableSorting: true,
+      sortDescFirst: false,
       accessorFn: (taskRun) => taskRun.status,
       cell: ({ row }) => <TaskRunStatusBadge taskRun={row.original} />,
     },
@@ -162,7 +224,8 @@ function getColumns(): TreeTableColumnDef<TaskRun>[] {
       header: t`Task Count`,
       width: "auto",
       minWidth: 150,
-      enableSorting: false,
+      enableSorting: true,
+      sortDescFirst: false,
       accessorFn: (taskRun) => taskRun.task_count,
       cell: ({ row }) => renderTaskRunCounters(row.original),
     },

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsTable.tsx
@@ -1,8 +1,9 @@
-import type { Row, SortingState, Updater } from "@tanstack/react-table";
+import type { Row } from "@tanstack/react-table";
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
 import { DateTime } from "metabase/common/components/DateTime";
+import { useSortingStateChange } from "metabase/common/hooks";
 import { useDispatch } from "metabase/redux";
 import { push } from "metabase/router";
 import {
@@ -17,11 +18,6 @@ import {
 } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
-import {
-  type Sorting,
-  getNextOptionalSorting,
-  getSortingState,
-} from "metabase/utils/sorting";
 import type {
   ListTaskRunsSortColumn,
   SortingOptions,
@@ -34,22 +30,6 @@ import { TaskRunStatusBadge } from "../TaskRunStatusBadge";
 import { DEFAULT_SORTING, TASK_RUN_SORT_COLUMNS } from "./utils";
 
 const COLUMN_WIDTHS = [0.2, 0.2, 0.17, 0.17, 0.13, 0.13];
-
-const toSorting = ({
-  sort_column,
-  sort_direction,
-}: SortingOptions<ListTaskRunsSortColumn>): Sorting<ListTaskRunsSortColumn> => ({
-  column: sort_column,
-  direction: sort_direction,
-});
-
-const toSortingOptions = ({
-  column,
-  direction,
-}: Sorting<ListTaskRunsSortColumn>): SortingOptions<ListTaskRunsSortColumn> => ({
-  sort_column: column,
-  sort_direction: direction,
-});
 
 type TaskRunsTableProps = {
   isLoading: boolean;
@@ -69,30 +49,18 @@ export const TaskRunsTable = ({
   const dispatch = useDispatch();
 
   const columns = useMemo(() => getColumns(), []);
-  const sortingState = useMemo(
-    () => getSortingState(toSorting(sortingOptions)),
-    [sortingOptions],
-  );
+  const { sortingState, onSortingChange } = useSortingStateChange({
+    sortingOptions,
+    columns: TASK_RUN_SORT_COLUMNS,
+    defaultSorting: DEFAULT_SORTING,
+    onSortingOptionsChange,
+  });
 
   const handleRowActivate = useCallback(
     (row: Row<TaskRun>) => {
       dispatch(push(Urls.monitorTaskRunDetails(row.original.id)));
     },
     [dispatch],
-  );
-
-  const handleSortingChange = useCallback(
-    (updater: Updater<SortingState>) => {
-      const newSortingState =
-        typeof updater === "function" ? updater(sortingState) : updater;
-      onSortingOptionsChange(
-        toSortingOptions(
-          getNextOptionalSorting(newSortingState, TASK_RUN_SORT_COLUMNS) ??
-            toSorting(DEFAULT_SORTING),
-        ),
-      );
-    },
-    [sortingState, onSortingOptionsChange],
   );
 
   const treeTableInstance = useTreeTableInstance<TaskRun>({
@@ -102,7 +70,7 @@ export const TaskRunsTable = ({
     manualSorting: true,
     getNodeId: (taskRun) => String(taskRun.id),
     onRowActivate: handleRowActivate,
-    onSortingChange: handleSortingChange,
+    onSortingChange,
   });
 
   return (

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsTable.tsx
@@ -145,7 +145,7 @@ function getColumns(): TreeTableColumnDef<TaskRun>[] {
       sortDescFirst: false,
       accessorFn: (taskRun) => taskRun.run_type,
       cell: ({ row }) => (
-        <Text fw="bold">{formatTaskRunType(row.original.run_type)}</Text>
+        <Text>{formatTaskRunType(row.original.run_type)}</Text>
       ),
     },
     {

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/utils.ts
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/utils.ts
@@ -3,7 +3,11 @@ import {
   type UrlStateConfig,
   getFirstParamValue,
 } from "metabase/common/hooks/use-url-state";
+import { isSortColumn } from "metabase/utils/sorting";
 import type {
+  ListTaskRunsSortColumn,
+  SortDirection,
+  SortingOptions,
   TaskRunDateFilterOption,
   TaskRunEntityType,
   TaskRunStatus,
@@ -17,8 +21,27 @@ import {
   guardTaskRunStatus,
 } from "../../utils";
 
+export const TASK_RUN_SORT_COLUMNS = [
+  "started_at",
+  "ended_at",
+  "run_type",
+  "status",
+  "entity_name",
+  "task_count",
+] satisfies readonly ListTaskRunsSortColumn[];
+
+const DEFAULT_SORT_COLUMN: ListTaskRunsSortColumn = "started_at";
+const DEFAULT_SORT_DIRECTION = "desc";
+
+export const DEFAULT_SORTING: SortingOptions<ListTaskRunsSortColumn> = {
+  sort_column: DEFAULT_SORT_COLUMN,
+  sort_direction: DEFAULT_SORT_DIRECTION,
+};
+
 type UrlState = {
   page: number;
+  sort_column: ListTaskRunsSortColumn;
+  sort_direction: SortDirection;
   "run-type": TaskRunType | null;
   "entity-type": TaskRunEntityType | null;
   "entity-id": number | null;
@@ -30,6 +53,8 @@ type UrlState = {
 export const urlStateConfig: UrlStateConfig<UrlState> = {
   parse: (query) => ({
     page: parsePage(query.page),
+    sort_column: parseSortColumn(query.sort_column),
+    sort_direction: parseSortDirection(query.sort_direction),
     "run-type": parseTaskRunRunType(query["run-type"]),
     "entity-type": parseTaskRunEntityType(query["entity-type"]),
     "entity-id": parseTaskRunEntityId(query["entity-id"]),
@@ -39,6 +64,8 @@ export const urlStateConfig: UrlStateConfig<UrlState> = {
   }),
   serialize: ({
     page,
+    sort_column,
+    sort_direction,
     "run-type": runType,
     "entity-type": entityType,
     "entity-id": entityId,
@@ -47,6 +74,9 @@ export const urlStateConfig: UrlStateConfig<UrlState> = {
     "include-today": includeToday,
   }) => ({
     page: page === 0 ? undefined : String(page),
+    sort_column: sort_column === DEFAULT_SORT_COLUMN ? undefined : sort_column,
+    sort_direction:
+      sort_direction === DEFAULT_SORT_DIRECTION ? undefined : sort_direction,
     "run-type": runType === null ? undefined : runType,
     "entity-type": entityType === null ? undefined : entityType,
     "entity-id": entityId === null ? undefined : String(entityId),
@@ -55,6 +85,18 @@ export const urlStateConfig: UrlStateConfig<UrlState> = {
     "include-today": includeToday ? "true" : undefined,
   }),
 };
+
+function parseSortColumn(param: QueryParam): UrlState["sort_column"] {
+  const value = getFirstParamValue(param);
+  return value && isSortColumn(value, TASK_RUN_SORT_COLUMNS)
+    ? value
+    : DEFAULT_SORT_COLUMN;
+}
+
+function parseSortDirection(param: QueryParam): UrlState["sort_direction"] {
+  const value = getFirstParamValue(param);
+  return value === "asc" ? "asc" : DEFAULT_SORT_DIRECTION;
+}
 
 const parsePage = (param: QueryParam): UrlState["page"] => {
   const value = getFirstParamValue(param);

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/utils.ts
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/utils.ts
@@ -2,8 +2,10 @@ import {
   type QueryParam,
   type UrlStateConfig,
   getFirstParamValue,
+  parsePage,
+  parseSortColumn,
+  parseSortDirection,
 } from "metabase/common/hooks/use-url-state";
-import { isSortColumn } from "metabase/utils/sorting";
 import type {
   ListTaskRunsSortColumn,
   SortDirection,
@@ -53,8 +55,15 @@ type UrlState = {
 export const urlStateConfig: UrlStateConfig<UrlState> = {
   parse: (query) => ({
     page: parsePage(query.page),
-    sort_column: parseSortColumn(query.sort_column),
-    sort_direction: parseSortDirection(query.sort_direction),
+    sort_column: parseSortColumn(
+      query.sort_column,
+      TASK_RUN_SORT_COLUMNS,
+      DEFAULT_SORT_COLUMN,
+    ),
+    sort_direction: parseSortDirection(
+      query.sort_direction,
+      DEFAULT_SORT_DIRECTION,
+    ),
     "run-type": parseTaskRunRunType(query["run-type"]),
     "entity-type": parseTaskRunEntityType(query["entity-type"]),
     "entity-id": parseTaskRunEntityId(query["entity-id"]),
@@ -84,24 +93,6 @@ export const urlStateConfig: UrlStateConfig<UrlState> = {
     "started-at": startedAt === null ? undefined : startedAt,
     "include-today": includeToday ? "true" : undefined,
   }),
-};
-
-function parseSortColumn(param: QueryParam): UrlState["sort_column"] {
-  const value = getFirstParamValue(param);
-  return value && isSortColumn(value, TASK_RUN_SORT_COLUMNS)
-    ? value
-    : DEFAULT_SORT_COLUMN;
-}
-
-function parseSortDirection(param: QueryParam): UrlState["sort_direction"] {
-  const value = getFirstParamValue(param);
-  return value === "asc" ? "asc" : DEFAULT_SORT_DIRECTION;
-}
-
-const parsePage = (param: QueryParam): UrlState["page"] => {
-  const value = getFirstParamValue(param);
-  const parsed = parseInt(value || "0", 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
 };
 
 const parseTaskRunRunType = (param: QueryParam): UrlState["run-type"] => {

--- a/frontend/src/metabase/utils/sorting.ts
+++ b/frontend/src/metabase/utils/sorting.ts
@@ -1,11 +1,25 @@
 import type { SortingState } from "@tanstack/react-table";
 
-import type { SortDirection } from "metabase-types/api";
+import type { SortDirection, SortingOptions } from "metabase-types/api";
 
 export type Sorting<TColumn extends string> = {
   column: TColumn;
   direction: SortDirection;
 };
+
+export function toSorting<TColumn extends string>({
+  sort_column,
+  sort_direction,
+}: SortingOptions<TColumn>): Sorting<TColumn> {
+  return { column: sort_column, direction: sort_direction };
+}
+
+export function toSortingOptions<TColumn extends string>({
+  column,
+  direction,
+}: Sorting<TColumn>): SortingOptions<TColumn> {
+  return { sort_column: column, sort_direction: direction };
+}
 
 export function getSortingState<TColumn extends string>(
   sorting: Sorting<TColumn> | undefined,

--- a/src/metabase/task_history/api.clj
+++ b/src/metabase/task_history/api.clj
@@ -192,12 +192,14 @@
 
 (defn- build-run-where-clause
   [{:keys [run-type entity-type entity-id status started-at]}]
+  ;; columns are qualified because the entity_name/task_count sorts add joins whose tables may share column names
+  ;; (e.g. report_card.entity_id)
   (let [conditions (cond-> []
-                     run-type    (conj [:= :run_type run-type])
-                     entity-type (conj [:= :entity_type entity-type])
-                     entity-id   (conj [:= :entity_id entity-id])
-                     status      (conj [:= :status status])
-                     started-at  (conj (timestamp-constraint :started_at started-at)))]
+                     run-type    (conj [:= :task_run.run_type run-type])
+                     entity-type (conj [:= :task_run.entity_type entity-type])
+                     entity-id   (conj [:= :task_run.entity_id entity-id])
+                     status      (conj [:= :task_run.status status])
+                     started-at  (conj (timestamp-constraint :task_run.started_at started-at)))]
     (if (seq conditions)
       {:where (into [:and] conditions)}
       {})))

--- a/src/metabase/task_history/api.clj
+++ b/src/metabase/task_history/api.clj
@@ -82,8 +82,8 @@
 
 (mr/def ::RunSortParams
   [:map
-   [:sort_column    {:default :started_at} (into [:enum] run-sort-columns)]
-   [:sort_direction {:default :desc}       [:enum :asc :desc]]])
+   [:sort-column    {:default :started_at} (into [:enum] run-sort-columns)]
+   [:sort-direction {:default :desc}       [:enum :asc :desc]]])
 
 (mr/def ::TaskRun
   [:map
@@ -208,7 +208,7 @@
   "Build the honeysql fragment used to order the task runs list. Direct columns order in place; `:entity_name` LEFT JOINs
   the three entity tables and orders by the coalesced name; `:task_count` LEFT JOINs a grouped `task_history` subquery.
   Derived-column variants keep the selected shape to `task_run.*` and add a deterministic `[:id :desc]` secondary key."
-  [{col :sort_column dir :sort_direction}]
+  [{col :sort-column dir :sort-direction}]
   (let [secondary [:task_run.id :desc]]
     (case col
       :entity_name

--- a/src/metabase/task_history/api.clj
+++ b/src/metabase/task_history/api.clj
@@ -76,6 +76,15 @@
    [:status      {:optional true} [:enum "started" "success" "failed" "abandoned"]]
    [:started-at  {:optional true} ms/NonBlankString]])
 
+(def ^:private run-sort-columns
+  "Columns that runs can be sorted by. `:entity_name` and `:task_count` are derived via joins in [[runs-order-by]]."
+  #{:started_at :ended_at :run_type :status :entity_name :task_count})
+
+(mr/def ::RunSortParams
+  [:map
+   [:sort_column    {:default :started_at} (into [:enum] run-sort-columns)]
+   [:sort_direction {:default :desc}       [:enum :asc :desc]]])
+
 (mr/def ::TaskRun
   [:map
    [:id          ms/PositiveInt]
@@ -193,18 +202,43 @@
       {:where (into [:and] conditions)}
       {})))
 
+(defn- runs-order-by
+  "Build the honeysql fragment used to order the task runs list. Direct columns order in place; `:entity_name` LEFT JOINs
+  the three entity tables and orders by the coalesced name; `:task_count` LEFT JOINs a grouped `task_history` subquery.
+  Derived-column variants keep the selected shape to `task_run.*` and add a deterministic `[:id :desc]` secondary key."
+  [{col :sort_column dir :sort_direction}]
+  (let [secondary [:task_run.id :desc]]
+    (case col
+      :entity_name
+      {:select    [:task_run.*]
+       :left-join [[:metabase_database :sort_db]  [:and [:= :task_run.entity_type "database"]  [:= :task_run.entity_id :sort_db.id]]
+                   [:report_card :sort_card]       [:and [:= :task_run.entity_type "card"]      [:= :task_run.entity_id :sort_card.id]]
+                   [:report_dashboard :sort_dash]  [:and [:= :task_run.entity_type "dashboard"] [:= :task_run.entity_id :sort_dash.id]]]
+       :order-by  [[[:coalesce :sort_db.name :sort_card.name :sort_dash.name] dir] secondary]}
+
+      :task_count
+      {:select    [:task_run.*]
+       :left-join [[{:select   [:run_id [[:count :*] :task_count]]
+                     :from     [:task_history]
+                     :group-by [:run_id]}
+                    :sort_tc]
+                   [:= :sort_tc.run_id :task_run.id]]
+       :order-by  [[[:coalesce :sort_tc.task_count [:inline 0]] dir] secondary]}
+
+      {:order-by [[col dir] secondary]})))
+
 (api.macros/defendpoint :get "/runs" :- ::TaskRunsResponse
   "List task runs with optional filters. Returns runs with hydrated entity names and task counts."
   [_
-   params :- [:maybe ::RunFilterParams]]
+   params :- [:maybe [:merge ::RunFilterParams ::RunSortParams]]]
   (perms/check-has-application-permission :monitoring)
   (let [where-clause (build-run-where-clause params)
         limit        (request/limit)
         offset       (request/offset)
         runs         (t2/select :model/TaskRun (merge where-clause
+                                                      (runs-order-by params)
                                                       (when limit {:limit limit})
-                                                      (when offset {:offset offset})
-                                                      {:order-by [[:started_at :desc]]}))]
+                                                      (when offset {:offset offset})))]
     {:total  (t2/count :model/TaskRun where-clause)
      :limit  limit
      :offset offset

--- a/src/metabase/task_history/models/task_history.clj
+++ b/src/metabase/task_history/models/task_history.clj
@@ -86,13 +86,25 @@
    [:status {:optional true} (into [:enum] task-history-status)]
    [:task {:optional true} [:string {:min 1}]]])
 
+(def ^:private join-sort-columns
+  "Sort columns that require a LEFT JOIN to `metabase_database`, mapped to the joined column to order by."
+  {:db_name   :metabase_database.name
+   :db_engine :metabase_database.engine})
+
 (defn- params->order-by
+  "Build the honeysql fragment needed to order the task history list. For `:db_name`/`:db_engine` this adds a LEFT JOIN
+  to `metabase_database` (ordering by the joined name/engine) while keeping the selected row shape to `task_history.*`.
+  A secondary `[:id :desc]` key makes ordering deterministic for low-cardinality columns."
   [{col :sort_column
     dir :sort_direction}]
-  {:order-by [[col dir]]})
+  (if-let [order-col (join-sort-columns col)]
+    {:select    [:task_history.*]
+     :left-join [:metabase_database [:= :task_history.db_id :metabase_database.id]]
+     :order-by  [[order-col dir] [:task_history.id :desc]]}
+    {:order-by [[col dir] [:id :desc]]}))
 
 (def ^:private available-sort-columns
-  #{:duration :ended_at :started_at})
+  #{:started_at :ended_at :duration :task :status :db_name :db_engine})
 
 (def SortParams
   "Sorting map schema."

--- a/src/metabase/task_history/models/task_history.clj
+++ b/src/metabase/task_history/models/task_history.clj
@@ -76,9 +76,10 @@
 (defn- params->where
   [{:keys [status task]}]
   (when (or status task)
+    ;; qualified so filters stay unambiguous when the db_name/db_engine sorts join metabase_database
     {:where (cond-> [:and]
-              task   (conj [:= :task task])
-              status (conj [:= :status (name status)]))}))
+              task   (conj [:= :task_history.task task])
+              status (conj [:= :task_history.status (name status)]))}))
 
 (def FilterParams
   "Schema for filter for task history."

--- a/test/metabase/task_history/api_test.clj
+++ b/test/metabase/task_history/api_test.clj
@@ -900,24 +900,24 @@
         (testing "default order is started_at desc when no sort params given"
           (is (= [(:id run-card) (:id run-db)] (ids))))
         (testing "sort by started_at asc"
-          (is (= [(:id run-db) (:id run-card)] (ids :sort_column :started_at :sort_direction :asc))))
+          (is (= [(:id run-db) (:id run-card)] (ids :sort-column :started_at :sort-direction :asc))))
         (testing "sort by ended_at asc"
-          (is (= [(:id run-db) (:id run-card)] (ids :sort_column :ended_at :sort_direction :asc))))
+          (is (= [(:id run-db) (:id run-card)] (ids :sort-column :ended_at :sort-direction :asc))))
         (testing "sort by status (failed < success)"
-          (is (= [(:id run-card) (:id run-db)] (ids :sort_column :status :sort_direction :asc)))
-          (is (= [(:id run-db) (:id run-card)] (ids :sort_column :status :sort_direction :desc))))
+          (is (= [(:id run-card) (:id run-db)] (ids :sort-column :status :sort-direction :asc)))
+          (is (= [(:id run-db) (:id run-card)] (ids :sort-column :status :sort-direction :desc))))
         (testing "sort by run_type (fingerprint < sync)"
-          (is (= [(:id run-card) (:id run-db)] (ids :sort_column :run_type :sort_direction :asc)))
-          (is (= [(:id run-db) (:id run-card)] (ids :sort_column :run_type :sort_direction :desc))))
+          (is (= [(:id run-card) (:id run-db)] (ids :sort-column :run_type :sort-direction :asc)))
+          (is (= [(:id run-db) (:id run-card)] (ids :sort-column :run_type :sort-direction :desc))))
         (testing "sort by entity_name across entity types (AAA Card < ZZZ DB)"
-          (is (= [(:id run-card) (:id run-db)] (ids :sort_column :entity_name :sort_direction :asc)))
-          (is (= [(:id run-db) (:id run-card)] (ids :sort_column :entity_name :sort_direction :desc))))
+          (is (= [(:id run-card) (:id run-db)] (ids :sort-column :entity_name :sort-direction :asc)))
+          (is (= [(:id run-db) (:id run-card)] (ids :sort-column :entity_name :sort-direction :desc))))
         (testing "sort by task_count (run-card=1 < run-db=2)"
-          (is (= [(:id run-card) (:id run-db)] (ids :sort_column :task_count :sort_direction :asc)))
-          (is (= [(:id run-db) (:id run-card)] (ids :sort_column :task_count :sort_direction :desc))))
+          (is (= [(:id run-card) (:id run-db)] (ids :sort-column :task_count :sort-direction :asc)))
+          (is (= [(:id run-db) (:id run-card)] (ids :sort-column :task_count :sort-direction :desc))))
         (testing "invalid sort_column returns 400"
-          (is (=? {:errors {:sort_column some?}}
-                  (mt/user-http-request :crowberto :get 400 "task/runs" :sort_column :bogus))))))))
+          (is (=? {:errors {:sort-column some?}}
+                  (mt/user-http-request :crowberto :get 400 "task/runs" :sort-column :bogus))))))))
 
 (deftest ^:synchronized runs-filter-with-sort-test
   ;; the entity_name/task_count sorts add joins, so filter columns must stay unambiguous. Notably `report_card` and
@@ -945,7 +945,7 @@
         (testing "entity filter composes with the entity_name sort joins"
           (is (= [(:id run-db)]
                  (ids :entity-type "database" :entity-id (:id db)
-                      :sort_column :entity_name :sort_direction :asc))))
+                      :sort-column :entity_name :sort-direction :asc))))
         (testing "status filter composes with the task_count sort join"
           (is (= [(:id run-card)]
-                 (ids :status "failed" :sort_column :task_count :sort_direction :asc))))))))
+                 (ids :status "failed" :sort-column :task_count :sort-direction :asc))))))))

--- a/test/metabase/task_history/api_test.clj
+++ b/test/metabase/task_history/api_test.clj
@@ -918,3 +918,34 @@
         (testing "invalid sort_column returns 400"
           (is (=? {:errors {:sort_column some?}}
                   (mt/user-http-request :crowberto :get 400 "task/runs" :sort_column :bogus))))))))
+
+(deftest ^:synchronized runs-filter-with-sort-test
+  ;; the entity_name/task_count sorts add joins, so filter columns must stay unambiguous. Notably `report_card` and
+  ;; `report_dashboard` have their own `entity_id` column.
+  (t2/delete! :model/TaskRun)
+  (t2/delete! :model/TaskHistory)
+  (let [now (t/zoned-date-time)]
+    (mt/with-temp [:model/Database db {:name "Some DB"}
+                   :model/Card card {:name "Some Card"}
+                   :model/TaskRun run-db {:run_type    :sync
+                                          :entity_type :database
+                                          :entity_id   (:id db)
+                                          :status      :success
+                                          :started_at  now}
+                   :model/TaskRun run-card {:run_type    :fingerprint
+                                            :entity_type :card
+                                            :entity_id   (:id card)
+                                            :status      :failed
+                                            :started_at  now}]
+      (letfn [(ids [& args]
+                (->> (apply mt/user-http-request :crowberto :get 200 "task/runs" args)
+                     :data
+                     (map :id)
+                     (filter #{(:id run-db) (:id run-card)})))]
+        (testing "entity filter composes with the entity_name sort joins"
+          (is (= [(:id run-db)]
+                 (ids :entity-type "database" :entity-id (:id db)
+                      :sort_column :entity_name :sort_direction :asc))))
+        (testing "status filter composes with the task_count sort join"
+          (is (= [(:id run-card)]
+                 (ids :status "failed" :sort_column :task_count :sort_direction :asc))))))))

--- a/test/metabase/task_history/api_test.clj
+++ b/test/metabase/task_history/api_test.clj
@@ -496,6 +496,65 @@
           (is (=? [{:duration 10000}]
                   (-> response :data vec))))))))
 
+(deftest ^:synchronized sort-tasks-by-task-and-status-test
+  (t2/delete! :model/TaskHistory)
+  (let [now       (t/zoned-date-time)
+        ;; shared random token as prefix (so rows are unique / filterable) with ordered a<b<c suffixes
+        token     (mt/random-name)
+        task-a    (str token "-a")
+        task-b    (str token "-b")
+        task-c    (str token "-c")
+        my-tasks  #{task-a task-b task-c}]
+    (mt/with-temp [:model/TaskHistory _ {:task task-b :status :success :started_at now :ended_at now}
+                   :model/TaskHistory _ {:task task-a :status :failed  :started_at now :ended_at now}
+                   :model/TaskHistory _ {:task task-c :status :started :started_at now}]
+      (letfn [(rows [& args]
+                (->> (apply mt/user-http-request :crowberto :get 200 "task/" args)
+                     :data
+                     (filter (comp my-tasks :task))))]
+        (testing "sort by task"
+          (is (= [task-a task-b task-c] (map :task (rows :sort_column :task :sort_direction :asc))))
+          (is (= [task-c task-b task-a] (map :task (rows :sort_column :task :sort_direction :desc)))))
+        (testing "sort by status (alphabetical: failed < started < success)"
+          (is (= ["failed" "started" "success"] (map :status (rows :sort_column :status :sort_direction :asc))))
+          (is (= ["success" "started" "failed"] (map :status (rows :sort_column :status :sort_direction :desc)))))))))
+
+(deftest ^:synchronized sort-tasks-by-db-test
+  (t2/delete! :model/TaskHistory)
+  (let [now (t/zoned-date-time)]
+    (mt/with-temp [:model/Database db-a {:name "AAA DB"}
+                   :model/Database db-b {:name "ZZZ DB"}
+                   :model/TaskHistory _ {:task "t-a"   :status :success :db_id (:id db-a) :started_at now :ended_at now}
+                   :model/TaskHistory _ {:task "t-b"   :status :success :db_id (:id db-b) :started_at now :ended_at now}
+                   :model/TaskHistory _ {:task "t-nil" :status :success :started_at now :ended_at now}]
+      (let [tracked (fn [& args]
+                      (->> (apply mt/user-http-request :crowberto :get 200 "task/" args)
+                           :data
+                           (map :task)
+                           (filter #{"t-a" "t-b" "t-nil"})
+                           vec))]
+        (testing "sort by db_name; nil db_id row is present and does not error"
+          (let [asc  (tracked :sort_column :db_name :sort_direction :asc)
+                desc (tracked :sort_column :db_name :sort_direction :desc)]
+            (is (= #{"t-a" "t-b" "t-nil"} (set asc)))
+            (is (= 3 (count asc)))
+            ;; AAA DB before ZZZ DB, and reversed for desc (nil position is DB-dependent, so only assert the two named)
+            (is (< (.indexOf asc "t-a") (.indexOf asc "t-b")))
+            (is (< (.indexOf desc "t-b") (.indexOf desc "t-a")))))
+        (testing "sort by db_engine (aaa-engine < zzz-engine)"
+          ;; Relabel engines via raw SQL (no Toucan hooks, so no driver init) purely to exercise ordering on the
+          ;; `engine` column; reset to h2 before with-temp teardown so deletion doesn't init a bogus driver.
+          (t2/query {:update :metabase_database :set {:engine "aaa-engine"} :where [:= :id (:id db-a)]})
+          (t2/query {:update :metabase_database :set {:engine "zzz-engine"} :where [:= :id (:id db-b)]})
+          (try
+            (let [asc  (tracked :sort_column :db_engine :sort_direction :asc)
+                  desc (tracked :sort_column :db_engine :sort_direction :desc)]
+              (is (= 3 (count asc)))
+              (is (< (.indexOf asc "t-a") (.indexOf asc "t-b")))
+              (is (< (.indexOf desc "t-b") (.indexOf desc "t-a"))))
+            (finally
+              (t2/query {:update :metabase_database :set {:engine "h2"} :where [:in :id [(:id db-a) (:id db-b)]]}))))))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              Task Runs API tests                                               |
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -810,3 +869,52 @@
                                                :started-at "past7days")]
             (is (= 1 (count response)))
             (is (= "DB2" (-> response first :entity_name)))))))))
+
+(deftest ^:synchronized runs-sort-test
+  (t2/delete! :model/TaskRun)
+  (t2/delete! :model/TaskHistory)
+  (let [now (t/zoned-date-time)]
+    (mt/with-temp [:model/Database db {:name "ZZZ DB"}
+                   :model/Card card {:name "AAA Card"}
+                   :model/TaskRun run-db {:run_type    :sync
+                                          :entity_type :database
+                                          :entity_id   (:id db)
+                                          :status      :success
+                                          :started_at  (t/minus now (t/hours 2))
+                                          :ended_at    (t/minus now (t/hours 1))}
+                   :model/TaskRun run-card {:run_type    :fingerprint
+                                            :entity_type :card
+                                            :entity_id   (:id card)
+                                            :status      :failed
+                                            :started_at  (t/minus now (t/hours 1))
+                                            :ended_at    now}
+                   ;; run-db has 2 child tasks, run-card has 1
+                   :model/TaskHistory _ {:task "a" :status :success :run_id (:id run-db)   :started_at now :ended_at now}
+                   :model/TaskHistory _ {:task "b" :status :success :run_id (:id run-db)   :started_at now :ended_at now}
+                   :model/TaskHistory _ {:task "c" :status :success :run_id (:id run-card) :started_at now :ended_at now}]
+      (let [my-ids #{(:id run-db) (:id run-card)}
+            ids    (fn [& args] (->> (apply mt/user-http-request :crowberto :get 200 "task/runs" args)
+                                     :data
+                                     (map :id)
+                                     (filter my-ids)))]
+        (testing "default order is started_at desc when no sort params given"
+          (is (= [(:id run-card) (:id run-db)] (ids))))
+        (testing "sort by started_at asc"
+          (is (= [(:id run-db) (:id run-card)] (ids :sort_column :started_at :sort_direction :asc))))
+        (testing "sort by ended_at asc"
+          (is (= [(:id run-db) (:id run-card)] (ids :sort_column :ended_at :sort_direction :asc))))
+        (testing "sort by status (failed < success)"
+          (is (= [(:id run-card) (:id run-db)] (ids :sort_column :status :sort_direction :asc)))
+          (is (= [(:id run-db) (:id run-card)] (ids :sort_column :status :sort_direction :desc))))
+        (testing "sort by run_type (fingerprint < sync)"
+          (is (= [(:id run-card) (:id run-db)] (ids :sort_column :run_type :sort_direction :asc)))
+          (is (= [(:id run-db) (:id run-card)] (ids :sort_column :run_type :sort_direction :desc))))
+        (testing "sort by entity_name across entity types (AAA Card < ZZZ DB)"
+          (is (= [(:id run-card) (:id run-db)] (ids :sort_column :entity_name :sort_direction :asc)))
+          (is (= [(:id run-db) (:id run-card)] (ids :sort_column :entity_name :sort_direction :desc))))
+        (testing "sort by task_count (run-card=1 < run-db=2)"
+          (is (= [(:id run-card) (:id run-db)] (ids :sort_column :task_count :sort_direction :asc)))
+          (is (= [(:id run-db) (:id run-card)] (ids :sort_column :task_count :sort_direction :desc))))
+        (testing "invalid sort_column returns 400"
+          (is (=? {:errors {:sort_column some?}}
+                  (mt/user-http-request :crowberto :get 400 "task/runs" :sort_column :bogus))))))))

--- a/test/metabase/task_history/api_test.clj
+++ b/test/metabase/task_history/api_test.clj
@@ -539,8 +539,8 @@
             (is (= #{"t-a" "t-b" "t-nil"} (set asc)))
             (is (= 3 (count asc)))
             ;; AAA DB before ZZZ DB, and reversed for desc (nil position is DB-dependent, so only assert the two named)
-            (is (< (.indexOf asc "t-a") (.indexOf asc "t-b")))
-            (is (< (.indexOf desc "t-b") (.indexOf desc "t-a")))))
+            (is (< (u/index-of #{"t-a"} asc) (u/index-of #{"t-b"} asc)))
+            (is (< (u/index-of #{"t-b"} desc) (u/index-of #{"t-a"} desc)))))
         (testing "sort by db_engine (aaa-engine < zzz-engine)"
           ;; Relabel engines via raw SQL (no Toucan hooks, so no driver init) purely to exercise ordering on the
           ;; `engine` column; reset to h2 before with-temp teardown so deletion doesn't init a bogus driver.
@@ -550,8 +550,8 @@
             (let [asc  (tracked :sort_column :db_engine :sort_direction :asc)
                   desc (tracked :sort_column :db_engine :sort_direction :desc)]
               (is (= 3 (count asc)))
-              (is (< (.indexOf asc "t-a") (.indexOf asc "t-b")))
-              (is (< (.indexOf desc "t-b") (.indexOf desc "t-a"))))
+              (is (< (u/index-of #{"t-a"} asc) (u/index-of #{"t-b"} asc)))
+              (is (< (u/index-of #{"t-b"} desc) (u/index-of #{"t-a"} desc))))
             (finally
               (t2/query {:update :metabase_database :set {:engine "h2"} :where [:in :id [(:id db-a) (:id db-b)]]}))))))))
 


### PR DESCRIPTION
Enables sorting on every column of the Monitor **Background tasks** and **Task runs** tables (GDGT-2810), and removes bold styling from first table columns across Monitor.

## Backend
- `GET /api/task/`: sort columns widened to `started_at | ended_at | duration | task | status | db_name | db_engine` (db columns sort via a LEFT JOIN to `metabase_database`, ordering only — response shape unchanged).
- `GET /api/task/runs`: previously hardcoded `started_at DESC`; now accepts `sort_column: started_at | ended_at | run_type | status | entity_name | task_count` + `sort_direction` (`entity_name` via polymorphic joins over database/card/dashboard with COALESCE; `task_count` via a grouped subquery). Invalid columns → 400.
- Deterministic `id DESC` secondary sort on both endpoints for stable pagination.

## Frontend
- Background tasks table: all 7 columns sortable.
- Task runs table: sorting added end-to-end (URL state, manual sorting, page reset on sort change), mirroring the tasks page pattern.
- Removed bold text styling from the first column of the 5 Monitor TreeTables that had it.

## Testing
- New BE tests for all sort columns incl. entity-name/task-count joins and 400 on invalid column.
- FE specs extended; TaskListPage sort scenarios consolidated into a single sequential test.
- Smoke-tested every sort column against a restored Stats dump (105k task_history / 253k task_run rows on Postgres): correct ordering, ≤190ms.