### PR TITLE
Add showDashboardQuestions prop to CollectionBrowser

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/public/CollectionBrowser/CollectionBrowser.schema.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/CollectionBrowser/CollectionBrowser.schema.ts
@@ -10,6 +10,7 @@ const propsSchema: Yup.SchemaOf<CollectionBrowserProps> = Yup.object({
   collectionId: Yup.mixed().optional(),
   onClick: Yup.mixed().optional(),
   pageSize: Yup.mixed().optional(),
+  showDashboardQuestions: Yup.mixed().optional(),
   style: Yup.mixed().optional(),
   visibleColumns: Yup.mixed().optional(),
   visibleEntityTypes: Yup.mixed().optional(),

--- a/frontend/src/embedding-sdk-bundle/components/public/CollectionBrowser/CollectionBrowser.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/CollectionBrowser/CollectionBrowser.tsx
@@ -82,6 +82,11 @@ export type CollectionBrowserProps = {
   visibleEntityTypes?: UserFacingEntityName[];
 
   /**
+   * Whether to show questions that belong to a dashboard alongside collection saved questions. Set to false to hide them and keep the list focused on collection content, matching the core Metabase app. Defaults to true.
+   */
+  showDashboardQuestions?: boolean;
+
+  /**
    * The columns to display in the collection items table. If not provided, all columns will be shown.
    */
   visibleColumns?: CollectionBrowserListColumns[];
@@ -102,6 +107,7 @@ export const CollectionBrowserInner = ({
   onClick,
   pageSize = COLLECTION_PAGE_SIZE,
   visibleEntityTypes = [...USER_FACING_ENTITY_NAMES],
+  showDashboardQuestions = true,
   EmptyContentComponent = null,
   visibleColumns = COLLECTION_BROWSER_LIST_COLUMNS,
   className,
@@ -189,6 +195,7 @@ export const CollectionBrowserInner = ({
         onClick={onClickItem}
         pageSize={pageSize}
         models={collectionTypes}
+        showDashboardQuestions={showDashboardQuestions}
         visibleColumns={visibleColumns}
         EmptyContentComponent={EmptyContentComponent ?? undefined}
       />

--- a/frontend/src/embedding-sdk-bundle/components/public/CollectionBrowser/CollectionBrowser.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/CollectionBrowser/CollectionBrowser.unit.spec.tsx
@@ -155,6 +155,18 @@ describe("CollectionBrowser", () => {
     expect(columnTexts).toContain("Description");
   });
 
+  it("should show dashboard questions by default", async () => {
+    await setup();
+
+    expect(getLastItemsRequestParam("show_dashboard_questions")).toBe("true");
+  });
+
+  it("should hide dashboard questions when showDashboardQuestions is false", async () => {
+    await setup({ props: { showDashboardQuestions: false } });
+
+    expect(getLastItemsRequestParam("show_dashboard_questions")).toBe("false");
+  });
+
   it("should resolve collectionId=tenant to user's tenant collection", async () => {
     const tenantCollection = createMockCollection({
       id: 999,
@@ -185,6 +197,12 @@ describe("CollectionBrowser", () => {
     expect(await screen.findByText(dashboardItem.name)).toBeInTheDocument();
   });
 });
+
+function getLastItemsRequestParam(param: string): string | null {
+  const calls = fetchMock.callHistory.calls("path:/api/collection/root/items");
+  const lastCall = calls[calls.length - 1];
+  return new URL(lastCall.url).searchParams.get(param);
+}
 
 async function setup({
   props,

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
@@ -76,6 +76,7 @@ export type CollectionItemsTableProps = {
   loadingPinnedItems: boolean;
   models: CollectionItemModel[];
   pageSize: number;
+  showDashboardQuestions: boolean;
   selected: CollectionItem[];
   selectOnlyTheseItems: (items: CollectionItem[]) => void;
   toggleItem: (item: CollectionItem) => void;
@@ -111,6 +112,7 @@ export const CollectionItemsTable = ({
   loadingPinnedItems,
   models = ALL_MODELS,
   pageSize = COLLECTION_PAGE_SIZE,
+  showDashboardQuestions = true,
   selected,
   selectOnlyTheseItems,
   toggleItem,
@@ -167,7 +169,7 @@ export const CollectionItemsTable = ({
         limit: pageSize,
         offset: pageSize * page,
         ...(showAllItems
-          ? { show_dashboard_questions: true }
+          ? { show_dashboard_questions: showDashboardQuestions }
           : { pinned_state: "is_not_pinned" }),
         ...unpinnedItemsSorting,
       }}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/MetabaseBrowser.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/MetabaseBrowser.tsx
@@ -166,6 +166,7 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
               collectionId={view.id}
               visibleColumns={settings.collectionVisibleColumns}
               visibleEntityTypes={settings.collectionEntityTypes}
+              showDashboardQuestions={settings.collectionShowDashboardQuestions}
               pageSize={settings.collectionPageSize}
               onClick={(item) => {
                 const type = match<string, SdkBreadcrumbItemType>(item.model)

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/constants.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/constants.ts
@@ -69,6 +69,7 @@ export const ALLOWED_EMBED_SETTING_KEYS_MAP = {
     "collectionVisibleColumns",
     "collectionEntityTypes",
     "collectionPageSize",
+    "collectionShowDashboardQuestions",
     "dataPickerEntityTypes",
     "withNewQuestion",
     "withNewDashboard",

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -188,6 +188,9 @@ export interface BrowserEmbedOptions {
   /** Which entities to show on the collection browser */
   collectionEntityTypes?: CollectionBrowserEntityTypes[];
 
+  /** Whether to show questions that belong to a dashboard in the collection browser. Defaults to true. */
+  collectionShowDashboardQuestions?: boolean;
+
   /** Which entities to show on the question's data picker */
   dataPickerEntityTypes?: EmbeddingEntityType[];
 


### PR DESCRIPTION
Closes [EMB-2109: Modular Embedding: CollectionBrowser shows dashboard questions](https://linear.app/metabase/issue/EMB-2109/modular-embedding-collectionbrowser-shows-dashboard-questions)

Closes #77905

### Description

The Embedding SDK `CollectionBrowser` (and the modular-embedding `metabase-browser`
web component) had no way to hide dashboard questions — questions whose container is a
dashboard (`dashboard_id` set) rather than the collection. In embedded setups these
flood the list alongside collection saved questions and make personal/saved content hard
to find. The only existing lever, `visibleEntityTypes`, hides *all* questions, including
the collection questions users need.

This adds a `showDashboardQuestions` prop to control them. It defaults to `true` (current
behavior — no change for existing integrations); set it to `false` to hide dashboard
questions and match the core Metabase app's collection view.

- `CollectionBrowser` gains `showDashboardQuestions?: boolean` (default `true`).
- The modular-embedding `metabase-browser` component gains a matching
  `collectionShowDashboardQuestions` setting.
- Under the hood, the core `CollectionItemsTable` now accepts a `showDashboardQuestions`
  prop that drives the `show_dashboard_questions` API flag (default `true`, so the Trash
  view and existing callers are unchanged).

### How to verify

1. In a collection, create a dashboard and add a **dashboard question** (Edit dashboard →
   add chart → New Question → save it to the dashboard). Also save a normal question to
   the collection.
2. Render `<CollectionBrowser collectionId={<id>} />` — the dashboard question appears
   (default `true`).
3. Render `<CollectionBrowser collectionId={<id>} showDashboardQuestions={false} />` —
   the dashboard question is hidden; the collection question and dashboard remain.
4. Confirm `GET /api/collection/:id/items` sends `show_dashboard_questions=false` when
   the prop is `false`.

### Demo

_n/a — list-content change; see How to verify._

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
