### PR TITLE
Bump schema-change test post-run waits on Redshift

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
@@ -537,11 +537,13 @@
                   (is (some? update-response) "Transform update should succeed"))
                 ;; Run updated transform and validate schema change
                 (transforms.tu/test-run transform-id)
-                (transforms.tu/wait-for-transform-completion transform-id 10000)
+                ;; test-run returns immediately for a rerun (:table is already set), so this wait
+                ;; covers the whole second execution. 10s was flaky on Redshift (GDGT-2818).
+                (transforms.tu/wait-for-transform-completion transform-id 30000)
                 ;; Sync runs after succeed-started-run! and activates new fields
                 ;; before retiring old ones (non-transactional). Waiting for "age"
                 ;; to be deactivated guarantees "friend" is already active too.
-                (transforms.tu/wait-for-field-inactive table-name "age" 10000)
+                (transforms.tu/wait-for-field-inactive table-name "age" 30000)
                 (let [updated-rows (transforms.tu/table-rows table-name)]
                   (is (= [["Alice" "Bob"] ["Bob" "Alice"]] updated-rows)
                       "Updated data should show Alice/Bob with friends instead of ages"))))))))))


### PR DESCRIPTION
the master-side failures in GDGT-2818 are the 10s waits being too tight. for the second run `test-run` returns immediately (the transform already has `:table` from run #1), so the whole second python execution (s3 copy, runner roundtrip, insert + rename swap) has to fit inside the single `wait-for-transform-completion` window. run #1 gets 20s for the same work via `test-run`, run #2 only gets 10. bumped the two post-run waits to 30s.

evidence this is slowness and not a hang: the failures hit the timeout branch (run still `:started`), not the run-failed branch, and the rate is tiny (0.04%). if it ever re-fires at 30s that would point at the python runner stalling instead, which is worth knowing on its own.

the "column age does not exist" failures in the same issue are a different thing: they come from backport PRs on release-x.58.x, which never got #70863/#71339. backported those separately in #77944.

Fixes https://linear.app/metabase/issue/GDGT-2818/flaky-test-be-tests-redshift-ee-metabase-enterprisetransforms
