### PR TITLE
Show a crossed-eye indicator with a tooltip on hidden pages in the exploration sidebar

### DIFF
--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationSidebar.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationSidebar.tsx
@@ -625,6 +625,7 @@ function ExplorationTreeItem({
 
   const pageData = item.data.type === "page" ? item.data : null;
   const isError = pageData?.status === "error";
+  const isHidden = pageData?.hidden === true;
   const isLoading = isLoadingStatus(item.data?.status);
 
   return (
@@ -654,6 +655,16 @@ function ExplorationTreeItem({
       >
         {item.name}
       </Ellipsified>
+      {isHidden && (
+        <Icon
+          name="eye_crossed_out"
+          c="icon-secondary"
+          size="1rem"
+          flex="none"
+          tooltip={t`Hidden`}
+          aria-label={t`Hidden`}
+        />
+      )}
       {isError && (
         <ExplorationErrorMarker
           message={t`We couldn't generate one or more of these charts.`}

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationSidebar.unit.spec.tsx
@@ -2,7 +2,6 @@ import userEvent from "@testing-library/user-event";
 import dayjs from "dayjs";
 import fetchMock from "fetch-mock";
 
-
 import {
   fireEvent,
   renderWithProviders,
@@ -342,6 +341,44 @@ describe("ExplorationSidebar", () => {
           hidden: false,
         });
       });
+    });
+  });
+
+  describe("hidden page indicator", () => {
+    const mixedBlock = createBlock({
+      id: 70,
+      name: "Costs",
+      pages: [
+        createPage({
+          id: 750,
+          name: "Hidden chart",
+          query_ids: [15],
+          hidden: true,
+        }),
+        createPage({ id: 751, name: "Visible chart", query_ids: [16] }),
+      ],
+    });
+    const mixedQueries = [
+      createQuery({ id: 15, name: "Hidden chart", status: "done" }),
+      createQuery({ id: 16, name: "Visible chart", status: "done" }),
+    ];
+
+    it("marks hidden pages with a crossed-eye icon when the filter shows them", async () => {
+      setup({
+        queries: mixedQueries,
+        blocks: [mixedBlock],
+        showHidden: true,
+        selectedEntityId: { type: "page", id: "750" },
+      });
+
+      const indicator = within(getRow("Hidden chart")).getByLabelText("Hidden");
+      expect(indicator).toBeInTheDocument();
+      expect(
+        within(getRow("Visible chart")).queryByLabelText("Hidden"),
+      ).not.toBeInTheDocument();
+
+      await userEvent.hover(indicator);
+      expect(await screen.findByRole("tooltip")).toHaveTextContent("Hidden");
     });
   });
 


### PR DESCRIPTION
### Description

Fixes [UXW-4838](https://linear.app/metabase/issue/UXW-4838/add-visual-indication-for-hidden-items).

Hidden pages were indistinguishable from visible ones when "Display hidden pages" was on. They now show a crossed-eye indicator (with a "Hidden" tooltip) in the sidebar tree.

### How to verify

- [ ] In an exploration, hide a chart, then turn on "Display hidden pages": the hidden row shows a crossed-eye icon, and unhiding removes it.

### Demo

<img width="706" height="582" alt="image" src="https://github.com/user-attachments/assets/97f0d7b5-b507-43c1-a712-e8a2c9ac721d" />
