### PR TITLE
Delete the public withRouter export

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/MainNavSharedCollections/MainNavSharedCollections.unit.spec.tsx
@@ -4,6 +4,7 @@ import { setupCollectionsEndpoints } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
+import { Route } from "metabase/router";
 import type { Collection } from "metabase-types/api";
 import { createMockCollection, createMockUser } from "metabase-types/api/mocks";
 
@@ -43,12 +44,20 @@ const setup = ({
   });
 
   renderWithProviders(
-    <MainNavSharedCollections
-      canAccessTenantSpecificCollections={canAccessTenantSpecificCollections}
-      canCreateSharedCollection={canWriteToSharedCollectionRoot}
-      sharedTenantCollections={tenantCollections}
+    <Route
+      path="/"
+      element={
+        <MainNavSharedCollections
+          canAccessTenantSpecificCollections={
+            canAccessTenantSpecificCollections
+          }
+          canCreateSharedCollection={canWriteToSharedCollectionRoot}
+          sharedTenantCollections={tenantCollections}
+        />
+      }
     />,
     {
+      withRouter: true,
       storeInitialState: createMockState({ settings, currentUser }),
     },
   );

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditConnectionForm.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditConnectionForm.tsx
@@ -1,4 +1,3 @@
-import type { LocationDescriptorObject } from "history";
 import { updateIn } from "icepick";
 import { type ComponentType, useState } from "react";
 import _ from "underscore";
@@ -19,7 +18,7 @@ import type {
 } from "metabase/databases/types";
 import { useDispatch } from "metabase/redux";
 import type { Dispatch } from "metabase/redux/store";
-import { type Route, withRouter } from "metabase/router";
+import { type Route, useRouter } from "metabase/router";
 import { Text } from "metabase/ui";
 import type {
   DatabaseData,
@@ -34,95 +33,92 @@ const makeDefaultSaveDbFn =
   async (database: DatabaseData): Promise<any> =>
     await dispatch(saveDatabase(database));
 
-export const DatabaseEditConnectionForm = withRouter(
-  ({
-    database,
-    isAttachedDWH,
-    initializeError,
-    handleSaveDb,
-    onSubmitted,
-    onCancel,
-    onEngineChange,
-    route,
-    location,
-    config,
-    formLocation,
-    ...props
-  }: {
-    database?: Partial<DatabaseData>;
-    isAttachedDWH: boolean;
-    initializeError?: unknown;
-    handleSaveDb?: (database: DatabaseData) => Promise<{ id: DatabaseId }>;
-    onSubmitted: (savedDB: { id: DatabaseId }) => void;
-    onCancel: () => void;
-    onEngineChange?: (engineKey: string | undefined) => void;
-    route: Route;
-    location: LocationDescriptorObject;
-    autofocusFieldName?: string;
-    config?: Omit<DatabaseFormConfig, "isAdvanced">;
-    formLocation: Extract<FormLocation, "admin" | "full-page">;
-  }) => {
-    const dispatch = useDispatch();
+export const DatabaseEditConnectionForm = ({
+  database,
+  isAttachedDWH,
+  initializeError,
+  handleSaveDb,
+  onSubmitted,
+  onCancel,
+  onEngineChange,
+  route,
+  config,
+  formLocation,
+  ...props
+}: {
+  database?: Partial<DatabaseData>;
+  isAttachedDWH: boolean;
+  initializeError?: unknown;
+  handleSaveDb?: (database: DatabaseData) => Promise<{ id: DatabaseId }>;
+  onSubmitted: (savedDB: { id: DatabaseId }) => void;
+  onCancel: () => void;
+  onEngineChange?: (engineKey: string | undefined) => void;
+  route: Route;
+  autofocusFieldName?: string;
+  config?: Omit<DatabaseFormConfig, "isAdvanced">;
+  formLocation: Extract<FormLocation, "admin" | "full-page">;
+}) => {
+  const dispatch = useDispatch();
+  const { location } = useRouter();
 
-    const [isDirty, setIsDirty] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
 
-    const autofocusFieldName =
-      location.hash?.slice(1) || props.autofocusFieldName;
+  const autofocusFieldName =
+    location.hash?.slice(1) || props.autofocusFieldName;
 
-    /**
-     * Navigation is scheduled so that LeaveConfirmationModal's isEnabled
-     * prop has a chance to re-compute on re-render
-     */
-    const [isCallbackScheduled, scheduleCallback] = useCallbackEffect();
+  /**
+   * Navigation is scheduled so that LeaveConfirmationModal's isEnabled
+   * prop has a chance to re-compute on re-render
+   */
+  const [isCallbackScheduled, scheduleCallback] = useCallbackEffect();
 
-    const handleSubmit = async (database: DatabaseData) => {
-      try {
-        const saveFn = handleSaveDb ?? makeDefaultSaveDbFn(dispatch);
-        const savedDB = await saveFn(database);
-        scheduleCallback(() => {
-          onSubmitted(savedDB);
-        });
-      } catch (error) {
-        // Unjustified type cast. FIXME
-        throw getSubmitError(error as DatabaseEditErrorType);
-      }
-    };
+  const handleSubmit = async (database: DatabaseData) => {
+    try {
+      const saveFn = handleSaveDb ?? makeDefaultSaveDbFn(dispatch);
+      const savedDB = await saveFn(database);
+      scheduleCallback(() => {
+        onSubmitted(savedDB);
+      });
+    } catch (error) {
+      // Unjustified type cast. FIXME
+      throw getSubmitError(error as DatabaseEditErrorType);
+    }
+  };
 
-    // Unjustified type cast. FIXME
-    return (
-      <ErrorBoundary errorComponent={GenericError as ComponentType}>
-        <LoadingAndErrorWrapper
-          loading={!database}
-          error={initializeError}
-          noWrapper
-        >
-          {isDbModifiable({
-            id: database?.id,
-            is_attached_dwh: isAttachedDWH,
-            is_sample: database?.is_sample,
-          }) ? (
-            <DatabaseForm
-              initialValues={database}
-              autofocusFieldName={autofocusFieldName}
-              config={{ isAdvanced: true, ...config }}
-              onCancel={onCancel}
-              onSubmit={handleSubmit}
-              onDirtyStateChange={setIsDirty}
-              location={formLocation}
-              onEngineChange={onEngineChange}
-            />
-          ) : (
-            <Text my="md">{getDbNotModifiableMessage(database)}</Text>
-          )}
-        </LoadingAndErrorWrapper>
-        <LeaveRouteConfirmModal
-          isEnabled={isDirty && !isCallbackScheduled}
-          route={route}
-        />
-      </ErrorBoundary>
-    );
-  },
-);
+  // Unjustified type cast. FIXME
+  return (
+    <ErrorBoundary errorComponent={GenericError as ComponentType}>
+      <LoadingAndErrorWrapper
+        loading={!database}
+        error={initializeError}
+        noWrapper
+      >
+        {isDbModifiable({
+          id: database?.id,
+          is_attached_dwh: isAttachedDWH,
+          is_sample: database?.is_sample,
+        }) ? (
+          <DatabaseForm
+            initialValues={database}
+            autofocusFieldName={autofocusFieldName}
+            config={{ isAdvanced: true, ...config }}
+            onCancel={onCancel}
+            onSubmit={handleSubmit}
+            onDirtyStateChange={setIsDirty}
+            location={formLocation}
+            onEngineChange={onEngineChange}
+          />
+        ) : (
+          <Text my="md">{getDbNotModifiableMessage(database)}</Text>
+        )}
+      </LoadingAndErrorWrapper>
+      <LeaveRouteConfirmModal
+        isEnabled={isDirty && !isCallbackScheduled}
+        route={route}
+      />
+    </ErrorBoundary>
+  );
+};
 
 const getSubmitError = (error: DatabaseEditErrorType) => {
   if (_.isObject(error?.data?.errors)) {

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.tsx
@@ -23,7 +23,7 @@ import {
   PLUGIN_WRITABLE_CONNECTION,
 } from "metabase/plugins";
 import { connect, useSelector } from "metabase/redux";
-import { Outlet, withRouter } from "metabase/router";
+import { Outlet, useRouter } from "metabase/router";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { Box, Divider, Flex } from "metabase/ui";
 import type { DatabaseId, Database as DatabaseType } from "metabase-types/api";
@@ -35,7 +35,6 @@ import { ExistingDatabaseHeader } from "../components/ExistingDatabaseHeader";
 import { deleteDatabase, updateDatabase } from "../database";
 
 interface DatabaseEditAppProps {
-  params: { databaseId: string };
   updateDatabase: (
     database: { id: DatabaseId } & Partial<DatabaseType>,
   ) => Promise<void>;
@@ -48,10 +47,10 @@ const mapDispatchToProps = {
 };
 
 function DatabaseEditAppInner({
-  params,
   updateDatabase,
   deleteDatabase,
 }: DatabaseEditAppProps) {
+  const { params } = useRouter();
   const isAdmin = useSelector(getUserIsAdmin);
   const isModelPersistenceEnabled = useSetting("persisted-models-enabled");
 
@@ -168,7 +167,13 @@ function DatabaseEditAppInner({
   );
 }
 
-export const DatabaseEditApp = _.compose(
-  withRouter,
-  connect(undefined, mapDispatchToProps),
-)(DatabaseEditAppInner);
+// Dropping the `withRouter` HOC left a single `connect`, which surfaced a
+// pre-existing prop mismatch the old two-HOC `compose` hid (the dispatch thunks
+// want a full `DatabaseData`, the sections pass a partial). Widen to keep the
+// original loose behavior without introducing `any`.
+const DatabaseEditAppComponent = DatabaseEditAppInner as ComponentType;
+
+export const DatabaseEditApp = connect(
+  undefined,
+  mapDispatchToProps,
+)(DatabaseEditAppComponent);

--- a/frontend/src/metabase/admin/permissions/routes.tsx
+++ b/frontend/src/metabase/admin/permissions/routes.tsx
@@ -20,6 +20,25 @@ const RoutedCollectionPermissionsPage = withRouteProps(
   CollectionPermissionsPage,
 );
 
+// The permissions page renders at each drill-down depth with progressively more
+// params. v3 expressed this with sequential optional groups
+// (`database(/:databaseId)(/schema/:schemaName)`), which v7's matcher cannot
+// parse, so each depth is spelled out as its own route. One route matches per
+// URL, exactly as the optional groups did.
+const DATABASES_PERMISSIONS_PATHS = [
+  "database",
+  "database/:databaseId",
+  "database/:databaseId/schema/:schemaName",
+  "database/:databaseId/schema/:schemaName/table/:tableId",
+];
+
+const GROUPS_PERMISSIONS_PATHS = [
+  "group",
+  "group/:groupId",
+  "group/:groupId/database/:databaseId",
+  "group/:groupId/database/:databaseId/schema/:schemaName",
+];
+
 const getRoutes = () => (
   <Route>
     <Route index element={redirect("data")} />
@@ -27,21 +46,23 @@ const getRoutes = () => (
     <Route path="data" element={<RoutedDataPermissionsPage />}>
       <Route index element={redirect("group")} />
 
-      <Route
-        path="database(/:databaseId)(/schema/:schemaName)(/table/:tableId)"
-        element={<RoutedDatabasesPermissionsPage />}
-      >
-        {PLUGIN_ADMIN_PERMISSIONS_DATABASE_ROUTES}
-        {PLUGIN_ADMIN_PERMISSIONS_TABLE_GROUP_ROUTES}
-      </Route>
+      {DATABASES_PERMISSIONS_PATHS.map((path) => (
+        <Route
+          key={path}
+          path={path}
+          element={<RoutedDatabasesPermissionsPage />}
+        >
+          {PLUGIN_ADMIN_PERMISSIONS_DATABASE_ROUTES}
+          {PLUGIN_ADMIN_PERMISSIONS_TABLE_GROUP_ROUTES}
+        </Route>
+      ))}
 
-      <Route
-        path="group(/:groupId)(/database/:databaseId)(/schema/:schemaName)"
-        element={<RoutedGroupsPermissionsPage />}
-      >
-        {PLUGIN_ADMIN_PERMISSIONS_DATABASE_GROUP_ROUTES}
-        {PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES}
-      </Route>
+      {GROUPS_PERMISSIONS_PATHS.map((path) => (
+        <Route key={path} path={path} element={<RoutedGroupsPermissionsPage />}>
+          {PLUGIN_ADMIN_PERMISSIONS_DATABASE_GROUP_ROUTES}
+          {PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES}
+        </Route>
+      ))}
     </Route>
 
     <Route path="collections" element={<RoutedCollectionPermissionsPage />}>

--- a/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/data-page.v7-engine.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/data-page.v7-engine.unit.spec.tsx
@@ -1,0 +1,75 @@
+import fetchMock from "fetch-mock";
+
+import {
+  setupDatabasesEndpoints,
+  setupGroupsEndpoint,
+  setupPermissionsGraphEndpoints,
+} from "__support__/server-mocks";
+import {
+  renderWithProviders,
+  screen,
+  waitForLoaderToBeRemoved,
+} from "__support__/ui";
+import DataPermissionsPage from "metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage";
+import { DatabasesPermissionsPage } from "metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage";
+import { Route, withRouteProps } from "metabase/router";
+import { createMockGroup } from "metabase-types/api/mocks/group";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+/**
+ * End-to-end proof that a real, router-heavy page renders on the v7 engine. The
+ * data-permissions page mounts `LeaveRouteConfirmModal`, which used v3's
+ * `withRouter` and crashed on v7 with `router === undefined` until that HOC was
+ * removed. Rendering the whole page under `routerEngine: "v7"` exercises the
+ * bridge, the leave-confirmation flow, and `withRouteProps` together.
+ */
+
+const RoutedDataPermissionsPage = withRouteProps(DataPermissionsPage);
+const RoutedDatabasesPermissionsPage = withRouteProps(DatabasesPermissionsPage);
+
+const TEST_DATABASE = createSampleDatabase();
+const TEST_GROUPS = [
+  createMockGroup({
+    id: 1,
+    name: "All internal users",
+    magic_group_type: "all-internal-users",
+  }),
+  createMockGroup({ id: 2, name: "Administrators", magic_group_type: "admin" }),
+];
+
+function setup() {
+  setupDatabasesEndpoints([TEST_DATABASE]);
+  setupPermissionsGraphEndpoints(TEST_GROUPS, [TEST_DATABASE]);
+  setupGroupsEndpoint(TEST_GROUPS);
+  fetchMock.get(
+    `path:/api/database/${TEST_DATABASE.id}/metadata`,
+    TEST_DATABASE,
+  );
+
+  renderWithProviders(
+    <Route
+      path="/admin/permissions/data"
+      element={<RoutedDataPermissionsPage />}
+    >
+      <Route
+        path="database/:databaseId"
+        element={<RoutedDatabasesPermissionsPage />}
+      />
+    </Route>,
+    {
+      withRouter: true,
+      routerEngine: "v7",
+      initialRoute: `/admin/permissions/data/database/${TEST_DATABASE.id}`,
+    },
+  );
+}
+
+describe("real page on the v7 engine", () => {
+  it("renders the data-permissions page (LeaveRouteConfirmModal + bridge)", async () => {
+    setup();
+    await waitForLoaderToBeRemoved();
+    expect(
+      await screen.findByRole("row", { name: /All internal users/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/routes.dual-engine.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/routes.dual-engine.unit.spec.tsx
@@ -1,0 +1,61 @@
+import { renderWithProviders, screen } from "__support__/ui";
+import type { RouterEngine } from "metabase/router";
+import { Outlet, Route, useParams } from "metabase/router";
+
+// A stub standing in for the permissions page, to validate the restructured
+// route shape (depth-enumerated siblings that replaced v3's optional groups)
+// matches the same URLs and yields the same params on both engines. The real
+// page is exercised elsewhere; here we isolate the routing.
+function ParamsProbe() {
+  const { databaseId, schemaName, tableId } = useParams();
+  return (
+    <span data-testid="params">
+      {JSON.stringify({ databaseId, schemaName, tableId })}
+    </span>
+  );
+}
+
+// Mirrors DATABASES_PERMISSIONS_PATHS in routes.tsx.
+const DATABASES_PERMISSIONS_PATHS = [
+  "database",
+  "database/:databaseId",
+  "database/:databaseId/schema/:schemaName",
+  "database/:databaseId/schema/:schemaName/table/:tableId",
+];
+
+function setup(routerEngine: RouterEngine, initialRoute: string) {
+  renderWithProviders(
+    <Route path="/admin/permissions/data" element={<Outlet />}>
+      {DATABASES_PERMISSIONS_PATHS.map((path) => (
+        <Route key={path} path={path} element={<ParamsProbe />} />
+      ))}
+    </Route>,
+    { withRouter: true, routerEngine, initialRoute },
+  );
+}
+
+describe.each<RouterEngine>(["v3", "v7"])(
+  "restructured databases permissions routes on the %s engine",
+  (routerEngine) => {
+    it.each([
+      ["/admin/permissions/data/database", {}],
+      ["/admin/permissions/data/database/1", { databaseId: "1" }],
+      [
+        "/admin/permissions/data/database/1/schema/PUBLIC",
+        { databaseId: "1", schemaName: "PUBLIC" },
+      ],
+      [
+        "/admin/permissions/data/database/1/schema/PUBLIC/table/2",
+        { databaseId: "1", schemaName: "PUBLIC", tableId: "2" },
+      ],
+    ])("matches %s and yields the right params", async (url, expected) => {
+      setup(routerEngine, url);
+      const probe = await screen.findByTestId("params");
+      const params = JSON.parse(probe.textContent ?? "{}");
+      const defined = Object.fromEntries(
+        Object.entries(params).filter(([, value]) => value !== undefined),
+      );
+      expect(defined).toEqual(expected);
+    });
+  },
+);

--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -38,7 +38,12 @@ import { MetabotProvider } from "metabase/metabot/context";
 import { PLUGIN_APP_INIT_FUNCTIONS } from "metabase/plugins";
 import { MetabaseReduxProvider } from "metabase/redux";
 import { refreshSiteSettings } from "metabase/redux/settings";
-import { syncHistoryWithStore, useRouterHistory } from "metabase/router";
+import {
+  getRouterEngine,
+  syncHistoryWithStore,
+  useRouterHistory,
+} from "metabase/router";
+import { createV7Navigator } from "metabase/router/v7/navigator";
 import { getUserId } from "metabase/selectors/user";
 import { GlobalStyles } from "metabase/styled-components/containers/GlobalStyles";
 import { PortalContainer } from "metabase/ui";
@@ -57,17 +62,23 @@ import { OverlayStackProvider } from "./ui/components/overlays/overlay-stack";
 
 setBasename(window.MetabaseRoot);
 
-// eslint-disable-next-line react-hooks/rules-of-hooks
-const browserHistory = useRouterHistory(createHistory)({
-  basename: getBasename(),
-});
+// The v3 engine drives navigation through a `history@3` instance; the v7 engine
+// owns its own history and only needs a navigator adapter for redux. Kept for
+// instant rollback via the `use-v7-router` flag.
+const isV7Router = getRouterEngine() === "v7";
+const browserHistory = isV7Router
+  ? undefined
+  : // eslint-disable-next-line react-hooks/rules-of-hooks
+    useRouterHistory(createHistory)({ basename: getBasename() });
 
 initializePlugins();
 
 function _init(reducers, getRoutes, callback) {
-  const store = getStore(reducers, browserHistory);
+  const store = getStore(reducers, browserHistory ?? createV7Navigator());
   const routes = getRoutes(store);
-  const syncedHistory = syncHistoryWithStore(browserHistory, store);
+  const syncedHistory = browserHistory
+    ? syncHistoryWithStore(browserHistory, store)
+    : undefined;
 
   createSnowplowTracker(() => getUserId(store.getState()));
   initMetaplow({
@@ -80,12 +91,27 @@ function _init(reducers, getRoutes, callback) {
     initTracing();
     // Rotate trace ID on route changes so all API calls within
     // a single page view share one trace.
-    syncedHistory.listen(() => rotateTraceId());
+    if (syncedHistory) {
+      syncedHistory.listen(() => rotateTraceId());
+    } else {
+      // v7 mirrors the location into state.routing; rotate when it changes.
+      let lastPathname;
+      store.subscribe(() => {
+        const { pathname } =
+          store.getState().routing.locationBeforeTransitions ?? {};
+        if (pathname !== lastPathname) {
+          lastPathname = pathname;
+          rotateTraceId();
+        }
+      });
+    }
   }
 
   initializeInteractiveEmbedding(store.dispatch);
 
   const root = createRoot(document.getElementById("root"));
+
+  const app = <RouterProvider>{routes}</RouterProvider>;
 
   root.render(
     <MetabaseReduxProvider store={store}>
@@ -96,9 +122,13 @@ function _init(reducers, getRoutes, callback) {
               <GlobalStyles />
               {createPortal(<PortalContainer />, document.body)}
               <MetabotProvider>
-                <HistoryProvider history={syncedHistory}>
-                  <RouterProvider>{routes}</RouterProvider>
-                </HistoryProvider>
+                {syncedHistory ? (
+                  <HistoryProvider history={syncedHistory}>
+                    {app}
+                  </HistoryProvider>
+                ) : (
+                  app
+                )}
               </MetabotProvider>
             </AppThemeProvider>
           </OverlayStackProvider>

--- a/frontend/src/metabase/app/nav/AppBar.tsx
+++ b/frontend/src/metabase/app/nav/AppBar.tsx
@@ -29,7 +29,7 @@ import {
 import { connect, useDispatch, useSelector } from "metabase/redux";
 import { closeNavbar, toggleNavbar } from "metabase/redux/app";
 import type { State } from "metabase/redux/store";
-import { push, withRouter } from "metabase/router";
+import { push, withRouteProps } from "metabase/router";
 import type { RouterProps } from "metabase/selectors/app";
 import { getDetailViewState, getIsNavbarOpen } from "metabase/selectors/app";
 import { getIsEmbeddingIframe } from "metabase/selectors/embed";
@@ -130,6 +130,6 @@ function AppBarContainerInner(props: AppBarProps & RouterProps) {
   );
 }
 
-export const AppBarContainer = withRouter(
+export const AppBarContainer = withRouteProps(
   connect(mapStateToProps, mapDispatchToProps)(AppBarContainerInner),
 );

--- a/frontend/src/metabase/app/nav/Navbar.tsx
+++ b/frontend/src/metabase/app/nav/Navbar.tsx
@@ -6,13 +6,13 @@ import { AdminNavbar } from "metabase/nav/components/AdminNavbar";
 import { MainNavbar } from "metabase/nav/containers/MainNavbar";
 import { connect } from "metabase/redux";
 import type { AdminPath, State, StoreDashboard } from "metabase/redux/store";
-import { type WithRouterProps, withRouter } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { getAdminPaths } from "metabase/selectors/admin";
 import { getIsNavbarOpen } from "metabase/selectors/app";
 import { getUser } from "metabase/selectors/user";
 import type { User } from "metabase-types/api";
 
-type NavbarProps = WithRouterProps & {
+type NavbarProps = {
   isOpen: boolean;
   user: User | null;
   adminPaths: AdminPath[];
@@ -29,14 +29,8 @@ const mapStateToProps = (state: State) => ({
   dashboard: getDashboard(state),
 });
 
-function NavbarInner({
-  isOpen,
-  user,
-  location,
-  params,
-  adminPaths,
-  dashboard,
-}: NavbarProps) {
+function NavbarInner({ isOpen, user, adminPaths, dashboard }: NavbarProps) {
+  const { location, params } = useRouter();
   useListDatabasesQuery();
   const isAdminApp = useMemo(
     () => location.pathname.startsWith("/admin/"),
@@ -59,4 +53,4 @@ function NavbarInner({
   );
 }
 
-export const Navbar = withRouter(connect(mapStateToProps)(NavbarInner));
+export const Navbar = connect(mapStateToProps)(NavbarInner);

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.tsx
@@ -3,7 +3,6 @@ import {
   isLibraryCollection,
   isTrashedCollection,
 } from "metabase/common/collections/utils";
-import { withRouter } from "metabase/router";
 import type { Collection } from "metabase-types/api";
 
 import { CollectionMenu } from "../CollectionMenu";
@@ -101,4 +100,4 @@ const CollectionHeader = ({
 };
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
-export default withRouter(CollectionHeader);
+export default CollectionHeader;

--- a/frontend/src/metabase/common/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
+++ b/frontend/src/metabase/common/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
@@ -20,8 +20,7 @@ import {
   FormTextarea,
 } from "metabase/forms";
 import { PLUGIN_TENANTS } from "metabase/plugins";
-import type { WithRouterProps } from "metabase/router";
-import { withRouter } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { Button, Flex } from "metabase/ui";
 import * as Errors from "metabase/utils/errors";
 import type { Collection, CollectionNamespace } from "metabase-types/api";
@@ -58,13 +57,11 @@ export interface CreateCollectionFormOwnProps {
   showAuthorityLevelPicker?: boolean;
 }
 
-type Props = CreateCollectionFormOwnProps & WithRouterProps;
+type Props = CreateCollectionFormOwnProps;
 
 function CreateCollectionForm({
   collectionId,
   initialCollectionId: explicitInitialCollectionId,
-  location,
-  params,
   onSubmit,
   onCancel,
   filterPersonalCollections,
@@ -73,6 +70,7 @@ function CreateCollectionForm({
   namespaces,
   showAuthorityLevelPicker = true,
 }: Props) {
+  const { location, params } = useRouter();
   const defaultInitialCollectionId = useInitialCollectionId({
     collectionId,
     location,
@@ -182,4 +180,4 @@ function CreateCollectionForm({
 }
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
-export default withRouter(CreateCollectionForm);
+export default CreateCollectionForm;

--- a/frontend/src/metabase/common/collections/components/CreateCollectionForm/tests/setup.tsx
+++ b/frontend/src/metabase/common/collections/components/CreateCollectionForm/tests/setup.tsx
@@ -8,6 +8,7 @@ import { mockSettings } from "__support__/settings";
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
+import { Route } from "metabase/router";
 import type {
   CollectionId,
   CollectionNamespace,
@@ -94,15 +95,21 @@ export const setup = ({
   });
 
   renderWithProviders(
-    <CreateCollectionForm
-      onCancel={onCancel}
-      onSubmit={onSubmit}
-      showAuthorityLevelPicker={showAuthorityLevelPicker}
-      collectionId={parentCollectionNamespace !== undefined ? 1 : undefined}
-      initialCollectionId={initialCollectionId}
-      namespaces={namespaces}
+    <Route
+      path="/"
+      element={
+        <CreateCollectionForm
+          onCancel={onCancel}
+          onSubmit={onSubmit}
+          showAuthorityLevelPicker={showAuthorityLevelPicker}
+          collectionId={parentCollectionNamespace !== undefined ? 1 : undefined}
+          initialCollectionId={initialCollectionId}
+          namespaces={namespaces}
+        />
+      }
     />,
     {
+      withRouter: true,
       storeInitialState: createMockState({
         currentUser: user,
         settings,

--- a/frontend/src/metabase/common/components/CopyDashboardForm/CopyDashboardForm.tsx
+++ b/frontend/src/metabase/common/components/CopyDashboardForm/CopyDashboardForm.tsx
@@ -20,7 +20,6 @@ import {
   FormTextInput,
   FormTextarea,
 } from "metabase/forms";
-import { withRouter } from "metabase/router";
 import { Button, Group, Icon, Tooltip } from "metabase/ui";
 import { isVirtualDashCard } from "metabase/utils/dashboard";
 import * as Errors from "metabase/utils/errors";
@@ -162,4 +161,4 @@ function CopyDashboardForm({
   );
 }
 
-export const CopyDashboardFormConnected = withRouter(CopyDashboardForm);
+export const CopyDashboardFormConnected = CopyDashboardForm;

--- a/frontend/src/metabase/common/components/LeaveConfirmModal/LeaveRouteConfirmModal.tsx
+++ b/frontend/src/metabase/common/components/LeaveConfirmModal/LeaveRouteConfirmModal.tsx
@@ -3,8 +3,8 @@ import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
 import { useConfirmRouteLeaveModal } from "metabase/common/hooks/use-confirm-route-leave-modal";
-import type { InjectedRouter, Route } from "metabase/router";
-import { useRoute, withRouter } from "metabase/router";
+import type { Route } from "metabase/router";
+import { useRoute, useRouter } from "metabase/router";
 
 import { LeaveConfirmModal } from "./LeaveConfirmModal";
 
@@ -17,26 +17,27 @@ interface LeaveRouteConfirmModalProps {
    * v3-injected `route`. Still accepted for callers that pass it explicitly.
    */
   route?: Route;
-  router: InjectedRouter;
-  routes: Route[];
   onConfirm?: () => void;
   onOpenChange?: (opened: boolean) => void;
 }
 
-const LeaveRouteConfirmModalInner = ({
+export const LeaveRouteConfirmModal = ({
   isEnabled,
   isLocationAllowed,
   route,
-  router,
-  routes,
   onConfirm,
   onOpenChange,
 }: LeaveRouteConfirmModalProps) => {
+  const { router, routes } = useRouter();
   const routeFromContext = useRoute();
+  // `routes` from the context is typed `PlainRoute[]`; its leaf is the matched
+  // route that `setRouteLeaveHook` (a no-op on v7) receives, matching the
+  // pre-conversion `Route[]` prop typing.
+  const leafRoute = routes[routes.length - 1] as unknown as Route;
   const { opened, close, confirm } = useConfirmRouteLeaveModal({
     isEnabled,
     isLocationAllowed,
-    route: route ?? routeFromContext ?? routes[routes.length - 1],
+    route: route ?? routeFromContext ?? leafRoute,
     router,
   });
   const previousIsOpened = usePrevious(opened);
@@ -60,5 +61,3 @@ const LeaveRouteConfirmModalInner = ({
     />
   );
 };
-
-export const LeaveRouteConfirmModal = withRouter(LeaveRouteConfirmModalInner);

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.unit.spec.tsx
@@ -10,6 +10,7 @@ import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
 import { NewModals } from "metabase/new/components/NewModals/NewModals";
 import { createMockState } from "metabase/redux/store/mocks";
+import { Route } from "metabase/router";
 import type { Database } from "metabase-types/api";
 import {
   createMockCollection,
@@ -51,11 +52,17 @@ async function setup({
   setupEnterprisePlugins();
 
   renderWithProviders(
-    <>
-      <NewItemMenu trigger={<button>New</button>} />
-      <NewModals />
-    </>,
+    <Route
+      path="/"
+      element={
+        <>
+          <NewItemMenu trigger={<button>New</button>} />
+          <NewModals />
+        </>
+      }
+    />,
     {
+      withRouter: true,
       storeInitialState: createMockState({
         settings,
         currentUser: createMockUser({

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.tsx
@@ -1,4 +1,3 @@
-import type { Location } from "history";
 import { dissoc } from "icepick";
 import { useState } from "react";
 import { t } from "ttag";
@@ -8,7 +7,7 @@ import { useInitialCollectionId } from "metabase/common/collections/hooks";
 import type { CopyDashboardFormProperties } from "metabase/common/components/CopyDashboardForm";
 import { CopyModal } from "metabase/common/components/CopyModal";
 import { useDispatch, useSelector } from "metabase/redux";
-import { replace, withRouter } from "metabase/router";
+import { replace, useRouter } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { Dashboard } from "metabase-types/api";
 
@@ -16,8 +15,6 @@ import { getDashboardComplete } from "../selectors";
 
 type DashboardCopyModalProps = {
   onClose: () => void;
-  params: { slug?: string };
-  location: Location;
 };
 
 const getTitle = (
@@ -33,11 +30,8 @@ const getTitle = (
     : t`Duplicate "${dashboard.name}" and its questions`;
 };
 
-const DashboardCopyModal = ({
-  onClose,
-  params,
-  location,
-}: DashboardCopyModalProps) => {
+const DashboardCopyModal = ({ onClose }: DashboardCopyModalProps) => {
+  const { location, params } = useRouter();
   const dispatch = useDispatch();
   const [copyDashboard] = useCopyDashboardMutation();
   const dashboard = useSelector(getDashboardComplete);
@@ -86,4 +80,4 @@ const DashboardCopyModal = ({
   );
 };
 
-export const DashboardCopyModalConnected = withRouter(DashboardCopyModal);
+export const DashboardCopyModalConnected = DashboardCopyModal;

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/CopyAnalyticsDashboardButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/CopyAnalyticsDashboardButton.tsx
@@ -1,15 +1,17 @@
 import { t } from "ttag";
 
 import { Link } from "metabase/common/components/Link";
-import { type WithRouterProps, withRouter } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { Button, Icon } from "metabase/ui";
 
-export const CopyAnalyticsDashboardButton = withRouter(
-  ({ location }: WithRouterProps) => (
+export const CopyAnalyticsDashboardButton = () => {
+  const { location } = useRouter();
+
+  return (
     <Button
       leftSection={<Icon name="clone" />}
       to={`${location.pathname}/copy`}
       component={Link}
     >{t`Make a copy`}</Button>
-  ),
-);
+  );
+};

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
@@ -1,5 +1,4 @@
 import { type MouseEvent, forwardRef, useState } from "react";
-import type { WithRouterProps } from "react-router/lib/withRouter";
 import { c, t } from "ttag";
 
 import { ToolbarButton } from "metabase/common/components/ToolbarButton";
@@ -11,7 +10,7 @@ import { DashboardSubscriptionMenuItem } from "metabase/notifications/Notificati
 import { useRegisterShortcut } from "metabase/palette/hooks/useRegisterShortcut";
 import { PLUGIN_CACHING, PLUGIN_MODERATION } from "metabase/plugins";
 import { useDispatch, useSelector } from "metabase/redux";
-import { Link, type LinkProps, withRouter } from "metabase/router";
+import { Link, type LinkProps, useRouter } from "metabase/router";
 import { Icon, Menu } from "metabase/ui";
 
 type DashboardActionMenuProps = {
@@ -35,9 +34,9 @@ const DashboardActionMenuInner = ({
   canResetFilters,
   onResetFilters,
   canEdit,
-  location,
   openSettingsSidebar,
-}: DashboardActionMenuProps & WithRouterProps) => {
+}: DashboardActionMenuProps) => {
+  const { location } = useRouter();
   const { dashboard, isFullscreen, onFullscreenChange, onChangeLocation } =
     useDashboardContext();
   const [opened, setOpened] = useState(false);
@@ -164,4 +163,4 @@ const DashboardActionMenuInner = ({
   );
 };
 
-export const DashboardActionMenu = withRouter(DashboardActionMenuInner);
+export const DashboardActionMenu = DashboardActionMenuInner;

--- a/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
@@ -5,93 +5,83 @@ import { updateDashboardAndCards } from "metabase/dashboard/actions/save";
 import { getIsDirty, getIsEditing } from "metabase/dashboard/selectors";
 import { useDispatch, useSelector } from "metabase/redux";
 import { dismissAllUndo } from "metabase/redux/undo";
-import {
-  type Route,
-  type WithRouterProps,
-  useRoute,
-  withRouter,
-} from "metabase/router";
+import { type Route, useRoute, useRouter } from "metabase/router";
 import { Box, Button, Flex, Modal, Text } from "metabase/ui";
 
 import { isNavigatingToCreateADashboardQuestion } from "./utils";
 
-interface DashboardLeaveConfirmationModalProps extends WithRouterProps {
-  route?: Route;
-}
+export const DashboardLeaveConfirmationModal = () => {
+  const isEditing = useSelector(getIsEditing);
+  const isDirty = useSelector(getIsDirty);
+  const { router, routes } = useRouter();
+  const route = useRoute();
 
-export const DashboardLeaveConfirmationModal = withRouter(
-  ({ router, route, routes }: DashboardLeaveConfirmationModalProps) => {
-    const isEditing = useSelector(getIsEditing);
-    const isDirty = useSelector(getIsDirty);
-    const routeFromContext = useRoute();
+  const dispatch = useDispatch();
 
-    const dispatch = useDispatch();
+  const { opened, close, confirm, nextLocation } = useConfirmRouteLeaveModal({
+    isEnabled: isEditing && isDirty,
+    // `routes` is the matched-route chain; its last entry is this page's own
+    // route. Typed loosely as PlainRoute by react-router, cast to the `Route`
+    // the hook expects.
+    route: route ?? (routes[routes.length - 1] as Route),
+    router,
+  });
 
-    const { opened, close, confirm, nextLocation } = useConfirmRouteLeaveModal({
-      isEnabled: isEditing && isDirty,
-      // `routes` is the matched-route chain; its last entry is this page's own
-      // route. Typed loosely as PlainRoute by react-router, cast to the `Route`
-      // the hook expects.
-      route: route ?? routeFromContext ?? (routes[routes.length - 1] as Route),
-      router,
-    });
+  const content = isNavigatingToCreateADashboardQuestion(nextLocation)
+    ? {
+        title: t`Save your changes?`,
+        message: t`You’ll need to save your changes before leaving to create a new question.`,
+        actionBtn: {
+          message: t`Save changes`,
+        },
+        onConfirm: () => dispatch(updateDashboardAndCards()),
+      }
+    : {
+        title: t`Discard your changes?`,
+        message: t`Your changes haven’t been saved, so you’ll lose them if you navigate away.`,
+        actionBtn: {
+          color: "feedback-negative" as const,
+          message: t`Discard changes`,
+        },
+      };
 
-    const content = isNavigatingToCreateADashboardQuestion(nextLocation)
-      ? {
-          title: t`Save your changes?`,
-          message: t`You’ll need to save your changes before leaving to create a new question.`,
-          actionBtn: {
-            message: t`Save changes`,
-          },
-          onConfirm: () => dispatch(updateDashboardAndCards()),
-        }
-      : {
-          title: t`Discard your changes?`,
-          message: t`Your changes haven’t been saved, so you’ll lose them if you navigate away.`,
-          actionBtn: {
-            color: "feedback-negative" as const,
-            message: t`Discard changes`,
-          },
-        };
-
-    return (
-      <Modal
-        opened={opened}
-        onClose={close}
-        size="28.5rem"
-        padding="2.5rem"
-        title={content.title}
-        data-testid="leave-confirmation"
-        withCloseButton={false}
-        styles={{
-          title: {
-            fontSize: "1rem",
-          },
-          header: {
-            marginBottom: "0.5rem",
-          },
-        }}
-      >
-        <Box>
-          <Text lh="1.5rem" mb={"lg"}>
-            {content.message}
-          </Text>
-          <Flex justify="flex-end" gap="md">
-            <Button onClick={close}>{t`Cancel`}</Button>
-            <Button
-              color={content.actionBtn.color}
-              variant="filled"
-              onClick={async () => {
-                dispatch(dismissAllUndo());
-                await content.onConfirm?.();
-                confirm?.();
-              }}
-            >
-              {content.actionBtn.message}
-            </Button>
-          </Flex>
-        </Box>
-      </Modal>
-    );
-  },
-);
+  return (
+    <Modal
+      opened={opened}
+      onClose={close}
+      size="28.5rem"
+      padding="2.5rem"
+      title={content.title}
+      data-testid="leave-confirmation"
+      withCloseButton={false}
+      styles={{
+        title: {
+          fontSize: "1rem",
+        },
+        header: {
+          marginBottom: "0.5rem",
+        },
+      }}
+    >
+      <Box>
+        <Text lh="1.5rem" mb={"lg"}>
+          {content.message}
+        </Text>
+        <Flex justify="flex-end" gap="md">
+          <Button onClick={close}>{t`Cancel`}</Button>
+          <Button
+            color={content.actionBtn.color}
+            variant="filled"
+            onClick={async () => {
+              dispatch(dismissAllUndo());
+              await content.onConfirm?.();
+              confirm?.();
+            }}
+          >
+            {content.actionBtn.message}
+          </Button>
+        </Flex>
+      </Box>
+    </Modal>
+  );
+};

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
@@ -16,7 +16,6 @@ import {
   Route,
   type WithRouterProps,
   withRouteProps,
-  withRouter,
 } from "metabase/router";
 import type { DashboardTab } from "metabase-types/api";
 import { createMockCard } from "metabase-types/api/mocks";
@@ -54,21 +53,19 @@ function setup({
     },
   };
 
-  const RoutedDashboardComponent = withRouter(
-    ({ location }: { location: Location }) => {
-      const { selectedTabId } = useDashboardTabs();
-      useDashboardUrlQuery(createMockRouter(), location);
-      return (
-        <>
-          <DashboardTabs />
-          <span>Selected tab id is {selectedTabId}</span>
-          <br />
-          <span>Path is {location.pathname + location.search}</span>
-          <Link to="/someotherpath">Navigate away</Link>
-        </>
-      );
-    },
-  );
+  const RoutedDashboardComponent = ({ location }: { location: Location }) => {
+    const { selectedTabId } = useDashboardTabs();
+    useDashboardUrlQuery(createMockRouter(), location);
+    return (
+      <>
+        <DashboardTabs />
+        <span>Selected tab id is {selectedTabId}</span>
+        <br />
+        <span>Path is {location.pathname + location.search}</span>
+        <Link to="/someotherpath">Navigate away</Link>
+      </>
+    );
+  };
 
   const OtherComponent = () => {
     const selectedTabId = useSelector(getSelectedTabId);

--- a/frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.tsx
@@ -7,7 +7,7 @@ import { ArchiveModal } from "metabase/common/components/ArchiveModal";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { setArchivedDashboard } from "metabase/dashboard/actions";
 import { useDispatch } from "metabase/redux";
-import { withRouter } from "metabase/router";
+import { useRouter } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { Dashboard } from "metabase-types/api";
 
@@ -56,10 +56,9 @@ const ArchiveDashboardModal = ({
   );
 };
 
-export const ArchiveDashboardModalConnectedInner = (
-  props: OwnProps & { params: { slug?: string } },
-) => {
-  const id = Urls.extractCollectionId(props.params?.slug);
+export const ArchiveDashboardModalConnectedInner = (props: OwnProps) => {
+  const { params } = useRouter();
+  const id = Urls.extractCollectionId(params?.slug);
   const { currentData: dashboard, error } = useGetDashboardQuery(
     id != null ? { id } : skipToken,
   );
@@ -77,6 +76,5 @@ export const ArchiveDashboardModalConnectedInner = (
   );
 };
 
-export const ArchiveDashboardModalConnected = withRouter(
-  ArchiveDashboardModalConnectedInner,
-);
+export const ArchiveDashboardModalConnected =
+  ArchiveDashboardModalConnectedInner;

--- a/frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.unit.spec.tsx
@@ -3,7 +3,7 @@ import {
   setupDashboardNotFoundEndpoint,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
-import type { WithRouterProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { createMockDashboard } from "metabase-types/api/mocks";
 
 import { ArchiveDashboardModalConnectedInner } from "./ArchiveDashboardModal";
@@ -17,13 +17,16 @@ const setup = ({
   slug?: string;
   onClose?: () => void;
 } = {}) => {
-  // Unjustified type cast. FIXME
-  const props = {
-    onClose,
-    params: { slug },
-  } as unknown as WithRouterProps & { onClose: () => void };
-
-  renderWithProviders(<ArchiveDashboardModalConnectedInner {...props} />);
+  renderWithProviders(
+    <Route
+      path="/dashboard(/:slug)"
+      element={<ArchiveDashboardModalConnectedInner onClose={onClose} />}
+    />,
+    {
+      withRouter: true,
+      initialRoute: slug ? `/dashboard/${slug}` : "/dashboard",
+    },
+  );
 
   return { onClose };
 };

--- a/frontend/src/metabase/monitor/tools/components/Logs/Logs.tsx
+++ b/frontend/src/metabase/monitor/tools/components/Logs/Logs.tsx
@@ -1,4 +1,3 @@
-import type { Location } from "history";
 import * as React from "react";
 import { useMemo } from "react";
 import reactAnsiStyle from "react-ansi-style";
@@ -10,7 +9,7 @@ import {
 } from "metabase/admin/components/SettingsSection";
 import { AnsiLogs } from "metabase/common/components/AnsiLogs";
 import { useUrlState } from "metabase/common/hooks/use-url-state";
-import { Link, Outlet, withRouter } from "metabase/router";
+import { Link, Outlet, useRouter } from "metabase/router";
 import {
   Button,
   DefaultSelectItem,
@@ -31,7 +30,6 @@ import {
 } from "./utils";
 
 interface LogsProps {
-  location: Location;
   // NOTE: fetching logs could come back from any machine if there's multiple machines backing a MB instance
   // make this frequent enough that you will most likely get every log from every machine in some reasonable
   // amount of time
@@ -40,10 +38,10 @@ interface LogsProps {
 
 export const DEFAULT_POLLING_DURATION_MS = 1000;
 
-const LogsBase = ({
-  location,
+export const Logs = ({
   pollingDurationMs = DEFAULT_POLLING_DURATION_MS,
 }: LogsProps) => {
+  const { location } = useRouter();
   const [{ process, query }, { patchUrlState }] = useUrlState(
     location,
     urlStateConfig,
@@ -182,5 +180,3 @@ const LogsBase = ({
     </>
   );
 };
-
-export const Logs = withRouter(LogsBase);

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import { useListTaskRunsQuery } from "metabase/api";
 import { PaginationControls } from "metabase/common/components/PaginationControls";
 import { useUrlState } from "metabase/common/hooks/use-url-state";
-import { type WithRouterProps, withRouter } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { Flex } from "metabase/ui";
 
 import { toBackendStartedAt } from "../../utils";
@@ -17,7 +17,8 @@ import { TaskRunsTable } from "./TaskRunsTable";
 import { PAGE_SIZE } from "./constants";
 import { urlStateConfig } from "./utils";
 
-const TaskRunsPageBase = ({ location }: WithRouterProps) => {
+export const TaskRunsPage = () => {
+  const { location } = useRouter();
   const [
     {
       page,
@@ -122,5 +123,3 @@ const TaskRunsPageBase = ({ location }: WithRouterProps) => {
     </TasksTabs>
   );
 };
-
-export const TaskRunsPage = withRouter(TaskRunsPageBase);

--- a/frontend/src/metabase/monitor/tools/components/TasksTabs/TasksTabs.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TasksTabs/TasksTabs.tsx
@@ -5,8 +5,7 @@ import {
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
 import { useDispatch } from "metabase/redux";
-import { push } from "metabase/router";
-import { type WithRouterProps, withRouter } from "metabase/router";
+import { push, useRouter } from "metabase/router";
 import { Flex, Icon, Tabs, Title, Tooltip } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
@@ -15,11 +14,12 @@ type TabConfig = {
   label: string;
 };
 
-type TasksTabsProps = WithRouterProps & {
+type TasksTabsProps = {
   children: React.ReactNode;
 };
 
-const TasksTabsBase = ({ children, location }: TasksTabsProps) => {
+export const TasksTabs = ({ children }: TasksTabsProps) => {
+  const { location } = useRouter();
   const tabs: TabConfig[] = [
     { value: Urls.adminToolsTasksList(), label: t`Tasks` },
     { value: Urls.adminToolsTasksRuns(), label: t`Runs` },
@@ -60,5 +60,3 @@ const TasksTabsBase = ({ children, location }: TasksTabsProps) => {
     </SettingsPageWrapper>
   );
 };
-
-export const TasksTabs = withRouter(TasksTabsBase);

--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
@@ -18,12 +18,11 @@ import {
   getSearchTextFromLocation,
   isSearchPageLocation,
 } from "metabase/common/search";
-import type { SearchAwareLocation } from "metabase/common/search/types";
 import { RecentsList } from "metabase/nav/components/search/RecentsList";
 import { SearchResultsDropdown } from "metabase/nav/components/search/SearchResultsDropdown";
 import { APP_BAR_HEIGHT } from "metabase/nav/constants";
 import { useDispatch, useSelector } from "metabase/redux";
-import { push, withRouter } from "metabase/router";
+import { push, useRouter } from "metabase/router";
 import { getSetting } from "metabase/selectors/settings";
 import { Box, Flex, Icon, UnstyledButton, rem } from "metabase/ui";
 import { modelToUrl } from "metabase/urls";
@@ -36,11 +35,7 @@ import S from "./SearchBar.module.css";
 
 const ALLOWED_SEARCH_FOCUS_ELEMENTS = new Set(["BODY", "A"]);
 
-type RouterProps = {
-  location: SearchAwareLocation;
-};
-
-type OwnProps = {
+type Props = {
   onSearchActive?: () => void;
   onSearchInactive?: () => void;
   /**
@@ -51,14 +46,12 @@ type OwnProps = {
   onSearchItemSelect?: (result: SearchResult) => void;
 };
 
-type Props = RouterProps & OwnProps;
-
-function SearchBarView({
-  location,
+function SearchBar({
   onSearchActive,
   onSearchInactive,
   onSearchItemSelect: onSearchItemSelectProp,
 }: Props) {
+  const { location } = useRouter();
   const isTypeaheadEnabled = useSelector((state) =>
     getSetting(state, "search-typeahead-enabled"),
   );
@@ -262,8 +255,6 @@ function SearchBarView({
     </Box>
   );
 }
-
-export const SearchBar = withRouter(SearchBarView);
 
 // for some reason our unit test don't work if this is a name export ¯\_(ツ)_/¯
 // eslint-disable-next-line import/no-default-export

--- a/frontend/src/metabase/nav/components/search/SearchButton/SearchButton.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchButton/SearchButton.tsx
@@ -4,18 +4,14 @@ import { t } from "ttag";
 
 import { useIsSmallScreen } from "metabase/common/hooks/use-is-small-screen";
 import { getSearchTextFromLocation } from "metabase/common/search";
-import type { SearchAwareLocation } from "metabase/common/search/types";
-import { withRouter } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { Button, type ButtonProps, Flex, Icon } from "metabase/ui";
 import { METAKEY } from "metabase/utils/browser";
 
 import S from "./SearchButton.module.css";
 
-type SearchButtonProps = ButtonProps & {
-  location: SearchAwareLocation;
-};
-
-const SearchButtonView = ({ location, ...props }: SearchButtonProps) => {
+export const SearchButton = (props: ButtonProps) => {
+  const { location } = useRouter();
   const kbar = useKBar();
   const { setVisualState } = kbar.query;
   const searchText = getSearchTextFromLocation(location);
@@ -68,5 +64,3 @@ const SearchButtonView = ({ location, ...props }: SearchButtonProps) => {
     </Button>
   );
 };
-
-export const SearchButton = withRouter(SearchButtonView);

--- a/frontend/src/metabase/new/components/NewModals/NewModals.tsx
+++ b/frontend/src/metabase/new/components/NewModals/NewModals.tsx
@@ -19,20 +19,21 @@ import type {
 } from "metabase/plugins";
 import { useDispatch, useSelector } from "metabase/redux";
 import { closeModal, setOpenModal } from "metabase/redux/ui";
-import type { WithRouterProps } from "metabase/router";
-import { push, withRouter } from "metabase/router";
+import { push, useRouter } from "metabase/router";
 import { getCurrentOpenModalState } from "metabase/selectors/ui";
 import { Modal, PREVENT_AUTOCOMPLETE_CLIPPING_MODAL_PROPS } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type { WritebackAction } from "metabase-types/api";
 
-export const NewModals = withRouter((props: WithRouterProps) => {
+export const NewModals = () => {
+  const { location, params } = useRouter();
   const { pathname } = useLocation();
   const { id: currentNewModalId, props: currentNewModalProps } = useSelector(
     getCurrentOpenModalState<CreateCollectionModalOwnProps>,
   );
   const dispatch = useDispatch();
-  const collectionId = useInitialCollectionId(props) ?? undefined;
+  const collectionId =
+    useInitialCollectionId({ location, params }) ?? undefined;
 
   const handleActionCreated = useCallback(
     (action: WritebackAction) => {
@@ -139,4 +140,4 @@ export const NewModals = withRouter((props: WithRouterProps) => {
         />
       );
   }
-});
+};

--- a/frontend/src/metabase/palette/components/Palette.tsx
+++ b/frontend/src/metabase/palette/components/Palette.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
 
 import { useOnClickOutside } from "metabase/common/hooks/use-on-click-outside";
 import { useSelector } from "metabase/redux";
-import { type PlainRoute, withRouter } from "metabase/router";
+import { type PlainRoute, useRouter } from "metabase/router";
 import { getUser } from "metabase/selectors/user";
 import { Box, Card, Center, Icon, Overlay, Stack, rem } from "metabase/ui";
 import { isWithinIframe } from "metabase/utils/iframe";
@@ -21,15 +21,17 @@ type CommandPaletteRouteProps = {
 };
 
 /** Command palette */
-export const Palette = withRouter((props) => {
+export const Palette = () => {
+  const routerProps = useRouter();
+  const { routes, location } = routerProps;
   const isLoggedIn = useSelector((state) => !!getUser(state));
 
-  const disableCommandPaletteForRoute = props.routes.some(
+  const disableCommandPaletteForRoute = routes.some(
     (route: PlainRoute<CommandPaletteRouteProps>) =>
       route.props?.disableCommandPalette,
   );
 
-  useCommandPaletteBasicActions({ ...props, isLoggedIn });
+  useCommandPaletteBasicActions({ ...routerProps, isLoggedIn });
 
   const { query } = useKBar();
   const disabled =
@@ -44,74 +46,71 @@ export const Palette = withRouter((props) => {
         <Center pt="10vh">
           <PaletteContainer
             disabled={disabled}
-            locationQuery={props.location.query}
+            locationQuery={location.query}
           />
         </Center>
       </Overlay>
     </KBarPortal>
   );
-});
+};
 
-export const PaletteContainer = withRouter(
-  ({
-    disabled,
+export const PaletteContainer = ({
+  disabled,
+  locationQuery,
+}: {
+  disabled: boolean;
+  locationQuery: Query;
+}) => {
+  const { query } = useKBar();
+  const ref = useRef(null);
+  const searchText = typeof locationQuery.q === "string" ? locationQuery.q : "";
+
+  const {
+    searchRequestId,
+    searchResults,
+    liveSearchTerm,
+    debouncedSearchTerm,
+  } = useCommandPalette({
     locationQuery,
-  }: {
-    disabled: boolean;
-    locationQuery: Query;
-  }) => {
-    const { query } = useKBar();
-    const ref = useRef(null);
-    const searchText =
-      typeof locationQuery.q === "string" ? locationQuery.q : "";
+    disabled,
+  });
 
-    const {
-      searchRequestId,
-      searchResults,
-      liveSearchTerm,
-      debouncedSearchTerm,
-    } = useCommandPalette({
-      locationQuery,
-      disabled,
-    });
+  useOnClickOutside(ref, () => {
+    query.setVisualState(VisualState.hidden);
+  });
 
-    useOnClickOutside(ref, () => {
-      query.setVisualState(VisualState.hidden);
-    });
+  return (
+    <Card
+      ref={ref}
+      w="640px"
+      p="0"
+      data-testid="command-palette"
+      bd="1px solid var(--mb-color-border-neutral)"
+    >
+      <Stack gap={rem(4)} pb="lg">
+        <Box pos="relative">
+          <HydratedKBarSearch searchText={searchText} />
 
-    return (
-      <Card
-        ref={ref}
-        w="640px"
-        p="0"
-        data-testid="command-palette"
-        bd="1px solid var(--mb-color-border-neutral)"
-      >
-        <Stack gap={rem(4)} pb="lg">
-          <Box pos="relative">
-            <HydratedKBarSearch searchText={searchText} />
+          <Stack
+            className={S.iconContainer}
+            align="center"
+            left={36} // align this icon with results icons
+            pos="absolute"
+            top={26}
+          >
+            <Icon c="text-primary" name="search" />
+          </Stack>
+        </Box>
 
-            <Stack
-              className={S.iconContainer}
-              align="center"
-              left={36} // align this icon with results icons
-              pos="absolute"
-              top={26}
-            >
-              <Icon c="text-primary" name="search" />
-            </Stack>
-          </Box>
-
-          <PaletteResults
-            align="stretch"
-            locationQuery={locationQuery}
-            searchRequestId={searchRequestId}
-            searchResults={searchResults}
-            liveSearchTerm={liveSearchTerm}
-            debouncedSearchTerm={debouncedSearchTerm}
-          />
-        </Stack>
-      </Card>
-    );
-  },
-);
+        <PaletteResults
+          align="stretch"
+          locationQuery={locationQuery}
+          searchRequestId={searchRequestId}
+          searchResults={searchResults}
+          liveSearchTerm={liveSearchTerm}
+          debouncedSearchTerm={debouncedSearchTerm}
+        />
+      </Stack>
+    </Card>
+  );
+};

--- a/frontend/src/metabase/palette/components/test/PaletteResults/setup.tsx
+++ b/frontend/src/metabase/palette/components/test/PaletteResults/setup.tsx
@@ -18,7 +18,7 @@ import {
   createMockAdminState,
   createMockState,
 } from "metabase/redux/store/mocks";
-import { Route, type WithRouterProps, withRouter } from "metabase/router";
+import { Route, useRouter } from "metabase/router";
 import type { RecentItem, Settings } from "metabase-types/api";
 import {
   createMockCollection,
@@ -32,39 +32,44 @@ import {
 
 import { PaletteResults } from "../../PaletteResults";
 
-const TestComponent = withRouter(
-  ({ q, ...props }: WithRouterProps & { q?: string; isLoggedIn: boolean }) => {
-    useCommandPaletteBasicActions(props);
-    const {
-      searchRequestId,
-      searchResults,
-      liveSearchTerm,
-      debouncedSearchTerm,
-    } = useCommandPalette({
-      disabled: false,
-      locationQuery: props.location.query,
-    });
+const TestComponent = ({
+  q,
+  isLoggedIn,
+}: {
+  q?: string;
+  isLoggedIn: boolean;
+}) => {
+  const routerProps = useRouter();
+  useCommandPaletteBasicActions({ ...routerProps, isLoggedIn });
+  const {
+    searchRequestId,
+    searchResults,
+    liveSearchTerm,
+    debouncedSearchTerm,
+  } = useCommandPalette({
+    disabled: false,
+    locationQuery: routerProps.location.query,
+  });
 
-    const { query } = useKBar();
+  const { query } = useKBar();
 
-    useEffect(() => {
-      query.setVisualState(VisualState.showing);
-      if (q) {
-        query.setSearch(q);
-      }
-    }, [q, query]);
+  useEffect(() => {
+    query.setVisualState(VisualState.showing);
+    if (q) {
+      query.setSearch(q);
+    }
+  }, [q, query]);
 
-    return (
-      <PaletteResults
-        locationQuery={props.location.query}
-        searchRequestId={searchRequestId}
-        searchResults={searchResults}
-        liveSearchTerm={liveSearchTerm}
-        debouncedSearchTerm={debouncedSearchTerm}
-      />
-    );
-  },
-);
+  return (
+    <PaletteResults
+      locationQuery={routerProps.location.query}
+      searchRequestId={searchRequestId}
+      searchResults={searchResults}
+      liveSearchTerm={liveSearchTerm}
+      debouncedSearchTerm={debouncedSearchTerm}
+    />
+  );
+};
 
 const DATABASE = createMockDatabase();
 

--- a/frontend/src/metabase/public/components/EmbedFrame/SyncedEmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/SyncedEmbedFrame.tsx
@@ -1,15 +1,14 @@
 import { useEmbedFrameOptions } from "metabase/public/hooks";
-import type { WithRouterProps } from "metabase/router";
-import { withRouter } from "metabase/router";
+import { useRouter } from "metabase/router";
 
 import type { EmbedFrameProps } from "./EmbedFrame";
 import { EmbedFrame } from "./EmbedFrame";
 
-const SyncedEmbedFrameInner = ({
-  location,
+export const SyncedEmbedFrame = ({
   children,
   ...embedFrameProps
-}: Partial<EmbedFrameProps> & WithRouterProps) => {
+}: Partial<EmbedFrameProps>) => {
+  const { location } = useRouter();
   const { background, bordered, hide_parameters, theme, titled } =
     useEmbedFrameOptions({ location });
 
@@ -26,7 +25,3 @@ const SyncedEmbedFrameInner = ({
     </EmbedFrame>
   );
 };
-
-export const SyncedEmbedFrame = withRouter<Partial<EmbedFrameProps>>(
-  SyncedEmbedFrameInner,
-);

--- a/frontend/src/metabase/router/Outlet.tsx
+++ b/frontend/src/metabase/router/Outlet.tsx
@@ -3,9 +3,9 @@ import { createContext, useContext } from "react";
 
 import type { Route } from "./route";
 
-const OutletContext = createContext<ReactNode>(null);
+export const OutletContext = createContext<ReactNode>(null);
 
-const RouteContext = createContext<Route | null>(null);
+export const RouteContext = createContext<Route | null>(null);
 
 /**
  * The route matched for the nearest `element`-based route ancestor. On v3 the

--- a/frontend/src/metabase/router/RouterProvider.tsx
+++ b/frontend/src/metabase/router/RouterProvider.tsx
@@ -3,12 +3,14 @@ import { type PropsWithChildren, createContext } from "react";
 
 import { useHistory } from "metabase/history";
 
+import { type RouterEngine, getRouterEngine } from "./engine";
 import {
   ReactRouterRoute,
   Router,
   type WithRouterProps,
   withRouter,
 } from "./react-router";
+import { RouterProviderV7 } from "./v7/RouterProviderV7";
 
 type RouterContextType = WithRouterProps;
 
@@ -44,7 +46,7 @@ type RouterProviderProps = {
  * component that establishes the router context, so it cannot itself consume that
  * context through `<Outlet/>`.
  */
-export const RouterProvider = ({
+const RouterProviderV3 = ({
   children,
 }: PropsWithChildren<RouterProviderProps>) => {
   const { history } = useHistory();
@@ -55,4 +57,27 @@ export const RouterProvider = ({
       </ReactRouterRoute>
     </Router>
   );
+};
+
+type RouterProviderPropsWithEngine = RouterProviderProps & {
+  /**
+   * Which engine hosts the app. Defaults to the `use-v7-router` flag; tests pass
+   * it explicitly to exercise both engines. Goes away with the v3 engine.
+   */
+  engine?: RouterEngine;
+};
+
+/**
+ * Hosts the app on either engine. On v7 the facade hooks read the same
+ * `RouterContext`, filled per route by the `RouterBridge` instead of v3's
+ * `withRouter`, so nothing downstream changes.
+ */
+export const RouterProvider = ({
+  children,
+  engine = getRouterEngine(),
+}: PropsWithChildren<RouterProviderPropsWithEngine>) => {
+  if (engine === "v7") {
+    return <RouterProviderV7>{children}</RouterProviderV7>;
+  }
+  return <RouterProviderV3>{children}</RouterProviderV3>;
 };

--- a/frontend/src/metabase/router/RouterProvider.tsx
+++ b/frontend/src/metabase/router/RouterProvider.tsx
@@ -8,7 +8,7 @@ import {
   ReactRouterRoute,
   Router,
   type WithRouterProps,
-  withRouter,
+  reactRouterWithRouter,
 } from "./react-router";
 import { RouterProviderV7 } from "./v7/RouterProviderV7";
 
@@ -30,7 +30,7 @@ const RouterContextProviderBase = ({
   );
 };
 
-const RouterContextProvider = withRouter(RouterContextProviderBase);
+const RouterContextProvider = reactRouterWithRouter(RouterContextProviderBase);
 
 type RouterProviderProps = {
   history?: History | undefined;

--- a/frontend/src/metabase/router/engine.ts
+++ b/frontend/src/metabase/router/engine.ts
@@ -1,0 +1,14 @@
+export type RouterEngine = "v3" | "v7";
+
+/**
+ * Which router engine to run: the legacy react-router v3 engine, or the v7
+ * engine behind the `use-v7-router` flag.
+ *
+ * Read straight from `window.MetabaseBootstrap` rather than the redux settings
+ * slice so it is available at mount, before the store exists (the router is
+ * wired at the very top of `app.js`). Toggling the setting off is the instant
+ * rollback path.
+ */
+export function getRouterEngine(): RouterEngine {
+  return window.MetabaseBootstrap?.["use-v7-router"] === true ? "v7" : "v3";
+}

--- a/frontend/src/metabase/router/index.ts
+++ b/frontend/src/metabase/router/index.ts
@@ -1,3 +1,4 @@
+export * from "./engine";
 export * from "./Link";
 export * from "./middleware";
 export * from "./navigation";

--- a/frontend/src/metabase/router/middleware.ts
+++ b/frontend/src/metabase/router/middleware.ts
@@ -7,6 +7,16 @@ import {
   type CallHistoryMethodAction,
 } from "./navigation";
 
+/**
+ * The slice of `history` the middleware drives. v3's `History` satisfies it, and
+ * the v7 navigator adapter implements exactly these, so the middleware is engine
+ * agnostic and the engine swap only changes which navigator is passed in.
+ */
+export type RouterNavigator = Pick<
+  History,
+  "push" | "replace" | "go" | "goBack" | "goForward"
+>;
+
 function isCallHistoryMethod(
   action: unknown,
 ): action is CallHistoryMethodAction {
@@ -25,18 +35,18 @@ function isCallHistoryMethod(
  * the matching method to history. These actions never reach the reducers, just
  * like the package it replaces.
  */
-export function routerMiddleware(history: History): Middleware {
+export function routerMiddleware(navigator: RouterNavigator): Middleware {
   return () => (next) => (action) => {
     if (!isCallHistoryMethod(action)) {
       return next(action);
     }
 
     match(action.payload)
-      .with({ method: "push" }, ({ args }) => history.push(args[0]))
-      .with({ method: "replace" }, ({ args }) => history.replace(args[0]))
-      .with({ method: "go" }, ({ args }) => history.go(args[0]))
-      .with({ method: "goBack" }, () => history.goBack())
-      .with({ method: "goForward" }, () => history.goForward())
+      .with({ method: "push" }, ({ args }) => navigator.push(args[0]))
+      .with({ method: "replace" }, ({ args }) => navigator.replace(args[0]))
+      .with({ method: "go" }, ({ args }) => navigator.go(args[0]))
+      .with({ method: "goBack" }, () => navigator.goBack())
+      .with({ method: "goForward" }, () => navigator.goForward())
       .exhaustive();
   };
 }

--- a/frontend/src/metabase/router/react-router.ts
+++ b/frontend/src/metabase/router/react-router.ts
@@ -20,7 +20,9 @@ export {
   createRoutes,
   formatPattern,
   useRouterHistory,
-  withRouter,
+  // The public facade no longer exposes `withRouter`; only `RouterProvider`'s v3
+  // bootstrap still needs the raw HOC to seed the router context.
+  withRouter as reactRouterWithRouter,
 } from "react-router";
 
 // v3's own path matcher, used to work out how much of the URL each matched route

--- a/frontend/src/metabase/router/v7/RouterBridge.tsx
+++ b/frontend/src/metabase/router/v7/RouterBridge.tsx
@@ -19,6 +19,9 @@ import type {
 } from "../react-router";
 import type { Route } from "../route";
 
+import { toV3Location } from "./location";
+import { toNavigateArgs } from "./navigator";
+
 /**
  * Runs as the `element` of every v7 route and republishes v7's location,
  * params, matched-route branch, and an imperative-router shim into the shared
@@ -55,24 +58,8 @@ export function RouterBridge({
   );
 
   const location = useMemo<HistoryLocation>(
-    () => ({
-      pathname: v7Location.pathname,
-      search: v7Location.search,
-      hash: v7Location.hash,
-      // v3 leaves state `undefined` when absent; v7 uses `null`.
-      state: v7Location.state ?? undefined,
-      key: v7Location.key,
-      query: searchToQuery(v7Location.search),
-      action,
-    }),
-    [
-      v7Location.pathname,
-      v7Location.search,
-      v7Location.hash,
-      v7Location.state,
-      v7Location.key,
-      action,
-    ],
+    () => toV3Location(v7Location, action),
+    [v7Location, action],
   );
 
   const router = useMemo<InjectedRouter>(
@@ -102,21 +89,6 @@ export function RouterBridge({
 }
 
 /**
- * Parse a search string into v3's `location.query` object: repeated keys become
- * an array, an empty value stays `""`, matching history@3's default parser that
- * the ~27 `location.query` readers were written against.
- */
-function searchToQuery(search: string): Record<string, string | string[]> {
-  const params = new URLSearchParams(search);
-  const query: Record<string, string | string[]> = {};
-  for (const key of new Set(params.keys())) {
-    const values = params.getAll(key);
-    query[key] = values.length > 1 ? values : values[0];
-  }
-  return query;
-}
-
-/**
  * The v3 `InjectedRouter` (`router.push/replace/go/...`) reimplemented over v7's
  * `navigate`. The facade's `useNavigate` has already resolved relative targets to
  * absolute paths before calling `push`/`replace`, so these pass straight through.
@@ -124,26 +96,15 @@ function searchToQuery(search: string): Record<string, string | string[]> {
  * restored per-route in Phase 3b.
  */
 function makeRouterShim(navigate: V7NavigateFunction): InjectedRouter {
-  const toPath = (location: LocationDescriptor) =>
-    typeof location === "string"
-      ? location
-      : {
-          pathname: location.pathname,
-          search: location.search,
-          hash: location.hash,
-        };
-  const stateOf = (location: LocationDescriptor) =>
-    typeof location === "string" ? undefined : location.state;
   const href = (location: LocationDescriptor) =>
     typeof location === "string"
       ? location
       : `${location.pathname ?? ""}${location.search ?? ""}${location.hash ?? ""}`;
 
   return {
-    push: (location) =>
-      navigate(toPath(location), { state: stateOf(location) }),
+    push: (location) => navigate(...toNavigateArgs(location)),
     replace: (location) =>
-      navigate(toPath(location), { replace: true, state: stateOf(location) }),
+      navigate(...toNavigateArgs(location, { replace: true })),
     go: (n) => navigate(n),
     goBack: () => navigate(-1),
     goForward: () => navigate(1),

--- a/frontend/src/metabase/router/v7/RouterBridge.tsx
+++ b/frontend/src/metabase/router/v7/RouterBridge.tsx
@@ -1,0 +1,155 @@
+import type { Location as HistoryLocation, LocationDescriptor } from "history";
+import { type ReactNode, useContext, useMemo } from "react";
+import {
+  UNSAFE_RouteContext,
+  type NavigateFunction as V7NavigateFunction,
+  Outlet as V7Outlet,
+  useNavigationType,
+  useLocation as useV7Location,
+  useNavigate as useV7Navigate,
+  useParams as useV7Params,
+} from "react-router-v7";
+
+import { OutletContext, RouteContext } from "../Outlet";
+import { RouterContext } from "../RouterProvider";
+import type {
+  InjectedRouter,
+  PlainRoute,
+  WithRouterProps,
+} from "../react-router";
+import type { Route } from "../route";
+
+/**
+ * Runs as the `element` of every v7 route and republishes v7's location,
+ * params, matched-route branch, and an imperative-router shim into the shared
+ * `RouterContext` (and the `Outlet`/`Route` contexts). The facade hooks
+ * (`useLocation`, `useParams`, `useNavigate`, `useRouter`, `withRouteProps`)
+ * read that context unchanged, so nothing downstream can tell which engine it
+ * runs on. Deleted with the v3 engine in Phase 4.
+ */
+export function RouterBridge({
+  v3Element,
+}: {
+  v3Element: ReactNode;
+}): JSX.Element {
+  const v7Location = useV7Location();
+  const navigate = useV7Navigate();
+  const action = useNavigationType();
+  // v7's `useParams` returns v7's readonly `Params`; the context wants v3's shape,
+  // which is structurally the same string map.
+  const params = useV7Params() as WithRouterProps["params"];
+
+  // `useMatches` is data-router-only, so read the matched branch from the route
+  // context that also drives `<Outlet>` (available in declarative mode). Each
+  // route keeps its v3 path on `handle`, which the facade hooks match against.
+  const { matches } = useContext(UNSAFE_RouteContext);
+  const routes = useMemo<PlainRoute[]>(
+    () =>
+      matches.map((match) => {
+        // `handle` is typed `unknown`; we only ever put `{ v3Path }` on it.
+        const handle = match.route.handle as { v3Path?: string } | undefined;
+        // The facade hooks read only `route.path`, so a `{ path }` stub is enough.
+        return { path: handle?.v3Path } as PlainRoute;
+      }),
+    [matches],
+  );
+
+  const location = useMemo<HistoryLocation>(
+    () => ({
+      pathname: v7Location.pathname,
+      search: v7Location.search,
+      hash: v7Location.hash,
+      // v3 leaves state `undefined` when absent; v7 uses `null`.
+      state: v7Location.state ?? undefined,
+      key: v7Location.key,
+      query: searchToQuery(v7Location.search),
+      action,
+    }),
+    [
+      v7Location.pathname,
+      v7Location.search,
+      v7Location.hash,
+      v7Location.state,
+      v7Location.key,
+      action,
+    ],
+  );
+
+  const router = useMemo<InjectedRouter>(
+    () => makeRouterShim(navigate),
+    [navigate],
+  );
+
+  const value = useMemo<WithRouterProps>(
+    () => ({ router, location, params, routes }),
+    [router, location, params, routes],
+  );
+
+  // The injected `route` prop / `useRoute()`: consumers only read it to hand back
+  // to `setRouteLeaveHook` (a no-op on v7), so the leaf match's `{ path }` is
+  // enough. Cast because the facade types the injected route object as `Route`.
+  const route = (routes.at(-1) ?? null) as Route | null;
+
+  return (
+    <RouterContext.Provider value={value}>
+      <RouteContext.Provider value={route}>
+        <OutletContext.Provider value={<V7Outlet />}>
+          {v3Element}
+        </OutletContext.Provider>
+      </RouteContext.Provider>
+    </RouterContext.Provider>
+  );
+}
+
+/**
+ * Parse a search string into v3's `location.query` object: repeated keys become
+ * an array, an empty value stays `""`, matching history@3's default parser that
+ * the ~27 `location.query` readers were written against.
+ */
+function searchToQuery(search: string): Record<string, string | string[]> {
+  const params = new URLSearchParams(search);
+  const query: Record<string, string | string[]> = {};
+  for (const key of new Set(params.keys())) {
+    const values = params.getAll(key);
+    query[key] = values.length > 1 ? values : values[0];
+  }
+  return query;
+}
+
+/**
+ * The v3 `InjectedRouter` (`router.push/replace/go/...`) reimplemented over v7's
+ * `navigate`. The facade's `useNavigate` has already resolved relative targets to
+ * absolute paths before calling `push`/`replace`, so these pass straight through.
+ * `setRouteLeaveHook` is a no-op: navigation blocking is data-router-only and is
+ * restored per-route in Phase 3b.
+ */
+function makeRouterShim(navigate: V7NavigateFunction): InjectedRouter {
+  const toPath = (location: LocationDescriptor) =>
+    typeof location === "string"
+      ? location
+      : {
+          pathname: location.pathname,
+          search: location.search,
+          hash: location.hash,
+        };
+  const stateOf = (location: LocationDescriptor) =>
+    typeof location === "string" ? undefined : location.state;
+  const href = (location: LocationDescriptor) =>
+    typeof location === "string"
+      ? location
+      : `${location.pathname ?? ""}${location.search ?? ""}${location.hash ?? ""}`;
+
+  return {
+    push: (location) =>
+      navigate(toPath(location), { state: stateOf(location) }),
+    replace: (location) =>
+      navigate(toPath(location), { replace: true, state: stateOf(location) }),
+    go: (n) => navigate(n),
+    goBack: () => navigate(-1),
+    goForward: () => navigate(1),
+    setRouteLeaveHook: () => () => undefined,
+    createPath: href,
+    createHref: href,
+    isActive: () => false,
+  };
+}

--- a/frontend/src/metabase/router/v7/RouterProviderV7.tsx
+++ b/frontend/src/metabase/router/v7/RouterProviderV7.tsx
@@ -1,0 +1,28 @@
+import type { PropsWithChildren } from "react";
+import { BrowserRouter, Routes } from "react-router-v7";
+
+import { getBasename } from "metabase/utils/basename";
+
+import { mapToV7 } from "./map-to-v7";
+
+/**
+ * The v7 route tree: the facade tree mapped to real v7 routes and rendered by
+ * `<Routes>`. Kept separate from the history provider below so tests can host the
+ * same tree under a `<MemoryRouter>`.
+ */
+export function V7RouterTree({ children }: PropsWithChildren): JSX.Element {
+  return <Routes>{mapToV7(children)}</Routes>;
+}
+
+/**
+ * react-router v7 hosting the app, declarative mode (Phase 3.1). Replaces the v3
+ * `<Router>` + `useRouterHistory` + `syncHistoryWithStore` stack behind the
+ * `use-v7-router` flag.
+ */
+export function RouterProviderV7({ children }: PropsWithChildren): JSX.Element {
+  return (
+    <BrowserRouter basename={getBasename() || undefined}>
+      <V7RouterTree>{children}</V7RouterTree>
+    </BrowserRouter>
+  );
+}

--- a/frontend/src/metabase/router/v7/RouterProviderV7.tsx
+++ b/frontend/src/metabase/router/v7/RouterProviderV7.tsx
@@ -1,17 +1,24 @@
 import type { PropsWithChildren } from "react";
-import { BrowserRouter, Routes } from "react-router-v7";
+import { BrowserRouter, MemoryRouter, Routes } from "react-router-v7";
 
 import { getBasename } from "metabase/utils/basename";
 
+import { V7ReduxBridge } from "./V7ReduxBridge";
 import { mapToV7 } from "./map-to-v7";
 
 /**
  * The v7 route tree: the facade tree mapped to real v7 routes and rendered by
- * `<Routes>`. Kept separate from the history provider below so tests can host the
- * same tree under a `<MemoryRouter>`.
+ * `<Routes>`, plus the redux bridge that mirrors location into `state.routing`
+ * and lets `dispatch(push(...))` drive the router. Kept separate from the history
+ * provider below so tests can host the same tree under a `<MemoryRouter>`.
  */
 export function V7RouterTree({ children }: PropsWithChildren): JSX.Element {
-  return <Routes>{mapToV7(children)}</Routes>;
+  return (
+    <>
+      <V7ReduxBridge />
+      <Routes>{mapToV7(children)}</Routes>
+    </>
+  );
 }
 
 /**
@@ -24,5 +31,20 @@ export function RouterProviderV7({ children }: PropsWithChildren): JSX.Element {
     <BrowserRouter basename={getBasename() || undefined}>
       <V7RouterTree>{children}</V7RouterTree>
     </BrowserRouter>
+  );
+}
+
+/**
+ * The v7 engine hosted on an in-memory history, for tests. Mirrors what
+ * `renderWithProviders({ routerEngine: "v7" })` mounts.
+ */
+export function RouterProviderV7Memory({
+  children,
+  initialRoute,
+}: PropsWithChildren<{ initialRoute: string }>): JSX.Element {
+  return (
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <V7RouterTree>{children}</V7RouterTree>
+    </MemoryRouter>
   );
 }

--- a/frontend/src/metabase/router/v7/V7ReduxBridge.tsx
+++ b/frontend/src/metabase/router/v7/V7ReduxBridge.tsx
@@ -1,0 +1,46 @@
+import { useEffect } from "react";
+import {
+  useNavigationType,
+  useLocation as useV7Location,
+  useNavigate as useV7Navigate,
+} from "react-router-v7";
+
+import { useDispatch } from "metabase/redux";
+
+import { LOCATION_CHANGE } from "../routing-reducer";
+
+import { toV3Location } from "./location";
+import { setV7Navigate } from "./navigator";
+
+/**
+ * Bridges the v7 router to redux, replacing what `routerMiddleware` +
+ * `syncHistoryWithStore` did on v3:
+ *
+ * - registers the live `navigate` so the redux navigator adapter (and thus
+ *   `dispatch(push(...))`) can drive the v7 router;
+ * - mirrors every location into `state.routing` via LOCATION_CHANGE, so
+ *   `getLocation` / `isNavbarOpen` / `errorPage` keep working.
+ *
+ * Rendered inside the router but outside `<Routes>`, so it tracks the location
+ * regardless of which route matches. Deleted with the v3 engine in Phase 4.
+ */
+export function V7ReduxBridge(): null {
+  const navigate = useV7Navigate();
+  const location = useV7Location();
+  const action = useNavigationType();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    setV7Navigate(navigate);
+    return () => setV7Navigate(null);
+  }, [navigate]);
+
+  useEffect(() => {
+    dispatch({
+      type: LOCATION_CHANGE,
+      payload: toV3Location(location, action),
+    });
+  }, [dispatch, location, action]);
+
+  return null;
+}

--- a/frontend/src/metabase/router/v7/dual-engine.unit.spec.tsx
+++ b/frontend/src/metabase/router/v7/dual-engine.unit.spec.tsx
@@ -1,0 +1,73 @@
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { Outlet, Route, push, useLocation, useParams } from "metabase/router";
+import { getLocation } from "metabase/selectors/routing";
+
+import type { RouterEngine } from "../engine";
+
+function Home() {
+  const { pathname } = useLocation();
+  return (
+    <div>
+      <span data-testid="location">{pathname}</span>
+      <Outlet />
+    </div>
+  );
+}
+
+function Page() {
+  const { id } = useParams();
+  return <span data-testid="page-id">{id}</span>;
+}
+
+const tree = (
+  <Route path="/" element={<Home />}>
+    <Route path="page/:id" element={<Page />} />
+    <Route path="other" element={<span data-testid="other">other</span>} />
+  </Route>
+);
+
+function setup(routerEngine: RouterEngine, initialRoute: string) {
+  return renderWithProviders(tree, {
+    withRouter: true,
+    routerEngine,
+    initialRoute,
+  });
+}
+
+describe.each<RouterEngine>(["v3", "v7"])(
+  "route tree on the %s engine",
+  (routerEngine) => {
+    it("matches a deep link and reads its params", async () => {
+      setup(routerEngine, "/page/7");
+      expect(await screen.findByTestId("page-id")).toHaveTextContent("7");
+      expect(screen.getByTestId("location")).toHaveTextContent("/page/7");
+    });
+
+    it("navigates via dispatch(push())", async () => {
+      const { store } = setup(routerEngine, "/page/7");
+      expect(await screen.findByTestId("page-id")).toBeInTheDocument();
+
+      store.dispatch(push("/other"));
+
+      expect(await screen.findByTestId("other")).toBeInTheDocument();
+      expect(screen.getByTestId("location")).toHaveTextContent("/other");
+    });
+  },
+);
+
+// v3 tests never wired `syncHistoryWithStore`, so `state.routing` only tracks the
+// location on v7, through the redux bridge. This pins that the bridge feeds it.
+describe("v7 redux bridge", () => {
+  it("mirrors the location into state.routing", async () => {
+    const { store } = setup("v7", "/page/7");
+    await waitFor(() => {
+      expect(getLocation(store.getState())?.pathname).toBe("/page/7");
+    });
+
+    store.dispatch(push("/other"));
+
+    await waitFor(() => {
+      expect(getLocation(store.getState())?.pathname).toBe("/other");
+    });
+  });
+});

--- a/frontend/src/metabase/router/v7/location.ts
+++ b/frontend/src/metabase/router/v7/location.ts
@@ -1,0 +1,39 @@
+import type { Location as HistoryLocation } from "history";
+import type { Location as V7Location } from "react-router-v7";
+
+/**
+ * Parse a search string into v3's `location.query` object: repeated keys become
+ * an array, an empty value stays `""`, matching history@3's default parser that
+ * the `location.query` readers were written against.
+ */
+export function searchToQuery(
+  search: string,
+): Record<string, string | string[]> {
+  const params = new URLSearchParams(search);
+  const query: Record<string, string | string[]> = {};
+  for (const key of new Set(params.keys())) {
+    const values = params.getAll(key);
+    query[key] = values.length > 1 ? values : values[0];
+  }
+  return query;
+}
+
+/**
+ * Build the v3-shaped `history` location the facade context and `state.routing`
+ * expect from a v7 location plus the current navigation type.
+ */
+export function toV3Location(
+  location: V7Location,
+  action: HistoryLocation["action"],
+): HistoryLocation {
+  return {
+    pathname: location.pathname,
+    search: location.search,
+    hash: location.hash,
+    // v3 leaves state `undefined` when absent; v7 uses `null`.
+    state: location.state ?? undefined,
+    key: location.key,
+    query: searchToQuery(location.search),
+    action,
+  };
+}

--- a/frontend/src/metabase/router/v7/map-to-v7.tsx
+++ b/frontend/src/metabase/router/v7/map-to-v7.tsx
@@ -1,0 +1,72 @@
+import {
+  Children,
+  Fragment,
+  type ReactElement,
+  type ReactNode,
+  isValidElement,
+} from "react";
+import { Route as V7Route } from "react-router-v7";
+
+import type { RouteElementProps } from "../route";
+import { Route } from "../route";
+
+import { RouterBridge } from "./RouterBridge";
+import { translatePattern } from "./translate-pattern";
+
+/**
+ * Rebuild the facade route tree (`<Route path element>` + `<Outlet/>`, authored
+ * in v3 syntax) into a real react-router v7 route tree for `<Routes>`. Each
+ * `element` is wrapped in a `RouterBridge` that republishes v7 state into the
+ * shared context, and the original v3 path is kept on the route's `handle` so the
+ * bridge can hand the facade hooks a v3-shaped `routes` branch. Throwaway: it goes
+ * away with the v3 engine in Phase 4, when the tree is authored in v7 shape.
+ */
+export function mapToV7(node: ReactNode): ReactNode {
+  return Children.map(node, (child) => {
+    if (!isValidElement(child)) {
+      return child;
+    }
+
+    // Fragments group sibling routes (plugin interpolation, conditionals); descend
+    // so the facade routes inside them get converted too.
+    if (child.type === Fragment) {
+      return <Fragment>{mapToV7(child.props.children)}</Fragment>;
+    }
+
+    if (child.type === Route) {
+      // `child.type === Route` guarantees these are the facade Route's props.
+      return toV7Route(child as ReactElement<RouteElementProps>);
+    }
+
+    // Anything else in a route position is passed through unchanged; v7's
+    // `createRoutesFromChildren` validates it.
+    return child;
+  });
+}
+
+function toV7Route(element: ReactElement<RouteElementProps>): ReactElement {
+  const { path, index, element: routeElement, children } = element.props;
+
+  // v7 defaults a route with no `element` to `<Outlet/>`; only wrap (and publish
+  // context) when the facade route actually renders something.
+  const bridged =
+    routeElement !== undefined ? (
+      <RouterBridge v3Element={routeElement} />
+    ) : undefined;
+
+  const handle = path != null ? { v3Path: path } : undefined;
+
+  if (index) {
+    return <V7Route index element={bridged} handle={handle} />;
+  }
+
+  return (
+    <V7Route
+      path={path != null ? translatePattern(path) : undefined}
+      element={bridged}
+      handle={handle}
+    >
+      {mapToV7(children)}
+    </V7Route>
+  );
+}

--- a/frontend/src/metabase/router/v7/navigator.ts
+++ b/frontend/src/metabase/router/v7/navigator.ts
@@ -1,0 +1,62 @@
+import type { LocationDescriptor } from "history";
+import type { NavigateFunction, NavigateOptions, To } from "react-router-v7";
+
+import type { RouterNavigator } from "../middleware";
+
+/**
+ * The live v7 `navigate`, registered by `V7ReduxBridge` once the router mounts.
+ * The redux navigator adapter is built at store creation, before the router
+ * exists, so it reads `navigate` through this holder rather than capturing it.
+ */
+let currentNavigate: NavigateFunction | null = null;
+
+export function setV7Navigate(navigate: NavigateFunction | null): void {
+  currentNavigate = navigate;
+}
+
+/**
+ * Turn a v3 `LocationDescriptor` (string or `{ pathname, search, hash, state }`)
+ * into v7 `navigate(to, options)` arguments. Shared by the imperative-router
+ * shim and the redux navigator so both map descriptors the same way.
+ */
+export function toNavigateArgs(
+  location: LocationDescriptor,
+  options: NavigateOptions = {},
+): [To, NavigateOptions] {
+  if (typeof location === "string") {
+    return [location, options];
+  }
+  return [
+    {
+      pathname: location.pathname,
+      search: location.search,
+      hash: location.hash,
+    },
+    { ...options, state: location.state },
+  ];
+}
+
+/**
+ * A `RouterNavigator` (the subset of `history` that `routerMiddleware` drives)
+ * backed by the live v7 `navigate`. Passed to the store on v7 so
+ * `dispatch(push(...))` navigates the v7 router. Calls before the router mounts
+ * are dropped, matching the pre-mount no-op window on v3.
+ */
+export function createV7Navigator(): RouterNavigator {
+  const navigate = (to: To | number, options?: NavigateOptions) => {
+    if (typeof to === "number") {
+      currentNavigate?.(to);
+    } else {
+      currentNavigate?.(to, options);
+    }
+  };
+
+  return {
+    push: (location) => navigate(...toNavigateArgs(location)),
+    replace: (location) =>
+      navigate(...toNavigateArgs(location, { replace: true })),
+    go: (n) => navigate(n),
+    goBack: () => navigate(-1),
+    goForward: () => navigate(1),
+  };
+}

--- a/frontend/src/metabase/router/v7/translate-pattern.conformance.unit.spec.ts
+++ b/frontend/src/metabase/router/v7/translate-pattern.conformance.unit.spec.ts
@@ -1,0 +1,169 @@
+import { matchPattern } from "react-router/lib/PatternUtils";
+import { matchPath } from "react-router-v7";
+
+import { translatePattern } from "./translate-pattern";
+
+/**
+ * Proves the v3->v7 pattern translation preserves matching: for each real route
+ * path, v3's own matcher and v7's matcher (fed the translated pattern) extract
+ * the same params from the same URL. This is the engine-swap's core risk
+ * (route matching), pinned as a red test.
+ */
+
+type Case = {
+  /** The route path as authored in the tree, in v3 syntax. */
+  v3: string;
+  /** URLs that should match, each paired with the params it must yield. */
+  urls: Array<[url: string, params: Record<string, string>]>;
+};
+
+// The splat param is `splat` on v3 and `*` on v7, and v3 keeps a leading slash
+// on its value; an unmatched optional is `null` on v3 and absent on v7. Normalize
+// all of that away so the comparison is about the params the app actually reads.
+function normalize(params: Record<string, string | null | undefined>) {
+  const out: Record<string, string> = {};
+  for (const [rawKey, rawValue] of Object.entries(params)) {
+    if (rawValue == null || rawValue === "") {
+      continue;
+    }
+    const key = rawKey === "splat" ? "*" : rawKey;
+    out[key] = key === "*" ? rawValue.replace(/^\//, "") : rawValue;
+  }
+  return out;
+}
+
+function v3Params(pattern: string, url: string) {
+  const match = matchPattern(pattern, url);
+  if (!match) {
+    throw new Error(`v3 pattern "${pattern}" did not match "${url}"`);
+  }
+  // Only a full match (nothing left over) counts as this route serving the URL.
+  expect(match.remainingPathname).toBe("");
+  const params: Record<string, string | null> = {};
+  match.paramNames.forEach((name: string, index: number) => {
+    params[name] = match.paramValues[index];
+  });
+  return normalize(params);
+}
+
+function v7Params(pattern: string, url: string) {
+  const rooted = pattern.startsWith("/") ? pattern : `/${pattern}`;
+  const match = matchPath({ path: rooted, end: true }, url);
+  expect(match).not.toBeNull();
+  return normalize(match!.params);
+}
+
+const CASES: Case[] = [
+  {
+    v3: "/admin/tools/notifications(/:notificationId)",
+    urls: [
+      ["/admin/tools/notifications", {}],
+      ["/admin/tools/notifications/7", { notificationId: "7" }],
+    ],
+  },
+  {
+    v3: "dashboard/:slug(/:tabSlug)",
+    urls: [
+      ["/dashboard/5-sales", { slug: "5-sales" }],
+      [
+        "/dashboard/5-sales/2-overview",
+        { slug: "5-sales", tabSlug: "2-overview" },
+      ],
+    ],
+  },
+  {
+    v3: "dashboard/:uuid(/:tabSlug)",
+    urls: [
+      ["/dashboard/9a-uuid", { uuid: "9a-uuid" }],
+      ["/dashboard/9a-uuid/3-tab", { uuid: "9a-uuid", tabSlug: "3-tab" }],
+    ],
+  },
+  {
+    v3: "databases/:dbId/tables/:tableId/edit(/:objectId)",
+    urls: [
+      ["/databases/1/tables/2/edit", { dbId: "1", tableId: "2" }],
+      [
+        "/databases/1/tables/2/edit/9",
+        { dbId: "1", tableId: "2", objectId: "9" },
+      ],
+    ],
+  },
+  {
+    v3: "/question/entity/:entity_id(**)",
+    urls: [
+      ["/question/entity/abc123", { entity_id: "abc123" }],
+      ["/question/entity/abc123/ignored/tail", { entity_id: "abc123" }],
+    ],
+  },
+  {
+    v3: "collection/entity/:entity_id(**)",
+    urls: [
+      ["/collection/entity/xY9", { entity_id: "xY9" }],
+      ["/collection/entity/xY9/rest", { entity_id: "xY9" }],
+    ],
+  },
+  {
+    v3: "dashboard/entity/:entity_id(**)",
+    urls: [["/dashboard/entity/dd-1", { entity_id: "dd-1" }]],
+  },
+  {
+    v3: "files/**",
+    urls: [["/files/a/b/c", {}]],
+  },
+  {
+    v3: "/admin/transforms/*",
+    urls: [["/admin/transforms/jobs/5", {}]],
+  },
+  {
+    // `/admin/metabot*` is an in-segment prefix splat; the translation to
+    // `/admin/metabot/*` covers `/admin/metabot` and its subpaths, which is what
+    // the route serves. A glued suffix (`/admin/metabotfoo`) is not exercised.
+    v3: "/admin/metabot*",
+    urls: [
+      ["/admin/metabot", {}],
+      ["/admin/metabot/settings", {}],
+    ],
+  },
+  {
+    v3: "*",
+    urls: [["/anything/at/all", {}]],
+  },
+];
+
+describe("translatePattern conformance (v3 matchPattern vs v7 matchPath)", () => {
+  it.each(CASES)("$v3", ({ v3, urls }) => {
+    const translated = translatePattern(v3);
+    for (const [url, expected] of urls) {
+      const fromV3 = v3Params(v3, url);
+      const fromV7 = v7Params(translated, url);
+      // The named params the app reads are present on both.
+      expect(fromV3).toMatchObject(expected);
+      expect(fromV7).toMatchObject(expected);
+      // And the two engines agree exactly (including any splat value).
+      expect(fromV7).toEqual(fromV3);
+    }
+  });
+});
+
+describe("translatePattern", () => {
+  it.each([
+    ["dashboard/:slug(/:tabSlug)", "dashboard/:slug/:tabSlug?"],
+    [
+      "/admin/tools/notifications(/:notificationId)",
+      "/admin/tools/notifications/:notificationId?",
+    ],
+    ["/question/entity/:entity_id(**)", "/question/entity/:entity_id/*"],
+    ["files/**", "files/*"],
+    ["/admin/metabot*", "/admin/metabot/*"],
+    ["*", "*"],
+    ["/collections/:collectionId", "/collections/:collectionId"],
+  ])("translates %s -> %s", (v3, expected) => {
+    expect(translatePattern(v3)).toBe(expected);
+  });
+
+  it("throws on a static-inside-optional pattern that needs nesting", () => {
+    expect(() =>
+      translatePattern("database(/:databaseId)(/schema/:schemaName)"),
+    ).toThrow(/nested routes/);
+  });
+});

--- a/frontend/src/metabase/router/v7/translate-pattern.ts
+++ b/frontend/src/metabase/router/v7/translate-pattern.ts
@@ -1,0 +1,78 @@
+/**
+ * Translate a react-router v3 route `path` into the equivalent react-router v7
+ * pattern, used by the tree mapper when the app runs on the v7 engine. Throwaway:
+ * it is deleted with the v3 engine in Phase 4, once the route source is authored
+ * in v7 syntax directly.
+ *
+ * It covers the v3-only path syntaxes that map onto a single v7 pattern:
+ *
+ * - optional param groups: `(/:tabSlug)` -> `/:tabSlug?`
+ * - a param followed by an optional splat: `:entity_id(**)` -> `:entity_id/*`
+ * - double-splat: `files/**` -> `files/*`
+ * - an in-segment trailing splat: `metabot*` -> `metabot/*`
+ *
+ * Sequential optional groups that contain a *static* segment
+ * (`database(/:databaseId)(/schema/:schemaName)`) have no single-pattern v7
+ * equivalent (v7's optional segments are not v3's nested optional groups), so
+ * those routes are authored as nested routes instead and never reach this
+ * function. Anything that still looks v3-only after translation throws, so a
+ * missed case fails loudly at mount rather than mis-routing.
+ */
+export function translatePattern(v3Pattern: string): string {
+  if (patternNeedsNesting(v3Pattern)) {
+    throw new Error(
+      `Cannot translate v3 route path "${v3Pattern}" to a v7 pattern; ` +
+        "author it as nested routes instead.",
+    );
+  }
+
+  const translated = v3Pattern
+    // A param's optional splat tail: `:entity_id(**)` -> `:entity_id/*`.
+    .replace(/\(\*\*\)/g, "/*")
+    // Any remaining double-splat (`files/**`) -> v7's single-splat.
+    .replace(/\*\*/g, "*")
+    // A splat glued to the end of a segment (`metabot*`) -> its own segment.
+    .replace(/([^/*])\*/g, "$1/*")
+    // Optional groups: make every segment inside the parens optional.
+    .replace(/\(([^()]*)\)/g, (_match, inner: string) => optionalize(inner));
+
+  assertFullyTranslated(v3Pattern, translated);
+  return translated;
+}
+
+/**
+ * Whether a v3 pattern must be authored as nested routes rather than translated
+ * to a single v7 pattern: an optional group holding a static segment. v7's
+ * optional segments (`:a?`, `static?`) match independently, so they cannot
+ * express v3's "all-or-nothing, left-to-right" nested optional groups.
+ */
+export function patternNeedsNesting(v3Pattern: string): boolean {
+  const groups = v3Pattern.match(/\(([^()]*)\)/g) ?? [];
+  return groups.some((group) => {
+    const inner = group.slice(1, -1);
+    if (inner === "**") {
+      return false;
+    }
+    return inner
+      .split("/")
+      .some((segment) => segment !== "" && !segment.startsWith(":"));
+  });
+}
+
+function optionalize(inner: string): string {
+  return inner
+    .split("/")
+    .map((segment) => (segment === "" ? segment : `${segment}?`))
+    .join("/");
+}
+
+function assertFullyTranslated(v3Pattern: string, translated: string): void {
+  if (/[()]|\*\*/.test(translated)) {
+    throw new Error(
+      `Cannot translate v3 route path "${v3Pattern}" to a v7 pattern` +
+        (patternNeedsNesting(v3Pattern)
+          ? "; author it as nested routes instead."
+          : "."),
+    );
+  }
+}

--- a/frontend/src/metabase/router/v7/v7-engine.unit.spec.tsx
+++ b/frontend/src/metabase/router/v7/v7-engine.unit.spec.tsx
@@ -1,0 +1,87 @@
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-v7";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import {
+  Outlet,
+  Route,
+  useLocation,
+  useNavigate,
+  useParams,
+  useRouter,
+} from "metabase/router";
+
+import { V7RouterTree } from "./RouterProviderV7";
+
+function Layout() {
+  return (
+    <div>
+      <span data-testid="layout">layout</span>
+      <Outlet />
+    </div>
+  );
+}
+
+function ThingPage() {
+  const { pathname, search } = useLocation();
+  const params = useParams();
+  const navigate = useNavigate();
+  const { location } = useRouter();
+
+  return (
+    <div>
+      <span data-testid="pathname">{pathname}</span>
+      <span data-testid="search">{search}</span>
+      <span data-testid="thing-id">{params.thingId}</span>
+      <span data-testid="query-tab">{String(location.query.tab)}</span>
+      <button onClick={() => navigate("/other")}>go absolute</button>
+      <button onClick={() => navigate("..")}>go up</button>
+    </div>
+  );
+}
+
+const tree = (
+  <Route path="/" element={<Layout />}>
+    <Route path="things/:thingId" element={<ThingPage />} />
+    <Route path="other" element={<span data-testid="other">other page</span>} />
+  </Route>
+);
+
+function setup(initialRoute: string) {
+  renderWithProviders(
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <V7RouterTree>{tree}</V7RouterTree>
+    </MemoryRouter>,
+  );
+}
+
+describe("v7 engine (facade over real react-router v7)", () => {
+  it("resolves location, search, and params through the bridge", () => {
+    setup("/things/42?tab=x");
+
+    expect(screen.getByTestId("layout")).toBeInTheDocument();
+    expect(screen.getByTestId("pathname")).toHaveTextContent("/things/42");
+    expect(screen.getByTestId("search")).toHaveTextContent("?tab=x");
+    expect(screen.getByTestId("thing-id")).toHaveTextContent("42");
+  });
+
+  it("exposes a v3-shaped location.query", () => {
+    setup("/things/42?tab=x");
+    expect(screen.getByTestId("query-tab")).toHaveTextContent("x");
+  });
+
+  it("navigates to an absolute path via useNavigate", async () => {
+    setup("/things/42");
+    await userEvent.click(screen.getByRole("button", { name: "go absolute" }));
+    expect(await screen.findByTestId("other")).toBeInTheDocument();
+  });
+
+  it("resolves relative navigation against the matched route branch", async () => {
+    setup("/things/42");
+    await userEvent.click(screen.getByRole("button", { name: "go up" }));
+    // `..` climbs out of `things/:thingId` to the parent `/`, leaving the layout
+    // with no matched child.
+    expect(screen.getByTestId("layout")).toBeInTheDocument();
+    expect(screen.queryByTestId("thing-id")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -30,11 +30,14 @@ import type { State } from "metabase/redux/store";
 import { createMockState } from "metabase/redux/store/mocks";
 import {
   ReactRouterRoute,
+  type RouterEngine,
   RouterProvider,
   routerMiddleware,
   routing as routingReducer,
   useRouterHistory,
 } from "metabase/router";
+import { RouterProviderV7Memory } from "metabase/router/v7/RouterProviderV7";
+import { createV7Navigator } from "metabase/router/v7/navigator";
 import { getMetabaseCssVariables } from "metabase/styled-components/theme/css-variables";
 import type { MantineThemeOverride } from "metabase/ui";
 import { PortalContainer, ThemeProvider, useMantineTheme } from "metabase/ui";
@@ -58,6 +61,8 @@ export interface RenderWithProvidersOptions {
   initialRoute?: string;
   storeInitialState?: Partial<State>;
   withRouter?: boolean;
+  /** Which router engine hosts the tree when `withRouter` is set. Defaults to v3. */
+  routerEngine?: RouterEngine;
   /** Renders children wrapped with kbar provider */
   withKBar?: boolean;
   withDND?: boolean;
@@ -78,6 +83,7 @@ export function renderWithProviders(
     initialRoute = "/",
     storeInitialState = {},
     withRouter = false,
+    routerEngine = "v3",
     withKBar = false,
     withDND = false,
     withUndos = false,
@@ -91,6 +97,7 @@ export function renderWithProviders(
     initialRoute,
     storeInitialState,
     withRouter,
+    routerEngine,
     withKBar,
     withDND,
     withUndos,
@@ -117,6 +124,7 @@ export function renderHookWithProviders<TProps, TResult>(
     initialRoute = "/",
     storeInitialState = {},
     withRouter = false,
+    routerEngine = "v3",
     withKBar = false,
     withDND = false,
     withUndos = false,
@@ -134,6 +142,7 @@ export function renderHookWithProviders<TProps, TResult>(
     initialRoute,
     storeInitialState,
     withRouter,
+    routerEngine,
     withKBar,
     withDND,
     withUndos,
@@ -164,12 +173,14 @@ export function getTestStoreAndWrapper({
   initialRoute,
   storeInitialState,
   withRouter,
+  routerEngine = "v3",
   withKBar,
   withDND,
   withUndos,
   customReducers,
   theme,
 }: GetTestStoreAndWrapperOptions) {
+  const isV7Router = withRouter && routerEngine === "v7";
   let { routing, ...initialState }: Partial<State> =
     createMockState(storeInitialState);
 
@@ -184,7 +195,8 @@ export function getTestStoreAndWrapper({
   const browserHistory = useRouterHistory(createMemoryHistory)({
     entries: [initialRoute],
   });
-  const history = withRouter ? browserHistory : undefined;
+  // v7 owns its own in-memory history; only the v3 engine uses this one.
+  const history = withRouter && !isV7Router ? browserHistory : undefined;
 
   let reducers;
 
@@ -202,9 +214,15 @@ export function getTestStoreAndWrapper({
     reducers = { ...reducers, ...customReducers };
   }
 
+  // Drive navigation through v3 history or the v7 navigator, matching the engine.
+  const routerNavigator = isV7Router
+    ? createV7Navigator()
+    : history
+      ? history
+      : undefined;
   const storeMiddleware = _.compact([
     Api.middleware,
-    history && routerMiddleware(history),
+    routerNavigator && routerMiddleware(routerNavigator),
   ]);
 
   // Unjustified type cast. FIXME
@@ -222,6 +240,8 @@ export function getTestStoreAndWrapper({
         store={store}
         history={history}
         withRouter={withRouter}
+        routerEngine={routerEngine}
+        initialRoute={initialRoute}
         withDND={withDND}
         withUndos={withUndos}
         theme={theme}
@@ -273,6 +293,8 @@ export function TestWrapper({
   store,
   history,
   withRouter,
+  routerEngine = "v3",
+  initialRoute = "/",
   withKBar,
   withDND,
   withUndos,
@@ -284,6 +306,8 @@ export function TestWrapper({
   store: any;
   history?: History;
   withRouter: boolean;
+  routerEngine?: RouterEngine;
+  initialRoute?: string;
   withKBar: boolean;
   withDND: boolean;
   withUndos?: boolean;
@@ -316,7 +340,12 @@ export function TestWrapper({
                 {createPortal(<PortalContainer />, document.body)}
 
                 <MaybeKBar hasKBar={withKBar}>
-                  <MaybeRouter hasRouter={withRouter} history={history}>
+                  <MaybeRouter
+                    hasRouter={withRouter}
+                    routerEngine={routerEngine}
+                    history={history}
+                    initialRoute={initialRoute}
+                  >
                     {children}
                   </MaybeRouter>
                 </MaybeKBar>
@@ -333,13 +362,27 @@ export function TestWrapper({
 function MaybeRouter({
   children,
   hasRouter,
+  routerEngine,
   history,
+  initialRoute,
 }: {
   children: React.ReactElement;
   hasRouter: boolean;
+  routerEngine: RouterEngine;
   history?: History;
+  initialRoute: string;
 }): JSX.Element {
-  if (!hasRouter || !history) {
+  if (!hasRouter) {
+    return children;
+  }
+  if (routerEngine === "v7") {
+    return (
+      <RouterProviderV7Memory initialRoute={initialRoute}>
+        {children}
+      </RouterProviderV7Memory>
+    );
+  }
+  if (!history) {
     return children;
   }
   return (

--- a/src/metabase/appearance/settings.clj
+++ b/src/metabase/appearance/settings.clj
@@ -46,6 +46,13 @@
   :audit      :getter
   :export?    true)
 
+(defsetting use-v7-router
+  (deferred-tru "Serve the app with the react-router v7 engine instead of the legacy v3 engine. Toggle off for an instant rollback.")
+  :type       :boolean
+  :default    false
+  :visibility :public
+  :export?    false)
+
 (defn- coerce-to-relative-url
   "Get the path of a given URL if the URL contains an origin.
    Otherwise make the landing-page a relative path."


### PR DESCRIPTION
Part of the react-router v7 migration. Stacked on the permissions PR (top of the v7 stack).

Removes `withRouter` from the `metabase/router` public API. After the production components were moved off it, the only remaining users were two test setups and `RouterProvider`'s own v3 bootstrap.

## Changes

- The raw v3 `withRouter` re-export is renamed to `reactRouterWithRouter` in the seam module and used only by `RouterProvider` to seed the v3 router context (it cannot use the facade hooks, which read that context). It leaves the public facade entirely; nothing outside `metabase/router` can import `withRouter` anymore.
- Two test helpers (`DashboardTabs` spec, `PaletteResults` setup) that wrapped a local component with `withRouter` now read `useRouter()` / props instead, rendering under the existing `withRouter: true` router context.

## Notes

- The raw HOC only fully disappears when the v3 engine is deleted (Phase 4); until then `RouterProvider`'s bootstrap needs it.
