### PR TITLE
Convert the table-permalink routes to v7 route syntax

### DIFF
--- a/frontend/src/metabase/browse/databases/BrowseDatabases.unit.spec.tsx
+++ b/frontend/src/metabase/browse/databases/BrowseDatabases.unit.spec.tsx
@@ -8,7 +8,7 @@ import {
 } from "__support__/ui";
 import { BrowseSchemas } from "metabase/browse/schemas/BrowseSchemas";
 import { createMockState } from "metabase/redux/store/mocks";
-import { Route } from "metabase/router";
+import { Route, withRouteProps } from "metabase/router";
 import type { Database } from "metabase-types/api";
 import {
   createMockDatabase,
@@ -17,6 +17,8 @@ import {
 } from "metabase-types/api/mocks";
 
 import { BrowseDatabases } from "./BrowseDatabases";
+
+const RoutedBrowseSchemas = withRouteProps(BrowseSchemas);
 
 type setupOpts = {
   isAdmin?: boolean;
@@ -48,8 +50,11 @@ describe("BrowseDatabases", () => {
       setupDatabasesEndpoints(databases);
       return renderWithProviders(
         <>
-          <Route path="/browse/databases" component={BrowseDatabases} />
-          <Route path="/browse/databases/:slug" component={BrowseSchemas} />
+          <Route path="/browse/databases" element={<BrowseDatabases />} />
+          <Route
+            path="/browse/databases/:slug"
+            element={<RoutedBrowseSchemas />}
+          />
         </>,
         {
           storeInitialState: createMockState({ currentUser: createMockUser() }),

--- a/frontend/src/metabase/browse/schemas/BrowseSchemas.unit.spec.tsx
+++ b/frontend/src/metabase/browse/schemas/BrowseSchemas.unit.spec.tsx
@@ -3,11 +3,13 @@ import fetchMock from "fetch-mock";
 
 import { setupDatabasesEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
-import { Route } from "metabase/router";
+import { Route, withRouteProps } from "metabase/router";
 import type { Database } from "metabase-types/api";
 import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
 
 import { BrowseSchemas } from "./BrowseSchemas";
+
+const RoutedBrowseSchemas = withRouteProps(BrowseSchemas);
 
 const setup = ({
   databases,
@@ -18,7 +20,7 @@ const setup = ({
 }) => {
   setupDatabasesEndpoints(databases);
   return renderWithProviders(
-    <Route path="/browse/databases/:slug" component={BrowseSchemas} />,
+    <Route path="/browse/databases/:slug" element={<RoutedBrowseSchemas />} />,
     { withRouter: true, initialRoute },
   );
 };

--- a/frontend/src/metabase/browse/tables/BrowseTables.unit.spec.tsx
+++ b/frontend/src/metabase/browse/tables/BrowseTables.unit.spec.tsx
@@ -2,11 +2,13 @@ import fetchMock from "fetch-mock";
 
 import { setupDatabasesEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
-import { Route } from "metabase/router";
+import { Route, withRouteProps } from "metabase/router";
 import type { Database } from "metabase-types/api";
 import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
 
 import { BrowseTables } from "./BrowseTables";
+
+const RoutedBrowseTables = withRouteProps(BrowseTables);
 
 const setup = ({
   databases,
@@ -19,7 +21,7 @@ const setup = ({
   return renderWithProviders(
     <Route
       path="/browse/databases/:dbId/schema/:schemaName"
-      component={BrowseTables}
+      element={<RoutedBrowseTables />}
     />,
     { withRouter: true, initialRoute },
   );

--- a/frontend/src/metabase/browse/tables/TablePermalinkRedirect.unit.spec.tsx
+++ b/frontend/src/metabase/browse/tables/TablePermalinkRedirect.unit.spec.tsx
@@ -5,11 +5,13 @@ import {
   setupTablesEndpoints,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
-import { Route } from "metabase/router";
+import { Route, withRouteProps } from "metabase/router";
 import type { Database, Table } from "metabase-types/api";
 import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
 
 import { TablePermalinkRedirect } from "./TablePermalinkRedirect";
+
+const RoutedTablePermalinkRedirect = withRouteProps(TablePermalinkRedirect);
 
 const PERMALINK_PATH =
   "/browse/databases/:dbName/schema/:schemaName/table/:tableName";
@@ -41,9 +43,9 @@ const setup = ({
     <>
       <Route
         path={noSchema ? PERMALINK_PATH_NO_SCHEMA : PERMALINK_PATH}
-        component={TablePermalinkRedirect}
+        element={<RoutedTablePermalinkRedirect />}
       />
-      <Route path="/table/:slug" component={() => <div>Table page</div>} />
+      <Route path="/table/:slug" element={<div>Table page</div>} />
     </>,
     { withRouter: true, initialRoute },
   );

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -102,6 +102,7 @@ const RoutedMetabotQueryBuilder = withRouteProps(MetabotQueryBuilder);
 const RoutedNewModelOptions = withRouteProps(NewModelOptions);
 const RoutedBrowseSchemas = withRouteProps(BrowseSchemas);
 const RoutedBrowseTables = withRouteProps(BrowseTables);
+const RoutedTablePermalinkRedirect = withRouteProps(TablePermalinkRedirect);
 const RoutedMetricsViewerPage = withRouteProps(MetricsViewerPage);
 const RoutedTableDetailPage = withRouteProps(TableDetailPage);
 const RoutedUnsubscribePage = withRouteProps(UnsubscribePage);
@@ -287,9 +288,15 @@ export const getRoutes = (store: AppStore) => {
               path="databases/:dbId/schema/:schemaName"
               element={<RoutedBrowseTables />}
             />
+            {/* The schema segment is optional; the v7 pattern syntax has no
+                optional static segments, so the permalink is two routes. */}
             <Route
-              path="databases/:dbName(/schema/:schemaName)/table/:tableName"
-              component={TablePermalinkRedirect}
+              path="databases/:dbName/table/:tableName"
+              element={<RoutedTablePermalinkRedirect />}
+            />
+            <Route
+              path="databases/:dbName/schema/:schemaName/table/:tableName"
+              element={<RoutedTablePermalinkRedirect />}
             />
 
             {PLUGIN_TABLE_EDITING.getRoutes()}


### PR DESCRIPTION
Fixes fe-type-check on master, which is currently broken by a collision between two merged PRs: 

1. the router migration removed `component` from `<Route>` (routes are authored in v7 syntax now), and 
2. the table permalinks PR (#77274) landed v3-style `component=` routes and specs. 

Master looks green only because the commits since are docs/e2e-timing changes that path-filter the check to skipped.

Fix: wrap `TablePermalinkRedirect` with `withRouteProps` and use `element=`, in `routes.tsx` and the four browse specs — the same pattern the migration used everywhere else. The v3 optional group `(/schema/:schemaName)` becomes two routes: v7 pattern syntax has no optional static segments, and the translation shim only handles optional dynamic ones.

No behavior change intended. The permalink specs cover both path shapes, including the schema-less redirect.