### PR TITLE
Pin exploration auto-binning to an explicit bin width (UXW-4391)

### DIFF
--- a/src/metabase/explorations/query_plan/mbql.clj
+++ b/src/metabase/explorations/query_plan/mbql.clj
@@ -73,15 +73,36 @@
   [query ref-clause]
   (boolean (seq (lib/available-binning-strategies query -1 ref-clause))))
 
+(defn- pinned-default-binning
+  "Explicit `:bin-width` binning equivalent to what the QP's `:default` strategy
+  would resolve for `ref-clause` against `query` as given — i.e. before any
+  per-segment filter is added. Exploration charts fan one query out into
+  several segment-filtered variants that share an x-axis; left as
+  `{:strategy :default}`, the QP re-derives the bin width per variant from that
+  variant's own filters, so a segment that range-filters the binned column gets
+  a different bin size than its siblings. Pinning the width keeps every variant
+  on the same bin grid, while the card's own filters (shared by all variants)
+  still narrow the domain. Falls back to `{:strategy :default}` when no width
+  can be resolved."
+  [query ref-clause]
+  (let [col (lib/find-matching-column query -1 ref-clause
+                                      (lib/breakoutable-columns query))]
+    (if-let [width (when col (lib/default-bin-width query -1 col))]
+      {:strategy :bin-width, :bin-width width}
+      {:strategy :default})))
+
 (defn apply-default-bucket
   "Return `ref-clause` with this dim's default temporal bucket or binning applied. Unchanged
-  when the dim has no default, or when the column can't be binned. See [[binnable-ref?]]"
+  when the dim has no default, or when the column can't be binned. See [[binnable-ref?]].
+  Numeric binning is pinned to an explicit bin width (see [[pinned-default-binning]])
+  so all segment variants of a chart share the same bins."
   [query ref-clause dim]
   (let [[kind v] (default-bucket-for-dim dim)]
     (case kind
       :temporal (lib/with-temporal-bucket ref-clause v)
       :binning  (cond-> ref-clause
-                  (binnable-ref? query ref-clause) (lib/with-binning v))
+                  (binnable-ref? query ref-clause)
+                  (lib/with-binning (pinned-default-binning query ref-clause)))
       nil       ref-clause)))
 
 (defn normalize-target-ref

--- a/src/metabase/lib/binning.cljc
+++ b/src/metabase/lib/binning.cljc
@@ -169,6 +169,29 @@
    column-binning :- [:maybe ::lib.schema.binning/binning]]
   (binning= (:mbql binning-option) column-binning))
 
+(mu/defn default-bin-width :- [:maybe ::lib.schema.binning/bin-width]
+  "Resolve the bin width the query processor's binning middleware will use for a `{:strategy :default}` binned
+  breakout on `column`, taking into account the query stage's own comparison/`:between` filters on the column (which
+  narrow the binned domain) and falling back to the column fingerprint's global min/max. Returns nil when no bounds
+  can be determined (e.g. a missing or incomplete fingerprint).
+
+  The middleware recomputes default bin widths per query from that query's filters, so two queries that differ only
+  by a filter on the binned column get different bin widths. Use this to pin a stable width across such a family of
+  queries by binning them all with `{:strategy :bin-width, :bin-width (default-bin-width ...)}`."
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   column       :- ::lib.schema.metadata/column]
+  (let [field-id-or-name->filters (lib.binning.util/filters->field-map
+                                   (:filters (lib.util/query-stage query stage-number)))]
+    (when-let [{:keys [min-value max-value], :as bounds}
+               (lib.binning.util/extract-bounds (or (:id column) (:name column))
+                                                (:fingerprint column)
+                                                field-id-or-name->filters)]
+      (let [[strategy options] (lib.binning.util/resolve-options query :default nil column min-value max-value)
+            options            (merge bounds options)]
+        (:bin-width (or (lib.binning.util/nicer-breakout strategy options)
+                        options))))))
+
 (mu/defn resolve-bin-width :- [:maybe [:map
                                        [:bin-width ::lib.schema.binning/bin-width]
                                        [:min-value number?]

--- a/src/metabase/lib/binning.cljc
+++ b/src/metabase/lib/binning.cljc
@@ -7,6 +7,7 @@
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.hierarchy :as lib.hierarchy]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.ref :as lib.ref]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.binning :as lib.schema.binning]
    [metabase.lib.schema.common :as lib.schema.common]
@@ -182,9 +183,12 @@
    stage-number :- :int
    column       :- ::lib.schema.metadata/column]
   (let [field-id-or-name->filters (lib.binning.util/filters->field-map
-                                   (:filters (lib.util/query-stage query stage-number)))]
+                                   (:filters (lib.util/query-stage query stage-number)))
+        ;; key the filter lookup by the ref's own id-or-name, like the middleware does — filters on a
+        ;; card/model-sourced column reference it by *name* even though its metadata still carries an `:id`
+        [_tag _opts id-or-name]   (lib.ref/ref column)]
     (when-let [{:keys [min-value max-value], :as bounds}
-               (lib.binning.util/extract-bounds (or (:id column) (:name column))
+               (lib.binning.util/extract-bounds id-or-name
                                                 (:fingerprint column)
                                                 field-id-or-name->filters)]
       (let [[strategy options] (lib.binning.util/resolve-options query :default nil column min-value max-value)

--- a/src/metabase/lib/binning/util.cljc
+++ b/src/metabase/lib/binning/util.cljc
@@ -1,14 +1,56 @@
 (ns metabase.lib.binning.util
-  (:refer-clojure :exclude [some])
+  (:refer-clojure :exclude [get-in some])
   (:require
    [clojure.math :as math]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.binning :as lib.schema.binning]
+   [metabase.lib.schema.expression :as lib.schema.expression]
+   [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.lib.schema.metadata.fingerprint :as lib.schema.metadata.fingerprint]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [some]]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.match :as match]
+   [metabase.util.performance :refer [get-in some]]))
+
+(mr/def ::field-id-or-name->filters
+  [:map-of [:or ::lib.schema.id/field :string] [:sequential ::lib.schema.expression/boolean]])
+
+(mu/defn filters->field-map :- ::field-id-or-name->filters
+  "Find any comparison or `:between` filter and return a map of referenced Field ID or Name -> all the clauses that
+  reference it."
+  [filters :- [:maybe [:sequential ::lib.schema.expression/boolean]]]
+  (reduce
+   (partial merge-with concat)
+   {}
+   (for [subclause        (match/match-many filters [#{:between :< :<= :> :>=} & _] &match)
+         field-id-or-name (match/match-many subclause [:field _opts field-id-or-name] field-id-or-name)]
+     {field-id-or-name [subclause]})))
+
+(mu/defn extract-bounds :- [:maybe [:map [:min-value number?] [:max-value number?]]]
+  "Given query criteria, find a min/max value for the binning strategy using the greatest user specified min value and
+  the smallest user specified max value. When a user specified min or max is not found, use the global min/max for the
+  given field. Returns nil when no bound can be determined at all (e.g. a missing or incomplete fingerprint)."
+  [field-id-or-name          :- [:maybe [:or ::lib.schema.id/field :string]]
+   fingerprint               :- [:maybe ::lib.schema.metadata.fingerprint/fingerprint]
+   field-id-or-name->filters :- ::field-id-or-name->filters]
+  (let [{global-min :min, global-max :max} (get-in fingerprint [:type :type/Number])
+        filter-clauses                     (get field-id-or-name->filters field-id-or-name)
+        ;; [:between <field> <min> <max>] or [:< <field> <x>]
+        user-maxes                         (match/match-many filter-clauses
+                                             [#{:< :<= :between} _opts & args] (last args))
+        user-mins                          (match/match-many filter-clauses
+                                             [#{:> :>= :between} _opts _field min-val & _] min-val)
+        min-value                          (or (when (seq user-mins)
+                                                 (apply max user-mins))
+                                               global-min)
+        max-value                          (or (when (seq user-maxes)
+                                                 (apply min user-maxes))
+                                               global-max)]
+    (when (and min-value max-value)
+      {:min-value min-value, :max-value max-value})))
 
 (mu/defn- calculate-bin-width :- ::lib.schema.binning/bin-width
   "Calculate bin width required to cover interval [`min-value`, `max-value`] with `num-bins`."

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -1415,6 +1415,7 @@
  [lib.binning
   available-binning-strategies
   binning
+  default-bin-width
   with-binning]
  [metabase.lib.card
   ->card-metadata-columns

--- a/src/metabase/query_processor/middleware/binning.clj
+++ b/src/metabase/query_processor/middleware/binning.clj
@@ -6,7 +6,6 @@
    [metabase.lib.binning.util :as lib.binning.util]
    [metabase.lib.core :as lib]
    [metabase.lib.schema :as lib.schema]
-   [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata.fingerprint :as lib.schema.metadata.fingerprint]
    [metabase.lib.walk :as lib.walk]
@@ -14,23 +13,8 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]
    [metabase.util.match :as match]
    [metabase.util.performance :refer [get-in]]))
-
-(mr/def ::field-id-or-name->filters
-  [:map-of [:or ::lib.schema.id/field :string] ::lib.schema/filters])
-
-(mu/defn- filters->field-map :- ::field-id-or-name->filters
-  "Find any comparison or `:between` filter and return a map of referenced Field ID or Name -> all the clauses the reference
-  it."
-  [filters :- [:maybe [:sequential ::lib.schema.expression/boolean]]]
-  (reduce
-   (partial merge-with concat)
-   {}
-   (for [subclause        (match/match-many filters [#{:between :< :<= :> :>=} & _] &match)
-         field-id-or-name (match/match-many subclause [:field _opts field-id-or-name] field-id-or-name)]
-     {field-id-or-name [subclause]})))
 
 (mu/defn- extract-bounds :- [:map [:min-value number?] [:max-value number?]]
   "Given query criteria, find a min/max value for the binning strategy using the greatest user specified min value and
@@ -38,26 +22,12 @@
   given field."
   [field-id-or-name          :- [:maybe [:or ::lib.schema.id/field :string]]
    fingerprint               :- [:maybe ::lib.schema.metadata.fingerprint/fingerprint]
-   field-id-or-name->filters :- ::field-id-or-name->filters]
-  (let [{global-min :min, global-max :max} (get-in fingerprint [:type :type/Number])
-        filter-clauses                     (get field-id-or-name->filters field-id-or-name)
-        ;; [:between <field> <min> <max>] or [:< <field> <x>]
-        user-maxes                         (match/match-many filter-clauses
-                                             [#{:< :<= :between} _opts & args] (last args))
-        user-mins                          (match/match-many filter-clauses
-                                             [#{:> :>= :between} _opts _field min-val & _] min-val)
-        min-value                          (or (when (seq user-mins)
-                                                 (apply max user-mins))
-                                               global-min)
-        max-value                          (or (when (seq user-maxes)
-                                                 (apply min user-maxes))
-                                               global-max)]
-    (when-not (and min-value max-value)
+   field-id-or-name->filters :- ::lib.binning.util/field-id-or-name->filters]
+  (or (lib.binning.util/extract-bounds field-id-or-name fingerprint field-id-or-name->filters)
       (throw (ex-info (tru "Unable to bin Field without a min/max value (missing or incomplete fingerprint)")
                       {:type             qp.error-type/invalid-query
                        :field-id-or-name field-id-or-name
-                       :fingerprint      fingerprint})))
-    {:min-value min-value, :max-value max-value}))
+                       :fingerprint      fingerprint}))))
 
 (mu/defn- update-binned-field :- :mbql.clause/field
   "Given a `binning-strategy` clause, resolve the binning strategy (either provided or found if default is specified)
@@ -65,7 +35,7 @@
   could narrow the domain for the field. This info is saved as part of each `binning-strategy` clause."
   [query                                                        :- ::lib.schema/query
    path                                                         :- ::lib.walk/path
-   field-id-or-name->filters                                    :- ::field-id-or-name->filters
+   field-id-or-name->filters                                    :- ::lib.binning.util/field-id-or-name->filters
    [_tag {:keys [binning], :as _opts} id-or-name :as field-ref] :- :mbql.clause/field]
   (let [metadata                                   (lib.walk/apply-f-for-stage-at-path lib/metadata query path field-ref)
         {:keys [min-value max-value], :as min-max} (extract-bounds id-or-name
@@ -94,7 +64,7 @@
   (let [path->field-id-or-name->filters (memoize
                                          (fn [path]
                                            (let [stage (get-in query path)]
-                                             (filters->field-map (:filters stage)))))]
+                                             (lib.binning.util/filters->field-map (:filters stage)))))]
     (lib.walk/walk-clauses
      query
      (fn [query path-type path clause]

--- a/test/metabase/explorations/api_test.clj
+++ b/test/metabase/explorations/api_test.clj
@@ -344,8 +344,8 @@
               brk (first (lib/breakouts qry))]
           (is (= 1 (count (lib/breakouts qry)))
               "snapshot MBQL adds a breakout from the dimension's target")
-          (is (= :default (:strategy (lib/binning brk)))
-              "numeric dim with a usable fingerprint picks up default auto-binning"))))))
+          (is (= :bin-width (:strategy (lib/binning brk)))
+              "numeric dim with a usable fingerprint picks up auto-binning pinned to an explicit width"))))))
 
 (deftest exploration-get-hydrates-thread-timelines-test
   (testing "GET /api/exploration/:id hydrates thread :timelines so the detail page can offer them"
@@ -520,11 +520,11 @@
           (is (= :day (lib/raw-temporal-bucket (get by-dim (duid "d"))))))
         (testing "Time dim → :hour bucket"
           (is (= :hour (lib/raw-temporal-bucket (get by-dim (duid "t"))))))
-        (testing "Number dim with a fingerprinted field → default auto-binning"
-          (is (= :default (:strategy (lib/binning (get by-dim (duid "n"))))))
+        (testing "Number dim with a fingerprinted field → auto-binning pinned to an explicit width"
+          (is (= :bin-width (:strategy (lib/binning (get by-dim (duid "n"))))))
           (is (nil? (lib/raw-temporal-bucket (get by-dim (duid "n"))))))
-        (testing "Coordinate (semantic Latitude over Float) with a fingerprinted field → default auto-binning"
-          (is (= :default (:strategy (lib/binning (get by-dim (duid "lat")))))))
+        (testing "Coordinate (semantic Latitude over Float) with a fingerprinted field → auto-binning pinned to an explicit width"
+          (is (= :bin-width (:strategy (lib/binning (get by-dim (duid "lat")))))))
         (testing "Non-numeric / non-temporal dim → no bucket"
           (is (nil? (lib/binning (get by-dim (duid "s")))))
           (is (nil? (lib/raw-temporal-bucket (get by-dim (duid "s"))))))))))

--- a/test/metabase/explorations/query_plan/variants_test.clj
+++ b/test/metabase/explorations/query_plan/variants_test.clj
@@ -349,13 +349,24 @@
   (select-keys (lib/binning (first (lib/breakouts q)))
                [:strategy :bin-width :num-bins]))
 
+(defn- products-segment-definition
+  "Inner legacy-MBQL segment `:definition` filtering PRODUCTS, built through lib.
+  `build-filter` takes a metadata provider and returns the filter clause."
+  [build-filter]
+  (let [mp (mt/metadata-provider)]
+    (-> (lib/query mp (lib.metadata/table mp (mt/id :products)))
+        (lib/filter (build-filter mp))
+        lib/->legacy-MBQL
+        :query)))
+
 (deftest default-segment-uniform-binning-test
   (testing "a segment that range-filters the binned dim gets the same pinned bin width as its
             unsegmented sibling — segments must not re-derive bins over their narrowed domain"
     (mt/with-temp [:model/Segment {seg-id :id} {:name       "Highly rated products"
                                                 :table_id   (mt/id :products)
-                                                :definition (:query (mt/mbql-query products
-                                                                      {:filter [:>= $rating 4]}))}]
+                                                :definition (products-segment-definition
+                                                             (fn [mp]
+                                                               (lib/>= (lib.metadata/field mp (mt/id :products :rating)) 4)))}]
       (let [mp      (mt/metadata-provider)
             card    (products-count-card 9000201)
             segment (resolve-segment mp card seg-id)
@@ -395,8 +406,9 @@
             the per-segment filter is excluded from the bin computation"
     (mt/with-temp [:model/Segment {seg-id :id} {:name       "Cheap products"
                                                 :table_id   (mt/id :products)
-                                                :definition (:query (mt/mbql-query products
-                                                                      {:filter [:< $price 30]}))}]
+                                                :definition (products-segment-definition
+                                                             (fn [mp]
+                                                               (lib/< (lib.metadata/field mp (mt/id :products :price)) 30)))}]
       (let [mp       (mt/metadata-provider)
             base-ctx {:mp mp :target (rating-target) :dim rating-dim :segment nil :params {}}
             q-full   (variants/dataset-query "default" (assoc base-ctx :card (products-count-card 9000202)))

--- a/test/metabase/explorations/query_plan/variants_test.clj
+++ b/test/metabase/explorations/query_plan/variants_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.explorations.query-plan.variants-test
   (:require
+   [clojure.set :as set]
    [clojure.test :refer :all]
    [metabase.explorations.query-plan.variants :as variants]
    [metabase.lib.core :as lib]
@@ -320,6 +321,95 @@
         (discover (mt/user->id :rasta))
         (is (= 2 @calls)
             "a repeat for the same user still hits the cache")))))
+
+;; ---------------------------------------------------------------------------
+;; Uniform binning across segment variants
+;; ---------------------------------------------------------------------------
+
+(def ^:private rating-dim
+  {:dimension-id   "d-rating"
+   :display-name   "Rating"
+   :effective-type :type/Float
+   :semantic-type  :type/Score})
+
+(defn- rating-target []
+  [:field (mt/id :products :rating) nil])
+
+(defn- resolve-segment
+  "Full segment metadata for `segment-id`, resolved the way the runner's
+  `build-row-context` does — via `lib/available-segments` on the card query."
+  [mp card segment-id]
+  (let [q (lib/query mp (:dataset_query card))]
+    (some #(when (= segment-id (:id %)) %) (lib/available-segments q))))
+
+(defn- breakout-binning
+  "The breakout's binning options, trimmed to the strategy keys — the full map
+  carries an opaque `:metadata-fn` closure that breaks value equality."
+  [q]
+  (select-keys (lib/binning (first (lib/breakouts q)))
+               [:strategy :bin-width :num-bins]))
+
+(deftest default-segment-uniform-binning-test
+  (testing "a segment that range-filters the binned dim gets the same pinned bin width as its
+            unsegmented sibling — segments must not re-derive bins over their narrowed domain"
+    (mt/with-temp [:model/Segment {seg-id :id} {:name       "Highly rated products"
+                                                :table_id   (mt/id :products)
+                                                :definition (:query (mt/mbql-query products
+                                                                      {:filter [:>= $rating 4]}))}]
+      (let [mp      (mt/metadata-provider)
+            card    (products-count-card 9000201)
+            segment (resolve-segment mp card seg-id)
+            ctx     {:mp mp :card card :target (rating-target) :dim rating-dim :segment nil :params {}}
+            q-all   (variants/dataset-query "default" ctx)
+            q-seg   (variants/dataset-query "default" (assoc ctx :segment segment))]
+        (is (some? segment))
+        (is (=? {:strategy :bin-width, :bin-width number?}
+                (breakout-binning q-all))
+            "default numeric binning is pinned to an explicit width")
+        (is (= (breakout-binning q-all) (breakout-binning q-seg)))
+        (testing "the QP resolves the same width for both charts, and the segmented chart's bins
+                  sit on the unsegmented chart's grid"
+          (let [res-all (qp/process-query q-all)
+                res-seg (qp/process-query q-seg)
+                info    (fn [res] (-> res :data :cols first :binning_info
+                                      (select-keys [:binning_strategy :bin_width])))
+                starts  (fn [res] (into #{} (map first) (-> res :data :rows)))]
+            (is (=? {:binning_strategy :bin-width, :bin_width number?}
+                    (info res-all)))
+            (is (= (info res-all) (info res-seg)))
+            (is (set/subset? (starts res-seg) (starts res-all)))))))))
+
+(defn- highly-rated-count-card
+  "Count metric on PRODUCTS scoped to `rating >= 4` in the card query itself — a
+  base filter shared by every variant, so it should keep narrowing the bins."
+  [card-id]
+  (let [mp (mt/metadata-provider)]
+    {:id            card-id
+     :dataset_query (lib/->legacy-MBQL
+                     (-> (lib/query mp (lib.metadata/table mp (mt/id :products)))
+                         (lib/aggregate (lib/count))
+                         (lib/filter (lib/>= (lib.metadata/field mp (mt/id :products :rating)) 4))))}))
+
+(deftest default-card-filter-still-narrows-binning-test
+  (testing "a range filter in the metric card's own query still narrows the pinned width — only
+            the per-segment filter is excluded from the bin computation"
+    (mt/with-temp [:model/Segment {seg-id :id} {:name       "Cheap products"
+                                                :table_id   (mt/id :products)
+                                                :definition (:query (mt/mbql-query products
+                                                                      {:filter [:< $price 30]}))}]
+      (let [mp       (mt/metadata-provider)
+            base-ctx {:mp mp :target (rating-target) :dim rating-dim :segment nil :params {}}
+            q-full   (variants/dataset-query "default" (assoc base-ctx :card (products-count-card 9000202)))
+            card     (highly-rated-count-card 9000203)
+            segment  (resolve-segment mp card seg-id)
+            q-all    (variants/dataset-query "default" (assoc base-ctx :card card))
+            q-seg    (variants/dataset-query "default" (assoc base-ctx :card card :segment segment))]
+        (is (some? segment))
+        (is (= (breakout-binning q-all) (breakout-binning q-seg))
+            "a segment on another column doesn't change the width")
+        (is (< (:bin-width (breakout-binning q-all))
+               (:bin-width (breakout-binning q-full)))
+            "the card's own filter still narrows the domain, giving finer bins than the unfiltered metric")))))
 
 (deftest cached-discovery-key-is-stable-across-query-rebuilds-test
   (testing "the cache key is stable across per-row query rebuilds, so the discovery query runs once —"

--- a/test/metabase/lib/binning/util_test.cljc
+++ b/test/metabase/lib/binning/util_test.cljc
@@ -1,8 +1,77 @@
 (ns metabase.lib.binning.util-test
   (:require
-   [clojure.test :refer [are deftest is]]
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
+   [clojure.test :refer [are deftest is testing]]
    [metabase.lib.binning.util :as lib.binning.util]
+   [metabase.lib.normalize :as lib.normalize]
+   [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.test-metadata :as meta]))
+
+#?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(deftest ^:parallel filter->field-map-test
+  (is (= {}
+         (lib.binning.util/filters->field-map
+          (lib.normalize/normalize
+           ::lib.schema/filters
+           [[:and
+             [:= {} [:field {} 1] 10]
+             [:= {} [:field {} 2] 10]]]))))
+  (is (=? {1 [[:< {} [:field {} 1] 10] [:> {} [:field {} 1] 1]]
+           2 [[:> {} [:field {} 2] 20] [:< {} [:field {} 2] 10]]
+           3 [[:between {} [:field {} 3] 5 10]]}
+          (lib.binning.util/filters->field-map
+           (lib.normalize/normalize
+            ::lib.schema/filters
+            [[:and
+              [:< {} [:field {} 1] 10]
+              [:> {} [:field {} 1] 1]
+              [:> {} [:field {} 2] 20]
+              [:< {} [:field {} 2] 10]
+              [:between {} [:field {} 3] 5 10]]])))))
+
+(def ^:private test-min-max-fingerprint
+  {:type {:type/Number {:min 100 :max 1000}}})
+
+(deftest ^:parallel extract-bounds-test
+  (are [field-id->filters expected] (= expected
+                                       (lib.binning.util/extract-bounds
+                                        1 test-min-max-fingerprint
+                                        (lib.normalize/normalize
+                                         [:map-of ::lib.schema.id/field ::lib.schema/filters]
+                                         field-id->filters)))
+    {1 [[:> {} [:field {} 1] 1]
+        [:< {} [:field {} 1] 10]]}
+    {:min-value 1, :max-value 10}
+
+    {1 [[:between {} [:field {} 1] 1 10]]}
+    {:min-value 1, :max-value 10}
+
+    {}
+    {:min-value 100, :max-value 1000}
+
+    {1 [[:> {} [:field {} 1] 500]]}
+    {:min-value 500, :max-value 1000}
+
+    {1 [[:< {} [:field {} 1] 500]]}
+    {:min-value 100, :max-value 500}
+
+    {1 [[:> {} [:field {} 1] 200] [:< {} [:field {} 1] 800] [:between {} [:field {} 1] 600 700]]}
+    {:min-value 600, :max-value 700}))
+
+(deftest ^:parallel extract-bounds-missing-fingerprint-test
+  (is (nil? (lib.binning.util/extract-bounds 1 nil {})))
+  (is (nil? (lib.binning.util/extract-bounds 1 {:type {:type/Number {:min nil :max nil}}} {}))))
+
+(deftest ^:parallel extract-bounds-field-name-test
+  (testing "Should be able to adjust min max based on filters against named field refs. (#26202)"
+    (is (= {:min-value 1, :max-value 10}
+           (lib.binning.util/extract-bounds
+            "foo" test-min-max-fingerprint
+            {"foo" (lib.normalize/normalize
+                    ::lib.schema/filters
+                    [[:> {} [:field {} 1] 1] [:< {} [:field {} 1] 10]])})))))
 
 (deftest ^:parallel calculate-bin-width-single-value-test
   (are [minv maxv bins] (= 1 (#'lib.binning.util/calculate-bin-width minv maxv bins))

--- a/test/metabase/lib/binning_test.cljc
+++ b/test/metabase/lib/binning_test.cljc
@@ -35,6 +35,30 @@
     (is (= {:bin-width 12.5, :min-value 15, :max-value 27.5}
            (lib.binning/resolve-bin-width query col-quantity 15)))))
 
+(deftest ^:parallel default-bin-width-test
+  (let [query    (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                     (lib/aggregate (lib/count)))
+        quantity (meta/field-metadata :orders :quantity)]
+    (testing "no filters → width resolved from the fingerprint's global range (0–100 over 8 bins)"
+      (is (= 12.5
+             (lib.binning/default-bin-width query -1 quantity))))
+    (testing "the query's own range filters on the column narrow the binned domain (80–100 over 8 bins)"
+      (is (= 2.5
+             (-> query
+                 (lib/filter (lib/>= quantity 80))
+                 (lib.binning/default-bin-width -1 quantity)))))
+    (testing "filters on other columns leave the width untouched"
+      (is (= 12.5
+             (-> query
+                 (lib/filter (lib/>= (meta/field-metadata :orders :total) 50))
+                 (lib.binning/default-bin-width -1 quantity)))))
+    (testing "missing fingerprint → nil"
+      (is (nil? (lib.binning/default-bin-width query -1 (dissoc quantity :fingerprint)))))
+    (testing "coordinate columns resolve to the fixed bin-width setting"
+      (let [people-query (lib/query meta/metadata-provider (meta/table-metadata :people))]
+        (is (= 10.0
+               (lib.binning/default-bin-width people-query -1 (meta/field-metadata :people :latitude))))))))
+
 (deftest ^:parallel binning-and-bucketing-only-show-up-for-returned-and-breakout-columns
   (testing "Within the stage, binning and bucketing at breakout should be invisible, outside the stage it should be visible"
     (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))

--- a/test/metabase/lib/binning_test.cljc
+++ b/test/metabase/lib/binning_test.cljc
@@ -59,6 +59,24 @@
         (is (= 10.0
                (lib.binning/default-bin-width people-query -1 (meta/field-metadata :people :latitude))))))))
 
+(deftest ^:parallel default-bin-width-card-source-column-test
+  (testing "filters on a card/model-sourced column still narrow the width — their refs carry the column
+            *name* even though the metadata has an `:id`, so the lookup must key on the ref (#78060)"
+    (let [mp       (lib.tu/metadata-provider-with-card-from-query
+                    1 (lib/query meta/metadata-provider (meta/table-metadata :orders)))
+          query    (-> (lib/query mp (lib.metadata/card mp 1))
+                       (lib/aggregate (lib/count)))
+          quantity (m/find-first #(= (:name %) "QUANTITY") (lib/filterable-columns query))]
+      (is (some? quantity))
+      (testing "unfiltered → width from the fingerprint's global range"
+        (is (= 12.5
+               (lib.binning/default-bin-width query -1 quantity))))
+      (testing "a range filter on the card-sourced column narrows the domain"
+        (is (= 2.5
+               (-> query
+                   (lib/filter (lib/>= quantity 80))
+                   (lib.binning/default-bin-width -1 quantity))))))))
+
 (deftest ^:parallel binning-and-bucketing-only-show-up-for-returned-and-breakout-columns
   (testing "Within the stage, binning and bucketing at breakout should be invisible, outside the stage it should be visible"
     (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))

--- a/test/metabase/query_processor/middleware/binning_test.clj
+++ b/test/metabase/query_processor/middleware/binning_test.clj
@@ -9,9 +9,6 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.result-metadata :as lib.metadata.result-metadata]
-   [metabase.lib.normalize :as lib.normalize]
-   [metabase.lib.schema :as lib.schema]
-   [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
@@ -21,64 +18,7 @@
    [metabase.query-processor.test :as qp]
    [metabase.test :as mt]))
 
-(deftest ^:parallel filter->field-map-test
-  (is (= {}
-         (#'binning/filters->field-map
-          (lib.normalize/normalize
-           ::lib.schema/filters
-           [[:and
-             [:= {} [:field {} 1] 10]
-             [:= {} [:field {} 2] 10]]]))))
-  (is (=? {1 [[:< {} [:field {} 1] 10] [:> {} [:field {} 1] 1]]
-           2 [[:> {} [:field {} 2] 20] [:< {} [:field {} 2] 10]]
-           3 [[:between {} [:field {} 3] 5 10]]}
-          (#'binning/filters->field-map
-           (lib.normalize/normalize
-            ::lib.schema/filters
-            [[:and
-              [:< {} [:field {} 1] 10]
-              [:> {} [:field {} 1] 1]
-              [:> {} [:field {} 2] 20]
-              [:< {} [:field {} 2] 10]
-              [:between {} [:field {} 3] 5 10]]])))))
-
-(def ^:private test-min-max-fingerprint
-  {:type {:type/Number {:min 100 :max 1000}}})
-
-(deftest ^:parallel extract-bounds-test
-  (are [field-id->filters expected] (= expected
-                                       (#'binning/extract-bounds
-                                        1 test-min-max-fingerprint
-                                        (lib.normalize/normalize
-                                         [:map-of ::lib.schema.id/field ::lib.schema/filters]
-                                         field-id->filters)))
-    {1 [[:> {} [:field {} 1] 1]
-        [:< {} [:field {} 1] 10]]}
-    {:min-value 1, :max-value 10}
-
-    {1 [[:between {} [:field {} 1] 1 10]]}
-    {:min-value 1, :max-value 10}
-
-    {}
-    {:min-value 100, :max-value 1000}
-
-    {1 [[:> {} [:field {} 1] 500]]}
-    {:min-value 500, :max-value 1000}
-
-    {1 [[:< {} [:field {} 1] 500]]}
-    {:min-value 100, :max-value 500}
-
-    {1 [[:> {} [:field {} 1] 200] [:< {} [:field {} 1] 800] [:between {} [:field {} 1] 600 700]]}
-    {:min-value 600, :max-value 700}))
-
-(deftest ^:parallel extract-bounds-field-name-test
-  (testing "Should be able to adjust min max based on filters against named field refs. (#26202)"
-    (is (= {:min-value 1, :max-value 10}
-           (#'binning/extract-bounds
-            "foo" test-min-max-fingerprint
-            {"foo" (lib.normalize/normalize
-                    ::lib.schema/filters
-                    [[:> {} [:field {} 1] 1] [:< {} [:field {} 1] 10]])})))))
+;; Unit tests for bounds extraction live in [[metabase.lib.binning.util-test]].
 
 ;; Try an end-to-end test of the middleware
 (defn- mock-field-metadata-provider []


### PR DESCRIPTION
Exploration charts fan one metric/dim query out into several segment-filtered variants that share an x-axis. With {:strategy :default} binning, the QP re-derives the bin width per variant from that variant's own filters, so a segment that range-filters the binned column (e.g. "Highly rated products", rating >= 4) got 0.125-wide bins while its siblings got 0.75-wide bins.

Fix: resolve the width the QP would use for the unsegmented query (card-level filters included, per-segment filter excluded) and pin it on the breakout as {:strategy :bin-width}. The binning middleware never renegotiates an explicit bin width, and bin edges snap to multiples of the width, so every variant lands on the same bin grid. Card-level range filters on the dim still narrow the bins, since they're shared by all variants.

- move filters->field-map + extract-bounds from the binning middleware into metabase.lib.binning.util (middleware delegates; extract-bounds now returns nil and the middleware keeps the qp.error-type throw)
- add metabase.lib.binning/default-bin-width (exported via lib.core): the width :default binning resolves for a column given the query's own filters, nicer-breakout fixed point included
- pin it in metabase.explorations.query-plan.mbql/apply-default-bucket