### PR TITLE
Fix explore-further on expression columns

### DIFF
--- a/src/metabase/explorations/query_plan/context.clj
+++ b/src/metabase/explorations/query_plan/context.clj
@@ -253,23 +253,47 @@
 (defn- explore-filter-display-name
   "Resolve the column label for one explore filter on `metric` within `block`."
   [mp card block metric filter-spec]
-  (let [block-dims (or (:dimensions block) [])]
-    (or (some-> (dimension-for-explore-filter mp card block-dims metric filter-spec)
-                (explore-filter-dimension-label block-dims))
-        (try
+  (try
+    (let [block-dims (or (:dimensions block) [])]
+      (or (some-> (dimension-for-explore-filter mp card block-dims metric filter-spec)
+                  (explore-filter-dimension-label block-dims))
           (let [base       (lib/query mp (:dataset_query card))
                 ref-clause (qp.mbql/normalize-target-ref (:field_ref filter-spec))
                 col        (lib/find-matching-column base -1 ref-clause
                                                      (lib/breakoutable-columns base))]
-            (when col (lib/display-name base col)))
-          (catch Exception _ nil)))))
+            (when col (lib/display-name base col)))))
+    (catch Exception _ nil)))
+
+(defn- expression-ref-name
+  "The expression name of `field-ref` when it is an `:expression` ref, else nil."
+  [field-ref]
+  (let [ref-clause (qp.mbql/normalize-target-ref field-ref)]
+    (when (and (vector? ref-clause) (= :expression (first ref-clause)))
+      (nth ref-clause 2 nil))))
+
+(defn- explore-filter-dimension-target
+  "The `top-n-other` variant breaks out on a synthetic CASE expression named after its dimension
+  that lives only on the variant query, not the metric Card — so a click ref against it can't be
+  resolved as a Card column. Map that expression name back to the dimension's real `:target` via the
+  metric's `:dimension_mappings` so the drilled filter scopes the actual column. Returns the target
+  ref, or nil when `field-ref` isn't such an expression."
+  [block metric field-ref]
+  (when-let [expr-name (expression-ref-name field-ref)]
+    (some (fn [dim]
+            (when (= expr-name (or (:display_name dim) (:dimension_id dim) "value"))
+              (qp.mbql/find-dimension-target (:dimension_id dim) (:dimension_mappings metric))))
+          (:dimensions block))))
 
 (defn enrich-explore-filters
-  "Stamp BE-computed `:display_name` onto each request filter, preserving the FE-supplied
-  `:display_value` when present."
+  "Normalize and label each request filter: remap a `top-n-other` bucket's synthetic expression ref
+  to its underlying dimension target (so the drill scopes the real column), then stamp the
+  BE-computed `:display_name`, preserving the FE-supplied `:display_value` when present."
   [mp card block metric explore-filters]
   (mapv (fn [filter-spec]
-          (let [display-name (explore-filter-display-name mp card block metric filter-spec)]
+          (let [target       (explore-filter-dimension-target block metric (:field_ref filter-spec))
+                filter-spec  (cond-> filter-spec
+                               target (assoc :field_ref target))
+                display-name (explore-filter-display-name mp card block metric filter-spec)]
             (cond-> filter-spec
               display-name (assoc :display_name display-name))))
         explore-filters))

--- a/src/metabase/metrics/transforms.clj
+++ b/src/metabase/metrics/transforms.clj
@@ -42,11 +42,26 @@
       (:has_field_values dim) (update :has_field_values keyword)
       (:sources dim)          (update :sources (fn [srcs] (mapv #(update % :type keyword) srcs))))))
 
+(defn- canonicalize-legacy-expression-ref
+  "`lib/normalize` relocates a legacy `:field` ref's id into MBQL-5 position (opts before id), but
+   the `:expression` ref schema has no such handler, so a legacy `[\"expression\" name]` /
+   `[\"expression\" name opts]` gets read as `[tag opts name]` and loses its name (yielding
+   `[:expression {} nil]`). Reshape those into MBQL-5 order `[\"expression\" opts name]` first. An
+   already-MBQL-5 ref (options map in the id slot) is returned untouched."
+  [target]
+  (if (and (sequential? target)
+           (#{"expression" :expression} (first target))
+           ;; legacy shape: the expression name (a string) sits in the id/index-1 slot
+           (string? (second target)))
+    (let [[tag nm opts] target]
+      [tag (or opts {}) nm])
+    target))
+
 (defn normalize-target-ref
   "Normalize a target ref after JSON parsing, e.g. [\"field\" {...} id] to a well-formed
    MBQL 5 [:field {...} id] ref, via the ref schema."
   [target]
-  (lib/normalize :metabase.lib.schema.ref/ref target))
+  (lib/normalize :metabase.lib.schema.ref/ref (canonicalize-legacy-expression-ref target)))
 
 (defn normalize-dimension-mapping
   "Normalize a dimension mapping after JSON parsing: rename legacy kebab-case

--- a/test/metabase/explorations/query_plan/context_test.clj
+++ b/test/metabase/explorations/query_plan/context_test.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.explorations.query-plan.context :as qp.context]
+   [metabase.explorations.query-plan.mbql :as qp.mbql]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.test :as mt]
@@ -277,6 +278,51 @@
              clojure.lang.ExceptionInfo #"Could not resolve explore filter field ref"
              (qp.context/build-row-context {:card_id cid :dimension_id "d1"
                                             :page_id page-id :params {}})))))))
+
+(deftest enrich-explore-filters-remaps-top-n-other-expression-test
+  (testing "a top-n-other bar's synthetic CASE-expression click ref is remapped to the underlying dimension"
+    ;; The `top-n-other` variant breaks out on a synthetic `[:expression <dim display-name>]` that
+    ;; exists only on the variant query, never on the metric Card. A click on a named bar sends that
+    ;; expression ref; enrich must resolve it back to the dimension's real target so the drilled
+    ;; filter scopes the actual column (`Name = "Smallville"`), not an unresolvable expression.
+    (mt/with-temp [:model/Card metric {:type :metric :dataset_query (count-metric-query)}]
+      (let [name-id    (mt/id :venues :name)
+            mappings   [{:dimension_id "d1" :table_id (mt/id :venues)
+                         :target ["field" {} name-id]}]
+            metric-sel {:card_id (:id metric) :dimension_mappings mappings}
+            block      {:metrics    [metric-sel]
+                        :dimensions [{:dimension_id "d1" :display_name "Name"
+                                      :effective_type "type/Text"}]}
+            filters    [{:field_ref ["expression" "Name"] :value "Smallville"}]
+            [enriched] (qp.context/enrich-explore-filters (mt/metadata-provider) metric block metric-sel filters)]
+        (testing "field_ref no longer references the synthetic expression"
+          (is (not (contains? #{"expression" :expression} (first (:field_ref enriched))))))
+        (testing "field_ref now targets the real dimension column"
+          (is (= name-id (nth (qp.mbql/normalize-target-ref (:field_ref enriched)) 2))))
+        (testing "value is preserved"
+          (is (= "Smallville" (:value enriched))))
+        (testing "the remapped filter actually applies to the metric Card"
+          (is (some #(and (str/includes? % "Name") (str/includes? % "Smallville"))
+                    (card-filter-display-names
+                     (reduce (fn [c ef] (#'qp.context/apply-single-explore-filter
+                                         (mt/metadata-provider) c ef))
+                             metric
+                             [enriched])))))))))
+
+(deftest enrich-explore-filters-tolerates-unresolvable-ref-test
+  (testing "enrich never throws on a click ref it can't resolve"
+    ;; Regression for the `POST /explore-further` 500: a top-n-other bar's expression ref used to
+    ;; normalize to `[:expression {} nil]` (name dropped), which `find-matching-column` rejected
+    ;; with an :invalid-input exception mid-request. It must degrade to "no display name" instead.
+    (mt/with-temp [:model/Card metric {:type :metric :dataset_query (count-metric-query)}]
+      (let [metric-sel {:card_id (:id metric) :dimension_mappings []}
+            block      {:metrics    [metric-sel]
+                        :dimensions [{:dimension_id "d1" :display_name "Name"}]}
+            filters    [{:field_ref ["expression" "Nonexistent"] :value "x"}]
+            enriched   (qp.context/enrich-explore-filters (mt/metadata-provider) metric block metric-sel filters)]
+        (is (= 1 (count enriched)))
+        (is (nil? (:display_name (first enriched))) "no label resolved, but no exception thrown")
+        (is (= "x" (:value (first enriched))))))))
 
 (deftest build-row-context-exposes-explore-filters-as-cache-key-material-test
   (testing "the ctx exposes stable :explore-filters for the discovery cache key —"

--- a/test/metabase/metrics/transforms_test.clj
+++ b/test/metabase/metrics/transforms_test.clj
@@ -4,6 +4,29 @@
    [metabase.metrics.transforms :as metrics.transforms]
    [metabase.util.json :as json]))
 
+(deftest ^:parallel normalize-target-ref-expression-test
+  (testing "legacy expression refs keep their name (regression: the name was dropped, yielding [:expression {} nil])"
+    (testing "2-element legacy ref"
+      (let [[tag opts nm] (metrics.transforms/normalize-target-ref ["expression" "Category"])]
+        (is (= :expression tag))
+        (is (map? opts))
+        (is (= "Category" nm))))
+    (testing "3-element legacy ref with trailing nil options"
+      (is (= "Category" (nth (metrics.transforms/normalize-target-ref ["expression" "Category" nil]) 2))))
+    (testing "3-element legacy ref with options carries them into MBQL-5 opts position"
+      (let [[tag opts nm] (metrics.transforms/normalize-target-ref ["expression" "Category" {:base-type "type/Text"}])]
+        (is (= :expression tag))
+        (is (= :type/Text (:base-type opts)))
+        (is (= "Category" nm))))
+    (testing "an already-MBQL-5 expression ref is left untouched"
+      (is (= "Category"
+             (nth (metrics.transforms/normalize-target-ref [:expression {:lib/uuid (str (random-uuid))} "Category"]) 2))))))
+
+(deftest ^:parallel normalize-target-ref-field-test
+  (testing "legacy field refs still relocate the id into MBQL-5 position (unchanged behavior)"
+    (is (= 7 (nth (metrics.transforms/normalize-target-ref ["field" 7 nil]) 2)))
+    (is (= 7 (nth (metrics.transforms/normalize-target-ref ["field" {} 7]) 2)))))
+
 (defn- dimensions-out
   "Run `dims` through the `:out` side of [[metrics.transforms/transform-dimensions]] the way a
   Toucan select would: JSON-encode then parse + normalize."


### PR DESCRIPTION
### Description

Clicking a bar to Explore further on a chart whose breakout dimension is an expression column throws a 500 error

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
