### PR TITLE
Don't Auto Log users out

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/users.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/users.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.advanced-config.file.users
   (:require
+   [clojure.data :as data]
    [clojure.spec.alpha :as s]
    [metabase-enterprise.advanced-config.file.interface
     :as advanced-config.file.i]
@@ -41,8 +42,9 @@
     (do
       (log/info (u/format-color :blue "Updating User with email %s" (pr-str (:email user))))
       (let [new-user (update user :login_attributes
-                             #(merge % (:login_attributes existing-user)))]
-        (t2/update! :model/User (:id existing-user) new-user)))
+                             #(merge % (:login_attributes existing-user)))
+            [_ user-to-save _] (data/diff existing-user new-user)]
+        (t2/update! :model/User (:id existing-user) user-to-save)))
     ;; create a new user. If they are the first non-internal User, force them to be an admin.
     (let [user (cond-> user
                  (not (setup/has-user-setup)) (assoc :is_superuser true))]


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/73591

### Description

Right now if you have a user defined by a config file they will be logged out on instance startup. We can avoid this by not updating the parts of their record that underly their auth.

### How to verify

* Define a user in a config file.
* Log in
* Restart server. Before changes you would be logged out, after you will stay logged in

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
