### PR TITLE
Add MB_DISABLED_SUBSYSTEMS startup toggles

### DIFF
--- a/src/metabase/core/bootstrap.clj
+++ b/src/metabase/core/bootstrap.clj
@@ -57,19 +57,53 @@
       ((requiring-resolve startup) args)
       (do (binding [*out* *err*]
             (output! (str "Unknown mode: " mode))
-            (output! "Available modes: checker, complexity-score"))
+            (output! "Available modes: checker, complexity-score, preview"))
           (System/exit 1)))))
+
+;;; ===========================================================================
+;;; Server modes
+;;;
+;;; Unlike standalone modes, these run the full Metabase server, just with a
+;;; preset of subsystems disabled (see metabase.core.core/toggleable-subsystems).
+;;; ===========================================================================
+
+(def ^:private server-mode->disabled-subsystems
+  {"preview" "scheduler,health-check,queue-listeners,audit-db"})
+
+(defn- install-server-mode-preset!
+  "Install the mode's disabled-subsystems preset, unioned with anything already in MB_DISABLED_SUBSYSTEMS, as a
+  system property for the config system to pick up. environ captures system properties once, at load time, and
+  gives them precedence over environment variables — so this must run before ANY metabase namespace loads,
+  including the classloader, whose require chain reaches metabase.config.core and loads environ."
+  [mode]
+  (let [preset   (server-mode->disabled-subsystems mode)
+        from-env (System/getenv "MB_DISABLED_SUBSYSTEMS")
+        combined (cond-> preset
+                   (seq from-env) (str "," from-env))]
+    (System/setProperty "mb.disabled.subsystems" combined)
+    (output! (str "Starting Metabase in " mode " mode (disabled subsystems: " combined ")"))))
 
 (defn -main
   "Main entrypoint. Invokes [[metabase.core.core/entrypoint]]"
   [& args]
-  ;; We need to install the classloader here before other namespaces are loaded since they could launch threads on load.
-  ;; If a thread is spun up and put back into a pool before this happens that pool will have a poisoned thread unable to
-  ;; see classes in our classloader.
-  ((requiring-resolve 'metabase.classloader.core/the-classloader))
-  ;; Check for standalone modes first - these skip loading metabase.core.core
-  (let [{:keys [options]} (cli/parse-opts args [[nil "--mode MODE"]])
-        mode              (:mode options)]
-    (if mode
+  (let [{:keys [options arguments]} (cli/parse-opts args [[nil "--mode MODE"]])
+        mode                        (:mode options)
+        server-mode?                (contains? server-mode->disabled-subsystems mode)]
+    ;; Must happen before the classloader (or anything else) loads a metabase namespace — see the docstring.
+    (when server-mode?
+      (install-server-mode-preset! mode))
+    ;; We need to install the classloader here before other namespaces are loaded since they could launch threads on
+    ;; load. If a thread is spun up and put back into a pool before this happens that pool will have a poisoned thread
+    ;; unable to see classes in our classloader.
+    ((requiring-resolve 'metabase.classloader.core/the-classloader))
+    (cond
+      ;; server modes run the normal entrypoint, minus the --mode args
+      server-mode?
+      (apply (requiring-resolve 'metabase.core.core/entrypoint) arguments)
+
+      ;; standalone modes skip loading metabase.core.core
+      mode
       (run-standalone-mode mode args)
+
+      :else
       (apply (requiring-resolve 'metabase.core.core/entrypoint) args))))

--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -167,7 +167,9 @@
                         which initializes the scheduler into standby but never starts it.
     :health-check    -- warehouse connection health checks at startup
     :queue-listeners -- in-process queue listeners (search indexing, etc.)
-    :audit-db        -- installing the audit / instance-analytics content"
+    :audit-db        -- installing the audit / instance-analytics content
+
+  `java -jar metabase.jar --mode preview` presets all of these (see [[metabase.core.bootstrap]])."
   #{:scheduler :health-check :queue-listeners :audit-db})
 
 (defn- disabled-subsystems

--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -157,11 +157,48 @@
         (catch Exception e
           (log/warnf e "Failed to register signal handler for SIG%s" signal-name))))))
 
+(def ^:private toggleable-subsystems
+  "Subsystems that can be turned off at startup via a comma-separated `MB_DISABLED_SUBSYSTEMS` list, e.g.
+  `MB_DISABLED_SUBSYSTEMS=scheduler,audit-db`. Intended for ephemeral instances (PR previews, CI) that want a
+  smaller, quieter Metabase.
+
+    :scheduler       -- Quartz is never initialized: no job registration, no background tasks (sync, subscriptions,
+                        alerts). All `task/schedule-task!`-family calls become no-ops. Unlike `MB_DISABLE_SCHEDULER`,
+                        which initializes the scheduler into standby but never starts it.
+    :health-check    -- warehouse connection health checks at startup
+    :queue-listeners -- in-process queue listeners (search indexing, etc.)
+    :audit-db        -- installing the audit / instance-analytics content"
+  #{:scheduler :health-check :queue-listeners :audit-db})
+
+(defn- disabled-subsystems
+  "The set of subsystems disabled via `MB_DISABLED_SUBSYSTEMS`."
+  []
+  (let [subsystems (into #{}
+                         (comp (map str/trim)
+                               (remove str/blank?)
+                               (map keyword))
+                         (some-> (config/config-str :mb-disabled-subsystems)
+                                 (str/split #",")))]
+    (when-let [unknown (not-empty (remove toggleable-subsystems subsystems))]
+      (log/warnf "Ignoring unknown subsystem(s) in MB_DISABLED_SUBSYSTEMS: %s (known subsystems: %s)"
+                 (str/join ", " (map name unknown))
+                 (str/join ", " (sort (map name toggleable-subsystems)))))
+    (set (filter toggleable-subsystems subsystems))))
+
+(def ^:private disabled-subsystems*
+  (delay (disabled-subsystems)))
+
+(defn- subsystem-enabled?
+  [subsystem]
+  (not (@disabled-subsystems* subsystem)))
+
 (defn- init!*
   "General application initialization function which should be run once at application startup."
   []
   (log/infof "Starting Metabase version %s ..." config/mb-version-string)
   (log/infof "System info:\n %s" (u/pprint-to-str (u.system-info/system-info)))
+  (when-let [disabled (not-empty @disabled-subsystems*)]
+    (log/infof "Disabled subsystems: %s" (str/join ", " (sort (map name disabled)))))
   (perf/maybe-enable-monitoring!)
   (init-signal-logging!)
   (init-status/set-progress! 0.1)
@@ -195,8 +232,9 @@
   (init-status/set-progress! 0.4)
   (analytics.core/observe-initial-values)
   (init-status/set-progress! 0.5)
-  (task/init-scheduler!)
-  (analytics.core/add-listeners-to-scheduler!)
+  (when (subsystem-enabled? :scheduler)
+    (task/init-scheduler!)
+    (analytics.core/add-listeners-to-scheduler!))
   ;; run a very quick check to see if we are doing a first time installation
   ;; the test we are using is if there is at least 1 User in the database
   (let [new-install? (not (setup/has-user-setup))]
@@ -223,7 +261,8 @@
       ;; currently enabled. Otherwise just refresh its connection details.
       (sample-data/update-sample-database-if-needed!))
     (init-status/set-progress! 0.8))
-  (ensure-audit-db-installed!)
+  (when (subsystem-enabled? :audit-db)
+    (ensure-audit-db-installed!))
   (notification/seed-notification!)
 
   (init-status/set-progress! 0.85)
@@ -231,12 +270,15 @@
   (llm.startup/check-and-sync-settings-on-startup!)
   (init-status/set-progress! 0.9)
   (setting/migrate-encrypted-settings!)
-  (database/check-health!)
+  (when (subsystem-enabled? :health-check)
+    (database/check-health!))
   (startup/run-startup-logic!)
   (setting/log-deprecated-env-var-usage!)
   (init-status/set-progress! 0.95)
-  (task/start-scheduler!)
-  (queue/start-listeners!)
+  (when (subsystem-enabled? :scheduler)
+    (task/start-scheduler!))
+  (when (subsystem-enabled? :queue-listeners)
+    (queue/start-listeners!))
   (init-status/set-complete!)
   (log/info "Metabase Initialization COMPLETE"))
 


### PR DESCRIPTION
## Motivation

Recreates the idea from #67872 from first principles, scoped to ephemeral instances (PR previews of git-synced asset repos, CI) that want a smaller, quieter Metabase. Env-driven rather than a `--mode` CLI flag, since `--mode` is now taken by the bootstrap standalone-mode dispatch (checker, complexity-score) and containers want env config anyway.

## What this does

`MB_DISABLED_SUBSYSTEMS` is a comma-separated list of subsystems to skip at startup:

- `scheduler` — Quartz is never initialized: no job registration, no background tasks (sync, fingerprinting, subscriptions, alerts, auto-imports). Unlike `MB_DISABLE_SCHEDULER`, which initializes the scheduler into standby and registers jobs into the QRTZ tables but never starts it.
- `health-check` — skip warehouse connection health checks at startup
- `queue-listeners` — skip in-process queue listeners (search indexing, etc.)
- `audit-db` — skip installing the audit / instance-analytics content

Unknown names warn and are ignored. Default behavior (var unset) is unchanged.

## Why scheduler-off is safe

- All `task/schedule-task!`-family functions are nil-guarded (`when-let [scheduler (scheduler)]`), so a never-initialized scheduler degrades to silent no-ops during module init.
- remote-sync's initial import runs via `startup/run-startup-logic!` (direct `async-import!`), not Quartz, so boot-time import still works for preview instances.

## Testing

Booted with all four disabled plus a bogus entry (fresh H2 app DB, dev mode): init completed in 6.6s, `/api/health` and `/api/session/properties` return 200, no Quartz init/start in the log, unknown-name warning fired.

Draft: also using the CI-built jar to get realistic boot numbers for the preview use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)