### PR TITLE
UXW-4475: self-heal missing metric dimensions in explorations read path

### DIFF
--- a/src/metabase/explorations/impl.clj
+++ b/src/metabase/explorations/impl.clj
@@ -145,6 +145,30 @@
           by-id  (u/index-by :id rows)]
       (into [] (keep by-id) card-ids))))
 
+(defn- sync-missing-dimensions!
+  "Self-heal metrics whose dimensions were never successfully synced (`:dimensions` NULL/empty) —
+   e.g. metrics created on a model before the model had `result_metadata`, or SQL-model metrics
+   that predate the source-card dimension-sync fix (UXW-4475). Syncs each such metric and returns
+   `cards` with the healed rows reloaded. Metrics whose sync computes nothing (or throws) are
+   returned unchanged; they will be retried on a later call, which is cheap (app-DB reads only,
+   no write when nothing changed)."
+  [cards]
+  (let [broken-ids (into []
+                         (comp (filter #(and (:dataset_query %) (empty? (:dimensions %))))
+                               (map :id))
+                         cards)]
+    (if (empty? broken-ids)
+      cards
+      (do
+        (doseq [id broken-ids]
+          (try
+            (metrics/sync-dimensions! :metadata/metric id)
+            (catch Throwable e
+              (log/warnf e "Failed to sync dimensions for metric card %d" id))))
+        (let [healed (u/index-by :id (t2/select (into [:model/Card] metric-card-cols)
+                                                :id [:in broken-ids]))]
+          (mapv #(or (get healed (:id %)) %) cards))))))
+
 (defn- simple-table-query?
   "True if `query` is a single-stage query over a base table (the metric's `:table_id`) with no
    explicit joins or expressions. Such a query's breakoutable columns depend only on the source
@@ -236,7 +260,7 @@
   (lib-be/with-metadata-provider-cache
     (let [library-ids (or (library-metrics-collection-ids) #{})
           card-ids   (accessible-metric-ids metric-ids library-ids)
-          cards      (load-metric-cards card-ids)
+          cards      (sync-missing-dimensions! (load-metric-cards card-ids))
           ;; Filter dimensions by user permissions for all metrics at once (one set of queries
           ;; for the whole batch, rather than per metric).
           permitted  (metrics/filter-dimensions-for-user-batch cards)

--- a/test/metabase/explorations/impl_test.clj
+++ b/test/metabase/explorations/impl_test.clj
@@ -233,6 +233,84 @@
         (testing "every referenced dimension id resolves to a dimension group (no dangling ids)"
           (is (= metric-dim-ids group-dim-ids)))))))
 
+;;; --------------------------------------- missing-dimension self-healing (UXW-4475) ---------------------------------------
+
+(defn- metric-on-card-query
+  "Metric dataset_query whose source is `card-id` (a model)."
+  [card-id]
+  (let [mp (mt/metadata-provider)]
+    (-> (lib/query mp (lib.metadata/card mp card-id))
+        (lib/aggregate (lib/count)))))
+
+(defn- wipe-dimensions!
+  "Simulate a metric row whose dimensions were never synced, bypassing Card transforms/hooks."
+  [metric-id]
+  (t2/update! (t2/table-name :model/Card) metric-id {:dimensions nil :dimension_mappings nil}))
+
+(deftest exploration-data-heals-missing-dimensions-test
+  (testing "a metric on an MBQL model with NULL dimensions is synced and persisted on read"
+    (mt/with-test-user :crowberto
+      (mt/with-temp [:model/Card model  {:name          "MBQL Model"
+                                         :type          :model
+                                         :database_id   (mt/id)
+                                         :table_id      (mt/id :venues)
+                                         :dataset_query (mt/mbql-query venues)}
+                     :model/Card metric {:name          "Metric on MBQL model"
+                                         :type          :metric
+                                         :database_id   (mt/id)
+                                         :dataset_query (metric-on-card-query (:id model))}]
+        (wipe-dimensions! (:id metric))
+        (let [res  (explorations.impl/exploration-data {:metric-ids [(:id metric)]})
+              mine (first (filter #(= (:id %) (:id metric)) (:metrics res)))]
+          (is (seq (:dimension_ids mine))
+              "response includes the freshly synced dimensions")
+          (is (seq (:dimensions (t2/select-one :model/Card :id (:id metric))))
+              "healed dimensions are persisted"))))))
+
+(deftest exploration-data-heals-missing-dimensions-sql-model-test
+  (testing "a metric on a native-SQL model with NULL dimensions is synced and persisted on read"
+    (mt/with-test-user :crowberto
+      (mt/with-temp [:model/Card model  {:name            "SQL Model"
+                                         :type            :model
+                                         :database_id     (mt/id)
+                                         :dataset_query   (mt/native-query
+                                                           {:query "SELECT ID, NAME, CATEGORY_ID FROM VENUES"})
+                                         :result_metadata [{:name "ID" :display_name "ID" :base_type :type/BigInteger}
+                                                           {:name "NAME" :display_name "Name" :base_type :type/Text}
+                                                           {:name "CATEGORY_ID" :display_name "Category ID" :base_type :type/Integer}]}
+                     :model/Card metric {:name          "Metric on SQL model"
+                                         :type          :metric
+                                         :database_id   (mt/id)
+                                         :dataset_query (metric-on-card-query (:id model))}]
+        (wipe-dimensions! (:id metric))
+        (let [res  (explorations.impl/exploration-data {:metric-ids [(:id metric)]})
+              mine (first (filter #(= (:id %) (:id metric)) (:metrics res)))]
+          (is (seq (:dimension_ids mine)))
+          (is (= #{"ID" "NAME" "CATEGORY_ID"}
+                 (into #{} (map :name) (:dimensions (t2/select-one :model/Card :id (:id metric)))))
+              "healed dimensions match the model's result_metadata columns"))))))
+
+(deftest exploration-data-uncomputable-metric-does-not-break-test
+  (testing "a metric whose model has no result_metadata computes no dimensions but doesn't break the response"
+    (mt/with-test-user :crowberto
+      (mt/with-temp [:model/Card model {:name          "SQL Model without metadata"
+                                        :type          :model
+                                        :database_id   (mt/id)
+                                        :dataset_query (mt/native-query
+                                                        {:query "SELECT ID, NAME FROM VENUES"})}]
+        (t2/update! (t2/table-name :model/Card) (:id model) {:result_metadata nil})
+        (mt/with-temp [:model/Card metric {:name          "Metric on metadata-less model"
+                                           :type          :metric
+                                           :database_id   (mt/id)
+                                           :dataset_query (metric-on-card-query (:id model))}]
+          (wipe-dimensions! (:id metric))
+          (let [res  (explorations.impl/exploration-data {:metric-ids [(:id metric)]})
+                mine (first (filter #(= (:id %) (:id metric)) (:metrics res)))]
+            (is (some? mine) "metric still appears in the response")
+            (is (empty? (:dimension_ids mine)))
+            (is (nil? (:dimensions (t2/select-one :model/Card :id (:id metric))))
+                "nothing computed -> nothing persisted, stays NULL for a later retry")))))))
+
 ;;; --------------------------------------- metric search matching ---------------------------------------
 
 (deftest metric-search-matches-displayed-names-test

--- a/test/metabase/metrics/core_test.clj
+++ b/test/metabase/metrics/core_test.clj
@@ -109,6 +109,32 @@
           (is (nil? (:dimension_mappings reloaded))
               "Dimension mappings should remain nil when query is empty"))))))
 
+(deftest metric-sync-dimensions-sql-model-test
+  (testing "sync-dimensions! computes dimensions for a metric built on a native-SQL model (UXW-4475)"
+    (with-bindings {#'card/*syncing-metric-dimensions* true}
+      (mt/with-temp [:model/Card model {:name            "SQL Model"
+                                        :type            :model
+                                        :database_id     (mt/id)
+                                        :dataset_query   (mt/native-query
+                                                          {:query "SELECT ID, NAME, CATEGORY_ID FROM VENUES"})
+                                        :result_metadata [{:name "ID" :display_name "ID" :base_type :type/BigInteger}
+                                                          {:name "NAME" :display_name "Name" :base_type :type/Text}
+                                                          {:name "CATEGORY_ID" :display_name "Category ID" :base_type :type/Integer}]}
+                     :model/Card metric {:name          "Metric on SQL model"
+                                         :type          :metric
+                                         :database_id   (mt/id)
+                                         :dataset_query (let [mp (mt/metadata-provider)]
+                                                          (-> (lib/query mp (lib.metadata/card mp (:id model)))
+                                                              (lib/aggregate (lib/count))))}]
+        (is (nil? (:table_id (t2/select-one :model/Card :id (:id model))))
+            "sanity check: native-SQL model has no table_id")
+        (metrics/sync-dimensions! :metadata/metric (:id metric))
+        (let [reloaded (t2/select-one :model/Card :id (:id metric))]
+          (is (= #{"ID" "NAME" "CATEGORY_ID"}
+                 (into #{} (map :name) (:dimensions reloaded)))
+              "dimensions come from the model's result_metadata")
+          (is (= (count (:dimensions reloaded)) (count (:dimension_mappings reloaded)))))))))
+
 ;;; ------------------------------------------------ Measure Dimension Sync Tests ------------------------------------------------
 
 (deftest measure-sync-dimensions-basic-test


### PR DESCRIPTION
Metrics whose dimensions were never successfully synced (dimensions NULL) - e.g. metrics created on a model before it had result_metadata, or SQL-model metrics predating the source-card sync fix - showed zero dimensions in the explorations picker and Metabot research tools forever, because those paths read persisted dimensions without ever syncing.

hydrated-metrics now runs sync-dimensions! for loaded metrics that have a dataset_query but empty dimensions, then reloads the healed rows. Metrics that compute nothing persist nothing and retry cheaply on a later request (app-DB reads only, no warehouse queries, no write when nothing changed).