### PR TITLE
Set showDashboardQuestions to false by default on SDK CollectionBrowser

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/public/CollectionBrowser/CollectionBrowser.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/CollectionBrowser/CollectionBrowser.tsx
@@ -82,7 +82,7 @@ export type CollectionBrowserProps = {
   visibleEntityTypes?: UserFacingEntityName[];
 
   /**
-   * Whether to show questions that belong to a dashboard alongside collection saved questions. Set to false to hide them and keep the list focused on collection content, matching the core Metabase app. Defaults to true.
+   * Whether to show questions that belong to a dashboard alongside collection saved questions. Set to true to show them. Defaults to false, keeping the list focused on collection content.
    */
   showDashboardQuestions?: boolean;
 
@@ -107,7 +107,7 @@ export const CollectionBrowserInner = ({
   onClick,
   pageSize = COLLECTION_PAGE_SIZE,
   visibleEntityTypes = [...USER_FACING_ENTITY_NAMES],
-  showDashboardQuestions = true,
+  showDashboardQuestions = false,
   EmptyContentComponent = null,
   visibleColumns = COLLECTION_BROWSER_LIST_COLUMNS,
   className,

--- a/frontend/src/embedding-sdk-bundle/components/public/CollectionBrowser/CollectionBrowser.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/CollectionBrowser/CollectionBrowser.unit.spec.tsx
@@ -155,16 +155,16 @@ describe("CollectionBrowser", () => {
     expect(columnTexts).toContain("Description");
   });
 
-  it("should show dashboard questions by default", async () => {
+  it("should hide dashboard questions by default", async () => {
     await setup();
 
-    expect(getLastItemsRequestParam("show_dashboard_questions")).toBe("true");
+    expect(getLastItemsRequestParam("show_dashboard_questions")).toBe("false");
   });
 
-  it("should hide dashboard questions when showDashboardQuestions is false", async () => {
-    await setup({ props: { showDashboardQuestions: false } });
+  it("should show dashboard questions when showDashboardQuestions is true", async () => {
+    await setup({ props: { showDashboardQuestions: true } });
 
-    expect(getLastItemsRequestParam("show_dashboard_questions")).toBe("false");
+    expect(getLastItemsRequestParam("show_dashboard_questions")).toBe("true");
   });
 
   it("should resolve collectionId=tenant to user's tenant collection", async () => {

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -188,7 +188,7 @@ export interface BrowserEmbedOptions {
   /** Which entities to show on the collection browser */
   collectionEntityTypes?: CollectionBrowserEntityTypes[];
 
-  /** Whether to show questions that belong to a dashboard in the collection browser. Defaults to true. */
+  /** Whether to show questions that belong to a dashboard in the collection browser. Defaults to false. */
   collectionShowDashboardQuestions?: boolean;
 
   /** Which entities to show on the question's data picker */


### PR DESCRIPTION
Closes [EMB-2128: Set `showDashboardQuestions` to `false` on SDK CollectionBrowser](https://linear.app/metabase/issue/EMB-2128/set-showdashboardquestions-to-false-on-sdk-collectionbrowser)

### Description

Follow-up to #77941, which introduced the `showDashboardQuestions` prop on the SDK
`CollectionBrowser` defaulting to `true`. This flips the SDK default to `false` so the
collection browser stays focused on collection content, matching the core Metabase app,
unless the embedder opts in.

- SDK `CollectionBrowser`: `showDashboardQuestions` now defaults to `false`; JSDoc updated.
- Modular embedding (`collectionShowDashboardQuestions`): undefined now flows to the new
  `false` default; doc comment updated.
- The core Metabase app is unaffected — `CollectionItemsTable` keeps its `true` default.

### How to verify

1. Embed the SDK `CollectionBrowser` (or a Modular embedding `metabase-browser`) pointed at
   a collection that contains dashboard questions.
2. By default, dashboard questions are hidden.
3. Pass `showDashboardQuestions={true}` (SDK) / `collectionShowDashboardQuestions="true"`
   (Modular embed) and confirm dashboard questions appear again.

### Demo

_N/A — behavior change covered by unit tests._

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
