### PR TITLE
feat(workspaces): HM child-instance orchestration + secret-safe client (split 3/3)

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3758,6 +3758,7 @@
            api-keys
            app-db
            cache
+           config
            driver
            lib
            models
@@ -3768,8 +3769,10 @@
            server
            settings
            sql-tools
+           system
            util
            workspaces
+           enterprise/harbormaster
            enterprise/remote-sync
            enterprise/serialization}
    :model-exports #{:model/Workspace}

--- a/enterprise/backend/src/metabase_enterprise/harbormaster/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/harbormaster/client.clj
@@ -4,6 +4,7 @@
    [clj-http.client :as http]
    [clojure.core.memoize :as memoize]
    [clojure.string :as str]
+   [clojure.walk :as walk]
    [martian.clj-http :as martian-http]
    [martian.core :as martian]
    [medley.core :as m]
@@ -15,7 +16,8 @@
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.secret :as u.secret]))
 
 (set! *warn-on-reflection* true)
 
@@ -63,7 +65,25 @@
 
 (mr/def :hm-client/http-reply [:tuple [:enum :ok :error] :map])
 
-(defn- send-request [request-method-fn store-api-url url request]
+(defn- expose-secrets
+  "Recursively replace every [[metabase.util.secret/Secret]] value in `x` with its
+   exposed value, for the wire payload only. A `Secret` left un-exposed serializes to
+   `<< REDACTED SECRET >>` and would ship a placeholder to Harbormaster instead of the
+   real value, so exposing must happen here, at the encode boundary — never earlier
+   (where it could leak into a log line)."
+  [x]
+  (walk/postwalk #(if (u.secret/secret? %) (u.secret/expose %) %) x))
+
+(defn- loggable-request
+  "A copy of `request` safe to log: any un-exposed `Secret` in the body prints as
+   `<< REDACTED SECRET >>` (that is why the body is logged BEFORE [[expose-secrets]]),
+   and the bearer credential in the Authorization header is scrubbed."
+  [request loggable-body]
+  (-> request
+      (assoc :body loggable-body)
+      (m/update-existing-in [:headers "Authorization"] (constantly "<< REDACTED SECRET >>"))))
+
+(defn- send-request [request-method-fn store-api-url url request loggable-body]
   (let [response (try
                    (request-method-fn
                     (str store-api-url (+slash-prefix url))
@@ -71,12 +91,12 @@
                    (catch Exception e
                      (log/errorf e "Error making request to %s" url)
                      {:ex-data (ex-data e)
-                      :request request
+                      :request (loggable-request request loggable-body)
                       :url     url}))]
     (log/info "Harbormaster API call:"
               {:method   (m.util/upper-case-en (last (str/split (-> request-method-fn class .getSimpleName) #"\$")))
                :url      url
-               :request-body  (:body request)
+               :request-body  loggable-body
                :response (select-keys response [:status :body])})
     response))
 
@@ -108,19 +128,28 @@
   The Harbormaster API uses snake_keys, and this fn automatically converts kebab-keys to snake_keys on request,
   and back to kebab-keys on response.
 
+  `opts` (optional) is merged into the clj-http request map — use it for per-call
+  settings like `:socket-timeout` / `:connection-timeout` (milliseconds).
+
   Returns a tuple of [:ok response] if the request was successful, or [:error response] if it failed."
   [method :- [:enum :get :head :post :put :delete :options :copy :move :patch]
    url :- :string
-   & [body]]
+   & [body opts]]
   (let [{:keys [store-api-url
                 api-key]} (->config)
-        request           (cond-> {:headers {"Authorization" (str "Bearer " api-key)
-                                             "Content-Type" "application/json"}}
-                            body (assoc :body (json/encode (m.util/deep-snake-keys body))))
+        ;; snake-cased body with `Secret`s still WRAPPED — safe to log (they self-redact)
+        loggable-body     (some-> body m.util/deep-snake-keys)
+        request           (cond-> (merge opts
+                                         {:headers {"Authorization" (str "Bearer " api-key)
+                                                    "Content-Type" "application/json"}})
+                            ;; wire body: expose secrets only here, at the encode boundary
+                            body (assoc :body (json/encode (expose-secrets loggable-body))))
+        ;; scrubbed request carried into any error map downstream (never the raw one)
+        safe-request      (loggable-request request loggable-body)
         request-method-fn (->requestor method)
-        unparsed-response (send-request request-method-fn store-api-url url request)
-        response          (m.util/deep-kebab-keys (decode-response unparsed-response url request))
-        success?          (calculate-success response url request)]
+        unparsed-response (send-request request-method-fn store-api-url url request loggable-body)
+        response          (m.util/deep-kebab-keys (decode-response unparsed-response url safe-request))
+        success?          (calculate-success response url safe-request)]
     [(if success? :ok :error) response]))
 
 ;; OpenAPI-based API

--- a/enterprise/backend/src/metabase_enterprise/workspaces/api/workspace_manager.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api/workspace_manager.clj
@@ -4,17 +4,21 @@
    [[metabase-enterprise.workspaces.core]] and permission predicates live on
    `:model/Workspace` and `:model/WorkspaceDatabase` (see `mi/can-read?`/`can-write?`/`can-create?`)."
   (:require
+   [clojure.string :as str]
    [medley.core :as m]
    [metabase-enterprise.serialization.core :as serialization]
    [metabase-enterprise.serialization.schema :as serialization.schema]
    [metabase-enterprise.workspaces.config :as ws.config]
    [metabase-enterprise.workspaces.core :as ws]
+   [metabase-enterprise.workspaces.hm-instance :as hm-instance]
+   [metabase-enterprise.workspaces.models.workspace :as workspace]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models.interface :as mi]
    [metabase.server.streaming-response :as sr]
    [metabase.util.malli.schema :as ms]
+   [metabase.util.secret :as u.secret]
    [toucan2.core :as t2]))
 
 (comment serialization.schema/keep-me)
@@ -31,7 +35,11 @@
    [:database_ids [:sequential {:min 1} ::lib.schema.id/database]]
    ;; export branch; omitted = auto-named ws-<slug>-<id>. 409 when another
    ;; workspace already exports to the same branch.
-   [:target_branch {:optional true} ms/NonBlankString]])
+   [:target_branch {:optional true} ms/NonBlankString]
+   ;; when true, also mint the agent api-key, build config.yml, and spawn the child
+   ;; instance via Harbormaster (blocking). Off by default so the config-download flow
+   ;; and local rigs keep working without HM.
+   [:spawn_instance {:optional true} [:maybe ms/BooleanValue]]])
 
 (def ^:private UpdateWorkspaceParams
   [:map {:closed true}
@@ -62,13 +70,16 @@
 
 (def ^:private WorkspaceResponse
   [:map {:closed true}
-   [:id          ms/PositiveInt]
-   [:name        ms/NonBlankString]
-   [:creator     [:maybe CreatorResponse]]
-   ;; git binding (GHY-4057): base = snapshot of the parent's remote-sync-branch at
-   ;; create; target = the workspace's export branch (nil only pre-migration rows)
+   [:id            ms/PositiveInt]
+   [:name          ms/NonBlankString]
+   [:creator       [:maybe CreatorResponse]]
    [:base_branch   {:optional true} [:maybe :string]]
    [:target_branch {:optional true} [:maybe :string]]
+   ;; child-instance fields: present once an instance has been spawned via HM
+   [:url          {:optional true} [:maybe :string]]
+   ;; returned ONLY by the create response when spawn_instance=true — the key value
+   ;; exists in memory at mint time only (the parent stores just its prefix)
+   [:api_key      {:optional true} ms/NonBlankString]
    [:created_at  DateTimeWithTimeZone]
    [:updated_at  DateTimeWithTimeZone]
    ;; `:databases` is only included when hydrated (i.e. the GET /:id endpoint).
@@ -90,13 +101,51 @@
 (defn- present-workspace [workspace]
   (some-> workspace
           (select-keys [:id :name :creator :base_branch :target_branch :created_at :updated_at :databases])
+          (m/assoc-some :url (:instance_url workspace))
           (update :creator present-creator)
           (m/update-existing :databases #(mapv present-workspace-database %))))
+
+(defn- creator-email-for-child
+  "Email stamped as the `api-keys:` section's `creator:` in the child config. Must
+  be a human admin that exists on the child at boot (the child's apply refuses
+  unknown/non-admin creators — see `advanced-config.file.api-keys`). When the
+  creating credential is itself an api-key, its synthetic `@api-key.invalid` user
+  exists nowhere else, so fall back to the oldest active superuser — the same
+  admin identity HM seeds child instances with (GHY-4063 contract point)."
+  []
+  ;; :type is not in the current-user column set, so fetch it directly
+  (if (= :api-key (t2/select-one-fn :type :model/User :id api/*current-user-id*))
+    (t2/select-one-fn :email :model/User
+                      :is_superuser true :is_active true :type :personal
+                      {:order-by [[:id :asc]]})
+    (:email @api/*current-user*)))
+
+(defn- spawn-instance!
+  "Create-orchestration tail for `spawn_instance=true`: mint the agent api-key
+  (GHY-4056), build the config.yml with the api-keys + settings sections (GHY-4057),
+  POST it to Harbormaster (blocking), record the HM instance id + child URL, and
+  return the workspace response with `:url` and — only here, only once — `:api_key`.
+
+  An HM failure throws a 502 and leaves the provisioned workspace in place: the
+  caller can retry by deleting and re-creating, and nothing secret has leaked (the
+  minted key died with this request; a retry mints a fresh one)."
+  [ws-id]
+  (let [api-key (u.secret/expose (workspace/mint-api-key! ws-id))
+        config  (ws.config/build-workspace-config ws-id
+                                                  {:api-key       api-key
+                                                   :creator-email (creator-email-for-child)})
+        {hm-id :id url :url} (hm-instance/create-instance! {:workspace-id ws-id
+                                                            :name         (str "ws-" ws-id)
+                                                            :config-yml   (ws.config/config->yaml config)})]
+    (t2/update! :model/Workspace :id ws-id {:hm_instance_id hm-id :instance_url url})
+    (-> (present-workspace (ws/get-workspace ws-id))
+        (assoc :api_key api-key))))
 
 ;;; ---------------------------------------------- Endpoints ---------------------------------------------------
 
 (api.macros/defendpoint :get "/" :- [:sequential WorkspaceResponse]
   "List all Workspaces."
+  {:scope "mb:workspace-manager"}
   []
   (api/check-superuser)
   (into [] (comp (filter mi/can-read?)
@@ -105,21 +154,31 @@
 
 (api.macros/defendpoint :get "/:id" :- WorkspaceResponse
   "Get a single Workspace by id."
+  {:scope "mb:workspace-manager"}
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
   (api/read-check :model/Workspace id)
   (present-workspace (api/check-404 (ws/get-workspace id))))
 
 (api.macros/defendpoint :post "/" :- WorkspaceResponse
   "Create a new Workspace attached to the given databases (each must be eligible
-   for workspaces) and provision it (blocking)."
-  [_route-params _query-params params :- CreateWorkspaceParams]
+   for workspaces) and provision it (blocking). With `spawn_instance=true`, also
+   mint the agent api-key, build the child config.yml, and spawn the child instance
+   via Harbormaster (blocking) — the response then carries `:url` and `:api_key`
+   (the only time the key is ever returned)."
+  {:scope "mb:workspace-manager"}
+  [_route-params _query-params {:keys [spawn_instance] :as params} :- CreateWorkspaceParams]
   (api/create-check :model/Workspace params)
-  (present-workspace
-   (ws/create-workspace!
-    (assoc params :creator_id api/*current-user-id*))))
+  (let [ws (ws/create-workspace!
+            (-> params
+                (dissoc :spawn_instance)
+                (assoc :creator_id api/*current-user-id*)))]
+    (if spawn_instance
+      (spawn-instance! (:id ws))
+      (present-workspace ws))))
 
 (api.macros/defendpoint :put "/:id" :- WorkspaceResponse
   "Update a workspace's name."
+  {:scope "mb:workspace-manager"}
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    _query-params
    params :- UpdateWorkspaceParams]
@@ -148,10 +207,19 @@
   unreachable for some `:provisioned` databases, the response includes
   `:orphaned_resources` and a `:message` describing the inert schema/user objects
   left behind for manual cleanup."
+  {:scope "mb:workspace-manager"}
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    {ignore-pending? :ignore-pending} :- [:map [:ignore-pending {:default false} [:maybe ms/BooleanValue]]]]
   (api/write-check :model/Workspace id)
-  (assoc (ws/delete-workspace! id (boolean ignore-pending?)) :id id))
+  ;; capture before the row is deleted; HM delete runs AFTER warehouse teardown so a
+  ;; teardown refusal (409) never orphans a half-deleted workspace
+  (let [hm-id  (t2/select-one-fn :hm_instance_id :model/Workspace :id id)
+        result (assoc (ws/delete-workspace! id (boolean ignore-pending?)) :id id)]
+    (if (and hm-id (not (hm-instance/delete-instance! hm-id)))
+      (update result :message #(->> [% (format "Harbormaster instance %s could not be deleted; HM's backstop reaper will collect it." hm-id)]
+                                    (remove nil?)
+                                    (str/join " ")))
+      result)))
 
 ;;; ------------------------------------------- Config download --------------------------------------------------
 
@@ -162,6 +230,7 @@
       [:body    :string]]
   "Download the workspace's developer-instance config as a YAML file. 409 if any
   of the workspace's databases is not `:provisioned`."
+  {:scope "mb:workspace-manager"}
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
   (api/write-check :model/Workspace id)
   (let [config (api/check-404 (ws.config/build-workspace-config id))]
@@ -188,6 +257,7 @@
   scoped to each database's `:input` namespaces. Same flag semantics as
   `/api/ee/serialization/metadata/export` — sections must be opted into via the
   `with-databases` / `with-tables` / `with-fields` query parameters."
+  {:scope "mb:workspace-manager"}
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    query-params
    :- [:map

--- a/enterprise/backend/src/metabase_enterprise/workspaces/hm_instance.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/hm_instance.clj
@@ -1,0 +1,60 @@
+(ns metabase-enterprise.workspaces.hm-instance
+  "Parent -> Harbormaster calls for workspace child instances.
+
+  Contract (HM tech design CLO-5715): `POST /api/v2/mb/workspaces/instances` with the
+  full config.yml in the body, `blocking=true` so the call returns only once the child
+  is healthy with the config hot-loaded; `DELETE .../instances/:id` is idempotent
+  (404 = already gone). HM keeps a backstop reaper, so a missed delete leaks money,
+  not data. The fake-hm rig (GHY-4048) mimics this exact surface."
+  (:require
+   [metabase-enterprise.harbormaster.client :as hm.client]
+   [metabase.config.core :as config]
+   [metabase.system.core :as system]
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.log :as log]
+   [metabase.util.secret :as u.secret]))
+
+(set! *warn-on-reflection* true)
+
+;; Bounded timeouts so a stalled HM never pins an API thread indefinitely. Create is
+;; blocking on the HM side (machine spin-up + config hot-load), so its read timeout
+;; is generous; delete just enqueues.
+(def ^:private create-timeouts {:connection-timeout 10000, :socket-timeout 600000})
+(def ^:private delete-timeouts {:connection-timeout 10000, :socket-timeout 30000})
+
+(defn create-instance!
+  "Create the child instance for a workspace (blocking; returns once the child is
+  active with `config-yml` applied). Returns `{:id .. :url .. :status ..}`.
+  Throws a 502 `ex-info` when HM refuses or is unreachable — the workspace and its
+  warehouse resources are left in place so the caller can retry or delete."
+  [{:keys [workspace-id name config-yml]}]
+  (let [[ok? resp] (hm.client/make-request :post "/api/v2/mb/workspaces/instances"
+                                           {:name       name
+                                            :blocking   true
+                                            :metadata   {:parent-instance (str (system/site-uuid))
+                                                         :workspace-id    workspace-id}
+                                            :mb-version (:tag config/mb-version-info)
+                                            ;; wrapped so it can never land in a log line; the client
+                                            ;; exposes it only at the JSON-encode boundary
+                                            :config-yml (u.secret/secret config-yml)}
+                                           create-timeouts)]
+    (if (= ok? :ok)
+      (select-keys (:body resp) [:id :url :status])
+      (throw (ex-info (tru "Harbormaster failed to create the workspace instance.")
+                      {:status-code  502
+                       :workspace_id workspace-id
+                       :hm_status    (:status resp)
+                       :hm_body      (:body resp)})))))
+
+(defn delete-instance!
+  "Delete the child instance. Idempotent: 404 means it is already gone and counts as
+  success. Returns true on success; on failure logs and returns false — the caller
+  reports it and HM's backstop reaper eventually collects the instance."
+  [hm-instance-id]
+  (let [[ok? resp] (hm.client/make-request :delete (str "/api/v2/mb/workspaces/instances/" hm-instance-id)
+                                           nil delete-timeouts)]
+    (or (= ok? :ok)
+        (= 404 (:status resp))
+        (do (log/warnf "Harbormaster delete failed for workspace instance %s: status %s"
+                       hm-instance-id (:status resp))
+            false))))

--- a/enterprise/backend/test/metabase_enterprise/harbormaster/client_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/harbormaster/client_test.clj
@@ -1,12 +1,16 @@
 (ns metabase-enterprise.harbormaster.client-test
   (:require
+   [clj-http.client :as http]
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [martian.clj-http :as martian-http]
    [martian.core :as martian]
    [metabase-enterprise.harbormaster.client :as hm.client]
    [metabase.settings.core :as setting]
    [metabase.settings.models.setting]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.log.capture :as log.capture]
+   [metabase.util.secret :as u.secret]))
 
 (deftest ->config-good-test
   (testing "Both needed values are present and pulled from settings"
@@ -72,3 +76,30 @@
           (let [req (hm.client/request :test-op)]
             (is (= "crowberto@metabase.com"
                    (get-in req [:headers "X-Metabase-User-Email"])))))))))
+
+(deftest secret-values-reach-the-wire-but-never-the-log-test
+  (testing "a Secret in the request body is exposed for the HTTP payload but redacted in logs"
+    (mt/with-temporary-setting-values [api-key "mb_api_key_123" store-api-url "http://hm.test"]
+      (let [captured (atom nil)]
+        (mt/with-dynamic-fn-redefs [http/post (fn [_url request]
+                                                (reset! captured request)
+                                                {:status 200 :body "{}"})]
+          (log.capture/with-log-messages-for-level [messages [metabase-enterprise.harbormaster.client :info]]
+            (hm.client/make-request :post "/things"
+                                    {:name       "ws"
+                                     :config-yml (u.secret/secret "SUPER_SECRET_YAML")})
+            (testing "the real secret value is in the outbound HTTP body"
+              (is (str/includes? (:body @captured) "SUPER_SECRET_YAML"))
+              (is (not (str/includes? (:body @captured) "REDACTED"))))
+            (testing "the secret never appears in any log message"
+              (let [logged (pr-str (messages))]
+                (is (not (str/includes? logged "SUPER_SECRET_YAML")))
+                (is (str/includes? logged "REDACTED SECRET")))))))))
+  (testing "on an HTTP error the scrubbed request (no bearer, no raw secret) rides the error map"
+    (mt/with-temporary-setting-values [api-key "mb_api_key_123" store-api-url "http://hm.test"]
+      (mt/with-dynamic-fn-redefs [http/post (fn [_ _] (throw (ex-info "boom" {})))]
+        (log.capture/with-log-messages-for-level [messages [metabase-enterprise.harbormaster.client :info]]
+          (hm.client/make-request :post "/things" {:config-yml (u.secret/secret "SUPER_SECRET_YAML")})
+          (let [logged (pr-str (messages))]
+            (is (not (str/includes? logged "SUPER_SECRET_YAML")))
+            (is (not (str/includes? logged "mb_api_key_123")))))))))

--- a/enterprise/backend/test/metabase_enterprise/workspaces/api/workspace_manager_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api/workspace_manager_test.clj
@@ -4,11 +4,14 @@
    verify routing, request/response shape, and that the model-level permission predicates
    are wired into the endpoints (one 403 spot-check is enough)."
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing use-fixtures]]
+   [metabase-enterprise.harbormaster.client :as hm.client]
    [metabase-enterprise.workspaces.provisioning :as provisioning]
    [metabase.permissions.test-util :as perms.test-util]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
+   [metabase.util.secret :as u.secret]
    [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db))
@@ -196,3 +199,95 @@
         (mt/user-http-request :rasta :put 403 (str "ee/workspace-manager/" ws-id) {:name "Nope"})
         (mt/user-http-request :rasta :get 403 (str "ee/workspace-manager/" ws-id "/config"))
         (mt/user-http-request :rasta :delete 403 (str "ee/workspace-manager/" ws-id))))))
+
+;;; ------------------------------------------- HM spawn orchestration -------------------------------------------
+
+(defn- fake-hm
+  "Stub hm.client/make-request. Records every call in `calls` (an atom of vectors)
+   and answers create/delete against an in-memory HM."
+  [calls & {:keys [create-response]}]
+  (fn [method url & [body]]
+    (swap! calls conj [method url body])
+    (cond
+      (and (= method :post) (= url "/api/v2/mb/workspaces/instances"))
+      (or create-response
+          [:ok {:status 200 :body {:id "hm-ws-1" :url "https://tutty-fruity.metabaseapp.com" :status "active"}}])
+
+      (= method :delete)
+      [:ok {:status 204 :body nil}]
+
+      :else
+      [:error {:status 404 :body nil}])))
+
+(deftest create-with-spawn-instance-test
+  (testing "POST with spawn_instance=true mints the key, ships config.yml to HM, records the instance"
+    (mt/with-temp [:model/Database {db-id :id} {:engine   :postgres
+                                                :details  {}
+                                                :settings {:database-enable-workspaces true}}]
+      (mt/with-model-cleanup [:model/Workspace]
+        (let [calls (atom [])]
+          (with-redefs [provisioning/dispatching-provisioner (stub-provisioner)
+                        hm.client/make-request               (fake-hm calls)]
+            (let [ws (mt/user-http-request :crowberto :post 200 "ee/workspace-manager/"
+                                           {:name "Spawned" :database_ids [db-id] :spawn_instance true})]
+              (testing "response carries the child url + the api key (only time it is returned)"
+                (is (= "https://tutty-fruity.metabaseapp.com" (:url ws)))
+                (is (re-matches #"mb_[A-Za-z0-9+/=]+" (:api_key ws))))
+              (testing "workspace row records hm instance id, url, and key prefix"
+                (is (=? {:hm_instance_id "hm-ws-1"
+                         :instance_url   "https://tutty-fruity.metabaseapp.com"
+                         :api_key_prefix (subs (:api_key ws) 0 7)}
+                        (t2/select-one :model/Workspace :id (:id ws)))))
+              (testing "HM create request shape"
+                (let [[method url body] (first @calls)]
+                  (is (= :post method))
+                  (is (= "/api/v2/mb/workspaces/instances" url))
+                  (is (true? (:blocking body)))
+                  (is (= (:id ws) (get-in body [:metadata :workspace-id])))
+                  (testing "config.yml rides the POST as a Secret (redacts in logs) and includes the api-keys section with the minted key"
+                    (is (u.secret/secret? (:config-yml body)))
+                    (let [yaml (u.secret/expose (:config-yml body))]
+                      (is (str/includes? yaml "api-keys"))
+                      (is (str/includes? yaml (:api_key ws)))))))
+              (testing "GET returns the child url but never the key"
+                (let [fetched (mt/user-http-request :crowberto :get 200 (str "ee/workspace-manager/" (:id ws)))]
+                  (is (= "https://tutty-fruity.metabaseapp.com" (:url fetched)))
+                  (is (not (contains? fetched :api_key)))))
+              (testing "DELETE tears down warehouse then calls HM delete"
+                (is (=? {:deleted true}
+                        (mt/user-http-request :crowberto :delete 200 (str "ee/workspace-manager/" (:id ws)))))
+                (let [[method url] (last @calls)]
+                  (is (= :delete method))
+                  (is (= "/api/v2/mb/workspaces/instances/hm-ws-1" url)))))))))))
+
+(deftest create-spawn-instance-hm-failure-test
+  (testing "HM refusal -> 502; the provisioned workspace survives for retry/delete"
+    (mt/with-temp [:model/Database {db-id :id} {:engine   :postgres
+                                                :details  {}
+                                                :settings {:database-enable-workspaces true}}]
+      (mt/with-model-cleanup [:model/Workspace]
+        (let [calls (atom [])]
+          (with-redefs [provisioning/dispatching-provisioner (stub-provisioner)
+                        hm.client/make-request               (fake-hm calls :create-response
+                                                                      [:error {:status 500 :body {:error "boom"}}])]
+            (mt/user-http-request :crowberto :post 502 "ee/workspace-manager/"
+                                  {:name "Doomed" :database_ids [db-id] :spawn_instance true})
+            (testing "workspace row still exists, no instance recorded"
+              (is (=? {:hm_instance_id nil :instance_url nil}
+                      (t2/select-one :model/Workspace :name "Doomed"))))))))))
+
+(deftest create-without-spawn-unchanged-test
+  (testing "spawn_instance omitted -> no HM call, no key minted"
+    (mt/with-temp [:model/Database {db-id :id} {:engine   :postgres
+                                                :details  {}
+                                                :settings {:database-enable-workspaces true}}]
+      (mt/with-model-cleanup [:model/Workspace]
+        (let [calls (atom [])]
+          (with-redefs [provisioning/dispatching-provisioner (stub-provisioner)
+                        hm.client/make-request               (fake-hm calls)]
+            (let [ws (mt/user-http-request :crowberto :post 200 "ee/workspace-manager/"
+                                           {:name "Plain" :database_ids [db-id]})]
+              (is (not (contains? ws :api_key)))
+              (is (not (contains? ws :url)))
+              (is (empty? @calls))
+              (is (nil? (t2/select-one-fn :api_key_prefix :model/Workspace :id (:id ws)))))))))))

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -111,6 +111,7 @@
      eid-translation
      embedding
      enterprise/api
+     enterprise/harbormaster
      enterprise/remote-sync
      enterprise/scim
      enterprise/serialization

--- a/resources/migrations/064/20260706_ghy_4058_workspace_hm_instance.yaml
+++ b/resources/migrations/064/20260706_ghy_4058_workspace_hm_instance.yaml
@@ -1,0 +1,41 @@
+## Add hm_instance_id / instance_url columns to workspace for the HM-provisioned child instance (GHY-4058)
+
+databaseChangeLog:
+
+  - changeSet:
+      id: v64.2026-07-06T21:10:00
+      author: escherize
+      comment: Add workspace.hm_instance_id recording the Harbormaster instance backing this workspace.
+      changes:
+        - addColumn:
+            tableName: workspace
+            columns:
+              - column:
+                  name: hm_instance_id
+                  type: varchar(254)
+                  remarks: Harbormaster instance id for the child instance. Null when no instance has been spawned.
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: workspace
+            columnName: hm_instance_id
+
+  - changeSet:
+      id: v64.2026-07-06T21:10:01
+      author: escherize
+      comment: Add workspace.instance_url recording the child instance's public URL.
+      changes:
+        - addColumn:
+            tableName: workspace
+            columns:
+              - column:
+                  name: instance_url
+                  type: varchar(254)
+                  remarks: Public URL of the HM-provisioned child instance. Null when no instance has been spawned.
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: workspace
+            columnName: instance_url


### PR DESCRIPTION
Split 3 of 3 from #77118, per review discussion. Resolves GHY-4058. **Stacked on #77888** (split 2) — retarget to master after it merges. The scope-tag lines on `workspace_manager.clj` also land via #77887 (split 1) with identical content, expect a trivial conflict there after #77887 merges — resolve by taking this branch's version (it is the superset; final state verified byte-identical to the pre-split branch).

## What this does

- **Spawn orchestration**: `POST /api/ee/workspace-manager` with `spawn_instance=true` mints the agent api-key, builds the config.yml (api-keys + settings sections), POSTs it to Harbormaster (`/api/v2/mb/workspaces/instances`, blocking), records `hm_instance_id`/`instance_url`, and returns `{name, url, api_key}` — the only time the key is ever returned (parent keeps just the prefix). HM refusal/unreachability = 502 with the provisioned workspace left in place for retry-by-recreate; nothing secret leaks (the minted key died with the request). The real HM endpoint (CLO-5715) isn't live yet; validated against a stub matching that surface.
- **DELETE** calls HM delete after warehouse teardown, conditional on `hm_instance_id` (never-spawned workspaces skip HM). 404 from HM = already gone = success; other failures are reported and left to HM's backstop reaper.
- **Secret-safe HM client**: `hm.client` logs request bodies, and the workspace config.yml carries warehouse credentials, the minted key, and the parent git token — so secrets travel as `metabase.util.secret/Secret` wrappers that the client exposes only at the JSON-encode boundary. Logged copies self-redact to `<< REDACTED SECRET >>`; the Authorization header is scrubbed on error paths. `make-request` gains per-request opts, used for bounded timeouts (create 10s connect / 10min socket for the blocking spin-up; delete 10s/30s) so a stalled HM can't pin an API thread.
- **Migration 064**: `hm_instance_id` + `instance_url` on `workspace`.

## Validation

hm client + workspace-manager (incl. spawn orchestration + HM-failure paths) + config suites green locally (31 tests / 121 assertions targeted run). Final file states byte-identical to the pre-split branch.