### PR TITLE
Update Jetty dependencies to version 12.1.11

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -161,10 +161,10 @@
   org.clojure/tools.namespace               {:mvn/version "1.5.0"}
   org.clojure/tools.reader                  {:mvn/version "1.5.2"}
   org.clojure/tools.trace                   {:mvn/version "0.8.0"}              ; function tracing
-  org.eclipse.jetty/jetty-server            {:mvn/version "12.1.7"}
-  org.eclipse.jetty/jetty-unixdomain-server {:mvn/version "12.1.7"}
-  org.eclipse.jetty.ee9/jetty-ee9-servlet   {:mvn/version "12.1.7"}
-  org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-jetty-server {:mvn/version "12.1.7"}
+  org.eclipse.jetty/jetty-server            {:mvn/version "12.1.11"}
+  org.eclipse.jetty/jetty-unixdomain-server {:mvn/version "12.1.11"}
+  org.eclipse.jetty.ee9/jetty-ee9-servlet   {:mvn/version "12.1.11"}
+  org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-jetty-server {:mvn/version "12.1.11"}
   org.eclipse.jgit/org.eclipse.jgit        {:mvn/version "7.3.0.202506031305-r"}; Java implementation of Git version control system
   org.flatland/ordered                      {:mvn/version "1.15.12"}            ; ordered maps & sets
   org.graalvm.polyglot/js-community         {:mvn/version "25.0.1" :extension "pom"} ; JavaScript engine


### PR DESCRIPTION
https://github.com/jetty/jetty.project/releases

check 12.1.7...12.1.11

https://github.com/jetty/jetty.project/releases/tag/jetty-12.1.11
https://github.com/jetty/jetty.project/releases/tag/jetty-12.1.10
https://github.com/jetty/jetty.project/releases/tag/jetty-12.1.9
https://github.com/jetty/jetty.project/releases/tag/jetty-12.1.8