### PR TITLE
Fix failure in "Re-run Flaky Workflows" workflow

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -35,10 +35,6 @@ jobs:
       - name: Prepare release scripts
         uses: ./.github/actions/prepare-release-scripts
 
-      - uses: actions/setup-node@v6.4.0
-        with:
-          node-version: lts/Jod # 22.x.x
-      - run: npm install @slack/web-api
       - name: Trigger a re-run
         uses: actions/github-script@v9
         with:
@@ -51,8 +47,6 @@ jobs:
             const AUTHOR = process.env.AUTHOR_NAME;
             const AUTHOR_LOGIN = process.env.AUTHOR_LOGIN;
             const BRANCH = process.env.BRANCH_NAME;
-
-            const { mentionUserByGithubLogin } = require('${{ github.workspace }}/release/dist/index.cjs');
 
             if (ATTEMPT <= MAX_ATTEMPTS) {
               try {
@@ -70,8 +64,7 @@ jobs:
               }
             } else if (!BRANCH.includes('backport-')) {
               // notify slack of repeated failure
-              const { WebClient } = require('@slack/web-api');
-              const slack = new WebClient('${{ secrets.SLACK_BOT_TOKEN }}');
+              const { mentionUserByGithubLogin, sendSlackMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
 
               // find out which jobs failed
               const { owner, repo } = context.repo;
@@ -102,9 +95,9 @@ jobs:
                 ]
               }));
 
-              await slack.chat.postMessage({
-                channel: 'engineering-ci',
-                text: 'Failing tests',
+              await sendSlackMessage({
+                channelName: 'engineering-ci',
+                message: 'Failing tests',
                 blocks: [
                   {
                     "type": "header",

--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Trigger a re-run
         uses: actions/github-script@v9
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           script: | # js
             const MAX_ATTEMPTS = 1;

--- a/release/src/slack.ts
+++ b/release/src/slack.ts
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import fs from 'fs';
 
 import { WebClient } from '@slack/web-api';
+import type { Block, KnownBlock, MessageAttachment } from '@slack/web-api';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import fetch from 'node-fetch';
@@ -162,10 +163,17 @@ export async function sendPreReleaseStatus({
   });
 }
 
-export function sendSlackMessage({ channelName = SLACK_CHANNEL_NAME, message }: { channelName?: string, message: string }) {
+export function sendSlackMessage({ channelName = SLACK_CHANNEL_NAME, message, blocks, attachments }: {
+  channelName?: string,
+  message: string,
+  blocks?: (Block | KnownBlock)[],
+  attachments?: MessageAttachment[],
+}) {
   return slack.chat.postMessage({
     channel: channelName,
     text: message,
+    blocks,
+    attachments,
   });
 }
 


### PR DESCRIPTION
Looks like there is a conflict between npm install and bun install happening in the setup scripts action, decided to make a small update to `sendSlackMessage` helper so that it works for this use case and we can have all the Slack functionality coming from one place and avoid multiple install steps.

Example failure - https://github.com/metabase/metabase/actions/runs/29756220013/job/88399113322

Successful run (with a modified workflow to enable testing) - https://github.com/metabase/metabase/actions/runs/29762102967