### PR TITLE
Fix Metabot exploration tools streaming empty results to the client

### DIFF
--- a/src/metabase/metabot/tools/explorations.clj
+++ b/src/metabase/metabot/tools/explorations.clj
@@ -1,7 +1,14 @@
 (ns metabase.metabot.tools.explorations
-  "Exploration-specific tool wrappers."
+  "Exploration-specific tool wrappers.
+
+  Every tool here returns `{:output <json-string>}`: the exploration chat FE applies plan edits
+  by parsing the tool result it sees on the `tool-output-available` stream event, and only a
+  result's `:output` string makes it onto the wire (see
+  `metabase.metabot.self.core/tool-output->wire-output`) — a bare map would reach the LLM but
+  stream to the client as an empty string, and the plan would silently never update."
   (:require
    [metabase.explorations.core :as explorations]
+   [metabase.util.json :as json]
    [metabase.util.malli :as mu]))
 
 (set! *warn-on-reflection* true)
@@ -17,7 +24,7 @@
    and the metric ids it can slice. Use this to choose valid metric and dimension ids before
    calling `add_research_groups`. Pass `q` to filter by a search term."
   [{:keys [q]} :- get-research-candidates-schema]
-  (explorations/research-candidates {:q q}))
+  {:output (json/encode (explorations/research-candidates {:q q}))})
 
 (def ^:private add-research-groups-schema
   [:map {:closed true}
@@ -46,7 +53,7 @@
      of metrics by one dimension — it reads as one \"by <dimension>\" block rather than several
      loose metrics."
   [{:keys [groups]} :- add-research-groups-schema]
-  (explorations/research-groups {:groups groups}))
+  {:output (json/encode (explorations/research-groups {:groups groups}))})
 
 (def ^:private remove-from-research-plan-schema
   [:map {:closed true}
@@ -78,9 +85,9 @@
    remove an entire group prefer `block_ids` directly. Removing a block, member, or id that isn't
    in the plan is a no-op."
   [{:keys [block_ids members timeline_ids]} :- remove-from-research-plan-schema]
-  {:block_ids    block_ids
-   :members      members
-   :timeline_ids timeline_ids})
+  {:output (json/encode {:block_ids    block_ids
+                         :members      members
+                         :timeline_ids timeline_ids})})
 
 (def ^:private set-exploration-name-schema
   [:map {:closed true}
@@ -90,7 +97,7 @@
   set-exploration-name-tool
   "Set the name of the research artifact."
   [{:keys [name]} :- set-exploration-name-schema]
-  {:name  name})
+  {:output (json/encode {:name name})})
 
 (def ^:private select-exploration-timelines-schema
   [:map {:closed true}
@@ -100,4 +107,4 @@
   select-exploration-timelines-tool
   "Select the timelines to include in the research. Populates the research artifact with the chosen timelines."
   [{:keys [timeline_ids]} :- select-exploration-timelines-schema]
-  {:timeline_ids timeline_ids})
+  {:output (json/encode {:timeline_ids timeline_ids})})

--- a/test/metabase/metabot/tools/explorations_test.clj
+++ b/test/metabase/metabot/tools/explorations_test.clj
@@ -1,25 +1,67 @@
 (ns metabase.metabot.tools.explorations-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase.metabot.tools.explorations :as tools.explorations]))
+   [metabase.metabot.self.core :as metabot.self]
+   [metabase.metabot.tools.explorations :as tools.explorations]
+   [metabase.util.json :as json]))
+
+(defn- decoded-output
+  "The exploration tools return `{:output <json-string>}` (only `:output` survives onto the
+   `tool-output-available` stream event the FE consumes); decode it back to a map."
+  [result]
+  (json/decode+kw (:output result)))
 
 (deftest ^:parallel remove-from-research-plan-tool-test
   (testing "echoes the block ids the agent asked to remove (pure-echo; the FE applies them)"
     (is (= {:block_ids ["metric:42" "dim:7"] :members nil :timeline_ids nil}
-           (tools.explorations/remove-from-research-plan-tool
-            {:block_ids ["metric:42" "dim:7"]}))))
+           (decoded-output
+            (tools.explorations/remove-from-research-plan-tool
+             {:block_ids ["metric:42" "dim:7"]})))))
   (testing "echoes member-level removals (deselect dimensions/metrics within a group)"
     (is (= {:block_ids    nil
             :members      [{:block_id "metric:42" :dimension_ids ["d1"]}
                            {:block_id "dim:7" :metric_ids [43]}]
             :timeline_ids nil}
-           (tools.explorations/remove-from-research-plan-tool
-            {:members [{:block_id "metric:42" :dimension_ids ["d1"]}
-                       {:block_id "dim:7" :metric_ids [43]}]}))))
+           (decoded-output
+            (tools.explorations/remove-from-research-plan-tool
+             {:members [{:block_id "metric:42" :dimension_ids ["d1"]}
+                        {:block_id "dim:7" :metric_ids [43]}]})))))
   (testing "echoes timeline removals"
     (is (= {:block_ids nil :members nil :timeline_ids [7 9]}
-           (tools.explorations/remove-from-research-plan-tool
-            {:timeline_ids [7 9]}))))
+           (decoded-output
+            (tools.explorations/remove-from-research-plan-tool
+             {:timeline_ids [7 9]})))))
   (testing "an empty list is valid (a no-op removal)"
     (is (= {:block_ids [] :members nil :timeline_ids nil}
-           (tools.explorations/remove-from-research-plan-tool {:block_ids []})))))
+           (decoded-output
+            (tools.explorations/remove-from-research-plan-tool {:block_ids []}))))))
+
+(defn- streamed-tool-output
+  "Run a tool `result` through the SSE serializer and return the decoded payload the FE would
+   see: the `tool-output-available` event's `:output` string, JSON-parsed."
+  [result]
+  (let [events (into [] (metabot.self/parts->aisdk-sse-xf)
+                     [{:type :start :id "s1"}
+                      {:type :tool-output :id "tc1" :result result}])
+        event  (some #(when (str/includes? % "\"tool-output-available\"")
+                        (json/decode+kw (str/replace-first % "data: " "")))
+                     events)]
+    (some-> (:output event) json/decode+kw)))
+
+(deftest ^:parallel plan-tool-results-reach-the-wire-test
+  (testing (str "the exploration chat FE applies plan edits by parsing the streamed tool result; "
+                "only a result's :output string makes it onto tool-output-available, so a bare-map "
+                "result would stream as \"\" and the plan would silently never update")
+    (testing "set_research_name"
+      (is (= {:name "Quarterly revenue"}
+             (streamed-tool-output
+              (tools.explorations/set-exploration-name-tool {:name "Quarterly revenue"})))))
+    (testing "select_research_timelines"
+      (is (= {:timeline_ids [3 5]}
+             (streamed-tool-output
+              (tools.explorations/select-exploration-timelines-tool {:timeline_ids [3 5]})))))
+    (testing "remove_from_research_plan"
+      (is (= {:block_ids ["metric:42"] :members nil :timeline_ids nil}
+             (streamed-tool-output
+              (tools.explorations/remove-from-research-plan-tool {:block_ids ["metric:42"]})))))))


### PR DESCRIPTION
Changes on master caused this to break - a bare map streams as "". The exploration plan tools returned bare maps, so the FE — which applies plan edits by parsing the streamed tool result — silently dropped every edit while the LLM (which still saw the full result) reported success. 🙃 