### PR TITLE
[perf] Implement containsKey for SnakeHatingMap

### DIFF
--- a/src/metabase/util/snake_hating_map.clj
+++ b/src/metabase/util/snake_hating_map.clj
@@ -48,6 +48,8 @@
       (if (identical? m m')
         this
         (->SnakeHatingMap m'))))
+  (containsKey [this k]
+    (contains? m (normalize-key k)))
   (keys [_this]
     (keys m))
   (meta [_this]


### PR DESCRIPTION
Without explicit `containsKey` implementation, `contains?` calls `keyset` on the map, which is very expensive. For example, here's alloc flamegraph for running `automagic-analysis-test` – 50% of the allocations are related to `SnakeHatingMap.containsKey`: https://flamebin.dev/tfeqDN