### PR TITLE
Handle numeric PKs/FKs better in explorations (UXW-4757)

### DIFF
--- a/src/metabase/explorations/query_plan/mbql.clj
+++ b/src/metabase/explorations/query_plan/mbql.clj
@@ -38,13 +38,17 @@
     `nil`               — no bucket; use a bare breakout.
 
   Resolution order matters: DateTime first (it derives from both HasDate and
-  HasTime), then Date, then Time. Coordinates come before generic numbers
-  because Coordinate also derives from Number."
+  HasTime), then Date, then Time. Keys (PK/FK) are checked before the binning
+  branches — lib offers no binning strategies for `:Relation/*` columns (see
+  `metabase.lib.field`), so treating a numeric key as binnable would make the
+  planner assume a ≤20-bar chart the QP can't actually produce. Coordinates
+  come before generic numbers because Coordinate also derives from Number."
   [dim]
   (cond
     (dim-type-isa? dim :type/DateTime)   [:temporal :month]
     (dim-type-isa? dim :type/Date)       [:temporal :day]
     (dim-type-isa? dim :type/Time)       [:temporal :hour]
+    (dim-type-isa? dim :Relation/*)      nil
     (dim-type-isa? dim :type/Coordinate) [:binning {:strategy :default}]
     (dim-type-isa? dim :type/Number)     [:binning {:strategy :default}]
     :else                                nil))

--- a/src/metabase/explorations/query_plan/mechanical.clj
+++ b/src/metabase/explorations/query_plan/mechanical.clj
@@ -96,9 +96,9 @@
       variants, not categorical rollups.
    2. Dim has no default bucket/binning — auto-binned numerics are already
       capped at `default-binning-max-bins` by `default`, so a top-K rollup
-      would be redundant. Mechanical stays conservative here: the LLM
-      planner allows numerics via `semantic_type`, but mechanical has no
-      semantic signal to lean on.
+      would be redundant. Key-typed numerics (PK/FK) have no default binning
+      (the QP refuses to bin `:Relation/*` columns), so high-cardinality ids
+      route here and get the bounded top-K + Other rollup.
    3. Dim's raw distinct-count is unknown OR > `top-n-other-min-cardinality`.
       Missing fingerprints fail *safe* into top-n-other (bounded by K) so a
       high-cardinality dim with no fingerprint doesn't fall through to the

--- a/src/metabase/explorations/query_plan/variants.clj
+++ b/src/metabase/explorations/query_plan/variants.clj
@@ -368,7 +368,10 @@
     (when (seq top-values)
       (let [base-query             (-> (lib/query mp (:dataset_query card)) lib/remove-all-breakouts)
             [ref-clause field-ref] (resolve-target base-query target)
-            pairs                  (mapv (fn [v] [(lib/= (or field-ref ref-clause) v) v]) top-values)
+            ;; THEN values are stringified so the CASE is single-typed: the ELSE arm is the string
+            ;; `other-bucket-label`, and a mixed CASE (numeric THEN, string ELSE) is rejected by
+            ;; Postgres and other strict warehouses. No-op for text dims.
+            pairs                  (mapv (fn [v] [(lib/= (or field-ref ref-clause) v) (str v)]) top-values)
             case-expr              (lib/case pairs other-bucket-label)
             expr-name              (or (:display_name dim) (:dimension_id dim) "value")
             with-expr              (lib/expression base-query expr-name case-expr)

--- a/src/metabase/interestingness/dimension.clj
+++ b/src/metabase/interestingness/dimension.clj
@@ -135,8 +135,11 @@
       (when-let [days (effective-day-span field)]
         (:score (best-temporal-buckets days)))
 
-      ;; Numeric with high cardinality and a nonzero range → auto-binning will produce good buckets
+      ;; Numeric with high cardinality and a nonzero range → auto-binning will produce good buckets.
+      ;; Keys (PK/FK) are excluded: the QP refuses to bin :Relation/* columns, so the binning
+      ;; premise doesn't hold for them — they fall through to raw distinct count below.
       (and numeric-fp (> distinct-count 50)
+           (not (isa? (:semantic-type field) :Relation/*))
            (some? (:min numeric-fp)) (some? (:max numeric-fp))
            (not= (:min numeric-fp) (:max numeric-fp)))
       0.9

--- a/src/metabase/interestingness/impl.clj
+++ b/src/metabase/interestingness/impl.clj
@@ -32,6 +32,10 @@
   "Hard-zero fields whose data values carry no exploratory meaning regardless of the
    role they're being scored for (dimension or measure):
    - `:type/PK`: opaque row identifiers
+   - numeric `:type/FK`: opaque row references — grouping by one gives a bar per id
+     value (the QP refuses to bin `:Relation/*` columns), and aggregating one is
+     meaningless. Non-numeric FKs (e.g. a country code referencing a lookup table)
+     keep their data meaning and are not penalized.
    - `:type/Collection` / `:type/Structured`: structured blobs (JSON, XML, arrays,
      dictionaries, text-stored serialized JSON) — not groupable or aggregatable
    - `:type/UpdatedTemporal` / `:type/DeletionTemporal`: audit fields that describe
@@ -41,10 +45,13 @@
    absence of a penalty isn't a positive signal, it just means this scorer has
    nothing to say about the field."
   [field]
-  (let [semantic-type (:semantic-type field)]
+  (let [semantic-type  (:semantic-type field)
+        effective-type (or (:effective-type field) (:base-type field))]
     (cond
       (nil? semantic-type)                        nil
       (isa? semantic-type :type/PK)               0.0
+      (and (isa? semantic-type :type/FK)
+           (isa? effective-type :type/Number))    0.0
       (isa? semantic-type :type/Collection)       0.0
       (isa? semantic-type :type/Structured)       0.0
       (isa? semantic-type :type/UpdatedTemporal)  0.0

--- a/test/metabase/explorations/query_plan/mechanical_test.clj
+++ b/test/metabase/explorations/query_plan/mechanical_test.clj
@@ -26,6 +26,17 @@
 (defn- datetime-dim [dim-id] {:dimension_id dim-id :display_name dim-id :effective_type :type/DateTime})
 (defn- numeric-dim  [dim-id] {:dimension_id dim-id :display_name dim-id :effective_type :type/Float})
 
+(defn- fk-dim
+  "Numeric FK dim. Keys never auto-bin (the QP refuses to bin :Relation/*
+  columns), so cardinality banding uses the raw distinct count."
+  ([dim-id]                (fk-dim dim-id nil))
+  ([dim-id distinct-count] {:dimension_id   dim-id
+                            :display_name   dim-id
+                            :effective_type :type/Integer
+                            :semantic_type  :type/FK
+                            :fingerprint    (when distinct-count
+                                              {:global {:distinct-count distinct-count}})}))
+
 (defn- metric-with-dims
   "Build a metric-context entry matching `qp.context/metric-and-dim-context`
   shape, just enough for the mechanical planner: id, applicability map,
@@ -135,6 +146,29 @@
   (testing "top-n-other skipped for auto-binned numeric dim (default already caps at bin count)"
     (let [r (plan! (metric-with-dims 1 {"n" (numeric-dim "n")}))]
       (is (not (contains? (set (map :variant (:plan r))) "top-n-other"))))))
+
+(deftest numeric-key-eligibility-test
+  (testing "numeric keys never auto-bin, so they band by raw distinct count like categoricals (UXW-4757)"
+    (testing "high-cardinality numeric FK → top-n-other only, never the unbounded default"
+      (let [r (plan! (metric-with-dims 1 {"fk" (fk-dim "fk" 1000)}))]
+        (is (= #{"top-n-other"} (set (map :variant (:plan r)))))))
+    (testing "unknown-cardinality numeric FK → top-n-other only (fail-safe)"
+      (let [r (plan! (metric-with-dims 1 {"fk" (fk-dim "fk")}))]
+        (is (= #{"top-n-other"} (set (map :variant (:plan r)))))))
+    (testing "low-cardinality numeric FK (≤20) → default only"
+      (let [r (plan! (metric-with-dims 1 {"fk" (fk-dim "fk" 10)}))]
+        (is (= #{"default"} (set (map :variant (:plan r)))))))
+    (testing "mid-cardinality numeric FK (21-100) → both"
+      (let [r (plan! (metric-with-dims 1 {"fk" (fk-dim "fk" 50)}))]
+        (is (= #{"default" "top-n-other"} (set (map :variant (:plan r)))))))
+    (testing "numeric PK bands the same way as a numeric FK"
+      (let [pk (assoc (fk-dim "pk" 1000) :semantic_type :type/PK)
+            r  (plan! (metric-with-dims 1 {"pk" pk}))]
+        (is (= #{"top-n-other"} (set (map :variant (:plan r)))))))
+    (testing "high-cardinality numeric FK is NOT time-facet eligible — raw count, not bin count,
+              is the series budget now"
+      (let [r (plan! (metric-with-dims 1 {"fk" (fk-dim "fk" 1000)} true))]
+        (is (not (contains? (set (map :variant (:plan r))) "time-facet")))))))
 
 (deftest segment-fan-out-test
   (testing "Each non-time-facet variant is fanned out across [nil + segments]"

--- a/test/metabase/explorations/query_plan/variants_test.clj
+++ b/test/metabase/explorations/query_plan/variants_test.clj
@@ -201,6 +201,32 @@
       (is (= [["Widget" 54] ["Gadget" 53] ["Gizmo" 51] ["Doohickey" 42]]
              (run-top-n-other {:card-id 9000002 :k 4}))))))
 
+(def ^:private product-id-fk-dim
+  {:dimension_id   "d-product-id"
+   :display_name   "Product ID"
+   :effective_type :type/Integer
+   :semantic_type  :type/FK})
+
+(deftest top-n-other-numeric-fk-test
+  (mt/test-drivers (mt/normal-drivers)
+    (testing "top-n-other on a numeric FK dim stringifies the bucket labels, so the CASE
+              expression is single-typed — a mixed CASE (numeric THEN arms, string (Other)
+              ELSE arm) is rejected by strict warehouses (UXW-4757)"
+      (let [ctx  {:mp      (mt/metadata-provider)
+                  :card    (orders-count-card 9000005)
+                  :target  [:field (mt/id :orders :product_id) nil]
+                  :dim     product-id-fk-dim
+                  :segment nil
+                  :params  {:k 2}}
+            rows (-> (variants/pin-other-last
+                      "top-n-other"
+                      (qp/process-query (variants/dataset-query "top-n-other" ctx)))
+                     :data :rows)]
+        (is (= 3 (count rows)) "top 2 ids + (Other)")
+        (is (every? string? (map first rows))
+            "every bucket label — discovered ids and (Other) — is a string")
+        (is (= "(Other)" (first (last rows))))))))
+
 (deftest pin-other-last-test
   (testing "pin-other-last stably moves the (Other) row to the end, preserving the
             metric-desc order of the named buckets"

--- a/test/metabase/interestingness/dimension_test.clj
+++ b/test/metabase/interestingness/dimension_test.clj
@@ -24,6 +24,17 @@
   (testing "missing top-3-fraction falls through to the bucket-count score (no gate on absence)"
     (is (> (dim/cardinality {:fingerprint {:global {:distinct-count 12}
                                            :type   {:type/Text {:average-length 8}}}}) 0.1)))
+  (testing "high-cardinality binnable numeric hits the auto-binnable branch"
+    (is (= 0.9 (dim/cardinality {:fingerprint {:global {:distinct-count 1000}
+                                               :type   {:type/Number {:min 1 :max 1000}}}}))))
+  (testing "keys (PK/FK) are excluded from the auto-binnable branch — the QP refuses to bin
+            :Relation/* columns, so they score by raw distinct count instead"
+    (doseq [sem-type [:type/FK :type/PK]]
+      (is (< (dim/cardinality {:semantic-type sem-type
+                               :fingerprint   {:global {:distinct-count 1000}
+                                               :type   {:type/Number {:min 1 :max 1000}}}})
+             0.3)
+          (str sem-type " should fall through to bucket-count-score"))))
   (testing "missing fingerprint returns nil (no signal)"
     (is (nil? (dim/cardinality {})))
     (is (nil? (dim/cardinality {:fingerprint {}})))))
@@ -164,6 +175,20 @@
     (is (= 0.0 (dim/dimension-interestingness
                 {:semantic-type :type/PK
                  :fingerprint   {:global {:distinct-count 1000 :nil% 0.0}}}))))
+  (testing "numeric FK scores 0.0 regardless of how good its fingerprint looks (UXW-4757)"
+    (is (= 0.0 (dim/dimension-interestingness
+                {:semantic-type  :type/FK
+                 :effective-type :type/Integer
+                 :fingerprint    {:global {:distinct-count 1000 :nil% 0.0}
+                                  :type   {:type/Number {:min 1 :max 1000}}}})))
+    (is (= 0.0 (dim/dimension-interestingness
+                {:semantic_type  :type/FK
+                 :effective_type :type/BigInteger})))
+    (testing "but a non-numeric FK stays scoreable"
+      (is (pos? (dim/dimension-interestingness
+                 {:semantic-type  :type/FK
+                  :effective-type :type/Text
+                  :fingerprint    {:global {:distinct-count 15 :nil% 0.0}}})))))
   (testing "structured-blob fields score 0.0 even with no fingerprint"
     (is (= 0.0 (dim/dimension-interestingness {:semantic-type :type/Collection})))
     (is (= 0.0 (dim/dimension-interestingness {:semantic-type :type/Structured}))))

--- a/test/metabase/interestingness/impl_test.clj
+++ b/test/metabase/interestingness/impl_test.clj
@@ -22,8 +22,14 @@
       :type/Name
       :type/CreationTimestamp
       :type/Number
-      :type/FK
+      :type/FK ; no effective/base type in the map, so the numeric-FK gate can't fire
       nil))
+  (testing "numeric FKs score 0.0 (opaque unbinnable ids); non-numeric FKs keep their data meaning"
+    (is (= 0.0 (impl/type-penalty {:semantic-type :type/FK :effective-type :type/Integer})))
+    (is (= 0.0 (impl/type-penalty {:semantic-type :type/FK :base-type :type/BigInteger}))
+        "base-type is the fallback when effective-type is absent")
+    (is (nil? (impl/type-penalty {:semantic-type :type/FK :effective-type :type/Text}))
+        "a text FK (e.g. country code referencing a lookup table) is not penalized"))
   (testing "nil semantic type scores nil (no signal)"
     (is (nil? (impl/type-penalty {})))))
 


### PR DESCRIPTION
Numeric PK/FK dimensions produced unusable one-bar-per-id charts and were auto-selected as interesting dimensions. Two root causes:

1. The query planner treated any numeric dim as auto-binnable, but... they're not, and we emitted unbounded bare breakouts, and ruled out the top-n-other variant.

2. Dimension interestingness hard-zeros PKs but not FKs, and the cardinality scorer's auto-binnable branch gave numeric FKs 0.9 for a binned chart the QP can never produce, so they got auto-selected.