### PR TITLE
Add linear issue link

### DIFF
--- a/.github/workflows/team-issues-slack-notification.yml
+++ b/.github/workflows/team-issues-slack-notification.yml
@@ -1,3 +1,15 @@
+# .github/workflows/team-issues-slack-notification.yml
+#
+# Posts newly team-labeled bugs to the team's Slack channel (e.g.
+# #team-graphy-bugs), now including a link to the synced Linear issue.
+#
+# Changes from the current version:
+# - Checks out .github/scripts so we can reuse find-linear-issue.js
+# - The message-building step now queries Linear (via attachmentsForURL)
+#   with a short retry, and appends "Linear: <link|ID>" when found
+# - Degrades gracefully: if no Linear issue is attached (or the API is
+#   down), the message posts without the Linear issue link
+
 name: Team Issues Slack Notification
 
 on:
@@ -14,12 +26,52 @@ jobs:
        ( contains(github.event.issue.labels.*.name, 'Type:Bug') ||
          contains(github.event.issue.labels.*.name, 'flaky-test-fix') )
     steps:
-      - name: Setting title
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+
+      - name: Build Slack message (with Linear link if available)
         uses: actions/github-script@v9
         id: vars
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
         with:
           script: |
-            core.setOutput('issue_title', JSON.stringify(${{ toJson(github.event.issue.title) }} + '\n' + ${{ toJson(github.event.issue.html_url) }}));
+            const { findLinearIssue } = require('./.github/scripts/find-linear-issue.js');
+
+            const title = context.payload.issue.title;
+            const issueUrl = context.payload.issue.html_url;
+
+            let text = title + '\n' + issueUrl;
+
+            // The Linear issue is usually already synced by the time the
+            // team label lands at triage, but retry briefly just in case.
+            try {
+              const delaysSeconds = [0, 15, 30];
+              let result = null;
+
+              for (const delay of delaysSeconds) {
+                if (delay) await new Promise((r) => setTimeout(r, delay * 1000));
+                result = await findLinearIssue({
+                  githubIssueUrl: issueUrl,
+                  linearApiKey: process.env.LINEAR_API_KEY,
+                });
+                if (result.success) break;
+              }
+
+              if (result && result.success) {
+                const id = result.issue; // e.g. "GIT-1234"
+                text += `\nLinear: <https://linear.app/metabase/issue/${id}|${id}>`;
+              } else {
+                core.info(`No Linear issue found for ${issueUrl}; posting without link.`);
+              }
+            } catch (e) {
+              // Never block the notification on a Linear lookup failure
+              core.warning(`Linear lookup failed: ${e.message}`);
+            }
+
+            core.setOutput('message', JSON.stringify(text));
+
       - name: Extracting team name
         id: team_name
         env:
@@ -55,7 +107,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ${{ steps.vars.outputs.issue_title }}
+                    "text": ${{ steps.vars.outputs.message }}
                   }
                 }
               ]

--- a/.github/workflows/team-issues-slack-notification.yml
+++ b/.github/workflows/team-issues-slack-notification.yml
@@ -77,7 +77,7 @@ jobs:
         env:
           LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          team_label=$(sed 's/&/\$/g' <<< "$LABEL_NAME")
+          team_label="${LABEL_NAME//&/$}"
           echo "$team_label"
           team_name=${team_label#*.Team/}
           echo "$team_name"


### PR DESCRIPTION
### Description

When an issue is created in Github, then gets triaged to a particular team, a bot posts a notification in that team's bugs channel.

<img width="540" height="114" alt="image" src="https://github.com/user-attachments/assets/2fd567a3-7f4e-4deb-a9fe-1f09063a21b2" />

We also synchronize the Github issue to be a Linear issue also. A developer reading the message in Slack likely will want to find the associated Linear issue. This PR adds to the Slack message a link to the Linear issue.

## How to verify

This seems hard to test before we merge to master. After merging I can un-label and re-label one of Graphy's issues to re-trigger a Slack notification to test that this works.