### PR TITLE
Re-home history@3 types onto the metabase/router facade

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModal.tsx
@@ -1,4 +1,3 @@
-import type { Location } from "history";
 import { useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 
@@ -7,6 +6,7 @@ import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/Loadin
 import { PaginationControls } from "metabase/common/components/PaginationControls";
 import { useUserSetting } from "metabase/common/hooks";
 import { useListSelect } from "metabase/common/hooks/use-list-select";
+import type { Location } from "metabase/router";
 import { Flex, Modal } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { useListStaleCollectionItemsQuery } from "metabase-enterprise/api/collection";

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/NewMetricPage/NewMetricPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/NewMetricPage/NewMetricPage.tsx
@@ -2,8 +2,7 @@ import { t } from "ttag";
 
 import { DataStudioBreadcrumbs } from "metabase/common/data-studio/components/DataStudioBreadcrumbs";
 import { NewMetricPage } from "metabase/metrics/pages/NewMetricPage";
-import type { Location } from "metabase/router";
-import { Link, type Route } from "metabase/router";
+import { Link, type Location, type Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 
 import { dataStudioMetricUrls } from "../../urls";

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/NewMetricPage/NewMetricPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/NewMetricPage/NewMetricPage.tsx
@@ -1,8 +1,8 @@
-import type { Location } from "history";
 import { t } from "ttag";
 
 import { DataStudioBreadcrumbs } from "metabase/common/data-studio/components/DataStudioBreadcrumbs";
 import { NewMetricPage } from "metabase/metrics/pages/NewMetricPage";
+import type { Location } from "metabase/router";
 import { Link, type Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/components/TableHeader/TableTabs/TableTabs.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/components/TableHeader/TableTabs/TableTabs.tsx
@@ -1,4 +1,3 @@
-import type { Location } from "history";
 import { t } from "ttag";
 
 import {
@@ -7,6 +6,7 @@ import {
 } from "metabase/common/data-studio/components/PaneHeader";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
+import type { Location } from "metabase/router";
 import { getLocation } from "metabase/selectors/routing";
 import * as Urls from "metabase/urls";
 import type { Table } from "metabase-types/api";

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/DependencyGraphPage/DependencyGraphPage.tsx
@@ -1,9 +1,9 @@
-import type { Location } from "history";
 import { useContext } from "react";
 
 import { skipToken } from "metabase/api";
 import { AppSwitcher } from "metabase/nav/components/AppSwitcher";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
+import type { Location } from "metabase/router";
 import { Stack } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { useGetDependencyGraphQuery } from "metabase-enterprise/api";

--- a/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/pages/DependencyDiagnosticsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/pages/DependencyDiagnosticsPage.tsx
@@ -1,8 +1,8 @@
-import type { Location } from "history";
 import { useEffect, useMemo, useRef } from "react";
 
 import { useUserKeyValue } from "metabase/common/hooks/use-user-key-value";
 import { useDispatch } from "metabase/redux";
+import type { Location } from "metabase/router";
 import { replace } from "metabase/router";
 import type * as Urls from "metabase/urls";
 import { DependencyDiagnostics } from "metabase-enterprise/monitor/dependency-diagnostics/components";

--- a/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/pages/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/dependency-diagnostics/pages/utils.ts
@@ -1,5 +1,4 @@
-import type { Location } from "history";
-
+import type { Location } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { DependencyDiagnosticsMode } from "metabase-enterprise/monitor/dependency-diagnostics/components/types";
 import {

--- a/enterprise/frontend/src/metabase-enterprise/schema_viewer/pages/SchemaViewerPage/SchemaViewerPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/schema_viewer/pages/SchemaViewerPage/SchemaViewerPage.tsx
@@ -1,9 +1,9 @@
-import type { Location } from "history";
 import { useMemo } from "react";
 import { t } from "ttag";
 
 import { skipToken } from "metabase/api";
 import { usePageTitle } from "metabase/hooks/use-page-title";
+import type { Location } from "metabase/router";
 import { Stack } from "metabase/ui";
 import { getSchemaViewerParams } from "metabase/urls";
 import { useGetErdQuery } from "metabase-enterprise/api";

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
@@ -1,4 +1,3 @@
-import type { Location } from "history";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { t } from "ttag";
 
@@ -7,6 +6,7 @@ import { useSyncSecurityAdvisoriesMutation } from "metabase/api";
 import { EmptyState } from "metabase/common/components/EmptyState";
 import { useSetting, useToast } from "metabase/common/hooks";
 import { useIsSmallScreen } from "metabase/common/hooks/use-is-small-screen";
+import type { Location } from "metabase/router";
 import {
   Box,
   Button,

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
@@ -1,7 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
-
 import { setupRecentViewsAndSelectionsEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, screen, within } from "__support__/ui";
 import { createMockSettingsState } from "metabase/redux/store/mocks";

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
@@ -1,10 +1,11 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
-import type { Location } from "history";
+
 
 import { setupRecentViewsAndSelectionsEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, screen, within } from "__support__/ui";
 import { createMockSettingsState } from "metabase/redux/store/mocks";
+import type { Location } from "metabase/router";
 import type { Advisory } from "metabase-types/api";
 import { createMockVersion } from "metabase-types/api/mocks";
 import { createAdvisory } from "metabase-types/api/mocks/security-center";

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/EditTableDataContainer.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/EditTableDataContainer.tsx
@@ -1,5 +1,4 @@
 import { useDisclosure } from "@mantine/hooks";
-import type { Location } from "history";
 import { useCallback, useMemo } from "react";
 import { msgid, ngettext, t } from "ttag";
 
@@ -11,6 +10,7 @@ import {
 import { GenericError } from "metabase/common/components/ErrorPages";
 import { useCloseNavbarOnMount } from "metabase/common/hooks/use-close-navbar-on-mount";
 import { useSelector } from "metabase/redux";
+import type { Location } from "metabase/router";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { Box, Flex, Stack, Text } from "metabase/ui";
 import { extractRemappedColumns } from "metabase/visualizations";

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/use-adhoc-table-query.ts
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/use-adhoc-table-query.ts
@@ -1,8 +1,8 @@
-import type { Location } from "history";
 import { useCallback, useEffect, useMemo } from "react";
 
 import { loadMetadataForTable } from "metabase/questions/actions";
 import { useDispatch, useSelector } from "metabase/redux";
+import type { Location } from "metabase/router";
 import { push } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import { b64url_to_utf8, utf8_to_b64url } from "metabase/utils/encoding";

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/use-edit-table-data.ts
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/use-edit-table-data.ts
@@ -1,7 +1,7 @@
-import type { Location } from "history";
 import { useCallback } from "react";
 
 import { skipToken, useGetAdhocQueryQuery } from "metabase/api";
+import type { Location } from "metabase/router";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import type { DatasetColumn } from "metabase-types/api";

--- a/enterprise/frontend/src/metabase-enterprise/tenants/containers/NewTenantModal/NewTenantModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/containers/NewTenantModal/NewTenantModal.tsx
@@ -1,9 +1,9 @@
-import type { Location } from "history";
 import { useMemo } from "react";
 import { t } from "ttag";
 
 import { useDispatch } from "metabase/redux";
 import { addUndo } from "metabase/redux/undo";
+import type { Location } from "metabase/router";
 import { Modal } from "metabase/ui";
 import { useCreateTenantMutation } from "metabase-enterprise/api";
 import type { Tenant } from "metabase-types/api";

--- a/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/TransformInspectPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/TransformInspectPage.tsx
@@ -1,9 +1,9 @@
-import type { Location } from "history";
 import { match } from "ts-pattern";
 import { t } from "ttag";
 
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
+import type { Location } from "metabase/router";
 import { TransformDisconnectedDatabaseBanner } from "metabase/transforms/components/TransformDisconnectedDatabaseBanner";
 import { TransformHeader } from "metabase/transforms/components/TransformHeader";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";

--- a/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/components/InspectorContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/components/InspectorContent.tsx
@@ -1,8 +1,8 @@
-import type { Location } from "history";
 import { useCallback } from "react";
 
 import { useGetInspectorDiscoveryQuery } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import type { Location } from "metabase/router";
 import { trackTransformInspectDrillLensClosed } from "metabase/transforms/analytics";
 import { Center } from "metabase/ui";
 import type { Transform } from "metabase-types/api";

--- a/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/components/LensNavigator/useLensNavigation.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/components/LensNavigator/useLensNavigation.ts
@@ -1,8 +1,8 @@
-import type { Location } from "history";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { useDispatch } from "metabase/redux";
+import type { Location } from "metabase/router";
 import { push, replace } from "metabase/router";
 import type { InspectorLensMetadata } from "metabase-types/api";
 

--- a/frontend/src/metabase/AppComponent.tsx
+++ b/frontend/src/metabase/AppComponent.tsx
@@ -1,4 +1,3 @@
-import type { Location } from "history";
 import { useEffect, useState } from "react";
 
 import { AppBarContainer } from "metabase/app/nav/AppBar";
@@ -26,6 +25,7 @@ import { usePageTitle } from "metabase/hooks/use-page-title";
 import { connect, useSelector } from "metabase/redux";
 import { setErrorPage } from "metabase/redux/app";
 import type { AppErrorDescriptor, State } from "metabase/redux/store";
+import type { Location } from "metabase/router";
 import { Outlet, useLocation } from "metabase/router";
 import { getErrorPage } from "metabase/selectors/app";
 import { getApplicationName } from "metabase/selectors/whitelabel";

--- a/frontend/src/metabase/account/app/components/AccountHeader/AccountHeader.tsx
+++ b/frontend/src/metabase/account/app/components/AccountHeader/AccountHeader.tsx
@@ -1,4 +1,3 @@
-import type { Path } from "history";
 import { useMemo } from "react";
 import { t } from "ttag";
 
@@ -14,7 +13,7 @@ import S from "./AccountHeader.module.css";
 type AccountHeaderProps = {
   user: User;
   path?: string;
-  onChangeLocation?: (nextLocation: Path) => void;
+  onChangeLocation?: (nextLocation: string) => void;
 };
 
 export const AccountHeader = ({

--- a/frontend/src/metabase/account/app/components/AccountLayout/AccountLayout.tsx
+++ b/frontend/src/metabase/account/app/components/AccountLayout/AccountLayout.tsx
@@ -1,5 +1,3 @@
-import type { Path } from "history";
-
 import { Outlet } from "metabase/router";
 import { Box, rem } from "metabase/ui";
 import type { User } from "metabase-types/api";
@@ -9,7 +7,7 @@ import { AccountHeader } from "../AccountHeader";
 interface AccountLayoutProps {
   user: User | null;
   path?: string;
-  onChangeLocation: (nextLocation: Path) => void;
+  onChangeLocation: (nextLocation: string) => void;
 }
 
 const AccountLayout = ({

--- a/frontend/src/metabase/account/app/containers/AccountApp/AccountApp.tsx
+++ b/frontend/src/metabase/account/app/containers/AccountApp/AccountApp.tsx
@@ -1,4 +1,3 @@
-
 import { connect } from "metabase/redux";
 import type { State } from "metabase/redux/store";
 import type { Location } from "metabase/router";

--- a/frontend/src/metabase/account/app/containers/AccountApp/AccountApp.tsx
+++ b/frontend/src/metabase/account/app/containers/AccountApp/AccountApp.tsx
@@ -1,7 +1,7 @@
-import type { Location } from "history";
 
 import { connect } from "metabase/redux";
 import type { State } from "metabase/redux/store";
+import type { Location } from "metabase/router";
 import { push } from "metabase/router";
 import { getUser } from "metabase/selectors/user";
 

--- a/frontend/src/metabase/account/notifications/containers/ArchiveAlertModal/DeleteAlertModal.tsx
+++ b/frontend/src/metabase/account/notifications/containers/ArchiveAlertModal/DeleteAlertModal.tsx
@@ -1,4 +1,3 @@
-import type { Location } from "history";
 import { t } from "ttag";
 
 import {
@@ -9,6 +8,7 @@ import {
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useToast } from "metabase/common/hooks/use-toast";
 import { DeleteAlertConfirmModal } from "metabase/notifications/modals/DeleteAlertConfirmModal";
+import type { Location } from "metabase/router";
 import type { Notification } from "metabase-types/api";
 
 import { getAlertId } from "../../selectors";

--- a/frontend/src/metabase/account/notifications/containers/ArchivePulseModal/ArchivePulseModal.tsx
+++ b/frontend/src/metabase/account/notifications/containers/ArchivePulseModal/ArchivePulseModal.tsx
@@ -1,5 +1,5 @@
 import { skipToken } from "@reduxjs/toolkit/query/react";
-import type { Location } from "history";
+
 
 import {
   useGetSubscriptionQuery,
@@ -7,6 +7,7 @@ import {
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useSelector } from "metabase/redux";
+import type { Location } from "metabase/router";
 import { getUser } from "metabase/selectors/user";
 
 import { ArchiveNotificationModal } from "../../components/ArchiveModal";

--- a/frontend/src/metabase/account/notifications/containers/ArchivePulseModal/ArchivePulseModal.tsx
+++ b/frontend/src/metabase/account/notifications/containers/ArchivePulseModal/ArchivePulseModal.tsx
@@ -1,6 +1,5 @@
 import { skipToken } from "@reduxjs/toolkit/query/react";
 
-
 import {
   useGetSubscriptionQuery,
   useUpdateSubscriptionMutation,

--- a/frontend/src/metabase/actions/containers/ActionCreatorModal/ActionCreatorModal.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreatorModal/ActionCreatorModal.tsx
@@ -1,4 +1,3 @@
-import type { LocationDescriptor } from "history";
 import { useEffect } from "react";
 
 import { skipToken, useGetActionQuery, useGetCardQuery } from "metabase/api";
@@ -7,6 +6,7 @@ import type { ModalComponentProps } from "metabase/common/components/ModalRoute"
 import { connect, useSelector } from "metabase/redux";
 import { setErrorPage } from "metabase/redux/app";
 import type { AppErrorDescriptor } from "metabase/redux/store";
+import type { LocationDescriptor } from "metabase/router";
 import type { Route } from "metabase/router";
 import { replace } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";

--- a/frontend/src/metabase/actions/containers/ActionCreatorModal/ActionCreatorModal.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreatorModal/ActionCreatorModal.tsx
@@ -6,9 +6,7 @@ import type { ModalComponentProps } from "metabase/common/components/ModalRoute"
 import { connect, useSelector } from "metabase/redux";
 import { setErrorPage } from "metabase/redux/app";
 import type { AppErrorDescriptor } from "metabase/redux/store";
-import type { LocationDescriptor } from "metabase/router";
-import type { Route } from "metabase/router";
-import { replace } from "metabase/router";
+import { type LocationDescriptor, type Route, replace } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import * as Urls from "metabase/urls";
 import type Question from "metabase-lib/v1/Question";

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.tsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { Location } from "history";
 import type { ReactNode } from "react";
 import { t } from "ttag";
 
@@ -14,6 +13,7 @@ import AdminS from "metabase/css/admin.module.css";
 import CS from "metabase/css/core/index.css";
 import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
+import type { Location } from "metabase/router";
 import { getShallowTables } from "metabase/selectors/metadata";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { Button } from "metabase/ui";

--- a/frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.tsx
+++ b/frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { Location } from "history";
 import { type ComponentType, type ReactNode, useState } from "react";
 import { t } from "ttag";
 
@@ -8,6 +7,7 @@ import { FieldSet } from "metabase/common/components/FieldSet";
 import CS from "metabase/css/core/index.css";
 import { DatabaseSchemaAndTableDataSelector } from "metabase/querying/common/components/DataSelector";
 import { connect, useSelector } from "metabase/redux";
+import type { Location } from "metabase/router";
 import { push } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Icon } from "metabase/ui";

--- a/frontend/src/metabase/admin/embedding/containers/AdminEmbeddingApp.tsx
+++ b/frontend/src/metabase/admin/embedding/containers/AdminEmbeddingApp.tsx
@@ -1,6 +1,5 @@
-import type { Location } from "history";
-
 import { AdminSettingsLayout } from "metabase/admin/components/AdminLayout/AdminSettingsLayout";
+import type { Location } from "metabase/router";
 import { Outlet } from "metabase/router";
 
 import { EmbeddingNav } from "../components/EmbeddingNav";

--- a/frontend/src/metabase/admin/performance/hooks/useConfirmOnRouteLeave.unit.spec.tsx
+++ b/frontend/src/metabase/admin/performance/hooks/useConfirmOnRouteLeave.unit.spec.tsx
@@ -1,6 +1,5 @@
-import type { History } from "history";
-
 import { act, renderWithProviders, screen } from "__support__/ui";
+import type { History } from "metabase/router";
 import { Route } from "metabase/router";
 import { checkNotNull } from "metabase/utils/types";
 

--- a/frontend/src/metabase/app/selectors.unit.spec.ts
+++ b/frontend/src/metabase/app/selectors.unit.spec.ts
@@ -1,6 +1,5 @@
-import type { Location } from "history";
-
 import { createMockState } from "metabase/redux/store/mocks";
+import type { Location } from "metabase/router";
 import type { RouterProps } from "metabase/selectors/app";
 
 import { getIsCollectionPathVisible } from "./selectors";

--- a/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.tsx
+++ b/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.tsx
@@ -1,9 +1,9 @@
-import type { Location } from "history";
 import { useCallback, useState } from "react";
 import { t } from "ttag";
 
 import { useDispatch, useSelector } from "metabase/redux";
 import { forgotPassword } from "metabase/redux/auth";
+import type { Location } from "metabase/router";
 import { Button } from "metabase/ui";
 
 import { getIsEmailConfigured, getIsLdapEnabled } from "../../selectors";

--- a/frontend/src/metabase/auth/components/Login/Login.tsx
+++ b/frontend/src/metabase/auth/components/Login/Login.tsx
@@ -1,10 +1,10 @@
-import type { Location } from "history";
 import { t } from "ttag";
 import _ from "underscore";
 
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import type { AuthProvider } from "metabase/plugins/types";
 import { useSelector } from "metabase/redux";
+import type { Location } from "metabase/router";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import { Box, Divider } from "metabase/ui";
 

--- a/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.tsx
+++ b/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.tsx
@@ -1,4 +1,3 @@
-import type { Location } from "history";
 import { useCallback } from "react";
 import { t } from "ttag";
 
@@ -8,6 +7,7 @@ import { useValidatePassword } from "metabase/common/hooks";
 import { useToast } from "metabase/common/hooks/use-toast";
 import { useDispatch } from "metabase/redux";
 import { resetPassword } from "metabase/redux/auth";
+import type { Location } from "metabase/router";
 import { replace } from "metabase/router";
 import { Button } from "metabase/ui";
 import * as Urls from "metabase/urls";

--- a/frontend/src/metabase/common/collections/hooks.ts
+++ b/frontend/src/metabase/common/collections/hooks.ts
@@ -1,10 +1,10 @@
-import type { Location } from "history";
 import { useMemo } from "react";
 
 import { skipToken, useGetCollectionQuery } from "metabase/api";
 import { ROOT_COLLECTION } from "metabase/common/collections/constants";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
+import type { Location } from "metabase/router";
 import { getUser, getUserPersonalCollectionId } from "metabase/selectors/user";
 import * as Urls from "metabase/urls/collections";
 import type { Collection, CollectionId } from "metabase-types/api";

--- a/frontend/src/metabase/common/components/LeaveConfirmModal/LeaveRouteConfirmModal.tsx
+++ b/frontend/src/metabase/common/components/LeaveConfirmModal/LeaveRouteConfirmModal.tsx
@@ -2,9 +2,12 @@ import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
 import { useConfirmRouteLeaveModal } from "metabase/common/hooks/use-confirm-route-leave-modal";
-import type { Location } from "metabase/router";
-import type { Route } from "metabase/router";
-import { useRoute, useRouter } from "metabase/router";
+import {
+  type Location,
+  type Route,
+  useRoute,
+  useRouter,
+} from "metabase/router";
 
 import { LeaveConfirmModal } from "./LeaveConfirmModal";
 

--- a/frontend/src/metabase/common/components/LeaveConfirmModal/LeaveRouteConfirmModal.tsx
+++ b/frontend/src/metabase/common/components/LeaveConfirmModal/LeaveRouteConfirmModal.tsx
@@ -1,8 +1,8 @@
-import type { Location } from "history";
 import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
 import { useConfirmRouteLeaveModal } from "metabase/common/hooks/use-confirm-route-leave-modal";
+import type { Location } from "metabase/router";
 import type { Route } from "metabase/router";
 import { useRoute, useRouter } from "metabase/router";
 

--- a/frontend/src/metabase/common/components/ModalRoute.tsx
+++ b/frontend/src/metabase/common/components/ModalRoute.tsx
@@ -1,6 +1,6 @@
-import type { Location } from "history";
 import { useCallback } from "react";
 
+import type { Location } from "metabase/router";
 import {
   Route,
   useNavigate,

--- a/frontend/src/metabase/common/components/NotFoundFallbackPage.tsx
+++ b/frontend/src/metabase/common/components/NotFoundFallbackPage.tsx
@@ -1,9 +1,9 @@
-import type { LocationDescriptor } from "history";
 import { useMount } from "react-use";
 
 import { NotFound } from "metabase/common/components/ErrorPages";
 import { connect } from "metabase/redux";
 import { refreshCurrentUser } from "metabase/redux/user";
+import type { LocationDescriptor } from "metabase/router";
 import { replace } from "metabase/router";
 
 type DispatchProps = {

--- a/frontend/src/metabase/common/components/SearchResult/SearchResult.tsx
+++ b/frontend/src/metabase/common/components/SearchResult/SearchResult.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { LocationDescriptorObject } from "history";
 import type { AnchorHTMLAttributes, HTMLAttributes, MouseEvent } from "react";
 import { forwardRef, useCallback } from "react";
 
@@ -7,6 +6,7 @@ import { Markdown } from "metabase/common/components/Markdown";
 import { trackSearchClick } from "metabase/common/search/analytics";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import { useDispatch } from "metabase/redux";
+import type { LocationDescriptorObject } from "metabase/router";
 import { push } from "metabase/router";
 import type { AnchorProps, BoxProps, StackProps } from "metabase/ui";
 import {

--- a/frontend/src/metabase/common/components/Unsubscribe.tsx
+++ b/frontend/src/metabase/common/components/Unsubscribe.tsx
@@ -1,4 +1,3 @@
-import type { Location } from "history";
 import { useMemo, useState } from "react";
 import { useAsync } from "react-use";
 import { jt, t } from "ttag";
@@ -15,6 +14,7 @@ import { LighthouseIllustration } from "metabase/common/components/LighthouseIll
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { LogoIcon } from "metabase/common/components/LogoIcon";
 import { useSelector } from "metabase/redux";
+import type { Location } from "metabase/router";
 import { getLoginPageIllustration } from "metabase/selectors/whitelabel";
 import { Button, Center, Stack, Text } from "metabase/ui";
 

--- a/frontend/src/metabase/common/hooks/use-confirm-route-leave-modal.ts
+++ b/frontend/src/metabase/common/hooks/use-confirm-route-leave-modal.ts
@@ -2,9 +2,15 @@ import { useCallback, useEffect, useState } from "react";
 import { match } from "ts-pattern";
 
 import { useDispatch } from "metabase/redux";
-import type { Location } from "metabase/router";
-import type { InjectedRouter, PlainRoute, Route } from "metabase/router";
-import { goBack, push, replace } from "metabase/router";
+import {
+  type InjectedRouter,
+  type Location,
+  type PlainRoute,
+  type Route,
+  goBack,
+  push,
+  replace,
+} from "metabase/router";
 
 import { useBeforeUnload } from "./use-before-unload";
 

--- a/frontend/src/metabase/common/hooks/use-confirm-route-leave-modal.ts
+++ b/frontend/src/metabase/common/hooks/use-confirm-route-leave-modal.ts
@@ -1,8 +1,8 @@
-import type { Location } from "history";
 import { useCallback, useEffect, useState } from "react";
 import { match } from "ts-pattern";
 
 import { useDispatch } from "metabase/redux";
+import type { Location } from "metabase/router";
 import type { InjectedRouter, PlainRoute, Route } from "metabase/router";
 import { goBack, push, replace } from "metabase/router";
 

--- a/frontend/src/metabase/common/hooks/use-url-state/types.ts
+++ b/frontend/src/metabase/common/hooks/use-url-state/types.ts
@@ -1,3 +1,3 @@
-import type { Query } from "history";
+import type { Query } from "metabase/router";
 
 export type QueryParam = Query[keyof Query];

--- a/frontend/src/metabase/common/hooks/use-url-state/use-url-state.ts
+++ b/frontend/src/metabase/common/hooks/use-url-state/use-url-state.ts
@@ -1,9 +1,9 @@
-import type { Location, Query } from "history";
 import { useCallback, useEffect, useState } from "react";
 import { useEffectOnce, useLatest } from "react-use";
 
 import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
 import { useDispatch } from "metabase/redux";
+import type { Location, Query } from "metabase/router";
 import { push, replace } from "metabase/router";
 
 type BaseState = Record<string, unknown>;

--- a/frontend/src/metabase/common/hooks/use-url-state/use-url-state.unit.spec.ts
+++ b/frontend/src/metabase/common/hooks/use-url-state/use-url-state.unit.spec.ts
@@ -1,4 +1,3 @@
-
 import { act, renderHookWithProviders, waitFor } from "__support__/ui";
 import { createMockLocation } from "metabase/redux/store/mocks";
 import type { Location } from "metabase/router";

--- a/frontend/src/metabase/common/hooks/use-url-state/use-url-state.unit.spec.ts
+++ b/frontend/src/metabase/common/hooks/use-url-state/use-url-state.unit.spec.ts
@@ -1,7 +1,7 @@
-import type { Location } from "history";
 
 import { act, renderHookWithProviders, waitFor } from "__support__/ui";
 import { createMockLocation } from "metabase/redux/store/mocks";
+import type { Location } from "metabase/router";
 
 import type { QueryParam } from "./types";
 import { type UrlStateConfig, useUrlState } from "./use-url-state";

--- a/frontend/src/metabase/common/search/types.ts
+++ b/frontend/src/metabase/common/search/types.ts
@@ -1,7 +1,7 @@
-import type { Location } from "history";
 import type { ComponentType } from "react";
 
 import type { SearchFilterKeys } from "metabase/common/search/constants";
+import type { Location } from "metabase/router";
 import type { EnabledSearchModel, IconName, UserId } from "metabase-types/api";
 
 export type TypeFilterProps = EnabledSearchModel[];

--- a/frontend/src/metabase/dashboard/actions/parameters.tsx
+++ b/frontend/src/metabase/dashboard/actions/parameters.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { LocationDescriptorObject } from "history";
 import { assoc } from "icepick";
 import { t } from "ttag";
 import _ from "underscore";
@@ -25,6 +24,7 @@ import { createAction, createThunkAction } from "metabase/redux";
 import { selectTab, setParameterValues } from "metabase/redux/dashboard";
 import type { Dispatch, GetState } from "metabase/redux/store";
 import { addUndo, dismissUndo } from "metabase/redux/undo";
+import type { LocationDescriptorObject } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Text } from "metabase/ui";
 import { isQuestionDashCard } from "metabase/utils/dashboard";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { LocationDescriptorObject } from "history";
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
@@ -20,6 +19,7 @@ import {
 import { EmbeddingEntityContextProvider } from "metabase/embedding/context";
 import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 import { useDispatch, useSelector } from "metabase/redux";
+import type { LocationDescriptorObject } from "metabase/router";
 import { push } from "metabase/router";
 import { getSetting } from "metabase/selectors/settings";
 import { Flex, Group, type IconProps, Menu, Title } from "metabase/ui";

--- a/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/utils.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/utils.ts
@@ -1,7 +1,6 @@
 import { deserializeCard, parseHash } from "metabase/common/utils/card";
 import type { Location } from "metabase/router";
 
-
 export const isNavigatingToCreateADashboardQuestion = (
   nextLocation?: Location,
 ): boolean => {

--- a/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/utils.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/utils.ts
@@ -1,6 +1,6 @@
-import type { Location } from "history";
-
 import { deserializeCard, parseHash } from "metabase/common/utils/card";
+import type { Location } from "metabase/router";
+
 
 export const isNavigatingToCreateADashboardQuestion = (
   nextLocation?: Location,

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
@@ -1,6 +1,5 @@
 import userEvent from "@testing-library/user-event";
 
-
 import { renderWithProviders, screen, within } from "__support__/ui";
 import { INPUT_WRAPPER_TEST_ID } from "metabase/common/components/TabButton";
 import { getDefaultTab, resetTempTabId } from "metabase/dashboard/actions";

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import type { Location } from "history";
+
 
 import { renderWithProviders, screen, within } from "__support__/ui";
 import { INPUT_WRAPPER_TEST_ID } from "metabase/common/components/TabButton";
@@ -10,6 +10,7 @@ import { getSelectedTabId } from "metabase/dashboard/selectors";
 import { createTabSlug } from "metabase/dashboard/utils";
 import { useSelector } from "metabase/redux";
 import type { DashboardState } from "metabase/redux/store";
+import type { Location } from "metabase/router";
 import {
   type InjectedRouter,
   Link,

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
@@ -9,10 +9,10 @@ import { getSelectedTabId } from "metabase/dashboard/selectors";
 import { createTabSlug } from "metabase/dashboard/utils";
 import { useSelector } from "metabase/redux";
 import type { DashboardState } from "metabase/redux/store";
-import type { Location } from "metabase/router";
 import {
   type InjectedRouter,
   Link,
+  type Location,
   Route,
   type WithRouterProps,
   withRouteProps,

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { Location } from "history";
 import { useState } from "react";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
@@ -32,6 +31,7 @@ import {
 } from "metabase/hooks/use-page-title";
 import { useDispatch, useSelector } from "metabase/redux";
 import { setErrorPage } from "metabase/redux/app";
+import type { Location } from "metabase/router";
 import { Outlet, replace, useRouter } from "metabase/router";
 import * as Urls from "metabase/urls";
 import { parseHashOptions, stringifyHashOptions } from "metabase/utils/browser";

--- a/frontend/src/metabase/dashboard/hooks/use-auto-scroll-to-dashcard.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-auto-scroll-to-dashcard.ts
@@ -1,7 +1,7 @@
-import type { LocationDescriptorObject } from "history";
 import { useCallback, useMemo } from "react";
 
 import { useDispatch } from "metabase/redux";
+import type { LocationDescriptorObject } from "metabase/router";
 import { replace } from "metabase/router";
 import { parseHashOptions, stringifyHashOptions } from "metabase/utils/browser";
 import type { DashCardId } from "metabase-types/api";

--- a/frontend/src/metabase/dashboard/hooks/use-dashboard-url-query.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-dashboard-url-query.ts
@@ -6,9 +6,12 @@ import { useSetting } from "metabase/common/hooks";
 import { isEmbedPreview } from "metabase/embedding/config";
 import { useDispatch, useSelector } from "metabase/redux";
 import { selectTab } from "metabase/redux/dashboard";
-import type { Location } from "metabase/router";
-import type { InjectedRouter } from "metabase/router";
-import { push, replace } from "metabase/router";
+import {
+  type InjectedRouter,
+  type Location,
+  push,
+  replace,
+} from "metabase/router";
 import * as Urls from "metabase/urls";
 import { getParameterValuesBySlug } from "metabase-lib/v1/parameters/utils/parameter-values";
 

--- a/frontend/src/metabase/dashboard/hooks/use-dashboard-url-query.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-dashboard-url-query.ts
@@ -1,4 +1,3 @@
-import type { Location } from "history";
 import { useEffect, useMemo } from "react";
 import { usePrevious } from "react-use";
 import _ from "underscore";
@@ -7,6 +6,7 @@ import { useSetting } from "metabase/common/hooks";
 import { isEmbedPreview } from "metabase/embedding/config";
 import { useDispatch, useSelector } from "metabase/redux";
 import { selectTab } from "metabase/redux/dashboard";
+import type { Location } from "metabase/router";
 import type { InjectedRouter } from "metabase/router";
 import { push, replace } from "metabase/router";
 import * as Urls from "metabase/urls";

--- a/frontend/src/metabase/dashboard/hooks/use-dashboard-url-query.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/hooks/use-dashboard-url-query.unit.spec.tsx
@@ -1,6 +1,5 @@
 import { act } from "@testing-library/react";
 
-
 import { renderHookWithProviders } from "__support__/ui";
 import { isEmbedPreview } from "metabase/embedding/config";
 import { selectTab } from "metabase/redux/dashboard";

--- a/frontend/src/metabase/dashboard/hooks/use-dashboard-url-query.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/hooks/use-dashboard-url-query.unit.spec.tsx
@@ -1,5 +1,5 @@
 import { act } from "@testing-library/react";
-import type { Location } from "history";
+
 
 import { renderHookWithProviders } from "__support__/ui";
 import { isEmbedPreview } from "metabase/embedding/config";
@@ -10,6 +10,7 @@ import {
   createMockState,
   createMockStoreDashboard,
 } from "metabase/redux/store/mocks";
+import type { Location } from "metabase/router";
 import { push, replace } from "metabase/router";
 import type { ParameterValueOrArray } from "metabase-types/api";
 import { createMockParameter } from "metabase-types/api/mocks";

--- a/frontend/src/metabase/dashboard/hooks/use-location-sync.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-location-sync.ts
@@ -1,9 +1,9 @@
-import type { Location } from "history";
 import { useEffect, useMemo } from "react";
 import { usePrevious } from "react-use";
 import { omit } from "underscore";
 
 import { useDispatch } from "metabase/redux";
+import type { Location } from "metabase/router";
 import { replace } from "metabase/router";
 import { parseHashOptions, stringifyHashOptions } from "metabase/utils/browser";
 import { isNullOrUndefined } from "metabase/utils/types";

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -1,9 +1,9 @@
-import type { Location } from "history";
 import { getIn } from "icepick";
 import { msgid, ngettext, t } from "ttag";
 import _ from "underscore";
 
 import type { SelectedTabId } from "metabase/redux/store";
+import type { Location } from "metabase/router";
 import {
   isQuestionDashCard,
   isVirtualDashCard,

--- a/frontend/src/metabase/dashboard/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/utils.unit.spec.ts
@@ -1,4 +1,3 @@
-
 import {
   canResetFilter,
   createTabSlug,

--- a/frontend/src/metabase/dashboard/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/utils.unit.spec.ts
@@ -1,4 +1,3 @@
-import type { Location } from "history";
 
 import {
   canResetFilter,
@@ -16,6 +15,7 @@ import {
   syncParametersAndEmbeddingParams,
 } from "metabase/dashboard/utils";
 import { createMockLocation } from "metabase/redux/store/mocks";
+import type { Location } from "metabase/router";
 import { SERVER_ERROR_TYPES } from "metabase/utils/errors";
 import { checkNotNull } from "metabase/utils/types";
 import { createMockUiParameter } from "metabase-lib/v1/parameters/mock";

--- a/frontend/src/metabase/documents/components/DocumentPage.tsx
+++ b/frontend/src/metabase/documents/components/DocumentPage.tsx
@@ -2,7 +2,6 @@ import { useForceUpdate } from "@mantine/hooks";
 import type { JSONContent, Editor as TiptapEditor } from "@tiptap/core";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import dayjs from "dayjs";
-import type { Location } from "history";
 import {
   type ReactNode,
   useCallback,
@@ -39,6 +38,7 @@ import { useCallbackEffect } from "metabase/common/hooks/use-callback-effect";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { useDispatch, useSelector } from "metabase/redux";
 import { setErrorPage } from "metabase/redux/app";
+import type { Location } from "metabase/router";
 import type { Route } from "metabase/router";
 import { Outlet, push, replace } from "metabase/router";
 import { Box } from "metabase/ui";

--- a/frontend/src/metabase/documents/components/DocumentPage.tsx
+++ b/frontend/src/metabase/documents/components/DocumentPage.tsx
@@ -38,9 +38,13 @@ import { useCallbackEffect } from "metabase/common/hooks/use-callback-effect";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { useDispatch, useSelector } from "metabase/redux";
 import { setErrorPage } from "metabase/redux/app";
-import type { Location } from "metabase/router";
-import type { Route } from "metabase/router";
-import { Outlet, push, replace } from "metabase/router";
+import {
+  type Location,
+  Outlet,
+  type Route,
+  push,
+  replace,
+} from "metabase/router";
 import { Box } from "metabase/ui";
 import { extractEntityId } from "metabase/urls";
 import * as Urls from "metabase/urls";

--- a/frontend/src/metabase/history/HistoryProvider.tsx
+++ b/frontend/src/metabase/history/HistoryProvider.tsx
@@ -1,5 +1,6 @@
-import type { History } from "history";
 import { type PropsWithChildren, createContext } from "react";
+
+import type { History } from "metabase/router";
 
 type HistoryContextType = {
   history: History;

--- a/frontend/src/metabase/metadata/pages/DataModelV1/DataModelV1.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModelV1/DataModelV1.tsx
@@ -1,5 +1,4 @@
 import { useDisclosure, useWindowEvent } from "@mantine/hooks";
-import type { Location } from "history";
 import { useMemo, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
@@ -10,6 +9,7 @@ import {
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { getRawTableFieldId } from "metabase/metadata/utils/field";
+import type { Location } from "metabase/router";
 import { Outlet } from "metabase/router";
 import { Box, Flex, Stack, rem } from "metabase/ui";
 import * as Urls from "metabase/urls";

--- a/frontend/src/metabase/metrics-viewer/hooks/use-viewer-url.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-viewer-url.ts
@@ -1,9 +1,9 @@
-import type { Location } from "history";
 import { useEffect, useRef } from "react";
 import { t } from "ttag";
 
 import { useToast } from "metabase/common/hooks";
 import { useDispatch } from "metabase/redux";
+import type { Location } from "metabase/router";
 import { push, replace } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { MeasureId } from "metabase-types/api";

--- a/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
+++ b/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
@@ -1,4 +1,3 @@
-import type { Location } from "history";
 
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { BreakoutLegend } from "metabase/metrics-viewer/components/BreakoutLegend/BreakoutLegend";
@@ -14,6 +13,7 @@ import {
   useMetricsViewerContext,
 } from "metabase/metrics-viewer/context";
 import { useViewerState } from "metabase/metrics-viewer/hooks";
+import type { Location } from "metabase/router";
 import { Box, Center, Flex, Stack } from "metabase/ui";
 
 import S from "./MetricsViewerPage.module.css";

--- a/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
+++ b/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
@@ -1,4 +1,3 @@
-
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { BreakoutLegend } from "metabase/metrics-viewer/components/BreakoutLegend/BreakoutLegend";
 import { DimensionPickerSidebar } from "metabase/metrics-viewer/components/DimensionPickerSidebar";

--- a/frontend/src/metabase/metrics/pages/NewMetricPage/NewMetricPage.tsx
+++ b/frontend/src/metabase/metrics/pages/NewMetricPage/NewMetricPage.tsx
@@ -1,5 +1,4 @@
 import { useDisclosure } from "@mantine/hooks";
-import type { Location } from "history";
 import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 import { t } from "ttag";
@@ -18,6 +17,7 @@ import { MetricQueryEditor } from "metabase/metrics/components/MetricQueryEditor
 import { NAME_MAX_LENGTH } from "metabase/metrics/constants";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
 import { useDispatch, useSelector } from "metabase/redux";
+import type { Location } from "metabase/router";
 import type { Route } from "metabase/router";
 import { goBack, push } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";

--- a/frontend/src/metabase/metrics/pages/NewMetricPage/NewMetricPage.tsx
+++ b/frontend/src/metabase/metrics/pages/NewMetricPage/NewMetricPage.tsx
@@ -1,6 +1,5 @@
 import { useDisclosure } from "@mantine/hooks";
-import type { ReactNode } from "react";
-import { useMemo, useState } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { useGetDefaultCollectionId } from "metabase/common/collections/hooks";
@@ -17,9 +16,7 @@ import { MetricQueryEditor } from "metabase/metrics/components/MetricQueryEditor
 import { NAME_MAX_LENGTH } from "metabase/metrics/constants";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
 import { useDispatch, useSelector } from "metabase/redux";
-import type { Location } from "metabase/router";
-import type { Route } from "metabase/router";
-import { goBack, push } from "metabase/router";
+import { type Location, type Route, goBack, push } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Breadcrumbs, Card, Icon } from "metabase/ui";
 import * as Urls from "metabase/urls";

--- a/frontend/src/metabase/models/containers/ModelActions/ModelActions.tsx
+++ b/frontend/src/metabase/models/containers/ModelActions/ModelActions.tsx
@@ -1,4 +1,3 @@
-import type { LocationDescriptor } from "history";
 import { useEffect, useMemo, useState } from "react";
 import { useMount } from "react-use";
 
@@ -16,6 +15,7 @@ import { loadMetadataForCard } from "metabase/questions/actions";
 import { connect, useSelector } from "metabase/redux";
 import type { State } from "metabase/redux/store";
 import { fetchTableForeignKeys } from "metabase/redux/tables";
+import type { LocationDescriptor } from "metabase/router";
 import { Outlet, replace } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import * as Urls from "metabase/urls";

--- a/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.tsx
+++ b/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { Location } from "history";
 import { t } from "ttag";
 
 import { ExternalLink } from "metabase/common/components/ExternalLink";
@@ -7,6 +6,7 @@ import { NoDatabasesEmptyState } from "metabase/common/components/NoDatabasesEmp
 import CS from "metabase/css/core/index.css";
 import { NewModelOption } from "metabase/models/components/NewModelOption";
 import { useSelector } from "metabase/redux";
+import type { Location } from "metabase/router";
 import { getLearnUrl, getSetting } from "metabase/selectors/settings";
 import {
   canUserCreateNativeQueries,

--- a/frontend/src/metabase/monitor/tools/components/Logs/Logs.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/Logs/Logs.unit.spec.tsx
@@ -1,6 +1,5 @@
 import fetchMock from "fetch-mock";
 
-
 import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
 import {
   createMockLocation,

--- a/frontend/src/metabase/monitor/tools/components/Logs/Logs.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/Logs/Logs.unit.spec.tsx
@@ -1,11 +1,12 @@
 import fetchMock from "fetch-mock";
-import type { Location } from "history";
+
 
 import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
 import {
   createMockLocation,
   createMockRoutingState,
 } from "metabase/redux/store/mocks";
+import type { Location } from "metabase/router";
 import { Route } from "metabase/router";
 
 import { DEFAULT_POLLING_DURATION_MS, Logs } from "./Logs";

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
@@ -1,7 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
-
 import {
   setupDatabasesEndpoints,
   setupTasksEndpoints,

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
-import type { Location } from "history";
+
 
 import {
   setupDatabasesEndpoints,
@@ -17,6 +17,7 @@ import {
 } from "__support__/ui";
 import { URL_UPDATE_DEBOUNCE_DELAY } from "metabase/common/hooks/use-url-state";
 import { createMockLocation } from "metabase/redux/store/mocks";
+import type { Location } from "metabase/router";
 import { Route, withRouteProps } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { ListTasksResponse } from "metabase-types/api";

--- a/frontend/src/metabase/monitor/tools/components/ToolsApp.tsx
+++ b/frontend/src/metabase/monitor/tools/components/ToolsApp.tsx
@@ -1,4 +1,3 @@
-import type { Location } from "history";
 import { t } from "ttag";
 
 import { AdminSettingsLayout } from "metabase/admin/components/AdminLayout/AdminSettingsLayout";
@@ -7,6 +6,7 @@ import {
   type AdminNavItemProps,
   AdminNavWrapper,
 } from "metabase/admin/components/AdminNav";
+import type { Location } from "metabase/router";
 import { Outlet } from "metabase/router";
 import * as Urls from "metabase/urls";
 

--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { LocationDescriptorObject } from "history";
 import { useKBar } from "kbar";
 import type {
   ChangeEvent,
@@ -22,6 +21,7 @@ import { RecentsList } from "metabase/nav/components/search/RecentsList";
 import { SearchResultsDropdown } from "metabase/nav/components/search/SearchResultsDropdown";
 import { APP_BAR_HEIGHT } from "metabase/nav/constants";
 import { useDispatch, useSelector } from "metabase/redux";
+import type { LocationDescriptorObject } from "metabase/router";
 import { push, useRouter } from "metabase/router";
 import { getSetting } from "metabase/selectors/settings";
 import { Box, Flex, Icon, UnstyledButton, rem } from "metabase/ui";

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.tsx
@@ -1,4 +1,3 @@
-import type { LocationDescriptor } from "history";
 import { useEffect, useMemo } from "react";
 
 import {
@@ -10,6 +9,7 @@ import { NavbarPromoSlot } from "metabase/nav/components/NavbarPromoSlot";
 import { connect } from "metabase/redux";
 import { closeNavbar, openNavbar } from "metabase/redux/app";
 import type { State } from "metabase/redux/store";
+import type { LocationDescriptor } from "metabase/router";
 import { push } from "metabase/router";
 import * as Urls from "metabase/urls";
 import Question from "metabase-lib/v1/Question";

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
@@ -1,4 +1,3 @@
-import type { LocationDescriptor } from "history";
 import { memo, useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
@@ -23,6 +22,7 @@ import { connect, useDispatch, useSelector } from "metabase/redux";
 import { logout } from "metabase/redux/auth";
 import type { State } from "metabase/redux/store";
 import { addUndo } from "metabase/redux/undo";
+import type { LocationDescriptor } from "metabase/router";
 import {
   getIsTenantUser,
   getUser,

--- a/frontend/src/metabase/nav/containers/MainNavbar/types.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/types.ts
@@ -1,6 +1,6 @@
-import type { Location } from "history";
-
 import type { StoreDashboard } from "metabase/redux/store";
+import type { Location } from "metabase/router";
+
 
 export interface MainNavbarOwnProps {
   isOpen: boolean;

--- a/frontend/src/metabase/nav/containers/MainNavbar/types.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/types.ts
@@ -1,7 +1,6 @@
 import type { StoreDashboard } from "metabase/redux/store";
 import type { Location } from "metabase/router";
 
-
 export interface MainNavbarOwnProps {
   isOpen: boolean;
   location: Location;

--- a/frontend/src/metabase/palette/components/Palette.tsx
+++ b/frontend/src/metabase/palette/components/Palette.tsx
@@ -3,8 +3,7 @@ import { useEffect, useRef } from "react";
 
 import { useOnClickOutside } from "metabase/common/hooks/use-on-click-outside";
 import { useSelector } from "metabase/redux";
-import type { Query } from "metabase/router";
-import { type PlainRoute, useRouter } from "metabase/router";
+import { type PlainRoute, type Query, useRouter } from "metabase/router";
 import { getUser } from "metabase/selectors/user";
 import { Box, Card, Center, Icon, Overlay, Stack, rem } from "metabase/ui";
 import { isWithinIframe } from "metabase/utils/iframe";

--- a/frontend/src/metabase/palette/components/Palette.tsx
+++ b/frontend/src/metabase/palette/components/Palette.tsx
@@ -1,9 +1,9 @@
-import type { Query } from "history";
 import { KBarPortal, VisualState, useKBar } from "kbar";
 import { useEffect, useRef } from "react";
 
 import { useOnClickOutside } from "metabase/common/hooks/use-on-click-outside";
 import { useSelector } from "metabase/redux";
+import type { Query } from "metabase/router";
 import { type PlainRoute, useRouter } from "metabase/router";
 import { getUser } from "metabase/selectors/user";
 import { Box, Card, Center, Icon, Overlay, Stack, rem } from "metabase/ui";

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -1,4 +1,3 @@
-import type { Query } from "history";
 import { VisualState, useKBar, useMatches } from "kbar";
 import { useEffect, useMemo } from "react";
 import { useKeyPressEvent } from "react-use";
@@ -7,6 +6,7 @@ import { t } from "ttag";
 import NoResults from "assets/img/no_results.svg";
 import { useShowOtherUsersCollections } from "metabase/common/hooks/use-show-other-users-collections";
 import { trackSearchClick } from "metabase/common/search/analytics";
+import type { Query } from "metabase/router";
 import { Link } from "metabase/router";
 import {
   Flex,

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -1,4 +1,3 @@
-import type { Query } from "history";
 import { Priority, VisualState, useKBar, useRegisterActions } from "kbar";
 import { type PropsWithChildren, useEffect, useMemo, useState } from "react";
 import { useDebounce } from "react-use";
@@ -12,6 +11,7 @@ import { useSetting } from "metabase/common/hooks";
 import { trackSearchClick } from "metabase/common/search/analytics";
 import { useGetIcon } from "metabase/hooks/use-icon";
 import { useSelector } from "metabase/redux";
+import type { Query } from "metabase/router";
 import { getDocsUrl, getSettings } from "metabase/selectors/settings";
 import { canAccessSettings, getUserIsAdmin } from "metabase/selectors/user";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";

--- a/frontend/src/metabase/palette/types.ts
+++ b/frontend/src/metabase/palette/types.ts
@@ -1,7 +1,7 @@
-import type { LocationDescriptor } from "history";
 import type { Action, ActionImpl } from "kbar";
 import type React from "react";
 
+import type { LocationDescriptor } from "metabase/router";
 import type { ColorName } from "metabase/ui/colors/types";
 import type { IconName, ModerationReviewStatus } from "metabase-types/api";
 

--- a/frontend/src/metabase/palette/utils.ts
+++ b/frontend/src/metabase/palette/utils.ts
@@ -1,7 +1,7 @@
-import type { LocationDescriptor } from "history";
 import { t } from "ttag";
 import _ from "underscore";
 
+import type { LocationDescriptor } from "metabase/router";
 import type { ColorName } from "metabase/ui/colors/types";
 import type { IconName, RecentItem } from "metabase-types/api";
 

--- a/frontend/src/metabase/palette/utils.unit.spec.ts
+++ b/frontend/src/metabase/palette/utils.unit.spec.ts
@@ -1,4 +1,4 @@
-import type { LocationDescriptor } from "history";
+import type { LocationDescriptor } from "metabase/router";
 
 import type { PaletteActionImpl } from "./types";
 import {

--- a/frontend/src/metabase/public/containers/PublicDocument/PublicDocument.tsx
+++ b/frontend/src/metabase/public/containers/PublicDocument/PublicDocument.tsx
@@ -1,7 +1,6 @@
 import Image from "@tiptap/extension-image";
 import { Link } from "@tiptap/extension-link";
 import { EditorContent, useEditor } from "@tiptap/react";
-import type { Location } from "history";
 import { useEffect, useMemo } from "react";
 import { useAsync, useMount } from "react-use";
 
@@ -24,6 +23,7 @@ import { ResizeNode } from "metabase/rich_text_editing/tiptap/extensions/ResizeN
 import { SmartLink } from "metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode";
 import { SupportingText } from "metabase/rich_text_editing/tiptap/extensions/SupportingText/SupportingText";
 import { DROP_ZONE_COLOR } from "metabase/rich_text_editing/tiptap/extensions/shared/constants";
+import type { Location } from "metabase/router";
 import { getSetting } from "metabase/selectors/settings";
 import { Box } from "metabase/ui";
 import { initializeIframeResizer } from "metabase/utils/dom";

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
@@ -1,4 +1,3 @@
-import type { Location } from "history";
 import { useCallback, useEffect, useState } from "react";
 import { useLatest, useMount } from "react-use";
 
@@ -15,6 +14,7 @@ import { useSetEmbedFont } from "metabase/public/hooks/use-set-embed-font";
 import { useDispatch, useSelector } from "metabase/redux";
 import { setErrorPage } from "metabase/redux/app";
 import { updateMetadata } from "metabase/redux/metadata";
+import type { Location } from "metabase/router";
 import { FieldSchema } from "metabase/schema";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getCanWhitelabel } from "metabase/selectors/whitelabel";

--- a/frontend/src/metabase/public/hooks/use-embed-frame-options.ts
+++ b/frontend/src/metabase/public/hooks/use-embed-frame-options.ts
@@ -1,9 +1,9 @@
-import type { Location } from "history";
 import { useEffect } from "react";
 
 import { useDocsUrl } from "metabase/common/hooks";
 import type { EmbeddingHashOptions } from "metabase/embedding/types";
 import { PLUGIN_RESOURCE_DOWNLOADS } from "metabase/plugins";
+import type { Location } from "metabase/router";
 import { parseHashOptions } from "metabase/utils/browser";
 import { isWithinIframe } from "metabase/utils/iframe";
 

--- a/frontend/src/metabase/public/hooks/use-set-embed-font.ts
+++ b/frontend/src/metabase/public/hooks/use-set-embed-font.ts
@@ -1,9 +1,9 @@
-import type { Location } from "history";
 import { useEffect } from "react";
 
 import type { EmbeddingHashOptions } from "metabase/embedding/types";
 import { useDispatch } from "metabase/redux";
 import { setOptions } from "metabase/redux/embed";
+import type { Location } from "metabase/router";
 import { parseHashOptions } from "metabase/utils/browser";
 
 export const useSetEmbedFont = ({ location }: { location: Location }) => {

--- a/frontend/src/metabase/public/hooks/use-set-embed-font.unit.spec.tsx
+++ b/frontend/src/metabase/public/hooks/use-set-embed-font.unit.spec.tsx
@@ -1,11 +1,11 @@
 import { renderHook } from "@testing-library/react";
-import type { Location } from "history";
 import type { PropsWithChildren } from "react";
 
 import { mainReducers } from "__support__/entities-store";
 import { MetabaseReduxProvider } from "metabase/redux";
 import type { EmbedState } from "metabase/redux/store";
 import { createMockState } from "metabase/redux/store/mocks";
+import type { Location } from "metabase/router";
 import { getStore } from "metabase/store";
 
 import { useSetEmbedFont } from "./use-set-embed-font";

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -1,4 +1,3 @@
-import type { LocationDescriptorObject } from "history";
 
 import { cardApi, databaseApi, snippetApi } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
@@ -22,6 +21,7 @@ import type {
   QueryBuilderUIControls,
 } from "metabase/redux/store";
 import { fetchTableMetadataAndForeignKeys } from "metabase/redux/tables";
+import type { LocationDescriptorObject } from "metabase/router";
 import { replace } from "metabase/router";
 import { FieldSchema } from "metabase/schema";
 import { getMetadata } from "metabase/selectors/metadata";

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -1,4 +1,3 @@
-
 import { cardApi, databaseApi, snippetApi } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import {

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -1,5 +1,5 @@
 import fetchMock from "fetch-mock";
-import type { LocationDescriptorObject } from "history";
+
 
 import { createMockEntitiesState } from "__support__/store";
 import { databaseApi, snippetApi } from "metabase/api";
@@ -10,6 +10,7 @@ import { setErrorPage } from "metabase/redux/app";
 import * as metadataActions from "metabase/redux/metadata";
 import * as sharedQB from "metabase/redux/query-builder";
 import { createMockState } from "metabase/redux/store/mocks";
+import type { LocationDescriptorObject } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import * as Urls from "metabase/urls";
 import { defer } from "metabase/utils/promise";

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -1,6 +1,5 @@
 import fetchMock from "fetch-mock";
 
-
 import { createMockEntitiesState } from "__support__/store";
 import { databaseApi, snippetApi } from "metabase/api";
 import * as rtkEndpointUtils from "metabase/api/utils/run-rtk-endpoint";

--- a/frontend/src/metabase/query_builder/actions/navigation.ts
+++ b/frontend/src/metabase/query_builder/actions/navigation.ts
@@ -1,9 +1,9 @@
-import type { Location } from "history";
 import _ from "underscore";
 
 import { createThunkAction } from "metabase/redux";
 import { resetUIControls } from "metabase/redux/query-builder";
 import type { Dispatch } from "metabase/redux/store";
+import type { Location } from "metabase/router";
 import { getLocation } from "metabase/selectors/routing";
 
 import {

--- a/frontend/src/metabase/query_builder/actions/navigation.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/navigation.unit.spec.ts
@@ -2,7 +2,7 @@
 // produces the pushes. locationChanged decides between re-running initializeQB
 // and dispatching popState based on location.action plus location.state. The
 // router migration re-plumbs this read seam, so this locks the current matrix.
-import type { Location } from "history";
+import type { Location } from "metabase/router";
 
 import * as initializeQBModule from "./core/initializeQB";
 import { locationChanged } from "./navigation";

--- a/frontend/src/metabase/query_builder/actions/url.ts
+++ b/frontend/src/metabase/query_builder/actions/url.ts
@@ -1,6 +1,5 @@
 import { parse as parseUrl } from "url";
 
-
 import { isEqualCard } from "metabase/common/utils/card";
 import { createThunkAction } from "metabase/redux";
 import type { LocationDescriptor } from "metabase/router";

--- a/frontend/src/metabase/query_builder/actions/url.ts
+++ b/frontend/src/metabase/query_builder/actions/url.ts
@@ -1,9 +1,9 @@
 import { parse as parseUrl } from "url";
 
-import type { LocationDescriptor } from "history";
 
 import { isEqualCard } from "metabase/common/utils/card";
 import { createThunkAction } from "metabase/redux";
+import type { LocationDescriptor } from "metabase/router";
 import { push, replace } from "metabase/router";
 import { getBasename } from "metabase/utils/basename";
 import * as Lib from "metabase-lib";

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
@@ -50,9 +50,12 @@ import {
   setUIControls,
 } from "metabase/redux/query-builder";
 import type { QueryBuilderUIControls, State } from "metabase/redux/store";
-import type { Location } from "metabase/router";
-import type { Route, WithRouterProps } from "metabase/router";
-import { push } from "metabase/router";
+import {
+  type Location,
+  type Route,
+  type WithRouterProps,
+  push,
+} from "metabase/router";
 import { getIsNavbarOpen } from "metabase/selectors/app";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getSetting } from "metabase/selectors/settings";

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
@@ -1,5 +1,4 @@
 import { useHotkeys } from "@mantine/hooks";
-import type { Location } from "history";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ConnectedProps } from "react-redux";
 import { useMount, usePrevious, useUnmount } from "react-use";
@@ -51,6 +50,7 @@ import {
   setUIControls,
 } from "metabase/redux/query-builder";
 import type { QueryBuilderUIControls, State } from "metabase/redux/store";
+import type { Location } from "metabase/router";
 import type { Route, WithRouterProps } from "metabase/router";
 import { push } from "metabase/router";
 import { getIsNavbarOpen } from "metabase/selectors/app";

--- a/frontend/src/metabase/query_builder/typed-utils.ts
+++ b/frontend/src/metabase/query_builder/typed-utils.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
-
 import type { DatasetEditorTab, QueryBuilderMode } from "metabase/redux/store";
+import type { LocationDescriptorObject } from "metabase/router";
+
 
 type LocationQBModeResult = {
   queryBuilderMode: QueryBuilderMode;

--- a/frontend/src/metabase/query_builder/typed-utils.ts
+++ b/frontend/src/metabase/query_builder/typed-utils.ts
@@ -1,7 +1,6 @@
 import type { DatasetEditorTab, QueryBuilderMode } from "metabase/redux/store";
 import type { LocationDescriptorObject } from "metabase/router";
 
-
 type LocationQBModeResult = {
   queryBuilderMode: QueryBuilderMode;
   datasetEditorTab?: DatasetEditorTab;

--- a/frontend/src/metabase/query_builder/utils/index.ts
+++ b/frontend/src/metabase/query_builder/utils/index.ts
@@ -1,10 +1,10 @@
 import querystring from "querystring";
 
-import type { Location } from "history";
 import _ from "underscore";
 
 import { serializeCardForUrl } from "metabase/common/utils/card";
 import type { DatasetEditorTab, QueryBuilderMode } from "metabase/redux/store";
+import type { Location } from "metabase/router";
 import * as Urls from "metabase/urls";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";

--- a/frontend/src/metabase/redux/store/mocks/routing.ts
+++ b/frontend/src/metabase/redux/store/mocks/routing.ts
@@ -1,5 +1,4 @@
-import type { Location } from "metabase/router";
-import type { RouterState } from "metabase/router";
+import type { Location, RouterState } from "metabase/router";
 
 export const createMockRoutingState = (
   opts?: Partial<RouterState>,

--- a/frontend/src/metabase/redux/store/mocks/routing.ts
+++ b/frontend/src/metabase/redux/store/mocks/routing.ts
@@ -1,5 +1,4 @@
-import type { Location } from "history";
-
+import type { Location } from "metabase/router";
 import type { RouterState } from "metabase/router";
 
 export const createMockRoutingState = (

--- a/frontend/src/metabase/reference/databases/DatabaseDetailContainer.tsx
+++ b/frontend/src/metabase/reference/databases/DatabaseDetailContainer.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { Location } from "history";
 import { Component } from "react";
 
 import CS from "metabase/css/core/index.css";
@@ -8,6 +7,7 @@ import * as metadataActions from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import DatabaseDetail from "metabase/reference/databases/DatabaseDetail";
 import * as actions from "metabase/reference/reference";
+import type { Location } from "metabase/router";
 import { type InjectedRouteProps, withRouteProps } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";

--- a/frontend/src/metabase/reference/databases/DatabaseDetailContainer.tsx
+++ b/frontend/src/metabase/reference/databases/DatabaseDetailContainer.tsx
@@ -7,16 +7,21 @@ import * as metadataActions from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import DatabaseDetail from "metabase/reference/databases/DatabaseDetail";
 import * as actions from "metabase/reference/reference";
-import type { Location } from "metabase/router";
-import { type InjectedRouteProps, withRouteProps } from "metabase/router";
+import {
+  type InjectedRouteProps,
+  type Location,
+  withRouteProps,
+} from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
-import type {
-  ReferenceRouteParams,
-  ReferenceRouteProps,
-  StateWithReference,
+import {
+  type ReferenceRouteParams,
+  type ReferenceRouteProps,
+  type StateWithReference,
+  getDatabase,
+  getDatabaseId,
+  getIsEditing,
 } from "../selectors";
-import { getDatabase, getDatabaseId, getIsEditing } from "../selectors";
 import type { StubbedDatabase } from "../types";
 
 import DatabaseSidebar from "./DatabaseSidebar";

--- a/frontend/src/metabase/reference/databases/FieldDetailContainer.tsx
+++ b/frontend/src/metabase/reference/databases/FieldDetailContainer.tsx
@@ -7,17 +7,18 @@ import * as metadataActions from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import FieldDetail from "metabase/reference/databases/FieldDetail";
 import * as actions from "metabase/reference/reference";
-import type { Location } from "metabase/router";
-import { type InjectedRouteProps, withRouteProps } from "metabase/router";
+import {
+  type InjectedRouteProps,
+  type Location,
+  withRouteProps,
+} from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 
 import type { ClearStateProps, FetchProps } from "../reference";
-import type {
-  ReferenceRouteParams,
-  ReferenceRouteProps,
-  StateWithReference,
-} from "../selectors";
 import {
+  type ReferenceRouteParams,
+  type ReferenceRouteProps,
+  type StateWithReference,
   getDatabase,
   getDatabaseId,
   getField,

--- a/frontend/src/metabase/reference/databases/FieldDetailContainer.tsx
+++ b/frontend/src/metabase/reference/databases/FieldDetailContainer.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { Location } from "history";
 import { Component } from "react";
 
 import CS from "metabase/css/core/index.css";
@@ -8,6 +7,7 @@ import * as metadataActions from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import FieldDetail from "metabase/reference/databases/FieldDetail";
 import * as actions from "metabase/reference/reference";
+import type { Location } from "metabase/router";
 import { type InjectedRouteProps, withRouteProps } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 

--- a/frontend/src/metabase/reference/databases/FieldListContainer.tsx
+++ b/frontend/src/metabase/reference/databases/FieldListContainer.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { Location } from "history";
 import { Component } from "react";
 
 import CS from "metabase/css/core/index.css";
@@ -8,6 +7,7 @@ import * as metadataActions from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import FieldList from "metabase/reference/databases/FieldList";
 import * as actions from "metabase/reference/reference";
+import type { Location } from "metabase/router";
 import { type InjectedRouteProps, withRouteProps } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";

--- a/frontend/src/metabase/reference/databases/FieldListContainer.tsx
+++ b/frontend/src/metabase/reference/databases/FieldListContainer.tsx
@@ -7,16 +7,17 @@ import * as metadataActions from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import FieldList from "metabase/reference/databases/FieldList";
 import * as actions from "metabase/reference/reference";
-import type { Location } from "metabase/router";
-import { type InjectedRouteProps, withRouteProps } from "metabase/router";
+import {
+  type InjectedRouteProps,
+  type Location,
+  withRouteProps,
+} from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
-import type {
-  ReferenceRouteParams,
-  ReferenceRouteProps,
-  StateWithReference,
-} from "../selectors";
 import {
+  type ReferenceRouteParams,
+  type ReferenceRouteProps,
+  type StateWithReference,
   getDatabase,
   getDatabaseId,
   getIsEditing,

--- a/frontend/src/metabase/reference/databases/TableDetailContainer.tsx
+++ b/frontend/src/metabase/reference/databases/TableDetailContainer.tsx
@@ -7,16 +7,17 @@ import * as metadataActions from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import TableDetail from "metabase/reference/databases/TableDetail";
 import * as actions from "metabase/reference/reference";
-import type { Location } from "metabase/router";
-import { type InjectedRouteProps, withRouteProps } from "metabase/router";
+import {
+  type InjectedRouteProps,
+  type Location,
+  withRouteProps,
+} from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
-import type {
-  ReferenceRouteParams,
-  ReferenceRouteProps,
-  StateWithReference,
-} from "../selectors";
 import {
+  type ReferenceRouteParams,
+  type ReferenceRouteProps,
+  type StateWithReference,
   getDatabase,
   getDatabaseId,
   getIsEditing,

--- a/frontend/src/metabase/reference/databases/TableDetailContainer.tsx
+++ b/frontend/src/metabase/reference/databases/TableDetailContainer.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { Location } from "history";
 import { Component } from "react";
 
 import CS from "metabase/css/core/index.css";
@@ -8,6 +7,7 @@ import * as metadataActions from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import TableDetail from "metabase/reference/databases/TableDetail";
 import * as actions from "metabase/reference/reference";
+import type { Location } from "metabase/router";
 import { type InjectedRouteProps, withRouteProps } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";

--- a/frontend/src/metabase/reference/databases/TableListContainer.tsx
+++ b/frontend/src/metabase/reference/databases/TableListContainer.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { Location } from "history";
 import { Component } from "react";
 
 import CS from "metabase/css/core/index.css";
@@ -8,6 +7,7 @@ import * as metadataActions from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import TableList from "metabase/reference/databases/TableList";
 import * as actions from "metabase/reference/reference";
+import type { Location } from "metabase/router";
 import { type InjectedRouteProps, withRouteProps } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";

--- a/frontend/src/metabase/reference/databases/TableListContainer.tsx
+++ b/frontend/src/metabase/reference/databases/TableListContainer.tsx
@@ -7,16 +7,21 @@ import * as metadataActions from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import TableList from "metabase/reference/databases/TableList";
 import * as actions from "metabase/reference/reference";
-import type { Location } from "metabase/router";
-import { type InjectedRouteProps, withRouteProps } from "metabase/router";
+import {
+  type InjectedRouteProps,
+  type Location,
+  withRouteProps,
+} from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
-import type {
-  ReferenceRouteParams,
-  ReferenceRouteProps,
-  StateWithReference,
+import {
+  type ReferenceRouteParams,
+  type ReferenceRouteProps,
+  type StateWithReference,
+  getDatabase,
+  getDatabaseId,
+  getIsEditing,
 } from "../selectors";
-import { getDatabase, getDatabaseId, getIsEditing } from "../selectors";
 import type { StubbedDatabase } from "../types";
 
 import DatabaseSidebar from "./DatabaseSidebar";

--- a/frontend/src/metabase/reference/databases/TableQuestionsContainer.tsx
+++ b/frontend/src/metabase/reference/databases/TableQuestionsContainer.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { Location } from "history";
 import { Component } from "react";
 
 import { cardApi } from "metabase/api";
@@ -11,6 +10,7 @@ import type { Dispatch } from "metabase/redux/store";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import TableQuestions from "metabase/reference/databases/TableQuestions";
 import * as actions from "metabase/reference/reference";
+import type { Location } from "metabase/router";
 import { type InjectedRouteProps, withRouteProps } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";

--- a/frontend/src/metabase/reference/databases/TableQuestionsContainer.tsx
+++ b/frontend/src/metabase/reference/databases/TableQuestionsContainer.tsx
@@ -10,16 +10,17 @@ import type { Dispatch } from "metabase/redux/store";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import TableQuestions from "metabase/reference/databases/TableQuestions";
 import * as actions from "metabase/reference/reference";
-import type { Location } from "metabase/router";
-import { type InjectedRouteProps, withRouteProps } from "metabase/router";
+import {
+  type InjectedRouteProps,
+  type Location,
+  withRouteProps,
+} from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
-import type {
-  ReferenceRouteParams,
-  ReferenceRouteProps,
-  StateWithReference,
-} from "../selectors";
 import {
+  type ReferenceRouteParams,
+  type ReferenceRouteProps,
+  type StateWithReference,
   getDatabase,
   getDatabaseId,
   getIsEditing,

--- a/frontend/src/metabase/reference/segments/SegmentDetailContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetailContainer.tsx
@@ -7,17 +7,23 @@ import * as metadataActions from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import * as actions from "metabase/reference/reference";
 import SegmentDetail from "metabase/reference/segments/SegmentDetail";
-import type { Location } from "metabase/router";
-import { type InjectedRouteProps, withRouteProps } from "metabase/router";
+import {
+  type InjectedRouteProps,
+  type Location,
+  withRouteProps,
+} from "metabase/router";
 import type { User } from "metabase-types/api";
 
 import type { ClearStateProps, FetchProps } from "../reference";
-import type {
-  ReferenceRouteParams,
-  ReferenceRouteProps,
-  StateWithReference,
+import {
+  type ReferenceRouteParams,
+  type ReferenceRouteProps,
+  type StateWithReference,
+  getIsEditing,
+  getSegment,
+  getSegmentId,
+  getUser,
 } from "../selectors";
-import { getIsEditing, getSegment, getSegmentId, getUser } from "../selectors";
 import type { StubbedSegment } from "../types";
 
 import SegmentSidebar from "./SegmentSidebar";

--- a/frontend/src/metabase/reference/segments/SegmentDetailContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetailContainer.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { Location } from "history";
 import { Component } from "react";
 
 import CS from "metabase/css/core/index.css";
@@ -8,6 +7,7 @@ import * as metadataActions from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import * as actions from "metabase/reference/reference";
 import SegmentDetail from "metabase/reference/segments/SegmentDetail";
+import type { Location } from "metabase/router";
 import { type InjectedRouteProps, withRouteProps } from "metabase/router";
 import type { User } from "metabase-types/api";
 

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetailContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetailContainer.tsx
@@ -7,16 +7,22 @@ import * as metadataActions from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import * as actions from "metabase/reference/reference";
 import SegmentFieldDetail from "metabase/reference/segments/SegmentFieldDetail";
-import type { Location } from "metabase/router";
-import { type InjectedRouteProps, withRouteProps } from "metabase/router";
+import {
+  type InjectedRouteProps,
+  type Location,
+  withRouteProps,
+} from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
-import type {
-  ReferenceRouteParams,
-  ReferenceRouteProps,
-  StateWithReference,
+import {
+  type ReferenceRouteParams,
+  type ReferenceRouteProps,
+  type StateWithReference,
+  getField,
+  getIsEditing,
+  getSegment,
+  getSegmentId,
 } from "../selectors";
-import { getField, getIsEditing, getSegment, getSegmentId } from "../selectors";
 import type { StubbedField, StubbedSegment } from "../types";
 
 import SegmentFieldSidebar from "./SegmentFieldSidebar";

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetailContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetailContainer.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { Location } from "history";
 import { Component } from "react";
 
 import CS from "metabase/css/core/index.css";
@@ -8,6 +7,7 @@ import * as metadataActions from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import * as actions from "metabase/reference/reference";
 import SegmentFieldDetail from "metabase/reference/segments/SegmentFieldDetail";
+import type { Location } from "metabase/router";
 import { type InjectedRouteProps, withRouteProps } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";

--- a/frontend/src/metabase/reference/segments/SegmentFieldListContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldListContainer.tsx
@@ -7,17 +7,18 @@ import * as metadataActions from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import * as actions from "metabase/reference/reference";
 import SegmentFieldList from "metabase/reference/segments/SegmentFieldList";
-import type { Location } from "metabase/router";
-import { type InjectedRouteProps, withRouteProps } from "metabase/router";
+import {
+  type InjectedRouteProps,
+  type Location,
+  withRouteProps,
+} from "metabase/router";
 import type { User } from "metabase-types/api";
 
 import type { ClearStateProps, FetchProps } from "../reference";
-import type {
-  ReferenceRouteParams,
-  ReferenceRouteProps,
-  StateWithReference,
-} from "../selectors";
 import {
+  type ReferenceRouteParams,
+  type ReferenceRouteProps,
+  type StateWithReference,
   getIsEditing,
   getSegment,
   getSegmentId,

--- a/frontend/src/metabase/reference/segments/SegmentFieldListContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldListContainer.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { Location } from "history";
 import { Component } from "react";
 
 import CS from "metabase/css/core/index.css";
@@ -8,6 +7,7 @@ import * as metadataActions from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import * as actions from "metabase/reference/reference";
 import SegmentFieldList from "metabase/reference/segments/SegmentFieldList";
+import type { Location } from "metabase/router";
 import { type InjectedRouteProps, withRouteProps } from "metabase/router";
 import type { User } from "metabase-types/api";
 

--- a/frontend/src/metabase/reference/segments/SegmentListContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentListContainer.tsx
@@ -8,16 +8,20 @@ import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import BaseSidebar from "metabase/reference/guide/BaseSidebar";
 import * as actions from "metabase/reference/reference";
 import { SegmentList } from "metabase/reference/segments/SegmentList";
-import type { Location } from "metabase/router";
-import { type InjectedRouteProps, withRouteProps } from "metabase/router";
+import {
+  type InjectedRouteProps,
+  type Location,
+  withRouteProps,
+} from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";
-import type {
-  ReferenceRouteParams,
-  ReferenceRouteProps,
-  StateWithReference,
+import {
+  type ReferenceRouteParams,
+  type ReferenceRouteProps,
+  type StateWithReference,
+  getDatabaseId,
+  getIsEditing,
 } from "../selectors";
-import { getDatabaseId, getIsEditing } from "../selectors";
 
 const mapStateToProps = (
   state: StateWithReference,

--- a/frontend/src/metabase/reference/segments/SegmentListContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentListContainer.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { Location } from "history";
 import { Component } from "react";
 
 import CS from "metabase/css/core/index.css";
@@ -9,6 +8,7 @@ import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import BaseSidebar from "metabase/reference/guide/BaseSidebar";
 import * as actions from "metabase/reference/reference";
 import { SegmentList } from "metabase/reference/segments/SegmentList";
+import type { Location } from "metabase/router";
 import { type InjectedRouteProps, withRouteProps } from "metabase/router";
 
 import type { ClearStateProps, FetchProps } from "../reference";

--- a/frontend/src/metabase/reference/segments/SegmentQuestionsContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestionsContainer.tsx
@@ -10,17 +10,23 @@ import type { Dispatch } from "metabase/redux/store";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import * as actions from "metabase/reference/reference";
 import { SegmentQuestions } from "metabase/reference/segments/SegmentQuestions";
-import type { Location } from "metabase/router";
-import { type InjectedRouteProps, withRouteProps } from "metabase/router";
+import {
+  type InjectedRouteProps,
+  type Location,
+  withRouteProps,
+} from "metabase/router";
 import type { User } from "metabase-types/api";
 
 import type { ClearStateProps, FetchProps } from "../reference";
-import type {
-  ReferenceRouteParams,
-  ReferenceRouteProps,
-  StateWithReference,
+import {
+  type ReferenceRouteParams,
+  type ReferenceRouteProps,
+  type StateWithReference,
+  getIsEditing,
+  getSegment,
+  getSegmentId,
+  getUser,
 } from "../selectors";
-import { getIsEditing, getSegment, getSegmentId, getUser } from "../selectors";
 import type { StubbedSegment } from "../types";
 
 import SegmentSidebar from "./SegmentSidebar";

--- a/frontend/src/metabase/reference/segments/SegmentQuestionsContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestionsContainer.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { Location } from "history";
 import { Component } from "react";
 
 import { cardApi } from "metabase/api";
@@ -11,6 +10,7 @@ import type { Dispatch } from "metabase/redux/store";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import * as actions from "metabase/reference/reference";
 import { SegmentQuestions } from "metabase/reference/segments/SegmentQuestions";
+import type { Location } from "metabase/router";
 import { type InjectedRouteProps, withRouteProps } from "metabase/router";
 import type { User } from "metabase-types/api";
 

--- a/frontend/src/metabase/reference/segments/SegmentRevisionsContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentRevisionsContainer.tsx
@@ -7,17 +7,23 @@ import * as metadataActions from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import * as actions from "metabase/reference/reference";
 import SegmentRevisions from "metabase/reference/segments/SegmentRevisions";
-import type { Location } from "metabase/router";
-import { type InjectedRouteProps, withRouteProps } from "metabase/router";
+import {
+  type InjectedRouteProps,
+  type Location,
+  withRouteProps,
+} from "metabase/router";
 import type { User } from "metabase-types/api";
 
 import type { ClearStateProps, FetchProps } from "../reference";
-import type {
-  ReferenceRouteParams,
-  ReferenceRouteProps,
-  StateWithReference,
+import {
+  type ReferenceRouteParams,
+  type ReferenceRouteProps,
+  type StateWithReference,
+  getIsEditing,
+  getSegment,
+  getSegmentId,
+  getUser,
 } from "../selectors";
-import { getIsEditing, getSegment, getSegmentId, getUser } from "../selectors";
 import type { StubbedSegment } from "../types";
 
 import SegmentSidebar from "./SegmentSidebar";

--- a/frontend/src/metabase/reference/segments/SegmentRevisionsContainer.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentRevisionsContainer.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { Location } from "history";
 import { Component } from "react";
 
 import CS from "metabase/css/core/index.css";
@@ -8,6 +7,7 @@ import * as metadataActions from "metabase/redux/metadata";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import * as actions from "metabase/reference/reference";
 import SegmentRevisions from "metabase/reference/segments/SegmentRevisions";
+import type { Location } from "metabase/router";
 import { type InjectedRouteProps, withRouteProps } from "metabase/router";
 import type { User } from "metabase-types/api";
 

--- a/frontend/src/metabase/router/RouterProvider.tsx
+++ b/frontend/src/metabase/router/RouterProvider.tsx
@@ -1,4 +1,3 @@
-import type { History } from "history";
 import { type PropsWithChildren, createContext, useMemo } from "react";
 
 import { useHistory } from "metabase/history";
@@ -10,6 +9,7 @@ import {
   type WithRouterProps,
   reactRouterWithRouter,
 } from "./react-router";
+import type { History } from "./types";
 import { RouterProviderV7 } from "./v7/RouterProviderV7";
 
 type RouterContextType = WithRouterProps;

--- a/frontend/src/metabase/router/guards.tsx
+++ b/frontend/src/metabase/router/guards.tsx
@@ -103,7 +103,9 @@ type GuardSelectors = {
  */
 function createGuard(
   { isAllowed, isAuthenticating = NEVER_AUTHENTICATING }: GuardSelectors,
-  renderRedirect: (location: Location) => ReactElement | null,
+  renderRedirect: (
+    location: Omit<Location, "query" | "action">,
+  ) => ReactElement | null,
 ) {
   return function Guard({ children = <Outlet /> }: Props) {
     const location = useLocation();
@@ -140,7 +142,7 @@ function FullPageRedirect({ to }: { to: string }): null {
   return null;
 }
 
-const loginUrlWithRedirect = (location: Location) => {
+const loginUrlWithRedirect = (location: Omit<Location, "query" | "action">) => {
   const from = `${location.pathname}${location.search}`;
   const query = new URLSearchParams({ redirect: from }).toString();
   return `/auth/login?${query}`;

--- a/frontend/src/metabase/router/middleware.ts
+++ b/frontend/src/metabase/router/middleware.ts
@@ -1,11 +1,11 @@
 import type { Middleware } from "@reduxjs/toolkit";
-import type { History } from "history";
 import { match } from "ts-pattern";
 
 import {
   CALL_HISTORY_METHOD,
   type CallHistoryMethodAction,
 } from "./navigation";
+import type { History } from "./types";
 
 /**
  * The slice of `history` the middleware drives. v3's `History` satisfies it, and

--- a/frontend/src/metabase/router/navigation.ts
+++ b/frontend/src/metabase/router/navigation.ts
@@ -1,4 +1,4 @@
-import type { LocationDescriptor } from "history";
+import type { LocationDescriptor } from "./types";
 
 /**
  * Re-owned equivalent of react-router-redux's navigation action creators.

--- a/frontend/src/metabase/router/routing-reducer.ts
+++ b/frontend/src/metabase/router/routing-reducer.ts
@@ -1,5 +1,6 @@
 import type { Action } from "@reduxjs/toolkit";
-import type { Location } from "history";
+
+import type { Location } from "./types";
 
 /**
  * Re-owned equivalent of react-router-redux's `routerReducer`.

--- a/frontend/src/metabase/router/sync.ts
+++ b/frontend/src/metabase/router/sync.ts
@@ -1,7 +1,6 @@
 import { LOCATION_CHANGE, type RouterState } from "./routing-reducer";
 import type { History } from "./types";
 
-
 // Only the slice of the redux store `sync` actually touches. Declared
 // structurally rather than as `Store<State>` so this leaf does not instantiate
 // RTK's store generic against the whole app state.

--- a/frontend/src/metabase/router/sync.ts
+++ b/frontend/src/metabase/router/sync.ts
@@ -1,6 +1,6 @@
-import type { History } from "history";
-
 import { LOCATION_CHANGE, type RouterState } from "./routing-reducer";
+import type { History } from "./types";
+
 
 // Only the slice of the redux store `sync` actually touches. Declared
 // structurally rather than as `Store<State>` so this leaf does not instantiate

--- a/frontend/src/metabase/router/types.ts
+++ b/frontend/src/metabase/router/types.ts
@@ -39,7 +39,6 @@ export type Query<T = DefaultQuery> = T;
  * legacy route-prop readers were written against that; tightened when the
  * `state.routing` slice is thinned to the pure v7 shape (DEV-2290).
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type LocationState = any;
 
 /**
@@ -66,7 +65,6 @@ export interface Location<Q = DefaultQuery> {
  * still be numbers or other primitives before serialization. Mirrors history@3's
  * `QueryLike`, distinct from the parsed `DefaultQuery` a `Location` carries.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type QueryLike = Record<string, any>;
 
 /**

--- a/frontend/src/metabase/router/types.ts
+++ b/frontend/src/metabase/router/types.ts
@@ -18,17 +18,104 @@ export interface Path {
 export type To = string | Partial<Path>;
 
 /**
- * An entry in a history stack. A location contains information about the URL
- * path, as well as possibly some arbitrary state and a key.
+ * The navigation action that produced a location.
+ */
+export type Action = "POP" | "PUSH" | "REPLACE";
+
+/**
+ * The default parsed `query` shape: repeated keys become arrays, matching
+ * history@3's parser that the `location.query` readers were written against.
+ */
+export type DefaultQuery = Record<string, string | string[] | null | undefined>;
+
+/**
+ * The parsed query object carried on a `Location`. The generic is the concrete
+ * shape a call site knows its query to have (e.g. `Location<{ tab?: string }>`).
+ */
+export type Query<T = DefaultQuery> = T;
+
+/**
+ * The `state` carried through a navigation. history@3 typed this `any` and the
+ * legacy route-prop readers were written against that; tightened when the
+ * `state.routing` slice is thinned to the pure v7 shape (DEV-2290).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type LocationState = any;
+
+/**
+ * An entry in a history stack. Mirrors history@3's `Location`: alongside the URL
+ * parts it carries the parsed `query` object and the navigation `action` that
+ * the legacy route-prop call sites still read. The generic is the shape of
+ * `query`, not `state`. Thinned to the pure v7 shape (no `query`/`action`) when
+ * the `state.routing` slice is retired (DEV-2290).
  *
  * @see https://api.reactrouter.com/v7/interfaces/react-router.Location.html
  */
-export interface Location<State = unknown> {
+export interface Location<Q = DefaultQuery> {
   pathname: string;
   search: string;
   hash: string;
-  state: State;
+  query: Query<Q>;
+  state: LocationState;
+  action: Action;
   key: string;
+}
+
+/**
+ * The loose query accepted when building a navigation target, where values may
+ * still be numbers or other primitives before serialization. Mirrors history@3's
+ * `QueryLike`, distinct from the parsed `DefaultQuery` a `Location` carries.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type QueryLike = Record<string, any>;
+
+/**
+ * A location to navigate to, as an object. Mirrors history@3's
+ * `LocationDescriptorObject`; the string form is `LocationDescriptor`.
+ */
+export interface LocationDescriptorObject {
+  pathname?: string;
+  search?: string;
+  query?: QueryLike;
+  hash?: string;
+  state?: LocationState;
+}
+
+/**
+ * A location to navigate to: either a path string or a descriptor object.
+ * Mirrors history@3's `LocationDescriptor`.
+ */
+export type LocationDescriptor = LocationDescriptorObject | string;
+
+type LocationListener = (location: Location) => void;
+type TransitionHook = (
+  location: Location,
+  callback: (result: unknown) => void,
+) => unknown;
+
+/**
+ * The `history` object interface the facade still passes around (the middleware
+ * driver, the sync bridge, and the route-leave tests). Mirrors history@3's
+ * `History` so the v3 engine and the v7 navigator both satisfy it.
+ */
+export interface History<Q = DefaultQuery> {
+  listenBefore(hook: TransitionHook): () => void;
+  listen(listener: LocationListener): () => void;
+  transitionTo(location: Location<Q>): void;
+  push(path: LocationDescriptor): void;
+  replace(path: LocationDescriptor): void;
+  go(n: number): void;
+  goBack(): void;
+  goForward(): void;
+  createKey(): string;
+  createPath(path: LocationDescriptor): string;
+  createHref(path: LocationDescriptor): string;
+  createLocation(
+    path?: LocationDescriptor,
+    action?: Action,
+    key?: string,
+  ): Location<Q>;
+  getCurrentLocation(): Location<Q>;
 }
 
 /**

--- a/frontend/src/metabase/router/use-location.ts
+++ b/frontend/src/metabase/router/use-location.ts
@@ -4,13 +4,14 @@ import type { Location } from "./types";
 import { useRouter } from "./use-router";
 
 /**
- * react-router v7's `useLocation`, implemented over the v3 location injected
- * into the router context (mirrored into redux `state.routing`). Returns the v7
- * `Location` shape (no v3 `query` field).
+ * react-router v7's `useLocation`, implemented over the location injected into
+ * the router context (mirrored into redux `state.routing`). Returns the pure v7
+ * `Location` shape (no v3 `query`/`action` fields); the legacy compat `Location`
+ * type carries those for the route-prop call sites.
  *
  * @see https://reactrouter.com/7.18.1/api/hooks/useLocation
  */
-export function useLocation(): Location {
+export function useLocation(): Omit<Location, "query" | "action"> {
   const { location } = useRouter();
 
   return useMemo(

--- a/frontend/src/metabase/router/v7/RouterBridge.tsx
+++ b/frontend/src/metabase/router/v7/RouterBridge.tsx
@@ -1,4 +1,3 @@
-import type { Location as HistoryLocation, LocationDescriptor } from "history";
 import { type ReactNode, useContext, useMemo, useRef } from "react";
 import {
   type NavigateOptions,
@@ -20,6 +19,7 @@ import type {
   WithRouterProps,
 } from "../react-router";
 import type { Route } from "../route";
+import type { Location as HistoryLocation, LocationDescriptor } from "../types";
 
 import { registerLeaveHook } from "./blocking-history";
 import { toV3Location } from "./location";

--- a/frontend/src/metabase/router/v7/blocking-history.ts
+++ b/frontend/src/metabase/router/v7/blocking-history.ts
@@ -1,10 +1,11 @@
-import type { Location as HistoryLocation } from "history";
 import {
   type HistoryRouterProps,
   type To,
   type Location as V7Location,
   parsePath,
 } from "react-router-v7";
+
+import type { Location as HistoryLocation } from "../types";
 
 import { toV3Location } from "./location";
 

--- a/frontend/src/metabase/router/v7/blocking-history.unit.spec.ts
+++ b/frontend/src/metabase/router/v7/blocking-history.unit.spec.ts
@@ -1,5 +1,6 @@
-import type { Location as HistoryLocation } from "history";
 import { UNSAFE_createMemoryHistory as createMemoryHistory } from "react-router-v7";
+
+import type { Location as HistoryLocation } from "../types";
 
 import {
   hasLeaveHooks,

--- a/frontend/src/metabase/router/v7/location.ts
+++ b/frontend/src/metabase/router/v7/location.ts
@@ -1,5 +1,6 @@
-import type { Location as HistoryLocation } from "history";
 import type { Location as V7Location } from "react-router-v7";
+
+import type { Location as HistoryLocation } from "../types";
 
 /**
  * Parse a search string into v3's `location.query` object: repeated keys become

--- a/frontend/src/metabase/router/v7/navigator.ts
+++ b/frontend/src/metabase/router/v7/navigator.ts
@@ -1,7 +1,10 @@
-import type { Location as HistoryLocation, LocationDescriptor } from "history";
 import type { NavigateFunction, NavigateOptions, To } from "react-router-v7";
 
 import type { RouterNavigator } from "../middleware";
+import type {
+  Location as HistoryLocation,
+  LocationDescriptor,
+} from "../types";
 
 import { queryToSearch } from "./location";
 

--- a/frontend/src/metabase/router/v7/navigator.ts
+++ b/frontend/src/metabase/router/v7/navigator.ts
@@ -1,10 +1,7 @@
 import type { NavigateFunction, NavigateOptions, To } from "react-router-v7";
 
 import type { RouterNavigator } from "../middleware";
-import type {
-  Location as HistoryLocation,
-  LocationDescriptor,
-} from "../types";
+import type { Location as HistoryLocation, LocationDescriptor } from "../types";
 
 import { queryToSearch } from "./location";
 

--- a/frontend/src/metabase/router/v7/router-listen.unit.spec.tsx
+++ b/frontend/src/metabase/router/v7/router-listen.unit.spec.tsx
@@ -1,10 +1,10 @@
-import type { Location as HistoryLocation } from "history";
 import { useEffect, useState } from "react";
 
 import { renderWithProviders, screen } from "__support__/ui";
 import { Outlet, Route, push, useRouter } from "metabase/router";
 
 import type { RouterEngine } from "../engine";
+import type { Location as HistoryLocation } from "../types";
 
 // Both engines expose `listen` at runtime; v3's `InjectedRouter` type omits it.
 type RouterWithListen = {

--- a/frontend/src/metabase/router/with-route-props.tsx
+++ b/frontend/src/metabase/router/with-route-props.tsx
@@ -1,9 +1,9 @@
-import type { Location } from "history";
 import type { ComponentType } from "react";
 
 import { useRoute } from "./Outlet";
 import type { InjectedRouter, PlainRoute } from "./react-router";
 import type { Route } from "./route";
+import type { Location } from "./types";
 import type { Params } from "./types";
 import { useRouter } from "./use-router";
 

--- a/frontend/src/metabase/router/with-route-props.tsx
+++ b/frontend/src/metabase/router/with-route-props.tsx
@@ -3,8 +3,7 @@ import type { ComponentType } from "react";
 import { useRoute } from "./Outlet";
 import type { InjectedRouter, PlainRoute } from "./react-router";
 import type { Route } from "./route";
-import type { Location } from "./types";
-import type { Params } from "./types";
+import type { Location, Params } from "./types";
 import { useRouter } from "./use-router";
 
 /**

--- a/frontend/src/metabase/search/containers/SearchApp.tsx
+++ b/frontend/src/metabase/search/containers/SearchApp.tsx
@@ -1,4 +1,3 @@
-import type { LocationDescriptorObject } from "history";
 import { useCallback, useMemo } from "react";
 import { jt, t } from "ttag";
 import _ from "underscore";
@@ -23,6 +22,7 @@ import type {
 } from "metabase/common/search/types";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { useDispatch } from "metabase/redux";
+import type { LocationDescriptorObject } from "metabase/router";
 import { push } from "metabase/router";
 import { SearchSidebar } from "metabase/search/components/SearchSidebar";
 import {

--- a/frontend/src/metabase/selectors/app.ts
+++ b/frontend/src/metabase/selectors/app.ts
@@ -1,8 +1,8 @@
 import type { Selector } from "@reduxjs/toolkit";
 import { createSelector } from "@reduxjs/toolkit";
-import type { Location } from "history";
 
 import type { State } from "metabase/redux/store";
+import type { Location } from "metabase/router";
 import {
   getEmbedOptions,
   getIsEmbeddingIframe,

--- a/frontend/src/metabase/selectors/routing.ts
+++ b/frontend/src/metabase/selectors/routing.ts
@@ -1,7 +1,6 @@
 import type { State } from "metabase/redux/store";
 import type { Location } from "metabase/router";
 
-
 const DEFAULT_LOCATION: Location = {
   pathname: "",
   search: "",

--- a/frontend/src/metabase/selectors/routing.ts
+++ b/frontend/src/metabase/selectors/routing.ts
@@ -1,6 +1,6 @@
-import type { Location } from "history";
-
 import type { State } from "metabase/redux/store";
+import type { Location } from "metabase/router";
+
 
 const DEFAULT_LOCATION: Location = {
   pathname: "",

--- a/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunListPage.tsx
+++ b/frontend/src/metabase/transforms/pages/JobRunListPage/JobRunListPage.tsx
@@ -1,6 +1,5 @@
 import { useDisclosure, useElementSize } from "@mantine/hooks";
 import cx from "classnames";
-import type { Location } from "history";
 import { useCallback, useLayoutEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 
@@ -13,6 +12,7 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { PaginationControls } from "metabase/common/components/PaginationControls";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { useDispatch } from "metabase/redux";
+import type { Location } from "metabase/router";
 import { replace } from "metabase/router";
 import { POLLING_INTERVAL } from "metabase/transforms/constants";
 import { useJobHeaderState } from "metabase/transforms/hooks/use-job-header-state";

--- a/frontend/src/metabase/transforms/pages/JobRunListPage/utils.ts
+++ b/frontend/src/metabase/transforms/pages/JobRunListPage/utils.ts
@@ -1,5 +1,4 @@
-import type { Location } from "history";
-
+import type { Location } from "metabase/router";
 import * as Urls from "metabase/urls";
 import {
   SORT_DIRECTIONS,

--- a/frontend/src/metabase/transforms/pages/NewTransformPage/NewTransformPage.tsx
+++ b/frontend/src/metabase/transforms/pages/NewTransformPage/NewTransformPage.tsx
@@ -1,5 +1,4 @@
 import { useDisclosure } from "@mantine/hooks";
-import type { Location } from "history";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { t } from "ttag";
 
@@ -17,6 +16,7 @@ import {
 import { PLUGIN_REMOTE_SYNC, PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
 import { useDispatch, useSelector } from "metabase/redux";
+import type { Location } from "metabase/router";
 import { push } from "metabase/router";
 import { Link, type Route } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";

--- a/frontend/src/metabase/transforms/pages/NewTransformPage/NewTransformPage.tsx
+++ b/frontend/src/metabase/transforms/pages/NewTransformPage/NewTransformPage.tsx
@@ -16,9 +16,7 @@ import {
 import { PLUGIN_REMOTE_SYNC, PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
 import { useDispatch, useSelector } from "metabase/redux";
-import type { Location } from "metabase/router";
-import { push } from "metabase/router";
-import { Link, type Route } from "metabase/router";
+import { Link, type Location, type Route, push } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import { useRegisterMetabotTransformContext } from "metabase/transforms/hooks/use-register-transform-metabot-context";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";

--- a/frontend/src/metabase/transforms/pages/RunListPage/RunListPage.tsx
+++ b/frontend/src/metabase/transforms/pages/RunListPage/RunListPage.tsx
@@ -1,6 +1,5 @@
 import { useDisclosure, useElementSize } from "@mantine/hooks";
 import cx from "classnames";
-import type { Location } from "history";
 import { useCallback, useLayoutEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 
@@ -15,6 +14,7 @@ import { PaneHeader } from "metabase/common/data-studio/components/PaneHeader";
 import { useSetting } from "metabase/common/hooks";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { useDispatch } from "metabase/redux";
+import type { Location } from "metabase/router";
 import { replace } from "metabase/router";
 import { LockedTransformsBanner } from "metabase/transforms/components/LockedTransformsBanner/LockedTransformsBanner";
 import { POLLING_INTERVAL } from "metabase/transforms/constants";

--- a/frontend/src/metabase/transforms/pages/RunListPage/utils.ts
+++ b/frontend/src/metabase/transforms/pages/RunListPage/utils.ts
@@ -1,5 +1,4 @@
-import type { Location } from "history";
-
+import type { Location } from "metabase/router";
 import * as Urls from "metabase/urls";
 import {
   SORT_DIRECTIONS,

--- a/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.tsx
+++ b/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.tsx
@@ -1,8 +1,8 @@
-import type { LocationDescriptorObject } from "history";
 import { Component } from "react";
 
 import { connect } from "metabase/redux";
 import type { Dispatch } from "metabase/redux/store";
+import type { LocationDescriptorObject } from "metabase/router";
 import { PopoverWithRef } from "metabase/ui/components/overlays/Popover/PopoverWithRef";
 import { getEventTarget } from "metabase/utils/dom";
 import { performAction } from "metabase/visualizations/lib/action";

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable complexity */
 import cx from "classnames";
-import type { LocationDescriptorObject } from "history";
 import React, {
   type CSSProperties,
   type ComponentType,
@@ -25,6 +24,7 @@ import { connect } from "metabase/redux";
 import { getIsDownloadingToImage } from "metabase/redux/downloads";
 import type { Dispatch, State } from "metabase/redux/store";
 import { CardEmbedLoadingState } from "metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedLoadingState";
+import type { LocationDescriptorObject } from "metabase/router";
 import { getTokenFeature } from "metabase/selectors/settings";
 import { getFont } from "metabase/styled-components/selectors";
 import type { IconProps } from "metabase/ui";

--- a/frontend/src/metabase/visualizations/lib/action.ts
+++ b/frontend/src/metabase/visualizations/lib/action.ts
@@ -1,7 +1,7 @@
-import type { LocationDescriptorObject } from "history";
 import _ from "underscore";
 
 import type { Dispatch } from "metabase/redux/store";
+import type { LocationDescriptorObject } from "metabase/router";
 import { push } from "metabase/router";
 import type Question from "metabase-lib/v1/Question";
 

--- a/frontend/src/metabase/visualizations/lib/open-url.ts
+++ b/frontend/src/metabase/visualizations/lib/open-url.ts
@@ -1,6 +1,5 @@
 import querystring from "querystring";
 
-
 import { handleLinkSdkPlugin } from "embedding-sdk-shared/lib/sdk-global-plugins";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import type {

--- a/frontend/src/metabase/visualizations/lib/open-url.ts
+++ b/frontend/src/metabase/visualizations/lib/open-url.ts
@@ -1,9 +1,12 @@
 import querystring from "querystring";
 
-import type { LocationDescriptor, LocationDescriptorObject } from "history";
 
 import { handleLinkSdkPlugin } from "embedding-sdk-shared/lib/sdk-global-plugins";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
+import type {
+  LocationDescriptor,
+  LocationDescriptorObject,
+} from "metabase/router";
 import {
   clickLink,
   getPathnameWithoutSubPath,


### PR DESCRIPTION
Closes DEV-2422.


`metabase/router` now owns the location/history types the app used to read from the `history` package. All 126 files that imported `Location`, `LocationDescriptor(Object)`, `Query`, `History`, or `Path` from `"history"` now import them from `metabase/router`. Nothing imports history types anymore.


- New facade types in `router/types.ts` faithfully mirror history@3: `Location<Q = DefaultQuery>` (the generic types `query`, matching every `Location<...>` call site), plus `LocationDescriptor(Object)`, `Query`, `Action`, and `History`.
- The facade `Location` keeps the compat `query` and `action` fields the route-prop call sites read. `useLocation()` still returns the pure v7 subset, so the conformance guarantee is unchanged.
- Two `any`s (`LocationState`, `QueryLike`) mirror history@3's own types. They get tightened when the `state.routing` slice is thinned (DEV-2290).



Type-only. The `history` package stays installed: three runtime importers remain (`app.js`, two test specs) and are removed alongside the v3 engine in a later slice.

