### PR TITLE
GHY-4136: query handles

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -157,8 +157,7 @@
 
   agent-api
   {:team    "Metabot"
-   :api     #{metabase.agent-api.api
-              metabase.agent-api.init}
+   :api     #{metabase.agent-api.api metabase.agent-api.init metabase.agent-api.query-guards}
    :uses    #{ai-tracing
               api
               auth-identity
@@ -1270,6 +1269,8 @@
            app-db
            config
            eid-translation
+           lib
+           lib-be
            llm
            metabot
            oauth-server
@@ -1279,6 +1280,7 @@
            session
            settings
            system
+           task
            util}
    :model-imports #{:model/Collection}}
 

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -3,6 +3,7 @@
   Endpoints are versioned (e.g., /v1/search) and use standard HTTP semantics."
   (:require
    [clojure.string :as str]
+   [metabase.agent-api.query-guards :as query-guards]
    [metabase.agent-api.settings :as agent-api.settings]
    [metabase.agent-api.validation :as agent-api.validation]
    [metabase.ai-tracing.core :as ait]
@@ -371,7 +372,7 @@
   "Decode a base64-encoded continuation token into {:query ... :pagination ...}.
    The token is client-supplied, so sanity-check the pagination ints to turn
    garbage into a 400 rather than a downstream 500. Permission re-validation on
-   the embedded query happens in [[check-token-query-permissions!]] — a token
+   the embedded query happens in [[query-guards/check-token-query-permissions!]] — a token
    doesn't grant access the bearer wouldn't otherwise have."
   [token]
   (let [decoded (decode-base64-json-map token)
@@ -468,71 +469,6 @@
    [:handle       [:map {:closed true} [:query ms/NonBlankString]]]
    [:fresh        ::construct-query-request]])
 
-(defn- native-marker?
-  "True if `node` is a map carrying a native-SQL marker: a `:native` query body (the universal signal
-   across legacy and MBQL 5 native forms), a legacy `:type :native`, or an MBQL 5 `:mbql.stage/native`
-   `:lib/type`. Membership tests cover the keyword and json-decoded string forms and never coerce, so
-   junk values don't throw. A legitimate serialized MBQL query carries none of these."
-  [node]
-  (and (map? node)
-       (or (contains? node :native)
-           (contains? #{:native "native"} (:type node))
-           (contains? #{:mbql.stage/native "mbql.stage/native"} (:lib/type node)))))
-
-(defn- native-query?
-  "True if `query-map` (a decoded, client-reachable query) contains native SQL anywhere in its tree —
-   legacy top-level `:type :native`, a legacy nested `:source-query`'s `:native`, or an MBQL 5
-   `:mbql.stage/native` stage, including inside joins or nested joins.
-   A whole-tree scan, because these endpoints are MBQL-only by scope: a native marker at any depth
-   means the payload is smuggling raw SQL, regardless of how it's nested."
-  [query-map]
-  (boolean (some native-marker? (tree-seq coll? seq query-map))))
-
-(defn- reject-native-query!
-  "Throw a 400 if `query-map` is a native query.
-
-  `/v2/query` and `/v1/execute` are gated by the MBQL-execution scopes (`agent:query` /
-  `agent:query:execute`), not `agent:sql:execute`. The opaque base64 payloads they accept (a
-  query_handle, a continuation token) could carry a native query — legacy top-level `:type :native`
-  or an MBQL 5 native stage; allowing either would let a token without the SQL-execution scope run
-  raw SQL, defeating the scope split and bypassing the execute-sql kill switch. Force native
-  execution onto `/v1/execute-sql`, which is correctly scoped."
-  [query-map]
-  (when (native-query? query-map)
-    (throw (ex-info "Native queries are not supported here; use execute_sql instead."
-                    {:status-code 400 :query-map query-map}))))
-
-(defn- validate-serialized-query!
-  "Sanity-check a decoded MBQL query map from a client-reachable base64 payload (query_handle or token).
-   Require `:stages` to be a non-empty sequence of maps, and the last-stage `:limit` (if present) an
-   integer; otherwise `serialized-query-limit`, `clamp-total-limit`, and `apply-page-to-query` would
-   throw on the malformed shape and surface a 500 instead of a clean 400.
-   Deep MBQL validation still happens in the QP at execution."
-  [query-map]
-  (let [stages (:stages query-map)]
-    (when-not (and (sequential? stages) (seq stages) (every? map? stages))
-      (throw (ex-info "Invalid query: expected a serialized MBQL query with a non-empty :stages of maps."
-                      {:status-code 400 :query-map query-map})))
-    ;; `contains?` (not `when-let`) so an explicit `false`/`nil` limit is caught, not skipped.
-    (when (contains? (last stages) :limit)
-      (let [limit (:limit (last stages))]
-        (when-not (and (int? limit) (pos? limit))
-          (throw (ex-info "Invalid query: last-stage :limit must be a positive integer."
-                          {:status-code 400 :query-map query-map})))))))
-
-(defn- check-token-query-permissions!
-  "Re-validate query permissions on the continuation-token path.
-
-  The token body is client-supplied and could in principle name a different source table than
-  the one the fresh `/v2/query` call was authorized against (a user's data perms can also
-  change between pages). The QP middleware would catch this at execution time, but running
-  the explicit `api/query-check` first gives a cleaner 403 and avoids spinning up the
-  streaming response just to abort."
-  [query-map]
-  (when-let [table-id (get-in query-map [:stages 0 :source-table])]
-    (when (int? table-id)
-      (api/query-check :model/Table table-id))))
-
 (defn- initial-page-state
   "Normalize the three /v2/query entry points into a single {:query :total-limit :page} shape.
 
@@ -548,15 +484,15 @@
   (cond
     (:continuation_token body)
     (let [{:keys [query pagination]} (decode-continuation-token (:continuation_token body))]
-      (reject-native-query! query)
-      (validate-serialized-query! query)
-      (check-token-query-permissions! query)
+      (query-guards/reject-native-query! query)
+      (query-guards/validate-serialized-query! query)
+      (query-guards/check-token-query-permissions! query)
       {:query query :total-limit (:limit pagination) :page (:page pagination)})
 
     (string? (:query body))
     (let [query (decode-base64-json-map (:query body))]
-      (reject-native-query! query)
-      (validate-serialized-query! query)
+      (query-guards/reject-native-query! query)
+      (query-guards/validate-serialized-query! query)
       {:query query :total-limit (clamp-total-limit (serialized-query-limit query)) :page 1})
 
     :else
@@ -667,7 +603,7 @@
   (let [query (-> encoded-query
                   u/decode-base64
                   json/decode+kw)]
-    (reject-native-query! query)
+    (query-guards/reject-native-query! query)
     (qp.streaming/streaming-response [rff :api]
       (qp/process-query (prepare-combined-query query) rff))))
 

--- a/src/metabase/agent_api/query_guards.clj
+++ b/src/metabase/agent_api/query_guards.clj
@@ -1,0 +1,72 @@
+(ns metabase.agent-api.query-guards
+  "Guards that every client-reachable serialized MBQL payload must pass before execution on an
+   MBQL-scoped path — whether it arrives as a fresh query, a continuation token, or a stored
+   query handle. Opaque payloads could otherwise smuggle native SQL past the MBQL-only scopes
+   (bypassing the execute-sql kill switch) or retain access the caller has since lost, so the
+   three `!` guards run together at every such entry point."
+  (:require
+   [metabase.api.common :as api]))
+
+(defn native-marker?
+  "True if `node` is a map carrying a native-SQL marker: a `:native` query body (the universal signal
+   across legacy and MBQL 5 native forms), a legacy `:type :native`, or an MBQL 5 `:mbql.stage/native`
+   `:lib/type`. Membership tests cover the keyword and json-decoded string forms and never coerce, so
+   junk values don't throw. A legitimate serialized MBQL query carries none of these."
+  [node]
+  (and (map? node)
+       (or (contains? node :native)
+           (contains? #{:native "native"} (:type node))
+           (contains? #{:mbql.stage/native "mbql.stage/native"} (:lib/type node)))))
+
+(defn native-query?
+  "True if `query-map` (a decoded, client-reachable query) contains native SQL anywhere in its tree —
+   legacy top-level `:type :native`, a legacy nested `:source-query`'s `:native`, or an MBQL 5
+   `:mbql.stage/native` stage, including inside joins or nested joins.
+   A whole-tree scan, because the callers are MBQL-only by scope: a native marker at any depth
+   means the payload is smuggling raw SQL, regardless of how it's nested."
+  [query-map]
+  (boolean (some native-marker? (tree-seq coll? seq query-map))))
+
+(defn reject-native-query!
+  "Throw a 400 if `query-map` is a native query.
+
+  The MBQL execution paths are gated by the MBQL-execution scopes (`agent:query` /
+  `agent:query:execute`), not `agent:sql:execute`. The opaque base64 payloads they accept (a
+  query_handle, a continuation token) could carry a native query — legacy top-level `:type :native`
+  or an MBQL 5 native stage; allowing either would let a token without the SQL-execution scope run
+  raw SQL, defeating the scope split and bypassing the execute-sql kill switch. Force native
+  execution onto the SQL-execution path, which is correctly scoped."
+  [query-map]
+  (when (native-query? query-map)
+    (throw (ex-info "Native queries are not supported here; use execute_sql instead."
+                    {:status-code 400 :query-map query-map}))))
+
+(defn validate-serialized-query!
+  "Sanity-check a decoded MBQL query map from a client-reachable base64 payload (query_handle or token).
+   Require `:stages` to be a non-empty sequence of maps, and the last-stage `:limit` (if present) a
+   positive integer; otherwise downstream paging arithmetic would throw on the malformed shape and
+   surface a 500 instead of a clean 400.
+   Deep MBQL validation still happens in the QP at execution."
+  [query-map]
+  (let [stages (:stages query-map)]
+    (when-not (and (sequential? stages) (seq stages) (every? map? stages))
+      (throw (ex-info "Invalid query: expected a serialized MBQL query with a non-empty :stages of maps."
+                      {:status-code 400 :query-map query-map})))
+    ;; `contains?` (not `when-let`) so an explicit `false`/`nil` limit is caught, not skipped.
+    (when (contains? (last stages) :limit)
+      (let [limit (:limit (last stages))]
+        (when-not (and (int? limit) (pos? limit))
+          (throw (ex-info "Invalid query: last-stage :limit must be a positive integer."
+                          {:status-code 400 :query-map query-map})))))))
+
+(defn check-token-query-permissions!
+  "Re-validate the current user's permissions on a stored or client-supplied query.
+
+  The payload could in principle name a different source table than the one the original call was
+  authorized against (a user's data perms can also change between calls). The QP middleware would
+  catch this at execution time, but running the explicit `api/query-check` first gives a cleaner
+  403 and avoids spinning up the streaming response just to abort."
+  [query-map]
+  (when-let [table-id (get-in query-map [:stages 0 :source-table])]
+    (when (int? table-id)
+      (api/query-check :model/Table table-id))))

--- a/src/metabase/mcp/init.clj
+++ b/src/metabase/mcp/init.clj
@@ -1,4 +1,5 @@
 (ns metabase.mcp.init
   (:require
    [metabase.mcp.resources]
-   [metabase.mcp.settings]))
+   [metabase.mcp.settings]
+   [metabase.mcp.task.mcp-query-handle-gc]))

--- a/src/metabase/mcp/settings.clj
+++ b/src/metabase/mcp/settings.clj
@@ -80,6 +80,14 @@
   :audit      :getter
   :doc        false)
 
+(defsetting mcp-query-handle-ttl-hours
+  (deferred-tru "Hours a stored MCP query handle is kept before the scheduled GC task deletes it.")
+  :type       :integer
+  :default    24
+  :visibility :internal
+  :export?    false
+  :doc        false)
+
 (defsetting mcp-apps-cors-enabled-clients
   (deferred-tru "Popular MCP clients enabled for CORS, stored as CSV client keys (e.g. claude, vscode).")
   :type       :csv

--- a/src/metabase/mcp/task/mcp_query_handle_gc.clj
+++ b/src/metabase/mcp/task/mcp_query_handle_gc.clj
@@ -1,0 +1,50 @@
+(ns metabase.mcp.task.mcp-query-handle-gc
+  "Scheduled task that deletes `mcp_query_handle` rows older than
+  [[metabase.mcp.settings/mcp-query-handle-ttl-hours]]. Handles tied to a live session are also
+  reaped by the `core_session` FK cascade and the explicit session delete; this task catches
+  handles whose sessions outlive the TTL, since every execute mints a handle and volume grows
+  much faster than sessions are torn down. Drill-through handles share the store and age out on
+  the same TTL."
+  (:require
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.schedule.cron :as cron]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [java-time.api :as t]
+   [metabase.mcp.models.mcp-query-handle]
+   [metabase.mcp.settings :as mcp.settings]
+   [metabase.task.core :as task]
+   [metabase.util.log :as log]
+   [toucan2.core :as t2])
+  (:import
+   (org.quartz DisallowConcurrentExecution)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private gc-job-key (jobs/key "metabase.task.mcp.query-handle-gc.job"))
+(def ^:private gc-trigger-key (triggers/key "metabase.task.mcp.query-handle-gc.trigger"))
+
+(defn- gc-expired-query-handles!
+  []
+  (let [ttl-hours (mcp.settings/mcp-query-handle-ttl-hours)
+        cutoff    (t/minus (t/offset-date-time) (t/hours (long ttl-hours)))
+        deleted   (t2/delete! :model/McpQueryHandle {:where [:< :created_at cutoff]})]
+    (log/infof "MCP query handle GC complete. Deleted %d handle(s) older than %d hours."
+               (or deleted 0) (long ttl-hours))))
+
+(task/defjob ^{DisallowConcurrentExecution true
+               :doc "Delete expired MCP query handles"}
+  McpQueryHandleGc [_ctx]
+  (gc-expired-query-handles!))
+
+(defmethod task/init! ::McpQueryHandleGc
+  [_]
+  (let [job     (jobs/build
+                 (jobs/of-type McpQueryHandleGc)
+                 (jobs/with-identity gc-job-key))
+        trigger (triggers/build
+                 (triggers/with-identity gc-trigger-key)
+                 (triggers/start-now)
+                 (triggers/with-schedule
+                  ;; daily at 23:27:11 (offset from the MCP usage trimmer's 23:19:41)
+                  (cron/cron-schedule "11 27 23 * * ?")))]
+    (task/schedule-task! job trigger)))

--- a/src/metabase/mcp/v2/common.clj
+++ b/src/metabase/mcp/v2/common.clj
@@ -9,9 +9,12 @@
    scopes for net-new capability; never rename."
   (:require
    [clojure.string :as str]
+   [metabase.agent-api.query-guards :as query-guards]
    [metabase.eid-translation.core :as eid-translation]
    [metabase.mcp.scope :as mcp.scope]
+   [metabase.mcp.session :as mcp.session]
    [metabase.mcp.v2.projections :as projections]
+   [metabase.util :as u]
    [metabase.util.json :as json])
   (:import
    (org.apache.commons.text.similarity LevenshteinDistance)))
@@ -305,6 +308,55 @@
       [:update id (dissoc args :method :id)])
 
     (throw-teaching-error (format "Invalid method %s — use \"create\" or \"update\"." (pr-str method)))))
+
+;;; ------------------------------------------------ Query handles -------------------------------------------------
+
+(defn encode-serialized-query
+  "Base64-encode a serialized MBQL query map ([[metabase.lib.core/prepare-for-serialization]] output)
+   for storage in the query-handle store. The inverse of the decode step in [[resolve-query-handle!]]."
+  [serialized-query]
+  (-> serialized-query json/encode u/encode-base64))
+
+(defn mint-query-handle!
+  "Store `encoded-query` (base64 serialized MBQL, exactly what ran — see [[encode-serialized-query]])
+   under a fresh handle owned by `user-id`, with the user's original `prompt` alongside for the
+   visualization feedback flow. Returns the handle UUID string. Execute tools mint on every call,
+   including `validate_only`, so what the agent later saves or visualizes through the handle is
+   byte-identical to what ran."
+  ([mcp-session-id user-id encoded-query]
+   (mint-query-handle! mcp-session-id user-id encoded-query nil))
+  ([mcp-session-id user-id encoded-query prompt]
+   (mcp.session/store-handle! mcp-session-id user-id encoded-query prompt)))
+
+(defn- decode-stored-query
+  "Decode a stored handle's base64 query payload to a map, surfacing garbage as a teaching error
+   rather than a decode exception."
+  [encoded]
+  (let [decoded (try
+                  (-> encoded u/decode-base64 json/decode+kw)
+                  (catch Exception _ ::invalid))]
+    (if (map? decoded)
+      decoded
+      (throw-teaching-error "Query handle contents are invalid — run the query again to get a fresh handle."))))
+
+(defn resolve-query-handle!
+  "Resolve `handle` for `user-id` and re-run the fresh-query guards on the stored query, so a
+   handle can never smuggle native SQL past the MBQL-scoped tools or grant access the caller has
+   since lost. Returns `{:query <decoded MBQL map> :prompt <string-or-nil>}`, or throws a teaching
+   error (unknown/expired handle, native query, malformed query, or missing permissions).
+
+   MBQL-path callers only: the MCP Apps UI tools read handles directly through
+   [[metabase.mcp.session/resolve-query-handle]] — a native/SQL handle is visualizable by design,
+   so the native-reject guard must never move into the store's read path."
+  [mcp-session-id user-id handle]
+  (let [{:keys [encoded_query prompt]}
+        (or (mcp.session/resolve-query-handle mcp-session-id user-id handle)
+            (throw-teaching-error "Query handle not found — it may have expired; run the query again."))
+        query (decode-stored-query encoded_query)]
+    (query-guards/reject-native-query! query)
+    (query-guards/validate-serialized-query! query)
+    (query-guards/check-token-query-permissions! query)
+    {:query query :prompt prompt}))
 
 ;;; ------------------------------------------------ Argument plumbing ---------------------------------------------
 

--- a/src/metabase/mcp/v2/query.clj
+++ b/src/metabase/mcp/v2/query.clj
@@ -1,0 +1,195 @@
+(ns metabase.mcp.v2.query
+  "Keyset cursors for the v2 query tools. A cursor is an ordinary query handle whose stored query
+   already embeds the page boundary — the same resolved query with a server-derived total order
+   and a keyset predicate past the last returned row — so paging is just another query on the
+   existing handle store: no page-state column, no content-addressing, no schema change."
+  (:require
+   [metabase.agent-api.query-guards :as query-guards]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.core :as lib]
+   [metabase.mcp.v2.common :as v2.common]
+   [metabase.util.log :as log]))
+
+(set! *warn-on-reflection* true)
+
+(defn- order-by-specs
+  "Map the last stage's order-bys onto positions in `ret-cols` as `[{:idx :dir} …]`, preserving
+   order. Returns nil when an order-by targets a column outside the projection — its boundary
+   value would be unreadable from the last returned row, so no gap-free cursor is possible."
+  [query ret-cols]
+  (reduce (fn [specs [dir _opts expr]]
+            (let [col (lib/find-matching-column query -1 expr ret-cols)
+                  idx (if col (.indexOf ^java.util.List ret-cols col) -1)]
+              (if (neg? idx)
+                (reduced nil)
+                (conj specs {:idx idx :dir dir}))))
+          []
+          (lib/order-bys query)))
+
+(defn- pk-index
+  "Position in `ret-cols` of the source table's PK, when the query sources a table directly and
+   the PK is in the projection."
+  [resolved-query ret-cols]
+  (let [source-table (get-in resolved-query [:stages 0 :source-table])]
+    (when (int? source-table)
+      (some (fn [[i col]]
+              (when (and (= (:semantic-type col) :type/PK)
+                         (= (:table-id col) source-table))
+                i))
+            (map-indexed vector ret-cols)))))
+
+(defn- tiebreaker-specs
+  "Deterministic tiebreakers appended after the existing order-bys to make the order total:
+   the projected source-table PK alone when there is one (unique, so nothing more is needed —
+   and none at all if it is already ordered), else the full remaining projected-column tuple."
+  [resolved-query ret-cols ordered-idxs]
+  (let [pk-idx (pk-index resolved-query ret-cols)]
+    (cond
+      (and pk-idx (contains? ordered-idxs pk-idx)) []
+      pk-idx                                       [{:idx pk-idx :dir :asc}]
+      :else                                        (into []
+                                                         (comp (remove ordered-idxs)
+                                                               (map (fn [i] {:idx i :dir :asc})))
+                                                         (range (count ret-cols))))))
+
+(defn- keyset-filter-clause
+  "Lexicographic strictly-past-the-boundary predicate over the key columns:
+   `(k₀ cmp v₀) OR (k₀ = v₀ AND k₁ cmp v₁) OR …`, where `cmp` is `>` for `:asc` keys and `<` for
+   `:desc`. `values` are the boundary row's values aligned with `specs`."
+  [target-cols specs values]
+  (let [cmp   (fn [{:keys [idx dir]} v]
+                (if (= dir :desc)
+                  (lib/< (nth target-cols idx) v)
+                  (lib/> (nth target-cols idx) v)))
+        eq    (fn [{:keys [idx]} v]
+                (lib/= (nth target-cols idx) v))
+        terms (map-indexed
+               (fn [i spec]
+                 (let [eqs (map eq (take i specs) (take i values))]
+                   (if (seq eqs)
+                     (apply lib/and (concat eqs [(cmp spec (nth values i))]))
+                     (cmp spec (nth values i)))))
+               specs)]
+    (if (= 1 (count terms))
+      (first terms)
+      (apply lib/or terms))))
+
+(def ^:private exact-temporal-units
+  "Truncation units at or coarser than a second. A value truncated this far renders without
+   sub-second digits, so the emitted string parses back to exactly the value that was compared."
+  #{:second :minute :hour :day :week :month :quarter :year})
+
+(defn- lossy-boundary-col?
+  "True when `col`'s emitted row values can't be trusted to round-trip exactly into a comparison
+   literal. Raw datetime/time values are the offender: the row carries a formatted string
+   (millisecond precision at best, driver-dependent rendering), so a keyset predicate built from
+   it can re-include or skip boundary rows. Plain dates and bucket-truncated values render
+   exactly and are safe."
+  [col]
+  (and (isa? (:effective-type col) :type/Temporal)
+       (not (isa? (:effective-type col) :type/Date))
+       (not (contains? exact-temporal-units (:unit (lib/temporal-bucket col))))))
+
+(defn- row-positions
+  "Positions in the result row of the query's projected columns, in projection order. The remap
+   middleware can inject display columns anywhere in the row (each marked `:remapped_from`);
+   dropping those must leave exactly the projection, verified 1:1 by name. Without the run's
+   `result-cols` the row must be exactly the projection. Nil when alignment can't be proven —
+   a misaligned read would build a wrong boundary, which is worse than no cursor."
+  [ret-cols result-cols last-row]
+  (let [positions (if result-cols
+                    (into [] (keep-indexed (fn [i col] (when-not (:remapped_from col) i))) result-cols)
+                    (vec (range (count ret-cols))))]
+    (when (and (= (count positions) (count ret-cols))
+               (every? #(< % (count last-row)) positions)
+               (if result-cols
+                 (every? (fn [[ret-col pos]]
+                           (= (:name ret-col) (:name (nth result-cols pos))))
+                         (map vector ret-cols positions))
+                 (= (count last-row) (count ret-cols))))
+      positions)))
+
+(defn- next-page-query
+  "The serialized next-page query for `resolved-query` given the truncated page's `last-row`
+   (and the run's `result-cols` metadata, used to locate the projected columns in the row), or
+   nil when no gap-free cursor can be built.
+
+   An unaggregated last stage takes the order and keyset filter in place — the filter applies
+   before the stage's own limit, so an embedded limit still yields exactly the next page. An
+   aggregated last stage takes them in an appended stage (an in-stage filter would apply
+   pre-aggregation); if that stage also carries its own limit the base set is cut before the
+   total order can pin it down, so no cursor."
+  [resolved-query result-cols last-row]
+  (let [mp          (lib-be/application-database-metadata-provider (:database resolved-query))
+        query       (lib/query mp resolved-query)
+        aggregated? (boolean (or (seq (lib/aggregations query))
+                                 (seq (lib/breakouts query))))]
+    (when-not (and aggregated? (lib/current-limit query))
+      (let [ret-cols  (vec (lib/returned-columns query))
+            positions (when (and (seq ret-cols) (sequential? last-row))
+                        (row-positions ret-cols result-cols last-row))]
+        (when positions
+          (when-let [ordered (order-by-specs query ret-cols)]
+            (let [tiebreakers (tiebreaker-specs resolved-query ret-cols (into #{} (map :idx) ordered))
+                  specs       (into ordered tiebreakers)
+                  values      (mapv #(nth last-row (nth positions (:idx %))) specs)
+                  ;; a remapped column can't be a cursor key (the remap middleware rewrites an
+                  ;; order-by on it to sort by the display value, so the executed order and the
+                  ;; keyset predicate — which compares raw values — would disagree: a gap), and
+                  ;; neither can a column whose boundary value doesn't round-trip exactly.
+                  unsafe-key?   (some (fn [{:keys [idx]}]
+                                        (let [col (nth ret-cols idx)]
+                                          (or (:lib/external-remap col)
+                                              (:lib/internal-remap col)
+                                              (lossy-boundary-col? col))))
+                                      specs)]
+              (when (and (seq specs) (not unsafe-key?) (every? some? values))
+                (let [base        (if aggregated? (lib/append-stage query) query)
+                      target-cols (if aggregated? (vec (lib/returned-columns base)) ret-cols)
+                      ;; the unaggregated stage already carries its own order-bys; the appended
+                      ;; stage starts bare, so the whole total order is re-imposed there.
+                      to-order    (if aggregated? specs tiebreakers)
+                      with-order  (reduce (fn [q {:keys [idx dir]}]
+                                            (lib/order-by q (nth target-cols idx) dir))
+                                          base
+                                          to-order)]
+                  (-> with-order
+                      (lib/filter (keyset-filter-clause target-cols specs values))
+                      lib/prepare-for-serialization))))))))))
+
+(defn next-page-cursor!
+  "For a truncated MBQL page, build the next-page query (the same resolved query with a
+   server-derived total order appended and a keyset predicate past `last-row`), store it as an
+   ordinary handle, and return that handle's UUID for use as an opaque `next_cursor`.
+
+   `resolved-query` is the decoded serialized MBQL map that ran; `last-row` is the page's last
+   returned row. Opts:
+
+   - `:result-cols` — the run's `[:data :cols]` metadata. Pass it whenever available: the remap
+     middleware can inject display columns anywhere in the row, and without `result-cols` the
+     row must match the projection exactly or no cursor is minted.
+   - `:prompt` — the user's original prompt, carried onto the cursor handle for the
+     visualization feedback flow.
+
+   Returns nil whenever a gap-free cursor cannot be guaranteed: native SQL anywhere in the
+   tree, an order-by outside the projection, a row that can't be aligned with the projection,
+   a nil boundary value, a key column that is remapped or whose values don't round-trip exactly
+   (raw datetimes), an aggregated stage carrying its own limit, or any failure to rehydrate or
+   manipulate the query."
+  ([mcp-session-id user-id resolved-query last-row]
+   (next-page-cursor! mcp-session-id user-id resolved-query last-row nil))
+  ([mcp-session-id user-id resolved-query last-row {:keys [result-cols prompt]}]
+   (when (and (map? resolved-query)
+              (pos-int? (:database resolved-query))
+              (sequential? (:stages resolved-query))
+              (seq (:stages resolved-query))
+              (not (query-guards/native-query? resolved-query)))
+     (when-let [serialized (try
+                             (next-page-query resolved-query result-cols last-row)
+                             (catch Exception e
+                               (log/warn e "Failed to build a next-page cursor query")
+                               nil))]
+       (v2.common/mint-query-handle! mcp-session-id
+                                     user-id
+                                     (v2.common/encode-serialized-query serialized)
+                                     prompt)))))

--- a/test/metabase/agent_api/query_guards_test.clj
+++ b/test/metabase/agent_api/query_guards_test.clj
@@ -1,0 +1,114 @@
+(ns metabase.agent-api.query-guards-test
+  "Tests for the MBQL-path guards (GHY-4136). The native-detection and shape-validation guards are
+   the security boundary that keeps opaque base64 payloads (query handles, continuation tokens) from
+   smuggling native SQL past the MBQL-only scopes, so they are exercised exhaustively here.
+   `check-token-query-permissions!`'s allow/deny cases need permission fixtures and live in the
+   DB-backed round; its no-op branches (which document that only a stage-0 numeric source-table is
+   checked) are covered here."
+  (:require
+   [clojure.test :refer [are deftest is testing]]
+   [metabase.agent-api.query-guards :as query-guards]
+   [metabase.test :as mt]))
+
+(set! *warn-on-reflection* true)
+
+(defn- thrown-status
+  "Return the `:status-code` from the ex-data of the exception `thunk` throws, or nil if it doesn't throw."
+  [thunk]
+  (try (thunk) nil
+       (catch clojure.lang.ExceptionInfo e (:status-code (ex-data e)))))
+
+(deftest native-marker?-test
+  (testing "every native-marker form is detected"
+    (are [node] (true? (query-guards/native-marker? node))
+      {:native "SELECT 1"}                    ; universal :native body
+      {:native {:query "SELECT 1"}}
+      {:type :native}                         ; legacy keyword
+      {:type "native"}                        ; legacy json-decoded string
+      {:lib/type :mbql.stage/native}          ; MBQL 5 keyword
+      {:lib/type "mbql.stage/native"}))       ; MBQL 5 json-decoded string
+  (testing "clean MBQL nodes are not markers"
+    (are [node] (false? (query-guards/native-marker? node))
+      {:type :query}
+      {:type "query"}
+      {:lib/type :mbql.stage/mbql}
+      {:lib/type "mbql.stage/mbql"}
+      {:source-table 1}
+      {}))
+  (testing "non-map and junk values never throw and are never markers"
+    (are [node] (false? (query-guards/native-marker? node))
+      nil 42 "native" :native [:native] #{:native} '(:native))))
+
+(deftest native-query?-test
+  (testing "native SQL is detected at every depth of the tree"
+    (are [query-map] (true? (query-guards/native-query? query-map))
+      {:type :native :native {:query "SELECT 1"}}                                    ; legacy top-level
+      {:database 1 :type :query :query {:source-query {:native "SELECT 1"}}}          ; legacy nested source-query
+      {:stages [{:lib/type :mbql.stage/native :native "SELECT 1"}]}                   ; MBQL 5 native stage
+      {:stages [{:lib/type :mbql.stage/mbql
+                 :joins [{:stages [{:lib/type :mbql.stage/native :native "x"}]}]}]}   ; native inside a join
+      {:stages [{:lib/type :mbql.stage/mbql
+                 :joins [{:stages [{:lib/type :mbql.stage/mbql
+                                    :joins [{:stages [{:lib/type :mbql.stage/native}]}]}]}]}]})) ; nested join
+  (testing "clean MBQL queries are not native"
+    (are [query-map] (false? (query-guards/native-query? query-map))
+      {:stages [{:lib/type :mbql.stage/mbql :source-table 1}]}
+      {:stages [{:lib/type :mbql.stage/mbql :source-table 1
+                 :joins [{:stages [{:lib/type :mbql.stage/mbql :source-table 2}]}]}]}
+      {:database 1 :type :query :query {:source-table 1}}
+      {}
+      {:stages []})))
+
+(deftest reject-native-query!-test
+  (testing "native queries throw a 400 with a steering message"
+    (let [query {:stages [{:lib/type :mbql.stage/native :native "SELECT 1"}]}]
+      (is (= 400 (thrown-status #(query-guards/reject-native-query! query))))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"execute_sql"
+                            (query-guards/reject-native-query! query)))))
+  (testing "clean MBQL queries pass (return nil, do not throw)"
+    (is (nil? (query-guards/reject-native-query! {:stages [{:lib/type :mbql.stage/mbql :source-table 1}]})))))
+
+(deftest validate-serialized-query!-test
+  (testing "well-formed serialized MBQL passes"
+    (are [query-map] (nil? (query-guards/validate-serialized-query! query-map))
+      {:stages [{:source-table 1}]}
+      {:stages [{:source-table 1} {:filters []}]}
+      {:stages [{:source-table 1 :limit 50}]}       ; positive int limit is fine
+      {:stages [{:source-table 1 :limit 1}]}))
+  (testing "a missing or malformed :stages is a 400, not a downstream 500"
+    (are [query-map] (= 400 (thrown-status #(query-guards/validate-serialized-query! query-map)))
+      {}                                 ; no :stages
+      {:stages nil}
+      {:stages []}                       ; empty
+      {:stages {:source-table 1}}        ; not sequential
+      {:stages [{:source-table 1} 42]})) ; a non-map stage
+  (testing "a present-but-invalid last-stage :limit is a 400 (contains?, so explicit false/nil is caught)"
+    (are [limit] (= 400 (thrown-status #(query-guards/validate-serialized-query! {:stages [{:limit limit}]})))
+      false
+      nil
+      0
+      -1
+      "50"
+      1.5)))
+
+(deftest check-token-query-permissions!-no-op-test
+  (testing "the guard is a no-op when there is no stage-0 numeric source-table"
+    ;; Documents the partial coverage: a source-card, a nil source-table, or a non-int value is not
+    ;; checked here — the QP is the authoritative backstop at execution (see review finding #3).
+    (are [query-map] (nil? (query-guards/check-token-query-permissions! query-map))
+      {:stages [{:source-card 10}]}                 ; card source, no source-table
+      {:stages [{}]}                                ; nothing to check
+      {:stages [{:source-table "card__10"}]}        ; string (virtual) source, not an int
+      {:stages []}
+      {})))
+
+(deftest check-token-query-permissions!-allow-deny-test
+  (testing "passes (does not throw) when the current user can query the stage-0 source table"
+    (mt/with-current-user (mt/user->id :rasta)
+      (is (nil? (thrown-status #(query-guards/check-token-query-permissions!
+                                 {:stages [{:source-table (mt/id :orders)}]}))))))
+  (testing "throws 403 when the current user lacks data perms on the source table"
+    (mt/with-no-data-perms-for-all-users!
+      (mt/with-current-user (mt/user->id :rasta)
+        (is (= 403 (thrown-status #(query-guards/check-token-query-permissions!
+                                    {:stages [{:source-table (mt/id :orders)}]}))))))))

--- a/test/metabase/mcp/task/mcp_query_handle_gc_test.clj
+++ b/test/metabase/mcp/task/mcp_query_handle_gc_test.clj
@@ -1,0 +1,43 @@
+(ns metabase.mcp.task.mcp-query-handle-gc-test
+  "Tests for the scheduled query-handle GC (GHY-4136): handles past the TTL are deleted, fresh ones kept,
+   and the TTL setting is honored."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [java-time.api :as t]
+   [metabase.mcp.task.mcp-query-handle-gc :as gc]
+   [metabase.mcp.v2.common :as common]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- mint!
+  "Mint a handle owned by `uid`; the query body is irrelevant — GC only reads `created_at`."
+  [uid]
+  (common/mint-query-handle! (str (random-uuid)) uid
+                             (common/encode-serialized-query {:stages [{:source-table 1}]})))
+
+(defn- hours-ago [n]
+  (t/minus (t/offset-date-time) (t/hours (long n))))
+
+(deftest gc-deletes-handles-past-ttl-test
+  (mt/with-model-cleanup [:model/McpQueryHandle]
+    (let [uid   (mt/user->id :rasta)
+          old   (mint! uid)
+          fresh (mint! uid)]
+      (t2/update! :model/McpQueryHandle old {:created_at (hours-ago 25)}) ; default TTL is 24h
+      (#'gc/gc-expired-query-handles!)
+      (testing "a handle older than the TTL is deleted"
+        (is (nil? (t2/select-one :model/McpQueryHandle :id old))))
+      (testing "a handle within the TTL is kept"
+        (is (some? (t2/select-one :model/McpQueryHandle :id fresh)))))))
+
+(deftest gc-respects-ttl-setting-test
+  (mt/with-model-cleanup [:model/McpQueryHandle]
+    (mt/with-temporary-setting-values [mcp-query-handle-ttl-hours 1]
+      (let [uid (mt/user->id :rasta)
+            h   (mint! uid)]
+        (t2/update! :model/McpQueryHandle h {:created_at (hours-ago 2)})
+        (#'gc/gc-expired-query-handles!)
+        (is (nil? (t2/select-one :model/McpQueryHandle :id h))
+            "a 2h-old handle is deleted when the TTL is set to 1h")))))

--- a/test/metabase/mcp/v2/common_test.clj
+++ b/test/metabase/mcp/v2/common_test.clj
@@ -7,7 +7,8 @@
    [metabase.mcp.v2.projections :as projections]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [metabase.util.json :as json]))
 
 (set! *warn-on-reflection* true)
 
@@ -163,3 +164,69 @@
     (testing "an unknown method is a teaching error"
       (is (thrown-with-msg? Exception #"create.*update"
                             (common/dispatch-write entry nil {:method "delete"}))))))
+
+;;; ------------------------------------------------ Query handles (GHY-4136) -------------------------------------
+
+(defn- thrown
+  "Return `[status-code message]` from the exception `thunk` throws, or nil if it doesn't throw."
+  [thunk]
+  (try (thunk) nil
+       (catch clojure.lang.ExceptionInfo e [(:status-code (ex-data e)) (ex-message e)])))
+
+(defn- mbql-handle!
+  "Mint a handle for an orders-sourced MBQL query owned by `uid` in session `sid`."
+  [sid uid & [prompt]]
+  (common/mint-query-handle! sid uid
+                             (common/encode-serialized-query
+                              {:database (mt/id) :stages [{:lib/type "mbql.stage/mbql"
+                                                           :source-table (mt/id :orders)}]})
+                             prompt))
+
+(deftest handle-round-trip-test
+  (mt/with-model-cleanup [:model/McpQueryHandle]
+    (let [uid (mt/user->id :rasta)
+          sid (str (random-uuid))
+          q   {:database (mt/id) :stages [{:lib/type "mbql.stage/mbql" :source-table (mt/id :orders)}]}]
+      (mt/with-current-user uid
+        (testing "mint then resolve returns the stored query and prompt"
+          (let [h        (common/mint-query-handle! sid uid (common/encode-serialized-query q) "show orders")
+                resolved (common/resolve-query-handle! sid uid h)]
+            (is (string? h))
+            (is (= "show orders" (:prompt resolved)))
+            ;; handles store base64 JSON, so the resolved query is the JSON round-trip of what was minted
+            (is (= (-> q json/encode json/decode+kw) (:query resolved)))))
+        (testing "prompt is optional"
+          (let [h (common/mint-query-handle! sid uid (common/encode-serialized-query q))]
+            (is (nil? (:prompt (common/resolve-query-handle! sid uid h))))))))))
+
+(deftest handle-ownership-test
+  (mt/with-model-cleanup [:model/McpQueryHandle]
+    (let [uid   (mt/user->id :rasta)
+          other (mt/user->id :lucky)
+          sid   (str (random-uuid))]
+      (mt/with-current-user uid
+        (testing "an unknown/expired handle is a teaching error, not a 500"
+          (is (= 400 (first (thrown #(common/resolve-query-handle! sid uid (str (random-uuid))))))))
+        (testing "a handle resolves for its owner but not for another user"
+          (let [h (mbql-handle! sid uid)]
+            (is (nil? (thrown #(common/resolve-query-handle! sid uid h))))              ; owner: ok
+            (is (= 400 (first (thrown #(common/resolve-query-handle! sid other h)))))))))))  ; other: not found
+
+(deftest handle-guards-test
+  (mt/with-model-cleanup [:model/McpQueryHandle]
+    (let [uid (mt/user->id :rasta)
+          sid (str (random-uuid))]
+      (mt/with-current-user uid
+        (testing "a stored NATIVE query is rejected on the MBQL read path"
+          (let [h (common/mint-query-handle! sid uid
+                                             (common/encode-serialized-query
+                                              {:stages [{:lib/type "mbql.stage/native" :native "SELECT 1"}]}))]
+            (is (= [400 "Native queries are not supported here; use execute_sql instead."]
+                   (thrown #(common/resolve-query-handle! sid uid h))))))
+        (testing "a garbage (non-map) stored payload is a teaching error, not a decode 500"
+          (let [h (common/mint-query-handle! sid uid (common/encode-serialized-query [1 2 3]))]
+            (is (= 400 (first (thrown #(common/resolve-query-handle! sid uid h)))))))
+        (testing "a stored query the caller can no longer access throws 403"
+          (let [h (mbql-handle! sid uid)]
+            (mt/with-no-data-perms-for-all-users!
+              (is (= 403 (first (thrown #(common/resolve-query-handle! sid uid h))))))))))))

--- a/test/metabase/mcp/v2/query_test.clj
+++ b/test/metabase/mcp/v2/query_test.clj
@@ -1,0 +1,77 @@
+(ns metabase.mcp.v2.query-test
+  "Tests for keyset (seek) pagination of MBQL query results (GHY-4136)."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.mcp.v2.common :as common]
+   [metabase.mcp.v2.query :as q]
+   [metabase.query-processor :as qp]
+   [metabase.test :as mt]))
+
+(set! *warn-on-reflection* true)
+
+(defn- mp [] (lib-be/application-database-metadata-provider (mt/id)))
+
+(defn- orders-query []
+  (lib/query (mp) (lib.metadata/table (mp) (mt/id :orders))))
+
+(defn- run-rows+cols [query]
+  (let [r (qp/process-query query)]
+    [(get-in r [:data :rows]) (get-in r [:data :cols])]))
+
+(defn- col-index [cols col-name]
+  (some (fn [[i c]] (when (= (:name c) col-name) i)) (map-indexed vector cols)))
+
+(deftest next-page-cursor-pk-test
+  (mt/with-current-user (mt/user->id :rasta)
+    (mt/with-model-cleanup [:model/McpQueryHandle]
+      (let [uid    (mt/user->id :rasta)
+            sid    (str (random-uuid))
+            query  (lib/limit (orders-query) 3)
+            [rows cols] (run-rows+cols query)
+            cursor (q/next-page-cursor! sid uid (lib/prepare-for-serialization query) (last rows)
+                                        {:result-cols cols})
+            stage  (-> (common/resolve-query-handle! sid uid cursor) :query :stages last)]
+        (testing "a table-sourced query gets a keyset cursor: ORDER BY the PK, WHERE strictly past the boundary, LIMIT preserved"
+          (is (some? cursor))
+          (is (seq (:order-by stage)) "the next-page query carries a total order")
+          (is (= ">" (ffirst (:filters stage))) "the next-page query filters strictly past the last row")
+          (is (= 3 (:limit stage))))))))
+
+(deftest next-page-cursor-bails-test
+  (mt/with-current-user (mt/user->id :rasta)
+    (let [uid (mt/user->id :rasta)
+          sid (str (random-uuid))]
+      (testing "no cursor for a native query (keyset can't be built over opaque SQL — caller falls back to limit-only)"
+        (is (nil? (q/next-page-cursor! sid uid
+                                       {:database (mt/id) :stages [{:lib/type "mbql.stage/native" :native "SELECT 1"}]}
+                                       [1] {}))))
+      (testing "no cursor for an unusable query shape"
+        (is (nil? (q/next-page-cursor! sid uid {:stages []} [1] {})))
+        (is (nil? (q/next-page-cursor! sid uid {:database (mt/id)} [1] {})))
+        (is (nil? (q/next-page-cursor! sid uid "not-a-map" [1] {})))))))
+
+(deftest next-page-cursor-pages-without-gaps-or-dups-test
+  ;; Proves the keyset seek is correct across page boundaries: for a unique-key (PK) source, paging
+  ;; returns strictly increasing, distinct PKs — no row skipped, none repeated. (The non-unique-key
+  ;; case, where the full-tuple tiebreaker can drop duplicate rows split across a boundary, is the
+  ;; known gap tracked as review finding #2.)
+  (mt/with-current-user (mt/user->id :rasta)
+    (let [page-size 4
+          n-pages   4
+          ids (loop [query (lib/limit (orders-query) page-size), acc [], pages 0]
+                (let [[rows cols] (run-rows+cols query)
+                      id-idx (col-index cols "ID")
+                      acc'   (into acc (map #(nth % id-idx) rows))
+                      pages' (inc pages)]
+                  (if (or (>= pages' n-pages) (< (count rows) page-size))
+                    acc'
+                    (if-let [nxt (#'q/next-page-query (lib/prepare-for-serialization query) cols (last rows))]
+                      (recur (lib/query (mp) nxt) acc' pages')
+                      acc'))))]
+      (testing "keyset paging yields strictly increasing, distinct PKs across boundaries"
+        (is (= (* page-size n-pages) (count ids)))
+        (is (apply < ids) "strictly increasing => no boundary repeats and no rows skipped backwards")
+        (is (= (count ids) (count (distinct ids))))))))


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GHY-4136/query-handles-mint-resolve-cleanup-cursor

## What

Builds the query-handle infrastructure for MCP v2: minting, resolving, keyset-cursor pagination, and TTL cleanup. Stacked on `mcp-v2-foundation`.

## Changes

**Shared MBQL guards (`metabase.agent-api.query-guards`)**
Extracts the four query guards (`native-query?`/`reject-native-query!`, `validate-serialized-query!`, `check-token-query-permissions!`) out of `agent_api/api.clj` into a new namespace so both the agent-API endpoints and the MCP v2 tools apply the identical checks. Pure move — the agent-api call sites just qualify the names. These guards keep opaque base64 payloads (query handles, continuation tokens) from smuggling native SQL past the MBQL-only scopes or retaining access the caller has since lost.

**Query-handle mint/resolve (`metabase.mcp.v2.common`)**
- `encode-serialized-query` — base64-encodes a serialized MBQL map for the handle store.
- `mint-query-handle!` — stores the encoded query (plus the user's prompt) under a fresh handle owned by the user.
- `resolve-query-handle!` — resolves a handle for a user and re-runs all three guards on the stored query, so a handle can never smuggle native SQL or grant lost access. The MCP Apps UI reads handles directly (native handles are visualizable by design), so the native-reject guard deliberately lives here, not in the store's read path.

**Keyset (seek) pagination (`metabase.mcp.v2.query`)**
`next-page-cursor!` builds a next-page query from a truncated page's last row — the same resolved query with a server-derived total order and a keyset predicate strictly past the last row — stores it as an ordinary handle, and returns the UUID as an opaque `next_cursor`. A cursor is just another query on the existing handle store: no page-state column, no content-addressing, no schema change. It returns `nil` (caller falls back to limit-only) whenever a gap-free cursor can't be guaranteed: native SQL, an order-by outside the projection, an unalignable row, a nil boundary value, a remapped or lossy-temporal key column, or an aggregated stage carrying its own limit.

**Scheduled GC (`metabase.mcp.task.mcp-query-handle-gc`)**
Daily Quartz job that deletes `mcp_query_handle` rows older than the new `mcp-query-handle-ttl-hours` setting (default 24h). Session-tied handles are also reaped by the `core_session` FK cascade; this task catches handles whose sessions outlive the TTL, since every execute mints a handle and handle volume grows faster than sessions are torn down.

## Notes

- The new mint/resolve/cursor functions have no production callers yet — wiring into the MCP v2 tools lands in a follow-up in the stack. Covered directly by tests here.
- Known limitations tracked in review: keyset paging over a non-unique key can drop duplicate rows split across a boundary; `check-token-query-permissions!` pre-checks only a stage-0 integer source-table (the QP is the authoritative backstop at execution).

## Tests

- `query_guards_test` — exhaustive native-detection and shape-validation coverage; permission allow/deny/no-op cases.
- `mcp/v2/common_test` — handle round-trip, ownership scoping, native-on-read rejection, garbage payload, permission loss.
- `mcp/v2/query_test` — PK keyset cursor, bail-out cases, and gap-free paging across boundaries for a unique key.
- `mcp/task/mcp_query_handle_gc_test` — past-TTL deletion, fresh retention, TTL-setting honored.
