### PR TITLE
Reap superseded CodeQL overlay caches daily

### DIFF
--- a/.github/workflows/cache-cleanup-codeql.yml
+++ b/.github/workflows/cache-cleanup-codeql.yml
@@ -1,0 +1,101 @@
+# CodeQL's overlay analysis saves a ~400MB "base database" cache on every master run, keyed by commit SHA, and
+# nothing ever removes the old ones. They had grown to 16 entries / 6.4GB — 61% of this repo's entire 10GB Actions
+# cache budget — which pushes GitHub into evicting caches we actually want (M2, node_modules, Cypress) and makes
+# unrelated jobs slower.
+#
+# Only the newest entry is ever restored: CodeQL looks its cache up by key *prefix* and takes the most recent match,
+# so everything behind it is dead weight. This job keeps the newest few and deletes the rest, daily.
+#
+# Safe by construction:
+#   - It only ever deletes keys starting with `codeql-overlay-base-database-`; nothing else is touched.
+#   - It keeps the newest `keep` entries, so in-flight runs and the next incremental analysis still get a hit.
+#   - Worst case if it deletes too much: CodeQL builds a full database instead of an incremental one. Slower, same
+#     results. Per the cache doctrine in cache-generator.yml — caches are for speed, never for correctness.
+name: Cache Cleanup (CodeQL)
+
+on:
+  schedule:
+    - cron: "0 4 * * *" # daily at 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      keep:
+        description: "How many of the newest CodeQL caches to keep"
+        required: false
+        default: "2"
+      dry-run:
+        description: "List what would be deleted without deleting it"
+        type: boolean
+        required: false
+        default: false
+
+concurrency:
+  group: cache-cleanup-codeql
+  cancel-in-progress: false
+
+permissions:
+  actions: write # required to delete cache entries
+  contents: read
+
+jobs:
+  cleanup:
+    # don't run the schedule on forks
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      KEEP: ${{ github.event.inputs.keep || '2' }}
+      DRY_RUN: ${{ github.event.inputs.dry-run || 'false' }}
+      PREFIX: codeql-overlay-base-database-
+    steps:
+      - name: Delete superseded CodeQL caches
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # created_at is ISO-8601, so a reverse lexicographic sort is newest-first.
+          gh api --paginate "/repos/${GITHUB_REPOSITORY}/actions/caches?per_page=100" \
+            --jq ".actions_caches[] | select(.key | startswith(\"${PREFIX}\")) | \"\(.created_at)\t\(.id)\t\(.size_in_bytes)\t\(.key)\"" \
+            | sort -r > all.tsv || true
+
+          found=$(wc -l < all.tsv | tr -d ' ')
+          echo "Found $found cache(s) matching '${PREFIX}'; keeping the newest $KEEP."
+          if [ "$found" -eq 0 ]; then
+            echo "Nothing to do." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          tail -n +$((KEEP + 1)) all.tsv > doomed.tsv || true
+          doomed=$(wc -l < doomed.tsv | tr -d ' ')
+
+          freed=0
+          while IFS=$'\t' read -r created id size key; do
+            [ -z "${id:-}" ] && continue
+            echo "  deleting $key ($((size / 1000000))MB, created $created)"
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "    (dry run — not deleted)"
+            else
+              # A cache can vanish between listing and deleting (concurrent eviction); don't fail the job over it.
+              gh api --method DELETE "/repos/${GITHUB_REPOSITORY}/actions/caches/${id}" >/dev/null \
+                || echo "    (already gone, skipping)"
+            fi
+            freed=$((freed + size))
+          done < doomed.tsv
+
+          {
+            echo "### CodeQL cache cleanup"
+            echo ""
+            echo "- matched: **$found**"
+            echo "- kept (newest): **$KEEP**"
+            echo "- deleted: **$doomed**"
+            echo "- reclaimed: **$((freed / 1000000)) MB**${DRY_RUN:+ (dry run: $DRY_RUN)}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report remaining cache usage
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api "/repos/${GITHUB_REPOSITORY}/actions/cache/usage" \
+            --jq '"Repo cache usage now: \(.active_caches_size_in_bytes / 1000000000 | .*100 | round / 100) GB across \(.active_caches_count) entries (limit 10 GB)"' \
+            | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
I went looking at our Actions cache while working on something else and found that we're sitting at **10.63GB against a 10GB per-repo limit**. So we're permanently over, which means GitHub is permanently evicting things by LRU — and LRU has no idea that our M2 cache (779MB) or node_modules (401MB) matter more than a CodeQL database from yesterday afternoon. I think this has been quietly making unrelated jobs slower for a while.

The culprit is CodeQL's overlay analysis. It saves a ~400MB "base database" cache on every master run, keyed by commit SHA:

```
codeql-overlay-base-database-1-6144223ab8882e93-javascript-2.26.0-<sha>-<run-id>-1
```

Nothing ever removes them, and codeql.yml runs on every push to master, so we accumulate about 8 a day. Right now there are **16 of them totalling 6.44GB — 61% of our entire cache budget**.

The thing is, only the newest one is ever actually used: CodeQL looks its cache up by key *prefix* and takes the most recent match. Everything behind it is dead weight taking up space we're actively short of.

So this adds a daily job that keeps the newest couple and deletes the rest. Dry-run against the repo as it stands right now: 16 matched, 2 kept, 14 deleted, **5.6GB reclaimed**, taking us from 10.63GB down to about 5GB.

## Why I think this is safe

- It only ever deletes keys starting with `codeql-overlay-base-database-`. Nothing else is touched.
- It keeps the newest `keep` (default 2), so anything in flight and the next incremental analysis still get a hit.
- Worst case, if it somehow deleted too much: CodeQL builds a full database instead of an incremental one. Slower, identical results. This is the doctrine we already wrote down in `cache-generator.yml` — "The cache is never wrong! Caches are for speeding up builds, not for correctness."

The deletion mechanism is the same one `.github/actions/update-cache` already uses (`gh api --method DELETE` with the default token), so nothing new there apart from `permissions: actions: write`.

## To test

`workflow_dispatch` takes a `dry-run` input, so you can run it with dry-run ticked and it'll print exactly what it would delete plus the reclaimed total, without touching anything. It also prints the repo's cache usage afterwards either way.

## Things to know

I picked `keep: 2` fairly arbitrarily — one would probably do, since only the newest is ever restored, but 2 felt like cheap insurance against a race with an in-flight run. Happy to change it.

While I was in there I noticed the next biggest target is `cache-trivy-<date>` — there's two of them at 974MB each, so ~1.9GB, and it looks like a daily that keeps yesterday's around too. Didn't touch it, but if we ever want more room back that's where I'd look next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)