### PR TITLE
Chain the publish off of the auto-release, not the tag

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -157,3 +157,12 @@ jobs:
     with:
       version: ${{ needs.prepare.outputs.version }}
       commit: ${{ needs.prepare.outputs.commit }}
+
+  auto-publish-release:
+    name: Auto-publish release ${{ inputs.version }}
+    needs: [prepare, trigger-release]
+    uses: ./.github/workflows/release.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.prepare.outputs.version }}
+      commit: ${{ needs.prepare.outputs.commit }}

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -59,6 +59,10 @@ jobs:
             const majorVersion = Number('${{ inputs.version }}');
             const kind = '${{ inputs.kind }}';
 
+            if (github.repository !== 'metabase/metabase') {
+              throw new Error(`This workflow is only intended to run in the metabase/metabase repo, but is running in ${github.repository}`);
+            }
+
             if (Number.isNaN(majorVersion)) {
               throw new Error(`Invalid version number: ${{ inputs.version }}`);
             }

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - name: Check if running on a fork
         run: |
-          if ([ "${{ github.repository }}" != "metabase/metabase" ]); then
+          if [ "${{ github.repository }}" != "metabase/metabase" ]; then
             echo "This workflow should not run on forks."
             exit 1
           fi

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -34,6 +34,12 @@ jobs:
       commit: ${{ steps.compute.outputs.commit }}
       should_release: ${{ steps.compute.outputs.should_release }}
     steps:
+      - name: Check if running on a fork
+        run: |
+          if ([ "${{ github.repository }}" != "metabase/metabase" ]); then
+            echo "This workflow should not run on forks."
+            exit 1
+          fi
       - uses: actions/checkout@v6
         with:
           sparse-checkout: |
@@ -58,10 +64,6 @@ jobs:
 
             const majorVersion = Number('${{ inputs.version }}');
             const kind = '${{ inputs.kind }}';
-
-            if (github.repository !== 'metabase/metabase') {
-              throw new Error(`This workflow is only intended to run in the metabase/metabase repo, but is running in ${github.repository}`);
-            }
 
             if (Number.isNaN(majorVersion)) {
               throw new Error(`Invalid version number: ${{ inputs.version }}`);
@@ -129,7 +131,7 @@ jobs:
 
             core.setOutput('should_release', 'false');
       - name: Write job summary
-        if: always()
+        if: always() && github.repository == 'metabase/metabase'
         shell: bash
         run: |
           {

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -140,8 +140,8 @@ jobs:
       run: |
         RELEASE_BRANCH=${{ steps.release_branch.outputs.result }}
         git checkout $RELEASE_BRANCH
-        git branch --contains ${{ inputs.commit }} | grep -q $RELEASE_BRANCH \
-          && echo "Commit found in correct release branch" \
+        (git branch --contains ${{ inputs.commit }} | grep -q $RELEASE_BRANCH \
+          && echo "Commit found in correct release branch") \
           || (echo "Commit not found in correct release branch" && exit 1)
         git checkout -
 
@@ -196,7 +196,7 @@ jobs:
           version='${{ needs.check-version.outputs.oss }}'
         fi
 
-        echo "VERSION=$version" >> $GITHUB_ENV
+        echo "VERSION=$version" >> "$GITHUB_ENV"
     - name: Setup Java
       uses: actions/setup-java@v5.2.0
       with:
@@ -215,9 +215,9 @@ jobs:
         echo "Old version.properties:"
         cat version.properties
         sed -i "s/^tag=.*/tag=$VERSION/" version.properties
-        echo "\n\nNew version.properties:"
+        printf "\n\nNew version.properties:"
         cat version.properties
-        echo "\n\nUpdating metabase.jar with new version.properties"
+        printf "\n\nUpdating metabase.jar with new version.properties"
         jar uf metabase.jar version.properties
 
     - name: Store commit's SHA-1 hash

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -280,12 +280,3 @@ jobs:
     with:
       commit: ${{ inputs.commit }}
       version: ${{ inputs.version }}
-
-  auto-publish-release:
-    name: Auto-publish release ${{ inputs.version }}
-    needs: run-pre-release-tests
-    uses: ./.github/workflows/release.yml
-    secrets: inherit
-    with:
-      version: ${{ inputs.version }}
-      commit: ${{ inputs.commit }}


### PR DESCRIPTION
We want the ability to tag and test a release artifact without publishing it.

This moves the auto-publish job to the `release-auto` workflow and removes it from the `tag-for-release` workflow.

So the normal flow will be
- auto release
  - tag release
    - test release
  - publish release

But we can also do it manually so that we can
- tag release
  - test release
- publish release

Which restores our ability to let us pause after tag + test if we want. 

This also disables auto-release on forks where it probably won't work anyway