### PR TITLE
[malli.defn] Don't gensym internal fn name twice

### DIFF
--- a/src/metabase/util/malli/defn.clj
+++ b/src/metabase/util/malli/defn.clj
@@ -104,7 +104,7 @@
   {:style/indent [:defn]}
   [& [fn-name :as fn-tail]]
   (let [parsed           (mu.fn/parse-fn-tail fn-tail)
-        cosmetic-name    (gensym (munge (str fn-name)))
+        cosmetic-name    (symbol (munge (str fn-name "&")))
         {attr-map :meta} (:values parsed)
         docstring        (annotated-docstring parsed)
         attr-map         (merge

--- a/src/metabase/util/malli/fn.clj
+++ b/src/metabase/util/malli/fn.clj
@@ -406,7 +406,7 @@
   (let [[fn-schema captured] (capture-schemas (fn-schema parsed))]
     `(let [~'&f ~(deparameterized-fn-form lang parsed fn-name)
            ~@(into [] cat captured)]
-       (core/fn ~@(instrumented-fn-tail error-context fn-schema)))))
+       (core/fn ~'mufn ~@(instrumented-fn-tail error-context fn-schema)))))
 
 ;; ------------------------------ Skipping Namespace Enforcement in prod ------------------------------
 

--- a/test/metabase/util/malli/defn_test.clj
+++ b/test/metabase/util/malli/defn_test.clj
@@ -176,8 +176,9 @@
         (let [expansion (macroexpand `(mu/defn ~'f :- :int [] "foo"))]
           (is (= '(def f
                     (clojure.core/let
-                     [&f (clojure.core/fn f [] "foo")]
+                     [&f (clojure.core/fn f_AMPERSAND_ [] "foo")]
                       (clojure.core/fn
+                        mufn
                         ([]
                          (try
                            (clojure.core/->> (&f) (metabase.util.malli.fn/validate-output {:fn-name 'f} :int))

--- a/test/metabase/util/malli/fn_test.clj
+++ b/test/metabase/util/malli/fn_test.clj
@@ -89,40 +89,40 @@
                           (walk/macroexpand-all (mu.fn/instrumented-fn-form {} :clj (mu.fn/parse-fn-tail form))))
     '([x :- :int y])
     '(let* [&f (fn* ([x y]))]
-       (fn* ([a b]
-             (try
-               (metabase.util.malli.fn/validate-input {} :int a)
-               (&f a b)
-               (catch java.lang.Exception error
-                 (throw (metabase.util.malli.fn/fixup-stacktrace error)))))))
+       (fn* mufn ([a b]
+                  (try
+                    (metabase.util.malli.fn/validate-input {} :int a)
+                    (&f a b)
+                    (catch java.lang.Exception error
+                      (throw (metabase.util.malli.fn/fixup-stacktrace error)))))))
 
     '(:- :int [x :- :int y])
     '(let* [&f (fn* ([x y]))]
-       (fn* ([a b]
-             (try
-               (metabase.util.malli.fn/validate-input {} :int a)
-               (metabase.util.malli.fn/validate-output {} :int (&f a b))
-               (catch java.lang.Exception error
-                 (throw (metabase.util.malli.fn/fixup-stacktrace error)))))))
+       (fn* mufn ([a b]
+                  (try
+                    (metabase.util.malli.fn/validate-input {} :int a)
+                    (metabase.util.malli.fn/validate-output {} :int (&f a b))
+                    (catch java.lang.Exception error
+                      (throw (metabase.util.malli.fn/fixup-stacktrace error)))))))
 
     '(:- :int [x :- :int y] (+ x y))
     '(let* [&f (fn* ([x y] (+ x y)))]
-       (fn* ([a b]
-             (try
-               (metabase.util.malli.fn/validate-input {} :int a)
-               (metabase.util.malli.fn/validate-output {} :int (&f a b))
-               (catch java.lang.Exception error
-                 (throw (metabase.util.malli.fn/fixup-stacktrace error)))))))
+       (fn* mufn ([a b]
+                  (try
+                    (metabase.util.malli.fn/validate-input {} :int a)
+                    (metabase.util.malli.fn/validate-output {} :int (&f a b))
+                    (catch java.lang.Exception error
+                      (throw (metabase.util.malli.fn/fixup-stacktrace error)))))))
 
     '([x :- :int y] {:pre [(int? x)]})
     '(let* [&f (fn* ([x y]
                      {:pre [(int? x)]}))]
-       (fn* ([a b]
-             (try
-               (metabase.util.malli.fn/validate-input {} :int a)
-               (&f a b)
-               (catch java.lang.Exception error
-                 (throw (metabase.util.malli.fn/fixup-stacktrace error)))))))
+       (fn* mufn ([a b]
+                  (try
+                    (metabase.util.malli.fn/validate-input {} :int a)
+                    (&f a b)
+                    (catch java.lang.Exception error
+                      (throw (metabase.util.malli.fn/fixup-stacktrace error)))))))
 
     '(:- :int
          ([x] (inc x))
@@ -132,6 +132,7 @@
                  ([x y]
                   (+ x y)))]
        (fn*
+         mufn
          ([a]
           (try
             (metabase.util.malli.fn/validate-output {} :int (&f a))
@@ -183,6 +184,7 @@
                         [path opts & {:keys [token-check?], :or {token-check? true}}]
                         (merge {:path path, :token-check? token-check?} opts))]
               (clojure.core/fn
+                mufn
                 ([a b & {:as kvs}]
                  (try
                    (metabase.util.malli.fn/validate-input {:fn-name 'my-fn} :map b)
@@ -216,6 +218,7 @@
                           (reduce + (list* x y more)))
                      &input-schema-0-a [:* :int]]
                 (clojure.core/fn
+                  mufn
                   ([a b & more]
                    (try
                      (metabase.util.malli.fn/validate-input {:fn-name 'my-plus} :int a)
@@ -254,6 +257,7 @@
                           {:options options, :output (+ x y)})
                      &input-schema-0-a [:map [:integer? :boolean]]]
                 (clojure.core/fn
+                  mufn
                   ([a b & {:as kvs}]
                    (try
                      (metabase.util.malli.fn/validate-input {:fn-name 'my-plus} :int a)


### PR DESCRIPTION
We are currently unnecessarily gensyming the cosmetic name for the generated function twice which leads to class names (and hence names in the stacktrace or in the profiler) to look like e.g. `metabase.query-permissions.impl/fn--101784/can-run-query?101783--101786` where after the fix it is `metabase.query-permissions.impl/mufn--101784/can-run-query?&--101786`. I also renamed opaque `fn` to `mufn` so that it is more apparent that the wrapper lambda is related to malli.util.fn machinery.