### PR TITLE
Gemini Agent Platform: BE support Gemini models

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -47,6 +47,7 @@
   com.github.steffan-westcott/clj-otel-sdk  {:mvn/version "0.2.10"}             ; OpenTelemetry SDK for programmatic configuration
   com.github.vertical-blank/sql-formatter   {:mvn/version "2.0.5"}              ; Java SQL formatting library https://github.com/vertical-blank/sql-formatter
   com.google.auth/google-auth-library-credentials {:mvn/version "1.40.0"}       ; dep for BigQuery, Databricks, and Snowflake. Require here rather than letting different dep versions stomp on each other — see #70908
+  com.google.auth/google-auth-library-oauth2-http {:mvn/version "1.40.0"}       ; Token refresh for the Metabot Google provider. Also a dep for BigQuery. Keep the version in step with google-auth-library-credentials
   com.google.code.gson/gson                 {:mvn/version "2.12.1"}             ; dep for BigQuery, Databricks, and Snowflake. Pin here so driver plugin JARs all use the same version — see #73736
   com.google.guava/guava                    {:mvn/version "33.5.0-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
   com.h2database/h2                         ^:antq/exclude                      ; https://metaboat.slack.com/archives/CKZEMT1MJ/p1727191010259979

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -221,6 +221,102 @@
   :export?    false
   :setter     (partial set-trimmed-string! :llm-moonshot-api-key))
 
+;;; ------------------------------------ Google Gemini Enterprise Agent Platform --------------------------------
+;;; The Gemini Enterprise Agent Platform (formerly Vertex AI). Every request applies to one Google Cloud project. The
+;;; project ID is necessary. The location is optional and defaults to `global`.
+
+(defsetting llm-google-service-account-key
+  (deferred-tru "A Google Cloud service account key JSON for the Gemini Enterprise Agent Platform. Takes precedence over the OAuth access token when both are set.")
+  :sensitive?  true
+  :visibility  :settings-manager
+  :export?     false
+  :setter      (partial set-trimmed-string! :llm-google-service-account-key))
+
+(defsetting llm-google-oauth-access-token
+  (deferred-tru "A short-lived OAuth2 access token for the Gemini Enterprise Agent Platform (e.g. from `gcloud auth print-access-token`). Useful for testing.")
+  :sensitive?  true
+  :visibility  :settings-manager
+  :export?     false
+  :setter      (partial set-trimmed-string! :llm-google-oauth-access-token))
+
+(def ^:private google-project-id-pattern
+  "Matches a Google Cloud project ID: 6 to 30 characters of lowercase letters, digits and hyphens, starting with a
+  letter and not ending with a hyphen.
+  https://docs.cloud.google.com/resource-manager/docs/creating-managing-projects"
+  #"[a-z][a-z0-9-]{4,28}[a-z0-9]")
+
+(defn valid-google-project-id?
+  "True if `project-id` looks like a valid google project id."
+  [project-id]
+  (boolean (and (string? project-id)
+                (re-matches google-project-id-pattern project-id))))
+
+(def ^:private google-location-pattern
+  "Matches a Google Cloud location ID, e.g. `us-central1`: hyphen-separated segments of lowercase letters and digits,
+  the first of which starts with a letter."
+  #"[a-z][a-z0-9]*(?:-[a-z0-9]+)*")
+
+(def ^:private google-location-max-length
+  "The longest location that still leaves a legal DNS label in `{location}-aiplatform.googleapis.com`.
+  A label holds 63 characters and the `-aiplatform` suffix takes 11 of them."
+  52)
+
+(defn valid-google-location?
+  "True if `location` can be spliced into a Gemini Enterprise Agent Platform request host.
+  A location becomes a DNS label of that host, so a value that is not one cannot be sent.
+  https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/locations"
+  [location]
+  (boolean (and (<= (count location) google-location-max-length)
+                (re-matches google-location-pattern location))))
+
+(defn- set-google-project-id!
+  [new-value]
+  (let [project-id (trimmed-string new-value)]
+    (when (and project-id (not (valid-google-project-id? project-id)))
+      (throw (ex-info (tru (str "{0} is not a valid Google Cloud project ID. Use the project ID — 6 to 30 lowercase "
+                                "letters, digits and hyphens — rather than the project name or number.")
+                           (pr-str project-id))
+                      {:status-code 400})))
+    (setting/set-value-of-type! :string :llm-google-project-id project-id)))
+
+(defsetting llm-google-project-id
+  (deferred-tru "The Google Cloud project ID for the Gemini Enterprise Agent Platform.")
+  :encryption  :no
+  :visibility  :settings-manager
+  :export?     false
+  :setter      set-google-project-id!)
+
+(defn- set-google-location!
+  [new-value]
+  (let [location (trimmed-string new-value)]
+    (when (and location (not (valid-google-location? location)))
+      (throw (ex-info (tru (str "{0} is not a valid Google Cloud location. Use a location ID like \"us-central1\", "
+                                "or leave it blank to use the global location.")
+                           (pr-str location))
+                      {:status-code 400})))
+    (setting/set-value-of-type! :string :llm-google-location location)))
+
+(defsetting llm-google-location
+  (deferred-tru "The Google Cloud location for the Gemini Enterprise Agent Platform (e.g. us-central1). Defaults to global.")
+  :encryption  :no
+  :visibility  :settings-manager
+  :export?     false
+  :setter      set-google-location!)
+
+(def google-global-api-base-url
+  "Google's global Gemini Enterprise Agent Platform host, and the default for [[llm-google-api-base-url]].
+  It serves only the `global` location. A regional location uses `https://{location}-aiplatform.googleapis.com`, and
+  the `us` and `eu` multi-region locations use `https://aiplatform.{location}.rep.googleapis.com`."
+  "https://aiplatform.googleapis.com")
+
+(defsetting llm-google-api-base-url
+  (deferred-tru "The Gemini Enterprise Agent Platform API base URL. Leave unset to derive it from the location.")
+  :encryption  :no
+  :visibility  :settings-manager
+  :default     google-global-api-base-url
+  :export?     false
+  :setter      (partial set-normalized-base-url! :llm-google-api-base-url))
+
 ;;; ----------------------------------------------- Amazon Bedrock ----------------------------------------------
 
 (defsetting llm-bedrock-access-key-id

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -355,16 +355,6 @@
   :export?     false
   :setter      set-bedrock-region!)
 
-(defsetting llm-bedrock-configured?
-  "Whether the required AWS Bedrock credentials are configured."
-  :type       :boolean
-  :visibility :public
-  :setter     :none
-  :export?    false
-  :getter     #(boolean (and (trimmed-string (llm-bedrock-access-key-id))
-                             (trimmed-string (llm-bedrock-secret-access-key))))
-  :doc        false)
-
 ;;; ----------------------------------------------- Microsoft Azure ---------------------------------------------
 
 (defsetting llm-azure-api-key

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -463,15 +463,21 @@
    [:models [:sequential llm-model-response-schema]]])
 
 (def ^:private provider-credentials-schema
-  "Provider credentials carried by the request body's `:credentials` map.
-  Bedrock sends AWS key material; Azure sends an API key and base URL."
+  "Provider credentials carried by the request body's `:credentials` map."
   [:map
-   [:access-key-id     {:optional true} [:maybe :string]]
-   [:secret-access-key {:optional true} [:maybe :string]]
-   [:region            {:optional true} [:maybe :string]]
-   [:session-token     {:optional true} [:maybe :string]]
-   [:api-key           {:optional true} [:maybe :string]]
-   [:base-url          {:optional true} [:maybe :string]]])
+   ;; bedrock
+   [:access-key-id       {:optional true} [:maybe :string]]
+   [:secret-access-key   {:optional true} [:maybe :string]]
+   [:region              {:optional true} [:maybe :string]]
+   [:session-token       {:optional true} [:maybe :string]]
+   ;; azure
+   [:api-key             {:optional true} [:maybe :string]]
+   [:base-url            {:optional true} [:maybe :string]]
+   ;; google
+   [:project-id          {:optional true} [:maybe :string]]
+   [:location            {:optional true} [:maybe :string]]
+   [:service-account-key {:optional true} [:maybe :string]]
+   [:oauth-access-token  {:optional true} [:maybe :string]]])
 
 (def ^:private metabot-settings-request-schema
   [:map
@@ -686,17 +692,32 @@
    :base-url (or (llm.settings/normalize-llm-base-url base-url)
                  (llm.settings/normalize-llm-base-url (llm.settings/llm-azure-api-base-url)))})
 
+(def ^:private google-credential-fields
+  [:service-account-key :oauth-access-token :project-id :location])
+
+(defn- effective-google-credentials
+  "The Google credentials a settings request resolves to.
+
+  Each field follows the same contract as the top-level `:credentials` key: a field present in the request replaces
+  the saved `llm-google-*` value, while an absent field keeps the saved value. Nil or blank means an explicit clear."
+  [supplied-creds]
+  (reduce (fn [creds field]
+            (cond-> creds
+              (contains? supplied-creds field) (assoc field (non-blank-string (get supplied-creds field)))))
+          (metabot.settings/configured-provider-credentials "google")
+          google-credential-fields))
+
 (defn- request-credentials
   "The credentials override carried by a `PUT /api/metabot/settings` request body as a provider credentials map.
 
   nil when the request does not touch credentials for `provider`.
 
-  An explicitly nil credential field in the body — `:api-key` for API-key providers, `:credentials` for Bedrock and
-  Azure — resolves to a credentials map whose key material is nil: an explicit clear. Fields *inside* the Bedrock
-  credentials map follow that map's presence contract (see [[effective-bedrock-credentials]]); blank fields *inside*
-  the Azure credentials map mean \"keep the saved value\" (see [[effective-azure-credentials]]), so e.g. a key-only
-  rotation can't wipe the base URL. Throws a 400 when non-nil Bedrock/Azure credentials don't resolve to a complete
-  set."
+  An explicitly nil credential field in the body — `:api-key` for API-key providers, `:credentials` for Bedrock,
+  Azure, and Google — resolves to a credentials map whose key material is nil: an explicit clear. Fields *inside* the
+  Bedrock and Google credentials maps follow that map's presence contract (see [[effective-bedrock-credentials]] and
+  [[effective-google-credentials]]); blank fields *inside* the Azure credentials map mean \"keep the saved value\" (see
+  [[effective-azure-credentials]]), so e.g. a key-only rotation can't wipe the base URL. Throws a 400 when non-nil
+  Bedrock/Azure/Google credentials don't resolve to a complete set."
   [provider {:keys [api-key credentials] :as body}]
   (case provider
     "bedrock"
@@ -729,59 +750,71 @@
                                                         [:api-key :base-url]))})))
           creds)))
 
+    "google"
+    (when (contains? body :credentials)
+      (if (nil? credentials)
+        {:service-account-key nil
+         :oauth-access-token  nil
+         :project-id          nil
+         :location            nil}
+        (let [creds (effective-google-credentials credentials)]
+          (when-not (metabot.settings/provider-credentials-complete? provider creds)
+            (throw (ex-info (tru "Google credentials are incomplete.")
+                            {:status-code  400
+                             :api-error    true
+                             :missing-keys (vec (remove #(non-blank-string (get creds %))
+                                                        [:service-account-key :oauth-access-token :project-id]))})))
+          creds)))
+
     (when (contains? body :api-key)
       {:api-key (non-blank-string api-key)})))
 
-(defn- save-bedrock-credentials!
-  "Persist a Bedrock credentials map resolved by [[request-credentials]]; nil key material clears those settings.
-  The region is written only when the map carries it — a nil region resets the setting to its default. A top-level
-  credentials clear (disconnect) carries `:region nil`, so it resets the region too; a field-level edit that omits
-  `:region` leaves the saved value in place."
-  [{:keys [access-key-id secret-access-key session-token] :as credentials}]
-  (setting/set! :llm-bedrock-access-key-id access-key-id)
-  (setting/set! :llm-bedrock-secret-access-key secret-access-key)
-  (setting/set! :llm-bedrock-session-token session-token)
-  (when (contains? credentials :region)
-    (setting/set! :llm-bedrock-region (:region credentials))))
-
 (defn- check-not-env-shadowed!
-  "Throw a 400 when `setting-key` is controlled by an env var. Writes to env-shadowed settings
-  persist to the app DB but the env var wins on every read, so they silently do nothing — reject
-  them up front instead."
-  [setting-key]
-  (when (some? (setting/env-var-value setting-key))
+  "Throw a 400 when writing `value` to `setting-key` would be silently ignored because an env var shadows it."
+  [setting-key value]
+  (when (and (some? (setting/env-var-value setting-key))
+             (some? value)
+             (not= value (setting/get setting-key)))
     (throw (ex-info (tru "This setting is set by the {0} environment variable and cannot be changed via the API."
                          (setting/env-var-name setting-key))
                     {:status-code 400
                      :setting     setting-key}))))
 
-(defn- save-azure-credentials!
-  "Persist an Azure credentials map resolved by [[request-credentials]]; nil values clear those settings."
-  [{:keys [api-key base-url]}]
-  (setting/set! :llm-azure-api-key api-key)
-  (setting/set! :llm-azure-api-base-url base-url))
+(defn- credential-setting-writes
+  "The settings that should be saved to store `credentials` for `provider`.
+  Returns `[setting-key value]` pairs. [[save-credentials!]] applies them.
+  An optional field is written only when actually present in the `credentials` map.
+  A disconnect includes every field explicitly, so it still clears them all."
+  [provider credentials]
+  (let [always   (fn [setting-key field]
+                   [[setting-key (get credentials field)]])
+        optional (fn [setting-key field]
+                   (when (contains? credentials field)
+                     [[setting-key (get credentials field)]]))]
+    (case provider
+      "bedrock" (concat (always :llm-bedrock-access-key-id       :access-key-id)
+                        (always :llm-bedrock-secret-access-key   :secret-access-key)
+                        (always :llm-bedrock-session-token       :session-token)
+                        (optional :llm-bedrock-region            :region))
+      "azure"   (concat (always :llm-azure-api-key               :api-key)
+                        (always :llm-azure-api-base-url          :base-url))
+      "google"  (concat (optional :llm-google-service-account-key :service-account-key)
+                        (optional :llm-google-oauth-access-token  :oauth-access-token)
+                        (optional :llm-google-project-id          :project-id)
+                        (optional :llm-google-location            :location))
+      (always (provider-api-key-setting-key provider) :api-key))))
 
 (defn- save-credentials!
-  "Persist the credentials override resolved by [[request-credentials]]; nil leaves the saved settings untouched."
+  "Persist the credentials override resolved by [[request-credentials]]; nil leaves the saved settings untouched.
+
+  A write that matches what the setting already reads is skipped — the same writes [[check-not-env-shadowed!]]
+  lets through. A field-level edit layers the request over the saved settings, so most of its fields carry the value
+  that is already there; for an env-backed one, writing it would persist an app-DB row that the env var only masks."
   [provider credentials]
   (when credentials
-    (case provider
-      "bedrock" (save-bedrock-credentials! credentials)
-      "azure"   (save-azure-credentials! credentials)
-      (setting/set! (provider-api-key-setting-key provider) (:api-key credentials)))))
-
-(defn- credential-setting-keys
-  "The app-DB settings that persisting `provider`'s resolved `credentials` map would write
-  (mirrors [[save-credentials!]]). Used to reject writes to env-shadowed settings up front: a write
-  to an env-shadowed setting persists a DB row the env var then silently wins over. Bedrock writes
-  `:llm-bedrock-region` only when the credentials carry it (see [[save-bedrock-credentials!]]), so it
-  is guarded only then; the other fields are always written."
-  [provider credentials]
-  (case provider
-    "bedrock" (cond-> [:llm-bedrock-access-key-id :llm-bedrock-secret-access-key :llm-bedrock-session-token]
-                (contains? credentials :region) (conj :llm-bedrock-region))
-    "azure"   [:llm-azure-api-key :llm-azure-api-base-url]
-    [(provider-api-key-setting-key provider)]))
+    (doseq [[setting-key value] (credential-setting-writes provider credentials)
+            :when               (not= value (setting/get setting-key))]
+      (setting/set! setting-key value))))
 
 (api.macros/defendpoint :put "/settings"
   :- metabot-settings-response-schema
@@ -815,16 +848,16 @@
                                                :provider    provider})))
                             (when model
                               (metabot.settings/validate-azure-model! (str provider "/" model) model)))
-        ;; Reject writes to env-shadowed settings before verifying or persisting anything: guard every
-        ;; credential setting a save would touch (see [[credential-setting-keys]]), plus the
-        ;; provider/model setting whenever a provider/model write would happen.
+        ;; Reject writes to env-shadowed settings before verifying or persisting anything.
         _                 (when credentials
-                            (run! check-not-env-shadowed! (credential-setting-keys provider credentials)))
+                            (run! (partial apply check-not-env-shadowed!)
+                                  (credential-setting-writes provider credentials)))
         _                 (when model
-                            (check-not-env-shadowed! :llm-metabot-provider))
-        ;; Azure connect validation needs the candidate model's wire family; credential-only
-        ;; rotations on a connected Azure provider fall back to the saved model.
-        validation-model  (when (= provider "azure")
+                            (check-not-env-shadowed! :llm-metabot-provider (str provider "/" model)))
+        ;; Azure connect validation needs the candidate model's wire family, and the Google connect
+        ;; probe needs it to check the model is served in the configured location; credential-only
+        ;; rotations on a connected provider fall back to the saved model.
+        validation-model  (when (contains? #{"azure" "google"} provider)
                             (or model
                                 (when-not provider-changed?
                                   (provider-util/provider-and-model->model (metabot.settings/llm-metabot-provider)))))

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -773,6 +773,8 @@
   "Throw a 400 when writing `value` to `setting-key` would be silently ignored because an env var shadows it."
   [setting-key value]
   (when (and (some? (setting/env-var-value setting-key))
+             ;; We only complain as an early warning if caller appears to be trying to change the value.
+             ;; set-setting-unless-env-shadowed! will in any case skip the shadowed write.
              (some? value)
              (not= value (setting/get setting-key)))
     (throw (ex-info (tru "This setting is set by the {0} environment variable and cannot be changed via the API."
@@ -804,17 +806,18 @@
                         (optional :llm-google-location            :location))
       (always (provider-api-key-setting-key provider) :api-key))))
 
-(defn- save-credentials!
-  "Persist the credentials override resolved by [[request-credentials]]; nil leaves the saved settings untouched.
+(defn- set-setting-unless-env-shadowed!
+  "Write `value` to `setting-key`, unless an env var supplies the setting and would mask the write."
+  [setting-key value]
+  (when-not (setting/env-var-value setting-key)
+    (setting/set! setting-key value)))
 
-  A write that matches what the setting already reads is skipped — the same writes [[check-not-env-shadowed!]]
-  lets through. A field-level edit layers the request over the saved settings, so most of its fields carry the value
-  that is already there; for an env-backed one, writing it would persist an app-DB row that the env var only masks."
+(defn- save-credentials!
+  "Persist the credentials override resolved by [[request-credentials]]; nil leaves the saved settings untouched."
   [provider credentials]
   (when credentials
-    (doseq [[setting-key value] (credential-setting-writes provider credentials)
-            :when               (not= value (setting/get setting-key))]
-      (setting/set! setting-key value))))
+    (doseq [[setting-key value] (credential-setting-writes provider credentials)]
+      (set-setting-unless-env-shadowed! setting-key value))))
 
 (api.macros/defendpoint :put "/settings"
   :- metabot-settings-response-schema
@@ -868,7 +871,7 @@
     (when credentials
       (save-credentials! provider credentials))
     (when model
-      (setting/set! :llm-metabot-provider (str provider "/" model)))
+      (set-setting-unless-env-shadowed! :llm-metabot-provider (str provider "/" model)))
     (assoc response :value (metabot.settings/llm-metabot-provider))))
 
 (def ^{:arglists '([request respond raise])} routes

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -773,8 +773,8 @@
   "Throw a 400 when writing `value` to `setting-key` would be silently ignored because an env var shadows it."
   [setting-key value]
   (when (and (some? (setting/env-var-value setting-key))
-             ;; We only complain as an early warning if caller appears to be trying to change the value.
-             ;; set-setting-unless-env-shadowed! will in any case skip the shadowed write.
+             ;; If value is nil we are attempting to clear the setting. We allow this so that callers can still
+             ;; disconnect a provider even if some settings are shadowed by env vars.
              (some? value)
              (not= value (setting/get setting-key)))
     (throw (ex-info (tru "This setting is set by the {0} environment variable and cannot be changed via the API."
@@ -807,9 +807,11 @@
       (always (provider-api-key-setting-key provider) :api-key))))
 
 (defn- set-setting-unless-env-shadowed!
-  "Write `value` to `setting-key`, unless an env var supplies the setting and would mask the write."
+  "Write `value` to `setting-key`, unless an env var supplies the setting and would mask the write.
+  A nil `value` always goes through. Skipping a clear would leave stale values in the appdb after a disconnect."
   [setting-key value]
-  (when-not (setting/env-var-value setting-key)
+  (when (or (nil? value)
+            (not (setting/env-var-value setting-key)))
     (setting/set! setting-key value)))
 
 (defn- save-credentials!

--- a/src/metabase/metabot/self.clj
+++ b/src/metabase/metabot/self.clj
@@ -19,6 +19,7 @@
    [metabase.metabot.self.bedrock :as bedrock]
    [metabase.metabot.self.claude :as claude]
    [metabase.metabot.self.core :as core]
+   [metabase.metabot.self.google :as google]
    [metabase.metabot.self.mistral :as mistral]
    [metabase.metabot.self.moonshot :as moonshot]
    [metabase.metabot.self.openai :as openai]
@@ -38,6 +39,7 @@
     "anthropic"  claude/claude
     "azure"      azure/azure
     "bedrock"    bedrock/bedrock
+    "google"     google/google
     "mistral"    mistral/mistral
     "moonshot"   moonshot/moonshot
     "openai"     openai/openai
@@ -52,6 +54,7 @@
     "anthropic"  claude/list-models
     "azure"      azure/list-models
     "bedrock"    bedrock/list-models
+    "google"     google/list-models
     "mistral"    mistral/list-models
     "moonshot"   moonshot/list-models
     "openai"     openai/list-models

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -1,7 +1,6 @@
 (ns metabase.metabot.self.claude
   (:require
    [clojure.string :as str]
-   [malli.json-schema :as mjs]
    [metabase.llm.settings :as llm]
    [metabase.metabot.self.core :as core]
    [metabase.metabot.self.debug :as debug]
@@ -279,16 +278,11 @@
 (defn- tool->claude
   "Convert a tool definition map to Claude API format.
   Accepts a ToolEntry map with :tool-name, :doc, :schema, :fn."
-  [{:keys [tool-name doc schema]}]
-  (let [[_:=> [_:cat params] _out] schema
-        params                     (schema/filter-schema-by-features params)
-        doc                        (if (str/starts-with? (or doc "") "Inputs: ")
-                                     ;; strip that stuff we're appending in mu/defn
-                                     (second (str/split doc #"\n\n  " 2))
-                                     doc)]
-    {:name         (or tool-name "unknown")
-     :description  doc
-     :input_schema (mjs/transform params {:additionalProperties false})}))
+  [tool]
+  (let [{:keys [name description parameters]} (schema/tool-function tool)]
+    {:name         (or name "unknown")
+     :description  description
+     :input_schema parameters}))
 
 (defn- add-tools-cache-breakpoint
   "Attach an ephemeral cache_control marker to the last tool in `tools`.

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -37,10 +37,8 @@
 (def LLMRequestOpts
   "Canonical schema for the opts map passed to every LLM provider adapter.
 
-  Required:
-    :model            - Model name string (e.g. \"claude-haiku-4-5\", \"gpt-5.4\")
-
   Optional:
+    :model            - Model name string (e.g. \"claude-haiku-4-5\", \"gpt-5.4\")
     :system           - System prompt string
     :input            - Sequence of AISDK parts and user messages
     :tools            - Sequence of tool definition maps
@@ -177,10 +175,12 @@
                                       :text (->> (map :delta chunks)
                                                  (str/join ""))}
                                pm (assoc :provider-metadata pm)))
-    :tool-input-start      {:type      :tool-input
-                            :id        (:toolCallId chunk)
-                            :function  (:toolName chunk)
-                            :arguments (parse-tool-arguments chunks)}
+    :tool-input-start      (let [pm (:providerMetadata chunk)]
+                             (cond-> {:type      :tool-input
+                                      :id        (:toolCallId chunk)
+                                      :function  (:toolName chunk)
+                                      :arguments (parse-tool-arguments chunks)}
+                               pm (assoc :provider-metadata pm)))
     :tool-output-available {:type        :tool-output
                             :id          (:toolCallId chunk)
                             :function    (:toolName chunk)

--- a/src/metabase/metabot/self/google.clj
+++ b/src/metabase/metabot/self/google.clj
@@ -1,0 +1,408 @@
+(ns metabase.metabot.self.google
+  "Google Gemini Enterprise Agent Platform (formerly Vertex AI) provider.
+
+  This namespace handles credentials, endpoint URLs, HTTP calls, error translation, and connect-time model validation.
+  Wire-format translation is in [[metabase.metabot.self.google.stream-generate-content]].
+
+  Like openrouter and azure, models for this provider must specify the sub-provider in the `llm-metabot-provider`
+  setting. For example `MB_LLM_METABOT_PROVIDER=google/google/gemini-3.6-flash`. Currently only google/gemini models
+  are supported, but this may expand in the future to anthropic or other third-party models.
+
+  Credentials can be supplied via either a service account key JSON or an OAuth access token.
+
+  Service account key JSON is the same auth method supported by the BigQuery driver and should be preferred for
+  production deployments. Short-lived OAuth access tokens can be generated via `gcloud auth print-access-token` and
+  are useful for local testing. If both are configured, then the service account key is used.
+
+  A project id is also required. This can either be extracted from the service account key JSON or provided explicitly
+  via the [[llm/llm-google-project-id]] setting (required when using an OAuth token).
+
+  You can also specify which Google Cloud location requests should be served from. The default is `global`, but we
+  also support the multi-region `us` and `eu` locations, as well as specific locations like `us-east1` or
+  `europe-west2` etc.
+
+  The effective endpoint URL depends on the location setting, but can also be overridden via an env var.
+  See [[api-base-url]] for details."
+  (:require
+   [clojure.string :as str]
+   [metabase.llm.settings :as llm]
+   [metabase.metabot.provider-util :as provider-util]
+   [metabase.metabot.self.core :as core]
+   [metabase.metabot.self.debug :as debug]
+   [metabase.metabot.self.google.stream-generate-content :as stream-generate-content]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.json :as json]
+   [metabase.util.malli :as mu]
+   [metabase.util.memoize :as u.memoize]
+   [metabase.util.o11y :refer [with-span]])
+  (:import
+   (com.google.auth.oauth2 GoogleCredentials ServiceAccountCredentials)
+   (java.io ByteArrayInputStream IOException)
+   (java.nio.charset StandardCharsets)
+   (java.util Collections)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private default-model
+  "The model to use when the request does not name one."
+  "google/gemini-3.5-flash")
+
+;;; Auth / HTTP plumbing
+
+(defn- settings-credentials
+  "Returns the Google credentials from the `llm-google-*` settings."
+  []
+  {:service-account-key (not-empty (llm/llm-google-service-account-key))
+   :oauth-access-token  (not-empty (llm/llm-google-oauth-access-token))
+   :project-id          (not-empty (llm/llm-google-project-id))
+   :location            (not-empty (llm/llm-google-location))})
+
+(def ^:private cloud-platform-scope
+  "The OAuth2 scope for access tokens made from the service account key.
+  There is also a `cloud-platform.read-only` scope, but inference calls made with the read-only scope are rejected."
+  "https://www.googleapis.com/auth/cloud-platform")
+
+(defn- parse-service-account-credentials
+  "Parses a service account key JSON string into scoped `ServiceAccountCredentials`."
+  ^ServiceAccountCredentials [^String sa-key]
+  (let [creds (try
+                (GoogleCredentials/fromStream (ByteArrayInputStream. (.getBytes sa-key StandardCharsets/UTF_8)))
+                (catch Exception e
+                  (throw (ex-info (if-let [reason (not-empty (ex-message e))]
+                                    (tru "Invalid Google service account key: {0}" reason)
+                                    (tru "Invalid Google service account key"))
+                                  {:api-error   true
+                                   :status-code 400
+                                   :error-code  :invalid-service-account-key}
+                                  e))))]
+    (when-not (instance? ServiceAccountCredentials creds)
+      (throw (ex-info (tru "This Google credential JSON is not a service account key.")
+                      {:api-error   true
+                       :status-code 400
+                       :error-code  :not-a-service-account-key})))
+    (.createScoped ^ServiceAccountCredentials creds (Collections/singletonList cloud-platform-scope))))
+
+(def ^:private cached-service-account-credentials
+  "Bounded memoization of [[parse-service-account-credentials]]
+  Cached so that we fetch an access token once per token lifetime (normally 1 hour), and not once per request."
+  (u.memoize/bounded #'parse-service-account-credentials :bounded/threshold 8))
+
+(defn- oauth-bearer-headers
+  "Returns Bearer auth headers for an OAuth2 access token."
+  [token]
+  {"Authorization" (str "Bearer " token)})
+
+(defn- fresh-bearer-headers
+  "Returns an Authorization header with a current OAuth2 access token for `creds`.
+  `refreshIfExpired` is thread-safe: it gives the cached token until it is near its expiry, then gets a new one."
+  [^GoogleCredentials creds]
+  (try
+    (.refreshIfExpired creds)
+    (oauth-bearer-headers (.getTokenValue (.getAccessToken creds)))
+    (catch IOException e
+      ;; :status-code 400 so that a connect attempt with e.g. a disabled service account surfaces the message as a
+      ;; credentials error rather than a raw 500.
+      (throw (ex-info (tru "Could not obtain a Google access token: {0}" (ex-message e))
+                      {:api-error   true
+                       :status-code 400
+                       :error-code  :google-token-refresh-failed}
+                      e)))))
+
+(defn- service-account-project-id
+  "Returns the project ID from a service account credential's key JSON."
+  [^ServiceAccountCredentials creds]
+  (not-empty (.getProjectId creds)))
+
+(def ^:private global-location
+  "The only location that Google's global endpoint serves.
+  This is also the default location."
+  "global")
+
+(def ^:private multi-region-locations
+  "The locations that a multi-region endpoint serves.
+  They keep the data in the US or in the EU, across the regions of that jurisdiction. The regional
+  `{location}-aiplatform` form is not an endpoint for them; their hosts have the form
+  `https://aiplatform.{location}.rep.googleapis.com`.
+
+  https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/locations"
+  #{"us" "eu"})
+
+(defn- effective-location
+  "Returns the location for a credential's requests.
+  If the credential does not set one, returns [[global-location]].
+  Throws if [[metabase.llm.settings/valid-google-location?]] rejects `location`."
+  [{:keys [location]}]
+  (cond
+    (nil? location)
+    global-location
+
+    (llm/valid-google-location? location)
+    location
+
+    :else
+    (throw (ex-info (tru (str "\"{0}\" is not a valid Google Cloud location. Use a location ID like \"us-central1\", "
+                              "or leave it blank to use the global location.")
+                         location)
+                    {:api-error   true
+                     :status-code 400
+                     :error-code  :invalid-location}))))
+
+(defn- location-host
+  "Returns the API host for a non-global `location`.
+  Multi-region locations use the `rep` host. All other locations use the regional host."
+  [location]
+  (if (contains? multi-region-locations location)
+    (format "https://aiplatform.%s.rep.googleapis.com" location)
+    (format "https://%s-aiplatform.googleapis.com" location)))
+
+(defn- api-base-url
+  "Returns the base URL for requests in the location of `credentials`.
+
+  The API host must agree with the location. The global host serves only `locations/global` and rejects all other
+  locations. Thus a non-global location gets its host from [[location-host]], and the admin does not have to set a
+  second setting. If the admin set a base URL, for example a proxy or a test double, this function returns it without
+  a change."
+  [credentials]
+  (let [configured (llm/llm-google-api-base-url)
+        location   (effective-location credentials)]
+    (if (and (not= location global-location)
+             (= configured llm/google-global-api-base-url))
+      (location-host location)
+      configured)))
+
+(defn- resolve-google-auth
+  "Resolves the `{:auth {:url ... :headers ...} :credentials ...}` pair for a Google request.
+
+  If `credentials` is nil, uses [[settings-credentials]]. The credentials in the result are the resolved ones, so that
+  callers can build resource paths from the project and the location. A service account key has precedence over an
+  OAuth access token. Throws if no project ID resolves, or if `ai-proxy?` is true."
+  [credentials ai-proxy?]
+  (when ai-proxy?
+    (throw (ex-info (tru "AI proxy is not supported for the Google provider")
+                    {:api-error  true
+                     :error-code :proxy-unsupported})))
+  (let [{:keys [service-account-key oauth-access-token project-id] :as creds} (or credentials (settings-credentials))
+        sa-creds    (when service-account-key
+                      (cached-service-account-credentials service-account-key))
+        project-id  (or project-id (some-> sa-creds service-account-project-id))
+        auth-method (cond
+                      sa-creds           :service-account
+                      oauth-access-token :oauth-token)]
+    (when (and auth-method (not project-id))
+      (throw (ex-info (tru "A Google Cloud project ID is required for the Google provider")
+                      {:api-error   true
+                       :status-code 400
+                       :error-code  :project-id-required})))
+    {:auth        (core/resolve-auth "google" "Google"
+                                     (when auth-method
+                                       {:url     (api-base-url creds)
+                                        :headers (case auth-method
+                                                   :service-account (fresh-bearer-headers sa-creds)
+                                                   :oauth-token     (oauth-bearer-headers oauth-access-token))})
+                                     ai-proxy?)
+     :credentials (assoc creds :project-id project-id)}))
+
+(defn- effective-project-id
+  "Returns the project ID for a credential's requests.
+  Throws if [[metabase.llm.settings/valid-google-project-id?]] rejects it."
+  [{:keys [project-id]}]
+  (if (llm/valid-google-project-id? project-id)
+    project-id
+    (throw (ex-info (tru (str "\"{0}\" is not a valid Google Cloud project ID. Use the project ID — 6 to 30 lowercase "
+                              "letters, digits and hyphens — rather than the project name or number.")
+                         project-id)
+                    {:api-error   true
+                     :status-code 400
+                     :error-code  :invalid-project-id}))))
+
+(defn- location-path
+  "Returns the URL path to the project's location resource.
+  This is the parent of every resource that we call."
+  [credentials]
+  (format "/v1/projects/%s/locations/%s" (effective-project-id credentials) (effective-location credentials)))
+
+(def ^:private max-model-segment-length
+  "The longest publisher or model ID that belongs in a request path.
+  Real IDs are far shorter; this only bounds what a mistyped setting can splice in."
+  128)
+
+(def ^:private publisher-pattern
+  "Matches a publisher ID, e.g. `google` or `anthropic`."
+  #"[a-z][a-z0-9-]*")
+
+(def ^:private model-id-pattern
+  "Matches a publisher model ID, e.g. `gemini-3.5-flash` or `claude-sonnet-4-5@20250929`."
+  #"[a-zA-Z0-9][a-zA-Z0-9._@-]*")
+
+(defn- valid-model-segment?
+  "True if `segment` is a path segment that `pattern` accepts and that is short enough to be one."
+  [pattern segment]
+  (boolean (and (string? segment)
+                (<= (count segment) max-model-segment-length)
+                (re-matches pattern segment))))
+
+(defn- model-resource-path
+  "Returns the URL path to a publisher model resource, without the `:method` verb at the end.
+  The `model` must include its `{publisher}/{model}` qualifier, e.g. `google/gemini-3.5-flash`.
+
+  Both segments become path segments of the request URL, so a character that does not belong in one is rejected here.
+  The `llm-metabot-provider` setting takes the Google model as free text — unlike a whitelisted provider, nothing
+  upstream of this constrains it."
+  [credentials model]
+  (let [model-str (str model)
+        publisher (provider-util/provider-and-model->provider model-str)
+        model-id  (provider-util/provider-and-model->model model-str)]
+    (when (str/blank? model-id)
+      (throw (ex-info (tru "Invalid Google model {0} — expected a publisher-qualified ID like \"google/gemini-3.5-flash\""
+                           (pr-str model))
+                      {:api-error   true
+                       :status-code 400
+                       :error-code  :invalid-model})))
+    (when-not (and (valid-model-segment? publisher-pattern publisher)
+                   (valid-model-segment? model-id-pattern model-id))
+      (throw (ex-info (tru (str "Invalid Google model {0} — a publisher and model ID can hold only letters, digits, "
+                                "and the characters \".\", \"_\", \"-\" and \"@\"")
+                           (pr-str model))
+                      {:api-error   true
+                       :status-code 400
+                       :error-code  :invalid-model})))
+    (format "%s/publishers/%s/models/%s" (location-path credentials) publisher model-id)))
+
+(defn- google-error-msg
+  "Returns the Google API error message for the status of `res`."
+  [res]
+  (let [status (long (:status res 0))]
+    (case status
+      400 (tru "Google API rejected the request as invalid")
+      401 (tru "Google API credentials expired or invalid")
+      403 (tru "Google API credentials have insufficient permissions or the API is not enabled for this project")
+      404 (tru "Google API endpoint is unavailable or the model was not found")
+      429 (tru "Google API has rate limited us")
+      500 (tru "Google API returned an internal server error")
+      501 (tru "Google API is not available in this location")
+      503 (tru "Google API is temporarily unavailable")
+      (tru "Google API error (HTTP {0})" status))))
+
+(defn- json-content?
+  "Returns true if an HTTP response has a JSON content type."
+  [{:keys [headers]}]
+  (str/includes? (str (or (get headers "content-type") (get headers "Content-Type")))
+                 "application/json"))
+
+(defn- include-endpoint-in-msg?
+  "Should an error with the given `status` include the endpoint URL in its error message?"
+  [status]
+  ;; A 404 means that this location does not serve the model, or that the host is not an endpoint. A 501 means that
+  ;; the API is not available in this location.
+  (contains? #{404 501} status))
+
+(defn- rethrow-google-api-error!
+  "Rethrows a Google HTTP exception like [[core/rethrow-api-error!]], with two changes:
+
+  - For a status that satisfies [[include-endpoint-in-msg?]], the message includes the endpoint URL.
+  - For 404s include a hint to check that the provided location is correct."
+  [credentials e]
+  (let [data        (ex-data e)
+        credentials (or credentials (settings-credentials))
+        location    (:location credentials)
+        known?      (conj multi-region-locations global-location)
+        endpoint    (delay (try (api-base-url credentials) (catch Exception _ nil)))
+        res->msg    (fn [res]
+                      (cond-> (google-error-msg res)
+                        (and (include-endpoint-in-msg? (:status res)) @endpoint)
+                        (str " " (tru "(endpoint: {0})" @endpoint))))]
+    (core/rethrow-api-error!
+     "google"
+     res->msg
+     (if (and location
+              (= 404 (:status data))
+              (not (known? location))
+              (not (json-content? data)))
+       ;; A wrong location gives a host that is not an API endpoint, hence the 404 check. If the body is json it
+       ;; usually contains a helpful error message (e.g. model not served by this endpoint), whereas an html body is
+       ;; usually a generic 404 message with html boilerplate that looks ugly and gets truncated when displayed to the
+       ;; user. Replace it with a hint to check that the location is valid.
+       (ex-info (ex-message e)
+                (assoc data :body (str (tru "check that \"{0}\" is a valid location" location)))
+                e)
+       e))))
+
+(def ^:private count-tokens-probe-body
+  "The smallest `countTokens` request body for the connect-time probe."
+  {:contents [{:role "user" :parts [{:text "hi"}]}]})
+
+(defn- count-tokens!
+  "Makes a free `countTokens` call for `model` and discards the response — the connect-time probe.
+
+  https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1/projects.locations.publishers.models/countTokens
+
+  This one call shows that the credential, the project ID, the endpoint, and the model are correct, and it uses no
+  inference tokens. It agrees with real inference about model availability."
+  [auth credentials model]
+  (core/request auth
+                {:method  :post
+                 :url     (str (model-resource-path credentials model) ":countTokens")
+                 :headers {"Content-Type" "application/json"}
+                 :body    (json/encode count-tokens-probe-body)})
+  nil)
+
+(defn- configured-google-model
+  "Returns the saved model string if the configured Metabot provider is Google."
+  []
+  (let [value (metabot.settings/llm-metabot-provider)]
+    (when (= (provider-util/provider-and-model->provider value) "google")
+      (provider-util/provider-and-model->model value))))
+
+(defn list-models
+  "Validates the Google credentials and the candidate model with a free `countTokens` call.
+
+  Similar to the Azure provider, there is no list-models call that we can use to whitelist models for the Gemini
+  Enterprise Agent Platform. An endpoint does exist, but it sometimes returns models that are not really available and
+  sometimes omits models that are available, hence we can't rely on it. See
+  https://github.com/googleapis/python-genai/issues/679
+
+  We therefore take an approach similar to the Azure provider: validate credentials and caller-provided model strings
+  by sending a `countTokens` probe, but always return an empty model list."
+  ([] (list-models {}))
+  ([{:keys [credentials model ai-proxy?]}]
+   (when-let [model (or (not-empty model) (configured-google-model))]
+     (try
+       (let [{:keys [auth credentials]} (resolve-google-auth credentials ai-proxy?)]
+         (count-tokens! auth credentials model))
+       (catch Exception e
+         (rethrow-google-api-error! credentials e))))
+   {:models []}))
+
+(mu/defn google-raw
+  "Makes a streaming `streamGenerateContent` request to the Gemini Enterprise Agent Platform.
+  `:ai-proxy?` is not supported and throws when it is true."
+  [{:keys [model input tools credentials ai-proxy?] :as opts
+    :or   {model default-model}} :- core/LLMRequestOpts]
+  (let [req (stream-generate-content/request-body opts)]
+    (with-span :info {:name       :metabot.google/request
+                      :model      model
+                      :msg-count  (count input)
+                      :tool-count (count tools)}
+      (try
+        (let [{:keys [auth credentials]} (resolve-google-auth credentials ai-proxy?)
+              url      (str (model-resource-path credentials model) ":streamGenerateContent?alt=sse")
+              response (core/request auth
+                                     {:method  :post
+                                      :url     url
+                                      :as      :stream
+                                      :headers {"Content-Type" "application/json"}
+                                      :body    (json/encode req)})]
+          (-> (core/sse-reducible (:body response))
+              (debug/capture-stream {:provider "google"
+                                     :model    model
+                                     :url      url
+                                     :request  req})))
+        (catch Exception e
+          (rethrow-google-api-error! credentials e))))))
+
+(defn google
+  "Call the Gemini Enterprise Agent Platform, return AISDK stream."
+  [& args]
+  (let [raw (apply google-raw args)]
+    (eduction (stream-generate-content/->aisdk-chunks-xf) raw)))

--- a/src/metabase/metabot/self/google/stream_generate_content.clj
+++ b/src/metabase/metabot/self/google/stream_generate_content.clj
@@ -7,7 +7,6 @@
   https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1/projects.locations.publishers.models/streamGenerateContent"
   (:require
    [clojure.string :as str]
-   [malli.json-schema :as mjs]
    [metabase.metabot.self.core :as core]
    [metabase.metabot.self.schema :as schema]
    [metabase.util :as u]
@@ -124,16 +123,11 @@
 
   Uses `parametersJsonSchema`, which is standard JSON Schema, and not the older `parameters` field. The `Schema`
   object of that field is a subset of OpenAPI and rejects keywords such as `additionalProperties`."
-  [{:keys [tool-name doc schema]}]
-  (let [[_:=> [_:cat params] _out] schema
-        params                     (schema/filter-schema-by-features params)
-        doc                        (if (str/starts-with? (or doc "") "Inputs: ")
-                                     ;; Remove the text that mu/defn adds.
-                                     (second (str/split doc #"\n\n  " 2))
-                                     doc)]
-    {:name                 tool-name
-     :description          doc
-     :parametersJsonSchema (mjs/transform params {:additionalProperties false})}))
+  [tool]
+  (let [{:keys [name description parameters]} (schema/tool-function tool)]
+    {:name                 name
+     :description          description
+     :parametersJsonSchema parameters}))
 
 ;;; Request body
 

--- a/src/metabase/metabot/self/google/stream_generate_content.clj
+++ b/src/metabase/metabot/self/google/stream_generate_content.clj
@@ -1,0 +1,298 @@
+(ns metabase.metabot.self.google.stream-generate-content
+  "Wire-format translation for Google's `streamGenerateContent` API.
+
+  This is the native protocol for Gemini models on the Gemini Enterprise Agent Platform. AISDK parts become
+  `GenerateContentRequest` bodies, and streamed `GenerateContentResponse` SSE events become AI SDK v5 chunks.
+
+  https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1/projects.locations.publishers.models/streamGenerateContent"
+  (:require
+   [clojure.string :as str]
+   [malli.json-schema :as mjs]
+   [metabase.metabot.self.core :as core]
+   [metabase.metabot.self.schema :as schema]
+   [metabase.util :as u]
+   [metabase.util.json :as json]
+   [metabase.util.malli :as mu]))
+
+(set! *warn-on-reflection* true)
+
+(defn- usage->aisdk-usage
+  "Converts a `usageMetadata` block into the AISDK `:usage` shape.
+
+  `promptTokenCount` is the total input count. `cachedContentTokenCount` is a part of that total, as with OpenAI, and
+  not a separate bucket, as with Anthropic. Gemini reports thinking output separately as `thoughtsTokenCount`. Google
+  bills it as output, thus it goes into :completionTokens. Implicit caching has no cache-write count, thus
+  :cacheCreationTokens is always 0.
+
+  `toolUsePromptTokenCount` counts the results of Google's server-side tools (code execution, URL context) fed back to
+  the model as input. It is a bucket of its own, not a part of `promptTokenCount`, thus we sum it in, even though we
+  don't currently support built-in server-side tools."
+  [u]
+  {:promptTokens        (+ (:promptTokenCount u 0)
+                           (:toolUsePromptTokenCount u 0))
+   :completionTokens    (+ (:candidatesTokenCount u 0)
+                           (:thoughtsTokenCount u 0))
+   :cacheCreationTokens 0
+   :cacheReadTokens     (:cachedContentTokenCount u 0)})
+
+;;; AISDK parts → Gemini contents
+
+(def ^:private missing-thought-signature
+  "Google's placeholder for a replayed functionCall part that has no real `thoughtSignature`.
+  For example a made-up tool exchange, or history that we rebuilt from storage. Gemini 3.x rejects a functionCall
+  replay in the current turn that has no signature. This placeholder skips that check.
+  https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/thought-signatures"
+  "skip_thought_signature_validator")
+
+(defn- ->gemini-role
+  "Maps a message role onto one of the two roles a Gemini allows: user or model."
+  [role]
+  (if (#{"assistant" "model"} (name role))
+    "model"
+    "user"))
+
+(defn- ->text-parts
+  "Converts message content into a vector of Gemini text parts."
+  [content]
+  (cond
+    (and (string? content) (str/blank? content)) []
+    (string? content)                            [{:text content}]
+    :else                                        content))
+
+(defn- merge-consecutive
+  "Merges consecutive contents that have the same role into one content with the combined parts.
+  Gemini expects user contents and model contents in alternation. Tool calls (role model) and their function responses
+  (role user) already alternate. But a text part and the tool-input part after it are both role model, thus they must
+  be in one content.
+
+  Contents that end up with no parts are dropped, because Google rejects a `contents` entry whose `parts` array is
+  empty. A blank message contributes no parts (see [[->text-parts]])."
+  [contents]
+  (into [] (comp (remove (comp empty? :parts))
+                 (partition-by :role)
+                 (map (fn [group]
+                        {:role  (:role (first group))
+                         :parts (into [] (mapcat :parts) group)})))
+        contents))
+
+(defn parts->contents
+  "Converts a flat sequence of AISDK parts and user messages into Gemini API contents.
+  Merges consecutive contents that have the same role.
+
+  Gemini has no tool-call id on the wire. functionResponses match functionCalls by name and order, which the flat
+  sequence of parts keeps. `functionResponse.name` is necessary, but a :tool-output part that we rebuilt from
+  conversation history has no :function. For such a part, the name comes from the :tool-input part with the same id. A
+  `thoughtSignature` from stream time (see [[->aisdk-chunks-xf]]) goes back on the replayed functionCall part, because
+  Gemini 3.x rejects a replay in the current turn that has no signature."
+  [parts]
+  (let [id->name (into {}
+                       (comp (filter #(= :tool-input (:type %)))
+                             (map (juxt :id :function)))
+                       parts)]
+    (->> parts
+         (mapv (fn [part]
+                 (case (:type part)
+                   :text        {:role  "model"
+                                 ;; An empty text part carries nothing and Google rejects it.
+                                 :parts (if (empty? (:text part))
+                                          []
+                                          [{:text (:text part)}])}
+                   :tool-input  {:role  "model"
+                                 :parts [{:functionCall     {:name (:function part)
+                                                             :args (or (:arguments part) {})}
+                                          :thoughtSignature (or (get-in part [:provider-metadata :google :thoughtSignature])
+                                                                missing-thought-signature)}]}
+                   :tool-output {:role  "user"
+                                 :parts [{:functionResponse
+                                          {:name     (or (:function part)
+                                                         (id->name (:id part))
+                                                         "unknown_function")
+                                           :response {:output (or (get-in part [:result :output])
+                                                                  (when-let [err (:error part)]
+                                                                    (str "Error: " (:message err)))
+                                                                  (pr-str (:result part)))}}}]}
+                   ;; User messages pass through.
+                   {:role  (->gemini-role (or (:role part) "user"))
+                    :parts (->text-parts (:content part))})))
+         merge-consecutive)))
+
+;;; Tool definition format
+
+(defn- tool->function-declaration
+  "Converts a tool definition map to a Gemini `FunctionDeclaration`.
+  Accepts a ToolEntry map with :tool-name, :doc, :schema, and :fn.
+
+  Uses `parametersJsonSchema`, which is standard JSON Schema, and not the older `parameters` field. The `Schema`
+  object of that field is a subset of OpenAPI and rejects keywords such as `additionalProperties`."
+  [{:keys [tool-name doc schema]}]
+  (let [[_:=> [_:cat params] _out] schema
+        params                     (schema/filter-schema-by-features params)
+        doc                        (if (str/starts-with? (or doc "") "Inputs: ")
+                                     ;; Remove the text that mu/defn adds.
+                                     (second (str/split doc #"\n\n  " 2))
+                                     doc)]
+    {:name                 tool-name
+     :description          doc
+     :parametersJsonSchema (mjs/transform params {:additionalProperties false})}))
+
+;;; Request body
+
+(mu/defn request-body
+  "Builds the `streamGenerateContent` request body for an LLM request."
+  [{:keys [system input tools schema tool_choice temperature max-tokens]} :- core/LLMRequestOpts]
+  (let [fdecls     (when (seq tools) (mapv tool->function-declaration tools))
+        gen-config (cond-> {}
+                     max-tokens  (assoc :maxOutputTokens max-tokens)
+                     temperature (assoc :temperature temperature))]
+    (cond-> {:contents (parts->contents input)}
+      (seq gen-config) (assoc :generationConfig gen-config)
+      system (assoc :systemInstruction {:parts [{:text system}]})
+      fdecls (assoc :tools [{:functionDeclarations fdecls}])
+
+      (and fdecls tool_choice)
+      (assoc :toolConfig {:functionCallingConfig {:mode (case (name tool_choice)
+                                                          "auto"     "AUTO"
+                                                          "required" "ANY")}})
+
+      ;; Structured output: force a call to one tool that carries the schema. The Claude and Chat Completions adapters
+      ;; do the same, thus the shared :tool-input extraction in call-llm-structured works.
+      schema (assoc :tools      [{:functionDeclarations
+                                  [{:name                 "structured_output"
+                                    :description          "Output structured data"
+                                    :parametersJsonSchema schema}]}]
+                    :toolConfig {:functionCallingConfig {:mode                 "ANY"
+                                                         :allowedFunctionNames ["structured_output"]}}))))
+
+;;; Streaming response → AISDK v5 chunks
+
+(def ^:private finish-reason-completed
+  "The one `finishReason` that means the model said all it had to say."
+  "STOP")
+
+(def ^:private finish-reason-details
+  "Explanations for the `finishReason` values whose names do not carry their meaning.
+  https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1/GenerateContentResponse#FinishReason"
+  {"MAX_TOKENS"              "the output token limit was reached"
+   "MALFORMED_FUNCTION_CALL" "the model emitted a tool call it could not parse"
+   "SAFETY"                  "the response was blocked by Google's safety filters"
+   "RECITATION"              "the response was blocked as recitation of copyrighted material"
+   "BLOCKLIST"               "the response was blocked by a term blocklist"
+   "PROHIBITED_CONTENT"      "the response was blocked as prohibited content"
+   "SPII"                    "the response was blocked as sensitive personally identifiable information"
+   "IMAGE_SAFETY"            "the generated image was blocked by Google's safety filters"
+   "UNEXPECTED_TOOL_CALL"    "the model called a tool that the request did not declare"})
+
+(defn- finish-reason-error
+  "Returns the error text for a `finishReason` that ended the turn early, or nil for a complete answer."
+  [reason]
+  (when-not (= reason finish-reason-completed)
+    (str "Gemini stopped early (" reason ")"
+         (when-let [detail (finish-reason-details reason)]
+           (str ": " detail)))))
+
+(defn ->aisdk-chunks-xf
+  "Translates `streamGenerateContent` SSE events into AI SDK v5 protocol chunks.
+
+  Each SSE event is a `GenerateContentResponse`:
+    {:responseId \"...\"
+     :modelVersion \"gemini-...\"
+     :candidates [{:content {:role \"model\" :parts [{:text \"...\"} {:functionCall {:name ... :args ...}}]}
+                   :finishReason \"STOP\"}]
+     :usageMetadata {:promptTokenCount 10 :candidatesTokenCount 5 ...}}
+
+  Emits the same internal chunk types as the other adapters:
+    :start, :text-start, :text-delta, :text-end,
+    :tool-input-start, :tool-input-delta, :tool-input-available,
+    :usage, :error
+
+  Unlike Claude, there are no content-block start and stop events. Text streams as consecutive parts, and one open
+  text block holds them all. Each functionCall part arrives with complete args, thus its start, delta, and available
+  chunks go out together. Parts with `:thought true` (thinking summaries) are ignored, as in the other adapters. A
+  `finishReason` closes the open text block, and any reason but STOP also emits an :error chunk (see
+  [[finish-reason-error]]). Usage is buffered, the last value wins, and it goes out once at the end of the stream,
+  because an event in the middle can have partial usageMetadata."
+  []
+  (fn [rf]
+    (let [message-id  (volatile! nil)
+          model-name  (volatile! nil)
+          text-id     (volatile! nil) ; Non-nil while a text block is open.
+          usage-acc   (volatile! nil)
+          close-text! (fn [result]
+                        (if-let [id @text-id]
+                          (do (vreset! text-id nil)
+                              (rf result {:type :text-end :id id}))
+                          result))
+          finish!     (fn [result reason]
+                        (let [result (close-text! result)]
+                          (if-let [error-text (finish-reason-error reason)]
+                            (rf result {:type :error :errorText error-text})
+                            result)))
+          emit-part   (fn [result {:keys [text functionCall thought thoughtSignature]}]
+                        (cond
+                          thought
+                          result
+
+                          functionCall
+                          (let [tool-id (core/mkid)
+                                ids     {:toolCallId tool-id :toolName (:name functionCall)}
+                                ;; Gemini 3.x adds a thoughtSignature to functionCall parts, which
+                                ;; must go back to Google on replay. Put it on the start chunk,
+                                ;; thus it stays in the :tool-input part as :provider-metadata.
+                                start   (cond-> (merge {:type :tool-input-start} ids)
+                                          thoughtSignature
+                                          (assoc :providerMetadata {:google {:thoughtSignature thoughtSignature}}))]
+                            (-> (close-text! result)
+                                (rf start)
+                                (rf {:type           :tool-input-delta
+                                     :toolCallId     tool-id
+                                     :inputTextDelta (json/encode (or (:args functionCall) {}))})
+                                (rf (merge {:type :tool-input-available} ids))))
+
+                          ;; Open a text block only for text that is not empty, thus an empty part
+                          ;; between tool calls does not divide them. In an open block, blank
+                          ;; deltas pass through and keep the whitespace.
+                          (some? text)
+                          (if-let [id @text-id]
+                            (rf result {:type :text-delta :id id :delta text})
+                            (if (empty? text)
+                              result
+                              (let [id (core/mkid)]
+                                (vreset! text-id id)
+                                (-> result
+                                    (rf {:type :text-start :id id})
+                                    (rf {:type :text-delta :id id :delta text})))))
+
+                          :else
+                          result))]
+      (fn
+        ([result]
+         (-> result
+             (close-text!)
+             (cond-> @usage-acc (rf {:type  :usage
+                                     :usage @usage-acc
+                                     :id    @message-id
+                                     :model @model-name}))
+             (rf)))
+        ([result {:keys [candidates usageMetadata responseId modelVersion promptFeedback error] :as _event}]
+         (when (some? usageMetadata)
+           (vreset! usage-acc (usage->aisdk-usage usageMetadata)))
+         ;; modelVersion can appear on any event. Keep the last one for the :usage chunk.
+         (when (some? modelVersion)
+           (vreset! model-name modelVersion))
+         (let [{:keys [content finishReason]} (first candidates)
+               block-reason                   (:blockReason promptFeedback)]
+           (cond-> result
+             ;; Emit :start on the first event.
+             (not @message-id)    (-> (u/prog1
+                                        (vreset! message-id (or responseId (core/mkid))))
+                                      (rf {:type :start :messageId @message-id}))
+             (seq (:parts content)) (as-> res (reduce emit-part res (:parts content)))
+             (some? finishReason) (finish! finishReason)
+             ;; A blocked prompt ends the stream with no candidates, only promptFeedback.
+             (some? block-reason) (-> (close-text!)
+                                      (rf {:type      :error
+                                           :errorText (str "Prompt blocked by Google: " block-reason)}))
+             ;; An error envelope in the stream, e.g. a failure in the middle of the stream.
+             (some? error)        (-> (close-text!)
+                                      (rf {:type      :error
+                                           :errorText (or (:message error) (pr-str error))})))))))))

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -1,7 +1,6 @@
 (ns metabase.metabot.self.openai
   (:require
    [clojure.string :as str]
-   [malli.json-schema :as mjs]
    [metabase.llm.settings :as llm]
    [metabase.metabot.self.core :as core]
    [metabase.metabot.self.debug :as debug]
@@ -232,17 +231,8 @@
 (defn- tool->openai
   "Convert a tool definition map to OpenAI Responses API format.
   Accepts a ToolEntry map with :tool-name, :doc, :schema, :fn."
-  [{:keys [tool-name doc schema]}]
-  (let [[_:=> [_:cat params] _out] schema
-        params                     (schema/filter-schema-by-features params)
-        doc                        (if (str/starts-with? (or doc "") "Inputs: ")
-                                     ;; strip that stuff we're appending in mu/defn
-                                     (second (str/split doc #"\n\n  " 2))
-                                     doc)]
-    {:type        "function"
-     :name        tool-name
-     :description doc
-     :parameters  (mjs/transform params {:additionalProperties false})}))
+  [tool]
+  (assoc (schema/tool-function tool) :type "function"))
 
 (defn- ai-proxy-unsupported-ex []
   (ex-info (tru "AI proxy is not supported for OpenAI")

--- a/src/metabase/metabot/self/openai/chat_completions.clj
+++ b/src/metabase/metabot/self/openai/chat_completions.clj
@@ -9,7 +9,6 @@
   which can post-process the body [[request-body]] returns."
   (:require
    [clojure.string :as str]
-   [malli.json-schema :as mjs]
    [metabase.metabot.self.core :as core]
    [metabase.metabot.self.schema :as schema]
    [metabase.util :as u]
@@ -97,16 +96,9 @@
 (defn- tool->cc-tool
   "Convert a tool definition map to Chat Completions tool format.
   Accepts a ToolEntry map with :tool-name, :doc, :schema, :fn."
-  [{:keys [tool-name doc schema]}]
-  (let [[_:=> [_:cat params] _out] schema
-        params     (schema/filter-schema-by-features params)
-        doc        (if (str/starts-with? (or doc "") "Inputs: ")
-                     (second (str/split doc #"\n\n  " 2))
-                     doc)]
-    {:type     "function"
-     :function {:name        tool-name
-                :description doc
-                :parameters  (mjs/transform params {:additionalProperties false})}}))
+  [tool]
+  {:type     "function"
+   :function (schema/tool-function tool)})
 
 ;;; Streaming response → AISDK v5 chunks
 

--- a/src/metabase/metabot/self/schema.clj
+++ b/src/metabase/metabot/self/schema.clj
@@ -2,9 +2,14 @@
   "Schema filtering for feature-gated properties.
 
   Walks Malli schemas and removes map entries whose `:feature` property
-  indicates a feature that is not available in the current context."
+  indicates a feature that is not available in the current context.
+
+  Also home to [[tool-function]], the provider-neutral half of converting a
+  ToolEntry into a provider tool declaration."
   (:require
+   [clojure.string :as str]
    [malli.core :as mc]
+   [malli.json-schema :as mjs]
    [metabase.metabot.self.features :as features]))
 
 (defn- filter-map-entries
@@ -36,3 +41,20 @@
               (if (= :map (mc/type s))
                 (filter-map-entries s)
                 s)))))
+
+(defn tool-function
+  "Converts a ToolEntry map (`:tool-name`, `:doc`, `:schema`) into the provider-neutral parts of a tool declaration:
+  `{:name ... :description ... :parameters <JSON Schema>}`. Adapters wrap this in their provider's envelope.
+
+  Filters feature-gated properties from the parameter schema (see [[filter-schema-by-features]]) and strips the
+  `Inputs: ...` block that `mu/defn` appends to the docstring."
+  [{:keys [tool-name doc schema]}]
+  (let [[_:=> [_:cat params] _out] schema
+        params                     (filter-schema-by-features params)
+        doc                        (if (str/starts-with? (or doc "") "Inputs: ")
+                                     ;; Strip the text that mu/defn adds.
+                                     (second (str/split doc #"\n\n  " 2))
+                                     doc)]
+    {:name        tool-name
+     :description doc
+     :parameters  (mjs/transform params {:additionalProperties false})}))

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -100,7 +100,7 @@
 
 (def ^:private direct-providers
   "Providers that can be used directly (not via the metabase/ proxy prefix)."
-  #{"anthropic" "azure" "bedrock" "mistral" "moonshot" "openai" "openrouter" "zai"})
+  #{"anthropic" "azure" "bedrock" "google" "mistral" "moonshot" "openai" "openrouter" "zai"})
 
 (def ^:private default-anthropic-llm-metabot-model
   "Default Anthropic model used for Metabot when no explicit model is selected."
@@ -109,6 +109,11 @@
 (def ^:private default-bedrock-llm-metabot-model
   "Default Bedrock model used for Metabot when no explicit model is selected."
   "anthropic.claude-opus-4-8")
+
+(def ^:private default-google-llm-metabot-model
+  "Default Google model used for Metabot when no explicit model is selected.
+  Note that Google model IDs include their `{publisher}/{model}` qualifier."
+  "google/gemini-3.5-flash")
 
 (def ^:private default-mistral-llm-metabot-model
   "Default Mistral model used for Metabot when no explicit model is selected."
@@ -139,10 +144,12 @@
 (def default-llm-metabot-model-by-provider
   "Default model payload keyed by provider for `PUT /api/metabot/settings`.
 
-  Values match the shape expected in the request body for each provider: direct providers use a bare model ID, while the
-  managed `metabase` provider uses the proxied `provider/model` form."
+  Values match the shape expected in the request body for each provider: direct providers use a bare model ID (except
+  OpenRouter and Google, whose IDs are publisher-qualified), while the managed `metabase` provider uses the proxied
+  `provider/model` form."
   {"anthropic"                            default-anthropic-llm-metabot-model
    "bedrock"                              default-bedrock-llm-metabot-model
+   "google"                               default-google-llm-metabot-model
    "mistral"                              default-mistral-llm-metabot-model
    "moonshot"                             default-moonshot-llm-metabot-model
    "openai"                               default-openai-llm-metabot-model
@@ -290,36 +297,8 @@
   (when-let [k (non-blank api-key)]
     {:api-key k}))
 
-(defn configured-provider-credentials
-  "Returns the configured credentials map for the given provider, or nil if unrecognized or unconfigured.
-
-  The shape of the map varies by provider: API-key providers return `{:api-key ...}`, Azure returns `:api-key` and
-  `:base-url` from the `llm-azure-*` settings, and Bedrock returns `:access-key-id`, `:secret-access-key`,
-  `:session-token`, and `:region` from the `llm-bedrock-*` settings. Azure counts as configured only when both the
-  API key and base URL are set; Bedrock only when both the access key ID and secret access key are set."
-  [provider]
-  (case provider
-    "anthropic"  (configured-api-key-credentials (llm.settings/llm-anthropic-api-key))
-    "azure"      (let [api-key  (non-blank (llm.settings/llm-azure-api-key))
-                       base-url (non-blank (llm.settings/llm-azure-api-base-url))]
-                   (when (and api-key base-url)
-                     {:api-key api-key :base-url base-url}))
-    "bedrock"    (when (llm.settings/llm-bedrock-configured?)
-                   {:access-key-id     (non-blank (llm.settings/llm-bedrock-access-key-id))
-                    :secret-access-key (non-blank (llm.settings/llm-bedrock-secret-access-key))
-                    :session-token     (non-blank (llm.settings/llm-bedrock-session-token))
-                    :region            (non-blank (llm.settings/llm-bedrock-region))})
-    "mistral"    (configured-api-key-credentials (llm.settings/llm-mistral-api-key))
-    "moonshot"   (configured-api-key-credentials (llm.settings/llm-moonshot-api-key))
-    "openai"     (configured-api-key-credentials (llm.settings/llm-openai-api-key))
-    "openrouter" (configured-api-key-credentials (llm.settings/llm-openrouter-api-key))
-    "zai"        (configured-api-key-credentials (llm.settings/llm-zai-api-key))
-    nil))
-
 (defn provider-credentials-complete?
-  "Whether a credentials map carries everything `provider` needs to make requests: both the AWS access key ID and
-  secret access key for Bedrock, both the API key and base URL for Azure, an `:api-key` for the other direct
-  providers."
+  "Whether a credentials map carries everything `provider` needs."
   [provider credentials]
   (boolean
    (case provider
@@ -327,7 +306,38 @@
                     (non-blank (:secret-access-key credentials)))
      "azure"   (and (non-blank (:api-key credentials))
                     (non-blank (:base-url credentials)))
+     "google"  (or (non-blank (:service-account-key credentials))
+                   (and (non-blank (:oauth-access-token credentials))
+                        (non-blank (:project-id credentials))))
      (non-blank (:api-key credentials)))))
+
+(defn configured-provider-credentials
+  "Returns the configured credentials map for the given provider, or nil if unrecognized or unconfigured."
+  [provider]
+  (case provider
+    "anthropic"  (configured-api-key-credentials (llm.settings/llm-anthropic-api-key))
+    "azure"      (let [creds {:api-key  (non-blank (llm.settings/llm-azure-api-key))
+                              :base-url (non-blank (llm.settings/llm-azure-api-base-url))}]
+                   (when (provider-credentials-complete? "azure" creds)
+                     creds))
+    "bedrock"    (let [creds {:access-key-id     (non-blank (llm.settings/llm-bedrock-access-key-id))
+                              :secret-access-key (non-blank (llm.settings/llm-bedrock-secret-access-key))
+                              :session-token     (non-blank (llm.settings/llm-bedrock-session-token))
+                              :region            (non-blank (llm.settings/llm-bedrock-region))}]
+                   (when (provider-credentials-complete? "bedrock" creds)
+                     creds))
+    "google"     (let [creds {:service-account-key (non-blank (llm.settings/llm-google-service-account-key))
+                              :oauth-access-token  (non-blank (llm.settings/llm-google-oauth-access-token))
+                              :project-id          (non-blank (llm.settings/llm-google-project-id))
+                              :location            (non-blank (llm.settings/llm-google-location))}]
+                   (when (provider-credentials-complete? "google" creds)
+                     creds))
+    "mistral"    (configured-api-key-credentials (llm.settings/llm-mistral-api-key))
+    "moonshot"   (configured-api-key-credentials (llm.settings/llm-moonshot-api-key))
+    "openai"     (configured-api-key-credentials (llm.settings/llm-openai-api-key))
+    "openrouter" (configured-api-key-credentials (llm.settings/llm-openrouter-api-key))
+    "zai"        (configured-api-key-credentials (llm.settings/llm-zai-api-key))
+    nil))
 
 (defn- llm-provider-configured?
   "Check if a provider-and-model string has the necessary configuration.

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -37,6 +37,137 @@
     (mt/with-temporary-setting-values [llm-anthropic-api-key "sk-ant-test"]
       (is (true? (llm.settings/llm-anthropic-api-key-configured?))))))
 
+;;; ------------------------------------------- llm-google-project-id Setter Tests -------------------------------------------
+
+(deftest llm-google-project-id-setter-accepts-valid-id-test
+  (testing "accepts a project ID and trims whitespace"
+    (mt/with-temp-env-var-value! [mb-llm-google-project-id nil]
+      (mt/discard-setting-changes [llm-google-project-id]
+        (llm.settings/llm-google-project-id! "  my-project-123  ")
+        (is (= "my-project-123" (llm.settings/llm-google-project-id)))))))
+
+(deftest llm-google-project-id-setter-accepts-length-boundaries-test
+  (testing "accepts the shortest and longest project IDs Google allows"
+    (mt/with-temp-env-var-value! [mb-llm-google-project-id nil]
+      (mt/discard-setting-changes [llm-google-project-id]
+        (doseq [project-id ["abc123" (apply str "a" (repeat 29 "b"))]]
+          (llm.settings/llm-google-project-id! project-id)
+          (is (= project-id (llm.settings/llm-google-project-id))))))))
+
+(deftest llm-google-project-id-setter-rejects-malformed-id-test
+  (testing "rejects a value that is not a project ID"
+    (doseq [project-id ["My Project"                                    ; spaces and uppercase
+                        "MY-PROJECT"                                    ; uppercase
+                        "1234567890"                                    ; the project number
+                        "abc"                                           ; shorter than 6 characters
+                        (apply str "a" (repeat 30 "b"))                 ; longer than 30 characters
+                        "-my-project"                                   ; does not start with a letter
+                        "my-project-"                                   ; ends with a hyphen
+                        "my_project"                                    ; underscores are not allowed
+                        "projects/my-project"                           ; the resource name
+                        "https://console.cloud.google.com/my-project"]] ; a pasted URL
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"is not a valid Google Cloud project ID"
+           (llm.settings/llm-google-project-id! project-id))))))
+
+(deftest llm-google-project-id-setter-rejected-value-not-stored-test
+  (testing "a rejected value leaves the stored project ID alone"
+    (mt/with-temp-env-var-value! [mb-llm-google-project-id nil]
+      (mt/discard-setting-changes [llm-google-project-id]
+        (llm.settings/llm-google-project-id! "my-project-123")
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"\"My Project\" is not a valid Google Cloud project ID"
+             (llm.settings/llm-google-project-id! "My Project")))
+        (is (= "my-project-123" (llm.settings/llm-google-project-id)))))))
+
+(deftest llm-google-project-id-setter-clears-on-blank-test
+  (testing "a whitespace-only value clears the setting"
+    (mt/with-temp-env-var-value! [mb-llm-google-project-id nil]
+      (mt/discard-setting-changes [llm-google-project-id]
+        (llm.settings/llm-google-project-id! "my-project-123")
+        (llm.settings/llm-google-project-id! "   ")
+        (is (nil? (llm.settings/llm-google-project-id)))))))
+
+;;; ------------------------------------------- llm-google-location Setter Tests -------------------------------------------
+
+(deftest llm-google-location-setter-accepts-served-locations-test
+  (testing "accepts the location spellings the platform serves, and trims whitespace"
+    (mt/with-temp-env-var-value! [mb-llm-google-location nil]
+      (mt/discard-setting-changes [llm-google-location]
+        (doseq [location ["global" "us" "eu" "us-central1" "europe-west4" "asia-northeast1"]]
+          (llm.settings/llm-google-location! (str "  " location "  "))
+          (is (= location (llm.settings/llm-google-location))))))))
+
+(deftest llm-google-location-setter-rejects-malformed-location-test
+  (testing "rejects a value that cannot be a request host"
+    (doseq [location ["us central1"                                     ; a space
+                      "us\tcentral1"                                    ; a tab
+                      "us\ncentral1"                                    ; a newline
+                      "US-CENTRAL1"                                     ; uppercase
+                      "us-central1/"                                    ; a slash
+                      "us_central1"                                     ; an underscore
+                      "locations/us-central1"                           ; the resource name
+                      "https://us-central1-aiplatform.googleapis.com"]] ; a pasted URL
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"is not a valid Google Cloud location"
+           (llm.settings/llm-google-location! location))))))
+
+(deftest llm-google-location-setter-rejects-malformed-dns-label-test
+  (testing "rejects a value that is not a well-formed DNS label"
+    (doseq [location ["-us-central1"                      ; a leading hyphen
+                      "us-central1-"                      ; a trailing hyphen
+                      "-"                                 ; a lone hyphen
+                      "us--central1"                      ; consecutive hyphens
+                      "1us-central"]]                     ; a leading digit
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"is not a valid Google Cloud location"
+           (llm.settings/llm-google-location! location))))))
+
+(deftest llm-google-location-setter-rejects-overlong-location-test
+  (testing "rejects a value too long to be a DNS label once the -aiplatform suffix is added"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"is not a valid Google Cloud location"
+         (llm.settings/llm-google-location! (apply str (repeat 53 "a")))))))
+
+(deftest llm-google-location-setter-rejected-value-not-stored-test
+  (testing "a rejected value leaves the stored location alone"
+    (mt/with-temp-env-var-value! [mb-llm-google-location nil]
+      (mt/discard-setting-changes [llm-google-location]
+        (llm.settings/llm-google-location! "us-central1")
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"\"us central1\" is not a valid Google Cloud location"
+             (llm.settings/llm-google-location! "us central1")))
+        (is (= "us-central1" (llm.settings/llm-google-location)))))))
+
+(deftest llm-google-location-setter-clears-on-blank-test
+  (testing "a whitespace-only value clears the setting, falling back to the global location"
+    (mt/with-temp-env-var-value! [mb-llm-google-location nil]
+      (mt/discard-setting-changes [llm-google-location]
+        (llm.settings/llm-google-location! "us-central1")
+        (llm.settings/llm-google-location! "   ")
+        (is (nil? (llm.settings/llm-google-location)))))))
+
+;;; ------------------------------------------- llm-google-api-base-url Setter Tests -------------------------------------------
+
+(deftest llm-google-api-base-url-setter-test
+  (testing "trims whitespace and trailing slashes"
+    (mt/with-temp-env-var-value! [mb-llm-google-api-base-url nil]
+      (mt/discard-setting-changes [llm-google-api-base-url]
+        (llm.settings/llm-google-api-base-url! "  https://proxy.example.com/aiplatform/  ")
+        (is (= "https://proxy.example.com/aiplatform" (llm.settings/llm-google-api-base-url))))))
+  (testing "blank restores the default global host"
+    (mt/with-temp-env-var-value! [mb-llm-google-api-base-url nil]
+      (mt/discard-setting-changes [llm-google-api-base-url]
+        (llm.settings/llm-google-api-base-url! "https://proxy.example.com/aiplatform")
+        (llm.settings/llm-google-api-base-url! "   ")
+        (is (= "https://aiplatform.googleapis.com" (llm.settings/llm-google-api-base-url)))))))
+
 ;;; ------------------------------------------- llm-bedrock-configured? Tests -------------------------------------------
 
 (deftest llm-bedrock-configured?-test

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -168,30 +168,6 @@
         (llm.settings/llm-google-api-base-url! "   ")
         (is (= "https://aiplatform.googleapis.com" (llm.settings/llm-google-api-base-url)))))))
 
-;;; ------------------------------------------- llm-bedrock-configured? Tests -------------------------------------------
-
-(deftest llm-bedrock-configured?-test
-  (testing "returns false when neither credential is set"
-    (mt/with-temporary-setting-values [llm-bedrock-access-key-id nil
-                                       llm-bedrock-secret-access-key nil]
-      (is (false? (llm.settings/llm-bedrock-configured?)))))
-  (testing "returns false when only the access key id is set"
-    (mt/with-temporary-setting-values [llm-bedrock-access-key-id "AKIAIOSFODNN7EXAMPLE"
-                                       llm-bedrock-secret-access-key nil]
-      (is (false? (llm.settings/llm-bedrock-configured?)))))
-  (testing "returns false when only the secret access key is set"
-    (mt/with-temporary-setting-values [llm-bedrock-access-key-id nil
-                                       llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"]
-      (is (false? (llm.settings/llm-bedrock-configured?)))))
-  (testing "returns false when a credential is blank rather than absent"
-    (mt/with-temporary-setting-values [llm-bedrock-access-key-id "   "
-                                       llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"]
-      (is (false? (llm.settings/llm-bedrock-configured?)))))
-  (testing "returns true when both credentials are set"
-    (mt/with-temporary-setting-values [llm-bedrock-access-key-id "AKIAIOSFODNN7EXAMPLE"
-                                       llm-bedrock-secret-access-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"]
-      (is (true? (llm.settings/llm-bedrock-configured?))))))
-
 ;;; ------------------------------------------- llm-bedrock credential Setter Tests -------------------------------------------
 
 (deftest llm-bedrock-access-key-id-setter-accepts-valid-key-test

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -2671,6 +2671,28 @@
         (testing "and the env var keeps supplying the location"
           (is (= "us-central1" (llm.settings/llm-google-location))))))))
 
+(deftest settings-put-google-disconnect-clears-env-shadowed-credential-row-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider           nil
+                                mb-llm-google-oauth-access-token  "ya29.env-token"
+                                mb-llm-google-service-account-key nil
+                                mb-llm-google-project-id          "env-project"
+                                mb-llm-google-location            nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-location            nil
+                                       metabot.settings/llm-metabot-provider       "google/google/gemini-3.5-flash"]
+      (mt/with-temporary-raw-setting-values [llm-google-oauth-access-token "ya29.stale-db-token"]
+        (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider _opts]
+                                                               (is false (str "unexpected list-models call: " provider)))]
+          (testing "disconnect deletes the app-DB row hiding behind the env var"
+            (is (=? {:value "google/google/gemini-3.5-flash"}
+                    (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                          {:provider    "google"
+                                           :credentials nil})))
+            (is (nil? (t2/select-one :model/Setting :key "llm-google-oauth-access-token"))
+                "a skipped clear would let the stale credential resurface once the env var is removed"))
+          (testing "the env var keeps supplying the value on read"
+            (is (= "ya29.env-token" (llm.settings/llm-google-oauth-access-token)))))))))
+
 (deftest settings-put-google-rejects-changing-env-shadowed-location-test
   (mt/with-temp-env-var-value! [mb-llm-metabot-provider           nil
                                 mb-llm-google-oauth-access-token  nil

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -892,6 +892,21 @@
         (is (= "sk-new" (llm.settings/llm-openai-api-key))
             "rotating the key for an env-set provider does not require a provider write and so is allowed")))))
 
+(deftest settings-put-env-shadowed-provider-no-op-write-not-persisted-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider "openai/gpt-5.1"
+                                mb-llm-openai-api-key   nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-openai-api-key "sk-old"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [_provider _opts]
+                                                             {:models [{:id "gpt-5.1" :display_name "GPT-5.1"}]})]
+        (t2/with-transaction [_conn nil {:rollback-only true}]
+          (t2/delete! :model/Setting :key "llm-metabot-provider")
+          (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                {:provider "openai"
+                                 :model    "gpt-5.1"
+                                 :api-key  "sk-new"})
+          (testing "a provider/model write that echoes the env var is allowed but persists nothing"
+            (is (nil? (t2/select-one :model/Setting :key "llm-metabot-provider")))))))))
+
 (deftest settings-permissions-test
   (mt/user-http-request :rasta :get 403 "metabot/settings" :provider "anthropic")
   (mt/user-http-request :rasta :put 403 "metabot/settings"

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -2167,6 +2167,29 @@
         (testing "the clear also resets the region to its default"
           (is (= "us-east-1" (llm.settings/llm-bedrock-region))))))))
 
+(deftest settings-put-bedrock-disconnect-allowed-when-region-env-set-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
+                                mb-llm-bedrock-access-key-id     nil
+                                mb-llm-bedrock-secret-access-key nil
+                                mb-llm-bedrock-session-token     nil
+                                mb-llm-bedrock-region            "us-west-2"]
+    (mt/with-temporary-setting-values [llm.settings/llm-bedrock-access-key-id     "AKIAIOSFODNN7EXAMPLE"
+                                       llm.settings/llm-bedrock-secret-access-key "test-secret"
+                                       llm.settings/llm-bedrock-session-token     "test-token"
+                                       metabot.settings/llm-metabot-provider      "bedrock/anthropic.claude-opus-4-8"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider _opts]
+                                                             (is false (str "unexpected list-models call: " provider)))]
+        (testing "an env-supplied region does not block disconnect"
+          (is (=? {:value "bedrock/anthropic.claude-opus-4-8"}
+                  (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                        {:provider    "bedrock"
+                                         :credentials nil})))
+          (is (nil? (llm.settings/llm-bedrock-access-key-id)))
+          (is (nil? (llm.settings/llm-bedrock-secret-access-key)))
+          (is (nil? (llm.settings/llm-bedrock-session-token))))
+        (testing "and the env var keeps supplying the region"
+          (is (= "us-west-2" (llm.settings/llm-bedrock-region))))))))
+
 (deftest settings-put-bedrock-absent-credentials-leaves-saved-credentials-test
   (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
                                 mb-llm-bedrock-access-key-id     nil
@@ -2335,12 +2358,30 @@
                                 mb-llm-azure-api-base-url "https://env.services.ai.azure.com/openai"]
     (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [_provider _opts]
                                                            (is false "should reject before verifying credentials"))]
-      (testing "the base URL env var is guarded the same way"
+      (testing "the base URL env var is guarded the same way when the request would change it"
         (is (re-find #"MB_LLM_AZURE_API_BASE_URL"
                      (:message (mt/user-http-request :crowberto :put 400 "metabot/settings"
                                                      {:provider    "azure"
                                                       :model       "openai/gpt-4.1-mini"
-                                                      :credentials {:api-key "new-key"}}))))))))
+                                                      :credentials {:api-key  "new-key"
+                                                                    :base-url "https://other.services.ai.azure.com/openai"}}))))))))
+
+(deftest settings-put-allows-azure-key-rotation-when-base-url-env-set-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider   nil
+                                mb-llm-azure-api-key      nil
+                                mb-llm-azure-api-base-url "https://env.services.ai.azure.com/openai"]
+    (mt/with-temporary-setting-values [llm.settings/llm-azure-api-key        "old-key"
+                                       metabot.settings/llm-metabot-provider "azure/openai/gpt-4.1-mini"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [_provider {:keys [credentials]}]
+                                                             (is (= {:api-key  "new-key"
+                                                                     :base-url "https://env.services.ai.azure.com/openai"}
+                                                                    credentials))
+                                                             {:models []})]
+        (testing "an env-set base URL is layered into the credentials unchanged, so it does not block a key rotation"
+          (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                {:provider    "azure"
+                                 :credentials {:api-key "new-key"}})
+          (is (= "new-key" (llm.settings/llm-azure-api-key))))))))
 
 (deftest settings-get-azure-returns-empty-models-test
   (mt/with-temporary-setting-values [llm.settings/llm-azure-api-key        "azure-key"
@@ -2356,3 +2397,446 @@
         (is (= {:value  "azure/anthropic/claude-sonnet-4-5"
                 :models []}
                (mt/user-http-request :crowberto :get 200 "metabot/settings" :provider "azure")))))))
+
+;;; ------------------------------------------------ Google settings ------------------------------------------------
+
+(deftest settings-put-saves-google-credentials-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider           nil
+                                mb-llm-google-oauth-access-token  nil
+                                mb-llm-google-service-account-key nil
+                                mb-llm-google-project-id          nil
+                                mb-llm-google-location            nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          nil
+                                       llm.settings/llm-google-location            nil
+                                       metabot.settings/llm-metabot-provider       "anthropic/claude-sonnet-4-6"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [credentials]}]
+                                                             (is (= "google" provider))
+                                                             (is (= {:oauth-access-token "ya29.secret-token"
+                                                                     :project-id         "my-project"
+                                                                     :location           "us-central1"}
+                                                                    credentials)
+                                                                 "validation runs against the resolved request credentials")
+                                                             (is (nil? (llm.settings/llm-google-oauth-access-token))
+                                                                 "validation should happen before saving the credentials")
+                                                             {:models []})]
+        (testing "connecting google saves the credentials and the composed provider/model value"
+          (is (=? {:value  "google/google/gemini-3.5-flash"
+                   :models []}
+                  (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                        {:provider    "google"
+                                         :model       "google/gemini-3.5-flash"
+                                         :credentials {:oauth-access-token "ya29.secret-token"
+                                                       :project-id         "my-project"
+                                                       :location           "us-central1"}}))))
+        (is (= "ya29.secret-token" (llm.settings/llm-google-oauth-access-token)))
+        (is (= "my-project" (llm.settings/llm-google-project-id)))
+        (is (= "us-central1" (llm.settings/llm-google-location)))))))
+
+(deftest settings-put-connect-google-defaults-model-test
+  (testing "connecting google with only credentials switches to the default google model"
+    (mt/with-temp-env-var-value! [mb-llm-metabot-provider           nil
+                                  mb-llm-google-oauth-access-token  nil
+                                  mb-llm-google-service-account-key nil
+                                  mb-llm-google-project-id          nil
+                                  mb-llm-google-location            nil]
+      (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                         llm.settings/llm-google-service-account-key nil
+                                         llm.settings/llm-google-project-id          nil
+                                         llm.settings/llm-google-location            nil
+                                         metabot.settings/llm-metabot-provider       "anthropic/claude-haiku-4-5"]
+        (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [model]}]
+                                                               (is (= "google" provider))
+                                                               (is (= "google/gemini-3.5-flash" model)
+                                                                   "the connect probe validates the defaulted model")
+                                                               {:models []})]
+          (is (=? {:value  "google/google/gemini-3.5-flash"
+                   :models []}
+                  (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                        {:provider    "google"
+                                         :credentials {:oauth-access-token "ya29.secret-token"
+                                                       :project-id         "my-project"}})))
+          (is (= "google/google/gemini-3.5-flash"
+                 (metabot.settings/llm-metabot-provider)))
+          (is (= "ya29.secret-token" (llm.settings/llm-google-oauth-access-token))))))))
+
+(deftest settings-put-google-model-passes-through-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider           nil
+                                mb-llm-google-oauth-access-token  nil
+                                mb-llm-google-service-account-key nil
+                                mb-llm-google-project-id          nil
+                                mb-llm-google-location            nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          nil
+                                       llm.settings/llm-google-location            nil
+                                       metabot.settings/llm-metabot-provider       "anthropic/claude-sonnet-4-6"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [_provider {:keys [model]}]
+                                                             (is (= "google/gemini-3.5-flash" model)
+                                                                 "validation runs against the model as sent — no qualification happens here")
+                                                             {:models []})]
+        (testing "a publisher-qualified Gemini model ID is validated and persisted as sent"
+          (is (=? {:value "google/google/gemini-3.5-flash"}
+                  (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                        {:provider    "google"
+                                         :model       "google/gemini-3.5-flash"
+                                         :credentials {:oauth-access-token "ya29.secret-token"
+                                                       :project-id         "my-project"}}))))))))
+
+(deftest settings-put-google-bare-model-rejected-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider           nil
+                                mb-llm-google-oauth-access-token  nil
+                                mb-llm-google-service-account-key nil
+                                mb-llm-google-project-id          nil
+                                mb-llm-google-location            nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          nil
+                                       llm.settings/llm-google-location            nil
+                                       metabot.settings/llm-metabot-provider       "anthropic/claude-sonnet-4-6"]
+      (testing "a bare Gemini model ID fails connect validation before any HTTP call, and nothing is persisted"
+        (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+          (is (=? {:message "Invalid Google model \"gemini-3.5-flash\" — expected a publisher-qualified ID like \"google/gemini-3.5-flash\""}
+                  (mt/user-http-request :crowberto :put 400 "metabot/settings"
+                                        {:provider    "google"
+                                         :model       "gemini-3.5-flash"
+                                         :credentials {:oauth-access-token "ya29.secret-token"
+                                                       :project-id         "my-project"}}))))
+        (is (= "anthropic/claude-sonnet-4-6" (metabot.settings/llm-metabot-provider)))
+        (is (nil? (llm.settings/llm-google-oauth-access-token)))))))
+
+(deftest settings-put-google-rotation-validates-against-saved-model-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
+                                mb-llm-google-oauth-access-token nil
+                                mb-llm-google-project-id         nil
+                                mb-llm-google-location           nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.old-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            nil
+                                       metabot.settings/llm-metabot-provider       "google/google/gemini-3.6-flash"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [_provider {:keys [model]}]
+                                                             (is (= "google/gemini-3.6-flash" model)
+                                                                 "a credential-only rotation validates against the saved model")
+                                                             {:models []})]
+        (is (=? {:value "google/google/gemini-3.6-flash"}
+                (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                      {:provider    "google"
+                                       :credentials {:oauth-access-token "ya29.new-token"}})))
+        (is (= "ya29.new-token" (llm.settings/llm-google-oauth-access-token)))))))
+
+(deftest settings-put-saves-google-service-account-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider             nil
+                                mb-llm-google-oauth-access-token    nil
+                                mb-llm-google-service-account-key   nil
+                                mb-llm-google-project-id            nil
+                                mb-llm-google-location              nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          nil
+                                       llm.settings/llm-google-location            nil
+                                       metabot.settings/llm-metabot-provider       "anthropic/claude-sonnet-4-6"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider {:keys [credentials]}]
+                                                             (is (= "google" provider))
+                                                             (is (= {:service-account-key "{\"type\": \"service_account\"}"}
+                                                                    credentials)
+                                                                 "a service account key alone is a complete credential — the project ID comes from the key JSON")
+                                                             {:models []})]
+        (testing "connecting google with only a service account key saves it and the composed provider/model value"
+          (is (=? {:value  "google/google/gemini-3.5-flash"
+                   :models []}
+                  (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                        {:provider    "google"
+                                         :model       "google/gemini-3.5-flash"
+                                         :credentials {:service-account-key "{\"type\": \"service_account\"}"}}))))
+        (is (= "{\"type\": \"service_account\"}" (llm.settings/llm-google-service-account-key)))
+        (is (nil? (llm.settings/llm-google-oauth-access-token)))
+        (is (nil? (llm.settings/llm-google-project-id)))))))
+
+(deftest settings-put-google-rejects-missing-project-id-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider           nil
+                                mb-llm-google-oauth-access-token  nil
+                                mb-llm-google-service-account-key nil
+                                mb-llm-google-project-id          nil
+                                mb-llm-google-location            nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          nil
+                                       llm.settings/llm-google-location            nil
+                                       metabot.settings/llm-metabot-provider       "anthropic/claude-sonnet-4-6"]
+      (testing "an OAuth access token without a project ID fails before validation and nothing is saved"
+        (is (=? {:message      "Google credentials are incomplete."
+                 :missing-keys ["service-account-key" "project-id"]}
+                (mt/user-http-request :crowberto :put 400 "metabot/settings"
+                                      {:provider    "google"
+                                       :model       "google/gemini-3.5-flash"
+                                       :credentials {:oauth-access-token "ya29.secret-token"}})))
+        (is (nil? (llm.settings/llm-google-oauth-access-token)))
+        (is (= "anthropic/claude-sonnet-4-6" (metabot.settings/llm-metabot-provider)))))))
+
+(deftest settings-put-google-rejects-missing-credential-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider           nil
+                                mb-llm-google-oauth-access-token  nil
+                                mb-llm-google-service-account-key nil
+                                mb-llm-google-project-id          nil
+                                mb-llm-google-location            nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          nil
+                                       llm.settings/llm-google-location            nil
+                                       metabot.settings/llm-metabot-provider       "anthropic/claude-sonnet-4-6"]
+      (testing "credentials without a service account key or OAuth access token fail before validation and nothing is saved"
+        (is (=? {:message      "Google credentials are incomplete."
+                 :missing-keys ["service-account-key" "oauth-access-token"]}
+                (mt/user-http-request :crowberto :put 400 "metabot/settings"
+                                      {:provider    "google"
+                                       :model       "google/gemini-3.5-flash"
+                                       :credentials {:project-id "my-project"}})))
+        (is (nil? (llm.settings/llm-google-project-id)))
+        (is (= "anthropic/claude-sonnet-4-6" (metabot.settings/llm-metabot-provider)))))))
+
+(deftest settings-put-google-connect-allowed-when-location-env-set-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider           nil
+                                mb-llm-google-oauth-access-token  nil
+                                mb-llm-google-service-account-key nil
+                                mb-llm-google-project-id          nil
+                                mb-llm-google-location            "us-central1"]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          nil
+                                       metabot.settings/llm-metabot-provider       "anthropic/claude-sonnet-4-6"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [_provider _opts] {:models []})]
+        (testing "an env-supplied location does not block a connect that never touches it"
+          (is (=? {:value "google/google/gemini-3.5-flash"}
+                  (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                        {:provider    "google"
+                                         :model       "google/gemini-3.5-flash"
+                                         :credentials {:oauth-access-token "ya29.secret-token"
+                                                       :project-id         "my-project"}})))
+          (is (= "ya29.secret-token" (llm.settings/llm-google-oauth-access-token)))
+          (is (= "my-project" (llm.settings/llm-google-project-id))))))))
+
+(deftest settings-put-google-rotation-allowed-when-location-env-set-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider           nil
+                                mb-llm-google-oauth-access-token  nil
+                                mb-llm-google-service-account-key nil
+                                mb-llm-google-project-id          nil
+                                mb-llm-google-location            "us-central1"]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.old-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       metabot.settings/llm-metabot-provider       "google/google/gemini-3.5-flash"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [_provider _opts] {:models []})]
+        (testing "the env-set location layered into a connected provider's credentials does not block a rotation"
+          (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                {:provider    "google"
+                                 :credentials {:oauth-access-token "ya29.new-token"}})
+          (is (= "ya29.new-token" (llm.settings/llm-google-oauth-access-token))))))))
+
+(deftest settings-put-google-disconnect-allowed-when-location-env-set-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider           nil
+                                mb-llm-google-oauth-access-token  nil
+                                mb-llm-google-service-account-key nil
+                                mb-llm-google-project-id          nil
+                                mb-llm-google-location            "us-central1"]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.secret-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       metabot.settings/llm-metabot-provider       "google/google/gemini-3.5-flash"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider _opts]
+                                                             (is false (str "unexpected list-models call: " provider)))]
+        (testing "an env-supplied location does not block disconnect"
+          (is (=? {:value "google/google/gemini-3.5-flash"}
+                  (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                        {:provider    "google"
+                                         :credentials nil})))
+          (is (nil? (llm.settings/llm-google-oauth-access-token)))
+          (is (nil? (llm.settings/llm-google-project-id))))
+        (testing "and the env var keeps supplying the location"
+          (is (= "us-central1" (llm.settings/llm-google-location))))))))
+
+(deftest settings-put-google-rejects-changing-env-shadowed-location-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider           nil
+                                mb-llm-google-oauth-access-token  nil
+                                mb-llm-google-service-account-key nil
+                                mb-llm-google-project-id          nil
+                                mb-llm-google-location            "us-central1"]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          nil
+                                       metabot.settings/llm-metabot-provider       "anthropic/claude-sonnet-4-6"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [_provider _opts]
+                                                             (is false "should reject before verifying credentials"))]
+        (testing "a request that would change the env-set location is still rejected"
+          (is (re-find #"MB_LLM_GOOGLE_LOCATION"
+                       (:message (mt/user-http-request :crowberto :put 400 "metabot/settings"
+                                                       {:provider    "google"
+                                                        :model       "google/gemini-3.5-flash"
+                                                        :credentials {:oauth-access-token "ya29.secret-token"
+                                                                      :project-id         "my-project"
+                                                                      :location           "europe-west4"}})))))))))
+
+(deftest settings-put-google-invalid-service-account-key-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider           nil
+                                mb-llm-google-oauth-access-token  nil
+                                mb-llm-google-service-account-key nil
+                                mb-llm-google-project-id          nil
+                                mb-llm-google-location            nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          nil
+                                       llm.settings/llm-google-location            nil
+                                       metabot.settings/llm-metabot-provider       "anthropic/claude-sonnet-4-6"]
+      (testing "a service account key the auth library rejects fails connect with its own message, not a generic 500"
+        (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+          (is (=? {:message #"(?s)Invalid Google service account key: .+"}
+                  (mt/user-http-request :crowberto :put 400 "metabot/settings"
+                                        {:provider    "google"
+                                         :model       "google/gemini-3.5-flash"
+                                         :credentials {:service-account-key "{\"type\": \"service_account\"}"}}))))
+        (is (nil? (llm.settings/llm-google-service-account-key)))
+        (is (= "anthropic/claude-sonnet-4-6" (metabot.settings/llm-metabot-provider)))))))
+
+(deftest settings-put-google-user-credential-key-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider           nil
+                                mb-llm-google-oauth-access-token  nil
+                                mb-llm-google-service-account-key nil
+                                mb-llm-google-project-id          nil
+                                mb-llm-google-location            nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          nil
+                                       llm.settings/llm-google-location            nil
+                                       metabot.settings/llm-metabot-provider       "anthropic/claude-sonnet-4-6"]
+      (testing "a gcloud user credential uploaded as the key file fails connect with its own message, not a generic 500"
+        (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+          (is (=? {:message "This Google credential JSON is not a service account key."}
+                  (mt/user-http-request :crowberto :put 400 "metabot/settings"
+                                        {:provider    "google"
+                                         :model       "google/gemini-3.5-flash"
+                                         :credentials {:service-account-key (json/encode {:type          "authorized_user"
+                                                                                          :client_id     "test-client-id"
+                                                                                          :client_secret "test-client-secret"
+                                                                                          :refresh_token "1//test-refresh-token"})}}))))
+        (is (nil? (llm.settings/llm-google-service-account-key)))
+        (is (= "anthropic/claude-sonnet-4-6" (metabot.settings/llm-metabot-provider)))))))
+
+(deftest settings-put-google-invalid-location-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider           nil
+                                mb-llm-google-oauth-access-token  nil
+                                mb-llm-google-service-account-key nil
+                                mb-llm-google-project-id          nil
+                                mb-llm-google-location            nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          nil
+                                       llm.settings/llm-google-location            nil
+                                       metabot.settings/llm-metabot-provider       "anthropic/claude-sonnet-4-6"]
+      (testing "a location that cannot be a host fails connect with the location message, not a generic 500"
+        (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+          (is (=? {:message (str "\"us central1\" is not a valid Google Cloud location. Use a location ID like"
+                                 " \"us-central1\", or leave it blank to use the global location.")}
+                  (mt/user-http-request :crowberto :put 400 "metabot/settings"
+                                        {:provider    "google"
+                                         :model       "google/gemini-3.5-flash"
+                                         :credentials {:oauth-access-token "ya29.secret-token"
+                                                       :project-id         "my-project"
+                                                       :location           "us central1"}}))))
+        (is (nil? (llm.settings/llm-google-location)))
+        (is (= "anthropic/claude-sonnet-4-6" (metabot.settings/llm-metabot-provider)))))))
+
+(deftest settings-put-google-token-rotation-keeps-project-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
+                                mb-llm-google-oauth-access-token nil
+                                mb-llm-google-project-id         nil
+                                mb-llm-google-location           nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.old-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            "us-central1"
+                                       metabot.settings/llm-metabot-provider       "google/google/gemini-3.5-flash"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [_provider {:keys [credentials]}]
+                                                             (is (= {:service-account-key nil
+                                                                     :oauth-access-token  "ya29.new-token"
+                                                                     :project-id          "my-project"
+                                                                     :location            "us-central1"}
+                                                                    credentials)
+                                                                 "the new token is layered over the saved project and location")
+                                                             {:models []})]
+        (is (=? {:value "google/google/gemini-3.5-flash"}
+                (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                      {:provider    "google"
+                                       :credentials {:oauth-access-token "ya29.new-token"}})))
+        (is (= "ya29.new-token" (llm.settings/llm-google-oauth-access-token)))
+        (is (= "my-project" (llm.settings/llm-google-project-id)))
+        (is (= "us-central1" (llm.settings/llm-google-location)))))))
+
+(deftest settings-put-google-clears-location-only-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
+                                mb-llm-google-oauth-access-token nil
+                                mb-llm-google-project-id         nil
+                                mb-llm-google-location           nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.secret-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            "us-central1"
+                                       metabot.settings/llm-metabot-provider       "google/google/gemini-3.5-flash"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [_provider {:keys [credentials]}]
+                                                             (is (= {:service-account-key nil
+                                                                     :oauth-access-token  "ya29.secret-token"
+                                                                     :project-id          "my-project"
+                                                                     :location            nil}
+                                                                    credentials)
+                                                                 "an explicit nil location field clears it (back to the global location)")
+                                                             {:models []})]
+        (is (=? {:value "google/google/gemini-3.5-flash"}
+                (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                      {:provider    "google"
+                                       :credentials {:location nil}})))
+        (is (= "ya29.secret-token" (llm.settings/llm-google-oauth-access-token)))
+        (is (= "my-project" (llm.settings/llm-google-project-id)))
+        (is (nil? (llm.settings/llm-google-location)))))))
+
+(deftest settings-put-google-rejects-clearing-project-id-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
+                                mb-llm-google-oauth-access-token nil
+                                mb-llm-google-project-id         nil
+                                mb-llm-google-location           nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.secret-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            "us-central1"
+                                       metabot.settings/llm-metabot-provider       "google/google/gemini-3.5-flash"]
+      (testing "an explicit nil project ID leaves incomplete credentials and is rejected; nothing changes"
+        (is (=? {:message      "Google credentials are incomplete."
+                 :missing-keys ["service-account-key" "project-id"]}
+                (mt/user-http-request :crowberto :put 400 "metabot/settings"
+                                      {:provider    "google"
+                                       :credentials {:project-id nil}})))
+        (is (= "ya29.secret-token" (llm.settings/llm-google-oauth-access-token)))
+        (is (= "my-project" (llm.settings/llm-google-project-id)))
+        (is (= "us-central1" (llm.settings/llm-google-location)))))))
+
+(deftest settings-put-nil-google-credentials-clears-saved-credentials-test
+  (mt/with-temp-env-var-value! [mb-llm-metabot-provider          nil
+                                mb-llm-google-oauth-access-token nil
+                                mb-llm-google-project-id         nil
+                                mb-llm-google-location           nil]
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.secret-token"
+                                       llm.settings/llm-google-service-account-key "{\"type\": \"service_account\"}"
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            "us-central1"
+                                       metabot.settings/llm-metabot-provider       "google/google/gemini-3.5-flash"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [provider _opts]
+                                                             (is false (str "unexpected list-models call: " provider)))]
+        (testing "an explicit nil credentials clears all saved settings without validating against them"
+          (is (=? {:value  "google/google/gemini-3.5-flash"
+                   :models []}
+                  (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                        {:provider    "google"
+                                         :credentials nil})))
+          (is (nil? (llm.settings/llm-google-oauth-access-token)))
+          (is (nil? (llm.settings/llm-google-service-account-key)))
+          (is (nil? (llm.settings/llm-google-project-id)))
+          (is (nil? (llm.settings/llm-google-location))))))))

--- a/test/metabase/metabot/self/google/stream_generate_content_test.clj
+++ b/test/metabase/metabot/self/google/stream_generate_content_test.clj
@@ -1,0 +1,600 @@
+(ns metabase.metabot.self.google.stream-generate-content-test
+  (:require
+   [clojure.test :refer :all]
+   [medley.core :as m]
+   [metabase.metabot.self.core :as self.core]
+   [metabase.metabot.self.google.stream-generate-content :as sgc]))
+
+(set! *warn-on-reflection* true)
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; parts->contents tests
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest ^:parallel parts->contents-plain-text-test
+  (testing "user text passes through; assistant text becomes role model"
+    (is (= [{:role "user" :parts [{:text "Hello"}]}
+            {:role "model" :parts [{:text "Hi there!"}]}]
+           (sgc/parts->contents
+            [{:role :user :content "Hello"}
+             {:type :text :text "Hi there!"}])))))
+
+(deftest ^:parallel parts->contents-assistant-role-maps-to-model-test
+  (testing "an explicit assistant role maps to Gemini's model role"
+    (is (= [{:role "model" :parts [{:text "prior reply"}]}]
+           (sgc/parts->contents
+            [{:role :assistant :content "prior reply"}])))))
+
+(deftest ^:parallel parts->contents-blank-message-folds-into-neighbour-test
+  (testing "a blank message contributes no parts to the content it merges with"
+    (is (= [{:role "user" :parts [{:text "Hello"}]}]
+           (sgc/parts->contents
+            [{:role :user :content ""}
+             {:role :user :content "Hello"}])))))
+
+(deftest ^:parallel parts->contents-standalone-blank-message-dropped-test
+  (testing "a blank message with no neighbour is dropped"
+    (is (= [{:role "model" :parts [{:text "Hi there!"}]}]
+           (sgc/parts->contents
+            [{:role :user :content ""}
+             {:type :text :text "Hi there!"}])))))
+
+(deftest ^:parallel parts->contents-blank-message-between-model-turns-does-not-split-them-test
+  (testing "dropping a blank message merges the model contents that surrounded it, rather than leaving two in a row"
+    (is (= [{:role "model" :parts [{:text "first"} {:text "second"}]}]
+           (sgc/parts->contents
+            [{:type :text :text "first"}
+             {:role :user :content ""}
+             {:type :text :text "second"}])))))
+
+(deftest ^:parallel parts->contents-content-with-no-text-blocks-dropped-test
+  (testing "a stored message whose content carries no parts is dropped rather than sent as an empty parts array"
+    (is (= [{:role "model" :parts [{:text "Hi there!"}]}]
+           (sgc/parts->contents
+            [{:role :user :content []}
+             {:type :text :text "Hi there!"}])))))
+
+(def ^:private placeholder-signature
+  "Google's documented bypass signature, sent when a replayed functionCall has no captured one."
+  "skip_thought_signature_validator")
+
+(deftest ^:parallel parts->contents-system-message-goes-in-the-user-channel-test
+  (testing "non-user non-model roles collapse to user"
+    (is (= [{:role "user" :parts [{:text "be nice"} {:text "hi"}]}]
+           (sgc/parts->contents
+            [{:role :system :content "be nice"}
+             {:role :user :content "hi"}])))))
+
+(deftest ^:parallel parts->contents-unknown-role-goes-in-the-user-channel-test
+  (testing "a role we don't recognize maps to user"
+    (is (= [{:role "user" :parts [{:text "from somewhere"}]}]
+           (sgc/parts->contents
+            [{:role :function :content "from somewhere"}])))))
+
+(deftest ^:parallel parts->contents-empty-text-part-dropped-test
+  (testing "an empty assistant text part contributes no parts"
+    (is (= [{:role "model" :parts [{:functionCall     {:name "search" :args {}}
+                                    :thoughtSignature placeholder-signature}]}]
+           (sgc/parts->contents
+            [{:type :text :text ""}
+             {:type :tool-input :id "call-1" :function "search" :arguments {}}])))))
+
+(deftest ^:parallel parts->contents-whitespace-text-part-kept-test
+  (testing "a whitespace-only text part survives: dropping it would run the surrounding words together"
+    (is (= [{:role "model" :parts [{:text "Hello"} {:text " "} {:text "world"}]}]
+           (sgc/parts->contents
+            [{:type :text :text "Hello"}
+             {:type :text :text " "}
+             {:type :text :text "world"}])))))
+
+(deftest ^:parallel parts->contents-tool-call-test
+  (testing "text + tool call merge into a single model content with two parts"
+    (is (= [{:role  "model"
+             :parts [{:text "Let me check..."}
+                     {:functionCall     {:name "search" :args {:query "revenue"}}
+                      :thoughtSignature placeholder-signature}]}]
+           (sgc/parts->contents
+            [{:type :text :text "Let me check..."}
+             {:type :tool-input :id "call-1" :function "search" :arguments {:query "revenue"}}])))))
+
+(deftest ^:parallel parts->contents-tool-result-test
+  (testing "tool output becomes a user-role functionResponse part keyed by function name"
+    (is (= [{:role  "user"
+             :parts [{:functionResponse {:name     "search"
+                                         :response {:output "Found 42 results"}}}]}]
+           (sgc/parts->contents
+            [{:type :tool-output :id "call-1" :function "search" :result {:output "Found 42 results"}}])))))
+
+(deftest ^:parallel parts->contents-tool-error-test
+  (testing "a failed tool output surfaces the error message in the functionResponse"
+    (is (= [{:role  "user"
+             :parts [{:functionResponse {:name     "search"
+                                         :response {:output "Error: boom"}}}]}]
+           (sgc/parts->contents
+            [{:type :tool-output :id "call-1" :function "search" :error {:message "boom"}}])))))
+
+(deftest ^:parallel parts->contents-tool-result-without-output-key-test
+  (testing "a result map that carries no :output is printed rather than sent as an empty response"
+    (is (= [{:role  "user"
+             :parts [{:functionResponse {:name     "search"
+                                         :response {:output "{:rows [1 2]}"}}}]}]
+           (sgc/parts->contents
+            [{:type :tool-output :id "call-1" :function "search" :result {:rows [1 2]}}])))))
+
+(deftest ^:parallel parts->contents-tool-output-with-neither-result-nor-error-test
+  (testing "a tool output with nothing in it sends a 'nil' response"
+    (is (= [{:role  "user"
+             :parts [{:functionResponse {:name "search" :response {:output "nil"}}}]}]
+           (sgc/parts->contents
+            [{:type :tool-output :id "call-1" :function "search"}])))))
+
+(deftest ^:parallel parts->contents-parallel-tool-calls-test
+  (testing "two tool calls and their two results each merge into one content keeping the model/user alternation"
+    (is (= [{:role  "model"
+             :parts [{:functionCall     {:name "f1" :args {:x 1}}
+                      :thoughtSignature placeholder-signature}
+                     {:functionCall     {:name "f2" :args {:y 2}}
+                      :thoughtSignature placeholder-signature}]}
+            {:role  "user"
+             :parts [{:functionResponse {:name "f1" :response {:output "o1"}}}
+                     {:functionResponse {:name "f2" :response {:output "o2"}}}]}]
+           (sgc/parts->contents
+            [{:type :tool-input :id "a" :function "f1" :arguments {:x 1}}
+             {:type :tool-input :id "b" :function "f2" :arguments {:y 2}}
+             {:type :tool-output :id "a" :result {:output "o1"}}
+             {:type :tool-output :id "b" :result {:output "o2"}}])))))
+
+(deftest ^:parallel parts->contents-full-conversation-test
+  (testing "a whole turn alternates user, model, user, model"
+    (is (= [{:role "user" :parts [{:text "What time is it?"}]}
+            {:role  "model"
+             :parts [{:text "Let me check..."}
+                     {:functionCall     {:name "get_time" :args {:tz "Europe/Kyiv"}}
+                      :thoughtSignature placeholder-signature}]}
+            {:role  "user"
+             :parts [{:functionResponse {:name     "get_time"
+                                         :response {:output "2026-02-13T14:00:00+02:00"}}}]}
+            {:role "model" :parts [{:text "It's 2:00 PM in Kyiv."}]}]
+           (sgc/parts->contents
+            [{:role :user :content "What time is it?"}
+             {:type :text :text "Let me check..."}
+             {:type :tool-input :id "call-1" :function "get_time" :arguments {:tz "Europe/Kyiv"}}
+             {:type :tool-output :id "call-1" :result {:output "2026-02-13T14:00:00+02:00"}}
+             {:type :text :text "It's 2:00 PM in Kyiv."}])))))
+
+(deftest ^:parallel parts->contents-tool-output-name-fallback-test
+  (testing "a tool output without :function (history-rebuilt parts) takes its name from the tool-input with the same id"
+    (is (= [{:role "model" :parts [{:functionCall     {:name "search" :args {:q "revenue"}}
+                                    :thoughtSignature placeholder-signature}]}
+            {:role "user"  :parts [{:functionResponse {:name     "search"
+                                                       :response {:output "Found it"}}}]}]
+           (sgc/parts->contents
+            [{:type :tool-input :id "call-1" :function "search" :arguments {:q "revenue"}}
+             {:type :tool-output :id "call-1" :result {:output "Found it"}}]))))
+  (testing "an orphan tool output gets a placeholder name — Gemini rejects a missing one"
+    (is (= [{:role "user" :parts [{:functionResponse {:name     "unknown_function"
+                                                      :response {:output "orphan"}}}]}]
+           (sgc/parts->contents
+            [{:type :tool-output :id "call-9" :result {:output "orphan"}}])))))
+
+(deftest ^:parallel parts->contents-thought-signature-replay-test
+  (testing "a thoughtSignature carried in :provider-metadata is echoed on the replayed functionCall part"
+    (is (= [{:role  "model"
+             :parts [{:functionCall     {:name "search" :args {:q "x"}}
+                      :thoughtSignature "sig-abc"}]}]
+           (sgc/parts->contents
+            [{:type              :tool-input
+              :id                "call-1"
+              :function          "search"
+              :arguments         {:q "x"}
+              :provider-metadata {:google {:thoughtSignature "sig-abc"}}}]))))
+  (testing "the documented bypass signature is sent when the part carries none"
+    (is (= [{:role "model" :parts [{:functionCall     {:name "search" :args {}}
+                                    :thoughtSignature placeholder-signature}]}]
+           (sgc/parts->contents
+            [{:type :tool-input :id "call-1" :function "search" :arguments {}}])))))
+
+(deftest ^:parallel parts->contents-foreign-provider-metadata-test
+  (testing "provider metadata from another provider is not mistaken for a Google signature"
+    (is (= [{:role  "model"
+             :parts [{:functionCall     {:name "search" :args {}}
+                      :thoughtSignature placeholder-signature}]}]
+           (sgc/parts->contents
+            [{:type              :tool-input
+              :id                "call-1"
+              :function          "search"
+              :arguments         {}
+              :provider-metadata {:anthropic {:signature "sig-abc"}}}])))))
+
+(deftest ^:parallel parts->contents-nil-arguments-test
+  (testing "a tool call with nil arguments sends an empty args object"
+    (is (= [{:role "model" :parts [{:functionCall     {:name "todo_read" :args {}}
+                                    :thoughtSignature placeholder-signature}]}]
+           (sgc/parts->contents
+            [{:type :tool-input :id "call-1" :function "todo_read" :arguments nil}])))))
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; request-body tests
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest ^:parallel request-body-system-instruction-test
+  (testing "the system prompt becomes systemInstruction, outside :contents"
+    (is (= {:systemInstruction {:parts [{:text "You are a helpful assistant."}]}
+            :contents          [{:role "user" :parts [{:text "hi"}]}]}
+           (sgc/request-body
+            {:system "You are a helpful assistant."
+             :input  [{:role :user :content "hi"}]})))))
+
+(deftest ^:parallel request-body-no-system-message-test
+  (testing "no systemInstruction is sent when system is not provided"
+    (is (= {:contents [{:role "user" :parts [{:text "hi"}]}]}
+           (sgc/request-body {:input [{:role :user :content "hi"}]})))))
+
+(deftest ^:parallel request-body-generation-config-test
+  (testing "max-tokens and temperature land in generationConfig"
+    (is (= {:contents         [{:role "user" :parts [{:text "hi"}]}]
+            :generationConfig {:maxOutputTokens 256 :temperature 0.2}}
+           (sgc/request-body {:input       [{:role :user :content "hi"}]
+                              :max-tokens  256
+                              :temperature 0.2})))))
+
+(deftest ^:parallel request-body-generation-config-only-when-set-test
+  (testing "maxOutputTokens is omitted when the caller doesn't pass max-tokens, letting the model use its own limit"
+    (is (= {:contents         [{:role "user" :parts [{:text "hi"}]}]
+            :generationConfig {:temperature 0.2}}
+           (sgc/request-body {:input       [{:role :user :content "hi"}]
+                              :temperature 0.2}))))
+  (testing "temperature is omitted when the caller doesn't pass one, letting the model use its own default"
+    (is (= {:contents         [{:role "user" :parts [{:text "hi"}]}]
+            :generationConfig {:maxOutputTokens 256}}
+           (sgc/request-body {:input      [{:role :user :content "hi"}]
+                              :max-tokens 256}))))
+  (testing "no generationConfig is sent when neither max-tokens nor temperature is provided"
+    (is (= {:contents [{:role "user" :parts [{:text "hi"}]}]}
+           (sgc/request-body {:input [{:role :user :content "hi"}]})))))
+
+(deftest ^:parallel request-body-tool-choice-without-tools-test
+  (testing "a tool_choice with no tools to choose from sends no toolConfig, which Gemini rejects on its own"
+    (is (= {:contents [{:role "user" :parts [{:text "hi"}]}]}
+           (sgc/request-body {:input       [{:role :user :content "hi"}]
+                              :tool_choice "required"})))))
+
+(deftest ^:parallel request-body-tools-test
+  (testing "tools become functionDeclarations carrying parametersJsonSchema, and no toolConfig without a tool_choice"
+    (is (=? {:tools      [{:functionDeclarations
+                           [{:name                 "get_weather"
+                             :description          "Get the weather."
+                             :parametersJsonSchema {:type       "object"
+                                                    :properties {:city {:type "string"}}
+                                                    :required   [:city]}}]}]
+             :toolConfig (symbol "nil #_\"key is not present.\"")}
+            (sgc/request-body
+             {:input [{:role :user :content "hi"}]
+              :tools [{:tool-name "get_weather"
+                       :doc       "Get the weather."
+                       :schema    [:=> [:cat [:map [:city :string]]] :any]
+                       :fn        identity}]})))))
+
+(deftest ^:parallel request-body-several-tools-test
+  (testing "several tools share one functionDeclarations array"
+    (is (=? {:tools [{:functionDeclarations [{:name "t1"} {:name "t2"}]}]}
+            (sgc/request-body
+             {:input [{:role :user :content "hi"}]
+              :tools [{:tool-name "t1" :doc "d1"
+                       :schema    [:=> [:cat [:map [:x :string]]] :any]
+                       :fn        identity}
+                      {:tool-name "t2" :doc "d2"
+                       :schema    [:=> [:cat [:map [:y :string]]] :any]
+                       :fn        identity}]})))))
+
+(deftest ^:parallel request-body-tool-choice-test
+  (testing "tool_choice maps to functionCallingConfig mode"
+    (let [body-for (fn [tool-choice]
+                     (sgc/request-body
+                      {:input       [{:role :user :content "hi"}]
+                       :tools       [{:tool-name "t" :doc "d"
+                                      :schema    [:=> [:cat [:map [:x :string]]] :any]
+                                      :fn        identity}]
+                       :tool_choice tool-choice}))]
+      (is (=? {:toolConfig {:functionCallingConfig {:mode "AUTO"}}}
+              (body-for "auto")))
+      (is (=? {:toolConfig {:functionCallingConfig {:mode "ANY"}}}
+              (body-for "required"))))))
+
+(deftest ^:parallel request-body-structured-output-test
+  (testing "a :schema forces a structured_output function call via mode ANY + allowedFunctionNames"
+    (let [schema {:type "object" :properties {:sql {:type "string"}}}]
+      (is (= {:contents   [{:role "user" :parts [{:text "hi"}]}]
+              :tools      [{:functionDeclarations [{:name                 "structured_output"
+                                                    :description          "Output structured data"
+                                                    :parametersJsonSchema schema}]}]
+              :toolConfig {:functionCallingConfig {:mode                 "ANY"
+                                                   :allowedFunctionNames ["structured_output"]}}}
+             (sgc/request-body
+              {:input  [{:role :user :content "hi"}]
+               :schema schema}))))))
+
+(deftest ^:parallel request-body-structured-output-replaces-tools-test
+  (testing "a :schema replaces the caller's tools and tool_choice"
+    (is (= {:contents   [{:role "user" :parts [{:text "hi"}]}]
+            :tools      [{:functionDeclarations [{:name                 "structured_output"
+                                                  :description          "Output structured data"
+                                                  :parametersJsonSchema {:type "object"}}]}]
+            :toolConfig {:functionCallingConfig {:mode                 "ANY"
+                                                 :allowedFunctionNames ["structured_output"]}}}
+           (sgc/request-body
+            {:input       [{:role :user :content "hi"}]
+             :tools       [{:tool-name "get_weather" :doc "Get the weather."
+                            :schema    [:=> [:cat [:map [:city :string]]] :any]
+                            :fn        identity}]
+             :tool_choice "auto"
+             :schema      {:type "object"}})))))
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; Streaming event conversion tests.
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest ^:parallel text-conv-test
+  (testing "streamed text events map through the full pipeline into one coalesced text part"
+    (let [events [{:responseId "r1" :modelVersion "gemini-3.5-flash"
+                   :candidates [{:content {:role "model" :parts [{:text "Hel"}]} :index 0}]}
+                  {:candidates [{:content {:role "model" :parts [{:text "lo"}]}}]}
+                  {:candidates [{:content {:role "model" :parts []} :finishReason "STOP"}]
+                   :usageMetadata {:promptTokenCount 5 :candidatesTokenCount 2 :totalTokenCount 7}}]]
+      (is (=? [{:type :start} {:type :text-start} {:type :text-delta} {:type :text-end} {:type :usage}]
+              (into [] (comp (sgc/->aisdk-chunks-xf) (m/distinct-by :type)) events)))
+      (is (=? [{:type :start :id "r1"}
+               {:type :text :text "Hello"}
+               {:type  :usage
+                :model "gemini-3.5-flash"
+                :usage {:promptTokens 5 :completionTokens 2}}]
+              (into [] (comp (sgc/->aisdk-chunks-xf) (self.core/aisdk-xf)) events))))))
+
+(deftest ^:parallel tool-call-conv-test
+  (testing "a functionCall part maps to a tool-input part with parsed arguments"
+    (let [events [{:responseId "r2" :modelVersion "gemini-3.5-flash"
+                   :candidates [{:content {:role "model"
+                                           :parts [{:functionCall {:name "get_time" :args {:tz "UTC"}}}]}
+                                 :finishReason "STOP"}]
+                   :usageMetadata {:promptTokenCount 8 :candidatesTokenCount 4}}]]
+      (is (=? [{:type :start}
+               {:type      :tool-input
+                :function  "get_time"
+                :arguments {:tz "UTC"}}
+               {:type :usage :usage {:promptTokens 8 :completionTokens 4}}]
+              (into [] (comp (sgc/->aisdk-chunks-xf) (self.core/aisdk-xf)) events))))))
+
+(deftest ^:parallel thought-signature-round-trip-test
+  (testing "a streamed thoughtSignature survives through the chunk pipeline into the :tool-input part"
+    (let [events [{:responseId "r-sig"
+                   :candidates [{:content {:role  "model"
+                                           :parts [{:functionCall     {:name "get_time" :args {:tz "UTC"}}
+                                                    :thoughtSignature "sig-abc"}]}
+                                 :finishReason "STOP"}]}]
+          parts  (into [] (comp (sgc/->aisdk-chunks-xf) (self.core/aisdk-xf)) events)
+          tool   (first (filter #(= :tool-input (:type %)) parts))]
+      (is (=? {:provider-metadata {:google {:thoughtSignature "sig-abc"}}}
+              tool))
+      (is (=? [{:role  "model"
+                :parts [{:functionCall     {:name "get_time"}
+                         :thoughtSignature "sig-abc"}]}]
+              (sgc/parts->contents [tool]))))))
+
+(deftest ^:parallel parallel-tool-calls-conv-test
+  (testing "multiple functionCall parts in one event become distinct tool-input parts"
+    (let [events [{:responseId "r3"
+                   :candidates [{:content {:role "model"
+                                           :parts [{:functionCall {:name "a" :args {:x 1}}}
+                                                   {:functionCall {:name "b" :args {:y 2}}}]}
+                                 :finishReason "STOP"}]}]
+          parts  (into [] (comp (sgc/->aisdk-chunks-xf) (self.core/aisdk-xf)) events)
+          tools  (filterv #(= :tool-input (:type %)) parts)]
+      (is (=? [{:function "a" :arguments {:x 1}}
+               {:function "b" :arguments {:y 2}}]
+              tools))
+      (is (apply distinct? (map :id tools))
+          "each generated toolCallId is unique"))))
+
+(deftest ^:parallel text-then-tool-call-closes-text-test
+  (testing "a functionCall closes the open text block before the tool chunks"
+    (let [events [{:responseId "r4"
+                   :candidates [{:content {:role "model" :parts [{:text "Looking..."}]}}]}
+                  {:candidates [{:content {:role "model"
+                                           :parts [{:functionCall {:name "search" :args {}}}]}
+                                 :finishReason "STOP"}]}]]
+      (is (=? [{:type :start}
+               {:type :text-start}
+               {:type :text-delta}
+               {:type :text-end}
+               {:type :tool-input-start}
+               {:type :tool-input-delta}
+               {:type :tool-input-available}]
+              (into [] (sgc/->aisdk-chunks-xf) events))))))
+
+(deftest ^:parallel empty-text-part-between-tool-calls-does-not-divide-them-test
+  (testing "an empty text part opens no text block, thus it leaves the tool calls around it whole"
+    (let [events [{:responseId "r4b"
+                   :candidates [{:content {:role  "model"
+                                           :parts [{:functionCall {:name "a" :args {}}}
+                                                   {:text ""}
+                                                   {:functionCall {:name "b" :args {}}}]}
+                                 :finishReason "STOP"}]}]]
+      (is (=? [{:type :start}
+               {:type :tool-input-start :toolName "a"}
+               {:type :tool-input-delta}
+               {:type :tool-input-available :toolName "a"}
+               {:type :tool-input-start :toolName "b"}
+               {:type :tool-input-delta}
+               {:type :tool-input-available :toolName "b"}]
+              (into [] (sgc/->aisdk-chunks-xf) events))))))
+
+(deftest ^:parallel whitespace-text-delta-kept-inside-an-open-block-test
+  (testing "a blank delta inside an open text block passes through, thus the space between two words survives"
+    (let [events [{:responseId "r4c"
+                   :candidates [{:content {:role  "model"
+                                           :parts [{:text "Hello"} {:text " "} {:text "world"}]}
+                                 :finishReason "STOP"}]}]]
+      (is (=? [{:type :start}
+               {:type :text :text "Hello world"}]
+              (into [] (comp (sgc/->aisdk-chunks-xf) (self.core/aisdk-xf)) events))))))
+
+(deftest ^:parallel thought-parts-ignored-test
+  (testing "thinking summaries are dropped"
+    (let [events [{:responseId "r5"
+                   :candidates [{:content {:role "model"
+                                           :parts [{:thought true :text "reasoning..."}
+                                                   {:text "Answer"}]}
+                                 :finishReason "STOP"}]}]]
+      (is (=? [{:type :start}
+               {:type :text :text "Answer"}]
+              (into [] (comp (sgc/->aisdk-chunks-xf) (self.core/aisdk-xf)) events))))))
+
+(deftest ^:parallel usage-buffered-and-emitted-once-test
+  (testing "usageMetadata is buffered last-wins and emitted once at stream end, after content"
+    (let [events [{:responseId "r6" :modelVersion "gemini-3.5-flash"
+                   :candidates [{:content {:role "model" :parts [{:text "Hi"}]}}]
+                   :usageMetadata {:promptTokenCount 10}}
+                  {:candidates [{:content {:role "model" :parts [{:text " there"}]} :finishReason "STOP"}]
+                   :usageMetadata {:promptTokenCount 10 :candidatesTokenCount 2 :totalTokenCount 12}}]
+          out    (into [] (sgc/->aisdk-chunks-xf) events)
+          usages (filterv #(= :usage (:type %)) out)]
+      (is (=? {:type :usage} (last out)))
+      (is (=? [{:type  :usage
+                :usage {:promptTokens       10
+                        :completionTokens    2
+                        :cacheCreationTokens 0
+                        :cacheReadTokens     0}}]
+              usages)))))
+
+(deftest ^:parallel usage-thoughts-and-cache-tokens-test
+  (testing "thoughtsTokenCount folds into completionTokens; cachedContentTokenCount maps to cacheReadTokens"
+    (let [events [{:responseId "r7"
+                   :candidates [{:content {:role "model" :parts [{:text "Hi"}]} :finishReason "STOP"}]
+                   :usageMetadata {:promptTokenCount        5000
+                                   :candidatesTokenCount    7
+                                   :thoughtsTokenCount      93
+                                   :cachedContentTokenCount 4200
+                                   :totalTokenCount         5100}}]
+          usage  (->> (into [] (sgc/->aisdk-chunks-xf) events)
+                      (filter #(= :usage (:type %)))
+                      first)]
+      (is (=? {:usage {:promptTokens        5000
+                       :completionTokens    100
+                       :cacheCreationTokens 0
+                       :cacheReadTokens     4200}}
+              usage)))))
+
+(deftest ^:parallel usage-tool-use-prompt-tokens-test
+  (testing "toolUsePromptTokenCount is a bucket of its own and sums into promptTokens rather than being dropped"
+    (let [events [{:responseId "r7b"
+                   :candidates [{:content {:role "model" :parts [{:text "Hi"}]} :finishReason "STOP"}]
+                   :usageMetadata {:promptTokenCount        30
+                                   :candidatesTokenCount    7
+                                   :toolUsePromptTokenCount 120
+                                   :totalTokenCount         157}}]
+          usage  (->> (into [] (sgc/->aisdk-chunks-xf) events)
+                      (filter #(= :usage (:type %)))
+                      first)]
+      (is (=? {:usage {:promptTokens        150
+                       :completionTokens    7
+                       :cacheCreationTokens 0
+                       :cacheReadTokens     0}}
+              usage)))))
+
+(deftest ^:parallel model-version-from-a-later-event-test
+  (testing "modelVersion can arrive on any event, and the last one reaches the :usage chunk"
+    (let [events [{:responseId "r7c"
+                   :candidates [{:content {:role "model" :parts [{:text "hi"}]}}]}
+                  {:candidates    [{:finishReason "STOP"}]
+                   :modelVersion  "gemini-3.5-pro"
+                   :usageMetadata {:promptTokenCount 1}}]]
+      (is (=? {:type :usage :model "gemini-3.5-pro"}
+              (last (into [] (sgc/->aisdk-chunks-xf) events)))))))
+
+(deftest ^:parallel missing-response-id-gets-a-generated-message-id-test
+  (testing "a stream with no responseId still gets a message id, thus the parts downstream group under one"
+    (let [events [{:candidates [{:content {:role "model" :parts [{:text "hi"}]} :finishReason "STOP"}]}]]
+      (is (=? [{:type :start :messageId #"mb-.+"}
+               {:type :text-start}
+               {:type :text-delta}
+               {:type :text-end}]
+              (into [] (sgc/->aisdk-chunks-xf) events))))))
+
+(deftest ^:parallel blocked-prompt-test
+  (testing "a blocked prompt (promptFeedback.blockReason, no candidates) emits an error part"
+    (let [events [{:responseId     "r8"
+                   :promptFeedback {:blockReason "PROHIBITED_CONTENT"}
+                   :usageMetadata  {:promptTokenCount 12}}]]
+      (is (=? [{:type :start}
+               {:type :error :error {:message "Prompt blocked by Google: PROHIBITED_CONTENT"}}
+               {:type :usage}]
+              (into [] (comp (sgc/->aisdk-chunks-xf) (self.core/aisdk-xf)) events))))))
+
+(deftest ^:parallel max-tokens-finish-reason-test
+  (testing "a MAX_TOKENS truncation emits an error part after the partial text, instead of reading as a complete answer"
+    (let [events [{:responseId "r11" :modelVersion "gemini-3.5-flash"
+                   :candidates [{:content {:role "model" :parts [{:text "half an ans"}]}
+                                 :finishReason "MAX_TOKENS"}]
+                   :usageMetadata {:promptTokenCount 4 :thoughtsTokenCount 2000}}]]
+      (is (=? [{:type :start}
+               {:type :text :text "half an ans"}
+               {:type  :error
+                :error {:message #"(?s)Gemini stopped early \(MAX_TOKENS\): the output token limit was reached.*"}}
+               {:type :usage}]
+              (into [] (comp (sgc/->aisdk-chunks-xf) (self.core/aisdk-xf)) events))))))
+
+(deftest ^:parallel malformed-function-call-finish-reason-test
+  (testing "MALFORMED_FUNCTION_CALL arrives with no parts at all, so the error part is the only diagnostic"
+    (let [events [{:responseId "r12"
+                   :candidates [{:finishReason "MALFORMED_FUNCTION_CALL"}]}]]
+      (is (=? [{:type :start}
+               {:type  :error
+                :error {:message #"(?s)Gemini stopped early \(MALFORMED_FUNCTION_CALL\).*"}}]
+              (into [] (comp (sgc/->aisdk-chunks-xf) (self.core/aisdk-xf)) events))))))
+
+(deftest ^:parallel unknown-finish-reason-test
+  (testing "a finish reason we have no message for still reports itself rather than passing silently"
+    (let [events [{:responseId "r13"
+                   :candidates [{:content {:role "model" :parts [{:text "hi"}]}
+                                 :finishReason "SOMETHING_NEW"}]}]]
+      (is (=? [{:type :start}
+               {:type :text :text "hi"}
+               {:type :error :error {:message "Gemini stopped early (SOMETHING_NEW)"}}]
+              (into [] (comp (sgc/->aisdk-chunks-xf) (self.core/aisdk-xf)) events))))))
+
+(deftest ^:parallel stop-finish-reason-emits-no-error-test
+  (testing "STOP is the one reason that means the model finished, and it emits no error part"
+    (let [events [{:responseId "r14"
+                   :candidates [{:content {:role "model" :parts [{:text "all done"}]}
+                                 :finishReason "STOP"}]}]]
+      (is (=? [{:type :start}
+               {:type :text :text "all done"}]
+              (into [] (comp (sgc/->aisdk-chunks-xf) (self.core/aisdk-xf)) events))))))
+
+(deftest ^:parallel in-stream-error-test
+  (testing "an error envelope in the stream becomes an error part"
+    (let [events [{:responseId "r9"
+                   :candidates [{:content {:role "model" :parts [{:text "partial"}]}}]}
+                  {:error {:code 503 :message "The model is overloaded." :status "UNAVAILABLE"}}]]
+      (is (=? [{:type :start}
+               {:type :text :text "partial"}
+               {:type :error :error {:message "The model is overloaded."}}]
+              (into [] (comp (sgc/->aisdk-chunks-xf) (self.core/aisdk-xf)) events))))))
+
+(deftest ^:parallel in-stream-error-without-a-message-test
+  (testing "an error envelope with no message is printed, thus the failure is never silent"
+    (let [events [{:responseId "r9b"
+                   :error      {:code 500 :status "INTERNAL"}}]]
+      (is (=? [{:type :start}
+               {:type :error :error {:message "{:code 500, :status \"INTERNAL\"}"}}]
+              (into [] (comp (sgc/->aisdk-chunks-xf) (self.core/aisdk-xf)) events))))))
+
+(deftest ^:parallel interrupted-stream-flushes-text-and-usage-test
+  (testing "when the stream ends without a finishReason, the open text block and buffered usage still flush"
+    (let [events [{:responseId "r10" :modelVersion "gemini-3.5-flash"
+                   :candidates [{:content {:role "model" :parts [{:text "partial answer"}]}}]
+                   :usageMetadata {:promptTokenCount 4}}]]
+      (is (=? [{:type :start}
+               {:type :text :text "partial answer"}
+               {:type :usage :usage {:promptTokens 4 :completionTokens 0}}]
+              (into [] (comp (sgc/->aisdk-chunks-xf) (self.core/aisdk-xf)) events))))))

--- a/test/metabase/metabot/self/google_test.clj
+++ b/test/metabase/metabot/self/google_test.clj
@@ -1,0 +1,793 @@
+(ns metabase.metabot.self.google-test
+  (:require
+   [clj-http.client :as http]
+   [clojure.core.memoize :as memoize]
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.llm.settings :as llm.settings]
+   [metabase.metabot.self.core :as self.core]
+   [metabase.metabot.self.debug :as debug]
+   [metabase.metabot.self.google :as google]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.test :as mt]
+   [metabase.util.json :as json])
+  (:import
+   (com.google.auth.oauth2 GoogleCredentials ServiceAccountCredentials)
+   (java.io IOException)
+   (java.security KeyPairGenerator)
+   (java.util Base64)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private test-private-key-pem
+  "PEM of a generated RSA key, so the real credential parser accepts it."
+  (delay
+    (let [key-pair (.generateKeyPair (doto (KeyPairGenerator/getInstance "RSA")
+                                       (.initialize 2048)))]
+      (str "-----BEGIN PRIVATE KEY-----\n"
+           (.encodeToString (Base64/getMimeEncoder 64 (byte-array [10]))
+                            (.getEncoded (.getPrivate key-pair)))
+           "\n-----END PRIVATE KEY-----\n"))))
+
+(defn- test-service-account-json
+  "A structurally valid service account key JSON for `project-id`."
+  [project-id]
+  (json/encode {:type           "service_account"
+                :project_id     project-id
+                :private_key_id "test-key-id"
+                :private_key    @test-private-key-pem
+                :client_email   (str "metabot-test@" project-id ".iam.gserviceaccount.com")
+                :client_id      "123456789012345678901"
+                :token_uri      "https://oauth2.googleapis.com/token"}))
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; Auth / HTTP tests
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest google-raw-project-scoped-url-test
+  (testing "requests are scoped to projects/{p}/locations/{l}, location defaulting to global, with a Bearer header"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            nil]
+      (mt/with-dynamic-fn-redefs [self.core/sse-reducible identity
+                                  debug/capture-stream    (fn [r _] r)
+                                  http/request            (fn [req] {:body req})]
+        (is (=? {:method  :post
+                 :url     (str "https://aiplatform.googleapis.com/v1/projects/my-project/locations/global"
+                               "/publishers/google/models/gemini-3.5-flash:streamGenerateContent?alt=sse")
+                 :headers {"Authorization" "Bearer ya29.pasted-access-token"}
+                 :body    string?}
+                (google/google-raw {:model "google/gemini-3.5-flash" :input [{:role :user :content "hi"}]})))))))
+
+(deftest google-raw-default-model-test
+  (testing "a request that does not name a model uses google/gemini-3.5-flash"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            nil]
+      (mt/with-dynamic-fn-redefs [self.core/sse-reducible identity
+                                  debug/capture-stream    (fn [r _] r)
+                                  http/request            (fn [req] {:body req})]
+        (is (=? {:url (str "https://aiplatform.googleapis.com/v1/projects/my-project/locations/global"
+                           "/publishers/google/models/gemini-3.5-flash:streamGenerateContent?alt=sse")}
+                (google/google-raw {:input [{:role :user :content "hi"}]})))))))
+
+(deftest google-raw-request-body-test
+  (testing "the request streams its response and carries the streamGenerateContent body as JSON"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            nil]
+      (mt/with-dynamic-fn-redefs [self.core/sse-reducible identity
+                                  debug/capture-stream    (fn [r _] r)
+                                  http/request            (fn [req] {:body req})]
+        (let [req (google/google-raw {:model "google/gemini-3.5-flash"
+                                      :input [{:role :user :content "hi"}]})]
+          (is (=? {:as      :stream
+                   :headers {"Content-Type" "application/json"}}
+                  req))
+          (is (= {:contents [{:role "user" :parts [{:text "hi"}]}]}
+                 (json/decode+kw (:body req)))))))))
+
+(deftest google-raw-regional-location-host-test
+  (testing "a regional location is served by its own regional host, which the path must agree with"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            "us-central1"]
+      (mt/with-dynamic-fn-redefs [self.core/sse-reducible identity
+                                  debug/capture-stream    (fn [r _] r)
+                                  http/request            (fn [req] {:body req})]
+        (is (=? {:url (str "https://us-central1-aiplatform.googleapis.com/v1/projects/my-project"
+                           "/locations/us-central1/publishers/google/models"
+                           "/gemini-3.5-flash:streamGenerateContent?alt=sse")}
+                (google/google-raw {:model "google/gemini-3.5-flash" :input [{:role :user :content "hi"}]})))))))
+
+(deftest google-raw-multi-region-host-test
+  (testing "the us/eu multi-region locations are served by their `rep` host, not the regional spelling"
+    (doseq [location ["us" "eu"]]
+      (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                         llm.settings/llm-google-service-account-key nil
+                                         llm.settings/llm-google-project-id          "my-project"
+                                         llm.settings/llm-google-location            location]
+        (mt/with-dynamic-fn-redefs [self.core/sse-reducible identity
+                                    debug/capture-stream    (fn [r _] r)
+                                    http/request            (fn [req] {:body req})]
+          (is (=? {:url (format (str "https://aiplatform.%s.rep.googleapis.com"
+                                     "/v1/projects/my-project/locations/%s"
+                                     "/publishers/google/models/gemini-3.5-flash:streamGenerateContent?alt=sse")
+                                location location)}
+                  (google/google-raw {:model "google/gemini-3.5-flash" :input [{:role :user :content "hi"}]}))))))))
+
+(deftest google-raw-invalid-location-rejected-test
+  (testing "a location that cannot be a host is rejected with its own message"
+    ;; the setter rejects these, so only an env var can put one in place
+    (doseq [location ["us central1" "us-central1/" "https://us-central1-aiplatform.googleapis.com"]]
+      (mt/with-temp-env-var-value! [mb-llm-google-location location]
+        (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                           llm.settings/llm-google-service-account-key nil
+                                           llm.settings/llm-google-project-id          "my-project"]
+          (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+            (let [e (try (google/google-raw {:model "google/gemini-3.5-flash" :input [{:role :user :content "hi"}]})
+                         nil
+                         (catch Exception e e))]
+              (is (= (str "\"" location "\" is not a valid Google Cloud location. Use a location ID like"
+                          " \"us-central1\", or leave it blank to use the global location.")
+                     (ex-message e)))
+              (is (=? {:api-error   true
+                       :status-code 400
+                       :error-code  :invalid-location}
+                      (ex-data e))))))))))
+
+(deftest effective-location-accepts-served-locations-test
+  (testing "the location spellings the platform serves all pass validation"
+    (doseq [location ["global" "us" "eu" "us-central1" "europe-west4" "asia-northeast1"]]
+      (is (= location (#'google/effective-location {:location location}))))))
+
+(def ^:private invalid-project-id-message
+  "The message [[metabase.metabot.self.google/effective-project-id]] throws, less the offending ID."
+  (str " is not a valid Google Cloud project ID. Use the project ID — 6 to 30 lowercase letters, digits and"
+       " hyphens — rather than the project name or number."))
+
+(deftest google-raw-invalid-project-id-rejected-test
+  (testing "a project ID that cannot be a path segment is rejected with its own message"
+    ;; the setter rejects these, so only an env var can put one in place
+    (doseq [project-id ["my-project/../../evil" "my project" "MY-PROJECT"]]
+      (mt/with-temp-env-var-value! [mb-llm-google-project-id project-id]
+        (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                           llm.settings/llm-google-service-account-key nil]
+          (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+            (let [e (try (google/google-raw {:model "google/gemini-3.5-flash" :input [{:role :user :content "hi"}]})
+                         nil
+                         (catch Exception e e))]
+              (is (= (str "\"" project-id "\"" invalid-project-id-message)
+                     (ex-message e)))
+              (is (=? {:api-error   true
+                       :status-code 400
+                       :error-code  :invalid-project-id}
+                      (ex-data e))))))))))
+
+(deftest list-models-invalid-credentials-project-id-rejected-test
+  (testing "a connect-time project ID override is validated too"
+    (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+      (let [e (try (google/list-models {:model       "google/gemini-3.5-flash"
+                                        :credentials {:oauth-access-token "ya29.token"
+                                                      :project-id         "my-project/../../evil"}})
+                   nil
+                   (catch Exception e e))]
+        (is (= (str "\"my-project/../../evil\"" invalid-project-id-message)
+               (ex-message e)))
+        (is (=? {:api-error   true
+                 :status-code 400
+                 :error-code  :invalid-project-id}
+                (ex-data e)))))))
+
+(deftest google-raw-service-account-json-project-id-rejected-test
+  (testing "the project ID carried by a service account key JSON is validated as well"
+    (let [sa-key (test-service-account-json "Not-A-Project")]
+      (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                         llm.settings/llm-google-service-account-key sa-key
+                                         llm.settings/llm-google-project-id          nil]
+        (mt/with-dynamic-fn-redefs [http/request                (fn [_] (throw (ex-info "should never be called" {})))
+                                    google/fresh-bearer-headers (constantly {"Authorization" "Bearer test-sa-token"})]
+          (let [e (try (google/google-raw {:model "google/gemini-3.5-flash" :input [{:role :user :content "hi"}]})
+                       nil
+                       (catch Exception e e))]
+            (is (= (str "\"Not-A-Project\"" invalid-project-id-message)
+                   (ex-message e)))
+            (is (=? {:api-error   true
+                     :status-code 400
+                     :error-code  :invalid-project-id}
+                    (ex-data e)))))))))
+
+(deftest google-raw-explicit-base-url-not-derived-test
+  (testing "an admin-set base URL is left alone — a regional location does not rewrite it"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            "us-central1"
+                                       llm.settings/llm-google-api-base-url        "https://gemini.proxy.example.com"]
+      (mt/with-dynamic-fn-redefs [self.core/sse-reducible identity
+                                  debug/capture-stream    (fn [r _] r)
+                                  http/request            (fn [req] {:body req})]
+        (is (=? {:url (str "https://gemini.proxy.example.com/v1/projects/my-project/locations/us-central1"
+                           "/publishers/google/models/gemini-3.5-flash:streamGenerateContent?alt=sse")}
+                (google/google-raw {:model "google/gemini-3.5-flash" :input [{:role :user :content "hi"}]})))))))
+
+(deftest google-raw-non-google-publisher-model-test
+  (testing "the publisher comes from the model ID's {publisher}/{model} qualifier"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            nil]
+      (mt/with-dynamic-fn-redefs [self.core/sse-reducible identity
+                                  debug/capture-stream    (fn [r _] r)
+                                  http/request            (fn [req] {:body req})]
+        (is (=? {:url (str "https://aiplatform.googleapis.com/v1/projects/my-project/locations/global"
+                           "/publishers/anthropic/models/claude-sonnet-4-6:streamGenerateContent?alt=sse")}
+                (google/google-raw {:model "anthropic/claude-sonnet-4-6" :input [{:role :user :content "hi"}]})))))))
+
+(def ^:private bare-model-id-message-re
+  "The message [[metabase.metabot.self.google/model-resource-path]] throws for an unqualified model ID."
+  #"Invalid Google model \"gemini-3\.5-flash\" — expected a publisher-qualified ID like \"google/gemini-3\.5-flash\"")
+
+(deftest google-raw-bare-model-id-throws-test
+  (testing "a bare model ID without a publisher qualifier throws instead of assuming the google publisher"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            nil]
+      (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             bare-model-id-message-re
+             (google/google-raw {:model "gemini-3.5-flash" :input [{:role :user :content "hi"}]})))))))
+
+(deftest google-raw-blank-model-id-throws-test
+  (testing "a model ID with a publisher qualifier but no model segment throws before any HTTP call"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            nil]
+      (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Invalid Google model \"google/\""
+             (google/google-raw {:model "google/" :input [{:role :user :content "hi"}]})))))))
+
+(deftest google-raw-invalid-model-characters-rejected-test
+  (testing "a model whose segments cannot be path segments is rejected before any HTTP call"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            nil]
+      (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+        (doseq [model ["google/../../../v1beta1/evil"
+                       "../../../v1beta1/evil"
+                       "google/models/gemini-3.5-flash"
+                       "google/gemini-3.5-flash?alt=json"
+                       "google/gemini-3.5-flash#"
+                       "google/gemini 3.5 flash"
+                       "Google/gemini-3.5-flash"]]
+          (let [e (try (google/google-raw {:model model :input [{:role :user :content "hi"}]})
+                       nil
+                       (catch Exception e e))]
+            (is (= (str "Invalid Google model " (pr-str model) " — a publisher and model ID can hold only letters,"
+                        " digits, and the characters \".\", \"_\", \"-\" and \"@\"")
+                   (ex-message e)))
+            (is (=? {:api-error   true
+                     :status-code 400
+                     :error-code  :invalid-model}
+                    (ex-data e)))))))))
+
+(deftest google-raw-versioned-partner-model-test
+  (testing "the @-versioned model ID that Model Garden partner models use survives validation"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            nil]
+      (mt/with-dynamic-fn-redefs [self.core/sse-reducible identity
+                                  debug/capture-stream    (fn [r _] r)
+                                  http/request            (fn [req] {:body req})]
+        (is (=? {:url (str "https://aiplatform.googleapis.com/v1/projects/my-project/locations/global"
+                           "/publishers/anthropic/models/claude-sonnet-4-5@20250929:streamGenerateContent?alt=sse")}
+                (google/google-raw {:model "anthropic/claude-sonnet-4-5@20250929"
+                                    :input [{:role :user :content "hi"}]})))))))
+
+(deftest google-raw-token-without-project-throws-test
+  (testing "an OAuth access token without a project ID throws before any HTTP call"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          nil]
+      (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"A Google Cloud project ID is required for the Google provider"
+             (google/google-raw {:model "google/gemini-3.5-flash" :input [{:role :user :content "hi"}]})))))))
+
+(deftest google-raw-missing-credentials-test
+  (testing "with no credential configured requests throw before any HTTP call"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                       llm.settings/llm-google-service-account-key nil]
+      (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"No Google API key is set"
+             (google/google-raw {:model "google/gemini-3.5-flash" :input [{:role :user :content "hi"}]})))))))
+
+(deftest google-raw-service-account-bearer-auth-test
+  (testing "a service account key authenticates with a Bearer token and with the project ID read from the key JSON"
+    (let [sa-key (test-service-account-json "json-project")]
+      (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                         llm.settings/llm-google-service-account-key sa-key
+                                         llm.settings/llm-google-project-id          nil
+                                         llm.settings/llm-google-location            nil]
+        (mt/with-dynamic-fn-redefs [self.core/sse-reducible     identity
+                                    debug/capture-stream        (fn [r _] r)
+                                    http/request                (fn [req] {:body req})
+                                    google/fresh-bearer-headers (constantly {"Authorization" "Bearer test-sa-token"})]
+          (is (=? {:url     (str "https://aiplatform.googleapis.com/v1/projects/json-project/locations/global"
+                                 "/publishers/google/models/gemini-3.5-flash:streamGenerateContent?alt=sse")
+                   :headers {"Authorization" "Bearer test-sa-token"}}
+                  (google/google-raw {:model "google/gemini-3.5-flash" :input [{:role :user :content "hi"}]}))))))))
+
+(deftest google-raw-service-account-explicit-project-wins-test
+  (testing "an explicit project ID setting overrides the one embedded in the service account key"
+    (let [sa-key (test-service-account-json "json-project")]
+      (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                         llm.settings/llm-google-service-account-key sa-key
+                                         llm.settings/llm-google-project-id          "explicit-project"
+                                         llm.settings/llm-google-location            nil]
+        (mt/with-dynamic-fn-redefs [self.core/sse-reducible     identity
+                                    debug/capture-stream        (fn [r _] r)
+                                    http/request                (fn [req] {:body req})
+                                    google/fresh-bearer-headers (constantly {"Authorization" "Bearer test-sa-token"})]
+          (is (=? {:url (str "https://aiplatform.googleapis.com/v1/projects/explicit-project/locations/global"
+                             "/publishers/google/models/gemini-3.5-flash:streamGenerateContent?alt=sse")}
+                  (google/google-raw {:model "google/gemini-3.5-flash" :input [{:role :user :content "hi"}]}))))))))
+
+(deftest google-raw-service-account-precedence-over-oauth-token-test
+  (testing "a service account key takes precedence over a configured OAuth access token"
+    (let [sa-key (test-service-account-json "json-project")]
+      (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                         llm.settings/llm-google-service-account-key sa-key
+                                         llm.settings/llm-google-project-id          nil
+                                         llm.settings/llm-google-location            nil]
+        (mt/with-dynamic-fn-redefs [self.core/sse-reducible     identity
+                                    debug/capture-stream        (fn [r _] r)
+                                    http/request                (fn [req] {:body req})
+                                    google/fresh-bearer-headers (constantly {"Authorization" "Bearer test-sa-token"})]
+          (is (=? {:headers {"Authorization" "Bearer test-sa-token"}}
+                  (google/google-raw {:model "google/gemini-3.5-flash" :input [{:role :user :content "hi"}]}))))))))
+
+(deftest parse-service-account-credentials-scope-test
+  (testing "service account tokens carry the correct scope"
+    (let [^ServiceAccountCredentials creds (#'google/parse-service-account-credentials
+                                            (test-service-account-json "scope-project"))]
+      (is (= ["https://www.googleapis.com/auth/cloud-platform"]
+             (vec (.getScopes creds)))))))
+
+(deftest google-raw-invalid-service-account-key-test
+  (testing "a service account key the auth library rejects throws before any HTTP call"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                       llm.settings/llm-google-service-account-key "{\"type\": \"service_account\"}"
+                                       llm.settings/llm-google-project-id          "my-project"]
+      (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Invalid Google service account key"
+             (google/google-raw {:model "google/gemini-3.5-flash" :input [{:role :user :content "hi"}]})))))))
+
+(deftest google-raw-invalid-service-account-key-status-test
+  (testing "a rejected service account key is tagged as a 400 so the connect form shows the message"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                       llm.settings/llm-google-service-account-key "{\"type\": \"service_account\"}"
+                                       llm.settings/llm-google-project-id          "my-project"]
+      (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+        (let [e (try (google/google-raw {:model "google/gemini-3.5-flash" :input [{:role :user :content "hi"}]})
+                     nil
+                     (catch Exception e e))]
+          (is (=? {:api-error   true
+                   :status-code 400
+                   :error-code  :invalid-service-account-key}
+                  (ex-data e))))))))
+
+(deftest google-raw-user-credential-key-test
+  (testing "a gcloud user credential JSON is rejected"
+    (let [user-credential-json (json/encode {:type          "authorized_user"
+                                             :client_id     "test-client-id"
+                                             :client_secret "test-client-secret"
+                                             :refresh_token "1//test-refresh-token"})]
+      (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                         llm.settings/llm-google-service-account-key user-credential-json
+                                         llm.settings/llm-google-project-id          "my-project"]
+        (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+          (let [e (try (google/google-raw {:model "google/gemini-3.5-flash" :input [{:role :user :content "hi"}]})
+                       nil
+                       (catch Exception e e))]
+            (is (= "This Google credential JSON is not a service account key."
+                   (ex-message e)))
+            (is (=? {:api-error   true
+                     :status-code 400
+                     :error-code  :not-a-service-account-key}
+                    (ex-data e)))))))))
+
+(deftest google-raw-non-object-service-account-key-test
+  (testing "a service account key JSON that is not an object gets the invalid-key message"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                       llm.settings/llm-google-service-account-key "[]"
+                                       llm.settings/llm-google-project-id          "my-project"]
+      (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+        (let [e (try (google/google-raw {:model "google/gemini-3.5-flash" :input [{:role :user :content "hi"}]})
+                     nil
+                     (catch Exception e e))]
+          (is (= "Invalid Google service account key" (ex-message e)))
+          (is (=? {:api-error   true
+                   :status-code 400
+                   :error-code  :invalid-service-account-key}
+                  (ex-data e))))))))
+
+(deftest google-raw-service-account-credentials-cached-test
+  (testing "repeated requests with the same service account key parse it once and reuse the credentials object"
+    (let [sa-key (test-service-account-json "sa-credentials-cached-test")
+          parses (atom 0)
+          orig   (mt/original-fn #'google/parse-service-account-credentials)]
+      ;; evict any entry from an earlier run in this JVM, so the test starts with a cache miss
+      (memoize/memo-clear! @#'google/cached-service-account-credentials [sa-key])
+      (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                         llm.settings/llm-google-service-account-key sa-key
+                                         llm.settings/llm-google-project-id          nil
+                                         llm.settings/llm-google-location            nil]
+        (mt/with-dynamic-fn-redefs
+          [self.core/sse-reducible                  identity
+           debug/capture-stream                     (fn [r _] r)
+           http/request                             (fn [req] {:body req})
+           google/fresh-bearer-headers              (constantly {"Authorization" "Bearer test-sa-token"})
+           google/parse-service-account-credentials (fn [json]
+                                                      (swap! parses inc)
+                                                      (orig json))]
+          (dotimes [_ 2]
+            (google/google-raw {:model "google/gemini-3.5-flash" :input [{:role :user :content "hi"}]}))
+          (is (= 1 @parses)))))))
+
+(deftest fresh-bearer-headers-refresh-failure-test
+  (testing "an IOException minting an access token surfaces as a friendly api-error"
+    (let [creds (proxy [GoogleCredentials] []
+                  (refreshIfExpired []
+                    (throw (IOException. "invalid_grant: account disabled"))))
+          e     (try (#'google/fresh-bearer-headers creds)
+                     nil
+                     (catch Exception e e))]
+      (is (= "Could not obtain a Google access token: invalid_grant: account disabled"
+             (ex-message e)))
+      (is (=? {:api-error   true
+               :status-code 400
+               :error-code  :google-token-refresh-failed}
+              (ex-data e))
+          "the 400 status makes a connect attempt surface this as a credentials error, not a 500"))))
+
+(deftest google-raw-ai-proxy-unsupported-test
+  (testing "ai-proxy? throws before credentials are even consulted"
+    (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"AI proxy is not supported for the Google provider"
+           (google/google-raw {:model     "google/gemini-3.5-flash"
+                               :input     [{:role :user :content "hi"}]
+                               :ai-proxy? true}))))))
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; End-to-end stream translation.
+;;; ──────────────────────────────────────────────────────────────────
+
+(defn- sse-response-for
+  "A stubbed clj-http response whose body is an SSE stream of `events`."
+  [events]
+  {:status 200
+   :body   (java.io.ByteArrayInputStream.
+            (.getBytes (str/join (map #(str "data: " (json/encode %) "\n\n") events)) "UTF-8"))})
+
+(defn- aisdk-parts-for!
+  "The AISDK parts [[metabase.metabot.self.google/google]] yields for an SSE stream of `events`."
+  [events]
+  (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                     llm.settings/llm-google-service-account-key nil
+                                     llm.settings/llm-google-project-id          "my-project"
+                                     llm.settings/llm-google-location            nil]
+    (mt/with-dynamic-fn-redefs [debug/capture-stream (fn [r _] r)
+                                http/request         (fn [_] (sse-response-for events))]
+      (into []
+            (self.core/aisdk-xf)
+            (google/google {:model "google/gemini-3.5-flash"
+                            :input [{:role :user :content "hi"}]})))))
+
+(deftest google-text-stream-test
+  (testing "streamed text off the wire arrives as one coalesced text part with usage"
+    (is (=? [{:type :start :id "r1"}
+             {:type :text :text "Hello"}
+             {:type  :usage
+              :model "gemini-3.5-flash"
+              :usage {:promptTokens 5 :completionTokens 2}}]
+            (aisdk-parts-for!
+             [{:responseId "r1" :modelVersion "gemini-3.5-flash"
+               :candidates [{:content {:role "model" :parts [{:text "Hel"}]} :index 0}]}
+              {:candidates [{:content {:role "model" :parts [{:text "lo"}]}}]}
+              {:candidates    [{:content {:role "model" :parts []} :finishReason "STOP"}]
+               :usageMetadata {:promptTokenCount 5 :candidatesTokenCount 2 :totalTokenCount 7}}])))))
+
+(deftest google-tool-call-stream-test
+  (testing "a streamed functionCall off the wire arrives as a tool-input part with parsed arguments"
+    (is (=? [{:type :start :id "r2"}
+             {:type      :tool-input
+              :function  "get_time"
+              :arguments {:tz "UTC"}}
+             {:type :usage :usage {:promptTokens 8 :completionTokens 4}}]
+            (aisdk-parts-for!
+             [{:responseId "r2" :modelVersion "gemini-3.5-flash"
+               :candidates [{:content {:role  "model"
+                                       :parts [{:functionCall {:name "get_time" :args {:tz "UTC"}}}]}
+                             :finishReason "STOP"}]
+               :usageMetadata {:promptTokenCount 8 :candidatesTokenCount 4}}])))))
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; list-models tests
+;;; ──────────────────────────────────────────────────────────────────
+
+(defn- stub-count-tokens
+  "An `http/request` stub answering the countTokens probe with a 200, recording every request
+  into `calls`."
+  [calls]
+  (fn [req]
+    (swap! calls conj req)
+    {:status 200
+     :body   (json/encode {:totalTokens 1})}))
+
+(deftest list-models-count-tokens-probe-test
+  (testing "list-models validates the candidate model countTokens and returns no models"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            nil]
+      (let [calls (atom [])]
+        (mt/with-dynamic-fn-redefs [http/request (stub-count-tokens calls)]
+          (is (= {:models []}
+                 (google/list-models {:model "google/gemini-3.5-flash"})))
+          (is (=? [{:method  :post
+                    :url     (str "https://aiplatform.googleapis.com/v1/projects/my-project/locations/global"
+                                  "/publishers/google/models/gemini-3.5-flash:countTokens")
+                    :headers {"Authorization" "Bearer ya29.pasted-access-token"}
+                    :body    (json/encode {:contents [{:role "user" :parts [{:text "hi"}]}]})}]
+                  @calls)))))))
+
+(deftest list-models-bare-model-throws-test
+  (testing "a bare model ID throws before any HTTP call"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            nil]
+      (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             bare-model-id-message-re
+             (google/list-models {:model "gemini-3.5-flash"})))))))
+
+(deftest list-models-defaults-to-saved-model-test
+  (testing "without a model in opts the probe runs against the saved Google model"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            nil
+                                       metabot.settings/llm-metabot-provider       "google/google/gemini-3.6-flash"]
+      (let [calls (atom [])]
+        (mt/with-dynamic-fn-redefs [http/request (stub-count-tokens calls)]
+          (is (= {:models []} (google/list-models)))
+          (is (=? [{:url (str "https://aiplatform.googleapis.com/v1/projects/my-project/locations/global"
+                              "/publishers/google/models/gemini-3.6-flash:countTokens")}]
+                  @calls)))))))
+
+(deftest list-models-no-model-skips-probe-test
+  (testing "with no candidate model and a non-Google provider configured no call is made"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       metabot.settings/llm-metabot-provider       "anthropic/claude-sonnet-4-6"]
+      (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+        (is (= {:models []} (google/list-models)))))))
+
+(deftest list-models-explicit-credentials-test
+  (testing "credentials in opts override the configured settings"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.saved-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "saved-project"]
+      (let [calls (atom [])]
+        (mt/with-dynamic-fn-redefs [http/request (stub-count-tokens calls)]
+          (is (= {:models []}
+                 (google/list-models {:model       "google/gemini-3.5-flash"
+                                      :credentials {:oauth-access-token "ya29.override-token"
+                                                    :project-id         "other-project"
+                                                    :location           "europe-west1"}})))
+          (is (=? [{:url     (str "https://europe-west1-aiplatform.googleapis.com/v1/projects/other-project"
+                                  "/locations/europe-west1/publishers/google/models/gemini-3.5-flash:countTokens")
+                    :headers {"Authorization" "Bearer ya29.override-token"}}]
+                  @calls)))))))
+
+(deftest list-models-multi-region-location-test
+  (testing "list-models reaches a multi-region location through its `rep` host"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.pasted-access-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            "eu"]
+      (let [calls (atom [])]
+        (mt/with-dynamic-fn-redefs [http/request (stub-count-tokens calls)]
+          (is (= {:models []} (google/list-models {:model "google/gemini-3.5-flash"})))
+          (is (=? [{:url (str "https://aiplatform.eu.rep.googleapis.com/v1/projects/my-project/locations/eu"
+                              "/publishers/google/models/gemini-3.5-flash:countTokens")}]
+                  @calls)))))))
+
+(deftest list-models-service-account-credentials-test
+  (testing "a service account key in the provided credentials is used"
+    (let [sa-key (test-service-account-json "sa-project")
+          calls  (atom [])]
+      (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  nil
+                                         llm.settings/llm-google-service-account-key nil
+                                         llm.settings/llm-google-project-id          nil]
+        (mt/with-dynamic-fn-redefs [google/fresh-bearer-headers (constantly {"Authorization" "Bearer test-sa-token"})
+                                    http/request                (stub-count-tokens calls)]
+          (is (= {:models []}
+                 (google/list-models {:model       "google/gemini-3.6-flash"
+                                      :credentials {:service-account-key sa-key}})))
+          (is (=? [{:method  :post
+                    :url     (str "https://aiplatform.googleapis.com/v1/projects/sa-project/locations/global"
+                                  "/publishers/google/models/gemini-3.6-flash:countTokens")
+                    :headers {"Authorization" "Bearer test-sa-token"}}]
+                  @calls)))))))
+
+(deftest list-models-missing-project-id-status-test
+  (testing "the missing project ID message is tagged as a 400"
+    (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+      (let [e (try (google/list-models {:model       "google/gemini-3.5-flash"
+                                        :credentials {:oauth-access-token "ya29.token"}})
+                   nil
+                   (catch Exception e e))]
+        (is (=? {:api-error   true
+                 :status-code 400
+                 :error-code  :project-id-required}
+                (ex-data e)))))))
+
+(deftest list-models-ai-proxy-unsupported-test
+  (testing "ai-proxy? throws before credentials are even consulted"
+    (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"AI proxy is not supported for the Google provider"
+           (google/list-models {:model "google/gemini-3.5-flash" :ai-proxy? true}))))))
+
+(def ^:private ^String html-404-body
+  "The HTML body the Google front end serves for a 404 from a host that does not exist."
+  "<!DOCTYPE html> <html lang=en> <title>Error 404 (Not Found)!!1</title>")
+
+(deftest list-models-html-404-hints-invalid-location-test
+  (testing "the HTML 404 is replaced with a location hint and the full endpoint"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            "nowhere1"]
+      (mt/with-dynamic-fn-redefs [http/request (fn [_]
+                                                 (throw (ex-info "clj-http: status 404"
+                                                                 {:status  404
+                                                                  :headers {"content-type" "text/html; charset=UTF-8"}
+                                                                  :body    html-404-body})))]
+        (let [e (try (google/list-models {:model "google/gemini-3.5-flash"}) nil (catch Exception e e))]
+          (is (= (str "Google API endpoint is unavailable or the model was not found "
+                      "(endpoint: https://nowhere1-aiplatform.googleapis.com) — "
+                      "check that \"nowhere1\" is a valid location")
+                 (ex-message e)))
+          (is (str/includes? (-> e ex-cause ex-cause ex-data :body) "<!DOCTYPE html>")
+              "the original HTML body survives on the cause chain"))))))
+
+(deftest list-models-json-404-with-location-keeps-upstream-message-test
+  (testing "a 404 with JSON body preserves the upstream message"
+    (let [upstream-message "Publisher Model was not found or your project does not have access to it."]
+      (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.token"
+                                         llm.settings/llm-google-service-account-key nil
+                                         llm.settings/llm-google-project-id          "my-project"
+                                         llm.settings/llm-google-location            "us-central1"]
+        (mt/with-dynamic-fn-redefs
+          [http/request (fn [_]
+                          (throw (ex-info "clj-http: status 404"
+                                          {:status  404
+                                           :headers {"content-type" "application/json; charset=UTF-8"}
+                                           :body    (json/encode
+                                                     {:error {:code    404
+                                                              :message upstream-message
+                                                              :status  "NOT_FOUND"}})})))]
+          (let [e (try (google/list-models {:model "google/gemini-3.5-flash"}) nil (catch Exception e e))]
+            (is (= (str "Google API endpoint is unavailable or the model was not found "
+                        "(endpoint: https://us-central1-aiplatform.googleapis.com) — "
+                        upstream-message)
+                   (ex-message e)))))))))
+
+(deftest list-models-501-names-endpoint-test
+  (testing "the 501 an unavailable-API location serves maps to a location message naming the endpoint"
+    (let [upstream-message "Operation is not implemented, or supported, or enabled."]
+      (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.token"
+                                         llm.settings/llm-google-service-account-key nil
+                                         llm.settings/llm-google-project-id          "my-project"
+                                         llm.settings/llm-google-location            "us-west8"]
+        (mt/with-dynamic-fn-redefs
+          [http/request (fn [_]
+                          (throw (ex-info "clj-http: status 501"
+                                          {:status  501
+                                           :headers {"content-type" "application/json; charset=UTF-8"}
+                                           :body    (json/encode
+                                                     {:error {:code    501
+                                                              :message upstream-message
+                                                              :status  "UNIMPLEMENTED"}})})))]
+          (let [e (try (google/list-models {:model "google/gemini-3.5-flash"}) nil (catch Exception e e))]
+            (is (= (str "Google API is not available in this location "
+                        "(endpoint: https://us-west8-aiplatform.googleapis.com) — "
+                        upstream-message)
+                   (ex-message e)))))))))
+
+(deftest google-raw-html-404-hints-invalid-location-test
+  (testing "the streaming call maps a wrong-location HTML 404 to the endpoint/location hint too"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"
+                                       llm.settings/llm-google-location            "nowhere1"]
+      (mt/with-dynamic-fn-redefs
+        [http/request (fn [_]
+                        (throw (ex-info "clj-http: status 404"
+                                        {:status  404
+                                         :headers {"content-type" "text/html; charset=UTF-8"}
+                                         :body    (java.io.ByteArrayInputStream.
+                                                   (.getBytes html-404-body))})))]
+        (let [e (try (google/google-raw {:model "google/gemini-3.5-flash" :input [{:role :user :content "hi"}]})
+                     nil
+                     (catch Exception e e))]
+          (is (= (str "Google API endpoint is unavailable or the model was not found "
+                      "(endpoint: https://nowhere1-aiplatform.googleapis.com) — "
+                      "check that \"nowhere1\" is a valid location")
+                 (ex-message e))))))))
+
+(deftest list-models-invalid-request-maps-to-google-error-test
+  (testing "a 400 from the countTokens probe surfaces the canonical message with the upstream detail"
+    (let [upstream-message "Request contains an invalid argument."]
+      (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.bad-token"
+                                         llm.settings/llm-google-service-account-key nil
+                                         llm.settings/llm-google-project-id          "my-project"]
+        (mt/with-dynamic-fn-redefs
+          [http/request (fn [_]
+                          (throw (ex-info "clj-http: status 400"
+                                          {:status  400
+                                           :headers {"content-type" "application/json"}
+                                           :body    (json/encode
+                                                     {:error {:code    400
+                                                              :message upstream-message
+                                                              :status  "INVALID_ARGUMENT"}})})))]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"Google API rejected the request as invalid — Request contains an invalid argument\."
+               (google/list-models {:model "google/gemini-3.5-flash"}))))))))
+
+(deftest list-models-error-status-messages-test
+  (testing "credential and quota statuses map to their canonical messages"
+    (mt/with-temporary-setting-values [llm.settings/llm-google-oauth-access-token  "ya29.test-token"
+                                       llm.settings/llm-google-service-account-key nil
+                                       llm.settings/llm-google-project-id          "my-project"]
+      (doseq [[status pattern]
+              [[401 #"Google API credentials expired or invalid"]
+               [403 #"Google API credentials have insufficient permissions or the API is not enabled for this project"]
+               [429 #"Google API has rate limited us"]]]
+        (testing (str "HTTP " status)
+          (mt/with-dynamic-fn-redefs
+            [http/request (fn [_]
+                            (throw (ex-info (str "clj-http: status " status)
+                                            {:status  status
+                                             :headers {"content-type" "application/json"}
+                                             :body    (json/encode {:error {:code status}})})))]
+            (is (thrown-with-msg?
+                 clojure.lang.ExceptionInfo
+                 pattern
+                 (google/list-models {:model "google/gemini-3.5-flash"})))))))))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -47,7 +47,9 @@
     (is (=? {:provider "mistral" :model "mistral-medium-3-5" :ai-proxy? false}
             (#'self/parse-provider-model "mistral/mistral-medium-3-5")))
     (is (=? {:provider "moonshot" :model "kimi-k2.6" :ai-proxy? false}
-            (#'self/parse-provider-model "moonshot/kimi-k2.6"))))
+            (#'self/parse-provider-model "moonshot/kimi-k2.6")))
+    (is (=? {:provider "google" :model "google/gemini-3.5-flash" :ai-proxy? false}
+            (#'self/parse-provider-model "google/google/gemini-3.5-flash"))))
   (testing "parses metabase/ prefix (AI proxy)"
     (is (=? {:provider "anthropic" :model "claude-haiku-4-5" :ai-proxy? true}
             (#'self/parse-provider-model "metabase/anthropic/claude-haiku-4-5")))
@@ -67,7 +69,8 @@
     (is (fn? (#'self/resolve-adapter "openrouter")))
     (is (fn? (#'self/resolve-adapter "zai")))
     (is (fn? (#'self/resolve-adapter "mistral")))
-    (is (fn? (#'self/resolve-adapter "moonshot"))))
+    (is (fn? (#'self/resolve-adapter "moonshot")))
+    (is (fn? (#'self/resolve-adapter "google"))))
   (testing "throws for unknown provider"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Unknown LLM provider"
                           (#'self/resolve-adapter "unknown")))))
@@ -177,16 +180,19 @@
                                                    (when (:body opts)
                                                      (reset! captured (json/decode+kw (:body opts))))
                                                    (throw (ex-info "stop" {::skip true :api-error true})))]
-          (mt/with-temporary-setting-values [llm-anthropic-api-key  "sk-ant-test-key"
-                                             llm-proxy-base-url     "http://proxy.example"
-                                             llm-openrouter-api-key "sk-or-v1-test-key"
-                                             llm-openai-api-key     "sk-test-key"
-                                             llm-zai-api-key        "zai-key.test"]
+          (mt/with-temporary-setting-values [llm-anthropic-api-key         "sk-ant-test-key"
+                                             llm-proxy-base-url            "http://proxy.example"
+                                             llm-openrouter-api-key        "sk-or-v1-test-key"
+                                             llm-openai-api-key            "sk-test-key"
+                                             llm-zai-api-key               "zai-key.test"
+                                             llm-google-oauth-access-token "ya29.test-token"
+                                             llm-google-project-id         "my-project"]
             (doseq [model ["anthropic/test-model"
                            "metabase/anthropic/claude-sonnet-4-6"
                            "openrouter/test-model"
                            "openai/test-model"
-                           "zai/glm-5.2"]]
+                           "zai/glm-5.2"
+                           "google/google/gemini-3.5-flash"]]
               (testing model
                 (reset! captured nil)
                 (try

--- a/test/metabase/metabot/settings_test.clj
+++ b/test/metabase/metabot/settings_test.clj
@@ -186,6 +186,13 @@
            clojure.lang.ExceptionInfo #"Unsupported provider \"moonshot\" for metabase managed AI"
            (metabot.settings/llm-metabot-provider! "metabase/moonshot/kimi-k2.6"))))))
 
+(deftest validate-metabot-provider-rejects-direct-only-provider-as-managed-google-test
+  (testing "rejects google under metabase/ prefix (not in the managed allow-list)"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"Unsupported provider \"google\" for metabase managed AI"
+           (metabot.settings/llm-metabot-provider! "metabase/google/google/gemini-3.5-flash"))))))
+
 (deftest validate-metabot-provider-rejects-unsupported-metabase-managed-model-test
   (testing "rejects unsupported model for an allowed metabase managed provider"
     (mt/with-premium-features #{:metabase-ai-managed}
@@ -429,3 +436,102 @@
              (metabot.settings/configured-provider-credentials "anthropic"))))
     (mt/with-temporary-setting-values [llm-anthropic-api-key nil]
       (is (nil? (metabot.settings/configured-provider-credentials "anthropic"))))))
+
+(deftest validate-metabot-provider-accepts-valid-direct-google-test
+  (testing "accepts google provider strings with a model name"
+    (mt/with-temporary-setting-values [llm-metabot-provider "google/google/gemini-3.5-flash"]
+      (is (= "google/google/gemini-3.5-flash" (metabot.settings/llm-metabot-provider))))))
+
+(deftest metabot-configured-with-google-credentials-test
+  (testing "returns true when google has an OAuth access token and project ID set — the location is optional"
+    (mt/with-temporary-setting-values [llm-metabot-provider          "google/google/gemini-3.5-flash"
+                                       llm-google-oauth-access-token "ya29.test-token"
+                                       llm-google-project-id         "my-project"
+                                       llm-google-location           nil]
+      (is (true? (metabot.settings/llm-metabot-configured?))))))
+
+(deftest metabot-configured-with-no-google-credentials-test
+  (testing "returns false when google has no service account key or OAuth access token"
+    (mt/with-temporary-setting-values [llm-metabot-provider           "google/google/gemini-3.5-flash"
+                                       llm-google-oauth-access-token  nil
+                                       llm-google-service-account-key nil]
+      (is (false? (metabot.settings/llm-metabot-configured?))))))
+
+(deftest metabot-configured-with-google-service-account-test
+  (testing "returns true when google has only a service account key — the project ID can come from the key JSON"
+    (mt/with-temporary-setting-values [llm-metabot-provider           "google/google/gemini-3.5-flash"
+                                       llm-google-oauth-access-token  nil
+                                       llm-google-service-account-key "{\"type\": \"service_account\"}"
+                                       llm-google-project-id          nil]
+      (is (true? (metabot.settings/llm-metabot-configured?))))))
+
+(deftest metabot-configured-google-without-project-id-test
+  (testing "returns false when google has an OAuth access token but no project ID"
+    (mt/with-temporary-setting-values [llm-metabot-provider           "google/google/gemini-3.5-flash"
+                                       llm-google-oauth-access-token  "ya29.test-token"
+                                       llm-google-service-account-key nil
+                                       llm-google-project-id          nil]
+      (is (false? (metabot.settings/llm-metabot-configured?))))))
+
+(deftest configured-provider-credentials-google-fully-configured-test
+  (testing "returns the oauth-access-token/project-id/location credentials map when google is fully configured"
+    (mt/with-temporary-setting-values [llm-google-oauth-access-token  "ya29.test-token"
+                                       llm-google-service-account-key nil
+                                       llm-google-project-id          "my-project"
+                                       llm-google-location            "us-central1"]
+      (is (= {:service-account-key nil
+              :oauth-access-token  "ya29.test-token"
+              :project-id          "my-project"
+              :location            "us-central1"}
+             (metabot.settings/configured-provider-credentials "google"))))))
+
+(deftest configured-provider-credentials-google-nil-location-test
+  (testing "the location is optional — a nil location still yields a configured credentials map"
+    (mt/with-temporary-setting-values [llm-google-oauth-access-token  "ya29.test-token"
+                                       llm-google-service-account-key nil
+                                       llm-google-project-id          "my-project"
+                                       llm-google-location            nil]
+      (is (= {:service-account-key nil
+              :oauth-access-token  "ya29.test-token"
+              :project-id          "my-project"
+              :location            nil}
+             (metabot.settings/configured-provider-credentials "google"))))))
+
+(deftest configured-provider-credentials-google-missing-project-id-test
+  (testing "returns nil when google has an OAuth access token but no project ID"
+    (mt/with-temporary-setting-values [llm-google-oauth-access-token  "ya29.test-token"
+                                       llm-google-service-account-key nil
+                                       llm-google-project-id          nil]
+      (is (nil? (metabot.settings/configured-provider-credentials "google"))))))
+
+(deftest configured-provider-credentials-google-service-account-only-test
+  (testing "a service account key alone counts as configured — no OAuth access token or project ID needed"
+    (mt/with-temporary-setting-values [llm-google-oauth-access-token  nil
+                                       llm-google-service-account-key "{\"type\": \"service_account\"}"
+                                       llm-google-project-id          nil
+                                       llm-google-location            nil]
+      (is (= {:service-account-key "{\"type\": \"service_account\"}"
+              :oauth-access-token  nil
+              :project-id          nil
+              :location            nil}
+             (metabot.settings/configured-provider-credentials "google"))))))
+
+(deftest configured-provider-credentials-google-missing-credential-test
+  (testing "returns nil when google has a project ID but no service account key or OAuth access token"
+    (mt/with-temporary-setting-values [llm-google-oauth-access-token  nil
+                                       llm-google-service-account-key nil
+                                       llm-google-project-id          "my-project"]
+      (is (nil? (metabot.settings/configured-provider-credentials "google"))))))
+
+(deftest provider-credentials-complete?-google-test
+  (testing "google credentials are complete with a non-blank OAuth access token and project ID; the location is optional"
+    (is (true? (metabot.settings/provider-credentials-complete?
+                "google"
+                {:oauth-access-token "ya29.test-token" :project-id "my-project"})))
+    (is (true? (metabot.settings/provider-credentials-complete?
+                "google"
+                {:oauth-access-token "ya29.test-token" :project-id "my-project" :location "us-central1"})))
+    (is (false? (metabot.settings/provider-credentials-complete? "google" {:oauth-access-token "ya29.test-token"})))
+    (is (false? (metabot.settings/provider-credentials-complete? "google" {:oauth-access-token "  " :project-id "my-project"})))
+    (is (false? (metabot.settings/provider-credentials-complete? "google" {:project-id "my-project"})))
+    (is (false? (metabot.settings/provider-credentials-complete? "google" nil)))))


### PR DESCRIPTION
Relates to [BOT-1875: Support Gemini models via streamGenerateContent API](https://linear.app/metabase/issue/BOT-1875/support-gemini-models-via-streamgeneratecontent-api)

See also
* https://github.com/metabase/metabase/pull/79558
* https://github.com/metabase/evals/pull/65

### Description

Add support for Gemini models via a new Gemini Enterprise Agent Platform provider (formerly Vertex AI) using the `streamGenerateContent` API.

* Add new `metabase.metabot.self.google` provider
* Add new `metabase.metabot.self.google.stream-generate-content` for wire-format to/from the Gemini API
* Users supply
  * **project-id**: optional if included in the service account key
  * **location**: global (default), us, eu, us-east1, etc
  * One of two options for creds:
    * **service account key JSON**: same as the big query driver
    * **OAuth2 access token**: e.g. via `gcloud auth print-access-token`
  * **model id**: similar to the Azure provider, model is free-text rather than whitelisted. Google does provide a list-models endpoint, but it sometimes returns models that are not available, and sometime omits models that are, so we can't rely on it.

### Review notes

If you want to test locally, checkout #79558 instead, which includes the FE / admin UI changes as well.

You can find eval results in https://github.com/metabase/evals/pull/65
PR Env: https://pr79558.coredev.metabase.com/

The meat of the changes are in the two new files, maybe start here:
* [`src/metabase/metabot/self/google.clj`](https://github.com/metabase/metabase/pull/78193/changes#diff-e845720ffd1f11e7eae423cc00235b64ea8a8db1ccc943ce904cde1391097bcf)
* [`src/metabase/metabot/self/google/stream_generate_content.clj`](https://github.com/metabase/metabase/pull/78193/changes#diff-6cc7004d16e1918917c2cb6cddc8b2b454706f3f2c4298da551254e20f90e2a6)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
