### PR TITLE
Build the uberjar on top of a cached deps-only base jar

### DIFF
--- a/.github/actions/get-cache-keys/action.yml
+++ b/.github/actions/get-cache-keys/action.yml
@@ -22,6 +22,12 @@ outputs:
   cypress-cache-key:
     description: "The cache key for Cypress cache"
     value: ${{ steps.keys-factory.outputs.cypress-cache-key }}
+  deps-base-jar-cache-key:
+    description: "The cache key for the deps-only base jars used to speed up the uberjar build."
+    value: ${{ steps.keys-factory.outputs.deps-base-jar-cache-key }}
+  deps-base-jar-restore-key:
+    description: "The fallback restore key prefix for the deps-only base jars."
+    value: ${{ steps.keys-factory.outputs.deps-base-jar-restore-key }}
 
 runs:
   using: "composite"
@@ -33,13 +39,16 @@ runs:
         NODE_CACHE_PREFIX='node-modules'
         ESLINT_CACHE_PREFIX='eslint'
         CYPRESS_CACHE_PREFIX='cypress'
+        DEPS_BASE_JAR_CACHE_PREFIX='deps-base-jar'
         WEEK_OF_YEAR=$(/bin/date "+%G-%V")
         CACHE_SUFFIX="${{ runner.os }}-$WEEK_OF_YEAR"
 
-        echo "m2-cache-key=$M2_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
-        echo "m2-restore-key=$M2_CACHE_PREFIX-" >> $GITHUB_OUTPUT
-        echo "node-cache-key=$NODE_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
-        echo "node-restore-key=$NODE_CACHE_PREFIX-" >> $GITHUB_OUTPUT
-        echo "eslint-cache-key=$ESLINT_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
-        echo "cypress-cache-key=$CYPRESS_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
+        echo "m2-cache-key=$M2_CACHE_PREFIX-$CACHE_SUFFIX" >> "$GITHUB_OUTPUT"
+        echo "m2-restore-key=$M2_CACHE_PREFIX-" >> "$GITHUB_OUTPUT"
+        echo "node-cache-key=$NODE_CACHE_PREFIX-$CACHE_SUFFIX" >> "$GITHUB_OUTPUT"
+        echo "node-restore-key=$NODE_CACHE_PREFIX-" >> "$GITHUB_OUTPUT"
+        echo "eslint-cache-key=$ESLINT_CACHE_PREFIX-$CACHE_SUFFIX" >> "$GITHUB_OUTPUT"
+        echo "cypress-cache-key=$CYPRESS_CACHE_PREFIX-$CACHE_SUFFIX" >> "$GITHUB_OUTPUT"
+        echo "deps-base-jar-cache-key=$DEPS_BASE_JAR_CACHE_PREFIX-$CACHE_SUFFIX" >> "$GITHUB_OUTPUT"
+        echo "deps-base-jar-restore-key=$DEPS_BASE_JAR_CACHE_PREFIX-" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/workflows/cache-generator.yml
+++ b/.github/workflows/cache-generator.yml
@@ -51,6 +51,7 @@ jobs:
       node-cache-key: ${{ steps.get-cache-keys.outputs.node-cache-key }}
       eslint-cache-key: ${{ steps.get-cache-keys.outputs.eslint-cache-key }}
       cypress-cache-key: ${{ steps.get-cache-keys.outputs.cypress-cache-key }}
+      deps-base-jar-cache-key: ${{ steps.get-cache-keys.outputs.deps-base-jar-cache-key }}
 
   generate-caches:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
@@ -61,6 +62,7 @@ jobs:
       NODE_CACHE_KEY: ${{ needs.get-cache-keys.outputs.node-cache-key }}
       CYPRESS_CACHE_KEY: ${{ needs.get-cache-keys.outputs.cypress-cache-key }}
       ESLINT_CACHE_KEY: ${{ needs.get-cache-keys.outputs.eslint-cache-key }}
+      DEPS_BASE_JAR_CACHE_KEY: ${{ needs.get-cache-keys.outputs.deps-base-jar-cache-key }}
     steps:
       - uses: actions/checkout@v6
 
@@ -117,6 +119,27 @@ jobs:
             ~/.m2
             ~/.gitlibs
           key: ${{ env.M2_CACHE_KEY }}
+
+      # Deps-only base jars: `b/uber` spends most of its time exploding and re-deflating the dependencies, which are
+      # ~75% of the uberjar's bytes but only change when a deps.edn does. Building them here lets the uberjar build
+      # append its own classes onto a prebuilt jar instead. Each build re-checks the resolved dependency set against
+      # the hash stored beside the jar and silently falls back to a full `b/uber` when it doesn't match, so a stale
+      # cache costs time, never correctness.
+      - name: Build deps-only base jars
+        run: |
+          set -euo pipefail
+          for edition in ee oss; do
+            echo "::group::deps base jar ($edition)"
+            clojure -X:build:build/uberjar build.uberjar/build-deps-base-jar! :edition ":$edition"
+            echo "::endgroup::"
+          done
+        shell: bash
+
+      - name: Update deps base jar cache
+        uses: ./.github/actions/update-cache
+        with:
+          path: target/deps-base
+          key: ${{ env.DEPS_BASE_JAR_CACHE_KEY }}
 
       # Frontend preparation and caches
       # `prepare-frontend` action (1) prepares Node.js and (2) fetches the node_modules cache if it exists.

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -144,6 +144,20 @@ jobs:
         uses: ./.github/actions/prepare-backend
         with:
           java-version: "${{ needs.get-build-requirements.outputs.java_version || 25 }}"
+      # Lets the build append its classes onto a prebuilt deps-only jar rather than re-deflating every dependency.
+      # Restore-only and best-effort: the build re-checks the resolved dependency set against the hash stored beside
+      # the jar and falls back to a full `b/uber` on a miss, a stale hit, or no cache at all.
+      - name: Get cache keys
+        uses: ./.github/actions/get-cache-keys
+        id: get-cache-keys
+      - name: Restore deps base jar cache
+        uses: actions/cache/restore@v5
+        continue-on-error: true
+        with:
+          path: target/deps-base
+          key: ${{ steps.get-cache-keys.outputs.deps-base-jar-cache-key }}
+          restore-keys: |
+            ${{ steps.get-cache-keys.outputs.deps-base-jar-restore-key }}
       - name: Build
         run: ./bin/build.sh
       - name: Upload bundle stats

--- a/bin/build/src/build/uberjar.clj
+++ b/bin/build/src/build/uberjar.clj
@@ -1,6 +1,7 @@
 (ns build.uberjar
   (:require
    [clojure.java.io :as io]
+   [clojure.pprint :as pprint]
    [clojure.string :as str]
    [clojure.tools.build.api :as b]
    [clojure.tools.build.util.zip :as build.zip]
@@ -12,7 +13,9 @@
    [org.corfield.log4j2-conflict-handler :refer [log4j2-conflict-handler]])
   (:import
    (java.io File OutputStream)
-   (java.nio.file Files OpenOption StandardOpenOption)
+   (java.nio.file CopyOption Files LinkOption OpenOption Path StandardCopyOption StandardOpenOption)
+   (java.nio.file.attribute FileAttribute)
+   (java.security MessageDigest)
    (java.util.jar Manifest)))
 
 (set! *warn-on-reflection* true)
@@ -212,6 +215,155 @@
                :exclude           dependency-ignore-patterns})
       (u/announce "Created uberjar in %.1f seconds." (/ duration-ms 1000.0)))))
 
+;;; ------------------------------------------- deps-only base jar ---------------------------------------------------
+;;;
+;;; `b/uber` explodes every dependency JAR into a temp directory and then deflates the whole tree into the uberjar.
+;;; Dependencies are ~75% of the jar's uncompressed bytes and ~84% of its entries, and they only change when a
+;;; `deps.edn` does (~2% of commits), so we pay for that work on nearly every build for nothing.
+;;;
+;;; Instead, CI's cache generator builds a "base jar" — the same `b/uber` call with an *empty* class-dir, so it holds
+;;; only the exploded, conflict-resolved dependencies — and caches it weekly. A build with a matching dependency set
+;;; copies that base jar and appends its own class-dir into it, which re-uses the dependencies' already-compressed
+;;; bytes instead of re-deflating them. When the dependency set doesn't match, we fall back to the normal `b/uber`
+;;; path, so the cache can only ever make the build faster, never wrong.
+
+(def ^:private deps-base-dir
+  "Directory holding the cached deps-only base jars. Deliberately outside `target/classes` and not touched by
+  `clean!`, since CI restores the cache into it before the build runs."
+  (u/filename u/project-root-directory "target" "deps-base"))
+
+(defn deps-base-jar-filename
+  "Path of the deps-only base jar for `edition`."
+  [edition]
+  (u/filename deps-base-dir (format "metabase-deps-%s.jar" (name edition))))
+
+(defn- deps-base-hash-filename [edition]
+  (str (deps-base-jar-filename edition) ".hash"))
+
+(defn- sha256 ^String [^String s]
+  (->> (.getBytes s "UTF-8")
+       (.digest (MessageDigest/getInstance "SHA-256"))
+       (map (partial format "%02x"))
+       (apply str)))
+
+(defn- basis-deps-hash
+  "Fingerprint of the resolved dependency set — exactly what the base jar contains. We hash the *resolved* libs rather
+  than the `deps.edn` files so that the check can't be fooled by a change that alters resolution without touching a
+  file we thought to hash (or vice versa). `:paths` are omitted because they are absolute and machine-specific."
+  [basis]
+  (->> (:libs basis)
+       (map (fn [[lib coord]]
+              (str lib " " (or (:mvn/version coord) (:git/sha coord) (:local/root coord)))))
+       sort
+       (str/join "\n")
+       sha256))
+
+(defn build-deps-base-jar!
+  "Build the deps-only base jar for `edition` plus the hash sidecar identifying which dependency set it holds. Run by
+  CI's cache generator; see .github/workflows/cache-generator.yml.
+
+    clojure -X:build:build/uberjar build.uberjar/build-deps-base-jar! :edition :ee"
+  [{:keys [edition], :or {edition :oss}}]
+  (u/step (format "Build %s deps base jar" edition)
+    (let [basis     (create-basis edition)
+          jar       (deps-base-jar-filename edition)
+          ;; an empty class-dir is what makes this deps-only: `b/uber` merges class-dir and libs into one tree, so
+          ;; giving it nothing to merge yields just the libs.
+          empty-dir (str (Files/createTempDirectory "empty-class-dir" (misc/varargs FileAttribute)))]
+      (u/delete-file-if-exists! jar)
+      (u/create-directory-unless-exists! deps-base-dir)
+      (with-duration-ms [duration-ms]
+        (b/uber {:class-dir         empty-dir
+                 :uber-file         jar
+                 :conflict-handlers conflict-handlers
+                 :basis             basis
+                 :exclude           dependency-ignore-patterns})
+        (spit (deps-base-hash-filename edition) (basis-deps-hash basis))
+        (u/announce "Built %s (%.1f MB) in %.1f seconds."
+                    jar (/ (.length (io/file jar)) 1e6) (/ duration-ms 1000.0))))))
+
+(defn- usable-deps-base-jar
+  "Path of a base jar we can build on top of, or nil. nil whenever anything is off — no cache restored, or the
+  dependency set moved since it was built — which just means the normal `b/uber` path runs."
+  [edition basis]
+  (let [jar       (deps-base-jar-filename edition)
+        hash-file (io/file (deps-base-hash-filename edition))]
+    (cond
+      (not (.exists (io/file jar)))
+      (do (u/announce "No deps base jar at %s; building the uberjar from scratch." jar) nil)
+
+      (not (.exists hash-file))
+      (do (u/announce "Deps base jar has no hash sidecar; building the uberjar from scratch.") nil)
+
+      (not= (str/trim (slurp hash-file)) (basis-deps-hash basis))
+      (do (u/announce "Deps base jar is stale (dependency set changed); building the uberjar from scratch.") nil)
+
+      :else
+      (do (u/announce "Using cached deps base jar %s." jar) jar))))
+
+(def ^:private uber-exclusions
+  "tools.build drops these from everything it writes into an uberjar — including class-dir content. Appending the app
+  layer ourselves has to drop exactly the same set or our jar would differ from a `b/uber` one. Read back out of
+  tools.build rather than copied here, so a version bump surfaces as a loud failure instead of silent drift."
+  (delay @(requiring-resolve 'clojure.tools.build.tasks.uber/uber-exclusions)))
+
+(defn- excluded-from-uber? [^String path]
+  (boolean (some #(re-matches % path) (concat @uber-exclusions dependency-ignore-patterns))))
+
+(defn- merged-data-readers
+  "Replicates tools.build's `:data-readers` conflict handler. `b/uber` explodes the class-dir *first* and then merges
+  each lib's data readers over it, so the app's entries come first and libs win any key collision — `(merge app base)`
+  reproduces both the ordering and the precedence."
+  [^String app-str ^String base-str]
+  (binding [*read-eval* false]
+    (let [read-readers #(read-string {:read-cond :preserve :features #{:clj}} %)]
+      (with-out-str
+        (pprint/pprint (merge (read-readers app-str) (read-readers base-str)))))))
+
+(defn- append-conflict!
+  "Resolve a class-dir file whose path already exists in the base jar (i.e. a lib shipped the same path)."
+  [^Path target ^File src ^String path]
+  (cond
+    (re-matches #"data_readers.clj[c]?" path)
+    (let [^String merged (merged-data-readers (slurp src) (String. (Files/readAllBytes target) "UTF-8"))]
+      (Files/write target (.getBytes merged "UTF-8")
+                   (misc/varargs OpenOption [StandardOpenOption/WRITE StandardOpenOption/TRUNCATE_EXISTING])))
+
+    ;; `b/uber` would concatenate/dedupe these rather than let one side win. Nothing under `resources/` produces them
+    ;; today, so rather than carry an untested merge, fail loudly if that ever changes.
+    (or (re-matches #"META-INF/services/.*" path)
+        (re-matches #"(?i)(META-INF/)?(COPYRIGHT|NOTICE|LICENSE)(\.(txt|md))?" path))
+    (throw (ex-info (str "Cannot append " path " onto the deps base jar: b/uber merges this path, and this code only"
+                         " knows how to merge data_readers. Teach append-conflict! how to merge it, or exclude it.")
+                    {:path path}))
+
+    ;; Everything else: `b/uber`'s default handler is `:ignore` (first writer wins) and the class-dir goes in first,
+    ;; so the app's copy wins.
+    :else
+    (Files/copy (.toPath src) target
+                (misc/varargs CopyOption [StandardCopyOption/REPLACE_EXISTING]))))
+
+(defn- create-uberjar-from-base!
+  "Build the uberjar by copying the deps-only `base-jar` and appending the class-dir into it."
+  [base-jar]
+  (u/step "Create uberjar from cached deps base jar"
+    (with-duration-ms [duration-ms]
+      (io/copy (io/file base-jar) (io/file uberjar-filename))
+      (let [root  (.toPath (io/file class-dir))
+            files (->> (io/file class-dir) file-seq (filter #(.isFile ^File %)))]
+        (u/with-open-jar-file-system [fs uberjar-filename]
+          (doseq [^File f files
+                  :let [path (str/replace (str (.relativize root (.toPath f))) File/separatorChar \/)]
+                  :when (not (excluded-from-uber? path))]
+            (let [target (u/get-path-in-filesystem fs path)]
+              (if (Files/exists target (misc/varargs LinkOption))
+                (append-conflict! target f path)
+                (do
+                  (when-let [parent (.getParent target)]
+                    (Files/createDirectories parent (misc/varargs FileAttribute)))
+                  (Files/copy (.toPath f) target (misc/varargs CopyOption))))))))
+      (u/announce "Created uberjar from base in %.1f seconds." (/ duration-ms 1000.0)))))
+
 (def ^:private manifest-entries
   {"Manifest-Version" "1.0"
    "Multi-Release"    "true"
@@ -271,7 +423,9 @@
       (let [basis (create-basis edition)]
         (compile-sources! basis)
         (copy-resources! basis)
-        (create-uberjar! basis)
+        (if-let [base-jar (usable-deps-base-jar edition basis)]
+          (create-uberjar-from-base! base-jar)
+          (create-uberjar! basis))
         (add-non-aot-driver-sources!)
         (update-manifest!))
       (u/announce "Built %s in %.1f seconds." uberjar-filename (/ duration-ms 1000.0)))))

--- a/bin/build/src/build/uberjar.clj
+++ b/bin/build/src/build/uberjar.clj
@@ -348,6 +348,8 @@
   [base-jar]
   (u/step "Create uberjar from cached deps base jar"
     (with-duration-ms [duration-ms]
+      ;; b/uber creates this for the cold path; on a clean workspace nothing else has.
+      (u/create-directory-unless-exists! (.getParent (io/file uberjar-filename)))
       (io/copy (io/file base-jar) (io/file uberjar-filename))
       (let [root  (.toPath (io/file class-dir))
             files (->> (io/file class-dir) file-seq (filter #(.isFile ^File %)))]


### PR DESCRIPTION
Speedup jar-build  by caching deps so we stop rebuilding them on every single build. 

## The deps-only base jar

`b/uber` explodes every dependency JAR into a temp tree and then deflates the whole lot into the uberjar. Dependencies are **75% of the jar's raw bytes** (1.28GB of 1.69GB) and 84% of its entries. Our own AOT output is 7.8%. But dependencies only change when a deps.edn does, which is about 2% of commits.

The cache generator now builds a "base jar" once a week. It's the same `b/uber` call with an **empty class-dir**, which is what makes it deps-only. uber merges class-dir and libs into one tree, so give it nothing to merge and you get just the libs, already conflict-resolved. Then a build whose dependency set matches copies that jar and appends its own class-dir into it via zipfs, which reuses the dependencies' already-compressed bytes instead of re-deflating them.

Locally that takes jar assembly from **139.4s to 36.8s** on a clean class-dir. End-to-end through `bin/build.sh` it's 173.9s → 59.5s.

### Cache busting

Every build re-hashes its resolved dependency set and compares it to a hash stored beside the jar. If there's no  cache, no sidecar or a  stale hash  it just runs the normal `b/uber` path. 

The hash of *resolved* libs (lib → version/sha) rather than the deps.edn files is on purpose. Hashing files means guessing which files affect resolution, but the resolved basis is exactly what's in the jar.

### How to review

The interesting file is `bin/build/src/build/uberjar.clj`. The rest is cache plumbing following the existing weekly-key pattern.

Something worth checking is `append-conflict!`, because reproducing `b/uber`'s merge semantics should be done carefully. Three gotchas:

**data_readers.clj has to be merged, not overwritten.** Our own file has two entries (`t`, `locale`) but the jar we ship has three becuse`cheshire/json` gets merged in from cheshire. A naive append silently drops it and breaks the `#cheshire/json` reader tag at runtime. `b/uber` explodes the class-dir first and merges each lib over it, so `(merge app base)` reproduces both the ordering and the precedence.

**`b/uber`'s `:exclude` strips `metabase*.clj` from the class-dir too**, not just from libs - which is the reason `add-non-aot-driver-sources!` exists at all. The first attempt put 1,823 stray .clj source files in the jar. Now it reads the exclusion list back out of tools.build rather than copying it, so a version bump fails loudly instead of drifting silently.

**META-INF/services and LICENSE-ish paths** get merged by `b/uber` too, but nothing under `resources/` produces them today, so rather than carry an untestable merge it will throw if that ever changes.
