### PR TITLE
Share one jsdom instance per jest worker

### DIFF
--- a/frontend/test/shared-jsdom-environment.js
+++ b/frontend/test/shared-jsdom-environment.js
@@ -204,8 +204,7 @@ class SharedJSDOMEnvironment extends JSDOMEnvironment {
     this.__activeIntervals.clear();
 
     // 4. Remove window/document listeners added during the file.
-    for (const { target, type, listener, options } of this
-      .__trackedListeners) {
+    for (const { target, type, listener, options } of this.__trackedListeners) {
       try {
         target.removeEventListener(type, listener, options);
       } catch (_e) {

--- a/frontend/test/shared-jsdom-environment.js
+++ b/frontend/test/shared-jsdom-environment.js
@@ -1,0 +1,256 @@
+/**
+ * A jest test environment that reuses one jsdom instance per worker instead
+ * of constructing a fresh one for every spec file.
+ *
+ * Building jsdom is a fixed per-file cost; across ~1,800 spec files it adds
+ * minutes of CPU per full run. Jest's module isolation is untouched — every
+ * file still gets a fresh module registry — only the DOM world (window,
+ * document, storage) is shared.
+ *
+ * The hard problem with sharing is ASYNC STRAGGLERS: a file can end while
+ * its components still have pending timers, fetches, or promise chains, and
+ * under stock jest those die against a torn-down window. Here the window
+ * stays alive, so the boundary reset builds a fence:
+ *
+ *  1. Fake timers left installed by a spec are disposed FIRST (sinon's
+ *     uninstall deletes globals like Date if the descriptor restore runs
+ *     before it).
+ *  2. A bounded drain (two macrotask turns) lets already-queued stragglers
+ *     fire into the OLD world.
+ *  3. All real timers scheduled during the file are cleared (setTimeout /
+ *     setInterval are wrapped to track ids).
+ *  4. Event listeners added to window/document during the file are removed
+ *     (their addEventListener is wrapped to track registrations).
+ *  5. document.body is REPLACED with a fresh node — element listeners die
+ *     with it, and stragglers holding references to old elements mutate a
+ *     detached tree, exactly like stock jest's dead window.
+ *  6. Global keys added since the pristine post-setup snapshot are deleted;
+ *     baseline globals whose descriptor changed are restored. Ditto for a
+ *     curated set of shared prototypes/objects tests are known to patch
+ *     (HTMLElement.prototype, navigator, URL, ...). This is also what lets
+ *     the compiled cljs bundle (which registers goog/$CLJS namespaces on the
+ *     global) re-register cleanly per file.
+ *  7. Storage/history/console/process-listener cleanup.
+ *
+ * Known limits: in-place mutation of arbitrary deep objects isn't restored,
+ * and a straggler can still run code between boundaries — the fence bounds
+ * the blast radius (detached DOM, cleared timers) rather than pausing the
+ * world. jsdom-internal errors route to the first file's console.
+ */
+const { TestEnvironment: JSDOMEnvironment } = require("jest-environment-jsdom");
+
+let shared = null;
+
+function restoreToBaseline(obj, baseline) {
+  for (const key of Reflect.ownKeys(obj)) {
+    const pristine = baseline.get(key);
+    try {
+      if (pristine === undefined) {
+        delete obj[key];
+      } else {
+        const current = Object.getOwnPropertyDescriptor(obj, key);
+        const changed =
+          current === undefined ||
+          current.value !== pristine.value ||
+          current.get !== pristine.get ||
+          current.set !== pristine.set;
+        if (changed) {
+          Object.defineProperty(obj, key, pristine);
+        }
+      }
+    } catch (_e) {
+      // Non-configurable property — leave it.
+    }
+  }
+  for (const [key, pristine] of baseline) {
+    if (!Object.getOwnPropertyDescriptor(obj, key)) {
+      try {
+        Object.defineProperty(obj, key, pristine);
+      } catch (_e) {
+        // Best effort.
+      }
+    }
+  }
+}
+
+class SharedJSDOMEnvironment extends JSDOMEnvironment {
+  constructor(config, context) {
+    if (shared) {
+      shared.__nextContext = context;
+      return shared;
+    }
+    super(config, context);
+    this.__nextContext = null;
+    shared = this;
+  }
+
+  __installTrackers() {
+    const g = this.global;
+
+    this.__activeTimers = new Set();
+    this.__activeIntervals = new Set();
+    const origSetTimeout = g.setTimeout.bind(g);
+    const origSetInterval = g.setInterval.bind(g);
+    const origClearTimeout = g.clearTimeout.bind(g);
+    const origClearInterval = g.clearInterval.bind(g);
+    this.__origSetTimeout = origSetTimeout;
+    this.__origClearTimeout = origClearTimeout;
+    this.__origClearInterval = origClearInterval;
+
+    const env = this;
+    g.setTimeout = function (...args) {
+      const id = origSetTimeout(...args);
+      env.__activeTimers.add(id);
+      return id;
+    };
+    g.setInterval = function (...args) {
+      const id = origSetInterval(...args);
+      env.__activeIntervals.add(id);
+      return id;
+    };
+    g.clearTimeout = function (id) {
+      env.__activeTimers.delete(id);
+      return origClearTimeout(id);
+    };
+    g.clearInterval = function (id) {
+      env.__activeIntervals.delete(id);
+      return origClearInterval(id);
+    };
+
+    this.__trackedListeners = [];
+    for (const target of [g, g.document]) {
+      const origAdd = target.addEventListener.bind(target);
+      target.addEventListener = (type, listener, options) => {
+        env.__trackedListeners.push({ target, type, listener, options });
+        return origAdd(type, listener, options);
+      };
+    }
+  }
+
+  async setup() {
+    if (this.__setupDone) {
+      await this.__resetBetweenFiles(this.__nextContext);
+      return;
+    }
+    await super.setup();
+    // Trackers must exist BEFORE the baseline snapshot so the wrapped
+    // setTimeout/addEventListener are what the descriptor restore preserves.
+    this.__installTrackers();
+    this.__baseline = new Map(
+      Reflect.ownKeys(this.global).map((key) => [
+        key,
+        Object.getOwnPropertyDescriptor(this.global, key),
+      ]),
+    );
+    const g = this.global;
+    this.__sharedObjects = [
+      g.EventTarget?.prototype,
+      g.Node?.prototype,
+      g.Element?.prototype,
+      g.HTMLElement?.prototype,
+      g.HTMLInputElement?.prototype,
+      g.HTMLCanvasElement?.prototype,
+      g.SVGElement?.prototype,
+      g.Range?.prototype,
+      g.Document?.prototype,
+      g.Navigator?.prototype,
+      g.navigator,
+      g.URL,
+      g.Storage?.prototype,
+    ].filter(Boolean);
+    this.__objectBaselines = new Map(
+      this.__sharedObjects.map((obj) => [
+        obj,
+        new Map(
+          Reflect.ownKeys(obj).map((key) => [
+            key,
+            Object.getOwnPropertyDescriptor(obj, key),
+          ]),
+        ),
+      ]),
+    );
+    this.__setupDone = true;
+  }
+
+  async teardown() {
+    // Intentionally keep the jsdom world alive for the next file. The worker
+    // process exit is the real teardown.
+  }
+
+  async __resetBetweenFiles(context) {
+    const g = this.global;
+
+    // 1. Fake timers first, while sinon's fakes are still installed.
+    try {
+      this.fakeTimers?.dispose?.();
+      this.fakeTimersModern?.dispose?.();
+    } catch (_e) {
+      // Timers weren't installed.
+    }
+
+    // 2. Bounded drain: let already-queued stragglers fire into the old
+    // world before we detach it.
+    await new Promise((resolve) => this.__origSetTimeout(resolve, 0));
+    await new Promise((resolve) => this.__origSetTimeout(resolve, 0));
+
+    // 3. Clear every real timer scheduled during the file.
+    for (const id of this.__activeTimers) {
+      this.__origClearTimeout(id);
+    }
+    for (const id of this.__activeIntervals) {
+      this.__origClearInterval(id);
+    }
+    this.__activeTimers.clear();
+    this.__activeIntervals.clear();
+
+    // 4. Remove window/document listeners added during the file.
+    for (const { target, type, listener, options } of this
+      .__trackedListeners) {
+      try {
+        target.removeEventListener(type, listener, options);
+      } catch (_e) {
+        // Listener already gone.
+      }
+    }
+    this.__trackedListeners.length = 0;
+
+    // 5. Fresh body: element listeners die with the old node; stragglers
+    // holding old references mutate a detached tree.
+    try {
+      const freshBody = g.document.createElement("body");
+      g.document.documentElement.replaceChild(freshBody, g.document.body);
+      g.document.head.innerHTML = "";
+    } catch (_e) {
+      // Extremely broken DOM; the descriptor restore below still runs.
+    }
+
+    // 6. Descriptor restores.
+    restoreToBaseline(g, this.__baseline);
+    for (const obj of this.__sharedObjects) {
+      restoreToBaseline(obj, this.__objectBaselines.get(obj));
+    }
+
+    // 7. Storage, history, console, sandboxed-process listeners.
+    try {
+      g.localStorage?.clear?.();
+      g.sessionStorage?.clear?.();
+      g.history?.replaceState?.(null, "", "http://localhost/");
+      g.process?.removeAllListeners?.("uncaughtException");
+    } catch (_e) {
+      // Best-effort; anything missed surfaces as a test failure.
+    }
+    if (context?.console) {
+      try {
+        Object.defineProperty(g, "console", {
+          configurable: true,
+          writable: true,
+          value: context.console,
+        });
+      } catch (_e) {
+        // Keep the previous console.
+      }
+    }
+  }
+}
+
+module.exports = SharedJSDOMEnvironment;

--- a/jest.config.js
+++ b/jest.config.js
@@ -138,7 +138,9 @@ const baseConfig = {
     "/target/cljs_release/",
     "/frontend/test/",
   ],
-  testEnvironment: "jest-environment-jsdom",
+  // Reuses one jsdom instance per worker (module isolation is unaffected);
+  // see the header comment in the environment file for reset semantics.
+  testEnvironment: "<rootDir>/frontend/test/shared-jsdom-environment.js",
 };
 
 /** @type {import('jest').Config} */


### PR DESCRIPTION
Reuses one jsdom instance per worker instead of building a fresh one for every spec file. Stacked on #77940 (fake timers) — see the dependency note below, it's load-bearing.

## Why

Constructing jsdom is a fixed cost every spec file pays before its first test runs. Jest gives every file a fresh module registry (that part is untouched here — module isolation still applies), but the DOM world doesn't need rebuilding 1,800 times per run if we can reset it reliably between files.

"Reliably" is where all the work went.

## The hard part: async stragglers

A spec file can end while its components still have pending timers, fetches, or promise chains. Under stock jest those fire into a torn-down window and die silently (there's even a comment in our jest-setup.js acknowledging this). With a shared window they fire into the NEXT file's world — stealing focus, mutating the DOM mid-test. My first attempt at this had suite failures that moved around between runs, which is about the worst failure mode CI can have.

The environment now fences the boundary: fake timers are disposed first (sinon's uninstall deletes globals like `Date` if you restore descriptors before disposing — found that one the hard way), a bounded two-macrotask drain lets queued stragglers land in the old world, real timers scheduled during the file are tracked and cleared, window/document listeners added during the file are removed, `document.body` is replaced with a fresh node so stragglers holding old element references mutate a detached tree, and the global object plus a curated set of prototypes (`HTMLElement.prototype`, `navigator`, `URL`...) are restored to a descriptor-level baseline. That last bit is also what lets the compiled cljs bundle re-register its `goog`/`$CLJS` namespaces cleanly per file.

## Why this depends on the fake-timers PR

I tested this both ways, deliberately. Standalone off master: 29 failing suites on one full run, 14 on the next, mostly different suites each time — real-timer specs generate deferred work through too many mechanisms (timers, rAF, promise chains, scheduler callbacks) for a fence to enumerate. Stacked on the fake-timers regime: the union of those 43 roaming victims is stable-green across four consecutive runs, failing only on the three known env-sensitive specs that fail everywhere. When the clock only moves when a test moves it, the dominant straggler classes can't exist. So if #77940 doesn't ship, this shouldn't either.

## Numbers

I'm deliberately not quoting a local full-suite number — my laptop's wall clock drifts too much between sessions to trust (see the measurement saga in #77937). The mechanism saves one jsdom construction per file; earlier same-session sampling put it around 10% of suite wall clock. CI timings on this PR are the number that matters.

## Things to know

- Module isolation is unchanged. Only the DOM world is shared; every file still gets fresh modules, mocks, and fetch-mock state.
- In-place mutation of deep objects (beyond the curated prototype list) isn't restored. jest's own `restoreAllMocks` covers `jest.spyOn`, and the descriptor baseline covers the patterns the suite actually uses today; anything exotic would surface as a test failure, not silent corruption.
- jsdom-internal errors (virtualConsole) route to the first file's console per worker. Test `console.*` output is rebound per file and reports correctly.
- If a genuinely un-fenceable leak class turns up later, the fallback design is batch recycling (rebuild jsdom every N files) — keeps most of the win, bounds any contamination. Not needed on current evidence.
