### PR TITLE
[PDFs] Add analytics for dashboard subscription runs and PDF API calls

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -747,6 +747,7 @@
    :api  #{metabase.dashboards-rest.api}
    :uses #{actions
            analytics
+           analytics-interface
            api
            app-db
            channel

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -531,6 +531,14 @@
    (prometheus/counter :metabase-notification/template-update
                        {:description "Number of notification templates updated."
                         :labels [:channel-type]})
+   (prometheus/counter :metabase-notification/dashboard-subscription-send
+                       {:description (str "Number of dashboard subscription sends, labeled by channel and by whether a "
+                                          "PDF was attached. The fraction with include-pdf=\"true\" measures adoption "
+                                          "of the \"attach PDF\" feature.")
+                        :labels [:channel-type :include-pdf]})
+   (prometheus/counter :metabase-dashboard/pdf-export
+                       {:description "Number of on-demand dashboard-to-PDF API requests (POST /api/dashboard/:id/pdf), labeled by outcome."
+                        :labels [:status]})
    (prometheus/counter :metabase-gsheets/connection-creation-began
                        {:description "How many times the instance has initiated a Google Sheets connection creation."})
    (prometheus/counter :metabase-gsheets/connection-creation-error

--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -42,6 +42,12 @@
     {:template-type template-type
      :channel-type  :channel/email}))
 
+(defmethod analytics.core/known-labels :metabase-notification/dashboard-subscription-send [_]
+  (for [channel-type [:channel/email :channel/slack]
+        include-pdf   [true false]]
+    {:channel-type channel-type
+     :include-pdf  include-pdf}))
+
 (def ^:private EmailMessage
   [:map
    [:subject                         :string]
@@ -339,6 +345,9 @@
         card-attachments    (map make-message-attachment merged-attachments)
         pdf-attachment      (when include_pdf
                               (dashboard-pdf-attachment (:id dashboard) (:name dashboard) creator_id parameters dashboard_parts))
+        _                   (analytics/inc! :metabase-notification/dashboard-subscription-send
+                                            {:channel-type :channel/email
+                                             :include-pdf  (boolean include_pdf)})
         attachments         (cond-> (into [icon-attachment] result-attachments)
                               (not attachment_only) (concat card-attachments)
                               pdf-attachment        (concat [pdf-attachment]))

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -1,6 +1,7 @@
 (ns metabase.channel.impl.slack
   (:require
    [clojure.string :as str]
+   [metabase.analytics-interface.core :as analytics]
    [metabase.appearance.core :as appearance]
    [metabase.channel.core :as channel]
    [metabase.channel.impl.util :as impl.util]
@@ -284,6 +285,9 @@
   (let [all-params       (:parameters payload)
         top-level-params (impl.util/remove-inline-parameters all-params (:dashboard_parts payload))
         dashboard        (:dashboard payload)
+        _                (analytics/inc! :metabase-notification/dashboard-subscription-send
+                                         {:channel-type :channel/slack
+                                          :include-pdf  (boolean include_pdf)})
         pdf              (some-> (when include_pdf
                                    (dashboard-pdf dashboard creator_id all-params (:dashboard_parts payload)))
                                  (assoc :comment (slack-dashboard-caption dashboard (:common_name creator)

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -6,7 +6,8 @@
    [clojure.set :as set]
    [medley.core :as m]
    [metabase.actions.core :as actions]
-   [metabase.analytics.core :as analytics]
+   [metabase.analytics-interface.core :as analytics]
+   [metabase.analytics.core :as analytics.core]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as app-db]
@@ -168,9 +169,9 @@
                          ;; Ok, now save the Dashboard
                          (first (t2/insert-returning-instances! :model/Dashboard dashboard-data)))]
     (events/publish-event! :event/dashboard-create {:object dash :user-id api/*current-user-id*})
-    (analytics/track-event! :snowplow/dashboard
-                            {:event        :dashboard-created
-                             :dashboard-id (u/the-id dash)})
+    (analytics.core/track-event! :snowplow/dashboard
+                                 {:event        :dashboard-created
+                                  :dashboard-id (u/the-id dash)})
     (-> dash
         hydrate-dashboard-details
         collection.root/hydrate-root-collection
@@ -592,9 +593,9 @@
                              (when (collections/moving-into-remote-synced? (:collection_id existing-dashboard)
                                                                            collection_id)
                                (collections/check-non-remote-synced-dependencies <>)))))]
-    (analytics/track-event! :snowplow/dashboard
-                            {:event        :dashboard-created
-                             :dashboard-id (u/the-id dashboard)})
+    (analytics.core/track-event! :snowplow/dashboard
+                                 {:event        :dashboard-created
+                                  :dashboard-id (u/the-id dashboard)})
     ;; must signal event outside of tx so cards are visible from other threads
     (when-let [newly-created-cards (seq @new-cards)]
       (doseq [card newly-created-cards]
@@ -645,6 +646,9 @@
       (u/prog1 (first (revisions/with-last-edit-info [dashboard] :dashboard))
         (events/publish-event! :event/dashboard-read {:object-id (:id dashboard) :user-id api/*current-user-id*})))))
 
+(defmethod analytics.core/known-labels :metabase-dashboard/pdf-export [_]
+  [{:status "success"} {:status "error"}])
+
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/:id/pdf" :- :any
   "Render Dashboard with ID to a PDF (server-side, the same way dashboard subscriptions render charts) and stream it
@@ -682,11 +686,13 @@
           filename  (str (or (not-empty (u/slugify (:name dashboard)))
                              (str "dashboard-" id))
                          ".pdf")]
+      (analytics/inc! :metabase-dashboard/pdf-export {:status "success"})
       (respond {:status  200
                 :headers {"Content-Type"        "application/pdf"
                           "Content-Disposition" (format "attachment; filename=\"%s\"" filename)}
                 :body    (java.io.ByteArrayInputStream. pdf-bytes)}))
     (catch Throwable e
+      (analytics/inc! :metabase-dashboard/pdf-export {:status "error"})
       (raise e))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
@@ -917,23 +923,23 @@
                            {:object dashboard :user-id api/*current-user-id* :dashcards created-dashcards})
     (for [{:keys [card_id]} created-dashcards
           :when             (pos-int? card_id)]
-      (analytics/track-event! :snowplow/dashboard
-                              {:event        :question-added-to-dashboard
-                               :dashboard-id dashboard-id
-                               :question-id  card_id})))
+      (analytics.core/track-event! :snowplow/dashboard
+                                   {:event        :question-added-to-dashboard
+                                    :dashboard-id dashboard-id
+                                    :question-id  card_id})))
   ;; Tabs events
   (when (seq deleted-tab-ids)
-    (analytics/track-event! :snowplow/dashboard
-                            {:event          :dashboard-tab-deleted
-                             :dashboard-id   dashboard-id
-                             :num-tabs       (count deleted-tab-ids)
-                             :total-num-tabs total-num-tabs}))
+    (analytics.core/track-event! :snowplow/dashboard
+                                 {:event          :dashboard-tab-deleted
+                                  :dashboard-id   dashboard-id
+                                  :num-tabs       (count deleted-tab-ids)
+                                  :total-num-tabs total-num-tabs}))
   (when (seq created-tab-ids)
-    (analytics/track-event! :snowplow/dashboard
-                            {:event          :dashboard-tab-created
-                             :dashboard-id   dashboard-id
-                             :num-tabs       (count created-tab-ids)
-                             :total-num-tabs total-num-tabs})))
+    (analytics.core/track-event! :snowplow/dashboard
+                                 {:event          :dashboard-tab-created
+                                  :dashboard-id   dashboard-id
+                                  :num-tabs       (count created-tab-ids)
+                                  :total-num-tabs total-num-tabs})))
 
 ;;;;;;;;;;;; Bad pulse check & repair
 

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -742,6 +742,21 @@
             (mt/user-http-request :rasta :post 400 (format "dashboard/%d/pdf" dash-id)
                                   {:paper_size "a3"})))))))
 
+(deftest dashboard-pdf-export-metric-test
+  (testing "POST /api/dashboard/:id/pdf records the pdf-export Prometheus counter by outcome"
+    (mt/with-prometheus-system! [_ system]
+      (mt/with-temp [:model/Dashboard {dash-id :id} {:name "My Bird Dashboard"}]
+        (testing "a successful render increments status=success"
+          (with-redefs [channel.render/render-dashboard-to-pdf (fn [& _] (.getBytes "%PDF-1.4 ok"))]
+            (mt/user-http-request :rasta :post 200 (format "dashboard/%d/pdf" dash-id)
+                                  {:request-options {:as :byte-array}} {}))
+          (is (= 1.0 (mt/metric-value system :metabase-dashboard/pdf-export {:status "success"}))))
+        (testing "a failing render increments status=error"
+          (with-redefs [channel.render/render-dashboard-to-pdf (fn [& _] (throw (ex-info "boom" {})))]
+            (mt/user-http-request :rasta :post 500 (format "dashboard/%d/pdf" dash-id)
+                                  {:request-options {:as :byte-array}} {}))
+          (is (= 1.0 (mt/metric-value system :metabase-dashboard/pdf-export {:status "error"}))))))))
+
 (deftest dashboard-pdf-permissions-test
   (testing "POST /api/dashboard/:id/pdf requires read permission on the dashboard"
     (with-redefs [channel.render/render-dashboard-to-pdf (fn [& _] (.getBytes "x"))]

--- a/test/metabase/pulse/dashboard_subscription_test.clj
+++ b/test/metabase/pulse/dashboard_subscription_test.clj
@@ -1596,6 +1596,35 @@
                     (first (:channel/email pulse-results))
                     #"Aviary KPIs")))))))))
 
+(deftest dashboard-sub-include-pdf-metric-test
+  (testing "Each email dashboard-subscription send records the dashboard-subscription-send counter, labeled by include-pdf"
+    (with-redefs [channel.render/render-dashboard-to-pdf (fn [& _] (.getBytes "%PDF-1.4 stub" "UTF-8"))]
+      (mt/with-prometheus-system! [_ system]
+        (letfn [(send-with-pdf! [include-pdf?]
+                  (mt/with-temp [:model/Card          {card-id :id} {:name          pulse.test-util/card-name
+                                                                     :dataset_query (mt/mbql-query orders {:limit 1})}
+                                 :model/Dashboard     {dashboard-id :id} {:name "Aviary KPIs"}
+                                 :model/DashboardCard _ {:dashboard_id dashboard-id
+                                                         :card_id      card-id}
+                                 :model/Pulse         {pulse-id :id} {:name         "Pulse Name"
+                                                                      :dashboard_id dashboard-id}
+                                 :model/PulseCard     _ {:pulse_id pulse-id
+                                                         :card_id  card-id
+                                                         :position 0}
+                                 :model/PulseChannel  {pc-id :id} {:pulse_id     pulse-id
+                                                                   :channel_type "email"
+                                                                   :details      {:include_pdf include-pdf?}}
+                                 :model/PulseChannelRecipient _ {:user_id          (pulse.test-util/rasta-id)
+                                                                 :pulse_channel_id pc-id}]
+                    (pulse.test-util/with-captured-channel-send-messages!
+                      (pulse.send/send-pulse! (t2/select-one :model/Pulse pulse-id)))))]
+          (send-with-pdf! true)
+          (send-with-pdf! false)
+          (is (= 1.0 (mt/metric-value system :metabase-notification/dashboard-subscription-send
+                                      {:channel-type :channel/email :include-pdf true})))
+          (is (= 1.0 (mt/metric-value system :metabase-notification/dashboard-subscription-send
+                                      {:channel-type :channel/email :include-pdf false}))))))))
+
 (deftest dashboard-sub-slack-include-pdf-test
   (testing "A Slack channel with :include_pdf renders the dashboard PDF and carries it on the message"
     (notification.tu/with-channel-fixtures [:channel/slack]
@@ -1615,18 +1644,22 @@
                           (reset! render-args {:dashboard-id dashboard-id :user-id user-id
                                                :parameters parameters :parts parts})
                           (.getBytes "%PDF-1.4 stub" "UTF-8"))]
-            (pulse.test-util/slack-test-setup!
-             (let [results (pulse.test-util/with-captured-channel-send-messages!
-                             (pulse.send/send-pulse! (t2/select-one :model/Pulse pulse-id)))
-                   msg     (first (:channel/slack results))]
-               (testing "renderer is called with the subscription's dashboard id"
-                 (is (= dashboard-id (:dashboard-id @render-args))))
-               (testing "the slack message carries the rendered PDF"
-                 (is (bytes? (-> msg :pdf :bytes)))
-                 (is (str/ends-with? (-> msg :pdf :filename) ".pdf")))
-               (testing "it's a single message: no chart-image blocks, title/link ride along as the PDF caption"
-                 (is (empty? (:blocks msg)))
-                 (is (str/includes? (-> msg :pdf :comment) "Aviary KPIs")))))))))))
+            (mt/with-prometheus-system! [_ system]
+              (pulse.test-util/slack-test-setup!
+               (let [results (pulse.test-util/with-captured-channel-send-messages!
+                               (pulse.send/send-pulse! (t2/select-one :model/Pulse pulse-id)))
+                     msg     (first (:channel/slack results))]
+                 (testing "renderer is called with the subscription's dashboard id"
+                   (is (= dashboard-id (:dashboard-id @render-args))))
+                 (testing "the slack message carries the rendered PDF"
+                   (is (bytes? (-> msg :pdf :bytes)))
+                   (is (str/ends-with? (-> msg :pdf :filename) ".pdf")))
+                 (testing "it's a single message: no chart-image blocks, title/link ride along as the PDF caption"
+                   (is (empty? (:blocks msg)))
+                   (is (str/includes? (-> msg :pdf :comment) "Aviary KPIs")))
+                 (testing "the slack send is recorded with channel-type=slack and include-pdf=true"
+                   (is (= 1.0 (mt/metric-value system :metabase-notification/dashboard-subscription-send
+                                               {:channel-type :channel/slack :include-pdf true})))))))))))))
 
 (deftest dashboard-sub-slack-no-pdf-sends-images-test
   (testing "Without :include_pdf, Slack still sends chart images and no PDF"


### PR DESCRIPTION
Fixes UXW-4728.

### Description

Add Prometheus metrics for:
1. Dashboard subscription *runs* (not static definitions)
    - Tagged with the medium: `:email` or `:slack`.
    - Tagged with a flag for whether PDFs were included.
2. PDF generation API calls, with a `:status #{:success :error}` tag


### How to verify

Runs dashboard subscriptions with and without PDFs included, and check the Prometheus metrics.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
