### PR TITLE
Restore table color range saturation for single conditional formatting rules

### DIFF
--- a/frontend/src/metabase/visualizations/lib/table_format.ts
+++ b/frontend/src/metabase/visualizations/lib/table_format.ts
@@ -144,6 +144,7 @@ export function compileFormatter(
   columnName: string | null = null,
   columnExtents: ColumnExtents | null = null,
   isRowFormatter: boolean = false,
+  matchOnlyWithinRange: boolean = false,
 ): Formatter {
   if (format.type === "single") {
     let { operator, value, color } = format;
@@ -200,7 +201,10 @@ export function compileFormatter(
       }),
     ).clamp(true);
     return (value) => {
-      if (!isNumber(value) || value < lowerBound || value > upperBound) {
+      if (!isNumber(value)) {
+        return null;
+      }
+      if (matchOnlyWithinRange && (value < lowerBound || value > upperBound)) {
         return null;
       }
       const colorValue = scale(value);
@@ -273,11 +277,27 @@ function compileFormatters(
   columnExtents: ColumnExtents,
 ): Formatters {
   const formatters: Formatters = {};
+  const rangeFormatterCounts: Record<string, number> = {};
+  formats.forEach((format) => {
+    if (format.type === "range") {
+      format.columns.forEach((columnName) => {
+        rangeFormatterCounts[columnName] =
+          (rangeFormatterCounts[columnName] ?? 0) + 1;
+      });
+    }
+  });
+
   formats.forEach((format) => {
     format.columns.forEach((columnName) => {
       formatters[columnName] = formatters[columnName] || [];
       formatters[columnName].push(
-        compileFormatter(format, columnName, columnExtents, false),
+        compileFormatter(
+          format,
+          columnName,
+          columnExtents,
+          false,
+          rangeFormatterCounts[columnName] > 1,
+        ),
       );
     });
   });

--- a/frontend/src/metabase/visualizations/lib/table_format.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/table_format.unit.spec.ts
@@ -245,6 +245,60 @@ describe("compileFormatter with extreme ranges", () => {
 });
 
 describe("makeCellBackgroundGetter", () => {
+  it("saturates values outside custom bounds when there is one range rule (#77957)", () => {
+    const getter = makeCellBackgroundGetter(
+      [[-0.1], [0], [0.6], [0.8]],
+      [createMockNumericColumn({ name: "score" })],
+      [
+        createMockColumnRangeFormattingSetting({
+          columns: ["score"],
+          colors: ["#ff0000", "#00ff00"],
+          min_type: "custom",
+          min_value: 0,
+          max_type: "custom",
+          max_value: 0.6,
+        }),
+      ],
+      false,
+    );
+
+    expect(getter(-0.1, 0, "score")).toBe(getter(0, 1, "score"));
+    expect(getter(0.8, 3, "score")).toBe(getter(0.6, 2, "score"));
+  });
+
+  it("saturates values when range rules target different columns (#77957)", () => {
+    const getter = makeCellBackgroundGetter(
+      [
+        [0.6, 0.6],
+        [0.8, 0.8],
+      ],
+      [
+        createMockNumericColumn({ name: "score" }),
+        createMockNumericColumn({ name: "total" }),
+      ],
+      [
+        createMockColumnRangeFormattingSetting({
+          columns: ["score"],
+          min_type: "custom",
+          min_value: 0,
+          max_type: "custom",
+          max_value: 0.6,
+        }),
+        createMockColumnRangeFormattingSetting({
+          columns: ["total"],
+          min_type: "custom",
+          min_value: 0,
+          max_type: "custom",
+          max_value: 0.6,
+        }),
+      ],
+      false,
+    );
+
+    expect(getter(0.8, 1, "score")).toBe(getter(0.6, 0, "score"));
+    expect(getter(0.8, 1, "total")).toBe(getter(0.6, 0, "total"));
+  });
+
   it("applies each range rule to values in its own range when ranges do not overlap (#75933)", () => {
     const getter = makeCellBackgroundGetter(
       [[-1000], [1000]],


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/77957

### Description

Restores endpoint color saturation for values outside a single color-range rule’s custom bounds.
Range rules remain strictly bounded when multiple rules target the same column, preserving the fix for #75933.

### How to verify

1. Create a native question returning numeric values `0.1`, `0.4`, `0.6`, and `0.8`.
```
SELECT 0.0 AS value
UNION ALL SELECT 0.1
UNION ALL SELECT 0.4
UNION ALL SELECT 0.6
UNION ALL SELECT 0.8
ORDER BY value
```
2. Add one color-range conditional formatting rule with a custom maximum of `0.6`.
3. Confirm `0.8` uses the same endpoint color as `0.6`.
4. Add two non-overlapping range rules to the same column and confirm each rule only colors values within its range. (see #75933)


### Demo:
Before:
<img width="1242" height="891" alt="image" src="https://github.com/user-attachments/assets/63548959-611a-477b-a808-50bd31298c67" />

After:
<img width="1242" height="891" alt="image" src="https://github.com/user-attachments/assets/a38cb7ce-443c-4a83-bcc3-12b90f0887cc" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)