### PR TITLE
Update user-visibility subtext

### DIFF
--- a/src/metabase/users/settings.clj
+++ b/src/metabase/users/settings.clj
@@ -136,7 +136,7 @@
   :default    [])
 
 (defsetting user-visibility
-  (deferred-tru "Note: Sandboxed users will never see suggestions.")
+  (deferred-tru "Note: Users with row or column security restrictions will never see suggestions.")
   :visibility   :authenticated
   :feature      :email-restrict-recipients
   :type         :keyword


### PR DESCRIPTION
### Description

Small copy update to the `user-visibility` setting in the admin panel

### How to verify

1. Admin -> Email (ensure that smtp is set up)
2. Check the text under "Suggest recipients on dashboard subscriptions and alerts

### Demo

<img width="874" height="531" alt="image" src="https://github.com/user-attachments/assets/9f14aca0-9fbc-459e-bae6-8b1938da6da0" />


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
