### PR TITLE
feat(oauth-server): mb:workspace-manager scope + workspace-login revocation + containment suite (split 1/3)

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/workspaces/api/workspace_manager.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api/workspace_manager.clj
@@ -90,6 +90,7 @@
 
 (api.macros/defendpoint :get "/" :- [:sequential WorkspaceResponse]
   "List all Workspaces."
+  {:scope "mb:workspace-manager"}
   []
   (api/check-superuser)
   (into [] (comp (filter mi/can-read?)
@@ -98,6 +99,7 @@
 
 (api.macros/defendpoint :get "/:id" :- WorkspaceResponse
   "Get a single Workspace by id."
+  {:scope "mb:workspace-manager"}
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
   (api/read-check :model/Workspace id)
   (present-workspace (api/check-404 (ws/get-workspace id))))
@@ -105,6 +107,7 @@
 (api.macros/defendpoint :post "/" :- WorkspaceResponse
   "Create a new Workspace attached to the given databases (each must be eligible
    for workspaces) and provision it (blocking)."
+  {:scope "mb:workspace-manager"}
   [_route-params _query-params params :- CreateWorkspaceParams]
   (api/create-check :model/Workspace params)
   (present-workspace
@@ -113,6 +116,7 @@
 
 (api.macros/defendpoint :put "/:id" :- WorkspaceResponse
   "Update a workspace's name."
+  {:scope "mb:workspace-manager"}
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    _query-params
    params :- UpdateWorkspaceParams]
@@ -141,6 +145,7 @@
   unreachable for some `:provisioned` databases, the response includes
   `:orphaned_resources` and a `:message` describing the inert schema/user objects
   left behind for manual cleanup."
+  {:scope "mb:workspace-manager"}
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    {ignore-pending? :ignore-pending} :- [:map [:ignore-pending {:default false} [:maybe ms/BooleanValue]]]]
   (api/write-check :model/Workspace id)
@@ -155,6 +160,7 @@
       [:body    :string]]
   "Download the workspace's developer-instance config as a YAML file. 409 if any
   of the workspace's databases is not `:provisioned`."
+  {:scope "mb:workspace-manager"}
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
   (api/write-check :model/Workspace id)
   (let [config (api/check-404 (ws.config/build-workspace-config id))]
@@ -181,6 +187,7 @@
   scoped to each database's `:input` namespaces. Same flag semantics as
   `/api/ee/serialization/metadata/export` — sections must be opted into via the
   `with-databases` / `with-tables` / `with-fields` query parameters."
+  {:scope "mb:workspace-manager"}
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    query-params
    :- [:map

--- a/enterprise/backend/test/metabase_enterprise/workspaces/containment_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/containment_test.clj
@@ -1,0 +1,120 @@
+(ns metabase-enterprise.workspaces.containment-test
+  "GHY-4062: the containment proof suite. This suite IS the answer to \"how can we be
+  certain\" — it fails the build when someone widens the hole.
+
+  Two layers, both about the parent-side `mb:workspace-manager` OAuth token:
+  1. Static allowlist sweep: exactly the intended endpoints carry the
+     `mb:workspace-manager` scope tag, and no other loaded namespace does.
+  2. Workspace-scoped OAuth token: reaches the allowlist, 403s everywhere else
+     (default-deny via `ensure-scopes-checked`).
+
+  Refresh-cannot-widen is pinned in `metabase.oauth-server.api-test`
+  (token-refresh-cannot-widen-scope-test); revocation of other sessions at
+  workspace login in workspace-login-revokes-other-sessions-test.
+
+  Child-side containment is out of scope: the child agent key is an admin key
+  (v0), so there is no child-endpoint allowlist to prove."
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [metabase-enterprise.workspaces.api.workspace-manager]
+   [metabase.api.macros :as api.macros]
+   [metabase.initialization-status.core :as init-status]
+   [metabase.oauth-server.core :as oauth-server]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [metabase.test.http-client :as client]
+   [metabase.users-rest.api]
+   [oidc-provider.store :as oidc.store]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db))
+
+;; the OAuth bearer bridge is gated on initialization being complete; the isolated
+;; test runner never boots the web server, so mark it complete as session tests do.
+(init-status/set-complete!)
+
+;;; ------------------------------------ 1. static allowlist sweep ------------------------------------
+
+(def ^:private workspace-manager-scope "mb:workspace-manager")
+
+(defn- scope-tagged-endpoints
+  "Endpoints in `ns-sym` whose defendpoint metadata carries the workspace-manager scope."
+  [ns-sym]
+  (into []
+        (filter #(= workspace-manager-scope (get-in % [:form :metadata :scope])))
+        (vals (api.macros/ns-routes ns-sym))))
+
+(deftest scope-allowlist-is-exactly-the-intended-surface-test
+  (testing "all 7 workspace-manager endpoints are tagged"
+    (let [routes (vals (api.macros/ns-routes 'metabase-enterprise.workspaces.api.workspace-manager))]
+      (is (= 7 (count routes)))
+      (is (= 7 (count (scope-tagged-endpoints 'metabase-enterprise.workspaces.api.workspace-manager)))
+          "every workspace-manager endpoint must carry the scope tag")))
+  (testing "users-rest exposes exactly one tagged endpoint (GET /current, whoami)"
+    (is (= 1 (count (scope-tagged-endpoints 'metabase.users-rest.api)))))
+  (testing "NO other loaded namespace tags an endpoint with mb:workspace-manager"
+    (let [allowed  '#{metabase-enterprise.workspaces.api.workspace-manager
+                      metabase.users-rest.api}
+          offender (for [n     (all-ns)
+                         :when (and (:api/endpoints (meta n))
+                                    (not (contains? allowed (ns-name n))))
+                         :when (seq (scope-tagged-endpoints (ns-name n)))]
+                     (ns-name n))]
+      (is (empty? offender)
+          "widening the workspace-manager scope surface requires updating this proof suite"))))
+
+;;; ------------------------------- 2. workspace-scoped token, parent side -------------------------------
+
+(defn- bearer [token]
+  {:request-options {:headers {"authorization" (str "Bearer " token)}}})
+
+(defn- seed-scoped-token!
+  "Save a workspace-manager-scoped OAuth access token for `user` through the live
+   provider's token store (the library hashes tokens at rest, so seeding must go
+   through it, not raw t2). Returns the bearer token string."
+  [user expiry]
+  (let [token (str "containment-" (random-uuid))]
+    (oidc.store/save-access-token (:token-store (oauth-server/get-provider))
+                                  token
+                                  (str (mt/user->id user))
+                                  "containment-suite"
+                                  [workspace-manager-scope]
+                                  expiry
+                                  nil)
+    token))
+
+(deftest workspace-scoped-token-reaches-only-the-allowlist-test
+  (mt/with-premium-features #{:workspaces}
+    (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+      ;; no rollback-only transaction here: the handler may look the token up outside
+      ;; this thread's transaction, so insert for real and clean up in `finally`
+      (let [token (seed-scoped-token! :crowberto (+ (inst-ms (java.util.Date.)) (* 60 60 1000)))]
+        (try
+          (testing "allowlist: workspace-manager list + whoami respond 200"
+            (is (sequential? (client/client :get 200 "ee/workspace-manager/" (bearer token))))
+            (is (=? {:email "crowberto@metabase.com"}
+                    (client/client :get 200 "user/current" (bearer token)))))
+          (testing "session/properties stays reachable (:scope :unchecked) — it serves anonymous
+                    callers, so a scoped token must never be weaker than no token (CLI preflight)"
+            (is (map? (client/client :get 200 "session/properties" (bearer token)))))
+          (testing "everything outside the allowlist rejects with scope_not_permitted"
+            (doseq [[method url] [[:post "card"]
+                                  [:get  "dashboard"]
+                                  [:get  "database"]
+                                  [:post "dataset"]
+                                  [:get  "collection"]
+                                  [:get  "user"]
+                                  [:get  "api-key"]
+                                  [:get  "permissions/group"]
+                                  [:put  "setting/site-name"]
+                                  [:get  "ee/workspace-instance/current"]]]
+              (testing (str method " /api/" url)
+                (is (= "scope_not_permitted"
+                       (:error (client/client method 403 url (bearer token))))))))
+          (testing "an expired scoped token does not authenticate at all"
+            (let [expired (seed-scoped-token! :crowberto (- (inst-ms (java.util.Date.)) 1000))]
+              (client/client :get 401 "user/current" (bearer expired))))
+          (finally
+            (t2/delete! :model/OAuthAccessToken :client_id "containment-suite")))))))

--- a/src/metabase/oauth_server/api/oauth.clj
+++ b/src/metabase/oauth_server/api/oauth.clj
@@ -11,6 +11,7 @@
    [metabase.oauth-server.core :as oauth-server]
    [metabase.oauth-server.models.oauth-client-event :as client-event]
    [metabase.oauth-server.settings :as oauth-settings]
+   [metabase.oauth-server.store :as oauth-store]
    [metabase.request.core :as request]
    [metabase.system.core :as system]
    [metabase.util.log :as log]
@@ -103,7 +104,10 @@
                   :description  (or (some-> (api-scope/scope-description s) str) s)
                   ;; Flag the broad first-party grant so the consent page can warn about it without
                   ;; hardcoding the scope string in the view.
-                  :full-access? (= s oauth-server/full-access-scope)})))))
+                  :full-access? (= s oauth-server/full-access-scope)
+                  ;; Flag the workspace-manager grant: approving it revokes ALL of the account's
+                  ;; other OAuth sessions (containment tier 1), and the consent page must say so.
+                  :revokes-other-sessions? (= s oauth-server/workspace-manager-scope)})))))
 
 (defn- redirect-authorization-decision
   "Issue a 302 redirect for an approved or denied authorization decision, clearing the CSRF cookie."
@@ -318,6 +322,25 @@
                                  :error_description "The authorization request is invalid."}}))))))
           {:status 404 :body {:error "not_found"}}))))
 
+(defn- revoke-other-sessions-on-workspace-login!
+  "Containment tier 1: a fresh workspace-scoped login (authorization_code grant whose
+   issued scope is exactly `mb:workspace-manager`) revokes all of the user's OTHER
+   OAuth sessions server-side — `mb:full`, every `agent:*` token, and any mixed token.
+   Only pure workspace-manager sessions survive: the workspace credential is meant to
+   be the only OAuth credential the agent holds, and any broader stale token (even a
+   non-`mb:full` `agent:sql:create` one) can still tinker with the parent. The consent
+   page warned the user this would happen (see [[requested-scope-descriptions]]).
+   Refresh grants are excluded — routine refresh of a workspace session must not
+   repeatedly sweep the account."
+  [body response]
+  (when (= (:grant_type body) "authorization_code")
+    (let [scopes (set (some-> (:scope response) (str/split #"\s+")))]
+      (when (= #{oauth-server/workspace-manager-scope} scopes)
+        (when-let [user-id (some-> (:access_token response) oauth-server/resolve-access-token :user-id)]
+          (let [counts (oauth-store/revoke-non-workspace-tokens-for-user! user-id)]
+            (log/infof "Workspace-scoped login for user %d: revoked other OAuth sessions %s"
+                       user-id (pr-str counts))))))))
+
 (api.macros/defendpoint :post "/token"
   :- [:map [:status [:enum 200 400 401 404 429]] [:body :map]]
   "Handles the token endpoint (POST /oauth/token)."
@@ -333,6 +356,13 @@
             (let [authorization-header (get-in request [:headers "authorization"])]
               (try
                 (let [response (oidc/token-request provider body authorization-header)]
+                  ;; Isolated so a revocation failure can't turn an already-issued token
+                  ;; into a 400 the client never receives — that would leave a live orphan
+                  ;; token, which is strictly worse than surviving stale sessions.
+                  (try
+                    (revoke-other-sessions-on-workspace-login! body response)
+                    (catch Exception e
+                      (log/error e "Failed to revoke other sessions on workspace-scoped login")))
                   {:status  200
                    :headers {"Content-Type"  "application/json"
                              "Cache-Control" "no-store"

--- a/src/metabase/oauth_server/consent_page.clj
+++ b/src/metabase/oauth_server/consent_page.clj
@@ -165,6 +165,13 @@
             [:span "This grants " [:strong "complete access to your account"] " — anything you can do, "
              (or client-name "this application") " can do, including reading and changing all data you "
              "can reach. Only approve it for a tool you trust and control."]])
+         (when (some :revokes-other-sessions? scopes)
+           [:div.warning
+            [:span.mark "!"]
+            [:span "Approving will also " [:strong "sign out this account's other agent sessions"]
+             " on this Metabase — every OAuth login except workspace-management ones. Workspace"
+             " credentials are designed to be the only credential an agent holds, so any other"
+             " login is revoked and can't be picked up alongside it."]])
          (render-scope-list scopes)
          (when-let [redirect-host (some-> (:redirect_uri oauth-params) not-empty (java.net.URI.) (.getHost))]
            [:p.destination "Redirects to " [:strong redirect-host]])

--- a/src/metabase/oauth_server/core.clj
+++ b/src/metabase/oauth_server/core.clj
@@ -19,6 +19,13 @@
    onto the unrestricted scope sentinel (see [[metabase.server.middleware.session]])."
   scopes/full-access)
 
+(def workspace-manager-scope
+  "The OAuth scope string that limits a bearer token to the workspace-manager endpoints
+   (plus `GET /api/user/current` for whoami). Unlike [[full-access-scope]] it is NOT mapped
+   to the unrestricted sentinel: it stays a narrow scope and only reaches endpoints tagged
+   `{:scope \"mb:workspace-manager\"}`."
+  scopes/workspace-manager)
+
 ;; Cache holds `{:site-url <string>, :provider <Provider>}`. Every endpoint baked into the provider config is
 ;; derived from the Site URL (see [[build-provider-config]]), so a changed Site URL must rebuild the provider --
 ;; otherwise discovery keeps advertising the stale issuer/endpoints (e.g. http:// behind a TLS-terminating proxy
@@ -38,7 +45,7 @@
    superset of [[all-agent-scopes]] — the extra scopes are not part of the default grant a
    client receives at registration, so a client must explicitly request them."
   []
-  (conj (vec (all-agent-scopes)) full-access-scope))
+  (conj (vec (all-agent-scopes)) full-access-scope workspace-manager-scope))
 
 (defn- build-provider-config
   "Build the configuration map for the OAuth provider from Metabase settings."

--- a/src/metabase/oauth_server/scopes.clj
+++ b/src/metabase/oauth_server/scopes.clj
@@ -13,3 +13,6 @@
 
 (api-scope/defscope full-access "mb:full"
   (deferred-tru "Full access to Metabase as your user account"))
+
+(api-scope/defscope workspace-manager "mb:workspace-manager"
+  (deferred-tru "Create, list, connect to, and destroy workspaces (no access to the rest of Metabase)"))

--- a/src/metabase/oauth_server/store.clj
+++ b/src/metabase/oauth_server/store.clj
@@ -1,6 +1,7 @@
 (ns metabase.oauth-server.store
   "Database-backed implementations of OAuth provider storage protocols."
   (:require
+   [metabase.oauth-server.scopes :as scopes]
    [metabase.util :as u]
    [oidc-provider.protocol :as proto]
    [toucan2.core :as t2]))
@@ -207,6 +208,34 @@
     (t2/update! :model/OAuthAccessToken {:token token} {:revoked_at :%now})
     (t2/update! :model/OAuthRefreshToken {:token token} {:revoked_at :%now})
     true))
+
+;;; ------------------------------------------- Bulk revocation ------------------------------------------------------
+
+(defn revoke-non-workspace-tokens-for-user!
+  "Revoke every unrevoked OAuth access and refresh token belonging to `user-id`
+   whose scope is not *exactly* `#{mb:workspace-manager}`. Tier 1 of the workspace
+   containment ladder: called when a workspace-scoped login is issued, so any other
+   session on the same account dies server-side.
+
+   Revokes `mb:full`, every `agent:*` token, and any mixed token — dropping `mb:full`
+   is not enough, since an `agent:sql:create` / `agent:transforms:write` token still
+   grants mutating access to the parent. The only session that survives is one scoped
+   to workspace management alone. The narrow workspace credential is meant to be the
+   *only* OAuth credential the agent holds; a broader stale token sitting in the same
+   profile store defeats that.
+
+   Returns `{:access-tokens <n> :refresh-tokens <n>}` revocation counts."
+  [user-id]
+  (let [workspace-only? (fn [scope] (= #{scopes/workspace-manager} (set scope)))
+        revoke! (fn [model]
+                  (let [ids (->> (t2/select [model :id :scope] :user_id user-id :revoked_at nil)
+                                 (remove #(workspace-only? (:scope %)))
+                                 (mapv :id))]
+                    (if (seq ids)
+                      (t2/update! model :id [:in ids] {:revoked_at :%now})
+                      0)))]
+    {:access-tokens  (revoke! :model/OAuthAccessToken)
+     :refresh-tokens (revoke! :model/OAuthRefreshToken)}))
 
 ;;; ------------------------------------------------ Constructors ------------------------------------------------------
 

--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -391,6 +391,11 @@
 (api.macros/defendpoint :get "/properties"
   "Get all properties and their values. These are the specific `Settings` that are readable by the current user, or are
   public if no user is logged in."
+  ;; :unchecked, not a scope tag: this endpoint already serves anonymous callers (public
+  ;; settings subset), so a scoped token must never be rejected where no token succeeds.
+  ;; Setting visibility filtering handles authorization; clients (e.g. the CLI's version
+  ;; probe) hit this with narrow tokens before any scoped call.
+  {:scope :unchecked}
   []
   (setting/user-readable-values-map (setting/current-user-readable-visibilities)))
 

--- a/src/metabase/users_rest/api.clj
+++ b/src/metabase/users_rest/api.clj
@@ -374,6 +374,9 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :get "/current"
   "Fetch the current `User`."
+  ;; whoami for workspace-manager-scoped tokens (the CLI shows who it is acting as);
+  ;; sessions and full-scope tokens are unaffected by the tag.
+  {:scope "mb:workspace-manager"}
   []
   (-> (api/check-404 @api/*current-user*)
       (t2/hydrate :personal_collection_id :group_ids :is_installer :has_invited_second_user :tenant_collection_id)

--- a/test/metabase/oauth_server/api_test.clj
+++ b/test/metabase/oauth_server/api_test.clj
@@ -585,26 +585,34 @@
 (defn- authorize-and-get-code!
   "Complete the authorize flow and return the authorization code.
    Creates a client, authorizes, and extracts the code from the redirect."
-  [client-id]
-  (let [consent-resp (get-consent-page! :crowberto client-id)
-        body         (:body consent-resp)
-        csrf-token   (extract-csrf-token-from-consent body)
-        csrf-cookie  (extract-csrf-cookie consent-resp)
-        params-sig   (extract-params-sig-from-consent body)
-        response     (form-post-decision!
-                      :crowberto
-                      {:approved      "true"
-                       :csrf_token    csrf-token
-                       :params_sig    params-sig
+  ([client-id]
+   (authorize-and-get-code! client-id "profile"))
+  ([client-id scope]
+   (let [consent-resp (mt/user-http-request-full-response
+                       :crowberto :get 200 "oauth/authorize"
                        :client_id     client-id
                        :redirect_uri  "https://example.com/callback"
                        :response_type "code"
-                       :scope         "profile"
-                       :state         "test-state"}
-                      302
-                      :csrf-cookie csrf-cookie)
-        location     (get-in response [:headers "Location"])]
-    (extract-query-param location "code")))
+                       :scope         scope
+                       :state         "test-state")
+         body         (:body consent-resp)
+         csrf-token   (extract-csrf-token-from-consent body)
+         csrf-cookie  (extract-csrf-cookie consent-resp)
+         params-sig   (extract-params-sig-from-consent body)
+         response     (form-post-decision!
+                       :crowberto
+                       {:approved      "true"
+                        :csrf_token    csrf-token
+                        :params_sig    params-sig
+                        :client_id     client-id
+                        :redirect_uri  "https://example.com/callback"
+                        :response_type "code"
+                        :scope         scope
+                        :state         "test-state"}
+                       302
+                       :csrf-cookie csrf-cookie)
+         location     (get-in response [:headers "Location"])]
+     (extract-query-param location "code"))))
 
 (defn- token-request!
   "POST to /oauth/token with form-encoded params."
@@ -700,6 +708,90 @@
                    :token_type   "Bearer"
                    :expires_in   pos-int?}
                   refresh-response)))))))
+
+(deftest token-refresh-cannot-widen-scope-test
+  (testing "Refresh token grant -- requesting a scope beyond the original grant is rejected"
+    (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+      (t2/with-transaction [_conn nil {:rollback-only true}]
+        (let [test-client    (create-test-client!)
+              client-id      (:client_id test-client)
+              client-secret  (:client_secret test-client)
+              code           (authorize-and-get-code! client-id)
+              token-response (token-request!
+                              {:grant_type    "authorization_code"
+                               :code          code
+                               :redirect_uri  "https://example.com/callback"}
+                              :authorization (basic-auth-header client-id client-secret))
+              response       (token-request!
+                              {:grant_type    "refresh_token"
+                               :refresh_token (:refresh_token token-response)
+                               :scope         "profile mb:full"}
+                              :expected-status 400
+                              :authorization (basic-auth-header client-id client-secret))]
+          (is (=? {:error string?} response)))))))
+
+(deftest workspace-login-revokes-other-sessions-test
+  (testing "a workspace-scoped authorization_code grant revokes ALL the user's other OAuth sessions"
+    (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+      (t2/with-transaction [_conn nil {:rollback-only true}]
+        (let [client        (create-test-client! {:scopes ["mb:workspace-manager" "profile"]})
+              client-id     (:client_id client)
+              client-secret (:client_secret client)
+              user-id       (mt/user->id :crowberto)
+              other-id      (mt/user->id :rasta)
+              expiry        (+ (System/currentTimeMillis) (* 60 60 1000))
+              seed!         (fn [model token uid scope]
+                              (t2/insert! model {:token token :user_id uid :client_id client-id
+                                                 :scope scope :expiry expiry}))]
+          (seed! :model/OAuthAccessToken  "stale-full-at"   user-id  ["mb:full"])
+          (seed! :model/OAuthRefreshToken "stale-full-rt"   user-id  ["mb:full"])
+          ;; a non-mb:full agent token still grants mutating parent access -> must die
+          (seed! :model/OAuthAccessToken  "agent-at"        user-id  ["agent:sql:create"])
+          (seed! :model/OAuthRefreshToken "agent-rt"        user-id  ["agent:query:execute"])
+          ;; a mixed token is not a pure workspace-manager token -> must die
+          (seed! :model/OAuthAccessToken  "mixed-at"        user-id  ["mb:workspace-manager" "agent:sql:read"])
+          ;; a pre-existing pure workspace-manager session survives
+          (seed! :model/OAuthAccessToken  "ws-only-at"      user-id  ["mb:workspace-manager"])
+          ;; another user's tokens are never touched
+          (seed! :model/OAuthAccessToken  "other-full-at"   other-id ["mb:full"])
+          (let [code (authorize-and-get-code! client-id "mb:workspace-manager")
+                resp (token-request!
+                      {:grant_type   "authorization_code"
+                       :code         code
+                       :redirect_uri "https://example.com/callback"}
+                      :authorization (basic-auth-header client-id client-secret))]
+            (is (= "mb:workspace-manager" (:scope resp)))
+            (testing "mb:full, agent:*, and mixed tokens are all revoked"
+              (doseq [[model token] [[:model/OAuthAccessToken  "stale-full-at"]
+                                     [:model/OAuthRefreshToken "stale-full-rt"]
+                                     [:model/OAuthAccessToken  "agent-at"]
+                                     [:model/OAuthRefreshToken "agent-rt"]
+                                     [:model/OAuthAccessToken  "mixed-at"]]]
+                (is (some? (t2/select-one-fn :revoked_at model :token token))
+                    (str token " should be revoked"))))
+            (testing "a pure workspace-manager session and other users' tokens are untouched"
+              (is (nil? (t2/select-one-fn :revoked_at :model/OAuthAccessToken :token "ws-only-at")))
+              (is (nil? (t2/select-one-fn :revoked_at :model/OAuthAccessToken :token "other-full-at"))))
+            (testing "the fresh workspace-scoped token itself is live (resolves to the user)"
+              (is (= user-id (:user-id (oauth-server/resolve-access-token (:access_token resp))))))))))))
+
+(deftest full-scope-login-does-not-revoke-test
+  (testing "an ordinary (non-workspace) authorization_code grant revokes nothing"
+    (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+      (t2/with-transaction [_conn nil {:rollback-only true}]
+        (let [client        (create-test-client!)
+              client-id     (:client_id client)
+              client-secret (:client_secret client)
+              expiry        (+ (System/currentTimeMillis) (* 60 60 1000))]
+          (t2/insert! :model/OAuthAccessToken {:token "existing-full-at" :user_id (mt/user->id :crowberto)
+                                               :client_id client-id :scope ["mb:full"] :expiry expiry})
+          (let [code (authorize-and-get-code! client-id)]
+            (token-request!
+             {:grant_type   "authorization_code"
+              :code         code
+              :redirect_uri "https://example.com/callback"}
+             :authorization (basic-auth-header client-id client-secret))
+            (is (nil? (t2/select-one-fn :revoked_at :model/OAuthAccessToken :token "existing-full-at")))))))))
 
 (deftest refresh-token-has-expiry-test
   (testing "Refresh tokens are stored with an expiry derived from oauth-server-refresh-token-ttl"

--- a/test/metabase/oauth_server/core_test.clj
+++ b/test/metabase/oauth_server/core_test.clj
@@ -1,6 +1,8 @@
 (ns metabase.oauth-server.core-test
   (:require
    [clojure.test :refer [deftest is testing use-fixtures]]
+   [metabase.api-scope.core :as api-scope]
+   [metabase.api.macros.scope :as scope]
    [metabase.oauth-server.core :as oauth-server]
    [metabase.test :as mt]))
 
@@ -26,3 +28,23 @@
         (is (= "http://localhost:3000" (:issuer config)))
         (is (= "http://localhost:3000/oauth/authorize" (:authorization-endpoint config)))
         (is (= "http://localhost:3000/oauth/token" (:token-endpoint config)))))))
+
+(deftest workspace-manager-scope-test
+  (testing "mb:workspace-manager is registered and advertised in the provider's supported scopes"
+    (is (api-scope/registered-scope? oauth-server/workspace-manager-scope))
+    (is (contains? (set (oauth-server/supported-scopes)) oauth-server/workspace-manager-scope)))
+  (testing "a workspace-manager token passes scope-tagged endpoints and nothing else"
+    (let [status-through (fn [middleware token-scopes]
+                           (let [p       (promise)
+                                 wrapped (middleware (fn [_ respond _] (respond {:status 200})))]
+                             (wrapped {:token-scopes token-scopes}
+                                      (fn [resp] (deliver p (:status resp)))
+                                      (fn [e] (deliver p e)))
+                             @p))
+          ws-scopes      #{oauth-server/workspace-manager-scope}]
+      (testing "passes endpoints tagged {:scope \"mb:workspace-manager\"}"
+        (is (= 200 (status-through (scope/enforce-scope oauth-server/workspace-manager-scope) ws-scopes))))
+      (testing "rejected by untagged endpoints (default-deny)"
+        (is (= 403 (status-through scope/ensure-scopes-checked ws-scopes))))
+      (testing "rejected by endpoints tagged with a different scope"
+        (is (= 403 (status-through (scope/enforce-scope "agent:query:execute") ws-scopes)))))))


### PR DESCRIPTION
Split 1 of 3 from #77118, per review discussion — the OAuth/credential surface, independently mergeable. Resolves GHY-4055, GHY-4059, GHY-4060, GHY-4062.

## What this does

- **Scope**: `defscope mb:workspace-manager` + `{:scope}` tags on the 7 workspace-manager endpoints and `GET /api/user/current` (whoami for the CLI). `GET /session/properties` tagged `:unchecked` — it already serves anonymous callers, so a narrow token must never be rejected where no token succeeds. Advertised in `supported-scopes`; NOT in the default DCR grant (a client must request it explicitly); NOT mapped to the unrestricted sentinel, so default-deny covers the rest of the API.
- **Revocation**: a workspace-scoped `authorization_code` login revokes the user's other OAuth sessions server-side (stale full-scope tokens on dirty dev machines are the threat; the consent page warns). The revoke runs isolated from the token response — a failure logs rather than turning an issued token into a 400 the client never receives.
- **Refresh pin**: refresh grants cannot widen scope (enforced by the oidc-provider lib, pinned by endpoint test).
- **Containment suite**: static allowlist sweep (exactly the intended endpoints carry the tag, via `api.macros/ns-routes` metadata) + scoped-token e2e (allowlist 200s, representative endpoints 403, expired tokens 401).

## Relationship to the other splits

Independent of splits 2 (branching/api-key/config) and 3 (HM provisioning). The scope-tag lines on `workspace_manager.clj` also appear in split 3's final file state — identical content, merges clean.

## Validation

oauth-server module (94 tests) + containment suite green locally.