### PR TITLE
[GDGT-2667] Content diagnostics duplicated API

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -104,17 +104,16 @@
 
 (def ^:private DuplicatedEntity
   "A hydrated peer of a `duplicated` finding: another entity **of the same type** sharing the flagged
-  entity's normalized name. `{id, name, entity_type, card_type?, view_count|run_count}` - `card_type`
-  (question/model/metric) only on card peers. Each peer carries a live usage signal for judging which
-  duplicate is the abandoned one: `view_count` (card/dashboard/document) or `run_count` (transform -
-  total runs, any status)."
+  entity's normalized name. `{id, name, entity_type, card_type?, view_count?}` - `card_type`
+  (question/model/metric) only on card peers. Card/dashboard/document peers carry their live
+  `view_count` for judging which duplicate is the abandoned one; transforms have no view concept, so
+  transform peers carry no usage signal."
   [:map
    [:id          :int]
    [:name        [:maybe :string]]
    [:entity_type :keyword]
    [:card_type   {:optional true} [:maybe :keyword]]
-   [:view_count  {:optional true} :int]
-   [:run_count   {:optional true} :int]])
+   [:view_count  {:optional true} :int]])
 
 (def ^:private DuplicatedFinding
   "Response item for a `duplicated` finding: flat identity + a top-level `duplicate_count` + nested typed

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -6,7 +6,8 @@
 
   Response shape: a flat identity (`id, finding_type, entity_type, entity_id, detected_at,
   entity_display_name`) plus a nested typed `details` merging the stored verdict with live-hydrated
-  `collection`, `description`, `owner`, and `creator`."
+  `collection`, `description`, `owner`, `creator`, and `view_count` (the entity's usage counter, present
+  for every type but transform)."
   (:require
    [java-time.api :as t]
    [metabase-enterprise.content-diagnostics.api.common :as api.common]
@@ -59,18 +60,21 @@
      [:description    [:maybe :string]]
      [:owner          NormalizedUser]
      [:creator        Creator]
+     [:view_count     {:optional true} :int]
      [:threshold_days {:optional true} :int]]]])
 
 (def ^:private SlowEntity
   "A hydrated culprit of a container roll-up: an embedded slow **card** of a dashboard/document finding.
   Always a card - a container embeds cards (a dashboard via its dashcards, a document via the cards embedded
   in its body) and is flagged slow when one of those cards' queries is slow; it never embeds a transform, and
-  a slow transform is its own leaf finding, not a member of another entity. `{id, name, entity_type, card_type?}`."
+  a slow transform is its own leaf finding, not a member of another entity.
+  `{id, name, entity_type, card_type?, view_count}`."
   [:map
    [:id          :int]
    [:name        [:maybe :string]]
    [:entity_type :keyword]
-   [:card_type   {:optional true} [:maybe :keyword]]])
+   [:card_type   {:optional true} [:maybe :keyword]]
+   [:view_count  :int]])
 
 (def ^:private SlowFinding
   "Response item for a `slow` finding: flat identity + a top-level `duration_ms` + nested typed `details`.
@@ -94,6 +98,7 @@
      [:description   [:maybe :string]]
      [:owner         NormalizedUser]
      [:creator       Creator]
+     [:view_count    {:optional true} :int]
      [:threshold_ms  {:optional true} :int]
      [:slow_entities {:optional true} [:sequential SlowEntity]]]]])
 

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -242,7 +242,7 @@
                                              [:id sort-direction]]}
                            (request/limit)  (assoc :limit (request/limit))
                            (request/offset) (assoc :offset (request/offset))))]
-    {:data         (api.common/hydrate-findings page {:top-level-cols [:last_active_at]})
+    {:data         (api.common/hydrate-findings page excluded-personal-ids)
      :total        (t2/count :model/ContentDiagnosticsFinding {:where where})
      :limit        (request/limit)
      :offset       (request/offset)
@@ -293,9 +293,7 @@
                                              [:id sort-direction]]}
                            (request/limit)  (assoc :limit (request/limit))
                            (request/offset) (assoc :offset (request/offset))))]
-    {:data         (api.common/hydrate-findings page {:top-level-cols                   [:duration_ms]
-                                                      :hydrate-culprits?                true
-                                                      :excluded-personal-collection-ids excluded-personal-ids})
+    {:data         (api.common/hydrate-findings page excluded-personal-ids)
      :total        (t2/count :model/ContentDiagnosticsFinding {:where where})
      :limit        (request/limit)
      :offset       (request/offset)
@@ -346,9 +344,7 @@
                                              [:id sort-direction]]}
                            (request/limit)  (assoc :limit (request/limit))
                            (request/offset) (assoc :offset (request/offset))))]
-    {:data         (api.common/hydrate-findings page {:top-level-cols                   [:duplicate_count]
-                                                      :hydrate-duplicate-entities?      true
-                                                      :excluded-personal-collection-ids excluded-personal-ids})
+    {:data         (api.common/hydrate-findings page excluded-personal-ids)
      :total        (t2/count :model/ContentDiagnosticsFinding {:where where})
      :limit        (request/limit)
      :offset       (request/offset)

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -104,13 +104,17 @@
 
 (def ^:private DuplicatedEntity
   "A hydrated peer of a `duplicated` finding: another entity **of the same type** sharing the flagged
-  entity's normalized name. `{id, name, entity_type, card_type?}` - `card_type` (question/model/metric)
-  only on card peers."
+  entity's normalized name. `{id, name, entity_type, card_type?, view_count|run_count}` - `card_type`
+  (question/model/metric) only on card peers. Each peer carries a live usage signal for judging which
+  duplicate is the abandoned one: `view_count` (card/dashboard/document) or `run_count` (transform -
+  total runs, any status)."
   [:map
    [:id          :int]
    [:name        [:maybe :string]]
    [:entity_type :keyword]
-   [:card_type   {:optional true} [:maybe :keyword]]])
+   [:card_type   {:optional true} [:maybe :keyword]]
+   [:view_count  {:optional true} :int]
+   [:run_count   {:optional true} :int]])
 
 (def ^:private DuplicatedFinding
   "Response item for a `duplicated` finding: flat identity + a top-level `duplicate_count` + nested typed

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -41,27 +41,44 @@
            [:name [:maybe :string]]
            [:type [:= :user]]]])
 
-(def ^:private StaleFinding
-  "Response item for a `stale` finding: flat identity + nested typed `details`."
+(def ^:private FindingBase
+  "The flat identity every finding response shares: stable id/type columns, the per-finding `detected_at`
+  freshness stamp, the display name, and the denormalized `created_at`. Each finding `:merge`s its own
+  top-level column (`last_active_at` / `duration_ms` / `duplicate_count`) and its typed `details` onto this."
   [:map
    [:id                  :int]
    [:finding_type        :keyword]
    [:entity_type         :keyword]
    [:entity_id           :int]
-   [:detected_at         some?]
+   [:detected_at         ms/TemporalInstant]
    [:entity_display_name [:maybe :string]]
-   ;; frozen scan-time activity anchor; nil ⇒ never used/ran (top-level, SQL-filterable by threshold-days)
-   [:last_active_at      [:maybe some?]]
    ;; entity's created_at, denormalized at scan time (immutable ⇒ equals live)
-   [:created_at          [:maybe some?]]
-   [:details
-    [:map
-     [:collection     [:maybe :map]]
-     [:description    [:maybe :string]]
-     [:owner          NormalizedUser]
-     [:creator        Creator]
-     [:view_count     {:optional true} :int]
-     [:threshold_days {:optional true} :int]]]])
+   [:created_at          [:maybe ms/TemporalInstant]]])
+
+(def ^:private FindingDetailsBase
+  "The display fields every finding's `details` carries: the collection breadcrumb, live `description`, the
+  hydrated `owner`/`creator`, and the entity's `view_count` (present for every type but transform). Each
+  finding type `:merge`s its own detail extras onto this."
+  [:map
+   [:collection  [:maybe :map]]
+   [:description [:maybe :string]]
+   [:owner       NormalizedUser]
+   [:creator     Creator]
+   [:view_count  {:optional true} :int]])
+
+(def ^:private StaleDetails
+  "`stale` details: the shared core plus the frozen `threshold_days` verdict."
+  [:merge FindingDetailsBase
+   [:map
+    [:threshold_days {:optional true} :int]]])
+
+(def ^:private StaleFinding
+  "Response item for a `stale` finding: flat identity + a top-level `last_active_at` + nested typed `details`."
+  [:merge FindingBase
+   [:map
+    ;; frozen scan-time activity anchor; nil ⇒ never used/ran (top-level, SQL-filterable by threshold-days)
+    [:last_active_at [:maybe ms/TemporalInstant]]
+    [:details        StaleDetails]]])
 
 (def ^:private SlowEntity
   "A hydrated culprit of a container roll-up: an embedded slow **card** of a dashboard/document finding.
@@ -76,31 +93,24 @@
    [:card_type   {:optional true} [:maybe :keyword]]
    [:view_count  :int]])
 
+(def ^:private SlowDetails
+  "`slow` details: the shared core plus a leaf's frozen `threshold_ms`, or a container's hydrated
+  `slow_entities` culprit cards."
+  [:merge FindingDetailsBase
+   [:map
+    [:threshold_ms  {:optional true} :int]
+    [:slow_entities {:optional true} [:sequential SlowEntity]]]])
+
 (def ^:private SlowFinding
   "Response item for a `slow` finding: flat identity + a top-level `duration_ms` + nested typed `details`.
   One open map covering both variants: a **leaf** (card/transform) freezes `details.threshold_ms`; a
   **container** (dashboard/document) carries `details.slow_entities` (hydrated culprit cards). Every slow
   row stamps `duration_ms` (leaf mean / container's slowest culprit), so it is never null in this result."
-  [:map
-   [:id                  :int]
-   [:finding_type        :keyword]
-   [:entity_type         :keyword]
-   [:entity_id           :int]
-   [:detected_at         some?]
-   [:entity_display_name [:maybe :string]]
-   ;; entity's created_at, denormalized at scan time (immutable ⇒ equals live)
-   [:created_at          [:maybe some?]]
-   ;; measured magnitude (top-level, SQL-filterable/sortable); always present on slow findings
-   [:duration_ms         :int]
-   [:details
-    [:map
-     [:collection    [:maybe :map]]
-     [:description   [:maybe :string]]
-     [:owner         NormalizedUser]
-     [:creator       Creator]
-     [:view_count    {:optional true} :int]
-     [:threshold_ms  {:optional true} :int]
-     [:slow_entities {:optional true} [:sequential SlowEntity]]]]])
+  [:merge FindingBase
+   [:map
+    ;; measured magnitude (top-level, SQL-filterable/sortable); always present on slow findings
+    [:duration_ms :int]
+    [:details     SlowDetails]]])
 
 (def ^:private DuplicatedEntity
   "A hydrated peer of a `duplicated` finding: another entity **of the same type** sharing the flagged
@@ -115,6 +125,14 @@
    [:card_type   {:optional true} [:maybe :keyword]]
    [:view_count  {:optional true} :int]])
 
+(def ^:private DuplicatedDetails
+  "`duplicated` details: the shared core plus the collided `normalized_name` and the hydrated same-type
+  `duplicate_entities` peers."
+  [:merge FindingDetailsBase
+   [:map
+    [:normalized_name    :string]
+    [:duplicate_entities [:sequential DuplicatedEntity]]]])
+
 (def ^:private DuplicatedFinding
   "Response item for a `duplicated` finding: flat identity + a top-level `duplicate_count` + nested typed
   `details`. `duplicate_count` is the peer count (cluster size minus 1) and is never null on duplicated
@@ -123,26 +141,11 @@
   `details.duplicate_entities` are the hydrated peers the caller can see - permission and
   personal-collection filtering can leave it shorter than `duplicate_count` (down to empty, but the key
   is always present)."
-  [:map
-   [:id                  :int]
-   [:finding_type        :keyword]
-   [:entity_type         :keyword]
-   [:entity_id           :int]
-   [:detected_at         some?]
-   [:entity_display_name [:maybe :string]]
-   ;; entity's created_at, denormalized at scan time (immutable ⇒ equals live)
-   [:created_at          [:maybe some?]]
-   ;; peer count (top-level, SQL-filterable/sortable); always present on duplicated findings
-   [:duplicate_count     :int]
-   [:details
-    [:map
-     [:collection         [:maybe :map]]
-     [:description        [:maybe :string]]
-     [:owner              NormalizedUser]
-     [:creator            Creator]
-     [:view_count         {:optional true} :int]
-     [:normalized_name    :string]
-     [:duplicate_entities [:sequential DuplicatedEntity]]]]])
+  [:merge FindingBase
+   [:map
+    ;; peer count (top-level, SQL-filterable/sortable); always present on duplicated findings
+    [:duplicate_count :int]
+    [:details         DuplicatedDetails]]])
 
 (def ^:private stale-sort-column->field
   "Sortable stale-list params → their native `content_diagnostics_finding` column. The shared base plus
@@ -206,7 +209,7 @@
       [:total        :int]
       [:limit        [:maybe :int]]
       [:offset       [:maybe :int]]
-      [:last_scan_at [:maybe some?]]]
+      [:last_scan_at [:maybe ms/TemporalInstant]]]
   "List **stale** findings - the latest valid `stale` finding per entity, permission-filtered
   for the current user. Each item is a flat identity + a nested `details` (collection, `description`, `owner`,
   `creator`, `threshold_days`). Paginated via `limit`/`offset`; `total` is the full valid count.
@@ -254,7 +257,7 @@
       [:total        :int]
       [:limit        [:maybe :int]]
       [:offset       [:maybe :int]]
-      [:last_scan_at [:maybe some?]]]
+      [:last_scan_at [:maybe ms/TemporalInstant]]]
   "List **slow** findings - the latest valid `slow` finding per entity, permission-filtered for the
   current user. Each item is a flat identity + a top-level `duration_ms` + a nested `details`. `details`
   varies by `entity_type`: leaves (card/transform) freeze `threshold_ms`; containers (dashboard/document)
@@ -305,7 +308,7 @@
       [:total        :int]
       [:limit        [:maybe :int]]
       [:offset       [:maybe :int]]
-      [:last_scan_at [:maybe some?]]]
+      [:last_scan_at [:maybe ms/TemporalInstant]]]
   "List **duplicated** findings - the latest valid `duplicated` finding per entity, permission-filtered
   for the current user. Each item is a flat identity + a top-level `duplicate_count` (the number of other
   same-type entities sharing the normalized name) + a nested `details` (collection, `description`,

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -118,7 +118,8 @@
 (def ^:private DuplicatedFinding
   "Response item for a `duplicated` finding: flat identity + a top-level `duplicate_count` + nested typed
   `details`. `duplicate_count` is the peer count (cluster size minus 1) and is never null on duplicated
-  findings. `details.normalized_name` is the normalized name the cluster collided on;
+  findings. `details.view_count` is the flagged entity's own live usage counter (present for every type
+  but transform). `details.normalized_name` is the normalized name the cluster collided on;
   `details.duplicate_entities` are the hydrated peers the caller can see - permission and
   personal-collection filtering can leave it shorter than `duplicate_count` (down to empty, but the key
   is always present)."
@@ -139,6 +140,7 @@
      [:description        [:maybe :string]]
      [:owner              NormalizedUser]
      [:creator            Creator]
+     [:view_count         {:optional true} :int]
      [:normalized_name    :string]
      [:duplicate_entities [:sequential DuplicatedEntity]]]]])
 

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -347,7 +347,7 @@
                            (request/limit)  (assoc :limit (request/limit))
                            (request/offset) (assoc :offset (request/offset))))]
     {:data         (api.common/hydrate-findings page {:top-level-cols                   [:duplicate_count]
-                                                      :hydrate-duplicate-peers?         true
+                                                      :hydrate-duplicate-entities?      true
                                                       :excluded-personal-collection-ids excluded-personal-ids})
      :total        (t2/count :model/ContentDiagnosticsFinding {:where where})
      :limit        (request/limit)

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -102,6 +102,42 @@
      [:threshold_ms  {:optional true} :int]
      [:slow_entities {:optional true} [:sequential SlowEntity]]]]])
 
+(def ^:private DuplicatedEntity
+  "A hydrated peer of a `duplicated` finding: another entity **of the same type** sharing the flagged
+  entity's normalized name. `{id, name, entity_type, card_type?}` - `card_type` (question/model/metric)
+  only on card peers."
+  [:map
+   [:id          :int]
+   [:name        [:maybe :string]]
+   [:entity_type :keyword]
+   [:card_type   {:optional true} [:maybe :keyword]]])
+
+(def ^:private DuplicatedFinding
+  "Response item for a `duplicated` finding: flat identity + a top-level `duplicate_count` + nested typed
+  `details`. `duplicate_count` is the peer count (cluster size minus 1) and is never null on duplicated
+  findings. `details.matched_name` is the normalized name the cluster collided on;
+  `details.duplicate_entities` are the hydrated peers the caller can see - permission and
+  personal-collection filtering can leave it shorter than `duplicate_count`."
+  [:map
+   [:id                  :int]
+   [:finding_type        :keyword]
+   [:entity_type         :keyword]
+   [:entity_id           :int]
+   [:detected_at         some?]
+   [:entity_display_name [:maybe :string]]
+   ;; entity's created_at, denormalized at scan time (immutable ⇒ equals live)
+   [:created_at          [:maybe some?]]
+   ;; peer count (top-level, SQL-filterable/sortable); always present on duplicated findings
+   [:duplicate_count     :int]
+   [:details
+    [:map
+     [:collection         [:maybe :map]]
+     [:description        [:maybe :string]]
+     [:owner              NormalizedUser]
+     [:creator            Creator]
+     [:matched_name       {:optional true} :string]
+     [:duplicate_entities {:optional true} [:sequential DuplicatedEntity]]]]])
+
 (def ^:private stale-sort-column->field
   "Sortable stale-list params → their native `content_diagnostics_finding` column. The shared base plus
   the stale-specific `last-active-at` magnitude column."
@@ -111,6 +147,11 @@
   "Sortable slow-list params → their native `content_diagnostics_finding` column. The shared base plus
   the slow-specific `duration-ms` magnitude column."
   (assoc api.common/base-sort-column->field :duration-ms :duration_ms))
+
+(def ^:private duplicated-sort-column->field
+  "Sortable duplicated-list params → their native `content_diagnostics_finding` column. The shared base
+  plus the duplicated-specific `duplicate-count` magnitude column."
+  (assoc api.common/base-sort-column->field :duplicate-count :duplicate_count))
 
 (defn- stale-where-clause
   "The shared finding-list WHERE plus the stale-specific `threshold-days` filter - keeps findings whose
@@ -131,6 +172,14 @@
   (api.common/findings-where
    "slow" params
    (when min-duration-ms [:>= :duration_ms min-duration-ms])))
+
+(defn- duplicated-where-clause
+  "The shared finding-list WHERE plus the duplicated-specific `min-duplicate-count` floor on the native
+  `duplicate_count` (the peer count - e.g. names shared by 3+ entities = `min-duplicate-count` 2)."
+  [{:keys [min-duplicate-count] :as params}]
+  (api.common/findings-where
+   "duplicated" params
+   (when min-duplicate-count [:>= :duplicate_count min-duplicate-count])))
 
 ;;; ------------------------------------------------ endpoints ------------------------------------------
 
@@ -240,6 +289,59 @@
                            (request/offset) (assoc :offset (request/offset))))]
     {:data         (api.common/hydrate-findings page {:top-level-cols                   [:duration_ms]
                                                       :hydrate-culprits?                true
+                                                      :excluded-personal-collection-ids excluded-personal-ids})
+     :total        (t2/count :model/ContentDiagnosticsFinding {:where where})
+     :limit        (request/limit)
+     :offset       (request/offset)
+     :last_scan_at (api.common/last-scan-at)}))
+
+(api.macros/defendpoint :get "/duplicated"
+  :- [:map
+      [:data         [:sequential DuplicatedFinding]]
+      [:total        :int]
+      [:limit        [:maybe :int]]
+      [:offset       [:maybe :int]]
+      [:last_scan_at [:maybe some?]]]
+  "List **duplicated** findings - the latest valid `duplicated` finding per entity, permission-filtered
+  for the current user. Each item is a flat identity + a top-level `duplicate_count` (the number of other
+  same-type entities sharing the normalized name) + a nested `details` (collection, `description`,
+  `owner`, `creator`, `matched_name`, and the hydrated same-type `duplicate_entities` peers). Paginated
+  via `limit`/`offset`; `total` is the full valid count.
+
+  Params: `include-personal-collections` (default false) - when false, entities currently in a personal
+  collection are excluded and personal-collection peers are omitted from `duplicate_entities`.
+  `entity-types` (repeatable; `card`|`dashboard`|`document`|`transform`, omitted = all).
+  `min-duplicate-count` (positive int) keeps findings with at least that many peers. `query`
+  case-insensitively substring-matches the entity name. `sort-column`
+  (`detected-at`|`entity-type`|`name`|`created-at`|`created-by`|`duplicate-count`, default `detected-at`)
+  + `sort-direction` (`asc`|`desc`, default `asc`); `id` is the stable tiebreak."
+  [_route-params
+   {:keys [include-personal-collections sort-column sort-direction entity-types min-duplicate-count query]
+    :or   {include-personal-collections false
+           sort-column                   :detected-at
+           sort-direction                :asc}}
+   :- [:map
+       [:include-personal-collections {:optional true} :boolean]
+       [:sort-column         {:optional true} (ms/enum-decode-keyword (keys duplicated-sort-column->field))]
+       [:sort-direction      {:optional true} (ms/enum-decode-keyword api.common/sort-directions)]
+       [:entity-types        {:optional true} [:or
+                                               (ms/enum-decode-keyword api.common/covered-entity-types)
+                                               [:sequential (ms/enum-decode-keyword api.common/covered-entity-types)]]]
+       [:min-duplicate-count {:optional true} ms/PositiveInt]
+       [:query               {:optional true} :string]]]
+  (let [excluded-personal-ids (api.common/excluded-personal-collection-ids include-personal-collections)
+        where (duplicated-where-clause {:excluded-personal-collection-ids excluded-personal-ids
+                                        :entity-types                 entity-types
+                                        :min-duplicate-count          min-duplicate-count
+                                        :query                        query})
+        page  (t2/select :model/ContentDiagnosticsFinding
+                         (cond-> {:where    where
+                                  :order-by [[(duplicated-sort-column->field sort-column) sort-direction]
+                                             [:id sort-direction]]}
+                           (request/limit)  (assoc :limit (request/limit))
+                           (request/offset) (assoc :offset (request/offset))))]
+    {:data         (api.common/hydrate-findings page {:top-level-cols                   [:duplicate_count]
+                                                      :hydrate-duplicate-peers?         true
                                                       :excluded-personal-collection-ids excluded-personal-ids})
      :total        (t2/count :model/ContentDiagnosticsFinding {:where where})
      :limit        (request/limit)

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -115,9 +115,10 @@
 (def ^:private DuplicatedFinding
   "Response item for a `duplicated` finding: flat identity + a top-level `duplicate_count` + nested typed
   `details`. `duplicate_count` is the peer count (cluster size minus 1) and is never null on duplicated
-  findings. `details.matched_name` is the normalized name the cluster collided on;
+  findings. `details.normalized_name` is the normalized name the cluster collided on;
   `details.duplicate_entities` are the hydrated peers the caller can see - permission and
-  personal-collection filtering can leave it shorter than `duplicate_count`."
+  personal-collection filtering can leave it shorter than `duplicate_count` (down to empty, but the key
+  is always present)."
   [:map
    [:id                  :int]
    [:finding_type        :keyword]
@@ -135,8 +136,8 @@
      [:description        [:maybe :string]]
      [:owner              NormalizedUser]
      [:creator            Creator]
-     [:matched_name       {:optional true} :string]
-     [:duplicate_entities {:optional true} [:sequential DuplicatedEntity]]]]])
+     [:normalized_name    :string]
+     [:duplicate_entities [:sequential DuplicatedEntity]]]]])
 
 (def ^:private stale-sort-column->field
   "Sortable stale-list params → their native `content_diagnostics_finding` column. The shared base plus
@@ -305,8 +306,8 @@
   "List **duplicated** findings - the latest valid `duplicated` finding per entity, permission-filtered
   for the current user. Each item is a flat identity + a top-level `duplicate_count` (the number of other
   same-type entities sharing the normalized name) + a nested `details` (collection, `description`,
-  `owner`, `creator`, `matched_name`, and the hydrated same-type `duplicate_entities` peers). Paginated
-  via `limit`/`offset`; `total` is the full valid count.
+  `owner`, `creator`, `normalized_name`, and the hydrated same-type `duplicate_entities` peers).
+  Paginated via `limit`/`offset`; `total` is the full valid count.
 
   Params: `include-personal-collections` (default false) - when false, entities currently in a personal
   collection are excluded and personal-collection peers are omitted from `duplicate_entities`.

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -172,6 +172,37 @@
                                   [:= :collection_id nil]
                                   [:not [:in :collection_id excluded-personal-ids]]])]})))
 
+(defn- hydrate-duplicate-peers
+  "The findings' stored `duplicate_entity_ids` → `{[entity-type id] → {:id :name :entity_type <etype>
+  :card_type <kw>}}` (`card_type` only on card peers). The generalization of [[hydrate-slow-entities]]:
+  duplicate peers share the **finding's own** entity type, which varies per finding, so each type's peer-id
+  union resolves from that type's own model. Mode-agnostic - it hydrates the union regardless of which
+  match modes produced it.
+
+  The per-caller read-time filters are re-applied exactly as in [[hydrate-slow-entities]]: caller
+  visibility always, personal-collection exclusion when `excluded-personal-ids` is provided (with the
+  nil-`collection_id` root-survival clause). A filtered-out peer drops out of `duplicate_entities` exactly
+  like a deleted one."
+  [findings excluded-personal-ids]
+  (into {}
+        (for [[etype rows] (group-by :entity_type findings)
+              :let  [model (common/entity-type->model etype)
+                     ids   (into #{} (mapcat (comp :duplicate_entity_ids :details)) rows)]
+              :when (and model (seq ids))
+              :let  [cols (cond-> [model :id :name]
+                            ;; :card_schema is required on any Card select - its after-select hook reads it.
+                            (= etype :card) (conj :type :card_schema))]
+              row   (t2/select cols
+                               {:where [:and
+                                        [:in :id ids]
+                                        (collection/visible-collection-filter-clause :collection_id)
+                                        (when excluded-personal-ids
+                                          [:or
+                                           [:= :collection_id nil]
+                                           [:not [:in :collection_id excluded-personal-ids]]])]})]
+          [[etype (:id row)] (cond-> {:id (:id row) :name (:name row) :entity_type etype}
+                               (= etype :card) (assoc :card_type (:type row)))])))
+
 (defn- normalized-owner
   "Normalized `owner` from the transform `:owner` hydrate: `{id,name,email,type:user}` or, for an external
   email-only owner, `{email,type:external}`. Nil for entity types with no owner (card/dashboard/document)."
@@ -191,10 +222,13 @@
   Options let each endpoint add its per-finding-type extras without changing the shared base:
   `:top-level-cols` - extra native finding columns hoisted to the top level (e.g. `:last_active_at` for
   stale, `:duration_ms` for slow); `:hydrate-culprits?` - replace `details.slow_entity_ids` with hydrated
-  `details.slow_entities` objects (slow roll-ups); `:excluded-personal-collection-ids` - the request's
-  resolved exclusion set (see `excluded-personal-collection-ids`), threaded to the culprit hydration so
-  its personal-collection exclusion matches the findings filter without re-querying."
-  [findings & [{:keys [top-level-cols hydrate-culprits? excluded-personal-collection-ids]
+  `details.slow_entities` objects (slow roll-ups); `:hydrate-duplicate-peers?` - replace
+  `details.duplicate_entity_ids` with hydrated same-type `details.duplicate_entities` objects (duplicated
+  findings), also dropping the stored `details.matches` envelope (its raw per-mode peer ids are not
+  permission-filtered - the hydrated list is the served form); `:excluded-personal-collection-ids` - the
+  request's resolved exclusion set (see `excluded-personal-collection-ids`), threaded to the culprit/peer
+  hydration so its personal-collection exclusion matches the findings filter without re-querying."
+  [findings & [{:keys [top-level-cols hydrate-culprits? hydrate-duplicate-peers? excluded-personal-collection-ids]
                 :or   {top-level-cols []}}]]
   (let [ctx-by-type (into {} (for [[etype rows] (group-by :entity_type findings)]
                                [etype (entity-context etype (map :entity_id rows))]))
@@ -204,7 +238,9 @@
         breadcrumbs (collection-breadcrumbs coll-ids)
         culprits    (when hydrate-culprits?
                       (hydrate-slow-entities (into #{} (mapcat (comp :slow_entity_ids :details)) findings)
-                                             excluded-personal-collection-ids))]
+                                             excluded-personal-collection-ids))
+        peers       (when hydrate-duplicate-peers?
+                      (hydrate-duplicate-peers findings excluded-personal-collection-ids))]
     (mapv (fn [{:keys [id finding_type entity_type entity_id detected_at entity_created_at
                        entity_name entity_creator_id entity_creator_name details] :as row}]
             (let [entity  (get-in ctx-by-type [entity_type entity_id])
@@ -218,11 +254,16 @@
                                                  {:id entity_creator_id :name entity_creator_name :type :user})}
                                  (when-some [view-count (:view_count entity)]
                                    {:view_count view-count}))
-                  details* (if (and hydrate-culprits? (contains? details :slow_entity_ids))
-                             (-> base
-                                 (dissoc :slow_entity_ids)
+                  details* (cond-> base
+                             (and hydrate-culprits? (contains? details :slow_entity_ids))
+                             (-> (dissoc :slow_entity_ids)
                                  (assoc :slow_entities (into [] (keep culprits) (:slow_entity_ids details))))
-                             base)]
+
+                             (and hydrate-duplicate-peers? (contains? details :duplicate_entity_ids))
+                             (-> (dissoc :duplicate_entity_ids :matches)
+                                 (assoc :duplicate_entities (into []
+                                                                  (keep #(get peers [entity_type %]))
+                                                                  (:duplicate_entity_ids details)))))]
               (merge {:id                  id
                       :finding_type        finding_type
                       :entity_type         entity_type

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -129,13 +129,15 @@
 
 (defn- context-rows
   "Build `{entity-id → row}` for a column-resident type: select `common/context-cols` plus `id`/`collection_id`,
-  hydrate the owner (`hydrate-owner`), index by id."
+  hydrate the owner (`hydrate-owner`), index by id. Empty `ids` → nil (skips a degenerate `IN ()`; callers use
+  `get-in`, so nil is fine)."
   [entity-type ids]
-  (->> (t2/select (into [(common/entity-type->model entity-type) :id :collection_id]
-                        (common/context-cols entity-type))
-                  :id [:in (set ids)])
-       (hydrate-owner entity-type)
-       (m/index-by :id)))
+  (when (seq ids)
+    (->> (t2/select (into [(common/entity-type->model entity-type) :id :collection_id]
+                          (common/context-cols entity-type))
+                    :id [:in (set ids)])
+         (hydrate-owner entity-type)
+         (m/index-by :id))))
 
 (defmulti ^:private entity-context
   "For one entity-type's id set → `{entity-id → row}` of the live display fields (description, collection_id,

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -116,21 +116,37 @@
 ;;; name/created_at/creator are denormalized (frozen at scan time); description, the collection
 ;;; breadcrumb, the transform owner, and slow roll-up culprits are live-hydrated, batched per entity-type.
 
-(defn- entity-context
-  "For one entity-type's id set → `{entity-id → row}`. Live-hydrates only the non-denormalized display
-  fields: `description`, `collection_id`, `view_count` (all but transform), and (transform only) the owner.
-  `document` has no description."
+(defmulti ^:private hydrate-owner
+  "Batch-hydrate the per-type `owner` onto already-selected rows. card/dashboard/document have no owner, so
+  `::collection-item` returns rows unchanged; transform hydrates its `:owner` (a user row, or an `{:email …}`
+  external stand-in)."
+  {:arglists '([entity-type rows])}
+  (fn [entity-type _rows] entity-type)
+  :hierarchy #'common/hierarchy)
+
+(defmethod hydrate-owner ::common/collection-item [_ rows] rows)
+(defmethod hydrate-owner :transform [_ rows] (t2/hydrate rows :owner))
+
+(defn- context-rows
+  "Build `{entity-id → row}` for a column-resident type: select `common/context-cols` plus `id`/`collection_id`,
+  hydrate the owner (`hydrate-owner`), index by id."
   [entity-type ids]
-  (when-let [model (common/entity-type->model entity-type)]
-    (let [cols (cond-> [:id :collection_id]
-                 (not= entity-type :document)  (conj :description)
-                 ;; card/dashboard/document have a native view_count column; transform has none.
-                 (not= entity-type :transform) (conj :view_count)
-                 (= entity-type :transform)    (conj :owner_user_id :owner_email))
-          rows (cond-> (t2/select (into [model] cols) :id [:in (set ids)])
-                 ;; reuse the transform model's batched :owner hydrate (user row, or {:email …} external)
-                 (= entity-type :transform) (t2/hydrate :owner))]
-      (m/index-by :id rows))))
+  (->> (t2/select (into [(common/entity-type->model entity-type) :id :collection_id]
+                        (common/context-cols entity-type))
+                  :id [:in (set ids)])
+       (hydrate-owner entity-type)
+       (m/index-by :id)))
+
+(defmulti ^:private entity-context
+  "For one entity-type's id set → `{entity-id → row}` of the live display fields (description, collection_id,
+  view_count, transform owner). card/dashboard/document (`::collection-item`) and transform share the
+  column-based [[context-rows]]; a non-column-resident type (e.g. collection) would get its own method."
+  {:arglists '([entity-type ids])}
+  (fn [entity-type _ids] entity-type)
+  :hierarchy #'common/hierarchy)
+
+(defmethod entity-context ::common/collection-item [entity-type ids] (context-rows entity-type ids))
+(defmethod entity-context :transform [entity-type ids] (context-rows entity-type ids))
 
 (defn- collection-breadcrumbs
   "For a set of collection ids → `{collection-id → {:id :name :effective_ancestors [{:id :name} …]}}`.
@@ -181,33 +197,43 @@
                       [:model/Card :id :name :type :view_count :card_schema]
                       {:where (readable-entities-where (set card-ids) excluded-personal-ids)})))
 
+(defmulti ^:private read-entity-rows
+  "Permission-filtered rows for hydrating a type's duplicate ids, read-gated by [[readable-entities-where]].
+  For card/dashboard/document (`::collection-item`) that collection clause IS the read permission (they derive
+  `:perms/use-parent-collection-perms`), with projection cols from `common/peer-select-cols`; transform
+  readability isn't collection-based, so it selects full rows and additionally filters by `mi/can-read?`."
+  {:arglists '([entity-type ids excluded-personal-ids])}
+  (fn [entity-type _ids _excluded] entity-type)
+  :hierarchy #'common/hierarchy)
+
+(defmethod read-entity-rows ::common/collection-item
+  [entity-type ids excluded-personal-ids]
+  ;; :card_schema (a peer-select-col for cards) is required on any Card select - its after-select hook reads it.
+  (t2/select (into [(common/entity-type->model entity-type) :id :name] (common/peer-select-cols entity-type))
+             {:where (readable-entities-where ids excluded-personal-ids)}))
+
+(defmethod read-entity-rows :transform
+  [_ ids excluded-personal-ids]
+  ;; mi/can-read? on a transform = source-type feature gate + (superuser, or data-analyst with readable
+  ;; source tables) - the collection clause alone would leak transform names to collection-granted
+  ;; non-analysts. It reads :source, so select full rows; peer sets are page-bounded, so the per-row check
+  ;; is cheap.
+  (filter mi/can-read? (t2/select :model/Transform {:where (readable-entities-where ids excluded-personal-ids)})))
+
 (defn- hydrate-duplicate-entities
   "The findings' stored `duplicate_entity_ids` → `{[entity-type id] → {:id :name :entity_type <etype>
   :card_type <kw> :view_count <int>}}`. `card_type` and `view_count` are present only on card/dashboard/
   document peers (transforms have no view concept, so their peers carry no usage signal). Peers share the
-  finding's own entity type, so each type's ids resolve from that type's own model, read-filtered by
-  [[readable-entities-where]]. For card/dashboard/document that collection gate IS the read permission
-  (they derive `:perms/use-parent-collection-perms`); transform readability is not collection-based, so
-  transform peers additionally require `mi/can-read?`. A filtered-out peer drops out of
-  `duplicate_entities` like a deleted one."
+  finding's own entity type, so each type's ids resolve from that type's own model via [[read-entity-rows]]
+  (which applies the per-type read gate); a filtered-out peer drops out of `duplicate_entities` like a
+  deleted one."
   [findings excluded-personal-ids]
   (into {}
         (for [[etype rows] (group-by :entity_type findings)
               :let  [model (common/entity-type->model etype)
                      ids   (into #{} (mapcat (comp :duplicate_entity_ids :details)) rows)]
               :when (and model (seq ids))
-              :let  [where (readable-entities-where ids excluded-personal-ids)]
-              row   (if (= etype :transform)
-                      ;; mi/can-read? on a transform = source-type feature gate + (superuser, or
-                      ;; data-analyst with readable source tables) - the collection clause alone would
-                      ;; leak transform names to collection-granted non-analysts. It reads :source, so
-                      ;; select full rows; peer sets are page-bounded, so the per-row check is cheap.
-                      (filter mi/can-read? (t2/select :model/Transform {:where where}))
-                      (t2/select (cond-> [model :id :name :view_count]
-                                   ;; :card_schema is required on any Card select - its after-select
-                                   ;; hook reads it.
-                                   (= etype :card) (conj :type :card_schema))
-                                 {:where where}))]
+              row   (read-entity-rows etype ids excluded-personal-ids)]
           [[etype (:id row)]
            (if (= etype :transform)
              {:id (:id row) :name (:name row) :entity_type etype}

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -261,8 +261,8 @@
   stale, `:duration_ms` for slow); `:hydrate-culprits?` - replace `details.slow_entity_ids` with hydrated
   `details.slow_entities` objects (slow roll-ups); `:hydrate-duplicate-entities?` - replace
   `details.duplicate_entity_ids` with hydrated same-type `details.duplicate_entities` objects (duplicated
-  findings), also dropping the stored `details.matches` envelope (its raw per-mode ids are not
-  permission-filtered - the hydrated list is the served form); `:excluded-personal-collection-ids` - the
+  findings) - the raw stored ids are not permission-filtered, so the hydrated list is the served form;
+  `:excluded-personal-collection-ids` - the
   request's resolved exclusion set (see `excluded-personal-collection-ids`), threaded to the
   culprit/duplicate-entity hydration so its personal-collection exclusion matches the findings filter
   without re-querying."
@@ -298,7 +298,7 @@
                                  (assoc :slow_entities (into [] (keep culprits) (:slow_entity_ids details))))
 
                              (and hydrate-duplicate-entities? (contains? details :duplicate_entity_ids))
-                             (-> (dissoc :duplicate_entity_ids :matches)
+                             (-> (dissoc :duplicate_entity_ids)
                                  (assoc :duplicate_entities (into []
                                                                   (keep #(get entities [entity_type %]))
                                                                   (:duplicate_entity_ids details)))))]

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -148,6 +148,21 @@
                      :effective_ancestors (mapv #(select-keys % [:id :name]) (:effective_ancestors c))}]))
             colls))))
 
+(defn- readable-entities-where
+  "HoneySQL WHERE keeping only the rows in `ids` the caller may read at hydration time: caller visibility
+  (the same gate as `visible-findings-clause`) always, plus the personal-collection exclusion when
+  `excluded-personal-ids` is provided. Shared by the culprit/peer hydrators so the read-time gate lives in
+  one place - a perms change lands once, not per hydrator."
+  [ids excluded-personal-ids]
+  [:and
+   [:in :id ids]
+   (collection/visible-collection-filter-clause :collection_id)
+   ;; root-collection entities (nil collection_id) must survive the NOT-IN.
+   (when excluded-personal-ids
+     [:or
+      [:= :collection_id nil]
+      [:not [:in :collection_id excluded-personal-ids]]])])
+
 (defn- hydrate-slow-entities
   "Card-id set → `{card-id → {:id :name :entity_type :card :card_type <kw> :view_count <int>}}`. The
   read-time hydration of a `slow` roll-up's stored culprit ids (`slow_entity_ids`) into objects.
@@ -164,44 +179,24 @@
     (t2/select-pk->fn (fn [c] {:id (:id c) :name (:name c) :entity_type :card :card_type (:type c)
                                :view_count (:view_count c)})
                       [:model/Card :id :name :type :view_count :card_schema]
-                      {:where [:and
-                               [:in :id (set card-ids)]
-                               (collection/visible-collection-filter-clause :collection_id)
-                               ;; root-collection culprits (nil collection_id) must survive the NOT-IN.
-                               (when excluded-personal-ids
-                                 [:or
-                                  [:= :collection_id nil]
-                                  [:not [:in :collection_id excluded-personal-ids]]])]})))
+                      {:where (readable-entities-where (set card-ids) excluded-personal-ids)})))
 
-(defn- hydrate-duplicate-peers
+(defn- hydrate-duplicate-entities
   "The findings' stored `duplicate_entity_ids` → `{[entity-type id] → {:id :name :entity_type <etype>
-  :card_type <kw> :view_count <int>}}` (`card_type` only on card peers). Card/dashboard/document peers
-  carry their live `view_count` so callers can judge which duplicate is the abandoned one; transforms
-  have no view concept, so transform peers carry no usage signal. The generalization of
-  [[hydrate-slow-entities]]:
-  duplicate peers share the **finding's own** entity type, which varies per finding, so each type's peer-id
-  union resolves from that type's own model. Mode-agnostic - it hydrates the union regardless of which
-  match modes produced it.
-
-  The per-caller read-time filters are re-applied exactly as in [[hydrate-slow-entities]]: caller
-  visibility always, personal-collection exclusion when `excluded-personal-ids` is provided (with the
-  nil-`collection_id` root-survival clause). For card/dashboard/document peers the collection clause IS
-  the model's read permission (they derive `:perms/use-parent-collection-perms`); transform readability
-  is not collection-based, so transform peers additionally require `mi/can-read?`. A filtered-out peer
-  drops out of `duplicate_entities` exactly like a deleted one."
+  :card_type <kw> :view_count <int>}}`. `card_type` and `view_count` are present only on card/dashboard/
+  document peers (transforms have no view concept, so their peers carry no usage signal). Peers share the
+  finding's own entity type, so each type's ids resolve from that type's own model, read-filtered by
+  [[readable-entities-where]]. For card/dashboard/document that collection gate IS the read permission
+  (they derive `:perms/use-parent-collection-perms`); transform readability is not collection-based, so
+  transform peers additionally require `mi/can-read?`. A filtered-out peer drops out of
+  `duplicate_entities` like a deleted one."
   [findings excluded-personal-ids]
   (into {}
         (for [[etype rows] (group-by :entity_type findings)
               :let  [model (common/entity-type->model etype)
                      ids   (into #{} (mapcat (comp :duplicate_entity_ids :details)) rows)]
               :when (and model (seq ids))
-              :let  [where [:and
-                            [:in :id ids]
-                            (collection/visible-collection-filter-clause :collection_id)
-                            (when excluded-personal-ids
-                              [:or
-                               [:= :collection_id nil]
-                               [:not [:in :collection_id excluded-personal-ids]]])]]
+              :let  [where (readable-entities-where ids excluded-personal-ids)]
               row   (if (= etype :transform)
                       ;; mi/can-read? on a transform = source-type feature gate + (superuser, or
                       ;; data-analyst with readable source tables) - the collection clause alone would
@@ -238,13 +233,14 @@
   Options let each endpoint add its per-finding-type extras without changing the shared base:
   `:top-level-cols` - extra native finding columns hoisted to the top level (e.g. `:last_active_at` for
   stale, `:duration_ms` for slow); `:hydrate-culprits?` - replace `details.slow_entity_ids` with hydrated
-  `details.slow_entities` objects (slow roll-ups); `:hydrate-duplicate-peers?` - replace
+  `details.slow_entities` objects (slow roll-ups); `:hydrate-duplicate-entities?` - replace
   `details.duplicate_entity_ids` with hydrated same-type `details.duplicate_entities` objects (duplicated
-  findings), also dropping the stored `details.matches` envelope (its raw per-mode peer ids are not
+  findings), also dropping the stored `details.matches` envelope (its raw per-mode ids are not
   permission-filtered - the hydrated list is the served form); `:excluded-personal-collection-ids` - the
-  request's resolved exclusion set (see `excluded-personal-collection-ids`), threaded to the culprit/peer
-  hydration so its personal-collection exclusion matches the findings filter without re-querying."
-  [findings & [{:keys [top-level-cols hydrate-culprits? hydrate-duplicate-peers? excluded-personal-collection-ids]
+  request's resolved exclusion set (see `excluded-personal-collection-ids`), threaded to the
+  culprit/duplicate-entity hydration so its personal-collection exclusion matches the findings filter
+  without re-querying."
+  [findings & [{:keys [top-level-cols hydrate-culprits? hydrate-duplicate-entities? excluded-personal-collection-ids]
                 :or   {top-level-cols []}}]]
   (let [ctx-by-type (into {} (for [[etype rows] (group-by :entity_type findings)]
                                [etype (entity-context etype (map :entity_id rows))]))
@@ -255,8 +251,8 @@
         culprits    (when hydrate-culprits?
                       (hydrate-slow-entities (into #{} (mapcat (comp :slow_entity_ids :details)) findings)
                                              excluded-personal-collection-ids))
-        peers       (when hydrate-duplicate-peers?
-                      (hydrate-duplicate-peers findings excluded-personal-collection-ids))]
+        entities    (when hydrate-duplicate-entities?
+                      (hydrate-duplicate-entities findings excluded-personal-collection-ids))]
     (mapv (fn [{:keys [id finding_type entity_type entity_id detected_at entity_created_at
                        entity_name entity_creator_id entity_creator_name details] :as row}]
             (let [entity  (get-in ctx-by-type [entity_type entity_id])
@@ -275,10 +271,10 @@
                              (-> (dissoc :slow_entity_ids)
                                  (assoc :slow_entities (into [] (keep culprits) (:slow_entity_ids details))))
 
-                             (and hydrate-duplicate-peers? (contains? details :duplicate_entity_ids))
+                             (and hydrate-duplicate-entities? (contains? details :duplicate_entity_ids))
                              (-> (dissoc :duplicate_entity_ids :matches)
                                  (assoc :duplicate_entities (into []
-                                                                  (keep #(get peers [entity_type %]))
+                                                                  (keep #(get entities [entity_type %]))
                                                                   (:duplicate_entity_ids details)))))]
               (merge {:id                  id
                       :finding_type        finding_type

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -250,67 +250,94 @@
         {:id id :name common_name :email email :type :user}
         {:email email :type :external}))))
 
+(defn- rewrite-ids->entities
+  "Replace `details.<ids-key>` with hydrated `details.<entities-key>`, each id looked up via `id->entity`
+  (misses dropped). A no-op when `ids-key` is absent."
+  [details ids-key entities-key id->entity]
+  (if (contains? details ids-key)
+    (-> details
+        (dissoc ids-key)
+        (assoc entities-key (into [] (keep id->entity) (ids-key details))))
+    details))
+
+(defn- with-slow-culprits
+  "Replace `details.slow_entity_ids` with hydrated `details.slow_entities` from `culprits`. A no-op for a
+  slow leaf (card/transform), which rolls up no culprits and so carries no `slow_entity_ids`."
+  [details culprits]
+  (rewrite-ids->entities details :slow_entity_ids :slow_entities culprits))
+
+(defn- with-duplicate-peers
+  "Replace `details.duplicate_entity_ids` with hydrated same-type `details.duplicate_entities` from
+  `entities` (keyed `[entity-type id]`). The raw stored ids are not permission-filtered, so the hydrated
+  list is the served form; a filtered-out peer drops out like a deleted one. A no-op when the finding
+  carries no `duplicate_entity_ids`."
+  [details entity-type entities]
+  (rewrite-ids->entities details :duplicate_entity_ids :duplicate_entities #(get entities [entity-type %])))
+
+(defmulti ^:private finalize-finding
+  "Apply the finding-type-specific tail to one assembled finding `base`: hoist the type's native top-level
+  column(s) from `row`, and rewrite `details` from the batch-hydrated `ctx` (`{:culprits _ :entities _}`).
+  Dispatches per row on `finding_type`, so a page may mix finding types (an umbrella endpoint); an
+  unregistered type throws - fail-closed, no `:default`."
+  {:arglists '([finding-type base row ctx])}
+  (fn [finding-type _base _row _ctx] finding-type))
+
+(defmethod finalize-finding :stale [_ base row _ctx]
+  (merge base (select-keys row [:last_active_at])))
+
+(defmethod finalize-finding :slow [_ base row {:keys [culprits]}]
+  (-> (merge base (select-keys row [:duration_ms]))
+      (update :details with-slow-culprits culprits)))
+
+(defmethod finalize-finding :duplicated [_ base row {:keys [entities]}]
+  (-> (merge base (select-keys row [:duplicate_count]))
+      (update :details with-duplicate-peers (:entity_type row) entities)))
+
 (defn hydrate-findings
   "Project stored findings into the response shape: flat identity + denormalized display fields, plus a
   nested `details` = stored verdict + {collection, description, owner, creator, view_count?}. `view_count`
   is the entity's live usage counter, present only for types that have the column (all but transform).
   Batched, page-size-independent.
 
-  Options let each endpoint add its per-finding-type extras without changing the shared base:
-  `:top-level-cols` - extra native finding columns hoisted to the top level (e.g. `:last_active_at` for
-  stale, `:duration_ms` for slow); `:hydrate-culprits?` - replace `details.slow_entity_ids` with hydrated
-  `details.slow_entities` objects (slow roll-ups); `:hydrate-duplicate-entities?` - replace
-  `details.duplicate_entity_ids` with hydrated same-type `details.duplicate_entities` objects (duplicated
-  findings) - the raw stored ids are not permission-filtered, so the hydrated list is the served form;
-  `:excluded-personal-collection-ids` - the
-  request's resolved exclusion set (see `excluded-personal-collection-ids`), threaded to the
-  culprit/duplicate-entity hydration so its personal-collection exclusion matches the findings filter
-  without re-querying."
-  [findings & [{:keys [top-level-cols hydrate-culprits? hydrate-duplicate-entities? excluded-personal-collection-ids]
-                :or   {top-level-cols []}}]]
+  The finding-type-specific tail - the hoisted native column(s) and any `details` rewrite (slow culprits /
+  duplicated peers) - is dispatched per row on each finding's `finding_type` via [[finalize-finding]], so a
+  page may mix finding types. `excluded-personal-ids` (the request's resolved exclusion set) gates the
+  culprit/peer hydration so it matches the findings filter without re-querying."
+  [findings excluded-personal-ids]
   (let [ctx-by-type (into {} (for [[etype rows] (group-by :entity_type findings)]
                                [etype (entity-context etype (map :entity_id rows))]))
         coll-ids    (into #{} (keep (fn [{:keys [entity_type entity_id]}]
                                       (get-in ctx-by-type [entity_type entity_id :collection_id])))
                           findings)
         breadcrumbs (collection-breadcrumbs coll-ids)
-        culprits    (when hydrate-culprits?
-                      (hydrate-slow-entities (into #{} (mapcat (comp :slow_entity_ids :details)) findings)
-                                             excluded-personal-collection-ids))
-        entities    (when hydrate-duplicate-entities?
-                      (hydrate-duplicate-entities findings excluded-personal-collection-ids))]
+        ;; Batch-prep runs over whatever the page carries - an absent finding type contributes no ids, so
+        ;; its hydrator issues no query.
+        culprits    (hydrate-slow-entities (into #{} (mapcat (comp :slow_entity_ids :details)) findings)
+                                           excluded-personal-ids)
+        entities    (hydrate-duplicate-entities findings excluded-personal-ids)
+        ctx         {:culprits culprits :entities entities}]
     (mapv (fn [{:keys [id finding_type entity_type entity_id detected_at entity_created_at
                        entity_name entity_creator_id entity_creator_name details] :as row}]
-            (let [entity  (get-in ctx-by-type [entity_type entity_id])
-                  base    (merge details
-                                 {:collection  (get breadcrumbs (:collection_id entity))
-                                  :description (:description entity)
-                                  ;; only transforms have owner columns; null for the rest.
-                                  :owner       (normalized-owner entity)
-                                  ;; creator denormalized (id + common_name) - no live :creator hydrate.
-                                  :creator     (when entity_creator_id
-                                                 {:id entity_creator_id :name entity_creator_name :type :user})}
-                                 (when-some [view-count (:view_count entity)]
-                                   {:view_count view-count}))
-                  details* (cond-> base
-                             (and hydrate-culprits? (contains? details :slow_entity_ids))
-                             (-> (dissoc :slow_entity_ids)
-                                 (assoc :slow_entities (into [] (keep culprits) (:slow_entity_ids details))))
-
-                             (and hydrate-duplicate-entities? (contains? details :duplicate_entity_ids))
-                             (-> (dissoc :duplicate_entity_ids)
-                                 (assoc :duplicate_entities (into []
-                                                                  (keep #(get entities [entity_type %]))
-                                                                  (:duplicate_entity_ids details)))))]
-              (merge {:id                  id
-                      :finding_type        finding_type
-                      :entity_type         entity_type
-                      :entity_id           entity_id
-                      :detected_at         detected_at
-                      :entity_display_name entity_name
-                      :created_at          entity_created_at
-                      :details             details*}
-                     (select-keys row top-level-cols))))
+            (let [entity   (get-in ctx-by-type [entity_type entity_id])
+                  details* (merge details
+                                  {:collection  (get breadcrumbs (:collection_id entity))
+                                   :description (:description entity)
+                                   ;; only transforms have owner columns; null for the rest.
+                                   :owner       (normalized-owner entity)
+                                   ;; creator denormalized (id + common_name) - no live :creator hydrate.
+                                   :creator     (when entity_creator_id
+                                                  {:id entity_creator_id :name entity_creator_name :type :user})}
+                                  (when-some [view-count (:view_count entity)]
+                                    {:view_count view-count}))
+                  base     {:id                  id
+                            :finding_type        finding_type
+                            :entity_type         entity_type
+                            :entity_id           entity_id
+                            :detected_at         detected_at
+                            :entity_display_name entity_name
+                            :created_at          entity_created_at
+                            :details             details*}]
+              (finalize-finding finding_type base row ctx)))
           findings)))
 
 (defn last-scan-at

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -11,6 +11,7 @@
    [medley.core :as m]
    [metabase-enterprise.content-diagnostics.common :as common]
    [metabase.collections.models.collection :as collection]
+   [metabase.models.interface :as mi]
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
@@ -181,25 +182,34 @@
 
   The per-caller read-time filters are re-applied exactly as in [[hydrate-slow-entities]]: caller
   visibility always, personal-collection exclusion when `excluded-personal-ids` is provided (with the
-  nil-`collection_id` root-survival clause). A filtered-out peer drops out of `duplicate_entities` exactly
-  like a deleted one."
+  nil-`collection_id` root-survival clause). For card/dashboard/document peers the collection clause IS
+  the model's read permission (they derive `:perms/use-parent-collection-perms`); transform readability
+  is not collection-based, so transform peers additionally require `mi/can-read?`. A filtered-out peer
+  drops out of `duplicate_entities` exactly like a deleted one."
   [findings excluded-personal-ids]
   (into {}
         (for [[etype rows] (group-by :entity_type findings)
               :let  [model (common/entity-type->model etype)
                      ids   (into #{} (mapcat (comp :duplicate_entity_ids :details)) rows)]
               :when (and model (seq ids))
-              :let  [cols (cond-> [model :id :name]
-                            ;; :card_schema is required on any Card select - its after-select hook reads it.
-                            (= etype :card) (conj :type :card_schema))]
-              row   (t2/select cols
-                               {:where [:and
-                                        [:in :id ids]
-                                        (collection/visible-collection-filter-clause :collection_id)
-                                        (when excluded-personal-ids
-                                          [:or
-                                           [:= :collection_id nil]
-                                           [:not [:in :collection_id excluded-personal-ids]]])]})]
+              :let  [where [:and
+                            [:in :id ids]
+                            (collection/visible-collection-filter-clause :collection_id)
+                            (when excluded-personal-ids
+                              [:or
+                               [:= :collection_id nil]
+                               [:not [:in :collection_id excluded-personal-ids]]])]]
+              row   (if (= etype :transform)
+                      ;; mi/can-read? on a transform = source-type feature gate + (superuser, or
+                      ;; data-analyst with readable source tables) - the collection clause alone would
+                      ;; leak transform names to collection-granted non-analysts. It reads :source, so
+                      ;; select full rows; peer sets are page-bounded, so the per-row check is cheap.
+                      (filter mi/can-read? (t2/select :model/Transform {:where where}))
+                      (t2/select (cond-> [model :id :name]
+                                   ;; :card_schema is required on any Card select - its after-select
+                                   ;; hook reads it.
+                                   (= etype :card) (conj :type :card_schema))
+                                 {:where where}))]
           [[etype (:id row)] (cond-> {:id (:id row) :name (:name row) :entity_type etype}
                                (= etype :card) (assoc :card_type (:type row)))])))
 

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -235,10 +235,9 @@
               :when (and model (seq ids))
               row   (read-entity-rows etype ids excluded-personal-ids)]
           [[etype (:id row)]
-           (if (= etype :transform)
-             {:id (:id row) :name (:name row) :entity_type etype}
-             (cond-> {:id (:id row) :name (:name row) :entity_type etype :view_count (:view_count row)}
-               (= etype :card) (assoc :card_type (:type row))))])))
+           (cond-> {:id (:id row) :name (:name row) :entity_type etype}
+             (not= etype :transform) (assoc :view_count (:view_count row))
+             (= etype :card)         (assoc :card_type (:type row)))])))
 
 (defn- normalized-owner
   "Normalized `owner` from the transform `:owner` hydrate: `{id,name,email,type:user}` or, for an external

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -173,9 +173,25 @@
                                   [:= :collection_id nil]
                                   [:not [:in :collection_id excluded-personal-ids]]])]})))
 
+(defn- transform-run-counts
+  "`{transform-id → total `transform_run` count}` for `ids` - one grouped count, every run status (a
+  failed run is still activity). A never-run transform has no entry; callers default to 0."
+  [ids]
+  (if (seq ids)
+    (into {}
+          (map (juxt :transform_id :run_count))
+          (t2/query {:select   [:transform_id [[:count :*] :run_count]]
+                     :from     [:transform_run]
+                     :where    [:in :transform_id ids]
+                     :group-by [:transform_id]}))
+    {}))
+
 (defn- hydrate-duplicate-peers
   "The findings' stored `duplicate_entity_ids` → `{[entity-type id] → {:id :name :entity_type <etype>
-  :card_type <kw>}}` (`card_type` only on card peers). The generalization of [[hydrate-slow-entities]]:
+  :card_type <kw> :view_count <int>}}` (`card_type` only on card peers). Each peer carries a live usage
+  signal so callers can judge which duplicate is the abandoned one: `view_count` for
+  card/dashboard/document, `run_count` (total `transform_run` rows) for transforms, which have no view
+  concept. The generalization of [[hydrate-slow-entities]]:
   duplicate peers share the **finding's own** entity type, which varies per finding, so each type's peer-id
   union resolves from that type's own model. Mode-agnostic - it hydrates the union regardless of which
   match modes produced it.
@@ -199,19 +215,26 @@
                               [:or
                                [:= :collection_id nil]
                                [:not [:in :collection_id excluded-personal-ids]]])]]
-              row   (if (= etype :transform)
-                      ;; mi/can-read? on a transform = source-type feature gate + (superuser, or
-                      ;; data-analyst with readable source tables) - the collection clause alone would
-                      ;; leak transform names to collection-granted non-analysts. It reads :source, so
-                      ;; select full rows; peer sets are page-bounded, so the per-row check is cheap.
-                      (filter mi/can-read? (t2/select :model/Transform {:where where}))
-                      (t2/select (cond-> [model :id :name]
-                                   ;; :card_schema is required on any Card select - its after-select
-                                   ;; hook reads it.
-                                   (= etype :card) (conj :type :card_schema))
-                                 {:where where}))]
-          [[etype (:id row)] (cond-> {:id (:id row) :name (:name row) :entity_type etype}
-                               (= etype :card) (assoc :card_type (:type row)))])))
+              :let  [peer-rows  (if (= etype :transform)
+                                  ;; mi/can-read? on a transform = source-type feature gate + (superuser,
+                                  ;; or data-analyst with readable source tables) - the collection clause
+                                  ;; alone would leak transform names to collection-granted non-analysts.
+                                  ;; It reads :source, so select full rows; peer sets are page-bounded,
+                                  ;; so the per-row check is cheap.
+                                  (filter mi/can-read? (t2/select :model/Transform {:where where}))
+                                  (t2/select (cond-> [model :id :name :view_count]
+                                               ;; :card_schema is required on any Card select - its
+                                               ;; after-select hook reads it.
+                                               (= etype :card) (conj :type :card_schema))
+                                             {:where where}))
+                     run-counts (when (= etype :transform)
+                                  (transform-run-counts (map :id peer-rows)))]
+              row   peer-rows]
+          [[etype (:id row)]
+           (if (= etype :transform)
+             {:id (:id row) :name (:name row) :entity_type etype :run_count (get run-counts (:id row) 0)}
+             (cond-> {:id (:id row) :name (:name row) :entity_type etype :view_count (:view_count row)}
+               (= etype :card) (assoc :card_type (:type row))))])))
 
 (defn- normalized-owner
   "Normalized `owner` from the transform `:owner` hydrate: `{id,name,email,type:user}` or, for an external

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -117,12 +117,15 @@
 
 (defn- entity-context
   "For one entity-type's id set → `{entity-id → row}`. Live-hydrates only the non-denormalized display
-  fields: `description`, `collection_id`, and (transform only) the owner. `document` has no description."
+  fields: `description`, `collection_id`, `view_count` (all but transform), and (transform only) the owner.
+  `document` has no description."
   [entity-type ids]
   (when-let [model (common/entity-type->model entity-type)]
     (let [cols (cond-> [:id :collection_id]
-                 (not= entity-type :document) (conj :description)
-                 (= entity-type :transform)   (conj :owner_user_id :owner_email))
+                 (not= entity-type :document)  (conj :description)
+                 ;; card/dashboard/document have a native view_count column; transform has none.
+                 (not= entity-type :transform) (conj :view_count)
+                 (= entity-type :transform)    (conj :owner_user_id :owner_email))
           rows (cond-> (t2/select (into [model] cols) :id [:in (set ids)])
                  ;; reuse the transform model's batched :owner hydrate (user row, or {:email …} external)
                  (= entity-type :transform) (t2/hydrate :owner))]
@@ -145,9 +148,10 @@
             colls))))
 
 (defn- hydrate-slow-entities
-  "Card-id set → `{card-id → {:id :name :entity_type :card :card_type <kw>}}`. The read-time hydration of
-  a `slow` roll-up's stored culprit ids (`slow_entity_ids`) into objects. `card_type` is the
-  `report_card.type` enum (question/model/metric) that drives the FE per-member link/icon. Batched.
+  "Card-id set → `{card-id → {:id :name :entity_type :card :card_type <kw> :view_count <int>}}`. The
+  read-time hydration of a `slow` roll-up's stored culprit ids (`slow_entity_ids`) into objects.
+  `card_type` is the `report_card.type` enum (question/model/metric) that drives the FE per-member
+  link/icon; `view_count` is the card's live usage counter. Batched.
 
   Culprit cards can live outside their container's collection, so the per-caller read-time filters are
   re-applied here: caller visibility (the same gate as `visible-findings-clause`) always, and the
@@ -156,8 +160,9 @@
   [card-ids excluded-personal-ids]
   (when (seq card-ids)
     ;; `:card_schema` is required on any Card select - its after-select schema-upgrade hook reads it.
-    (t2/select-pk->fn (fn [c] {:id (:id c) :name (:name c) :entity_type :card :card_type (:type c)})
-                      [:model/Card :id :name :type :card_schema]
+    (t2/select-pk->fn (fn [c] {:id (:id c) :name (:name c) :entity_type :card :card_type (:type c)
+                               :view_count (:view_count c)})
+                      [:model/Card :id :name :type :view_count :card_schema]
                       {:where [:and
                                [:in :id (set card-ids)]
                                (collection/visible-collection-filter-clause :collection_id)
@@ -179,7 +184,9 @@
 
 (defn hydrate-findings
   "Project stored findings into the response shape: flat identity + denormalized display fields, plus a
-  nested `details` = stored verdict + {collection, description, owner, creator}. Batched, page-size-independent.
+  nested `details` = stored verdict + {collection, description, owner, creator, view_count?}. `view_count`
+  is the entity's live usage counter, present only for types that have the column (all but transform).
+  Batched, page-size-independent.
 
   Options let each endpoint add its per-finding-type extras without changing the shared base:
   `:top-level-cols` - extra native finding columns hoisted to the top level (e.g. `:last_active_at` for
@@ -208,7 +215,9 @@
                                   :owner       (normalized-owner entity)
                                   ;; creator denormalized (id + common_name) - no live :creator hydrate.
                                   :creator     (when entity_creator_id
-                                                 {:id entity_creator_id :name entity_creator_name :type :user})})
+                                                 {:id entity_creator_id :name entity_creator_name :type :user})}
+                                 (when-some [view-count (:view_count entity)]
+                                   {:view_count view-count}))
                   details* (if (and hydrate-culprits? (contains? details :slow_entity_ids))
                              (-> base
                                  (dissoc :slow_entity_ids)

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -173,25 +173,12 @@
                                   [:= :collection_id nil]
                                   [:not [:in :collection_id excluded-personal-ids]]])]})))
 
-(defn- transform-run-counts
-  "`{transform-id → total `transform_run` count}` for `ids` - one grouped count, every run status (a
-  failed run is still activity). A never-run transform has no entry; callers default to 0."
-  [ids]
-  (if (seq ids)
-    (into {}
-          (map (juxt :transform_id :run_count))
-          (t2/query {:select   [:transform_id [[:count :*] :run_count]]
-                     :from     [:transform_run]
-                     :where    [:in :transform_id ids]
-                     :group-by [:transform_id]}))
-    {}))
-
 (defn- hydrate-duplicate-peers
   "The findings' stored `duplicate_entity_ids` → `{[entity-type id] → {:id :name :entity_type <etype>
-  :card_type <kw> :view_count <int>}}` (`card_type` only on card peers). Each peer carries a live usage
-  signal so callers can judge which duplicate is the abandoned one: `view_count` for
-  card/dashboard/document, `run_count` (total `transform_run` rows) for transforms, which have no view
-  concept. The generalization of [[hydrate-slow-entities]]:
+  :card_type <kw> :view_count <int>}}` (`card_type` only on card peers). Card/dashboard/document peers
+  carry their live `view_count` so callers can judge which duplicate is the abandoned one; transforms
+  have no view concept, so transform peers carry no usage signal. The generalization of
+  [[hydrate-slow-entities]]:
   duplicate peers share the **finding's own** entity type, which varies per finding, so each type's peer-id
   union resolves from that type's own model. Mode-agnostic - it hydrates the union regardless of which
   match modes produced it.
@@ -215,24 +202,20 @@
                               [:or
                                [:= :collection_id nil]
                                [:not [:in :collection_id excluded-personal-ids]]])]]
-              :let  [peer-rows  (if (= etype :transform)
-                                  ;; mi/can-read? on a transform = source-type feature gate + (superuser,
-                                  ;; or data-analyst with readable source tables) - the collection clause
-                                  ;; alone would leak transform names to collection-granted non-analysts.
-                                  ;; It reads :source, so select full rows; peer sets are page-bounded,
-                                  ;; so the per-row check is cheap.
-                                  (filter mi/can-read? (t2/select :model/Transform {:where where}))
-                                  (t2/select (cond-> [model :id :name :view_count]
-                                               ;; :card_schema is required on any Card select - its
-                                               ;; after-select hook reads it.
-                                               (= etype :card) (conj :type :card_schema))
-                                             {:where where}))
-                     run-counts (when (= etype :transform)
-                                  (transform-run-counts (map :id peer-rows)))]
-              row   peer-rows]
+              row   (if (= etype :transform)
+                      ;; mi/can-read? on a transform = source-type feature gate + (superuser, or
+                      ;; data-analyst with readable source tables) - the collection clause alone would
+                      ;; leak transform names to collection-granted non-analysts. It reads :source, so
+                      ;; select full rows; peer sets are page-bounded, so the per-row check is cheap.
+                      (filter mi/can-read? (t2/select :model/Transform {:where where}))
+                      (t2/select (cond-> [model :id :name :view_count]
+                                   ;; :card_schema is required on any Card select - its after-select
+                                   ;; hook reads it.
+                                   (= etype :card) (conj :type :card_schema))
+                                 {:where where}))]
           [[etype (:id row)]
            (if (= etype :transform)
-             {:id (:id row) :name (:name row) :entity_type etype :run_count (get run-counts (:id row) 0)}
+             {:id (:id row) :name (:name row) :entity_type etype}
              (cond-> {:id (:id row) :name (:name row) :entity_type etype :view_count (:view_count row)}
                (= etype :card) (assoc :card_type (:type row))))])))
 

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
@@ -22,8 +22,8 @@
   [s]
   (-> (or (u/remove-diacritical-marks s) "")   ; remove-diacritical-marks returns nil on empty input
       u/lower-case-en
-      (str/replace #"(?U)\p{Cf}" "")
-      (str/replace #"(?U)\s+" " ")
+      (str/replace #"(?U)\p{Cf}" "")   ; strip Unicode format chars (zero-width joiners, bidi marks, soft hyphens)
+      (str/replace #"(?U)\s+" " ")     ; collapse any run of Unicode whitespace to a single space
       str/trim))
 
 (defmulti ^:private candidate-rows

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
@@ -1,0 +1,72 @@
+(ns metabase-enterprise.content-diagnostics.checkers.duplicated
+  "The `duplicated` Content Diagnostics checker - match mode `name`: two or more non-archived entities of
+  the same type whose normalized names are equal and non-blank form a duplicate cluster. Every member of
+  a cluster of size k gets one `:duplicated` finding whose peers are the other k-1 members, with
+  `:duplicate-count` = the peer count (→ the native `duplicate_count` column).
+
+  `details` carries the mode-aware envelope shared by all future match modes: `matches` =
+  `[{match_type, entity_ids}, …]` (single-element here), `matched_name` (the normalized name the cluster
+  collided on), and `duplicate_entity_ids` (the flattened union of all matches' peers - what the serve
+  layer hydrates). Cards are grouped by their sub-kind (`type` - question/model/metric): a question and a
+  model sharing a name are not duplicates. One lightweight (id, name) load per entity type, grouped
+  in memory - no per-entity loop, app-db only."
+  (:require
+   [clojure.string :as str]
+   [metabase-enterprise.content-diagnostics.common :as common]
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- normalize-name
+  "lowercase → trim → collapse internal whitespace. Deliberately not `search.scoring/normalize-text`,
+  which also maps commas to spaces - commas are meaningful in content names. Internal-whitespace collapse
+  is why grouping happens app-side: it has no portable SQL form across the supported app dbs."
+  [s]
+  (-> s u/lower-case-en str/trim (str/replace #"\s+" " ")))
+
+(defn- entity-rows
+  "Lightweight `(id, name[, type])` rows for one covered entity type - non-archived only. Transform has
+  no archived column (transforms are hard-deleted), so every row counts."
+  [entity-type]
+  (case entity-type
+    ;; :card_schema is required on any Card select - its after-select schema-upgrade hook reads it.
+    :card      (t2/select [:model/Card :id :name :type :card_schema] :archived false)
+    :dashboard (t2/select [:model/Dashboard :id :name] :archived false)
+    :document  (t2/select [:model/Document :id :name] :archived false)
+    :transform (t2/select [:model/Transform :id :name])))
+
+(defn- cluster-findings
+  "One `:duplicated` finding per member of a name cluster; peers are the other members (symmetric: in
+  {A,B,C}, A's finding lists {B,C}, B's {A,C}, C's {A,B})."
+  [entity-type matched-name rows]
+  (let [ids (mapv :id rows)]
+    (for [id ids
+          :let [peer-ids (filterv #(not= % id) ids)]]
+      {:entity-type     entity-type
+       :entity-id       id
+       :finding-type    :duplicated
+       :duplicate-count (count peer-ids)
+       :details         {:matches              [{:match_type "name" :entity_ids peer-ids}]
+                         :matched_name         matched-name
+                         :duplicate_entity_ids peer-ids}})))
+
+(defn- findings-for-type
+  "Group one entity type's rows by normalized name - cards additionally by sub-kind (`:type`, nil for the
+  other types) - and emit findings for every cluster of ≥ 2. Clusters with a blank normalized name are
+  skipped: `name` is NOT NULL on all four models but can be whitespace-only, and unknown is not duplicate."
+  [entity-type]
+  (for [[[norm-name _card-type] rows] (group-by (fn [{nm :name card-type :type}]
+                                                  [(normalize-name nm) card-type])
+                                                (entity-rows entity-type))
+        :when   (and (not (str/blank? norm-name)) (>= (count rows) 2))
+        finding (cluster-findings entity-type norm-name rows)]
+    finding))
+
+(defn checker
+  "Instance-wide `:duplicated` finding maps across all covered entity types. The denormalized display
+  attrs are stamped by `common/attach-entity-attrs`; `:duration-ms`/`:last-active-at` are left unset
+  (those columns stay NULL on duplicated findings)."
+  []
+  (common/attach-entity-attrs
+   (into [] (mapcat findings-for-type) (keys common/entity-type->model))))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
@@ -5,9 +5,9 @@
   `:duplicate-count` = the peer count (→ the native `duplicate_count` column).
 
   `details` carries the mode-aware envelope shared by all future match modes: `matches` =
-  `[{match_type, entity_ids}, …]` (single-element here), `matched_name` (the normalized name the cluster
-  collided on), and `duplicate_entity_ids` (the flattened union of all matches' peers - what the serve
-  layer hydrates). Cards are grouped by their sub-kind (`type` - question/model/metric): a question and a
+  `[{match_type, entity_ids}, …]` (single-element here), `normalized_name` (the normalized name the
+  cluster collided on), and `duplicate_entity_ids` (the flattened union of all matches' peers - what the
+  serve layer hydrates). Cards are grouped by their sub-kind (`type` - question/model/metric): a question and a
   model sharing a name are not duplicates. One lightweight (id, name) load per entity type, grouped
   in memory - no per-entity loop, app-db only."
   (:require
@@ -39,7 +39,7 @@
 (defn- cluster-findings
   "One `:duplicated` finding per member of a name cluster; peers are the other members (symmetric: in
   {A,B,C}, A's finding lists {B,C}, B's {A,C}, C's {A,B})."
-  [entity-type matched-name rows]
+  [entity-type normalized-name rows]
   (let [ids (mapv :id rows)]
     (for [id ids
           :let [peer-ids (filterv #(not= % id) ids)]]
@@ -48,7 +48,7 @@
        :finding-type    :duplicated
        :duplicate-count (count peer-ids)
        :details         {:matches              [{:match_type "name" :entity_ids peer-ids}]
-                         :matched_name         matched-name
+                         :normalized_name      normalized-name
                          :duplicate_entity_ids peer-ids}})))
 
 (defn- findings-for-type

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
@@ -4,12 +4,11 @@
   a cluster of size k gets one `:duplicated` finding whose peers are the other k-1 members, with
   `:duplicate-count` = the peer count (→ the native `duplicate_count` column).
 
-  `details` carries the mode-aware envelope shared by all future match modes: `matches` =
-  `[{match_type, entity_ids}, …]` (single-element here), `normalized_name` (the normalized name the
-  cluster collided on), and `duplicate_entity_ids` (the flattened union of all matches' peers - what the
-  serve layer hydrates). Cards are grouped by their sub-kind (`type` - question/model/metric): a question and a
-  model sharing a name are not duplicates. One lightweight (id, name) load per entity type, grouped
-  in memory - no per-entity loop, app-db only."
+  `details` carries `normalized_name` (the normalized name the cluster collided on) and
+  `duplicate_entity_ids` (the flagged entity's peer ids - what the serve layer hydrates). Cards are grouped
+  by their sub-kind (`type` - question/model/metric): a question and a model sharing a name are not
+  duplicates. One lightweight (id, name) load per entity type, grouped in memory - no per-entity loop,
+  app-db only."
   (:require
    [clojure.string :as str]
    [metabase-enterprise.content-diagnostics.common :as common]
@@ -57,8 +56,7 @@
        :entity-id       id
        :finding-type    :duplicated
        :duplicate-count (count peer-ids)
-       :details         {:matches              [{:match_type "name" :entity_ids peer-ids}]
-                         :normalized_name      normalized-name
+       :details         {:normalized_name      normalized-name
                          :duplicate_entity_ids peer-ids}})))
 
 (defn- findings-for-type

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
@@ -27,16 +27,24 @@
       (str/replace #"(?U)\s+" " ")
       str/trim))
 
-(defn- entity-rows
-  "Lightweight `(id, name[, type])` rows for one covered entity type - non-archived only. Transform has
-  no archived column (transforms are hard-deleted), so every row counts."
+(defmulti ^:private candidate-rows
+  "Lightweight non-archived `(id, name[, sub-kind])` rows for one entity type, for name clustering.
+  card/dashboard/document (`::collection-item`) filter on their `archived` column, sub-kind cols from
+  `common/candidate-cols`; transform has no `archived` column (hard-deleted), so every row counts. Scan-time
+  and instance-wide - deliberately un-permissioned, unlike the serve layer's `read-entity-rows`."
+  {:arglists '([entity-type])}
+  identity
+  :hierarchy #'common/hierarchy)
+
+(defmethod candidate-rows ::common/collection-item
   [entity-type]
-  (case entity-type
-    ;; :card_schema is required on any Card select - its after-select schema-upgrade hook reads it.
-    :card      (t2/select [:model/Card :id :name :type :card_schema] :archived false)
-    :dashboard (t2/select [:model/Dashboard :id :name] :archived false)
-    :document  (t2/select [:model/Document :id :name] :archived false)
-    :transform (t2/select [:model/Transform :id :name])))
+  ;; :card_schema (a candidate-col for cards) is required on any Card select - its after-select hook reads it.
+  (t2/select (into [(common/entity-type->model entity-type) :id :name] (common/candidate-cols entity-type))
+             :archived false))
+
+(defmethod candidate-rows :transform
+  [_]
+  (t2/select [:model/Transform :id :name]))
 
 (defn- cluster-findings
   "One `:duplicated` finding per member of a name cluster; peers are the other members (symmetric: in
@@ -60,7 +68,7 @@
   [entity-type]
   (for [[[norm-name _card-type] rows] (group-by (fn [{nm :name card-type :type}]
                                                   [(normalize-name nm) card-type])
-                                                (entity-rows entity-type))
+                                                (candidate-rows entity-type))
         :when   (and (not (str/blank? norm-name)) (>= (count rows) 2))
         finding (cluster-findings entity-type norm-name rows)]
     finding))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
@@ -19,11 +19,13 @@
 (set! *warn-on-reflection* true)
 
 (defn- normalize-name
-  "lowercase → trim → collapse internal whitespace. Deliberately not `search.scoring/normalize-text`,
-  which also maps commas to spaces - commas are meaningful in content names. Internal-whitespace collapse
-  is why grouping happens app-side: it has no portable SQL form across the supported app dbs."
+  "Normalize a name for duplicate detection: remove diacritical marks, lowercase, remove invisible and collapse whitespace"
   [s]
-  (-> s u/lower-case-en str/trim (str/replace #"\s+" " ")))
+  (-> (or (u/remove-diacritical-marks s) "")   ; remove-diacritical-marks returns nil on empty input
+      u/lower-case-en
+      (str/replace #"(?U)\p{Cf}" "")
+      (str/replace #"(?U)\s+" " ")
+      str/trim))
 
 (defn- entity-rows
   "Lightweight `(id, name[, type])` rows for one covered entity type - non-archived only. Transform has

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
@@ -5,10 +5,10 @@
   `:duplicate-count` = the peer count (→ the native `duplicate_count` column).
 
   `details` carries `normalized_name` (the normalized name the cluster collided on) and
-  `duplicate_entity_ids` (the flagged entity's peer ids - what the serve layer hydrates). Cards are grouped
-  by their sub-kind (`type` - question/model/metric): a question and a model sharing a name are not
-  duplicates. One lightweight (id, name) load per entity type, grouped in memory - no per-entity loop,
-  app-db only."
+  `duplicate_entity_ids` (the flagged entity's peer ids - what the serve layer hydrates). Clustering is by
+  normalized name within an entity type; cards cluster across all sub-kinds (`type` -
+  question/model/metric), so a question and a model sharing a name are duplicates. One lightweight
+  (id, name) load per entity type, grouped in memory - no per-entity loop, app-db only."
   (:require
    [clojure.string :as str]
    [metabase-enterprise.content-diagnostics.common :as common]
@@ -27,10 +27,11 @@
       str/trim))
 
 (defmulti ^:private candidate-rows
-  "Lightweight non-archived `(id, name[, sub-kind])` rows for one entity type, for name clustering.
-  card/dashboard/document (`::collection-item`) filter on their `archived` column, sub-kind cols from
-  `common/candidate-cols`; transform has no `archived` column (hard-deleted), so every row counts. Scan-time
-  and instance-wide - deliberately un-permissioned, unlike the serve layer's `read-entity-rows`."
+  "Lightweight non-archived `(id, name)` rows for one entity type, for name clustering. card/dashboard/document
+  (`::collection-item`) filter on their `archived` column and add any `common/candidate-cols` (card carries
+  `:card_schema`, required by its after-select hook); transform has no `archived` column (hard-deleted), so
+  every row counts. Scan-time and instance-wide - deliberately un-permissioned, unlike the serve layer's
+  `read-entity-rows`."
   {:arglists '([entity-type])}
   identity
   :hierarchy #'common/hierarchy)
@@ -60,13 +61,11 @@
                          :duplicate_entity_ids peer-ids}})))
 
 (defn- findings-for-type
-  "Group one entity type's rows by normalized name - cards additionally by sub-kind (`:type`, nil for the
-  other types) - and emit findings for every cluster of ≥ 2. Clusters with a blank normalized name are
-  skipped: `name` is NOT NULL on all four models but can be whitespace-only, and unknown is not duplicate."
+  "Group one entity type's rows by normalized name and emit findings for every cluster of ≥ 2 (cards cluster
+  across all sub-kinds - grouping is by name alone). Clusters with a blank normalized name are skipped:
+  `name` is NOT NULL on all four models but can be whitespace-only, and unknown is not duplicate."
   [entity-type]
-  (for [[[norm-name _card-type] rows] (group-by (fn [{nm :name card-type :type}]
-                                                  [(normalize-name nm) card-type])
-                                                (candidate-rows entity-type))
+  (for [[norm-name rows] (group-by (comp normalize-name :name) (candidate-rows entity-type))
         :when   (and (not (str/blank? norm-name)) (>= (count rows) 2))
         finding (cluster-findings entity-type norm-name rows)]
     finding))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
@@ -44,7 +44,7 @@
   are explicit methods)."
   {:card      {:context   [:description :view_count]
                :peer      [:view_count :type :card_schema]
-               :candidate [:type :card_schema]}
+               :candidate [:card_schema]}
    :dashboard {:context   [:description :view_count]
                :peer      [:view_count]
                :candidate []}

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
@@ -21,6 +21,55 @@
   keywords like `:model/Card`."
   (set/map-invert entity-type->model))
 
+;;; ----------------------------- entity-type multimethod dispatch (shared) -----------------------------
+;;; What the serve/scan multimethods dispatch on: a module-local `hierarchy` (keeping bare entity-type
+;;; keywords out of the global one - the driver.impl pattern) and a per-type column registry, so the
+;;; multimethods carry behavior, not column lists.
+
+(def hierarchy
+  "Dispatch hierarchy for the module's per-entity-type multimethods (module-local, mirroring
+  `metabase.driver.impl/hierarchy`). card/dashboard/document derive `::collection-item` and share one method
+  each (collection-gated read, no owner, archivable); transform diverges and carries explicit methods. Add a
+  type by deriving it here or giving it its own methods - an unregistered type throws at dispatch."
+  (-> (make-hierarchy)
+      (derive :card      ::collection-item)
+      (derive :dashboard ::collection-item)
+      (derive :document  ::collection-item)))
+
+(def ^:private entity-spec
+  "Per-entity-type column lists the serve/scan multimethods read, so column choices stay out of `defmethod`
+  bodies. Per type: `:context` = extra display cols beyond `[:id :collection_id]`; `:peer` / `:candidate` =
+  extra cols the duplicate-entity hydrate / duplicated checker select beyond `[:id :name]`. Only card carries
+  the `:card_schema` its after-select hook requires; transform has only `:context` (its peer/candidate reads
+  are explicit methods)."
+  {:card      {:context   [:description :view_count]
+               :peer      [:view_count :type :card_schema]
+               :candidate [:type :card_schema]}
+   :dashboard {:context   [:description :view_count]
+               :peer      [:view_count]
+               :candidate []}
+   :document  {:context   [:view_count]
+               :peer      [:view_count]
+               :candidate []}
+   :transform {:context   [:description :owner_user_id :owner_email]}})
+
+(defn context-cols
+  "Extra display cols `entity-context` selects for `entity-type` beyond `[:id :collection_id]` (see
+  `entity-spec`)."
+  [entity-type]
+  (get-in entity-spec [entity-type :context]))
+
+(defn peer-select-cols
+  "Extra cols the duplicate-entity hydrate selects for `entity-type` beyond `[:id :name]` (see
+  `entity-spec`)."
+  [entity-type]
+  (get-in entity-spec [entity-type :peer]))
+
+(defn candidate-cols
+  "Extra cols the duplicated checker selects for `entity-type` beyond `[:id :name]` (see `entity-spec`)."
+  [entity-type]
+  (get-in entity-spec [entity-type :candidate]))
+
 (defn attach-entity-attrs
   "Stamp each finding with the denormalized display/sort columns - `:entity-name`, `:entity-created-at`,
   `:entity-creator-id`, `:entity-creator-name` - batch-resolved from each entity's own model (F ≪ N: one

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
@@ -77,7 +77,8 @@
     (t2/with-transaction [_conn]
       (t2/insert! :model/ContentDiagnosticsFinding
                   (for [{:keys [entity-type entity-id finding-type details scope-collection-id last-active-at
-                                duration-ms entity-name entity-created-at entity-creator-id entity-creator-name]} chunk]
+                                duration-ms duplicate-count entity-name entity-created-at entity-creator-id
+                                entity-creator-name]} chunk]
                     {:scan_id             scan-id
                      :entity_type         entity-type
                      :entity_id           entity-id
@@ -85,6 +86,7 @@
                      :scope_collection_id scope-collection-id
                      :last_active_at      last-active-at
                      :duration_ms         duration-ms
+                     :duplicate_count     duplicate-count
                      :entity_name         entity-name
                      :entity_created_at   entity-created-at
                      :entity_creator_id   entity-creator-id

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
@@ -4,6 +4,7 @@
   `checkers/*`, the shared entity-type mapping + denormalization helper in `common`."
   (:require
    [medley.core :as m]
+   [metabase-enterprise.content-diagnostics.checkers.duplicated :as duplicated]
    [metabase-enterprise.content-diagnostics.checkers.slow :as slow]
    [metabase-enterprise.content-diagnostics.checkers.stale :as stale]
    [metabase-enterprise.content-diagnostics.common :as common]
@@ -23,8 +24,9 @@
   returning finding maps. Declaring the types (rather than inferring them from a scan's output) is what
   lets post-scan invalidation know its supersession scope even when a scan emits **zero** rows - i.e. an
   all-clean scan still resolves the previous scan's findings."
-  [{:finding-types #{:stale} :run stale/checker}
-   {:finding-types #{:slow}  :run slow/checker}])
+  [{:finding-types #{:stale}      :run stale/checker}
+   {:finding-types #{:slow}       :run slow/checker}
+   {:finding-types #{:duplicated} :run duplicated/checker}])
 
 (defn covered-finding-types
   "The set of finding-types the registered checkers own - the supersession scope for post-scan invalidation."

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
@@ -2,9 +2,12 @@
   "Direct contract tests for the shared module core both checkers and the read layer depend on: the
   entity-type <-> model mapping and `attach-entity-attrs`, the scan-time denormalization helper. These
   pin the helper's semantics (batched per-type stamping, checker-set values win, missing entity is nil)
-  independently of the full scan/serve pipeline that exercises them end to end."
+  independently of the full scan/serve pipeline that exercises them end to end, plus the module-wide
+  fail-closed dispatch contract of the per-entity-type multimethods keyed off `common/hierarchy`."
   (:require
    [clojure.test :refer :all]
+   [metabase-enterprise.content-diagnostics.api.common :as api.common]
+   [metabase-enterprise.content-diagnostics.checkers.duplicated :as checkers.duplicated]
    [metabase-enterprise.content-diagnostics.common :as common]
    [metabase.test :as mt]))
 
@@ -15,6 +18,47 @@
       (is (= model (common/entity-type->model etype)))))
   (testing "it covers exactly the four content-diagnostics entity types"
     (is (= #{:card :dashboard :document :transform} (set (keys common/entity-type->model))))))
+
+(deftest entity-type-hierarchy-and-registry-test
+  (testing "card/dashboard/document derive ::collection-item; transform is an explicit outlier"
+    (doseq [etype [:card :dashboard :document]]
+      (is (isa? common/hierarchy etype ::common/collection-item)
+          (str etype " should derive ::collection-item")))
+    (is (not (isa? common/hierarchy :transform ::common/collection-item))
+        "transform must not derive ::collection-item - it carries explicit methods"))
+  (testing "the column registry covers every collection-resident type it feeds"
+    (doseq [etype [:card :dashboard :document]]
+      (is (vector? (common/context-cols etype)))
+      (is (vector? (common/peer-select-cols etype)))
+      (is (vector? (common/candidate-cols etype))))
+    (testing "transform is column-based for context only - its peer/candidate reads are bespoke methods"
+      (is (vector? (common/context-cols :transform)))
+      (is (nil? (common/peer-select-cols :transform)))
+      (is (nil? (common/candidate-cols :transform))))))
+
+(deftest entity-type-multimethods-are-fail-closed-test
+  ;; The per-entity-type multimethods all dispatch through `common/hierarchy` with NO permissive :default, so
+  ;; (1) every covered type must resolve a method - a new type left unregistered fails here, not in prod -
+  ;; and (2) an unregistered type throws at dispatch rather than silently inheriting collection_id/owner
+  ;; assumptions it violates.
+  (let [mm-by-name {"read-entity-rows" @#'api.common/read-entity-rows
+                    "hydrate-owner"    @#'api.common/hydrate-owner
+                    "entity-context"   @#'api.common/entity-context
+                    "candidate-rows"   @#'checkers.duplicated/candidate-rows}]
+    (testing "every covered entity-type resolves a method (registry completeness)"
+      (doseq [[mm-name mm] mm-by-name
+              etype        api.common/covered-entity-types]
+        (is (some? (get-method mm etype))
+            (format "%s has no method for covered type %s" mm-name etype))))
+    (testing "an unregistered entity-type resolves no method (no catch-all :default)"
+      (doseq [[mm-name mm] mm-by-name]
+        (is (nil? (get-method mm :not-an-entity-type))
+            (format "%s must stay fail-closed for unregistered types" mm-name))))
+    (testing "invoking a multimethod with an unregistered entity-type throws at dispatch"
+      (is (thrown? IllegalArgumentException (@#'api.common/hydrate-owner :not-an-entity-type [])))
+      (is (thrown? IllegalArgumentException (@#'api.common/entity-context :not-an-entity-type #{})))
+      (is (thrown? IllegalArgumentException (@#'api.common/read-entity-rows :not-an-entity-type #{} nil)))
+      (is (thrown? IllegalArgumentException (@#'checkers.duplicated/candidate-rows :not-an-entity-type))))))
 
 (deftest attach-entity-attrs-stamps-denormalized-columns-test
   (testing "each finding is stamped with its entity's name/created_at/creator across multiple entity types"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
@@ -3,7 +3,8 @@
   entity-type <-> model mapping and `attach-entity-attrs`, the scan-time denormalization helper. These
   pin the helper's semantics (batched per-type stamping, checker-set values win, missing entity is nil)
   independently of the full scan/serve pipeline that exercises them end to end, plus the module-wide
-  fail-closed dispatch contract of the per-entity-type multimethods keyed off `common/hierarchy`."
+  fail-closed dispatch contract of the per-entity-type multimethods keyed off `common/hierarchy` and of
+  the per-finding-type `finalize-finding` multimethod in the read layer."
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.content-diagnostics.api.common :as api.common]
@@ -59,6 +60,21 @@
       (is (thrown? IllegalArgumentException (@#'api.common/entity-context :not-an-entity-type #{})))
       (is (thrown? IllegalArgumentException (@#'api.common/read-entity-rows :not-an-entity-type #{} nil)))
       (is (thrown? IllegalArgumentException (@#'checkers.duplicated/candidate-rows :not-an-entity-type))))))
+
+(deftest finding-type-multimethod-is-fail-closed-test
+  ;; `finalize-finding` dispatches per row on the stored `finding_type` with NO permissive :default, so a
+  ;; new finding type left unregistered fails here (and at dispatch), not by silently serving an
+  ;; unfinalized row missing its native top-level column / details rewrite.
+  (let [covered-finding-types #{:stale :slow :duplicated}] ; the finding types this branch serves
+    (testing "every served finding-type resolves a method (registry completeness)"
+      (doseq [ftype covered-finding-types]
+        (is (some? (get-method @#'api.common/finalize-finding ftype))
+            (format "finalize-finding has no method for finding-type %s" ftype))))
+    (testing "an unregistered finding-type resolves no method (no catch-all :default)"
+      (is (nil? (get-method @#'api.common/finalize-finding :not-a-finding-type))))
+    (testing "invoking a multimethod with an unregistered finding-type throws at dispatch"
+      (is (thrown? IllegalArgumentException
+                   (@#'api.common/finalize-finding :not-a-finding-type {} {} {}))))))
 
 (deftest attach-entity-attrs-stamps-denormalized-columns-test
   (testing "each finding is stamped with its entity's name/created_at/creator across multiple entity types"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -1,0 +1,470 @@
+(ns metabase-enterprise.content-diagnostics.duplicated-test
+  "The `duplicated` checker (match mode `name`) flags clusters of ≥2 same-type non-archived entities
+  whose normalized names collide, stamping the peer count in the top-level `duplicate_count` column and
+  freezing the `matches`/`matched_name`/`duplicate_entity_ids` envelope in `details` at scan time. The
+  `/duplicated` endpoint serves them with hydrated same-type peers and the shared filter/sort/pagination
+  envelope."
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.content-diagnostics.scan :as scan]
+   [metabase.collections.models.collection :as collection]
+   [metabase.permissions.core :as perms]
+   [metabase.test :as mt]
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
+
+(defn- scope-prefix
+  "Unique per-test entity-name prefix - both the checker's name grouping and the API reads are scoped by
+  it (the checker scans instance-wide and the findings table is shared across tests)."
+  []
+  (str "cd-" (mt/random-name)))
+
+(defn- duplicated-findings-by-entity!
+  "Run a scan and index its `:duplicated` findings by `[entity-type entity-id]`."
+  []
+  (let [scan-id (:scan_id (scan/scan!))]
+    (into {}
+          (map (juxt (juxt :entity_type :entity_id) identity))
+          (t2/select :model/ContentDiagnosticsFinding :scan_id scan-id :finding_type :duplicated))))
+
+;;; --------------------------------------------- checker --------------------------------------------------
+
+(deftest duplicated-checker-flags-same-name-clusters-test
+  (testing "same-type same-name pairs are flagged for all four covered types; a unique name is not"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [prefix (scope-prefix)]
+          (mt/with-temp
+            [:model/Collection {coll-id :id}  {}
+             :model/Card       {card-a :id}   {:collection_id coll-id :name (str prefix " Revenue")}
+             :model/Card       {card-b :id}   {:collection_id coll-id :name (str prefix " Revenue")}
+             :model/Card       {unique-c :id} {:collection_id coll-id :name (str prefix " One Of A Kind")}
+             :model/Dashboard  {dash-a :id}   {:collection_id coll-id :name (str prefix " Ops")}
+             :model/Dashboard  {dash-b :id}   {:collection_id coll-id :name (str prefix " Ops")}
+             :model/Document   {doc-a :id}    {:collection_id coll-id :name (str prefix " Notes")}
+             :model/Document   {doc-b :id}    {:collection_id coll-id :name (str prefix " Notes")}
+             ;; transform has no archived column - every row participates
+             :model/Transform  {xf-a :id}     {:name (str prefix " ETL")}
+             :model/Transform  {xf-b :id}     {:name (str prefix " ETL")}]
+            (let [by-entity (duplicated-findings-by-entity!)]
+              (testing "card pair: peers are symmetric, duplicate_count 1, the details envelope is frozen"
+                (let [f (by-entity [:card card-a])]
+                  (is (some? f))
+                  (is (= 1 (:duplicate_count f)))
+                  (is (= {:matches              [{:match_type "name" :entity_ids [card-b]}]
+                          :matched_name         (u/lower-case-en (str prefix " Revenue"))
+                          :duplicate_entity_ids [card-b]}
+                         (:details f)))
+                  (testing "the other magnitude columns stay null on duplicated findings"
+                    (is (nil? (:duration_ms f)))
+                    (is (nil? (:last_active_at f)))))
+                (is (= [card-a] (get-in (by-entity [:card card-b]) [:details :duplicate_entity_ids]))))
+              (testing "a unique name yields no finding"
+                (is (nil? (by-entity [:card unique-c]))))
+              (testing "dashboard, document, and transform pairs are each flagged with each other as peer"
+                (doseq [[etype a b] [[:dashboard dash-a dash-b]
+                                     [:document  doc-a  doc-b]
+                                     [:transform xf-a   xf-b]]]
+                  (let [f (by-entity [etype a])]
+                    (is (some? f))
+                    (is (= 1 (:duplicate_count f)))
+                    (is (= [b] (get-in f [:details :duplicate_entity_ids])))))))))))))
+
+(deftest duplicated-checker-normalization-test
+  (testing "names collide under lowercase + trim + internal-whitespace collapse; commas stay meaningful"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [prefix (scope-prefix)]
+          (mt/with-temp
+            [:model/Collection {coll-id :id} {}
+             ;; case-insensitive
+             :model/Card {case-a :id} {:collection_id coll-id :name (str prefix " Rev")}
+             :model/Card {case-b :id} {:collection_id coll-id :name (str prefix " REV")}
+             ;; leading/trailing whitespace
+             :model/Card {pad-a :id}  {:collection_id coll-id :name (str " " prefix " pad ")}
+             :model/Card {pad-b :id}  {:collection_id coll-id :name (str prefix " pad")}
+             ;; internal whitespace collapses
+             :model/Card {gap-a :id}  {:collection_id coll-id :name (str prefix " a  gap")}
+             :model/Card {gap-b :id}  {:collection_id coll-id :name (str prefix " a gap")}
+             ;; a comma is NOT whitespace - these two must stay distinct
+             :model/Card {comma-a :id} {:collection_id coll-id :name (str prefix " a, b")}
+             :model/Card {comma-b :id} {:collection_id coll-id :name (str prefix " a b")}]
+            (let [by-entity (duplicated-findings-by-entity!)]
+              (testing "case-insensitive match; matched_name is the normalized (lowercased) form"
+                (let [f (by-entity [:card case-a])]
+                  (is (some? f))
+                  (is (= (u/lower-case-en (str prefix " Rev"))
+                         (get-in f [:details :matched_name])))
+                  (is (= [case-b] (get-in f [:details :duplicate_entity_ids])))))
+              (testing "leading/trailing whitespace is ignored"
+                (is (= [pad-b] (get-in (by-entity [:card pad-a]) [:details :duplicate_entity_ids]))))
+              (testing "internal whitespace runs collapse to one space"
+                (is (= [gap-b] (get-in (by-entity [:card gap-a]) [:details :duplicate_entity_ids]))))
+              (testing "a comma-separated name does not match its space-separated sibling"
+                (is (nil? (by-entity [:card comma-a])))
+                (is (nil? (by-entity [:card comma-b])))))))))))
+
+(deftest duplicated-checker-splits-cards-by-sub-kind-test
+  (testing "cards group by (type, normalized name): a question and a model sharing a name are not duplicates"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [prefix (scope-prefix)]
+          (mt/with-temp
+            [:model/Collection {coll-id :id} {}
+             :model/Card {question :id} {:collection_id coll-id :name (str prefix " Sales") :type :question}
+             :model/Card {model :id}    {:collection_id coll-id :name (str prefix " Sales") :type :model}
+             ;; positive control: two same-kind cards with a shared name ARE duplicates
+             :model/Card {model-a :id}  {:collection_id coll-id :name (str prefix " Sales Model") :type :model}
+             :model/Card {model-b :id}  {:collection_id coll-id :name (str prefix " Sales Model") :type :model}]
+            (let [by-entity (duplicated-findings-by-entity!)]
+              (testing "cross-kind name collision yields no findings"
+                (is (nil? (by-entity [:card question])))
+                (is (nil? (by-entity [:card model]))))
+              (testing "same-kind collision is flagged, with entity_type :card"
+                (let [f (by-entity [:card model-a])]
+                  (is (some? f))
+                  (is (= :card (:entity_type f)))
+                  (is (= [model-b] (get-in f [:details :duplicate_entity_ids]))))))))))))
+
+(deftest duplicated-checker-excludes-archived-test
+  (testing "archived cards/dashboards/documents neither get findings nor count as peers"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [prefix (scope-prefix)]
+          (mt/with-temp
+            [:model/Collection {coll-id :id} {}
+             ;; a pair whose second member is archived - no cluster survives
+             :model/Card      {pair-live :id}     {:collection_id coll-id :name (str prefix " Pair")}
+             :model/Card      {pair-archived :id} {:collection_id coll-id :name (str prefix " Pair") :archived true}
+             :model/Dashboard {dpair-live :id}    {:collection_id coll-id :name (str prefix " DPair")}
+             :model/Dashboard {dpair-archived :id} {:collection_id coll-id :name (str prefix " DPair") :archived true}
+             :model/Document  {doc-live :id}      {:collection_id coll-id :name (str prefix " Doc")}
+             :model/Document  {doc-archived :id}  {:collection_id coll-id :name (str prefix " Doc") :archived true}
+             ;; a trio whose third member is archived - the two live ones still cluster, count 1 not 2
+             :model/Card {trio-a :id}        {:collection_id coll-id :name (str prefix " Trio")}
+             :model/Card {trio-b :id}        {:collection_id coll-id :name (str prefix " Trio")}
+             :model/Card {trio-archived :id} {:collection_id coll-id :name (str prefix " Trio") :archived true}]
+            (let [by-entity (duplicated-findings-by-entity!)]
+              (testing "a live entity whose only name-twin is archived is not flagged"
+                (is (nil? (by-entity [:card pair-live])))
+                (is (nil? (by-entity [:dashboard dpair-live])))
+                (is (nil? (by-entity [:document doc-live]))))
+              (testing "archived entities are never flagged themselves"
+                (is (nil? (by-entity [:card pair-archived])))
+                (is (nil? (by-entity [:dashboard dpair-archived])))
+                (is (nil? (by-entity [:document doc-archived]))))
+              (testing "an archived member drops out of a surviving cluster's peer set"
+                (let [f (by-entity [:card trio-a])]
+                  (is (some? f))
+                  (is (= 1 (:duplicate_count f)))
+                  (is (= [trio-b] (get-in f [:details :duplicate_entity_ids])))
+                  (is (nil? (by-entity [:card trio-archived]))))))))))))
+
+(deftest duplicated-checker-skips-blank-names-test
+  (testing "whitespace-only names never cluster - unknown is not duplicate"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (mt/with-temp
+          [:model/Collection {coll-id :id} {}
+           :model/Dashboard {blank-a :id} {:collection_id coll-id :name "   "}
+           :model/Dashboard {blank-b :id} {:collection_id coll-id :name "   "}]
+          (let [by-entity (duplicated-findings-by-entity!)]
+            (is (nil? (by-entity [:dashboard blank-a])))
+            (is (nil? (by-entity [:dashboard blank-b])))))))))
+
+(deftest duplicated-checker-cluster-of-three-test
+  (testing "every member of a cluster of 3 gets duplicate_count 2 and the other two as peers"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [prefix (scope-prefix)
+              nm     (str prefix " Nightly Sync")]
+          (mt/with-temp [:model/Transform {xf-a :id} {:name nm}
+                         :model/Transform {xf-b :id} {:name nm}
+                         :model/Transform {xf-c :id} {:name nm}]
+            (let [by-entity (duplicated-findings-by-entity!)]
+              (doseq [[member peers] {xf-a #{xf-b xf-c}
+                                      xf-b #{xf-a xf-c}
+                                      xf-c #{xf-a xf-b}}]
+                (let [f (by-entity [:transform member])]
+                  (is (some? f))
+                  (is (= 2 (:duplicate_count f)))
+                  (is (= peers (set (get-in f [:details :duplicate_entity_ids]))))
+                  (testing "duplicate_entity_ids equals the single name-mode match's entity_ids"
+                    (is (= (get-in f [:details :duplicate_entity_ids])
+                           (get-in f [:details :matches 0 :entity_ids])))))))))))))
+
+(deftest duplicated-checker-same-type-only-test
+  (testing "a name shared across different entity types is not a duplicate"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [prefix (scope-prefix)
+              nm     (str prefix " Shared Name")]
+          (mt/with-temp [:model/Collection {coll-id :id} {}
+                         :model/Card      {card-id :id} {:collection_id coll-id :name nm}
+                         :model/Dashboard {dash-id :id} {:collection_id coll-id :name nm}
+                         :model/Document  {doc-id :id}  {:collection_id coll-id :name nm}
+                         :model/Transform {xf-id :id}   {:name nm}]
+            (let [by-entity (duplicated-findings-by-entity!)]
+              (is (nil? (by-entity [:card card-id])))
+              (is (nil? (by-entity [:dashboard dash-id])))
+              (is (nil? (by-entity [:document doc-id])))
+              (is (nil? (by-entity [:transform xf-id]))))))))))
+
+(deftest duplicated-supersession-test
+  (testing "renaming one of a pair to be unique supersedes both findings on the next scan"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [prefix (scope-prefix)
+              nm     (str prefix " Sales")]
+          (mt/with-temp [:model/Collection {coll-id :id} {}
+                         :model/Card {card-a :id} {:collection_id coll-id :name nm}
+                         :model/Card {card-b :id} {:collection_id coll-id :name nm}]
+            (let [by-entity (duplicated-findings-by-entity!)
+                  fa        (by-entity [:card card-a])
+                  fb        (by-entity [:card card-b])]
+              (is (some? fa))
+              (is (some? fb))
+              (t2/update! :model/Card card-b {:name (str prefix " Renamed Unique")})
+              (scan/scan!)
+              (testing "both prior findings are soft-invalidated and neither entity has an active one"
+                (is (some? (:invalidated_at (t2/select-one :model/ContentDiagnosticsFinding :id (:id fa)))))
+                (is (some? (:invalidated_at (t2/select-one :model/ContentDiagnosticsFinding :id (:id fb)))))
+                (is (empty? (t2/select :model/ContentDiagnosticsFinding
+                                       :finding_type :duplicated :invalidated_at nil
+                                       :entity_type :card :entity_id [:in [card-a card-b]])))))))))))
+
+;;; ------------------------------------------------- API --------------------------------------------------
+
+(deftest duplicated-api-hydration-test
+  (testing "GET /duplicated serves findings with hydrated context + same-type peers"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [prefix (scope-prefix)
+              nm     (str prefix " Sales Model")]
+          (mt/with-temp
+            [:model/Collection {coll-id :id} {:name "Analytics"}
+             :model/Card {card-a :id} {:collection_id coll-id :name nm :type :model
+                                       :creator_id (mt/user->id :rasta)}
+             :model/Card {card-b :id} {:collection_id coll-id :name nm :type :model}]
+            (scan/scan!)
+            (let [resp  (mt/user-http-request :crowberto :get 200 "ee/content-diagnostics/duplicated"
+                                              :query prefix)
+                  by-id (into {} (map (juxt (juxt :entity_type :entity_id) identity)) (:data resp))]
+              (testing "the envelope carries last_scan_at + total"
+                (is (contains? resp :last_scan_at))
+                (is (= 2 (:total resp))))
+              (let [f (by-id ["card" card-a])]
+                (is (some? f))
+                (is (= nm (:entity_display_name f)))
+                (testing "top-level duplicate_count + normalized matched_name in details"
+                  (is (= 1 (:duplicate_count f)))
+                  (is (= (u/lower-case-en nm) (get-in f [:details :matched_name]))))
+                (testing "the peer hydrates with its card sub-kind"
+                  (is (= [{:id card-b :name nm :entity_type "card" :card_type "model"}]
+                         (get-in f [:details :duplicate_entities]))))
+                (testing "the raw stored peer envelope (ids + matches) is not served"
+                  (is (not (contains? (:details f) :duplicate_entity_ids)))
+                  (is (not (contains? (:details f) :matches))))
+                (testing "shared display hydration: collection breadcrumb + denormalized creator"
+                  (is (= coll-id (get-in f [:details :collection :id])))
+                  (is (= (mt/user->id :rasta) (get-in f [:details :creator :id]))))))))))))
+
+(deftest duplicated-api-filter-and-sort-test
+  (testing "GET /duplicated filters by entity-types/min-duplicate-count and sorts by duplicate-count/name"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {coll-id :id} {}
+                         :model/Collection {tcoll-id :id} {:namespace "transforms"}
+                         :model/Card {card-id :id} {:collection_id coll-id}
+                         :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                         :model/Transform {xform-id :id} {:collection_id tcoll-id}]
+            (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+            (perms/grant-collection-read-permissions! (perms/all-users-group) tcoll-id)
+            (let [prefix (scope-prefix)
+                  insert (fn [etype eid nm dup-count]
+                           (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                            {:scan_id         "s"
+                                                             :entity_type     etype
+                                                             :entity_id       eid
+                                                             :entity_name     (str prefix " " nm)
+                                                             :finding_type    :duplicated
+                                                             :duplicate_count dup-count
+                                                             :details         {:matched_name nm}})))
+                  card-fid  (insert :card      card-id  "Alpha" 1)
+                  dash-fid  (insert :dashboard dash-id  "Beta"  2)
+                  xform-fid (insert :transform xform-id "Gamma" 4)
+                  ids   (fn [& kvs] (set (map :id (:data (apply mt/user-http-request :rasta :get 200
+                                                                "ee/content-diagnostics/duplicated"
+                                                                :query prefix kvs)))))
+                  order (fn [& kvs] (mapv :id (:data (apply mt/user-http-request :rasta :get 200
+                                                            "ee/content-diagnostics/duplicated"
+                                                            :query prefix kvs))))]
+              (testing "no filter → all three"
+                (is (= #{card-fid dash-fid xform-fid} (ids))))
+              (testing "entity-types (single + multi)"
+                (is (= #{card-fid} (ids :entity-types "card")))
+                (is (= #{card-fid dash-fid} (ids :entity-types ["card" "dashboard"]))))
+              (testing "min-duplicate-count floor is inclusive - a pair (count 1) drops at min 2, a trio (count 2) stays"
+                (is (= #{dash-fid xform-fid} (ids :min-duplicate-count "2")))
+                (is (= #{xform-fid} (ids :min-duplicate-count "3"))))
+              (testing "sort by duplicate-count, both directions"
+                (is (= [card-fid dash-fid xform-fid] (order :sort-column "duplicate-count" :sort-direction "asc")))
+                (is (= [xform-fid dash-fid card-fid] (order :sort-column "duplicate-count" :sort-direction "desc"))))
+              (testing "sort by name (Alpha < Beta < Gamma), both directions"
+                (is (= [card-fid dash-fid xform-fid] (order :sort-column "name" :sort-direction "asc")))
+                (is (= [xform-fid dash-fid card-fid] (order :sort-column "name" :sort-direction "desc")))))))))))
+
+(deftest duplicated-api-paginates-test
+  (testing "GET /duplicated honors limit/offset and reports the full valid total"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {coll-id :id} {}
+                         :model/Card {c1 :id} {:collection_id coll-id}
+                         :model/Card {c2 :id} {:collection_id coll-id}
+                         :model/Card {c3 :id} {:collection_id coll-id}]
+            (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+            (let [prefix (scope-prefix)]
+              (doseq [cid [c1 c2 c3]]
+                (t2/insert! :model/ContentDiagnosticsFinding
+                            {:scan_id "p" :entity_type :card :entity_id cid
+                             :entity_name (str prefix "-" cid)
+                             :finding_type :duplicated :duplicate_count 1 :details {}}))
+              (let [page (fn [limit offset]
+                           (mt/user-http-request :rasta :get 200 "ee/content-diagnostics/duplicated"
+                                                 :query prefix :limit limit :offset offset))]
+                (testing "limit caps the page; total reflects the full valid set; limit/offset echoed back"
+                  (let [r (page 2 0)]
+                    (is (= 2 (count (:data r))))
+                    (is (= 3 (:total r)))
+                    (is (= 2 (:limit r)))
+                    (is (= 0 (:offset r)))))
+                (testing "offset advances to the remainder"
+                  (is (= 1 (count (:data (page 2 2))))))))))))))
+
+(deftest duplicated-api-hides-unreadable-peers-test
+  (testing "GET /duplicated omits peers the caller can't read - the count can exceed the hydrated list"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {readable :id}   {}
+                         :model/Collection {unreadable :id} {}
+                         :model/Card {open-card :id}   {:collection_id readable}
+                         :model/Card {secret-card :id} {:collection_id unreadable}]
+            (perms/grant-collection-read-permissions! (perms/all-users-group) readable)
+            (let [prefix (scope-prefix)
+                  fid    (first (t2/insert-returning-pks!
+                                 :model/ContentDiagnosticsFinding
+                                 {:scan_id "perm" :entity_type :card :entity_id open-card
+                                  :entity_name (str prefix "-card")
+                                  :finding_type :duplicated :duplicate_count 1
+                                  :details {:matches              [{:match_type "name" :entity_ids [secret-card]}]
+                                            :matched_name         "x"
+                                            :duplicate_entity_ids [secret-card]}}))
+                  finding (fn [user]
+                            (some #(when (= fid (:id %)) %)
+                                  (:data (mt/user-http-request user :get 200
+                                                               "ee/content-diagnostics/duplicated"
+                                                               :query prefix))))]
+              (testing "superuser sees the peer"
+                (is (= [secret-card] (mapv :id (get-in (finding :crowberto) [:details :duplicate_entities])))))
+              (testing "non-admin gets an empty peer list while duplicate_count still reports 1"
+                (let [f (finding :rasta)]
+                  (is (= [] (get-in f [:details :duplicate_entities])))
+                  (is (= 1 (:duplicate_count f))))))))))))
+
+(deftest duplicated-api-personal-peers-follow-param-test
+  (testing "GET /duplicated peer hydration honors include-personal-collections like the findings filter"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (let [pers-id (:id (collection/user->personal-collection (mt/user->id :rasta)))]
+            (mt/with-temp [:model/Collection {reg-id :id}     {}
+                           :model/Card       {flagged :id}    {:collection_id reg-id}
+                           :model/Card       {reg-peer :id}   {:collection_id reg-id}
+                           :model/Card       {pers-peer :id}  {:collection_id pers-id}]
+              (perms/grant-collection-read-permissions! (perms/all-users-group) reg-id)
+              (let [prefix   (scope-prefix)
+                    fid      (first (t2/insert-returning-pks!
+                                     :model/ContentDiagnosticsFinding
+                                     {:scan_id "pc" :entity_type :card :entity_id flagged
+                                      :entity_name (str prefix "-card")
+                                      :finding_type :duplicated :duplicate_count 2
+                                      :details {:matches              [{:match_type  "name"
+                                                                        :entity_ids [reg-peer pers-peer]}]
+                                                :matched_name         "x"
+                                                :duplicate_entity_ids [reg-peer pers-peer]}}))
+                    peer-ids (fn [& kvs]
+                               (let [finding (some #(when (= fid (:id %)) %)
+                                                   (:data (apply mt/user-http-request
+                                                                 :rasta :get 200
+                                                                 "ee/content-diagnostics/duplicated"
+                                                                 :query prefix kvs)))]
+                                 (into #{} (map :id) (get-in finding [:details :duplicate_entities]))))]
+                (testing "default → the caller's own (readable) personal-collection peer is hidden too"
+                  (is (= #{reg-peer} (peer-ids))))
+                (testing "include-personal-collections=true → both peers hydrate"
+                  (is (= #{reg-peer pers-peer} (peer-ids :include-personal-collections true))))))))))))
+
+(deftest duplicated-api-transform-peers-hydrate-test
+  (testing "GET /duplicated hydrates transform peers from the transform model, with no card_type key"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [prefix (scope-prefix)
+              nm     (str prefix " Nightly Sync")]
+          (mt/with-temp [:model/Transform {xf-a :id} {:name nm}
+                         :model/Transform {xf-b :id} {:name nm}]
+            (scan/scan!)
+            (let [f (some #(when (= [xf-a "transform"] [(:entity_id %) (:entity_type %)]) %)
+                          (:data (mt/user-http-request :crowberto :get 200
+                                                       "ee/content-diagnostics/duplicated"
+                                                       :query prefix)))]
+              (is (some? f))
+              (is (= [{:id xf-b :name nm :entity_type "transform"}]
+                     (get-in f [:details :duplicate_entities]))))))))))
+
+(deftest duplicated-api-does-not-leak-across-finding-types-test
+  (testing "a duplicated finding never surfaces in /stale or /slow, and theirs never surface in /duplicated"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (mt/with-temp [:model/Collection {coll-id :id} {}
+                         :model/Card {stale-card :id} {:collection_id coll-id}
+                         :model/Card {slow-card :id}  {:collection_id coll-id}
+                         :model/Card {dup-card :id}   {:collection_id coll-id}]
+            (perms/grant-collection-read-permissions! (perms/all-users-group) coll-id)
+            (let [prefix    (scope-prefix)
+                  stale-fid (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                             {:scan_id "x" :entity_type :card :entity_id stale-card
+                                                              :entity_name (str prefix "-stale")
+                                                              :finding_type :stale :details {:threshold_days 90}}))
+                  slow-fid  (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                             {:scan_id "x" :entity_type :card :entity_id slow-card
+                                                              :entity_name (str prefix "-slow")
+                                                              :finding_type :slow :duration_ms 20000
+                                                              :details {:threshold_ms 15000}}))
+                  dup-fid   (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                             {:scan_id "x" :entity_type :card :entity_id dup-card
+                                                              :entity_name (str prefix "-dup")
+                                                              :finding_type :duplicated :duplicate_count 1
+                                                              :details {:matched_name "x"
+                                                                        :duplicate_entity_ids []}}))
+                  ids (fn [path] (set (map :id (:data (mt/user-http-request :rasta :get 200 path :query prefix)))))]
+              (testing "/duplicated returns only the duplicated finding"
+                (is (= #{dup-fid} (ids "ee/content-diagnostics/duplicated"))))
+              (testing "/slow and /stale each exclude the duplicated finding"
+                (is (= #{slow-fid} (ids "ee/content-diagnostics/slow")))
+                (is (= #{stale-fid} (ids "ee/content-diagnostics/stale")))))))))))
+
+(deftest duplicated-api-feature-gated-test
+  (testing "GET /duplicated is gated on the :content-diagnostics premium feature (premium-handler)"
+    (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+      (testing "licensed → 200 with the paginated envelope"
+        (mt/with-premium-features #{:content-diagnostics}
+          (let [resp (mt/user-http-request :rasta :get 200 "ee/content-diagnostics/duplicated")]
+            (is (contains? resp :data))
+            (is (contains? resp :total)))))
+      (testing "unlicensed → 402"
+        (mt/with-premium-features #{}
+          (mt/user-http-request :rasta :get 402 "ee/content-diagnostics/duplicated"))))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -132,27 +132,24 @@
               (testing "a zero-width space is stripped, joining the surrounding text"
                 (is (= [zwsp-b] (get-in (by-entity [:card zwsp-a]) [:details :duplicate_entity_ids])))))))))))
 
-(deftest duplicated-checker-splits-cards-by-sub-kind-test
-  (testing "cards group by (type, normalized name): a question and a model sharing a name are not duplicates"
+(deftest duplicated-checker-clusters-cards-across-sub-kinds-test
+  (testing "cards cluster by normalized name regardless of sub-kind: a question and a model sharing a name are duplicates"
     (mt/with-premium-features #{:content-diagnostics}
       (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
         (let [prefix (scope-prefix)]
           (mt/with-temp
             [:model/Collection {coll-id :id} {}
              :model/Card {question :id} {:collection_id coll-id :name (str prefix " Sales") :type :question}
-             :model/Card {model :id}    {:collection_id coll-id :name (str prefix " Sales") :type :model}
-             ;; positive control: two same-kind cards with a shared name ARE duplicates
-             :model/Card {model-a :id}  {:collection_id coll-id :name (str prefix " Sales Model") :type :model}
-             :model/Card {model-b :id}  {:collection_id coll-id :name (str prefix " Sales Model") :type :model}]
-            (let [by-entity (duplicated-findings-by-entity!)]
-              (testing "cross-kind name collision yields no findings"
-                (is (nil? (by-entity [:card question])))
-                (is (nil? (by-entity [:card model]))))
-              (testing "same-kind collision is flagged, with entity_type :card"
-                (let [f (by-entity [:card model-a])]
-                  (is (some? f))
-                  (is (= :card (:entity_type f)))
-                  (is (= [model-b] (get-in f [:details :duplicate_entity_ids]))))))))))))
+             :model/Card {model :id}    {:collection_id coll-id :name (str prefix " Sales") :type :model}]
+            (let [by-entity        (duplicated-findings-by-entity!)
+                  question-finding (by-entity [:card question])
+                  model-finding    (by-entity [:card model])]
+              (testing "the question and the model are mutual peers, entity_type :card"
+                (is (some? question-finding))
+                (is (some? model-finding))
+                (is (= :card (:entity_type question-finding)))
+                (is (= [model] (get-in question-finding [:details :duplicate_entity_ids])))
+                (is (= [question] (get-in model-finding [:details :duplicate_entity_ids])))))))))))
 
 (deftest duplicated-checker-excludes-archived-test
   (testing "archived cards/dashboards/documents neither get findings nor count as peers"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -6,6 +6,7 @@
   envelope."
   (:require
    [clojure.test :refer :all]
+   [java-time.api :as t]
    [metabase-enterprise.content-diagnostics.scan :as scan]
    [metabase.collections.models.collection :as collection]
    [metabase.permissions.core :as perms]
@@ -245,7 +246,7 @@
             [:model/Collection {coll-id :id} {:name "Analytics"}
              :model/Card {card-a :id} {:collection_id coll-id :name nm :type :model
                                        :creator_id (mt/user->id :rasta)}
-             :model/Card {card-b :id} {:collection_id coll-id :name nm :type :model}]
+             :model/Card {card-b :id} {:collection_id coll-id :name nm :type :model :view_count 7}]
             (scan/scan!)
             (let [resp  (mt/user-http-request :crowberto :get 200 "ee/content-diagnostics/duplicated"
                                               :query prefix)
@@ -259,8 +260,8 @@
                 (testing "top-level duplicate_count + normalized_name in details"
                   (is (= 1 (:duplicate_count f)))
                   (is (= (u/lower-case-en nm) (get-in f [:details :normalized_name]))))
-                (testing "the peer hydrates with its card sub-kind"
-                  (is (= [{:id card-b :name nm :entity_type "card" :card_type "model"}]
+                (testing "the peer hydrates with its card sub-kind and live view_count"
+                  (is (= [{:id card-b :name nm :entity_type "card" :card_type "model" :view_count 7}]
                          (get-in f [:details :duplicate_entities]))))
                 (testing "the raw stored peer envelope (ids + matches) is not served"
                   (is (not (contains? (:details f) :duplicate_entity_ids)))
@@ -416,15 +417,22 @@
         (let [prefix (scope-prefix)
               nm     (str prefix " Nightly Sync")]
           (mt/with-temp [:model/Transform {xf-a :id} {:name nm}
-                         :model/Transform {xf-b :id} {:name nm}]
+                         :model/Transform {xf-b :id} {:name nm}
+                         ;; run_count counts every run status - a failed run is still activity
+                         :model/TransformRun _ {:transform_id xf-b :status :succeeded
+                                                :start_time (t/minus (t/offset-date-time) (t/minutes 2))
+                                                :end_time   (t/minus (t/offset-date-time) (t/minutes 1))}
+                         :model/TransformRun _ {:transform_id xf-b :status :failed
+                                                :start_time (t/minus (t/offset-date-time) (t/minutes 4))
+                                                :end_time   (t/minus (t/offset-date-time) (t/minutes 3))}]
             (scan/scan!)
             (let [finding (fn [user]
                             (some #(when (= [xf-a "transform"] [(:entity_id %) (:entity_type %)]) %)
                                   (:data (mt/user-http-request user :get 200
                                                                "ee/content-diagnostics/duplicated"
                                                                :query prefix))))]
-              (testing "superuser: the peer hydrates from the transform model, with no card_type key"
-                (is (= [{:id xf-b :name nm :entity_type "transform"}]
+              (testing "superuser: the peer hydrates from the transform model with its run_count, no card_type key"
+                (is (= [{:id xf-b :name nm :entity_type "transform" :run_count 2}]
                        (get-in (finding :crowberto) [:details :duplicate_entities]))))
               (testing "a non-data-analyst sees the finding (collection-visible) but not the peer"
                 (let [f (finding :rasta)]

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -104,6 +104,35 @@
                 (is (nil? (by-entity [:card comma-a])))
                 (is (nil? (by-entity [:card comma-b])))))))))))
 
+(deftest duplicated-checker-unicode-normalization-test
+  (testing "diacritics fold, Unicode whitespace collapses, and zero-width invisibles are stripped before comparison"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [prefix (scope-prefix)]
+          (mt/with-temp
+            [:model/Collection {coll-id :id} {}
+             ;; combining-mark accents fold: Café Über ≡ Cafe Uber
+             :model/Card {accent-a :id} {:collection_id coll-id :name (str prefix " Café Über")}
+             :model/Card {accent-b :id} {:collection_id coll-id :name (str prefix " Cafe Uber")}
+             ;; a non-breaking space (U+00A0) collapses like a regular space
+             :model/Card {nbsp-a :id} {:collection_id coll-id :name (str prefix " a\u00A0gap")}
+             :model/Card {nbsp-b :id} {:collection_id coll-id :name (str prefix " a gap")}
+             ;; an em space (U+2003, another Unicode whitespace form) collapses too
+             :model/Card {emsp-a :id} {:collection_id coll-id :name (str prefix " b\u2003gap")}
+             :model/Card {emsp-b :id} {:collection_id coll-id :name (str prefix " b gap")}
+             ;; a zero-width space (U+200B) is invisible - stripped, so the surrounding text joins
+             :model/Card {zwsp-a :id} {:collection_id coll-id :name (str prefix " c\u200Bjoin")}
+             :model/Card {zwsp-b :id} {:collection_id coll-id :name (str prefix " cjoin")}]
+            (let [by-entity (duplicated-findings-by-entity!)]
+              (testing "combining-mark accents fold (Café Über ≡ Cafe Uber)"
+                (is (= [accent-b] (get-in (by-entity [:card accent-a]) [:details :duplicate_entity_ids]))))
+              (testing "a non-breaking space collapses to a regular space"
+                (is (= [nbsp-b] (get-in (by-entity [:card nbsp-a]) [:details :duplicate_entity_ids]))))
+              (testing "an em space collapses to a regular space"
+                (is (= [emsp-b] (get-in (by-entity [:card emsp-a]) [:details :duplicate_entity_ids]))))
+              (testing "a zero-width space is stripped, joining the surrounding text"
+                (is (= [zwsp-b] (get-in (by-entity [:card zwsp-a]) [:details :duplicate_entity_ids])))))))))))
+
 (deftest duplicated-checker-splits-cards-by-sub-kind-test
   (testing "cards group by (type, normalized name): a question and a model sharing a name are not duplicates"
     (mt/with-premium-features #{:content-diagnostics}
@@ -161,16 +190,21 @@
                   (is (nil? (by-entity [:card trio-archived]))))))))))))
 
 (deftest duplicated-checker-skips-blank-names-test
-  (testing "whitespace-only names never cluster - unknown is not duplicate"
+  (testing "whitespace-only names - including Unicode whitespace and zero-width invisibles - never cluster; unknown is not duplicate"
     (mt/with-premium-features #{:content-diagnostics}
       (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
         (mt/with-temp
           [:model/Collection {coll-id :id} {}
            :model/Dashboard {blank-a :id} {:collection_id coll-id :name "   "}
-           :model/Dashboard {blank-b :id} {:collection_id coll-id :name "   "}]
+           :model/Dashboard {blank-b :id} {:collection_id coll-id :name "   "}
+           ;; NBSP-only and zero-width-only names normalize to blank too, so they never cluster
+           :model/Dashboard {nbsp-a :id} {:collection_id coll-id :name "\u00A0\u00A0"}
+           :model/Dashboard {nbsp-b :id} {:collection_id coll-id :name "\u00A0\u00A0"}
+           :model/Dashboard {zwsp-a :id} {:collection_id coll-id :name "\u200B"}
+           :model/Dashboard {zwsp-b :id} {:collection_id coll-id :name "\u200B"}]
           (let [by-entity (duplicated-findings-by-entity!)]
-            (is (nil? (by-entity [:dashboard blank-a])))
-            (is (nil? (by-entity [:dashboard blank-b])))))))))
+            (are [d] (nil? (by-entity [:dashboard d]))
+              blank-a blank-b nbsp-a nbsp-b zwsp-a zwsp-b)))))))
 
 (deftest duplicated-checker-cluster-of-three-test
   (testing "every member of a cluster of 3 gets duplicate_count 2 and the other two as peers"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -6,7 +6,6 @@
   envelope."
   (:require
    [clojure.test :refer :all]
-   [java-time.api :as t]
    [metabase-enterprise.content-diagnostics.scan :as scan]
    [metabase.collections.models.collection :as collection]
    [metabase.permissions.core :as perms]
@@ -417,22 +416,15 @@
         (let [prefix (scope-prefix)
               nm     (str prefix " Nightly Sync")]
           (mt/with-temp [:model/Transform {xf-a :id} {:name nm}
-                         :model/Transform {xf-b :id} {:name nm}
-                         ;; run_count counts every run status - a failed run is still activity
-                         :model/TransformRun _ {:transform_id xf-b :status :succeeded
-                                                :start_time (t/minus (t/offset-date-time) (t/minutes 2))
-                                                :end_time   (t/minus (t/offset-date-time) (t/minutes 1))}
-                         :model/TransformRun _ {:transform_id xf-b :status :failed
-                                                :start_time (t/minus (t/offset-date-time) (t/minutes 4))
-                                                :end_time   (t/minus (t/offset-date-time) (t/minutes 3))}]
+                         :model/Transform {xf-b :id} {:name nm}]
             (scan/scan!)
             (let [finding (fn [user]
                             (some #(when (= [xf-a "transform"] [(:entity_id %) (:entity_type %)]) %)
                                   (:data (mt/user-http-request user :get 200
                                                                "ee/content-diagnostics/duplicated"
                                                                :query prefix))))]
-              (testing "superuser: the peer hydrates from the transform model with its run_count, no card_type key"
-                (is (= [{:id xf-b :name nm :entity_type "transform" :run_count 2}]
+              (testing "superuser: the peer hydrates from the transform model - no card_type, no view_count"
+                (is (= [{:id xf-b :name nm :entity_type "transform"}]
                        (get-in (finding :crowberto) [:details :duplicate_entities]))))
               (testing "a non-data-analyst sees the finding (collection-visible) but not the peer"
                 (let [f (finding :rasta)]

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.content-diagnostics.duplicated-test
   "The `duplicated` checker (match mode `name`) flags clusters of ≥2 same-type non-archived entities
   whose normalized names collide, stamping the peer count in the top-level `duplicate_count` column and
-  freezing the `matches`/`matched_name`/`duplicate_entity_ids` envelope in `details` at scan time. The
+  freezing the `matches`/`normalized_name`/`duplicate_entity_ids` envelope in `details` at scan time. The
   `/duplicated` endpoint serves them with hydrated same-type peers and the shared filter/sort/pagination
   envelope."
   (:require
@@ -52,7 +52,7 @@
                   (is (some? f))
                   (is (= 1 (:duplicate_count f)))
                   (is (= {:matches              [{:match_type "name" :entity_ids [card-b]}]
-                          :matched_name         (u/lower-case-en (str prefix " Revenue"))
+                          :normalized_name      (u/lower-case-en (str prefix " Revenue"))
                           :duplicate_entity_ids [card-b]}
                          (:details f)))
                   (testing "the other magnitude columns stay null on duplicated findings"
@@ -90,11 +90,11 @@
              :model/Card {comma-a :id} {:collection_id coll-id :name (str prefix " a, b")}
              :model/Card {comma-b :id} {:collection_id coll-id :name (str prefix " a b")}]
             (let [by-entity (duplicated-findings-by-entity!)]
-              (testing "case-insensitive match; matched_name is the normalized (lowercased) form"
+              (testing "case-insensitive match; normalized_name is the normalized (lowercased) form"
                 (let [f (by-entity [:card case-a])]
                   (is (some? f))
                   (is (= (u/lower-case-en (str prefix " Rev"))
-                         (get-in f [:details :matched_name])))
+                         (get-in f [:details :normalized_name])))
                   (is (= [case-b] (get-in f [:details :duplicate_entity_ids])))))
               (testing "leading/trailing whitespace is ignored"
                 (is (= [pad-b] (get-in (by-entity [:card pad-a]) [:details :duplicate_entity_ids]))))
@@ -256,9 +256,9 @@
               (let [f (by-id ["card" card-a])]
                 (is (some? f))
                 (is (= nm (:entity_display_name f)))
-                (testing "top-level duplicate_count + normalized matched_name in details"
+                (testing "top-level duplicate_count + normalized_name in details"
                   (is (= 1 (:duplicate_count f)))
-                  (is (= (u/lower-case-en nm) (get-in f [:details :matched_name]))))
+                  (is (= (u/lower-case-en nm) (get-in f [:details :normalized_name]))))
                 (testing "the peer hydrates with its card sub-kind"
                   (is (= [{:id card-b :name nm :entity_type "card" :card_type "model"}]
                          (get-in f [:details :duplicate_entities]))))
@@ -290,7 +290,8 @@
                                                              :entity_name     (str prefix " " nm)
                                                              :finding_type    :duplicated
                                                              :duplicate_count dup-count
-                                                             :details         {:matched_name nm}})))
+                                                             :details         {:normalized_name      nm
+                                                                               :duplicate_entity_ids []}})))
                   card-fid  (insert :card      card-id  "Alpha" 1)
                   dash-fid  (insert :dashboard dash-id  "Beta"  2)
                   xform-fid (insert :transform xform-id "Gamma" 4)
@@ -330,7 +331,8 @@
                 (t2/insert! :model/ContentDiagnosticsFinding
                             {:scan_id "p" :entity_type :card :entity_id cid
                              :entity_name (str prefix "-" cid)
-                             :finding_type :duplicated :duplicate_count 1 :details {}}))
+                             :finding_type :duplicated :duplicate_count 1
+                             :details {:normalized_name "x" :duplicate_entity_ids []}}))
               (let [page (fn [limit offset]
                            (mt/user-http-request :rasta :get 200 "ee/content-diagnostics/duplicated"
                                                  :query prefix :limit limit :offset offset))]
@@ -360,7 +362,7 @@
                                   :entity_name (str prefix "-card")
                                   :finding_type :duplicated :duplicate_count 1
                                   :details {:matches              [{:match_type "name" :entity_ids [secret-card]}]
-                                            :matched_name         "x"
+                                            :normalized_name      "x"
                                             :duplicate_entity_ids [secret-card]}}))
                   finding (fn [user]
                             (some #(when (= fid (:id %)) %)
@@ -393,7 +395,7 @@
                                       :finding_type :duplicated :duplicate_count 2
                                       :details {:matches              [{:match_type  "name"
                                                                         :entity_ids [reg-peer pers-peer]}]
-                                                :matched_name         "x"
+                                                :normalized_name      "x"
                                                 :duplicate_entity_ids [reg-peer pers-peer]}}))
                     peer-ids (fn [& kvs]
                                (let [finding (some #(when (= fid (:id %)) %)
@@ -448,7 +450,7 @@
                                                              {:scan_id "x" :entity_type :card :entity_id dup-card
                                                               :entity_name (str prefix "-dup")
                                                               :finding_type :duplicated :duplicate_count 1
-                                                              :details {:matched_name "x"
+                                                              :details {:normalized_name      "x"
                                                                         :duplicate_entity_ids []}}))
                   ids (fn [path] (set (map :id (:data (mt/user-http-request :rasta :get 200 path :query prefix)))))]
               (testing "/duplicated returns only the duplicated finding"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -244,7 +244,7 @@
           (mt/with-temp
             [:model/Collection {coll-id :id} {:name "Analytics"}
              :model/Card {card-a :id} {:collection_id coll-id :name nm :type :model
-                                       :creator_id (mt/user->id :rasta)}
+                                       :creator_id (mt/user->id :rasta) :view_count 4}
              :model/Card {card-b :id} {:collection_id coll-id :name nm :type :model :view_count 7}]
             (scan/scan!)
             (let [resp  (mt/user-http-request :crowberto :get 200 "ee/content-diagnostics/duplicated"
@@ -259,6 +259,8 @@
                 (testing "top-level duplicate_count + normalized_name in details"
                   (is (= 1 (:duplicate_count f)))
                   (is (= (u/lower-case-en nm) (get-in f [:details :normalized_name]))))
+                (testing "the flagged entity's own live view_count is hydrated into details"
+                  (is (= 4 (get-in f [:details :view_count]))))
                 (testing "the peer hydrates with its card sub-kind and live view_count"
                   (is (= [{:id card-b :name nm :entity_type "card" :card_type "model" :view_count 7}]
                          (get-in f [:details :duplicate_entities]))))
@@ -268,6 +270,45 @@
                 (testing "shared display hydration: collection breadcrumb + denormalized creator"
                   (is (= coll-id (get-in f [:details :collection :id])))
                   (is (= (mt/user->id :rasta) (get-in f [:details :creator :id]))))))))))))
+
+(deftest duplicated-api-subject-view-count-test
+  (testing "GET /duplicated hydrates each finding's own live view_count into details; a transform omits it"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (mt/with-temp
+          [:model/Collection {coll-id :id}  {}
+           :model/Collection {tcoll-id :id} {:namespace "transforms"}
+           :model/Card       {card-id :id}  {:collection_id coll-id :view_count 7}
+           :model/Dashboard  {dash-id :id}  {:collection_id coll-id :view_count 12}
+           :model/Document   {doc-id :id}   {:collection_id coll-id :view_count 3}
+           :model/Transform  {xform-id :id} {:collection_id tcoll-id}]
+          (let [prefix (scope-prefix)]
+            (doseq [[etype eid] [[:card card-id] [:dashboard dash-id] [:document doc-id] [:transform xform-id]]]
+              (t2/insert! :model/ContentDiagnosticsFinding
+                          {:scan_id         "vc"
+                           :entity_type     etype
+                           :entity_id       eid
+                           :entity_name     (str prefix "-" (name etype))
+                           :finding_type    :duplicated
+                           :duplicate_count 1
+                           :details         {:normalized_name      "x"
+                                             :duplicate_entity_ids []}}))
+            (let [by-type (into {} (map (juxt :entity_type identity))
+                                (:data (mt/user-http-request :crowberto :get 200
+                                                             "ee/content-diagnostics/duplicated" :query prefix)))]
+              (testing "card/dashboard/document each carry their own live view_count in details"
+                (is (= 7  (get-in by-type ["card" :details :view_count])))
+                (is (= 12 (get-in by-type ["dashboard" :details :view_count])))
+                (is (= 3  (get-in by-type ["document" :details :view_count]))))
+              (testing "a transform (no view_count column) omits the key entirely from details"
+                (is (contains? by-type "transform"))
+                (is (not (contains? (get-in by-type ["transform" :details]) :view_count))))
+              (testing "view_count is hydrated live at read time, not frozen at scan time"
+                (t2/update! :model/Card card-id {:view_count 99})
+                (let [card-f (some #(when (= "card" (:entity_type %)) %)
+                                   (:data (mt/user-http-request :crowberto :get 200
+                                                                "ee/content-diagnostics/duplicated" :query prefix)))]
+                  (is (= 99 (get-in card-f [:details :view_count]))))))))))))
 
 (deftest duplicated-api-filter-and-sort-test
   (testing "GET /duplicated filters by entity-types/min-duplicate-count and sorts by duplicate-count/name"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -297,9 +297,10 @@
                                 (:data (mt/user-http-request :crowberto :get 200
                                                              "ee/content-diagnostics/duplicated" :query prefix)))]
               (testing "card/dashboard/document each carry their own live view_count in details"
-                (is (= 7  (get-in by-type ["card" :details :view_count])))
-                (is (= 12 (get-in by-type ["dashboard" :details :view_count])))
-                (is (= 3  (get-in by-type ["document" :details :view_count]))))
+                (are [etype vc] (= vc (get-in by-type [etype :details :view_count]))
+                  "card"      7
+                  "dashboard" 12
+                  "document"  3))
               (testing "a transform (no view_count column) omits the key entirely from details"
                 (is (contains? by-type "transform"))
                 (is (not (contains? (get-in by-type ["transform" :details]) :view_count))))
@@ -451,7 +452,7 @@
                   (is (= #{reg-peer pers-peer} (peer-ids :include-personal-collections true))))))))))))
 
 (deftest duplicated-api-transform-peers-hydrate-test
-  (testing "GET /duplicated gates transform peers on transform readability (mi/can-read?), not collection visibility"
+  (testing "GET /duplicated gates transform peers on transform readability, not collection visibility"
     (mt/with-premium-features #{:content-diagnostics}
       (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
         (let [prefix (scope-prefix)
@@ -506,7 +507,7 @@
                 (is (= #{stale-fid} (ids "ee/content-diagnostics/stale")))))))))))
 
 (deftest duplicated-api-feature-gated-test
-  (testing "GET /duplicated is gated on the :content-diagnostics premium feature (premium-handler)"
+  (testing "GET /duplicated is gated on the :content-diagnostics premium feature"
     (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
       (testing "licensed → 200 with the paginated envelope"
         (mt/with-premium-features #{:content-diagnostics}

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.content-diagnostics.duplicated-test
   "The `duplicated` checker (match mode `name`) flags clusters of ≥2 same-type non-archived entities
   whose normalized names collide, stamping the peer count in the top-level `duplicate_count` column and
-  freezing the `matches`/`normalized_name`/`duplicate_entity_ids` envelope in `details` at scan time. The
+  freezing the `normalized_name`/`duplicate_entity_ids` envelope in `details` at scan time. The
   `/duplicated` endpoint serves them with hydrated same-type peers and the shared filter/sort/pagination
   envelope."
   (:require
@@ -51,8 +51,7 @@
                 (let [f (by-entity [:card card-a])]
                   (is (some? f))
                   (is (= 1 (:duplicate_count f)))
-                  (is (= {:matches              [{:match_type "name" :entity_ids [card-b]}]
-                          :normalized_name      (u/lower-case-en (str prefix " Revenue"))
+                  (is (= {:normalized_name      (u/lower-case-en (str prefix " Revenue"))
                           :duplicate_entity_ids [card-b]}
                          (:details f)))
                   (testing "the other magnitude columns stay null on duplicated findings"
@@ -222,10 +221,7 @@
                 (let [f (by-entity [:transform member])]
                   (is (some? f))
                   (is (= 2 (:duplicate_count f)))
-                  (is (= peers (set (get-in f [:details :duplicate_entity_ids]))))
-                  (testing "duplicate_entity_ids equals the single name-mode match's entity_ids"
-                    (is (= (get-in f [:details :duplicate_entity_ids])
-                           (get-in f [:details :matches 0 :entity_ids])))))))))))))
+                  (is (= peers (set (get-in f [:details :duplicate_entity_ids])))))))))))))
 
 (deftest duplicated-checker-same-type-only-test
   (testing "a name shared across different entity types is not a duplicate"
@@ -298,9 +294,8 @@
                 (testing "the peer hydrates with its card sub-kind and live view_count"
                   (is (= [{:id card-b :name nm :entity_type "card" :card_type "model" :view_count 7}]
                          (get-in f [:details :duplicate_entities]))))
-                (testing "the raw stored peer envelope (ids + matches) is not served"
-                  (is (not (contains? (:details f) :duplicate_entity_ids)))
-                  (is (not (contains? (:details f) :matches))))
+                (testing "the raw stored peer ids are not served"
+                  (is (not (contains? (:details f) :duplicate_entity_ids))))
                 (testing "shared display hydration: collection breadcrumb + denormalized creator"
                   (is (= coll-id (get-in f [:details :collection :id])))
                   (is (= (mt/user->id :rasta) (get-in f [:details :creator :id]))))))))))))
@@ -437,8 +432,7 @@
                                  {:scan_id "perm" :entity_type :card :entity_id open-card
                                   :entity_name (str prefix "-card")
                                   :finding_type :duplicated :duplicate_count 1
-                                  :details {:matches              [{:match_type "name" :entity_ids [secret-card]}]
-                                            :normalized_name      "x"
+                                  :details {:normalized_name      "x"
                                             :duplicate_entity_ids [secret-card]}}))
                   finding (fn [user]
                             (some #(when (= fid (:id %)) %)
@@ -469,9 +463,7 @@
                                      {:scan_id "pc" :entity_type :card :entity_id flagged
                                       :entity_name (str prefix "-card")
                                       :finding_type :duplicated :duplicate_count 2
-                                      :details {:matches              [{:match_type  "name"
-                                                                        :entity_ids [reg-peer pers-peer]}]
-                                                :normalized_name      "x"
+                                      :details {:normalized_name      "x"
                                                 :duplicate_entity_ids [reg-peer pers-peer]}}))
                     peer-ids (fn [& kvs]
                                (let [finding (some #(when (= fid (:id %)) %)

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -410,7 +410,7 @@
                   (is (= #{reg-peer pers-peer} (peer-ids :include-personal-collections true))))))))))))
 
 (deftest duplicated-api-transform-peers-hydrate-test
-  (testing "GET /duplicated hydrates transform peers from the transform model, with no card_type key"
+  (testing "GET /duplicated gates transform peers on transform readability (mi/can-read?), not collection visibility"
     (mt/with-premium-features #{:content-diagnostics}
       (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
         (let [prefix (scope-prefix)
@@ -418,13 +418,18 @@
           (mt/with-temp [:model/Transform {xf-a :id} {:name nm}
                          :model/Transform {xf-b :id} {:name nm}]
             (scan/scan!)
-            (let [f (some #(when (= [xf-a "transform"] [(:entity_id %) (:entity_type %)]) %)
-                          (:data (mt/user-http-request :crowberto :get 200
-                                                       "ee/content-diagnostics/duplicated"
-                                                       :query prefix)))]
-              (is (some? f))
-              (is (= [{:id xf-b :name nm :entity_type "transform"}]
-                     (get-in f [:details :duplicate_entities]))))))))))
+            (let [finding (fn [user]
+                            (some #(when (= [xf-a "transform"] [(:entity_id %) (:entity_type %)]) %)
+                                  (:data (mt/user-http-request user :get 200
+                                                               "ee/content-diagnostics/duplicated"
+                                                               :query prefix))))]
+              (testing "superuser: the peer hydrates from the transform model, with no card_type key"
+                (is (= [{:id xf-b :name nm :entity_type "transform"}]
+                       (get-in (finding :crowberto) [:details :duplicate_entities]))))
+              (testing "a non-data-analyst sees the finding (collection-visible) but not the peer"
+                (let [f (finding :rasta)]
+                  (is (some? f))
+                  (is (= [] (get-in f [:details :duplicate_entities]))))))))))))
 
 (deftest duplicated-api-does-not-leak-across-finding-types-test
   (testing "a duplicated finding never surfaces in /stale or /slow, and theirs never surface in /duplicated"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/models/finding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/models/finding_test.clj
@@ -39,3 +39,23 @@
     (is (= 15 (cd.settings/content-diagnostics-slow-card-threshold-seconds))))
   (testing "the slow-transform run-time threshold defaults to 60 seconds"
     (is (= 60 (cd.settings/content-diagnostics-slow-transform-threshold-seconds)))))
+
+;; `duplicated` has no settings-defaults test: a duplicate is definitionally a cluster of >= 2, so there
+;; is no threshold to configure.
+
+(deftest duplicated-details-round-trip-test
+  (testing "the duplicated details envelope - a nested matches vector - survives the JSON round-trip"
+    (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+      (let [details {:matches              [{:match_type "name" :entity_ids [10 11]}]
+                     :matched_name         "orders by month"
+                     :duplicate_entity_ids [10 11]}
+            fid     (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                     {:scan_id         "dup-round-trip"
+                                                      :entity_type     :card
+                                                      :entity_id       1
+                                                      :finding_type    :duplicated
+                                                      :duplicate_count 2
+                                                      :details         details}))
+            row     (t2/select-one :model/ContentDiagnosticsFinding :id fid)]
+        (is (= details (:details row)))
+        (is (= 2 (:duplicate_count row)))))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/models/finding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/models/finding_test.clj
@@ -44,10 +44,9 @@
 ;; is no threshold to configure.
 
 (deftest duplicated-details-round-trip-test
-  (testing "the duplicated details envelope - a nested matches vector - survives the JSON round-trip"
+  (testing "the duplicated details envelope survives the JSON round-trip"
     (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
-      (let [details {:matches              [{:match_type "name" :entity_ids [10 11]}]
-                     :normalized_name      "orders by month"
+      (let [details {:normalized_name      "orders by month"
                      :duplicate_entity_ids [10 11]}
             fid     (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
                                                      {:scan_id         "dup-round-trip"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/models/finding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/models/finding_test.clj
@@ -47,7 +47,7 @@
   (testing "the duplicated details envelope - a nested matches vector - survives the JSON round-trip"
     (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
       (let [details {:matches              [{:match_type "name" :entity_ids [10 11]}]
-                     :matched_name         "orders by month"
+                     :normalized_name      "orders by month"
                      :duplicate_entity_ids [10 11]}
             fid     (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
                                                      {:scan_id         "dup-round-trip"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/slow_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/slow_test.clj
@@ -378,6 +378,7 @@
              :model/Card           {slow-card :id} {:collection_id coll-id
                                                     :name          "Full Orders Export"
                                                     :type          :model
+                                                    :view_count    5
                                                     :creator_id    (mt/user->id :rasta)}
              :model/QueryExecution _ {:card_id slow-card :started_at (t/offset-date-time)
                                       :cache_hit false :running_time 25000}
@@ -409,9 +410,52 @@
                   (is (nil? (get-in f [:details :slow_entity_ids])))
                   (let [entities (get-in f [:details :slow_entities])]
                     (is (= 1 (count entities)))
-                    (is (= {:id slow-card :name "Full Orders Export"
-                            :entity_type "card" :card_type "model"}
-                           (first entities)))))))))))))
+                    (testing "each culprit carries its own live view_count alongside id/name/type"
+                      (is (= {:id slow-card :name "Full Orders Export"
+                              :entity_type "card" :card_type "model" :view_count 5}
+                             (first entities))))))))))))))
+
+(deftest slow-api-subject-view-count-test
+  (testing "GET /slow hydrates each finding's own live view_count into details; a transform omits it"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (mt/with-temp
+          [:model/Collection {coll-id :id}  {}
+           :model/Collection {tcoll-id :id} {:namespace "transforms"}
+           :model/Card       {card-id :id}  {:collection_id coll-id :view_count 7}
+           :model/Dashboard  {dash-id :id}  {:collection_id coll-id :view_count 12}
+           :model/Document   {doc-id :id}   {:collection_id coll-id
+                                             :view_count    3
+                                             :creator_id    (mt/user->id :rasta)
+                                             :content_type  prose-mirror/prose-mirror-content-type
+                                             :document      {:type "doc" :content []}}
+           :model/Transform  {xform-id :id} {:collection_id tcoll-id}]
+          (let [prefix (scope-prefix)]
+            (doseq [[etype eid] [[:card card-id] [:dashboard dash-id] [:document doc-id] [:transform xform-id]]]
+              (t2/insert! :model/ContentDiagnosticsFinding
+                          {:scan_id      "vc"
+                           :entity_type  etype
+                           :entity_id    eid
+                           :entity_name  (str prefix "-" (name etype))
+                           :finding_type :slow
+                           :duration_ms  20000
+                           :details      {:threshold_ms 15000}}))
+            (let [by-type (into {} (map (juxt :entity_type identity))
+                                (:data (mt/user-http-request :crowberto :get 200
+                                                             "ee/content-diagnostics/slow" :query prefix)))]
+              (testing "card/dashboard/document each carry their own live view_count in details"
+                (is (= 7  (get-in by-type ["card" :details :view_count])))
+                (is (= 12 (get-in by-type ["dashboard" :details :view_count])))
+                (is (= 3  (get-in by-type ["document" :details :view_count]))))
+              (testing "a transform (no view_count column) omits the key entirely from details"
+                (is (contains? by-type "transform"))
+                (is (not (contains? (get-in by-type ["transform" :details]) :view_count))))
+              (testing "view_count is hydrated live at read time, not frozen at scan time"
+                (t2/update! :model/Card card-id {:view_count 99})
+                (let [card-f (some #(when (= "card" (:entity_type %)) %)
+                                   (:data (mt/user-http-request :crowberto :get 200
+                                                                "ee/content-diagnostics/slow" :query prefix)))]
+                  (is (= 99 (get-in card-f [:details :view_count]))))))))))))
 
 (deftest slow-api-filter-and-sort-test
   (testing "GET /slow filters by entity-types/min-duration-ms and sorts by duration-ms/name"

--- a/resources/migrations/064/20260720_content_diagnostics_duplicated.yaml
+++ b/resources/migrations/064/20260720_content_diagnostics_duplicated.yaml
@@ -1,0 +1,31 @@
+## Content Diagnostics - `duplicated` finding type.
+## Adds the per-type verdict magnitude column + composite index the `duplicated` checker/serve path needs.
+## Append-only, on the `content_diagnostics_finding` table created in 064/20260708_content_diagnostics.yaml.
+
+databaseChangeLog:
+  - changeSet:
+      id: v64.q8vh2n
+      author: yb
+      comment: Content Diagnostics - duplicate_count verdict magnitude for duplicated findings
+      changes:
+        - addColumn:
+            tableName: content_diagnostics_finding
+            columns:
+              - column:
+                  name: duplicate_count
+                  type: bigint
+                  remarks: Verdict magnitude for duplicated findings - the number of other same-type entities sharing the normalized name (cluster size minus 1); null on all other finding types (per-type named magnitude column).
+
+  - changeSet:
+      id: v64.j5tk9w
+      author: yb
+      comment: Content Diagnostics - index findings by finding_type + duplicate_count
+      changes:
+        - createIndex:
+            tableName: content_diagnostics_finding
+            indexName: idx_cd_finding_ftype_duplicate_count
+            columns:
+              - column:
+                  name: finding_type
+              - column:
+                  name: duplicate_count


### PR DESCRIPTION
### Description

Adds a checker for duplicate names (case-insensitive, whitespace-collapsed, also agnostic of junky characters or diacritical marks) across entity types, and adds a `duplicated` content diagnostics endpoint.

I've also refactored the code that branched based on `entity-type` to use multimethods & a data map (`entity-spec`) based on feedback from an earlier PR. See https://github.com/metabase/metabase/pull/78125/commits/5328d746d459c81052684f453b37fb3f3cd11609. 

Similar refactoring but for dispatching `finalize-finding` on `finding-type` done to simplify the hydrate-findings method: https://github.com/metabase/metabase/pull/78125/changes/52a6d16b6b990d70215ee992f94cff256219cf54

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
