### PR TITLE
Justify the grandfathered kondo ignores

### DIFF
--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -15,7 +15,7 @@
                   :deprecated-var                                                      86
                   :discouraged-java-method                                             4
                   :discouraged-namespace                                               81
-                  :discouraged-var                                                     134
+                  :discouraged-var                                                     132
                   :duplicate-require                                                   1
                   :equals-true                                                         1
                   :main-without-gen-class                                              1
@@ -70,41 +70,12 @@
                   :unresolved-symbol                       19
                   :unresolved-var                          1
                   :unused-referred-var                     4}
- :comment-exempt #{:aliased-namespace-symbol
-                   :case-symbol-test
-                   :clojure-lsp/unused-public-var
-                   :def-fn
-                   :deprecated-namespace
-                   :deprecated-var
-                   :discouraged-java-method
+ :comment-exempt #{:deprecated-namespace
                    :discouraged-namespace
                    :discouraged-var
-                   :duplicate-require
-                   :equals-true
-                   :metabase/defsetting-namespace
-                   :metabase/discourage-millis-duration
-                   :metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests
                    :metabase/modules
-                   :metabase/namespace-name
-                   :metabase/prefer-with-dynamic-fn-redefs
-                   :metabase/test-helpers-use-non-thread-safe-functions
                    :metabase/validate-defendpoint-has-response-schema
                    :metabase/validate-defendpoint-query-params-use-kebab-case
                    :metabase/validate-defendpoint-route-uses-kebab-case
-                   :metabase/validate-deftest
-                   :missing-docstring
-                   :missing-protocol-method
-                   :reduce-without-init
-                   :redundant-do
-                   :syntax
-                   :type-mismatch
-                   :unquote-not-syntax-quoted
-                   :unresolved-namespace
-                   :unresolved-require
-                   :unresolved-symbol
-                   :unused-alias
-                   :unused-binding
                    :unused-excluded-var
-                   :unused-namespace
-                   :unused-private-var
-                   :unused-value}}
+                   :unused-private-var}}

--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -23,7 +23,7 @@
                   :metabase/disallow-hardcoded-driver-names-in-tests                   34
                   :metabase/discourage-millis-duration                                 1
                   :metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests 13
-                  :metabase/modules                                                    9
+                  :metabase/modules                                                    10
                   :metabase/namespace-name                                             4
                   :metabase/prefer-with-dynamic-fn-redefs                              28
                   :metabase/test-helpers-use-non-thread-safe-functions                 18

--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -6,7 +6,7 @@
 ;; automatically. Raising a budget, adding one (`--seed` for inline, by hand for config), or
 ;; widening the exemptions is a hand edit to defend in your PR.
 ;; :all is the vector-less ignore form, which suppresses every linter on the next form.
-{:ignore-counts  {:aliased-namespace-symbol                                            5
+{:ignore-counts  {:aliased-namespace-symbol                                            3
                   :case-symbol-test                                                    1
                   :clojure-lsp/unused-public-var                                       9
                   :consistent-alias                                                    2
@@ -40,7 +40,7 @@
                   :type-mismatch                                                       8
                   :uninitialized-var                                                   1
                   :unquote-not-syntax-quoted                                           1
-                  :unresolved-namespace                                                8
+                  :unresolved-namespace                                                3
                   :unresolved-require                                                  1
                   :unresolved-symbol                                                   11
                   :unsorted-required-namespaces                                        1

--- a/.clj-kondo/src/hooks/metabase/settings/models/setting.clj
+++ b/.clj-kondo/src/hooks/metabase/settings/models/setting.clj
@@ -286,6 +286,7 @@
     (update context :node update-node)))
 
 (comment
+  (require '[clojure.pprint])
   (defn- defsetting* [form]
     (hooks/sexpr
      (:node
@@ -293,7 +294,6 @@
         {:node
          (hooks/parse-string
           (with-out-str
-            #_{:clj-kondo/ignore [:unresolved-namespace]}
             (clojure.pprint/pprint
              form)))}))))
 

--- a/bin/build/src/i18n/create_artifacts/frontend.clj
+++ b/bin/build/src/i18n/create_artifacts/frontend.clj
@@ -1,5 +1,6 @@
 (ns i18n.create-artifacts.frontend
   (:require
+   ;; build tooling never loads app namespaces, so the metabase.util.json facade isn't usable here
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [cheshire.core :as json]
    [clojure.java.io :as io]

--- a/bin/lint-migrations-file/src/column/common.clj
+++ b/bin/lint-migrations-file/src/column/common.clj
@@ -7,6 +7,7 @@
 (s/def ::remarks string?)
 
 (s/def :column.common.constraints/onDelete
+  ;; the bare string is an intentional in-body note explaining why onDelete is always rejected
   #_{:clj-kondo/ignore [:unused-value]}
   (fn [_]
     "Don't try to use onDelete in constraints! onDelete is only for addForeignKeyConstraints. Use deleteCascade!"

--- a/bin/lint-migrations-file/src/lint_migrations_file.cljc
+++ b/bin/lint-migrations-file/src/lint_migrations_file.cljc
@@ -1,5 +1,6 @@
 (ns lint-migrations-file
   "This is cljc because it is used from both Clojure (:clj) and Babashka (:bb). Not cljs!"
+  ;; kondo also lints cljc as cljs, where the :bb/:clj conditional below hides the only io usage
   #_{:clj-kondo/ignore [:unused-alias :unused-namespace]}
   (:require
    [change-set.strict]

--- a/bin/lint-migrations-file/src/lint_migrations_file.cljc
+++ b/bin/lint-migrations-file/src/lint_migrations_file.cljc
@@ -337,6 +337,7 @@
   :ok)
 
 (defn- migration-files []
+  ;; kondo can't parse the :bb reader-conditional branch and mangles the surrounding let
   #_{:clj-kondo/ignore [:unresolved-symbol :unused-binding :syntax]}
   (let [dir-str #?(:bb "resources/migrations" :clj "../../resources/migrations")
         dir (io/file dir-str)]

--- a/bin/lint-migrations-file/src/lint_migrations_file.cljc
+++ b/bin/lint-migrations-file/src/lint_migrations_file.cljc
@@ -15,7 +15,7 @@
    (java.lang Integer)))
 
 ;; kondo also lints a :cljs branch where this doesn't resolve; the file is :clj + :bb only
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (set! *warn-on-reflection* true)
 
 (comment change-set.strict/keep-me)
@@ -154,7 +154,7 @@
                                 seq)]
      (throw (validation-error
              ;; false unresolved-symbol from kondo's :cljs pass; this cljc is :clj+:bb only
-             #_:clj-kondo/ignore
+             #_{:clj-kondo/ignore [:unresolved-symbol]}
              (format "Migration(s) [%s] uses invalid types (in %s)"
                      (str/join "," (map #(str "'" % "'") using-types?))
                      (str/join "," (map #(str "'" % "'") target-types)))
@@ -363,7 +363,7 @@
                   :else x))]
     (fix-vals (yaml/parse-string
                ;; false unresolved-symbol from kondo's :cljs pass; this cljc is :clj+:bb only
-               #_:clj-kondo/ignore (slurp file)))))
+               #_{:clj-kondo/ignore [:unresolved-symbol]} (slurp file)))))
 
 (defn- display-name
   "Returns a human-readable name for a migration file.
@@ -392,14 +392,14 @@
     (validate-all)
     (println "Ok.")
     ;; false unresolved warning from kondo's :cljs pass; this cljc is :clj+:bb only
-    #_:clj-kondo/ignore
+    #_{:clj-kondo/ignore [:unresolved-namespace]}
     (System/exit 0)
     (catch ExceptionInfo e
       (if (validation-error? e)
         (do
           (println)
           ;; false unresolved-symbol from kondo's :cljs pass; this cljc is :clj+:bb only
-          #_:clj-kondo/ignore
+          #_{:clj-kondo/ignore [:unresolved-symbol]}
           (printf "Error in %s:\t%s\n" (:file (ex-data e)) (.getMessage e))
           (printf "Details:\n\n %s" (with-out-str (pprint/pprint (dissoc (ex-data e) ::validation-error))))
           (println))
@@ -408,7 +408,7 @@
           (println (.getMessage e))))
       (System/exit 1))
     ;; false unresolved-symbol from kondo's :cljs pass; this cljc is :clj+:bb only
-    (catch #_:clj-kondo/ignore
+    (catch #_{:clj-kondo/ignore [:unresolved-symbol]}
      Throwable e
            (pprint/pprint (Throwable->map e))
            (println (.getMessage e))

--- a/bin/lint-migrations-file/src/lint_migrations_file.cljc
+++ b/bin/lint-migrations-file/src/lint_migrations_file.cljc
@@ -14,7 +14,8 @@
    (clojure.lang ExceptionInfo)
    (java.lang Integer)))
 
-#_{:clj-kondo/ignore [:unresolved-symbol]}
+;; kondo also lints a :cljs branch where this doesn't resolve; the file is :clj + :bb only
+#_:clj-kondo/ignore
 (set! *warn-on-reflection* true)
 
 (comment change-set.strict/keep-me)
@@ -152,7 +153,8 @@
                                 (map #(get-in % [:changeSet :id]))
                                 seq)]
      (throw (validation-error
-             #_{:clj-kondo/ignore [:unresolved-symbol]}
+             ;; false unresolved-symbol from kondo's :cljs pass; this cljc is :clj+:bb only
+             #_:clj-kondo/ignore
              (format "Migration(s) [%s] uses invalid types (in %s)"
                      (str/join "," (map #(str "'" % "'") using-types?))
                      (str/join "," (map #(str "'" % "'") target-types)))
@@ -360,7 +362,8 @@
                   (sequential? x) (mapv fix-vals x)
                   :else x))]
     (fix-vals (yaml/parse-string
-               #_{:clj-kondo/ignore [:unresolved-symbol]} (slurp file)))))
+               ;; false unresolved-symbol from kondo's :cljs pass; this cljc is :clj+:bb only
+               #_:clj-kondo/ignore (slurp file)))))
 
 (defn- display-name
   "Returns a human-readable name for a migration file.
@@ -388,13 +391,15 @@
   (try
     (validate-all)
     (println "Ok.")
-    #_{:clj-kondo/ignore [:unresolved-namespace]}
+    ;; false unresolved warning from kondo's :cljs pass; this cljc is :clj+:bb only
+    #_:clj-kondo/ignore
     (System/exit 0)
     (catch ExceptionInfo e
       (if (validation-error? e)
         (do
           (println)
-          #_{:clj-kondo/ignore [:unresolved-symbol]}
+          ;; false unresolved-symbol from kondo's :cljs pass; this cljc is :clj+:bb only
+          #_:clj-kondo/ignore
           (printf "Error in %s:\t%s\n" (:file (ex-data e)) (.getMessage e))
           (printf "Details:\n\n %s" (with-out-str (pprint/pprint (dissoc (ex-data e) ::validation-error))))
           (println))
@@ -402,7 +407,8 @@
           (pprint/pprint (Throwable->map e))
           (println (.getMessage e))))
       (System/exit 1))
-    (catch #_{:clj-kondo/ignore [:unresolved-symbol]}
+    ;; false unresolved-symbol from kondo's :cljs pass; this cljc is :clj+:bb only
+    (catch #_:clj-kondo/ignore
      Throwable e
            (pprint/pprint (Throwable->map e))
            (println (.getMessage e))

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -104,7 +104,8 @@
 
 (apply require clojure.main/repl-requires)
 
-#_{:clj-kondo/ignore [:discouraged-var :missing-docstring]}
+;; REPL spy helper; tap> is the point
+#_:clj-kondo/ignore
 (defn tap>-spy [x]
   (doto x tap>))
 
@@ -391,7 +392,8 @@
   [form]
   (hashp/p* form))
 
-#_{:clj-kondo/ignore [:discouraged-var]}
+;; pipeline tap helper; calling tap> is the point
+#_:clj-kondo/ignore
 (defn tap
   "#tap, but to use in pipelines like `(-> 1 inc dev/tap prn inc)`."
   [form]

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -105,7 +105,7 @@
 (apply require clojure.main/repl-requires)
 
 ;; REPL spy helper; tap> is the point
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:discouraged-var :missing-docstring]}
 (defn tap>-spy [x]
   (doto x tap>))
 
@@ -393,7 +393,7 @@
   (hashp/p* form))
 
 ;; pipeline tap helper; calling tap> is the point
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:discouraged-var]}
 (defn tap
   "#tap, but to use in pipelines like `(-> 1 inc dev/tap prn inc)`."
   [form]

--- a/dev/src/dev/debug_qp.clj
+++ b/dev/src/dev/debug_qp.clj
@@ -398,6 +398,7 @@
   ([sql]
    (pprint-sql (mdb/db-type) sql))
   ([driver sql]
+   ;; dev REPL helper; pretty SQL goes to the console for a human
    #_{:clj-kondo/ignore [:discouraged-var]}
    (println (driver/prettify-native-form driver sql))))
 
@@ -429,5 +430,6 @@
      (stop-portal!)
      (reset! portal (portal.api/start config))
      (add-tap #'portal.api/submit)
+     ;; dev REPL feedback; the startup notice goes to the console
      #_{:clj-kondo/ignore [:discouraged-var]}
      (printf "Started Portal on port %d.\n" (:port config)))))

--- a/dev/src/dev/deps_graph.clj
+++ b/dev/src/dev/deps_graph.clj
@@ -564,6 +564,7 @@
   (let [deps        (dependencies)
         all-modules (into (sorted-set) (map :module) deps)
         module-deps (set (keys (all-module-deps-paths deps module)))]
+    ;; dev REPL tool; the summary line is for the human at the console
     #_{:clj-kondo/ignore [:discouraged-var]}
     (printf "Module %s depends on %d/%d (%.1f%%) other modules.\n"
             module

--- a/dev/src/dev/migrate.clj
+++ b/dev/src/dev/migrate.clj
@@ -43,6 +43,7 @@
   ;; do we really use this in dev?
   ([direction & [version]]
    (mdb/migrate! (mdb/data-source) direction version)
+   ;; dev migration CLI; status goes to stdout for the human running it
    #_{:clj-kondo/ignore [:discouraged-var]}
    (println (format "Migrated %s. Latest migration: %s" (name direction) (latest-migration)))))
 
@@ -117,6 +118,7 @@
    (let [n (case (keyword k)
              :last-deployment (last-deployment))]
      (rollback-n-migrations! n)
+     ;; dev migration CLI; status goes to stdout for the human running it
      #_{:clj-kondo/ignore [:discouraged-var]}
      (println (format "Rollbacked %d migrations. Latest migration: %s" n (latest-migration)))))
 
@@ -126,12 +128,14 @@
              :id               (migration-since target)
              :count            (maybe-parse-long target))]
      (rollback-n-migrations! n)
+     ;; dev migration CLI; status goes to stdout for the human running it
      #_{:clj-kondo/ignore [:discouraged-var]}
      (println (format "Rollbacked %d migrations. Latest migration: %s" n (latest-migration))))))
 
 (defn migration-status
   "Print the latest migration ID."
   []
+  ;; dev migration CLI; status goes to stdout for the human running it
   #_{:clj-kondo/ignore [:discouraged-var]}
   (println "Current migration:" (latest-migration)))
 

--- a/dev/src/dev/modules_config.clj
+++ b/dev/src/dev/modules_config.clj
@@ -288,14 +288,17 @@
   []
   (let [original                (slurp config-path)
         {:keys [text warnings]} (rewrite-config original (compute-desired))]
+    ;; CLI tool output: mage fix-modules-config callers read these lines from stdout
     #_{:clj-kondo/ignore [:discouraged-var]}
     (doseq [w warnings]
       (println (str "WARNING: " w)))
     (if (= text original)
+      ;; CLI tool output: mage fix-modules-config callers read these lines from stdout
       (do #_{:clj-kondo/ignore [:discouraged-var]}
        (println "config.edn already up to date.")
           :unchanged)
       (do (spit config-path text)
+          ;; CLI tool output: mage fix-modules-config callers read these lines from stdout
           #_{:clj-kondo/ignore [:discouraged-var]}
           (println "Updated" config-path)
           :updated))))

--- a/dev/src/dev/portal.clj
+++ b/dev/src/dev/portal.clj
@@ -35,6 +35,7 @@
                 line   -1
                 column -1
                 time   (java.util.Date.)}}]
+   ;; tap> is how values reach Portal; that's this helper's whole job
    #_{:clj-kondo/ignore [:discouraged-var]}
    (tap> {:result value
           :level  level
@@ -75,6 +76,7 @@
 (defmacro diff->
   "Drop-in replacement for `->` that sends diffs to Portal at each stage."
   [x & forms]
+  ;; the expansion taps each stage to Portal; tap> is the delivery mechanism
   #_{:clj-kondo/ignore [:discouraged-var]}
   (loop [x x, forms forms]
     (if forms

--- a/dev/src/dev/private_things_test.clj
+++ b/dev/src/dev/private_things_test.clj
@@ -73,10 +73,10 @@
 
   (privatize-symbol! symb+analysis))
 
-;; entry point for the privacy-reporter.yml GitHub action, not referenced from code
+;; standalone dev utility for ad hoc privacy audits, with no in-tree caller
 #_{:clj-kondo/ignore [:unused-private-var]}
 (defn- privacy-report
-  "Writes privacy report into a file, which is used by the privacy-reporter.yml github action."
+  "Write the privacy report to a file for ad hoc inspection."
   [& _args]
   (when-let [ttsbp (things-that-should-be-private)]
     (spit "privacy_report.txt"

--- a/dev/src/dev/private_things_test.clj
+++ b/dev/src/dev/private_things_test.clj
@@ -73,6 +73,7 @@
 
   (privatize-symbol! symb+analysis))
 
+;; entry point for the privacy-reporter.yml GitHub action, not referenced from code
 #_{:clj-kondo/ignore [:unused-private-var]}
 (defn- privacy-report
   "Writes privacy report into a file, which is used by the privacy-reporter.yml github action."

--- a/dev/src/dev/reload.clj
+++ b/dev/src/dev/reload.clj
@@ -10,7 +10,7 @@
 (set! *warn-on-reflection* true)
 
 ;; internal dev-reload state, not an API
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:missing-docstring]}
 (defonce *reload-timestamps (atom {}))
 
 (defn system-classpath

--- a/dev/src/dev/reload.clj
+++ b/dev/src/dev/reload.clj
@@ -9,7 +9,8 @@
 
 (set! *warn-on-reflection* true)
 
-#_{:clj-kondo/ignore [:missing-docstring]}
+;; internal dev-reload state, not an API
+#_:clj-kondo/ignore
 (defonce *reload-timestamps (atom {}))
 
 (defn system-classpath

--- a/dev/src/dev/toucan2_monitor.clj
+++ b/dev/src/dev/toucan2_monitor.clj
@@ -151,5 +151,5 @@
   (to-csv!)
   (doseq [q (querles)]
     ;; REPL scratch; stdout is the point
-    #_:clj-kondo/ignore
+    #_{:clj-kondo/ignore [:discouraged-var]}
     (println q)))

--- a/dev/src/dev/toucan2_monitor.clj
+++ b/dev/src/dev/toucan2_monitor.clj
@@ -150,5 +150,6 @@
   (summary)
   (to-csv!)
   (doseq [q (querles)]
-    #_{:clj-kondo/ignore [:discouraged-var]}
+    ;; REPL scratch; stdout is the point
+    #_:clj-kondo/ignore
     (println q)))

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -111,7 +111,7 @@
        rest ; First file in the enumeration will be this file, so skip it.
        (run! #(do
                 ;; bootstrap chatter on stdout; logging isn't configured this early
-                #_:clj-kondo/ignore
+                #_{:clj-kondo/ignore [:discouraged-var]}
                 (println "Loading" (str %))
                 (clojure.lang.Compiler/load (io/reader %))))))
 
@@ -169,7 +169,7 @@
   (let [{:keys [help hot port]} (:options (cli/parse-opts args cli-spec))]
     (when help
       ;; CLI help text belongs on stdout
-      #_:clj-kondo/ignore
+      #_{:clj-kondo/ignore [:discouraged-var :redundant-do]}
       (do
         (println "Usage: clj -M:dev:dev-start:drivers:drivers-dev:ee:ee-dev [options]")
         (println "Options:")
@@ -177,12 +177,12 @@
       (System/exit 0))
     (when hot
       ;; CLI startup message belongs on stdout
-      #_:clj-kondo/ignore
+      #_{:clj-kondo/ignore [:discouraged-var]}
       (println "Enabling hot reloading of code. Backend code will reload on every request.")
       (alter-var-root #'*enable-hot-reload* (constantly true)))
     (future
       ;; CLI startup message belongs on stdout
-      #_:clj-kondo/ignore
+      #_{:clj-kondo/ignore [:discouraged-var]}
       (println "Starting Metabase cider repl on port" port)
       (spit ".nrepl-port" port)
       (nrepl-server/start-server

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -110,7 +110,8 @@
        enumeration-seq
        rest ; First file in the enumeration will be this file, so skip it.
        (run! #(do
-                #_{:clj-kondo/ignore [:discouraged-var]}
+                ;; bootstrap chatter on stdout; logging isn't configured this early
+                #_:clj-kondo/ignore
                 (println "Loading" (str %))
                 (clojure.lang.Compiler/load (io/reader %))))))
 
@@ -167,18 +168,21 @@
   [& args]
   (let [{:keys [help hot port]} (:options (cli/parse-opts args cli-spec))]
     (when help
-      #_{:clj-kondo/ignore [:discouraged-var :redundant-do]}
+      ;; CLI help text belongs on stdout
+      #_:clj-kondo/ignore
       (do
         (println "Usage: clj -M:dev:dev-start:drivers:drivers-dev:ee:ee-dev [options]")
         (println "Options:")
         (println (:summary (cli/parse-opts [] cli-spec))))
       (System/exit 0))
     (when hot
-      #_{:clj-kondo/ignore [:discouraged-var]}
+      ;; CLI startup message belongs on stdout
+      #_:clj-kondo/ignore
       (println "Enabling hot reloading of code. Backend code will reload on every request.")
       (alter-var-root #'*enable-hot-reload* (constantly true)))
     (future
-      #_{:clj-kondo/ignore [:discouraged-var]}
+      ;; CLI startup message belongs on stdout
+      #_:clj-kondo/ignore
       (println "Starting Metabase cider repl on port" port)
       (spit ".nrepl-port" port)
       (nrepl-server/start-server

--- a/enterprise/backend/src/metabase_enterprise/api/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/api/core.clj
@@ -5,6 +5,7 @@
 
 (comment metabase-enterprise.api.routes.common/keep-me)
 
+;; module facade must keep re-exporting +when-premium-feature while route-swapping callers remain
 #_{:clj-kondo/ignore [:deprecated-var]}
 (p/import-vars
  [metabase-enterprise.api.routes.common

--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/common.clj
@@ -85,6 +85,7 @@
   (mdb/memoize-for-application-db
    (memoize/ttl
     (fn []
+      ;; the JDBC-spec variant works on the app-db datasource without building a driver connection pool
       #_{:clj-kondo/ignore [:deprecated-var]}
       (sql-jdbc.sync/db-default-timezone (mdb/db-type) {:datasource (mdb/app-db)}))
     :ttl/threshold (u/hours->ms 1))))

--- a/enterprise/backend/src/metabase_enterprise/data_complexity_score/cli.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_complexity_score/cli.clj
@@ -45,6 +45,7 @@
 
 (set! *warn-on-reflection* true)
 
+;; CLI entry point: stdout/stderr is the user interface
 #_{:clj-kondo/ignore [:discouraged-var]}
 (def ^:private output!
   "Alias for println so the lint suppression stays in one place."

--- a/enterprise/backend/src/metabase_enterprise/dependencies/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/core.clj
@@ -142,6 +142,7 @@
                        (merge errors)))
                  {} by-db))))))
 
+;; REPL comment block calls metabase.premium-features.core without a ns require
 #_{:clj-kondo/ignore [:unresolved-namespace]}
 (comment
   ;; This should work on any fresh-ish Metabase instance; these are the built-in example questions.

--- a/enterprise/backend/src/metabase_enterprise/dependencies/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/core.clj
@@ -142,9 +142,8 @@
                        (merge errors)))
                  {} by-db))))))
 
-;; REPL comment block calls metabase.premium-features.core without a ns require
-#_{:clj-kondo/ignore [:unresolved-namespace]}
 (comment
+  (require '[metabase.premium-features.core])
   ;; This should work on any fresh-ish Metabase instance; these are the built-in example questions.
   (let [base-mp (lib-be/application-database-metadata-provider 39)
         transform (lib.metadata/transform base-mp 1)

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/routes.clj
@@ -32,5 +32,6 @@
   is not enabled, this passes thru to the OSS implementation of the endpoint."
   (->> (api.macros/ns-handler 'metabase-enterprise.sandbox.api.table)
        +auth
+       ;; sandboxing swaps out the OSS table endpoint; +when-premium-feature is the only swap mechanism
        #_{:clj-kondo/ignore [:deprecated-var]}
        (ee.api/+when-premium-feature :sandboxes)))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
@@ -33,6 +33,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.match :as match]
+   ;; caches inferred result_metadata onto the sandbox Card row; a write the metadata provider can't do
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/db/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/db/util.clj
@@ -7,6 +7,7 @@
 (defn tx-or-throw!
   "Throw if not in transaction."
   [conn]
+  ;; checks the pgvector conn, not the app DB; app-db in-transaction? only tracks app-db tx depth
   (when-not #_{:clj-kondo/ignore [:discouraged-var]} (jdbc/active-tx? (.unwrap ^java.sql.Connection conn java.sql.Connection))
             (throw (Exception. "Not in transaction."))))
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -1416,7 +1416,7 @@
   (query-index db index {:search-string "Copper knife"})
 
   ;; REPL scratch; metabase.test is off-limits to this module's real code
-  #_:clj-kondo/ignore
+  #_{:clj-kondo/ignore [:metabase/modules]}
   (require '[metabase.test :as mt])
   (mt/with-test-user :crowberto
     (doall (query-index db index {:search-string "Copper knife"}))))
@@ -1469,14 +1469,14 @@
   ;; only be realized in memory once a thread is available.
   (defn process-batch [batch]
     ;; REPL scratch; println shows batch progress on stdout
-    #_:clj-kondo/ignore
+    #_{:clj-kondo/ignore [:discouraged-var]}
     (println "Processing batch starting with " (first batch))
     (Thread/sleep 2000)
     {:count (count batch)})
 
   (defn logging-range [n]
     ;; REPL scratch; println shows lazy realization on stdout
-    #_:clj-kondo/ignore
+    #_{:clj-kondo/ignore [:discouraged-var]}
     (map #(do (println "Realizing item" %) %)
          (range n)))
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -1415,7 +1415,8 @@
   ;; no user
   (query-index db index {:search-string "Copper knife"})
 
-  #_{:clj-kondo/ignore [:metabase/modules]}
+  ;; REPL scratch; metabase.test is off-limits to this module's real code
+  #_:clj-kondo/ignore
   (require '[metabase.test :as mt])
   (mt/with-test-user :crowberto
     (doall (query-index db index {:search-string "Copper knife"}))))
@@ -1467,13 +1468,15 @@
   ;; Code to test the custom thread pool. The transduction should process batches in parallel and new batches should
   ;; only be realized in memory once a thread is available.
   (defn process-batch [batch]
-    #_{:clj-kondo/ignore [:discouraged-var]}
+    ;; REPL scratch; println shows batch progress on stdout
+    #_:clj-kondo/ignore
     (println "Processing batch starting with " (first batch))
     (Thread/sleep 2000)
     {:count (count batch)})
 
   (defn logging-range [n]
-    #_{:clj-kondo/ignore [:discouraged-var]}
+    ;; REPL scratch; println shows lazy realization on stdout
+    #_:clj-kondo/ignore
     (map #(do (println "Realizing item" %) %)
          (range n)))
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/pgvector_api.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/pgvector_api.clj
@@ -203,6 +203,7 @@
   (let [{:keys [index]} (ensure-active-index-state pgvector index-metadata)]
     (semantic.index/delete-from-index! pgvector index model ids)))
 
+;; REPL-only requires in the comment block; metabase.test also crosses the module boundary
 #_{:clj-kondo/ignore [:unresolved-require :metabase/modules]}
 (comment
   (init-semantic-search! pgvector index-metadata embedding-model)

--- a/enterprise/backend/test/metabase_enterprise/cache/config_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/config_test.clj
@@ -103,6 +103,7 @@
                       deleted?        (fn [{id :id}]
                                         (not (t2/exists? :model/PersistedInfo :id id)))
                       test-refresher
+                      ;; prune path only calls unpersist!; leaving refresh! out makes a stray call throw
                       #_{:clj-kondo/ignore [:missing-protocol-method]}
                       (reify task.persist-refresh/Refresher
                         (unpersist! [_ _database persisted-info]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/pulse_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/pulse_test.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.sandbox.pulse-test
   {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.sandbox.pulse-test]}}}}}}
+  ;; exercises the deprecated /api/pulse endpoints under sandboxing until notification APIs replace them
   #_{:clj-kondo/ignore [:deprecated-namespace]}
   (:require
    [clojure.data.csv :as csv]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
@@ -29,6 +29,7 @@
    [metabase.query-processor.pivot :as qp.pivot]
    [metabase.query-processor.pivot.test-util :as qp.pivot.test-util]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.streaming.test-util :as streaming.test-util]
    [metabase.query-processor.test :as qp]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -641,7 +641,7 @@
     (or (:count result) 0)))
 
 ;; REPL debugging helper, never called from tests; the thread-safe-name rule targets test helpers
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn full-index
   "Query the full index table and return all documents with decoded embeddings.
   Not used in tests, but useful for debugging."

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -331,7 +331,7 @@
   :resolve-model         embeddings.provider/legacy-resolved-model
   :embed-texts           (fn [_ texts _opts] (get-mock-embeddings-batch texts))})
 
-;; read-only query; the bang-named datasource getter mutates nothing
+;; read-only query; the bang-named getter at most lazily initializes the shared pool
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn query-index [search-context]
   (:results (semantic.index/query-index (semantic.env/get-pgvector-datasource!) mock-index search-context)))
@@ -515,7 +515,7 @@
         step (fn [] (semantic.indexer/indexing-step pgvector mock-index-metadata mock-index indexing-state))]
     (while (do (step) (pos? (:last-novel-count @indexing-state))))))
 
-;; read-only existence check; the bang-named datasource getter mutates nothing
+;; read-only existence check; the bang-named getter at most lazily initializes the shared pool
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn table-exists-in-db?
   "Check if a table actually exists in the database"
@@ -525,7 +525,7 @@
       (semantic.util/table-exists? (semantic.env/get-pgvector-datasource!) (name table-name))
       (catch Exception _ false))))
 
-;; read-only pg_indexes lookup; the bang-named calls mutate nothing
+;; read-only pg_indexes lookup; the bang-named calls at most lazily initialize the shared pool
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn table-has-index?
   [table-name index-name]
@@ -538,7 +538,7 @@
         (-> result first vals first))
       (catch Exception _ false))))
 
-;; read-only pg_indexes lookup; the bang-named calls mutate nothing
+;; read-only pg_indexes lookup; the bang-named calls at most lazily initialize the shared pool
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn table-indexes
   "Map of index name -> pg_indexes indexdef for `table-name`; empty when the table does not exist."
@@ -549,7 +549,7 @@
                        ["SELECT indexname, indexdef FROM pg_indexes WHERE tablename = ?" (name table-name)]
                        {:builder-fn jdbc.rs/as-unqualified-lower-maps})))
 
-;; read-only pg_class lookup; the bang-named calls mutate nothing
+;; read-only pg_class lookup; the bang-named calls at most lazily initialize the shared pool
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn index-relfilenode
   "Return the on-disk relfilenode for the index named `index-name`, or nil if it doesn't exist. A stable
@@ -628,7 +628,7 @@
       (unwrap-column :text_search_vector)
       (unwrap-column :text_search_with_native_query_vector)))
 
-;; read-only count query; the bang-named calls mutate nothing
+;; read-only count query; the bang-named calls at most lazily initialize the shared pool
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn index-count
   "Count the number of documents in the index."
@@ -653,7 +653,7 @@
                       {:builder-fn jdbc.rs/as-unqualified-lower-maps})
        (mapv decode-embedding)))
 
-;; read-only select; the bang-named calls mutate nothing
+;; read-only select; the bang-named calls at most lazily initialize the shared pool
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn query-embeddings
   "Query the `mock-index` table and return the decoded `:embedding`s for the given `model`"
@@ -668,7 +668,7 @@
                       {:builder-fn jdbc.rs/as-unqualified-lower-maps})
        (mapv decode-embedding)))
 
-;; read-only select; the bang-named calls mutate nothing
+;; read-only select; the bang-named calls at most lazily initialize the shared pool
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn query-tsvectors
   "Query the `mock-index` table and return the unwrapped tsvector columns for the given `model`"
@@ -696,7 +696,7 @@
            (query-embeddings {:model "dashboard"
                               :model_id "456"})))))
 
-;; read-only assertions over the index table; the bang-named calls mutate nothing
+;; read-only assertions over the index table; the bang-named calls at most lazily initialize the shared pool
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn check-index-has-no-mock-docs []
   (let [{:keys [table-name]}     mock-index

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -331,6 +331,7 @@
   :resolve-model         embeddings.provider/legacy-resolved-model
   :embed-texts           (fn [_ texts _opts] (get-mock-embeddings-batch texts))})
 
+;; read-only query; the bang-named datasource getter mutates nothing
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn query-index [search-context]
   (:results (semantic.index/query-index (semantic.env/get-pgvector-datasource!) mock-index search-context)))
@@ -514,6 +515,7 @@
         step (fn [] (semantic.indexer/indexing-step pgvector mock-index-metadata mock-index indexing-state))]
     (while (do (step) (pos? (:last-novel-count @indexing-state))))))
 
+;; read-only existence check; the bang-named datasource getter mutates nothing
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn table-exists-in-db?
   "Check if a table actually exists in the database"
@@ -523,6 +525,7 @@
       (semantic.util/table-exists? (semantic.env/get-pgvector-datasource!) (name table-name))
       (catch Exception _ false))))
 
+;; read-only pg_indexes lookup; the bang-named calls mutate nothing
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn table-has-index?
   [table-name index-name]
@@ -535,6 +538,7 @@
         (-> result first vals first))
       (catch Exception _ false))))
 
+;; read-only pg_indexes lookup; the bang-named calls mutate nothing
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn table-indexes
   "Map of index name -> pg_indexes indexdef for `table-name`; empty when the table does not exist."
@@ -545,6 +549,7 @@
                        ["SELECT indexname, indexdef FROM pg_indexes WHERE tablename = ?" (name table-name)]
                        {:builder-fn jdbc.rs/as-unqualified-lower-maps})))
 
+;; read-only pg_class lookup; the bang-named calls mutate nothing
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn index-relfilenode
   "Return the on-disk relfilenode for the index named `index-name`, or nil if it doesn't exist. A stable
@@ -623,6 +628,7 @@
       (unwrap-column :text_search_vector)
       (unwrap-column :text_search_with_native_query_vector)))
 
+;; read-only count query; the bang-named calls mutate nothing
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn index-count
   "Count the number of documents in the index."
@@ -646,6 +652,7 @@
                       {:builder-fn jdbc.rs/as-unqualified-lower-maps})
        (mapv decode-embedding)))
 
+;; read-only select; the bang-named calls mutate nothing
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn query-embeddings
   "Query the `mock-index` table and return the decoded `:embedding`s for the given `model`"
@@ -660,6 +667,7 @@
                       {:builder-fn jdbc.rs/as-unqualified-lower-maps})
        (mapv decode-embedding)))
 
+;; read-only select; the bang-named calls mutate nothing
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn query-tsvectors
   "Query the `mock-index` table and return the unwrapped tsvector columns for the given `model`"
@@ -687,6 +695,7 @@
            (query-embeddings {:model "dashboard"
                               :model_id "456"})))))
 
+;; read-only assertions over the index table; the bang-named calls mutate nothing
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn check-index-has-no-mock-docs []
   (let [{:keys [table-name]}     mock-index

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -640,7 +640,8 @@
                                   {:builder-fn jdbc.rs/as-unqualified-lower-maps})]
     (or (:count result) 0)))
 
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
+;; REPL debugging helper, never called from tests; the thread-safe-name rule targets test helpers
+#_:clj-kondo/ignore
 (defn full-index
   "Query the full index table and return all documents with decoded embeddings.
   Not used in tests, but useful for debugging."

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -108,6 +108,7 @@
   [entity]
   (dissoc entity :created_at :result_metadata :metadata_sync_schedule :cache_field_values_schedule))
 
+;; one generated random dump feeds all storage+ingestion assertions; splitting regenerates it per test
 #_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest e2e-storage-ingestion-test
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -109,6 +109,7 @@
           (is (= #{coll-eid child-eid}
                  (ids-by-model "Collection" (extract/extract {:user-id 218921})))))))))
 
+;; dozens of extraction cases share one hand-built dashboard/card graph; splitting duplicates the fixture
 #_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest dashboard-and-cards-test
   (mt/with-empty-h2-app-db!
@@ -1291,6 +1292,7 @@
           (is (= [{:id "def" :type :category :name "CATEGORY" :position 0}]
                  (:parameters (first (get by-model "Dashboard"))))))))))
 
+;; the selective-serialization cases all walk one shared entity graph; splitting duplicates the fixture
 #_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest selective-serialization-basic-test
   (mt/with-empty-h2-app-db!

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -747,6 +747,7 @@
                        :database (:id @db1d)}
                       (:definition @msr1d))))))))))
 
+;; full serdes round-trip: source graph, export, load, then cross-check remapped IDs -- one indivisible flow
 #_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest dashboard-card-test
   ;; DashboardCard.parameter_mappings and Card.parameter_mappings are JSON-encoded lists of parameter maps, which

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/job_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/job_test.clj
@@ -1,6 +1,7 @@
 (ns ^:mb/driver-tests ^:mb/transforms-python-test metabase-enterprise.transforms-python.job-test
   (:require
    [clojure.test :refer :all]
+   ;; tests redef log/log* to capture log lines; util.log macros bottom out in tools.logging
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [clojure.tools.logging :as log]
    [metabase.driver :as driver]

--- a/mage/src/mage/cli.clj
+++ b/mage/src/mage/cli.clj
@@ -74,6 +74,7 @@
         (println "\n"
                  #_{:clj-kondo/ignore [:discouraged-var]}
                  ((eval usage-fn) current-task)))
+      ;; u/exit's exit-exception would be swallowed by parse!'s catch-all; only a hard exit works here
       #_{:clj-kondo/ignore [:discouraged-java-method]}
       (System/exit 0))))
 
@@ -104,6 +105,7 @@
     (when @*error-hit?
       (println "Usage:")
       (println summary)
+      ;; u/exit's exit-exception would be swallowed by parse!'s catch-all; only a hard exit works here
       #_{:clj-kondo/ignore [:discouraged-java-method]}
       (System/exit 0))))
 
@@ -136,6 +138,7 @@
       parsed)
     (catch Exception e
       (println (c/red "Mage CLI parsing Error:") (.getMessage e))
+      ;; parse failure must kill the bb process with code 1; u/exit's throw could be caught upstream
       #_{:clj-kondo/ignore [:discouraged-java-method]}
       (System/exit 1))))
 

--- a/mage/src/mage/cli.clj
+++ b/mage/src/mage/cli.clj
@@ -72,7 +72,8 @@
           (println "\n" cmd "\n -" (c/magenta effect))))
       (when usage-fn
         (println "\n"
-                 #_{:clj-kondo/ignore [:discouraged-var]}
+                 ;; usage-fn comes as data from bb.edn; eval makes it callable
+                 #_:clj-kondo/ignore
                  ((eval usage-fn) current-task)))
       ;; u/exit's exit-exception would be swallowed by parse!'s catch-all; only a hard exit works here
       #_{:clj-kondo/ignore [:discouraged-java-method]}

--- a/mage/src/mage/cli.clj
+++ b/mage/src/mage/cli.clj
@@ -73,7 +73,7 @@
       (when usage-fn
         (println "\n"
                  ;; usage-fn comes as data from bb.edn; eval makes it callable
-                 #_:clj-kondo/ignore
+                 #_{:clj-kondo/ignore [:discouraged-var]}
                  ((eval usage-fn) current-task)))
       ;; u/exit's exit-exception would be swallowed by parse!'s catch-all; only a hard exit works here
       #_{:clj-kondo/ignore [:discouraged-java-method]}

--- a/mage/src/mage/jar_download.clj
+++ b/mage/src/mage/jar_download.clj
@@ -3,6 +3,7 @@
    [babashka.curl :as curl]
    [babashka.fs :as fs]
    [babashka.process :as p]
+   ;; mage runs under babashka, which bundles cheshire; metabase.util.json isn't on its classpath
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [cheshire.core :as json]
    [clojure.edn :as edn]

--- a/mage/src/mage/quick_test_runner.clj
+++ b/mage/src/mage/quick_test_runner.clj
@@ -79,7 +79,8 @@
     (let [out (backend/nrepl-eval the-ns the-cmd)
           elapsed (u/since-ms start)]
       (println)
-      (try (u/pp (edn/read-string out)) (catch Exception _ #_{:clj-kondo/ignore [:discouraged-var]} (prn out)))
+      ;; CLI tool; raw nREPL output belongs on stdout
+      (try (u/pp (edn/read-string out)) (catch Exception _ #_:clj-kondo/ignore (prn out)))
       (println (c/green (str "Tests completed in " elapsed " ms.\n")))
       (when (u/env "MAGE_DEBUG" (constantly nil))
         (bling/callout {:type :positive
@@ -96,7 +97,8 @@
       (let [out-data (try (edn/read-string out)
                           (catch Exception _
                             (println (c/red "Problem parsing output, raw output follows:"))
-                            #_{:clj-kondo/ignore [:discouraged-var]}
+                            ;; CLI tool; raw nREPL output belongs on stdout
+                            #_:clj-kondo/ignore
                             (prn out)))
             exit-code (if (zero? (+ (:fail out-data) (:error out-data))) 0 1)]
         (println (feedback-bar out-data))

--- a/mage/src/mage/quick_test_runner.clj
+++ b/mage/src/mage/quick_test_runner.clj
@@ -80,7 +80,7 @@
           elapsed (u/since-ms start)]
       (println)
       ;; CLI tool; raw nREPL output belongs on stdout
-      (try (u/pp (edn/read-string out)) (catch Exception _ #_:clj-kondo/ignore (prn out)))
+      (try (u/pp (edn/read-string out)) (catch Exception _ #_{:clj-kondo/ignore [:discouraged-var]} (prn out)))
       (println (c/green (str "Tests completed in " elapsed " ms.\n")))
       (when (u/env "MAGE_DEBUG" (constantly nil))
         (bling/callout {:type :positive
@@ -98,7 +98,7 @@
                           (catch Exception _
                             (println (c/red "Problem parsing output, raw output follows:"))
                             ;; CLI tool; raw nREPL output belongs on stdout
-                            #_:clj-kondo/ignore
+                            #_{:clj-kondo/ignore [:discouraged-var]}
                             (prn out)))
             exit-code (if (zero? (+ (:fail out-data) (:error out-data))) 0 1)]
         (println (feedback-bar out-data))

--- a/mage/src/mage/readability_check.clj
+++ b/mage/src/mage/readability_check.clj
@@ -14,7 +14,7 @@
                           'js)]
     (zipmap reader-tags (map (fn [tag]
                                ;; eval builds a quoting reader fn per dynamic tag
-                               #_:clj-kondo/ignore
+                               #_{:clj-kondo/ignore [:discouraged-var]}
                                (eval `(fn [v] (list (quote ~tag) v))))
                              reader-tags))))
 
@@ -102,7 +102,7 @@
   (let [content (try (slurp file) (catch Exception _ (read-check-problem :missing-file)))]
     (if-not line-number
       ;; CLI output; results print to stdout by design
-      #_:clj-kondo/ignore
+      #_{:clj-kondo/ignore [:discouraged-var]}
       (let [result (can-read-content? content)]
         (prn result)
         result)
@@ -138,7 +138,7 @@
                 :data data}))))))
 
 ;; REPL scratch full of deliberately unreadable tokens and ad-hoc requires
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:duplicate-require]}
 (comment ;; hi self
 
   (check "test/metabase/queries/models/card_test.clj" 20)

--- a/mage/src/mage/readability_check.clj
+++ b/mage/src/mage/readability_check.clj
@@ -13,7 +13,8 @@
                                  (slurp "resources/data_readers.clj")))
                           'js)]
     (zipmap reader-tags (map (fn [tag]
-                               #_{:clj-kondo/ignore [:discouraged-var]}
+                               ;; eval builds a quoting reader fn per dynamic tag
+                               #_:clj-kondo/ignore
                                (eval `(fn [v] (list (quote ~tag) v))))
                              reader-tags))))
 
@@ -100,7 +101,8 @@
   [file & [line-number]]
   (let [content (try (slurp file) (catch Exception _ (read-check-problem :missing-file)))]
     (if-not line-number
-      #_{:clj-kondo/ignore [:discouraged-var]}
+      ;; CLI output; results print to stdout by design
+      #_:clj-kondo/ignore
       (let [result (can-read-content? content)]
         (prn result)
         result)
@@ -135,7 +137,8 @@
                 :message (ex-message e)
                 :data data}))))))
 
-#_{:clj-kondo/ignore [:duplicate-require]}
+;; REPL scratch full of deliberately unreadable tokens and ad-hoc requires
+#_:clj-kondo/ignore
 (comment ;; hi self
 
   (check "test/metabase/queries/models/card_test.clj" 20)

--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -520,7 +520,7 @@
     (vec (jdbc/metadata-result rs))))
 
 ;; one-off REPL script kept for reference; leans on test namespaces drivers can't require
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:aliased-namespace-symbol :discouraged-var :unresolved-namespace]}
 (comment
   ;; Script on following lines was used to get available table types, used in the `get-tables` implementation.
   (with-open [conn (clojure.java.jdbc/get-connection

--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -519,7 +519,8 @@
                                                  "VIEW"]))]
     (vec (jdbc/metadata-result rs))))
 
-#_{:clj-kondo/ignore [:aliased-namespace-symbol :discouraged-var :unresolved-namespace]}
+;; one-off REPL script kept for reference; leans on test namespaces drivers can't require
+#_:clj-kondo/ignore
 (comment
   ;; Script on following lines was used to get available table types, used in the `get-tables` implementation.
   (with-open [conn (clojure.java.jdbc/get-connection

--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -519,11 +519,14 @@
                                                  "VIEW"]))]
     (vec (jdbc/metadata-result rs))))
 
-;; one-off REPL script kept for reference; leans on test namespaces drivers can't require
-#_{:clj-kondo/ignore [:aliased-namespace-symbol :discouraged-var :unresolved-namespace]}
+;; one-off REPL script kept for reference
+#_{:clj-kondo/ignore [:discouraged-var]}
 (comment
+  (require
+   '[metabase.test.data.dataset-definitions]
+   '[metabase.test.data.interface])
   ;; Script on following lines was used to get available table types, used in the `get-tables` implementation.
-  (with-open [conn (clojure.java.jdbc/get-connection
+  (with-open [conn (jdbc/get-connection
                     (sql-jdbc.conn/connection-details->spec
                      :athena
                      (metabase.test.data.interface/dbdef->connection-details

--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -519,8 +519,8 @@
                                                  "VIEW"]))]
     (vec (jdbc/metadata-result rs))))
 
-;; one-off REPL script kept for reference
-#_{:clj-kondo/ignore [:discouraged-var]}
+;; one-off REPL script kept for reference; requires test namespaces a driver module can't normally use
+#_{:clj-kondo/ignore [:discouraged-var :metabase/modules]}
 (comment
   (require
    '[metabase.test.data.dataset-definitions]

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -30,6 +30,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.performance :refer [every? mapv some empty? not-empty]]
+   ;; sync fix-ups read and write Database/Table/Field rows directly; the metadata provider is read-only
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])
   (:import

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/common.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/common.clj
@@ -5,6 +5,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   ;; persists the project-id resolved from credentials back to the Database row; a write, not metadata
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])
   (:import

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -18,6 +18,7 @@
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.util.add-alias-info :as add]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test/reconciliation_test_util.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test/reconciliation_test_util.clj
@@ -7,6 +7,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.query-processor.util.add-alias-info :as add]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -18,6 +18,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.pipeline :as qp.pipeline]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.sync.core :as sync]

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_impersonation_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_impersonation_test.clj
@@ -9,6 +9,7 @@
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.test-util :as driver.tu]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.sync.core :as sync.core]

--- a/modules/drivers/databricks/test/metabase/test/data/databricks.clj
+++ b/modules/drivers/databricks/test/metabase/test/data/databricks.clj
@@ -145,6 +145,7 @@
    table-identifier
    rows]
   (let [statements (ddl/insert-rows-dml-statements driver table-identifier rows)]
+    ;; test loader has a raw Connection; reuses the driver's declared SET-timezone SQL format string
     (when-let [set-timezone-format-string #_{:clj-kondo/ignore [:deprecated-var]} (sql-jdbc.execute/set-timezone-sql driver)]
       (let [set-timezone-sql (format set-timezone-format-string "'UTC'")]
         (log/debugf "Setting timezone to UTC before inserting data with SQL \"%s\"" set-timezone-sql)

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -609,6 +609,7 @@ function(bin) {
           :quarter
           (if supports-dateTrunc?
             (truncate :quarter)
+            ;; mongo-let vars are referenced via :$$parts.* keywords, which kondo can't see
             (mongo-let [#_{:clj-kondo/ignore [:unused-binding]} parts {:$dateToParts {:date column :timezone (driver-api/results-timezone-id)}}]
               {:$dateFromParts {:year  :$$parts.year
                                 :month {$subtract [:$$parts.month

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -25,6 +25,7 @@
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.order-by-test :as qp-test.order-by-test]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.sync.core :as sync]

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -848,6 +848,7 @@
     (doseq [[k v] column-definitions]
       (f driver db-id table-name {k v} settings))))
 
+;; overriding the old method is picked up by alter-table-columns!'s back-compat dispatch, covering both
 #_{:clj-kondo/ignore [:deprecated-var]}
 (defmethod driver/alter-columns! :redshift
   [_driver _db-id _table-name column-definitions]

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -15,6 +15,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-util :as lib.tu]
    [metabase.plugins.jdbc-proxy :as jdbc-proxy]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.sync.core :as sync]

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -152,6 +152,7 @@
     (with-write-stmt!
       (fn [^java.sql.Statement stmt]
         (doseq [dataset-name old-datasets]
+          ;; test-harness cleanup output goes to the CI console, not the app log
           #_{:clj-kondo/ignore [:discouraged-var]}
           (println "[Snowflake] Deleting old dataset:" dataset-name)
           (try
@@ -162,6 +163,7 @@
             ;; same time. No big deal. Just log this and carry on trying to delete the other datasets. If we don't end up
             ;; deleting anything it's not the end of the world because it won't affect our ability to run our tests
             (catch Throwable e
+              ;; test-harness cleanup output goes to the CI console, not the app log
               #_{:clj-kondo/ignore [:discouraged-var]}
               (println "[Snowflake] Error deleting old dataset:" (ex-message e)))))))))
 
@@ -223,6 +225,7 @@
   (let [database-name (qualified-db-name dbdef)
         sql           (format "DROP DATABASE \"%s\";" database-name)]
     (log/infof "[Snowflake] %s" sql)
+    ;; test-harness cleanup output goes to the CI console, not the app log
     #_{:clj-kondo/ignore [:discouraged-var]}
     (println "[Snowflake] destroy database " database-name (:database-name dbdef))
     (jdbc/query (no-db-connection-spec)

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -178,6 +178,7 @@
   (let [inner-query (-> (assoc inner-query
                                :remark   (driver-api/query->remark :sparksql outer-query)
                                :query    sql
+                               ;; driver still executes legacy outer queries; legacy limit calculation matches
                                :max-rows #_{:clj-kondo/ignore [:deprecated-var]} (driver-api/query->max-rows-limit outer-query))
                         (dissoc :params))
         query       (assoc outer-query :native inner-query)]

--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -23,6 +23,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -433,6 +433,7 @@
                             [(t/zoned-date-time  date time (t/zone-id "America/Los_Angeles"))
                              (t/offset-date-time (t/local-date-time date time) (t/zone-offset -8))]]]
         (let [expected (or expected t)]
+          ;; pr renders the value into the testing label via with-out-str; nothing hits the console
           #_{:clj-kondo/ignore [:discouraged-var]}
           (testing (format "Convert %s to SQL literal" (colorize/magenta (with-out-str (pr t))))
             (let [sql (format "SELECT %s AS t;" (sql.qp/inline-value :sqlserver t))]

--- a/src/metabase/actions/http_action.clj
+++ b/src/metabase/actions/http_action.clj
@@ -128,6 +128,8 @@
                   {:type        :http
                    :status-code 400})))
 
+;; the real implementation, kept intact while execute-http-action! above refuses; nothing calls it
+;; until HTTP actions are switched back on
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var :unused-private-var]}
 (defn- execute-http-action-impl!
   [action params->value]

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -1048,6 +1048,7 @@
       (assert (= #{"analytics_uuid" "features" "grouped_metrics" "instance_attributes" "metadata" "metrics" "settings"}
                  (set (keys snowplow-data)))
               (str "Missing required keys in snowplow-data. got:" (sort (keys snowplow-data))))
+      ;; legacy usage-stats endpoint still runs alongside Snowplow until it is decommissioned
       #_{:clj-kondo/ignore [:deprecated-var]}
       (send-stats-deprecated! stats)
       (analytics.event/track-event! :snowplow/instance_stats snowplow-data)

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -94,6 +94,7 @@
 
 (declare check-403 check-404)
 
+;; p/import-vars needs the literal ns symbol; the open-api alias won't resolve inside the macro
 #_{:clj-kondo/ignore [:aliased-namespace-symbol]}
 (p/import-vars [metabase.api.open-api root-open-api-object])
 

--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -35,7 +35,7 @@
   "Note: this is called in a macro context, so it can potentially be passed a symbol that resolves to a schema."
   [schema]
   ;; eval runs at macroexpansion time; the schema arg may be a form needing evaluation
-  (let [schema      (try #_:clj-kondo/ignore
+  (let [schema      (try #_{:clj-kondo/ignore [:discouraged-var]}
                      (eval schema)
                          (catch Exception _
                            (requiring-resolve-form schema)))

--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -34,7 +34,8 @@
 (defn ->matching-regex
   "Note: this is called in a macro context, so it can potentially be passed a symbol that resolves to a schema."
   [schema]
-  (let [schema      (try #_{:clj-kondo/ignore [:discouraged-var]}
+  ;; eval runs at macroexpansion time; the schema arg may be a form needing evaluation
+  (let [schema      (try #_:clj-kondo/ignore
                      (eval schema)
                          (catch Exception _
                            (requiring-resolve-form schema)))

--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -185,7 +185,7 @@
   (when-let [ks (not-empty (metabase.api.common.internal/route-arg-keywords route))]
     (let [route-params-schema (some-> (get-in args [:params :route :schema])
                                       ;; eval runs at macroexpansion time to resolve the schema form
-                                      #_:clj-kondo/ignore
+                                      #_{:clj-kondo/ignore [:discouraged-var]}
                                       eval
                                       mr/resolve-schema
                                       mc/schema)]

--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -184,7 +184,8 @@
    args  :- :map]
   (when-let [ks (not-empty (metabase.api.common.internal/route-arg-keywords route))]
     (let [route-params-schema (some-> (get-in args [:params :route :schema])
-                                      #_{:clj-kondo/ignore [:discouraged-var]}
+                                      ;; eval runs at macroexpansion time to resolve the schema form
+                                      #_:clj-kondo/ignore
                                       eval
                                       mr/resolve-schema
                                       mc/schema)]

--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -978,6 +978,7 @@
 ;;;; Example usages
 ;;;;
 
+;; examples are fully qualified so they can be pasted into a REPL from any namespace
 #_{:clj-kondo/ignore [:aliased-namespace-symbol]}
 (comment
   (metabase.api.macros/ns-routes 'metabase.timeline.api.timeline)

--- a/src/metabase/api/macros/defendpoint/open_api.clj
+++ b/src/metabase/api/macros/defendpoint/open_api.clj
@@ -262,7 +262,7 @@
      :components {:schemas @*definitions*}}))
 
 ;; REPL example; api.macros requires this ns, so it can't be required back without a cycle
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:unresolved-namespace]}
 (comment
   (open-api-spec (metabase.api.macros/ns-routes 'metabase.geojson.api) "/api/geojson")
 

--- a/src/metabase/api/macros/defendpoint/open_api.clj
+++ b/src/metabase/api/macros/defendpoint/open_api.clj
@@ -261,9 +261,9 @@
              (vals endpoints))
      :components {:schemas @*definitions*}}))
 
-;; REPL example; api.macros requires this ns, so it can't be required back without a cycle
-#_{:clj-kondo/ignore [:unresolved-namespace]}
 (comment
+  (require '[metabase.api.macros])
+
   (open-api-spec (metabase.api.macros/ns-routes 'metabase.geojson.api) "/api/geojson")
 
   (metabase.api.macros.defendpoint.open-api/path-item

--- a/src/metabase/api/macros/defendpoint/open_api.clj
+++ b/src/metabase/api/macros/defendpoint/open_api.clj
@@ -261,7 +261,8 @@
              (vals endpoints))
      :components {:schemas @*definitions*}}))
 
-#_{:clj-kondo/ignore [:unresolved-namespace]}
+;; REPL example; api.macros requires this ns, so it can't be required back without a cycle
+#_:clj-kondo/ignore
 (comment
   (open-api-spec (metabase.api.macros/ns-routes 'metabase.geojson.api) "/api/geojson")
 

--- a/src/metabase/api/open_api.clj
+++ b/src/metabase/api/open_api.clj
@@ -345,7 +345,7 @@
                                  :description "API key for authentication"}}))))
 
 ;; REPL example; api.macros requires this ns (cycle) and api-routes is cross-module, so no requires
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:metabase/modules :unresolved-namespace]}
 (comment
   (open-api-spec (metabase.api.macros/ns-handler 'metabase.geojson.api) "/api/geojson")
   (root-open-api-object (requiring-resolve 'metabase.api-routes.core/routes)))

--- a/src/metabase/api/open_api.clj
+++ b/src/metabase/api/open_api.clj
@@ -344,7 +344,8 @@
                                  :name        "X-API-Key"
                                  :description "API key for authentication"}}))))
 
-#_{:clj-kondo/ignore [:metabase/modules :unresolved-namespace]}
+;; REPL example; api.macros requires this ns (cycle) and api-routes is cross-module, so no requires
+#_:clj-kondo/ignore
 (comment
   (open-api-spec (metabase.api.macros/ns-handler 'metabase.geojson.api) "/api/geojson")
   (root-open-api-object (requiring-resolve 'metabase.api-routes.core/routes)))

--- a/src/metabase/api/open_api.clj
+++ b/src/metabase/api/open_api.clj
@@ -344,8 +344,10 @@
                                  :name        "X-API-Key"
                                  :description "API key for authentication"}}))))
 
-;; REPL example; api.macros requires this ns (cycle) and api-routes is cross-module, so no requires
-#_{:clj-kondo/ignore [:metabase/modules :unresolved-namespace]}
+;; REPL example; api-routes is cross-module, resolved at runtime
+#_{:clj-kondo/ignore [:metabase/modules]}
 (comment
+  (require '[metabase.api.macros])
+
   (open-api-spec (metabase.api.macros/ns-handler 'metabase.geojson.api) "/api/geojson")
   (root-open-api-object (requiring-resolve 'metabase.api-routes.core/routes)))

--- a/src/metabase/api/util/handlers.clj
+++ b/src/metabase/api/util/handlers.clj
@@ -66,6 +66,7 @@
   "Replacement for [[compojure.core/routes]] that supports [[open-api-spec]]."
   [& handlers]
   (open-api/handler-with-open-api-spec
+   ;; this is the sanctioned routes wrapper itself; it delegates to compojure and adds OpenAPI
    (apply #_{:clj-kondo/ignore [:discouraged-var]} compojure/routes handlers)
    (fn [prefix]
      (routes->open-api-spec handlers prefix))))

--- a/src/metabase/api_keys/api.clj
+++ b/src/metabase/api_keys/api.clj
@@ -117,7 +117,7 @@
   api/generic-204-no-content)
 
 ;; REPL doc-check example; uses namespaces this ns doesn't require
-#_:clj-kondo/ignore
+#_{:clj-kondo/ignore [:aliased-namespace-symbol :unresolved-namespace]}
 (comment
   ;; check the generated docs
   (metabase.api.open-api/open-api-spec (metabase.api.macros/ns-handler) "/api/api-key"))

--- a/src/metabase/api_keys/api.clj
+++ b/src/metabase/api_keys/api.clj
@@ -116,7 +116,8 @@
   (t2/delete! :model/ApiKey id)
   api/generic-204-no-content)
 
-#_{:clj-kondo/ignore [:aliased-namespace-symbol :unresolved-namespace]}
+;; REPL doc-check example; uses namespaces this ns doesn't require
+#_:clj-kondo/ignore
 (comment
   ;; check the generated docs
   (metabase.api.open-api/open-api-spec (metabase.api.macros/ns-handler) "/api/api-key"))

--- a/src/metabase/api_keys/api.clj
+++ b/src/metabase/api_keys/api.clj
@@ -116,8 +116,8 @@
   (t2/delete! :model/ApiKey id)
   api/generic-204-no-content)
 
-;; REPL doc-check example; uses namespaces this ns doesn't require
-#_{:clj-kondo/ignore [:aliased-namespace-symbol :unresolved-namespace]}
 (comment
+  (require '[metabase.api.open-api])
+
   ;; check the generated docs
-  (metabase.api.open-api/open-api-spec (metabase.api.macros/ns-handler) "/api/api-key"))
+  (metabase.api.open-api/open-api-spec (api.macros/ns-handler) "/api/api-key"))

--- a/src/metabase/app_db/custom_migrations.clj
+++ b/src/metabase/app_db/custom_migrations.clj
@@ -1256,6 +1256,7 @@
   (defn- pretty-spit [file-name data]
     (with-open [writer (io/writer file-name)]
       (binding [*out* writer]
+        ;; REPL recipe in (comment): pprints EDN into a file writer, not the console
         #_{:clj-kondo/ignore [:discouraged-var]}
         (pprint/pprint data))))
 

--- a/src/metabase/app_db/custom_migrations/pulse_to_notification.clj
+++ b/src/metabase/app_db/custom_migrations/pulse_to_notification.clj
@@ -152,6 +152,7 @@
 (defn migrate-alerts!
   "Migrate alerts from `pulse` to `notification`."
   []
+  ;; kondo can't see that with-temp-schedule! binds scheduler
   #_{:clj-kondo/ignore [:unresolved-symbol]}
   (custom-migrations.util/with-temp-schedule! [scheduler]
     (run! #(alert->notification! scheduler %)

--- a/src/metabase/app_db/custom_migrations/reserve_at_symbol_user_attributes.clj
+++ b/src/metabase/app_db/custom_migrations/reserve_at_symbol_user_attributes.clj
@@ -29,7 +29,7 @@
   code will actually run on, plus this will only run one time per Metabase install, so I'd rather not spend a ton of
   time optimizing for an incredibly unlikely case."
   (:require
-   ;; migrations must be frozen in time; raw cheshire avoids util.json's evolving custom encoders
+   ;; migrations are frozen in time; this keeps the exact serialization the migration shipped with
    #_{:clj-kondo/ignore [:discouraged-namespace]}
    [cheshire.core :as cheshire]
    [clojure.set :as set]

--- a/src/metabase/app_db/custom_migrations/reserve_at_symbol_user_attributes.clj
+++ b/src/metabase/app_db/custom_migrations/reserve_at_symbol_user_attributes.clj
@@ -29,6 +29,7 @@
   code will actually run on, plus this will only run one time per Metabase install, so I'd rather not spend a ton of
   time optimizing for an incredibly unlikely case."
   (:require
+   ;; migrations must be frozen in time; raw cheshire avoids util.json's evolving custom encoders
    #_{:clj-kondo/ignore [:discouraged-namespace]}
    [cheshire.core :as cheshire]
    [clojure.set :as set]

--- a/src/metabase/app_db/custom_migrations/reserve_at_symbol_user_attributes.clj
+++ b/src/metabase/app_db/custom_migrations/reserve_at_symbol_user_attributes.clj
@@ -29,7 +29,7 @@
   code will actually run on, plus this will only run one time per Metabase install, so I'd rather not spend a ton of
   time optimizing for an incredibly unlikely case."
   (:require
-   ;; migrations are frozen in time; this keeps the exact serialization the migration shipped with
+   ;; keep this migration decoupled from later changes to the metabase.util.json facade
    #_{:clj-kondo/ignore [:discouraged-namespace]}
    [cheshire.core :as cheshire]
    [clojure.set :as set]

--- a/src/metabase/batch_processing/impl.clj
+++ b/src/metabase/batch_processing/impl.clj
@@ -11,6 +11,7 @@
 
   Batch processing can be disabled by setting the environment variable `MB_SYNCHRONOUS_BATCH_UPDATES=true`"
   (:require
+   ;; this ns is our grouper facade; the rest of the codebase goes through it
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [grouper.core :as grouper]
    [metabase.app-db.core :as mdb]

--- a/src/metabase/cache/core.clj
+++ b/src/metabase/cache/core.clj
@@ -7,6 +7,7 @@
 (comment metabase.cache.models.cache-config/keep-me
          metabase.cache.settings/keep-me)
 
+;; the re-exported var carries the docstring; kondo can't see through import-def
 #_{:clj-kondo/ignore [:missing-docstring]}
 (p/import-def metabase.cache.models.cache-config/invalidate! invalidate-config!)
 

--- a/src/metabase/config/core.clj
+++ b/src/metabase/config/core.clj
@@ -40,6 +40,7 @@
 
 (def ^Boolean is-windows?
   "Are we running on a Windows machine?"
+  ;; u/lower-case-en would be a circular dep (metabase.util requires config); os.name is ASCII
   #_{:clj-kondo/ignore [:discouraged-var]}
   (str/includes? (str/lower-case (System/getProperty "os.name")) "win"))
 

--- a/src/metabase/config/core.clj
+++ b/src/metabase/config/core.clj
@@ -40,7 +40,7 @@
 
 (def ^Boolean is-windows?
   "Are we running on a Windows machine?"
-  ;; u/lower-case-en would be a circular dep (metabase.util requires config); os.name is ASCII
+  ;; u/lower-case-en would be a circular dep (metabase.util requires config)
   #_{:clj-kondo/ignore [:discouraged-var]}
   (str/includes? (str/lower-case (System/getProperty "os.name")) "win"))
 

--- a/src/metabase/config/core.clj
+++ b/src/metabase/config/core.clj
@@ -13,6 +13,7 @@
 ;; this existed long before 0.39.0, but that's when it was made public
 (def ^{:doc "Indicates whether Enterprise Edition extensions are available" :added "0.39.0"} ee-available?
   (try
+    ;; classpath probe for EE availability; the namespace is never actually used
     #_{:clj-kondo/ignore [:metabase/modules]}
     (require 'metabase-enterprise.core.dummy-namespace)
     true
@@ -30,6 +31,7 @@
   "Whether code from `./test` is available. This is mainly to facilitate certain things like test QP middleware that we
   want to load only when test code is present."
   (try
+    ;; classpath probe for test-code availability; the namespace is never actually used
     #_{:clj-kondo/ignore [:metabase/modules]}
     (require 'metabase.test.dummy-namespace)
     true

--- a/src/metabase/config/core.clj
+++ b/src/metabase/config/core.clj
@@ -40,9 +40,8 @@
 
 (def ^Boolean is-windows?
   "Are we running on a Windows machine?"
-  ;; u/lower-case-en would be a circular dep (metabase.util requires config)
-  #_{:clj-kondo/ignore [:discouraged-var]}
-  (str/includes? (str/lower-case (System/getProperty "os.name")) "win"))
+  ;; Locale/US casing so a Turkish default locale can't hide "Windows" (dotless i)
+  (str/includes? (.toLowerCase (System/getProperty "os.name") java.util.Locale/US) "win"))
 
 (def ^:private app-defaults
   "Global application defaults"

--- a/src/metabase/core/bootstrap.clj
+++ b/src/metabase/core/bootstrap.clj
@@ -37,6 +37,7 @@
 ;;;   java -jar metabase.jar --mode complexity-score [scorer-specific args...]
 ;;; ===========================================================================
 
+;; standalone-mode CLI output: stdout is the user interface, not the log
 #_{:clj-kondo/ignore [:discouraged-var]}
 (def output!
   "Alias for println so can suppress warning in one place"

--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -306,6 +306,7 @@
 (defn- legacy-result-metadata-for-query
   "Fetch the results metadata for a `query` by running the query and seeing what the `qp` gives us in return."
   [query]
+  ;; card result_metadata is persisted in legacy shape; Lib-shape migration pending
   #_{:clj-kondo/ignore [:deprecated-var]}
   (qp.metadata/legacy-result-metadata query api/*current-user-id*))
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1,3 +1,4 @@
+;; grandfathered two-segment ns; third-party drivers depend on this exact name
 #_{:clj-kondo/ignore [:metabase/namespace-name]}
 (ns metabase.driver
   "Metabase Drivers handle various things we need to do with connected data warehouse databases, including things like

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1208,6 +1208,7 @@
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
+;; default impl of the deprecated multimethod; throws to point implementers at the replacement
 #_{:clj-kondo/ignore [:deprecated-var]}
 (defmethod splice-parameters-into-native-query ::driver
   [_driver _query]

--- a/src/metabase/driver/events/report_timezone_updated.clj
+++ b/src/metabase/driver/events/report_timezone_updated.clj
@@ -5,6 +5,7 @@
    [metabase.events.core :as events]
    [metabase.util.log :as log]
    [methodical.core :as methodical]
+   ;; event handler runs outside any query; it enumerates Database rows itself, no metadata provider exists
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -320,6 +320,7 @@
       ;; else
       message)))
 
+;; the JDBC-spec variant is still needed so the audit/app-db path can reuse it without a driver pool
 #_{:clj-kondo/ignore [:deprecated-var]}
 (defmethod sql-jdbc.sync/db-default-timezone :mysql
   [_ spec]

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -123,6 +123,7 @@
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)
 
+;; default impl of the deprecated multimethod itself, kept until the method is removed
 #_{:clj-kondo/ignore [:deprecated-var]}
 (defmethod set-role-statement :default
   [_driver _role]

--- a/src/metabase/driver/sql/pivot.clj
+++ b/src/metabase/driver/sql/pivot.clj
@@ -9,6 +9,7 @@
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.lib.options :as lib.options]
    [metabase.lib.pivot :as lib.pivot]
+   ;; :as-alias only, for ::add-remaps keywords; no runtime dependency on QP internals
    ^{:clj-kondo/ignore [:metabase/modules]}
    [metabase.query-processor.middleware.add-remaps :as-alias add-remaps]
    [metabase.query-processor.pivot :as qp.pivot]

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1692,6 +1692,7 @@
 
 (def ^:private ^{:deprecated "0.64.0"} LegacyStringValueOrFieldOrExpression
   "Deprecated: use MBQL 5 going forward."
+  ;; a deprecated schema assembled from equally-deprecated legacy MBQL schemas; they go away together
   #_{:clj-kondo/ignore [:deprecated-var]}
   [:or
    [:and driver-api/mbql.schema.value
@@ -1739,6 +1740,7 @@
   "Generate pattern to match against in like clause. Lowercasing for case insensitive matching also happens here."
   [driver
    pre
+   ;; still typed by the deprecated legacy schema above; both go away with the MBQL 5 migration
    [type _ :as arg] :- #_{:clj-kondo/ignore [:deprecated-var]} LegacyStringValueOrFieldOrExpression
    post
    {:keys [case-sensitive] :or {case-sensitive true} :as _options}]

--- a/src/metabase/driver/sql/util/unprepare.clj
+++ b/src/metabase/driver/sql/util/unprepare.clj
@@ -21,5 +21,6 @@
  #'sql.qp/inline-value
  ::reload
  (fn [_key _ref _old-state _new-state]
+   ;; keeps the deprecated alias in sync with inline-value on reload; the whole ns is the shim
    #_{:clj-kondo/ignore [:deprecated-var]}
    (alter-var-root #'unprepare-value (constantly sql.qp/inline-value))))

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -294,6 +294,7 @@
   [driver db-id table-name column-definitions]
   (driver-api/execute-write-sql! db-id (sql-jdbc.sync/alter-columns-sql driver table-name column-definitions)))
 
+;; back-compat: honors driver overrides of the old alter-columns! method until drivers migrate
 #_{:clj-kondo/ignore [:deprecated-var]}
 (defmethod driver/alter-table-columns! :sql-jdbc
   [driver db-id table-name column-definitions & opts]

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -478,6 +478,7 @@
 
 ;; TODO (Cam 2026-07-23) Update this stuff to use MBQL 5 instead of legacy MBQL
 (mu/defn- model-create! :- (result-schema [:map [:created-row driver-api/schema.actions.args.row]])
+  ;; the legacy MBQL query schema is deprecated, and goes away with the TODO above
   [action context legacy-queries :- #_{:clj-kondo/ignore [:deprecated-var]} [:sequential driver-api/mbql.schema.Query]]
   (let [database (inputs->db legacy-queries)
         ;; TODO it would be nice to make this 1 statement per table, instead of N.

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -19,6 +19,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.performance :refer [get-in mapv select-keys]]
    [potemkin :as p]
+   ;; pool invalidation re-fetches Database details from the app db; runs outside any query context
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])
   (:import

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -282,6 +282,7 @@
     ;; directly.
     (reify DataSource
       (getConnection [_this]
+        ;; inside do-with-connection-with-options' own default impl; a raw jdbc spec has no DataSource
         #_{:clj-kondo/ignore [:discouraged-var]}
         (jdbc/get-connection db-or-id-or-spec)))
     ;; otherwise this is either a Database or Database ID.

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -286,6 +286,7 @@
         (jdbc/get-connection db-or-id-or-spec)))
     ;; otherwise this is either a Database or Database ID.
     (if-let [old-method-impl (get-method
+                              ;; honor drivers still implementing the old connection-with-timezone
                               #_{:clj-kondo/ignore [:deprecated-var]} sql-jdbc.execute.old/connection-with-timezone
                               driver)]
       ;; use the deprecated impl for `connection-with-timezone` if one exists.
@@ -968,6 +969,7 @@
 ;;; |                                       Convenience Imports from Old Impl                                        |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+;; re-exports the old-impl vars so drivers referencing them via this ns keep compiling
 #_{:clj-kondo/ignore [:deprecated-var]}
 (p/import-vars
  [sql-jdbc.execute.old

--- a/src/metabase/driver/sql_jdbc/sync.clj
+++ b/src/metabase/driver/sql_jdbc/sync.clj
@@ -11,6 +11,7 @@
 
 (comment sql-jdbc.dbms-version/keep-me sql-jdbc.sync.interface/keep-me sql-jdbc.describe-database/keep-me sql-jdbc.describe-table/keep-me)
 
+;; facade ns must keep re-exporting the interface's deprecated vars until drivers migrate off them
 #_{:clj-kondo/ignore [:deprecated-var]}
 (p/import-vars
  [sql-jdbc.sync.interface

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -26,6 +26,7 @@
    [metabase.util.malli.registry :as mr]
    [metabase.util.performance :refer [some select-keys every? mapv empty? not-empty]]
    [potemkin :as p]
+   ;; sync-time read of already-synced Field rows; sync runs without a metadata provider
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])
   (:import

--- a/src/metabase/driver/sql_jdbc/sync/interface.clj
+++ b/src/metabase/driver/sql_jdbc/sync/interface.clj
@@ -97,6 +97,7 @@
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)
 
+;; default impl of the deprecated multimethod itself, kept until the method is removed
 #_{:clj-kondo/ignore [:deprecated-var]}
 (defmethod db-default-timezone :sql-jdbc
   [_driver _jdbc-spec]

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -22,6 +22,7 @@
    [metabase.util.i18n :refer [deferred-tru trs]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   ;; ms/InstanceOf validates Toucan Database instances; lib.schema has no app-db instance schemas
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.util.malli.schema :as ms]
    [metabase.util.performance :refer [mapv empty? some]])
   (:import

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -16,6 +16,7 @@
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.premium-features.core :as premium-features]
    [metabase.query-processor.error-type :as qp.error-type]
+   ;; the legacy QP pipeline still conveys the metadata provider via the ambient store; no MBQL 5 path yet
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.http :as u.http]

--- a/src/metabase/driver_api/core.clj
+++ b/src/metabase/driver_api/core.clj
@@ -60,6 +60,7 @@
    [metabase.warehouse-schema.models.table :as table]
    [potemkin :as p]))
 
+;; driver-api facade must keep re-exporting deprecated vars until all drivers migrate off them
 #_{:clj-kondo/ignore [:deprecated-var :discouraged-var]}
 (p/import-vars
  actions/cached-database

--- a/src/metabase/driver_api/impl.clj
+++ b/src/metabase/driver_api/impl.clj
@@ -81,6 +81,7 @@
   [lib-query-or-legacy-inner-query]
   (if (:lib/type lib-query-or-legacy-inner-query)
     (nest-query/nest-expressions lib-query-or-legacy-inner-query)
+    ;; legacy-MBQL branch for drivers not yet on MBQL 5; the deprecated bridge is the only conversion path
     #_{:clj-kondo/ignore [:deprecated-var :discouraged-var]}
     (-> lib-query-or-legacy-inner-query
         (->> (lib/query-from-legacy-inner-query (qp.store/metadata-provider)

--- a/src/metabase/embedding/settings.clj
+++ b/src/metabase/embedding/settings.clj
@@ -265,6 +265,7 @@
   "Is any kind of embedding setup?"
   []
   (or
+   ;; the deprecated umbrella setting must still count as embedding-enabled while instances have it set
    #_{:clj-kondo/ignore [:deprecated-var]} (enable-embedding)
    (enable-embedding-static)
    (enable-embedding-interactive)

--- a/src/metabase/indexed_entities/api.clj
+++ b/src/metabase/indexed_entities/api.clj
@@ -14,6 +14,7 @@
 (defn- ensure-type
   "Ensure that the ref exists and is of type required for indexing."
   [t ref metadata]
+  ;; stored refs are legacy MBQL; normalize as legacy to match metadata field_refs
   (if-let [field (some (fn [f] (when ((comp #{#_{:clj-kondo/ignore [:deprecated-var]} (mbql.normalize/normalize-field-ref ref)}
                                             :field_ref)
                                       f)

--- a/src/metabase/indexed_entities/models/model_index.clj
+++ b/src/metabase/indexed_entities/models/model_index.clj
@@ -83,6 +83,7 @@
   (let [model     (t2/select-one :model/Card :id (:model_id model-index))
         fix       (mu/fn [field-ref :- some?
                           base-type :- ::lib.schema.common/base-type]
+                    ;; stored value/pk refs are legacy MBQL; normalize as legacy before use
                     (-> field-ref #_{:clj-kondo/ignore [:deprecated-var]} mbql.normalize/normalize-field-ref (fix-expression-refs base-type)))
         ;; :type/Text and :type/Integer are ensured at creation time on the api.
         value-ref (-> model-index :value_ref (fix :type/Text))

--- a/src/metabase/indexed_entities/models/model_index.clj
+++ b/src/metabase/indexed_entities/models/model_index.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    ;; legacy usage, do not use this in new code
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
+   ;; model-index pk/value refs are stored as legacy field refs; validated against the legacy schema
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]

--- a/src/metabase/indexed_entities/task/index_values.clj
+++ b/src/metabase/indexed_entities/task/index_values.clj
@@ -17,6 +17,7 @@
 
 (set! *warn-on-reflection* true)
 
+;; reference list of possible model-index :state values; not consulted by code
 #_{:clj-kondo/ignore [:unused-private-var]}
 ;; Possible values for the :state field on model index records.
 ;; Unused, but kept here for reference.

--- a/src/metabase/legacy_mbql/util.cljc
+++ b/src/metabase/legacy_mbql/util.cljc
@@ -57,6 +57,7 @@
       (do
         (log/error "normalize-token should not be getting called on a base type! This probably means we're using a base type in the wrong place, like as a parameter type")
         (keyword s))
+      ;; cljs-only branch: JS toLowerCase has no locale trap, so it matches u/lower-case-en
       #_{:clj-kondo/ignore [:discouraged-var]}
       (-> s
           #?(:clj u/lower-case-en :cljs str/lower-case)

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -787,6 +787,7 @@
     stage-number :- :int
     legacy-ref   :- some?]
    (let [legacy-ref                  (->> #?(:clj legacy-ref :cljs (js->clj legacy-ref :keywordize-keys true))
+                                          ;; input is a legacy ref; normalize as legacy MBQL before conversion
                                           #_{:clj-kondo/ignore [:deprecated-var]}
                                           mbql.normalize/normalize-field-ref)
          {aggregations :aggregation} (lib.util/query-stage query stage-number)]

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -6,7 +6,9 @@
    [clojure.string :as str]
    [malli.error :as me]
    [medley.core :as m]
+   ;; this ns is the legacy <-> MBQL 5 converter; legacy input must be normalized before lifting
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
+   ;; the converter validates against the legacy schema it converts from
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.lib.convert.metadata-to-legacy :as lib.convert.metadata-to-legacy]
    [metabase.lib.dispatch :as lib.dispatch]

--- a/src/metabase/lib/convert/metadata_to_legacy.cljc
+++ b/src/metabase/lib/convert/metadata_to_legacy.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.convert.metadata-to-legacy
   (:require
    [medley.core :as m]
+   ;; side-effect require: registers the legacy-column-metadata schema this ns's output is checked against
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.schema]
    [metabase.lib.normalize :as lib.normalize]
    [metabase.util :as u]

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -49,6 +49,7 @@
     existing calls when practical. Will be unexported when there are no callers left. Docstrings should suggest an
     alternative to calling these functions.
   - **Deprecated:** Stronger than Leak - the function should be removed altogether, not just unexported."
+  ;; remove and ->> have no lib export yet; excluded so the clojure.core versions can't leak into the API
   {:clj-kondo/ignore [:unused-excluded-var]}
   (:refer-clojure :exclude [filter remove replace and or not = < <= > ->> >= not-empty case count distinct max min
                             + - * / time abs concat replace ref float])

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -63,6 +63,7 @@
    [metabase.analytics-interface.core :as analytics.interface]
    [metabase.analytics.experiment]
    [metabase.analytics.impl]
+   ;; the FE still hands this entry point legacy MBQL; it must normalize before converting to MBQL 5
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.binning :as lib.binning]

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1576,6 +1576,7 @@
   (-> a-legacy-ref
       (js->clj :keywordize-keys true)
       (update 0 keyword)
+      ;; input is a legacy ref from the FE; must be normalized as legacy MBQL before converting to MBQL 5
       #_{:clj-kondo/ignore [:deprecated-var]}
       mbql.normalize/normalize-field-ref
       lib.convert/->mbql5

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1652,6 +1652,7 @@
                              legacy-refs)]
       (if (every? #(and % (>= % 0)) exact-matches)
         (to-array exact-matches)
+        ;; the exported JS contract is a parallel list of indexes; only this fn yields positions
         #_{:clj-kondo/ignore [:discouraged-var]}
         (to-array (lib.equality/find-column-indexes-for-refs a-query stage-number needles haystack))))))
 

--- a/src/metabase/lib/js/metadata.cljc
+++ b/src/metabase/lib/js/metadata.cljc
@@ -1,5 +1,6 @@
 (ns metabase.lib.js.metadata
   (:require
+   ;; the :clj branch normalizes legacy :field-ref metadata values; cljs leaves them as JS arrays
    #?@(:clj  (#_{:clj-kondo/ignore [:discouraged-namespace]}
               [metabase.legacy-mbql.normalize :as legacy-mbql.normalize])
        :cljs ([goog]

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -13,7 +13,9 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [medley.core :as m]
+   ;; result metadata's field-ref wire format is still legacy MBQL; schemas describe legacy refs
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.schema :as mbql.s]
+   ;; legacy ref munging (update-field-options) on the legacy wire format; dies with the MBQL 5 port
    ^{:clj-kondo/ignore [:discouraged-namespace :deprecated-namespace]} [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.card :as lib.card]

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -239,6 +239,7 @@
   used by individual pieces of middleware or driver implementations for tracking little bits of information that
   should not be considered relevant when comparing clauses for equality."
   [legacy-ref]
+  ;; operates on legacy refs kept for FE compat; the legacy options helper matches that shape
   ^{:clj-kondo/ignore [:deprecated-var]}
   (mbql.u/update-field-options legacy-ref (partial into {} (remove (fn [[k _]]
                                                                      (qualified-keyword? k))))))

--- a/src/metabase/lib/metric.cljc
+++ b/src/metabase/lib/metric.cljc
@@ -4,6 +4,7 @@
   (:refer-clojure :exclude [select-keys some not-empty])
   (:require
    [clojure.string :as str]
+   ;; metric definitions may still be stored as legacy MBQL; normalize before lib.convert/->mbql5
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.convert :as lib.convert]

--- a/src/metabase/logger/core.clj
+++ b/src/metabase/logger/core.clj
@@ -3,6 +3,7 @@
   logging options are set in [[metabase.core.bootstrap]]: the context locator for log4j2 and ensuring log4j2 is the
   logger that clojure.tools.logging uses."
   (:require
+   ;; this ns wires tools.logging to log4j2 and reads *logger-factory*; util.log sits on top of it
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [clojure.tools.logging :as log]
    [clojure.tools.logging.impl :as log.impl]

--- a/src/metabase/logger/core.clj
+++ b/src/metabase/logger/core.clj
@@ -240,7 +240,7 @@
         (.addAppender new-logger appender (.getLevel new-logger) (.getFilter new-logger)))
       (.addLogger (configuration) (logger-name a-namespace) new-logger)
       (.updateLoggers (context))
-      ;; startup notice for the log4j rewire; goes to stdout
+      ;; deliberately bypasses log4j: this reports logger reconfiguration itself, so it must not depend on it
       #_{:clj-kondo/ignore [:discouraged-var]}
       (println "Created a new logger for" (logger-name a-namespace)))))
 

--- a/src/metabase/logger/core.clj
+++ b/src/metabase/logger/core.clj
@@ -240,7 +240,7 @@
         (.addAppender new-logger appender (.getLevel new-logger) (.getFilter new-logger)))
       (.addLogger (configuration) (logger-name a-namespace) new-logger)
       (.updateLoggers (context))
-      ;; we are mid-rewire of log4j itself here; logging through it would be unreliable
+      ;; startup notice for the log4j rewire; goes to stdout
       #_{:clj-kondo/ignore [:discouraged-var]}
       (println "Created a new logger for" (logger-name a-namespace)))))
 

--- a/src/metabase/logger/core.clj
+++ b/src/metabase/logger/core.clj
@@ -240,6 +240,7 @@
         (.addAppender new-logger appender (.getLevel new-logger) (.getFilter new-logger)))
       (.addLogger (configuration) (logger-name a-namespace) new-logger)
       (.updateLoggers (context))
+      ;; we are mid-rewire of log4j itself here; logging through it would be unreliable
       #_{:clj-kondo/ignore [:discouraged-var]}
       (println "Created a new logger for" (logger-name a-namespace)))))
 

--- a/src/metabase/metabot/agent/links.clj
+++ b/src/metabase/metabot/agent/links.clj
@@ -38,6 +38,7 @@
   Normalize before converting so rehydrated queries have their canonical enum
   values restored."
   [query]
+  ;; frontend /question# URL hashes only decode legacy MBQL; conversion is the contract here
   #_{:clj-kondo/ignore [:discouraged-var]}
   (if (and (map? query) (:lib/type query))
     (lib/->legacy-MBQL (lib/normalize query))

--- a/src/metabase/metabot/agent/links.clj
+++ b/src/metabase/metabot/agent/links.clj
@@ -38,7 +38,7 @@
   Normalize before converting so rehydrated queries have their canonical enum
   values restored."
   [query]
-  ;; frontend /question# URL hashes only decode legacy MBQL; conversion is the contract here
+  ;; builds the legacy-MBQL /question# hash; the FE also accepts MBQL 5, so this could migrate
   #_{:clj-kondo/ignore [:discouraged-var]}
   (if (and (map? query) (:lib/type query))
     (lib/->legacy-MBQL (lib/normalize query))

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -214,6 +214,7 @@
 (def ^{:deprecated "0.57.0"} transform-legacy-field-ref
   "Transform field refs"
   {:in  json-in
+   ;; inside the deprecated transform itself; legacy refs from the app DB need the legacy normalizer
    :out (comp (catch-normalization-exceptions #_{:clj-kondo/ignore [:deprecated-var]} mbql.normalize/normalize-field-ref)
               json-out-with-keywordization)})
 

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -15,7 +15,9 @@
    [clojure.string :as str]
    [clojure.walk :as walk]
    [medley.core :as m]
+   ;; Toucan out-transforms normalize stored legacy MBQL on read; needed until the app db is MBQL 5
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
+   ;; stored card queries/refs are still legacy MBQL; validated against the legacy schema on read/write
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.lib.core :as lib]
    [metabase.models.dispatch :as models.dispatch]

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -668,6 +668,7 @@
   ([model pk]
    (can-read? model pk)))
 
+;; only reached through the :can_write hydration key, never called by name
 #_{:clj-kondo/ignore [:unused-private-var]}
 (define-simple-hydration-method ^:private hydrate-can-write
   :can_write

--- a/src/metabase/pivot/core.cljc
+++ b/src/metabase/pivot/core.cljc
@@ -287,6 +287,7 @@
 
   Takes raw pivot data and generates hierarchical tree structures for both rows
   and columns, along with a lookup map for cell values."
+  ;; settings is only used by the :cljs branch of this function
   #_{:clj-kondo/ignore [:unused-binding]}
   [rows cols row-indexes col-indexes val-indexes settings col-settings]
   (let [row-tree (->TreeNode nil (perf/make-list) (perf/make-map) false)

--- a/src/metabase/pivot/core.cljc
+++ b/src/metabase/pivot/core.cljc
@@ -161,6 +161,7 @@
         tree
         parsed-collapsed-subtotals))))
 
+;; defrecord has no docstring slot for the vars it interns
 #_{:clj-kondo/ignore [:missing-docstring]}
 (defrecord TreeNode [value children value->child-pos isCollapsed])
 
@@ -598,6 +599,7 @@
       #?(:cljs (perf/clj->js result)
          :clj result))))
 
+;; defrecord has no docstring slot for the vars it interns
 #_{:clj-kondo/ignore [:missing-docstring]}
 (defrecord ResultItem [value rawValue clicked isCollapsed hasSubtotal isGrandTotal isSubtotal isValueColumn depth offset
                        hasChildren path span maxDepthBelow])

--- a/src/metabase/pulse/api.clj
+++ b/src/metabase/pulse/api.clj
@@ -5,8 +5,10 @@
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :as routes.common]
    [metabase.api.util.handlers :as handlers]
+   ;; this router keeps mounting the deprecated pulse/alert routes until the notification APIs replace them
    ^{:clj-kondo/ignore [:deprecated-namespace]}
    [metabase.pulse.api.alert]
+   ;; this router keeps mounting the deprecated pulse/alert routes until the notification APIs replace them
    ^{:clj-kondo/ignore [:deprecated-namespace]}
    [metabase.pulse.api.pulse]
    [metabase.pulse.api.unsubscribe]

--- a/src/metabase/queries/core.clj
+++ b/src/metabase/queries/core.clj
@@ -64,16 +64,20 @@
   assert-can-view-card-snapshots!
   carry-pairings-for-document!])
 
+;; the re-exported var carries the docstring; kondo can't see through import-def
 #_{:clj-kondo/ignore [:missing-docstring]}
 (p/import-def metabase.queries.models.card/populate-query-fields populate-card-query-fields)
 
+;; the re-exported var carries the docstring; kondo can't see through import-def
 #_{:clj-kondo/ignore [:missing-docstring]}
 (p/import-def metabase.queries.models.card/template-tag-parameters card-template-tag-parameters)
 
+;; the re-exported var carries the docstring; kondo can't see through import-def
 #_{:clj-kondo/ignore [:missing-docstring]}
 (p/import-def metabase.queries.models.parameter-card/delete-all-for-parameterized-object!
               delete-all-parameter-cards-for-parameterized-object!)
 
+;; the re-exported var carries the docstring; kondo can't see through import-def
 #_{:clj-kondo/ignore [:missing-docstring]}
 (p/import-def metabase.queries.models.parameter-card/upsert-or-delete-from-parameters!
               upsert-or-delete-parameter-cards-from-parameters!)

--- a/src/metabase/queries/models/card/metadata.clj
+++ b/src/metabase/queries/models/card/metadata.clj
@@ -27,6 +27,7 @@
   [query :- :map]
   (future
     (try
+      ;; card result_metadata is persisted in legacy shape; Lib-shape migration pending
       #_{:clj-kondo/ignore [:deprecated-var]}
       (qp.metadata/legacy-result-metadata query api/*current-user-id*)
       (catch Throwable e

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -266,6 +266,7 @@
     (cond-> card
       legacy-mbql?
       (update :dataset_query (fn [query]
+                               ;; ?legacy-mbql=true promises MBQL 4; conversion is the endpoint contract
                                #_{:clj-kondo/ignore [:discouraged-var]}
                                (cond-> query
                                  (seq query) lib/->legacy-MBQL))))))

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -1,3 +1,4 @@
+;; grandfathered two-segment ns; the canonical QP entrypoint name predates the module layout
 #_{:clj-kondo/ignore [:metabase/namespace-name]}
 (ns metabase.query-processor
   "Primary entrypoints to running Metabase (MBQL) queries.

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -36,9 +36,11 @@
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   ;; defendpoint param schemas (ms/PositiveInt etc.); lib.schema has no API-param coercion schemas
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.util.malli.schema :as ms]
    [metabase.util.performance :refer [get-in select-keys]]
    [steffan-westcott.clj-otel.api.trace.span :as span]
+   ;; endpoint side effects: table-read events and source-card lookups hit the app db directly
    ^{:clj-kondo/ignore [:discouraged-namespace]} [toucan2.core :as t2]))
 
 ;;; -------------------------------------------- Running a Query Normally --------------------------------------------

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -24,6 +24,7 @@
    [metabase.query-processor.middleware.results-metadata :as qp.results-metadata]
    [metabase.query-processor.pivot :as qp.pivot]
    [metabase.query-processor.schema :as qp.schema]
+   ;; the legacy QP pipeline still conveys the metadata provider via the ambient store; no MBQL 5 path yet
    ^{:clj-kondo/ignore [:deprecated-namespace]}
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.streaming :as qp.streaming]

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -24,6 +24,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.performance :refer [some not-empty get-in]]
    [steffan-westcott.clj-otel.api.trace.span :as span]
+   ;; 404-checks dashcard/series membership in the app db; an existence check, not query metadata
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 

--- a/src/metabase/query_processor/debug.clj
+++ b/src/metabase/query_processor/debug.clj
@@ -16,6 +16,7 @@
   "tap> something for debug purposes if [[*debug*]] is enabled. Body is not evaluated unless debugging is enabled."
   {:style/indent 0}
   [& body]
+  ;; tapping for Portal is this macro's entire purpose; inert unless *debug* is bound
   #_{:clj-kondo/ignore [:discouraged-var]}
   `(when *debug*
      (when-some [result# (do ~@body)]

--- a/src/metabase/query_processor/debug.clj
+++ b/src/metabase/query_processor/debug.clj
@@ -16,7 +16,7 @@
   "tap> something for debug purposes if [[*debug*]] is enabled. Body is not evaluated unless debugging is enabled."
   {:style/indent 0}
   [& body]
-  ;; tapping for Portal is this macro's entire purpose; inert unless *debug* is bound
+  ;; tapping for Portal is this macro's entire purpose; inert unless *debug* is truthy
   #_{:clj-kondo/ignore [:discouraged-var]}
   `(when *debug*
      (when-some [result# (do ~@body)]

--- a/src/metabase/query_processor/metadata.clj
+++ b/src/metabase/query_processor/metadata.clj
@@ -155,6 +155,7 @@
   [query           :- :map
    current-user-id :- [:maybe ::lib.schema.id/user]]
   (mapv
+   ;; deprecated fn delegating to its deprecated private helper; both leave together
    #_{:clj-kondo/ignore [:deprecated-var]}
    ensure-legacy
    (result-metadata* query current-user-id)))

--- a/src/metabase/query_processor/middleware/add_remaps.clj
+++ b/src/metabase/query_processor/middleware/add_remaps.clj
@@ -41,6 +41,7 @@
    [metabase.lib.walk :as lib.walk]
    [metabase.query-processor.middleware.large-int :as large-int]
    [metabase.query-processor.schema :as qp.schema]
+   ;; the store's miscellaneous-value slot is the only channel for passing state between middleware stages
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.log :as log]

--- a/src/metabase/query_processor/middleware/add_remaps.clj
+++ b/src/metabase/query_processor/middleware/add_remaps.clj
@@ -41,7 +41,7 @@
    [metabase.lib.walk :as lib.walk]
    [metabase.query-processor.middleware.large-int :as large-int]
    [metabase.query-processor.schema :as qp.schema]
-   ;; the store's miscellaneous-value slot is the only channel for passing state between middleware stages
+   ;; still passes state via the store's miscellaneous-value slot; general-cached-value migration pending
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.log :as log]

--- a/src/metabase/query_processor/middleware/annotate/legacy_helper_fns.clj
+++ b/src/metabase/query_processor/middleware/annotate/legacy_helper_fns.clj
@@ -14,6 +14,7 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.query-processor.error-type :as qp.error-type]
+   ;; this ns is itself the legacy compat layer; it reads the store the legacy pipeline fills
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util.add-alias-info :as-alias add]
    [metabase.util.i18n :refer [tru]]

--- a/src/metabase/query_processor/middleware/annotate/legacy_helper_fns.clj
+++ b/src/metabase/query_processor/middleware/annotate/legacy_helper_fns.clj
@@ -7,6 +7,7 @@
   (:require
    ;; existing legacy usage -- don't use legacy MBQL namespaces in QP going forward
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
+   ;; helpers convert to legacy MBQL for drivers not yet on MBQL 5; typed against the legacy schema
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]

--- a/src/metabase/query_processor/middleware/annotate/legacy_helper_fns.clj
+++ b/src/metabase/query_processor/middleware/annotate/legacy_helper_fns.clj
@@ -55,6 +55,7 @@
     (or (::add/desired-alias (lib/options ag-clause))
         (:name (lib/options ag-clause))
         (lib/column-name
+         ;; this ns is the legacy-MBQL bridge for drivers; the deprecated conversion is its purpose
          #_{:clj-kondo/ignore [:deprecated-var]}
          (legacy-inner-query->mbql5-query legacy-inner-query)
          (lib/->mbql5 legacy-ag-clause)))))

--- a/src/metabase/query_processor/middleware/cache_backend/db.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/db.clj
@@ -7,6 +7,7 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.encryption :as encryption]
    [metabase.util.log :as log]
+   ;; this backend's whole job is reading and writing app-db QueryCache rows
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])
   (:import

--- a/src/metabase/query_processor/middleware/large_int.clj
+++ b/src/metabase/query_processor/middleware/large_int.clj
@@ -2,6 +2,7 @@
   "Middleware for handling conversion of integers to strings for proper display of large numbers"
   (:refer-clojure :exclude [mapv])
   (:require
+   ;; the store's miscellaneous-value slot is the only channel for passing state between middleware stages
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util.performance :refer [mapv]])
   (:import

--- a/src/metabase/query_processor/middleware/large_int.clj
+++ b/src/metabase/query_processor/middleware/large_int.clj
@@ -2,7 +2,7 @@
   "Middleware for handling conversion of integers to strings for proper display of large numbers"
   (:refer-clojure :exclude [mapv])
   (:require
-   ;; the store's miscellaneous-value slot is the only channel for passing state between middleware stages
+   ;; still passes state via the store's miscellaneous-value slot; general-cached-value migration pending
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util.performance :refer [mapv]])
   (:import

--- a/src/metabase/query_processor/middleware/limit.clj
+++ b/src/metabase/query_processor/middleware/limit.clj
@@ -6,6 +6,7 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.settings :as qp.settings]
+   ;; the legacy QP pipeline still conveys the metadata provider via the ambient store; no MBQL 5 path yet
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.malli :as mu]

--- a/src/metabase/query_processor/middleware/normalize_query.clj
+++ b/src/metabase/query_processor/middleware/normalize_query.clj
@@ -6,6 +6,7 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.query-processor.error-type :as qp.error-type]
+   ;; the legacy QP pipeline still conveys the metadata provider via the ambient store; no MBQL 5 path yet
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util.malli :as mu]))
 

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -11,6 +11,7 @@
    [metabase.query-permissions.core :as query-perms]
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.schema :as qp.schema]
+   ;; the legacy QP pipeline still conveys the metadata provider via the ambient store; no MBQL 5 path yet
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util :as qp.util]
    [metabase.util :as u]

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -26,6 +26,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.performance :refer [every? empty? get-in not-empty]]
+   ;; records QueryExecution rows in the app db; a write the metadata provider can't do
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -14,6 +14,7 @@
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.query-processor.reducible :as qp.reducible]
    [metabase.query-processor.schema :as qp.schema]
+   ;; the store's miscellaneous-value slot is the only channel for passing state between middleware stages
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.log :as log]

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -14,7 +14,7 @@
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.query-processor.reducible :as qp.reducible]
    [metabase.query-processor.schema :as qp.schema]
-   ;; the store's miscellaneous-value slot is the only channel for passing state between middleware stages
+   ;; still passes state via the store's miscellaneous-value slot; general-cached-value migration pending
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.log :as log]

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -20,6 +20,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.performance :refer [mapv select-keys get-in]]
+   ;; persists recomputed result_metadata back to the Card row; the metadata provider is read-only
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 

--- a/src/metabase/query_processor/middleware/update_used_cards.clj
+++ b/src/metabase/query_processor/middleware/update_used_cards.clj
@@ -10,6 +10,7 @@
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   ;; batch-updates Card.last_used_at in the app db; a write outside the metadata provider's scope
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 

--- a/src/metabase/query_processor/middleware/update_used_cards.clj
+++ b/src/metabase/query_processor/middleware/update_used_cards.clj
@@ -7,6 +7,7 @@
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.query-processor.schema :as qp.schema]
+   ;; the legacy QP pipeline still conveys the metadata provider via the ambient store; no MBQL 5 path yet
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]

--- a/src/metabase/query_processor/middleware/wrap_value_literals.clj
+++ b/src/metabase/query_processor/middleware/wrap_value_literals.clj
@@ -11,7 +11,7 @@
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.walk :as lib.walk]
    [metabase.query-processor.error-type :as qp.error-type]
-   ;; the legacy pipeline path reads the metadata provider from the ambient store; the MBQL 5 entry point sidesteps it
+   ;; every path still reads field metadata from the ambient store when it's initialized, even the deprecated mbql5 shim
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.util.date-2 :as u.date]

--- a/src/metabase/query_processor/middleware/wrap_value_literals.clj
+++ b/src/metabase/query_processor/middleware/wrap_value_literals.clj
@@ -11,6 +11,7 @@
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.walk :as lib.walk]
    [metabase.query-processor.error-type :as qp.error-type]
+   ;; the legacy QP pipeline still conveys the metadata provider via the ambient store; no MBQL 5 path yet
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.util.date-2 :as u.date]

--- a/src/metabase/query_processor/middleware/wrap_value_literals.clj
+++ b/src/metabase/query_processor/middleware/wrap_value_literals.clj
@@ -11,7 +11,7 @@
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.walk :as lib.walk]
    [metabase.query-processor.error-type :as qp.error-type]
-   ;; the legacy QP pipeline still conveys the metadata provider via the ambient store; no MBQL 5 path yet
+   ;; the legacy pipeline path reads the metadata provider from the ambient store; the MBQL 5 entry point sidesteps it
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.util.date-2 :as u.date]

--- a/src/metabase/query_processor/parameters/dates.clj
+++ b/src/metabase/query_processor/parameters/dates.clj
@@ -16,6 +16,7 @@
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.parameter :as lib.schema.parameter]
    [metabase.query-processor.error-type :as qp.error-type]
+   ;; probes whether the ambient store is bound so qp.timezone/now can use the query's timezone
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.util.date-2 :as u.date]

--- a/src/metabase/query_processor/setup.clj
+++ b/src/metabase/query_processor/setup.clj
@@ -17,6 +17,7 @@
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.schema :as qp.schema]
+   ;; qp.setup is the code that initializes the ambient store for the legacy pipeline
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.settings.core :as setting]
    [metabase.util.i18n :as i18n]

--- a/src/metabase/query_processor/setup.clj
+++ b/src/metabase/query_processor/setup.clj
@@ -22,6 +22,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   ;; pre-seeds bare-bones card metadata from the app db before any metadata provider exists
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])
   (:import

--- a/src/metabase/query_processor/streaming/common.clj
+++ b/src/metabase/query_processor/streaming/common.clj
@@ -7,6 +7,7 @@
    [metabase.appearance.core :as appearance]
    [metabase.driver :as driver]
    [metabase.models.visualization-settings :as mb.viz]
+   ;; qp.store/cached is the only per-query-execution cache; nothing replaces it yet
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.util.currency :as currency]

--- a/src/metabase/query_processor/streaming/common.clj
+++ b/src/metabase/query_processor/streaming/common.clj
@@ -7,7 +7,7 @@
    [metabase.appearance.core :as appearance]
    [metabase.driver :as driver]
    [metabase.models.visualization-settings :as mb.viz]
-   ;; qp.store/cached is the only per-query-execution cache; nothing replaces it yet
+   ;; per-query-execution cache via qp.store/cached; general-cached-value migration pending
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.util.currency :as currency]

--- a/src/metabase/query_processor/timezone.clj
+++ b/src/metabase/query_processor/timezone.clj
@@ -7,6 +7,7 @@
    [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
+   ;; the legacy QP pipeline still conveys the metadata provider via the ambient store; no MBQL 5 path yet
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]

--- a/src/metabase/query_processor/timezone.clj
+++ b/src/metabase/query_processor/timezone.clj
@@ -11,6 +11,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
+   ;; ms/InstanceOf validates a Toucan Database instance; lib.schema has no equivalent
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.util.malli.schema :as ms])
   (:import
    (java.time ZoneId ZonedDateTime)))

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -90,6 +90,7 @@
   ensure survives."
   {:deprecated "0.57.0"}
   [new-metadata old-metadata]
+  ;; deprecated fn using its own deprecated helper; both leave together
   #_{:clj-kondo/ignore [:deprecated-var]}
   (let [old-cols-by-desired-col-alias (m/index-by :lib/desired-column-alias (filter :lib/desired-column-alias old-metadata))
         old-cols-by-name (m/index-by :name old-metadata)]

--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -551,6 +551,7 @@
      ;; MBQL 4 inner MBQL query
      ((some-fn :source-table :source-query) query)
      (-> query
+         ;; legacy inner-query entry point; the deprecated bridge is the only path to a Lib query here
          #_{:clj-kondo/ignore [:deprecated-var]}
          annotate.legacy-helper-fns/legacy-inner-query->mbql5-query
          (add-alias-info options)

--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -55,6 +55,7 @@
    [metabase.lib.walk :as lib.walk]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.annotate.legacy-helper-fns :as annotate.legacy-helper-fns]
+   ;; the legacy QP pipeline still conveys the metadata provider via the ambient store; no MBQL 5 path yet
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]

--- a/src/metabase/query_processor/writeback.clj
+++ b/src/metabase/query_processor/writeback.clj
@@ -14,6 +14,7 @@
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.query-processor.setup :as qp.setup]
+   ;; the legacy QP pipeline still conveys the metadata provider via the ambient store; no MBQL 5 path yet
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]

--- a/src/metabase/server/routes.clj
+++ b/src/metabase/server/routes.clj
@@ -104,7 +104,7 @@
 (mu/defn make-routes :- ::api.macros/handler
   "Create the top-level Ring route handler for Metabase."
   [api-routes :- ::api.macros/handler]
-  ;; top-level non-/api routes (SPA shell, health, redirects) have no OpenAPI surface
+  ;; top-level routes defined outside the api.macros surface (SPA shell, health, redirects) have no OpenAPI metadata
   #_{:clj-kondo/ignore [:discouraged-var]}
   (compojure/routes
    auth-wrapper/routes

--- a/src/metabase/server/routes.clj
+++ b/src/metabase/server/routes.clj
@@ -2,6 +2,7 @@
   "Main Compojure routes tables. See https://github.com/weavejester/compojure/wiki/Routes-In-Detail for details about
    how these work. `/api/` routes are in [[metabase.api-routes.routes]]."
   (:require
+   ;; non-/api routes in this ns have no OpenAPI surface; plain compojure is fine
    [compojure.core :as compojure :refer #_{:clj-kondo/ignore [:discouraged-var]} [context defroutes GET OPTIONS]]
    [compojure.route :as route]
    [metabase.api.macros :as api.macros]
@@ -75,6 +76,7 @@
   ([_request respond _raise]
    (respond (livez-handler))))
 
+;; static-file routes have no OpenAPI surface; plain compojure defroutes is fine
 #_{:clj-kondo/ignore [:discouraged-var]}
 (defroutes ^:private static-files-handler
   (GET "/embedding-sdk.js" request
@@ -102,6 +104,7 @@
 (mu/defn make-routes :- ::api.macros/handler
   "Create the top-level Ring route handler for Metabase."
   [api-routes :- ::api.macros/handler]
+  ;; top-level non-/api routes (SPA shell, health, redirects) have no OpenAPI surface
   #_{:clj-kondo/ignore [:discouraged-var]}
   (compojure/routes
    auth-wrapper/routes

--- a/src/metabase/slackbot/config.clj
+++ b/src/metabase/slackbot/config.clj
@@ -69,6 +69,7 @@
         (channel.settings/unobfuscated-slack-app-token)
         (encryption/default-encryption-enabled?))))
 
+;; referenced from with-slackbot-setup's syntax-quoted with-redefs, which clojure-lsp cannot see
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn validate-bot-token!
   "Validate a Slack bot token using the auth.test endpoint.

--- a/src/metabase/sso/core.clj
+++ b/src/metabase/sso/core.clj
@@ -31,8 +31,10 @@
   sso-enabled?
   sso-source-enabled?])
 
+;; the re-exported var carries the docstring; kondo can't see through import-def
 #_{:clj-kondo/ignore [:missing-docstring]}
 (p/import-def metabase.sso.ldap.default-implementation/UserInfo LDAPUserInfo)
 
+;; the re-exported var carries the docstring; kondo can't see through import-def
 #_{:clj-kondo/ignore [:missing-docstring]}
 (p/import-def metabase.sso.ldap.default-implementation/search ldap-search)

--- a/src/metabase/task/impl.clj
+++ b/src/metabase/task/impl.clj
@@ -357,6 +357,7 @@
          (log/error msg# (ex-message e#))
          (throw (JobExecutionException. msg# e# true))))))
 
+;; this is the sanctioned metabase.task/defjob wrapper; it must expand to the quartzite macro
 #_{:clj-kondo/ignore [:discouraged-var]}
 (defmacro defjob
   "Like `clojurewerkz.quartzite.task/defjob` but with a log context and an OpenTelemetry tracing span."

--- a/src/metabase/task_history/models/task_history.clj
+++ b/src/metabase/task_history/models/task_history.clj
@@ -1,5 +1,6 @@
 (ns metabase.task-history.models.task-history
   (:require
+   ;; installs a capturing LoggerFactory via *logger-factory*; util.log doesn't expose the factory plumbing
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [clojure.tools.logging]
    [clojure.tools.logging.impl]

--- a/src/metabase/tiles/api.clj
+++ b/src/metabase/tiles/api.clj
@@ -5,6 +5,7 @@
    [metabase.api.macros :as api.macros]
    ;; TODO (Cam 10/10/25) -- update the tile API to use MBQL 5
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
+   ;; tile API field refs are still legacy MBQL; keep the legacy schema until the MBQL 5 port above
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]

--- a/src/metabase/types/core.cljc
+++ b/src/metabase/types/core.cljc
@@ -405,6 +405,7 @@
   DEPRECATED: Prefer using MBQL 5 + [[metabase.lib.types.isa/temporal?]] going forward."
   {:deprecated "0.57.0"}
   [field :- ::snake-cased-type-info]
+  ;; deprecated shim delegating to the equally-deprecated field-is-type?; both go away together
   #_{:clj-kondo/ignore [:deprecated-var]}
   (field-is-type? :type/Temporal field))
 

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1,3 +1,4 @@
+;; grandfathered two-segment ns; renaming metabase.util would touch nearly every namespace
 #_{:clj-kondo/ignore [:metabase/namespace-name]}
 (ns metabase.util
   "Common utility functions useful throughout the codebase."

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1228,6 +1228,7 @@
      "Return how many milliseconds have elapsed since the given system millisecond time.
      For cases where you can't use u/start-timer, e.g., external time sources or process boundaries."
      [start-ms]
+     ;; the sanctioned wall-clock helper: nanoTime timers can't cross process or external-source boundaries
      #_{:clj-kondo/ignore [:metabase/discourage-millis-duration]}
      (- (System/currentTimeMillis) start-ms)))
 

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1303,7 +1303,7 @@
   #?(:clj
      (reify CollReduce
        (coll-reduce [_ f]
-         ;; this IS the no-init reduce arity; delegating without init preserves CollReduce semantics
+         ;; this IS the no-init reduce arity; it must delegate without an init
          #_{:clj-kondo/ignore [:reduce-without-init]}
          (let [acc1 (reduce f r1)
                acc2 (reduce f acc1 r2)]

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -792,6 +792,7 @@
   (^String [x]
    #?(:clj
       (with-out-str
+        ;; pprint-to-str exists to render a string; output is captured by with-out-str, never printed
         #_{:clj-kondo/ignore [:discouraged-var]}
         (pp/pprint x {:max-width 120}))
       :cljs-dev
@@ -799,6 +800,7 @@
       ;; default value wastes too much space, 120 is a little easier to read actually.
       (binding [pprint/*print-right-margin* 120]
         (with-out-str
+          ;; pprint-to-str exists to render a string; output is captured by with-out-str, never printed
           #_{:clj-kondo/ignore [:discouraged-var]}
           (pprint/pprint x)))
       :default

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -820,6 +820,7 @@
   `profile` form or 1 for a form inside that."
   0)
 
+;; only called from `profile` macroexpansions, so clojure-lsp sees no usage
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn -profile-print-time
   "Impl for [[profile]] macro -- don't use this directly. Prints the `___ took ___` message at the conclusion of a

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1299,6 +1299,7 @@
   #?(:clj
      (reify CollReduce
        (coll-reduce [_ f]
+         ;; this IS the no-init reduce arity; delegating without init preserves CollReduce semantics
          #_{:clj-kondo/ignore [:reduce-without-init]}
          (let [acc1 (reduce f r1)
                acc2 (reduce f acc1 r2)]

--- a/src/metabase/util/experiment/settings.clj
+++ b/src/metabase/util/experiment/settings.clj
@@ -4,6 +4,7 @@
    [metabase.util.experiment :as experiment]
    [metabase.util.i18n :refer [deferred-tru]]))
 
+;; experiment lives under util rather than a top-level module, so no <module>.settings ns exists for it
 #_{:clj-kondo/ignore [:metabase/defsetting-namespace]}
 (defsetting experiments-enabled
   (deferred-tru "Enable or disable all code experiments. When disabled, only the production code path runs.")

--- a/src/metabase/util/format.cljc
+++ b/src/metabase/util/format.cljc
@@ -61,6 +61,7 @@
        false
        (config/config-bool :mb-colorize-logs))))
 
+;; picks the implementation fn once at load from config; defn would re-check colorize? on every call
 #_{:clj-kondo/ignore [:def-fn]}
 (def ^{:arglists '(^String [color-symb x])} colorize
   "Colorize string `x` using `color`, a symbol or keyword, but only if `MB_COLORIZE_LOGS` is enabled (the default).

--- a/src/metabase/util/i18n/impl.clj
+++ b/src/metabase/util/i18n/impl.clj
@@ -29,7 +29,7 @@
   Returns `nil` for invalid strings -- you can use this to check whether a String is valid."
   ^String [s]
   {:pre [((some-fn nil? string?) s)]}
-  ;; u/lower-case-en would be a circular dep (metabase.util requires i18n); locale codes are ASCII
+  ;; u/lower-case-en would be a circular dep (metabase.util requires i18n)
   #_{:clj-kondo/ignore [:discouraged-var]}
   (when (string? s)
     (when-let [[_ language country] (re-matches #"^(\w{2})(?:[-_](\w{2}))?$" s)]

--- a/src/metabase/util/i18n/impl.clj
+++ b/src/metabase/util/i18n/impl.clj
@@ -29,13 +29,12 @@
   Returns `nil` for invalid strings -- you can use this to check whether a String is valid."
   ^String [s]
   {:pre [((some-fn nil? string?) s)]}
-  ;; u/lower-case-en would be a circular dep (metabase.util requires i18n)
-  #_{:clj-kondo/ignore [:discouraged-var]}
   (when (string? s)
     (when-let [[_ language country] (re-matches #"^(\w{2})(?:[-_](\w{2}))?$" s)]
-      (let [language (str/lower-case language)]
+      ;; Locale/US casing so a Turkish default locale can't mangle codes like "ID"
+      (let [language (.toLowerCase ^String language Locale/US)]
         (if country
-          (str language \_ (some-> country str/upper-case))
+          (str language \_ (some-> ^String country (.toUpperCase Locale/US)))
           language)))))
 
 (extend-protocol CoerceToLocale

--- a/src/metabase/util/i18n/impl.clj
+++ b/src/metabase/util/i18n/impl.clj
@@ -29,6 +29,7 @@
   Returns `nil` for invalid strings -- you can use this to check whether a String is valid."
   ^String [s]
   {:pre [((some-fn nil? string?) s)]}
+  ;; u/lower-case-en would be a circular dep (metabase.util requires i18n); locale codes are ASCII
   #_{:clj-kondo/ignore [:discouraged-var]}
   (when (string? s)
     (when-let [[_ language country] (re-matches #"^(\w{2})(?:[-_](\w{2}))?$" s)]

--- a/src/metabase/util/json.clj
+++ b/src/metabase/util/json.clj
@@ -1,6 +1,7 @@
 (ns metabase.util.json
   "Functions for encoding and decoding JSON that abstract away the underlying implementation."
   (:require
+   ;; this ns is the JSON facade; it wraps cheshire directly
    #_{:clj-kondo/ignore [:discouraged-namespace]}
    [cheshire.core :as cheshire]
    [cheshire.factory]

--- a/src/metabase/util/log.clj
+++ b/src/metabase/util/log.clj
@@ -9,6 +9,7 @@
    [clojure.java.io :as io]
    [clojure.pprint :as pprint]
    [clojure.string :as str]
+   ;; this ns is the facade over tools.logging; it has to require the real thing
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [clojure.tools.logging]
    [clojure.tools.logging.impl]

--- a/src/metabase/util/log.clj
+++ b/src/metabase/util/log.clj
@@ -294,6 +294,7 @@
      :cljs (glogi-spy (str *ns*) level expr
                       #(str/trim-newline
                         (with-out-str
+                          ;; spy's own formatter: pprint goes into with-out-str, nothing is printed
                           #_{:clj-kondo/ignore [:discouraged-var]}
                           (pprint/with-pprint-dispatch pprint/code-dispatch
                             (pprint/pprint '~expr)

--- a/src/metabase/util/log.clj
+++ b/src/metabase/util/log.clj
@@ -2,6 +2,7 @@
   "Common logging interface that wraps clojure.tools.logging in JVM Clojure and Glogi in CLJS.
 
   The interface is the same as [[clojure.tools.logging]]."
+  ;; kondo mis-tracks unquote nesting in the doubly syntax-quoted log macros below
   {:clj-kondo/ignore [:unquote-not-syntax-quoted]}
   (:require
    [clojure.edn :as edn]

--- a/src/metabase/util/log.clj
+++ b/src/metabase/util/log.clj
@@ -269,6 +269,7 @@
   [& args]
   `(logf :error ~@args))
 
+;; part of the public log API; its callers live in test and EE code outside this lint's view
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defmacro fatal
   "Log one or more args at the `:fatal` level."
@@ -299,6 +300,7 @@
                             (pprint/pprint %)))))
      :clj  `(clojure.tools.logging/spy ~level ~expr))))
 
+;; REPL/debug sibling of `spy`; kept as public log API though nothing in-tree calls it
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defmacro spyf
   "Evaluates an expression, and may write both the form and its formatted result to the log.

--- a/src/metabase/util/log.clj
+++ b/src/metabase/util/log.clj
@@ -302,7 +302,7 @@
                             (pprint/pprint %)))))
      :clj  `(clojure.tools.logging/spy ~level ~expr))))
 
-;; REPL/debug sibling of `spy`; kept as public log API though nothing in-tree calls it
+;; legacy REPL/debug API with no in-tree callers; retained pending a compatibility/removal audit
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defmacro spyf
   "Evaluates an expression, and may write both the form and its formatted result to the log.

--- a/src/metabase/util/log.cljs
+++ b/src/metabase/util/log.cljs
@@ -16,7 +16,7 @@
 (glogi-console/install!)
 (log/set-levels {:glogi/root :info})
 
-;; called only from glogi-logp/logf macroexpansions, which clojure-lsp can't see
+;; called only from glogi macroexpansions (logp/logf/spy), which clojure-lsp can't see
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn is-loggable?
   "Part of the internals of [[glogi-logp]] etc."

--- a/src/metabase/util/log.cljs
+++ b/src/metabase/util/log.cljs
@@ -16,12 +16,14 @@
 (glogi-console/install!)
 (log/set-levels {:glogi/root :info})
 
+;; called only from glogi-logp/logf macroexpansions, which clojure-lsp can't see
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn is-loggable?
   "Part of the internals of [[glogi-logp]] etc."
   [logger-name level]
   (glog/isLoggable (log/logger logger-name) (log/level level)))
 
+;; called only from logf macroexpansions, which clojure-lsp can't see
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn format-msg
   "Part of the internals of [[logf]]."

--- a/src/metabase/util/malli/defn.clj
+++ b/src/metabase/util/malli/defn.clj
@@ -54,6 +54,7 @@
                                                      (:arities arities-value)))
                                       ")"))
           "\n  Return: " (str/replace (with-out-str
+                                        ;; renders the schema into the generated docstring via with-out-str
                                         #_{:clj-kondo/ignore [:discouraged-var]}
                                         (pp/pprint (:schema (:values return) :any)
                                                    {:max-width 120}))

--- a/src/metabase/util/malli/registry.cljc
+++ b/src/metabase/util/malli/registry.cljc
@@ -80,6 +80,7 @@
   [schema]
   (letfn [(make-validator* []
             (try
+              ;; this is the sanctioned caching wrapper; it must call raw malli once to build the cached fn
               #_{:clj-kondo/ignore [:discouraged-var]}
               (mc/validator (cached-schema schema))
               (catch #?(:clj Throwable :cljs :default) e
@@ -108,6 +109,7 @@
   [schema]
   (letfn [(make-explainer []
             (try
+              ;; this is the sanctioned caching wrapper; it must call raw malli once to build the cached fn
               #_{:clj-kondo/ignore [:discouraged-var]}
               (let [validator* (validator schema)
                     explainer* (mc/explainer (cached-schema schema))]

--- a/src/metabase/xrays/domain_entities/specs.clj
+++ b/src/metabase/xrays/domain_entities/specs.clj
@@ -6,6 +6,7 @@
    [medley.core :as m]
    ;; legacy usages, do not use legacy MBQL stuff in new code.
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
+   ;; domain-entity specs are written against legacy MBQL clauses; no MBQL 5 port yet
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]

--- a/test/metabase/actions/settings_test.clj
+++ b/test/metabase/actions/settings_test.clj
@@ -16,6 +16,7 @@
       (or (some->> (:setting/disabled-reasons (ex-data e)) (map :key))
           (throw e)))))
 
+;; validate-settable-for-db! only validates and throws despite the bang; nothing is mutated
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn- can-configure-data-editing-for-db? [db]
   (try

--- a/test/metabase/analyze/query_results_test.clj
+++ b/test/metabase/analyze/query_results_test.clj
@@ -8,6 +8,7 @@
    [metabase.analyze.query-results :as qr]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.test-util :as lib.tu]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/api/macros/defendpoint/tools_manifest_test.clj
+++ b/test/metabase/api/macros/defendpoint/tools_manifest_test.clj
@@ -357,6 +357,7 @@
 (api.macros/defendpoint :delete "/v1/test/:id"
   "Delete a test resource."
   {:tool {:name "delete_test"}}
+  ;; binding exists only to carry the param schema into the generated tool manifest
   [#_{:clj-kondo/ignore [:unused-binding]}
    {:keys [id]} :- [:map [:id :int]]]
   nil)
@@ -367,6 +368,7 @@
   "Search for things."
   {:tool {:name "test_search"}}
   [_route-params
+   ;; binding exists only to carry the param schema into the generated tool manifest
    #_{:clj-kondo/ignore [:unused-binding]}
    {:keys [q limit]} :- [:map
                          [:q :string]
@@ -384,6 +386,7 @@
           :task-support :parallel}}
   [{:keys [id]} :- [:map [:id :int]]
    _query-params
+   ;; binding exists only to carry the param schema into the generated tool manifest
    #_{:clj-kondo/ignore [:unused-binding]}
    body :- [:map [:action :string]]]
   {:id id :status "active"})
@@ -393,6 +396,7 @@
   "Update a test resource."
   {:tool {:name "test_resource"}}
   [{:keys [id]} :- [:map [:id :int]]
+   ;; binding exists only to carry the param schema into the generated tool manifest
    #_{:clj-kondo/ignore [:unused-binding]}
    {:keys [dry-run]} :- [:map [:dry-run {:optional true} [:maybe :boolean]]]
    body :- [:map [:name :string]]]

--- a/test/metabase/api/macros_test.clj
+++ b/test/metabase/api/macros_test.clj
@@ -67,6 +67,7 @@
 
 (mr/def ::id pos-int?)
 
+;; referenced only inside quoted defendpoint args that parse-args resolves at runtime
 #_{:clj-kondo/ignore [:unused-private-var]}
 (def ^:private RouteParams
   [:map

--- a/test/metabase/app_db/custom_migrations/metrics_v2_batch_test.clj
+++ b/test/metabase/app_db/custom_migrations/metrics_v2_batch_test.clj
@@ -150,11 +150,13 @@
   ([] (process-instances nil))
   ([{:keys [print-stats?]}]
    (when print-stats?
+     ;; opt-in CSV stats for REPL analysis runs; console output is the point
      #_{:clj-kondo/ignore [:discouraged-var]}
      (println "instance,metrics,metric consuming cards,all cards"))
    (doseq [{instance-name :instance :as instance} (read-instance)]
      (let [{:keys [v2-metrics cards]} (process-instance instance)]
        (when print-stats?
+         ;; opt-in CSV stats for REPL analysis runs; console output is the point
          #_{:clj-kondo/ignore [:discouraged-var]}
          (printf "%s,%d,%d%n" instance-name (count v2-metrics) (count cards)))
        (doseq [{:keys [input metric-card]} v2-metrics

--- a/test/metabase/app_db/schema_migrations_test.clj
+++ b/test/metabase/app_db/schema_migrations_test.clj
@@ -2022,6 +2022,7 @@
                  (t2/select-one-fn :perm_value (t2/table-name :model/DataPermissions)
                                    :db_id db-id :table_id table-id-2 :group_id group-id :perm_type "perms/create-queries"))))))))
 
+;; every scenario reuses one expensive test-migrations rollback window; splitting re-runs it per case
 #_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest ^:mb/old-migrations-test split-data-permissions-legacy-no-self-service-migration-test
   (testing "view-data is set to `legacy-no-self-service` for groups that meet specific conditions"

--- a/test/metabase/app_db/test_util.clj
+++ b/test/metabase/app_db/test_util.clj
@@ -22,6 +22,7 @@
 
   javax.sql.DataSource
   (getConnection [_]
+    ;; this shim's job is adapting a raw jdbc spec into a DataSource; it opens the connection itself
     #_{:clj-kondo/ignore [:discouraged-var]}
     (jdbc/get-connection jdbc-spec))
 

--- a/test/metabase/channel/impl/http_test.clj
+++ b/test/metabase/channel/impl/http_test.clj
@@ -67,6 +67,7 @@
   (let [handler        (as-> route+handlers routes+handlers
                          (mapv :route routes+handlers)
                          (conj routes+handlers (compojure.route/not-found {:status-code 404 :body "Not found."}))
+                         ;; throwaway Jetty test handler; no OpenAPI spec needed
                          (apply #_{:clj-kondo/ignore [:discouraged-var]} compojure/routes routes+handlers))
         ^Server server (jetty/run-jetty (apply-middleware handler middlewares) {:port 0 :join? false})]
     (try

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -32,6 +32,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor.compile :as qp.compile]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.string-extracts-test :as string-extracts-test]
    [metabase.query-processor.test :as qp]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -2174,6 +2174,7 @@
       (let [db-name "sync_writable_test"
             details (tx/dbdef->connection-details :postgres :db {:database-name db-name})]
         (tx/drop-if-exists-and-create-db! driver/*driver* db-name)
+        ;; fixture DDL on a scratch pg database with no :model/Database row, so raw jdbc on the spec
         #_{:clj-kondo/ignore [:discouraged-var]}
         (jdbc/with-db-connection [conn (sql-jdbc.conn/connection-details->spec :postgres details)]
           (try

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -49,6 +49,7 @@
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.pivot :as qp.pivot]
    [metabase.query-processor.reducible :as qp.reducible]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.secrets.models.secret :as secret]

--- a/test/metabase/driver/sql/parameters/substitution_test.clj
+++ b/test/metabase/driver/sql/parameters/substitution_test.clj
@@ -11,6 +11,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
+   ;; reads the provider that mt/with-metadata-provider binds in the ambient store
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]
    [metabase.util.honey-sql-2 :as h2x]))

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -24,6 +24,7 @@
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.middleware.limit :as limit]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.util.add-alias-info :as add]

--- a/test/metabase/driver/sql_jdbc/actions_test.clj
+++ b/test/metabase/driver/sql_jdbc/actions_test.clj
@@ -12,6 +12,7 @@
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.actions :as sql-jdbc.actions]
    [metabase.lib.schema.id :as lib.schema.id]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]
    [metabase.util.honey-sql-2 :as h2x]

--- a/test/metabase/driver/sql_jdbc/execute_test.clj
+++ b/test/metabase/driver/sql_jdbc/execute_test.clj
@@ -216,6 +216,7 @@
 
 (deftest bad-connection-details-throw-client-error-test
   (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc})
+    ;; needs a real Database row: the query goes through the HTTP API, not a metadata provider
     #_{:clj-kondo/ignore [:discouraged-var]}
     (mt/with-temp [:model/Database tmp-db {:details (tx/bad-connection-details driver/*driver*)
                                            :engine  driver/*driver*}]
@@ -237,6 +238,7 @@
 (deftest connection-pool-checkout-timeout-returns-503-test
   (testing "A c3p0 checkout timeout (saturated pool) surfaces to the frontend as a retriable HTTP 503"
     (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc})
+      ;; needs a real Database row: the query goes through the HTTP API, not a metadata provider
       #_{:clj-kondo/ignore [:discouraged-var]}
       (mt/with-temp [:model/Database tmp-db {:details (tx/bad-connection-details driver/*driver*)
                                              :engine  driver/*driver*}]
@@ -274,6 +276,7 @@
 (deftest connection-pool-full-checkout-queue-returns-503-test
   (testing "When the checkout queue is full, additional queries fail fast with a retriable HTTP 503"
     (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc})
+      ;; needs a real Database row: the query goes through the HTTP API, not a metadata provider
       #_{:clj-kondo/ignore [:discouraged-var]}
       (mt/with-temp [:model/Database tmp-db {:details (tx/bad-connection-details driver/*driver*)
                                              :engine  driver/*driver*}]

--- a/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
@@ -13,6 +13,7 @@
    [metabase.driver.sql-jdbc.sync.describe-database :as sql-jdbc.describe-database]
    [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync.interface]
    [metabase.driver.util :as driver.u]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.sync.core :as sync]

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -12,6 +12,7 @@
    [metabase.driver.util :as driver.u]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]

--- a/test/metabase/embedding/settings_test.clj
+++ b/test/metabase/embedding/settings_test.clj
@@ -138,7 +138,7 @@
 
 (defn test-enabled-sync! [env expected-behavior]
   ;; reads the deprecated enable-embedding setting on purpose; the sync under test bridges from it
-  (let [unsyncd-settings {:enable-embedding             #_:clj-kondo/ignore (embed.settings/enable-embedding)
+  (let [unsyncd-settings {:enable-embedding             #_{:clj-kondo/ignore [:deprecated-var]} (embed.settings/enable-embedding)
                           :enable-embedding-interactive (embed.settings/enable-embedding-interactive)
                           :enable-embedding-sdk         (embed.settings/enable-embedding-sdk)
                           :enable-embedding-static      (embed.settings/enable-embedding-static)}]
@@ -178,7 +178,7 @@
 (defn test-origin-sync! [env expected-behavior]
   (testing (str "origin sync with expected-behavior: " expected-behavior)
     ;; reads the deprecated embedding-app-origin setting on purpose; the sync under test bridges from it
-    (let [unsyncd-setting {:embedding-app-origin              #_:clj-kondo/ignore (embed.settings/embedding-app-origin)
+    (let [unsyncd-setting {:embedding-app-origin              #_{:clj-kondo/ignore [:deprecated-var]} (embed.settings/embedding-app-origin)
                            :embedding-app-origins-interactive (embed.settings/embedding-app-origins-interactive)
                            :embedding-app-origins-sdk         (embed.settings/embedding-app-origins-sdk)}]
       ;; called for side effects

--- a/test/metabase/embedding/settings_test.clj
+++ b/test/metabase/embedding/settings_test.clj
@@ -137,7 +137,8 @@
   (depricated-setting-throws #'embed.settings/check-origins-settings! {:mb-embedding-app-origin true :mb-embedding-app-origins-interactive true :mb-embedding-app-origins-sdk false}))
 
 (defn test-enabled-sync! [env expected-behavior]
-  (let [unsyncd-settings {:enable-embedding             #_{:clj-kondo/ignore [:deprecated-var]} (embed.settings/enable-embedding)
+  ;; reads the deprecated enable-embedding setting on purpose; the sync under test bridges from it
+  (let [unsyncd-settings {:enable-embedding             #_:clj-kondo/ignore (embed.settings/enable-embedding)
                           :enable-embedding-interactive (embed.settings/enable-embedding-interactive)
                           :enable-embedding-sdk         (embed.settings/enable-embedding-sdk)
                           :enable-embedding-static      (embed.settings/enable-embedding-static)}]
@@ -176,7 +177,8 @@
 
 (defn test-origin-sync! [env expected-behavior]
   (testing (str "origin sync with expected-behavior: " expected-behavior)
-    (let [unsyncd-setting {:embedding-app-origin              #_{:clj-kondo/ignore [:deprecated-var]} (embed.settings/embedding-app-origin)
+    ;; reads the deprecated embedding-app-origin setting on purpose; the sync under test bridges from it
+    (let [unsyncd-setting {:embedding-app-origin              #_:clj-kondo/ignore (embed.settings/embedding-app-origin)
                            :embedding-app-origins-interactive (embed.settings/embedding-app-origins-interactive)
                            :embedding-app-origins-sdk         (embed.settings/embedding-app-origins-sdk)}]
       ;; called for side effects

--- a/test/metabase/embedding_rest/api/embed_test.clj
+++ b/test/metabase/embedding_rest/api/embed_test.clj
@@ -344,11 +344,13 @@
           (let [expected-status (response-format->status-code response-format)]
             (testing "it should be possible to run a Card successfully if you jump through the right hoops..."
               (with-temp-card [card {:enable_embedding true}]
+                ;; embed tests still assert via the deprecated helper; not yet migrated
                 #_{:clj-kondo/ignore [:deprecated-var]}
                 (test-query-results
                  response-format
                  (client/real-client :get expected-status (card-query-url card response-format)
                                      {:request-options request-options}))
+                ;; embed tests still assert via the deprecated helper; not yet migrated
                 #_{:clj-kondo/ignore [:deprecated-var]}
                 (test-query-results
                  response-format
@@ -430,6 +432,7 @@
             (is (= "You must specify a value for :venue_id in the JWT."
                    (client/client :get 400 (card-query-url card response-format)))))
           (testing "if `:locked` param is present, request should succeed"
+            ;; embed tests still assert via the deprecated helper; not yet migrated
             #_{:clj-kondo/ignore [:deprecated-var]}
             (test-query-results
              response-format
@@ -470,6 +473,7 @@
                                                         "&venue_id=100"
                                                         "?venue_id=100")))))))
           (testing "If an `:enabled` param is present in the JWT, that's ok"
+            ;; embed tests still assert via the deprecated helper; not yet migrated
             #_{:clj-kondo/ignore [:deprecated-var]}
             (test-query-results
              response-format
@@ -477,6 +481,7 @@
                                  (card-query-url card response-format {:params {:venue_id "enabled"}})
                                  {:request-options request-options})))
           (testing "If an `:enabled` param is present in URL params but *not* the JWT, that's ok"
+            ;; embed tests still assert via the deprecated helper; not yet migrated
             #_{:clj-kondo/ignore [:deprecated-var]}
             (test-query-results
              response-format
@@ -783,8 +788,10 @@
   (testing "it should be possible to run a Card successfully if you jump through the right hoops..."
     (with-embedding-enabled-and-new-secret-key!
       (with-temp-dashcard [dashcard {:dash {:enable_embedding true}}]
+        ;; embed tests still assert via the deprecated helper; not yet migrated
         #_{:clj-kondo/ignore [:deprecated-var]}
         (test-query-results (client/client :get 202 (dashcard-url dashcard)))
+        ;; embed tests still assert via the deprecated helper; not yet migrated
         #_{:clj-kondo/ignore [:deprecated-var]}
         (test-query-results (client/client :get 202 (dashcard-url dashcard {} (dashcard->dash-eid dashcard))))))))
 

--- a/test/metabase/embedding_rest/api/preview_embed_test.clj
+++ b/test/metabase/embedding_rest/api/preview_embed_test.clj
@@ -78,6 +78,7 @@
     (embed-test/with-embedding-enabled-and-new-secret-key!
       (embed-test/with-temp-card [card]
         (testing "It should be possible to run a Card successfully if you jump through the right hoops..."
+          ;; embed tests still assert via the deprecated helper; not yet migrated
           #_{:clj-kondo/ignore [:deprecated-var]}
           (embed-test/test-query-results
            (mt/user-http-request :crowberto :get 202 (card-query-url card))))
@@ -101,6 +102,7 @@
             (is (= "You must specify a value for :venue_id in the JWT."
                    (mt/user-http-request :crowberto :get 400 (card-query-url card {:_embedding_params {:venue_id "locked"}})))))
           (testing "if `:locked` param is supplied, request should succeed"
+            ;; embed tests still assert via the deprecated helper; not yet migrated
             #_{:clj-kondo/ignore [:deprecated-var]}
             (embed-test/test-query-results
              (mt/user-http-request :crowberto :get 202 (card-query-url card {:_embedding_params {:venue_id "locked"}
@@ -136,11 +138,13 @@
                                                                                         :params            {:venue_id 100}})
                                                                   "?venue_id=200")))))
           (testing "If an `:enabled` param is present in the JWT, that's ok"
+            ;; embed tests still assert via the deprecated helper; not yet migrated
             #_{:clj-kondo/ignore [:deprecated-var]}
             (embed-test/test-query-results
              (mt/user-http-request :crowberto :get 202 (card-query-url card {:_embedding_params {:venue_id "enabled"}
                                                                              :params            {:venue_id "enabled"}}))))
           (testing "If an `:enabled` param is present in URL params but *not* the JWT, that's ok"
+            ;; embed tests still assert via the deprecated helper; not yet migrated
             #_{:clj-kondo/ignore [:deprecated-var]}
             (embed-test/test-query-results
              (mt/user-http-request :crowberto :get 202 (str (card-query-url card {:_embedding_params {:venue_id "enabled"}})
@@ -263,6 +267,7 @@
     (embed-test/with-embedding-enabled-and-new-secret-key!
       (embed-test/with-temp-dashcard [dashcard]
         (testing "It should be possible to run a Card successfully if you jump through the right hoops..."
+          ;; embed tests still assert via the deprecated helper; not yet migrated
           #_{:clj-kondo/ignore [:deprecated-var]}
           (embed-test/test-query-results
            (mt/user-http-request :crowberto :get 202 (dashcard-url dashcard))))

--- a/test/metabase/lib/equality_test.cljc
+++ b/test/metabase/lib/equality_test.cljc
@@ -488,6 +488,7 @@
                     (->> refs
                          (map #(lib.equality/find-matching-column all-4 -1 % ret-4)))))
             (is (=? [0 1 2 3]
+                    ;; the test targets find-column-indexes-for-refs itself
                     #_{:clj-kondo/ignore [:discouraged-var]}
                     (lib.equality/find-column-indexes-for-refs all-4 -1 refs ret-4))))
           (testing "just-3 does not match the joined TAX"
@@ -498,6 +499,7 @@
                     (->> refs
                          (map #(lib.equality/find-matching-column just-3 -1 % ret-3)))))
             (is (=? [0 1 2 -1]
+                    ;; the test targets find-column-indexes-for-refs itself
                     #_{:clj-kondo/ignore [:discouraged-var]}
                     (lib.equality/find-column-indexes-for-refs just-3 -1 refs ret-3)))))))))
 

--- a/test/metabase/lib/metadata/cached_provider_test.cljc
+++ b/test/metabase/lib/metadata/cached_provider_test.cljc
@@ -12,6 +12,7 @@
   (let [fetch-count (atom 0)
         missing-id  123
         provider    (lib.metadata.cached-provider/cached-metadata-provider
+                     ;; stub: the test only hits metadatas; other methods would throw if called
                      #_{:clj-kondo/ignore [:missing-protocol-method]}
                      (reify
                        lib.metadata.protocols/MetadataProvider

--- a/test/metabase/lib/query/test_spec_test.cljc
+++ b/test/metabase/lib/query/test_spec_test.cljc
@@ -690,6 +690,7 @@
       (is (= 1 (count (lib/filters query 1))))
       (is (= 5 (lib/current-limit query 2))))))
 
+;; intentionally one giant spec: proves every test-query feature composes in a single multi-stage build
 #_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest ^:parallel test-query-comprehensive-all-features-test
   (testing "test-query exercises all functionality in a comprehensive multi-stage query"

--- a/test/metabase/lib/query/test_spec_test.cljc
+++ b/test/metabase/lib/query/test_spec_test.cljc
@@ -690,7 +690,7 @@
       (is (= 1 (count (lib/filters query 1))))
       (is (= 5 (lib/current-limit query 2))))))
 
-;; intentionally one giant spec: proves every test-query feature composes in a single multi-stage build
+;; intentionally one giant spec: the test-query features compose in one build (:fields covered below)
 #_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest ^:parallel test-query-comprehensive-all-features-test
   (testing "test-query exercises all functionality in a comprehensive multi-stage query"

--- a/test/metabase/lib/query_test.cljc
+++ b/test/metabase/lib/query_test.cljc
@@ -642,6 +642,7 @@
            (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Error creating query from legacy query"
                                  (lib/query meta/metadata-provider legacy)))))
        (testing "a fatal Error thrown while converting a legacy query propagates unwrapped"
+         ;; ->mbql5 is a multimethod, which with-dynamic-fn-redefs refuses; plain with-redefs is required
          #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
          (with-redefs [lib.convert/->mbql5 (fn [& _] (throw (Error. "boom")))]
            (is (thrown? Error

--- a/test/metabase/lib/test_util/generators.cljc
+++ b/test/metabase/lib/test_util/generators.cljc
@@ -601,6 +601,7 @@
                                            frequencies
                                            (into (sorted-map))))]))])))
 
+  ;; REPL tuning harness in (comment): ASCII histograms print to the console by design
   #_{:clj-kondo/ignore [:discouraged-var]}
   (defn- print-histogram [m]
     (let [mode   (reduce max 0 (vals m))
@@ -619,6 +620,7 @@
 
   (print-histogram (get-in stats [0.04 0.34]))
 
+  ;; REPL tuning harness in (comment): ASCII histograms print to the console by design
   #_{:clj-kondo/ignore [:discouraged-var]}
   (defn- print-stats [st]
     (doseq [[p-reset inner] st

--- a/test/metabase/lib/util/unique_name_generator_test.cljc
+++ b/test/metabase/lib/util/unique_name_generator_test.cljc
@@ -139,6 +139,7 @@
 (deftest ^:parallel unique-name-generator-options-test
   (testing "options"
     (testing :name-key-fn
+      ;; exercising :name-key-fn with a simple case-folder over ASCII fixtures; locale safety is moot
       (let [f (lib.util.unique-name-generator/unique-name-generator-with-options :name-key-fn #_{:clj-kondo/ignore [:discouraged-var]} str/lower-case)]
         (is (= ["x" "X_2" "X_3"]
                (map f ["x" "X" "X"])))))))

--- a/test/metabase/logger/core_test.clj
+++ b/test/metabase/logger/core_test.clj
@@ -3,6 +3,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.test :refer :all]
+   ;; exercises the raw tools.logging pipeline that metabase.logger.core plugs into
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [clojure.tools.logging :as log]
    [clojure.tools.logging.impl :as log.impl]

--- a/test/metabase/notification/test_util.clj
+++ b/test/metabase/notification/test_util.clj
@@ -120,6 +120,7 @@
 
 (def default-card-name "Card notification test card")
 
+;; the `!` calls only create and delete this helper's own temp notification, so parallel use is safe
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn do-with-temp-notification
   "Create a temporary notification for testing."

--- a/test/metabase/permissions/util_test.clj
+++ b/test/metabase/permissions/util_test.clj
@@ -188,13 +188,13 @@
       nil
       ;; these trigger Kondo warnings because the function expects a string or nil, but we should probably test behavior
       ;; anyway for cases where you're passing in a local and Kondo can't infer the type
-      #_:clj-kondo/ignore {}
+      #_{:clj-kondo/ignore [:type-mismatch]} {}
       ;; the rows below feed intentionally wrong types to exercise runtime validation
-      #_:clj-kondo/ignore []
-      #_:clj-kondo/ignore true
-      #_:clj-kondo/ignore false
-      #_:clj-kondo/ignore (keyword "/asdf/")
-      #_:clj-kondo/ignore 1234)))
+      #_{:clj-kondo/ignore [:type-mismatch]} []
+      #_{:clj-kondo/ignore [:type-mismatch]} true                 ;; boolean, not a string or nil
+      #_{:clj-kondo/ignore [:type-mismatch]} false                ;; boolean, not a string or nil
+      #_{:clj-kondo/ignore [:type-mismatch]} (keyword "/asdf/")   ;; keyword, not a string or nil
+      #_{:clj-kondo/ignore [:type-mismatch]} 1234)))              ;; number, not a string or nil
 
 (deftest ^:parallel permission-classify-path
   (are [path expected] (= expected

--- a/test/metabase/permissions/util_test.clj
+++ b/test/metabase/permissions/util_test.clj
@@ -188,12 +188,13 @@
       nil
       ;; these trigger Kondo warnings because the function expects a string or nil, but we should probably test behavior
       ;; anyway for cases where you're passing in a local and Kondo can't infer the type
-      #_{:clj-kondo/ignore [:type-mismatch]} {}
-      #_{:clj-kondo/ignore [:type-mismatch]} []
-      #_{:clj-kondo/ignore [:type-mismatch]} true                 ;; boolean, not a string or nil
-      #_{:clj-kondo/ignore [:type-mismatch]} false                ;; boolean, not a string or nil
-      #_{:clj-kondo/ignore [:type-mismatch]} (keyword "/asdf/")   ;; keyword, not a string or nil
-      #_{:clj-kondo/ignore [:type-mismatch]} 1234)))              ;; number, not a string or nil
+      #_:clj-kondo/ignore {}
+      ;; the rows below feed intentionally wrong types to exercise runtime validation
+      #_:clj-kondo/ignore []
+      #_:clj-kondo/ignore true
+      #_:clj-kondo/ignore false
+      #_:clj-kondo/ignore (keyword "/asdf/")
+      #_:clj-kondo/ignore 1234)))
 
 (deftest ^:parallel permission-classify-path
   (are [path expected] (= expected

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -333,6 +333,7 @@
                   [:field "EXAMPLE_SECOND" {:base-type :type/Integer}]]
    :source-table (format "card__%s" base-card-id)})
 
+;; one native->model->metamodel card chain must be asserted consistent across every render path at once
 #_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest consistent-date-formatting-test
   (mt/with-temporary-setting-values [custom-formatting nil]

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -333,7 +333,7 @@
                   [:field "EXAMPLE_SECOND" {:base-type :type/Integer}]]
    :source-table (format "card__%s" base-card-id)})
 
-;; one native->model->metamodel card chain must be asserted consistent across every render path at once
+;; one native->model->metamodel card chain asserted consistent across the CSV attachment renders
 #_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest consistent-date-formatting-test
   (mt/with-temporary-setting-values [custom-formatting nil]

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -94,6 +94,7 @@
 
 (deftest result-metadata-preservation-in-html-static-viz-for-dashboard-test
   (testing "In a dashboard, results metadata applied to a model or query based on a model should be used in the HTML rendering of the pulse email."
+    ;; kondo can't see that with-metadata-data-cards binds the three card-id symbols
     #_{:clj-kondo/ignore [:unresolved-symbol]}
     (with-metadata-data-cards [base-card-id model-card-id question-card-id]
       (mt/with-temp [:model/Dashboard {dash-id :id} {:name "just dash"}
@@ -762,6 +763,7 @@
        ~@body)))
 
 (deftest skip-if-empty-test
+  ;; with-skip-if-empty-pulse-result! binds result and pulse anaphorically; invisible to kondo
   #_{:clj-kondo/ignore [:unresolved-symbol]}
   (testing "Only send non-empty cards when 'Don't send if there aren't results is enabled' (#34777)"
     (mt/dataset test-data

--- a/test/metabase/query_processor/aggregation_test.clj
+++ b/test/metabase/query_processor/aggregation_test.clj
@@ -11,6 +11,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -28,6 +28,7 @@
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.pivot.test-util :as qp.pivot.test-util]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/query_processor/breakout_test.clj
+++ b/test/metabase/query_processor/breakout_test.clj
@@ -11,6 +11,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor.middleware.add-remaps :as qp.add-remaps]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/query_processor/card_test.clj
+++ b/test/metabase/query_processor/card_test.clj
@@ -17,6 +17,7 @@
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.query-processor.card :as qp.card]
    [metabase.query-processor.middleware.results-metadata :as qp.results-metadata]
+   ;; asserts on the store's miscellaneous-value slot that the results-metadata middleware writes
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/query_processor/coercion_test.clj
+++ b/test/metabase/query_processor/coercion_test.clj
@@ -5,6 +5,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.notebook-helpers :as lib.tu.notebook]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/query_processor/count_where_test.clj
+++ b/test/metabase/query_processor/count_where_test.clj
@@ -6,6 +6,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-util :as lib.tu]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.test :as mt]))

--- a/test/metabase/query_processor/date_bucketing_test.clj
+++ b/test/metabase/query_processor/date_bucketing_test.clj
@@ -33,6 +33,7 @@
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.middleware.format-rows :as format-rows]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; reads the provider that mt/with-metadata-provider binds in the ambient store
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/query_processor/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor/date_time_zone_functions_test.clj
@@ -15,6 +15,7 @@
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor.middleware.annotate :as annotate]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.timezone :as qp.timezone]

--- a/test/metabase/query_processor/distinct_where_test.clj
+++ b/test/metabase/query_processor/distinct_where_test.clj
@@ -6,6 +6,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-util :as lib.tu]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]))
 

--- a/test/metabase/query_processor/drill_thru_e2e_test.clj
+++ b/test/metabase/query_processor/drill_thru_e2e_test.clj
@@ -7,6 +7,7 @@
    [metabase.lib.ref :as lib.ref]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.notebook-helpers :as lib.tu.notebook]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.test :as mt]))

--- a/test/metabase/query_processor/explicit_joins_test.clj
+++ b/test/metabase/query_processor/explicit_joins_test.clj
@@ -20,6 +20,7 @@
    [metabase.lib.test-util.notebook-helpers :as notebook-helpers]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/query_processor/field_ref_repro_test.clj
+++ b/test/metabase/query_processor/field_ref_repro_test.clj
@@ -10,6 +10,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/query_processor/field_visibility_test.clj
+++ b/test/metabase/query_processor/field_visibility_test.clj
@@ -9,6 +9,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor :as qp]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test-util :as qp.test-util]
    [metabase.test :as mt]

--- a/test/metabase/query_processor/filter_test.clj
+++ b/test/metabase/query_processor/filter_test.clj
@@ -12,6 +12,7 @@
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/query_processor/implicit_joins_test.clj
+++ b/test/metabase/query_processor/implicit_joins_test.clj
@@ -11,6 +11,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-util :as lib.tu]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.test :as mt]

--- a/test/metabase/query_processor/metadata_test.clj
+++ b/test/metabase/query_processor/metadata_test.clj
@@ -86,6 +86,7 @@
                {:name          "CREATED_AT"
                 :display_name  "CREATED_AT"
                 :semantic_type :type/CreationTimestamp}]
+              ;; the deprecated legacy path is itself under test
               #_{:clj-kondo/ignore [:deprecated-var]}
               (qp.metadata/legacy-result-metadata query nil))))))
 
@@ -121,6 +122,7 @@
               ((get-method driver/query-result-metadata :default) :h2 query))))))
 
 (deftest ^:parallel combine-metadata-test
+  ;; the deprecated combine-metadata is itself under test
   #_{:clj-kondo/ignore [:deprecated-var]}
   (are [old-metadata new-metadata expected] (= expected (qp.util/combine-metadata new-metadata old-metadata))
     ;; columns get the correct display name after columns with the same name are removed

--- a/test/metabase/query_processor/middleware/add_remaps_test.clj
+++ b/test/metabase/query_processor/middleware/add_remaps_test.clj
@@ -11,6 +11,7 @@
    [metabase.query-processor.middleware.add-remaps :as qp.add-remaps]
    [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.query-processor.reducible :as qp.reducible]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.test :as mt]

--- a/test/metabase/query_processor/middleware/add_timezone_info_test.clj
+++ b/test/metabase/query_processor/middleware/add_timezone_info_test.clj
@@ -4,6 +4,7 @@
    [metabase.driver :as driver]
    [metabase.lib.test-metadata :as meta]
    [metabase.query-processor.middleware.add-timezone-info :as add-timezone-info]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]))
 

--- a/test/metabase/query_processor/middleware/annotate/legacy_helper_fns_test.clj
+++ b/test/metabase/query_processor/middleware/annotate/legacy_helper_fns_test.clj
@@ -4,6 +4,7 @@
    [clojure.walk :as walk]
    [metabase.lib.test-metadata :as meta]
    [metabase.query-processor.middleware.annotate.legacy-helper-fns :as annotate.legacy-helper-fns]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]))
 

--- a/test/metabase/query_processor/middleware/annotate/legacy_helper_fns_test.clj
+++ b/test/metabase/query_processor/middleware/annotate/legacy_helper_fns_test.clj
@@ -18,5 +18,6 @@
                      :aggregation     [[:count]]}]
     (qp.store/with-metadata-provider meta/metadata-provider
       (is (= "count"
+             ;; the deprecated fn is what this test exists to cover
              #_{:clj-kondo/ignore [:deprecated-var]}
              (annotate.legacy-helper-fns/aggregation-name inner-query [:count]))))))

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -12,6 +12,7 @@
    [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.query-processor.middleware.annotate :as annotate]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]
    [metabase.util :as u]

--- a/test/metabase/query_processor/middleware/auto_bucket_datetimes_test.clj
+++ b/test/metabase/query_processor/middleware/auto_bucket_datetimes_test.clj
@@ -8,6 +8,7 @@
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.query-processor.middleware.auto-bucket-datetimes :as qp.auto-bucket-datetimes]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util.malli :as mu]))
 

--- a/test/metabase/query_processor/middleware/binning_test.clj
+++ b/test/metabase/query_processor/middleware/binning_test.clj
@@ -14,6 +14,7 @@
    [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.query-processor.middleware.binning :as binning]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.test :as mt]))

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -244,6 +244,7 @@
 
 (deftest refresh-lease-test
   (testing "try-acquire-refresh-lease! (the db backend) elects a single refresher across processes via a conditional UPDATE"
+    ;; the db cache backend reads real :model/QueryCache rows; metadata providers don't model it
     #_{:clj-kondo/ignore [:discouraged-var]}
     (mt/with-temp [:model/QueryCache {query-hash :query_hash} {:query_hash (byte-array (range 32))
                                                                :results    (byte-array [0])
@@ -260,6 +261,7 @@
                 "updated_at means 'when the results blob was last written' -- freshness, purging, and the EE refresh "
                 "scheduler all read it that way. Bumping it on lease claim makes a crashed refresh look freshly "
                 "written, so the stale row is treated as fresh for a full additional cache window.")
+    ;; the db cache backend reads real :model/QueryCache rows; metadata providers don't model it
     #_{:clj-kondo/ignore [:discouraged-var]}
     (let [original-updated-at (t/offset-date-time "2020-01-01T00:00Z")]
       (mt/with-temp [:model/QueryCache {query-hash :query_hash} {:query_hash (byte-array (range 32))
@@ -275,6 +277,7 @@
 
 (deftest delete-entry-test
   (testing "delete-entry! (the db backend) removes the cache entry, and with it any held refresh lease"
+    ;; the db cache backend reads real :model/QueryCache rows; metadata providers don't model it
     #_{:clj-kondo/ignore [:discouraged-var]}
     (mt/with-temp [:model/QueryCache {query-hash :query_hash} {:query_hash (byte-array (range 32))
                                                                :results    (byte-array [0])

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -44,6 +44,7 @@
 
 (set! *warn-on-reflection* true)
 
+;; one-time DB init; a :once fixture runs before any tests, parallel or not
 #_{:clj-kondo/ignore [:metabase/validate-deftest]}
 (use-fixtures :once (fn [thunk]
                       (initialize/initialize-if-needed! :db)

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -25,6 +25,7 @@
    [metabase.query-processor.middleware.process-userland-query :as process-userland-query]
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.reducible :as qp.reducible]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.streaming :as qp.streaming]
    [metabase.query-processor.test :as qp]

--- a/test/metabase/query_processor/middleware/expand_macros_test.clj
+++ b/test/metabase/query_processor/middleware/expand_macros_test.clj
@@ -10,6 +10,7 @@
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.query-processor.middleware.expand-macros :as expand-macros]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]))
 
 (defn- expand-macros

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -14,6 +14,7 @@
    [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.query-processor.middleware.fetch-source-query :as fetch-source-query]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/query_processor/middleware/large_int_test.clj
+++ b/test/metabase/query_processor/middleware/large_int_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.query-processor.middleware.large-int :as large-int]
-   ;; binds mock metadata providers via the ambient store, which the code under test reads
+   ;; the middleware writes its column mask into the ambient store; the test must run inside one
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]))
 

--- a/test/metabase/query_processor/middleware/large_int_test.clj
+++ b/test/metabase/query_processor/middleware/large_int_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.query-processor.middleware.large-int :as large-int]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]))
 

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -19,6 +19,7 @@
    [metabase.lib.util :as lib.util]
    [metabase.query-processor.middleware.fetch-source-query :as fetch-source-query]
    [metabase.query-processor.middleware.metrics :as metrics]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.test :as mt]

--- a/test/metabase/query_processor/middleware/normalize_query_test.clj
+++ b/test/metabase/query_processor/middleware/normalize_query_test.clj
@@ -4,6 +4,7 @@
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.test-metadata :as meta]
    [metabase.query-processor.middleware.normalize-query :as normalize-query]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]))
 
 (deftest ^:parallel normalize-test

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -16,6 +16,7 @@
    [metabase.query-processor.pivot :as qp.pivot]
    [metabase.query-processor.pivot.test-util :as qp.pivot.tu]
    [metabase.query-processor.setup :as qp.setup]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.test :as mt]

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -13,6 +13,7 @@
    [metabase.query-processor.middleware.process-userland-query :as process-userland-query]
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.reducible :as qp.reducible]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.util :as qp.util]

--- a/test/metabase/query_processor/middleware/remove_inactive_field_refs_test.clj
+++ b/test/metabase/query_processor/middleware/remove_inactive_field_refs_test.clj
@@ -14,6 +14,7 @@
    [metabase.lib.util :as lib.util]
    [metabase.query-processor.middleware.remove-inactive-field-refs :as remove-inactive-field-refs]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/query_processor/middleware/resolve_referenced_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_referenced_test.clj
@@ -55,6 +55,7 @@
         ;; allowing `with-temp` here: this exercises app-DB permission enforcement (card-read perms, current user)
         ;; via `process-query-for-card`, which a metadata provider does not model
         (let [mp (mt/metadata-provider)]
+          ;; card-read perms via process-query-for-card need real app-db cards; MPs don't model perms
           #_{:clj-kondo/ignore [:discouraged-var]}
           (mt/with-temp
             [:model/Card {parent-id :id} {:database_id   (mt/id)

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -19,6 +19,7 @@
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.middleware.results-metadata :as middleware.results-metadata]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.util :as qp.util]

--- a/test/metabase/query_processor/middleware/wrap_value_literals_test.clj
+++ b/test/metabase/query_processor/middleware/wrap_value_literals_test.clj
@@ -10,6 +10,7 @@
    [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.query-processor.middleware.wrap-value-literals :as qp.wrap-value-literals]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.test :as mt]

--- a/test/metabase/query_processor/native_test.clj
+++ b/test/metabase/query_processor/native_test.clj
@@ -9,6 +9,7 @@
    [metabase.lib.options :as lib.options]
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor.date-time-zone-functions-test :as dt-fn-test]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/query_processor/nested_queries_test.clj
+++ b/test/metabase/query_processor/nested_queries_test.clj
@@ -26,6 +26,7 @@
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/query_processor/nested_queries_test.clj
+++ b/test/metabase/query_processor/nested_queries_test.clj
@@ -631,6 +631,7 @@
                           :unit         :day)
                    (dissoc :semantic_type :coercion_strategy :table_id
                            :id :settings :fingerprint :nfc_path)
+                   ;; mirrors annotate's legacy display-name handling in the expected col
                    #_{:clj-kondo/ignore [:deprecated-var]}
                    lib.temporal-bucket/ensure-temporal-unit-in-display-name)
                (qp.test-util/aggregate-col :count)]

--- a/test/metabase/query_processor/nested_queries_test.clj
+++ b/test/metabase/query_processor/nested_queries_test.clj
@@ -1755,6 +1755,7 @@
   (testing "can query a card that has an empty column alias (#57685)"
     (let [mp (mt/metadata-provider)
           card-query (lib/native-query mp "select id as \"\" from orders limit 2")]
+      ;; the card is fetched via the app-db metadata provider mid-query, so it must be a real row
       #_{:clj-kondo/ignore [:discouraged-var]}
       (mt/with-temp [:model/Card card {:dataset_query card-query}]
         (let [query (->> (lib/query mp (lib.metadata/card mp (:id card)))

--- a/test/metabase/query_processor/parameters/dates_test.clj
+++ b/test/metabase/query_processor/parameters/dates_test.clj
@@ -10,6 +10,7 @@
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor.parameters.dates :as params.dates]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]))
 

--- a/test/metabase/query_processor/parameters/values_test.clj
+++ b/test/metabase/query_processor/parameters/values_test.clj
@@ -444,7 +444,7 @@
         (mt/with-persistence-enabled! [persist-models!]
           (let [mp         (mt/metadata-provider)
                 mbql-query (lib/query mp (lib.metadata/table mp (mt/id :categories)))]
-            ;; model persistence (persist-models!, PersistedInfo) needs real app-db rows; no MP support
+            ;; persist-models! and the persistence job machinery need real app-db rows
             #_{:clj-kondo/ignore [:discouraged-var]}
             (mt/with-temp [:model/Card model {:name          "model"
                                               :type          :model

--- a/test/metabase/query_processor/parameters/values_test.clj
+++ b/test/metabase/query_processor/parameters/values_test.clj
@@ -444,6 +444,7 @@
         (mt/with-persistence-enabled! [persist-models!]
           (let [mp         (mt/metadata-provider)
                 mbql-query (lib/query mp (lib.metadata/table mp (mt/id :categories)))]
+            ;; model persistence (persist-models!, PersistedInfo) needs real app-db rows; no MP support
             #_{:clj-kondo/ignore [:discouraged-var]}
             (mt/with-temp [:model/Card model {:name          "model"
                                               :type          :model

--- a/test/metabase/query_processor/perf_test.clj
+++ b/test/metabase/query_processor/perf_test.clj
@@ -174,6 +174,7 @@
       (qp.compile/compile (query-fn (mp-fn))))
     {})))
 
+;; kept for REPL perf work: single-run timing alternative to the criterium helper above
 #_{:clj-kondo/ignore [:unused-private-var]}
 (defn- compile-time1
   "Times a single run rather than [[crit/quick-benchmark]]."

--- a/test/metabase/query_processor/perf_test.clj
+++ b/test/metabase/query_processor/perf_test.clj
@@ -179,6 +179,7 @@
 (defn- compile-time1
   "Times a single run rather than [[crit/quick-benchmark]]."
   [mp-fn query-fn _mem-fn]
+  ;; REPL-only single-run timing helper; time's console report is the output
   #_{:clj-kondo/ignore [:discouraged-var]}
   (time (mu/disable-enforcement
           (qp.compile/compile (query-fn (mp-fn))))))
@@ -293,6 +294,7 @@
       (let [q (lib.tu.huge/huge-query)
             [t result] (crit/time-body
                         (qp.compile/compile q))]
+        ;; REPL benchmark in (comment): the timing line prints to the console
         #_{:clj-kondo/ignore [:discouraged-var]}
         (println (format "%.2fms" (/ t 1000000.0)))
         result)))

--- a/test/metabase/query_processor/persistence_test.clj
+++ b/test/metabase/query_processor/persistence_test.clj
@@ -102,6 +102,7 @@
 (defn- populate-metadata [{query :dataset_query, id :id, :as _model}]
   (let [updater (a/thread
                   (let [metadata (-> query
+                                     ;; card result_metadata is persisted in legacy shape
                                      #_{:clj-kondo/ignore [:deprecated-var]}
                                      (qp.metadata/legacy-result-metadata nil))]
                     (t2/update! :model/Card id {:result_metadata metadata})))]

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -28,6 +28,7 @@
    [metabase.query-processor.pivot.common :as pivot.common]
    [metabase.query-processor.pivot.test-util :as qp.pivot.test-util]
    [metabase.query-processor.settings :as qp.settings]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.test :as mt]

--- a/test/metabase/query_processor/preprocess_test.clj
+++ b/test/metabase/query_processor/preprocess_test.clj
@@ -17,6 +17,7 @@
    [metabase.lib.test-util.mocks-31769 :as lib.tu.mocks-31769]
    [metabase.query-processor.middleware.annotate :as annotate]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/query_processor/reducible_test.clj
+++ b/test/metabase/query_processor/reducible_test.clj
@@ -21,6 +21,7 @@
      acc)
 
     ([row-count row]
+     ;; the printed rows ARE the behavior under test, asserted via with-out-str
      #_{:clj-kondo/ignore [:discouraged-var]}
      (printf "ROW %d -> %s\n" (inc row-count) (pr-str row))
      (inc row-count))))

--- a/test/metabase/query_processor/remapping_test.clj
+++ b/test/metabase/query_processor/remapping_test.clj
@@ -12,6 +12,7 @@
    [metabase.query-processor.pivot :as qp.pivot]
    [metabase.query-processor.pivot.test-util :as qp.pivot.tu]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/query_processor/setup_test.clj
+++ b/test/metabase/query_processor/setup_test.clj
@@ -7,6 +7,7 @@
    [metabase.lib.test-metadata :as meta]
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.setup :as qp.setup]
+   ;; exercises qp.setup's initialization of the ambient store itself
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]))
 
 (set! *warn-on-reflection* true)

--- a/test/metabase/query_processor/store_test.clj
+++ b/test/metabase/query_processor/store_test.clj
@@ -6,6 +6,7 @@
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
+   ;; this is the deprecated store's own test namespace
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]))
 

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -11,6 +11,7 @@
    [metabase.models.visualization-settings :as mb.viz]
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.schema :as qp.schema]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.streaming :as qp.streaming]
    [metabase.query-processor.streaming.test-util :as streaming.test-util]

--- a/test/metabase/query_processor/sum_where_test.clj
+++ b/test/metabase/query_processor/sum_where_test.clj
@@ -6,6 +6,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-util :as lib.tu]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]))
 

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -23,6 +23,7 @@
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.core :as qp]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; qp.test-util wraps the store's helpers for the many tests still on the legacy pipeline
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.test.data :as data]

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -31,6 +31,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   ;; test helpers build expected metadata from real app-db Field rows
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -91,6 +91,7 @@
         (if (qp.store/initialized?)
           (-> (lib.metadata/field (qp.store/metadata-provider) (data/id table-kw field-kw))
               (select-keys [:lib/type :id :table-id :semantic-type :base-type :effective-type :coercion-strategy :name :display-name :fingerprint])
+              ;; QP results :cols are legacy-shaped; convert Lib metadata to legacy for comparison
               #_{:clj-kondo/ignore [:deprecated-var]}
               qp.store/->legacy-metadata
               (dissoc :lib/type))
@@ -417,6 +418,7 @@
                    (assoc outer-query :query {:source-query (:query outer-query)}))]
       (recur nested (dec n-levels)))))
 
+;; tests the deprecated nest-query helper itself
 #_{:clj-kondo/ignore [:deprecated-var]}
 (deftest ^:parallel nest-query-test
   (testing "MBQL"

--- a/test/metabase/query_processor/timezones_test.clj
+++ b/test/metabase/query_processor/timezones_test.clj
@@ -11,6 +11,7 @@
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.test :as mt]

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -16,6 +16,7 @@
    [metabase.lib.test-util.metadata-providers.mock :as providers.mock]
    [metabase.lib.test-util.uuid-dogs-metadata-provider :as lib.tu.uuid-dogs-metadata-provider]
    [metabase.query-processor.preprocess :as qp.preprocess]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util.add-alias-info :as add]
    [metabase.test :as mt]

--- a/test/metabase/server/statistics_handler_test.clj
+++ b/test/metabase/server/statistics_handler_test.clj
@@ -14,6 +14,7 @@
 (set! *warn-on-reflection* true)
 
 (defn- routes [started continue]
+  ;; throwaway Jetty test handler; no OpenAPI spec needed
   #_{:clj-kondo/ignore [:discouraged-var]}
   (compojure/routes
    (GET "/route" []

--- a/test/metabase/server/test_handler.clj
+++ b/test/metabase/server/test_handler.clj
@@ -7,6 +7,7 @@
 
 (mu/defn- make-test-handler :- ::api.macros/handler
   []
+  ;; late-bound: a static require here would drag the whole API route tree into the server module
   (let [api-routes    #_{:clj-kondo/ignore [:metabase/modules]} (requiring-resolve 'metabase.api-routes.core/routes)
         server-routes (server/make-routes api-routes)
         handler       (server/make-handler server-routes)]

--- a/test/metabase/slackbot/test_util.clj
+++ b/test/metabase/slackbot/test_util.clj
@@ -142,6 +142,7 @@
     {:request-options {:headers {"x-slack-signature" signature
                                  "x-slack-request-timestamp" timestamp}}}))
 
+;; flagged for the `!` vars it rebinds, not calls; with-dynamic-fn-redefs keeps the redefs thread-safe
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn with-slackbot-mocks
   "Helper to set up common mocks for slackbot tests.

--- a/test/metabase/sso/common_test.clj
+++ b/test/metabase/sso/common_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.sso.common-test
   (:require
    [clojure.test :refer :all]
+   ;; redefs clojure.tools.logging/log* to capture log calls; util.log macros bottom out there
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [clojure.tools.logging]
    [metabase.permissions.core :as perms]

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -20,6 +20,7 @@
    [metabase.model-persistence.test-util]
    [metabase.permissions.test-util :as perms.test-util]
    [metabase.premium-features.test-util :as premium-features.test-util]
+   ;; mt re-exports with-metadata-provider, which legacy-pipeline tests still rely on
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -101,6 +101,7 @@
   u.random/keep-me)
 
 ;; Add more stuff here as needed
+;; re-exported vars keep their deprecated/discouraged status for callers; the facade must require them
 #_{:clj-kondo/ignore [:discouraged-var :deprecated-var]}
 (p/import-vars
  [actions.test-util

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -210,6 +210,7 @@
   Like `mbql-query`, but runs the query as well."
   {:style/indent :defn, :deprecated "0.61.0"}
   [table-name & [query]]
+  ;; deprecated shim expands to the equally-deprecated mbql-query; they leave together
   #_{:clj-kondo/ignore [:deprecated-var]}
   `(run-mbql-query* (mbql-query ~table-name ~(or query {}))))
 

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -210,7 +210,7 @@
   Like `mbql-query`, but runs the query as well."
   {:style/indent :defn, :deprecated "0.61.0"}
   [table-name & [query]]
-  ;; deprecated shim expands to the equally-deprecated mbql-query; they leave together
+  ;; deprecated shim expands to the equally-deprecated mbql-query; they'll be removed together
   #_{:clj-kondo/ignore [:deprecated-var]}
   `(run-mbql-query* (mbql-query ~table-name ~(or query {}))))
 

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -428,11 +428,11 @@
     (tx/destroy-db! driver dbdef)
     (log! "[%s] Done." (name driver))))
 
-;; deliberately bang-less; the docstring documents the clojure -X naming concern
+;; kept bang-less to preserve this documented CLI entry point; it is only invoked explicitly
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn test-drop-dataset
   "Like [[drop-dataset!]] but checks existence before and after, verifying deletion.
-   Name lacks `!` because clojure -X cannot resolve function names ending in `!`.
+   The historical CLI name is retained for compatibility.
 
      clojure -X:dev:drivers:drivers-dev:test metabase.test.data.impl/test-drop-dataset :driver '\"snowflake\"' :dataset-name '\"test-data\"'"
   [{:keys [driver dataset-name] :as opts}]

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -406,6 +406,7 @@
       (f))))
 
 (defn- log! [fmt & args]
+  ;; drop-dataset! is a clojure -X CLI entry point; stdout is the user interface
   #_{:clj-kondo/ignore [:discouraged-var]}
   (println (apply format fmt args)))
 

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -427,6 +427,7 @@
     (tx/destroy-db! driver dbdef)
     (log! "[%s] Done." (name driver))))
 
+;; wants the conventional `!` but clojure -X can't resolve `!`-suffixed fn names (see docstring)
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn test-drop-dataset
   "Like [[drop-dataset!]] but checks existence before and after, verifying deletion.

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -428,7 +428,7 @@
     (tx/destroy-db! driver dbdef)
     (log! "[%s] Done." (name driver))))
 
-;; wants the conventional `!` but clojure -X can't resolve `!`-suffixed fn names (see docstring)
+;; deliberately bang-less; the docstring documents the clojure -X naming concern
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn test-drop-dataset
   "Like [[drop-dataset!]] but checks existence before and after, verifying deletion.

--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -448,6 +448,7 @@
       ;; Destroying the DB when there's a failure loading and syncing is fine
       ;; for most DBs, but for cloud databases it makes things worse.
       (when (driver/database-supports? driver :test/dynamic-dataset-loading nil)
+        ;; test-harness console notice; stays visible even when log output is captured
         #_{:clj-kondo/ignore [:discouraged-var]}
         (println "create-database! failed; destroying database"
                  driver (pr-str database-name))

--- a/test/metabase/test/data/mbql_query_impl.cljc
+++ b/test/metabase/test/data/mbql_query_impl.cljc
@@ -1,6 +1,7 @@
 (ns metabase.test.data.mbql-query-impl
   "Internal implementation of [[metabase.test.data/$ids]] and [[metabase.test.data/$ids]] and related macros."
   (:require
+   ;; $ids/mbql-query resolution reuses the ambient store's provider when one is already bound
    #?@(:clj (^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
              [metabase.lib-be.core :as lib-be]
              [metabase.lib.metadata :as lib.metadata]))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -1078,6 +1078,7 @@
         called-query? (promise)
         pause-query (promise)
         query-thunk (fn []
+                      ;; legacy query builder; helper not yet migrated to Lib
                       #_{:clj-kondo/ignore [:deprecated-var]}
                       (data/run-mbql-query checkins
                         {:aggregation [[:count]]}))
@@ -1364,6 +1365,7 @@
          (= (first x) 'values-of))
     (let [[_ table+field] x
           [table field] (str/split (str table+field) #"\.")]
+      ;; legacy query builder; helper not yet migrated to Lib
       #_{:clj-kondo/ignore [:deprecated-var]}
       `(into {} (get-in (data/run-mbql-query ~(symbol table)
                           {:fields [~'$id ~(symbol (str \$ field))]})

--- a/test/metabase/test/util/log.clj
+++ b/test/metabase/test/util/log.clj
@@ -13,6 +13,7 @@
   ns-log-level
   set-ns-log-level!])
 
+;; non-thread-safe by design; assert-test-is-not-parallel guards it, and do-with-* must mirror `with-log-level`
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn do-with-log-level [a-namespace level thunk]
   (mb.hawk.parallel/assert-test-is-not-parallel "with-log-level")

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -1,3 +1,4 @@
+;; grandfathered two-segment ns; deps.edn aliases invoke metabase.test-runner/find-and-run-tests-cli
 #_{:clj-kondo/ignore [:metabase/namespace-name]}
 (ns metabase.test-runner
   "The only purpose of this namespace is to make sure all of the other stuff below gets loaded."

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -132,6 +132,7 @@
   ([options]
    (hawk/find-tests-with-options (parse-options options))))
 
+;; runs once at runner startup before any tests execute, so the thread-safety naming rule is moot
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn- initialize-all-fixtures []
   (let [steps (initialize/all-components)]

--- a/test/metabase/transforms/jobs_test.clj
+++ b/test/metabase/transforms/jobs_test.clj
@@ -1,4 +1,5 @@
 (ns ^:mb/driver-tests metabase.transforms.jobs-test
+  ;; raw tools.logging is required so tests can redef log/log* and capture log output
   #_{:clj-kondo/ignore [:discouraged-namespace]}
   (:require
    [clojure.string :as str]

--- a/test/metabase/upload/impl_test.clj
+++ b/test/metabase/upload/impl_test.clj
@@ -636,6 +636,7 @@
   "Because life is too short for zillions of temp files."
   [^String s]
   (let [bytes (.getBytes s "UTF-8")]
+    ;; only the input side is exercised; the writer methods would throw if hit
     #_{:clj-kondo/ignore [:missing-protocol-method]}
     (reify
       io/IOFactory

--- a/test/metabase/util/experiment_test.cljc
+++ b/test/metabase/util/experiment_test.cljc
@@ -11,6 +11,7 @@
     [(fn [result] (swap! results conj result))
      results]))
 
+;; fixture rebinding is safe here; this ns has no ^:parallel tests
 #_{:clj-kondo/ignore [:metabase/validate-deftest]}
 (use-fixtures :each
   (fn [t]

--- a/test/metabase/util/i18n/impl_test.clj
+++ b/test/metabase/util/i18n/impl_test.clj
@@ -27,6 +27,11 @@
       (is (= expected
              (i18n.impl/normalized-locale-string s))))))
 
+(deftest normalized-locale-string-ignores-default-locale-test
+  (mt/with-locale! "tr"
+    (is (= "id_IN"
+           (i18n.impl/normalized-locale-string "ID-in")))))
+
 (deftest ^:parallel locale-test
   (testing "Should be able to coerce various types of objects to Locales"
     (doseq [arg-type [:str :keyword]

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -62,6 +62,7 @@
 
 #?(:clj
    (deftest ^:parallel domain?-test
+     ;; expected in the are table is literal true/false; the expansion inlines it into (=)
      #_{:clj-kondo/ignore [:equals-true]}
      (are [s expected] (= expected (u/domain? s))
        "metabase.com"         true

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -604,6 +604,7 @@
 #?(:clj
    (deftest ^:parallel case-enum-test
      (testing "case does not work"
+       ;; deliberately exercises the broken case-on-enums behavior that case-enum exists to fix
        #_{:clj-kondo/ignore [:case-symbol-test]}
        (is (= 3 (case Month/MAY
                   Month/APRIL 1

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -389,6 +389,7 @@
     false "cam.saul+1@metabase.co.uk" "metabase.com"
     true  "cam.saul+1@metabase.com"   "metabase.com"))
 
+;; defspec-generated test var; the runner finds it via metadata, clojure-lsp sees no reference
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defspec pick-first-test 100
   (prop/for-all [coll (gen/list gen/small-integer)]

--- a/test/metabase/warehouses/models/database_test.clj
+++ b/test/metabase/warehouses/models/database_test.clj
@@ -15,6 +15,7 @@
    [metabase.permissions.core :as perms]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
+   ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.request.core :as request]
    [metabase.secrets.core :as secret]

--- a/test/metabase/xrays/automagic_dashboards/core_test.clj
+++ b/test/metabase/xrays/automagic_dashboards/core_test.clj
@@ -325,6 +325,7 @@
 
 (mu/defn- result-metadata-for-query :- [:maybe [:sequential :map]]
   [query :- :map]
+  ;; x-ray tests consume legacy-shaped result metadata (persisted card result_metadata format)
   #_{:clj-kondo/ignore [:deprecated-var]}
   (qp.metadata/legacy-result-metadata query nil))
 

--- a/test/metabase/xrays/automagic_dashboards/interesting_test.clj
+++ b/test/metabase/xrays/automagic_dashboards/interesting_test.clj
@@ -384,6 +384,7 @@
                                                (->> dimension-defs cycle (drop 3) (take 4)))))))))
 
 (defn- result-metadata-for-query [query]
+  ;; x-ray tests consume legacy-shaped result metadata (persisted card result_metadata format)
   #_{:clj-kondo/ignore [:deprecated-var]}
   (qp.metadata/legacy-result-metadata query nil))
 


### PR DESCRIPTION
The exemption set shrinks from 38 linters to 9. Every ignore of the other 29 now carries a one-line comment saying why it's there, enforced by the ratchet from here on.

The justification ratchet (#77820) had to grandfather those 38, since their ignores predate the comment requirement. This branch works through them: 31 commits, one per linter, plus the bare-form sites and follow-ups. Nine audit passes read every site, and each ignore that earned its keep got a comment. The rest were fixed or removed.

Three of the 9 left are deliberate keeps, where a per-site comment would be noise:

| Linter | Ignores | |
|---|---|---|
| `validate-defendpoint-has-response-schema` | 441 | the same "schema TODO" 441 times |
| `validate-defendpoint-route-uses-kebab-case` | 44 | the same "it's a public API name" note |
| `validate-defendpoint-query-params-use-kebab-case` | 40 | as above |

That debt burns down by fixing endpoints, not by commenting them.

The other six are each held open by a handful of sites, 14 in all, and most look like stale ignores to remove rather than sites to justify:

| Linter | Ignores | Unjustified | What's left |
|---|---|---|---|
| `discouraged-namespace` | 81 | 9 | four `clj-yaml.core` requires whose config rule was dropped, plus one-off requires of `pprint`, `io`, `tools.logging.impl`, `u.jvm` and `qp.store` |
| `discouraged-var` | 127 | 2 | `lib/->legacy-MBQL` in a metabot tool, `str/upper-case` in a handlebars helper |
| `deprecated-namespace` | 95 | 1 | the `qp.store` require in the Snowflake driver tests |
| `metabase/modules` | 10 | 1 | an `:as-alias` require of a namespace in the same module |
| `unused-private-var` | 8 | 1 | a possibly-dead var in `util.malli.schema` |
| `unused-excluded-var` | 2 | 1 | an ns-level `:refer-clojure :exclude` in `lib.aggregation` |

Removing those unexempts most of the six. They're kept out of this PR so each removal can be eyeballed.

#79531 lands *below* this branch, so the bare `#_:clj-kondo/ignore` sites arrive already named and justified, and `:all` is retired before this branch starts.
