### PR TITLE
Backport flaky schema-change test fixes to 58 (#70863, #71339)

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/test_util.clj
@@ -129,6 +129,23 @@
           (throw (ex-info (format "Transform run failed with status %s" status)
                           {:resp resp :status status})))))))
 
+(defn wait-for-field
+  "Wait for a field with `field-name` to appear as active on the table named `table-name`.
+   Useful after schema changes where sync runs asynchronously."
+  [table-name field-name timeout-ms]
+  (let [timer (u/start-timer)]
+    (loop []
+      (let [table  (t2/select-one :model/Table :name table-name :db_id (mt/id))
+            field  (when table
+                     (t2/select-one :model/Field :table_id (:id table) :name field-name :active true))]
+        (cond
+          field    field
+          (> (u/since-ms timer) timeout-ms)
+          (throw (ex-info (format "Field %s on table %s did not appear after %dms" field-name table-name timeout-ms)
+                          {:table-name table-name :field-name field-name :timeout-ms timeout-ms}))
+          :else    (do (Thread/sleep 200)
+                       (recur)))))))
+
 (defn get-test-schema
   "Get the schema from the products table in the test dataset.
    This is needed for databases like BigQuery that require a schema/dataset."

--- a/enterprise/backend/test/metabase_enterprise/transforms/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/test_util.clj
@@ -129,22 +129,35 @@
           (throw (ex-info (format "Transform run failed with status %s" status)
                           {:resp resp :status status})))))))
 
-(defn wait-for-field
-  "Wait for a field with `field-name` to appear as active on the table named `table-name`.
-   Useful after schema changes where sync runs asynchronously."
-  [table-name field-name timeout-ms]
+(defn- poll-field
+  "Poll until `pred` is satisfied for the active-field lookup of `field-name` on `table-name`.
+   Returns the first truthy result of `pred`, or throws after `timeout-ms`."
+  [table-name field-name timeout-ms pred timeout-msg]
   (let [timer (u/start-timer)]
     (loop []
-      (let [table  (t2/select-one :model/Table :name table-name :db_id (mt/id))
-            field  (when table
-                     (t2/select-one :model/Field :table_id (:id table) :name field-name :active true))]
-        (cond
-          field    field
-          (> (u/since-ms timer) timeout-ms)
-          (throw (ex-info (format "Field %s on table %s did not appear after %dms" field-name table-name timeout-ms)
-                          {:table-name table-name :field-name field-name :timeout-ms timeout-ms}))
-          :else    (do (Thread/sleep 200)
-                       (recur)))))))
+      (let [table (t2/select-one :model/Table :name table-name :db_id (mt/id))
+            field (when table
+                    (t2/select-one :model/Field :table_id (:id table) :name field-name :active true))]
+        (or (pred field)
+            (if (> (u/since-ms timer) timeout-ms)
+              (throw (ex-info (format timeout-msg field-name table-name timeout-ms)
+                              {:table-name table-name :field-name field-name :timeout-ms timeout-ms}))
+              (do (Thread/sleep 200)
+                  (recur))))))))
+
+(defn wait-for-field
+  "Wait for a field with `field-name` to appear as active on `table-name`."
+  [table-name field-name timeout-ms]
+  (poll-field table-name field-name timeout-ms
+              some?
+              "Field %s on table %s did not appear after %dms"))
+
+(defn wait-for-field-inactive
+  "Wait for a field with `field-name` to no longer be active on `table-name`."
+  [table-name field-name timeout-ms]
+  (poll-field table-name field-name timeout-ms
+              nil?
+              "Field %s on table %s still active after %dms"))
 
 (defn get-test-schema
   "Get the schema from the products table in the test dataset.

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
@@ -535,8 +535,9 @@
                 (transforms.tu/test-run transform-id)
                 (transforms.tu/wait-for-transform-completion transform-id 10000)
 
-                ;; hmmm, looks like QP needs a bit more time to update metadata
-                (Thread/sleep 2000)
+                ;; Sync runs asynchronously after succeed-started-run!, so wait for
+                ;; the new "friend" field to appear in metadata before querying.
+                (transforms.tu/wait-for-field table-name "friend" 10000)
                 (let [updated-rows (transforms.tu/table-rows table-name)]
                   (is (= [["Alice" "Bob"] ["Bob" "Alice"]] updated-rows)
                       "Updated data should show Alice/Bob with friends instead of ages"))))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
@@ -535,9 +535,10 @@
                 (transforms.tu/test-run transform-id)
                 (transforms.tu/wait-for-transform-completion transform-id 10000)
 
-                ;; Sync runs asynchronously after succeed-started-run!, so wait for
-                ;; the new "friend" field to appear in metadata before querying.
-                (transforms.tu/wait-for-field table-name "friend" 10000)
+                ;; Sync runs after succeed-started-run! and activates new fields
+                ;; before retiring old ones (non-transactional). Waiting for "age"
+                ;; to be deactivated guarantees "friend" is already active too.
+                (transforms.tu/wait-for-field-inactive table-name "age" 10000)
                 (let [updated-rows (transforms.tu/table-rows table-name)]
                   (is (= [["Alice" "Bob"] ["Bob" "Alice"]] updated-rows)
                       "Updated data should show Alice/Bob with friends instead of ages"))))))))))


### PR DESCRIPTION
most of the GDGT-2818 flake is coming from this branch. the test here still does a blind `Thread/sleep 2000` after the schema-changing rerun, but the run flips to succeeded before the target sync updates field metadata. so the QP can still see the old `age` column and query it against the already-swapped table, hence "column age does not exist" on redshift.

master fixed this back in march (#70863 + #71339) and the fixes were backported to 59 but never to 58, so every backport PR here keeps rolling the dice. this is a clean cherry-pick of both, test files only.

Part of https://linear.app/metabase/issue/GDGT-2818/flaky-test-be-tests-redshift-ee-metabase-enterprisetransforms