### PR TITLE
Backport "Better destination-db errors"

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1145,6 +1145,7 @@
            cache
            config
            dashboards
+           database-routing
            driver
            events
            formatter
@@ -1934,7 +1935,6 @@
   {:team "UX West"
    :api  #{metabase-enterprise.database-routing.api}
    :uses #{api
-           config
            database-routing
            driver
            events

--- a/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.database-routing.common
   (:require
    [metabase.api.common :as api]
-   [metabase.config.core :as config]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
@@ -75,14 +74,19 @@
 ;; only use router databases. In these cases we don't want database routing, we just want to ensure we're not hitting
 ;; a Destination Database
 ;;
-;; The former looks like:
-;; - I am looking at a Router Database,
-;; - `router-db-or-id->destination-db-id` returns a *different* database ID, and
-;; - `*database-routing-on*` is `:on` or `:unset`
+;; `*database-routing-on*` records our intent: `:on` inside a routed query (destinations are expected), `:off` when we
+;; explicitly want the router (e.g. sync), `:unset` otherwise. Concretely:
 ;;
-;; The latter looks like:
-;; - I am looking at a destination Database,
-;; - `*database-routing-on*` is `:off` or `:unset`
+;; (a) looks like:
+;; - I am looking at a Router Database,
+;; - the current user's attribute would route me to a *different* destination, and
+;; - `*database-routing-on*` is `:on` or `:unset`.
+;; A correctness concern, owned by the routing middleware (which makes the routing decision); not enforced here.
+;;
+;; (b) looks like:
+;; - I am looking at a destination Database, and
+;; - `*database-routing-on*` is not `:on` (i.e. `:off` or `:unset`).
+;; A tenancy boundary, enforced by `check-allowed-access!` below.
 
 (defenterprise with-database-routing-on-fn
   "Enterprise version. Calls the function with Database Routing allowed."
@@ -98,34 +102,25 @@
   (binding [*database-routing-on* :off]
     (f)))
 
-(defn- is-disallowed-router-db-access?
-  [db-or-id]
-  (and (some-> (router-db-or-id->destination-db-id db-or-id)
-               (not= db-or-id))
-       (not= *database-routing-on* :off)))
-
 (defn- is-disallowed-destination-db-access?
   [db-or-id]
   (and (t2/exists? :model/Database :id db-or-id :router_database_id [:not= nil])
        (not= *database-routing-on* :on)))
 
+(defn assert-not-direct-destination-access!
+  "Throws a 403 when `db-or-id` is a destination database queried directly, outside a routing-on
+  context. A destination is reachable only through its router; a direct query bypasses the router's
+  attribute check, and with it tenant isolation."
+  [db-or-id]
+  (when (is-disallowed-destination-db-access? (u/the-id db-or-id))
+    (throw (ex-info (tru "You cannot query a destination database directly.")
+                    {:status-code 403}))))
+
 (defenterprise check-allowed-access!
-  "This is intended as a safety harness. In dev/testing, if any access to a router or destination database is detected
-  outside those circumstances where we've explicitly declared it okay, throw an exception.
-
-  In production, skip this (fairly expensive) check.
-
-  The idea here is that at all times we should be aware of whether:
-
-  - we're explicitly accessing a router database (e.g. sync) and DO NOT want to reroute to a destination database, or
-
-  - we're explicitly using the Database Routing feature (e.g. a query) and DO NOT want to access the router
-  database (unless that was the user's intent, i.e. the user's attribute was `__METABASE_ROUTER__`) "
+  "Throws a 403 if `db-or-id-or-spec` is a destination database accessed while database routing is
+  not `:on`, i.e. a direct hit that bypasses its router. Legitimate access to a destination goes
+  through its router, which turns routing `:on`."
   :feature :database-routing
   [db-or-id-or-spec]
-  (when-let [db-id (and (not config/is-prod?)
-                        (u/id db-or-id-or-spec))]
-    (when (is-disallowed-router-db-access? db-id)
-      (throw (ex-info "Forbidden access to Router Database without `with-database-routing-off`" {})))
-    (when (is-disallowed-destination-db-access? db-id)
-      (throw (ex-info "Forbidden access to Destination Database without `with-database-routing-on`" {})))))
+  (when-let [db-id (u/id db-or-id-or-spec)]
+    (assert-not-direct-destination-access! db-id)))

--- a/enterprise/backend/src/metabase_enterprise/database_routing/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/middleware.clj
@@ -3,7 +3,7 @@
   `:destination-database/id`, on the query if a destination database should be used. The second middleware runs around query
   execution, and should be THE LAST middleware before we hit the database and query execution actually occurs."
   (:require
-   [metabase-enterprise.database-routing.common :refer [router-db-or-id->destination-db-id]]
+   [metabase-enterprise.database-routing.common :as common :refer [router-db-or-id->destination-db-id]]
    [metabase.database-routing.core :refer [with-database-routing-on]]
    [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
@@ -39,6 +39,7 @@
   :feature :none
   [query]
   (let [database (lib.metadata/database (qp.store/metadata-provider))
+        _ (common/assert-not-direct-destination-access! database)
         destination-db-id (router-db-or-id->destination-db-id database)]
     (when destination-db-id
       (premium-features/assert-has-feature :database-routing (tru "Database Routing"))
@@ -46,5 +47,7 @@
                                     :database-routing
                                     database)
         (throw (ex-info "Unsupported database for database routing" {}))))
-    (cond-> query
+    ;; dissoc first: a client-supplied :destination-database/id must never survive preprocessing,
+    ;; since swap-destination-db trusts this key at execution time.
+    (cond-> (dissoc query :destination-database/id)
       destination-db-id (assoc :destination-database/id destination-db-id))))

--- a/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
@@ -5,8 +5,11 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [clojurewerkz.quartzite.conversion :as qc]
+   [metabase-enterprise.database-routing.common :as common]
    [metabase-enterprise.test :as met]
    [metabase.app-db.core :as mdb]
+   [metabase.config.core :as config]
+   [metabase.database-routing.core :as database-routing]
    [metabase.driver :as driver]
    [metabase.driver.settings :as driver.settings]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -79,6 +82,96 @@
                   (is (= [["destination-2"]] (mt/rows response))))
                 (let [response (mt/user-http-request :crowberto :post 202 (str "card/" (u/the-id card) "/query"))]
                   (is (= [["router"]] (mt/rows response))))))))))))
+
+;; The reported exploit, verbatim: POST /api/dataset with a destination's id and a native query.
+;; Before the fix this returned the destination's rows (a cross-tenant leak); it must be rejected,
+;; in production too. Exercises the real HTTP surface, above the QP-level test below.
+(deftest direct-destination-query-via-dataset-endpoint-is-forbidden-test
+  (testing "POST /api/dataset at a destination id is rejected, not leaked"
+    (mt/with-premium-features #{:database-routing}
+      (binding [driver.settings/*allow-testing-h2-connections* true]
+        (with-temp-dbs! [router-db destination-db]
+          (t2/update! :model/Database (u/the-id destination-db)
+                      {:name "destination-db" :router_database_id (u/the-id router-db)})
+          (sync/sync-database! router-db)
+          (mt/with-temp [:model/DatabaseRouter _ {:database_id    (u/the-id router-db)
+                                                  :user_attribute "db_name"}]
+            (execute-statement! destination-db "INSERT INTO \"my_database_name\" (str) VALUES ('tenant-b-secret')")
+            (let [exploit {:database (u/the-id destination-db)
+                           :type     :native
+                           :native   {:query "SELECT str FROM \"my_database_name\""}}]
+              (doseq [prod? [false true]]
+                (testing (str "config/is-prod? = " prod?)
+                  (with-redefs [config/is-prod? prod?]
+                    ;; :crowberto is a superuser -> permissions never block; the routing guard must.
+                    ;; On this branch /api/dataset reports all QP errors as HTTP 202 with the error in
+                    ;; the body (see e.g. the native syntax-error test in query-processor.api-test), so
+                    ;; the contract to pin is the rejection message and the absence of the rows.
+                    (let [response (mt/user-http-request :crowberto :post 202 "dataset" exploit)]
+                      (is (re-find #"(?i)cannot query a destination database directly" (str response)))
+                      (is (not (str/includes? (str response) "tenant-b-secret"))
+                          "the destination's rows must not appear in the response"))))))))))))
+
+;; Must hold in production too, where the dev-only connection-pool harness is disabled; a query-level
+;; guard, not the harness and not permissions, has to reject a directly-submitted destination id.
+(deftest direct-destination-database-access-is-forbidden-test
+  (testing "a directly-submitted destination id is rejected"
+    (mt/with-premium-features #{:database-routing}
+      (binding [driver.settings/*allow-testing-h2-connections* true]
+        (met/with-user-attributes! :rasta {"db_name" "destination-db"}
+          (with-temp-dbs! [router-db destination-db]
+            ;; wiring an already-created (perm-carrying) DB as a destination mirrors the vulnerable
+            ;; state: the destination retains permissions, so perms alone do not block access.
+            (t2/update! :model/Database (u/the-id destination-db)
+                        {:name "destination-db" :router_database_id (u/the-id router-db)})
+            (sync/sync-database! router-db)
+            (mt/with-temp [:model/DatabaseRouter _ {:database_id    (u/the-id router-db)
+                                                    :user_attribute "db_name"}]
+              (execute-statement! destination-db "INSERT INTO \"my_database_name\" (str) VALUES ('secret')")
+              (let [table-id      (t2/select-one-pk :model/Table :db_id (u/the-id router-db))
+                    ;; native (the reported exploit) and MBQL. MBQL exercises the setup-layer check:
+                    ;; the destination has no synced tables, so without an early reject the query would
+                    ;; die later with a confusing "table not found" instead of a clean 403.
+                    direct-queries {:native {:database (u/the-id destination-db)
+                                             :type     :native
+                                             :native   {:query "SELECT str FROM \"my_database_name\""}}
+                                    :mbql   {:database (u/the-id destination-db)
+                                             :type     :query
+                                             :query    {:source-table table-id}}}]
+                (doseq [prod?           [false true]
+                        [qtype a-query] direct-queries]
+                  (testing (str "config/is-prod? = " prod? ", query type = " qtype)
+                    (with-redefs [config/is-prod? prod?]
+                      ;; :crowberto is a superuser -> resolves to most-permissive perms on every database,
+                      ;; so the permission layer never blocks; the routing invariant must.
+                      (mt/with-test-user :crowberto
+                        (is (thrown-with-msg?
+                             clojure.lang.ExceptionInfo
+                             #"(?i)cannot query a destination database directly"
+                             (qp/process-query a-query)))))))))))))))
+
+;; The connection-pool guard is the backstop for non-query paths (sync, actions, downloads); it must
+;; fire in production too, so exercise it directly rather than through the query pipeline.
+(deftest check-allowed-access-blocks-destinations-in-prod-test
+  (testing "connection-pool backstop rejects direct destination access"
+    (mt/with-premium-features #{:database-routing}
+      (binding [driver.settings/*allow-testing-h2-connections* true]
+        (with-temp-dbs! [router-db destination-db]
+          (t2/update! :model/Database (u/the-id destination-db)
+                      {:name "destination-db" :router_database_id (u/the-id router-db)})
+          (mt/with-temp [:model/DatabaseRouter _ {:database_id    (u/the-id router-db)
+                                                  :user_attribute "db_name"}]
+            (with-redefs [config/is-prod? true]
+              (testing "direct destination access is forbidden"
+                (is (thrown-with-msg?
+                     clojure.lang.ExceptionInfo
+                     #"(?i)cannot query a destination database directly"
+                     (common/check-allowed-access! (u/the-id destination-db)))))
+              (testing "destination access is allowed inside a routing-on context (legit routed query)"
+                (is (nil? (database-routing/with-database-routing-on
+                            (common/check-allowed-access! (u/the-id destination-db))))))
+              (testing "the router database itself is not treated as a forbidden destination"
+                (is (nil? (common/check-allowed-access! (u/the-id router-db))))))))))))
 
 (deftest an-error-is-thrown-if-user-attribute-is-missing-or-no-match
   (mt/with-premium-features #{:database-routing}

--- a/enterprise/backend/test/metabase_enterprise/database_routing/middleware_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/middleware_test.clj
@@ -1,0 +1,24 @@
+(ns metabase-enterprise.database-routing.middleware-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase-enterprise.database-routing.middleware :as routing.middleware]
+   [metabase.test :as mt]))
+
+(deftest attach-destination-db-middleware-scrubs-client-supplied-destination-test
+  (testing "a client-supplied :destination-database/id never survives preprocessing"
+    (mt/with-temp [:model/Database {db-id :id} {}]
+      (mt/with-metadata-provider db-id
+        (let [query {:database db-id, :type :query, :query {}, :destination-database/id 99999}]
+          (is (not (contains? (routing.middleware/attach-destination-db-middleware query)
+                              :destination-database/id))))))))
+
+(deftest attach-destination-db-middleware-rejects-direct-destination-access-test
+  (testing "direct destination-database access is rejected"
+    (mt/with-temp [:model/Database {router-id :id} {}
+                   :model/Database {destination-id :id} {:router_database_id router-id}]
+      (mt/with-metadata-provider destination-id
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"(?i)cannot query a destination database directly"
+             (routing.middleware/attach-destination-db-middleware
+              {:database destination-id, :type :query, :query {}})))))))

--- a/src/metabase/query_processor/setup.clj
+++ b/src/metabase/query_processor/setup.clj
@@ -4,6 +4,7 @@
    [clojure.core.async.impl.dispatch :as a.impl.dispatch]
    [clojure.set :as set]
    [metabase.config.core :as config]
+   [metabase.database-routing.core :as database-routing]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.lib.computed :as lib.computed]
@@ -144,8 +145,14 @@
       (f query)
 
       :else
-      (qp.store/with-metadata-provider (:database query)
-        (f (maybe-attach-metadata-provider-to-query query))))))
+      ;; `:database` here is whatever the user submitted, so a destination at this point is a direct
+      ;; request to query one; reject it before building a provider. Legitimate routing never passes
+      ;; through this branch: when a router query is routed to a destination, that swap happens later,
+      ;; in the execution middleware, binding its own metadata provider.
+      (do
+        (database-routing/check-allowed-access! (:database query))
+        (qp.store/with-metadata-provider (:database query)
+          (f (maybe-attach-metadata-provider-to-query query)))))))
 
 (mu/defn- do-with-driver :- fn?
   [f :- [:=> [:cat ::qp.schema/any-query] :any]]


### PR DESCRIPTION
[Context](https://metaboat.slack.com/archives/C0BG6L3A8UV/p1784147234091709?thread_ts=1783980381.808639&cid=C0BG6L3A8UV).

Different endpoints dealing with destination databases handled checks differently, causing confusing error messages depending on code path. This consolidates and standardizes both the messages and the HTTP code.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
