### PR TITLE
Allow obsolete semantic search kill-switch

### DIFF
--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -105,11 +105,15 @@
   []
   ;; An empty value is "explicitly unset" per the usual env-var semantics, so only a non-blank value trips this.
   (when-not (str/blank? (env/env :mb-semantic-search-enabled))
-    (let [engines           (search.engine/supported-engines)
-          semantic-default? (= :search.engine/semantic (first engines))
-          semantic-active?  (contains? (set (search.engine/active-engines)) :search.engine/semantic)
-          fallback          (when semantic-default? (second engines))]
+    (let [engines              (search.engine/supported-engines)
+          semantic-default?    (= :search.engine/semantic (first engines))
+          semantic-additional? (contains? (set (search.engine/additional-engines)) :search.engine/semantic)
+          fallback             (when semantic-default? (second engines))]
       (if-let [msg (cond
+                     (and fallback semantic-additional?)
+                     (trs "MB_SEMANTIC_SEARCH_ENABLED has been removed. Set MB_SEARCH_ENGINE={0} and remove semantic from additional-search-engines to keep semantic search off, then remove MB_SEMANTIC_SEARCH_ENABLED."
+                          (name fallback))
+
                      fallback
                      (trs "MB_SEMANTIC_SEARCH_ENABLED has been removed. Set MB_SEARCH_ENGINE={0} to keep semantic search off, then remove MB_SEMANTIC_SEARCH_ENABLED."
                           (name fallback))
@@ -117,7 +121,7 @@
                      semantic-default?
                      (trs "MB_SEMANTIC_SEARCH_ENABLED has been removed. Semantic search is the only supported engine and cannot be disabled; remove MB_SEMANTIC_SEARCH_ENABLED.")
 
-                     semantic-active?
+                     semantic-additional?
                      (trs "MB_SEMANTIC_SEARCH_ENABLED has been removed. Remove semantic from additional-search-engines to keep semantic search off, then remove MB_SEMANTIC_SEARCH_ENABLED."))]
         (throw (ex-info msg {:env-var "MB_SEMANTIC_SEARCH_ENABLED"}))
         (log/warn "MB_SEMANTIC_SEARCH_ENABLED is no longer supported; remove it from your configuration.")))))

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -109,21 +109,26 @@
           semantic-default?    (= :search.engine/semantic (first engines))
           semantic-additional? (contains? (set (search.engine/additional-engines)) :search.engine/semantic)
           fallback             (when semantic-default? (second engines))
-          remedies             (cond-> []
-                                 fallback             (conj (trs "set MB_SEARCH_ENGINE={0}" (name fallback)))
-                                 semantic-additional? (conj (trs "remove semantic from additional-search-engines")))]
-      (let [detail (cond
-                     (and semantic-default? (not fallback))
-                     (trs "Semantic search is the only supported engine and cannot be disabled; remove MB_SEMANTIC_SEARCH_ENABLED.")
+          ;; Each case is a complete sentence so translators can reorder it freely.
+          detail               (cond
+                                 (and semantic-default? (not fallback))
+                                 (trs "Semantic search is the only supported engine and cannot be disabled; remove MB_SEMANTIC_SEARCH_ENABLED.")
 
-                     (seq remedies)
-                     (trs "To keep semantic search off, {0}; then remove MB_SEMANTIC_SEARCH_ENABLED."
-                          (str/join " and " remedies)))
-            msg    (str (trs "MB_SEMANTIC_SEARCH_ENABLED is no longer supported.") " "
-                        (or detail (trs "Remove it from your configuration.")))]
-        (if detail
-          (throw (ex-info msg {:env-var "MB_SEMANTIC_SEARCH_ENABLED"}))
-          (log/warn msg))))))
+                                 (and fallback semantic-additional?)
+                                 (trs "To keep semantic search off, set MB_SEARCH_ENGINE={0} and remove semantic from additional-search-engines, then remove MB_SEMANTIC_SEARCH_ENABLED."
+                                      (name fallback))
+
+                                 fallback
+                                 (trs "To keep semantic search off, set MB_SEARCH_ENGINE={0}, then remove MB_SEMANTIC_SEARCH_ENABLED."
+                                      (name fallback))
+
+                                 semantic-additional?
+                                 (trs "To keep semantic search off, remove semantic from additional-search-engines, then remove MB_SEMANTIC_SEARCH_ENABLED."))
+          msg                  (str (trs "MB_SEMANTIC_SEARCH_ENABLED is no longer supported.") " "
+                                    (or detail (trs "Remove it from your configuration.")))]
+      (if detail
+        (throw (ex-info msg {:env-var "MB_SEMANTIC_SEARCH_ENABLED"}))
+        (log/warn msg)))))
 
 (defmethod startup/def-startup-validation! ::check-for-removed-env-vars [_]
   (check-for-removed-env-vars!))

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -99,26 +99,28 @@
   (seq (search.engine/active-engines)))
 
 (defn check-for-removed-env-vars!
-  "Fail startup when the removed MB_SEMANTIC_SEARCH_ENABLED kill switch is still set, naming the exact
-  MB_SEARCH_ENGINE value the switch would have fallen back to when semantic is now serving search."
+  "Fail startup when the removed MB_SEMANTIC_SEARCH_ENABLED kill switch is still set, and would have been
+  required to disable the engine, naming the exact configuration change that keeps semantic search off.
+  Otherwise just log a warning."
   []
   ;; An empty value is "explicitly unset" per the usual env-var semantics, so only a non-blank value trips this.
   (when-not (str/blank? (env/env :mb-semantic-search-enabled))
     (let [engines           (search.engine/supported-engines)
-          semantic-serving? (= :search.engine/semantic (first engines))
-          fallback          (when semantic-serving? (second engines))]
-      (throw (ex-info
-              (cond
-                fallback
-                (trs "MB_SEMANTIC_SEARCH_ENABLED has been removed. Set MB_SEARCH_ENGINE={0} to keep semantic search off, then remove MB_SEMANTIC_SEARCH_ENABLED."
-                     (name fallback))
+          semantic-default? (= :search.engine/semantic (first engines))
+          semantic-active?  (contains? (set (search.engine/active-engines)) :search.engine/semantic)
+          fallback          (when semantic-default? (second engines))]
+      (if-let [msg (cond
+                     fallback
+                     (trs "MB_SEMANTIC_SEARCH_ENABLED has been removed. Set MB_SEARCH_ENGINE={0} to keep semantic search off, then remove MB_SEMANTIC_SEARCH_ENABLED."
+                          (name fallback))
 
-                semantic-serving?
-                (trs "MB_SEMANTIC_SEARCH_ENABLED has been removed. Semantic search is the only supported engine and cannot be disabled; remove MB_SEMANTIC_SEARCH_ENABLED.")
+                     semantic-default?
+                     (trs "MB_SEMANTIC_SEARCH_ENABLED has been removed. Semantic search is the only supported engine and cannot be disabled; remove MB_SEMANTIC_SEARCH_ENABLED.")
 
-                :else
-                (trs "MB_SEMANTIC_SEARCH_ENABLED has been removed; remove it from your configuration."))
-              {:env-var "MB_SEMANTIC_SEARCH_ENABLED"})))))
+                     semantic-active?
+                     (trs "MB_SEMANTIC_SEARCH_ENABLED has been removed. Remove semantic from additional-search-engines to keep semantic search off, then remove MB_SEMANTIC_SEARCH_ENABLED."))]
+        (throw (ex-info msg {:env-var "MB_SEMANTIC_SEARCH_ENABLED"}))
+        (log/warn "MB_SEMANTIC_SEARCH_ENABLED is no longer supported; remove it from your configuration.")))))
 
 (defmethod startup/def-startup-validation! ::check-for-removed-env-vars [_]
   (check-for-removed-env-vars!))

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -108,21 +108,17 @@
     (let [engines              (search.engine/supported-engines)
           semantic-default?    (= :search.engine/semantic (first engines))
           semantic-additional? (contains? (set (search.engine/additional-engines)) :search.engine/semantic)
-          fallback             (when semantic-default? (second engines))]
+          fallback             (when semantic-default? (second engines))
+          remedies             (cond-> []
+                                 fallback             (conj (trs "set MB_SEARCH_ENGINE={0}" (name fallback)))
+                                 semantic-additional? (conj (trs "remove semantic from additional-search-engines")))]
       (if-let [msg (cond
-                     (and fallback semantic-additional?)
-                     (trs "MB_SEMANTIC_SEARCH_ENABLED has been removed. Set MB_SEARCH_ENGINE={0} and remove semantic from additional-search-engines to keep semantic search off, then remove MB_SEMANTIC_SEARCH_ENABLED."
-                          (name fallback))
-
-                     fallback
-                     (trs "MB_SEMANTIC_SEARCH_ENABLED has been removed. Set MB_SEARCH_ENGINE={0} to keep semantic search off, then remove MB_SEMANTIC_SEARCH_ENABLED."
-                          (name fallback))
-
-                     semantic-default?
+                     (and semantic-default? (not fallback))
                      (trs "MB_SEMANTIC_SEARCH_ENABLED has been removed. Semantic search is the only supported engine and cannot be disabled; remove MB_SEMANTIC_SEARCH_ENABLED.")
 
-                     semantic-additional?
-                     (trs "MB_SEMANTIC_SEARCH_ENABLED has been removed. Remove semantic from additional-search-engines to keep semantic search off, then remove MB_SEMANTIC_SEARCH_ENABLED."))]
+                     (seq remedies)
+                     (trs "MB_SEMANTIC_SEARCH_ENABLED has been removed. To keep semantic search off, {0}; then remove MB_SEMANTIC_SEARCH_ENABLED."
+                          (str/join " and " remedies)))]
         (throw (ex-info msg {:env-var "MB_SEMANTIC_SEARCH_ENABLED"}))
         (log/warn "MB_SEMANTIC_SEARCH_ENABLED is no longer supported; remove it from your configuration.")))))
 

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -112,15 +112,18 @@
           remedies             (cond-> []
                                  fallback             (conj (trs "set MB_SEARCH_ENGINE={0}" (name fallback)))
                                  semantic-additional? (conj (trs "remove semantic from additional-search-engines")))]
-      (if-let [msg (cond
+      (let [detail (cond
                      (and semantic-default? (not fallback))
-                     (trs "MB_SEMANTIC_SEARCH_ENABLED has been removed. Semantic search is the only supported engine and cannot be disabled; remove MB_SEMANTIC_SEARCH_ENABLED.")
+                     (trs "Semantic search is the only supported engine and cannot be disabled; remove MB_SEMANTIC_SEARCH_ENABLED.")
 
                      (seq remedies)
-                     (trs "MB_SEMANTIC_SEARCH_ENABLED has been removed. To keep semantic search off, {0}; then remove MB_SEMANTIC_SEARCH_ENABLED."
-                          (str/join " and " remedies)))]
-        (throw (ex-info msg {:env-var "MB_SEMANTIC_SEARCH_ENABLED"}))
-        (log/warn "MB_SEMANTIC_SEARCH_ENABLED is no longer supported; remove it from your configuration.")))))
+                     (trs "To keep semantic search off, {0}; then remove MB_SEMANTIC_SEARCH_ENABLED."
+                          (str/join " and " remedies)))
+            msg    (str (trs "MB_SEMANTIC_SEARCH_ENABLED is no longer supported.") " "
+                        (or detail (trs "Remove it from your configuration.")))]
+        (if detail
+          (throw (ex-info msg {:env-var "MB_SEMANTIC_SEARCH_ENABLED"}))
+          (log/warn msg))))))
 
 (defmethod startup/def-startup-validation! ::check-for-removed-env-vars [_]
   (check-for-removed-env-vars!))

--- a/src/metabase/search/engine.clj
+++ b/src/metabase/search/engine.clj
@@ -168,7 +168,7 @@
     ;; metabase.search.init loads the engine implementations, and supported-engine? throws on unknown engines.
     (distinct (filter supported-engine? (filter known-engine? potential-engines)))))
 
-(defn- additional-engines
+(defn additional-engines
   "The supported engines force-enabled by [[settings/additional-search-engines]]."
   []
   (->> (settings/additional-search-engines)

--- a/test/metabase/search/engine_test.clj
+++ b/test/metabase/search/engine_test.clj
@@ -73,6 +73,12 @@
                  clojure.lang.ExceptionInfo
                  #"only supported engine and cannot be disabled"
                  (search/check-for-removed-env-vars!))))))
+      (testing "naming both settings when semantic is the default and also force-enabled as additional"
+        (with-engines {:supported all-engines :additional ["semantic"]}
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"Set MB_SEARCH_ENGINE=appdb and remove semantic from additional-search-engines"
+               (search/check-for-removed-env-vars!)))))
       (testing "pointing at additional-search-engines when semantic is only force-enabled through it"
         (with-engines {:supported all-engines :configured :appdb :additional ["semantic"]}
           (is (thrown-with-msg?

--- a/test/metabase/search/engine_test.clj
+++ b/test/metabase/search/engine_test.clj
@@ -59,13 +59,13 @@
         (with-engines {:supported all-engines}
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"Set MB_SEARCH_ENGINE=appdb to keep semantic search off"
+               #"To keep semantic search off, set MB_SEARCH_ENGINE=appdb"
                (search/check-for-removed-env-vars!))))
         (testing "the fallback follows precedence, not a hardcoded engine"
           (with-engines {:supported #{:search.engine/semantic :search.engine/in-place}}
             (is (thrown-with-msg?
                  clojure.lang.ExceptionInfo
-                 #"Set MB_SEARCH_ENGINE=in-place"
+                 #"set MB_SEARCH_ENGINE=in-place"
                  (search/check-for-removed-env-vars!)))))
         (testing "when semantic is the only supported engine there is nothing to fall back to"
           (with-engines {:supported #{:search.engine/semantic}}
@@ -77,13 +77,13 @@
         (with-engines {:supported all-engines :additional ["semantic"]}
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"Set MB_SEARCH_ENGINE=appdb and remove semantic from additional-search-engines"
+               #"set MB_SEARCH_ENGINE=appdb and remove semantic from additional-search-engines"
                (search/check-for-removed-env-vars!)))))
       (testing "pointing at additional-search-engines when semantic is only force-enabled through it"
         (with-engines {:supported all-engines :configured :appdb :additional ["semantic"]}
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"Remove semantic from additional-search-engines"
+               #"To keep semantic search off, remove semantic from additional-search-engines"
                (search/check-for-removed-env-vars!)))))
       (testing "startup proceeds with just a warning when another engine already serves search"
         (with-engines {:supported #{:search.engine/appdb :search.engine/in-place}}

--- a/test/metabase/search/engine_test.clj
+++ b/test/metabase/search/engine_test.clj
@@ -73,12 +73,19 @@
                  clojure.lang.ExceptionInfo
                  #"only supported engine and cannot be disabled"
                  (search/check-for-removed-env-vars!))))))
-      (testing "with a plain remove-it message when another engine already serves search"
-        (with-engines {:supported #{:search.engine/appdb :search.engine/in-place}}
+      (testing "pointing at additional-search-engines when semantic is only force-enabled through it"
+        (with-engines {:supported all-engines :configured :appdb :additional ["semantic"]}
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"remove it from your configuration"
+               #"Remove semantic from additional-search-engines"
                (search/check-for-removed-env-vars!)))))
+      (testing "startup proceeds with just a warning when another engine already serves search"
+        (with-engines {:supported #{:search.engine/appdb :search.engine/in-place}}
+          (is (=? [{:level   :warn
+                    :message "MB_SEMANTIC_SEARCH_ENABLED is no longer supported; remove it from your configuration."}]
+                  (mt/with-log-messages-for-level [messages :warn]
+                    (search/check-for-removed-env-vars!)
+                    (messages))))))
       (testing "the check runs as a startup validation so a throw aborts the boot"
         (is (contains? (methods startup/def-startup-validation!)
                        :metabase.search.core/check-for-removed-env-vars)))))

--- a/test/metabase/search/engine_test.clj
+++ b/test/metabase/search/engine_test.clj
@@ -88,7 +88,7 @@
       (testing "startup proceeds with just a warning when another engine already serves search"
         (with-engines {:supported #{:search.engine/appdb :search.engine/in-place}}
           (is (=? [{:level   :warn
-                    :message "MB_SEMANTIC_SEARCH_ENABLED is no longer supported; remove it from your configuration."}]
+                    :message "MB_SEMANTIC_SEARCH_ENABLED is no longer supported. Remove it from your configuration."}]
                   (mt/with-log-messages-for-level [messages :warn]
                     (search/check-for-removed-env-vars!)
                     (messages))))))


### PR DESCRIPTION
Closes BOT-1868

A leftover `MB_SEMANTIC_SEARCH_ENABLED` now only aborts boot when the removed kill switch would actually have been disabling semantic search. When semantic isn't active, it's a harmless leftover: log a warning and start up normally.

- Semantic is the default engine: still fails, naming the `MB_SEARCH_ENGINE` fallback (or "cannot be disabled" when it's the only supported engine).
- Semantic is only force-enabled through `additional-search-engines`: previously slipped through the default-engine check; now fails pointing at that setting.
- Semantic not active: warn and boot.