### PR TITLE
POC Generic Chat Completions Metabot Provider

### DIFF
--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -167,6 +167,7 @@ export type MetabotProvider =
   | "anthropic"
   | "azure"
   | "bedrock"
+  | "chat-completions"
   | "openai"
   | "openrouter";
 
@@ -182,10 +183,15 @@ export interface AzureCredentials {
   "base-url"?: string | null;
 }
 
+export interface ChatCompletionsCredentials {
+  "api-key"?: string | null;
+  "base-url"?: string | null;
+}
+
 /** One permissive map mirroring the backend's request schema: Bedrock sends AWS key
- * material, Azure sends an API key and base URL. */
+ * material, Azure and the generic Chat Completions provider send an API key and base URL. */
 export interface MetabotCredentials
-  extends BedrockCredentials, AzureCredentials {}
+  extends BedrockCredentials, AzureCredentials, ChatCompletionsCredentials {}
 
 export interface MetabotSettingsResponse {
   value: string | null;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -540,6 +540,8 @@ interface SettingsManagerSettings {
   "llm-openrouter-api-key"?: string | null;
   "llm-azure-api-key"?: string | null;
   "llm-azure-api-base-url"?: string | null;
+  "llm-chat-completions-api-key"?: string | null;
+  "llm-chat-completions-api-base-url"?: string | null;
   "llm-bedrock-access-key-id"?: string | null;
   "llm-bedrock-secret-access-key"?: string | null;
   "llm-bedrock-region"?: string | null;

--- a/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AIProviderSettingsSection.unit.spec.tsx
@@ -73,6 +73,11 @@ const DEFAULT_RESPONSES: Record<MetabotProvider, MetabotSettingsResponse> = {
     value: "azure/anthropic/claude-sonnet-4-5",
     models: [],
   },
+  "chat-completions": {
+    // Generic Chat Completions has no model dropdown — the model name is free text.
+    value: "chat-completions/my-model",
+    models: [],
+  },
   bedrock: {
     value: "bedrock/anthropic.claude-haiku-4-5",
     models: [
@@ -123,6 +128,8 @@ type MetabotSettingKey =
   | "llm-anthropic-api-key"
   | "llm-azure-api-key"
   | "llm-azure-api-base-url"
+  | "llm-chat-completions-api-key"
+  | "llm-chat-completions-api-base-url"
   | "llm-openai-api-key"
   | "llm-openrouter-api-key"
   | "llm-bedrock-access-key-id"
@@ -210,12 +217,13 @@ async function setup({
   const updateMetabotSettingsDeferred = defer<void>();
 
   const mergedApiKeyValues: Record<
-    MetabotApiKeyProvider | "azure" | "bedrock",
+    MetabotApiKeyProvider | "azure" | "bedrock" | "chat-completions",
     string | null
   > = {
     anthropic: "**********45",
     azure: null,
     bedrock: null,
+    "chat-completions": null,
     openai: null,
     openrouter: null,
     ...apiKeyValues,
@@ -270,6 +278,17 @@ async function setup({
       key: "llm-azure-api-base-url",
       value: mergedApiKeyValues.azure
         ? "https://my-resource.services.ai.azure.com/anthropic"
+        : undefined,
+    }),
+    "llm-chat-completions-api-key": createMockSettingDefinition({
+      key: "llm-chat-completions-api-key",
+      value: mergedApiKeyValues["chat-completions"] ?? undefined,
+    }),
+    // The base URL is configured whenever the Chat Completions API key is — they are saved together.
+    "llm-chat-completions-api-base-url": createMockSettingDefinition({
+      key: "llm-chat-completions-api-base-url",
+      value: mergedApiKeyValues["chat-completions"]
+        ? "https://api.example.com/v1"
         : undefined,
     }),
     "llm-openai-api-key": createMockSettingDefinition({
@@ -2171,6 +2190,126 @@ describe("AIProviderSettingsSection", () => {
       expect(
         await screen.findByText("Connect to an AI provider"),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("Generic Chat Completions", () => {
+    it("shows Generic Chat Completions as selectable in the provider dropdown", async () => {
+      await setup({ savedProviderValue: null, isConfigured: false });
+
+      await userEvent.click(screen.getByLabelText("Provider"));
+
+      const option = await screen.findByRole("option", {
+        name: "Generic Chat Completions",
+      });
+      expect(option).toBeInTheDocument();
+      expect(option).not.toHaveAttribute("data-combobox-disabled");
+    });
+
+    it("shows the base URL, API key, and free-text model fields when selected", async () => {
+      await setup({ savedProviderValue: null, isConfigured: false });
+
+      await selectProvider("Generic Chat Completions");
+
+      expect(await screen.findByLabelText("Base URL")).toBeInTheDocument();
+      expect(screen.getByLabelText("API key")).toBeInTheDocument();
+      expect(screen.getByLabelText("Model name")).toBeInTheDocument();
+      // No model dropdown — the model is free text.
+      expect(screen.queryByLabelText("Model")).not.toBeInTheDocument();
+    });
+
+    it("connects by sending the model and the credentials object", async () => {
+      await setup({
+        savedProviderValue: null,
+        isConfigured: false,
+        updateResponse: {
+          value: "chat-completions/my-model",
+          models: [],
+        },
+      });
+
+      await selectProvider("Generic Chat Completions");
+
+      const connectButton = screen.getByRole("button", { name: "Connect" });
+      expect(connectButton).toBeDisabled();
+
+      await userEvent.type(
+        await screen.findByLabelText("Base URL"),
+        "https://api.example.com/v1",
+      );
+      await userEvent.type(screen.getByLabelText("API key"), "secret-key");
+      await userEvent.type(screen.getByLabelText("Model name"), "my-model");
+
+      expect(connectButton).toBeEnabled();
+      await userEvent.click(connectButton);
+
+      await waitFor(() => {
+        expect(
+          fetchMock.callHistory.called("path:/api/metabot/settings", {
+            method: "PUT",
+          }),
+        ).toBe(true);
+      });
+
+      const [request] = fetchMock.callHistory.calls(
+        "path:/api/metabot/settings",
+        { method: "PUT" },
+      );
+
+      expect(request?.options?.body).toBe(
+        JSON.stringify({
+          provider: "chat-completions",
+          model: "my-model",
+          credentials: {
+            "api-key": "secret-key",
+            "base-url": "https://api.example.com/v1",
+          },
+        }),
+      );
+    });
+
+    it("shows the saved base URL and model for a connected provider", async () => {
+      await setup({
+        savedProviderValue: "chat-completions/my-model",
+        apiKeyValues: { "chat-completions": "**********ey" },
+      });
+
+      expect(await screen.findByLabelText("Base URL")).toHaveValue(
+        "https://api.example.com/v1",
+      );
+      expect(screen.getByLabelText("Model name")).toHaveValue("my-model");
+      expect(screen.queryByLabelText("Model")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Disconnect" }),
+      ).toBeInTheDocument();
+    });
+
+    it("disconnects by clearing the credentials before the provider setting", async () => {
+      await setup({
+        savedProviderValue: "chat-completions/my-model",
+        apiKeyValues: { "chat-completions": "**********ey" },
+      });
+
+      await screen.findByLabelText("Model name");
+      await confirmDisconnectProvider();
+
+      await waitFor(() => {
+        expect(
+          fetchMock.callHistory.called("path:/api/metabot/settings", {
+            method: "PUT",
+            body: { provider: "chat-completions", credentials: null },
+          }),
+        ).toBe(true);
+      });
+
+      await waitFor(() => {
+        expect(
+          fetchMock.callHistory.called("path:/api/setting", {
+            method: "PUT",
+            body: { "llm-metabot-provider": null },
+          }),
+        ).toBe(true);
+      });
     });
   });
 

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationForm.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderConfigurationForm.tsx
@@ -22,6 +22,7 @@ import { AIProviderConfigurationContext } from "./AIProviderConfigurationContext
 import { ApiKeyProviderFields } from "./ApiKeyProviderFields";
 import { AzureProviderFields } from "./AzureProviderFields";
 import { BedrockProviderFields } from "./BedrockProviderFields";
+import { ChatCompletionsProviderFields } from "./ChatCompletionsProviderFields";
 import {
   API_KEY_SETTING_BY_PROVIDER,
   getProviderOptions,
@@ -98,7 +99,8 @@ export function AIProviderConfigurationForm({
     if (
       connectedProvider !== "metabase" &&
       connectedProvider !== "bedrock" &&
-      connectedProvider !== "azure"
+      connectedProvider !== "azure" &&
+      connectedProvider !== "chat-completions"
     ) {
       const apiKeySettingKey = API_KEY_SETTING_BY_PROVIDER[connectedProvider];
       const apiKeySetting = providerApiKeyDetails[apiKeySettingKey];
@@ -109,10 +111,15 @@ export function AIProviderConfigurationForm({
     }
 
     try {
-      if (connectedProvider === "bedrock" || connectedProvider === "azure") {
-        // Bedrock and Azure key material spans several settings; an explicit
-        // `credentials: null` clears them all in one call. It runs before the provider
-        // is deselected so a failure can't leave saved keys behind.
+      if (
+        connectedProvider === "bedrock" ||
+        connectedProvider === "azure" ||
+        connectedProvider === "chat-completions"
+      ) {
+        // Bedrock, Azure, and the generic Chat Completions provider spread key material
+        // across several settings; an explicit `credentials: null` clears them all in one
+        // call. It runs before the provider is deselected so a failure can't leave saved
+        // keys behind.
         await updateMetabotSettings({
           provider: connectedProvider,
           credentials: null,
@@ -264,6 +271,13 @@ export function AIProviderConfigurationForm({
           ))
           .with("bedrock", () => (
             <BedrockProviderFields
+              connectedModel={connectedModel}
+              isCurrentConfigured={isCurrentConfigured}
+              isEnvSetting={isEnvSetting}
+            />
+          ))
+          .with("chat-completions", () => (
+            <ChatCompletionsProviderFields
               connectedModel={connectedModel}
               isCurrentConfigured={isCurrentConfigured}
               isEnvSetting={isEnvSetting}

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/ChatCompletionsProviderFields.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/ChatCompletionsProviderFields.tsx
@@ -1,0 +1,143 @@
+import { type FormikHelpers, useFormikContext } from "formik";
+import { useMemo } from "react";
+import { t } from "ttag";
+
+import { useUpdateMetabotSettingsMutation } from "metabase/api";
+import { useAdminSettings } from "metabase/api/utils";
+import { SetByEnvVar } from "metabase/common/components/SetByEnvVar";
+import { FormErrorMessage, FormProvider, FormTextInput } from "metabase/forms";
+
+import { useAIProviderConfigurationContext } from "./AIProviderConfigurationContext";
+import { getProviderOptions } from "./utils";
+
+const CHAT_COMPLETIONS_SETTING_KEYS = [
+  "llm-chat-completions-api-key",
+  "llm-chat-completions-api-base-url",
+] as const;
+
+type ChatCompletionsValues = {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+};
+
+export const ChatCompletionsProviderFields = ({
+  connectedModel,
+  isCurrentConfigured,
+  isEnvSetting,
+}: {
+  connectedModel: string | undefined;
+  isCurrentConfigured: boolean;
+  isEnvSetting: boolean;
+}) => {
+  const [updateMetabotSettings] = useUpdateMetabotSettingsMutation();
+  const { details } = useAdminSettings(CHAT_COMPLETIONS_SETTING_KEYS);
+
+  const initialValues = useMemo<ChatCompletionsValues>(
+    () => ({
+      baseUrl: String(
+        details["llm-chat-completions-api-base-url"]?.value ?? "",
+      ),
+      apiKey: String(details["llm-chat-completions-api-key"]?.value ?? ""),
+      model: isCurrentConfigured ? (connectedModel ?? "") : "",
+    }),
+    [connectedModel, details, isCurrentConfigured],
+  );
+
+  const handleSubmit = async (
+    values: ChatCompletionsValues,
+    { resetForm }: FormikHelpers<ChatCompletionsValues>,
+  ) => {
+    const changedValueOrNull = (field: "apiKey" | "baseUrl") =>
+      values[field] !== initialValues[field] ? values[field] || null : null;
+
+    await updateMetabotSettings({
+      provider: "chat-completions",
+      model: values.model.trim(),
+      credentials: {
+        "api-key": changedValueOrNull("apiKey"),
+        "base-url": changedValueOrNull("baseUrl"),
+      },
+    }).unwrap();
+
+    resetForm({ values });
+  };
+
+  return (
+    <FormProvider
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      enableReinitialize
+    >
+      <ChatCompletionsCredentialFields
+        isCurrentConfigured={isCurrentConfigured}
+        isEnvSetting={isEnvSetting}
+      />
+    </FormProvider>
+  );
+};
+
+const ChatCompletionsCredentialFields = ({
+  isCurrentConfigured,
+  isEnvSetting,
+}: {
+  isCurrentConfigured: boolean;
+  isEnvSetting: boolean;
+}) => {
+  const { dirty, submitForm, values } =
+    useFormikContext<ChatCompletionsValues>();
+
+  const { details } = useAdminSettings(CHAT_COMPLETIONS_SETTING_KEYS);
+  const apiKeySetting = details["llm-chat-completions-api-key"];
+  const baseUrlSetting = details["llm-chat-completions-api-base-url"];
+
+  const apiKeyEnvName = apiKeySetting?.is_env_setting
+    ? apiKeySetting.env_name
+    : undefined;
+  const baseUrlEnvName = baseUrlSetting?.is_env_setting
+    ? baseUrlSetting.env_name
+    : undefined;
+
+  const isComplete =
+    !!values.baseUrl.trim() && !!values.apiKey.trim() && !!values.model.trim();
+  const connectHandler =
+    isComplete && (!isCurrentConfigured || dirty) ? submitForm : null;
+  const { isMutating } = useAIProviderConfigurationContext(connectHandler);
+
+  const providerDetails = getProviderOptions(true)["chat-completions"];
+
+  return (
+    <>
+      <FormTextInput
+        name="baseUrl"
+        label={t`Base URL`}
+        description={t`The base URL of your OpenAI-compatible Chat Completions endpoint, including the version segment.`}
+        placeholder="https://api.example.com/v1"
+        disabled={isMutating || isEnvSetting || !!baseUrlEnvName}
+        w="100%"
+      />
+      {baseUrlEnvName && <SetByEnvVar varName={baseUrlEnvName} />}
+
+      <FormTextInput
+        name="apiKey"
+        label={t`API key`}
+        type="password"
+        placeholder={providerDetails.apiKey.placeholder}
+        disabled={isMutating || isEnvSetting || !!apiKeyEnvName}
+        w="100%"
+      />
+      {apiKeyEnvName && <SetByEnvVar varName={apiKeyEnvName} />}
+
+      <FormTextInput
+        name="model"
+        label={t`Model name`}
+        description={t`The model to send to your endpoint, e.g. the value it expects in the request's "model" field.`}
+        placeholder={t`Enter your model name`}
+        disabled={isMutating || isEnvSetting}
+        w="100%"
+      />
+
+      <FormErrorMessage />
+    </>
+  );
+};

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/utils.ts
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/utils.ts
@@ -77,12 +77,21 @@ export function getProviderOptions(
         addKeyUrl: "https://openrouter.ai/keys",
       },
     },
+    "chat-completions": {
+      value: "chat-completions",
+      label: t`Generic Chat Completions`,
+      apiKey: {
+        placeholder: t`Enter your API key`,
+        // Generic endpoint — there is no single provider console to link to.
+        addKeyUrl: "",
+      },
+    },
   };
 }
 
 export type MetabotApiKeyProvider = Exclude<
   MetabotProvider,
-  "metabase" | "azure" | "bedrock"
+  "metabase" | "azure" | "bedrock" | "chat-completions"
 >;
 
 export function isMetabotProvider(
@@ -96,6 +105,7 @@ export function isAvailableProvider(provider: MetabotProvider): boolean {
     provider === "anthropic" ||
     provider === "azure" ||
     provider === "bedrock" ||
+    provider === "chat-completions" ||
     provider === "metabase" ||
     provider === "openai" ||
     provider === "openrouter"

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -25,6 +25,14 @@
   [setting-key new-value]
   (setting/set-value-of-type! :string setting-key (trimmed-string new-value)))
 
+(defn normalize-llm-base-url
+  "Trim whitespace and trailing slashes from an admin-entered LLM base URL; blank values become nil.
+  The URL is otherwise persisted exactly as entered — admin-entered URLs are not silently rewritten."
+  [value]
+  (some-> (trimmed-string value)
+          (str/replace #"/+$" "")
+          not-empty))
+
 (defn- set-prefixed-api-key!
   [setting-key prefix deferred-message new-value]
   (let [trimmed (trimmed-string new-value)]
@@ -134,6 +142,30 @@
                              (deferred-tru "Invalid OpenRouter API key format. Key must start with ''sk-or-v1-''."))
   :doc              false)
 
+;;; ---------------------------------------- Generic Chat Completions -------------------------------------------
+;;; A provider-agnostic OpenAI-compatible Chat Completions (`/v1/chat/completions`) endpoint. Unlike the direct
+;;; providers, both the base URL and the model are admin-supplied, so there are no defaults and the API key has no
+;;; recognizable prefix to validate against.
+
+(defsetting llm-chat-completions-api-base-url
+  (deferred-tru "The base URL of an OpenAI-compatible Chat Completions endpoint, e.g. https://api.example.com/v1.")
+  :encryption  :no
+  :visibility  :settings-manager
+  :export?     false
+  :doc         false
+  :setter      (fn [new-value]
+                 (setting/set-value-of-type! :string :llm-chat-completions-api-base-url (normalize-llm-base-url new-value))))
+
+(defsetting llm-chat-completions-api-key
+  (deferred-tru "The API key for the generic Chat Completions endpoint.")
+  ;; Generic endpoints use arbitrary key formats (or none), so unlike the direct-provider keys there is no
+  ;; format validation.
+  :sensitive?  true
+  :visibility  :settings-manager
+  :export?     false
+  :doc         false
+  :setter      (partial set-trimmed-string! :llm-chat-completions-api-key))
+
 ;;; ----------------------------------------------- Amazon Bedrock ----------------------------------------------
 
 (defsetting llm-bedrock-access-key-id
@@ -196,14 +228,6 @@
   :export?     false
   :doc         false
   :setter      (partial set-trimmed-string! :llm-azure-api-key))
-
-(defn normalize-llm-base-url
-  "Trim whitespace and trailing slashes from an admin-entered LLM base URL; blank values become nil.
-  The URL is otherwise persisted exactly as entered — admin-entered URLs are not silently rewritten."
-  [value]
-  (some-> (trimmed-string value)
-          (str/replace #"/+$" "")
-          not-empty))
 
 (defsetting llm-azure-api-base-url
   (deferred-tru "The base URL of the Azure resource''s OpenAI- or Anthropic-compatible surface, e.g. https://<resource>.services.ai.azure.com/openai.")

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -655,6 +655,17 @@
    :base-url (or (llm.settings/normalize-llm-base-url base-url)
                  (llm.settings/normalize-llm-base-url (llm.settings/llm-azure-api-base-url)))})
 
+(defn- effective-chat-completions-credentials
+  "The generic Chat Completions credentials a settings request resolves to.
+
+  Non-blank request fields are layered over the saved `llm-chat-completions-*` settings, so e.g. a
+  key-only rotation keeps the saved base URL. Mirrors [[effective-azure-credentials]]."
+  [{:keys [api-key base-url]}]
+  {:api-key  (or (non-blank-string api-key)
+                 (non-blank-string (llm.settings/llm-chat-completions-api-key)))
+   :base-url (or (llm.settings/normalize-llm-base-url base-url)
+                 (llm.settings/normalize-llm-base-url (llm.settings/llm-chat-completions-api-base-url)))})
+
 (defn- request-credentials
   "The credentials override carried by a `PUT /api/metabot/settings` request body as a provider credentials map.
 
@@ -698,6 +709,20 @@
                                                         [:api-key :base-url]))})))
           creds)))
 
+    "chat-completions"
+    (when (contains? body :credentials)
+      (if (nil? credentials)
+        {:api-key  nil
+         :base-url nil}
+        (let [creds (effective-chat-completions-credentials credentials)]
+          (when-not (metabot.settings/provider-credentials-complete? provider creds)
+            (throw (ex-info (tru "Chat Completions credentials are incomplete.")
+                            {:status-code  400
+                             :api-error    true
+                             :missing-keys (vec (remove #(non-blank-string (get creds %))
+                                                        [:api-key :base-url]))})))
+          creds)))
+
     (when (contains? body :api-key)
       {:api-key (non-blank-string api-key)})))
 
@@ -730,13 +755,21 @@
   (setting/set! :llm-azure-api-key api-key)
   (setting/set! :llm-azure-api-base-url base-url))
 
+(defn- save-chat-completions-credentials!
+  "Persist a generic Chat Completions credentials map resolved by [[request-credentials]]; nil values clear those
+  settings."
+  [{:keys [api-key base-url]}]
+  (setting/set! :llm-chat-completions-api-key api-key)
+  (setting/set! :llm-chat-completions-api-base-url base-url))
+
 (defn- save-credentials!
   "Persist the credentials override resolved by [[request-credentials]]; nil leaves the saved settings untouched."
   [provider credentials]
   (when credentials
     (case provider
-      "bedrock" (save-bedrock-credentials! credentials)
-      "azure"   (save-azure-credentials! credentials)
+      "bedrock"          (save-bedrock-credentials! credentials)
+      "azure"            (save-azure-credentials! credentials)
+      "chat-completions" (save-chat-completions-credentials! credentials)
       (setting/set! (provider-api-key-setting-key provider) (:api-key credentials)))))
 
 (defn- credential-setting-keys
@@ -747,9 +780,10 @@
   is guarded only then; the other fields are always written."
   [provider credentials]
   (case provider
-    "bedrock" (cond-> [:llm-bedrock-access-key-id :llm-bedrock-secret-access-key :llm-bedrock-session-token]
-                (contains? credentials :region) (conj :llm-bedrock-region))
-    "azure"   [:llm-azure-api-key :llm-azure-api-base-url]
+    "bedrock"          (cond-> [:llm-bedrock-access-key-id :llm-bedrock-secret-access-key :llm-bedrock-session-token]
+                         (contains? credentials :region) (conj :llm-bedrock-region))
+    "azure"            [:llm-azure-api-key :llm-azure-api-base-url]
+    "chat-completions" [:llm-chat-completions-api-key :llm-chat-completions-api-base-url]
     [(provider-api-key-setting-key provider)]))
 
 (api.macros/defendpoint :put "/settings"

--- a/src/metabase/metabot/self.clj
+++ b/src/metabase/metabot/self.clj
@@ -19,6 +19,7 @@
    [metabase.metabot.self.claude :as claude]
    [metabase.metabot.self.core :as core]
    [metabase.metabot.self.openai :as openai]
+   [metabase.metabot.self.openai.chat-completions :as chat-completions]
    [metabase.metabot.self.openrouter :as openrouter]
    [metabase.metabot.usage :as usage]
    [metabase.util :as u]
@@ -30,22 +31,24 @@
 (defn- resolve-adapter [provider]
   ;; a `case` inside of function instead of a map so that with-redefs work well
   (case provider
-    "anthropic"  claude/claude
-    "azure"      azure/azure
-    "bedrock"    bedrock/bedrock
-    "openai"     openai/openai
-    "openrouter" openrouter/openrouter
+    "anthropic"        claude/claude
+    "azure"            azure/azure
+    "bedrock"          bedrock/bedrock
+    "chat-completions" chat-completions/chat-completions
+    "openai"           openai/openai
+    "openrouter"       openrouter/openrouter
     (throw (ex-info (str "Unknown LLM provider: " provider)
                     {:provider provider}))))
 
 (defn- resolve-model-lister [provider]
   ;; a `case` inside of function instead of a map so that with-redefs work well
   (case provider
-    "anthropic"  claude/list-models
-    "azure"      azure/list-models
-    "bedrock"    bedrock/list-models
-    "openai"     openai/list-models
-    "openrouter" openrouter/list-models
+    "anthropic"        claude/list-models
+    "azure"            azure/list-models
+    "bedrock"          bedrock/list-models
+    "chat-completions" chat-completions/list-models
+    "openai"           openai/list-models
+    "openrouter"       openrouter/list-models
     (throw (ex-info (str "Unknown LLM provider: " provider)
                     {:provider provider}))))
 

--- a/src/metabase/metabot/self/openai/chat_completions.clj
+++ b/src/metabase/metabot/self/openai/chat_completions.clj
@@ -1,0 +1,357 @@
+(ns metabase.metabot.self.openai.chat-completions
+  "Generic, provider-agnostic OpenAI Chat Completions adapter.
+
+  Speaks the OpenAI-compatible Chat Completions API against any endpoint the admin points
+  us at — vLLM, Ollama, LiteLLM, Together, Fireworks, Groq, a self-hosted gateway, etc.
+  Both the base URL and the model are admin-supplied (see `llm-chat-completions-*` settings);
+  there is no model whitelist and no provider-specific behavior.
+
+  Following the universal OpenAI-SDK convention, the configured base URL includes the API
+  version segment (e.g. `https://api.example.com/v1`); this adapter appends `/chat/completions`
+  and `/models` to it.
+
+  This deliberately carries *no* vendor-specific concerns: unlike
+  [[metabase.metabot.self.openrouter]] it never detects Anthropic models, never adds
+  `cache_control` breakpoints, and sends no OpenRouter routing headers. It is meant to
+  be the reusable core that the OpenRouter adapter can later be ported onto.
+
+  The agent loop produces AISDK parts as its canonical message format; this adapter
+  converts those directly to Chat Completions messages."
+  (:require
+   [clojure.string :as str]
+   [malli.json-schema :as mjs]
+   [metabase.llm.settings :as llm]
+   [metabase.metabot.self.core :as core]
+   [metabase.metabot.self.debug :as debug]
+   [metabase.metabot.self.schema :as schema]
+   [metabase.util :as u]
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.json :as json]
+   [metabase.util.log :as log]
+   [metabase.util.malli :as mu]
+   [metabase.util.o11y :refer [with-span]]))
+
+(set! *warn-on-reflection* true)
+
+(defn- usage->aisdk-usage
+  "Convert a Chat Completions `usage` block into the AISDK `:usage` shape.
+
+  The OpenAI-compatible `usage` reports `prompt_tokens` as the total input count, with
+  the cache buckets a subset breakdown of it under `prompt_tokens_details`. Endpoints
+  that don't report caching simply omit these, so they default to 0."
+  [u]
+  (let [details (:prompt_tokens_details u)]
+    {:promptTokens        (:prompt_tokens u 0)
+     :completionTokens    (:completion_tokens u 0)
+     :cacheCreationTokens (or (:cache_write_tokens details) 0)
+     :cacheReadTokens     (or (:cached_tokens details) 0)}))
+
+;;; AISDK parts → Chat Completions messages
+
+(defn- merge-consecutive-assistant-messages
+  "Merge consecutive assistant messages.
+
+  Chat Completions allows text + tool_calls on a single assistant message, so
+  when we see a :text part followed by :tool-input parts we fold them together."
+  [messages]
+  (into [] (comp (partition-by :role)
+                 (mapcat (fn [group]
+                           (if (and (< 1 (count group))
+                                    (= "assistant" (:role (first group))))
+                             (let [text       (->> group (keep :content) (str/join ""))
+                                   tool-calls (into [] (mapcat :tool_calls) group)]
+                               ;; :content should be always there, even if empty/nil
+                               [(cond-> {:role "assistant" :content text}
+                                  (seq tool-calls) (assoc :tool_calls tool-calls))])
+                             group))))
+        messages))
+
+(defn parts->cc-messages
+  "Convert a sequence of AISDK parts into Chat Completions messages.
+
+  Input: flat sequence of AISDK parts and user messages:
+    {:role :user, :content \"...\"}
+    {:type :text, :text \"...\"}
+    {:type :tool-input, :id ..., :function ..., :arguments ...}
+    {:type :tool-output, :id ..., :result ...}
+
+  Output: Chat Completions messages (user, assistant with tool_calls, tool)."
+  [parts]
+  (->> parts
+       (map (fn [part]
+              (case (:type part)
+                :text        {:role "assistant" :content (:text part)}
+                :tool-input  {:role       "assistant"
+                              :content    nil
+                              :tool_calls [{:id       (:id part)
+                                            :type     "function"
+                                            :function {:name      (:function part)
+                                                       :arguments (let [args (:arguments part)]
+                                                                    (if (string? args) args (json/encode (or args {}))))}}]}
+                :tool-output {:role         "tool"
+                              :tool_call_id (:id part)
+                              :content      (or (get-in part [:result :output])
+                                                (when-let [err (:error part)]
+                                                  (str "Error: " (:message err)))
+                                                (pr-str (:result part)))}
+                ;; User messages pass through
+                {:role    (name (or (:role part) "user"))
+                 :content (or (:content part) "")})))
+       merge-consecutive-assistant-messages))
+
+;;; Tool definition format
+
+(defn- tool->cc
+  "Convert a tool definition map to Chat Completions tool format.
+  Accepts a ToolEntry map with :tool-name, :doc, :schema, :fn."
+  [{:keys [tool-name doc schema]}]
+  (let [[_:=> [_:cat params] _out] schema
+        params     (schema/filter-schema-by-features params)
+        doc        (if (str/starts-with? (or doc "") "Inputs: ")
+                     (second (str/split doc #"\n\n  " 2))
+                     doc)]
+    {:type     "function"
+     :function {:name        tool-name
+                :description doc
+                :parameters  (mjs/transform params {:additionalProperties false})}}))
+
+;;; Auth / HTTP plumbing
+
+(defn- settings-credentials
+  "Chat Completions credentials from the `llm-chat-completions-*` settings."
+  []
+  {:api-key  (not-empty (llm/llm-chat-completions-api-key))
+   :base-url (not-empty (llm/llm-chat-completions-api-base-url))})
+
+(defn- ai-proxy-unsupported-ex []
+  (ex-info (tru "AI proxy is not supported for the Chat Completions provider")
+           {:api-error  true
+            :error-code :proxy-unsupported}))
+
+(defn- resolve-cc-auth
+  "Resolve the `{:url ... :headers ...}` auth map for a Chat Completions request.
+
+  Falls back to [[settings-credentials]] when `credentials` is nil. Throws when the base URL
+  or API key is missing. `:ai-proxy?` is not supported and throws when true (it is accepted
+  only for parity with the other adapters)."
+  [credentials ai-proxy?]
+  (when ai-proxy?
+    (throw (ai-proxy-unsupported-ex)))
+  (let [{:keys [api-key base-url]} (or credentials (settings-credentials))]
+    (when (str/blank? base-url)
+      (throw (ex-info (tru "No Chat Completions base URL is set")
+                      {:api-error  true
+                       :error-code :api-key-missing})))
+    (core/resolve-auth "chat-completions" "Chat Completions"
+                       (when-not (str/blank? api-key)
+                         {:url     base-url
+                          :headers {"Authorization" (str "Bearer " api-key)}})
+                       ai-proxy?)))
+
+(defn- error-msg
+  "Canonical, status-specific Chat Completions error message."
+  [res]
+  (let [status (long (:status res 0))]
+    (case status
+      401 (tru "Chat Completions API key expired or invalid")
+      403 (tru "Chat Completions API key has insufficient permissions")
+      404 (tru "Chat Completions endpoint was not found — check the base URL")
+      429 (tru "Chat Completions endpoint has rate limited us")
+      500 (tru "Chat Completions endpoint returned an internal server error")
+      502 (tru "Chat Completions upstream provider returned an error")
+      503 (tru "Chat Completions endpoint is unavailable")
+      (tru "Chat Completions API error (HTTP {0})" status))))
+
+(defn list-models
+  "List the models advertised by the configured Chat Completions endpoint (`GET /v1/models`).
+
+  Doubles as the connect-time credential check: a successful round trip proves the base URL and
+  API key reach an authenticated OpenAI-compatible surface. No-arg uses the configured settings.
+  Opts map supports `:credentials` (`{:api-key ... :base-url ...}`) and `:ai-proxy?`;
+  `:ai-proxy?` is not supported and throws when true."
+  ([] (list-models {}))
+  ([{:keys [credentials ai-proxy?]}]
+   (try
+     (let [auth (resolve-cc-auth credentials ai-proxy?)
+           res  (core/request auth {:method  :get
+                                    :url     "/models"
+                                    :as      :json
+                                    :headers {"Content-Type" "application/json"}})]
+       {:models (->> (get-in res [:body :data])
+                     (keep :id)
+                     sort
+                     (mapv (fn [id] {:id id :display_name id})))})
+     (catch Exception e
+       (core/rethrow-api-error! "chat-completions" error-msg e)))))
+
+;;; Streaming response → AISDK v5 chunks
+
+(defn cc->aisdk-chunks-xf
+  "Translates Chat Completions streaming chunks into AI SDK v5 protocol chunks.
+
+  Chat Completions streaming format:
+    {\"id\":\"chatcmpl-xxx\",
+     \"object\":\"chat.completion.chunk\",
+     \"model\":\"...\",
+     \"choices\":[{\"index\":0,
+                   \"delta\":{\"role\":\"assistant\",\"content\":\"Hello\"},
+                   \"finish_reason\":null}],
+     \"usage\":{...}}
+
+  Emits the same internal chunk types as claude.clj and openai.clj:
+    :start, :text-start, :text-delta, :text-end,
+    :tool-input-start, :tool-input-delta, :tool-input-available,
+    :usage
+
+  Chat Completions has no explicit start/stop events per content block like
+  Claude or OpenAI Responses do — we infer transitions from the delta shape.
+  Parallel tool calls arrive with different `index` values; when a new index
+  appears the previous tool is complete."
+  []
+  (fn [rf]
+    (let [current-type (volatile! nil) ;; :text | :function_call | nil
+          current-id   (volatile! nil) ;; active chunk id (text-id or tool call_id)
+          message-id   (volatile! nil)
+          model-name   (volatile! nil)
+          payload      (volatile! {})  ;; carried across start/delta/end, same as openai.clj
+          close!       (fn [result]
+                         (u/prog1 (rf result (merge {:type (case @current-type
+                                                             :text          :text-end
+                                                             :function_call :tool-input-available)}
+                                                    @payload))
+                           (vreset! current-type nil)
+                           (vreset! current-id nil)
+                           (vreset! payload {})))]
+      (fn
+        ([result]
+         (cond-> result
+           @current-type (close!)
+           true          (rf)))
+
+        ([result {:keys [id model choices usage] :as _chunk}]
+         (let [choice        (first choices)
+               delta         (:delta choice)
+               finish-reason (:finish_reason choice)
+               tool-call     (first (:tool_calls delta))
+               ;; Determine what kind of content this chunk carries.
+               ;; Empty-string content (common between tool calls) is ignored
+               ;; to avoid spurious text blocks that would close open tools.
+               chunk-type    (cond
+                               (not-empty (:content delta)) :text
+                               (some? tool-call)            :function_call
+                               :else                        nil)
+               ;; For new tool calls, the id comes from the chunk; for deltas
+               ;; on the same tool, we keep current-id.
+               chunk-id      (or (:id tool-call) @current-id (core/mkid))]
+           (cond-> result
+             ;; Emit :start on first chunk
+             (and id (not @message-id))                       (-> (rf {:type :start :messageId id})
+                                                                  (u/prog1
+                                                                    (vreset! message-id id)
+                                                                    (vreset! model-name model)))
+             ;; Close previous block when type changes, or when a new tool
+             ;; call arrives (different id = different tool in parallel)
+             (and @current-type
+                  (or (and chunk-type
+                           (not= chunk-type @current-type))
+                      (and (= chunk-type :function_call)
+                           (not= chunk-id @current-id))))     (close!)
+             ;; Start a new text block
+             (and (= chunk-type :text)
+                  (not= @current-type :text))                 (-> (u/prog1
+                                                                    (let [tid (core/mkid)]
+                                                                      (vreset! current-type :text)
+                                                                      (vreset! current-id tid)
+                                                                      (vreset! payload {:id tid})))
+                                                                  (rf (merge {:type :text-start} @payload)))
+             ;; Text delta
+             (and (= chunk-type :text)
+                  (some? (:content delta)))                   (rf {:type  :text-delta
+                                                                   :id    @current-id
+                                                                   :delta (:content delta)})
+             ;; Start a new tool call block
+             (and (= chunk-type :function_call)
+                  (:id tool-call)
+                  (:name (:function tool-call)))              (-> (u/prog1
+                                                                    (vreset! current-type :function_call)
+                                                                    (vreset! current-id (:id tool-call))
+                                                                    (vreset! payload {:toolCallId (:id tool-call)
+                                                                                      :toolName   (:name (:function tool-call))}))
+                                                                  (rf (merge {:type :tool-input-start} @payload))
+                                                                  ;; Emit initial arguments if present
+                                                                  (cond-> (not (str/blank? (:arguments (:function tool-call))))
+                                                                    (rf {:type           :tool-input-delta
+                                                                         :toolCallId     (:id tool-call)
+                                                                         :inputTextDelta (:arguments (:function tool-call))})))
+             ;; Tool argument delta (continuation of existing tool call)
+             (and (= chunk-type :function_call)
+                  (not (:id tool-call))
+                  (some? (:arguments (:function tool-call)))) (rf {:type           :tool-input-delta
+                                                                   :toolCallId     (:toolCallId @payload)
+                                                                   :inputTextDelta (:arguments (:function tool-call))})
+             ;; Finish reason — close whatever is open
+             (some? finish-reason)                            (cond->
+                                                               @current-type (close!))
+             ;; Usage (often on a separate final chunk with empty choices)
+             (some? usage)                                    (rf {:type  :usage
+                                                                   :usage (usage->aisdk-usage usage)
+                                                                   :id    @message-id
+                                                                   :model @model-name}))))))))
+
+;;; HTTP request
+
+(mu/defn chat-completions-request-body
+  "Build the Chat Completions request body for an LLM request."
+  [{:keys [model system input tools temperature max-tokens tool_choice schema]} :- core/LLMRequestOpts]
+  (let [messages  (cond-> (parts->cc-messages input)
+                    system (as-> msgs (into [{:role "system" :content system}] msgs)))
+        all-tools (or (when schema
+                        ;; Structured output: force a tool call with the given JSON schema
+                        [{:type     "function"
+                          :function {:name        "structured_output"
+                                     :description "Output structured data"
+                                     :parameters  schema}}])
+                      (seq (mapv tool->cc tools)))]
+    (cond-> {:model          model
+             :stream         true
+             :stream_options {:include_usage true}
+             :messages       messages}
+      all-tools   (assoc :tools       (vec all-tools)
+                         :tool_choice (cond
+                                        schema      "required"
+                                        tool_choice tool_choice
+                                        :else       "auto"))
+      temperature (assoc :temperature temperature)
+      max-tokens  (assoc :max_tokens max-tokens))))
+
+(mu/defn chat-completions-raw
+  "Perform a streaming request to the Chat Completions API.
+  `:ai-proxy?` is not supported and throws when true."
+  [{:keys [model tools credentials ai-proxy?] :as opts} :- core/LLMRequestOpts]
+  (let [req (chat-completions-request-body opts)]
+    (log/debug "Chat Completions request" {:model model :msg-count (count (:messages req)) :tools (count (or tools []))})
+    (with-span :info {:name       :metabot.chat-completions/request
+                      :model      model
+                      :msg-count  (count (:messages req))
+                      :tool-count (count (or tools []))}
+      (try
+        (let [auth     (resolve-cc-auth credentials ai-proxy?)
+              response (core/request auth
+                                     {:method  :post
+                                      :url     "/chat/completions"
+                                      :as      :stream
+                                      :headers {"Content-Type" "application/json"}
+                                      :body    (json/encode req)})]
+          (-> (core/sse-reducible (:body response))
+              (debug/capture-stream {:provider "chat-completions"
+                                     :model    model
+                                     :url      "/chat/completions"
+                                     :request  req})))
+        (catch Exception e
+          (core/rethrow-api-error! "chat-completions" error-msg e))))))
+
+(defn chat-completions
+  "Call a generic Chat Completions API, return AISDK stream."
+  [& args]
+  (let [raw (apply chat-completions-raw args)]
+    (eduction (cc->aisdk-chunks-xf) raw)))

--- a/src/metabase/metabot/self/openai/chat_completions.clj
+++ b/src/metabase/metabot/self/openai/chat_completions.clj
@@ -332,7 +332,7 @@
                                         tool_choice tool_choice
                                         :else       "auto"))
       temperature (assoc :temperature temperature)
-      max-tokens  (assoc :max_tokens max-tokens))))
+      max-tokens  (assoc :max_completion_tokens max-tokens))))
 
 (mu/defn chat-completions-raw
   "Perform a streaming request to the Chat Completions API.

--- a/src/metabase/metabot/self/openai/chat_completions.clj
+++ b/src/metabase/metabot/self/openai/chat_completions.clj
@@ -214,6 +214,14 @@
           message-id   (volatile! nil)
           model-name   (volatile! nil)
           payload      (volatile! {})  ;; carried across start/delta/end, same as openai.clj
+          ;; Latest-wins usage buffer. The OpenAI spec sends usage once, on a final content-free
+          ;; chunk; but some OpenAI-compatible endpoints (e.g. Gemini's compat layer) attach usage
+          ;; to *every* chunk, including the one carrying a tool call. Emitting usage inline there
+          ;; would interleave a self-contained :usage chunk between a tool call's :tool-input-delta
+          ;; and its closing :tool-input-available, which the downstream aisdk grouping then splits
+          ;; into an orphan tool block. So we buffer it and emit exactly one :usage at stream end,
+          ;; after any open block is closed — matching claude.clj/openai.clj, which also emit usage once.
+          usage-acc    (volatile! nil)
           close!       (fn [result]
                          (u/prog1 (rf result (merge {:type (case @current-type
                                                              :text          :text-end
@@ -224,11 +232,18 @@
                            (vreset! payload {})))]
       (fn
         ([result]
-         (cond-> result
-           @current-type (close!)
-           true          (rf)))
+         (-> result
+             (cond-> @current-type (close!))
+             (cond-> @usage-acc (rf {:type  :usage
+                                     :usage @usage-acc
+                                     :id    @message-id
+                                     :model @model-name}))
+             (rf)))
 
         ([result {:keys [id model choices usage] :as _chunk}]
+         ;; Buffer usage (last-wins); it is emitted once at stream completion. See usage-acc above.
+         (when (some? usage)
+           (vreset! usage-acc (usage->aisdk-usage usage)))
          (let [choice        (first choices)
                delta         (:delta choice)
                finish-reason (:finish_reason choice)
@@ -291,12 +306,7 @@
                                                                    :inputTextDelta (:arguments (:function tool-call))})
              ;; Finish reason — close whatever is open
              (some? finish-reason)                            (cond->
-                                                               @current-type (close!))
-             ;; Usage (often on a separate final chunk with empty choices)
-             (some? usage)                                    (rf {:type  :usage
-                                                                   :usage (usage->aisdk-usage usage)
-                                                                   :id    @message-id
-                                                                   :model @model-name}))))))))
+                                                               @current-type (close!)))))))))
 
 ;;; HTTP request
 

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -104,7 +104,7 @@
 
 (def ^:private direct-providers
   "Providers that can be used directly (not via the metabase/ proxy prefix)."
-  #{"anthropic" "azure" "bedrock" "openai" "openrouter"})
+  #{"anthropic" "azure" "bedrock" "chat-completions" "openai" "openrouter"})
 
 (def ^:private default-anthropic-llm-metabot-model
   "Default Anthropic model used for Metabot when no explicit model is selected."
@@ -288,31 +288,36 @@
   API key and base URL are set; Bedrock only when both the access key ID and secret access key are set."
   [provider]
   (case provider
-    "anthropic"  (configured-api-key-credentials (llm.settings/llm-anthropic-api-key))
-    "azure"      (let [api-key  (non-blank (llm.settings/llm-azure-api-key))
-                       base-url (non-blank (llm.settings/llm-azure-api-base-url))]
-                   (when (and api-key base-url)
-                     {:api-key api-key :base-url base-url}))
-    "bedrock"    (when (llm.settings/llm-bedrock-configured?)
-                   {:access-key-id     (non-blank (llm.settings/llm-bedrock-access-key-id))
-                    :secret-access-key (non-blank (llm.settings/llm-bedrock-secret-access-key))
-                    :session-token     (non-blank (llm.settings/llm-bedrock-session-token))
-                    :region            (non-blank (llm.settings/llm-bedrock-region))})
-    "openai"     (configured-api-key-credentials (llm.settings/llm-openai-api-key))
-    "openrouter" (configured-api-key-credentials (llm.settings/llm-openrouter-api-key))
+    "anthropic"        (configured-api-key-credentials (llm.settings/llm-anthropic-api-key))
+    "azure"            (let [api-key  (non-blank (llm.settings/llm-azure-api-key))
+                             base-url (non-blank (llm.settings/llm-azure-api-base-url))]
+                         (when (and api-key base-url)
+                           {:api-key api-key :base-url base-url}))
+    "chat-completions" (let [api-key  (non-blank (llm.settings/llm-chat-completions-api-key))
+                             base-url (non-blank (llm.settings/llm-chat-completions-api-base-url))]
+                         (when (and api-key base-url)
+                           {:api-key api-key :base-url base-url}))
+    "bedrock"          (when (llm.settings/llm-bedrock-configured?)
+                         {:access-key-id     (non-blank (llm.settings/llm-bedrock-access-key-id))
+                          :secret-access-key (non-blank (llm.settings/llm-bedrock-secret-access-key))
+                          :session-token     (non-blank (llm.settings/llm-bedrock-session-token))
+                          :region            (non-blank (llm.settings/llm-bedrock-region))})
+    "openai"           (configured-api-key-credentials (llm.settings/llm-openai-api-key))
+    "openrouter"       (configured-api-key-credentials (llm.settings/llm-openrouter-api-key))
     nil))
 
 (defn provider-credentials-complete?
   "Whether a credentials map carries everything `provider` needs to make requests: both the AWS access key ID and
-  secret access key for Bedrock, both the API key and base URL for Azure, an `:api-key` for the other direct
-  providers."
+  secret access key for Bedrock, both the API key and base URL for Azure and the generic Chat Completions provider,
+  an `:api-key` for the other direct providers."
   [provider credentials]
   (boolean
    (case provider
-     "bedrock" (and (non-blank (:access-key-id credentials))
-                    (non-blank (:secret-access-key credentials)))
-     "azure"   (and (non-blank (:api-key credentials))
-                    (non-blank (:base-url credentials)))
+     "bedrock"          (and (non-blank (:access-key-id credentials))
+                             (non-blank (:secret-access-key credentials)))
+     ("azure"
+      "chat-completions") (and (non-blank (:api-key credentials))
+                               (non-blank (:base-url credentials)))
      (non-blank (:api-key credentials)))))
 
 (defn- llm-provider-configured?

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -2167,3 +2167,90 @@
         (is (= {:value  "azure/anthropic/claude-sonnet-4-5"
                 :models []}
                (mt/user-http-request :crowberto :get 200 "metabot/settings" :provider "azure")))))))
+
+;;; ------------------------------------------- chat-completions settings PUT/GET -------------------------------
+
+(deftest settings-put-saves-chat-completions-credentials-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider              nil
+                                mb-llm-chat-completions-api-key      nil
+                                mb-llm-chat-completions-api-base-url nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-chat-completions-api-key      nil
+                                       llm.settings/llm-chat-completions-api-base-url nil
+                                       metabot.settings/llm-metabot-provider          "anthropic/claude-sonnet-4-6"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [credentials]}]
+                                                             (is (= "chat-completions" provider))
+                                                             (is (= {:api-key  "secret-key"
+                                                                     :base-url "https://api.example.com/v1"}
+                                                                    credentials)
+                                                                 "validation runs against the normalized request credentials")
+                                                             (is (nil? (llm.settings/llm-chat-completions-api-key))
+                                                                 "validation should happen before saving the credentials")
+                                                             {:models []})]
+        (testing "connecting chat-completions saves the credentials and the composed provider/model value"
+          (is (=? {:value  "chat-completions/my-model"
+                   :models []}
+                  (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                        {:provider    "chat-completions"
+                                         :model       "my-model"
+                                         :credentials {:api-key  "secret-key"
+                                                       :base-url "https://api.example.com/v1/"}}))))
+        (is (= "secret-key" (llm.settings/llm-chat-completions-api-key)))
+        (testing "the trailing slash is trimmed before persisting"
+          (is (= "https://api.example.com/v1"
+                 (llm.settings/llm-chat-completions-api-base-url))))))))
+
+(deftest settings-put-chat-completions-rejects-incomplete-credentials-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider              nil
+                                mb-llm-chat-completions-api-key      nil
+                                mb-llm-chat-completions-api-base-url nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-chat-completions-api-key      nil
+                                       llm.settings/llm-chat-completions-api-base-url nil
+                                       metabot.settings/llm-metabot-provider          "anthropic/claude-sonnet-4-6"]
+      (testing "credentials missing the base URL fail before validation and nothing is saved"
+        (is (=? {:message      "Chat Completions credentials are incomplete."
+                 :missing-keys ["base-url"]}
+                (mt/user-http-request :crowberto :put 400 "metabot/settings"
+                                      {:provider    "chat-completions"
+                                       :model       "my-model"
+                                       :credentials {:api-key "secret-key"}})))
+        (is (nil? (llm.settings/llm-chat-completions-api-key)))
+        (is (= "anthropic/claude-sonnet-4-6" (metabot.settings/llm-metabot-provider)))))))
+
+(deftest settings-put-chat-completions-key-rotation-uses-saved-base-url-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider              nil
+                                mb-llm-chat-completions-api-key      nil
+                                mb-llm-chat-completions-api-base-url nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-chat-completions-api-key      "old-key"
+                                       llm.settings/llm-chat-completions-api-base-url "https://api.example.com/v1"
+                                       metabot.settings/llm-metabot-provider          "chat-completions/my-model"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [_provider {:keys [credentials]}]
+                                                             (is (= {:api-key  "new-key"
+                                                                     :base-url "https://api.example.com/v1"}
+                                                                    credentials)
+                                                                 "the new key is layered over the saved base URL")
+                                                             {:models []})]
+        (is (=? {:value "chat-completions/my-model"}
+                (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                      {:provider    "chat-completions"
+                                       :credentials {:api-key "new-key"}})))
+        (is (= "new-key" (llm.settings/llm-chat-completions-api-key)))
+        (is (= "https://api.example.com/v1"
+               (llm.settings/llm-chat-completions-api-base-url)))))))
+
+(deftest settings-put-nil-chat-completions-credentials-clears-saved-credentials-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider              nil
+                                mb-llm-chat-completions-api-key      nil
+                                mb-llm-chat-completions-api-base-url nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-chat-completions-api-key      "secret-key"
+                                       llm.settings/llm-chat-completions-api-base-url "https://api.example.com/v1"
+                                       metabot.settings/llm-metabot-provider          "chat-completions/my-model"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider _opts]
+                                                             (is false (str "unexpected list-models call: " provider)))]
+        (testing "an explicit nil credentials clears both saved settings without validating against them"
+          (is (=? {:value  "chat-completions/my-model"
+                   :models []}
+                  (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                        {:provider    "chat-completions"
+                                         :credentials nil})))
+          (is (nil? (llm.settings/llm-chat-completions-api-key)))
+          (is (nil? (llm.settings/llm-chat-completions-api-base-url))))))))

--- a/test/metabase/metabot/self/openai/chat_completions_test.clj
+++ b/test/metabase/metabot/self/openai/chat_completions_test.clj
@@ -152,6 +152,47 @@
               :cacheReadTokens     4200}
              (:usage usage))))))
 
+(deftest ^:parallel usage-emitted-once-at-stream-end-test
+  (testing "usage is buffered (last-wins) and emitted exactly once at stream completion, after content —
+            even when the endpoint repeats usage on every chunk (the OpenAI spec sends it once on a final
+            content-free chunk, but some compatible endpoints attach it to content chunks)"
+    (let [chunks [{:id "m" :model "mdl" :choices [{:delta {:role "assistant" :content "Hi"}}]
+                   :usage {:prompt_tokens 10 :completion_tokens 1 :total_tokens 11}}
+                  {:choices [{:delta {:content " there"} :finish_reason "stop"}]
+                   :usage {:prompt_tokens 10 :completion_tokens 2 :total_tokens 12}}]
+          out   (into [] (cc/cc->aisdk-chunks-xf) chunks)
+          usages (filterv #(= :usage (:type %)) out)]
+      (is (= :usage (:type (last out)))
+          "the single usage part is emitted last, after the text block closes")
+      (is (= 1 (count usages)) "exactly one usage part despite usage on every chunk")
+      (is (= {:promptTokens 10 :completionTokens 2 :cacheCreationTokens 0 :cacheReadTokens 0}
+             (:usage (first usages)))
+          "last-wins: the final chunk's completion count is reported"))))
+
+(deftest ^:parallel usage-on-tool-call-chunk-does-not-orphan-tool-test
+  (testing "an endpoint that attaches usage to the tool-call chunk (Gemini's OpenAI-compat shape: whole tool
+            call in one delta, usage on that chunk, finish_reason on a later empty chunk) streams through the
+            full pipeline without crashing, and the tool call is captured with parsed arguments"
+    ;; Regression for `No matching clause: :tool-input-available` — inline usage used to split the tool group
+    ;; and orphan the closing :tool-input-available.
+    (let [chunks [{:id "m1" :model "gemini-3.5-flash"
+                   :choices [{:index 0 :delta {:role "assistant"
+                                               :tool_calls [{:id "call_1" :type "function"
+                                                             :function {:name "structured_output" :arguments "{\"x\":1}"}}]}}]
+                   :usage {:prompt_tokens 49 :completion_tokens 14 :total_tokens 167}}
+                  {:id "m1" :model "gemini-3.5-flash"
+                   :choices [{:index 0 :delta {:role "assistant"} :finish_reason "stop"}]
+                   :usage {:prompt_tokens 49 :completion_tokens 14 :total_tokens 167}}]]
+      (is (=? [{:type :start}
+               {:type      :tool-input
+                :id        "call_1"
+                :function  "structured_output"
+                :arguments {:x 1}}
+               {:type  :usage
+                :model "gemini-3.5-flash"
+                :usage {:promptTokens 49 :completionTokens 14}}]
+              (into [] (comp (cc/cc->aisdk-chunks-xf) (self.core/aisdk-xf)) chunks))))))
+
 ;;; ──────────────────────────────────────────────────────────────────
 ;;; Auth / HTTP tests
 ;;; ──────────────────────────────────────────────────────────────────

--- a/test/metabase/metabot/self/openai/chat_completions_test.clj
+++ b/test/metabase/metabot/self/openai/chat_completions_test.clj
@@ -103,6 +103,19 @@
                                          :parameters {:type "object"}}}]}
               body)))))
 
+(deftest ^:parallel request-body-max-tokens-uses-max-completion-tokens-test
+  (testing "the token limit is sent as :max_completion_tokens (OpenAI deprecated :max_tokens); :max_tokens is not sent"
+    (let [body (cc/chat-completions-request-body
+                {:model      "my-model"
+                 :input      [{:role :user :content "hi"}]
+                 :max-tokens 256})]
+      (is (= 256 (:max_completion_tokens body)))
+      (is (not (contains? body :max_tokens)))))
+  (testing "no token-limit key is sent when :max-tokens is absent"
+    (let [body (cc/chat-completions-request-body {:model "my-model" :input [{:role :user :content "hi"}]})]
+      (is (not (contains? body :max_completion_tokens)))
+      (is (not (contains? body :max_tokens))))))
+
 ;;; ──────────────────────────────────────────────────────────────────
 ;;; Streaming chunk conversion tests (synthetic chunks — no live API)
 ;;; ──────────────────────────────────────────────────────────────────

--- a/test/metabase/metabot/self/openai/chat_completions_test.clj
+++ b/test/metabase/metabot/self/openai/chat_completions_test.clj
@@ -1,0 +1,227 @@
+(ns metabase.metabot.self.openai.chat-completions-test
+  (:require
+   [clj-http.client :as http]
+   [clojure.test :refer :all]
+   [medley.core :as m]
+   [metabase.llm.settings :as llm.settings]
+   [metabase.metabot.self.core :as self.core]
+   [metabase.metabot.self.debug :as debug]
+   [metabase.metabot.self.openai.chat-completions :as cc]
+   [metabase.test :as mt]))
+
+(set! *warn-on-reflection* true)
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; parts->cc-messages tests
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest ^:parallel parts->cc-messages-plain-text-test
+  (testing "plain user and assistant text"
+    (is (=? [{:role "user" :content "Hello"}
+             {:role "assistant" :content "Hi there!"}]
+            (cc/parts->cc-messages
+             [{:role :user :content "Hello"}
+              {:type :text :text "Hi there!"}])))))
+
+(deftest ^:parallel parts->cc-messages-tool-call-test
+  (testing "text + tool call merges into single assistant message"
+    (is (=? [{:role       "assistant"
+              :content    "Let me check..."
+              :tool_calls [{:id       "call-1"
+                            :type     "function"
+                            :function {:name "search"}}]}]
+            (cc/parts->cc-messages
+             [{:type :text :text "Let me check..."}
+              {:type :tool-input :id "call-1" :function "search" :arguments {:query "revenue"}}])))))
+
+(deftest ^:parallel parts->cc-messages-tool-result-test
+  (testing "tool output becomes tool role message"
+    (is (=? [{:role         "tool"
+              :tool_call_id "call-1"
+              :content      "Found 42 results"}]
+            (cc/parts->cc-messages
+             [{:type :tool-output :id "call-1" :result {:output "Found 42 results"}}])))))
+
+(deftest ^:parallel parts->cc-messages-nil-arguments-test
+  (testing "tool call with nil arguments defaults to empty object JSON string"
+    (is (=? [{:role       "assistant"
+              :content    nil
+              :tool_calls [{:id       "call-1"
+                            :type     "function"
+                            :function {:name      "todo_read"
+                                       :arguments "{}"}}]}]
+            (cc/parts->cc-messages
+             [{:type :tool-input :id "call-1" :function "todo_read" :arguments nil}])))))
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; request-body tests — no vendor-specific concerns
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest ^:parallel request-body-plain-string-system-test
+  (testing "the system prompt is a plain string, with no cache_control markup for any model"
+    (doseq [model ["anthropic/claude-haiku-4.5" "openai/gpt-5.4" "llama-3.3-70b"]]
+      (let [body (cc/chat-completions-request-body
+                  {:model  model
+                   :system "You are a helpful assistant."
+                   :input  [{:role :user :content "hi"}]})]
+        (is (= {:role "system" :content "You are a helpful assistant."}
+               (-> body :messages first))
+            (str "model " model " should get a plain-string system message"))))))
+
+(deftest ^:parallel request-body-no-system-message-test
+  (testing "no system message is added when system is not provided"
+    (let [body (cc/chat-completions-request-body
+                {:model "my-model"
+                 :input [{:role :user :content "hi"}]})]
+      (is (= ["user"] (map :role (:messages body)))))))
+
+(deftest ^:parallel request-body-tools-test
+  (testing "tools are converted to the Chat Completions function shape with auto tool_choice"
+    (let [body (cc/chat-completions-request-body
+                {:model "my-model"
+                 :input [{:role :user :content "hi"}]
+                 :tools [{:tool-name "get_weather"
+                          :doc       "Get the weather."
+                          :schema    [:=> [:cat [:map [:city :string]]] :any]
+                          :fn        identity}]})]
+      (is (=? {:tool_choice "auto"
+               :tools       [{:type     "function"
+                              :function {:name        "get_weather"
+                                         :description "Get the weather."
+                                         :parameters  {:type "object"}}}]}
+              body)))))
+
+(deftest ^:parallel request-body-structured-output-test
+  (testing "a :schema forces a structured_output tool call"
+    (let [body (cc/chat-completions-request-body
+                {:model  "my-model"
+                 :input  [{:role :user :content "hi"}]
+                 :schema {:type "object" :properties {:sql {:type "string"}}}})]
+      (is (=? {:tool_choice "required"
+               :tools       [{:type     "function"
+                              :function {:name       "structured_output"
+                                         :parameters {:type "object"}}}]}
+              body)))))
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; Streaming chunk conversion tests (synthetic chunks — no live API)
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest ^:parallel text-conv-test
+  (testing "text streaming chunks are mapped correctly through the full pipeline"
+    (let [chunks [{:id "cc-1" :model "m" :choices [{:delta {:role "assistant" :content "Hel"}}]}
+                  {:choices [{:delta {:content "lo"}}]}
+                  {:choices [{:delta {} :finish_reason "stop"}]}
+                  {:choices [] :usage {:prompt_tokens 5 :completion_tokens 2 :total_tokens 7}}]]
+      (is (=? [{:type :start} {:type :text-start} {:type :text-delta} {:type :text-end} {:type :usage}]
+              (into [] (comp (cc/cc->aisdk-chunks-xf) (m/distinct-by :type)) chunks)))
+      (is (=? [{:type :start}
+               {:type :text :text "Hello"}
+               {:type :usage :model "m" :usage {:promptTokens 5 :completionTokens 2}}]
+              (into [] (comp (cc/cc->aisdk-chunks-xf) (self.core/aisdk-xf)) chunks))))))
+
+(deftest ^:parallel tool-call-conv-test
+  (testing "a streamed tool call is mapped to a tool-input part"
+    (let [chunks [{:id "cc-2" :model "m"
+                   :choices [{:delta {:tool_calls [{:id "call-1" :function {:name "get_time" :arguments ""}}]}}]}
+                  {:choices [{:delta {:tool_calls [{:function {:arguments "{\"tz\":\"UTC\"}"}}]}}]}
+                  {:choices [{:delta {} :finish_reason "tool_calls"}]}
+                  {:choices [] :usage {:prompt_tokens 8 :completion_tokens 4 :total_tokens 12}}]]
+      (is (=? [{:type :start}
+               {:type      :tool-input
+                :id        "call-1"
+                :function  "get_time"
+                :arguments {:tz "UTC"}}
+               {:type :usage :usage {:promptTokens 8 :completionTokens 4}}]
+              (into [] (comp (cc/cc->aisdk-chunks-xf) (self.core/aisdk-xf)) chunks))))))
+
+(deftest ^:parallel usage-cache-tokens-test
+  (testing "cache read/write counts are extracted from prompt_tokens_details, missing fields default to 0"
+    (let [chunks [{:id "cc-3" :model "m" :choices [{:delta {:role "assistant" :content "Hi"}}]}
+                  {:choices [{:delta {} :finish_reason "stop"}]}
+                  {:choices [] :usage {:prompt_tokens         5000
+                                       :completion_tokens     7
+                                       :total_tokens          5007
+                                       :prompt_tokens_details {:cached_tokens 4200 :cache_write_tokens 250}}}]
+          usage  (->> (into [] (cc/cc->aisdk-chunks-xf) chunks)
+                      (filter #(= :usage (:type %)))
+                      first)]
+      (is (= {:promptTokens        5000
+              :completionTokens    7
+              :cacheCreationTokens 250
+              :cacheReadTokens     4200}
+             (:usage usage))))))
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; Auth / HTTP tests
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest chat-completions-raw-uses-configured-settings-test
+  (testing "the base URL and API key from settings drive the request"
+    (mt/with-temporary-setting-values [llm.settings/llm-chat-completions-api-base-url "https://api.example.com/v1"
+                                       llm.settings/llm-chat-completions-api-key      "secret-key"]
+      (with-redefs [self.core/sse-reducible identity
+                    debug/capture-stream    (fn [r _] r)
+                    http/request            (fn [req] {:body req})]
+        (is (=? {:method  :post
+                 :url     "https://api.example.com/v1/chat/completions"
+                 :headers {"Authorization" "Bearer secret-key"}
+                 :body    string?}
+                (cc/chat-completions-raw {:model "m" :input [{:role :user :content "hi"}]})))))))
+
+(deftest chat-completions-raw-missing-base-url-test
+  (testing "a missing base URL throws before any HTTP call"
+    (mt/with-temporary-setting-values [llm.settings/llm-chat-completions-api-base-url nil
+                                       llm.settings/llm-chat-completions-api-key      "secret-key"]
+      (with-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"No Chat Completions base URL is set"
+             (cc/chat-completions-raw {:model "m" :input [{:role :user :content "hi"}]})))))))
+
+(deftest chat-completions-raw-ai-proxy-unsupported-test
+  (testing "ai-proxy? throws before credentials are even consulted"
+    (with-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"AI proxy is not supported for the Chat Completions provider"
+           (cc/chat-completions-raw {:model "m" :input [{:role :user :content "hi"}] :ai-proxy? true}))))))
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; list-models tests
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest list-models-returns-full-catalog-test
+  (testing "list-models returns the endpoint's whole catalog, id-sorted, id as display name (no whitelist)"
+    (mt/with-temporary-setting-values [llm.settings/llm-chat-completions-api-base-url "https://api.example.com/v1"
+                                       llm.settings/llm-chat-completions-api-key      "secret-key"]
+      (with-redefs [http/request (fn [req]
+                                   (is (=? {:method  :get
+                                            :url     "https://api.example.com/v1/models"
+                                            :headers {"Authorization" "Bearer secret-key"}}
+                                           req))
+                                   {:status 200 :body {:data [{:id "zeta"} {:id "alpha"} {:id "beta"}]}})]
+        (is (= {:models [{:id "alpha" :display_name "alpha"}
+                         {:id "beta"  :display_name "beta"}
+                         {:id "zeta"  :display_name "zeta"}]}
+               (cc/list-models)))))))
+
+(deftest list-models-explicit-credentials-test
+  (testing "credentials in opts override the configured settings"
+    (mt/with-temporary-setting-values [llm.settings/llm-chat-completions-api-base-url "https://saved.example/v1"
+                                       llm.settings/llm-chat-completions-api-key      "saved-key"]
+      (mt/with-dynamic-fn-redefs [http/request (fn [req]
+                                                 (is (=? {:url     "https://override.example/v1/models"
+                                                          :headers {"Authorization" "Bearer override-key"}}
+                                                         req))
+                                                 {:status 200 :body {:data []}})]
+        (is (= {:models []}
+               (cc/list-models {:credentials {:api-key "override-key" :base-url "https://override.example/v1"}})))))))
+
+(deftest list-models-ai-proxy-unsupported-test
+  (testing "ai-proxy? throws before credentials are even consulted"
+    (with-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"AI proxy is not supported for the Chat Completions provider"
+           (cc/list-models {:ai-proxy? true}))))))

--- a/test/metabase/metabot/settings_test.clj
+++ b/test/metabase/metabot/settings_test.clj
@@ -341,6 +341,53 @@
                  {:base-url "https://my-resource.services.ai.azure.com/openai"})))
     (is (false? (metabot.settings/provider-credentials-complete? "azure" nil)))))
 
+(deftest validate-metabot-provider-accepts-valid-direct-chat-completions-test
+  (testing "accepts chat-completions provider strings with a free-text model name"
+    (mt/with-temporary-setting-values [llm-metabot-provider "chat-completions/my-model"]
+      (is (= "chat-completions/my-model" (metabot.settings/llm-metabot-provider))))
+    (mt/with-temporary-setting-values [llm-metabot-provider "chat-completions/vendor/some-model:free"]
+      (is (= "chat-completions/vendor/some-model:free" (metabot.settings/llm-metabot-provider))))))
+
+(deftest metabot-configured-with-chat-completions-credentials-test
+  (testing "returns true when chat-completions has both the API key and base URL set"
+    (mt/with-temporary-setting-values [llm-metabot-provider              "chat-completions/my-model"
+                                       llm-chat-completions-api-key      "secret-key"
+                                       llm-chat-completions-api-base-url "https://api.example.com/v1"]
+      (is (true? (metabot.settings/llm-metabot-configured?))))))
+
+(deftest metabot-configured-with-partial-chat-completions-credentials-test
+  (testing "returns false when chat-completions has an API key but no base URL"
+    (mt/with-temporary-setting-values [llm-metabot-provider              "chat-completions/my-model"
+                                       llm-chat-completions-api-key      "secret-key"
+                                       llm-chat-completions-api-base-url nil]
+      (is (false? (metabot.settings/llm-metabot-configured?))))))
+
+(deftest configured-provider-credentials-chat-completions-fully-configured-test
+  (testing "returns the api-key/base-url credentials map when chat-completions is fully configured"
+    (mt/with-temporary-setting-values [llm-chat-completions-api-key      "secret-key"
+                                       llm-chat-completions-api-base-url "https://api.example.com/v1"]
+      (is (= {:api-key  "secret-key"
+              :base-url "https://api.example.com/v1"}
+             (metabot.settings/configured-provider-credentials "chat-completions"))))))
+
+(deftest configured-provider-credentials-chat-completions-partial-credentials-test
+  (testing "returns nil when chat-completions has a base URL but no API key"
+    (mt/with-temporary-setting-values [llm-chat-completions-api-key      nil
+                                       llm-chat-completions-api-base-url "https://api.example.com/v1"]
+      (is (nil? (metabot.settings/configured-provider-credentials "chat-completions"))))))
+
+(deftest provider-credentials-complete?-chat-completions-test
+  (testing "chat-completions credentials are complete only with both a non-blank API key and base URL"
+    (is (true? (metabot.settings/provider-credentials-complete?
+                "chat-completions"
+                {:api-key "secret-key" :base-url "https://api.example.com/v1"})))
+    (is (false? (metabot.settings/provider-credentials-complete? "chat-completions" {:api-key "secret-key"})))
+    (is (false? (metabot.settings/provider-credentials-complete? "chat-completions" {:api-key "secret-key" :base-url "  "})))
+    (is (false? (metabot.settings/provider-credentials-complete?
+                 "chat-completions"
+                 {:base-url "https://api.example.com/v1"})))
+    (is (false? (metabot.settings/provider-credentials-complete? "chat-completions" nil)))))
+
 (deftest provider-credentials-complete?-api-key-provider-test
   (testing "API-key provider credentials are complete only with a non-blank :api-key"
     (is (true? (metabot.settings/provider-credentials-complete? "openai" {:api-key "sk-valid"})))


### PR DESCRIPTION
Refs [BOT-1849: POC Allow configuring a generic Chat Completions provider](https://linear.app/metabase/issue/BOT-1849/poc-allow-configuring-a-generic-chat-completions-provider)

### Description

WIP / POC

The PR-Env is configured with GLM-5.2 from z.ai via the generic Chat Completions provider.

See linked linear issue for more details.

| Provider | connect | agent-chat | agent-sql | prompt-gen | document |
| -- | -- | -- | -- | -- | -- |
| openai gpt-4.1 | ✅ | ✅ | ✅ | ✅ | ✅ | 
| openrouter deepseek v4 | ✅ | ✅ | ✅ | ✅ | ✅ |
| z.ai GLM-5.2 | ✅ | ✅ | ✅ | ✅ | ✅ |
| togetherai GLM 5.2 | ✅ | ✅ | ✅ | ✅ | ✅ |
| litellm glm-5.2 | ✅ | ✅ | ✅ | ✅ | ✅ |
| Mistral Medium 3.5  | ✅ | ✅ | ✅ | ✅ | ✅ |
| openrouter kimi-k2.6 | ✅ | ✅ | ✅ | ❌ | ❌ | 
| gemini-3.5-flash | ✅ | ❌ | ❌ | ✅ | ❌ | 
| Deepseek v4 Pro | ✅ | ✅ | ❌ | ❌ | ❌ | 
| litellm deepseek-v4-pro | ✅ | ✅ | ❌ | ❌ | ❌ | 
| openai gpt-5.6-luna | ✅ | ❌ | ❌ | ❌ | ❌ | 

* **connect**: simple connect test
* **agent-chat**: agent chat with `:internal` profile
* **agent-sql**: agent chat with `:sql` profile
* **prompt-gen**: generate example prompts
* **document**: document-generate-content call

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
