### PR TITLE
Backport "Better destination-db errors"

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1772,6 +1772,7 @@
            cache
            config
            dashboards
+           database-routing
            driver
            events
            formatter
@@ -2917,7 +2918,6 @@
   {:team "UX West"
    :api  #{metabase-enterprise.database-routing.api}
    :uses #{api
-           config
            database-routing
            driver
            events

--- a/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.database-routing.common
   (:require
    [metabase.api.common :as api]
-   [metabase.config.core :as config]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
@@ -75,14 +74,19 @@
 ;; only use router databases. In these cases we don't want database routing, we just want to ensure we're not hitting
 ;; a Destination Database
 ;;
-;; The former looks like:
-;; - I am looking at a Router Database,
-;; - `router-db-or-id->destination-db-id` returns a *different* database ID, and
-;; - `*database-routing-on*` is `:on` or `:unset`
+;; `*database-routing-on*` records our intent: `:on` inside a routed query (destinations are expected), `:off` when we
+;; explicitly want the router (e.g. sync), `:unset` otherwise. Concretely:
 ;;
-;; The latter looks like:
-;; - I am looking at a destination Database,
-;; - `*database-routing-on*` is `:off` or `:unset`
+;; (a) looks like:
+;; - I am looking at a Router Database,
+;; - the current user's attribute would route me to a *different* destination, and
+;; - `*database-routing-on*` is `:on` or `:unset`.
+;; A correctness concern, owned by the routing middleware (which makes the routing decision); not enforced here.
+;;
+;; (b) looks like:
+;; - I am looking at a destination Database, and
+;; - `*database-routing-on*` is not `:on` (i.e. `:off` or `:unset`).
+;; A tenancy boundary, enforced by `check-allowed-access!` below.
 
 (defenterprise with-database-routing-on-fn
   "Enterprise version. Calls the function with Database Routing allowed."
@@ -98,34 +102,25 @@
   (binding [*database-routing-on* :off]
     (f)))
 
-(defn- is-disallowed-router-db-access?
-  [db-or-id]
-  (and (some-> (router-db-or-id->destination-db-id db-or-id)
-               (not= db-or-id))
-       (not= *database-routing-on* :off)))
-
 (defn- is-disallowed-destination-db-access?
   [db-or-id]
   (and (t2/exists? :model/Database :id db-or-id :router_database_id [:not= nil])
        (not= *database-routing-on* :on)))
 
+(defn assert-not-direct-destination-access!
+  "Throws a 403 when `db-or-id` is a destination database queried directly, outside a routing-on
+  context. A destination is reachable only through its router; a direct query bypasses the router's
+  attribute check, and with it tenant isolation."
+  [db-or-id]
+  (when (is-disallowed-destination-db-access? (u/the-id db-or-id))
+    (throw (ex-info (tru "You cannot query a destination database directly.")
+                    {:status-code 403}))))
+
 (defenterprise check-allowed-access!
-  "This is intended as a safety harness. In dev/testing, if any access to a router or destination database is detected
-  outside those circumstances where we've explicitly declared it okay, throw an exception.
-
-  In production, skip this (fairly expensive) check.
-
-  The idea here is that at all times we should be aware of whether:
-
-  - we're explicitly accessing a router database (e.g. sync) and DO NOT want to reroute to a destination database, or
-
-  - we're explicitly using the Database Routing feature (e.g. a query) and DO NOT want to access the router
-  database (unless that was the user's intent, i.e. the user's attribute was `__METABASE_ROUTER__`) "
+  "Throws a 403 if `db-or-id-or-spec` is a destination database accessed while database routing is
+  not `:on`, i.e. a direct hit that bypasses its router. Legitimate access to a destination goes
+  through its router, which turns routing `:on`."
   :feature :database-routing
   [db-or-id-or-spec]
-  (when-let [db-id (and (not config/is-prod?)
-                        (u/id db-or-id-or-spec))]
-    (when (is-disallowed-router-db-access? db-id)
-      (throw (ex-info "Forbidden access to Router Database without `with-database-routing-off`" {})))
-    (when (is-disallowed-destination-db-access? db-id)
-      (throw (ex-info "Forbidden access to Destination Database without `with-database-routing-on`" {})))))
+  (when-let [db-id (u/id db-or-id-or-spec)]
+    (assert-not-direct-destination-access! db-id)))

--- a/enterprise/backend/src/metabase_enterprise/database_routing/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/middleware.clj
@@ -3,7 +3,7 @@
   `:destination-database/id`, on the query if a destination database should be used. The second middleware runs around query
   execution, and should be THE LAST middleware before we hit the database and query execution actually occurs."
   (:require
-   [metabase-enterprise.database-routing.common :refer [router-db-or-id->destination-db-id]]
+   [metabase-enterprise.database-routing.common :as common :refer [router-db-or-id->destination-db-id]]
    [metabase.database-routing.core :refer [with-database-routing-on]]
    [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
@@ -61,7 +61,11 @@
   :feature :none
   [query]
   (let [database (lib.metadata/database (qp.store/metadata-provider))
+        ;; both the assert and the routing computation hit the app-db, which skip-middleware contexts
+        ;; (e.g. the offline semantic checker) must not do; they never execute queries, so there is
+        ;; nothing for the assert to protect there.
         destination-db-id (when-not qp.i/*skip-middleware-because-app-db-access*
+                            (common/assert-not-direct-destination-access! database)
                             (router-db-or-id->destination-db-id database))]
     (when destination-db-id
       (premium-features/assert-has-feature :database-routing (tru "Database Routing"))
@@ -69,5 +73,7 @@
                                     :database-routing
                                     database)
         (throw (ex-info "Unsupported database for database routing" {}))))
-    (cond-> query
+    ;; dissoc first: a client-supplied :destination-database/id must never survive preprocessing,
+    ;; since swap-destination-db trusts this key at execution time.
+    (cond-> (dissoc query :destination-database/id)
       destination-db-id (assoc :destination-database/id destination-db-id))))

--- a/enterprise/backend/test/metabase_enterprise/database_routing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/api_test.clj
@@ -1,8 +1,11 @@
 (ns metabase-enterprise.database-routing.api-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing use-fixtures]]
+   [metabase-enterprise.test :as met]
    [metabase.driver :as driver]
    [metabase.driver.settings :as driver.settings]
+   [metabase.metabot.tools.resources :as read-resource]
    [metabase.permissions-rest.data-permissions.graph :as data-perms.graph]
    [metabase.permissions.core :as perms]
    [metabase.test :as mt]
@@ -204,6 +207,33 @@
       (mt/user-http-request :crowberto :get 404 (str "database/" destination-db-id "/syncable_schemas")))
     (testing "GET /database/:id/schemas"
       (mt/user-http-request :crowberto :get 404 (str "database/" destination-db-id "/schemas")))))
+
+(deftest routed-destination-database-names-are-hidden-in-metabot-resources
+  (mt/with-temp [:model/Database {router-id :id} {:name "Postgres Router"}
+                 :model/DatabaseRouter _ {:database_id router-id :user_attribute "db_name"}
+                 :model/Database {selected-destination-id :id} {:name "customer-a"
+                                                                :router_database_id router-id}
+                 :model/Database {other-destination-id :id} {:name "customer-b"
+                                                             :router_database_id router-id}]
+    (met/with-user-attributes! :rasta {"db_name" "customer-a"}
+      (mt/with-current-user (mt/user->id :rasta)
+        (testing "database list includes the router and hides destination databases"
+          (let [{:keys [output]} (read-resource/read-resource {:uris ["metabase://databases"]})]
+            (is (str/includes? output "Postgres Router"))
+            (is (not (str/includes? output "customer-a")))
+            (is (not (str/includes? output "customer-b")))))
+        (testing "a sibling destination cannot be read by URI"
+          (is (some? (-> (read-resource/read-resource
+                          {:uris [(str "metabase://database/" other-destination-id)]})
+                         :resources
+                         first
+                         :error))))
+        (testing "the current user's routed destination cannot be read by URI"
+          (is (some? (-> (read-resource/read-resource
+                          {:uris [(str "metabase://database/" selected-destination-id)]})
+                         :resources
+                         first
+                         :error))))))))
 
 (deftest destination-databases-excluded-from-permissions-graph
   (mt/with-temp [:model/Database {db-id :id} {}

--- a/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
@@ -5,8 +5,11 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [clojurewerkz.quartzite.conversion :as qc]
+   [metabase-enterprise.database-routing.common :as common]
    [metabase-enterprise.test :as met]
    [metabase.app-db.core :as mdb]
+   [metabase.config.core :as config]
+   [metabase.database-routing.core :as database-routing]
    [metabase.driver :as driver]
    [metabase.driver.settings :as driver.settings]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -79,6 +82,93 @@
                   (is (= [["destination-2"]] (mt/rows response))))
                 (let [response (mt/user-http-request :crowberto :post 202 (str "card/" (u/the-id card) "/query"))]
                   (is (= [["router"]] (mt/rows response))))))))))))
+
+;; The reported exploit, verbatim: POST /api/dataset with a destination's id and a native query.
+;; Before the fix this returned the destination's rows (a cross-tenant leak); it must be rejected,
+;; in production too. Exercises the real HTTP surface, above the QP-level test below.
+(deftest direct-destination-query-via-dataset-endpoint-is-forbidden-test
+  (testing "POST /api/dataset at a destination id is rejected, not leaked"
+    (mt/with-premium-features #{:database-routing}
+      (binding [driver.settings/*allow-testing-h2-connections* true]
+        (with-temp-dbs! [router-db destination-db]
+          (t2/update! :model/Database (u/the-id destination-db)
+                      {:name "destination-db" :router_database_id (u/the-id router-db)})
+          (sync/sync-database! router-db)
+          (mt/with-temp [:model/DatabaseRouter _ {:database_id    (u/the-id router-db)
+                                                  :user_attribute "db_name"}]
+            (execute-statement! destination-db "INSERT INTO \"my_database_name\" (str) VALUES ('tenant-b-secret')")
+            (let [exploit {:database (u/the-id destination-db)
+                           :type     :native
+                           :native   {:query "SELECT str FROM \"my_database_name\""}}]
+              (doseq [prod? [false true]]
+                (testing (str "config/is-prod? = " prod?)
+                  (with-redefs [config/is-prod? prod?]
+                    ;; :crowberto is a superuser -> permissions never block; the routing guard must.
+                    (let [response (mt/user-http-request :crowberto :post 403 "dataset" exploit)]
+                      (is (re-find #"(?i)cannot query a destination database directly" (str response)))
+                      (is (not (str/includes? (str response) "tenant-b-secret"))
+                          "the destination's rows must not appear in the response"))))))))))))
+
+;; Must hold in production too, where the dev-only connection-pool harness is disabled; a query-level
+;; guard, not the harness and not permissions, has to reject a directly-submitted destination id.
+(deftest direct-destination-database-access-is-forbidden-test
+  (testing "a directly-submitted destination id is rejected"
+    (mt/with-premium-features #{:database-routing}
+      (binding [driver.settings/*allow-testing-h2-connections* true]
+        (met/with-user-attributes! :rasta {"db_name" "destination-db"}
+          (with-temp-dbs! [router-db destination-db]
+            ;; wiring an already-created (perm-carrying) DB as a destination mirrors the vulnerable
+            ;; state: the destination retains permissions, so perms alone do not block access.
+            (t2/update! :model/Database (u/the-id destination-db)
+                        {:name "destination-db" :router_database_id (u/the-id router-db)})
+            (sync/sync-database! router-db)
+            (mt/with-temp [:model/DatabaseRouter _ {:database_id    (u/the-id router-db)
+                                                    :user_attribute "db_name"}]
+              (execute-statement! destination-db "INSERT INTO \"my_database_name\" (str) VALUES ('secret')")
+              (let [table-id      (t2/select-one-pk :model/Table :db_id (u/the-id router-db))
+                    ;; native (the reported exploit) and MBQL. MBQL exercises the setup-layer check:
+                    ;; the destination has no synced tables, so without an early reject the query would
+                    ;; die later with a confusing "table not found" instead of a clean 403.
+                    direct-queries {:native {:database (u/the-id destination-db)
+                                             :type     :native
+                                             :native   {:query "SELECT str FROM \"my_database_name\""}}
+                                    :mbql   {:database (u/the-id destination-db)
+                                             :type     :query
+                                             :query    {:source-table table-id}}}]
+                (doseq [prod?           [false true]
+                        [qtype a-query] direct-queries]
+                  (testing (str "config/is-prod? = " prod? ", query type = " qtype)
+                    (with-redefs [config/is-prod? prod?]
+                      ;; :crowberto is a superuser -> resolves to most-permissive perms on every database,
+                      ;; so the permission layer never blocks; the routing invariant must.
+                      (mt/with-test-user :crowberto
+                        (is (thrown-with-msg?
+                             clojure.lang.ExceptionInfo
+                             #"(?i)cannot query a destination database directly"
+                             (qp/process-query a-query)))))))))))))))
+
+;; The connection-pool guard is the backstop for non-query paths (sync, actions, downloads); it must
+;; fire in production too, so exercise it directly rather than through the query pipeline.
+(deftest check-allowed-access-blocks-destinations-in-prod-test
+  (testing "connection-pool backstop rejects direct destination access"
+    (mt/with-premium-features #{:database-routing}
+      (binding [driver.settings/*allow-testing-h2-connections* true]
+        (with-temp-dbs! [router-db destination-db]
+          (t2/update! :model/Database (u/the-id destination-db)
+                      {:name "destination-db" :router_database_id (u/the-id router-db)})
+          (mt/with-temp [:model/DatabaseRouter _ {:database_id    (u/the-id router-db)
+                                                  :user_attribute "db_name"}]
+            (with-redefs [config/is-prod? true]
+              (testing "direct destination access is forbidden"
+                (is (thrown-with-msg?
+                     clojure.lang.ExceptionInfo
+                     #"(?i)cannot query a destination database directly"
+                     (common/check-allowed-access! (u/the-id destination-db)))))
+              (testing "destination access is allowed inside a routing-on context (legit routed query)"
+                (is (nil? (database-routing/with-database-routing-on
+                            (common/check-allowed-access! (u/the-id destination-db))))))
+              (testing "the router database itself is not treated as a forbidden destination"
+                (is (nil? (common/check-allowed-access! (u/the-id router-db))))))))))))
 
 (deftest an-error-is-thrown-if-user-attribute-is-missing-or-no-match
   (mt/with-premium-features #{:database-routing}

--- a/enterprise/backend/test/metabase_enterprise/database_routing/middleware_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/middleware_test.clj
@@ -1,0 +1,49 @@
+(ns metabase-enterprise.database-routing.middleware-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase-enterprise.database-routing.middleware :as routing.middleware]
+   [metabase.query-processor.interface :as qp.i]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(deftest attach-destination-db-middleware-respects-skip-app-db-access-test
+  (testing "no app-db access, and no destination rejection, when *skip-middleware-because-app-db-access* is bound true"
+    (mt/with-temp [:model/Database {router-id :id} {}
+                   :model/Database {destination-id :id} {:router_database_id router-id}]
+      (mt/with-metadata-provider destination-id
+        (binding [qp.i/*skip-middleware-because-app-db-access* true]
+          (let [query {:database destination-id, :type :query, :query {}}]
+            ;; the first invocation warms the metadata provider's Database cache, so the second
+            ;; measures the middleware alone
+            (routing.middleware/attach-destination-db-middleware query)
+            (t2/with-call-count [call-count]
+              (is (= query (routing.middleware/attach-destination-db-middleware query)))
+              (is (zero? (call-count))))))))))
+
+(deftest attach-destination-db-middleware-scrubs-client-supplied-destination-test
+  (testing "a client-supplied :destination-database/id never survives preprocessing"
+    (testing "for a plain un-routed database"
+      (mt/with-temp [:model/Database {db-id :id} {}]
+        (mt/with-metadata-provider db-id
+          (let [query {:database db-id, :type :query, :query {}, :destination-database/id 99999}]
+            (is (not (contains? (routing.middleware/attach-destination-db-middleware query)
+                                :destination-database/id)))))))
+    (testing "in skip-middleware contexts"
+      (mt/with-temp [:model/Database {router-id :id} {}
+                     :model/Database {destination-id :id} {:router_database_id router-id}]
+        (mt/with-metadata-provider destination-id
+          (binding [qp.i/*skip-middleware-because-app-db-access* true]
+            (let [query {:database destination-id, :type :query, :query {}, :destination-database/id 99999}]
+              (is (not (contains? (routing.middleware/attach-destination-db-middleware query)
+                                  :destination-database/id))))))))))
+
+(deftest attach-destination-db-middleware-rejects-direct-destination-access-test
+  (testing "outside skip-middleware contexts, direct destination-database access is rejected"
+    (mt/with-temp [:model/Database {router-id :id} {}
+                   :model/Database {destination-id :id} {:router_database_id router-id}]
+      (mt/with-metadata-provider destination-id
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"(?i)cannot query a destination database directly"
+             (routing.middleware/attach-destination-db-middleware
+              {:database destination-id, :type :query, :query {}})))))))

--- a/src/metabase/metabot/tools/resources.clj
+++ b/src/metabase/metabot/tools/resources.clj
@@ -64,6 +64,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.match :as match]
+   [metabase.warehouses.core :as warehouses]
    [ring.util.codec :as codec]
    [toucan2.core :as t2]))
 
@@ -250,6 +251,7 @@
 (defn- fetch-databases-list []
   (let [dbs (->> (t2/select [:model/Database :id :name :engine :description :is_audit]
                             :is_audit false
+                            :router_database_id nil
                             {:order-by [[:%lower.name :asc]]})
                  (filter mi/can-read?)
                  (mapv present-database))]
@@ -303,12 +305,12 @@
 ;; ----- Database drill-down -----
 
 (defn- fetch-database [id-str]
-  (let [db (api/read-check :model/Database (parse-long id-str))]
+  (let [db (warehouses/get-database (parse-long id-str))]
     (entity-result (present-database db))))
 
 (defn- fetch-database-tables [id-str]
   (let [db-id  (parse-long id-str)
-        _      (api/read-check :model/Database db-id)
+        _      (warehouses/get-database db-id)
         tables (->> (t2/select [:model/Table :id :name :display_name :schema :db_id :description]
                                :db_id  db-id
                                :active true
@@ -319,7 +321,7 @@
 
 (defn- fetch-database-models [id-str]
   (let [db-id  (parse-long id-str)
-        _      (api/read-check :model/Database db-id)
+        _      (warehouses/get-database db-id)
         models (->> (t2/select [:model/Card :id :name :type :description :card_schema
                                 :collection_id :database_id :table_id]
                                :type        :model
@@ -332,7 +334,7 @@
 
 (defn- fetch-database-schemas [id-str]
   (let [db-id   (parse-long id-str)
-        _       (api/read-check :model/Database db-id)
+        _       (warehouses/get-database db-id)
         rows    (t2/query
                  {:select-distinct [:schema]
                   :from            [:metabase_table]
@@ -349,7 +351,7 @@
 
 (defn- fetch-database-schema-tables [id-str schema-name]
   (let [db-id  (parse-long id-str)
-        _      (api/read-check :model/Database db-id)
+        _      (warehouses/get-database db-id)
         tables (->> (t2/select [:model/Table :id :name :display_name :schema :db_id :description]
                                :db_id  db-id
                                :schema schema-name
@@ -403,10 +405,29 @@
 
 ;; ----- Table -----
 
+(defn- check-resource-database
+  "Require that a resource's backing database is addressable as a Metabot resource.
+   Routed destination databases are routing internals here: users should navigate via
+   the router database, not direct destination-backed resource URIs."
+  [db-id]
+  (when db-id
+    (warehouses/get-database db-id)))
+
+(defn- check-table-resource-database [table-id]
+  (when-let [table (api/read-check :model/Table table-id)]
+    (check-resource-database (:db_id table))))
+
+(defn- check-card-resource-database [card-id]
+  (when-let [card (api/read-check :model/Card card-id)]
+    (check-resource-database (:database_id card))))
+
 (defn- table-details
   "Shared `entity-details/get-table-details` call for both /table/{id} and /table/{id}/fields.
    `entity-type` is :table, :model, or :question."
   [entity-type id with-fields?]
+  (case entity-type
+    :table (check-table-resource-database id)
+    (:model :question) (check-card-resource-database id))
   (entity-details/get-table-details {:entity-type          entity-type
                                      :entity-id            id
                                      :with-fields?         with-fields?
@@ -422,15 +443,18 @@
   (table-details :table (parse-long id-str) true))
 
 (defn- fetch-table-field [id-str field-id]
-  (field-stats/field-values {:entity-type "table"
-                             :entity-id   (parse-long id-str)
-                             :field-id    field-id
-                             :limit       30}))
+  (let [table-id (parse-long id-str)]
+    (check-table-resource-database table-id)
+    (field-stats/field-values {:entity-type "table"
+                               :entity-id   table-id
+                               :field-id    field-id
+                               :limit       30})))
 
 (defn- fetch-table-derived [id-str]
   (let [table-id   (parse-long id-str)
         table      (api/read-check :model/Table table-id)
         db-id      (:db_id table)
+        _          (check-resource-database db-id)
         cards      (->> (t2/select [:model/Card :id :name :type :description :card_schema
                                     :collection_id :database_id :table_id]
                                    :table_id table-id
@@ -463,32 +487,41 @@
   (table-details (keyword type-str) (parse-long id-str) true))
 
 (defn- fetch-card-field [type-str id-str field-id]
-  (field-stats/field-values {:entity-type type-str
-                             :entity-id   (parse-long id-str)
-                             :field-id    field-id
-                             :limit       30}))
+  (let [card-id (parse-long id-str)]
+    (check-card-resource-database card-id)
+    (field-stats/field-values {:entity-type type-str
+                               :entity-id   card-id
+                               :field-id    field-id
+                               :limit       30})))
 
 (defn- fetch-card-sources [id-str]
   (let [card (api/read-check :model/Card (parse-long id-str))]
+    (check-resource-database (:database_id card))
     (list-result :card-sources (card-sources-items card))))
 
 ;; ----- Metric -----
 
 (defn- fetch-metric [id-str]
-  (entity-details/get-metric-details {:metric-id                 (parse-long id-str)
-                                      :with-queryable-dimensions false
-                                      :with-field-values         false}))
+  (let [metric-id (parse-long id-str)]
+    (check-card-resource-database metric-id)
+    (entity-details/get-metric-details {:metric-id                 metric-id
+                                        :with-queryable-dimensions false
+                                        :with-field-values         false})))
 
 (defn- fetch-metric-dimensions [id-str]
-  (entity-details/get-metric-details {:metric-id                 (parse-long id-str)
-                                      :with-queryable-dimensions true
-                                      :with-field-values         false}))
+  (let [metric-id (parse-long id-str)]
+    (check-card-resource-database metric-id)
+    (entity-details/get-metric-details {:metric-id                 metric-id
+                                        :with-queryable-dimensions true
+                                        :with-field-values         false})))
 
 (defn- fetch-metric-dimension [id-str dim-id]
-  (field-stats/field-values {:entity-type "metric"
-                             :entity-id   (parse-long id-str)
-                             :field-id    dim-id
-                             :limit       30}))
+  (let [metric-id (parse-long id-str)]
+    (check-card-resource-database metric-id)
+    (field-stats/field-values {:entity-type "metric"
+                               :entity-id   metric-id
+                               :field-id    dim-id
+                               :limit       30})))
 
 ;; ----- Transform -----
 

--- a/src/metabase/query_processor/setup.clj
+++ b/src/metabase/query_processor/setup.clj
@@ -4,6 +4,7 @@
    [clojure.core.async.impl.dispatch :as a.impl.dispatch]
    [clojure.set :as set]
    [metabase.config.core :as config]
+   [metabase.database-routing.core :as database-routing]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.lib.computed :as lib.computed]
@@ -144,8 +145,14 @@
       (f query)
 
       :else
-      (qp.store/with-metadata-provider (:database query)
-        (f (maybe-attach-metadata-provider-to-query query))))))
+      ;; `:database` here is whatever the user submitted, so a destination at this point is a direct
+      ;; request to query one; reject it before building a provider. Legitimate routing never passes
+      ;; through this branch: when a router query is routed to a destination, that swap happens later,
+      ;; in the execution middleware, binding its own metadata provider.
+      (do
+        (database-routing/check-allowed-access! (:database query))
+        (qp.store/with-metadata-provider (:database query)
+          (f (maybe-attach-metadata-provider-to-query query)))))))
 
 (mu/defn- do-with-driver :- fn?
   [f :- [:=> [:cat ::qp.schema/any-query] :any]]

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -219,9 +219,13 @@
   "Get a status code for the supplied error object."
   [err]
   (cond
+    ;; A raw exception thrown outside the QP's exception-formatting (e.g. during setup) arrives here as
+    ;; a Throwable, not a formatted map, so the keyword lookups below can't read its declared status
+    ;; code off it. Pull it from ex-data.
+    (and (instance? Throwable err) (:status-code (ex-data err)))
+    (:status-code (ex-data err))
     ;; If the error is setting its own status code use that
     (:status-code err) (:status-code err)
-    ;; If the error is setting its own status code use that
     (-> err :ex-data :status-code) (-> err :ex-data :status-code)
     ;; If the connection pool is saturated (checkout timed out, or the checkout queue is full) return 503 so clients
     ;; retry/back off

--- a/test/metabase/metabot/tools/resources_test.clj
+++ b/test/metabase/metabot/tools/resources_test.clj
@@ -127,33 +127,33 @@
   (testing "every supported URI pattern routes to the expected handler with the expected args"
     (let [calls (atom nil)
           spy   (fn [tag] (fn [& args] (reset! calls [tag (vec args)]) :spied))]
-      (with-redefs [read-resource/fetch-databases-list             (spy :databases-list)
-                    read-resource/fetch-collections-list           (spy :collections-list)
-                    read-resource/fetch-user-recents               (spy :user-recents)
-                    read-resource/fetch-database                   (spy :database)
-                    read-resource/fetch-database-tables            (spy :database-tables)
-                    read-resource/fetch-database-models            (spy :database-models)
-                    read-resource/fetch-database-schemas           (spy :database-schemas)
-                    read-resource/fetch-database-schema-tables     (spy :database-schema-tables)
-                    read-resource/fetch-collection                 (spy :collection)
-                    read-resource/fetch-collection-items           (spy :collection-items)
-                    read-resource/fetch-collection-subcollections  (spy :collection-subcollections)
-                    read-resource/fetch-table                      (spy :table)
-                    read-resource/fetch-table-fields               (spy :table-fields)
-                    read-resource/fetch-table-field                (spy :table-field)
-                    read-resource/fetch-table-derived              (spy :table-derived)
-                    read-resource/fetch-card                       (spy :card)
-                    read-resource/fetch-card-fields                (spy :card-fields)
-                    read-resource/fetch-card-field                 (spy :card-field)
-                    read-resource/fetch-card-sources               (spy :card-sources)
-                    read-resource/fetch-metric                     (spy :metric)
-                    read-resource/fetch-metric-dimensions          (spy :metric-dimensions)
-                    read-resource/fetch-metric-dimension           (spy :metric-dimension)
-                    read-resource/fetch-transform                  (spy :transform)
-                    read-resource/fetch-transform-sources          (spy :transform-sources)
-                    read-resource/fetch-transform-target           (spy :transform-target)
-                    read-resource/fetch-dashboard                  (spy :dashboard)
-                    read-resource/fetch-dashboard-items            (spy :dashboard-items)]
+      (mt/with-dynamic-fn-redefs [read-resource/fetch-databases-list             (spy :databases-list)
+                                  read-resource/fetch-collections-list           (spy :collections-list)
+                                  read-resource/fetch-user-recents               (spy :user-recents)
+                                  read-resource/fetch-database                   (spy :database)
+                                  read-resource/fetch-database-tables            (spy :database-tables)
+                                  read-resource/fetch-database-models            (spy :database-models)
+                                  read-resource/fetch-database-schemas           (spy :database-schemas)
+                                  read-resource/fetch-database-schema-tables     (spy :database-schema-tables)
+                                  read-resource/fetch-collection                 (spy :collection)
+                                  read-resource/fetch-collection-items           (spy :collection-items)
+                                  read-resource/fetch-collection-subcollections  (spy :collection-subcollections)
+                                  read-resource/fetch-table                      (spy :table)
+                                  read-resource/fetch-table-fields               (spy :table-fields)
+                                  read-resource/fetch-table-field                (spy :table-field)
+                                  read-resource/fetch-table-derived              (spy :table-derived)
+                                  read-resource/fetch-card                       (spy :card)
+                                  read-resource/fetch-card-fields                (spy :card-fields)
+                                  read-resource/fetch-card-field                 (spy :card-field)
+                                  read-resource/fetch-card-sources               (spy :card-sources)
+                                  read-resource/fetch-metric                     (spy :metric)
+                                  read-resource/fetch-metric-dimensions          (spy :metric-dimensions)
+                                  read-resource/fetch-metric-dimension           (spy :metric-dimension)
+                                  read-resource/fetch-transform                  (spy :transform)
+                                  read-resource/fetch-transform-sources          (spy :transform-sources)
+                                  read-resource/fetch-transform-target           (spy :transform-target)
+                                  read-resource/fetch-dashboard                  (spy :dashboard)
+                                  read-resource/fetch-dashboard-items            (spy :dashboard-items)]
         (doseq [[uri expected-handler expected-args] dispatch-cases]
           (testing uri
             (reset! calls nil)
@@ -339,6 +339,17 @@
               (is (str/includes? output "VISIBLE-DB"))
               (is (not (str/includes? output "HIDDEN-DB"))
                   "unreadable database must not appear in the list"))))))))
+
+(deftest list-filters-destination-databases-test
+  (testing "metabase://databases hides destination DBs"
+    (mt/with-current-user (mt/user->id :crowberto)
+      (mt/with-temp [:model/Database {router-id :id} {:name "ROUTER-DB"}
+                     :model/Database _               {:name "DESTINATION-DB" :router_database_id router-id}]
+        (with-redefs [mi/can-read? (constantly true)]
+          (let [{:keys [output]} (read-resource/read-resource {:uris ["metabase://databases"]})]
+            (is (str/includes? output "ROUTER-DB"))
+            (is (not (str/includes? output "DESTINATION-DB"))
+                "destination database must not appear in the list")))))))
 
 (deftest list-filters-collections-by-can-read-test
   (testing "metabase://collections hides collections the user can't read"
@@ -618,6 +629,48 @@
           (is (str/includes? output (str "uri=\"metabase://database/" db-id "\"")))
           (is (str/includes? output "engine=\"h2\"")))))))
 
+(deftest read-database-detail-rejects-destination-databases-test
+  (testing "metabase://database/{destination-id} returns an error"
+    (mt/with-current-user (mt/user->id :crowberto)
+      (mt/with-temp [:model/Database {router-id :id} {}
+                     :model/Database {destination-id :id} {:router_database_id router-id}]
+        (with-redefs [mi/can-read? (constantly true)]
+          (is (error? (read-resource/read-resource
+                       {:uris [(str "metabase://database/" destination-id)]}))
+              "destination database must not be readable by direct URI"))))))
+
+(deftest read-destination-backed-entities-return-errors-test
+  (testing "destination-backed entity resources cannot expose destination database metadata"
+    (mt/with-current-user (mt/user->id :crowberto)
+      (mt/with-temp [:model/Database {router-id :id} {}
+                     :model/Database {destination-id :id} {:router_database_id router-id}
+                     :model/Table    {table-id :id}       {:db_id destination-id :active true}
+                     :model/Card     {model-id :id}       {:type :model :database_id destination-id}
+                     :model/Card     {question-id :id}    {:type :question :database_id destination-id}
+                     :model/Card     {metric-id :id}      {:type :metric :database_id destination-id}]
+        (with-redefs [mi/can-read? (constantly true)]
+          (doseq [uri [(str "metabase://table/" table-id)
+                       (str "metabase://table/" table-id "/fields")
+                       (str "metabase://table/" table-id "/fields/42")
+                       (str "metabase://table/" table-id "/derived")
+                       (str "metabase://model/" model-id)
+                       (str "metabase://model/" model-id "/fields")
+                       (str "metabase://model/" model-id "/fields/42")
+                       (str "metabase://model/" model-id "/sources")
+                       (str "metabase://question/" question-id)
+                       (str "metabase://question/" question-id "/fields")
+                       (str "metabase://question/" question-id "/fields/42")
+                       (str "metabase://question/" question-id "/sources")
+                       (str "metabase://metric/" metric-id)
+                       (str "metabase://metric/" metric-id "/dimensions")
+                       (str "metabase://metric/" metric-id "/dimensions/42")]]
+            (testing uri
+              ;; Match the guard's 404 message exactly: a plain `error?` check can't tell the
+              ;; destination-database guard from unrelated failures like "Field 42 not found".
+              (is (= "Not found."
+                     (-> (read-resource/read-resource {:uris [uri]}) :resources first :error))
+                  "destination-backed entity resource must 404 via the destination-database guard"))))))))
+
 (deftest read-database-models-test
   (mt/with-current-user (mt/user->id :crowberto)
     (mt/with-temp [:model/Database {db-id :id}    {}
@@ -706,8 +759,8 @@
 (deftest read-table-field-with-slash-test
   (testing "field IDs containing slashes (e.g. composite ids c75/17) are preserved through dispatch"
     (let [calls (atom nil)]
-      (with-redefs [read-resource/fetch-table-field
-                    (fn [& args] (reset! calls args) {:structured-output {:result-type :metabot-entity :type :stub}})]
+      (mt/with-dynamic-fn-redefs [read-resource/fetch-table-field
+                                  (fn [& args] (reset! calls args) {:structured-output {:result-type :metabot-entity :type :stub}})]
         (#'read-resource/dispatch "metabase://table/3/fields/c75/17")
         (is (= ["3" "c75/17"] @calls))))))
 

--- a/test/metabase/query_processor/middleware/prefetch_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/prefetch_metadata_test.clj
@@ -33,9 +33,10 @@
       ;; - fetch the Tables in bulk
       ;; - fetch the Tables' columns in bulk
       ;; - the permissions check (EE only)
+      ;; - the destination-database access check, before the metadata provider is bound (EE only)
       ;; - the database-routing check (EE only)
       ;; - the table-remapping check (EE only)
-      (is (<= (preprocess-app-db-call-count query) 6)))))
+      (is (<= (preprocess-app-db-call-count query) 7)))))
 
 (deftest prefetch-metadata-mbql-three-tables-call-count-test
   (mt/dataset test-data
@@ -50,7 +51,7 @@
                     (lib/limit 1))]
       ;; the same number of calls as for a single-table query: all the referenced tables and their columns are
       ;; bulk-loaded, so the count does not depend on the number of tables
-      (is (<= (preprocess-app-db-call-count query) 6)))))
+      (is (<= (preprocess-app-db-call-count query) 7)))))
 
 (deftest prefetch-metadata-native-one-field-filter-call-count-test
   (mt/dataset test-data
@@ -68,7 +69,7 @@
                                          :value  [1]}]))]
       ;; one more call than for MBQL queries: the fields referenced by the template tags are bulk-loaded by ID, which
       ;; is also how their tables are discovered
-      (is (<= (preprocess-app-db-call-count query) 7)))))
+      (is (<= (preprocess-app-db-call-count query) 8)))))
 
 (deftest prefetch-metadata-native-three-field-filters-call-count-test
   (mt/dataset test-data
@@ -90,7 +91,7 @@
                                          :value  [1]}]))]
       ;; the same calls as with a single field filter: all the template-tag Fields are loaded with a single bulk
       ;; call, while without prefetching parameter substitution would resolve them one at a time
-      (is (<= (preprocess-app-db-call-count query) 7)))))
+      (is (<= (preprocess-app-db-call-count query) 8)))))
 
 (deftest prefetch-metadata-card-source-call-count-test
   (mt/dataset test-data
@@ -101,7 +102,7 @@
           ;; the baseline calls, plus:
           ;; - one bulk fetch of the referenced Cards; resolving the source card afterwards hits the cache, and the
           ;;   card's table and columns are folded into the baseline bulk loads
-          (is (<= (preprocess-app-db-call-count query) 7)))))))
+          (is (<= (preprocess-app-db-call-count query) 8)))))))
 
 (deftest prefetch-metadata-nested-card-source-call-count-test
   (mt/dataset test-data
@@ -112,7 +113,7 @@
                           (lib/limit 1))]
             ;; one more call than for a single source card: referenced Cards are prefetched with one bulk fetch per
             ;; level of nesting, and both cards' tables and columns are folded into the same bulk loads
-            (is (<= (preprocess-app-db-call-count query) 8))))))))
+            (is (<= (preprocess-app-db-call-count query) 9))))))))
 
 (deftest prefetch-metadata-card-source-with-join-call-count-test
   (mt/dataset test-data
@@ -125,4 +126,4 @@
                         (lib/limit 1))]
           ;; the same calls as for a plain source card: the joined Table and its columns are folded into the same
           ;; bulk loads
-          (is (<= (preprocess-app-db-call-count query) 7)))))))
+          (is (<= (preprocess-app-db-call-count query) 8)))))))


### PR DESCRIPTION
[Context](https://metaboat.slack.com/archives/C0BG6L3A8UV/p1784147234091709?thread_ts=1783980381.808639&cid=C0BG6L3A8UV).

Different endpoints dealing with destination databases handled checks differently, causing confusing error messages depending on code path. This consolidates and standardizes both the messages and the HTTP code.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
