### PR TITLE
Make highlighted state in line charts more obvious when hovering over comment badge

### DIFF
--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.tsx
@@ -50,7 +50,12 @@ import { ActionToolbar } from "./ActionToolbar";
 import { ExplorationChartSkeleton } from "./ExplorationChartSkeleton";
 import S from "./ExplorationGroupVisualization.module.css";
 import { ExplorationVisualizationHeader } from "./ExplorationVisualizationHeader";
-import { type LegendItem, buildSeriesGroup, getCommentLabel } from "./utils";
+import {
+  type LegendItem,
+  buildSeriesGroup,
+  getCommentLabel,
+  getHighlightedWithShouldShowTooltip,
+} from "./utils";
 
 interface ExplorationGroupVisualizationProps {
   explorationId: ExplorationId;
@@ -239,11 +244,12 @@ function ExplorationGroupVisualizationChart({
     (comment: Comment) => {
       const context = comment.context;
 
-      // comment context is an untyped JSON blob; `highlighted` is written by
-      // us as a HighlightedObject when the comment captures a chart point
-      const commentHighlight = context?.highlighted as
-        | HighlightedObject
-        | undefined;
+      const commentHighlight = getHighlightedWithShouldShowTooltip(
+        // comment context is an untyped JSON blob; `highlighted` is written by
+        // us as a HighlightedObject when the comment captures a chart point
+        context?.highlighted as HighlightedObject | undefined,
+        seriesGroup,
+      );
       const commentLabel = getCommentLabel(
         commentHighlight,
         seriesGroup,

--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.unit.spec.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.unit.spec.tsx
@@ -612,6 +612,7 @@ describe("ExplorationGroupVisualization", () => {
           cardId: 101,
           columnName: "count",
           dimensions: [{ columnName: "ts", value: "2025-01-01" }],
+          shouldShowTooltip: true,
         }),
       );
 

--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/utils.ts
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/utils.ts
@@ -476,8 +476,30 @@ export function canExploreFurther(
   return true;
 }
 
-export function getCommentLabel(
+export function getHighlightedWithShouldShowTooltip(
   highlighted?: HighlightedObject,
+  seriesGroup?: SeriesGroup,
+): HighlightedObject | null {
+  if (!highlighted || !seriesGroup) {
+    return null;
+  }
+  const { series } = seriesGroup;
+  const {
+    card: { display },
+    data: { cols },
+  } = series[0];
+  const hasMultipleSeries = series.length > 1;
+  const hasBreakout = cols.length > 2;
+  const shouldShowTooltip =
+    display === "line" && !hasMultipleSeries && !hasBreakout;
+  return {
+    ...highlighted,
+    shouldShowTooltip,
+  };
+}
+
+export function getCommentLabel(
+  highlighted?: HighlightedObject | null,
   seriesGroup?: SeriesGroup,
   computedSettings?: ComputedVisualizationSettings,
 ): string | null | undefined {

--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/utils.ts
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/utils.ts
@@ -484,10 +484,14 @@ export function getHighlightedWithShouldShowTooltip(
     return null;
   }
   const { series } = seriesGroup;
+  const firstSeries = series[0];
+  if (!firstSeries) {
+    return null;
+  }
   const {
     card: { display },
     data: { cols },
-  } = series[0];
+  } = firstSeries;
   const hasMultipleSeries = series.length > 1;
   const hasBreakout = cols.length > 2;
   const shouldShowTooltip =

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -495,6 +495,7 @@ const buildEChartsBarSeries = (
       itemStyle: {
         color: seriesModel.color,
       },
+      blurScope: "global",
     },
     blur: {
       label: getBlurLabelStyle(settings, hasMultipleSeries),
@@ -647,6 +648,7 @@ const buildEChartsLineAreaSeries = (
       areaStyle: {
         opacity: CHART_STYLE.opacity.areaFocused,
       },
+      blurScope: "global",
     },
     blur: {
       itemStyle: {

--- a/frontend/src/metabase/visualizations/types/hover.ts
+++ b/frontend/src/metabase/visualizations/types/hover.ts
@@ -58,4 +58,5 @@ export interface HighlightedObject {
   cardId?: CardId;
   dimensions?: HighlightedDimension[];
   columnName?: string;
+  shouldShowTooltip?: boolean;
 }

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -18,10 +18,8 @@ import {
   CartesianChartLegendLayout,
   CartesianChartRoot,
 } from "metabase/visualizations/visualizations/CartesianChart/CartesianChart.styled";
-import {
-  type CartesianHoveredObject,
-  useChartEvents,
-} from "metabase/visualizations/visualizations/CartesianChart/use-chart-events";
+import type { CartesianHoveredObject } from "metabase/visualizations/visualizations/CartesianChart/types";
+import { useChartEvents } from "metabase/visualizations/visualizations/CartesianChart/use-chart-events";
 
 import { TimelineEventsBand } from "./TimelineEventsBand";
 import { useChartDebug } from "./use-chart-debug";

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -147,18 +147,11 @@ function CartesianChartInner(props: VisualizationProps) {
       return props.hovered;
     }
     if (props.highlighted) {
-      const hovered = getHoveredFromHighlighted(
+      return getHoveredFromHighlighted(
         props.highlighted,
         rawSeries,
         chartModel,
       );
-      if (!hovered) {
-        return null;
-      }
-      return {
-        ...hovered,
-        isFromHighlighted: true,
-      };
     }
     return null;
   }, [props.hovered, props.highlighted, rawSeries, chartModel]);

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -18,7 +18,10 @@ import {
   CartesianChartLegendLayout,
   CartesianChartRoot,
 } from "metabase/visualizations/visualizations/CartesianChart/CartesianChart.styled";
-import { useChartEvents } from "metabase/visualizations/visualizations/CartesianChart/use-chart-events";
+import {
+  type CartesianHoveredObject,
+  useChartEvents,
+} from "metabase/visualizations/visualizations/CartesianChart/use-chart-events";
 
 import { TimelineEventsBand } from "./TimelineEventsBand";
 import { useChartDebug } from "./use-chart-debug";
@@ -139,16 +142,23 @@ function CartesianChartInner(props: VisualizationProps) {
     [chartModel, hiddenSeries, toggleSeriesVisibility],
   );
 
-  const hovered = useMemo(() => {
+  const hovered: CartesianHoveredObject | null = useMemo(() => {
     if (props.hovered) {
       return props.hovered;
     }
     if (props.highlighted) {
-      return getHoveredFromHighlighted(
+      const hovered = getHoveredFromHighlighted(
         props.highlighted,
         rawSeries,
         chartModel,
       );
+      if (!hovered) {
+        return null;
+      }
+      return {
+        ...hovered,
+        isFromHighlighted: true,
+      };
     }
     return null;
   }, [props.hovered, props.highlighted, rawSeries, chartModel]);

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -44,7 +44,7 @@ import { useTooltipMouseLeave } from "./use-tooltip-mouse-leave";
 import { getHoveredEChartsSeriesDataKeyAndIndex } from "./utils";
 
 export interface CartesianHoveredObject extends HoveredObject {
-  isFromHighlighted?: boolean;
+  shouldShowTooltip?: boolean;
 }
 
 function getSplitPanelGrids(option: EChartsOption) {
@@ -297,8 +297,8 @@ export const useChartEvents = (
       });
 
       // a normal hover triggers the tooltip via the tooltip option's `trigger` "item"
-      // but we need to show the tooltip manually for highlighted items
-      if (hovered.isFromHighlighted) {
+      // but we may need to show the tooltip manually for highlighted items
+      if (hovered.shouldShowTooltip) {
         // setTimeout because ChartItemTooltip/reactNodeToHtmlString uses flushSync
         setTimeout(() => {
           chart.dispatchAction({
@@ -315,7 +315,7 @@ export const useChartEvents = (
           dataIndex,
           seriesIndex: hoveredEChartsSeriesIndex,
         });
-        if (hovered.isFromHighlighted) {
+        if (hovered.shouldShowTooltip) {
           chart.dispatchAction({
             type: "hideTip",
           });

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -24,7 +24,6 @@ import {
 } from "metabase/visualizations/echarts/types";
 import { useChartYAxisVisibility } from "metabase/visualizations/hooks/use-chart-y-axis-visibility";
 import type {
-  HoveredObject,
   RenderingContext,
   VisualizationProps,
 } from "metabase/visualizations/types";
@@ -39,13 +38,10 @@ import {
 import { getVisualizerSeriesCardIndex } from "metabase/visualizer/utils";
 import type { CardId } from "metabase-types/api";
 
+import type { CartesianHoveredObject } from "./types";
 import { useBrush } from "./use-brush";
 import { useTooltipMouseLeave } from "./use-tooltip-mouse-leave";
 import { getHoveredEChartsSeriesDataKeyAndIndex } from "./utils";
-
-export interface CartesianHoveredObject extends HoveredObject {
-  shouldShowTooltip?: boolean;
-}
 
 function getSplitPanelGrids(option: EChartsOption) {
   const { grid } = option;
@@ -298,9 +294,10 @@ export const useChartEvents = (
 
       // a normal hover triggers the tooltip via the tooltip option's `trigger` "item"
       // but we may need to show the tooltip manually for highlighted items
+      let showTipTimeout: ReturnType<typeof setTimeout> | undefined;
       if (hovered.shouldShowTooltip) {
         // setTimeout because ChartItemTooltip/reactNodeToHtmlString uses flushSync
-        setTimeout(() => {
+        showTipTimeout = setTimeout(() => {
           chart.dispatchAction({
             type: "showTip",
             dataIndex,
@@ -310,6 +307,7 @@ export const useChartEvents = (
       }
 
       return () => {
+        clearTimeout(showTipTimeout);
         chart.dispatchAction({
           type: "downplay",
           dataIndex,

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -43,6 +43,10 @@ import { useBrush } from "./use-brush";
 import { useTooltipMouseLeave } from "./use-tooltip-mouse-leave";
 import { getHoveredEChartsSeriesDataKeyAndIndex } from "./utils";
 
+export interface CartesianHoveredObject extends HoveredObject {
+  isFromHighlighted?: boolean;
+}
+
 function getSplitPanelGrids(option: EChartsOption) {
   const { grid } = option;
   return Array.isArray(grid) && grid.length > 1 ? grid : null;
@@ -54,7 +58,7 @@ export const useChartEvents = (
   chartModel: BaseCartesianChartModel,
   option: EChartsOption,
   renderingContext: RenderingContext,
-  hovered: HoveredObject | null,
+  hovered: CartesianHoveredObject | null,
   {
     card,
     rawSeries,
@@ -292,12 +296,30 @@ export const useChartEvents = (
         seriesIndex: hoveredEChartsSeriesIndex,
       });
 
+      // a normal hover triggers the tooltip via the tooltip option's `trigger` "item"
+      // but we need to show the tooltip manually for highlighted items
+      if (hovered.isFromHighlighted) {
+        // setTimeout because ChartItemTooltip/reactNodeToHtmlString uses flushSync
+        setTimeout(() => {
+          chart.dispatchAction({
+            type: "showTip",
+            dataIndex,
+            seriesIndex: hoveredEChartsSeriesIndex,
+          });
+        }, 0);
+      }
+
       return () => {
         chart.dispatchAction({
           type: "downplay",
           dataIndex,
           seriesIndex: hoveredEChartsSeriesIndex,
         });
+        if (hovered.isFromHighlighted) {
+          chart.dispatchAction({
+            type: "hideTip",
+          });
+        }
       };
     },
     [

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
@@ -16,7 +16,7 @@ import type {
 import type { RawSeries } from "metabase-types/api";
 
 import { normalizeDimensionValue } from "./events";
-import type { CartesianHoveredObject } from "./use-chart-events";
+import type { CartesianHoveredObject } from "./types";
 
 export { getDashboardAdjustedSettings };
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
@@ -16,6 +16,7 @@ import type {
 import type { RawSeries } from "metabase-types/api";
 
 import { normalizeDimensionValue } from "./events";
+import type { CartesianHoveredObject } from "./use-chart-events";
 
 export { getDashboardAdjustedSettings };
 
@@ -55,7 +56,7 @@ export const getHoveredFromHighlighted = (
   highlighted: HighlightedObject,
   rawSeries: RawSeries,
   chartModel: BaseCartesianChartModel,
-): HoveredObject | null => {
+): CartesianHoveredObject | null => {
   if (!highlighted.dimensions || rawSeries.length === 0) {
     return null;
   }
@@ -126,5 +127,6 @@ export const getHoveredFromHighlighted = (
   return {
     index: seriesIndex,
     datumIndex,
+    shouldShowTooltip: highlighted.shouldShowTooltip,
   };
 };


### PR DESCRIPTION
Closes [UXW-4839: Explore clearer line chart hover state from comments](https://linear.app/metabase/issue/UXW-4839/explore-clearer-line-chart-hover-state-from-comments)

[Context](https://metaboat.slack.com/archives/C0AVA05GUKW/p1784240455969359)
[Loom](https://www.loom.com/share/e636f49c362b4f9aa385c789e8d91e10)