### PR TITLE
Add data app listing sidebar section for non-admins

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -106,7 +106,9 @@
   [_route-params
    {:keys [available]} :- [:map [:available {:optional true} [:maybe :boolean]]]]
   (->> (data-app/select-non-blob (cond-> {:order-by [[:display_name :asc]]}
-                                   available (assoc :enabled true :sync_error nil)))
+                                   available (assoc :where [:and
+                                                            [:= :enabled true]
+                                                            [:= :sync_error nil]])))
        (map api/read-check)
        (mapv data-app-response)))
 

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -101,9 +101,12 @@
     (select-keys app [:name :display_name])))
 
 (api.macros/defendpoint :get "/" :- [:sequential [:or DataAppResponse PublicDataAppResponse]]
-  "List the data apps provided by the connected repository."
-  []
-  (->> (data-app/select-non-blob {:order-by [[:display_name :asc]]})
+  "List the data apps provided by the connected repository. Pass `available=true`
+   to return only enabled apps without sync errors."
+  [_route-params
+   {:keys [available]} :- [:map [:available {:optional true} [:maybe :boolean]]]]
+  (->> (data-app/select-non-blob (cond-> {:order-by [[:display_name :asc]]}
+                                   available (assoc :enabled true :sync_error nil)))
        (map api/read-check)
        (mapv data-app-response)))
 

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -71,6 +71,11 @@
    [:created_at      :any]
    [:updated_at      :any]])
 
+(def ^:private PublicDataAppResponse
+  [:map {:closed true}
+   [:name         ms/NonBlankString]
+   [:display_name ms/NonBlankString]])
+
 (def ^:private RepoStatusResponse
   [:map
    [:configured :boolean]
@@ -88,12 +93,19 @@
 
 ;;; ------------------------------------------------ Apps ------------------------------------------------
 
-(api.macros/defendpoint :get "/" :- [:sequential DataAppResponse]
+(defn- data-app-response
+  "Return full data-app metadata to superusers and only navigational fields to other users."
+  [app]
+  (if api/*is-superuser?*
+    app
+    (select-keys app [:name :display_name])))
+
+(api.macros/defendpoint :get "/" :- [:sequential [:or DataAppResponse PublicDataAppResponse]]
   "List the data apps provided by the connected repository."
   []
-  (api/check-superuser)
   (->> (data-app/select-non-blob {:order-by [[:display_name :asc]]})
-       (mapv api/read-check)))
+       (map api/read-check)
+       (mapv data-app-response)))
 
 ;; NOTE on the `slug-regex` constraint: the default path-param matcher allows
 ;; slashes inside a segment, so `/:slug` would otherwise swallow `/x/bundle`.
@@ -120,10 +132,10 @@
   ;; above (returning `generic-204-no-content` would fail that validation).
   nil)
 
-(api.macros/defendpoint :get ["/:slug" :slug slug-regex] :- DataAppResponse
+(api.macros/defendpoint :get ["/:slug" :slug slug-regex] :- [:or DataAppResponse PublicDataAppResponse]
   "Fetch metadata for a single enabled data app by its slug."
   [{:keys [slug]} :- [:map [:slug ms/NonBlankString]]]
-  (api/read-check (data-app/select-one-non-blob :name slug :enabled true)))
+  (data-app-response (api/read-check (data-app/select-one-non-blob :name slug :enabled true))))
 
 (api.macros/defendpoint :get ["/:slug/bundle" :slug slug-regex] :- :any
   "Serve the cached JS bundle for a single enabled data app by slug. Honors

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -46,7 +46,7 @@
 
 ;;; ---------------------------------------------- Permissions ----------------------------------------------
 
-(deftest non-superuser-can-view-but-not-manage-test
+(deftest non-superuser-can-view-and-list-but-not-manage-test
   ;; global mode so the `:data-apps` premium feature is visible to the real-HTTP
   ;; `user-real-request` calls below (which run on Jetty threads that don't inherit
   ;; a thread-local `binding`).
@@ -55,14 +55,14 @@
       (mt/with-model-cleanup [:model/DataApp]
         (create-app!)
         (testing "a non-superuser can view (open) a data app"
-          (is (=? {:name "demo"}
-                  (mt/user-http-request :rasta :get 200 "apps/demo")))
+          (is (= [{:name "demo" :display_name "Demo"}]
+                 (mt/user-http-request :rasta :get 200 "apps")))
+          (is (= {:name "demo" :display_name "Demo"}
+                 (mt/user-http-request :rasta :get 200 "apps/demo")))
           (is (str/includes?
                (str (mt/user-real-request :rasta :get 200 "apps/demo/bundle"))
                "BUNDLE")))
         (testing "but is still forbidden from managing data apps"
-          (is (= "You don't have permissions to do that."
-                 (mt/user-http-request :rasta :get 403 "apps")))
           (is (= "You don't have permissions to do that."
                  (mt/user-http-request :rasta :get 403 "apps/repo-status")))
           (is (= "You don't have permissions to do that."

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -82,6 +82,17 @@
                (str (mt/user-real-request :crowberto :get 200 "apps/demo/bundle"))
                "BUNDLE")))))))
 
+(deftest list-available-apps-test
+  (mt/with-premium-features #{:data-apps}
+    (mt/with-model-cleanup [:model/DataApp]
+      (t2/insert! :model/DataApp :name "ready" :display_name "Ready" :bundle_path "data_apps/ready/index.js")
+      (t2/insert! :model/DataApp :name "disabled" :display_name "Disabled" :bundle_path "data_apps/disabled/index.js"
+                  :enabled false)
+      (t2/insert! :model/DataApp :name "failed" :display_name "Failed" :bundle_path "data_apps/failed/index.js"
+                  :sync_error "Could not read bundle")
+      (is (=? [{:name "ready" :display_name "Ready"}]
+              (mt/user-http-request :crowberto :get 200 "apps?available=true"))))))
+
 (deftest bundle-includes-allowed-hosts-header-test
   (mt/with-premium-features #{:data-apps}
     (mt/with-model-cleanup [:model/DataApp]

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -91,7 +91,7 @@
       (t2/insert! :model/DataApp :name "failed" :display_name "Failed" :bundle_path "data_apps/failed/index.js"
                   :sync_error "Could not read bundle")
       (is (=? [{:name "ready" :display_name "Ready"}]
-              (mt/user-http-request :crowberto :get 200 "apps?available=true"))))))
+              (mt/user-http-request :rasta :get 200 "apps?available=true"))))))
 
 (deftest bundle-includes-allowed-hosts-header-test
   (mt/with-premium-features #{:data-apps}

--- a/enterprise/frontend/src/metabase-enterprise/api/data-app.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/data-app.ts
@@ -11,12 +11,15 @@ import { idTag, invalidateTags, listTag } from "./tags";
 // when a sync changes things.
 const REPO_STATUS_TAG = idTag("data-app", "REPO-STATUS");
 
+type ListDataAppsOptions = { available?: boolean };
+
 export const dataAppApi = EnterpriseApi.injectEndpoints({
   endpoints: (builder) => ({
-    listDataApps: builder.query<DataApp[], void>({
-      query: () => ({
+    listDataApps: builder.query<DataApp[], ListDataAppsOptions | void>({
+      query: (options) => ({
         method: "GET",
         url: "/api/apps",
+        params: options,
       }),
       providesTags: (apps = []) => [
         listTag("data-app"),

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/index.tsx
@@ -2,6 +2,7 @@ import { PLUGIN_DATA_APPS } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { ManageDataAppsPage } from "./admin/ManageDataAppsPage";
+import { DataAppsNavbarSection } from "./navbar/DataAppsNavbarSection";
 import { getRoutes } from "./routes";
 
 /**
@@ -16,5 +17,6 @@ export function initializePlugin() {
     PLUGIN_DATA_APPS.isEnabled = true;
     PLUGIN_DATA_APPS.getRoutes = getRoutes;
     PLUGIN_DATA_APPS.ManageDataAppsPage = ManageDataAppsPage;
+    PLUGIN_DATA_APPS.MainNavbarSection = DataAppsNavbarSection;
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/navbar/DataAppsNavbarSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/navbar/DataAppsNavbarSection.tsx
@@ -27,12 +27,12 @@ export function DataAppsNavbarSection({
         initialState="expanded"
         iconPosition="right"
         iconSize={8}
-        role="section"
         aria-label={t`Data apps`}
       >
         {dataApps.map((dataApp) => (
           <PaddedSidebarLink
-            key={dataApp.id}
+            // Data-app names are globally unique slugs, enforced by the database.
+            key={dataApp.name}
             icon="app"
             onClick={onItemSelect}
             url={Urls.dataApp(dataApp.name)}

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/navbar/DataAppsNavbarSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/navbar/DataAppsNavbarSection.tsx
@@ -1,0 +1,45 @@
+import { t } from "ttag";
+
+import { CollapseSection } from "metabase/common/components/CollapseSection";
+import {
+  PaddedSidebarLink,
+  SidebarHeading,
+  SidebarSection,
+} from "metabase/nav/containers/MainNavbar/MainNavbar.styled";
+import * as Urls from "metabase/urls";
+import { useListDataAppsQuery } from "metabase-enterprise/api";
+
+export function DataAppsNavbarSection({
+  onItemSelect,
+}: {
+  onItemSelect: () => void;
+}) {
+  const { data: dataApps = [] } = useListDataAppsQuery();
+
+  if (dataApps.length === 0) {
+    return null;
+  }
+
+  return (
+    <SidebarSection>
+      <CollapseSection
+        header={<SidebarHeading>{t`Data apps`}</SidebarHeading>}
+        initialState="expanded"
+        iconPosition="right"
+        iconSize={8}
+        role="section"
+        aria-label={t`Data apps`}
+      >
+        {dataApps.map((dataApp) => (
+          <PaddedSidebarLink
+            key={dataApp.id}
+            onClick={onItemSelect}
+            url={Urls.dataApp(dataApp.name)}
+          >
+            {dataApp.display_name}
+          </PaddedSidebarLink>
+        ))}
+      </CollapseSection>
+    </SidebarSection>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/navbar/DataAppsNavbarSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/navbar/DataAppsNavbarSection.tsx
@@ -14,7 +14,7 @@ export function DataAppsNavbarSection({
 }: {
   onItemSelect: () => void;
 }) {
-  const { data: dataApps = [] } = useListDataAppsQuery();
+  const { data: dataApps = [] } = useListDataAppsQuery({ available: true });
 
   if (dataApps.length === 0) {
     return null;

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/navbar/DataAppsNavbarSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/navbar/DataAppsNavbarSection.tsx
@@ -33,6 +33,7 @@ export function DataAppsNavbarSection({
         {dataApps.map((dataApp) => (
           <PaddedSidebarLink
             key={dataApp.id}
+            icon="app"
             onClick={onItemSelect}
             url={Urls.dataApp(dataApp.name)}
           >

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/navbar/DataAppsNavbarSection.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/navbar/DataAppsNavbarSection.unit.spec.tsx
@@ -1,6 +1,6 @@
 import fetchMock from "fetch-mock";
 
-import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
 import { Route } from "metabase/router";
 import { createMockDataApp } from "metabase-types/api/mocks";
 
@@ -37,12 +37,14 @@ describe("DataAppsNavbarSection", () => {
       await screen.findByRole("heading", { name: "Data apps" }),
     ).toBeInTheDocument();
 
-    expect(await screen.findByRole("link", { name: "Gizmo" })).toHaveAttribute(
-      "href",
-      "/apps/gizmo",
-    );
+    const gizmoLink = await screen.findByRole("link", { name: /Gizmo/ });
+    expect(gizmoLink).toHaveAttribute("href", "/apps/gizmo");
 
-    expect(screen.getByRole("link", { name: "Gadget" })).toHaveAttribute(
+    expect(
+      within(gizmoLink).getByRole("img", { name: "app icon" }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole("link", { name: /Gadget/ })).toHaveAttribute(
       "href",
       "/apps/gadget",
     );

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/navbar/DataAppsNavbarSection.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/navbar/DataAppsNavbarSection.unit.spec.tsx
@@ -1,0 +1,50 @@
+import fetchMock from "fetch-mock";
+
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { Route } from "metabase/router";
+import { createMockDataApp } from "metabase-types/api/mocks";
+
+import { DataAppsNavbarSection } from "./DataAppsNavbarSection";
+
+describe("DataAppsNavbarSection", () => {
+  it("does not show apps section when there are no data apps", async () => {
+    fetchMock.get("path:/api/apps", []);
+
+    renderWithProviders(<DataAppsNavbarSection onItemSelect={jest.fn()} />);
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("heading", { name: "Data apps" }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("shows every data app as a link", async () => {
+    fetchMock.get("path:/api/apps", [
+      createMockDataApp({ id: 1, name: "gizmo", display_name: "Gizmo" }),
+      createMockDataApp({ id: 2, name: "gadget", display_name: "Gadget" }),
+    ]);
+
+    renderWithProviders(
+      <Route
+        path="/"
+        component={() => <DataAppsNavbarSection onItemSelect={jest.fn()} />}
+      />,
+      { withRouter: true },
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Data apps" }),
+    ).toBeInTheDocument();
+
+    expect(await screen.findByRole("link", { name: "Gizmo" })).toHaveAttribute(
+      "href",
+      "/apps/gizmo",
+    );
+
+    expect(screen.getByRole("link", { name: "Gadget" })).toHaveAttribute(
+      "href",
+      "/apps/gadget",
+    );
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/navbar/DataAppsNavbarSection.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/navbar/DataAppsNavbarSection.unit.spec.tsx
@@ -8,7 +8,7 @@ import { DataAppsNavbarSection } from "./DataAppsNavbarSection";
 
 describe("DataAppsNavbarSection", () => {
   it("does not show apps section when there are no data apps", async () => {
-    fetchMock.get("path:/api/apps", []);
+    fetchMock.get("path:/api/apps?available=true", []);
 
     renderWithProviders(<DataAppsNavbarSection onItemSelect={jest.fn()} />);
 
@@ -20,7 +20,7 @@ describe("DataAppsNavbarSection", () => {
   });
 
   it("shows every data app as a link", async () => {
-    fetchMock.get("path:/api/apps", [
+    fetchMock.get("path:/api/apps?available=true", [
       createMockDataApp({ id: 1, name: "gizmo", display_name: "Gizmo" }),
       createMockDataApp({ id: 2, name: "gadget", display_name: "Gadget" }),
     ]);

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/navbar/DataAppsNavbarSection.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/navbar/DataAppsNavbarSection.unit.spec.tsx
@@ -2,7 +2,6 @@ import fetchMock from "fetch-mock";
 
 import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
 import { Route } from "metabase/router";
-import { createMockDataApp } from "metabase-types/api/mocks";
 
 import { DataAppsNavbarSection } from "./DataAppsNavbarSection";
 
@@ -21,8 +20,8 @@ describe("DataAppsNavbarSection", () => {
 
   it("shows every data app as a link", async () => {
     fetchMock.get("path:/api/apps?available=true", [
-      createMockDataApp({ id: 1, name: "gizmo", display_name: "Gizmo" }),
-      createMockDataApp({ id: 2, name: "gadget", display_name: "Gadget" }),
+      { name: "gizmo", display_name: "Gizmo" },
+      { name: "gadget", display_name: "Gadget" },
     ]);
 
     renderWithProviders(

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -17,7 +17,11 @@ import { useSetting, useUserSetting } from "metabase/common/hooks";
 import { useIsAtHomepageDashboard } from "metabase/common/hooks/use-is-at-homepage-dashboard";
 import { useShowOtherUsersCollections } from "metabase/common/hooks/use-show-other-users-collections";
 import { NavbarLibrarySection } from "metabase/nav/containers/MainNavbar/NavbarLibrarySection";
-import { PLUGIN_REMOTE_SYNC, PLUGIN_TENANTS } from "metabase/plugins";
+import {
+  PLUGIN_DATA_APPS,
+  PLUGIN_REMOTE_SYNC,
+  PLUGIN_TENANTS,
+} from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import {
   getCanAccessOnboardingPage,
@@ -302,6 +306,10 @@ export function MainNavbarView({
               </CollapseSection>
             </ErrorBoundary>
           </SidebarSection>
+
+          {PLUGIN_DATA_APPS.isEnabled && (
+            <PLUGIN_DATA_APPS.MainNavbarSection onItemSelect={onItemSelect} />
+          )}
 
           <SidebarSection>
             <ErrorBoundary>

--- a/frontend/src/metabase/plugins/oss/data-apps.ts
+++ b/frontend/src/metabase/plugins/oss/data-apps.ts
@@ -6,12 +6,14 @@ export type DataAppsPlugin = {
   isEnabled: boolean;
   getRoutes: () => ReactNode | null;
   ManageDataAppsPage: ComponentType;
+  MainNavbarSection: ComponentType<{ onItemSelect: () => void }>;
 };
 
 const getDefaultPluginDataApps = (): DataAppsPlugin => ({
   isEnabled: false,
   getRoutes: () => null,
   ManageDataAppsPage: PluginPlaceholder,
+  MainNavbarSection: PluginPlaceholder,
 });
 
 export const PLUGIN_DATA_APPS: DataAppsPlugin = getDefaultPluginDataApps();


### PR DESCRIPTION
Closes [EMB-2098](https://linear.app/metabase/issue/EMB-2098/add-sidebar-section-for-data-app-list-in-the-main-app)

### Description

Adds a new "data apps" section after collections when apps exist. All users of the instance can discover app names and links.

If you are not an admin, `/api/apps` API responses will only give you `name` and `display_name` metadata needed to show the sidebar link, and nothing else.

### How to verify

1. Sync at least one data app and open the main sidebar: the data apps section appears after collections with app links.
2. Sign in as a non-admin. The links will remain visible, while `GET /api/apps` returns only `name` and `display_name`.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR