### PR TITLE
Update table-level permissions targeting sample DB to use the correct schema on upgrade

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1999,8 +1999,7 @@
            settings
            sync
            util}
-   :model-imports #{:model/Database
-                    :model/Table}}
+   :model-imports #{:model/DataPermissions :model/Database :model/Table}}
 
   search
   {:team "UX West"

--- a/src/metabase/sample_data/impl.clj
+++ b/src/metabase/sample_data/impl.clj
@@ -129,7 +129,16 @@
   (let [details (try-to-extract-sample-database! engine)]
     (t2/with-transaction [_conn]
       (t2/update! :model/Database (:id old-sample-db) {:engine engine, :details details})
-      (t2/update! :model/Table :db_id (:id old-sample-db) {:schema (table-schema-for-engine engine)}))
+      (t2/update! :model/Table :db_id (:id old-sample-db) {:schema (table-schema-for-engine engine)})
+      ;; Table-level permission rows denormalize the table's schema; keep them matching or schema-scoped
+      ;; permission checks (e.g. schema visibility in the data picker) stop counting them. Raw table update:
+      ;; the model's before-update rejects all updates, and delete+reinsert would churn ids for a rename that
+      ;; doesn't change any permission value.
+      (t2/query {:update (t2/table-name :model/DataPermissions)
+                 :set    {:schema_name (table-schema-for-engine engine)}
+                 :where  [:and
+                          [:= :db_id (:id old-sample-db)]
+                          [:not= :table_id nil]]}))
     (sync/sync-database! (t2/select-one :model/Database :id (:id old-sample-db)))))
 
 (defn update-sample-database-if-needed!

--- a/test/metabase/sample_data/impl_test.clj
+++ b/test/metabase/sample_data/impl_test.clj
@@ -126,6 +126,50 @@
               (is (= :completed (:status result)))
               (is (pos? (count (mt/rows result)))))))))))
 
+(deftest migrate-sample-database-engine-in-place-preserves-granular-permissions-test
+  (testing "Table-level (granular) permissions on the sample DB survive the engine migration. The migration
+           changes every table's schema (H2 PUBLIC -> SQLite nil) while data_permissions rows carry a
+           denormalized schema_name, so schema-scoped permission checks must still line up."
+    (mt/with-model-cleanup [:model/Database]
+      (mt/with-temp [:model/PermissionsGroup           group {}
+                     :model/User                       user  {}
+                     :model/PermissionsGroupMembership _     {:user_id (:id user) :group_id (:id group)}]
+        (let [h2-db (t2/insert-returning-instance! :model/Database
+                                                   {:name "Sample Database" :engine :h2 :is_sample true
+                                                    :details (#'sample-data/try-to-extract-sample-database! :h2)})]
+          (sync/sync-database! h2-db)
+          (let [db-id     (:id h2-db)
+                orders-id (t2/select-one-pk :model/Table :db_id db-id :name "ORDERS")
+                people-id (t2/select-one-pk :model/Table :db_id db-id :name "PEOPLE")]
+            ;; Granular state: All Users sees nothing; the custom group can query everything except ORDERS.
+            ;; Blocking a single table splits the group's db-level rows into per-table rows, each carrying the
+            ;; table's schema_name ("PUBLIC" pre-migration).
+            (perms/set-database-permission! (perms/all-users-group) db-id :perms/view-data :blocked)
+            (perms/set-database-permission! (perms/all-users-group) db-id :perms/create-queries :no)
+            (perms/set-database-permission! group db-id :perms/view-data :unrestricted)
+            (perms/set-database-permission! group db-id :perms/create-queries :query-builder-and-native)
+            (perms/set-table-permission! group orders-id :perms/view-data :blocked)
+            (perms/set-table-permission! group orders-id :perms/create-queries :no)
+            (let [effective (fn [schema]
+                              {:orders-view   (perms/table-permission-for-user (:id user) :perms/view-data db-id orders-id)
+                               :people-view   (perms/table-permission-for-user (:id user) :perms/view-data db-id people-id)
+                               ;; what GET /api/database/:id/schemas visibility keys on
+                               :schema-create (perms/schema-permission-for-user (:id user) :perms/create-queries db-id schema)})
+                  before    (effective "PUBLIC")]
+              (is (= {:orders-view   :blocked
+                      :people-view   :unrestricted
+                      ;; splitting a DB's create-queries perms per-table caps the value at :query-builder,
+                      ;; since native access is all-or-nothing per database
+                      :schema-create :query-builder}
+                     before)
+                  "precondition: granular perms are in effect on the H2 sample DB")
+              ;; ---- the migration under test ----
+              (#'sample-data/migrate-sample-database-engine-in-place! :sqlite (t2/select-one :model/Database :id db-id))
+              (testing "permission checks give the same answers under the new (nil) schema"
+                (is (= before (effective nil))))
+              (testing "no data_permissions rows are left pointing at the departed PUBLIC schema"
+                (is (not (t2/exists? :model/DataPermissions :db_id db-id :schema_name "PUBLIC")))))))))))
+
 (def ^:private extracted-db-path-regex #".*plugins/sample-database\.sqlite$")
 
 (deftest extract-sample-database-test


### PR DESCRIPTION
Closes: [GHY-4135: Granular sample-database permissions silently break on v62 -> v63 upgrade](https://linear.app/metabase/issue/GHY-4135/granular-sample-database-permissions-silently-break-on-v62-v63-upgrade)

### Description

Table-level permissions records are specified in terms of the schema of the target table. When the sample DB is upgraded from H2 to SQLite, the tables go from having schema `"PUBLIC"` to schema `nil`. Any permissions records describing access to one of the H2 tables should be updated to target the `nil` schema value for the SQLite tables.