### PR TITLE
fix clickhouse parameter rewriting on sql-tools

### DIFF
--- a/resources/python-sources/sql_tools.py
+++ b/resources/python-sources/sql_tools.py
@@ -6,7 +6,25 @@ import sqlglot.lineage as lineage
 import sqlglot.optimizer as optimizer
 import sqlglot.optimizer.qualify as qualify
 from sqlglot import exp
+from sqlglot.dialects.clickhouse import ClickHouse
 from sqlglot.errors import OptimizeError, ParseError
+
+# sqlglot (as of 28.6.0) renders every placeholder in ClickHouse's named-parameter
+# syntax `{name: Type}`, so a positional JDBC placeholder `?` (a nameless Placeholder)
+# round-trips to `{?: }`, which ClickHouse rejects with "Expected substitution name"
+# (Code 62). Compiled queries we rewrite can carry prepared-statement params — e.g.
+# workspace table remapping of an incremental transform's checkpoint filter — so keep
+# positional placeholders as `?`; named query parameters still take the upstream path.
+_clickhouse_placeholder_sql = ClickHouse.Generator.placeholder_sql
+
+
+def _placeholder_sql_keep_positional(self, expression: exp.Placeholder) -> str:
+    if not expression.this:
+        return "?"
+    return _clickhouse_placeholder_sql(self, expression)
+
+
+ClickHouse.Generator.placeholder_sql = _placeholder_sql_keep_positional
 
 
 def is_quoted_identifier(name: str, dialect: str = None) -> bool:

--- a/test/metabase/sql_tools/sqlglot/replace_names_test.clj
+++ b/test/metabase/sql_tools/sqlglot/replace_names_test.clj
@@ -15,6 +15,7 @@
                   :postgres "postgres"
                   :mysql "mysql"
                   :sqlserver "tsql"
+                  :clickhouse "clickhouse"
                   nil)
         replacements' (-> replacements
                           (update :tables #(when % (vec %)))
@@ -119,3 +120,19 @@
            (replace-names :postgres
                           "SELECT * FROM orders"
                           {:tables {{:table "orders"} {:schema "public" :table "orders"}}})))))
+
+(deftest ^:parallel clickhouse-positional-placeholders-preserved-test
+  (testing "ClickHouse: positional `?` placeholders survive the rewrite"
+    ;; sqlglot renders ClickHouse placeholders in named-parameter syntax, which turns a
+    ;; positional `?` into the invalid `{?: }` — this broke workspace-isolated incremental
+    ;; transforms, whose compiled checkpoint filters carry prepared-statement params
+    ;; (GDGT-2847). Patched in sql_tools.py.
+    (is (= "SELECT * FROM \"zz\".\"iso__src\" WHERE (\"ts\" > \"parseDateTimeBestEffort\"(?)) AND (\"ts\" <= \"parseDateTimeBestEffort\"(?))"
+           (replace-names :clickhouse
+                          "SELECT * FROM `zz`.`src` WHERE (`ts` > `parseDateTimeBestEffort`(?)) AND (`ts` <= `parseDateTimeBestEffort`(?))"
+                          {:tables {{:schema "zz" :table "src"} "iso__src"}}))))
+  (testing "ClickHouse: named query parameters still render as {name: Type}"
+    (is (= "SELECT * FROM \"zz\".\"iso__src\" WHERE \"id\" = {uid: UInt32}"
+           (replace-names :clickhouse
+                          "SELECT * FROM `zz`.`src` WHERE `id` = {uid: UInt32}"
+                          {:tables {{:schema "zz" :table "src"} "iso__src"}})))))


### PR DESCRIPTION
Closes [GDGT-2871: ClickHouse incremental checkpoint is broken whenever the watermark is non-null (Code 62)](https://linear.app/metabase/issue/GDGT-2871/clickhouse-incremental-checkpoint-is-broken-whenever-the-watermark-is)

Workspace-isolated transforms on ClickHouse rewrite their compiled SQL through sqlglot for table remapping. 
sqlglot's ClickHouse generator renders every placeholder in named-parameter syntax `{name: Type}`, so positional `?` params  come back as the invalid `{?: }`


Before:
```clojure
metabase.sql-tools.sqlglot.replace-names-test> (replace-names :clickhouse "SELECT * FROM `zz`.`src` WHERE (`ts` > `parseDateTimeBestEffort`(?))" {:tables {{:schema "zz" :table "src"} "iso__src"}})
"SELECT * FROM \"zz\".\"iso__src\" WHERE (\"ts\" > \"parseDateTimeBestEffort\"({?: }))"

```

After:
```clojure
metabase.sql-tools.sqlglot.replace-names-test> (replace-names :clickhouse "SELECT * FROM `zz`.`src` WHERE (`ts` > `parseDateTimeBestEffort`(?))" {:tables {{:schema "zz" :table "src"} "iso__src"}})
"SELECT * FROM \"zz\".\"iso__src\" WHERE (\"ts\" > \"parseDateTimeBestEffort\"(?))"
```