### PR TITLE
Compile e2e CLJS in parallel with the uberjar build

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -125,10 +125,8 @@ jobs:
         if: github.run_attempt != '1'
         run: echo "specs=$(cat failed-specs)" >> $GITHUB_ENV
 
-      # The `e2e-cljs` job in run-tests.yml compiles this once, in parallel with the
-      # uberjar build, and shares it as an artifact — downloading it is ~10x faster
-      # than compiling it here. Callers without that job (stress tests, coverage
-      # shards, cross-run re-runs) fall through to compiling as before.
+      # run-tests.yml compiles this in parallel with the uberjar build. downloading it is ~10x faster than compiling it here.
+      # Callers without that job (stress tests, coverage shards, cross-run re-runs) fall through to compiling as before.
       - name: Download pre-built CLJS
         id: prebuilt-cljs
         uses: actions/download-artifact@v8

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Get failed specs
         if: github.run_attempt != '1'
-        run: echo "specs=$(cat failed-specs)" >> $GITHUB_ENV
+        run: echo "specs=$(cat failed-specs)" >> "$GITHUB_ENV"
 
       # run-tests.yml compiles this in parallel with the uberjar build. downloading it is ~10x faster than compiling it here.
       # Callers without that job (stress tests, coverage shards, cross-run re-runs) fall through to compiling as before.

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -125,7 +125,7 @@ jobs:
         if: github.run_attempt != '1'
         run: echo "specs=$(cat failed-specs)" >> "$GITHUB_ENV"
 
-      # run-tests.yml compiles this in parallel with the uberjar build. downloading it is ~10x faster than compiling it here.
+      # run-tests.yml compiles this in parallel with the uberjar build. Downloading it is ~10x faster than compiling it here.
       # Callers without that job (stress tests, coverage shards, cross-run re-runs) fall through to compiling as before.
       - name: Download pre-built CLJS
         id: prebuilt-cljs

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -125,7 +125,20 @@ jobs:
         if: github.run_attempt != '1'
         run: echo "specs=$(cat failed-specs)" >> $GITHUB_ENV
 
+      # The `e2e-cljs` job in run-tests.yml compiles this once, in parallel with the
+      # uberjar build, and shares it as an artifact — downloading it is ~10x faster
+      # than compiling it here. Callers without that job (stress tests, coverage
+      # shards, cross-run re-runs) fall through to compiling as before.
+      - name: Download pre-built CLJS
+        id: prebuilt-cljs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: e2e-cljs-${{ github.event.pull_request.head.sha || github.sha }}
+          path: target/cljs_dev
+
       - name: Compile CLJS
+        if: steps.prebuilt-cljs.outcome != 'success'
         run: bun run build-pure:cljs
 
       - name: Run Metabase

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -93,6 +93,36 @@ jobs:
     uses: ./.github/workflows/uberjar.yml
     secrets: inherit
 
+  # Compile the CLJS that e2e specs import (shadow-cljs `app` build, an npm-module
+  # consumed by the Cypress webpack preprocessor) once, in parallel with the uberjar
+  # build, and share it as an artifact. Each e2e chunk downloads it (~5s) instead of
+  # compiling it themselves (~50s). Chunks fall back to compiling if the artifact is
+  # missing (see e2e-test.yml), so this job failing or being skipped never blocks e2e.
+  # The compile is edition-independent: MB_EDITION only affects rspack bundling and
+  # the Cypress runner, not the shadow-cljs build.
+  e2e-cljs:
+    name: Compile CLJS for e2e
+    needs: [create-test-plan]
+    if: ${{ !cancelled() && needs.create-test-plan.result == 'success' && needs.create-test-plan.outputs.e2e_all == 'true' }}
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+      - name: Compile CLJS
+        run: bun run build-pure:cljs
+      - name: Upload compiled CLJS
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-cljs-${{ github.event.pull_request.head.sha || github.sha }}
+          path: target/cljs_dev
+          if-no-files-found: error
+          # a re-run of all jobs would otherwise fail the upload (artifacts are immutable per name)
+          overwrite: true
+
   backend-tests:
     if: ${{ !cancelled() && needs.create-test-plan.result == 'success' }}
     needs: [create-test-plan]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -93,8 +93,7 @@ jobs:
     uses: ./.github/workflows/uberjar.yml
     secrets: inherit
 
-  # Compile  CLJS  in parallel with the uberjar , and share it as an artifact.
-  # build Each e2e group downloads it instead of compiling it themselves.
+  # Compile CLJS in parallel with the uberjar and pass it to each e2e group.
   # The compile is doesn't depend on MB_EDITION
   e2e-cljs:
     name: Compile CLJS for e2e

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -93,13 +93,9 @@ jobs:
     uses: ./.github/workflows/uberjar.yml
     secrets: inherit
 
-  # Compile the CLJS that e2e specs import (shadow-cljs `app` build, an npm-module
-  # consumed by the Cypress webpack preprocessor) once, in parallel with the uberjar
-  # build, and share it as an artifact. Each e2e chunk downloads it (~5s) instead of
-  # compiling it themselves (~50s). Chunks fall back to compiling if the artifact is
-  # missing (see e2e-test.yml), so this job failing or being skipped never blocks e2e.
-  # The compile is edition-independent: MB_EDITION only affects rspack bundling and
-  # the Cypress runner, not the shadow-cljs build.
+  # Compile  CLJS  in parallel with the uberjar , and share it as an artifact.
+  # build Each e2e group downloads it instead of compiling it themselves.
+  # The compile is doesn't depend on MB_EDITION
   e2e-cljs:
     name: Compile CLJS for e2e
     needs: [create-test-plan]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -116,7 +116,8 @@ jobs:
           name: e2e-cljs-${{ github.event.pull_request.head.sha || github.sha }}
           path: target/cljs_dev
           if-no-files-found: error
-          # a re-run of all jobs would otherwise fail the upload (artifacts are immutable per name)
+          # Uploads fail when an artifact of this name already exists in the run
+          # replace it rather than fail on a re-run.
           overwrite: true
 
   backend-tests:


### PR DESCRIPTION
While the uberjar is building we may as well do something useful.

Every e2e group needs the cljs. Previously we were waiting for the uberjar, then on each group building the cljs. Now we compile cljs while we're waiting. This saves 50s for each group. It falls back to compiling cljs if the prebuild cljs isn't found