### PR TITLE
fix continuous /api/session/properties and /api/database requests 

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.unit.spec.tsx
@@ -1,0 +1,127 @@
+import fetchMock from "fetch-mock";
+
+import {
+  setupDatabaseListEndpoint,
+  setupGdriveGetFolderEndpoint,
+  setupGdriveServiceAccountEndpoint,
+  setupPropertiesEndpoints,
+} from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockState } from "metabase/redux/store/mocks";
+import { StorageSetupProvider } from "metabase-enterprise/storage/StorageSetupProvider";
+import type { TokenFeatures } from "metabase-types/api";
+import {
+  createMockDatabase,
+  createMockSettings,
+  createMockTokenFeatures,
+  createMockUser,
+} from "metabase-types/api/mocks";
+import { mockStorageCloudAddOn } from "metabase-types/api/mocks/add-ons";
+
+import { GdriveAddDataPanel } from "./GdriveAddDataPanel";
+
+interface SetupOpts {
+  isAdmin?: boolean;
+  tokenFeatures?: Partial<TokenFeatures>;
+  hasAttachedDwhDatabase?: boolean;
+  canUploadToDwh?: boolean;
+}
+
+const setup = ({
+  isAdmin = true,
+  tokenFeatures = {},
+  hasAttachedDwhDatabase = false,
+  canUploadToDwh = true,
+}: SetupOpts = {}) => {
+  const settingValues = {
+    "is-hosted?": true,
+    "store-url": "https://store.metabase.com",
+    "show-google-sheets-integration": true,
+    "token-features": createMockTokenFeatures(tokenFeatures),
+  };
+
+  setupPropertiesEndpoints(createMockSettings(settingValues));
+  setupDatabaseListEndpoint(
+    hasAttachedDwhDatabase
+      ? [
+          createMockDatabase({
+            id: 1,
+            can_upload: canUploadToDwh,
+            is_attached_dwh: true,
+          }),
+        ]
+      : [],
+  );
+  setupGdriveGetFolderEndpoint({ status: "not-connected" });
+  setupGdriveServiceAccountEndpoint("service-account@testing.metabase.com");
+  fetchMock.get("path:/api/ee/cloud-add-ons/addons", [mockStorageCloudAddOn]);
+  fetchMock.post("path:/api/premium-features/token/refresh", {});
+
+  renderWithProviders(
+    <StorageSetupProvider>
+      <GdriveAddDataPanel onAddDataModalClose={jest.fn()} />
+    </StorageSetupProvider>,
+    {
+      storeInitialState: createMockState({
+        currentUser: createMockUser({ is_superuser: isAdmin }),
+        settings: mockSettings(settingValues),
+      }),
+    },
+  );
+};
+
+describe("GdriveAddDataPanel storage states", () => {
+  it("points non-admins at their administrator", async () => {
+    setup({ isAdmin: false });
+
+    expect(
+      await screen.findByText(
+        /To enable Google Sheets import, please contact your administrator/,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Add Metabase Storage/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers to add storage when the instance has none", async () => {
+    setup();
+
+    expect(
+      await screen.findByText(
+        /To work with spreadsheets, you can add storage to your instance\./,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: /Add Metabase Storage/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the setting-up view while storage is provisioning", async () => {
+    // Token feature flipped, DWH database not synced yet — the mid-provisioning
+    // window (e.g. before the post-purchase redeploy finishes).
+    setup({ tokenFeatures: { attached_dwh: true } });
+
+    expect(await screen.findByText("Setting up storage")).toBeInTheDocument();
+  });
+
+  it("proceeds to the connect flow when storage exists, even if its database does not accept uploads", async () => {
+    // CSV uploads being disabled on the storage database must not gate Google
+    // Sheets sync, and re-offering storage the instance already has would be
+    // wrong (#77822 follow-up: this state used to read as provisioning).
+    setup({
+      tokenFeatures: { attached_dwh: true },
+      hasAttachedDwhDatabase: true,
+      canUploadToDwh: false,
+    });
+
+    expect(
+      await screen.findByRole("button", { name: "Connect" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Setting up storage")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Add Metabase Storage/ }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/storage/CSVPanel.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/storage/CSVPanel.unit.spec.tsx
@@ -36,6 +36,7 @@ interface SetupOpts {
   addOns?: ICloudAddOnProduct[];
   tokenFeatures?: Partial<TokenFeatures>;
   hasAttachedDwhDatabase?: boolean;
+  canUploadToDwh?: boolean;
   panelProps?: Partial<PanelProps>;
 }
 
@@ -43,6 +44,7 @@ const setup = ({
   addOns = [mockStorageCloudAddOn],
   tokenFeatures = {},
   hasAttachedDwhDatabase = false,
+  canUploadToDwh = true,
   panelProps,
 }: SetupOpts = {}) => {
   const props = { ...DEFAULT_PANEL_PROPS, ...panelProps };
@@ -58,7 +60,13 @@ const setup = ({
   setupPropertiesEndpoints(createMockSettings(settingValues));
   setupDatabaseListEndpoint(
     hasAttachedDwhDatabase
-      ? [createMockDatabase({ id: 1, can_upload: true, is_attached_dwh: true })]
+      ? [
+          createMockDatabase({
+            id: 1,
+            can_upload: canUploadToDwh,
+            is_attached_dwh: true,
+          }),
+        ]
       : [],
   );
   fetchMock.get("path:/api/ee/cloud-add-ons/addons", addOns);
@@ -149,6 +157,31 @@ describe("CSVPanel storage purchase", () => {
     expect(await screen.findByText("Setting up storage")).toBeInTheDocument();
     expect(
       screen.queryByText(/You are not permitted to upload CSV files/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the enable-uploads CTA without the storage upsell when storage exists but uploads are disabled", async () => {
+    // Storage is provisioned, but uploads are turned off on its database — a
+    // steady state an admin resolves in the Uploads settings. Regression for
+    // #77822: this used to render the setting-up spinner (with endless
+    // polling), and offering to buy storage again would be wrong.
+    setup({
+      tokenFeatures: { attached_dwh: true },
+      hasAttachedDwhDatabase: true,
+      canUploadToDwh: false,
+    });
+
+    // The upsell-free subtitle only renders once the databases list has
+    // resolved and the panel knows storage is already provisioned.
+    expect(
+      await screen.findByText(
+        /To work with CSVs, enable file uploads in your database\./,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Enable uploads")).toBeInTheDocument();
+    expect(screen.queryByText("Setting up storage")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Add Metabase Storage/ }),
     ).not.toBeInTheDocument();
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/storage/StorageSetupProvider.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/storage/StorageSetupProvider.unit.spec.tsx
@@ -36,21 +36,27 @@ const TestConsumer = () => {
 interface SetupOpts {
   tokenFeatures?: Partial<TokenFeatures>;
   hasAttachedDwhDatabase?: boolean;
+  canUploadToDwh?: boolean;
   isHosted?: boolean;
+  isAdmin?: boolean;
   addOns?: ICloudAddOnProduct[];
+  purchaseStatus?: number;
 }
 
 const setup = ({
   tokenFeatures = {},
   hasAttachedDwhDatabase = false,
+  canUploadToDwh = true,
   isHosted = true,
+  isAdmin = true,
   addOns = [mockStorageCloudAddOn],
+  purchaseStatus = 200,
 }: SetupOpts = {}) => {
   const settingValues = {
     "is-hosted?": isHosted,
     "token-features": createMockTokenFeatures(tokenFeatures),
     "uploads-settings": {
-      db_id: hasAttachedDwhDatabase ? 1 : null,
+      db_id: hasAttachedDwhDatabase && canUploadToDwh ? 1 : null,
       schema_name: null,
       table_prefix: null,
     },
@@ -64,22 +70,23 @@ const setup = ({
       }),
     }),
   );
-  // Storage is only "ready" once the provisioned Cloud Storage database
-  // (marked `is_attached_dwh`) surfaces in the databases list and accepts
-  // uploads, so seed it when the provisioned state is expected.
+  // Storage is "ready" once the provisioned Cloud Storage database (marked
+  // `is_attached_dwh`) surfaces in the databases list, so seed it when the
+  // provisioned state is expected. Whether it accepts uploads is a separate,
+  // possibly permanent state (`canUploadToDwh`).
   setupDatabaseListEndpoint(
     hasAttachedDwhDatabase
       ? [
           createMockDatabase({
             id: 1,
-            can_upload: true,
+            can_upload: canUploadToDwh,
             is_attached_dwh: true,
           }),
         ]
       : [],
   );
   fetchMock.get("path:/api/ee/cloud-add-ons/addons", addOns);
-  fetchMock.post("path:/api/ee/cloud-add-ons/dwh-rent", 200);
+  fetchMock.post("path:/api/ee/cloud-add-ons/dwh-rent", purchaseStatus);
   fetchMock.post(
     "path:/api/premium-features/token/refresh",
     createMockTokenStatus(),
@@ -92,7 +99,7 @@ const setup = ({
     </StorageSetupProvider>,
     {
       storeInitialState: createMockState({
-        currentUser: createMockUser({ is_superuser: true }),
+        currentUser: createMockUser({ is_superuser: isAdmin }),
         settings: mockSettings(settingValues),
       }),
     },
@@ -197,6 +204,83 @@ describe("StorageSetupProvider", () => {
     expect(
       screen.queryByText("Metabase Storage is ready"),
     ).not.toBeInTheDocument();
+  });
+
+  it("does not enter the setting-up state on load when storage exists but uploads are disabled", async () => {
+    // Storage is provisioned but its database does not accept uploads (uploads
+    // disabled or pointed elsewhere) — a permanent state, not provisioning.
+    // Regression for #77822: this used to read as setting-up and poll the
+    // settings and databases endpoints forever on every page.
+    setup({
+      tokenFeatures: { attached_dwh: true },
+      hasAttachedDwhDatabase: true,
+      canUploadToDwh: false,
+    });
+
+    await waitFor(() => {
+      expect(fetchMock.callHistory.called("path:/api/database")).toBe(true);
+    });
+
+    expect(screen.queryByText("setting up")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Metabase Storage is ready"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("stays inert for non-admins, even in a state that reads as provisioning for admins", async () => {
+    // The token feature is on and no DWH database exists — for an admin this
+    // is the provisioning window with its polling. Non-admins cannot set up
+    // storage, so nothing may be fetched on their behalf.
+    setup({ isAdmin: false, tokenFeatures: { attached_dwh: true } });
+
+    await screen.findByRole("button", { name: "Open purchase modal" });
+
+    expect(screen.queryByText("setting up")).not.toBeInTheDocument();
+    expect(fetchMock.callHistory.called("path:/api/database")).toBe(false);
+  });
+
+  it("stays inert on self-hosted instances", async () => {
+    setup({ isHosted: false, tokenFeatures: { attached_dwh: true } });
+
+    await screen.findByRole("button", { name: "Open purchase modal" });
+
+    expect(screen.queryByText("setting up")).not.toBeInTheDocument();
+    expect(fetchMock.callHistory.called("path:/api/database")).toBe(false);
+  });
+
+  it("shows an error toast and leaves the setting-up state when the purchase fails", async () => {
+    setup({ purchaseStatus: 500 });
+
+    await purchaseStorage();
+
+    expect(
+      await screen.findByText(
+        "It looks like something went wrong. Please refresh the page and try again.",
+      ),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText("setting up")).not.toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText("Metabase Storage is ready"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("leaves the setting-up state after a purchase once the DWH database appears, even if it does not accept uploads yet", async () => {
+    setup({
+      tokenFeatures: { attached_dwh: true },
+      hasAttachedDwhDatabase: true,
+      canUploadToDwh: false,
+    });
+
+    await purchaseStorage();
+
+    await waitFor(() => {
+      expect(screen.queryByText("setting up")).not.toBeInTheDocument();
+    });
+    expect(
+      await screen.findByText("Metabase Storage is ready"),
+    ).toBeInTheDocument();
   });
 
   describe("purchase confirmation modal", () => {

--- a/enterprise/frontend/src/metabase-enterprise/storage/use-purchase-storage-add-on.ts
+++ b/enterprise/frontend/src/metabase-enterprise/storage/use-purchase-storage-add-on.ts
@@ -38,10 +38,9 @@ export function usePurchaseStorageAddOn() {
   });
   // Until loaded, "no attached DWH" is indistinguishable from "not fetched yet".
   const areDatabasesLoaded = databasesResponse !== undefined;
-  const attachedDwhDatabase = databasesResponse?.data?.find(
+  const hasAttachedDwh = !!databasesResponse?.data?.some(
     (db) => db.is_attached_dwh,
   );
-  const hasAttachedDwh = !!attachedDwhDatabase?.can_upload;
 
   // Keeps us in setting-up from the POST until storage is ready; collapses on
   // its own on error (mutation no longer pending or successful).

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/Panels/CSVPanel.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/Panels/CSVPanel.tsx
@@ -24,8 +24,12 @@ export const CSVPanel = ({
   onCloseAddDataModal,
   uploadsEnabled,
 }: CSVPanelProps) => {
-  const { isSettingUp, isLoadingStorageAddOn, canSetUpStorage } =
-    useStorageSetup();
+  const {
+    isSettingUp,
+    isLoadingStorageAddOn,
+    canSetUpStorage,
+    hasAttachedDwh,
+  } = useStorageSetup();
 
   const showObtainPermissionPrompt = uploadsEnabled && !canUpload;
   const showEnableUploadsCTA = !uploadsEnabled && canManageUploads;
@@ -61,7 +65,7 @@ export const CSVPanel = ({
           to: Urls.uploadsSettings(),
         }}
         secondaryAction={
-          canSetUpStorage ? (
+          canSetUpStorage && !hasAttachedDwh ? (
             <StoragePurchaseButton location="add-data-modal-csv" />
           ) : undefined
         }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/77822

### Description

When dwh-rent addon is provisioned, but uploads are disabled, there are continuous /api/session/properties and /api/database requests 

### How to verify

1. open an instance as admin https://pointed-blade.hosted.staging.metabase.com/
2. observe network
3. enable uploads https://pointed-blade.hosted.staging.metabase.com/admin/settings/uploads and get back to main app, check add data modal, observe network
4. disabled uploads and do the same

### Where to verify

https://pointed-blade.hosted.staging.metabase.com/

1password

https://start.1password.com/open/i?a=AEO4BXOSHNFCJLK26XA7AD522E&v=jc42hdh6wgip5i74fuxzhtqe2i&i=7sjygl72hh52fj636ftp35xbzi&h=metabaseinc.1password.com