### PR TITLE
Return invalid for password-reset tokens belonging to deactivated users

### DIFF
--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -382,7 +382,16 @@
                       [:provider/support-access-grant
                        :provider/emailed-secret-password-reset]
                       {:token token})]
-    {:valid (:success? auth-result)}))
+    ;; A deactivated user must not be shown the password-reset form even with an
+    ;; otherwise-valid token. `authenticate` only validates the token; the
+    ;; active-user check happens later in the login flow (see `create-session!`
+    ;; in metabase.auth-identity.provider), so `reset_password` would reject them
+    ;; with a misleading "Invalid reset token". Report the token as invalid up
+    ;; front when it belongs to a deactivated account -- this reveals no account
+    ;; state, since the response is identical to that for any invalid token.
+    {:valid (boolean (and (:success? auth-result)
+                          (when-let [user-id (:user-id auth-result)]
+                            (t2/select-one-fn :is_active [:model/User :is_active] :id user-id))))}))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -507,7 +507,16 @@
       (let [token (str (mt/user->id :rasta) "_" (random-uuid))]
         (t2/update! :model/User (mt/user->id :rasta) {:reset_token token, :reset_triggered 0})
         (is (= {:valid false}
-               (mt/client :get 200 "session/password_reset_token_valid", :token token)))))))
+               (mt/client :get 200 "session/password_reset_token_valid", :token token)))))
+    (testing "Check that a valid, unexpired token for a deactivated user returns false (#77560)"
+      ;; A deactivated user should never be offered the reset form: reset_password
+      ;; would later fail in the login flow and report a misleading "Invalid reset
+      ;; token", so the token-validity endpoint must report invalid up front.
+      (mt/with-temp [:model/User {user-id :id} {:is_active false}]
+        (let [token (str user-id "_" (random-uuid))]
+          (t2/update! :model/User user-id {:reset_token token, :reset_triggered (dec (System/currentTimeMillis))})
+          (is (= {:valid false}
+                 (mt/client :get 200 "session/password_reset_token_valid", :token token))))))))
 
 (deftest reset-token-ttl-hours-test
   (testing "Test reset-token-ttl-hours-test"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/77560

### Description

`GET /api/session/password_reset_token_valid` validated only the reset token via `auth-identity/authenticate`, which does not check `is_active`. A deactivated user (`is_active = false`) holding an otherwise-valid token was therefore shown the password-reset form, and then hit a misleading `Invalid reset token` on submit — the active-user check happens later in the login flow (`create-session!` in `metabase.auth-identity.provider`).

This requires the token's user to be active before the endpoint reports the token valid. Both providers in the fallback list — `:provider/support-access-grant` (which derives from `:provider/emailed-secret`) and `:provider/emailed-secret-password-reset` — return `:user-id` on success, so the single guard covers both. The response is identical to that for any invalid token, so no account state is revealed beyond the existing token-holder context.

### How to verify

1. Create a password-authenticated user and deactivate it (`is_active = false`).
2. Generate a valid password-reset token for that user.
3. `GET /api/session/password_reset_token_valid?token=<token>` now returns `{"valid": false}` (previously `{"valid": true}`).
4. Because the form is no longer offered, the user no longer reaches the misleading `Invalid reset token` error on submit.

Automated: `check-reset-token-valid-test` in `test/metabase/session/api_test.clj` gains a case asserting `{:valid false}` for a valid, unexpired token belonging to a deactivated user.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

