### PR TITLE
Backport "remove claude from mise as it's not a required tool" (#71138) to release-x.58.x

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -106,7 +106,3 @@ op = "latest"
 # jq - Command-line JSON processor
 # https://github.com/jqlang/jq
 jq = "latest"
-
-# claude code - Terminal AI coding agent
-# https://github.com/anthropics/claude-code
-claude = "latest"


### PR DESCRIPTION
Backport of #71138 (master commit 45cd62fe3e8) to `release-x.58.x`.

Removes `claude = "latest"` (and its comment) from `mise.toml`. Checked all release branches with a `mise.toml` (x.58–x.63): only x.58 still had it — x.59+ were cut after the removal landed on master, so this is the only backport needed.