### PR TITLE
Explorations sort order

### DIFF
--- a/frontend/src/metabase-types/api/exploration.ts
+++ b/frontend/src/metabase-types/api/exploration.ts
@@ -259,6 +259,7 @@ export interface ExplorationQuery {
   segment_id: SegmentId | null;
   segment_name: string | null;
   params?: ExplorationQueryParams | null;
+  row_count?: number | null;
 }
 
 export interface ExplorationDocument {
@@ -313,6 +314,9 @@ export function getExplorationQueryGroupStatus(
   }
   if (queries.some((q) => q.status === "canceled")) {
     return "canceled";
+  }
+  if (queries.every((q) => q.row_count === 0)) {
+    return "error";
   }
   return "done";
 }

--- a/frontend/src/metabase-types/api/exploration.ts
+++ b/frontend/src/metabase-types/api/exploration.ts
@@ -321,20 +321,6 @@ export function getExplorationQueryGroupStatus(
   return "done";
 }
 
-export function getExplorationQueryGroupInterestingness(
-  queries: ExplorationQuery[],
-): number | null {
-  let max: number | null = null;
-  for (const q of queries) {
-    const score =
-      q.contextual_interestingness_score ?? q.interestingness_score ?? null;
-    if (score != null && (max == null || score > max)) {
-      max = score;
-    }
-  }
-  return max;
-}
-
 export interface ExplorationThread {
   id: ExplorationThreadId;
   exploration_id: ExplorationId;

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationSidebar.unit.spec.tsx
@@ -155,7 +155,7 @@ function setup({
     showHidden
       ? treeItemFilter
       : (node) => treeItemFilter(node) && !isHiddenTreeItem(node),
-    undefined,
+    sortOrder,
     { keepEmptyInitialThread: tab === "all" },
   );
 
@@ -1411,6 +1411,70 @@ describe("ExplorationSidebar", () => {
       const heading = screen.getByRole("group", { name: /Status metric/ });
       expect(heading).toHaveAttribute("aria-busy", "true");
       expect(within(heading).queryByLabelText("Ready")).not.toBeInTheDocument();
+    });
+
+    it("sorts zero-row pages to the bottom and shows them as errors", () => {
+      const done = createQuery({
+        id: 1,
+        name: "Done",
+        status: "done",
+      });
+      const running = createQuery({
+        id: 2,
+        name: "Running",
+        status: "pending",
+      });
+      const empty = createQuery({
+        id: 3,
+        name: "Empty",
+        status: "done",
+        row_count: 0,
+      });
+
+      const SORT_BLOCK_ID = 50;
+      setup({
+        queries: [empty, running, done],
+        blocks: [
+          createBlock({
+            id: SORT_BLOCK_ID,
+            name: "Sort metric",
+            position: 0,
+            pages: [
+              createPage({
+                id: 3,
+                name: "Empty",
+                position: 0,
+                query_ids: [empty.id],
+              }),
+              createPage({
+                id: 2,
+                name: "Running",
+                position: 1,
+                query_ids: [running.id],
+              }),
+              createPage({
+                id: 1,
+                name: "Done",
+                position: 2,
+                query_ids: [done.id],
+              }),
+            ],
+          }),
+        ],
+        selectedEntityId: { type: "page", id: "1" },
+      });
+
+      const rows = screen.getAllByRole("treeitem");
+      const rowIndex = (name: string) =>
+        rows.findIndex((row) =>
+          within(row).queryByText(name, { exact: false }),
+        );
+
+      expect(rowIndex("Done")).toBeLessThan(rowIndex("Running"));
+      expect(rowIndex("Running")).toBeLessThan(rowIndex("Empty"));
+      expect(
+        within(getRow("Empty")).getByLabelText("Failed to generate"),
+      ).toBeInTheDocument();
     });
 
     it("auto-expands the heading that owns the selected page and leaves the other heading collapsed", () => {

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/utils.ts
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/utils.ts
@@ -17,7 +17,6 @@ import type {
 } from "metabase-types/api";
 import {
   getExplorationPages,
-  getExplorationQueryGroupInterestingness,
   getExplorationQueryGroupStatus,
 } from "metabase-types/api";
 
@@ -136,12 +135,25 @@ export function getExplorationSidebarTree(
     ExplorationThreadId,
     ITreeNodeItem<ExplorationTreeNode>
   >();
+
+  // use the initial thread's interestingness scores to sort all threads
+  // that means each thread has a consistent order
+  // plus we don't have to run the expensive contextual interestingness for each thread
+  const interestingnessByPageKey = getInterestingnessByPageKey(
+    threads[0]?.queries ?? [],
+  );
+
   threads.forEach((thread, index) => {
     const parentThreadId = getParentThreadId(thread);
     const isFollowUp = parentThreadId != null;
     const isTopLevelFollowUp = isFollowUp && parentThreadId === initialThreadId;
 
-    let children = getExplorationQueryTree(thread, treeItemFilter, sortOrder);
+    let children = getExplorationQueryTree(
+      thread,
+      treeItemFilter,
+      sortOrder,
+      interestingnessByPageKey,
+    );
     let metricName: string | undefined;
 
     if (
@@ -214,6 +226,32 @@ export function getExplorationSidebarTree(
   );
 }
 
+type PageKey = string;
+
+// every query in a page has the same card_id, dimension_id, and query_type
+// we use this to identify the same shaped pages across threads
+function getPageKey(query: ExplorationQuery): PageKey {
+  const { card_id, dimension_id, query_type } = query;
+  return `${card_id}-${dimension_id}-${query_type}`;
+}
+
+// max interestingness (contextual preferred) across all queries in a page
+function getInterestingnessByPageKey(
+  queries: ExplorationQuery[],
+): Record<PageKey, number | null> {
+  const interestingnessByPageKey: Record<PageKey, number | null> = {};
+  for (const q of queries) {
+    const key = getPageKey(q);
+    const score =
+      q.contextual_interestingness_score ?? q.interestingness_score ?? null;
+    const existingScore = interestingnessByPageKey[key];
+    if (score != null && (existingScore == null || score > existingScore)) {
+      interestingnessByPageKey[key] = score;
+    }
+  }
+  return interestingnessByPageKey;
+}
+
 function pruneEmptyHeadings(
   nodes: ITreeNodeItem<ExplorationTreeNode>[],
   initialThreadId: ExplorationThreadId | undefined,
@@ -281,6 +319,7 @@ function getExplorationQueryTree(
   thread: ExplorationThread,
   treeItemFilter: TreeItemFilter,
   sortOrder: ExplorationSortOrder,
+  interestingnessByPageKey: Record<PageKey, number | null>,
 ): ITreeNodeItem<ExplorationTreeNode>[] {
   const queriesById = new Map<ExplorationQueryId, ExplorationQuery>(
     (thread.queries ?? []).map((query) => [query.id, query]),
@@ -300,6 +339,7 @@ function getExplorationQueryTree(
           return null;
         }
         const status = getExplorationQueryGroupStatus(queries);
+        const pageKey = getPageKey(queries[0]);
         return {
           id: String(page.id),
           name: page.name ?? "",
@@ -312,7 +352,7 @@ function getExplorationQueryTree(
             status,
             interestingness_score:
               status === "done"
-                ? getExplorationQueryGroupInterestingness(queries)
+                ? (interestingnessByPageKey[pageKey] ?? null)
                 : null,
             parent_id: String(block.id),
             hidden: page.hidden ?? false,

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/utils.unit.spec.ts
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/utils.unit.spec.ts
@@ -406,6 +406,172 @@ describe("getExplorationSidebarTree sorting", () => {
 
     expect(getLeafIds(getMetricHeadings(tree)[0])).toEqual(["1", "2"]);
   });
+
+  it("sorts follow-up thread pages by the initial thread's interestingness scores", () => {
+    const sharedCardId = 1;
+    const countryDim = "dim-country";
+    const planDim = "dim-plan";
+
+    const initialCountry = createQuery({
+      id: 1,
+      name: "Revenue by country",
+      status: "done",
+      card_id: sharedCardId,
+      dimension_id: countryDim,
+      interestingness_score: 0.9,
+    });
+    const initialPlan = createQuery({
+      id: 2,
+      name: "Revenue by plan",
+      status: "done",
+      card_id: sharedCardId,
+      dimension_id: planDim,
+      interestingness_score: 0.2,
+    });
+
+    const followUpPlan = createQuery({
+      id: 3,
+      name: "Revenue by plan (TX)",
+      status: "done",
+      exploration_thread_id: 2,
+      card_id: sharedCardId,
+      dimension_id: planDim,
+      interestingness_score: 0.99,
+    });
+    const followUpCountry = createQuery({
+      id: 4,
+      name: "Revenue by country (TX)",
+      status: "done",
+      exploration_thread_id: 2,
+      card_id: sharedCardId,
+      dimension_id: countryDim,
+      interestingness_score: 0.01,
+    });
+
+    const exploration = createExploration({
+      threads: [
+        createThread({
+          id: 1,
+          position: 0,
+          queries: [initialCountry, initialPlan],
+          blocks: [
+            createBlock({
+              id: METRIC_A_BLOCK_ID,
+              name: "Revenue",
+              position: 0,
+              pages: [
+                createPage({
+                  id: 100,
+                  name: "By country",
+                  position: 0,
+                  query_ids: [initialCountry.id],
+                }),
+                createPage({
+                  id: 101,
+                  name: "By plan",
+                  position: 1,
+                  query_ids: [initialPlan.id],
+                }),
+              ],
+            }),
+          ],
+        }),
+        createThread({
+          id: 2,
+          name: "State = TX",
+          position: 1,
+          source_page_id: 100,
+          queries: [followUpPlan, followUpCountry],
+          blocks: [
+            createBlock({
+              id: 30,
+              name: "Revenue",
+              position: 0,
+              pages: [
+                createPage({
+                  id: 200,
+                  name: "By plan",
+                  position: 0,
+                  query_ids: [followUpPlan.id],
+                }),
+                createPage({
+                  id: 201,
+                  name: "By country",
+                  position: 1,
+                  query_ids: [followUpCountry.id],
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const tree = getExplorationSidebarTree(exploration, allTreeFilter);
+    const followUpNode = tree.find((node) => node.id === 2);
+    const followUpPageIds = (followUpNode?.children ?? [])
+      .filter((child) => child.data?.type === "page")
+      .map((child) => String(child.id));
+
+    expect(followUpPageIds).toEqual(["201", "200"]);
+    expect(
+      followUpNode?.children?.find((child) => child.id === "201")?.data,
+    ).toMatchObject({
+      type: "page",
+      interestingness_score: 0.9,
+    });
+    expect(
+      followUpNode?.children?.find((child) => child.id === "200")?.data,
+    ).toMatchObject({
+      type: "page",
+      interestingness_score: 0.2,
+    });
+  });
+
+  it("uses the max effective score across grouped queries, preferring contextual over heuristic", () => {
+    const groupedLowContextual = createQuery({
+      id: 1,
+      name: "Revenue (US)",
+      status: "done",
+      card_id: 1,
+      dimension_id: "dim-region",
+      interestingness_score: 0.9,
+      contextual_interestingness_score: 0.4,
+    });
+    const groupedHighContextual = createQuery({
+      id: 2,
+      name: "Revenue (EU)",
+      status: "done",
+      card_id: 1,
+      dimension_id: "dim-region",
+      interestingness_score: 0.3,
+      contextual_interestingness_score: 0.85,
+    });
+
+    const tree = getAllTabExplorationSidebarTree({
+      queries: [groupedLowContextual, groupedHighContextual],
+      blocks: [
+        createBlock({
+          id: METRIC_A_BLOCK_ID,
+          name: "Revenue",
+          position: 0,
+          pages: [
+            createPage({
+              id: 100,
+              name: "Revenue by region",
+              position: 0,
+              query_ids: [groupedLowContextual.id, groupedHighContextual.id],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    expect(getPageData(getMetricHeadings(tree)[0], "100")).toMatchObject({
+      status: "done",
+      interestingness_score: 0.85,
+    });
+  });
 });
 
 describe("getExplorationSidebarTree passes BE-computed names through", () => {

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/utils.unit.spec.ts
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/utils.unit.spec.ts
@@ -263,6 +263,56 @@ describe("getExplorationSidebarTree sorting", () => {
     expect(getLeafIds(getMetricHeadings(tree)[0])).toEqual(["1", "2", "3"]);
   });
 
+  it("orders zero-row pages with errors at the bottom", () => {
+    const done = createQuery({
+      id: 1,
+      name: "Done",
+      status: "done",
+    });
+    const running = createQuery({ id: 2, name: "Running", status: "pending" });
+    const empty = createQuery({
+      id: 3,
+      name: "Empty",
+      status: "done",
+      row_count: 0,
+    });
+
+    const tree = getAllTabExplorationSidebarTree({
+      queries: [empty, running, done],
+      blocks: [
+        createBlock({
+          id: METRIC_A_BLOCK_ID,
+          name: "Metric A",
+          position: 0,
+          pages: [
+            createPage({
+              id: 3,
+              name: "Empty",
+              position: 0,
+              query_ids: [empty.id],
+            }),
+            createPage({
+              id: 2,
+              name: "Running",
+              position: 1,
+              query_ids: [running.id],
+            }),
+            createPage({
+              id: 1,
+              name: "Done",
+              position: 2,
+              query_ids: [done.id],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const heading = getMetricHeadings(tree)[0];
+    expect(getLeafIds(heading)).toEqual(["1", "2", "3"]);
+    expect(getPageData(heading, "3")).toMatchObject({ status: "error" });
+  });
+
   it("orders metric headings by their best settled child score", () => {
     const metricALeaf = createQuery({
       id: 1,


### PR DESCRIPTION
Closes [UXW-4459: Handle empty metric results more clearly in explorations](https://linear.app/metabase/issue/UXW-4459/handle-empty-metric-results-more-clearly-in-explorations)
Closes [UXW-4835: Match subexploration sort order to the initial investigation's sort order](https://linear.app/metabase/issue/UXW-4835/match-subexploration-sort-order-to-the-initial-investigations-sort)