### PR TITLE
Fix uberjar resource ignore patterns (they never matched anything)

### DIFF
--- a/bin/build/src/build/uberjar.clj
+++ b/bin/build/src/build/uberjar.clj
@@ -128,22 +128,24 @@
 
 (def ^:private resource-ignore-patterns
   "Files to ignore when copying resources from source directories (`src` and `enterprise/backend/src`) and resource
-  directories (`resources`)."
-  [#"\.clj[c|s]?$"
-   #""
-   ;; ignore .~undo-tree~ or other nonsense files created by editors. I was considering using
-   ;;
-   ;;    git ls-files --ignored --exclude-from=.gitignore --others
-   ;;
-   ;; to find ALL the files to ignore here but then we run into problems accidentally ignoring build artifacts like
-   ;; translation files. This should be good enough for now -- we don't really NEED to do this stuff since we build in a
-   ;; clean Docker env, so it's more of a nice to have to keep the clutter in our JARs down when building locally.
-   #"\~$"
-   #"^\.?#"
-   #"\.rej$"
-   ;; Driver classes are now flattened directly into the uberjar via the :drivers alias — the old nested
-   ;; driver JARs in resources/modules/ must not be included or we'd ship everything twice.
-   #"^modules/"])
+  directories (`resources`).
+
+  `b/copy-dir` matches each pattern with `re-matches` against the bare file NAME (not the relative path), so every
+  pattern must fully match a filename — path prefixes like `modules/` can never match, and unanchored fragments like
+  `\\.rej$` silently match nothing. None of this matters for CI/Docker builds from a clean checkout; it keeps dev
+  leftovers out of locally-built jars.
+
+  Deliberately NOT ignored: `.clj[cs]` sources. `b/uber`'s `:exclude` already strips Metabase sources from the jar by
+  path, and some .clj resources (data_readers.clj, locales.clj) must ship."
+  [;; nonsense files created by editors: foo~, #foo#, .#foo, *.rej
+   #".*~$"
+   #"^\.?#.*"
+   #".*\.rej$"
+   ;; webpack/rspack dev-server HMR output left under resources/frontend_client by a local dev server
+   #".*\.hot-update\..*"
+   ;; Driver classes are now flattened directly into the uberjar via the :drivers alias — nested driver JARs built
+   ;; into resources/modules/ by bin/build-drivers must not be included or we'd ship every driver twice.
+   #".*\.metabase-driver\.jar$"])
 
 (defn- copy-resources! [basis]
   (u/step "Copy resources"


### PR DESCRIPTION
While validating the parallel jar build experiment I noticed our locally-built uberjars were 1.33GB while CI's are 711MB. It turns out `resource-ignore-patterns` in `bin/build/src/build/uberjar.clj` is dead code: `b/copy-dir` matches each ignore with `re-matches` against the bare file name, not the relative path. `re-matches` needs the whole string to match, so unanchored fragments like `#"\.rej$"` and `#"\~$"` can never match a real filename, and `#"^modules/"` can never match at all since file names don't contain slashes.

CI doesn't care because it builds from a clean checkout. But anyone building locally (or self-hosting from source) ships whatever is lying around in their checkout:

- the nested driver jars in `resources/modules/` (256MB in my checkout, and every driver's classes are already flattened into the uberjar via the `:drivers` alias, so these shipped twice)
- webpack HMR leftovers under `resources/frontend_client/` from a dev server run (about 600MB of `*.hot-update.js*` files in my case)
- editor junk files

I rewrote the patterns to fully match filenames, swapped `^modules/` for `.*\.metabase-driver\.jar$` (ignores are filename-only, so a path prefix can't be expressed), and added a pattern for the hot-update files.

One deliberate omission: I dropped the `.clj[cs]` pattern rather than fixing it. `resources/data_readers.clj` and `resources/locales.clj` ship in the jar today and are needed at runtime, so a working version of that pattern would have broken the jar. Metabase sources are already stripped at the `b/uber` stage by `dependency-ignore-patterns`, which matches against jar paths and does work.

To verify I rebuilt the jar locally with the fix: 1.33GB down to 876MB, no nested driver jars, no hot-update files, and `data_readers.clj` and `locales.clj` still present. For a clean checkout nothing changes; none of the new patterns match any entry in the jar CI built from this same code.

A rough edge I couldn't fix: my local jar is still somewhat bigger than CI's, because a dev server also leaves ordinary chunk files under `resources/frontend_client/app/embedding-sdk/` that can't be told apart from production output by filename alone. I don't think that's expressible with the filename-only ignore mechanism, short of the frontend build cleaning that directory itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)