### PR TITLE
Add view count to hydration layer of content diagnostics API

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -6,7 +6,8 @@
 
   Response shape: a flat identity (`id, finding_type, entity_type, entity_id, detected_at,
   entity_display_name`) plus a nested typed `details` merging the stored verdict with live-hydrated
-  `collection`, `description`, `owner`, and `creator`."
+  `collection`, `description`, `owner`, `creator`, and `view_count` (the entity's usage counter, present
+  for every type but transform)."
   (:require
    [java-time.api :as t]
    [metabase-enterprise.content-diagnostics.api.common :as api.common]
@@ -59,18 +60,21 @@
      [:description    [:maybe :string]]
      [:owner          NormalizedUser]
      [:creator        Creator]
+     [:view_count     {:optional true} :int]
      [:threshold_days {:optional true} :int]]]])
 
 (def ^:private SlowEntity
   "A hydrated culprit of a container roll-up: an embedded slow **card** of a dashboard/document finding.
   Always a card - a container embeds cards (a dashboard via its dashcards, a document via the cards embedded
   in its body) and is flagged slow when one of those cards' queries is slow; it never embeds a transform, and
-  a slow transform is its own leaf finding, not a member of another entity. `{id, name, entity_type, card_type?}`."
+  a slow transform is its own leaf finding, not a member of another entity.
+  `{id, name, entity_type, card_type?, view_count}`."
   [:map
    [:id          :int]
    [:name        [:maybe :string]]
    [:entity_type :keyword]
-   [:card_type   {:optional true} [:maybe :keyword]]])
+   [:card_type   {:optional true} [:maybe :keyword]]
+   [:view_count  :int]])
 
 (def ^:private SlowFinding
   "Response item for a `slow` finding: flat identity + a top-level `duration_ms` + nested typed `details`.
@@ -94,6 +98,7 @@
      [:description   [:maybe :string]]
      [:owner         NormalizedUser]
      [:creator       Creator]
+     [:view_count    {:optional true} :int]
      [:threshold_ms  {:optional true} :int]
      [:slow_entities {:optional true} [:sequential SlowEntity]]]]])
 

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -117,12 +117,15 @@
 
 (defn- entity-context
   "For one entity-type's id set → `{entity-id → row}`. Live-hydrates only the non-denormalized display
-  fields: `description`, `collection_id`, and (transform only) the owner. `document` has no description."
+  fields: `description`, `collection_id`, `view_count` (all but transform), and (transform only) the owner.
+  `document` has no description."
   [entity-type ids]
   (when-let [model (common/entity-type->model entity-type)]
     (let [cols (cond-> [:id :collection_id]
-                 (not= entity-type :document) (conj :description)
-                 (= entity-type :transform)   (conj :owner_user_id :owner_email))
+                 (not= entity-type :document)  (conj :description)
+                 ;; card/dashboard/document have a native view_count column; transform has none.
+                 (not= entity-type :transform) (conj :view_count)
+                 (= entity-type :transform)    (conj :owner_user_id :owner_email))
           rows (cond-> (t2/select (into [model] cols) :id [:in (set ids)])
                  ;; reuse the transform model's batched :owner hydrate (user row, or {:email …} external)
                  (= entity-type :transform) (t2/hydrate :owner))]
@@ -145,9 +148,10 @@
             colls))))
 
 (defn- hydrate-slow-entities
-  "Card-id set → `{card-id → {:id :name :entity_type :card :card_type <kw>}}`. The read-time hydration of
-  a `slow` roll-up's stored culprit ids (`slow_entity_ids`) into objects. `card_type` is the
-  `report_card.type` enum (question/model/metric) that drives the FE per-member link/icon. Batched.
+  "Card-id set → `{card-id → {:id :name :entity_type :card :card_type <kw> :view_count <int>}}`. The
+  read-time hydration of a `slow` roll-up's stored culprit ids (`slow_entity_ids`) into objects.
+  `card_type` is the `report_card.type` enum (question/model/metric) that drives the FE per-member
+  link/icon; `view_count` is the card's live usage counter. Batched.
 
   Culprit cards can live outside their container's collection, so the per-caller read-time filters are
   re-applied here: caller visibility (the same gate as `visible-findings-clause`) always, and the
@@ -156,8 +160,9 @@
   [card-ids excluded-personal-ids]
   (when (seq card-ids)
     ;; `:card_schema` is required on any Card select - its after-select schema-upgrade hook reads it.
-    (t2/select-pk->fn (fn [c] {:id (:id c) :name (:name c) :entity_type :card :card_type (:type c)})
-                      [:model/Card :id :name :type :card_schema]
+    (t2/select-pk->fn (fn [c] {:id (:id c) :name (:name c) :entity_type :card :card_type (:type c)
+                               :view_count (:view_count c)})
+                      [:model/Card :id :name :type :view_count :card_schema]
                       {:where [:and
                                [:in :id (set card-ids)]
                                (collection/visible-collection-filter-clause :collection_id)
@@ -179,7 +184,9 @@
 
 (defn hydrate-findings
   "Project stored findings into the response shape: flat identity + denormalized display fields, plus a
-  nested `details` = stored verdict + {collection, description, owner, creator}. Batched, page-size-independent.
+  nested `details` = stored verdict + {collection, description, owner, creator, view_count?}. `view_count`
+  is the entity's live usage counter, present only for types that have the column (all but transform).
+  Batched, page-size-independent.
 
   Options let each endpoint add its per-finding-type extras without changing the shared base:
   `:top-level-cols` - extra native finding columns hoisted to the top level (e.g. `:last_active_at` for
@@ -208,7 +215,9 @@
                                   :owner       (normalized-owner entity)
                                   ;; creator denormalized (id + common_name) - no live :creator hydrate.
                                   :creator     (when entity_creator_id
-                                                 {:id entity_creator_id :name entity_creator_name :type :user})})
+                                                 {:id entity_creator_id :name entity_creator_name :type :user})}
+                                 (when-some [view-count (:view_count entity)]
+                                   {:view_count view-count}))
                   details* (if (and hydrate-culprits? (contains? details :slow_entity_ids))
                              (-> base
                                  (dissoc :slow_entity_ids)

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/slow_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/slow_test.clj
@@ -378,6 +378,7 @@
              :model/Card           {slow-card :id} {:collection_id coll-id
                                                     :name          "Full Orders Export"
                                                     :type          :model
+                                                    :view_count    5
                                                     :creator_id    (mt/user->id :rasta)}
              :model/QueryExecution _ {:card_id slow-card :started_at (t/offset-date-time)
                                       :cache_hit false :running_time 25000}
@@ -409,9 +410,52 @@
                   (is (nil? (get-in f [:details :slow_entity_ids])))
                   (let [entities (get-in f [:details :slow_entities])]
                     (is (= 1 (count entities)))
-                    (is (= {:id slow-card :name "Full Orders Export"
-                            :entity_type "card" :card_type "model"}
-                           (first entities)))))))))))))
+                    (testing "each culprit carries its own live view_count alongside id/name/type"
+                      (is (= {:id slow-card :name "Full Orders Export"
+                              :entity_type "card" :card_type "model" :view_count 5}
+                             (first entities))))))))))))))
+
+(deftest slow-api-subject-view-count-test
+  (testing "GET /slow hydrates each finding's own live view_count into details; a transform omits it"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (mt/with-temp
+          [:model/Collection {coll-id :id}  {}
+           :model/Collection {tcoll-id :id} {:namespace "transforms"}
+           :model/Card       {card-id :id}  {:collection_id coll-id :view_count 7}
+           :model/Dashboard  {dash-id :id}  {:collection_id coll-id :view_count 12}
+           :model/Document   {doc-id :id}   {:collection_id coll-id
+                                             :view_count    3
+                                             :creator_id    (mt/user->id :rasta)
+                                             :content_type  prose-mirror/prose-mirror-content-type
+                                             :document      {:type "doc" :content []}}
+           :model/Transform  {xform-id :id} {:collection_id tcoll-id}]
+          (let [prefix (scope-prefix)]
+            (doseq [[etype eid] [[:card card-id] [:dashboard dash-id] [:document doc-id] [:transform xform-id]]]
+              (t2/insert! :model/ContentDiagnosticsFinding
+                          {:scan_id      "vc"
+                           :entity_type  etype
+                           :entity_id    eid
+                           :entity_name  (str prefix "-" (name etype))
+                           :finding_type :slow
+                           :duration_ms  20000
+                           :details      {:threshold_ms 15000}}))
+            (let [by-type (into {} (map (juxt :entity_type identity))
+                                (:data (mt/user-http-request :crowberto :get 200
+                                                             "ee/content-diagnostics/slow" :query prefix)))]
+              (testing "card/dashboard/document each carry their own live view_count in details"
+                (is (= 7  (get-in by-type ["card" :details :view_count])))
+                (is (= 12 (get-in by-type ["dashboard" :details :view_count])))
+                (is (= 3  (get-in by-type ["document" :details :view_count]))))
+              (testing "a transform (no view_count column) omits the key entirely from details"
+                (is (contains? by-type "transform"))
+                (is (not (contains? (get-in by-type ["transform" :details]) :view_count))))
+              (testing "view_count is hydrated live at read time, not frozen at scan time"
+                (t2/update! :model/Card card-id {:view_count 99})
+                (let [card-f (some #(when (= "card" (:entity_type %)) %)
+                                   (:data (mt/user-http-request :crowberto :get 200
+                                                                "ee/content-diagnostics/slow" :query prefix)))]
+                  (is (= 99 (get-in card-f [:details :view_count]))))))))))))
 
 (deftest slow-api-filter-and-sort-test
   (testing "GET /slow filters by entity-types/min-duration-ms and sorts by duration-ms/name"


### PR DESCRIPTION
### Description

Adds the view_count property during live hydration of top level findings and nested entities (where applicable for certain diagnostic APIs like `slow`).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
