### PR TITLE
Enforce transform readability in the search engine

### DIFF
--- a/src/metabase/metabot/tools/search.clj
+++ b/src/metabase/metabot/tools/search.clj
@@ -15,7 +15,6 @@
    [metabase.permissions.core :as perms]
    [metabase.search.core :as search]
    [metabase.search.engine :as search.engine]
-   [metabase.transforms.core :as transforms]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -166,22 +165,6 @@
                   r)
                 r))))))
 
-(defn- remove-unreadable-transforms
-  "Remove transforms from search results that the user cannot read.
-  This filters out transforms where the user doesn't have access to the source tables/database."
-  [results]
-  (let [transform-ids (->> results (filter #(= "transform" (:type %))) (map :id) set)
-        readable-ids (when (seq transform-ids)
-                       (->> (t2/select :model/Transform :id [:in transform-ids])
-                            transforms/add-source-readable
-                            (filter :source_readable)
-                            (map :id)
-                            set))]
-    (cond->> results
-      (seq transform-ids) (filterv (fn [result]
-                                     (or (not= "transform" (:type result))
-                                         (contains? readable-ids (:id result))))))))
-
 (defn- search-result-id
   "Generate a unique identifier for a search result based on its id and model."
   [search-result]
@@ -322,8 +305,7 @@
          enrich-with-collection-descriptions
          enrich-with-database-engines
          enrich-with-portable-entity-ids
-         enrich-with-metric-base-tables
-         remove-unreadable-transforms)))
+         enrich-with-metric-base-tables)))
 
 (defn- table-refs->results
   [ids]
@@ -443,8 +425,7 @@
          enrich-with-database-engines
          enrich-with-portable-entity-ids
          enrich-with-metric-base-tables
-         enrich-with-measure-segment-base-tables
-         remove-unreadable-transforms)))
+         enrich-with-measure-segment-base-tables)))
 
 (defn- format-search-output
   "Format search results as an LLM-ready string."

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -106,6 +106,13 @@
     (can-write? search-ctx instance)
     (can-read? search-ctx instance)))
 
+(defmethod check-permissions-for-model :transform
+  [search-ctx instance]
+  ;; Enforce transform readability here — in the ranked set — rather than as a post-filter on the
+  ;; page, so `:total` reflects it and every search surface agrees. `:database_id` is the indexed
+  ;; source database; a nil one (orphaned transform) only passes for superusers.
+  (perms/has-db-transforms-permission? (:current-user-id search-ctx) (:database_id instance)))
+
 (defn- hydrate-user-metadata
   "Hydrate common-name for last_edited_by and created_by for each result."
   [results]

--- a/test/metabase/metabot/tools/search_test.clj
+++ b/test/metabase/metabot/tools/search_test.clj
@@ -3,12 +3,9 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.api.common :as api]
-   [metabase.lib-be.metadata.jvm :as lib-be]
-   [metabase.lib.core :as lib]
    [metabase.metabot.tools.search :as search]
    [metabase.metabot.tools.shared.llm-shape :as llm-shape]
    [metabase.permissions.core :as perms]
-   [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.search.core :as search-core]
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
@@ -559,31 +556,6 @@
             (testing "base_table_portable_fk is `[database_name, schema, table_name]`"
               (is (= [db-name (:schema orders-t) (:name orders-t)]
                      (:base_table_portable_fk metric-res))))))))))
-
-(deftest remove-unreadable-transforms-test
-  (testing "remove-unreadable-transforms correctly filters transforms based on source database access"
-    (mt/with-premium-features #{:transforms-basic}
-      (mt/with-temp [:model/Database {db-id :id} {}]
-        (let [mp (lib-be/application-database-metadata-provider db-id)]
-          (mt/with-temp [:model/Transform {transform-id :id}
-                         {:name   "Test Transform"
-                          :source {:type  "query"
-                                   :query (lib/native-query mp "SELECT 1")}}]
-            (let [mock-results [{:id transform-id :type "transform" :name "Test Transform"}
-                                {:id 999 :type "dashboard" :name "Some Dashboard"}]]
-              (testing "keeps transforms when user can query the source database"
-                (mt/with-test-user :crowberto
-                  (let [results (#'search/remove-unreadable-transforms mock-results)]
-                    (is (= 2 (count results))))))
-              (testing "filters out transforms when user cannot query the source database"
-                (mt/with-user-in-groups [group {:name "No Query Access"}
-                                         user [group]]
-                  (mt/with-db-perm-for-group! (perms-group/all-users) db-id :perms/create-queries :no
-                    (mt/with-db-perm-for-group! group db-id :perms/create-queries :no
-                      (binding [api/*current-user-id* (:id user)]
-                        (let [results (#'search/remove-unreadable-transforms mock-results)]
-                          (is (= 1 (count results)))
-                          (is (= "dashboard" (:type (first results)))))))))))))))))
 
 (deftest weight-override-test
   (testing "weights can be overridden on a per-tool-call basis"

--- a/test/metabase/search/impl_test.clj
+++ b/test/metabase/search/impl_test.clj
@@ -372,3 +372,17 @@
               (doseq [[model id] result]
                 (is (= "card" model))
                 (is (= 0 (mod id 2)))))))))))
+
+(deftest check-permissions-for-model-transform-test
+  (testing "transform readability is enforced in the engine — on the ranked set, so :total reflects
+            it and every search surface agrees — via the source database's transforms permission"
+    (mt/with-temp [:model/Database {db-id :id} {}
+                   :model/User {user-id :id} {}]
+      (let [check     #'search.impl/check-permissions-for-model
+            transform {:model "transform" :id 1 :database_id db-id}
+            orphaned  {:model "transform" :id 2 :database_id nil}]
+        (testing "a superuser sees every transform, including one whose source database was deleted"
+          (is (check {:current-user-id (mt/user->id :crowberto)} transform))
+          (is (check {:current-user-id (mt/user->id :crowberto)} orphaned)))
+        (testing "a user without the transforms permission on the source database is filtered out"
+          (is (not (check {:current-user-id user-id} transform))))))))


### PR DESCRIPTION
## What

Move transform readability enforcement out of the metabot layer and into the search engine's per-model permission check, so `:total` reflects it and every search surface agrees.

- `search/impl.clj`: add `check-permissions-for-model :transform`, gating on the source database's transforms permission via the indexed `:database_id`.
- `metabot/tools/search.clj`: remove the now-redundant `remove-unreadable-transforms` post-filter (and its now-unused `transforms.core` require).

## Why

`remove-unreadable-transforms` ran in the metabot layer on the **already-paginated page**, *after* the engine had computed `:total` over the full ranked set. Two consequences:

1. **`:total` overcounts.** A search matching transforms the caller can't read reported a total larger than the rows returned — the MCP/metabot search tool then steered an agent toward pages that don't exist.
2. **Inconsistent enforcement.** Only the metabot path filtered unreadable transforms; the core search API (`/api/search`) never did.

Every other model is permission-checked inside the ranked set via `check-permissions-for-model`. Transforms should be too. Doing so filters them *before* `:total` is counted, so the count is correct by construction and all callers behave the same.

## Behavior change

Transforms are `:visibility :superuser`, so the only population that sees them in search is superusers — who pass the new check unconditionally. The user-visible effects:

- **`:total` is now correct** for searches that include transforms.
- **Superusers now see transforms whose source database was deleted.** The old post-filter used per-source-table query-readability (`source-tables-readable?`), which returns false for an orphaned source even for a superuser, so it hid those. That contradicted `can-read? :model/Transform`, which grants superusers read on every transform. This PR aligns the two.

## Decisions flagged for your review

- **Predicate choice.** I used `has-db-transforms-permission?` (source-db transforms permission — in-memory, no per-row refetch, matches the `:indexed-entity` pattern). The old post-filter used per-source-table query-readability. For the superuser-only search population the two are equivalent; the choice only matters for a hypothetical future non-superuser transform search. Happy to switch if you'd prefer read-query semantics.
- **The check is defense-in-depth for today's population** (superusers pass unconditionally). Its real value is making `:total` correct and enforcing transform permission at the engine consistently, rather than relying on a metabot-only post-filter.

## Testing

- New unit test `check-permissions-for-model-transform-test` (search impl): a superuser passes every transform (including an orphaned one); a user without the transforms permission is filtered.
- `metabot.tools.search-test`: 30 tests / 71 assertions pass (the removed post-filter's test is gone; nothing else changed).
- `./bin/mage kondo` clean; `fix-modules-config` unchanged (search already `:uses permissions`).
- Note: `search.impl-test/old-values-removed-from-index` errors on this branch **and on clean master** (an appdb search-index setup issue in the test env) — pre-existing, unrelated to this change.

## Context

This unblocks accurate `:total` reporting for the MCP v2 search tool (GHY-4137). That branch currently omits `:total` for superuser transform searches as a stopgap; once this lands, that stopgap can be removed.
