### PR TITLE
feat(workspaces): git-branch binding + api-key mint + child config build (split 2/3)

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3755,6 +3755,7 @@
            metabase-enterprise.workspaces.core
            metabase-enterprise.workspaces.init}
    :uses #{api
+           api-keys
            app-db
            cache
            driver
@@ -3769,6 +3770,7 @@
            sql-tools
            util
            workspaces
+           enterprise/remote-sync
            enterprise/serialization}
    :model-exports #{:model/Workspace}
    :model-imports #{:model/Database

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/workspace.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/workspace.clj
@@ -111,6 +111,17 @@
                                  :databases resolved-databases})
     (log/infof "Loaded workspace %s from config.yml with %d database(s)"
                (pr-str name) (count resolved-databases))
+    ;; First boot of a workspace child: pull the target branch's content before
+    ;; reporting the section applied (GHY-4121). Blocking is deliberate — the HM
+    ;; create call and the config-apply endpoint both treat 2xx as "instance
+    ;; ready", so content must be live by then. The `:settings` section always
+    ;; initializes first, so the remote-sync settings are in place here. An
+    ;; import failure leaves a working-but-empty child; recoverable via a manual
+    ;; import, so log rather than fail the whole config apply.
+    (try
+      (ws/initial-import-if-needed!)
+      (catch Exception e
+        (log/error e "Initial workspace import failed; the child starts empty")))
     {:workspace-name name
      :database-count (count resolved-databases)}))
 

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/core.clj
@@ -1,6 +1,8 @@
 (ns metabase-enterprise.remote-sync.core
   (:require
    [metabase-enterprise.remote-sync.guards :as guards]
+   [metabase-enterprise.remote-sync.impl :as impl]
+   [metabase-enterprise.remote-sync.models.remote-sync-task :as remote-sync.task]
    [metabase-enterprise.remote-sync.settings :as settings]
    [metabase-enterprise.remote-sync.source :as source]
    [metabase-enterprise.remote-sync.source.protocol :as source.p]
@@ -9,9 +11,12 @@
    [metabase.collections.core :as collections]
    [metabase.events.core :as events]
    [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [potemkin :as p]
    [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
 
 (comment
   source/keep-me)
@@ -19,7 +24,59 @@
 (p/import-vars
  [source]
  [source.p
-  ->ingestable])
+  ->ingestable]
+ [settings
+  remote-sync-url
+  remote-sync-token
+  remote-sync-branch])
+
+;;; --------------------------- Workspace child-branch helpers ---------------------------
+
+(defn create-workspace-branch!
+  "Create `branch` on the configured git remote, cut from the last-synced commit
+   (falling back to the `remote-sync-branch` tip when nothing has synced yet).
+   No-op when the branch already exists on the remote — which makes workspace
+   create idempotent on retry and lets a re-created workspace reuse its old
+   branch. Unlike the create-branch API path, this never touches this instance's
+   `remote-sync-branch` setting: the branch belongs to a child instance, not us.
+
+   Returns the base commit-ish the branch was cut from, or nil when skipped."
+  [branch]
+  (let [src (source/source-from-settings)]
+    (when-not (contains? (set (source.p/branches src)) branch)
+      (let [base (or (remote-sync.task/last-version) (settings/remote-sync-branch))]
+        (source.p/create-branch src branch base)
+        base))))
+
+(defn initial-import-if-needed!
+  "Blocking initial import of the configured `remote-sync-branch`, for a workspace
+   child instance's first boot: runs only when remote sync is enabled and no sync
+   task has ever completed, and skips (with a log line) when the branch does not
+   exist on the remote yet. Blocks until the import task finishes so the caller —
+   the config.yml apply path — can treat a 2xx response as \"content is live\".
+
+   Returns the finished RemoteSyncTask row, or nil when skipped."
+  []
+  (when (and (settings/remote-sync-enabled)
+             (nil? (remote-sync.task/last-version)))
+    (let [branch (settings/remote-sync-branch)
+          src    (source/source-from-settings)]
+      (if (contains? (set (source.p/branches src)) branch)
+        ;; force? true: first import on a fresh child, nothing local to protect;
+        ;; force-deletion? false mirrors finish-remote-config! (GHY-3900).
+        (let [{task-id :id} (impl/async-import! branch true {} :force-deletion? false)
+              ;; same ceiling run-async! enforces on the task itself
+              deadline (+ (System/currentTimeMillis) (* (settings/remote-sync-task-time-limit-ms) 10))]
+          (loop []
+            (let [task (t2/select-one :model/RemoteSyncTask :id task-id)]
+              (cond
+                (:ended_at task) task
+                (> (System/currentTimeMillis) deadline)
+                (do (log/errorf "Initial workspace import (task %d) did not finish in time" task-id)
+                    task)
+                :else (do (Thread/sleep 500) (recur))))))
+        (log/infof "Remote-sync branch %s does not exist on the remote yet; skipping initial import"
+                   (pr-str branch))))))
 
 (defenterprise collection-editable?
   "Determines if a remote-synced collection should be editable.

--- a/enterprise/backend/src/metabase_enterprise/workspaces/api/workspace_manager.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api/workspace_manager.clj
@@ -28,7 +28,10 @@
 (def ^:private CreateWorkspaceParams
   [:map {:closed true}
    [:name         ms/NonBlankString]
-   [:database_ids [:sequential {:min 1} ::lib.schema.id/database]]])
+   [:database_ids [:sequential {:min 1} ::lib.schema.id/database]]
+   ;; export branch; omitted = auto-named ws-<slug>-<id>. 409 when another
+   ;; workspace already exports to the same branch.
+   [:target_branch {:optional true} ms/NonBlankString]])
 
 (def ^:private UpdateWorkspaceParams
   [:map {:closed true}
@@ -62,6 +65,10 @@
    [:id          ms/PositiveInt]
    [:name        ms/NonBlankString]
    [:creator     [:maybe CreatorResponse]]
+   ;; git binding (GHY-4057): base = snapshot of the parent's remote-sync-branch at
+   ;; create; target = the workspace's export branch (nil only pre-migration rows)
+   [:base_branch   {:optional true} [:maybe :string]]
+   [:target_branch {:optional true} [:maybe :string]]
    [:created_at  DateTimeWithTimeZone]
    [:updated_at  DateTimeWithTimeZone]
    ;; `:databases` is only included when hydrated (i.e. the GET /:id endpoint).
@@ -82,7 +89,7 @@
 
 (defn- present-workspace [workspace]
   (some-> workspace
-          (select-keys [:id :name :creator :created_at :updated_at :databases])
+          (select-keys [:id :name :creator :base_branch :target_branch :created_at :updated_at :databases])
           (update :creator present-creator)
           (m/update-existing :databases #(mapv present-workspace-database %))))
 

--- a/enterprise/backend/src/metabase_enterprise/workspaces/config.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/config.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.workspaces.config
   (:require
    [clojure.string :as str]
+   [metabase-enterprise.remote-sync.core :as remote-sync]
    [metabase-enterprise.workspaces.core :as ws]
    [metabase-enterprise.workspaces.models.workspace :as workspace]
    [metabase-enterprise.workspaces.models.workspace-database]
@@ -116,6 +117,33 @@
       :details   {}
       :is_sample true}]))
 
+(defn- git-settings-section
+  "The child's `settings:` section: point remote-sync at the parent's configured git
+   repo, read-write, on the workspace's `target_branch`. Nil when the parent has no
+   git remote configured (local dev without git-sync) — the child then boots without
+   sync and export is unavailable."
+  [ws]
+  (when-let [url (not-empty (remote-sync/remote-sync-url))]
+    {:remote-sync-enabled true
+     :remote-sync-url     url
+     :remote-sync-token   (remote-sync/remote-sync-token)
+     :remote-sync-type    "read-write"
+     :remote-sync-branch  (:target_branch ws)}))
+
+(defn- api-keys-section
+  "The child's `api-keys:` section registering the parent-minted agent key.
+   `admin` group: deliberate v0 reversal of the GHY-4061 all-users call
+   (GHY-4078 has the reasoning). The exfil paths admin opens are bounded —
+   the child holds only the disposable workspace-user warehouse cred, dropped
+   at destroy — and all-users cannot transform at all (no boot-grant mechanism
+   exists yet). Revisit at GA/multi-user, where child-admin gets real teeth.
+   `creator` must be an admin user that exists on the child at boot."
+  [ws api-key creator-email]
+  [{:name    (str "workspace " (:name ws) " agent key")
+    :key     api-key
+    :creator creator-email
+    :group   "admin"}])
+
 (defn build-workspace-config
   "Return a downloadable config.yml-shaped map for `workspace-id`:
 
@@ -123,39 +151,57 @@
      :config  {:databases [...]
                :workspace {:name      <ws-name>
                            :databases {<db-name> {:input_schemas [<schema-name> ...]
-                                                  :output        {:db ? :schema ?}}}}}
+                                                  :output        {:db ? :schema ?}}}
+               :settings  {...remote-sync settings, when the parent has git configured...}
+               :api-keys  [...only when `:api-key` is supplied...]}}
 
   Each database entry merges the underlying `metabase_database.details` with the
   WorkspaceDatabase's override credentials and adds `schema-filters-*` keys
   derived from `:input_schemas`. Per-database workspace entries carry the
   expanded `{:db ?, :schema ?}` namespace map directly — the same shape the
-  `instance-workspace` setting stores. Returns nil when the workspace does not
-  exist. Throws a 409 `ex-info` if any of the workspace's databases is not
-  `:provisioned`."
-  [workspace-id]
-  (when-let [ws (workspace/get-workspace workspace-id)]
-    (let [wsds (:databases ws)]
-      (when (some #(not= :provisioned (:status %)) wsds)
-        (throw (ex-info "Cannot build config while workspace has databases that are not :provisioned"
-                        {:status-code  409
-                         :workspace_id workspace-id})))
-      (let [workspace-db-ids (mapv :database_id wsds)
-            dbs-by-id        (if-let [ids (seq workspace-db-ids)]
-                               (into {} (map (juxt :id identity))
-                                     (t2/select :model/Database :id [:in ids]))
-                               {})
-            pairs            (for [wsd wsds
-                                   :let [db (get dbs-by-id (:database_id wsd))]]
-                               [wsd db])
-            ws-entries       (mapv (fn [[wsd db]] (database-entry wsd db)) pairs)
-            stub-entries     (mapv stub-database-entry (stub-databases workspace-db-ids))
-            sample-entries   (sample-database-entries)]
-        {:version 1
-         :config  {:databases (-> ws-entries
-                                  (into stub-entries)
-                                  (into sample-entries))
-                   :workspace {:name      (:name ws)
-                               :databases (into {} (map (fn [[wsd db]] (workspace-database-entry wsd db))) pairs)}}}))))
+  `instance-workspace` setting stores.
+
+  The `:settings` section (remote-sync url/token/type + `remote-sync-branch` =
+  the workspace's `target_branch`) is emitted whenever the parent has a git
+  remote configured. The `:api-keys` section requires opts — the key value only
+  exists in memory at mint time (the parent stores just its prefix), so only the
+  create orchestration can emit it:
+
+    :api-key       unhashed mb_ key string from [[workspace/mint-api-key!]]
+    :creator-email admin email that exists on the child at boot (attribution for
+                   the key row the child creates)
+
+  Returns nil when the workspace does not exist. Throws a 409 `ex-info` if any
+  of the workspace's databases is not `:provisioned`."
+  ([workspace-id]
+   (build-workspace-config workspace-id {}))
+  ([workspace-id {:keys [api-key creator-email]}]
+   (when-let [ws (workspace/get-workspace workspace-id)]
+     (let [wsds (:databases ws)]
+       (when (some #(not= :provisioned (:status %)) wsds)
+         (throw (ex-info "Cannot build config while workspace has databases that are not :provisioned"
+                         {:status-code  409
+                          :workspace_id workspace-id})))
+       (let [workspace-db-ids (mapv :database_id wsds)
+             dbs-by-id        (if-let [ids (seq workspace-db-ids)]
+                                (into {} (map (juxt :id identity))
+                                      (t2/select :model/Database :id [:in ids]))
+                                {})
+             pairs            (for [wsd wsds
+                                    :let [db (get dbs-by-id (:database_id wsd))]]
+                                [wsd db])
+             ws-entries       (mapv (fn [[wsd db]] (database-entry wsd db)) pairs)
+             stub-entries     (mapv stub-database-entry (stub-databases workspace-db-ids))
+             sample-entries   (sample-database-entries)
+             settings         (git-settings-section ws)]
+         {:version 1
+          :config  (cond-> {:databases (-> ws-entries
+                                           (into stub-entries)
+                                           (into sample-entries))
+                            :workspace {:name      (:name ws)
+                                        :databases (into {} (map (fn [[wsd db]] (workspace-database-entry wsd db))) pairs)}}
+                     settings (assoc :settings settings)
+                     api-key  (assoc :api-keys (api-keys-section ws api-key creator-email)))})))))
 
 (defn config->yaml
   "Render a workspace config map as a pretty-printed YAML string."

--- a/enterprise/backend/src/metabase_enterprise/workspaces/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/core.clj
@@ -32,6 +32,7 @@
          └──────────────────────────────────────── provisioned"
   (:require
    [clojure.string :as str]
+   [metabase-enterprise.remote-sync.core :as remote-sync]
    [metabase-enterprise.workspaces.models.workspace :as workspace]
    [metabase-enterprise.workspaces.models.workspace-database :as workspace-database]
    [metabase-enterprise.workspaces.provisioning :as provisioning]
@@ -39,6 +40,7 @@
    [metabase.driver.sql :as driver.sql]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.settings.core :as setting]
+   [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.workspaces.core :as ws]
@@ -103,6 +105,16 @@
   []
   (ws.settings/instance-workspace! nil)
   nil)
+
+(defn initial-import-if-needed!
+  "Blocking first import of this child instance's remote-sync branch (GHY-4121):
+   runs only when remote sync is enabled and nothing has ever synced; skips when
+   the branch doesn't exist on the remote. Called by the config.yml `:workspace`
+   section loader so a 2xx config apply means content is live. Thin delegate —
+   lives here because the advanced-config module depends on workspaces, not on
+   remote-sync."
+  []
+  (remote-sync/initial-import-if-needed!))
 
 ;;; ------------------------------- Instance-workspace lock -------------------------------
 
@@ -186,6 +198,26 @@
     (throw (ex-info "Workspaces are not enabled for this database"
                     {:status-code 400 :database_id (:id database)}))))
 
+(defn- assert-target-branch-available [target-branch]
+  (when (t2/exists? :model/Workspace :target_branch target-branch)
+    (throw (ex-info "Another workspace already exports to this branch"
+                    {:status-code 409 :target_branch target-branch}))))
+
+(defn- cut-target-branch!
+  "Cut the workspace's `target_branch` from the base on the git remote (GHY-4121),
+   so the child's first import finds it populated. Runs after the create
+   transaction commits — a remote git call must not hold the transaction open.
+   Best-effort: on failure the child boots empty and its first export creates the
+   branch, so we log rather than fail the (already committed) create."
+  [{:keys [target_branch] :as _ws}]
+  (when (not-empty (remote-sync/remote-sync-url))
+    (try
+      (when-let [base (remote-sync/create-workspace-branch! target_branch)]
+        (log/infof "Cut workspace branch %s from %s" (pr-str target_branch) (pr-str base)))
+      (catch Exception e
+        (log/warnf e "Could not create workspace branch %s on the git remote; the child will boot empty"
+                   (pr-str target_branch))))))
+
 ;;; ------------------------------------- Manager-side reads --------------------------------------------------
 
 (defn get-workspace
@@ -208,21 +240,42 @@
    known schemas as
    `input_schemas`, and provision each database (blocking). Everything runs in a
    single transaction, so a provisioning failure rolls back the workspace and its
-   database rows. Returns the created workspace, hydrated."
-  [{:keys [name creator_id database_ids]}]
+   database rows. Returns the created workspace, hydrated.
+
+   Git binding: the export branch (`:target_branch`) defaults to `ws-<slug>-<id>` —
+   the id suffix keeps branches distinct when two workspace names slugify to the
+   same string (names are not unique). A caller-supplied `:target_branch` is used
+   verbatim; it 409s when another workspace already exports to that branch (the
+   suffix can't protect user-chosen names). `:base_branch` (what the child's
+   initial import will read from, once wired — GHY-4121) records the parent's
+   `remote-sync-branch` at create; deliberately not caller-supplied, so a
+   workspace can never be based on another workspace's target branch (no stacked
+   PRs — GHY-4121 has the reasoning). Snapshot semantics: changing the parent
+   setting later never affects existing workspaces. Nil when the parent has no
+   git remote configured."
+  [{:keys [name creator_id database_ids target_branch]}]
   (let [databases (mapv (fn [db-id]
                           (let [database (assert-database-exists db-id)]
                             (assert-database-eligible-for-workspaces database)
                             {:database_id   db-id
                              :input_schemas (workspace-database/database-input-schemas database)}))
                         database_ids)]
-    (t2/with-transaction [_conn]
-      (let [ws (workspace/create-workspace! {:name       name
-                                             :creator_id creator_id
-                                             :databases  databases})]
-        (doseq [{wsd-id :id} (:databases ws)]
-          (provisioning/provision-single! wsd-id))
-        (workspace/get-workspace (:id ws))))))
+    (when target_branch
+      (assert-target-branch-available target_branch))
+    (let [ws (t2/with-transaction [_conn]
+               (let [ws (workspace/create-workspace! {:name          name
+                                                      :creator_id    creator_id
+                                                      :databases     databases
+                                                      :base_branch   (remote-sync/remote-sync-branch)
+                                                      :target_branch target_branch})]
+                 (when-not target_branch
+                   (t2/update! :model/Workspace :id (:id ws)
+                               {:target_branch (str "ws-" (u/slugify name) "-" (:id ws))}))
+                 (doseq [{wsd-id :id} (:databases ws)]
+                   (provisioning/provision-single! wsd-id))
+                 (workspace/get-workspace (:id ws))))]
+      (cut-target-branch! ws)
+      ws)))
 
 (defn- orphaned-resources-message
   [workspace-id failures]

--- a/enterprise/backend/src/metabase_enterprise/workspaces/models/workspace.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/models/workspace.clj
@@ -1,9 +1,11 @@
 (ns metabase-enterprise.workspaces.models.workspace
   (:require
    [metabase-enterprise.workspaces.models.workspace-database]
+   [metabase.api-keys.core :as api-keys]
    [metabase.api.common :as api]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
+   [metabase.util.secret :as u.secret]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -84,17 +86,37 @@
 
 (defn create-workspace!
   "Create a Workspace and its nested WorkspaceDatabase rows in a single transaction.
-  The param map must supply `:creator_id`. Returns the created Workspace with
-  `:databases` and `:creator` hydrated."
-  [{:keys [name creator_id databases]}]
+  The param map must supply `:creator_id`. Optional `:base_branch` /
+  `:target_branch` record the child's git-sync binding (see the config builder).
+  Returns the created Workspace with `:databases` and `:creator` hydrated."
+  [{:keys [name creator_id databases base_branch target_branch]}]
   (t2/with-transaction [_conn]
     (let [workspace-id (t2/insert-returning-pk! :model/Workspace
-                                                {:name       name
-                                                 :creator_id creator_id})]
+                                                {:name          name
+                                                 :creator_id    creator_id
+                                                 :base_branch   base_branch
+                                                 :target_branch target_branch})]
       (when (seq databases)
         (t2/insert! :model/WorkspaceDatabase
                     (map #(with-workspace-database-defaults % workspace-id) databases)))
       (get-workspace workspace-id))))
+
+(defn mint-api-key!
+  "Mint the api-key for `workspace-id`'s child instance: generate a fresh `mb_` key,
+  record its prefix on the workspace row, and return the unhashed key (a
+  [[metabase.util.secret]]; `u.secret/expose` it at the single point of use).
+
+  Accounting only: the parent stores just the prefix — deliberately NOT a
+  `:model/ApiKey` row — so the key can never authenticate against the parent. It
+  authenticates against the child, which registers it at boot from the config.yml
+  `api-keys:` section. ws<->key = this prefix; key<->user = the workspace's
+  `creator_id`. One key per workspace, minted at create; calling again replaces
+  the recorded prefix (the old key dies with the child instance it was born for)."
+  [workspace-id]
+  (let [k (api-keys/generate-key)]
+    (t2/update! :model/Workspace :id workspace-id
+                {:api_key_prefix (api-keys/prefix (u.secret/expose k))})
+    k))
 
 (defn- reject-active-modification!
   "Throw a 409 if any row in `existing-active` (everything other than `:unprovisioned`)

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/workspace_branch_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/workspace_branch_test.clj
@@ -1,0 +1,82 @@
+(ns metabase-enterprise.remote-sync.workspace-branch-test
+  "Tests for the workspace child-branch helpers in [[metabase-enterprise.remote-sync.core]]:
+   the parent-side branch cut and the child-side blocking initial import (GHY-4121)."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase-enterprise.remote-sync.core :as remote-sync.core]
+   [metabase-enterprise.remote-sync.impl :as impl]
+   [metabase-enterprise.remote-sync.models.remote-sync-task :as remote-sync.task]
+   [metabase-enterprise.remote-sync.source :as source]
+   [metabase-enterprise.remote-sync.source.protocol :as source.p]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- stub-source
+  "A Source stub that reports `existing-branches` and records create-branch calls
+   in `created` (an atom of [branch base] vectors)."
+  [existing-branches created]
+  (reify source.p/Source
+    (branches [_] existing-branches)
+    (create-branch [_ branch base] (swap! created conj [branch base]))
+    (default-branch [_] "main")))
+
+(deftest create-workspace-branch-test
+  (testing "cuts the branch from last-synced commit, falling back to the remote-sync-branch setting"
+    (mt/with-temporary-setting-values [remote-sync-branch "main"]
+      (let [created (atom [])]
+        (with-redefs [source/source-from-settings   (fn [& _] (stub-source ["main"] created))
+                      remote-sync.task/last-version (constantly "abc123")]
+          (is (= "abc123" (remote-sync.core/create-workspace-branch! "ws-foo-1")))
+          (is (= [["ws-foo-1" "abc123"]] @created)))
+        (testing "no prior sync -> base is the branch name"
+          (reset! created [])
+          (with-redefs [source/source-from-settings   (fn [& _] (stub-source ["main"] created))
+                        remote-sync.task/last-version (constantly nil)]
+            (is (= "main" (remote-sync.core/create-workspace-branch! "ws-bar-2")))
+            (is (= [["ws-bar-2" "main"]] @created)))))))
+  (testing "no-op when the branch already exists (idempotent create / re-created workspace)"
+    (let [created (atom [])]
+      (with-redefs [source/source-from-settings (fn [& _] (stub-source ["main" "ws-foo-1"] created))]
+        (is (nil? (remote-sync.core/create-workspace-branch! "ws-foo-1")))
+        (is (= [] @created))))))
+
+(deftest initial-import-if-needed-gates-test
+  ;; remote-sync-enabled is derived: (some? remote-sync-url), so gate via the url
+  (testing "no-op when remote sync is disabled"
+    (mt/with-temporary-setting-values [remote-sync-url nil]
+      (is (nil? (remote-sync.core/initial-import-if-needed!)))))
+  (testing "no-op when something has already synced"
+    (mt/with-temporary-setting-values [remote-sync-url "https://git.example.com/repo.git"]
+      (with-redefs [remote-sync.task/last-version (constantly "abc123")]
+        (is (nil? (remote-sync.core/initial-import-if-needed!))))))
+  (testing "skips (nil) when the branch does not exist on the remote yet"
+    (mt/with-temporary-setting-values [remote-sync-url    "https://git.example.com/repo.git"
+                                       remote-sync-branch "ws-foo-1"]
+      (with-redefs [remote-sync.task/last-version (constantly nil)
+                    source/source-from-settings   (fn [& _] (stub-source ["main"] (atom [])))]
+        (is (nil? (remote-sync.core/initial-import-if-needed!)))))))
+
+(deftest initial-import-if-needed-blocks-until-task-ends-test
+  (testing "kicks a forced import of the branch and returns the finished task"
+    (mt/with-temporary-setting-values [remote-sync-url    "https://git.example.com/repo.git"
+                                       remote-sync-branch "ws-foo-1"]
+      (mt/with-model-cleanup [:model/RemoteSyncTask]
+        (let [import-args (atom nil)]
+          (with-redefs [remote-sync.task/last-version (constantly nil)
+                        source/source-from-settings   (fn [& _] (stub-source ["main" "ws-foo-1"] (atom [])))
+                        impl/async-import!            (fn [branch force? args & _kvs]
+                                                        (reset! import-args [branch force? args])
+                                                        (let [id (t2/insert-returning-pk! :model/RemoteSyncTask
+                                                                                          {:sync_task_type "import"
+                                                                                           :initiated_by   (mt/user->id :crowberto)})]
+                                                          ;; finish it on a delay so the poll loop actually waits
+                                                          (future
+                                                            (Thread/sleep 700)
+                                                            (t2/update! :model/RemoteSyncTask :id id
+                                                                        {:ended_at :%now}))
+                                                          {:id id}))]
+            (let [task (remote-sync.core/initial-import-if-needed!)]
+              (is (some? (:ended_at task)) "returned only after the task ended")
+              (is (= ["ws-foo-1" true {}] @import-args)))))))))

--- a/enterprise/backend/test/metabase_enterprise/workspaces/api/workspace_manager_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api/workspace_manager_test.clj
@@ -94,6 +94,31 @@
             (mt/user-http-request :crowberto :post 400 "ee/workspace-manager/"
                                   {:name "Nope" :database_ids []})))))))
 
+(deftest create-workspace-user-named-target-branch-test
+  (testing "POST / with target_branch uses it verbatim; a second workspace targeting the same branch 409s"
+    (mt/with-temp [:model/Database {db-id :id} {:engine   :postgres
+                                                :details  {}
+                                                :settings {:database-enable-workspaces true}}]
+      (mt/with-model-cleanup [:model/Workspace]
+        (with-redefs [provisioning/dispatching-provisioner (stub-provisioner)]
+          (is (=? {:target_branch "my-feature-branch"}
+                  (mt/user-http-request :crowberto :post 200 "ee/workspace-manager/"
+                                        {:name          "Named Branch"
+                                         :database_ids  [db-id]
+                                         :target_branch "my-feature-branch"})))
+          (testing "same branch again -> 409"
+            (mt/user-http-request :crowberto :post 409 "ee/workspace-manager/"
+                                  {:name          "Named Branch Two"
+                                   :database_ids  [db-id]
+                                   :target_branch "my-feature-branch"}))
+          (testing "collision with an auto-named branch also 409s"
+            (let [{:keys [target_branch]} (mt/user-http-request :crowberto :post 200 "ee/workspace-manager/"
+                                                                {:name "Auto Named" :database_ids [db-id]})]
+              (mt/user-http-request :crowberto :post 409 "ee/workspace-manager/"
+                                    {:name          "Squatter"
+                                     :database_ids  [db-id]
+                                     :target_branch target_branch}))))))))
+
 (deftest metadata-export-test
   (testing "GET /:id/metadata/export streams metadata scoped to the workspace's databases + input"
     (mt/with-temp [:model/Database {db-id :id db-name :name} {:engine :postgres :details {}}

--- a/enterprise/backend/test/metabase_enterprise/workspaces/config_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/config_test.clj
@@ -1,7 +1,9 @@
 (ns metabase-enterprise.workspaces.config-test
   (:require
    [clojure.test :refer [deftest is testing use-fixtures]]
+   [metabase-enterprise.remote-sync.core :as remote-sync]
    [metabase-enterprise.workspaces.config :as config]
+   [metabase-enterprise.workspaces.core :as ws.core]
    [metabase-enterprise.workspaces.test-util :as workspaces.tu]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -267,3 +269,79 @@
                  (first samples))))
         (testing "sample entry is NOT also marked as a stub"
           (is (not (:is_stub (first samples)))))))))
+
+(deftest build-workspace-config-git-settings-section-test
+  (mt/with-temp [:model/Workspace {ws-id :id} {:name          "gitty"
+                                               :creator_id    (mt/user->id :crowberto)
+                                               :target_branch "ws-gitty"}]
+    (testing "no git remote configured on the parent -> no :settings section"
+      (mt/with-temporary-setting-values [remote-sync-url nil]
+        (is (not (contains? (:config (config/build-workspace-config ws-id)) :settings)))))
+    (testing "parent git settings flow into the child's :settings section, branch = target_branch, always read-write"
+      (mt/with-temporary-setting-values [remote-sync-url   "https://github.com/acme/mb-content.git"
+                                         remote-sync-token "ghp_secret"]
+        (is (= {:remote-sync-enabled true
+                :remote-sync-url     "https://github.com/acme/mb-content.git"
+                :remote-sync-token   "ghp_secret"
+                :remote-sync-type    "read-write"
+                :remote-sync-branch  "ws-gitty"}
+               (get-in (config/build-workspace-config ws-id) [:config :settings])))))))
+
+(deftest build-workspace-config-api-keys-section-test
+  (mt/with-temp [:model/Workspace {ws-id :id} {:name       "gitty"
+                                               :creator_id (mt/user->id :crowberto)}]
+    (testing "no :api-keys section without the mint-time opts (the parent cannot reproduce the key)"
+      (is (not (contains? (:config (config/build-workspace-config ws-id)) :api-keys))))
+    (testing "create orchestration supplies the freshly-minted key -> admin api-keys entry (GHY-4078)"
+      (is (= [{:name    "workspace gitty agent key"
+               :key     "mb_0123456789abcdef"
+               :creator "admin@child.test"
+               :group   "admin"}]
+             (get-in (config/build-workspace-config ws-id {:api-key       "mb_0123456789abcdef"
+                                                           :creator-email "admin@child.test"})
+                     [:config :api-keys]))))))
+
+(deftest create-workspace-names-target-branch-test
+  (testing "ws.core/create-workspace! names target_branch ws-<slug>-<id> and snapshots base_branch"
+    (mt/with-model-cleanup [:model/Workspace]
+      (testing "no parent git remote -> base_branch nil"
+        (let [ws (ws.core/create-workspace! {:name         "My Cool Workspace"
+                                             :creator_id   (mt/user->id :crowberto)
+                                             :database_ids []})]
+          (is (= (str "ws-my_cool_workspace-" (:id ws)) (:target_branch ws)))
+          (is (nil? (:base_branch ws)))))
+      (testing "base_branch snapshots the parent's remote-sync-branch at create"
+        (mt/with-temporary-setting-values [remote-sync-branch "develop"]
+          (let [ws (ws.core/create-workspace! {:name         "branchy"
+                                               :creator_id   (mt/user->id :crowberto)
+                                               :database_ids []})]
+            (is (= "develop" (:base_branch ws))))))
+      (testing "id suffix keeps branches distinct for slug-equal names"
+        (let [ws1 (ws.core/create-workspace! {:name         "branchy"
+                                              :creator_id   (mt/user->id :crowberto)
+                                              :database_ids []})
+              ws2 (ws.core/create-workspace! {:name         "Branchy"
+                                              :creator_id   (mt/user->id :crowberto)
+                                              :database_ids []})]
+          (is (= (str "ws-branchy-" (:id ws1)) (:target_branch ws1)))
+          (is (not= (:target_branch ws1) (:target_branch ws2))))))))
+
+(deftest create-workspace-cuts-target-branch-test
+  (testing "create cuts the target branch on the git remote when one is configured (GHY-4121)"
+    (mt/with-model-cleanup [:model/Workspace]
+      (let [cut (atom [])]
+        (with-redefs [remote-sync/create-workspace-branch! (fn [branch] (swap! cut conj branch) "main")]
+          (testing "no git remote -> no cut attempted"
+            (mt/with-temporary-setting-values [remote-sync-url nil]
+              (ws.core/create-workspace! {:name "no git" :creator_id (mt/user->id :crowberto) :database_ids []})
+              (is (= [] @cut))))
+          (testing "git remote configured -> branch cut after create"
+            (mt/with-temporary-setting-values [remote-sync-url "https://git.example.com/repo.git"]
+              (let [ws (ws.core/create-workspace! {:name "gitty cut" :creator_id (mt/user->id :crowberto) :database_ids []})]
+                (is (= [(:target_branch ws)] @cut))))))
+        (testing "a failing cut is best-effort: create still succeeds"
+          (mt/with-temporary-setting-values [remote-sync-url "https://git.example.com/repo.git"]
+            (with-redefs [remote-sync/create-workspace-branch! (fn [_] (throw (ex-info "remote unreachable" {})))]
+              (is (some? (ws.core/create-workspace! {:name         "flaky remote"
+                                                     :creator_id   (mt/user->id :crowberto)
+                                                     :database_ids []}))))))))))

--- a/enterprise/backend/test/metabase_enterprise/workspaces/models/workspace_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/models/workspace_test.clj
@@ -5,6 +5,7 @@
    [metabase.models.interface :as mi]
    [metabase.permissions.test-util :as perms.test-util]
    [metabase.test :as mt]
+   [metabase.util.secret :as u.secret]
    [toucan2.core :as t2]))
 
 (defn- ws-db-attrs
@@ -275,3 +276,19 @@
                    :model/WorkspaceDatabase _                  {:workspace_id ws-id, :database_id db2-id}]
       (testing "superuser with attached databases — true"
         (with-admin (is (true? (mi/can-write? ws))))))))
+
+(deftest mint-api-key-test
+  (mt/with-model-cleanup [:model/Workspace]
+    (let [{ws-id :id} (create-ws! {:name "Keyed" :databases []})
+          k           (u.secret/expose (workspace/mint-api-key! ws-id))]
+      (testing "returns a well-formed mb_ key and records its prefix on the workspace"
+        (is (re-matches #"mb_[A-Za-z0-9+/=]+" k))
+        (is (= (subs k 0 7)
+               (t2/select-one-fn :api_key_prefix :model/Workspace :id ws-id))))
+      (testing "accounting only: no ApiKey row exists on the parent, so the key cannot authenticate here"
+        (is (not (t2/exists? :model/ApiKey :key_prefix (subs k 0 7)))))
+      (testing "minting again replaces the recorded prefix (one live key per workspace)"
+        (let [k2 (u.secret/expose (workspace/mint-api-key! ws-id))]
+          (is (not= k k2))
+          (is (= (subs k2 0 7)
+                 (t2/select-one-fn :api_key_prefix :model/Workspace :id ws-id))))))))

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -111,6 +111,7 @@
      eid-translation
      embedding
      enterprise/api
+     enterprise/remote-sync
      enterprise/scim
      enterprise/serialization
      enterprise/sso

--- a/resources/migrations/064/20260706_ghy_4056_workspace_api_key_prefix.yaml
+++ b/resources/migrations/064/20260706_ghy_4056_workspace_api_key_prefix.yaml
@@ -1,0 +1,22 @@
+## Add api_key_prefix column to workspace for child-instance api-key accounting (GHY-4056)
+
+databaseChangeLog:
+
+  - changeSet:
+      id: v64.2026-07-06T19:46:54
+      author: escherize
+      comment: Add workspace.api_key_prefix to record the prefix of the api-key minted for the workspace's child instance.
+      changes:
+        - addColumn:
+            tableName: workspace
+            columns:
+              - column:
+                  name: api_key_prefix
+                  type: varchar(7)
+                  remarks: Prefix of the api-key minted for this workspace's child instance. Accounting only - the key itself is never stored on the parent.
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: workspace
+            columnName: api_key_prefix

--- a/resources/migrations/064/20260706_ghy_4057_workspace_branches.yaml
+++ b/resources/migrations/064/20260706_ghy_4057_workspace_branches.yaml
@@ -1,0 +1,41 @@
+## Add base_branch / target_branch columns to workspace for git-sync binding (GHY-4057)
+
+databaseChangeLog:
+
+  - changeSet:
+      id: v64.2026-07-06T19:52:00
+      author: escherize
+      comment: Add workspace.base_branch for the child instance's git-sync binding.
+      changes:
+        - addColumn:
+            tableName: workspace
+            columns:
+              - column:
+                  name: base_branch
+                  type: varchar(254)
+                  remarks: Git branch the child's initial import reads from. Null means the repo's default branch.
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: workspace
+            columnName: base_branch
+
+  - changeSet:
+      id: v64.2026-07-06T19:52:01
+      author: escherize
+      comment: Add workspace.target_branch for the child instance's git-sync binding.
+      changes:
+        - addColumn:
+            tableName: workspace
+            columns:
+              - column:
+                  name: target_branch
+                  type: varchar(254)
+                  remarks: Git branch the child's exports write to (remote-sync-branch on the child). Named ws-<name> at create.
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: workspace
+            columnName: target_branch


### PR DESCRIPTION
Split 2 of 3 from #77118, per review discussion. Resolves GHY-4056, GHY-4057, GHY-4121, GHY-4122. Independent of split 1 (#77887); split 3 (HM provisioning) stacks on this.

## What this does

**Branch model** — each workspace binds to two git branches, PR-shaped:
- `base_branch` snapshots the parent's `remote-sync-branch` at create. Deliberately not caller-supplied: a workspace can never be based on another workspace's export branch (no stacked PRs), and branch sequences never enter deletion logic. Snapshot semantics — changing the setting later never affects existing workspaces.
- `target_branch` = the child's export branch: auto-named `ws-<slug>-<id>` (id suffix because names aren't unique), or user-named at create with a 409 when any other workspace already exports to that branch.
- At create (post-transaction — a remote git call must not hold the txn), the parent cuts the target branch from its last-synced commit (`(or last-version remote-sync-branch)`, the create-branch endpoint's convention). Skip-if-exists: create is idempotent and a re-created workspace reuses its old branch. Best-effort: on failure the child boots empty and its first export creates the branch.
- Child-side, after the config.yml `:workspace` section applies, a blocking initial import of the configured branch runs — only when remote-sync is enabled and nothing has ever synced. Blocking is deliberate: the config-apply contract is 2xx = content live. The child never learns `base_branch`.

**API-key mint + accounting (GHY-4056)** — `mint-api-key!`: one `mb_` key per workspace. The parent records only the display prefix (`api_key_prefix` column) — deliberately NOT a `:model/ApiKey` row, so the agent-held key structurally cannot authenticate against the parent. The raw key exists in memory at mint time only; re-mint replaces the prefix (lost key = rotated key).

**Config build (GHY-4057)** — `build-workspace-config` gains a `settings:` section (parent's remote-sync url/token, `read-write`, `remote-sync-branch` = the workspace's `target_branch`; nil section without a git remote) and an `api-keys:` section emitted only when the caller supplies the key + creator — which only the spawn orchestration (split 3) can do, so config downloads can't leak credentials.

**Migrations (064)**: `base_branch`/`target_branch` + `api_key_prefix` on `workspace`.

## Validation

Green locally: workspaces config/model/manager suites, remote-sync workspace-branch tests, advanced-config workspace loader tests (63 tests / 227 assertions in the targeted run).