### PR TITLE
Auto-switch the add metrics modal to the All tab when the library has nothing to show

### DIFF
--- a/frontend/src/metabase/explorations/components/NewExplorationData/modals/AddMetricsModal.tsx
+++ b/frontend/src/metabase/explorations/components/NewExplorationData/modals/AddMetricsModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { useGetExplorationDataQuery } from "metabase/api";
@@ -28,9 +28,14 @@ export function AddMetricsModal({
   const { addMetric, metricBlockIds } = selection;
 
   const libraryEnabled = PLUGIN_LIBRARY.isEnabled;
-  const [tab, setTab] = useState<MetricsTab>(
-    libraryEnabled ? "library" : "all",
-  );
+  const [tab, setTab] = useState<MetricsTab | null>(null);
+
+  // The modal stays mounted across opens; forget the previous open's tab choice on reopen (resetting on close instead would flip tabs mid close-animation) so each open re-derives the default from current data.
+  useEffect(() => {
+    if (opened) {
+      setTab(null);
+    }
+  }, [opened]);
 
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebouncedValue(search, SEARCH_DEBOUNCE_DURATION);
@@ -62,12 +67,22 @@ export function AddMetricsModal({
     [metrics],
   );
 
+  const hasLibraryMetrics = metrics.some((metric) => metric.in_library);
+
+  // Until the user picks a tab, default to Library, falling back to All when
+  // the loaded data has nothing in the library to show.
+  const defaultTab: MetricsTab =
+    libraryEnabled && (response === undefined || hasLibraryMetrics)
+      ? "library"
+      : "all";
+  const activeTab = tab ?? defaultTab;
+
   const visibleMetrics = useMemo(
     () =>
-      libraryEnabled && tab === "library"
+      libraryEnabled && activeTab === "library"
         ? metrics.filter((metric) => metric.in_library)
         : metrics,
-    [libraryEnabled, tab, metrics],
+    [libraryEnabled, activeTab, metrics],
   );
 
   const items = visibleMetrics.map((metric) => ({
@@ -88,7 +103,7 @@ export function AddMetricsModal({
 
   const tabs = libraryEnabled ? (
     <Tabs
-      value={tab}
+      value={activeTab}
       onChange={(value) => {
         if (value === "library" || value === "all") {
           setTab(value);

--- a/frontend/src/metabase/explorations/components/NewExplorationData/modals/AddMetricsModal.unit.spec.tsx
+++ b/frontend/src/metabase/explorations/components/NewExplorationData/modals/AddMetricsModal.unit.spec.tsx
@@ -1,0 +1,192 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { setupExplorationDataEndpoint } from "__support__/server-mocks/metric";
+import {
+  mockGetBoundingClientRect,
+  renderWithProviders,
+  screen,
+} from "__support__/ui";
+import type { ExplorationBlock } from "metabase/explorations/hooks";
+import {
+  makeMockSelection,
+  mockMetricBlock,
+} from "metabase/explorations/test-utils";
+import { PLUGIN_LIBRARY } from "metabase/plugins";
+import type { ExplorationMetric } from "metabase-types/api";
+import { createMockMetric } from "metabase-types/api/mocks/metric";
+
+import { AddMetricsModal } from "./AddMetricsModal";
+
+const libraryMetric: ExplorationMetric = {
+  ...createMockMetric({ id: 1, name: "Revenue" }),
+  dimension_ids: [],
+  in_library: true,
+};
+const otherMetric: ExplorationMetric = {
+  ...createMockMetric({ id: 2, name: "Churn" }),
+  dimension_ids: [],
+};
+
+function setup({
+  metrics,
+  blocks = [],
+}: {
+  metrics: ExplorationMetric[];
+  blocks?: ExplorationBlock[];
+}) {
+  setupExplorationDataEndpoint(metrics);
+  const selection = makeMockSelection({ blocks });
+
+  renderWithProviders(
+    <AddMetricsModal opened onClose={jest.fn()} selection={selection} />,
+  );
+}
+
+function libraryTab() {
+  return screen.getByRole("tab", { name: /Library/ });
+}
+
+function allTab() {
+  return screen.getByRole("tab", { name: "All" });
+}
+
+describe("AddMetricsModal", () => {
+  // The picker list is virtualized; give the scroll container a real size so
+  // rows render in jsdom.
+  beforeAll(() => {
+    mockGetBoundingClientRect({ height: 600, width: 600 });
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    PLUGIN_LIBRARY.isEnabled = true;
+  });
+
+  afterEach(() => {
+    PLUGIN_LIBRARY.isEnabled = false;
+  });
+
+  it("stays on the Library tab when the library has metrics", async () => {
+    setup({ metrics: [libraryMetric, otherMetric] });
+
+    expect(await screen.findByText("Revenue")).toBeInTheDocument();
+    expect(libraryTab()).toHaveAttribute("aria-selected", "true");
+    expect(screen.queryByText("Churn")).not.toBeInTheDocument();
+  });
+
+  it("keeps Library selected while the metrics are loading", async () => {
+    let resolveResponse: () => void = () => {};
+    fetchMock.get(
+      "path:/api/exploration/dimensions",
+      new Promise((resolve) => {
+        resolveResponse = () => resolve({ metrics: [], dimension_groups: [] });
+      }),
+    );
+    renderWithProviders(
+      <AddMetricsModal
+        opened
+        onClose={jest.fn()}
+        selection={makeMockSelection()}
+      />,
+    );
+
+    try {
+      expect(libraryTab()).toHaveAttribute("aria-selected", "true");
+      expect(allTab()).toHaveAttribute("aria-selected", "false");
+    } finally {
+      // Resolve even on assertion failure: the global afterEach awaits in-flight requests, and a forever-pending one times out the rest of the file.
+      resolveResponse();
+    }
+    expect(await screen.findByText("No results")).toBeInTheDocument();
+  });
+
+  it("switches to the All tab when there is nothing in the library", async () => {
+    setup({ metrics: [otherMetric] });
+
+    expect(await screen.findByText("Churn")).toBeInTheDocument();
+    expect(allTab()).toHaveAttribute("aria-selected", "true");
+    expect(libraryTab()).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("switches to the All tab when every library metric is already in the plan", async () => {
+    setup({
+      metrics: [libraryMetric, otherMetric],
+      blocks: [mockMetricBlock(libraryMetric)],
+    });
+
+    expect(await screen.findByText("Churn")).toBeInTheDocument();
+    expect(allTab()).toHaveAttribute("aria-selected", "true");
+    expect(screen.queryByText("Revenue")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the All tab when a search matches nothing in the library", async () => {
+    setup({ metrics: [libraryMetric, otherMetric] });
+
+    expect(await screen.findByText("Revenue")).toBeInTheDocument();
+
+    await userEvent.type(
+      screen.getByPlaceholderText("Search for a metric"),
+      "Churn",
+    );
+
+    expect(await screen.findByText("Churn")).toBeInTheDocument();
+    expect(allTab()).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("re-derives the tab when reopened after adding every library metric", async () => {
+    setupExplorationDataEndpoint([libraryMetric, otherMetric]);
+    const { rerender } = renderWithProviders(
+      <AddMetricsModal
+        opened
+        onClose={jest.fn()}
+        selection={makeMockSelection()}
+      />,
+    );
+
+    expect(await screen.findByText("Revenue")).toBeInTheDocument();
+
+    await userEvent.click(allTab());
+    await userEvent.click(libraryTab());
+
+    const planWithLibraryMetric = makeMockSelection({
+      blocks: [mockMetricBlock(libraryMetric)],
+    });
+    rerender(
+      <AddMetricsModal
+        opened={false}
+        onClose={jest.fn()}
+        selection={planWithLibraryMetric}
+      />,
+    );
+    rerender(
+      <AddMetricsModal
+        opened
+        onClose={jest.fn()}
+        selection={planWithLibraryMetric}
+      />,
+    );
+
+    expect(await screen.findByText("Churn")).toBeInTheDocument();
+    expect(allTab()).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("keeps an explicitly chosen tab during searches", async () => {
+    setup({ metrics: [libraryMetric, otherMetric] });
+
+    expect(await screen.findByText("Revenue")).toBeInTheDocument();
+
+    await userEvent.click(allTab());
+    await userEvent.click(libraryTab());
+    await userEvent.type(
+      screen.getByPlaceholderText("Search for a metric"),
+      "Churn",
+    );
+
+    expect(await screen.findByText("No results")).toBeInTheDocument();
+    expect(libraryTab()).toHaveAttribute("aria-selected", "true");
+  });
+});


### PR DESCRIPTION
### Description

Fixes [UXW-4841](https://linear.app/metabase/issue/UXW-4841).

The add metrics modal now lands on the All tab whenever the Library tab has nothing to show, including when every library metric is already in the research plan. An explicit tab click still wins while the modal stays open; the choice is forgotten on reopen so a stale selection can't strand you on an empty Library.

- Subtle behavior change: before any tab click, a search whose matches are all outside the library shows them on the All tab instead of "No results", and snaps back when the search clears.

### How to verify

- [ ] With nothing in the Library, open +Data -> Metrics in a research plan: the modal opens on the All tab (Library stays clickable and shows its empty state)
- [ ] Add every Library metric to the plan, then reopen the modal: it opens on All again

### Demo


https://github.com/user-attachments/assets/7e78150d-823b-40a5-921b-eee5e41e9d33

