### PR TITLE
Explorations timeline fixes

### DIFF
--- a/e2e/test/scenarios/explorations/explorations.cy.spec.ts
+++ b/e2e/test/scenarios/explorations/explorations.cy.spec.ts
@@ -558,32 +558,49 @@ describe("scenarios > explorations > detail page", () => {
   });
 
   it("preserves the URL `timeline` param across navigation and reload", () => {
-    cy.request("POST", "/api/timeline", {
-      name: "Releases",
-      collection_id: null,
-      icon: "star",
-      default: false,
-    }).then(({ body: timeline }) => {
-      // Unjustified type cast. FIXME
-      const timelineId = timeline.id as number;
-      H.createExplorationViaApi({
-        name: "Timeline persistence fixture",
-        timelineIds: [timelineId],
-      }).then((id) => {
-        cy.visit(`/question/research/${id}?timeline=${timelineId}`);
-        // Sidebar treeitems appear once the BE returns query rows.
-        cy.findAllByRole("treeitem", { timeout: 15000 })
-          .first()
-          .should("be.visible");
-        cy.location("search").should("include", `timeline=${timelineId}`);
+    createTimelineWithSentinelEvent("Releases", "star").then((timelineId) => {
+      cy.request("GET", "/api/exploration/dimensions").then(({ body }) => {
+        // Unjustified type cast. FIXME
+        const data = body as GetExplorationDataResponse;
+        const temporalDimension = data.dimension_groups
+          .flatMap((group) => group.dimensions)
+          .find((dim) => dim.effective_type.includes("Date"));
+        expect(temporalDimension, "sample DB exposes a temporal dimension").to
+          .exist;
 
-        // Reload — the URL param is the source of truth and the
-        // router shouldn't rewrite it away on hydration.
-        cy.reload();
-        cy.findAllByRole("treeitem", { timeout: 15000 })
-          .first()
-          .should("be.visible");
-        cy.location("search").should("include", `timeline=${timelineId}`);
+        H.createExplorationViaApi({
+          name: "Timeline persistence fixture",
+          timelineIds: [timelineId],
+          dimensionIds: [temporalDimension!.id],
+        }).then((id) => {
+          cy.visit(`/question/research/${id}?timeline=${timelineId}`);
+          // Sidebar treeitems appear once the BE returns query rows.
+          cy.findAllByRole("treeitem", { timeout: 15000 })
+            .first()
+            .should("be.visible");
+
+          cy.findByRole("treeitem", {
+            name: new RegExp(`${temporalDimension!.display_name}$`), // anchor at end so we don't match day of week or hour of day
+          }).click();
+
+          cy.findByTestId("exploration-chart-grid").within(() => {
+            H.timelineEventChip("Releases event").should("be.visible");
+          });
+
+          cy.location("search").should("include", `timeline=${timelineId}`);
+
+          // Reload — the URL param is the source of truth and the
+          // router shouldn't rewrite it away on hydration.
+          cy.reload();
+          cy.findAllByRole("treeitem", { timeout: 15000 })
+            .first()
+            .should("be.visible");
+          cy.location("search").should("include", `timeline=${timelineId}`);
+
+          cy.findByTestId("exploration-chart-grid").within(() => {
+            H.timelineEventChip("Releases event").should("be.visible");
+          });
+        });
       });
     });
   });

--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.tsx
@@ -37,6 +37,7 @@ import type {
   IconName,
   SingleSeries,
   Timeline,
+  TimelineEvent,
   TimelineId,
 } from "metabase-types/api";
 import { isSettledExplorationQueryStatus } from "metabase-types/api";
@@ -58,6 +59,7 @@ interface ExplorationGroupVisualizationProps {
   availableTimelines: Timeline[];
   selectedTimelineId: TimelineId | null;
   onSelectTimelineId: (timelineId: TimelineId | null) => void;
+  timelineEvents: TimelineEvent[];
   commentDrafts: CommentDrafts;
   setCommentDrafts: Dispatch<SetStateAction<CommentDrafts>>;
   isCommentsSidebarOpen: boolean;
@@ -151,6 +153,7 @@ function ExplorationGroupVisualizationChart({
   availableTimelines,
   selectedTimelineId,
   onSelectTimelineId,
+  timelineEvents,
   groupName,
   commentDrafts,
   setCommentDrafts,
@@ -201,13 +204,12 @@ function ExplorationGroupVisualizationChart({
     }));
     return buildSeriesGroup({
       queriesWithDatasets,
-      selectedTimelineId,
     });
     // datasets are reconstructed every render but its identity-stable
     // entries make this safe; including the array directly would cause
     // an unstable dep warning.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [queries, selectedTimelineId, ...datasets]);
+  }, [queries, ...datasets]);
 
   const showTimelineDropdown = useMemo(() => {
     return seriesGroup?.isTimeseries && availableTimelines.length > 0;
@@ -341,6 +343,7 @@ function ExplorationGroupVisualizationChart({
             <ExplorationCartesianChart
               key={series[0].card.id}
               series={series}
+              timelineEvents={timelineEvents}
               mode={clickActionsMode}
               highlighted={highlighted}
             />
@@ -401,18 +404,21 @@ function ExplorationGroupVisualizationChart({
 
 interface ExplorationCartesianChartProps {
   series: SingleSeries[];
+  timelineEvents: TimelineEvent[];
   mode: ClickActionsMode;
   highlighted?: HighlightedObject | null;
 }
 
 function ExplorationCartesianChart({
   series,
+  timelineEvents,
   mode,
   highlighted,
 }: ExplorationCartesianChartProps) {
   return (
     <ExplorationVisualization
       rawSeries={series}
+      timelineEvents={timelineEvents}
       className={S.chart}
       mode={mode}
       highlighted={highlighted}
@@ -511,6 +517,7 @@ function ExplorationMap({
 
 interface ExplorationVisualizationProps {
   rawSeries: SingleSeries[];
+  timelineEvents?: TimelineEvent[];
   className?: string;
   mode?: ClickActionsMode;
   highlighted?: HighlightedObject | null;
@@ -518,6 +525,7 @@ interface ExplorationVisualizationProps {
 
 export function ExplorationVisualization({
   rawSeries,
+  timelineEvents,
   className,
   mode,
   highlighted,
@@ -529,6 +537,7 @@ export function ExplorationVisualization({
       <Warnings warnings={warnings} className={S.warnings} size={18} />
       <Visualization
         rawSeries={rawSeries}
+        timelineEvents={timelineEvents}
         className={className}
         onUpdateWarnings={setWarnings}
         mode={mode}

--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.tsx
@@ -212,7 +212,12 @@ function ExplorationGroupVisualizationChart({
   }, [queries, ...datasets]);
 
   const showTimelineDropdown = useMemo(() => {
-    return seriesGroup?.isTimeseries && availableTimelines.length > 0;
+    return (
+      seriesGroup?.isTimeseries &&
+      availableTimelines.length > 0 &&
+      // row doesn't support timelines
+      !seriesGroup.series.some((s) => s.card.display === "row")
+    );
   }, [seriesGroup, availableTimelines]);
 
   const computedSettings = useMemo(

--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.unit.spec.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.unit.spec.tsx
@@ -129,10 +129,25 @@ function makeTimeseriesDataset(): Dataset {
         createMockColumn({ name: "ts", base_type: "type/DateTime" }),
         createMockColumn({ name: "count", base_type: "type/Integer" }),
       ],
+      // Need more than MIN_ROWS_TO_SHOW_LINE_OR_BAR (3) to avoid row fallback.
       rows: [
         ["2025-01-01", 1],
         ["2025-02-01", 2],
+        ["2025-03-01", 3],
+        ["2025-04-01", 4],
       ],
+    }),
+  });
+}
+
+function makeSmallTimeseriesDataset(): Dataset {
+  return createMockDataset({
+    data: createMockDatasetData({
+      cols: [
+        createMockColumn({ name: "ts", base_type: "type/DateTime" }),
+        createMockColumn({ name: "count", base_type: "type/Integer" }),
+      ],
+      rows: [["2025-01-01", 1]],
     }),
   });
 }
@@ -423,6 +438,27 @@ describe("ExplorationGroupVisualization", () => {
       ]),
       availableTimelines: [createMockTimeline({ id: 1, name: "Releases" })],
     });
+
+    expect(
+      screen.queryByRole("button", { name: "Select timeline" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show the timeline dropdown when a timeseries group falls back to row charts", () => {
+    setup({
+      queries: [
+        createQuery({ id: 101, name: "Revenue trend", status: "done" }),
+      ],
+      datasets: new Map([[101, makeSmallTimeseriesDataset()]]),
+      availableTimelines: [createMockTimeline({ id: 1, name: "Releases" })],
+    });
+
+    const rawSeries = JSON.parse(
+      screen
+        .getByTestId("visualization-stub")
+        .getAttribute("data-raw-series") ?? "[]",
+    );
+    expect(rawSeries[0].card.display).toBe("row");
 
     expect(
       screen.queryByRole("button", { name: "Select timeline" }),

--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.unit.spec.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.unit.spec.tsx
@@ -11,12 +11,14 @@ import type {
   ExplorationBlockNodeType,
   ExplorationQuery,
   Timeline,
+  TimelineEvent,
 } from "metabase-types/api";
 import {
   createMockColumn,
   createMockDataset,
   createMockDatasetData,
   createMockTimeline,
+  createMockTimelineEvent,
 } from "metabase-types/api/mocks";
 import { createMockComment } from "metabase-types/api/mocks/comment";
 
@@ -181,6 +183,7 @@ interface SetupOpts {
   errors?: Map<number, unknown>;
   availableTimelines?: Timeline[];
   selectedTimelineId?: number | null;
+  timelineEvents?: TimelineEvent[];
   onSelectTimelineId?: (timelineId: number | null) => void;
   isCommentsSidebarOpen?: boolean;
   wasCommentsSidebarOpen?: boolean;
@@ -193,6 +196,7 @@ function setup({
   errors,
   availableTimelines = [],
   selectedTimelineId = null,
+  timelineEvents = [],
   onSelectTimelineId = jest.fn(),
   isCommentsSidebarOpen = false,
   wasCommentsSidebarOpen = false,
@@ -223,6 +227,7 @@ function setup({
           availableTimelines={availableTimelines}
           selectedTimelineId={selectedTimelineId}
           onSelectTimelineId={onSelectTimelineId}
+          timelineEvents={timelineEvents}
           commentDrafts={{}}
           setCommentDrafts={jest.fn()}
           isCommentsSidebarOpen={isCommentsSidebarOpen}
@@ -369,6 +374,31 @@ describe("ExplorationGroupVisualization", () => {
     expect(
       screen.getByRole("button", { name: "Select timeline" }),
     ).toBeInTheDocument();
+  });
+
+  it("passes selected timeline events to Visualization for timeseries charts", () => {
+    const releasesEvent = createMockTimelineEvent({
+      id: 10,
+      name: "Releases event",
+      timeline_id: 42,
+    });
+    setup({
+      queries: [
+        createQuery({ id: 101, name: "Revenue trend", status: "done" }),
+      ],
+      datasets: new Map([[101, makeTimeseriesDataset()]]),
+      availableTimelines: [
+        createMockTimeline({
+          id: 42,
+          name: "Releases",
+          events: [releasesEvent],
+        }),
+      ],
+      selectedTimelineId: 42,
+      timelineEvents: [releasesEvent],
+    });
+
+    expect(lastVisualizationProps?.timelineEvents).toEqual([releasesEvent]);
   });
 
   it("does not show the timeline dropdown for non-timeseries charts", () => {

--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/utils.ts
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/utils.ts
@@ -51,7 +51,6 @@ interface ExplorationQueryWithDataset extends ExplorationQuery {
 
 interface BuildSeriesGroupParams {
   queriesWithDatasets: ExplorationQueryWithDataset[];
-  selectedTimelineId: TimelineId | null;
 }
 
 export interface LegendItem {
@@ -68,7 +67,6 @@ export interface SeriesGroup {
 
 export function buildSeriesGroup({
   queriesWithDatasets,
-  selectedTimelineId,
 }: BuildSeriesGroupParams): SeriesGroup {
   let isTimeseries = false;
   let stackCount: number | undefined;
@@ -100,7 +98,6 @@ export function buildSeriesGroup({
         queryWithDataset,
         queriesWithDatasets.length,
         queriesWithSegments.length,
-        selectedTimelineId,
       );
       isTimeseries = isTimeseries || Boolean(isTimeseriesForQuery);
       // this works because we should always get the same stackCount for all queries in a group
@@ -153,7 +150,6 @@ function getDisplay(
   queryWithDataset: ExplorationQueryWithDataset,
   numQueries: number,
   numSegmentQueries: number,
-  selectedTimelineId: TimelineId | null,
 ): GetDisplayResult {
   const { cols, rows } = queryWithDataset.dataset.data;
   const isTimeseries = cols.some(isDate);
@@ -184,8 +180,6 @@ function getDisplay(
         // the page header tells you the breakout column, not the date column
         // so we need an x axis label here
         "graph.x_axis.labels_enabled": true,
-        "timeline.selected_timeline_ids":
-          selectedTimelineId != null ? [selectedTimelineId] : undefined,
       },
       stackCount: shouldStack ? breakoutValues.size : undefined,
       isTimeseries,
@@ -199,8 +193,6 @@ function getDisplay(
       display: "line",
       settings: {
         "graph.split_panels": shouldStack,
-        "timeline.selected_timeline_ids":
-          selectedTimelineId != null ? [selectedTimelineId] : undefined,
       },
       stackCount: shouldStack ? numQueries : undefined,
       isTimeseries,

--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/utils.unit.spec.ts
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/utils.unit.spec.ts
@@ -124,7 +124,6 @@ const smallTimeFacetDataset = makeDataset(
 function buildSeriesGroupFor(query: ExplorationQuery, dataset: Dataset) {
   return buildSeriesGroup({
     queriesWithDatasets: [{ ...query, dataset }],
-    selectedTimelineId: null,
   });
 }
 
@@ -659,7 +658,6 @@ describe("buildSeriesGroup", () => {
     );
     const group = buildSeriesGroup({
       queriesWithDatasets: queries.map((q) => ({ ...q, dataset: categorical })),
-      selectedTimelineId: null,
     });
     expect(group.series[0].card.display).toBe("table");
   });
@@ -676,7 +674,6 @@ describe("buildSeriesGroup", () => {
           dataset: stateDataset,
         },
       ],
-      selectedTimelineId: null,
     });
     const ramp1 = group.series[0].card.visualization_settings["map.colors"];
     const ramp2 = group.series[1].card.visualization_settings["map.colors"];

--- a/frontend/src/metabase/explorations/pages/ExplorationPage.tsx
+++ b/frontend/src/metabase/explorations/pages/ExplorationPage.tsx
@@ -27,6 +27,7 @@ import type {
   ExplorationQuery,
   ExplorationThread,
   Timeline,
+  TimelineEvent,
   TimelineId,
 } from "metabase-types/api";
 import { isSettledExplorationQueryStatus } from "metabase-types/api";
@@ -517,6 +518,16 @@ export function ExplorationPage({
     return getMostInterestingTimelineId(selectedQueries, availableTimelineIds);
   }, [selectedPage, location.query, selectedQueries, availableTimelineIds]);
 
+  const timelineEvents: TimelineEvent[] = useMemo(() => {
+    if (selectedTimelineId == null) {
+      return [];
+    }
+    return (
+      availableTimelines.find((timeline) => timeline.id === selectedTimelineId)
+        ?.events ?? []
+    );
+  }, [availableTimelines, selectedTimelineId]);
+
   const handleSelectTimelineId = useCallback(
     (timelineId: TimelineId | null) => {
       // Update the `timeline` URL query param while preserving the
@@ -622,6 +633,7 @@ export function ExplorationPage({
               availableTimelines={availableTimelines}
               selectedTimelineId={selectedTimelineId}
               onSelectTimelineId={handleSelectTimelineId}
+              timelineEvents={timelineEvents}
               commentDrafts={commentDrafts}
               setCommentDrafts={setCommentDrafts}
               isCommentsSidebarOpen={isCommentsSidebarOpen}


### PR DESCRIPTION
Closes [UXW-4836: timelines are broken](https://linear.app/metabase/issue/UXW-4836/timelines-are-broken)
Closes [UXW-4833: Hide the timeline picker on row charts](https://linear.app/metabase/issue/UXW-4833/hide-the-timeline-picker-on-row-charts)

Timelines were broken by [the commit removing timelines from documents](https://github.com/metabase/metabase/pull/73244/changes/104d7ece7f39d14ac222290b8d787aab3817cd8b). Timelines were implemented using a viz setting, which was needed back when explorations had the "add chart to document" flow. Now, the viz setting has been removed, so we should instead pass `timelineEvents` to `Visualization`.

This PR also sneaks in a drive-by fix disabling timelines for row charts.