### PR TITLE
Add Metabot option to the Transforms New menu

### DIFF
--- a/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
@@ -217,7 +217,6 @@ export const MetabotPromptInput = forwardRef<
     useEffect(() => {
       if (value !== serializedRef.current) {
         editor?.commands.setContent(parseMetabotMessageToTiptapDoc(value));
-        editor?.commands.setTextSelection(editor.state.doc.content.size);
       }
     }, [editor, value]);
 

--- a/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.tsx
@@ -99,7 +99,7 @@ export const MetabotPromptInput = forwardRef<
       {
         extensions,
         content: parseMetabotMessageToTiptapDoc(value),
-        autofocus: autoFocus,
+        autofocus: autoFocus ? "end" : false,
         injectNonce: getCspNonce(),
         onUpdate: ({ editor }) => {
           const jsonContent = editor.getJSON();
@@ -217,6 +217,7 @@ export const MetabotPromptInput = forwardRef<
     useEffect(() => {
       if (value !== serializedRef.current) {
         editor?.commands.setContent(parseMetabotMessageToTiptapDoc(value));
+        editor?.commands.setTextSelection(editor.state.doc.content.size);
       }
     }, [editor, value]);
 

--- a/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotPromptInput/MetabotPromptInput.unit.spec.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { EditorState } from "@tiptap/pm/state";
+import type { Editor } from "@tiptap/react";
 import fetchMock from "fetch-mock";
 import { createRef } from "react";
 
@@ -96,6 +97,42 @@ describe("MetabotPromptInput", () => {
     expect(editor).toBeTruthy();
     const mentionState = MetabotMentionPluginKey.getState(editor!.view.state);
     expect(mentionState?.active).toBe(true);
+  });
+
+  it("places the caret at the end of a prompt seeded on mount", async () => {
+    const ref = createRef<MetabotPromptInputRef>();
+    setup({ ref, value: "Create a transform that " });
+
+    // The imperative handle is `Object.assign(editor, …)`, so `ref.current` is the
+    // underlying tiptap Editor at runtime; the public ref type just narrows it.
+    const editor = ref.current as unknown as Editor;
+    await waitFor(() => {
+      const { selection, doc } = editor.state;
+      expect(selection.empty).toBe(true);
+      expect(selection.from).toBe(doc.content.size - 1);
+    });
+  });
+
+  it("moves the caret to the end when the value is changed externally", async () => {
+    const ref = createRef<MetabotPromptInputRef>();
+    const { rerender } = setup({ ref, value: "" });
+
+    rerender(
+      <MetabotPromptInput
+        {...defaultProps}
+        ref={ref}
+        value="Create a transform that "
+        autoFocus
+      />,
+    );
+
+    // The imperative handle is `Object.assign(editor, …)`, so `ref.current` is the
+    // underlying tiptap Editor at runtime; the public ref type just narrows it.
+    const editor = ref.current as unknown as Editor;
+    await waitFor(() => {
+      const { selection, doc } = editor.state;
+      expect(selection.from).toBe(doc.content.size - 1);
+    });
   });
 
   it("should close mention popup if {escape} is pressed", async () => {

--- a/frontend/src/metabase/transforms/analytics.ts
+++ b/frontend/src/metabase/transforms/analytics.ts
@@ -35,7 +35,7 @@ export function trackTransformJobTriggerManualRun({
 export function trackTransformCreate({
   creationType,
 }: {
-  creationType: "query" | "native" | "python" | "saved-question";
+  creationType: "query" | "native" | "python" | "saved-question" | "metabot";
 }) {
   trackSimpleEvent({
     event: "transform_create",

--- a/frontend/src/metabase/transforms/pages/TransformListPage/CreateTransformMenu/CreateTransformMenu.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformListPage/CreateTransformMenu/CreateTransformMenu.tsx
@@ -53,7 +53,6 @@ export const CreateTransformMenu = () => {
     trackTransformCreate({ creationType: "metabot" });
     metabot.setPrompt(t`Create a transform that `);
     metabot.setVisible(true);
-    metabot.promptInputRef?.current?.focus();
   };
 
   const handlePythonClick = () => {

--- a/frontend/src/metabase/transforms/pages/TransformListPage/CreateTransformMenu/CreateTransformMenu.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformListPage/CreateTransformMenu/CreateTransformMenu.tsx
@@ -5,6 +5,11 @@ import { useListDatabasesQuery } from "metabase/api";
 import { QuestionPickerModal } from "metabase/common/components/Pickers";
 import { UpsellGem } from "metabase/common/components/upsells/components/UpsellGem";
 import { useHasTokenFeature } from "metabase/common/hooks";
+import {
+  useMetabotAgent,
+  useMetabotName,
+  useUserMetabotPermissions,
+} from "metabase/metabot/hooks";
 import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
 import { useDispatch, useSelector } from "metabase/redux";
 import { push } from "metabase/router";
@@ -39,6 +44,17 @@ export const CreateTransformMenu = () => {
   const isRemoteSyncReadOnly = useSelector(
     PLUGIN_REMOTE_SYNC.getIsRemoteSyncReadOnly,
   );
+
+  const metabot = useMetabotAgent("omnibot");
+  const metabotName = useMetabotName();
+  const { hasMetabotAccess } = useUserMetabotPermissions();
+
+  const handleMetabotClick = () => {
+    trackTransformCreate({ creationType: "metabot" });
+    metabot.setPrompt(t`Create a transform that `);
+    metabot.setVisible(true);
+    metabot.promptInputRef?.current?.focus();
+  };
 
   const handlePythonClick = () => {
     dispatch(push(Urls.newPythonTransform())); // Route will show upsell modal if feature is not enabled
@@ -85,6 +101,14 @@ export const CreateTransformMenu = () => {
           ) : (
             <>
               <Menu.Label>{t`Create your transform with…`}</Menu.Label>
+              {hasMetabotAccess && (
+                <Menu.Item
+                  leftSection={<Icon name="metabot" />}
+                  onClick={handleMetabotClick}
+                >
+                  {metabotName}
+                </Menu.Item>
+              )}
               <Menu.Item
                 leftSection={<Icon name="notebook" />}
                 onClick={() => {

--- a/frontend/src/metabase/transforms/pages/TransformListPage/CreateTransformMenu/CreateTransformMenu.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformListPage/CreateTransformMenu/CreateTransformMenu.unit.spec.tsx
@@ -14,7 +14,6 @@ import { CreateTransformMenu } from "./CreateTransformMenu";
 
 const mockSetPrompt = jest.fn();
 const mockSetVisible = jest.fn();
-const mockFocus = jest.fn();
 
 jest.mock("../../../analytics", () => ({
   ...jest.requireActual("../../../analytics"),
@@ -42,7 +41,6 @@ function setup({
   jest.mocked(useMetabotAgent).mockReturnValue({
     setPrompt: mockSetPrompt,
     setVisible: mockSetVisible,
-    promptInputRef: { current: { focus: mockFocus } },
   } as unknown as ReturnType<typeof useMetabotAgent>);
 
   return renderWithProviders(<CreateTransformMenu />);
@@ -86,6 +84,5 @@ describe("CreateTransformMenu", () => {
     });
     expect(mockSetPrompt).toHaveBeenCalledWith("Create a transform that ");
     expect(mockSetVisible).toHaveBeenCalledWith(true);
-    expect(mockFocus).toHaveBeenCalled();
   });
 });

--- a/frontend/src/metabase/transforms/pages/TransformListPage/CreateTransformMenu/CreateTransformMenu.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformListPage/CreateTransformMenu/CreateTransformMenu.unit.spec.tsx
@@ -1,0 +1,91 @@
+import userEvent from "@testing-library/user-event";
+
+import { setupDatabaseListEndpoint } from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import {
+  useMetabotAgent,
+  useMetabotName,
+  useUserMetabotPermissions,
+} from "metabase/metabot/hooks";
+
+import { trackTransformCreate } from "../../../analytics";
+
+import { CreateTransformMenu } from "./CreateTransformMenu";
+
+const mockSetPrompt = jest.fn();
+const mockSetVisible = jest.fn();
+const mockFocus = jest.fn();
+
+jest.mock("../../../analytics", () => ({
+  ...jest.requireActual("../../../analytics"),
+  trackTransformCreate: jest.fn(),
+}));
+
+jest.mock("metabase/metabot/hooks", () => ({
+  ...jest.requireActual("metabase/metabot/hooks"),
+  useMetabotAgent: jest.fn(),
+  useMetabotName: jest.fn(),
+  useUserMetabotPermissions: jest.fn(),
+}));
+
+function setup({
+  hasMetabotAccess = true,
+}: { hasMetabotAccess?: boolean } = {}) {
+  setupDatabaseListEndpoint([]);
+
+  jest.mocked(useMetabotName).mockReturnValue("Metabot");
+  // The menu only reads `hasMetabotAccess`; casting avoids stubbing every permission flag.
+  jest.mocked(useUserMetabotPermissions).mockReturnValue({
+    hasMetabotAccess,
+  } as ReturnType<typeof useUserMetabotPermissions>);
+  // The menu only calls these three members of the agent hook.
+  jest.mocked(useMetabotAgent).mockReturnValue({
+    setPrompt: mockSetPrompt,
+    setVisible: mockSetVisible,
+    promptInputRef: { current: { focus: mockFocus } },
+  } as unknown as ReturnType<typeof useMetabotAgent>);
+
+  return renderWithProviders(<CreateTransformMenu />);
+}
+
+async function openMenu() {
+  await userEvent.click(
+    screen.getByRole("button", { name: "Create a transform" }),
+  );
+}
+
+describe("CreateTransformMenu", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows the Metabot item as the first option when the user has Metabot access", async () => {
+    setup({ hasMetabotAccess: true });
+    await openMenu();
+
+    const items = await screen.findAllByRole("menuitem");
+    expect(items[0]).toHaveTextContent("Metabot");
+  });
+
+  it("hides the Metabot item when the user lacks Metabot access", async () => {
+    setup({ hasMetabotAccess: false });
+    await openMenu();
+
+    expect(await screen.findByText("SQL query")).toBeInTheDocument();
+    expect(screen.queryByText("Metabot")).not.toBeInTheDocument();
+  });
+
+  it("opens Metabot with a pre-seeded prompt when the Metabot item is clicked", async () => {
+    setup({ hasMetabotAccess: true });
+    await openMenu();
+
+    await userEvent.click(await screen.findByText("Metabot"));
+
+    expect(trackTransformCreate).toHaveBeenCalledWith({
+      creationType: "metabot",
+    });
+    expect(mockSetPrompt).toHaveBeenCalledWith("Create a transform that ");
+    expect(mockSetVisible).toHaveBeenCalledWith(true);
+    expect(mockFocus).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/metabase/transforms/pages/TransformListPage/CreateTransformMenu/CreateTransformMenu.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformListPage/CreateTransformMenu/CreateTransformMenu.unit.spec.tsx
@@ -1,72 +1,54 @@
 import userEvent from "@testing-library/user-event";
 
-import { setupDatabaseListEndpoint } from "__support__/server-mocks";
-import { renderWithProviders, screen } from "__support__/ui";
+import { mockSettings } from "__support__/settings";
+import { screen } from "__support__/ui";
+import { Metabot } from "metabase/metabot/components/Metabot";
+import { getMetabotInitialState } from "metabase/metabot/state/reducer-utils";
 import {
-  useMetabotAgent,
-  useMetabotName,
-  useUserMetabotPermissions,
-} from "metabase/metabot/hooks";
-
-import { trackTransformCreate } from "../../../analytics";
+  assertVisible as assertMetabotVisible,
+  input as metabotInput,
+  setup as setupMetabot,
+} from "metabase/metabot/tests/utils";
 
 import { CreateTransformMenu } from "./CreateTransformMenu";
 
-const mockSetPrompt = jest.fn();
-const mockSetVisible = jest.fn();
-
-jest.mock("../../../analytics", () => ({
-  ...jest.requireActual("../../../analytics"),
-  trackTransformCreate: jest.fn(),
-}));
-
-jest.mock("metabase/metabot/hooks", () => ({
-  ...jest.requireActual("metabase/metabot/hooks"),
-  useMetabotAgent: jest.fn(),
-  useMetabotName: jest.fn(),
-  useUserMetabotPermissions: jest.fn(),
-}));
-
 function setup({
-  hasMetabotAccess = true,
-}: { hasMetabotAccess?: boolean } = {}) {
-  setupDatabaseListEndpoint([]);
-
-  jest.mocked(useMetabotName).mockReturnValue("Metabot");
-  // The menu only reads `hasMetabotAccess`; casting avoids stubbing every permission flag.
-  jest.mocked(useUserMetabotPermissions).mockReturnValue({
-    hasMetabotAccess,
-  } as ReturnType<typeof useUserMetabotPermissions>);
-  // The menu only calls these three members of the agent hook.
-  jest.mocked(useMetabotAgent).mockReturnValue({
-    setPrompt: mockSetPrompt,
-    setVisible: mockSetVisible,
-  } as unknown as ReturnType<typeof useMetabotAgent>);
-
-  return renderWithProviders(<CreateTransformMenu />);
+  isMetabotEnabled = true,
+}: { isMetabotEnabled?: boolean } = {}) {
+  return setupMetabot({
+    ui: (
+      <>
+        <CreateTransformMenu />
+        <Metabot />
+      </>
+    ),
+    metabotInitialState: getMetabotInitialState(),
+    storeInitialState: {
+      settings: mockSettings({
+        "metabot-enabled?": isMetabotEnabled,
+        "llm-metabot-configured?": true,
+      }),
+    },
+  });
 }
 
 async function openMenu() {
   await userEvent.click(
-    screen.getByRole("button", { name: "Create a transform" }),
+    await screen.findByRole("button", { name: "Create a transform" }),
   );
 }
 
 describe("CreateTransformMenu", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it("shows the Metabot item as the first option when the user has Metabot access", async () => {
-    setup({ hasMetabotAccess: true });
+  it("shows the Metabot item as the first option when Metabot is available", async () => {
+    setup({ isMetabotEnabled: true });
     await openMenu();
 
     const items = await screen.findAllByRole("menuitem");
     expect(items[0]).toHaveTextContent("Metabot");
   });
 
-  it("hides the Metabot item when the user lacks Metabot access", async () => {
-    setup({ hasMetabotAccess: false });
+  it("hides the Metabot item when Metabot is disabled", async () => {
+    setup({ isMetabotEnabled: false });
     await openMenu();
 
     expect(await screen.findByText("SQL query")).toBeInTheDocument();
@@ -74,15 +56,12 @@ describe("CreateTransformMenu", () => {
   });
 
   it("opens Metabot with a pre-seeded prompt when the Metabot item is clicked", async () => {
-    setup({ hasMetabotAccess: true });
+    setup({ isMetabotEnabled: true });
     await openMenu();
 
     await userEvent.click(await screen.findByText("Metabot"));
 
-    expect(trackTransformCreate).toHaveBeenCalledWith({
-      creationType: "metabot",
-    });
-    expect(mockSetPrompt).toHaveBeenCalledWith("Create a transform that ");
-    expect(mockSetVisible).toHaveBeenCalledWith(true);
+    await assertMetabotVisible();
+    expect(await metabotInput()).toHaveTextContent("Create a transform that");
   });
 });


### PR DESCRIPTION
Closes [GDGT-1773](https://linear.app/metabase/issue/GDGT-1773)

### Description

Adds a **Metabot** entry (first option) to the Transforms "New" menu. It opens the Data Studio Metabot sidebar and pre-seeds `Create a transform that `.

Also changes editor behavior so a seeded prompt moves cursor to the end (previously it was at the start of input)

### How to verify

1. Connect an AI provider so Metabot is available (Admin → Settings → AI).
2. **Data Studio → Transforms → New** — **Metabot** is the first option; click it.
3. The sidebar opens with `Create a transform that ` pre-filled and the cursor at the **end**.
4. Finish the prompt and send — Metabot returns a transform suggestion to apply.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR