### PR TITLE
Prevent race conditions in responses of useMetabaseQuery hook

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useAsyncFn } from "react-use";
 
 import { useLazySelector } from "embedding-sdk-package/hooks/private/use-lazy-selector";
 import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-metabase-provider-props-store";
@@ -39,11 +40,6 @@ const useMetabaseQueryImpl = <
   const queryDataset = getEmbeddingSdkBundle()?.queryDataset;
   const resolveDatasetQuery = getResolveDatasetQueryFromBundle();
 
-  const [data, setData] =
-    useState<UseMetabaseQueryResult<TEntity, TQuery>["data"]>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<unknown>(null);
-
   const queryKey = useMemo(() => stableStringifyQuery(query), [query]);
   const queryRef = useRef(query);
 
@@ -51,41 +47,39 @@ const useMetabaseQueryImpl = <
     queryRef.current = query;
   }, [query, queryKey]);
 
-  const refetch = useCallback(async () => {
-    const currentQuery = queryRef.current;
+  const [{ value: data = null, loading: isLoading, error }, fetchQuery] =
+    useAsyncFn(async (): Promise<
+      UseMetabaseQueryResult<TEntity, TQuery>["data"]
+    > => {
+      const currentQuery = queryRef.current;
 
-    if (currentQuery.enabled === false) {
-      return;
-    }
+      if (currentQuery.enabled === false) {
+        return null;
+      }
 
-    if (!reduxStore) {
-      return;
-    }
+      if (!reduxStore) {
+        return null;
+      }
 
-    setIsLoading(true);
-    setError(null);
-
-    try {
       if (isQueryInput(currentQuery)) {
         if (!queryDataset || !resolveDatasetQuery) {
-          return;
+          return null;
         }
 
         const datasetQuery =
           await resolveDatasetQuery(reduxStore)(currentQuery);
-
         const result = await queryDataset(reduxStore)({ datasetQuery });
 
-        setData(mapDatasetQueryData(result));
-        return;
+        return mapDatasetQueryData(result);
       }
-    } catch (err) {
-      setError(err);
-      setData(null);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [queryDataset, reduxStore, resolveDatasetQuery]);
+
+      return null;
+    }, [queryDataset, reduxStore, resolveDatasetQuery]);
+
+  // Type signature of refetch requires returning Promise<void>
+  const refetch = useCallback(async () => {
+    await fetchQuery();
+  }, [fetchQuery]);
 
   useEffect(() => {
     if (loginStatus?.status === "success") {
@@ -96,7 +90,7 @@ const useMetabaseQueryImpl = <
   return {
     data,
     isLoading,
-    error,
+    error: isLoading ? null : (error ?? null),
     refetch,
   };
 };

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/use-metabase-query.unit.spec.tsx
@@ -1,6 +1,7 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 
 import { resolveDatasetQuery as resolveDatasetQueryInBundle } from "embedding-sdk-bundle/lib/create-metabase-query";
+import type { QueryDatasetResult } from "embedding-sdk-bundle/lib/query-dataset";
 import type { SdkStore } from "embedding-sdk-bundle/store/types";
 import type { MetabaseEmbeddingSdkBundleExports } from "embedding-sdk-bundle/types/sdk-bundle";
 import { useLazySelector } from "embedding-sdk-package/hooks/private/use-lazy-selector";
@@ -1481,15 +1482,19 @@ describe("useMetabaseQueryObject", () => {
   it("does not expose stale query results after the input changes", async () => {
     const firstDeferred = createDeferred<DatasetQuery>();
     const secondDeferred = createDeferred<DatasetQuery>();
+
     const firstQuery = {
       source: TEST_SCHEMA.tables.orders,
       limit: 10,
     };
+
     const secondQuery = {
       source: TEST_SCHEMA.tables.orders,
       limit: 20,
     };
+
     const secondDatasetQuery = mbqlQuery([{ "source-table": 1, limit: 20 }]);
+
     // Which deferred a call gets is decided by the only field that differs.
     const resolveDatasetQuery = jest.fn(
       () => (input: QueryInput) =>
@@ -1497,6 +1502,7 @@ describe("useMetabaseQueryObject", () => {
           ? firstDeferred.promise
           : secondDeferred.promise,
     );
+
     stubSdkBundle({ resolveDatasetQuery });
 
     const { result, rerender } = renderHook(
@@ -1526,6 +1532,90 @@ describe("useMetabaseQueryObject", () => {
 });
 
 describe("useMetabaseQuery", () => {
+  it("ignores a stale response after the query changes", async () => {
+    const firstQuery = {
+      source: TEST_SCHEMA.tables.orders,
+      limit: 10,
+    };
+
+    const secondQuery = {
+      source: TEST_SCHEMA.tables.orders,
+      limit: 20,
+    };
+
+    const firstDatasetQuery = mbqlQuery([{ "source-table": 1, limit: 10 }]);
+    const secondDatasetQuery = mbqlQuery([{ "source-table": 1, limit: 20 }]);
+
+    const firstResponse = createDeferred<QueryDatasetResult>();
+    const secondResponse = createDeferred<QueryDatasetResult>();
+
+    const runDatasetQuery = jest.fn(
+      ({ datasetQuery }: { datasetQuery: DatasetQuery }) =>
+        datasetQuery === firstDatasetQuery
+          ? firstResponse.promise
+          : secondResponse.promise,
+    );
+
+    const resolveDatasetQuery = jest.fn(
+      () => (input: QueryInput) =>
+        Promise.resolve(
+          "limit" in input && input.limit === 10
+            ? firstDatasetQuery
+            : secondDatasetQuery,
+        ),
+    );
+
+    stubSdkBundle({
+      resolveDatasetQuery,
+      queryDataset: jest.fn(() => runDatasetQuery),
+    });
+
+    const { result, rerender } = renderHook(
+      ({ currentQuery }) => useMetabaseQuery(currentQuery),
+      { initialProps: { currentQuery: firstQuery } },
+    );
+
+    await waitFor(() => expect(runDatasetQuery).toHaveBeenCalledTimes(1));
+    rerender({ currentQuery: secondQuery });
+
+    await waitFor(() => expect(runDatasetQuery).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      firstResponse.resolve({
+        rowCount: 1,
+        runningTime: 1,
+        columns: [],
+        rows: [],
+      });
+      await firstResponse.promise;
+    });
+
+    expect(result.current).toMatchObject({
+      data: null,
+      error: null,
+      isLoading: true,
+    });
+
+    await act(async () => {
+      secondResponse.resolve({
+        rowCount: 2,
+        runningTime: 2,
+        columns: [],
+        rows: [],
+      });
+
+      await secondResponse.promise;
+    });
+
+    await waitFor(() =>
+      expect(result.current).toMatchObject({
+        data: expect.objectContaining({ rowCount: 2 }),
+        error: null,
+        isLoading: false,
+      }),
+    );
+  });
+
   it("waits for async query creation before querying the dataset", async () => {
     const deferred = createDeferred<DatasetQuery>();
     const queryDataset = jest.fn(() =>


### PR DESCRIPTION
Closes [EMB-2126: Prevent race conditions in responses of useMetabaseQuery hook](https://linear.app/metabase/issue/EMB-2126/prevent-race-conditions-in-responses-of-usemetabasequery-hook)

### Description

Let's guard useMetabaseQuery against stale responses.

When the query prop changes while a previous request is still in flight (for example, a data app updates filters quickly), both async calls still reach this setData/setIsLoading path.

A slower response for the old query can overwrite the newer query's data and clear the loading state early, so consumers can display results for the wrong filters. We should track a request id or abort/ignore prior requests before updating state.

The `useAsyncFn` hook is designed to prevent this, as it auto-tracks the request id.

### How to verify

The `ignores a stale response after the query changes` unit test should passes.

If you change the data app filters very quickly, it should be resistant to race conditions.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

