### PR TITLE
Remove withRouter from production and delete its public export

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.unit.spec.tsx
@@ -4,6 +4,7 @@ import { setupCollectionsEndpoints } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
+import { Route } from "metabase/router";
 import type { Collection } from "metabase-types/api";
 import { createMockCollection, createMockUser } from "metabase-types/api/mocks";
 
@@ -43,12 +44,20 @@ const setup = ({
   });
 
   renderWithProviders(
-    <MainNavSharedCollections
-      canAccessTenantSpecificCollections={canAccessTenantSpecificCollections}
-      canCreateSharedCollection={canWriteToSharedCollectionRoot}
-      sharedTenantCollections={tenantCollections}
+    <Route
+      path="/"
+      element={
+        <MainNavSharedCollections
+          canAccessTenantSpecificCollections={
+            canAccessTenantSpecificCollections
+          }
+          canCreateSharedCollection={canWriteToSharedCollectionRoot}
+          sharedTenantCollections={tenantCollections}
+        />
+      }
     />,
     {
+      withRouter: true,
       storeInitialState: createMockState({ settings, currentUser }),
     },
   );

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditConnectionForm.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditConnectionForm.tsx
@@ -1,4 +1,3 @@
-import type { LocationDescriptorObject } from "history";
 import { updateIn } from "icepick";
 import { type ComponentType, useState } from "react";
 import _ from "underscore";
@@ -19,7 +18,7 @@ import type {
 } from "metabase/databases/types";
 import { useDispatch } from "metabase/redux";
 import type { Dispatch } from "metabase/redux/store";
-import { type Route, withRouter } from "metabase/router";
+import { type Route, useRouter } from "metabase/router";
 import { Text } from "metabase/ui";
 import type {
   DatabaseData,
@@ -34,95 +33,92 @@ const makeDefaultSaveDbFn =
   async (database: DatabaseData): Promise<any> =>
     await dispatch(saveDatabase(database));
 
-export const DatabaseEditConnectionForm = withRouter(
-  ({
-    database,
-    isAttachedDWH,
-    initializeError,
-    handleSaveDb,
-    onSubmitted,
-    onCancel,
-    onEngineChange,
-    route,
-    location,
-    config,
-    formLocation,
-    ...props
-  }: {
-    database?: Partial<DatabaseData>;
-    isAttachedDWH: boolean;
-    initializeError?: unknown;
-    handleSaveDb?: (database: DatabaseData) => Promise<{ id: DatabaseId }>;
-    onSubmitted: (savedDB: { id: DatabaseId }) => void;
-    onCancel: () => void;
-    onEngineChange?: (engineKey: string | undefined) => void;
-    route: Route;
-    location: LocationDescriptorObject;
-    autofocusFieldName?: string;
-    config?: Omit<DatabaseFormConfig, "isAdvanced">;
-    formLocation: Extract<FormLocation, "admin" | "full-page">;
-  }) => {
-    const dispatch = useDispatch();
+export const DatabaseEditConnectionForm = ({
+  database,
+  isAttachedDWH,
+  initializeError,
+  handleSaveDb,
+  onSubmitted,
+  onCancel,
+  onEngineChange,
+  route,
+  config,
+  formLocation,
+  ...props
+}: {
+  database?: Partial<DatabaseData>;
+  isAttachedDWH: boolean;
+  initializeError?: unknown;
+  handleSaveDb?: (database: DatabaseData) => Promise<{ id: DatabaseId }>;
+  onSubmitted: (savedDB: { id: DatabaseId }) => void;
+  onCancel: () => void;
+  onEngineChange?: (engineKey: string | undefined) => void;
+  route: Route;
+  autofocusFieldName?: string;
+  config?: Omit<DatabaseFormConfig, "isAdvanced">;
+  formLocation: Extract<FormLocation, "admin" | "full-page">;
+}) => {
+  const dispatch = useDispatch();
+  const { location } = useRouter();
 
-    const [isDirty, setIsDirty] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
 
-    const autofocusFieldName =
-      location.hash?.slice(1) || props.autofocusFieldName;
+  const autofocusFieldName =
+    location.hash?.slice(1) || props.autofocusFieldName;
 
-    /**
-     * Navigation is scheduled so that LeaveConfirmationModal's isEnabled
-     * prop has a chance to re-compute on re-render
-     */
-    const [isCallbackScheduled, scheduleCallback] = useCallbackEffect();
+  /**
+   * Navigation is scheduled so that LeaveConfirmationModal's isEnabled
+   * prop has a chance to re-compute on re-render
+   */
+  const [isCallbackScheduled, scheduleCallback] = useCallbackEffect();
 
-    const handleSubmit = async (database: DatabaseData) => {
-      try {
-        const saveFn = handleSaveDb ?? makeDefaultSaveDbFn(dispatch);
-        const savedDB = await saveFn(database);
-        scheduleCallback(() => {
-          onSubmitted(savedDB);
-        });
-      } catch (error) {
-        // Unjustified type cast. FIXME
-        throw getSubmitError(error as DatabaseEditErrorType);
-      }
-    };
+  const handleSubmit = async (database: DatabaseData) => {
+    try {
+      const saveFn = handleSaveDb ?? makeDefaultSaveDbFn(dispatch);
+      const savedDB = await saveFn(database);
+      scheduleCallback(() => {
+        onSubmitted(savedDB);
+      });
+    } catch (error) {
+      // Unjustified type cast. FIXME
+      throw getSubmitError(error as DatabaseEditErrorType);
+    }
+  };
 
-    // Unjustified type cast. FIXME
-    return (
-      <ErrorBoundary errorComponent={GenericError as ComponentType}>
-        <LoadingAndErrorWrapper
-          loading={!database}
-          error={initializeError}
-          noWrapper
-        >
-          {isDbModifiable({
-            id: database?.id,
-            is_attached_dwh: isAttachedDWH,
-            is_sample: database?.is_sample,
-          }) ? (
-            <DatabaseForm
-              initialValues={database}
-              autofocusFieldName={autofocusFieldName}
-              config={{ isAdvanced: true, ...config }}
-              onCancel={onCancel}
-              onSubmit={handleSubmit}
-              onDirtyStateChange={setIsDirty}
-              location={formLocation}
-              onEngineChange={onEngineChange}
-            />
-          ) : (
-            <Text my="md">{getDbNotModifiableMessage(database)}</Text>
-          )}
-        </LoadingAndErrorWrapper>
-        <LeaveRouteConfirmModal
-          isEnabled={isDirty && !isCallbackScheduled}
-          route={route}
-        />
-      </ErrorBoundary>
-    );
-  },
-);
+  // Unjustified type cast. FIXME
+  return (
+    <ErrorBoundary errorComponent={GenericError as ComponentType}>
+      <LoadingAndErrorWrapper
+        loading={!database}
+        error={initializeError}
+        noWrapper
+      >
+        {isDbModifiable({
+          id: database?.id,
+          is_attached_dwh: isAttachedDWH,
+          is_sample: database?.is_sample,
+        }) ? (
+          <DatabaseForm
+            initialValues={database}
+            autofocusFieldName={autofocusFieldName}
+            config={{ isAdvanced: true, ...config }}
+            onCancel={onCancel}
+            onSubmit={handleSubmit}
+            onDirtyStateChange={setIsDirty}
+            location={formLocation}
+            onEngineChange={onEngineChange}
+          />
+        ) : (
+          <Text my="md">{getDbNotModifiableMessage(database)}</Text>
+        )}
+      </LoadingAndErrorWrapper>
+      <LeaveRouteConfirmModal
+        isEnabled={isDirty && !isCallbackScheduled}
+        route={route}
+      />
+    </ErrorBoundary>
+  );
+};
 
 const getSubmitError = (error: DatabaseEditErrorType) => {
   if (_.isObject(error?.data?.errors)) {

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.tsx
@@ -23,7 +23,7 @@ import {
   PLUGIN_WRITABLE_CONNECTION,
 } from "metabase/plugins";
 import { connect, useSelector } from "metabase/redux";
-import { Outlet, withRouter } from "metabase/router";
+import { Outlet, useRouter } from "metabase/router";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { Box, Divider, Flex } from "metabase/ui";
 import type { DatabaseId, Database as DatabaseType } from "metabase-types/api";
@@ -35,7 +35,6 @@ import { ExistingDatabaseHeader } from "../components/ExistingDatabaseHeader";
 import { deleteDatabase, updateDatabase } from "../database";
 
 interface DatabaseEditAppProps {
-  params: { databaseId: string };
   updateDatabase: (
     database: { id: DatabaseId } & Partial<DatabaseType>,
   ) => Promise<void>;
@@ -48,10 +47,10 @@ const mapDispatchToProps = {
 };
 
 function DatabaseEditAppInner({
-  params,
   updateDatabase,
   deleteDatabase,
 }: DatabaseEditAppProps) {
+  const { params } = useRouter();
   const isAdmin = useSelector(getUserIsAdmin);
   const isModelPersistenceEnabled = useSetting("persisted-models-enabled");
 
@@ -168,7 +167,13 @@ function DatabaseEditAppInner({
   );
 }
 
-export const DatabaseEditApp = _.compose(
-  withRouter,
-  connect(undefined, mapDispatchToProps),
-)(DatabaseEditAppInner);
+// Dropping the `withRouter` HOC left a single `connect`, which surfaced a
+// pre-existing prop mismatch the old two-HOC `compose` hid (the dispatch thunks
+// want a full `DatabaseData`, the sections pass a partial). Widen to keep the
+// original loose behavior without introducing `any`.
+const DatabaseEditAppComponent = DatabaseEditAppInner as ComponentType;
+
+export const DatabaseEditApp = connect(
+  undefined,
+  mapDispatchToProps,
+)(DatabaseEditAppComponent);

--- a/frontend/src/metabase/app/nav/AppBar.tsx
+++ b/frontend/src/metabase/app/nav/AppBar.tsx
@@ -29,7 +29,7 @@ import {
 import { connect, useDispatch, useSelector } from "metabase/redux";
 import { closeNavbar, toggleNavbar } from "metabase/redux/app";
 import type { State } from "metabase/redux/store";
-import { push, withRouter } from "metabase/router";
+import { push, withRouteProps } from "metabase/router";
 import type { RouterProps } from "metabase/selectors/app";
 import { getDetailViewState, getIsNavbarOpen } from "metabase/selectors/app";
 import { getIsEmbeddingIframe } from "metabase/selectors/embed";
@@ -130,6 +130,6 @@ function AppBarContainerInner(props: AppBarProps & RouterProps) {
   );
 }
 
-export const AppBarContainer = withRouter(
+export const AppBarContainer = withRouteProps(
   connect(mapStateToProps, mapDispatchToProps)(AppBarContainerInner),
 );

--- a/frontend/src/metabase/app/nav/Navbar.tsx
+++ b/frontend/src/metabase/app/nav/Navbar.tsx
@@ -6,13 +6,13 @@ import { AdminNavbar } from "metabase/nav/components/AdminNavbar";
 import { MainNavbar } from "metabase/nav/containers/MainNavbar";
 import { connect } from "metabase/redux";
 import type { AdminPath, State, StoreDashboard } from "metabase/redux/store";
-import { type WithRouterProps, withRouter } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { getAdminPaths } from "metabase/selectors/admin";
 import { getIsNavbarOpen } from "metabase/selectors/app";
 import { getUser } from "metabase/selectors/user";
 import type { User } from "metabase-types/api";
 
-type NavbarProps = WithRouterProps & {
+type NavbarProps = {
   isOpen: boolean;
   user: User | null;
   adminPaths: AdminPath[];
@@ -29,14 +29,8 @@ const mapStateToProps = (state: State) => ({
   dashboard: getDashboard(state),
 });
 
-function NavbarInner({
-  isOpen,
-  user,
-  location,
-  params,
-  adminPaths,
-  dashboard,
-}: NavbarProps) {
+function NavbarInner({ isOpen, user, adminPaths, dashboard }: NavbarProps) {
+  const { location, params } = useRouter();
   useListDatabasesQuery();
   const isAdminApp = useMemo(
     () => location.pathname.startsWith("/admin/"),
@@ -59,4 +53,4 @@ function NavbarInner({
   );
 }
 
-export const Navbar = withRouter(connect(mapStateToProps)(NavbarInner));
+export const Navbar = connect(mapStateToProps)(NavbarInner);

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.tsx
@@ -3,7 +3,6 @@ import {
   isLibraryCollection,
   isTrashedCollection,
 } from "metabase/common/collections/utils";
-import { withRouter } from "metabase/router";
 import type { Collection } from "metabase-types/api";
 
 import { CollectionMenu } from "../CollectionMenu";
@@ -101,4 +100,4 @@ const CollectionHeader = ({
 };
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
-export default withRouter(CollectionHeader);
+export default CollectionHeader;

--- a/frontend/src/metabase/common/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
+++ b/frontend/src/metabase/common/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
@@ -20,8 +20,7 @@ import {
   FormTextarea,
 } from "metabase/forms";
 import { PLUGIN_TENANTS } from "metabase/plugins";
-import type { WithRouterProps } from "metabase/router";
-import { withRouter } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { Button, Flex } from "metabase/ui";
 import * as Errors from "metabase/utils/errors";
 import type { Collection, CollectionNamespace } from "metabase-types/api";
@@ -58,13 +57,11 @@ export interface CreateCollectionFormOwnProps {
   showAuthorityLevelPicker?: boolean;
 }
 
-type Props = CreateCollectionFormOwnProps & WithRouterProps;
+type Props = CreateCollectionFormOwnProps;
 
 function CreateCollectionForm({
   collectionId,
   initialCollectionId: explicitInitialCollectionId,
-  location,
-  params,
   onSubmit,
   onCancel,
   filterPersonalCollections,
@@ -73,6 +70,7 @@ function CreateCollectionForm({
   namespaces,
   showAuthorityLevelPicker = true,
 }: Props) {
+  const { location, params } = useRouter();
   const defaultInitialCollectionId = useInitialCollectionId({
     collectionId,
     location,
@@ -182,4 +180,4 @@ function CreateCollectionForm({
 }
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
-export default withRouter(CreateCollectionForm);
+export default CreateCollectionForm;

--- a/frontend/src/metabase/common/collections/components/CreateCollectionForm/tests/setup.tsx
+++ b/frontend/src/metabase/common/collections/components/CreateCollectionForm/tests/setup.tsx
@@ -8,6 +8,7 @@ import { mockSettings } from "__support__/settings";
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
+import { Route } from "metabase/router";
 import type {
   CollectionId,
   CollectionNamespace,
@@ -94,15 +95,21 @@ export const setup = ({
   });
 
   renderWithProviders(
-    <CreateCollectionForm
-      onCancel={onCancel}
-      onSubmit={onSubmit}
-      showAuthorityLevelPicker={showAuthorityLevelPicker}
-      collectionId={parentCollectionNamespace !== undefined ? 1 : undefined}
-      initialCollectionId={initialCollectionId}
-      namespaces={namespaces}
+    <Route
+      path="/"
+      element={
+        <CreateCollectionForm
+          onCancel={onCancel}
+          onSubmit={onSubmit}
+          showAuthorityLevelPicker={showAuthorityLevelPicker}
+          collectionId={parentCollectionNamespace !== undefined ? 1 : undefined}
+          initialCollectionId={initialCollectionId}
+          namespaces={namespaces}
+        />
+      }
     />,
     {
+      withRouter: true,
       storeInitialState: createMockState({
         currentUser: user,
         settings,

--- a/frontend/src/metabase/common/components/CopyDashboardForm/CopyDashboardForm.tsx
+++ b/frontend/src/metabase/common/components/CopyDashboardForm/CopyDashboardForm.tsx
@@ -20,7 +20,6 @@ import {
   FormTextInput,
   FormTextarea,
 } from "metabase/forms";
-import { withRouter } from "metabase/router";
 import { Button, Group, Icon, Tooltip } from "metabase/ui";
 import { isVirtualDashCard } from "metabase/utils/dashboard";
 import * as Errors from "metabase/utils/errors";
@@ -162,4 +161,4 @@ function CopyDashboardForm({
   );
 }
 
-export const CopyDashboardFormConnected = withRouter(CopyDashboardForm);
+export const CopyDashboardFormConnected = CopyDashboardForm;

--- a/frontend/src/metabase/common/components/LeaveConfirmModal/LeaveRouteConfirmModal.tsx
+++ b/frontend/src/metabase/common/components/LeaveConfirmModal/LeaveRouteConfirmModal.tsx
@@ -3,8 +3,8 @@ import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
 import { useConfirmRouteLeaveModal } from "metabase/common/hooks/use-confirm-route-leave-modal";
-import type { InjectedRouter, Route } from "metabase/router";
-import { useRoute, withRouter } from "metabase/router";
+import type { Route } from "metabase/router";
+import { useRoute, useRouter } from "metabase/router";
 
 import { LeaveConfirmModal } from "./LeaveConfirmModal";
 
@@ -17,26 +17,27 @@ interface LeaveRouteConfirmModalProps {
    * v3-injected `route`. Still accepted for callers that pass it explicitly.
    */
   route?: Route;
-  router: InjectedRouter;
-  routes: Route[];
   onConfirm?: () => void;
   onOpenChange?: (opened: boolean) => void;
 }
 
-const LeaveRouteConfirmModalInner = ({
+export const LeaveRouteConfirmModal = ({
   isEnabled,
   isLocationAllowed,
   route,
-  router,
-  routes,
   onConfirm,
   onOpenChange,
 }: LeaveRouteConfirmModalProps) => {
+  const { router, routes } = useRouter();
   const routeFromContext = useRoute();
+  // `routes` from the context is typed `PlainRoute[]`; its leaf is the matched
+  // route that `setRouteLeaveHook` (a no-op on v7) receives, matching the
+  // pre-conversion `Route[]` prop typing.
+  const leafRoute = routes[routes.length - 1] as unknown as Route;
   const { opened, close, confirm } = useConfirmRouteLeaveModal({
     isEnabled,
     isLocationAllowed,
-    route: route ?? routeFromContext ?? routes[routes.length - 1],
+    route: route ?? routeFromContext ?? leafRoute,
     router,
   });
   const previousIsOpened = usePrevious(opened);
@@ -60,5 +61,3 @@ const LeaveRouteConfirmModalInner = ({
     />
   );
 };
-
-export const LeaveRouteConfirmModal = withRouter(LeaveRouteConfirmModalInner);

--- a/frontend/src/metabase/common/components/LeaveConfirmModal/LeaveRouteConfirmModal.tsx
+++ b/frontend/src/metabase/common/components/LeaveConfirmModal/LeaveRouteConfirmModal.tsx
@@ -30,10 +30,9 @@ export const LeaveRouteConfirmModal = ({
 }: LeaveRouteConfirmModalProps) => {
   const { router, routes } = useRouter();
   const routeFromContext = useRoute();
-  // `routes` from the context is typed `PlainRoute[]`; its leaf is the matched
-  // route that `setRouteLeaveHook` (a no-op on v7) receives, matching the
-  // pre-conversion `Route[]` prop typing.
-  const leafRoute = routes[routes.length - 1] as unknown as Route;
+  // The matched-route chain's leaf is this page's own route, which
+  // `setRouteLeaveHook` (a no-op on v7) receives.
+  const leafRoute = routes[routes.length - 1];
   const { opened, close, confirm } = useConfirmRouteLeaveModal({
     isEnabled,
     isLocationAllowed,

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.unit.spec.tsx
@@ -10,6 +10,7 @@ import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
 import { NewModals } from "metabase/new/components/NewModals/NewModals";
 import { createMockState } from "metabase/redux/store/mocks";
+import { Route } from "metabase/router";
 import type { Database } from "metabase-types/api";
 import {
   createMockCollection,
@@ -51,11 +52,17 @@ async function setup({
   setupEnterprisePlugins();
 
   renderWithProviders(
-    <>
-      <NewItemMenu trigger={<button>New</button>} />
-      <NewModals />
-    </>,
+    <Route
+      path="/"
+      element={
+        <>
+          <NewItemMenu trigger={<button>New</button>} />
+          <NewModals />
+        </>
+      }
+    />,
     {
+      withRouter: true,
       storeInitialState: createMockState({
         settings,
         currentUser: createMockUser({

--- a/frontend/src/metabase/common/hooks/use-confirm-route-leave-modal.ts
+++ b/frontend/src/metabase/common/hooks/use-confirm-route-leave-modal.ts
@@ -3,14 +3,17 @@ import { useCallback, useEffect, useState } from "react";
 import { match } from "ts-pattern";
 
 import { useDispatch } from "metabase/redux";
-import type { InjectedRouter, Route } from "metabase/router";
+import type { InjectedRouter, PlainRoute, Route } from "metabase/router";
 import { goBack, push, replace } from "metabase/router";
 
 import { useBeforeUnload } from "./use-before-unload";
 
 interface UseConfirmLeaveModalInput {
   router: InjectedRouter;
-  route: Route;
+  // The matched route handed to `setRouteLeaveHook` (typed `any`). Accepts the
+  // route object in either representation the app threads it as: the config
+  // object from `useRouter().routes` (`PlainRoute`) or the `Route` prop type.
+  route: Route | PlainRoute;
   isEnabled: boolean;
   isLocationAllowed?: (location: Location | undefined) => boolean;
 }

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.tsx
@@ -1,4 +1,3 @@
-import type { Location } from "history";
 import { dissoc } from "icepick";
 import { useState } from "react";
 import { t } from "ttag";
@@ -8,7 +7,7 @@ import { useInitialCollectionId } from "metabase/common/collections/hooks";
 import type { CopyDashboardFormProperties } from "metabase/common/components/CopyDashboardForm";
 import { CopyModal } from "metabase/common/components/CopyModal";
 import { useDispatch, useSelector } from "metabase/redux";
-import { replace, withRouter } from "metabase/router";
+import { replace, useRouter } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { Dashboard } from "metabase-types/api";
 
@@ -16,8 +15,6 @@ import { getDashboardComplete } from "../selectors";
 
 type DashboardCopyModalProps = {
   onClose: () => void;
-  params: { slug?: string };
-  location: Location;
 };
 
 const getTitle = (
@@ -33,11 +30,8 @@ const getTitle = (
     : t`Duplicate "${dashboard.name}" and its questions`;
 };
 
-const DashboardCopyModal = ({
-  onClose,
-  params,
-  location,
-}: DashboardCopyModalProps) => {
+const DashboardCopyModal = ({ onClose }: DashboardCopyModalProps) => {
+  const { location, params } = useRouter();
   const dispatch = useDispatch();
   const [copyDashboard] = useCopyDashboardMutation();
   const dashboard = useSelector(getDashboardComplete);
@@ -86,4 +80,4 @@ const DashboardCopyModal = ({
   );
 };
 
-export const DashboardCopyModalConnected = withRouter(DashboardCopyModal);
+export const DashboardCopyModalConnected = DashboardCopyModal;

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/CopyAnalyticsDashboardButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/CopyAnalyticsDashboardButton.tsx
@@ -1,15 +1,17 @@
 import { t } from "ttag";
 
 import { Link } from "metabase/common/components/Link";
-import { type WithRouterProps, withRouter } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { Button, Icon } from "metabase/ui";
 
-export const CopyAnalyticsDashboardButton = withRouter(
-  ({ location }: WithRouterProps) => (
+export const CopyAnalyticsDashboardButton = () => {
+  const { location } = useRouter();
+
+  return (
     <Button
       leftSection={<Icon name="clone" />}
       to={`${location.pathname}/copy`}
       component={Link}
     >{t`Make a copy`}</Button>
-  ),
-);
+  );
+};

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
@@ -1,5 +1,4 @@
 import { type MouseEvent, forwardRef, useState } from "react";
-import type { WithRouterProps } from "react-router/lib/withRouter";
 import { c, t } from "ttag";
 
 import { ToolbarButton } from "metabase/common/components/ToolbarButton";
@@ -11,7 +10,7 @@ import { DashboardSubscriptionMenuItem } from "metabase/notifications/Notificati
 import { useRegisterShortcut } from "metabase/palette/hooks/useRegisterShortcut";
 import { PLUGIN_CACHING, PLUGIN_MODERATION } from "metabase/plugins";
 import { useDispatch, useSelector } from "metabase/redux";
-import { Link, type LinkProps, withRouter } from "metabase/router";
+import { Link, type LinkProps, useRouter } from "metabase/router";
 import { Icon, Menu } from "metabase/ui";
 
 type DashboardActionMenuProps = {
@@ -35,9 +34,9 @@ const DashboardActionMenuInner = ({
   canResetFilters,
   onResetFilters,
   canEdit,
-  location,
   openSettingsSidebar,
-}: DashboardActionMenuProps & WithRouterProps) => {
+}: DashboardActionMenuProps) => {
+  const { location } = useRouter();
   const { dashboard, isFullscreen, onFullscreenChange, onChangeLocation } =
     useDashboardContext();
   const [opened, setOpened] = useState(false);
@@ -164,4 +163,4 @@ const DashboardActionMenuInner = ({
   );
 };
 
-export const DashboardActionMenu = withRouter(DashboardActionMenuInner);
+export const DashboardActionMenu = DashboardActionMenuInner;

--- a/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
@@ -5,7 +5,7 @@ import { updateDashboardAndCards } from "metabase/dashboard/actions/save";
 import { getIsDirty, getIsEditing } from "metabase/dashboard/selectors";
 import { useDispatch, useSelector } from "metabase/redux";
 import { dismissAllUndo } from "metabase/redux/undo";
-import { type Route, useRoute, useRouter } from "metabase/router";
+import { useRoute, useRouter } from "metabase/router";
 import { Box, Button, Flex, Modal, Text } from "metabase/ui";
 
 import { isNavigatingToCreateADashboardQuestion } from "./utils";
@@ -21,9 +21,8 @@ export const DashboardLeaveConfirmationModal = () => {
   const { opened, close, confirm, nextLocation } = useConfirmRouteLeaveModal({
     isEnabled: isEditing && isDirty,
     // `routes` is the matched-route chain; its last entry is this page's own
-    // route. Typed loosely as PlainRoute by react-router, cast to the `Route`
-    // the hook expects.
-    route: route ?? (routes[routes.length - 1] as Route),
+    // route.
+    route: route ?? routes[routes.length - 1],
     router,
   });
 

--- a/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
@@ -5,93 +5,83 @@ import { updateDashboardAndCards } from "metabase/dashboard/actions/save";
 import { getIsDirty, getIsEditing } from "metabase/dashboard/selectors";
 import { useDispatch, useSelector } from "metabase/redux";
 import { dismissAllUndo } from "metabase/redux/undo";
-import {
-  type Route,
-  type WithRouterProps,
-  useRoute,
-  withRouter,
-} from "metabase/router";
+import { type Route, useRoute, useRouter } from "metabase/router";
 import { Box, Button, Flex, Modal, Text } from "metabase/ui";
 
 import { isNavigatingToCreateADashboardQuestion } from "./utils";
 
-interface DashboardLeaveConfirmationModalProps extends WithRouterProps {
-  route?: Route;
-}
+export const DashboardLeaveConfirmationModal = () => {
+  const isEditing = useSelector(getIsEditing);
+  const isDirty = useSelector(getIsDirty);
+  const { router, routes } = useRouter();
+  const route = useRoute();
 
-export const DashboardLeaveConfirmationModal = withRouter(
-  ({ router, route, routes }: DashboardLeaveConfirmationModalProps) => {
-    const isEditing = useSelector(getIsEditing);
-    const isDirty = useSelector(getIsDirty);
-    const routeFromContext = useRoute();
+  const dispatch = useDispatch();
 
-    const dispatch = useDispatch();
+  const { opened, close, confirm, nextLocation } = useConfirmRouteLeaveModal({
+    isEnabled: isEditing && isDirty,
+    // `routes` is the matched-route chain; its last entry is this page's own
+    // route. Typed loosely as PlainRoute by react-router, cast to the `Route`
+    // the hook expects.
+    route: route ?? (routes[routes.length - 1] as Route),
+    router,
+  });
 
-    const { opened, close, confirm, nextLocation } = useConfirmRouteLeaveModal({
-      isEnabled: isEditing && isDirty,
-      // `routes` is the matched-route chain; its last entry is this page's own
-      // route. Typed loosely as PlainRoute by react-router, cast to the `Route`
-      // the hook expects.
-      route: route ?? routeFromContext ?? (routes[routes.length - 1] as Route),
-      router,
-    });
+  const content = isNavigatingToCreateADashboardQuestion(nextLocation)
+    ? {
+        title: t`Save your changes?`,
+        message: t`You’ll need to save your changes before leaving to create a new question.`,
+        actionBtn: {
+          message: t`Save changes`,
+        },
+        onConfirm: () => dispatch(updateDashboardAndCards()),
+      }
+    : {
+        title: t`Discard your changes?`,
+        message: t`Your changes haven’t been saved, so you’ll lose them if you navigate away.`,
+        actionBtn: {
+          color: "feedback-negative" as const,
+          message: t`Discard changes`,
+        },
+      };
 
-    const content = isNavigatingToCreateADashboardQuestion(nextLocation)
-      ? {
-          title: t`Save your changes?`,
-          message: t`You’ll need to save your changes before leaving to create a new question.`,
-          actionBtn: {
-            message: t`Save changes`,
-          },
-          onConfirm: () => dispatch(updateDashboardAndCards()),
-        }
-      : {
-          title: t`Discard your changes?`,
-          message: t`Your changes haven’t been saved, so you’ll lose them if you navigate away.`,
-          actionBtn: {
-            color: "feedback-negative" as const,
-            message: t`Discard changes`,
-          },
-        };
-
-    return (
-      <Modal
-        opened={opened}
-        onClose={close}
-        size="28.5rem"
-        padding="2.5rem"
-        title={content.title}
-        data-testid="leave-confirmation"
-        withCloseButton={false}
-        styles={{
-          title: {
-            fontSize: "1rem",
-          },
-          header: {
-            marginBottom: "0.5rem",
-          },
-        }}
-      >
-        <Box>
-          <Text lh="1.5rem" mb={"lg"}>
-            {content.message}
-          </Text>
-          <Flex justify="flex-end" gap="md">
-            <Button onClick={close}>{t`Cancel`}</Button>
-            <Button
-              color={content.actionBtn.color}
-              variant="filled"
-              onClick={async () => {
-                dispatch(dismissAllUndo());
-                await content.onConfirm?.();
-                confirm?.();
-              }}
-            >
-              {content.actionBtn.message}
-            </Button>
-          </Flex>
-        </Box>
-      </Modal>
-    );
-  },
-);
+  return (
+    <Modal
+      opened={opened}
+      onClose={close}
+      size="28.5rem"
+      padding="2.5rem"
+      title={content.title}
+      data-testid="leave-confirmation"
+      withCloseButton={false}
+      styles={{
+        title: {
+          fontSize: "1rem",
+        },
+        header: {
+          marginBottom: "0.5rem",
+        },
+      }}
+    >
+      <Box>
+        <Text lh="1.5rem" mb={"lg"}>
+          {content.message}
+        </Text>
+        <Flex justify="flex-end" gap="md">
+          <Button onClick={close}>{t`Cancel`}</Button>
+          <Button
+            color={content.actionBtn.color}
+            variant="filled"
+            onClick={async () => {
+              dispatch(dismissAllUndo());
+              await content.onConfirm?.();
+              confirm?.();
+            }}
+          >
+            {content.actionBtn.message}
+          </Button>
+        </Flex>
+      </Box>
+    </Modal>
+  );
+};

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
@@ -16,7 +16,6 @@ import {
   Route,
   type WithRouterProps,
   withRouteProps,
-  withRouter,
 } from "metabase/router";
 import type { DashboardTab } from "metabase-types/api";
 import { createMockCard } from "metabase-types/api/mocks";
@@ -54,21 +53,19 @@ function setup({
     },
   };
 
-  const RoutedDashboardComponent = withRouter(
-    ({ location }: { location: Location }) => {
-      const { selectedTabId } = useDashboardTabs();
-      useDashboardUrlQuery(createMockRouter(), location);
-      return (
-        <>
-          <DashboardTabs />
-          <span>Selected tab id is {selectedTabId}</span>
-          <br />
-          <span>Path is {location.pathname + location.search}</span>
-          <Link to="/someotherpath">Navigate away</Link>
-        </>
-      );
-    },
-  );
+  const RoutedDashboardComponent = ({ location }: { location: Location }) => {
+    const { selectedTabId } = useDashboardTabs();
+    useDashboardUrlQuery(createMockRouter(), location);
+    return (
+      <>
+        <DashboardTabs />
+        <span>Selected tab id is {selectedTabId}</span>
+        <br />
+        <span>Path is {location.pathname + location.search}</span>
+        <Link to="/someotherpath">Navigate away</Link>
+      </>
+    );
+  };
 
   const OtherComponent = () => {
     const selectedTabId = useSelector(getSelectedTabId);

--- a/frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.tsx
@@ -7,7 +7,7 @@ import { ArchiveModal } from "metabase/common/components/ArchiveModal";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { setArchivedDashboard } from "metabase/dashboard/actions";
 import { useDispatch } from "metabase/redux";
-import { withRouter } from "metabase/router";
+import { useRouter } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { Dashboard } from "metabase-types/api";
 
@@ -56,10 +56,9 @@ const ArchiveDashboardModal = ({
   );
 };
 
-export const ArchiveDashboardModalConnectedInner = (
-  props: OwnProps & { params: { slug?: string } },
-) => {
-  const id = Urls.extractCollectionId(props.params?.slug);
+export const ArchiveDashboardModalConnectedInner = (props: OwnProps) => {
+  const { params } = useRouter();
+  const id = Urls.extractCollectionId(params?.slug);
   const { currentData: dashboard, error } = useGetDashboardQuery(
     id != null ? { id } : skipToken,
   );
@@ -77,6 +76,5 @@ export const ArchiveDashboardModalConnectedInner = (
   );
 };
 
-export const ArchiveDashboardModalConnected = withRouter(
-  ArchiveDashboardModalConnectedInner,
-);
+export const ArchiveDashboardModalConnected =
+  ArchiveDashboardModalConnectedInner;

--- a/frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.unit.spec.tsx
@@ -3,7 +3,7 @@ import {
   setupDashboardNotFoundEndpoint,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
-import type { WithRouterProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { createMockDashboard } from "metabase-types/api/mocks";
 
 import { ArchiveDashboardModalConnectedInner } from "./ArchiveDashboardModal";
@@ -17,13 +17,16 @@ const setup = ({
   slug?: string;
   onClose?: () => void;
 } = {}) => {
-  // Unjustified type cast. FIXME
-  const props = {
-    onClose,
-    params: { slug },
-  } as unknown as WithRouterProps & { onClose: () => void };
-
-  renderWithProviders(<ArchiveDashboardModalConnectedInner {...props} />);
+  renderWithProviders(
+    <Route
+      path="/dashboard(/:slug)"
+      element={<ArchiveDashboardModalConnectedInner onClose={onClose} />}
+    />,
+    {
+      withRouter: true,
+      initialRoute: slug ? `/dashboard/${slug}` : "/dashboard",
+    },
+  );
 
   return { onClose };
 };

--- a/frontend/src/metabase/monitor/tools/components/Logs/Logs.tsx
+++ b/frontend/src/metabase/monitor/tools/components/Logs/Logs.tsx
@@ -1,4 +1,3 @@
-import type { Location } from "history";
 import * as React from "react";
 import { useMemo } from "react";
 import reactAnsiStyle from "react-ansi-style";
@@ -10,7 +9,7 @@ import {
 } from "metabase/admin/components/SettingsSection";
 import { AnsiLogs } from "metabase/common/components/AnsiLogs";
 import { useUrlState } from "metabase/common/hooks/use-url-state";
-import { Link, Outlet, withRouter } from "metabase/router";
+import { Link, Outlet, useRouter } from "metabase/router";
 import {
   Button,
   DefaultSelectItem,
@@ -31,7 +30,6 @@ import {
 } from "./utils";
 
 interface LogsProps {
-  location: Location;
   // NOTE: fetching logs could come back from any machine if there's multiple machines backing a MB instance
   // make this frequent enough that you will most likely get every log from every machine in some reasonable
   // amount of time
@@ -40,10 +38,10 @@ interface LogsProps {
 
 export const DEFAULT_POLLING_DURATION_MS = 1000;
 
-const LogsBase = ({
-  location,
+export const Logs = ({
   pollingDurationMs = DEFAULT_POLLING_DURATION_MS,
 }: LogsProps) => {
+  const { location } = useRouter();
   const [{ process, query }, { patchUrlState }] = useUrlState(
     location,
     urlStateConfig,
@@ -182,5 +180,3 @@ const LogsBase = ({
     </>
   );
 };
-
-export const Logs = withRouter(LogsBase);

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import { useListTaskRunsQuery } from "metabase/api";
 import { PaginationControls } from "metabase/common/components/PaginationControls";
 import { useUrlState } from "metabase/common/hooks/use-url-state";
-import { type WithRouterProps, withRouter } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { Flex } from "metabase/ui";
 
 import { toBackendStartedAt } from "../../utils";
@@ -17,7 +17,8 @@ import { TaskRunsTable } from "./TaskRunsTable";
 import { PAGE_SIZE } from "./constants";
 import { urlStateConfig } from "./utils";
 
-const TaskRunsPageBase = ({ location }: WithRouterProps) => {
+export const TaskRunsPage = () => {
+  const { location } = useRouter();
   const [
     {
       page,
@@ -122,5 +123,3 @@ const TaskRunsPageBase = ({ location }: WithRouterProps) => {
     </TasksTabs>
   );
 };
-
-export const TaskRunsPage = withRouter(TaskRunsPageBase);

--- a/frontend/src/metabase/monitor/tools/components/TasksTabs/TasksTabs.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TasksTabs/TasksTabs.tsx
@@ -5,8 +5,7 @@ import {
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
 import { useDispatch } from "metabase/redux";
-import { push } from "metabase/router";
-import { type WithRouterProps, withRouter } from "metabase/router";
+import { push, useRouter } from "metabase/router";
 import { Flex, Icon, Tabs, Title, Tooltip } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
@@ -15,11 +14,12 @@ type TabConfig = {
   label: string;
 };
 
-type TasksTabsProps = WithRouterProps & {
+type TasksTabsProps = {
   children: React.ReactNode;
 };
 
-const TasksTabsBase = ({ children, location }: TasksTabsProps) => {
+export const TasksTabs = ({ children }: TasksTabsProps) => {
+  const { location } = useRouter();
   const tabs: TabConfig[] = [
     { value: Urls.adminToolsTasksList(), label: t`Tasks` },
     { value: Urls.adminToolsTasksRuns(), label: t`Runs` },
@@ -60,5 +60,3 @@ const TasksTabsBase = ({ children, location }: TasksTabsProps) => {
     </SettingsPageWrapper>
   );
 };
-
-export const TasksTabs = withRouter(TasksTabsBase);

--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
@@ -18,12 +18,11 @@ import {
   getSearchTextFromLocation,
   isSearchPageLocation,
 } from "metabase/common/search";
-import type { SearchAwareLocation } from "metabase/common/search/types";
 import { RecentsList } from "metabase/nav/components/search/RecentsList";
 import { SearchResultsDropdown } from "metabase/nav/components/search/SearchResultsDropdown";
 import { APP_BAR_HEIGHT } from "metabase/nav/constants";
 import { useDispatch, useSelector } from "metabase/redux";
-import { push, withRouter } from "metabase/router";
+import { push, useRouter } from "metabase/router";
 import { getSetting } from "metabase/selectors/settings";
 import { Box, Flex, Icon, UnstyledButton, rem } from "metabase/ui";
 import { modelToUrl } from "metabase/urls";
@@ -36,11 +35,7 @@ import S from "./SearchBar.module.css";
 
 const ALLOWED_SEARCH_FOCUS_ELEMENTS = new Set(["BODY", "A"]);
 
-type RouterProps = {
-  location: SearchAwareLocation;
-};
-
-type OwnProps = {
+type Props = {
   onSearchActive?: () => void;
   onSearchInactive?: () => void;
   /**
@@ -51,14 +46,12 @@ type OwnProps = {
   onSearchItemSelect?: (result: SearchResult) => void;
 };
 
-type Props = RouterProps & OwnProps;
-
-function SearchBarView({
-  location,
+function SearchBar({
   onSearchActive,
   onSearchInactive,
   onSearchItemSelect: onSearchItemSelectProp,
 }: Props) {
+  const { location } = useRouter();
   const isTypeaheadEnabled = useSelector((state) =>
     getSetting(state, "search-typeahead-enabled"),
   );
@@ -262,8 +255,6 @@ function SearchBarView({
     </Box>
   );
 }
-
-export const SearchBar = withRouter(SearchBarView);
 
 // for some reason our unit test don't work if this is a name export ¯\_(ツ)_/¯
 // eslint-disable-next-line import/no-default-export

--- a/frontend/src/metabase/nav/components/search/SearchButton/SearchButton.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchButton/SearchButton.tsx
@@ -4,18 +4,14 @@ import { t } from "ttag";
 
 import { useIsSmallScreen } from "metabase/common/hooks/use-is-small-screen";
 import { getSearchTextFromLocation } from "metabase/common/search";
-import type { SearchAwareLocation } from "metabase/common/search/types";
-import { withRouter } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { Button, type ButtonProps, Flex, Icon } from "metabase/ui";
 import { METAKEY } from "metabase/utils/browser";
 
 import S from "./SearchButton.module.css";
 
-type SearchButtonProps = ButtonProps & {
-  location: SearchAwareLocation;
-};
-
-const SearchButtonView = ({ location, ...props }: SearchButtonProps) => {
+export const SearchButton = (props: ButtonProps) => {
+  const { location } = useRouter();
   const kbar = useKBar();
   const { setVisualState } = kbar.query;
   const searchText = getSearchTextFromLocation(location);
@@ -68,5 +64,3 @@ const SearchButtonView = ({ location, ...props }: SearchButtonProps) => {
     </Button>
   );
 };
-
-export const SearchButton = withRouter(SearchButtonView);

--- a/frontend/src/metabase/new/components/NewModals/NewModals.tsx
+++ b/frontend/src/metabase/new/components/NewModals/NewModals.tsx
@@ -19,20 +19,21 @@ import type {
 } from "metabase/plugins";
 import { useDispatch, useSelector } from "metabase/redux";
 import { closeModal, setOpenModal } from "metabase/redux/ui";
-import type { WithRouterProps } from "metabase/router";
-import { push, withRouter } from "metabase/router";
+import { push, useRouter } from "metabase/router";
 import { getCurrentOpenModalState } from "metabase/selectors/ui";
 import { Modal, PREVENT_AUTOCOMPLETE_CLIPPING_MODAL_PROPS } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type { WritebackAction } from "metabase-types/api";
 
-export const NewModals = withRouter((props: WithRouterProps) => {
+export const NewModals = () => {
+  const { location, params } = useRouter();
   const { pathname } = useLocation();
   const { id: currentNewModalId, props: currentNewModalProps } = useSelector(
     getCurrentOpenModalState<CreateCollectionModalOwnProps>,
   );
   const dispatch = useDispatch();
-  const collectionId = useInitialCollectionId(props) ?? undefined;
+  const collectionId =
+    useInitialCollectionId({ location, params }) ?? undefined;
 
   const handleActionCreated = useCallback(
     (action: WritebackAction) => {
@@ -139,4 +140,4 @@ export const NewModals = withRouter((props: WithRouterProps) => {
         />
       );
   }
-});
+};

--- a/frontend/src/metabase/palette/components/Palette.tsx
+++ b/frontend/src/metabase/palette/components/Palette.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
 
 import { useOnClickOutside } from "metabase/common/hooks/use-on-click-outside";
 import { useSelector } from "metabase/redux";
-import { type PlainRoute, withRouter } from "metabase/router";
+import { type PlainRoute, useRouter } from "metabase/router";
 import { getUser } from "metabase/selectors/user";
 import { Box, Card, Center, Icon, Overlay, Stack, rem } from "metabase/ui";
 import { isWithinIframe } from "metabase/utils/iframe";
@@ -21,15 +21,17 @@ type CommandPaletteRouteProps = {
 };
 
 /** Command palette */
-export const Palette = withRouter((props) => {
+export const Palette = () => {
+  const routerProps = useRouter();
+  const { routes, location } = routerProps;
   const isLoggedIn = useSelector((state) => !!getUser(state));
 
-  const disableCommandPaletteForRoute = props.routes.some(
+  const disableCommandPaletteForRoute = routes.some(
     (route: PlainRoute<CommandPaletteRouteProps>) =>
       route.props?.disableCommandPalette,
   );
 
-  useCommandPaletteBasicActions({ ...props, isLoggedIn });
+  useCommandPaletteBasicActions({ ...routerProps, isLoggedIn });
 
   const { query } = useKBar();
   const disabled =
@@ -44,74 +46,71 @@ export const Palette = withRouter((props) => {
         <Center pt="10vh">
           <PaletteContainer
             disabled={disabled}
-            locationQuery={props.location.query}
+            locationQuery={location.query}
           />
         </Center>
       </Overlay>
     </KBarPortal>
   );
-});
+};
 
-export const PaletteContainer = withRouter(
-  ({
-    disabled,
+export const PaletteContainer = ({
+  disabled,
+  locationQuery,
+}: {
+  disabled: boolean;
+  locationQuery: Query;
+}) => {
+  const { query } = useKBar();
+  const ref = useRef(null);
+  const searchText = typeof locationQuery.q === "string" ? locationQuery.q : "";
+
+  const {
+    searchRequestId,
+    searchResults,
+    liveSearchTerm,
+    debouncedSearchTerm,
+  } = useCommandPalette({
     locationQuery,
-  }: {
-    disabled: boolean;
-    locationQuery: Query;
-  }) => {
-    const { query } = useKBar();
-    const ref = useRef(null);
-    const searchText =
-      typeof locationQuery.q === "string" ? locationQuery.q : "";
+    disabled,
+  });
 
-    const {
-      searchRequestId,
-      searchResults,
-      liveSearchTerm,
-      debouncedSearchTerm,
-    } = useCommandPalette({
-      locationQuery,
-      disabled,
-    });
+  useOnClickOutside(ref, () => {
+    query.setVisualState(VisualState.hidden);
+  });
 
-    useOnClickOutside(ref, () => {
-      query.setVisualState(VisualState.hidden);
-    });
+  return (
+    <Card
+      ref={ref}
+      w="640px"
+      p="0"
+      data-testid="command-palette"
+      bd="1px solid var(--mb-color-border-neutral)"
+    >
+      <Stack gap={rem(4)} pb="lg">
+        <Box pos="relative">
+          <HydratedKBarSearch searchText={searchText} />
 
-    return (
-      <Card
-        ref={ref}
-        w="640px"
-        p="0"
-        data-testid="command-palette"
-        bd="1px solid var(--mb-color-border-neutral)"
-      >
-        <Stack gap={rem(4)} pb="lg">
-          <Box pos="relative">
-            <HydratedKBarSearch searchText={searchText} />
+          <Stack
+            className={S.iconContainer}
+            align="center"
+            left={36} // align this icon with results icons
+            pos="absolute"
+            top={26}
+          >
+            <Icon c="text-primary" name="search" />
+          </Stack>
+        </Box>
 
-            <Stack
-              className={S.iconContainer}
-              align="center"
-              left={36} // align this icon with results icons
-              pos="absolute"
-              top={26}
-            >
-              <Icon c="text-primary" name="search" />
-            </Stack>
-          </Box>
-
-          <PaletteResults
-            align="stretch"
-            locationQuery={locationQuery}
-            searchRequestId={searchRequestId}
-            searchResults={searchResults}
-            liveSearchTerm={liveSearchTerm}
-            debouncedSearchTerm={debouncedSearchTerm}
-          />
-        </Stack>
-      </Card>
-    );
-  },
-);
+        <PaletteResults
+          align="stretch"
+          locationQuery={locationQuery}
+          searchRequestId={searchRequestId}
+          searchResults={searchResults}
+          liveSearchTerm={liveSearchTerm}
+          debouncedSearchTerm={debouncedSearchTerm}
+        />
+      </Stack>
+    </Card>
+  );
+};

--- a/frontend/src/metabase/palette/components/test/PaletteResults/setup.tsx
+++ b/frontend/src/metabase/palette/components/test/PaletteResults/setup.tsx
@@ -18,7 +18,7 @@ import {
   createMockAdminState,
   createMockState,
 } from "metabase/redux/store/mocks";
-import { Route, type WithRouterProps, withRouter } from "metabase/router";
+import { Route, useRouter } from "metabase/router";
 import type { RecentItem, Settings } from "metabase-types/api";
 import {
   createMockCollection,
@@ -32,39 +32,44 @@ import {
 
 import { PaletteResults } from "../../PaletteResults";
 
-const TestComponent = withRouter(
-  ({ q, ...props }: WithRouterProps & { q?: string; isLoggedIn: boolean }) => {
-    useCommandPaletteBasicActions(props);
-    const {
-      searchRequestId,
-      searchResults,
-      liveSearchTerm,
-      debouncedSearchTerm,
-    } = useCommandPalette({
-      disabled: false,
-      locationQuery: props.location.query,
-    });
+const TestComponent = ({
+  q,
+  isLoggedIn,
+}: {
+  q?: string;
+  isLoggedIn: boolean;
+}) => {
+  const routerProps = useRouter();
+  useCommandPaletteBasicActions({ ...routerProps, isLoggedIn });
+  const {
+    searchRequestId,
+    searchResults,
+    liveSearchTerm,
+    debouncedSearchTerm,
+  } = useCommandPalette({
+    disabled: false,
+    locationQuery: routerProps.location.query,
+  });
 
-    const { query } = useKBar();
+  const { query } = useKBar();
 
-    useEffect(() => {
-      query.setVisualState(VisualState.showing);
-      if (q) {
-        query.setSearch(q);
-      }
-    }, [q, query]);
+  useEffect(() => {
+    query.setVisualState(VisualState.showing);
+    if (q) {
+      query.setSearch(q);
+    }
+  }, [q, query]);
 
-    return (
-      <PaletteResults
-        locationQuery={props.location.query}
-        searchRequestId={searchRequestId}
-        searchResults={searchResults}
-        liveSearchTerm={liveSearchTerm}
-        debouncedSearchTerm={debouncedSearchTerm}
-      />
-    );
-  },
-);
+  return (
+    <PaletteResults
+      locationQuery={routerProps.location.query}
+      searchRequestId={searchRequestId}
+      searchResults={searchResults}
+      liveSearchTerm={liveSearchTerm}
+      debouncedSearchTerm={debouncedSearchTerm}
+    />
+  );
+};
 
 const DATABASE = createMockDatabase();
 

--- a/frontend/src/metabase/public/components/EmbedFrame/SyncedEmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/SyncedEmbedFrame.tsx
@@ -1,15 +1,14 @@
 import { useEmbedFrameOptions } from "metabase/public/hooks";
-import type { WithRouterProps } from "metabase/router";
-import { withRouter } from "metabase/router";
+import { useRouter } from "metabase/router";
 
 import type { EmbedFrameProps } from "./EmbedFrame";
 import { EmbedFrame } from "./EmbedFrame";
 
-const SyncedEmbedFrameInner = ({
-  location,
+export const SyncedEmbedFrame = ({
   children,
   ...embedFrameProps
-}: Partial<EmbedFrameProps> & WithRouterProps) => {
+}: Partial<EmbedFrameProps>) => {
+  const { location } = useRouter();
   const { background, bordered, hide_parameters, theme, titled } =
     useEmbedFrameOptions({ location });
 
@@ -26,7 +25,3 @@ const SyncedEmbedFrameInner = ({
     </EmbedFrame>
   );
 };
-
-export const SyncedEmbedFrame = withRouter<Partial<EmbedFrameProps>>(
-  SyncedEmbedFrameInner,
-);

--- a/frontend/src/metabase/router/RouterProvider.tsx
+++ b/frontend/src/metabase/router/RouterProvider.tsx
@@ -7,7 +7,7 @@ import {
   ReactRouterRoute,
   Router,
   type WithRouterProps,
-  withRouter,
+  reactRouterWithRouter,
 } from "./react-router";
 
 type RouterContextType = WithRouterProps;
@@ -37,7 +37,7 @@ const RouterContextProviderBase = ({
   );
 };
 
-const RouterContextProvider = withRouter(RouterContextProviderBase);
+const RouterContextProvider = reactRouterWithRouter(RouterContextProviderBase);
 
 type RouterProviderProps = {
   history?: History | undefined;

--- a/frontend/src/metabase/router/react-router.ts
+++ b/frontend/src/metabase/router/react-router.ts
@@ -21,7 +21,9 @@ export {
   createRoutes,
   formatPattern,
   useRouterHistory,
-  withRouter,
+  // The public facade no longer exposes `withRouter`; only `RouterProvider`'s v3
+  // bootstrap still needs the raw HOC to seed the router context.
+  withRouter as reactRouterWithRouter,
 } from "react-router";
 
 // v3's own path matcher, used to work out how much of the URL each matched route


### PR DESCRIPTION
Closes DEV-1142

Part of the react-router v7 migration. Stacked on the pattern-translator PR. This kills `withRouter` (except the irreducible v3 bootstrap): it removes it from every production component and deletes the public export.

v3's `withRouter` reads the router from React legacy context that only the v3 `<Router>` provides, so under the v7 engine it injects `router = undefined` and crashes components like `LeaveRouteConfirmModal`. This PR fixes that.

Each production component now reads router state from the facade hooks, which work on both engines.

- 21 components converted. Function components read `useRouter()` / `useRoute()` (the facade hooks return the same `{ router, location, params, routes }` shape `withRouter` injected).
- `AppBar` uses `withRouteProps` instead, because it feeds the injected `location` into `connect`'s `mapStateToProps`.
- `DatabaseEditApp` drops a `compose(withRouter, connect)` to a plain `connect`.
- Consumer specs that rendered these components bare now wrap them in a `<Route element>` with `withRouter: true`.

With production off it, the only remaining users were two test setups and `RouterProvider`'s own v3 bootstrap.

- The raw v3 `withRouter` re-export is renamed to `reactRouterWithRouter` in the seam module and used only by `RouterProvider` to seed the v3 router context (it cannot use the facade hooks, which read that context). It leaves the public facade entirely.
- Two test helpers (`DashboardTabs` spec, `PaletteResults` setup) now read `useRouter()` instead.

