### PR TITLE
Add a beta badge in data apps admin page heading

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppsPage.tsx
@@ -4,7 +4,7 @@ import {
   SettingsPageWrapper,
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
-import { Box, Flex, Loader, Stack, Title } from "metabase/ui";
+import { Badge, Box, Flex, Group, Loader, Stack, Title } from "metabase/ui";
 import {
   useGetDataAppRepoStatusQuery,
   useListDataAppsQuery,
@@ -42,9 +42,11 @@ export const ManageDataAppsPage = () => {
 
   return (
     <SettingsPageWrapper>
-      <Title order={1} style={{ height: "2.5rem" }}>
-        {t`Data apps`}
-      </Title>
+      <Group gap="sm" align="center">
+        <Title order={1}>{t`Data apps`}</Title>
+
+        <Badge>{t`Beta`}</Badge>
+      </Group>
 
       <DataAppsBanner />
 


### PR DESCRIPTION
Closes [EMB-2100: Add a beta badge next to the page heading](https://linear.app/metabase/issue/EMB-2100/add-a-beta-badge-next-to-the-page-heading)

### Description

Adds a Beta badge next to the page's heading per Maz's feedback.

<img width="2348" height="1802" alt="CleanShot 2569-07-16 at 02 00 39@2x" src="https://github.com/user-attachments/assets/42052ebf-47c4-4e43-88f0-a3d22137e79d" />

