### PR TITLE
Restructure permissions routes for v7 matching

### DIFF
--- a/frontend/src/metabase/admin/permissions/routes.tsx
+++ b/frontend/src/metabase/admin/permissions/routes.tsx
@@ -20,6 +20,25 @@ const RoutedCollectionPermissionsPage = withRouteProps(
   CollectionPermissionsPage,
 );
 
+// The permissions page renders at each drill-down depth with progressively more
+// params. v3 expressed this with sequential optional groups
+// (`database(/:databaseId)(/schema/:schemaName)`), which v7's matcher cannot
+// parse, so each depth is spelled out as its own route. One route matches per
+// URL, exactly as the optional groups did.
+const DATABASES_PERMISSIONS_PATHS = [
+  "database",
+  "database/:databaseId",
+  "database/:databaseId/schema/:schemaName",
+  "database/:databaseId/schema/:schemaName/table/:tableId",
+];
+
+const GROUPS_PERMISSIONS_PATHS = [
+  "group",
+  "group/:groupId",
+  "group/:groupId/database/:databaseId",
+  "group/:groupId/database/:databaseId/schema/:schemaName",
+];
+
 const getRoutes = () => (
   <Route>
     <Route index element={redirect("data")} />
@@ -27,21 +46,23 @@ const getRoutes = () => (
     <Route path="data" element={<RoutedDataPermissionsPage />}>
       <Route index element={redirect("group")} />
 
-      <Route
-        path="database(/:databaseId)(/schema/:schemaName)(/table/:tableId)"
-        element={<RoutedDatabasesPermissionsPage />}
-      >
-        {PLUGIN_ADMIN_PERMISSIONS_DATABASE_ROUTES}
-        {PLUGIN_ADMIN_PERMISSIONS_TABLE_GROUP_ROUTES}
-      </Route>
+      {DATABASES_PERMISSIONS_PATHS.map((path) => (
+        <Route
+          key={path}
+          path={path}
+          element={<RoutedDatabasesPermissionsPage />}
+        >
+          {PLUGIN_ADMIN_PERMISSIONS_DATABASE_ROUTES}
+          {PLUGIN_ADMIN_PERMISSIONS_TABLE_GROUP_ROUTES}
+        </Route>
+      ))}
 
-      <Route
-        path="group(/:groupId)(/database/:databaseId)(/schema/:schemaName)"
-        element={<RoutedGroupsPermissionsPage />}
-      >
-        {PLUGIN_ADMIN_PERMISSIONS_DATABASE_GROUP_ROUTES}
-        {PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES}
-      </Route>
+      {GROUPS_PERMISSIONS_PATHS.map((path) => (
+        <Route key={path} path={path} element={<RoutedGroupsPermissionsPage />}>
+          {PLUGIN_ADMIN_PERMISSIONS_DATABASE_GROUP_ROUTES}
+          {PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES}
+        </Route>
+      ))}
     </Route>
 
     <Route path="collections" element={<RoutedCollectionPermissionsPage />}>

--- a/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/routes.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/routes.unit.spec.tsx
@@ -1,0 +1,57 @@
+import { renderWithProviders, screen } from "__support__/ui";
+import { Outlet, Route, useParams } from "metabase/router";
+
+// Validates the restructured route shape (depth-enumerated siblings that replaced
+// v3's optional groups): the same URLs match and yield the same params the
+// optional groups did. v7 matching of these patterns is covered by the
+// pattern-translator conformance suite.
+function ParamsProbe() {
+  const { databaseId, schemaName, tableId } = useParams();
+  return (
+    <span data-testid="params">
+      {JSON.stringify({ databaseId, schemaName, tableId })}
+    </span>
+  );
+}
+
+// Mirrors DATABASES_PERMISSIONS_PATHS in routes.tsx.
+const DATABASES_PERMISSIONS_PATHS = [
+  "database",
+  "database/:databaseId",
+  "database/:databaseId/schema/:schemaName",
+  "database/:databaseId/schema/:schemaName/table/:tableId",
+];
+
+function setup(initialRoute: string) {
+  renderWithProviders(
+    <Route path="/admin/permissions/data" element={<Outlet />}>
+      {DATABASES_PERMISSIONS_PATHS.map((path) => (
+        <Route key={path} path={path} element={<ParamsProbe />} />
+      ))}
+    </Route>,
+    { withRouter: true, initialRoute },
+  );
+}
+
+describe("restructured databases permissions routes", () => {
+  it.each([
+    ["/admin/permissions/data/database", {}],
+    ["/admin/permissions/data/database/1", { databaseId: "1" }],
+    [
+      "/admin/permissions/data/database/1/schema/PUBLIC",
+      { databaseId: "1", schemaName: "PUBLIC" },
+    ],
+    [
+      "/admin/permissions/data/database/1/schema/PUBLIC/table/2",
+      { databaseId: "1", schemaName: "PUBLIC", tableId: "2" },
+    ],
+  ])("matches %s and yields the right params", async (url, expected) => {
+    setup(url);
+    const probe = await screen.findByTestId("params");
+    const params = JSON.parse(probe.textContent ?? "{}");
+    const defined = Object.fromEntries(
+      Object.entries(params).filter(([, value]) => value !== undefined),
+    );
+    expect(defined).toEqual(expected);
+  });
+});


### PR DESCRIPTION
Closes DEV-2373

The permissions page rendered at several drill-down depths from a single route with v3 sequential optional groups (`database(/:databaseId)(/schema/:schemaName)(/table/:tableId)`). v7's matcher cannot parse that syntax, so each depth is now spelled out as its own route.

- `database` and `group` permission routes become depth-enumerated sibling routes; exactly one matches per URL, as the optional groups did.
- The page still renders once per URL with the right params, and the modal child routes still attach.