### PR TITLE
Move MCP url to the top and update inline origins copy

### DIFF
--- a/frontend/src/metabase/admin/ai/McpAppsSettings.tsx
+++ b/frontend/src/metabase/admin/ai/McpAppsSettings.tsx
@@ -150,8 +150,8 @@ function CustomMcpOriginsSection() {
     <Box>
       <AdminSettingInput
         name="mcp-apps-cors-custom-origins"
-        title={t`Custom MCP client origins to show inline charts`}
-        description={t`Add the origins for self-hosted MCP clients, such as LibreChat and Open WebUI, where we want to show inline charts. Separate values with a space.`}
+        title={t`Allowed origins for custom MCP clients`}
+        description={t`To display charts in your self-hosted MCP clients (like LibreChat and Open WebUI), add each MCP client's base URL (origin) here. Separate origins with a space.`}
         inputType="text"
         placeholder="https://*.example.com"
       />

--- a/frontend/src/metabase/admin/ai/McpAppsSettings.tsx
+++ b/frontend/src/metabase/admin/ai/McpAppsSettings.tsx
@@ -3,10 +3,11 @@ import { jt, t } from "ttag";
 
 import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
+import { AdminSettingInput } from "metabase/admin/settings/components/widgets/AdminSettingInput";
 import { useAdminSetting } from "metabase/api/utils";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { useDocsUrl } from "metabase/common/hooks";
-import { Box, Flex, Stack, Switch, Text, TextInput } from "metabase/ui";
+import { Box, Flex, Stack, Switch, Text } from "metabase/ui";
 
 import { CursorInstallLink } from "./CursorInstallLink";
 import { McpServerUrlSection } from "./MCPServerUrlSection";
@@ -79,6 +80,8 @@ export const McpAppsSettings = ({ id }: { id?: string }) => {
         </ExternalLink>
       )}`}
     >
+      <McpServerUrlSection />
+
       {isEnabled && (
         <Stack gap="lg">
           <CommonMcpClientsSection />
@@ -86,7 +89,6 @@ export const McpAppsSettings = ({ id }: { id?: string }) => {
           <CustomMcpOriginsSection />
         </Stack>
       )}
-      <McpServerUrlSection />
     </SettingsSection>
   );
 };
@@ -144,35 +146,16 @@ function CommonMcpClientsSection() {
 }
 
 function CustomMcpOriginsSection() {
-  const { value: savedValue, updateSetting } = useAdminSetting(
-    "mcp-apps-cors-custom-origins",
-  );
-
-  const [localValue, setLocalValue] = useState(savedValue ?? "");
-
-  const handleBlur = useCallback(() => {
-    if (localValue !== savedValue) {
-      updateSetting({
-        key: "mcp-apps-cors-custom-origins",
-        value: localValue,
-      });
-    }
-  }, [localValue, savedValue, updateSetting]);
-
   return (
     <Box>
-      <SettingHeader
-        id="custom-mcp-origins"
-        title={t`Custom inline chart origins`}
-        description={t`Add custom origins for MCP clients that should display inline charts. Separate values with a space.`}
-      />
-      <TextInput
-        mt="md"
-        value={localValue}
-        onChange={(e) => setLocalValue(e.target.value)}
-        onBlur={handleBlur}
+      <AdminSettingInput
+        name="mcp-apps-cors-custom-origins"
+        title={t`Custom MCP client origins to show inline charts`}
+        description={t`Add the origins for self-hosted MCP clients, such as LibreChat and Open WebUI, where we want to show inline charts. Separate values with a space.`}
+        inputType="text"
         placeholder="https://*.example.com"
       />
+
       <Text c="text-disabled" fz="sm" mt="xs">
         {t`Changes will take effect within one minute.`}
       </Text>

--- a/frontend/src/metabase/admin/ai/McpAppsSettings.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/McpAppsSettings.unit.spec.tsx
@@ -7,7 +7,7 @@ import {
   setupUpdateSettingEndpoint,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
 import { createMockSettings } from "metabase-types/api/mocks";
 
@@ -86,19 +86,6 @@ describe("McpAppsSettings", () => {
     ).toBeInTheDocument();
   });
 
-  it("should show custom inline chart origins copy", async () => {
-    await setup();
-
-    expect(
-      await screen.findByText("Custom inline chart origins"),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(
-        "Add custom origins for MCP clients that should display inline charts. Separate values with a space.",
-      ),
-    ).toBeInTheDocument();
-  });
-
   it("can toggle all MCP clients on", async () => {
     await setup();
 
@@ -132,11 +119,23 @@ describe("McpAppsSettings", () => {
     ).toBeInTheDocument();
   });
 
-  it("can update custom origins on blur", async () => {
-    await setup();
+  it("updates custom inline chart origins on blur", async () => {
+    await setup({ customOrigins: "https://librechat.example.com" });
 
     const input = await screen.findByPlaceholderText("https://*.example.com");
-    await userEvent.type(input, "https://my-app.example.com");
+
+    await waitFor(() => {
+      expect(input).toHaveValue("https://librechat.example.com");
+    });
+
+    await userEvent.clear(input);
+
+    // MCP client custom origins are separated by spaces
+    await userEvent.type(
+      input,
+      "https://librechat.example.com https://openwebui.example.com",
+    );
+
     await userEvent.tab();
 
     const puts = await findRequests("PUT");
@@ -144,7 +143,10 @@ describe("McpAppsSettings", () => {
 
     const [{ url, body }] = puts;
     expect(url).toContain("/setting/mcp-apps-cors-custom-origins");
-    expect(body).toEqual({ value: "https://my-app.example.com" });
+
+    expect(body).toEqual({
+      value: "https://librechat.example.com https://openwebui.example.com",
+    });
   });
 
   it("hides MCP client configuration when the MCP server is off", async () => {


### PR DESCRIPTION
Closes [EMB-1920: Rename custom inline chart origins field](https://linear.app/metabase/issue/EMB-1920/rename-custom-inline-chart-origins-field)
Closes [EMB-1922: Move MCP server URL to the top of MCP server settings](https://linear.app/metabase/issue/EMB-1922/move-mcp-server-url-to-the-top-of-mcp-server-settings)

### Description

Moves the "MCP server URL" display to the top of MCP admin settings, and renames the "custom inline chart origins" form field to be more descriptive.

Requested @metabase/tech-writers to review the copywriting of the field description and field title.

Let's single-backport this as we already had the other small tweaks to MCP settings in 63 - this would go well together.

### How to verify

1. MCP server URL is displayed at the top of the "MCP" page in admin settings
2. The "custom inline chart origins" field are renamed

<img width="2076" height="1682" alt="CleanShot 2569-07-21 at 01 12 11@2x" src="https://github.com/user-attachments/assets/92a46d0a-2eea-4d9a-a057-310aa5c86c04" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

