### PR TITLE
Fix Monitor code review findings

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/queries.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/queries.clj
@@ -15,24 +15,24 @@
     sort-column
     sort-direction]
    (let [total-count (volatile! nil)]
-     {:metadata [[:card_id         {:display_name "Card ID",            :base_type :type/Integer :remapped_to   :card_name}]
-                 [:card_name       {:display_name "Question",           :base_type :type/Text    :remapped_from :card_id}]
-                 [:error_substr    {:display_name "Error",              :base_type :type/Text    :code          true}]
-                 [:collection_id   {:display_name "Collection ID",      :base_type :type/Integer :remapped_to   :collection_name}]
-                 [:collection_name {:display_name "Collection",         :base_type :type/Text    :remapped_from :collection_id}]
-                 [:database_id     {:display_name "Database ID",        :base_type :type/Integer :remapped_to   :database_name}]
-                 [:database_name   {:display_name "Database",           :base_type :type/Text    :remapped_from :database_id}]
-                 [:schema_name     {:display_name "Schema",             :base_type :type/Text}]
-                 [:table_id        {:display_name "Table ID",           :base_type :type/Integer :remapped_to   :table_name}]
-                 [:table_name      {:display_name "Table",              :base_type :type/Text    :remapped_from :table_id}]
-                 [:last_run_at     {:display_name "Last run at",        :base_type :type/DateTime}]
-                 [:total_runs      {:display_name "Total runs",         :base_type :type/Integer}]
-                 ;; if it appears a billion times each in 2 dashboards, that's 2 billion appearances
-                 [:num_dashboards  {:display_name "Dashboards it's in", :base_type :type/Integer}]
-                 [:user_id         {:display_name "Created By ID",      :base_type :type/Integer :remapped_to   :user_name}]
-                 [:user_name       {:display_name "Created By",         :base_type :type/Text    :remapped_from :user_id}]
-                 [:updated_at      {:display_name "Updated At",         :base_type :type/DateTime}]]
-      ;; Append total_count to the root response rather than each row
+     {:metadata
+      [[:card_id         {:display_name "Card ID",            :base_type :type/Integer,  :remapped_to :card_name}]
+       [:card_name       {:display_name "Question",           :base_type :type/Text,     :remapped_from :card_id}]
+       [:error_substr    {:display_name "Error",              :base_type :type/Text,     :code true}]
+       [:collection_id   {:display_name "Collection ID",      :base_type :type/Integer,  :remapped_to :collection_name}]
+       [:collection_name {:display_name "Collection",         :base_type :type/Text,     :remapped_from :collection_id}]
+       [:database_id     {:display_name "Database ID",        :base_type :type/Integer,  :remapped_to :database_name}]
+       [:database_name   {:display_name "Database",           :base_type :type/Text,     :remapped_from :database_id}]
+       [:schema_name     {:display_name "Schema",             :base_type :type/Text}]
+       [:table_id        {:display_name "Table ID",           :base_type :type/Integer,  :remapped_to :table_name}]
+       [:table_name      {:display_name "Table",              :base_type :type/Text,     :remapped_from :table_id}]
+       [:last_run_at     {:display_name "Last run at",        :base_type :type/DateTime}]
+       [:total_runs      {:display_name "Total runs",         :base_type :type/Integer}]
+       ;; if it appears a billion times each in 2 dashboards, that's 2 billion appearances
+       [:num_dashboards  {:display_name "Dashboards it's in", :base_type :type/Integer}]
+       [:user_id         {:display_name "Created By ID",      :base_type :type/Integer,  :remapped_to :user_name}]
+       [:user_name       {:display_name "Created By",         :base_type :type/Text,     :remapped_from :user_id}]
+       [:updated_at      {:display_name "Updated At",         :base_type :type/DateTime}]]
       :xform (fn [rf]
                (fn
                  ([] (rf))
@@ -69,6 +69,7 @@
                                 [:card.creator_id :user_id]
                                 [(common/user-full-name :u) :user_name]
                                 [:card.updated_at :updated_at]
+                                ;; Keep this last: the streaming xform strips it positionally and hoists it to the root.
                                 [[:over [[:count :*] {} :total_count]]]]
                     :from      [[:report_card :card]]
                     :left-join [[:collection :coll]                [:= :card.collection_id :coll.id]

--- a/enterprise/backend/test/metabase_enterprise/audit_app/pages/queries_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/pages/queries_test.clj
@@ -32,8 +32,8 @@
 (deftest bad-table-total-count-test
   (testing "bad-table carries a total_count matching the filtered set"
     (mt/test-helpers-set-global-values!
-      (mt/with-temp [:model/Card {bad-card-id :id} {:name "Erroring card"}
-                     :model/Card {ok-card-id :id}  {:name "Healthy card"}
+      (mt/with-temp [:model/Card {bad-card-id :id} {:name "Toucan card"}
+                     :model/Card {ok-card-id :id}  {:name "Sparrow card"}
                      :model/QueryExecution _ (merge query-execution-defaults
                                                     {:card_id     bad-card-id
                                                      :executor_id (mt/user->id :crowberto)
@@ -54,17 +54,17 @@
 (deftest bad-table-search-term-matches-any-field-test
   (testing "the single search term matches against question name, error text, db name, or collection name (OR, not AND)"
     (mt/test-helpers-set-global-values!
-      (mt/with-temp [:model/Database   {db-a :id} {:name "erroring-db-alpha"}
-                     :model/Database   {db-b :id} {:name "erroring-db-beta"}
-                     :model/Collection {coll-a :id} {:name "Erroring Collection Alpha"}
+      (mt/with-temp [:model/Database   {db-a :id} {:name "kingfisher-db-alpha"}
+                     :model/Database   {db-b :id} {:name "kingfisher-db-beta"}
+                     :model/Collection {coll-a :id} {:name "Heron Collection Alpha"}
                      ;; two erroring cards sharing a unique error marker (so they can be
                      ;; isolated from any other erroring cards in the app DB) but living in
                      ;; different databases/collections
-                     :model/Card {card-a :id} {:name          "Erroring Card Name Alpha"
+                     :model/Card {card-a :id} {:name          "Sparrow Card Name Alpha"
                                                :database_id   db-a
                                                :collection_id coll-a}
                      ;; null collection -> "Our Analytics" fallback, different database
-                     :model/Card {card-b :id} {:name        "Filter card B"
+                     :model/Card {card-b :id} {:name        "Wren card B"
                                                :database_id db-b}
                      :model/QueryExecution _ (merge query-execution-defaults
                                                     {:card_id     card-a
@@ -78,11 +78,11 @@
         (testing "a term matching the shared error text matches both cards"
           (is (= 2 (bad-table-total "shared-filter-marker-qq" nil nil))))
         (testing "a term matching only a question name reaches that field, not just error text"
-          (is (= 1 (bad-table-total "Erroring Card Name Alpha" nil nil))))
+          (is (= 1 (bad-table-total "Sparrow Card Name Alpha" nil nil))))
         (testing "a term matching only a db name reaches that field, not just error text"
-          (is (= 1 (bad-table-total "erroring-db-alpha" nil nil))))
+          (is (= 1 (bad-table-total "kingfisher-db-alpha" nil nil))))
         (testing "a term matching only a collection name reaches that field too"
-          (is (= 1 (bad-table-total "Erroring Collection Alpha" nil nil))))
+          (is (= 1 (bad-table-total "Heron Collection Alpha" nil nil))))
         (testing "the null-collection card is reachable via the Our Analytics fallback name"
           ;; "Our Analytics" is a common fallback shared by every uncollected card in the
           ;; app db, so unlike the other terms above this can't be isolated to an exact
@@ -91,14 +91,14 @@
                                          :args ["Our Analytics" nil nil]))]
             (is (contains? (set (map first rows)) card-b))))
         (testing "a term shared by both db names matches both cards via the db-name field"
-          (is (= 2 (bad-table-total "erroring-db" nil nil))))))))
+          (is (= 2 (bad-table-total "kingfisher-db" nil nil))))))))
 
 (deftest bad-table-no-duplicate-cards-test
   (testing "cards aren't duplicated when executions across cards share a started_at (latest_qe joins on card_id, not timestamp alone)"
     (mt/test-helpers-set-global-values!
       (let [shared-ts #t "2026-02-02T12:00:00Z"]
-        (mt/with-temp [:model/Card {erroring-id :id} {:name "Collision erroring card"}
-                       :model/Card {healthy-id :id}  {:name "Collision healthy card"}
+        (mt/with-temp [:model/Card {erroring-id :id} {:name "Magpie collision card"}
+                       :model/Card {healthy-id :id}  {:name "Finch collision card"}
                        ;; both cards' latest run is at the SAME timestamp; only one errored
                        :model/QueryExecution _ (merge query-execution-defaults
                                                       {:card_id     erroring-id

--- a/enterprise/backend/test/metabase_enterprise/audit_app/pages_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/pages_test.clj
@@ -156,3 +156,29 @@
         (is (=? {:status "completed"
                  :row_count integer?}
                 response))))))
+
+(deftest bad-table-total-count-over-dataset-api-test
+  (testing "the bad-table :total_count survives the real streaming path over POST /api/dataset"
+    (mt/test-helpers-set-global-values!
+      (mt/with-premium-features #{:audit-app}
+        (mt/with-temp [:model/Card {bad-id :id} {:name "Toucan dataset card"}
+                       :model/QueryExecution _ {:card_id      bad-id
+                                                :executor_id  (mt/user->id :crowberto)
+                                                :hash         (qp.util/query-hash {})
+                                                :result_rows  0
+                                                :running_time 0
+                                                :native       false
+                                                :started_at   #t "2026-05-05T10:00:00Z"
+                                                :context      :ad-hoc
+                                                :error        "dataset-total-marker-uvw not found"}]
+          ;; a unique error marker isolates exactly one erroring card, so total_count is deterministic
+          (let [response (mt/user-http-request :crowberto :post 202
+                                               "dataset"
+                                               {:type       :internal
+                                                :fn         "metabase-enterprise.audit-app.pages.queries/bad-table"
+                                                :args       ["dataset-total-marker-uvw" "last_run_at" "desc"]
+                                                :parameters []})]
+            (is (=? {:status      "completed"
+                     :row_count   1
+                     :total_count 1}
+                    response))))))))

--- a/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErrorOverview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErrorOverview.tsx
@@ -136,8 +136,6 @@ export const ErrorOverview = () => {
         <MonitorMain>
           <MonitorHeaderTitle mb="sm">{t`Erroring questions`}</MonitorHeaderTitle>
 
-          {/* Keep the search mounted even on error so the user can change the
-              query to recover; RTK only clears the error on an arg change. */}
           <ErroringQuestionsSearch
             hasLoader={isFetching && !isLoading}
             onFiltersChange={handleFiltersChange}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErrorOverview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErrorOverview.tsx
@@ -78,8 +78,25 @@ export const ErrorOverview = () => {
 
   const handleSortingChange = (newSorting: ErroringQuestionsSorting) => {
     setSorting(newSorting);
+    setRowSelection({});
     patchUrlState({ page: 0 });
   };
+
+  const handlePageChange = (nextPage: number) => {
+    setRowSelection({});
+    patchUrlState({ page: nextPage });
+  };
+
+  // A stale/shrunk `?page=N` can point past the result set: the backend returns
+  // no rows and a total of 0, which hides the pagination controls and strands
+  // the user on an empty page. Once the query settles, recover to the first page.
+  const isStrandedPage =
+    !isFetching && pageError == null && cards.length === 0 && page > 0;
+  useEffect(() => {
+    if (isStrandedPage) {
+      patchUrlState({ page: 0 });
+    }
+  }, [isStrandedPage, patchUrlState]);
 
   // Refresh the list once the last queued rerun settles: questions that now
   // succeed drop off, ones that still error stay.
@@ -119,6 +136,13 @@ export const ErrorOverview = () => {
         <MonitorMain>
           <MonitorHeaderTitle mb="sm">{t`Erroring questions`}</MonitorHeaderTitle>
 
+          {/* Keep the search mounted even on error so the user can change the
+              query to recover; RTK only clears the error on an arg change. */}
+          <ErroringQuestionsSearch
+            hasLoader={isFetching && !isLoading}
+            onFiltersChange={handleFiltersChange}
+          />
+
           {pageError != null ? (
             <Center flex={1}>
               <DelayedLoadingAndErrorWrapper
@@ -128,11 +152,6 @@ export const ErrorOverview = () => {
             </Center>
           ) : (
             <>
-              <ErroringQuestionsSearch
-                hasLoader={isFetching && !isLoading}
-                onFiltersChange={handleFiltersChange}
-              />
-
               <ErroringQuestionsTable
                 cards={cards}
                 isFetching={isFetching}
@@ -145,7 +164,7 @@ export const ErrorOverview = () => {
                 onRowSelectionChange={setRowSelection}
               />
 
-              {!isLoading && total != null && (
+              {!isLoading && (
                 <Flex justify="end">
                   <PaginationControls
                     page={page}
@@ -153,8 +172,8 @@ export const ErrorOverview = () => {
                     itemsLength={cards.length}
                     total={total}
                     showTotal
-                    onPreviousPage={() => patchUrlState({ page: page - 1 })}
-                    onNextPage={() => patchUrlState({ page: page + 1 })}
+                    onPreviousPage={() => handlePageChange(page - 1)}
+                    onNextPage={() => handlePageChange(page + 1)}
                   />
                 </Flex>
               )}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErrorOverview.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErrorOverview.unit.spec.tsx
@@ -2,6 +2,7 @@ import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
 import {
+  act,
   fireEvent,
   mockGetBoundingClientRect,
   renderWithProviders,
@@ -9,6 +10,7 @@ import {
   waitFor,
   within,
 } from "__support__/ui";
+import { URL_UPDATE_DEBOUNCE_DELAY } from "metabase/common/hooks/use-url-state";
 import { Route } from "metabase/router";
 import type { RowValue } from "metabase-types/api";
 import {
@@ -67,6 +69,7 @@ type SetupOpts = {
   total?: number;
   error?: boolean;
   initialRoute?: string;
+  deferResponse?: boolean;
 };
 
 async function setup({
@@ -74,14 +77,25 @@ async function setup({
   total,
   error,
   initialRoute = "/",
+  deferResponse = false,
 }: SetupOpts = {}) {
   mockGetBoundingClientRect({ width: 100, height: 100 });
 
+  let resolveResponse:
+    | ((response: ReturnType<typeof createDatasetResponse>) => void)
+    | undefined;
   if (error) {
     fetchMock.post("path:/api/dataset", {
       status: 500,
       body: { message: "Audit query failed" },
     });
+  } else if (deferResponse) {
+    const response = new Promise<ReturnType<typeof createDatasetResponse>>(
+      (resolve) => {
+        resolveResponse = resolve;
+      },
+    );
+    fetchMock.post("path:/api/dataset", () => response);
   } else {
     fetchMock.post("path:/api/dataset", createDatasetResponse(cards, total));
   }
@@ -97,7 +111,11 @@ async function setup({
     });
   }
 
-  return utils;
+  return {
+    ...utils,
+    resolveResponse: () =>
+      resolveResponse?.(createDatasetResponse(cards, total)),
+  };
 }
 
 describe("ErrorOverview", () => {
@@ -141,13 +159,40 @@ describe("ErrorOverview", () => {
     expect(await screen.findByText("No results")).toBeInTheDocument();
   });
 
-  it("shows the error message when the audit query fails", async () => {
+  it("shows the error message when the audit query fails, keeping the search mounted", async () => {
     await setup({ error: true });
 
     expect(await screen.findByText("Audit query failed")).toBeInTheDocument();
+    // the search stays mounted so the user has a recovery path
+    expect(screen.getByPlaceholderText(SEARCH_PLACEHOLDER)).toBeInTheDocument();
     expect(
-      screen.queryByPlaceholderText(SEARCH_PLACEHOLDER),
+      screen.queryByTestId("erroring-questions-table"),
     ).not.toBeInTheDocument();
+  });
+
+  it("recovers from an error when the search changes and the retry succeeds", async () => {
+    mockGetBoundingClientRect({ width: 100, height: 100 });
+
+    let shouldFail = true;
+    fetchMock.post("path:/api/dataset", () =>
+      shouldFail
+        ? { status: 500, body: { message: "Audit query failed" } }
+        : createDatasetResponse([{ id: 1, card_name: "Recovered question" }]),
+    );
+
+    renderWithProviders(<Route path="/" element={<ErrorOverview />} />, {
+      withRouter: true,
+    });
+
+    expect(await screen.findByText("Audit query failed")).toBeInTheDocument();
+    const search = screen.getByPlaceholderText(SEARCH_PLACEHOLDER);
+
+    // changing the query is the only way to clear RTK's error and refire
+    shouldFail = false;
+    await userEvent.type(search, "recovered");
+
+    expect(await screen.findByText("Recovered question")).toBeInTheDocument();
+    expect(screen.queryByText("Audit query failed")).not.toBeInTheDocument();
   });
 
   it("surfaces an internal-query error returned in the dataset body", async () => {
@@ -169,9 +214,8 @@ describe("ErrorOverview", () => {
     expect(
       await screen.findByText("Internal audit query blew up"),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByPlaceholderText(SEARCH_PLACEHOLDER),
-    ).not.toBeInTheDocument();
+    // the search stays mounted so the user has a recovery path
+    expect(screen.getByPlaceholderText(SEARCH_PLACEHOLDER)).toBeInTheDocument();
     expect(
       screen.queryByTestId("erroring-questions-table"),
     ).not.toBeInTheDocument();
@@ -216,11 +260,18 @@ describe("ErrorOverview", () => {
 
   it("sorts by column with asc/desc toggle, reverting to the default sort on the 3rd click", async () => {
     await setup();
-    await screen.findByTestId("erroring-question");
+    const row = await screen.findByTestId("erroring-question");
+
+    // a selection must not survive a sort change
+    await userEvent.click(within(row).getByLabelText("Select row"));
+    expect(await screen.findByText("1 question selected")).toBeInTheDocument();
 
     await userEvent.click(
       screen.getByRole("columnheader", { name: /Question/ }),
     );
+    await waitFor(() => {
+      expect(screen.queryByText("1 question selected")).not.toBeInTheDocument();
+    });
     await waitFor(async () => {
       const query = await getLastDatasetQuery();
       expect(query.args.slice(1)).toEqual(["card_name", "asc"]);
@@ -464,11 +515,18 @@ describe("ErrorOverview", () => {
     expect(await screen.findByTestId("pagination-total")).toHaveTextContent(
       "120",
     );
-    await screen.findAllByTestId("erroring-question");
+    const rows = await screen.findAllByTestId("erroring-question");
+
+    // a selection must not survive a page change
+    await userEvent.click(within(rows[0]).getByLabelText("Select row"));
+    expect(await screen.findByText("1 question selected")).toBeInTheDocument();
 
     const nextButton = await screen.findByLabelText("Next page");
     await userEvent.click(nextButton);
 
+    await waitFor(() => {
+      expect(screen.queryByText("1 question selected")).not.toBeInTheDocument();
+    });
     await waitFor(async () => {
       const query = await getLastDatasetQuery();
       expect(query.offset).toBe(PAGE_SIZE);
@@ -491,6 +549,38 @@ describe("ErrorOverview", () => {
       const query = await getLastDatasetQuery();
       expect(query.offset).toBe(PAGE_SIZE * 2);
     });
+  });
+
+  it("waits for the empty response before recovering from a stranded page", async () => {
+    jest.useFakeTimers({ advanceTimers: true });
+    try {
+      const { history, resolveResponse } = await setup({
+        cards: [],
+        total: 0,
+        initialRoute: "/?page=2",
+        deferResponse: true,
+      });
+
+      expect((await getLastDatasetQuery()).offset).toBe(2 * PAGE_SIZE);
+      act(() => {
+        jest.advanceTimersByTime(URL_UPDATE_DEBOUNCE_DELAY + 50);
+      });
+      expect(history?.getCurrentLocation().search).toBe("?page=2");
+
+      act(() => {
+        resolveResponse();
+      });
+
+      await waitFor(async () => {
+        const query = await getLastDatasetQuery();
+        expect(query.offset).toBe(0);
+      });
+      await waitFor(() => {
+        expect(history?.getCurrentLocation().search).toBe("");
+      });
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it("links each row to the question and navigates there on click", async () => {

--- a/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErrorOverview.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErrorOverview.unit.spec.tsx
@@ -163,7 +163,6 @@ describe("ErrorOverview", () => {
     await setup({ error: true });
 
     expect(await screen.findByText("Audit query failed")).toBeInTheDocument();
-    // the search stays mounted so the user has a recovery path
     expect(screen.getByPlaceholderText(SEARCH_PLACEHOLDER)).toBeInTheDocument();
     expect(
       screen.queryByTestId("erroring-questions-table"),

--- a/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErroringQuestionsSearch.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErroringQuestionsSearch.tsx
@@ -27,10 +27,13 @@ export function ErroringQuestionsSearch({
     handleChangeDebounced(event.target.value);
   };
 
+  const searchLabel = t`Search by question, error, database, or collection`;
+
   return (
     <TextInput
       value={value}
-      placeholder={t`Search by question, error, database, or collection`}
+      aria-label={searchLabel}
+      placeholder={searchLabel}
       w="100%"
       leftSection={<FixedSizeIcon name="search" />}
       rightSection={hasLoader ? <Loader size="sm" /> : undefined}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErroringQuestionsTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/ErroringQuestionsTable.tsx
@@ -293,7 +293,7 @@ function getColumns(): TreeTableColumnDef<ErroringCard>[] {
     },
     {
       id: "user_name",
-      header: t`Created By`,
+      header: t`Created by`,
       width: "auto",
       minWidth: 110,
       maxAutoWidth: 200,
@@ -309,7 +309,7 @@ function getColumns(): TreeTableColumnDef<ErroringCard>[] {
     },
     {
       id: "updated_at",
-      header: t`Updated At`,
+      header: t`Updated at`,
       width: "auto",
       minWidth: 130,
       enableSorting: true,

--- a/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/utils.ts
@@ -65,8 +65,6 @@ export function getErroringQuestions(dataset: Dataset): ErroringCard[] {
   return rows.flatMap((row) => {
     const value = (name: string) => row[indexByName[name]];
     const id = asCount(value("card_id"));
-    // A row without a valid card id can't link to a question and would collide
-    // on the table's row id; drop it rather than fabricate an id.
     if (id == null) {
       return [];
     }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/tools/ErrorOverview/utils.ts
@@ -3,7 +3,11 @@ import {
   type UrlStateConfig,
   getFirstParamValue,
 } from "metabase/common/hooks/use-url-state";
-import type { Dataset, DatasetQuery, RowValue } from "metabase-types/api";
+import type {
+  Dataset,
+  InternalDatasetQuery,
+  RowValue,
+} from "metabase-types/api";
 
 import type {
   ErroringCard,
@@ -37,31 +41,18 @@ export const DEFAULT_SORTING: ErroringQuestionsSorting = {
   direction: "desc",
 };
 
-// "internal" query shape, which is later converted to DatasetQuery (opaque type).
-type InternalDatasetQuery = {
-  type: "internal";
-  fn: string;
-  args: string[];
-  limit?: number;
-  offset?: number;
-};
-
-const toDatasetQuery = (query: InternalDatasetQuery): DatasetQuery =>
-  // conversion to the branded opaque DatasetQuery union required by /api/dataset
-  query as unknown as DatasetQuery;
-
 export function getErroringQuestionsQuery(
   { search }: ErroringQuestionsFilters,
   { column, direction }: ErroringQuestionsSorting,
   page: number,
-): DatasetQuery {
-  return toDatasetQuery({
+): InternalDatasetQuery {
+  return {
     type: "internal",
     fn: "metabase-enterprise.audit-app.pages.queries/bad-table",
     args: [search, column, direction],
     limit: PAGE_SIZE,
     offset: PAGE_SIZE * page,
-  });
+  };
 }
 
 export function getErroringQuestions(dataset: Dataset): ErroringCard[] {
@@ -71,10 +62,16 @@ export function getErroringQuestions(dataset: Dataset): ErroringCard[] {
     indexByName[col.name] = index;
   });
 
-  return rows.map((row) => {
+  return rows.flatMap((row) => {
     const value = (name: string) => row[indexByName[name]];
+    const id = asCount(value("card_id"));
+    // A row without a valid card id can't link to a question and would collide
+    // on the table's row id; drop it rather than fabricate an id.
+    if (id == null) {
+      return [];
+    }
     return {
-      id: asCount(value("card_id")) ?? 0,
+      id,
       card_name: asText(value("card_name")) ?? "",
       error_substr: asText(value("error_substr")) ?? "",
       collection_name: asText(value("collection_name")),

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -60,3 +60,20 @@ export type InviteToViewOpenedEvent = ValidateEvent<{
   triggered_from: "dashboard" | "question";
   target_id: number | null;
 }>;
+
+export type MonitorOpenedEvent = ValidateEvent<{
+  event: "monitor_opened";
+  triggered_from: "nav_menu";
+}>;
+
+export type MonitorSectionClickedEvent = ValidateEvent<{
+  event: "monitor_section_clicked";
+  event_detail:
+    | "diagnostics"
+    | "erroring-questions"
+    | "alerts"
+    | "tasks"
+    | "jobs"
+    | "logs"
+    | "model-caching";
+}>;

--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -38,6 +38,16 @@ export type DatasetQuery = OpaqueDatasetQuery | LegacyDatasetQuery;
 
 export type LegacyDatasetQuery = StructuredDatasetQuery | NativeDatasetQuery;
 
+// Audit-only query shape accepted by /api/dataset. `fn` names a whitelisted
+// backend function (audit-app internal queries); there is no `database`.
+export interface InternalDatasetQuery {
+  type: "internal";
+  fn: string;
+  args: string[];
+  limit?: number;
+  offset?: number;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- used for types
 declare const OpaqueDatasetQuerySymbol: unique symbol;
 export type OpaqueDatasetQuery = unknown & {

--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -38,8 +38,8 @@ export type DatasetQuery = OpaqueDatasetQuery | LegacyDatasetQuery;
 
 export type LegacyDatasetQuery = StructuredDatasetQuery | NativeDatasetQuery;
 
-// Audit-only query shape accepted by /api/dataset. `fn` names a whitelisted
-// backend function (audit-app internal queries); there is no `database`.
+// Audit-only query shape accepted by /api/dataset.
+// `fn` names a backend function.
 export interface InternalDatasetQuery {
   type: "internal";
   fn: string;

--- a/frontend/src/metabase/api/dataset.ts
+++ b/frontend/src/metabase/api/dataset.ts
@@ -6,6 +6,7 @@ import type {
   DatasetQuery,
   FieldValue,
   GetRemappedParameterValueRequest,
+  InternalDatasetQuery,
   NativeDatasetResponse,
 } from "metabase-types/api";
 
@@ -55,7 +56,7 @@ export const datasetApi = Api.injectEndpoints({
     }),
     getAdhocQuery: builder.query<
       Dataset,
-      DatasetQuery & RtkCacheKeyed & IgnorableError
+      (DatasetQuery | InternalDatasetQuery) & RtkCacheKeyed & IgnorableError
     >({
       query: ({ ignore_error, ...body }) => ({
         method: "POST",

--- a/frontend/src/metabase/common/hooks/use-abortable-query.ts
+++ b/frontend/src/metabase/common/hooks/use-abortable-query.ts
@@ -30,13 +30,11 @@ type UseAbortableQueryOptions = {
  *
  * Caching mirrors `useQuery`: cache-first by default.
  *
- * Skipping: pass `skipToken` as the arg, or set `{ skip: true }`. While skipped
- * no request is issued and `refetch` is a no-op. Passing `skipToken` avoids
- * having to fabricate a placeholder arg for the skipped state.
- *
  * Each hook instance gets its own RTK cache entry, so aborting is safe.
  * The trade-off is that instances don't share cached responses and
  * identical concurrent requests aren't deduplicated.
+ *
+ * Skipping: pass `skipToken` as the arg, or set `{ skip: true }`.
  */
 export function useAbortableQuery<
   Arg extends object,
@@ -59,8 +57,6 @@ export function useAbortableQuery<
 
   const skip = skipOption || arg === skipToken;
 
-  // Keep the last concrete arg; a `skipToken` arg never overwrites it, so
-  // `stableArg` only equals `skipToken` before any real arg has arrived.
   const argRef = useRef(arg);
   if (arg !== skipToken && !_.isEqual(argRef.current, arg)) {
     argRef.current = arg;

--- a/frontend/src/metabase/common/hooks/use-abortable-query.ts
+++ b/frontend/src/metabase/common/hooks/use-abortable-query.ts
@@ -1,3 +1,4 @@
+import { skipToken } from "@reduxjs/toolkit/query";
 import { useCallback, useEffect, useRef } from "react";
 import _ from "underscore";
 
@@ -29,6 +30,10 @@ type UseAbortableQueryOptions = {
  *
  * Caching mirrors `useQuery`: cache-first by default.
  *
+ * Skipping: pass `skipToken` as the arg, or set `{ skip: true }`. While skipped
+ * no request is issued and `refetch` is a no-op. Passing `skipToken` avoids
+ * having to fabricate a placeholder arg for the skipped state.
+ *
  * Each hook instance gets its own RTK cache entry, so aborting is safe.
  * The trade-off is that instances don't share cached responses and
  * identical concurrent requests aren't deduplicated.
@@ -42,9 +47,9 @@ export function useAbortableQuery<
     TResult,
     ...unknown[],
   ],
-  arg: Arg,
+  arg: Arg | typeof skipToken,
   {
-    skip = false,
+    skip: skipOption = false,
     refetchOnMountOrArgChange = false,
   }: UseAbortableQueryOptions = {},
 ): TResult & { refetch: () => void } {
@@ -52,14 +57,21 @@ export function useAbortableQuery<
   const requestRef = useRef<LazyQueryRequest | null>(null);
   const instanceKey = useUniqueId("abortable-query");
 
+  const skip = skipOption || arg === skipToken;
+
+  // Keep the last concrete arg; a `skipToken` arg never overwrites it, so
+  // `stableArg` only equals `skipToken` before any real arg has arrived.
   const argRef = useRef(arg);
-  if (!_.isEqual(argRef.current, arg)) {
+  if (arg !== skipToken && !_.isEqual(argRef.current, arg)) {
     argRef.current = arg;
   }
   const stableArg = argRef.current;
 
   const run = useCallback(
     (preferCache: boolean) => {
+      if (stableArg === skipToken) {
+        return null;
+      }
       requestRef.current?.abort();
       const request = trigger(
         { ...stableArg, [RTK_CACHE_KEY_PARAM]: instanceKey },
@@ -71,7 +83,11 @@ export function useAbortableQuery<
     [trigger, stableArg, instanceKey],
   );
 
-  const refetch = useCallback(() => run(false), [run]);
+  const refetch = useCallback(() => {
+    if (!skip) {
+      run(false);
+    }
+  }, [run, skip]);
 
   useEffect(() => {
     if (skip) {

--- a/frontend/src/metabase/common/hooks/use-abortable-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-abortable-query.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { QueryStatus } from "@reduxjs/toolkit/query";
+import { QueryStatus, skipToken } from "@reduxjs/toolkit/query";
 import fetchMock from "fetch-mock";
 
 import { act, renderHookWithProviders, waitFor } from "__support__/ui";
@@ -370,6 +370,106 @@ describe("useAbortableQuery", () => {
 
     await waitFor(() => {
       expect(result.current.error).toBeDefined();
+    });
+  });
+
+  it("does not fire a request when refetch is called while skipped", async () => {
+    fetchMock.get("path:/api/task", makeResponse(PAGE_0_TASK_ID));
+
+    const { result } = setup({ arg: { limit: 50, offset: 0 }, skip: true });
+
+    expect(getTaskCalls()).toHaveLength(0);
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    // Give any (erroneously scheduled) request a chance to fire.
+    await Promise.resolve();
+    expect(getTaskCalls()).toHaveLength(0);
+  });
+
+  describe("skipToken arg", () => {
+    function setupWithToken(initialArg: ListTasksRequest | typeof skipToken) {
+      return renderHookWithProviders(
+        ({ arg }: { arg: ListTasksRequest | typeof skipToken }) =>
+          useAbortableQuery(useLazyListTasksQuery, arg),
+        { initialProps: { arg: initialArg } },
+      );
+    }
+
+    it("issues no request while the arg is skipToken", async () => {
+      fetchMock.get("path:/api/task", makeResponse(PAGE_0_TASK_ID));
+
+      const { result } = setupWithToken(skipToken);
+
+      await Promise.resolve();
+      expect(getTaskCalls()).toHaveLength(0);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isFetching).toBe(false);
+      expect(result.current.data).toBeUndefined();
+    });
+
+    it("does not fire a request when refetch is called while the arg is skipToken", async () => {
+      fetchMock.get("path:/api/task", makeResponse(PAGE_0_TASK_ID));
+
+      const { result } = setupWithToken(skipToken);
+
+      act(() => {
+        result.current.refetch();
+      });
+
+      await Promise.resolve();
+      expect(getTaskCalls()).toHaveLength(0);
+    });
+
+    it("fires exactly one request when transitioning from skipToken to a real arg", async () => {
+      fetchMock.get("path:/api/task", makeResponse(PAGE_0_TASK_ID));
+
+      const { result, rerender } = setupWithToken(skipToken);
+
+      expect(getTaskCalls()).toHaveLength(0);
+
+      rerender({ arg: { limit: 50, offset: 0 } });
+
+      await waitFor(() =>
+        expect(result.current.data?.data[0].id).toBe(PAGE_0_TASK_ID),
+      );
+      expect(getTaskCalls()).toHaveLength(1);
+    });
+
+    it("preserves abort semantics after transitioning from skipToken to a real arg", async () => {
+      fetchMock.get({
+        url: "path:/api/task",
+        query: { offset: "0" },
+        name: "page-0",
+        response: makeResponse(PAGE_0_TASK_ID),
+        delay: 200,
+      });
+      fetchMock.get({
+        url: "path:/api/task",
+        query: { offset: "50" },
+        name: "page-1",
+        response: makeResponse(PAGE_1_TASK_ID),
+        delay: 10,
+      });
+
+      const { result, rerender } = setupWithToken(skipToken);
+
+      rerender({ arg: { limit: 50, offset: 0 } });
+
+      const getPage0Call = () =>
+        getTaskCalls().find((call) => call.url.includes("offset=0"));
+      await waitFor(() => expect(getPage0Call()).toBeDefined());
+
+      rerender({ arg: { limit: 50, offset: 50 } });
+
+      await waitFor(() => {
+        expect(result.current.data?.data[0].id).toBe(PAGE_1_TASK_ID);
+      });
+
+      expect(getPage0Call()?.request?.signal.aborted).toBe(true);
+      expect(result.current.error).toBeUndefined();
     });
   });
 });

--- a/frontend/src/metabase/common/hooks/use-abortable-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-abortable-query.unit.spec.tsx
@@ -384,7 +384,6 @@ describe("useAbortableQuery", () => {
       result.current.refetch();
     });
 
-    // Give any (erroneously scheduled) request a chance to fire.
     await Promise.resolve();
     expect(getTaskCalls()).toHaveLength(0);
   });

--- a/frontend/src/metabase/common/hooks/use-scroll-to-top.ts
+++ b/frontend/src/metabase/common/hooks/use-scroll-to-top.ts
@@ -10,20 +10,28 @@ type UseScrollToTopProps = {
 /**
  * Scrolls the element back to the top when `keys` change, e.g. after
  * paginating or sorting.
+ *
+ * The scroll is deferred until `skip` is false, so callers can bind `skip`
+ * to `isFetching` and have the reset land once the new page is in view.
+ * When `keys` change while not skipped (e.g. a cache hit where `isFetching`
+ * never toggles), the reset fires immediately. Never fires on mount.
  */
 export function useScrollToTop({
   ref,
   keys,
   skip = false,
 }: UseScrollToTopProps) {
-  const keysRef = useRef(keys);
+  const previousKeysRef = useRef(keys);
+  const keysVersionRef = useRef(0);
   const isResetPendingRef = useRef(false);
 
-  if (!_.isEqual(keysRef.current, keys)) {
-    keysRef.current = keys;
+  if (!_.isEqual(previousKeysRef.current, keys)) {
+    previousKeysRef.current = keys;
+    keysVersionRef.current += 1;
     isResetPendingRef.current = true;
   }
 
+  const keysVersion = keysVersionRef.current;
   useLayoutEffect(() => {
     if (!skip && isResetPendingRef.current) {
       isResetPendingRef.current = false;
@@ -31,5 +39,5 @@ export function useScrollToTop({
         ref.current.scrollTop = 0;
       }
     }
-  }, [ref, skip]);
+  }, [ref, skip, keysVersion]);
 }

--- a/frontend/src/metabase/common/hooks/use-scroll-to-top.ts
+++ b/frontend/src/metabase/common/hooks/use-scroll-to-top.ts
@@ -11,10 +11,7 @@ type UseScrollToTopProps = {
  * Scrolls the element back to the top when `keys` change, e.g. after
  * paginating or sorting.
  *
- * The scroll is deferred until `skip` is false, so callers can bind `skip`
- * to `isFetching` and have the reset land once the new page is in view.
- * When `keys` change while not skipped (e.g. a cache hit where `isFetching`
- * never toggles), the reset fires immediately. Never fires on mount.
+ * The scroll is deferred until `skip` is false.
  */
 export function useScrollToTop({
   ref,

--- a/frontend/src/metabase/common/hooks/use-scroll-to-top.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-scroll-to-top.unit.spec.tsx
@@ -1,0 +1,111 @@
+import { renderHook } from "@testing-library/react";
+import type { RefObject } from "react";
+
+import { useScrollToTop } from "./use-scroll-to-top";
+
+type Props = {
+  keys: unknown[];
+  skip: boolean;
+};
+
+function setup(initialProps: Props) {
+  const element = document.createElement("div");
+  const ref: RefObject<HTMLElement> = { current: element };
+  element.scrollTop = 100;
+
+  const view = renderHook(
+    ({ keys, skip }: Props) => useScrollToTop({ ref, keys, skip }),
+    { initialProps },
+  );
+
+  return { ...view, element };
+}
+
+describe("useScrollToTop", () => {
+  it("does not scroll on mount", () => {
+    const { element } = setup({ keys: [0], skip: false });
+    expect(element.scrollTop).toBe(100);
+  });
+
+  it("scrolls to top on a keys change while not skipped (cache-hit path)", () => {
+    const { rerender, element } = setup({ keys: [0], skip: false });
+    expect(element.scrollTop).toBe(100);
+
+    rerender({ keys: [1], skip: false });
+    expect(element.scrollTop).toBe(0);
+  });
+
+  it("defers the scroll until skip becomes false, then scrolls exactly once", () => {
+    const { rerender, element } = setup({ keys: [0], skip: false });
+
+    // Keys change while skipped (fetching): no scroll yet.
+    rerender({ keys: [1], skip: true });
+    expect(element.scrollTop).toBe(100);
+
+    // Fetch finishes: scroll now.
+    rerender({ keys: [1], skip: false });
+    expect(element.scrollTop).toBe(0);
+
+    // Reset the scroll position and toggle skip again: no further scroll,
+    // because the pending reset was already consumed.
+    element.scrollTop = 100;
+    rerender({ keys: [1], skip: true });
+    rerender({ keys: [1], skip: false });
+    expect(element.scrollTop).toBe(100);
+  });
+
+  it("does not scroll when skip toggles with unchanged keys", () => {
+    const { rerender, element } = setup({ keys: [0], skip: false });
+
+    rerender({ keys: [0], skip: true });
+    expect(element.scrollTop).toBe(100);
+
+    rerender({ keys: [0], skip: false });
+    expect(element.scrollTop).toBe(100);
+
+    rerender({ keys: [0], skip: true });
+    rerender({ keys: [0], skip: false });
+    expect(element.scrollTop).toBe(100);
+  });
+
+  it("scrolls on each distinct keys change", () => {
+    const { rerender, element } = setup({ keys: [0], skip: false });
+
+    rerender({ keys: [1], skip: false });
+    expect(element.scrollTop).toBe(0);
+
+    element.scrollTop = 100;
+    rerender({ keys: [2], skip: false });
+    expect(element.scrollTop).toBe(0);
+  });
+
+  it("treats deeply-equal object keys as unchanged", () => {
+    const { rerender, element } = setup({
+      keys: [1, { sortColumn: "name", sortDirection: "asc" }],
+      skip: false,
+    });
+
+    rerender({
+      keys: [1, { sortColumn: "name", sortDirection: "asc" }],
+      skip: false,
+    });
+    expect(element.scrollTop).toBe(100);
+
+    rerender({
+      keys: [1, { sortColumn: "name", sortDirection: "desc" }],
+      skip: false,
+    });
+    expect(element.scrollTop).toBe(0);
+  });
+
+  it("distinguishes key values that serialize identically", () => {
+    const { rerender, element } = setup({
+      keys: [undefined],
+      skip: false,
+    });
+
+    rerender({ keys: [null], skip: false });
+
+    expect(element.scrollTop).toBe(0);
+  });
+});

--- a/frontend/src/metabase/common/monitor/analytics.ts
+++ b/frontend/src/metabase/common/monitor/analytics.ts
@@ -1,0 +1,21 @@
+import { trackSimpleEvent } from "metabase/analytics";
+import type {
+  MonitorOpenedEvent,
+  MonitorSectionClickedEvent,
+} from "metabase-types/analytics/event";
+
+export type MonitorSection = MonitorSectionClickedEvent["event_detail"];
+
+export const trackMonitorOpened = () => {
+  trackSimpleEvent({
+    event: "monitor_opened",
+    triggered_from: "nav_menu",
+  } satisfies MonitorOpenedEvent);
+};
+
+export const trackMonitorSectionClicked = (section: MonitorSection) => {
+  trackSimpleEvent({
+    event: "monitor_section_clicked",
+    event_detail: section,
+  } satisfies MonitorSectionClickedEvent);
+};

--- a/frontend/src/metabase/common/monitor/selectors.unit.spec.ts
+++ b/frontend/src/metabase/common/monitor/selectors.unit.spec.ts
@@ -12,7 +12,10 @@ jest.mock("metabase/selectors/embed", () => ({
   getIsEmbeddingIframe: jest.fn(() => false),
 }));
 
-const { getIsEmbeddingIframe } = jest.requireMock("metabase/selectors/embed");
+// Jest's requireMock API is untyped, so define the mock module boundary.
+const { getIsEmbeddingIframe } = jest.requireMock(
+  "metabase/selectors/embed",
+) as { getIsEmbeddingIframe: jest.Mock };
 
 describe("canAccessMonitor", () => {
   beforeEach(() => {

--- a/frontend/src/metabase/common/monitor/selectors.unit.spec.ts
+++ b/frontend/src/metabase/common/monitor/selectors.unit.spec.ts
@@ -12,10 +12,7 @@ jest.mock("metabase/selectors/embed", () => ({
   getIsEmbeddingIframe: jest.fn(() => false),
 }));
 
-// Jest's requireMock API is untyped, so define the mock module boundary.
-const { getIsEmbeddingIframe } = jest.requireMock(
-  "metabase/selectors/embed",
-) as { getIsEmbeddingIframe: jest.Mock };
+const { getIsEmbeddingIframe } = jest.requireMock("metabase/selectors/embed");
 
 describe("canAccessMonitor", () => {
   beforeEach(() => {

--- a/frontend/src/metabase/data-studio/routes.tsx
+++ b/frontend/src/metabase/data-studio/routes.tsx
@@ -43,6 +43,13 @@ export function getDataStudioRoutes(
 ) {
   return (
     <>
+      {/* These redirects sit
+       * OUTSIDE the CanAccessDataStudio guard — users without Data Studio access must
+       * still be forwarded —
+       * and are declared BEFORE the guarded subtree so they win over its `path="*"`
+       * catch-all
+       */}
+
       {getDataStudioDependencyDiagnosticsRedirects()}
       <Route element={<CanAccessDataStudio />}>
         <Route path="data-studio" element={<DataStudioLayout />}>
@@ -89,13 +96,7 @@ export function getDataStudioRoutes(
 }
 
 /**
- * Dependency Diagnostics moved from Data Studio to Monitor. These redirects sit
- * OUTSIDE the CanAccessDataStudio guard — users without Data Studio access must
- * still be forwarded (the guard would otherwise bounce them to /unauthorized) —
- * and are declared BEFORE the guarded subtree so they win over its `path="*"`
- * catch-all (first full match in declaration order wins), which would otherwise
- * shadow them with a NotFound inside the Data Studio layout.
- */
+ * Dependency Diagnostics moved from Data Studio to Monitor.  */
 export function getDataStudioDependencyDiagnosticsRedirects() {
   return (
     <>

--- a/frontend/src/metabase/data-studio/routes.tsx
+++ b/frontend/src/metabase/data-studio/routes.tsx
@@ -12,6 +12,7 @@ import {
   Navigate,
   Route,
   type RouteComponent,
+  redirect,
   withRouteProps,
 } from "metabase/router";
 import { getDataStudioTransformRoutes } from "metabase/transforms/routes";
@@ -41,46 +42,72 @@ export function getDataStudioRoutes(
   IsAdmin: RouteComponent,
 ) {
   return (
-    <Route element={<CanAccessDataStudio />}>
-      <Route path="data-studio" element={<DataStudioLayout />}>
-        <Route index element={<DataStudioIndexRedirect />} />
-        <Route path="data" element={<CanAccessDataModel />}>
-          <Route element={<DataSectionLayout />}>
-            {getDataStudioMetadataRoutes(IsAdmin)}
+    <>
+      {getDataStudioDependencyDiagnosticsRedirects()}
+      <Route element={<CanAccessDataStudio />}>
+        <Route path="data-studio" element={<DataStudioLayout />}>
+          <Route index element={<DataStudioIndexRedirect />} />
+          <Route path="data" element={<CanAccessDataModel />}>
+            <Route element={<DataSectionLayout />}>
+              {getDataStudioMetadataRoutes(IsAdmin)}
+            </Route>
           </Route>
-        </Route>
-        <Route path="transforms" element={<RoutedTransformsSectionLayout />}>
-          {getDataStudioTransformRoutes()}
-        </Route>
-        <Route element={<WorkspacesSectionLayout />}>
-          {PLUGIN_WORKSPACES.getDataStudioRoutes()}
-        </Route>
-        {getDataStudioGlossaryRoutes()}
-        {getDataStudioSettingsRoutes()}
-        {PLUGIN_LIBRARY.isEnabled ? (
-          PLUGIN_LIBRARY.getDataStudioLibraryRoutes(IsAdmin)
-        ) : (
-          <Route path="library" element={<LibraryUpsellPage />} />
-        )}
-        {PLUGIN_DEPENDENCIES.isEnabled ? (
-          <Route path="dependencies" element={<DependenciesSectionLayout />}>
-            {PLUGIN_DEPENDENCIES.getDataStudioDependencyRoutes()}
+          <Route path="transforms" element={<RoutedTransformsSectionLayout />}>
+            {getDataStudioTransformRoutes()}
           </Route>
-        ) : (
-          <Route path="dependencies" element={<DependenciesUpsellPage />} />
-        )}
-        {PLUGIN_SCHEMA_VIEWER.isEnabled ? (
-          <Route path="schema-viewer">
-            {PLUGIN_SCHEMA_VIEWER.getDataStudioSchemaViewerRoutes()}
+          <Route element={<WorkspacesSectionLayout />}>
+            {PLUGIN_WORKSPACES.getDataStudioRoutes()}
           </Route>
-        ) : (
-          <Route path="schema-viewer" element={<SchemaViewerUpsellPage />} />
-        )}
-        <Route path="git-sync" element={<GitSyncSectionLayout />} />
+          {getDataStudioGlossaryRoutes()}
+          {getDataStudioSettingsRoutes()}
+          {PLUGIN_LIBRARY.isEnabled ? (
+            PLUGIN_LIBRARY.getDataStudioLibraryRoutes(IsAdmin)
+          ) : (
+            <Route path="library" element={<LibraryUpsellPage />} />
+          )}
+          {PLUGIN_DEPENDENCIES.isEnabled ? (
+            <Route path="dependencies" element={<DependenciesSectionLayout />}>
+              {PLUGIN_DEPENDENCIES.getDataStudioDependencyRoutes()}
+            </Route>
+          ) : (
+            <Route path="dependencies" element={<DependenciesUpsellPage />} />
+          )}
+          {PLUGIN_SCHEMA_VIEWER.isEnabled ? (
+            <Route path="schema-viewer">
+              {PLUGIN_SCHEMA_VIEWER.getDataStudioSchemaViewerRoutes()}
+            </Route>
+          ) : (
+            <Route path="schema-viewer" element={<SchemaViewerUpsellPage />} />
+          )}
+          <Route path="git-sync" element={<GitSyncSectionLayout />} />
 
-        <Route path="*" element={<NotFound />} />
+          <Route path="*" element={<NotFound />} />
+        </Route>
       </Route>
-    </Route>
+    </>
+  );
+}
+
+/**
+ * Dependency Diagnostics moved from Data Studio to Monitor. These redirects sit
+ * OUTSIDE the CanAccessDataStudio guard — users without Data Studio access must
+ * still be forwarded (the guard would otherwise bounce them to /unauthorized) —
+ * and are declared BEFORE the guarded subtree so they win over its `path="*"`
+ * catch-all (first full match in declaration order wins), which would otherwise
+ * shadow them with a NotFound inside the Data Studio layout.
+ */
+export function getDataStudioDependencyDiagnosticsRedirects() {
+  return (
+    <>
+      <Route
+        path="data-studio/dependency-diagnostics"
+        element={redirect(Urls.dependencyDiagnostics())}
+      />
+      <Route
+        path="data-studio/dependency-diagnostics/*"
+        element={redirect(`${Urls.dependencyDiagnostics()}/*`)}
+      />
+    </>
   );
 }
 

--- a/frontend/src/metabase/data-studio/routes.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/routes.unit.spec.tsx
@@ -1,0 +1,52 @@
+import { renderWithProviders, screen } from "__support__/ui";
+import { Outlet, Route } from "metabase/router";
+
+import { getDataStudioRoutes } from "./routes";
+
+const DenyingDataStudioGuard = () => (
+  <div data-testid="data-studio-access-denied" />
+);
+const AllowingGuard = () => <Outlet />;
+
+function setup(initialRoute: string) {
+  renderWithProviders(
+    <Route path="/">
+      {getDataStudioRoutes(
+        DenyingDataStudioGuard,
+        AllowingGuard,
+        AllowingGuard,
+      )}
+      <Route
+        path="monitor/dependency-diagnostics"
+        element={<div data-testid="diagnostics-index" />}
+      />
+      <Route
+        path="monitor/dependency-diagnostics/unreferenced"
+        element={<div data-testid="diagnostics-unreferenced" />}
+      />
+    </Route>,
+    { initialRoute, withRouter: true },
+  );
+}
+
+describe("Data Studio routes", () => {
+  it("redirects the legacy Dependency Diagnostics index outside the Data Studio access guard", async () => {
+    setup("/data-studio/dependency-diagnostics");
+
+    expect(await screen.findByTestId("diagnostics-index")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("data-studio-access-denied"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("preserves the child path instead of matching the Data Studio catch-all", async () => {
+    setup("/data-studio/dependency-diagnostics/unreferenced");
+
+    expect(
+      await screen.findByTestId("diagnostics-unreferenced"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("data-studio-access-denied"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.tsx
+++ b/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.tsx
@@ -4,6 +4,10 @@ import { t } from "ttag";
 import { useHasTokenFeature } from "metabase/common/hooks";
 import { useUserKeyValue } from "metabase/common/hooks/use-user-key-value";
 import {
+  type MonitorSection,
+  trackMonitorSectionClicked,
+} from "metabase/common/monitor/analytics";
+import {
   canAccessAlertsManagement,
   canAccessMonitorDiagnostics,
   canAccessMonitoringTools,
@@ -20,15 +24,6 @@ import { FixedSizeIcon, Flex } from "metabase/ui";
 import * as Urls from "metabase/urls";
 
 import { MonitorContent } from "./MonitorContent";
-
-type MonitorSection =
-  | "diagnostics"
-  | "erroring-questions"
-  | "alerts"
-  | "tasks"
-  | "jobs"
-  | "logs"
-  | "model-caching";
 
 function getActiveSection(pathname: string): MonitorSection | null {
   return match(pathname)
@@ -92,6 +87,7 @@ export function MonitorLayout() {
               isSelected={activeSection === "diagnostics"}
               showLabel={isNavbarOpened}
               isGated={!hasDependenciesFeature}
+              onClick={() => trackMonitorSectionClicked("diagnostics")}
             />
           )}
           {canAccessTools && (
@@ -102,6 +98,7 @@ export function MonitorLayout() {
               isSelected={activeSection === "erroring-questions"}
               showLabel={isNavbarOpened}
               isGated={!hasAuditAppFeature}
+              onClick={() => trackMonitorSectionClicked("erroring-questions")}
             />
           )}
           {canAccessAlerts && (
@@ -111,6 +108,7 @@ export function MonitorLayout() {
               to={Urls.monitorNotifications()}
               isSelected={activeSection === "alerts"}
               showLabel={isNavbarOpened}
+              onClick={() => trackMonitorSectionClicked("alerts")}
             />
           )}
         </AreaTabGroup>
@@ -123,6 +121,7 @@ export function MonitorLayout() {
             to={Urls.monitorTasks()}
             isSelected={activeSection === "tasks"}
             showLabel={isNavbarOpened}
+            onClick={() => trackMonitorSectionClicked("tasks")}
           />
           <AreaTab
             label={t`Scheduled jobs`}
@@ -130,6 +129,7 @@ export function MonitorLayout() {
             to={Urls.monitorJobs()}
             isSelected={activeSection === "jobs"}
             showLabel={isNavbarOpened}
+            onClick={() => trackMonitorSectionClicked("jobs")}
           />
           <AreaTab
             label={t`Application logs`}
@@ -137,6 +137,7 @@ export function MonitorLayout() {
             to={Urls.monitorLogs()}
             isSelected={activeSection === "logs"}
             showLabel={isNavbarOpened}
+            onClick={() => trackMonitorSectionClicked("logs")}
           />
           <AreaTab
             label={t`Model caching log`}
@@ -144,6 +145,7 @@ export function MonitorLayout() {
             to={Urls.monitorModelCaching()}
             isSelected={activeSection === "model-caching"}
             showLabel={isNavbarOpened}
+            onClick={() => trackMonitorSectionClicked("model-caching")}
           />
         </AreaTabGroup>
       )}

--- a/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.unit.spec.tsx
@@ -29,10 +29,9 @@ jest.mock("metabase/common/monitor/analytics", () => ({
   trackMonitorSectionClicked: jest.fn(),
 }));
 
-// Jest's requireMock API is untyped, so define the mock module boundary.
 const { trackMonitorSectionClicked } = jest.requireMock(
   "metabase/common/monitor/analytics",
-) as { trackMonitorSectionClicked: jest.Mock };
+);
 
 interface SetupOpts {
   isNavbarOpened?: boolean;

--- a/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/components/MonitorLayout/MonitorLayout.unit.spec.tsx
@@ -25,6 +25,15 @@ import {
 import { MonitorLayout } from "./MonitorLayout";
 import { Sidebar } from "./Sidebar";
 
+jest.mock("metabase/common/monitor/analytics", () => ({
+  trackMonitorSectionClicked: jest.fn(),
+}));
+
+// Jest's requireMock API is untyped, so define the mock module boundary.
+const { trackMonitorSectionClicked } = jest.requireMock(
+  "metabase/common/monitor/analytics",
+) as { trackMonitorSectionClicked: jest.Mock };
+
 interface SetupOpts {
   isNavbarOpened?: boolean;
   tokenFeatures?: Partial<TokenFeatures>;
@@ -146,15 +155,43 @@ describe("MonitorLayout", () => {
     });
   });
 
-  const SECTION_CASES: { label: string; route: string }[] = [
-    { label: "Dependency diagnostics", route: Urls.dependencyDiagnostics() },
-    { label: "Erroring questions", route: Urls.monitorErroringQuestions() },
-    { label: "Alerts management", route: Urls.monitorNotifications() },
-    { label: "Background tasks", route: Urls.monitorTasks() },
-    { label: "Scheduled jobs", route: Urls.monitorJobs() },
-    { label: "Application logs", route: Urls.monitorLogs() },
-    { label: "Model caching log", route: Urls.monitorModelCaching() },
-  ];
+  const SECTION_CASES = [
+    {
+      label: "Dependency diagnostics",
+      route: Urls.dependencyDiagnostics(),
+      section: "diagnostics",
+    },
+    {
+      label: "Erroring questions",
+      route: Urls.monitorErroringQuestions(),
+      section: "erroring-questions",
+    },
+    {
+      label: "Alerts management",
+      route: Urls.monitorNotifications(),
+      section: "alerts",
+    },
+    {
+      label: "Background tasks",
+      route: Urls.monitorTasks(),
+      section: "tasks",
+    },
+    {
+      label: "Scheduled jobs",
+      route: Urls.monitorJobs(),
+      section: "jobs",
+    },
+    {
+      label: "Application logs",
+      route: Urls.monitorLogs(),
+      section: "logs",
+    },
+    {
+      label: "Model caching log",
+      route: Urls.monitorModelCaching(),
+      section: "model-caching",
+    },
+  ] as const;
 
   it.each(SECTION_CASES)(
     "marks $label as the current page for its route",
@@ -170,6 +207,18 @@ describe("MonitorLayout", () => {
       expect(screen.getAllByRole("link", { current: "page" })).toEqual([
         activeLink,
       ]);
+    },
+  );
+
+  it.each(SECTION_CASES)(
+    "tracks opening the $label section",
+    async ({ label, section }) => {
+      trackMonitorSectionClicked.mockClear();
+      setup();
+
+      await userEvent.click(await screen.findByRole("link", { name: label }));
+
+      expect(trackMonitorSectionClicked).toHaveBeenCalledWith(section);
     },
   );
 

--- a/frontend/src/metabase/monitor/routes.tsx
+++ b/frontend/src/metabase/monitor/routes.tsx
@@ -106,7 +106,6 @@ function getMonitorIndexPath(state: State) {
  * Legacy redirects for Admin Tools pages that moved into the Monitor area:
  *   - /admin/tools → /monitor
  *   - /admin/tools/help → /admin/help
- *   - /admin/tools/dependencies → /data-studio/dependencies (the dependency graph)
  *
  * The Data Studio → Monitor redirect for Dependency Diagnostics lives in
  * data-studio/routes.tsx instead: it must be declared inside the Data Studio
@@ -158,14 +157,6 @@ export function getMonitorRedirects() {
       <Route
         path="/admin/tools/notifications/*"
         element={redirect(`${Urls.monitorNotifications()}/*`)}
-      />
-      <Route
-        path="/admin/tools/dependencies"
-        element={redirect(Urls.dependencyGraph())}
-      />
-      <Route
-        path="/admin/tools/dependencies/*"
-        element={redirect(`${Urls.dependencyGraph()}/*`)}
       />
       <Route path="/admin/tools" element={redirect(Urls.monitor())} />
     </>

--- a/frontend/src/metabase/monitor/routes.tsx
+++ b/frontend/src/metabase/monitor/routes.tsx
@@ -103,24 +103,19 @@ function getMonitorIndexPath(state: State) {
 }
 
 /**
- * Legacy redirects for views that moved into the Monitor area:
- * - Dependency Diagnostics: Data Studio → Monitor.
- * - Admin Tools pages:
+ * Legacy redirects for Admin Tools pages that moved into the Monitor area:
  *   - /admin/tools → /monitor
  *   - /admin/tools/help → /admin/help
+ *   - /admin/tools/dependencies → /data-studio/dependencies (the dependency graph)
+ *
+ * The Data Studio → Monitor redirect for Dependency Diagnostics lives in
+ * data-studio/routes.tsx instead: it must be declared inside the Data Studio
+ * region (before that subtree's catch-all) so it isn't shadowed, yet outside the
+ * Data Studio access guard so it forwards every user.
  */
 export function getMonitorRedirects() {
   return (
     <>
-      <Route
-        path="/data-studio/dependency-diagnostics"
-        element={redirect(Urls.dependencyDiagnostics())}
-      />
-      <Route
-        path="/data-studio/dependency-diagnostics/*"
-        element={redirect(`${Urls.dependencyDiagnostics()}/*`)}
-      />
-
       <Route path="/admin/tools/help" element={redirect(Urls.adminHelp())} />
       <Route
         path="/admin/tools/help/*"
@@ -163,6 +158,14 @@ export function getMonitorRedirects() {
       <Route
         path="/admin/tools/notifications/*"
         element={redirect(`${Urls.monitorNotifications()}/*`)}
+      />
+      <Route
+        path="/admin/tools/dependencies"
+        element={redirect(Urls.dependencyGraph())}
+      />
+      <Route
+        path="/admin/tools/dependencies/*"
+        element={redirect(`${Urls.dependencyGraph()}/*`)}
       />
       <Route path="/admin/tools" element={redirect(Urls.monitor())} />
     </>

--- a/frontend/src/metabase/monitor/routes.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/routes.unit.spec.tsx
@@ -98,27 +98,6 @@ const CanAccessAlertsManagement = () => <Outlet />;
 const UPSELL_TITLE =
   "Find and fix broken dependencies without hunting them down";
 
-// Stand-in for the Data Studio subtree (data-studio/routes.tsx). Its `path="*"`
-// catch-all is exactly what shadowed the legacy dependency-diagnostics redirect
-// before the fix, so we mount it here — declared before the Monitor region, as
-// in metabase/routes.tsx — to reproduce the app's real declaration order.
-const DataStudioCatchAll = () => (
-  <div data-testid="data-studio-catch-all">{"Data Studio Not Found"}</div>
-);
-const DataStudioDependencies = () => (
-  <div data-testid="data-studio-dependencies">{"Dependency graph"}</div>
-);
-
-const dataStudioStandInRoutes = (
-  <Route path="data-studio">
-    <Route path="dependencies">
-      <Route index element={<DataStudioDependencies />} />
-      <Route path="*" element={<DataStudioDependencies />} />
-    </Route>
-    <Route path="*" element={<DataStudioCatchAll />} />
-  </Route>
-);
-
 type SetupOpts = {
   initialRoute: string;
   user?: ReturnType<typeof createMockUser>;
@@ -130,7 +109,6 @@ const setup = ({
 }: SetupOpts) => {
   return renderWithProviders(
     <Route path="/">
-      {dataStudioStandInRoutes}
       {getMonitorRedirects()}
       {getMonitorRoutes(
         CanAccessMonitor,
@@ -164,7 +142,6 @@ const setupWithGuards = ({
 }) => {
   return renderWithProviders(
     <Route path="/">
-      {dataStudioStandInRoutes}
       {getMonitorRedirects()}
       {getMonitorRoutes(CanAccessMonitor, Diagnostics, Tools, AlertsManagement)}
     </Route>,
@@ -380,17 +357,6 @@ describe("monitor routes", () => {
       setup({ initialRoute: "/admin/tools" });
 
       expect(await screen.findByText(UPSELL_TITLE)).toBeInTheDocument();
-    });
-
-    it.each([
-      ["/admin/tools/dependencies"],
-      ["/admin/tools/dependencies/some-node"],
-    ])("redirects %s to the Data Studio dependency graph", async (route) => {
-      setup({ initialRoute: route });
-
-      expect(
-        await screen.findByTestId("data-studio-dependencies"),
-      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/monitor/routes.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/routes.unit.spec.tsx
@@ -98,6 +98,27 @@ const CanAccessAlertsManagement = () => <Outlet />;
 const UPSELL_TITLE =
   "Find and fix broken dependencies without hunting them down";
 
+// Stand-in for the Data Studio subtree (data-studio/routes.tsx). Its `path="*"`
+// catch-all is exactly what shadowed the legacy dependency-diagnostics redirect
+// before the fix, so we mount it here — declared before the Monitor region, as
+// in metabase/routes.tsx — to reproduce the app's real declaration order.
+const DataStudioCatchAll = () => (
+  <div data-testid="data-studio-catch-all">{"Data Studio Not Found"}</div>
+);
+const DataStudioDependencies = () => (
+  <div data-testid="data-studio-dependencies">{"Dependency graph"}</div>
+);
+
+const dataStudioStandInRoutes = (
+  <Route path="data-studio">
+    <Route path="dependencies">
+      <Route index element={<DataStudioDependencies />} />
+      <Route path="*" element={<DataStudioDependencies />} />
+    </Route>
+    <Route path="*" element={<DataStudioCatchAll />} />
+  </Route>
+);
+
 type SetupOpts = {
   initialRoute: string;
   user?: ReturnType<typeof createMockUser>;
@@ -109,6 +130,7 @@ const setup = ({
 }: SetupOpts) => {
   return renderWithProviders(
     <Route path="/">
+      {dataStudioStandInRoutes}
       {getMonitorRedirects()}
       {getMonitorRoutes(
         CanAccessMonitor,
@@ -142,6 +164,7 @@ const setupWithGuards = ({
 }) => {
   return renderWithProviders(
     <Route path="/">
+      {dataStudioStandInRoutes}
       {getMonitorRedirects()}
       {getMonitorRoutes(CanAccessMonitor, Diagnostics, Tools, AlertsManagement)}
     </Route>,
@@ -276,20 +299,6 @@ describe("monitor routes", () => {
     });
   });
 
-  describe("getMonitorRedirects (legacy Data Studio URLs)", () => {
-    it("redirects the old base URL into the Monitor area", async () => {
-      setup({ initialRoute: "/data-studio/dependency-diagnostics" });
-
-      expect(await screen.findByText(UPSELL_TITLE)).toBeInTheDocument();
-    });
-
-    it("redirects old child URLs (e.g. /broken) to the Monitor equivalent", async () => {
-      setup({ initialRoute: "/data-studio/dependency-diagnostics/broken" });
-
-      expect(await screen.findByText(UPSELL_TITLE)).toBeInTheDocument();
-    });
-  });
-
   describe("Tools sections (migrated from /admin/tools)", () => {
     it("renders the Logs section at /monitor/logs", async () => {
       setup({ initialRoute: "/monitor/logs" });
@@ -371,6 +380,17 @@ describe("monitor routes", () => {
       setup({ initialRoute: "/admin/tools" });
 
       expect(await screen.findByText(UPSELL_TITLE)).toBeInTheDocument();
+    });
+
+    it.each([
+      ["/admin/tools/dependencies"],
+      ["/admin/tools/dependencies/some-node"],
+    ])("redirects %s to the Data Studio dependency graph", async (route) => {
+      setup({ initialRoute: route });
+
+      expect(
+        await screen.findByTestId("data-studio-dependencies"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobInfoApp.tsx
+++ b/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobInfoApp.tsx
@@ -17,7 +17,7 @@ type RouteParams = {
 };
 
 export const JobInfoApp = ({ params }: WithRouterProps<RouteParams>) => {
-  const { data, error, isFetching } = useGetTasksInfoQuery();
+  const { data, error, isLoading, isFetching } = useGetTasksInfoQuery();
   const { ref: containerRef, width: containerWidth } = useElementSize();
   const { jobKey } = params;
 
@@ -36,7 +36,7 @@ export const JobInfoApp = ({ params }: WithRouterProps<RouteParams>) => {
                 {data.scheduler.join("\n")}
               </Code>
             )}
-            <JobsTable jobs={data?.jobs ?? []} isLoading={isFetching} />
+            <JobsTable jobs={data?.jobs ?? []} isLoading={isLoading} />
           </>
         )}
       </MonitorMain>

--- a/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobsTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobsTable.tsx
@@ -2,13 +2,12 @@ import type { Row } from "@tanstack/react-table";
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
+import { MonitorEmptyState } from "metabase/monitor/components/MonitorEmptyState";
 import { useDispatch } from "metabase/redux";
 import { push } from "metabase/router";
 import {
   Card,
   Ellipsified,
-  Stack,
-  Text,
   TreeTable,
   type TreeTableColumnDef,
   TreeTableSkeleton,
@@ -58,11 +57,7 @@ export const JobsTable = ({ isLoading, jobs }: JobsTableProps) => {
           instance={treeTableInstance}
           hierarchical={false}
           ariaLabel={t`Jobs`}
-          emptyState={
-            <Stack p="xl" align="center">
-              <Text c="text-disabled">{t`No results`}</Text>
-            </Stack>
-          }
+          emptyState={<MonitorEmptyState label={t`No results`} />}
           getRowProps={() => ({ "data-testid": "job" })}
           onRowClick={handleRowActivate}
         />

--- a/frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
+++ b/frontend/src/metabase/monitor/tools/components/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
@@ -46,7 +46,7 @@ export function ModelCacheRefreshJobs() {
   const [refreshModelCache] = useRefreshModelCacheMutation();
   const { page, handleNextPage, handlePreviousPage } = usePagination();
 
-  const { data, error, isFetching } = useAbortableQuery(
+  const { data, error, isLoading, isFetching } = useAbortableQuery(
     useLazyListPersistedInfoQuery,
     {
       limit: PAGE_SIZE,
@@ -99,7 +99,7 @@ export function ModelCacheRefreshJobs() {
         withBorder
         data-testid="model-cache-logs"
       >
-        {isFetching ? (
+        {isLoading ? (
           <TreeTableSkeleton columnWidths={COLUMN_WIDTHS} />
         ) : (
           <TreeTable
@@ -113,7 +113,7 @@ export function ModelCacheRefreshJobs() {
         )}
       </Card>
 
-      {!isFetching && hasPagination && (
+      {!isLoading && hasPagination && (
         <Flex justify="end">
           <PaginationControls
             showTotal
@@ -163,7 +163,7 @@ function getColumns(
       maxAutoWidth: 240,
       enableSorting: true,
       sortDescFirst: false,
-      accessorFn: (job) => job.collection_name ?? t`Our analytics`,
+      accessorFn: (job) => job.collection_name || t`Our analytics`,
       cell: ({ row }) => {
         const { collection_id, collection_name } = row.original;
         return (
@@ -212,7 +212,7 @@ function getColumns(
       maxAutoWidth: 200,
       enableSorting: true,
       sortDescFirst: false,
-      accessorFn: (job) => job.creator?.common_name ?? t`Automatic`,
+      accessorFn: (job) => job.creator?.common_name || t`Automatic`,
       cell: ({ row }) => row.original.creator?.common_name || t`Automatic`,
     },
     {

--- a/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
@@ -69,7 +69,6 @@ export const TaskDetailsPage = ({ params }: TaskDetailsPageProps) => {
           label={t`Back to Tasks`}
         />
 
-        {/* <Box flex="1 1 auto" mih={0}> */}
         <MonitorPageContent className={S.content}>
           <Stack gap="sm">
             <MonitorHeaderTitle>{t`Task details`}</MonitorHeaderTitle>
@@ -190,7 +189,6 @@ export const TaskDetailsPage = ({ params }: TaskDetailsPageProps) => {
             )}
           </Stack>
         </MonitorPageContent>
-        {/* </Box> */}
       </MonitorMain>
     </Flex>
   );

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+
 import { useLazyListTasksQuery, useListDatabasesQuery } from "metabase/api";
 import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
 import { PaginationControls } from "metabase/common/components/PaginationControls";
@@ -20,7 +22,10 @@ export const TaskListPage = ({ location }: WithRouterProps) => {
     { page, sort_column, sort_direction, status, task },
     { patchUrlState },
   ] = useUrlState(location, urlStateConfig);
-  const sortingOptions = { sort_column, sort_direction };
+  const sortingOptions = useMemo(
+    () => ({ sort_column, sort_direction }),
+    [sort_column, sort_direction],
+  );
 
   const {
     data: tasksData,

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TasksTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TasksTable.tsx
@@ -5,13 +5,13 @@ import _ from "underscore";
 
 import { DateTime } from "metabase/common/components/DateTime";
 import { useScrollToTop, useSortingStateChange } from "metabase/common/hooks";
+import { MonitorEmptyState } from "metabase/monitor/components/MonitorEmptyState";
 import { TaskStatusBadge } from "metabase/monitor/tools/components/TaskStatusBadge";
 import { useDispatch } from "metabase/redux";
 import { push } from "metabase/router";
 import {
   Card,
   Ellipsified,
-  Stack,
   Text,
   TreeTable,
   type TreeTableColumnDef,
@@ -99,11 +99,7 @@ export const TasksTable = ({
           instance={treeTableInstance}
           hierarchical={false}
           ariaLabel={t`Tasks`}
-          emptyState={
-            <Stack p="xl" align="center">
-              <Text c="text-disabled">{t`No results`}</Text>
-            </Stack>
-          }
+          emptyState={<MonitorEmptyState label={t`No results`} />}
           getRowProps={() => ({ "data-testid": "task" })}
           onRowClick={handleRowActivate}
         />

--- a/frontend/src/metabase/monitor/tools/components/TaskRunEntityPicker/TaskRunEntityPicker.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunEntityPicker/TaskRunEntityPicker.tsx
@@ -1,14 +1,10 @@
 import { useMemo } from "react";
 import { t } from "ttag";
 
-import { useLazyListTaskRunEntitiesQuery } from "metabase/api";
+import { skipToken, useLazyListTaskRunEntitiesQuery } from "metabase/api";
 import { useAbortableQuery } from "metabase/common/hooks/use-abortable-query";
 import { Loader, Select, type SelectProps, Tooltip } from "metabase/ui";
-import type {
-  ListTaskRunEntitiesRequest,
-  TaskRunDateFilterOption,
-  TaskRunType,
-} from "metabase-types/api";
+import type { TaskRunDateFilterOption, TaskRunType } from "metabase-types/api";
 
 import { toBackendStartedAt } from "../../utils";
 
@@ -18,11 +14,6 @@ import {
   parseValue,
   serializeValue,
 } from "./utils";
-
-const SKIPPED_ENTITY_REQUEST: ListTaskRunEntitiesRequest = {
-  "run-type": "sync",
-  "started-at": "thisday",
-};
 
 type TaskRunEntityPickerProps = Omit<
   SelectProps,
@@ -49,8 +40,7 @@ export const TaskRunEntityPicker = ({
     useLazyListTaskRunEntitiesQuery,
     hasAllRequiredParams
       ? { "run-type": runType, "started-at": effectiveStartedAt }
-      : SKIPPED_ENTITY_REQUEST,
-    { skip: !hasAllRequiredParams },
+      : skipToken,
   );
 
   const data = useMemo(

--- a/frontend/src/metabase/monitor/tools/components/TaskRunEntityPicker/TaskRunEntityPicker.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunEntityPicker/TaskRunEntityPicker.unit.spec.tsx
@@ -1,0 +1,85 @@
+import fetchMock from "fetch-mock";
+
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import type {
+  RunEntity,
+  TaskRunDateFilterOption,
+  TaskRunType,
+} from "metabase-types/api";
+
+import { TaskRunEntityPicker } from "./TaskRunEntityPicker";
+
+const ENTITIES: RunEntity[] = [
+  { entity_type: "database", entity_id: 1, entity_name: "Sample DB" },
+  { entity_type: "card", entity_id: 2, entity_name: "My question" },
+];
+
+function setup({
+  runType = "sync",
+  startedAt = "past7days",
+  includeToday = false,
+  entities = ENTITIES,
+}: {
+  runType?: TaskRunType | null;
+  startedAt?: TaskRunDateFilterOption | null;
+  includeToday?: boolean;
+  entities?: RunEntity[];
+} = {}) {
+  fetchMock.get("path:/api/task/runs/entities", entities);
+
+  const onChange = jest.fn();
+  renderWithProviders(
+    <TaskRunEntityPicker
+      runType={runType}
+      startedAt={startedAt}
+      includeToday={includeToday}
+      value={null}
+      onChange={onChange}
+    />,
+  );
+
+  return { onChange };
+}
+
+const getEntityCalls = () =>
+  fetchMock.callHistory.calls("path:/api/task/runs/entities");
+
+describe("TaskRunEntityPicker", () => {
+  it("does not request entities when the run type is missing", async () => {
+    setup({ runType: null });
+
+    // Give any erroneously scheduled request a chance to fire.
+    await Promise.resolve();
+    expect(getEntityCalls()).toHaveLength(0);
+    expect(screen.getByPlaceholderText("Filter by entity")).toBeDisabled();
+  });
+
+  it("does not request entities when the start time is missing", async () => {
+    setup({ startedAt: null });
+
+    await Promise.resolve();
+    expect(getEntityCalls()).toHaveLength(0);
+    expect(screen.getByPlaceholderText("Filter by entity")).toBeDisabled();
+  });
+
+  it("requests entities with the resolved params once all are set", async () => {
+    setup({ runType: "sync", startedAt: "past7days" });
+
+    await waitFor(() => expect(getEntityCalls()).toHaveLength(1));
+
+    const url = getEntityCalls()[0].url;
+    expect(url).toContain("run-type=sync");
+    expect(url).toContain("started-at=past7days");
+
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("Filter by entity")).toBeEnabled(),
+    );
+  });
+
+  it("appends the include-today suffix to relative ranges", async () => {
+    setup({ runType: "sync", startedAt: "past7days", includeToday: true });
+
+    await waitFor(() => expect(getEntityCalls()).toHaveLength(1));
+    expect(getEntityCalls()[0].url).toContain("started-at=past7days%7E");
+  });
+});

--- a/frontend/src/metabase/monitor/tools/components/TaskRunEntityPicker/TaskRunEntityPicker.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunEntityPicker/TaskRunEntityPicker.unit.spec.tsx
@@ -48,7 +48,6 @@ describe("TaskRunEntityPicker", () => {
   it("does not request entities when the run type is missing", async () => {
     setup({ runType: null });
 
-    // Give any erroneously scheduled request a chance to fire.
     await Promise.resolve();
     expect(getEntityCalls()).toHaveLength(0);
     expect(screen.getByPlaceholderText("Filter by entity")).toBeDisabled();

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { t } from "ttag";
 
 import { useLazyListTaskRunsQuery } from "metabase/api";
@@ -35,7 +36,10 @@ export const TaskRunsPage = () => {
     },
     { patchUrlState },
   ] = useUrlState(location, urlStateConfig);
-  const sortingOptions = { sort_column, sort_direction };
+  const sortingOptions = useMemo(
+    () => ({ sort_column, sort_direction }),
+    [sort_column, sort_direction],
+  );
 
   const {
     data: taskRunsData,

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsPage.unit.spec.tsx
@@ -371,6 +371,50 @@ describe("TaskRunsPage", () => {
       ).toBeInTheDocument();
       expect(getLastRunsParams().get("started-at")).toBe("past1weeks~");
     });
+
+    it("does not append the ~ suffix for a this* range", async () => {
+      setup({
+        initialRoute: `${PATHNAME}?started-at=thisday&include-today=true`,
+      });
+      await waitForLoaderToBeRemoved();
+
+      expect(getLastRunsParams().get("started-at")).toBe("thisday");
+    });
+  });
+
+  describe("entity filter", () => {
+    it("ignores a lone entity-id without a matching entity-type", async () => {
+      setup({
+        initialRoute: `${PATHNAME}?entity-id=5`,
+      });
+      await waitForLoaderToBeRemoved();
+
+      const params = getLastRunsParams();
+      expect(params.get("entity-id")).toBeNull();
+      expect(params.get("entity-type")).toBeNull();
+    });
+
+    it("ignores a lone entity-type without a matching entity-id", async () => {
+      setup({
+        initialRoute: `${PATHNAME}?entity-type=card`,
+      });
+      await waitForLoaderToBeRemoved();
+
+      const params = getLastRunsParams();
+      expect(params.get("entity-id")).toBeNull();
+      expect(params.get("entity-type")).toBeNull();
+    });
+
+    it("forwards the entity pair when both are present", async () => {
+      setup({
+        initialRoute: `${PATHNAME}?entity-type=card&entity-id=5`,
+      });
+      await waitForLoaderToBeRemoved();
+
+      const params = getLastRunsParams();
+      expect(params.get("entity-type")).toBe("card");
+      expect(params.get("entity-id")).toBe("5");
+    });
   });
 });
 

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsTable.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/TaskRunsTable.tsx
@@ -4,12 +4,12 @@ import { t } from "ttag";
 
 import { DateTime } from "metabase/common/components/DateTime";
 import { useScrollToTop, useSortingStateChange } from "metabase/common/hooks";
+import { MonitorEmptyState } from "metabase/monitor/components/MonitorEmptyState";
 import { useDispatch } from "metabase/redux";
 import { push } from "metabase/router";
 import {
   Card,
   Ellipsified,
-  Stack,
   Text,
   TreeTable,
   type TreeTableColumnDef,
@@ -98,11 +98,7 @@ export const TaskRunsTable = ({
           instance={treeTableInstance}
           hierarchical={false}
           ariaLabel={t`Task runs`}
-          emptyState={
-            <Stack p="xl" align="center">
-              <Text c="text-disabled">{t`No results`}</Text>
-            </Stack>
-          }
+          emptyState={<MonitorEmptyState label={t`No results`} />}
           getRowProps={() => ({ "data-testid": "task-run" })}
           onRowClick={handleRowActivate}
         />

--- a/frontend/src/metabase/monitor/tools/components/TaskRunsPage/utils.ts
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunsPage/utils.ts
@@ -53,24 +53,33 @@ type UrlState = {
 };
 
 export const urlStateConfig: UrlStateConfig<UrlState> = {
-  parse: (query) => ({
-    page: parsePage(query.page),
-    sort_column: parseSortColumn(
-      query.sort_column,
-      TASK_RUN_SORT_COLUMNS,
-      DEFAULT_SORT_COLUMN,
-    ),
-    sort_direction: parseSortDirection(
-      query.sort_direction,
-      DEFAULT_SORT_DIRECTION,
-    ),
-    "run-type": parseTaskRunRunType(query["run-type"]),
-    "entity-type": parseTaskRunEntityType(query["entity-type"]),
-    "entity-id": parseTaskRunEntityId(query["entity-id"]),
-    status: parseTaskRunStatus(query.status),
-    "started-at": parseTaskRunStartedAt(query["started-at"]),
-    "include-today": parseIncludeToday(query["include-today"]),
-  }),
+  parse: (query) => {
+    // entity-type and entity-id only filter meaningfully as a pair (the picker
+    // shows a value only when both are set, and the backend needs the type to
+    // interpret the id), so drop both when either is missing.
+    const entityType = parseTaskRunEntityType(query["entity-type"]);
+    const entityId = parseTaskRunEntityId(query["entity-id"]);
+    const hasEntityPair = entityType !== null && entityId !== null;
+
+    return {
+      page: parsePage(query.page),
+      sort_column: parseSortColumn(
+        query.sort_column,
+        TASK_RUN_SORT_COLUMNS,
+        DEFAULT_SORT_COLUMN,
+      ),
+      sort_direction: parseSortDirection(
+        query.sort_direction,
+        DEFAULT_SORT_DIRECTION,
+      ),
+      "run-type": parseTaskRunRunType(query["run-type"]),
+      "entity-type": hasEntityPair ? entityType : null,
+      "entity-id": hasEntityPair ? entityId : null,
+      status: parseTaskRunStatus(query.status),
+      "started-at": parseTaskRunStartedAt(query["started-at"]),
+      "include-today": parseIncludeToday(query["include-today"]),
+    };
+  },
   serialize: ({
     page,
     sort_column,

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationDetailSidebar/NotificationDetailSidebar.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationDetailSidebar/NotificationDetailSidebar.tsx
@@ -29,8 +29,11 @@ export const NotificationDetailSidebar = ({
   onClose,
   onDelete,
 }: SidebarProps) => {
-  const { currentData: detail, isFetching: isDetailFetching } =
-    useAdminNotificationDetailQuery(notificationId);
+  const {
+    currentData: detail,
+    error: detailError,
+    isFetching: isDetailFetching,
+  } = useAdminNotificationDetailQuery(notificationId);
   const notification = detail ?? notificationSummary;
 
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
@@ -86,14 +89,16 @@ export const NotificationDetailSidebar = ({
               setIsEditModalOpen(true);
             }}
           />
-          {notification ? (
+          {detailError ? (
+            <LoadingAndErrorWrapper error={detailError} />
+          ) : notification ? (
             <SidebarBody
               notification={notification}
               detail={detail}
               isDetailFetching={isDetailFetching}
             />
           ) : (
-            <LoadingAndErrorWrapper loading />
+            <LoadingAndErrorWrapper loading={isDetailFetching} />
           )}
         </Stack>
       </Flex>

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.tsx
@@ -77,20 +77,26 @@ export const NotificationsAdminPage = ({
   );
   const selectedCount = selectedNotifications.length;
 
-  const { data: failingData, isLoading: isFailingLoading } =
-    useAdminListNotificationsQuery({
-      limit: 1,
-      offset: 0,
-      active: true,
-      last_check_status: "failing",
-    });
-  const { data: ownerlessData, isLoading: isOwnerlessLoading } =
-    useAdminListNotificationsQuery({
-      limit: 1,
-      offset: 0,
-      active: true,
-      creatorless: true,
-    });
+  const {
+    data: failingData,
+    error: failingError,
+    isLoading: isFailingLoading,
+  } = useAdminListNotificationsQuery({
+    limit: 1,
+    offset: 0,
+    active: urlState.active ?? undefined,
+    last_check_status: "failing",
+  });
+  const {
+    data: ownerlessData,
+    error: ownerlessError,
+    isLoading: isOwnerlessLoading,
+  } = useAdminListNotificationsQuery({
+    limit: 1,
+    offset: 0,
+    active: urlState.active ?? undefined,
+    creatorless: true,
+  });
   const failingCount = failingData?.total ?? 0;
   const ownerlessCount = ownerlessData?.total ?? 0;
 
@@ -278,6 +284,7 @@ export const NotificationsAdminPage = ({
 
   const isSidebarOpen = notificationId !== undefined;
   const isPageLoading = isLoading || isFailingLoading || isOwnerlessLoading;
+  const countError = failingError ?? ownerlessError;
 
   const { prevNotificationId, nextNotificationId, notificationSummary } =
     useMemo(() => {
@@ -306,8 +313,10 @@ export const NotificationsAdminPage = ({
       };
     }, [notificationId, notifications]);
 
-  if (isPageLoading) {
-    return <LoadingAndErrorWrapper loading />;
+  if (isPageLoading || countError) {
+    return (
+      <LoadingAndErrorWrapper loading={isPageLoading} error={countError} />
+    );
   }
 
   return (

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
@@ -9,6 +9,7 @@ import {
 } from "__support__/server-mocks";
 import {
   setupAdminNotificationDetailEndpoint,
+  setupAdminNotificationDetailErrorEndpoint,
   setupBulkNotificationActionEndpoint,
 } from "__support__/server-mocks/notification";
 import {
@@ -24,7 +25,11 @@ import { URL_UPDATE_DEBOUNCE_DELAY } from "metabase/common/hooks/use-url-state";
 import { MonitorContent } from "metabase/monitor/components/MonitorLayout/MonitorContent";
 import { Route, withRouteProps } from "metabase/router";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
-import type { AdminNotification, UserListResult } from "metabase-types/api";
+import type {
+  AdminNotification,
+  NotificationId,
+  UserListResult,
+} from "metabase-types/api";
 import {
   createMockAdminNotification,
   createMockCard,
@@ -133,6 +138,8 @@ type SetupOpts = {
   initialRoute?: string;
   cardDelay?: number;
   detailDelay?: number;
+  detailErrorId?: NotificationId;
+  failingCountError?: boolean;
 };
 
 const setup = ({
@@ -144,6 +151,8 @@ const setup = ({
   initialRoute = PATHNAME,
   cardDelay,
   detailDelay,
+  detailErrorId,
+  failingCountError = false,
 }: SetupOpts = {}) => {
   fetchMock.get("path:/api/notification/admin", (call) => {
     const params = new URL(call.url).searchParams;
@@ -151,7 +160,9 @@ const setup = ({
       params.get("limit") === "1" &&
       params.get("last_check_status") === "failing"
     ) {
-      return { data: [], total: failingCount, limit: 1, offset: 0 };
+      return failingCountError
+        ? { status: 500, body: { message: "Count failed" } }
+        : { data: [], total: failingCount, limit: 1, offset: 0 };
     }
     if (params.get("limit") === "1" && params.get("creatorless") === "true") {
       return { data: [], total: ownerlessCount, limit: 1, offset: 0 };
@@ -178,6 +189,9 @@ const setup = ({
         )
       : setupAdminNotificationDetailEndpoint(notification),
   );
+  if (detailErrorId !== undefined) {
+    setupAdminNotificationDetailErrorEndpoint(detailErrorId);
+  }
 
   return renderWithProviders(
     <Route
@@ -199,6 +213,15 @@ const getListCalls = () =>
       (call) =>
         new URL(call.url).searchParams.get("limit") === String(PAGE_SIZE),
     );
+
+const getFailingCountCalls = () =>
+  fetchMock.callHistory.calls("path:/api/notification/admin").filter((call) => {
+    const params = new URL(call.url).searchParams;
+    return (
+      params.get("limit") === "1" &&
+      params.get("last_check_status") === "failing"
+    );
+  });
 
 const getBulkPosts = async () =>
   (await findRequests("POST")).filter((request) =>
@@ -327,6 +350,20 @@ describe("NotificationsAdminPage", () => {
       await waitFor(() => {
         expect(history?.getCurrentLocation().search).not.toContain("failing");
       });
+    });
+
+    it("counts inactive failing alerts when the status filter includes them", async () => {
+      setup({ initialRoute: `${PATHNAME}?active=all` });
+      await waitForLoaderToBeRemoved();
+
+      const [countCall] = getFailingCountCalls();
+      expect(new URL(countCall.url).searchParams.get("active")).toBeNull();
+    });
+
+    it("shows count query errors", async () => {
+      setup({ failingCountError: true });
+
+      expect(await screen.findByText("Count failed")).toBeInTheDocument();
     });
   });
 
@@ -743,6 +780,16 @@ describe("NotificationsAdminPage", () => {
         ).toHaveLength(2);
       });
       expect(screen.queryAllByTestId("run-summary-loader")).toHaveLength(0);
+    });
+
+    it("shows an error when a deep-linked alert cannot be loaded", async () => {
+      setup({
+        notifications: [],
+        initialRoute: `${PATHNAME}/999`,
+        detailErrorId: 999,
+      });
+
+      expect(await screen.findByText("An error occurred")).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/metabase/monitor/tools/utils.ts
+++ b/frontend/src/metabase/monitor/tools/utils.ts
@@ -117,7 +117,11 @@ export const toBackendStartedAt = (
   }
   // A trailing "~" makes the date range open-ended on the upper bound,
   // extending it through today so the current day's runs are included.
-  return includeToday ? `${value}~` : value;
+  // The backend grammar only accepts "~" on the relative "past*" forms;
+  // appending it to "this*" values (e.g. "thisday~") is a parse error, so
+  // includeToday is ignored for those.
+  const supportsIncludeToday = value.startsWith("past");
+  return includeToday && supportsIncludeToday ? `${value}~` : value;
 };
 
 export const guardTaskRunStartedAtRange = (

--- a/frontend/src/metabase/monitor/tools/utils.unit.spec.ts
+++ b/frontend/src/metabase/monitor/tools/utils.unit.spec.ts
@@ -1,0 +1,23 @@
+import { toBackendStartedAt } from "./utils";
+
+describe("toBackendStartedAt", () => {
+  it("returns undefined when no range is selected", () => {
+    expect(toBackendStartedAt(null, false)).toBeUndefined();
+    expect(toBackendStartedAt(null, true)).toBeUndefined();
+  });
+
+  it("appends the ~ suffix for past* ranges when today is included", () => {
+    expect(toBackendStartedAt("past7days", true)).toBe("past7days~");
+    expect(toBackendStartedAt("past1weeks", true)).toBe("past1weeks~");
+    expect(toBackendStartedAt("past12months", true)).toBe("past12months~");
+  });
+
+  it("does not append the ~ suffix for past* ranges when today is excluded", () => {
+    expect(toBackendStartedAt("past7days", false)).toBe("past7days");
+  });
+
+  it("never appends the ~ suffix for this* ranges (backend rejects thisday~)", () => {
+    expect(toBackendStartedAt("thisday", true)).toBe("thisday");
+    expect(toBackendStartedAt("thisday", false)).toBe("thisday");
+  });
+});

--- a/frontend/src/metabase/nav/components/AppSwitcher/AppSwitcher.tsx
+++ b/frontend/src/metabase/nav/components/AppSwitcher/AppSwitcher.tsx
@@ -7,6 +7,7 @@ import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { ForwardRefLink } from "metabase/common/components/Link";
 import { trackDataStudioOpened } from "metabase/common/data-studio/analytics";
 import { canAccessDataStudio as canAccessDataStudioSelector } from "metabase/common/data-studio/selectors";
+import { trackMonitorOpened } from "metabase/common/monitor/analytics";
 import { canAccessMonitor as canAccessMonitorSelector } from "metabase/common/monitor/selectors";
 import { prepareInitials } from "metabase/common/utils/user";
 import { useDispatch, useSelector } from "metabase/redux";
@@ -123,6 +124,8 @@ export const AppSwitcher = ({ className }: { className?: string }) => {
           key="monitor-app-link"
           component={ForwardRefLink}
           to={Urls.monitor()}
+          onAuxClick={trackMonitorOpened}
+          onClickCapture={trackMonitorOpened}
           leftSection={
             <Icon
               name="pulse"

--- a/frontend/src/metabase/nav/components/AppSwitcher/AppSwitcher.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/AppSwitcher/AppSwitcher.unit.spec.tsx
@@ -24,10 +24,9 @@ jest.mock("metabase/common/monitor/analytics", () => ({
   trackMonitorOpened: jest.fn(),
 }));
 
-// Jest's requireMock API is untyped, so define the mock module boundary.
 const { trackMonitorOpened } = jest.requireMock(
   "metabase/common/monitor/analytics",
-) as { trackMonitorOpened: jest.Mock };
+);
 
 const USER = createMockUser();
 

--- a/frontend/src/metabase/nav/components/AppSwitcher/AppSwitcher.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/AppSwitcher/AppSwitcher.unit.spec.tsx
@@ -20,6 +20,15 @@ import {
 import { AppSwitcher } from "./AppSwitcher";
 import type { CurrentApp } from "./useGetCurrentApp";
 
+jest.mock("metabase/common/monitor/analytics", () => ({
+  trackMonitorOpened: jest.fn(),
+}));
+
+// Jest's requireMock API is untyped, so define the mock module boundary.
+const { trackMonitorOpened } = jest.requireMock(
+  "metabase/common/monitor/analytics",
+) as { trackMonitorOpened: jest.Mock };
+
 const USER = createMockUser();
 
 const REGULAR_ITEMS = [
@@ -199,6 +208,15 @@ describe("ProfileLink", () => {
       WITH_AREAS.forEach((title) => {
         expect(screen.getByText(title)).toBeInTheDocument();
       });
+    });
+
+    it("tracks opening Monitor from the app switcher", async () => {
+      trackMonitorOpened.mockClear();
+      await setup({ isAdmin: true });
+
+      await userEvent.click(await getMonitorMenuItem());
+
+      expect(trackMonitorOpened).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/frontend/src/metabase/nav/components/AreaLayout/AreaTab.tsx
+++ b/frontend/src/metabase/nav/components/AreaLayout/AreaTab.tsx
@@ -17,6 +17,7 @@ type AreaTabProps = {
   showLabel: boolean;
   rightSection?: ReactNode;
   isGated?: boolean;
+  onClick?: () => void;
 };
 
 export function AreaTab({
@@ -27,6 +28,7 @@ export function AreaTab({
   showLabel,
   rightSection,
   isGated,
+  onClick,
 }: AreaTabProps) {
   const upsellGem = isGated ? <UpsellGem.New size={14} /> : null;
   const effectiveRightSection = rightSection ?? upsellGem;
@@ -42,6 +44,7 @@ export function AreaTab({
         className={cx(S.tab, { [S.selected]: isSelected })}
         component={ForwardRefLink}
         to={to}
+        onClick={onClick}
         p="sm"
         gap="sm"
         bdrs="md"

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.tsx
@@ -92,9 +92,12 @@ const TreeTableRowContent = memo(function TreeTableRowContent<
         ? "some"
         : "none";
 
+  const isCheckboxDisabled =
+    isDisabled || (!getSelectionState && !row.getCanSelect());
+
   const handleCheckboxToggle = (event: MouseEvent) => {
     event.stopPropagation();
-    if (isLoading) {
+    if (isLoading || isCheckboxDisabled) {
       return;
     }
     if (onCheckboxClick) {
@@ -143,9 +146,7 @@ const TreeTableRowContent = memo(function TreeTableRowContent<
             <SelectionCheckbox
               isSelected={selectionState === "all"}
               isSomeSelected={selectionState === "some"}
-              disabled={
-                isDisabled || (!getSelectionState && !row.getCanSelect())
-              }
+              disabled={isCheckboxDisabled}
               onClick={handleCheckboxToggle}
               className={classNames?.checkbox}
             />

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.unit.spec.tsx
@@ -1,0 +1,133 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen } from "__support__/ui";
+
+import { useTreeTableInstance } from "../hooks";
+import type { TreeNodeData, TreeTableColumnDef } from "../types";
+
+import { TreeTableRow } from "./TreeTableRow";
+
+interface TestNode extends TreeNodeData {
+  id: string;
+  name: string;
+}
+
+const DATA: TestNode[] = [{ id: "1", name: "Orders" }];
+
+const COLUMNS: TreeTableColumnDef<TestNode>[] = [
+  {
+    id: "name",
+    header: "Name",
+    cell: ({ row }) => <span>{row.original.name}</span>,
+  },
+];
+
+interface SetupOpts {
+  isDisabled?: boolean;
+  enableRowSelection?: boolean;
+  onCheckboxClick?: (index: number) => void;
+}
+
+function setup({
+  isDisabled,
+  enableRowSelection = true,
+  onCheckboxClick,
+}: SetupOpts = {}) {
+  function Harness() {
+    const instance = useTreeTableInstance({
+      data: DATA,
+      columns: COLUMNS,
+      getNodeId: (node) => node.id,
+      enableRowSelection,
+    });
+    const row = instance.rows[0];
+    const selectedIds = Object.keys(instance.table.getState().rowSelection);
+
+    return (
+      <>
+        <div data-testid="selected-ids">{selectedIds.join(",")}</div>
+        <TreeTableRow
+          row={row}
+          rowIndex={0}
+          // Pinned position renders without the virtualizer, which does not
+          // measure in jsdom.
+          virtualItemOrPinnedPosition="top"
+          table={instance.table}
+          columnWidths={instance.columnWidths}
+          showCheckboxes
+          showExpandButtons={false}
+          indentWidth={20}
+          activeRowId={null}
+          selectedRowId={null}
+          isExpanded={false}
+          canExpand={false}
+          measureElement={() => {}}
+          isDisabled={isDisabled}
+          onCheckboxClick={
+            onCheckboxClick ? (r, index) => onCheckboxClick(index) : undefined
+          }
+          hierarchical={false}
+        />
+      </>
+    );
+  }
+
+  renderWithProviders(<Harness />);
+}
+
+function getCheckboxWrapper() {
+  // The checkbox column wrapper (padding around the checkbox) is the first
+  // child of the row. Clicking it must behave like clicking the checkbox.
+  return screen.getByRole("row").firstElementChild as HTMLElement;
+}
+
+describe("TreeTableRow checkbox wrapper", () => {
+  it("does not fire onCheckboxClick when the row is disabled", async () => {
+    const onCheckboxClick = jest.fn();
+    setup({ isDisabled: true, onCheckboxClick });
+
+    await userEvent.click(getCheckboxWrapper());
+
+    expect(onCheckboxClick).not.toHaveBeenCalled();
+  });
+
+  it("does not toggle selection via the default path when the row is disabled", async () => {
+    setup({ isDisabled: true });
+
+    expect(screen.getByTestId("selected-ids")).toBeEmptyDOMElement();
+
+    await userEvent.click(getCheckboxWrapper());
+
+    expect(screen.getByTestId("selected-ids")).toBeEmptyDOMElement();
+  });
+
+  it("fires onCheckboxClick on a wrapper click for an enabled row", async () => {
+    const onCheckboxClick = jest.fn();
+    setup({ onCheckboxClick });
+
+    await userEvent.click(getCheckboxWrapper());
+
+    expect(onCheckboxClick).toHaveBeenCalledWith(0);
+  });
+
+  it("toggles selection on a wrapper click for an enabled row", async () => {
+    setup();
+
+    expect(screen.getByTestId("selected-ids")).toBeEmptyDOMElement();
+
+    await userEvent.click(getCheckboxWrapper());
+
+    expect(screen.getByTestId("selected-ids")).toHaveTextContent("1");
+  });
+
+  it("does not fire onCheckboxClick when the row cannot be selected", async () => {
+    const onCheckboxClick = jest.fn();
+    // enableRowSelection false makes row.getCanSelect() return false; without a
+    // getSelectionState override the checkbox (and wrapper) must be disabled.
+    setup({ enableRowSelection: false, onCheckboxClick });
+
+    await userEvent.click(getCheckboxWrapper());
+
+    expect(onCheckboxClick).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.unit.spec.tsx
@@ -33,7 +33,7 @@ function setup({
   enableRowSelection = true,
   onCheckboxClick,
 }: SetupOpts = {}) {
-  function Harness() {
+  function RowContainer() {
     const instance = useTreeTableInstance({
       data: DATA,
       columns: COLUMNS,
@@ -62,7 +62,7 @@ function setup({
           measureElement={() => {}}
           isDisabled={isDisabled}
           onCheckboxClick={
-            onCheckboxClick ? (r, index) => onCheckboxClick(index) : undefined
+            onCheckboxClick ? (_, index) => onCheckboxClick(index) : undefined
           }
           hierarchical={false}
         />
@@ -70,7 +70,7 @@ function setup({
     );
   }
 
-  renderWithProviders(<Harness />);
+  renderWithProviders(<RowContainer />);
 }
 
 function getCheckboxWrapper() {

--- a/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTableRow/TreeTableRow.unit.spec.tsx
@@ -49,8 +49,6 @@ function setup({
         <TreeTableRow
           row={row}
           rowIndex={0}
-          // Pinned position renders without the virtualizer, which does not
-          // measure in jsdom.
           virtualItemOrPinnedPosition="top"
           table={instance.table}
           columnWidths={instance.columnWidths}
@@ -76,8 +74,7 @@ function setup({
 }
 
 function getCheckboxWrapper() {
-  // The checkbox column wrapper (padding around the checkbox) is the first
-  // child of the row. Clicking it must behave like clicking the checkbox.
+  // Cast to avoid additional checks in tests.
   return screen.getByRole("row").firstElementChild as HTMLElement;
 }
 
@@ -122,8 +119,6 @@ describe("TreeTableRow checkbox wrapper", () => {
 
   it("does not fire onCheckboxClick when the row cannot be selected", async () => {
     const onCheckboxClick = jest.fn();
-    // enableRowSelection false makes row.getCanSelect() return false; without a
-    // getSelectionState override the checkbox (and wrapper) must be disabled.
     setup({ enableRowSelection: false, onCheckboxClick });
 
     await userEvent.click(getCheckboxWrapper());

--- a/src/metabase/channel/urls.clj
+++ b/src/metabase/channel/urls.clj
@@ -122,7 +122,7 @@
 (defn tools-caching-details-url
   "Return an appropriate URL for linking to caching log details."
   [^Integer persisted-info-id]
-  (format "%s/admin/tools/model-caching/%d" (site-url) persisted-info-id))
+  (format "%s/monitor/model-caching/%d" (site-url) persisted-info-id))
 
 (defn transform-job-url
   "URL for a transform job."

--- a/src/metabase/task_history/api.clj
+++ b/src/metabase/task_history/api.clj
@@ -157,8 +157,10 @@
     (let [run-ids      (map :id runs)
           counts       (t2/query {:select   [:run_id
                                              [[:count :id] :task_count]
-                                             [[:raw "SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END)"] :success_count]
-                                             [[:raw "SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END)"] :failed_count]]
+                                             [[:raw "SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END)"]
+                                              :success_count]
+                                             [[:raw "SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END)"]
+                                              :failed_count]]
                                   :from     :task_history
                                   :where    [:in :run_id run-ids]
                                   :group-by [:run_id]})
@@ -205,17 +207,21 @@
       {})))
 
 (defn- runs-order-by
-  "Build the honeysql fragment used to order the task runs list. Direct columns order in place; `:entity_name` LEFT JOINs
-  the three entity tables and orders by the coalesced name; `:task_count` LEFT JOINs a grouped `task_history` subquery.
-  Derived-column variants keep the selected shape to `task_run.*` and add a deterministic `[:id :desc]` secondary key."
+  "Build the honeysql fragment used to order the task runs list. Direct columns order in place; `:entity_name`
+  LEFT JOINs the three entity tables and orders by the coalesced name; `:task_count` LEFT JOINs a grouped
+  `task_history` subquery. Derived-column variants keep the selected shape to `task_run.*` and add a
+  deterministic `[:id :desc]` secondary key."
   [{col :sort-column dir :sort-direction}]
   (let [secondary [:task_run.id :desc]]
     (case col
       :entity_name
       {:select    [:task_run.*]
-       :left-join [[:metabase_database :sort_db]  [:and [:= :task_run.entity_type "database"]  [:= :task_run.entity_id :sort_db.id]]
-                   [:report_card :sort_card]       [:and [:= :task_run.entity_type "card"]      [:= :task_run.entity_id :sort_card.id]]
-                   [:report_dashboard :sort_dash]  [:and [:= :task_run.entity_type "dashboard"] [:= :task_run.entity_id :sort_dash.id]]]
+       :left-join [[:metabase_database :sort_db]
+                   [:and [:= :task_run.entity_type "database"]  [:= :task_run.entity_id :sort_db.id]]
+                   [:report_card :sort_card]
+                   [:and [:= :task_run.entity_type "card"]      [:= :task_run.entity_id :sort_card.id]]
+                   [:report_dashboard :sort_dash]
+                   [:and [:= :task_run.entity_type "dashboard"] [:= :task_run.entity_id :sort_dash.id]]]
        :order-by  [[[:coalesce :sort_db.name :sort_card.name :sort_dash.name] dir] secondary]}
 
       :task_count

--- a/test/metabase/channel/urls_test.clj
+++ b/test/metabase/channel/urls_test.clj
@@ -36,6 +36,11 @@
       (is (= "https://metabase.com/dashboard/1?%26=contains%3F"
              (urls/dashboard-url 1 [{:value "contains?", :slug "&"}]))))))
 
+(deftest tools-caching-details-url-test
+  (mt/with-temporary-setting-values [site-url "https://metabase.com"]
+    (is (= "https://metabase.com/monitor/model-caching/42"
+           (urls/tools-caching-details-url 42)))))
+
 (deftest dashcard-url-test
   (mt/with-temporary-setting-values [site-url "https://metabase.com"]
     (testing "A valid dashcard URL can be generated without parameters"

--- a/test/metabase/task_history/api_test.clj
+++ b/test/metabase/task_history/api_test.clj
@@ -8,7 +8,8 @@
    [toucan2.core :as t2]))
 
 (def ^:private default-task-history
-  {:id true, :db_id true, :started_at true, :ended_at true, :duration 10, :task_details nil :status "success" :logs nil :run_id false})
+  {:id true, :db_id true, :started_at true, :ended_at true, :duration 10, :task_details nil
+   :status "success" :logs nil :run_id false})
 
 (defn- generate-tasks
   "Creates `n` task history maps with guaranteed increasing `:ended_at` times. This means that when stored and queried
@@ -522,8 +523,8 @@
 (deftest ^:synchronized sort-tasks-by-db-test
   (t2/delete! :model/TaskHistory)
   (let [now (t/zoned-date-time)]
-    (mt/with-temp [:model/Database db-a {:name "AAA DB"}
-                   :model/Database db-b {:name "ZZZ DB"}
+    (mt/with-temp [:model/Database db-a {:name "Albatross DB"}
+                   :model/Database db-b {:name "Wren DB"}
                    :model/TaskHistory _ {:task "t-a"   :status :success :db_id (:id db-a) :started_at now :ended_at now}
                    :model/TaskHistory _ {:task "t-b"   :status :success :db_id (:id db-b) :started_at now :ended_at now}
                    :model/TaskHistory _ {:task "t-nil" :status :success :started_at now :ended_at now}]
@@ -538,7 +539,8 @@
                 desc (tracked :sort_column :db_name :sort_direction :desc)]
             (is (= #{"t-a" "t-b" "t-nil"} (set asc)))
             (is (= 3 (count asc)))
-            ;; AAA DB before ZZZ DB, and reversed for desc (nil position is DB-dependent, so only assert the two named)
+            ;; Albatross DB before Wren DB, and reversed for desc (nil position is DB-dependent, so only
+            ;; assert the two named)
             (is (< (u/index-of #{"t-a"} asc) (u/index-of #{"t-b"} asc)))
             (is (< (u/index-of #{"t-b"} desc) (u/index-of #{"t-a"} desc)))))
         (testing "sort by db_engine (aaa-engine < zzz-engine)"
@@ -553,7 +555,8 @@
               (is (< (u/index-of #{"t-a"} asc) (u/index-of #{"t-b"} asc)))
               (is (< (u/index-of #{"t-b"} desc) (u/index-of #{"t-a"} desc))))
             (finally
-              (t2/query {:update :metabase_database :set {:engine "h2"} :where [:in :id [(:id db-a) (:id db-b)]]}))))))))
+              (t2/query {:update :metabase_database :set {:engine "h2"}
+                         :where  [:in :id [(:id db-a) (:id db-b)]]}))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              Task Runs API tests                                               |
@@ -874,8 +877,8 @@
   (t2/delete! :model/TaskRun)
   (t2/delete! :model/TaskHistory)
   (let [now (t/zoned-date-time)]
-    (mt/with-temp [:model/Database db {:name "ZZZ DB"}
-                   :model/Card card {:name "AAA Card"}
+    (mt/with-temp [:model/Database db {:name "Wren DB"}
+                   :model/Card card {:name "Albatross Card"}
                    :model/TaskRun run-db {:run_type    :sync
                                           :entity_type :database
                                           :entity_id   (:id db)
@@ -889,9 +892,12 @@
                                             :started_at  (t/minus now (t/hours 1))
                                             :ended_at    now}
                    ;; run-db has 2 child tasks, run-card has 1
-                   :model/TaskHistory _ {:task "a" :status :success :run_id (:id run-db)   :started_at now :ended_at now}
-                   :model/TaskHistory _ {:task "b" :status :success :run_id (:id run-db)   :started_at now :ended_at now}
-                   :model/TaskHistory _ {:task "c" :status :success :run_id (:id run-card) :started_at now :ended_at now}]
+                   :model/TaskHistory _ {:task "a" :status :success :run_id (:id run-db)
+                                         :started_at now :ended_at now}
+                   :model/TaskHistory _ {:task "b" :status :success :run_id (:id run-db)
+                                         :started_at now :ended_at now}
+                   :model/TaskHistory _ {:task "c" :status :success :run_id (:id run-card)
+                                         :started_at now :ended_at now}]
       (let [my-ids #{(:id run-db) (:id run-card)}
             ids    (fn [& args] (->> (apply mt/user-http-request :crowberto :get 200 "task/runs" args)
                                      :data
@@ -909,7 +915,7 @@
         (testing "sort by run_type (fingerprint < sync)"
           (is (= [(:id run-card) (:id run-db)] (ids :sort-column :run_type :sort-direction :asc)))
           (is (= [(:id run-db) (:id run-card)] (ids :sort-column :run_type :sort-direction :desc))))
-        (testing "sort by entity_name across entity types (AAA Card < ZZZ DB)"
+        (testing "sort by entity_name across entity types (Albatross Card < Wren DB)"
           (is (= [(:id run-card) (:id run-db)] (ids :sort-column :entity_name :sort-direction :asc)))
           (is (= [(:id run-db) (:id run-card)] (ids :sort-column :entity_name :sort-direction :desc))))
         (testing "sort by task_count (run-card=1 < run-db=2)"


### PR DESCRIPTION
Closes [GDGT-2886](https://linear.app/metabase/issue/GDGT-2886/address-pr-branch-code-review-comments)

## Summary

Tightens some loose ends around Monitor PR https://github.com/metabase/metabase/pull/76806 by addressing confirmed findings from the independent review of the Monitor work:

- fixes Erroring Questions pagination, recovery, selection, typing, accessibility, and streaming count coverage
- fixes shadowed Data Studio Dependency Diagnostics redirects
- hardens abortable-query skipping, scroll resets, task-run URL filters, and loading states
- fixes notification sidebar/count error handling and count/list filter consistency
- fixes TreeTable disabled checkbox behavior and consolidates Monitor empty states
- adds few extra unit tests for covered fixes
- adds Monitor navigation analytics and updates model-caching email links
- applies the requested Clojure/TypeScript cleanup and regression coverage

Original review: https://gist.github.com/escherize/e6dcdf82386e2126dc2519b76d98d127

## Deliberately excluded

- Issue 8 (same-card identical-timestamp tie-break) was reverted because the attempted full-table ranking caused a substantial `/api/dataset` performance regression; and the issue itself is not really grave.
- Issue 27 (`/admin/tools/dependencies` redirects) was omitted because that legacy route has long been inaccessible.
- Issue 29 was intentionally left unchanged, backend already had restrictions in place, so it was just UI update.
- Issues 4 and 19 required no code changes after verification.

## Verification

- all checks pass



