### PR TITLE
remove unnecessary uses of skipOn

### DIFF
--- a/e2e/test/scenarios/admin-2/people.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/people.cy.spec.js
@@ -892,7 +892,9 @@ describe("scenarios > admin > people > group managers", () => {
   });
 });
 
-describe("issue 23689", () => {
+// TODO: remove skip when this issue gets fixed. Initial attempt: https://github.com/metabase/metabase/pull/23825,
+// reverted in https://github.com/metabase/metabase/pull/24760 to fix a security vulnerability.
+describe.skip("issue 23689", () => {
   function findUserByFullName(user) {
     const { first_name, last_name } = user;
     return cy.findByText(`${first_name} ${last_name}`);
@@ -904,9 +906,6 @@ describe("issue 23689", () => {
   }
 
   beforeEach(() => {
-    // TODO: remove the next line when this issue gets fixed
-    cy.skipOn(true);
-
     cy.intercept("GET", "/api/permissions/membership").as("membership");
 
     H.restore();

--- a/e2e/test/scenarios/admin-2/people.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/people.cy.spec.js
@@ -894,7 +894,7 @@ describe("scenarios > admin > people > group managers", () => {
 
 // TODO: remove skip when this issue gets fixed. Initial attempt: https://github.com/metabase/metabase/pull/23825,
 // reverted in https://github.com/metabase/metabase/pull/24760 to fix a security vulnerability.
-describe.skip("issue 23689", () => {
+describe("issue 23689", { tags: "@skip" }, () => {
   function findUserByFullName(user) {
     const { first_name, last_name } = user;
     return cy.findByText(`${first_name} ${last_name}`);

--- a/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
@@ -86,12 +86,6 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
 
   ["X-ray", "Compare to the rest"].forEach((action) => {
     it(`"${action.toUpperCase()}" should work on a nested question made from base native question (metabase#15655)`, () => {
-      if (action === "Compare to the rest") {
-        cy.log(
-          "Skipping Compare to the rest test because it takes 8 minutes in ci",
-        );
-        cy.skipOn(action === "Compare to the rest");
-      }
       cy.intercept("GET", "/api/automagic-dashboards/**").as("xray");
 
       H.createNativeQuestion({

--- a/e2e/test/scenarios/sharing/downloads/sharing-download-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/sharing-download-reproductions.cy.spec.js
@@ -127,9 +127,6 @@ describe("issue 18382", () => {
 
   testCases.forEach((fileType) => {
     it(`should handle the old syntax in downloads for ${fileType} (metabase#18382)`, () => {
-      // TODO: Please remove this line when issue gets fixed
-      cy.skipOn(fileType === "csv");
-
       H.downloadAndAssert({ fileType });
     });
   });

--- a/e2e/test/scenarios/visualizations-tabular/scalar.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/scalar.cy.spec.js
@@ -21,8 +21,6 @@ describe("scenarios > visualizations > scalar", () => {
     it(`should render human readable numbers on ${size} screen size (metabase`, () => {
       const [width, height] = viewport;
 
-      cy.skipOn(size === "mobile");
-
       cy.viewport(width, height);
       H.createQuestionAndDashboard({
         questionDetails: {
@@ -41,7 +39,14 @@ describe("scenarios > visualizations > scalar", () => {
         },
       }).then(({ body: { dashboard_id } }) => {
         H.visitDashboard(dashboard_id);
-        cy.findByText("1.5T");
+        // cards on mobile take up the full viewport width so there is enough room to display the uncompacted value
+        // If https://github.com/metabase/metabase/issues/6201 is completed this may change but in this instance showing
+        // the uncompacted value for mobile is the expected behaviour.
+        if (size === "mobile") {
+          cy.findByText("1,510,621,683,050.63");
+        } else {
+          cy.findByText("1.5T");
+        }
       });
     });
   });


### PR DESCRIPTION
Found three uses of `skipOn` that could be removed since the underlying issues were resolved based on the digging I did.
- validated that the x-ray tests don't seem to be that slow in CI anymore - ` dashboard/x-rays.cy.spec.js              01:10`, based on this [PR](https://github.com/metabase/metabase/pull/44286) and the related discussion in Slack it looks like the issue has been resolved - https://github.com/metabase/metabase/issues/43258
- the sharing download reproduction issue has been closed and the test passes - https://github.com/metabase/metabase/issues/18382
- added a comment about scalar test that was being skipped for mobile, I think everything is working as expected but open to more discussion
- moved admin-2 use to the builtin Cypress `skip` but this test is still failing

Currently have 6 more uses of `skipOn` but they all seem to be used to filter which tests run when iterating through an array of options rather than skipping a test that fails because of a bug.

Note that the library adding this functionality is [no longer maintained](https://github.com/cypress-io/cypress-skip-test) so we may want to consider using some other method to skip tests we don't want to run.