### PR TITLE
Backport "Better destination-db errors"

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1733,6 +1733,7 @@
            cache
            config
            dashboards
+           database-routing
            driver
            events
            formatter
@@ -2839,7 +2840,6 @@
   {:team "UX West"
    :api  #{metabase-enterprise.database-routing.api}
    :uses #{api
-           config
            database-routing
            driver
            events

--- a/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.database-routing.common
   (:require
    [metabase.api.common :as api]
-   [metabase.config.core :as config]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
@@ -75,14 +74,19 @@
 ;; only use router databases. In these cases we don't want database routing, we just want to ensure we're not hitting
 ;; a Destination Database
 ;;
-;; The former looks like:
-;; - I am looking at a Router Database,
-;; - `router-db-or-id->destination-db-id` returns a *different* database ID, and
-;; - `*database-routing-on*` is `:on` or `:unset`
+;; `*database-routing-on*` records our intent: `:on` inside a routed query (destinations are expected), `:off` when we
+;; explicitly want the router (e.g. sync), `:unset` otherwise. Concretely:
 ;;
-;; The latter looks like:
-;; - I am looking at a destination Database,
-;; - `*database-routing-on*` is `:off` or `:unset`
+;; (a) looks like:
+;; - I am looking at a Router Database,
+;; - the current user's attribute would route me to a *different* destination, and
+;; - `*database-routing-on*` is `:on` or `:unset`.
+;; A correctness concern, owned by the routing middleware (which makes the routing decision); not enforced here.
+;;
+;; (b) looks like:
+;; - I am looking at a destination Database, and
+;; - `*database-routing-on*` is not `:on` (i.e. `:off` or `:unset`).
+;; A tenancy boundary, enforced by `check-allowed-access!` below.
 
 (defenterprise with-database-routing-on-fn
   "Enterprise version. Calls the function with Database Routing allowed."
@@ -98,34 +102,25 @@
   (binding [*database-routing-on* :off]
     (f)))
 
-(defn- is-disallowed-router-db-access?
-  [db-or-id]
-  (and (some-> (router-db-or-id->destination-db-id db-or-id)
-               (not= db-or-id))
-       (not= *database-routing-on* :off)))
-
 (defn- is-disallowed-destination-db-access?
   [db-or-id]
   (and (t2/exists? :model/Database :id db-or-id :router_database_id [:not= nil])
        (not= *database-routing-on* :on)))
 
+(defn assert-not-direct-destination-access!
+  "Throws a 403 when `db-or-id` is a destination database queried directly, outside a routing-on
+  context. A destination is reachable only through its router; a direct query bypasses the router's
+  attribute check, and with it tenant isolation."
+  [db-or-id]
+  (when (is-disallowed-destination-db-access? (u/the-id db-or-id))
+    (throw (ex-info (tru "You cannot query a destination database directly.")
+                    {:status-code 403}))))
+
 (defenterprise check-allowed-access!
-  "This is intended as a safety harness. In dev/testing, if any access to a router or destination database is detected
-  outside those circumstances where we've explicitly declared it okay, throw an exception.
-
-  In production, skip this (fairly expensive) check.
-
-  The idea here is that at all times we should be aware of whether:
-
-  - we're explicitly accessing a router database (e.g. sync) and DO NOT want to reroute to a destination database, or
-
-  - we're explicitly using the Database Routing feature (e.g. a query) and DO NOT want to access the router
-  database (unless that was the user's intent, i.e. the user's attribute was `__METABASE_ROUTER__`) "
+  "Throws a 403 if `db-or-id-or-spec` is a destination database accessed while database routing is
+  not `:on`, i.e. a direct hit that bypasses its router. Legitimate access to a destination goes
+  through its router, which turns routing `:on`."
   :feature :database-routing
   [db-or-id-or-spec]
-  (when-let [db-id (and (not config/is-prod?)
-                        (u/id db-or-id-or-spec))]
-    (when (is-disallowed-router-db-access? db-id)
-      (throw (ex-info "Forbidden access to Router Database without `with-database-routing-off`" {})))
-    (when (is-disallowed-destination-db-access? db-id)
-      (throw (ex-info "Forbidden access to Destination Database without `with-database-routing-on`" {})))))
+  (when-let [db-id (u/id db-or-id-or-spec)]
+    (assert-not-direct-destination-access! db-id)))

--- a/enterprise/backend/src/metabase_enterprise/database_routing/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/middleware.clj
@@ -3,7 +3,7 @@
   `:destination-database/id`, on the query if a destination database should be used. The second middleware runs around query
   execution, and should be THE LAST middleware before we hit the database and query execution actually occurs."
   (:require
-   [metabase-enterprise.database-routing.common :refer [router-db-or-id->destination-db-id]]
+   [metabase-enterprise.database-routing.common :as common :refer [router-db-or-id->destination-db-id]]
    [metabase.database-routing.core :refer [with-database-routing-on]]
    [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
@@ -39,6 +39,7 @@
   :feature :none
   [query]
   (let [database (lib.metadata/database (qp.store/metadata-provider))
+        _ (common/assert-not-direct-destination-access! database)
         destination-db-id (router-db-or-id->destination-db-id database)]
     (when destination-db-id
       (premium-features/assert-has-feature :database-routing (tru "Database Routing"))
@@ -46,5 +47,7 @@
                                     :database-routing
                                     database)
         (throw (ex-info "Unsupported database for database routing" {}))))
-    (cond-> query
+    ;; dissoc first: a client-supplied :destination-database/id must never survive preprocessing,
+    ;; since swap-destination-db trusts this key at execution time.
+    (cond-> (dissoc query :destination-database/id)
       destination-db-id (assoc :destination-database/id destination-db-id))))

--- a/enterprise/backend/test/metabase_enterprise/database_routing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/api_test.clj
@@ -1,8 +1,11 @@
 (ns metabase-enterprise.database-routing.api-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing use-fixtures]]
+   [metabase-enterprise.test :as met]
    [metabase.driver :as driver]
    [metabase.driver.settings :as driver.settings]
+   [metabase.metabot.tools.resources :as read-resource]
    [metabase.permissions-rest.data-permissions.graph :as data-perms.graph]
    [metabase.permissions.core :as perms]
    [metabase.test :as mt]
@@ -204,6 +207,30 @@
       (mt/user-http-request :crowberto :get 404 (str "database/" destination-db-id "/syncable_schemas")))
     (testing "GET /database/:id/schemas"
       (mt/user-http-request :crowberto :get 404 (str "database/" destination-db-id "/schemas")))))
+
+(deftest routed-destination-database-names-are-hidden-in-metabot-resources
+  (mt/with-temp [:model/Database {router-id :id} {:name "Postgres Router"}
+                 :model/DatabaseRouter _ {:database_id router-id :user_attribute "db_name"}
+                 :model/Database {selected-destination-id :id} {:name "customer-a"
+                                                                :router_database_id router-id}
+                 :model/Database {other-destination-id :id} {:name "customer-b"
+                                                             :router_database_id router-id}
+                 :model/Table {selected-table-id :id} {:db_id selected-destination-id :active true}
+                 :model/Table {other-table-id :id} {:db_id other-destination-id :active true}]
+    (met/with-user-attributes! :rasta {"db_name" "customer-a"}
+      (mt/with-current-user (mt/user->id :rasta)
+        (testing "a table on a sibling destination cannot be read by URI and leaks no destination names"
+          (let [{:keys [output resources]} (read-resource/read-resource
+                                            {:uris [(str "metabase://table/" other-table-id)]})]
+            (is (some? (-> resources first :error)))
+            (is (not (str/includes? output "customer-a")))
+            (is (not (str/includes? output "customer-b")))))
+        (testing "a table on the current user's routed destination cannot be read by URI either"
+          (let [{:keys [output resources]} (read-resource/read-resource
+                                            {:uris [(str "metabase://table/" selected-table-id)]})]
+            (is (some? (-> resources first :error)))
+            (is (not (str/includes? output "customer-a")))
+            (is (not (str/includes? output "customer-b")))))))))
 
 (deftest destination-databases-excluded-from-permissions-graph
   (mt/with-temp [:model/Database {db-id :id} {}

--- a/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
@@ -5,8 +5,11 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [clojurewerkz.quartzite.conversion :as qc]
+   [metabase-enterprise.database-routing.common :as common]
    [metabase-enterprise.test :as met]
    [metabase.app-db.core :as mdb]
+   [metabase.config.core :as config]
+   [metabase.database-routing.core :as database-routing]
    [metabase.driver :as driver]
    [metabase.driver.settings :as driver.settings]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -79,6 +82,93 @@
                   (is (= [["destination-2"]] (mt/rows response))))
                 (let [response (mt/user-http-request :crowberto :post 202 (str "card/" (u/the-id card) "/query"))]
                   (is (= [["router"]] (mt/rows response))))))))))))
+
+;; The reported exploit, verbatim: POST /api/dataset with a destination's id and a native query.
+;; Before the fix this returned the destination's rows (a cross-tenant leak); it must be rejected,
+;; in production too. Exercises the real HTTP surface, above the QP-level test below.
+(deftest direct-destination-query-via-dataset-endpoint-is-forbidden-test
+  (testing "POST /api/dataset at a destination id is rejected, not leaked"
+    (mt/with-premium-features #{:database-routing}
+      (binding [driver.settings/*allow-testing-h2-connections* true]
+        (with-temp-dbs! [router-db destination-db]
+          (t2/update! :model/Database (u/the-id destination-db)
+                      {:name "destination-db" :router_database_id (u/the-id router-db)})
+          (sync/sync-database! router-db)
+          (mt/with-temp [:model/DatabaseRouter _ {:database_id    (u/the-id router-db)
+                                                  :user_attribute "db_name"}]
+            (execute-statement! destination-db "INSERT INTO \"my_database_name\" (str) VALUES ('tenant-b-secret')")
+            (let [exploit {:database (u/the-id destination-db)
+                           :type     :native
+                           :native   {:query "SELECT str FROM \"my_database_name\""}}]
+              (doseq [prod? [false true]]
+                (testing (str "config/is-prod? = " prod?)
+                  (with-redefs [config/is-prod? prod?]
+                    ;; :crowberto is a superuser -> permissions never block; the routing guard must.
+                    (let [response (mt/user-http-request :crowberto :post 403 "dataset" exploit)]
+                      (is (re-find #"(?i)cannot query a destination database directly" (str response)))
+                      (is (not (str/includes? (str response) "tenant-b-secret"))
+                          "the destination's rows must not appear in the response"))))))))))))
+
+;; Must hold in production too, where the dev-only connection-pool harness is disabled; a query-level
+;; guard, not the harness and not permissions, has to reject a directly-submitted destination id.
+(deftest direct-destination-database-access-is-forbidden-test
+  (testing "a directly-submitted destination id is rejected"
+    (mt/with-premium-features #{:database-routing}
+      (binding [driver.settings/*allow-testing-h2-connections* true]
+        (met/with-user-attributes! :rasta {"db_name" "destination-db"}
+          (with-temp-dbs! [router-db destination-db]
+            ;; wiring an already-created (perm-carrying) DB as a destination mirrors the vulnerable
+            ;; state: the destination retains permissions, so perms alone do not block access.
+            (t2/update! :model/Database (u/the-id destination-db)
+                        {:name "destination-db" :router_database_id (u/the-id router-db)})
+            (sync/sync-database! router-db)
+            (mt/with-temp [:model/DatabaseRouter _ {:database_id    (u/the-id router-db)
+                                                    :user_attribute "db_name"}]
+              (execute-statement! destination-db "INSERT INTO \"my_database_name\" (str) VALUES ('secret')")
+              (let [table-id      (t2/select-one-pk :model/Table :db_id (u/the-id router-db))
+                    ;; native (the reported exploit) and MBQL. MBQL exercises the setup-layer check:
+                    ;; the destination has no synced tables, so without an early reject the query would
+                    ;; die later with a confusing "table not found" instead of a clean 403.
+                    direct-queries {:native {:database (u/the-id destination-db)
+                                             :type     :native
+                                             :native   {:query "SELECT str FROM \"my_database_name\""}}
+                                    :mbql   {:database (u/the-id destination-db)
+                                             :type     :query
+                                             :query    {:source-table table-id}}}]
+                (doseq [prod?           [false true]
+                        [qtype a-query] direct-queries]
+                  (testing (str "config/is-prod? = " prod? ", query type = " qtype)
+                    (with-redefs [config/is-prod? prod?]
+                      ;; :crowberto is a superuser -> resolves to most-permissive perms on every database,
+                      ;; so the permission layer never blocks; the routing invariant must.
+                      (mt/with-test-user :crowberto
+                        (is (thrown-with-msg?
+                             clojure.lang.ExceptionInfo
+                             #"(?i)cannot query a destination database directly"
+                             (qp/process-query a-query)))))))))))))))
+
+;; The connection-pool guard is the backstop for non-query paths (sync, actions, downloads); it must
+;; fire in production too, so exercise it directly rather than through the query pipeline.
+(deftest check-allowed-access-blocks-destinations-in-prod-test
+  (testing "connection-pool backstop rejects direct destination access"
+    (mt/with-premium-features #{:database-routing}
+      (binding [driver.settings/*allow-testing-h2-connections* true]
+        (with-temp-dbs! [router-db destination-db]
+          (t2/update! :model/Database (u/the-id destination-db)
+                      {:name "destination-db" :router_database_id (u/the-id router-db)})
+          (mt/with-temp [:model/DatabaseRouter _ {:database_id    (u/the-id router-db)
+                                                  :user_attribute "db_name"}]
+            (with-redefs [config/is-prod? true]
+              (testing "direct destination access is forbidden"
+                (is (thrown-with-msg?
+                     clojure.lang.ExceptionInfo
+                     #"(?i)cannot query a destination database directly"
+                     (common/check-allowed-access! (u/the-id destination-db)))))
+              (testing "destination access is allowed inside a routing-on context (legit routed query)"
+                (is (nil? (database-routing/with-database-routing-on
+                            (common/check-allowed-access! (u/the-id destination-db))))))
+              (testing "the router database itself is not treated as a forbidden destination"
+                (is (nil? (common/check-allowed-access! (u/the-id router-db))))))))))))
 
 (deftest an-error-is-thrown-if-user-attribute-is-missing-or-no-match
   (mt/with-premium-features #{:database-routing}

--- a/enterprise/backend/test/metabase_enterprise/database_routing/middleware_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/middleware_test.clj
@@ -1,0 +1,24 @@
+(ns metabase-enterprise.database-routing.middleware-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase-enterprise.database-routing.middleware :as routing.middleware]
+   [metabase.test :as mt]))
+
+(deftest attach-destination-db-middleware-scrubs-client-supplied-destination-test
+  (testing "a client-supplied :destination-database/id never survives preprocessing"
+    (mt/with-temp [:model/Database {db-id :id} {}]
+      (mt/with-metadata-provider db-id
+        (let [query {:database db-id, :type :query, :query {}, :destination-database/id 99999}]
+          (is (not (contains? (routing.middleware/attach-destination-db-middleware query)
+                              :destination-database/id))))))))
+
+(deftest attach-destination-db-middleware-rejects-direct-destination-access-test
+  (testing "direct destination-database access is rejected"
+    (mt/with-temp [:model/Database {router-id :id} {}
+                   :model/Database {destination-id :id} {:router_database_id router-id}]
+      (mt/with-metadata-provider destination-id
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"(?i)cannot query a destination database directly"
+             (routing.middleware/attach-destination-db-middleware
+              {:database destination-id, :type :query, :query {}})))))))

--- a/src/metabase/metabot/tools/resources.clj
+++ b/src/metabase/metabot/tools/resources.clj
@@ -19,13 +19,15 @@
   - metabase://dashboard/{id} - Dashboard details"
   (:require
    [clojure.string :as str]
+   [metabase.api.common :as api]
    [metabase.metabot.tools.entity-details :as entity-details]
    [metabase.metabot.tools.field-stats :as field-stats]
    [metabase.metabot.tools.shared.instructions :as instructions]
    [metabase.metabot.tools.shared.llm-representations :as llm-rep]
    [metabase.transforms.core :as transforms]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.warehouses.core :as warehouses]))
 
 (set! *warn-on-reflection* true)
 
@@ -61,10 +63,27 @@
                         ;; Handle field IDs with slashes (e.g., c75/17)
                         (str/join "/" (drop 3 parts)))}))
 
+(defn- check-resource-database
+  "Require that a resource's backing database is addressable as a Metabot resource.
+   Routed destination databases are routing internals here: users should navigate via
+   the router database, not direct destination-backed resource URIs."
+  [db-id]
+  (when db-id
+    (warehouses/get-database db-id)))
+
+(defn- check-table-resource-database [table-id]
+  (when-let [table (api/read-check :model/Table table-id)]
+    (check-resource-database (:db_id table))))
+
+(defn- check-card-resource-database [card-id]
+  (when-let [card (api/read-check :model/Card card-id)]
+    (check-resource-database (:database_id card))))
+
 (defn- fetch-table-resource
   "Fetch table resource based on URI components."
   [{:keys [resource-id sub-resource sub-resource-id]}]
   (let [table-id (parse-long resource-id)]
+    (check-table-resource-database table-id)
     (cond
       ;; metabase://table/123/fields/FIELD_ID
       (and (= sub-resource "fields") sub-resource-id)
@@ -103,6 +122,7 @@
   (let [resource-id* (parse-long resource-id)
         resource-type* (keyword resource-type)]
     (assert (#{:question :model} resource-type*))
+    (check-card-resource-database resource-id*)
     (cond
       ;; metabase://<model,question>/123/fields/FIELD_ID
       (and (= sub-resource "fields") sub-resource-id)
@@ -141,6 +161,7 @@
   "Fetch metric resource based on URI components."
   [{:keys [resource-id sub-resource sub-resource-id]}]
   (let [metric-id (parse-long resource-id)]
+    (check-card-resource-database metric-id)
     (cond
       ;; metabase://metric/123/dimensions/DIMENSION_ID
       (and (= sub-resource "dimensions") sub-resource-id)

--- a/src/metabase/query_processor/setup.clj
+++ b/src/metabase/query_processor/setup.clj
@@ -4,6 +4,7 @@
    [clojure.core.async.impl.dispatch :as a.impl.dispatch]
    [clojure.set :as set]
    [metabase.config.core :as config]
+   [metabase.database-routing.core :as database-routing]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.lib.computed :as lib.computed]
@@ -144,8 +145,14 @@
       (f query)
 
       :else
-      (qp.store/with-metadata-provider (:database query)
-        (f (maybe-attach-metadata-provider-to-query query))))))
+      ;; `:database` here is whatever the user submitted, so a destination at this point is a direct
+      ;; request to query one; reject it before building a provider. Legitimate routing never passes
+      ;; through this branch: when a router query is routed to a destination, that swap happens later,
+      ;; in the execution middleware, binding its own metadata provider.
+      (do
+        (database-routing/check-allowed-access! (:database query))
+        (qp.store/with-metadata-provider (:database query)
+          (f (maybe-attach-metadata-provider-to-query query)))))))
 
 (mu/defn- do-with-driver :- fn?
   [f :- [:=> [:cat ::qp.schema/any-query] :any]]

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -219,9 +219,13 @@
   "Get a status code for the supplied error object."
   [err]
   (cond
+    ;; A raw exception thrown outside the QP's exception-formatting (e.g. during setup) arrives here as
+    ;; a Throwable, not a formatted map, so the keyword lookups below can't read its declared status
+    ;; code off it. Pull it from ex-data.
+    (and (instance? Throwable err) (:status-code (ex-data err)))
+    (:status-code (ex-data err))
     ;; If the error is setting its own status code use that
     (:status-code err) (:status-code err)
-    ;; If the error is setting its own status code use that
     (-> err :ex-data :status-code) (-> err :ex-data :status-code)
     ;; If the connection pool is saturated (checkout timed out, or the checkout queue is full) return 503 so clients
     ;; retry/back off

--- a/test/metabase/metabot/tools/resources_test.clj
+++ b/test/metabase/metabot/tools/resources_test.clj
@@ -7,6 +7,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.metabot.tools.resources :as read-resource]
+   [metabase.models.interface :as mi]
    [metabase.query-processor :as qp]
    [metabase.test :as mt]))
 
@@ -149,6 +150,35 @@
         (testing "returns error for unknown transform"
           (is (=? {:resources [{:error string?}]}
                   (read-resource/read-resource {:uris ["metabase://transform/99999"]}))))))))
+
+(deftest read-destination-backed-entities-return-errors-test
+  (testing "destination-backed entity resources cannot expose destination database metadata"
+    (mt/with-current-user (mt/user->id :crowberto)
+      (mt/with-temp [:model/Database {router-id :id} {}
+                     :model/Database {destination-id :id} {:router_database_id router-id}
+                     :model/Table    {table-id :id}       {:db_id destination-id :active true}
+                     :model/Card     {model-id :id}       {:type :model :database_id destination-id}
+                     :model/Card     {question-id :id}    {:type :question :database_id destination-id}
+                     :model/Card     {metric-id :id}      {:type :metric :database_id destination-id}]
+        (with-redefs [mi/can-read? (constantly true)]
+          (doseq [uri [(str "metabase://table/" table-id)
+                       (str "metabase://table/" table-id "/fields")
+                       (str "metabase://table/" table-id "/fields/42")
+                       (str "metabase://model/" model-id)
+                       (str "metabase://model/" model-id "/fields")
+                       (str "metabase://model/" model-id "/fields/42")
+                       (str "metabase://question/" question-id)
+                       (str "metabase://question/" question-id "/fields")
+                       (str "metabase://question/" question-id "/fields/42")
+                       (str "metabase://metric/" metric-id)
+                       (str "metabase://metric/" metric-id "/dimensions")
+                       (str "metabase://metric/" metric-id "/dimensions/42")]]
+            (testing uri
+              ;; Match the guard's 404 message exactly: a plain error check can't tell the
+              ;; destination-database guard from unrelated failures like "Field 42 not found".
+              (is (= "Not found."
+                     (-> (read-resource/read-resource {:uris [uri]}) :resources first :error))
+                  "destination-backed entity resource must 404 via the destination-database guard"))))))))
 
 (deftest format-resources-test
   (testing "formats resources with content"

--- a/test/metabase/query_processor/middleware/prefetch_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/prefetch_metadata_test.clj
@@ -33,9 +33,10 @@
       ;; - fetch the Tables in bulk
       ;; - fetch the Tables' columns in bulk
       ;; - the permissions check (EE only)
+      ;; - the destination-database access check, before the metadata provider is bound (EE only)
       ;; - the database-routing check (EE only)
       ;; - the table-remapping check (EE only)
-      (is (<= (preprocess-app-db-call-count query) 6)))))
+      (is (<= (preprocess-app-db-call-count query) 7)))))
 
 (deftest prefetch-metadata-mbql-three-tables-call-count-test
   (mt/dataset test-data
@@ -50,7 +51,7 @@
                     (lib/limit 1))]
       ;; the same number of calls as for a single-table query: all the referenced tables and their columns are
       ;; bulk-loaded, so the count does not depend on the number of tables
-      (is (<= (preprocess-app-db-call-count query) 6)))))
+      (is (<= (preprocess-app-db-call-count query) 7)))))
 
 (deftest prefetch-metadata-native-one-field-filter-call-count-test
   (mt/dataset test-data
@@ -68,7 +69,7 @@
                                          :value  [1]}]))]
       ;; one more call than for MBQL queries: the fields referenced by the template tags are bulk-loaded by ID, which
       ;; is also how their tables are discovered
-      (is (<= (preprocess-app-db-call-count query) 7)))))
+      (is (<= (preprocess-app-db-call-count query) 8)))))
 
 (deftest prefetch-metadata-native-three-field-filters-call-count-test
   (mt/dataset test-data
@@ -90,7 +91,7 @@
                                          :value  [1]}]))]
       ;; the same calls as with a single field filter: all the template-tag Fields are loaded with a single bulk
       ;; call, while without prefetching parameter substitution would resolve them one at a time
-      (is (<= (preprocess-app-db-call-count query) 7)))))
+      (is (<= (preprocess-app-db-call-count query) 8)))))
 
 (deftest prefetch-metadata-card-source-call-count-test
   (mt/dataset test-data
@@ -101,7 +102,7 @@
           ;; the baseline calls, plus:
           ;; - one bulk fetch of the referenced Cards; resolving the source card afterwards hits the cache, and the
           ;;   card's table and columns are folded into the baseline bulk loads
-          (is (<= (preprocess-app-db-call-count query) 7)))))))
+          (is (<= (preprocess-app-db-call-count query) 8)))))))
 
 (deftest prefetch-metadata-nested-card-source-call-count-test
   (mt/dataset test-data
@@ -112,7 +113,7 @@
                           (lib/limit 1))]
             ;; one more call than for a single source card: referenced Cards are prefetched with one bulk fetch per
             ;; level of nesting, and both cards' tables and columns are folded into the same bulk loads
-            (is (<= (preprocess-app-db-call-count query) 8))))))))
+            (is (<= (preprocess-app-db-call-count query) 9))))))))
 
 (deftest prefetch-metadata-card-source-with-join-call-count-test
   (mt/dataset test-data
@@ -125,4 +126,4 @@
                         (lib/limit 1))]
           ;; the same calls as for a plain source card: the joined Table and its columns are folded into the same
           ;; bulk loads
-          (is (<= (preprocess-app-db-call-count query) 7)))))))
+          (is (<= (preprocess-app-db-call-count query) 8)))))))


### PR DESCRIPTION
[Context](https://metaboat.slack.com/archives/C0BG6L3A8UV/p1784147234091709?thread_ts=1783980381.808639&cid=C0BG6L3A8UV).

Different endpoints dealing with destination databases handled checks differently, causing confusing error messages depending on code path. This consolidates and standardizes both the messages and the HTTP code.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
