### PR TITLE
Don't block dashboard saves on pre-existing foreign internal cards

### DIFF
--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -859,24 +859,31 @@
     (dashboard-card/delete-dashboard-cards! dashcard-ids)
     dashboard-cards))
 
-(defn- assert-dashcards-are-not-internal-to-other-dashboards [dashboard dashcards]
-  (when-let [card-ids (seq (concat
-                            (seq (keep :card_id dashcards))
-                            (->> dashcards
-                                 (mapcat :series)
-                                 (keep :id))))]
-    (api/check-400 (not (t2/exists? :model/Card
-                                    {:where [:and
-                                             [:not= :dashboard_id (u/the-id dashboard)]
-                                             [:not= :dashboard_id nil]
-                                             [:in :id (set card-ids)]]})))))
+(defn- dashcard-card-ids [dashcard]
+  (concat (when-let [card-id (:card_id dashcard)]
+            [card-id])
+          (keep :id (:series dashcard))))
+
+(defn- assert-dashcards-are-not-internal-to-other-dashboards
+  "Reject `dashcards` that newly reference a question internal to another dashboard. Card ids the dashboard
+  already references (as a dashcard's card or series, per `dashboard`'s hydrated `:dashcards`) are
+  grandfathered so that pre-existing associations never block saving the dashboard (UXW-4870)."
+  [dashboard dashcards]
+  (let [grandfathered-ids (into #{} (mapcat dashcard-card-ids) (:dashcards dashboard))]
+    (when-let [card-ids (seq (remove grandfathered-ids (mapcat dashcard-card-ids dashcards)))]
+      (api/check-400 (not (t2/exists? :model/Card
+                                      {:where [:and
+                                               [:not= :dashboard_id (u/the-id dashboard)]
+                                               [:not= :dashboard_id nil]
+                                               [:in :id (set card-ids)]]}))))))
 
 (defn- do-update-dashcards!
   [dashboard current-cards new-cards]
   (let [{:keys [to-create to-update to-delete]} (u/row-diff current-cards new-cards)]
     (dashboard/archive-or-unarchive-internal-dashboard-questions! (:id dashboard) new-cards)
     ;; Check both created and updated dashcards: a "Replace" keeps the dashcard id and only swaps
-    ;; card_id, so it lands in `to-update`, not `to-create` (UXW-4731).
+    ;; card_id, so it lands in `to-update`, not `to-create` (UXW-4731). Card ids the dashboard already
+    ;; references are grandfathered, so pre-existing foreign internal cards don't block saving (UXW-4870).
     (assert-dashcards-are-not-internal-to-other-dashboards dashboard (concat to-create to-update))
     (when (seq to-update)
       (update-dashcards! dashboard to-update))

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -865,15 +865,16 @@
           (keep :id (:series dashcard))))
 
 (defn- assert-dashcards-are-not-internal-to-other-dashboards
-  "Reject `dashcards` that newly reference a question internal to another dashboard. Card ids the dashboard
-  already references (as a dashcard's card or series, per `dashboard`'s hydrated `:dashcards`) are
-  grandfathered so that pre-existing associations never block saving the dashboard (UXW-4870)."
-  [dashboard dashcards]
-  (let [grandfathered-ids (into #{} (mapcat dashcard-card-ids) (:dashcards dashboard))]
-    (when-let [card-ids (seq (remove grandfathered-ids (mapcat dashcard-card-ids dashcards)))]
+  "Reject `new-dashcards` that newly reference a question internal to another dashboard. Card ids the
+  dashboard already references (as a dashcard's card or series, per `existing-dashboard`'s hydrated
+  `:dashcards`) are grandfathered so that pre-existing associations never block saving the dashboard
+  (UXW-4870)."
+  [existing-dashboard new-dashcards]
+  (let [grandfathered-ids (into #{} (mapcat dashcard-card-ids) (:dashcards existing-dashboard))]
+    (when-let [card-ids (seq (remove grandfathered-ids (mapcat dashcard-card-ids new-dashcards)))]
       (api/check-400 (not (t2/exists? :model/Card
                                       {:where [:and
-                                               [:not= :dashboard_id (u/the-id dashboard)]
+                                               [:not= :dashboard_id (u/the-id existing-dashboard)]
                                                [:not= :dashboard_id nil]
                                                [:in :id (set card-ids)]]}))))))
 

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -5292,6 +5292,28 @@
       (is (not (t2/exists? :model/DashboardCard :dashboard_id other-dash-id :card_id dq-card-id)))
       (is (not (t2/exists? :model/DashboardCardSeries :card_id dq-card-id))))))
 
+(deftest ^:parallel pre-existing-foreign-internal-card-does-not-block-dashboard-save-test
+  ;; UXW-4870: dashboards that already reference a question internal to another dashboard (a state that can
+  ;; pre-date the UXW-4731 guard) must remain savable. Only *newly introduced* foreign internal cards are
+  ;; rejected; card ids already associated with the dashboard are grandfathered — including moving one to a
+  ;; different dashcard (delete + re-add) in a single save.
+  (mt/with-temp [:model/Dashboard     {source-dash-id :id}  {}
+                 :model/Card          {dq-card-id :id}      {:dashboard_id source-dash-id}
+                 :model/Dashboard     {other-dash-id :id}   {}
+                 :model/Card          {normal-card-id :id}  {}
+                 :model/DashboardCard {dashcard-id :id}     {:card_id dq-card-id :dashboard_id other-dash-id}]
+    (testing "An unrelated edit (resize the dashcard, add a separate normal card) succeeds"
+      (mt/user-http-request :crowberto :put 200 (str "dashboard/" other-dash-id)
+                            {:dashcards [{:id dashcard-id :size_x 4 :size_y 4 :row 0 :col 0 :card_id dq-card-id}
+                                         {:id -1 :size_x 1 :size_y 1 :row 4 :col 0 :card_id normal-card-id}]})
+      (is (= 4 (t2/select-one-fn :size_x :model/DashboardCard :id dashcard-id)))
+      (is (t2/exists? :model/DashboardCard :dashboard_id other-dash-id :card_id normal-card-id)))
+    (testing "Deleting the dashcard and re-adding its grandfathered card on a new dashcard in one save succeeds"
+      (mt/user-http-request :crowberto :put 200 (str "dashboard/" other-dash-id)
+                            {:dashcards [{:id -1 :size_x 2 :size_y 2 :row 1 :col 1 :card_id dq-card-id}]})
+      (is (not (t2/exists? :model/DashboardCard :id dashcard-id)))
+      (is (t2/exists? :model/DashboardCard :dashboard_id other-dash-id :card_id dq-card-id)))))
+
 (deftest dashboard-questions-are-archived-with-the-dashboard
   (testing "It gets archived with the dashboard"
     (mt/with-temp [:model/Dashboard {dash-id :id} {}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #78131
UXW-4870: the guard added in #77236 (reject assigning a dashcard's card to a question internal to another dashboard) checked updated dashcards unconditionally, so any dashboard with a pre-existing foreign internal card association became unsavable — every edit, even a resize, returned 400 "Invalid Request.".

Scope the guard to newly-introduced card ids: card ids the dashboard already references (as a dashcard's card or in a series) are grandfathered, so existing associations never block saving — including moving such a card to a different dashcard in the same save. Newly assigning a question internal to another dashboard is still rejected.