### PR TITLE
Enable the react-router v7 engine by default, with the fixes it needs

### DIFF
--- a/frontend/src/metabase/router/router-link.tsx
+++ b/frontend/src/metabase/router/router-link.tsx
@@ -111,6 +111,7 @@ export const RouterLink = forwardRef<HTMLAnchorElement, Props>(
             {...navRest}
             to={v7To}
             state={state}
+            replace={false}
             ref={linkRef}
             end={onlyActiveOnIndex}
             className={({ isActive }) =>
@@ -125,7 +126,19 @@ export const RouterLink = forwardRef<HTMLAnchorElement, Props>(
         );
       }
 
-      return <V7Link {...rest} to={v7To} state={state} ref={linkRef} />;
+      // v7's `<Link>` silently downgrades a click to a `replace` when the target
+      // equals the current URL. v3 always pushed, and call sites rely on it: the
+      // "New document" menu item links to `/document/new` from `/document/new`,
+      // and the unsaved-changes prompt keys off the new location. Push always.
+      return (
+        <V7Link
+          {...rest}
+          to={v7To}
+          state={state}
+          replace={false}
+          ref={linkRef}
+        />
+      );
     }
 
     return (

--- a/frontend/src/metabase/router/router-link.tsx
+++ b/frontend/src/metabase/router/router-link.tsx
@@ -63,12 +63,13 @@ export const RouterLink = forwardRef<HTMLAnchorElement, Props>(
       const { activeClassName, activeStyle, onlyActiveOnIndex, ...rest } =
         props;
 
-      // A `<Link>` with no destination is used as a button: it navigates through
-      // its `onClick`. v7's `<Link>` would additionally navigate to the current
-      // route on click, clobbering any push the handler performs, so render a
-      // plain anchor instead. On v3 this matches `router.push(undefined)`, which
-      // is a no-op, so only the handler runs.
-      if (to == null) {
+      // A `<Link>` with no destination (`to` null or `""`) is used as a button: it
+      // navigates through its `onClick`. v7's `<Link>` would additionally navigate
+      // on click (an empty `to` resolves to the current route, or `/` from a
+      // top-level portal like a toast), clobbering any push the handler performs,
+      // so render a plain anchor instead. On v3 this matches `router.push("")` /
+      // `router.push(undefined)`, which are no-ops, so only the handler runs.
+      if (to == null || to === "") {
         return <a {...rest} ref={linkRef} />;
       }
 

--- a/frontend/src/metabase/router/router-link.tsx
+++ b/frontend/src/metabase/router/router-link.tsx
@@ -30,11 +30,16 @@ type V3To = RouterLinkProps["to"];
  * v3 resolved a bare path against the root, so call sites write `to="reference"`
  * meaning `/reference`. v7 resolves it against the current route instead, which
  * would nest it (that link sits on `/browse/databases`). Anchor it so the target
- * does not depend on where the link is rendered. A leading `?` or `#` keeps the
- * current path by design, so leave those alone.
+ * does not depend on where the link is rendered.
+ *
+ * Left alone: a leading `?` or `#`, which keeps the current path by design, and
+ * anything carrying a scheme (`https:`, `mailto:`) or a protocol-relative `//`,
+ * which is not a route at all.
  */
 function toRootRelative(pathname: string): string {
-  return pathname === "" || /^[/?#]/.test(pathname) ? pathname : `/${pathname}`;
+  const isAlreadyAnchored = pathname === "" || /^[/?#]/.test(pathname);
+  const hasScheme = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(pathname);
+  return isAlreadyAnchored || hasScheme ? pathname : `/${pathname}`;
 }
 
 function toV7Target(to: V3To): { to: V7LinkProps["to"]; state?: unknown } {

--- a/frontend/src/metabase/router/router-link.tsx
+++ b/frontend/src/metabase/router/router-link.tsx
@@ -26,9 +26,23 @@ type V3To = RouterLinkProps["to"];
 // v3 descriptors carry the query as a `query` object and `state` inline; v7 uses
 // a `search` string and a separate `state` prop. Translate so existing call sites
 // keep working on v7.
+/**
+ * v3 resolved a bare path against the root, so call sites write `to="reference"`
+ * meaning `/reference`. v7 resolves it against the current route instead, which
+ * would nest it (that link sits on `/browse/databases`). Anchor it so the target
+ * does not depend on where the link is rendered. A leading `?` or `#` keeps the
+ * current path by design, so leave those alone.
+ */
+function toRootRelative(pathname: string): string {
+  return pathname === "" || /^[/?#]/.test(pathname) ? pathname : `/${pathname}`;
+}
+
 function toV7Target(to: V3To): { to: V7LinkProps["to"]; state?: unknown } {
-  if (to == null || typeof to === "string") {
-    return { to: to ?? "" };
+  if (to == null) {
+    return { to: "" };
+  }
+  if (typeof to === "string") {
+    return { to: toRootRelative(to) };
   }
   if (typeof to === "function") {
     // v3's function form of `to` has no v7 analog and is not used in the app.
@@ -39,7 +53,11 @@ function toV7Target(to: V3To): { to: V7LinkProps["to"]; state?: unknown } {
   // `{ ...location, query }`, where the spread carries a stale `search`.
   const searchString = query ? queryToSearch(query) : search;
   return {
-    to: { pathname: pathname ?? "", search: searchString, hash },
+    to: {
+      pathname: pathname == null ? "" : toRootRelative(pathname),
+      search: searchString,
+      hash,
+    },
     state,
   };
 }

--- a/frontend/src/metabase/router/router-link.tsx
+++ b/frontend/src/metabase/router/router-link.tsx
@@ -7,6 +7,7 @@ import {
 } from "react-router-v7";
 
 import { type RouterLinkProps, V3RouterLink } from "./react-router";
+import { queryToSearch } from "./v7/location";
 
 /**
  * The app's `<Link>`, engine-aware.
@@ -34,8 +35,9 @@ function toV7Target(to: V3To): { to: V7LinkProps["to"]; state?: unknown } {
     return { to: "" };
   }
   const { pathname, search, hash, query, state } = to;
-  const searchString =
-    search ?? (query ? `?${new URLSearchParams(query).toString()}` : undefined);
+  // `query` wins over `search`, matching history@3: call sites build
+  // `{ ...location, query }`, where the spread carries a stale `search`.
+  const searchString = query ? queryToSearch(query) : search;
   return {
     to: { pathname: pathname ?? "", search: searchString, hash },
     state,

--- a/frontend/src/metabase/router/router-link.unit.spec.tsx
+++ b/frontend/src/metabase/router/router-link.unit.spec.tsx
@@ -7,11 +7,12 @@ import { Link, Outlet, Route, push, useLocation } from "metabase/router";
 import type { RouterEngine } from "./engine";
 
 function Home() {
-  const { pathname } = useLocation();
+  const { pathname, key } = useLocation();
   const dispatch = useDispatch();
   return (
     <div>
       <span data-testid="location">{pathname}</span>
+      <span data-testid="location-key">{key}</span>
       <Link to="/other">go</Link>
       {/* A `<Link>` used as a button: it navigates through its own onClick. */}
       <Link onClick={() => dispatch(push("/other"))}>act</Link>
@@ -91,6 +92,26 @@ describe.each<RouterEngine>(["v3", "v7"])(
       expect(screen.getByRole("link", { name: "mail" })).toHaveAttribute(
         "href",
         "mailto:help@metabase.com",
+      );
+    });
+
+    // v7's `<Link>` downgrades a click to a `replace` when the target equals the
+    // current URL, which leaves the location key untouched. v3 always pushed, and
+    // the documents page shows its unsaved-changes prompt when the key changes.
+    it("pushes a new entry when linking to the current url", async () => {
+      renderWithProviders(tree, {
+        withRouter: true,
+        routerEngine,
+        initialRoute: "/other",
+      });
+
+      await screen.findByTestId("other");
+      const keyBefore = screen.getByTestId("location-key").textContent;
+
+      await userEvent.click(screen.getByRole("link", { name: "go" }));
+
+      expect(screen.getByTestId("location-key")).not.toHaveTextContent(
+        String(keyBefore),
       );
     });
 

--- a/frontend/src/metabase/router/router-link.unit.spec.tsx
+++ b/frontend/src/metabase/router/router-link.unit.spec.tsx
@@ -27,6 +27,8 @@ function Home() {
       </Link>
       {/* v3 resolved a bare path against the root, not the current route. */}
       <Link to="other">bare</Link>
+      <Link to="https://www.metabase.com/docs">external</Link>
+      <Link to="mailto:help@metabase.com">mail</Link>
       <Outlet />
     </div>
   );
@@ -71,6 +73,25 @@ describe.each<RouterEngine>(["v3", "v7"])(
       await userEvent.click(screen.getByRole("link", { name: "bare" }));
 
       expect(await screen.findByTestId("other")).toBeInTheDocument();
+    });
+
+    // Anchoring bare paths must not touch absolute URLs, or a docs link becomes
+    // `/https:/www.metabase.com/...`.
+    it("leaves absolute urls untouched", async () => {
+      renderWithProviders(tree, {
+        withRouter: true,
+        routerEngine,
+        initialRoute: "/",
+      });
+
+      expect(screen.getByRole("link", { name: "external" })).toHaveAttribute(
+        "href",
+        "https://www.metabase.com/docs",
+      );
+      expect(screen.getByRole("link", { name: "mail" })).toHaveAttribute(
+        "href",
+        "mailto:help@metabase.com",
+      );
     });
 
     it("applies activeClassName to the link that matches the route", async () => {

--- a/frontend/src/metabase/router/router-link.unit.spec.tsx
+++ b/frontend/src/metabase/router/router-link.unit.spec.tsx
@@ -15,6 +15,10 @@ function Home() {
       <Link to="/other">go</Link>
       {/* A `<Link>` used as a button: it navigates through its own onClick. */}
       <Link onClick={() => dispatch(push("/other"))}>act</Link>
+      {/* A button-like `<Link to="">` (e.g. the undo toast) must not navigate. */}
+      <Link to="" onClick={() => undefined}>
+        noop
+      </Link>
       <Link to="/" activeClassName="is-active" onlyActiveOnIndex>
         home
       </Link>
@@ -78,6 +82,23 @@ describe.each<RouterEngine>(["v3", "v7"])(
       await userEvent.click(screen.getByText("act"));
 
       expect(await screen.findByTestId("other")).toBeInTheDocument();
+      expect(screen.getByTestId("location")).toHaveTextContent("/other");
+    });
+
+    it("does not navigate when a button-like `to=''` link is clicked", async () => {
+      renderWithProviders(tree, {
+        withRouter: true,
+        routerEngine,
+        initialRoute: "/other",
+      });
+
+      await screen.findByTestId("other");
+
+      // On v7 an empty `to` resolved to "/" and navigated home, unmounting the
+      // current view. It must stay put so only the onClick handler runs.
+      await userEvent.click(screen.getByText("noop"));
+
+      expect(screen.getByTestId("other")).toBeInTheDocument();
       expect(screen.getByTestId("location")).toHaveTextContent("/other");
     });
   },

--- a/frontend/src/metabase/router/router-link.unit.spec.tsx
+++ b/frontend/src/metabase/router/router-link.unit.spec.tsx
@@ -25,6 +25,8 @@ function Home() {
       <Link to="/other" activeClassName="is-active">
         section
       </Link>
+      {/* v3 resolved a bare path against the root, not the current route. */}
+      <Link to="other">bare</Link>
       <Outlet />
     </div>
   );
@@ -54,6 +56,21 @@ describe.each<RouterEngine>(["v3", "v7"])(
 
       expect(await screen.findByTestId("other")).toBeInTheDocument();
       expect(screen.getByTestId("location")).toHaveTextContent("/other");
+    });
+
+    // Only the destination is asserted: v3's memory history leaves the bare path
+    // literal in tests, though a real browser resolves it against the root the way
+    // v7 now does.
+    it("resolves a bare relative path against the root", async () => {
+      renderWithProviders(tree, {
+        withRouter: true,
+        routerEngine,
+        initialRoute: "/",
+      });
+
+      await userEvent.click(screen.getByRole("link", { name: "bare" }));
+
+      expect(await screen.findByTestId("other")).toBeInTheDocument();
     });
 
     it("applies activeClassName to the link that matches the route", async () => {

--- a/frontend/src/metabase/router/v7/RouterBridge.tsx
+++ b/frontend/src/metabase/router/v7/RouterBridge.tsx
@@ -45,9 +45,18 @@ export function RouterBridge({
   const v7Location = useV7Location();
   const navigate = useV7Navigate();
   const action = useNavigationType();
+  const v7Params = useV7Params();
   // v7's `useParams` returns v7's readonly `Params`; the context wants v3's shape,
-  // which is structurally the same string map.
-  const params = useV7Params() as WithRouterProps["params"];
+  // which is structurally the same string map apart from the splat: v3 exposed the
+  // wildcard match as `splat`, v7 names it `*`. Republish it under both so v3-era
+  // readers (`params.splat` in `AutomaticDashboardApp`) keep working.
+  const params = useMemo<WithRouterProps["params"]>(() => {
+    const { "*": splat, ...rest } = v7Params;
+    const v3Params = splat === undefined ? rest : { ...rest, splat };
+    // Cast because v7 types params as readonly and partial; v3's shape is the same
+    // string map.
+    return v3Params as WithRouterProps["params"];
+  }, [v7Params]);
 
   // `useMatches` is data-router-only, so read the matched branch from the route
   // context that also drives `<Outlet>` (available in declarative mode). Each

--- a/frontend/src/metabase/router/v7/RouterBridge.tsx
+++ b/frontend/src/metabase/router/v7/RouterBridge.tsx
@@ -2,10 +2,10 @@ import type { Location as HistoryLocation, LocationDescriptor } from "history";
 import { type ReactNode, useContext, useMemo, useRef } from "react";
 import {
   type NavigateOptions,
+  type To,
   UNSAFE_RouteContext,
   type NavigateFunction as V7NavigateFunction,
   Outlet as V7Outlet,
-  type To,
   useNavigationType,
   useLocation as useV7Location,
   useNavigate as useV7Navigate,
@@ -85,6 +85,8 @@ export function RouterBridge({
         navigateRef.current(to, options);
       }
     };
+    // `NavigateFunction` is an overloaded signature (a `To` or a delta); the
+    // wrapper implements both arms but TS cannot infer it back into the overload.
     return makeRouterShim(navigateLatest as V7NavigateFunction);
   }, []);
 
@@ -124,6 +126,8 @@ function makeRouterShim(navigate: V7NavigateFunction): InjectedRouter {
       ? location
       : `${location.pathname ?? ""}${location.search ?? ""}${location.hash ?? ""}`;
 
+  // Cast because v3's own `InjectedRouter` type omits `listen`, even though both
+  // engines expose it at runtime.
   return {
     push: (location) => navigate(...toNavigateArgs(location)),
     replace: (location) =>
@@ -140,10 +144,8 @@ function makeRouterShim(navigate: V7NavigateFunction): InjectedRouter {
     createPath: href,
     createHref: href,
     isActive: () => false,
-    // v3's `router.listen` (used by e.g. `use-dashboard-url-query`) is absent from
-    // v3's own `InjectedRouter` type, so the cast re-adds it. `V7ReduxBridge` feeds
-    // these subscribers every location change.
-    listen: (callback: (location: HistoryLocation) => void) =>
-      subscribeLocation(callback),
+    // Stands in for v3's `router.listen` (used by e.g. `use-dashboard-url-query`).
+    // `V7ReduxBridge` feeds these subscribers every location change.
+    listen: subscribeLocation,
   } as InjectedRouter;
 }

--- a/frontend/src/metabase/router/v7/RouterBridge.tsx
+++ b/frontend/src/metabase/router/v7/RouterBridge.tsx
@@ -53,6 +53,17 @@ export function RouterBridge({
   // context that also drives `<Outlet>` (available in declarative mode). Each
   // route keeps its v3 path on `handle`, which the facade hooks match against.
   const { matches } = useContext(UNSAFE_RouteContext);
+  // react-router hands back a fresh `matches` array on every render, so memoizing
+  // on it would republish a new `routes`/`route` each time. v3's were stable, and
+  // consumers key effects on `route`: the leave-confirm modal resets itself when
+  // `route` changes, which closed it mid-interaction. Key on the matched branch.
+  const matchesKey = matches
+    .map((match) => {
+      // `handle` is typed `unknown`; we only ever put `{ v3Path }` on it.
+      const handle = match.route.handle as { v3Path?: string } | undefined;
+      return `${match.pathname}|${handle?.v3Path ?? ""}`;
+    })
+    .join(">");
   const routes = useMemo<RouteStub[]>(
     () =>
       matches.map((match) => {
@@ -62,7 +73,9 @@ export function RouterBridge({
         // pathname, which `setRouteLeaveHook` uses to scope its hook to this route.
         return { path: handle?.v3Path, pathnameBase: match.pathname };
       }),
-    [matches],
+    // Keyed on the matched branch, not the array identity, which changes each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [matchesKey],
   );
 
   const location = useMemo<HistoryLocation>(

--- a/frontend/src/metabase/router/v7/RouterBridge.tsx
+++ b/frontend/src/metabase/router/v7/RouterBridge.tsx
@@ -1,9 +1,11 @@
 import type { Location as HistoryLocation, LocationDescriptor } from "history";
-import { type ReactNode, useContext, useMemo } from "react";
+import { type ReactNode, useContext, useMemo, useRef } from "react";
 import {
+  type NavigateOptions,
   UNSAFE_RouteContext,
   type NavigateFunction as V7NavigateFunction,
   Outlet as V7Outlet,
+  type To,
   useNavigationType,
   useLocation as useV7Location,
   useNavigate as useV7Navigate,
@@ -21,7 +23,7 @@ import type { Route } from "../route";
 
 import { registerLeaveHook } from "./blocking-history";
 import { toV3Location } from "./location";
-import { toNavigateArgs } from "./navigator";
+import { subscribeLocation, toNavigateArgs } from "./navigator";
 
 // The facade route stub, plus the route's matched pathname so `setRouteLeaveHook`
 // can scope its hook to the route the way v3 does.
@@ -68,10 +70,23 @@ export function RouterBridge({
     [v7Location, action],
   );
 
-  const router = useMemo<InjectedRouter>(
-    () => makeRouterShim(navigate),
-    [navigate],
-  );
+  // v3 handed consumers a stable `router`, so effects keyed on it (notably the
+  // `router.listen` subscriptions in `use-dashboard-url-query`) survive a
+  // navigation. v7's `navigate` changes identity per location, which would tear
+  // those effects down and re-subscribe them around every location change, so read
+  // `navigate` through a ref and keep the shim itself stable.
+  const navigateRef = useRef(navigate);
+  navigateRef.current = navigate;
+  const router = useMemo<InjectedRouter>(() => {
+    const navigateLatest = (to: To | number, options?: NavigateOptions) => {
+      if (typeof to === "number") {
+        navigateRef.current(to);
+      } else {
+        navigateRef.current(to, options);
+      }
+    };
+    return makeRouterShim(navigateLatest as V7NavigateFunction);
+  }, []);
 
   const value = useMemo<WithRouterProps>(
     () => ({ router, location, params, routes }),
@@ -125,5 +140,10 @@ function makeRouterShim(navigate: V7NavigateFunction): InjectedRouter {
     createPath: href,
     createHref: href,
     isActive: () => false,
-  };
+    // v3's `router.listen` (used by e.g. `use-dashboard-url-query`) is absent from
+    // v3's own `InjectedRouter` type, so the cast re-adds it. `V7ReduxBridge` feeds
+    // these subscribers every location change.
+    listen: (callback: (location: HistoryLocation) => void) =>
+      subscribeLocation(callback),
+  } as InjectedRouter;
 }

--- a/frontend/src/metabase/router/v7/RouterProviderV7.tsx
+++ b/frontend/src/metabase/router/v7/RouterProviderV7.tsx
@@ -1,17 +1,24 @@
 import type { PropsWithChildren } from "react";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import {
+  type HistoryRouterProps,
   Routes,
   UNSAFE_createBrowserHistory as createBrowserHistory,
   UNSAFE_createMemoryHistory as createMemoryHistory,
 } from "react-router-v7";
 
+import { useDispatch } from "metabase/redux";
 import { getBasename } from "metabase/utils/basename";
+
+import { LOCATION_CHANGE } from "../routing-reducer";
+
 
 import { SyncHistoryRouter } from "./SyncHistoryRouter";
 import { V7ReduxBridge } from "./V7ReduxBridge";
 import { withBlocking } from "./blocking-history";
+import { toV3Location } from "./location";
 import { mapToV7 } from "./map-to-v7";
+import { notifyLocationListeners } from "./navigator";
 
 /**
  * The v7 route tree: the facade tree mapped to real v7 routes and rendered by
@@ -19,12 +26,37 @@ import { mapToV7 } from "./map-to-v7";
  * and lets `dispatch(push(...))` drive the router. Kept separate from the history
  * provider below so tests can host the same tree under a `<MemoryRouter>`.
  */
-export function V7RouterTree({ children }: PropsWithChildren): JSX.Element {
+export function V7RouterTree({
+  children,
+  history,
+}: PropsWithChildren<{
+  history?: HistoryRouterProps["history"];
+}>): JSX.Element {
   return (
     <>
-      <V7ReduxBridge />
+      <V7ReduxBridge history={history} />
       <Routes>{mapToV7(children)}</Routes>
     </>
+  );
+}
+
+/**
+ * Mirrors each location into `state.routing` (and the `router.listen`
+ * subscribers) from inside the history subscription, so the store is current
+ * before any thunk reads it. Replaces v3's `syncHistoryWithStore`.
+ */
+function useLocationMirror() {
+  const dispatch = useDispatch();
+  return useCallback(
+    (
+      location: Parameters<typeof toV3Location>[0],
+      action: Parameters<typeof toV3Location>[1],
+    ) => {
+      const v3Location = toV3Location(location, action);
+      dispatch({ type: LOCATION_CHANGE, payload: v3Location });
+      notifyLocationListeners(v3Location);
+    },
+    [dispatch],
   );
 }
 
@@ -40,9 +72,14 @@ export function RouterProviderV7({ children }: PropsWithChildren): JSX.Element {
   const [history] = useState(() =>
     withBlocking(createBrowserHistory({ v5Compat: true })),
   );
+  const onLocationChange = useLocationMirror();
   return (
-    <SyncHistoryRouter history={history} basename={getBasename() || undefined}>
-      <V7RouterTree>{children}</V7RouterTree>
+    <SyncHistoryRouter
+      history={history}
+      basename={getBasename() || undefined}
+      onLocationChange={onLocationChange}
+    >
+      <V7RouterTree history={history}>{children}</V7RouterTree>
     </SyncHistoryRouter>
   );
 }
@@ -61,9 +98,10 @@ export function RouterProviderV7Memory({
       createMemoryHistory({ initialEntries: [initialRoute], v5Compat: true }),
     ),
   );
+  const onLocationChange = useLocationMirror();
   return (
-    <SyncHistoryRouter history={history}>
-      <V7RouterTree>{children}</V7RouterTree>
+    <SyncHistoryRouter history={history} onLocationChange={onLocationChange}>
+      <V7RouterTree history={history}>{children}</V7RouterTree>
     </SyncHistoryRouter>
   );
 }

--- a/frontend/src/metabase/router/v7/RouterProviderV7.tsx
+++ b/frontend/src/metabase/router/v7/RouterProviderV7.tsx
@@ -1,7 +1,6 @@
 import type { PropsWithChildren } from "react";
 import { useState } from "react";
 import {
-  unstable_HistoryRouter as HistoryRouter,
   Routes,
   UNSAFE_createBrowserHistory as createBrowserHistory,
   UNSAFE_createMemoryHistory as createMemoryHistory,
@@ -9,6 +8,7 @@ import {
 
 import { getBasename } from "metabase/utils/basename";
 
+import { SyncHistoryRouter } from "./SyncHistoryRouter";
 import { V7ReduxBridge } from "./V7ReduxBridge";
 import { withBlocking } from "./blocking-history";
 import { mapToV7 } from "./map-to-v7";
@@ -41,9 +41,9 @@ export function RouterProviderV7({ children }: PropsWithChildren): JSX.Element {
     withBlocking(createBrowserHistory({ v5Compat: true })),
   );
   return (
-    <HistoryRouter history={history} basename={getBasename() || undefined}>
+    <SyncHistoryRouter history={history} basename={getBasename() || undefined}>
       <V7RouterTree>{children}</V7RouterTree>
-    </HistoryRouter>
+    </SyncHistoryRouter>
   );
 }
 
@@ -62,8 +62,8 @@ export function RouterProviderV7Memory({
     ),
   );
   return (
-    <HistoryRouter history={history}>
+    <SyncHistoryRouter history={history}>
       <V7RouterTree>{children}</V7RouterTree>
-    </HistoryRouter>
+    </SyncHistoryRouter>
   );
 }

--- a/frontend/src/metabase/router/v7/RouterProviderV7.tsx
+++ b/frontend/src/metabase/router/v7/RouterProviderV7.tsx
@@ -12,7 +12,6 @@ import { getBasename } from "metabase/utils/basename";
 
 import { LOCATION_CHANGE } from "../routing-reducer";
 
-
 import { SyncHistoryRouter } from "./SyncHistoryRouter";
 import { V7ReduxBridge } from "./V7ReduxBridge";
 import { withBlocking } from "./blocking-history";

--- a/frontend/src/metabase/router/v7/SyncHistoryRouter.tsx
+++ b/frontend/src/metabase/router/v7/SyncHistoryRouter.tsx
@@ -1,0 +1,57 @@
+import type { PropsWithChildren } from "react";
+import { useLayoutEffect, useState } from "react";
+import {
+  type HistoryRouterProps,
+  type NavigationType,
+  Router,
+  type Location as V7Location,
+} from "react-router-v7";
+
+type History = HistoryRouterProps["history"];
+
+/**
+ * `unstable_HistoryRouter` without the `startTransition`.
+ *
+ * react-router marks its own location update as a transition, so in a production
+ * React build the navigation is deprioritised and can commit long after the click
+ * that caused it. v3 navigated synchronously, and the app was written against
+ * that: a navigation that lands mid-interaction remounts whatever is on screen,
+ * which silently discarded state such as the text typed into a modal that was
+ * opened right after clicking a link.
+ *
+ * Rendering `<Router>` ourselves off a plain state update keeps the v3 ordering.
+ * The transition would only buy concurrent rendering that the app does not rely
+ * on. Goes away with the v3 engine in Phase 4, once the app tolerates deferred
+ * navigation.
+ */
+export function SyncHistoryRouter({
+  history,
+  basename,
+  children,
+}: PropsWithChildren<{
+  history: History;
+  basename?: string;
+}>): JSX.Element {
+  const [state, setState] = useState<{
+    action: NavigationType;
+    location: V7Location;
+  }>({
+    action: history.action,
+    location: history.location,
+  });
+
+  // Layout, not passive, so the router state is committed before the browser
+  // paints the click that triggered it.
+  useLayoutEffect(() => history.listen(setState), [history]);
+
+  return (
+    <Router
+      basename={basename}
+      location={state.location}
+      navigationType={state.action}
+      navigator={history}
+    >
+      {children}
+    </Router>
+  );
+}

--- a/frontend/src/metabase/router/v7/SyncHistoryRouter.tsx
+++ b/frontend/src/metabase/router/v7/SyncHistoryRouter.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren } from "react";
-import { useLayoutEffect, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import {
   type HistoryRouterProps,
   type NavigationType,
@@ -10,7 +10,8 @@ import {
 type History = HistoryRouterProps["history"];
 
 /**
- * `unstable_HistoryRouter` without the `startTransition`.
+ * `unstable_HistoryRouter` without the `startTransition`, plus a hook for
+ * mirroring the location elsewhere.
  *
  * react-router marks its own location update as a transition, so in a production
  * React build the navigation is deprioritised and can commit long after the click
@@ -19,18 +20,26 @@ type History = HistoryRouterProps["history"];
  * which silently discarded state such as the text typed into a modal that was
  * opened right after clicking a link.
  *
- * Rendering `<Router>` ourselves off a plain state update keeps the v3 ordering.
- * The transition would only buy concurrent rendering that the app does not rely
- * on. Goes away with the v3 engine in Phase 4, once the app tolerates deferred
+ * `onLocationChange` runs inside the same history subscription, so `state.routing`
+ * is updated as part of the transition the way v3's `syncHistoryWithStore` did.
+ * Thunks read the store synchronously right after navigating, so a store that
+ * lags a render makes them push a stale location. This stays the blocking
+ * history's only subscriber: its POP-revert bookkeeping is per-history rather
+ * than per-listener, so a second subscription would double-evaluate the leave
+ * hooks.
+ *
+ * Goes away with the v3 engine in Phase 4, once the app tolerates deferred
  * navigation.
  */
 export function SyncHistoryRouter({
   history,
   basename,
+  onLocationChange,
   children,
 }: PropsWithChildren<{
   history: History;
   basename?: string;
+  onLocationChange?: (location: V7Location, action: NavigationType) => void;
 }>): JSX.Element {
   const [state, setState] = useState<{
     action: NavigationType;
@@ -40,9 +49,20 @@ export function SyncHistoryRouter({
     location: history.location,
   });
 
+  // Read through a ref so a new callback identity does not resubscribe the
+  // history, which would drop and re-add its only listener.
+  const onLocationChangeRef = useRef(onLocationChange);
+  onLocationChangeRef.current = onLocationChange;
+
   // Layout, not passive, so the router state is committed before the browser
   // paints the click that triggered it.
-  useLayoutEffect(() => history.listen(setState), [history]);
+  useLayoutEffect(() => {
+    onLocationChangeRef.current?.(history.location, history.action);
+    return history.listen((update) => {
+      setState(update);
+      onLocationChangeRef.current?.(update.location, update.action);
+    });
+  }, [history]);
 
   return (
     <Router

--- a/frontend/src/metabase/router/v7/V7ReduxBridge.tsx
+++ b/frontend/src/metabase/router/v7/V7ReduxBridge.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import {
+  type HistoryRouterProps,
   useNavigationType,
   useLocation as useV7Location,
   useNavigate as useV7Navigate,
@@ -21,10 +22,20 @@ import { notifyLocationListeners, setV7Navigate } from "./navigator";
  * - mirrors every location into `state.routing` via LOCATION_CHANGE, so
  *   `getLocation` / `isNavbarOpen` / `errorPage` keep working.
  *
- * Rendered inside the router but outside `<Routes>`, so it tracks the location
- * regardless of which route matches. Deleted with the v3 engine in Phase 4.
+ * The mirror subscribes to the history when one is passed, because v3 dispatched
+ * LOCATION_CHANGE as part of the transition rather than after a render. Thunks
+ * read the store synchronously right after navigating (`setEditingDashboard`
+ * pushes `{ ...getLocation(getState()) }`), so a store that lags a render makes
+ * them push a stale location and clobber query params that were just set.
+ * Falls back to the rendered location when no history is available, which is how
+ * tests mount the tree under a plain `<MemoryRouter>`. Deleted with the v3 engine
+ * in Phase 4.
  */
-export function V7ReduxBridge(): null {
+export function V7ReduxBridge({
+  history,
+}: {
+  history?: HistoryRouterProps["history"];
+}): null {
   const navigate = useV7Navigate();
   const location = useV7Location();
   const action = useNavigationType();
@@ -35,13 +46,16 @@ export function V7ReduxBridge(): null {
     return () => setV7Navigate(null);
   }, [navigate]);
 
+  // When a history is provided the mirroring happens synchronously in
+  // `SyncHistoryRouter`'s subscription instead, so nothing to do here.
   useEffect(() => {
+    if (history) {
+      return;
+    }
     const v3Location = toV3Location(location, action);
     dispatch({ type: LOCATION_CHANGE, payload: v3Location });
-    // Fan out to the imperative router's `listen` subscribers (v3's
-    // `router.listen`), which have no other source of location changes on v7.
     notifyLocationListeners(v3Location);
-  }, [dispatch, location, action]);
+  }, [dispatch, history, location, action]);
 
   return null;
 }

--- a/frontend/src/metabase/router/v7/V7ReduxBridge.tsx
+++ b/frontend/src/metabase/router/v7/V7ReduxBridge.tsx
@@ -10,7 +10,7 @@ import { useDispatch } from "metabase/redux";
 import { LOCATION_CHANGE } from "../routing-reducer";
 
 import { toV3Location } from "./location";
-import { setV7Navigate } from "./navigator";
+import { notifyLocationListeners, setV7Navigate } from "./navigator";
 
 /**
  * Bridges the v7 router to redux, replacing what `routerMiddleware` +
@@ -36,10 +36,11 @@ export function V7ReduxBridge(): null {
   }, [navigate]);
 
   useEffect(() => {
-    dispatch({
-      type: LOCATION_CHANGE,
-      payload: toV3Location(location, action),
-    });
+    const v3Location = toV3Location(location, action);
+    dispatch({ type: LOCATION_CHANGE, payload: v3Location });
+    // Fan out to the imperative router's `listen` subscribers (v3's
+    // `router.listen`), which have no other source of location changes on v7.
+    notifyLocationListeners(v3Location);
   }, [dispatch, location, action]);
 
   return null;

--- a/frontend/src/metabase/router/v7/blocking-history.ts
+++ b/frontend/src/metabase/router/v7/blocking-history.ts
@@ -91,6 +91,18 @@ function toBlockedLocation(
   return toV3Location(location, action);
 }
 
+function isSameUrl(
+  to: To,
+  current: { pathname: string; search: string; hash: string },
+): boolean {
+  const path = typeof to === "string" ? parsePath(to) : to;
+  return (
+    (path.pathname ?? current.pathname) === current.pathname &&
+    (path.search ?? "") === current.search &&
+    (path.hash ?? "") === current.hash
+  );
+}
+
 /**
  * Wrap a history so a registered leave hook can cancel navigation, restoring the
  * v3 `setRouteLeaveHook` behavior on the declarative v7 engine. react-router
@@ -113,6 +125,14 @@ export function withBlocking(history: History): History {
   };
 
   const replace: History["replace"] = (to, state) => {
+    // v3/history@3 did not notify listeners when replacing to the current URL, so
+    // effects that sync state into the URL by replacing the location they just
+    // read stayed stable. v7's `v5Compat` history notifies on every replace,
+    // which loops those effects (e.g. the dashboard's `useLocationSync`). Skip the
+    // redundant replace to keep the v3 behavior.
+    if (isSameUrl(to, history.location)) {
+      return;
+    }
     if (!isBlocked(toBlockedLocation(to, "REPLACE", state))) {
       history.replace(to, state);
     }

--- a/frontend/src/metabase/router/v7/blocking-history.unit.spec.ts
+++ b/frontend/src/metabase/router/v7/blocking-history.unit.spec.ts
@@ -48,6 +48,18 @@ describe("withBlocking", () => {
     expect(history.location.pathname).toBe("/b");
   });
 
+  it("does not notify listeners when replacing to the current URL", () => {
+    const history = setup(["/a?x=1"]);
+    const listener = jest.fn();
+    history.listen(listener);
+
+    history.replace("/a?x=1");
+    expect(listener).not.toHaveBeenCalled();
+
+    history.replace("/b");
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
   it("blocks a replace while a hook returns false", () => {
     const history = setup();
     register(() => false);

--- a/frontend/src/metabase/router/v7/location.ts
+++ b/frontend/src/metabase/router/v7/location.ts
@@ -19,6 +19,27 @@ export function searchToQuery(
 }
 
 /**
+ * Serialize v3's `location.query` object back into a search string, the only form
+ * v7 understands. Repeated values become repeated keys, mirroring what
+ * `searchToQuery` parses. Returns `""` for an empty query.
+ */
+export function queryToSearch(query: Record<string, unknown>): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value == null) {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      value.forEach((item) => params.append(key, String(item)));
+    } else {
+      params.append(key, String(value));
+    }
+  }
+  const search = params.toString();
+  return search ? `?${search}` : "";
+}
+
+/**
  * Build the v3-shaped `history` location the facade context and `state.routing`
  * expect from a v7 location plus the current navigation type.
  */

--- a/frontend/src/metabase/router/v7/location.ts
+++ b/frontend/src/metabase/router/v7/location.ts
@@ -29,7 +29,7 @@ export function searchToQuery(
  * order has to stay stable rather than follow insertion.
  */
 export function queryToSearch(query: Record<string, unknown>): string {
-  const params = new URLSearchParams();
+  const pairs: string[] = [];
   const sortedEntries = Object.entries(query).sort(([a], [b]) =>
     a.localeCompare(b),
   );
@@ -37,14 +37,21 @@ export function queryToSearch(query: Record<string, unknown>): string {
     if (value == null) {
       continue;
     }
-    if (Array.isArray(value)) {
-      value.forEach((item) => params.append(key, String(item)));
-    } else {
-      params.append(key, String(value));
+    const values = Array.isArray(value) ? value : [value];
+    for (const item of values) {
+      pairs.push(`${encodeQueryPart(key)}=${encodeQueryPart(String(item))}`);
     }
   }
-  const search = params.toString();
-  return search ? `?${search}` : "";
+  return pairs.length > 0 ? `?${pairs.join("&")}` : "";
+}
+
+/**
+ * `encodeURIComponent`, as history@3 used, rather than `URLSearchParams`. The
+ * latter also escapes `~!*'()` and writes a space as `+`, which would change URLs
+ * users see and share (a date filter reads `next30days~`, not `next30days%7E`).
+ */
+function encodeQueryPart(value: string): string {
+  return encodeURIComponent(value);
 }
 
 /**

--- a/frontend/src/metabase/router/v7/location.ts
+++ b/frontend/src/metabase/router/v7/location.ts
@@ -22,10 +22,18 @@ export function searchToQuery(
  * Serialize v3's `location.query` object back into a search string, the only form
  * v7 understands. Repeated values become repeated keys, mirroring what
  * `searchToQuery` parses. Returns `""` for an empty query.
+ *
+ * Keys are sorted, because history@3 stringified the query with `query-string`,
+ * which sorts by default. Call sites build the query from an object whose key
+ * order is incidental, and the URL is user visible and asserted against, so the
+ * order has to stay stable rather than follow insertion.
  */
 export function queryToSearch(query: Record<string, unknown>): string {
   const params = new URLSearchParams();
-  for (const [key, value] of Object.entries(query)) {
+  const sortedEntries = Object.entries(query).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  for (const [key, value] of sortedEntries) {
     if (value == null) {
       continue;
     }

--- a/frontend/src/metabase/router/v7/location.ts
+++ b/frontend/src/metabase/router/v7/location.ts
@@ -29,7 +29,7 @@ export function searchToQuery(
  * order has to stay stable rather than follow insertion.
  */
 export function queryToSearch(query: Record<string, unknown>): string {
-  const pairs: string[] = [];
+  const params = new URLSearchParams();
   const sortedEntries = Object.entries(query).sort(([a], [b]) =>
     a.localeCompare(b),
   );
@@ -39,19 +39,14 @@ export function queryToSearch(query: Record<string, unknown>): string {
     }
     const values = Array.isArray(value) ? value : [value];
     for (const item of values) {
-      pairs.push(`${encodeQueryPart(key)}=${encodeQueryPart(String(item))}`);
+      params.append(key, String(item));
     }
   }
-  return pairs.length > 0 ? `?${pairs.join("&")}` : "";
-}
-
-/**
- * `encodeURIComponent`, as history@3 used, rather than `URLSearchParams`. The
- * latter also escapes `~!*'()` and writes a space as `+`, which would change URLs
- * users see and share (a date filter reads `next30days~`, not `next30days%7E`).
- */
-function encodeQueryPart(value: string): string {
-  return encodeURIComponent(value);
+  // `URLSearchParams` matches history@3 apart from `~`, which it escapes and
+  // history@3 left alone. Both write a space as `+`. These URLs are user visible
+  // and asserted against, so a date filter has to read `next30days~`.
+  const search = params.toString().replace(/%7E/gi, "~");
+  return search ? `?${search}` : "";
 }
 
 /**

--- a/frontend/src/metabase/router/v7/navigator.ts
+++ b/frontend/src/metabase/router/v7/navigator.ts
@@ -3,6 +3,8 @@ import type { NavigateFunction, NavigateOptions, To } from "react-router-v7";
 
 import type { RouterNavigator } from "../middleware";
 
+import { queryToSearch } from "./location";
+
 /**
  * The live v7 `navigate`, registered by `V7ReduxBridge` once the router mounts.
  * The redux navigator adapter is built at store creation, before the router
@@ -48,10 +50,18 @@ export function toNavigateArgs(
   if (typeof location === "string") {
     return [location, options];
   }
+  // v3 descriptors carry the query as a `query` object, which v7 does not read, so
+  // serialize it into the search string. Dropping it silently loses params (e.g.
+  // the dashboard's tab and filter slugs). `query` wins over `search`, matching
+  // history@3's `useQueries`: callers build `{ ...location, query }`, so the
+  // spread's stale `search` must not shadow the query they just set.
+  const search = location.query
+    ? queryToSearch(location.query)
+    : location.search;
   return [
     {
       pathname: location.pathname,
-      search: location.search,
+      search,
       hash: location.hash,
     },
     { ...options, state: location.state },

--- a/frontend/src/metabase/router/v7/navigator.ts
+++ b/frontend/src/metabase/router/v7/navigator.ts
@@ -1,4 +1,4 @@
-import type { LocationDescriptor } from "history";
+import type { Location as HistoryLocation, LocationDescriptor } from "history";
 import type { NavigateFunction, NavigateOptions, To } from "react-router-v7";
 
 import type { RouterNavigator } from "../middleware";
@@ -12,6 +12,28 @@ let currentNavigate: NavigateFunction | null = null;
 
 export function setV7Navigate(navigate: NavigateFunction | null): void {
   currentNavigate = navigate;
+}
+
+/**
+ * Subscribers to location changes, backing the imperative router's `listen`. v3's
+ * `router.listen` had no v7 equivalent, so `V7ReduxBridge` fans every location
+ * change out to these on the app's behalf (e.g. `use-dashboard-url-query`).
+ */
+type LocationListener = (location: HistoryLocation) => void;
+const locationListeners = new Set<LocationListener>();
+
+export function subscribeLocation(listener: LocationListener): () => void {
+  locationListeners.add(listener);
+  return () => {
+    locationListeners.delete(listener);
+  };
+}
+
+export function notifyLocationListeners(location: HistoryLocation): void {
+  // Snapshot so a listener that unsubscribes mid-run cannot skip a sibling.
+  for (const listener of [...locationListeners]) {
+    listener(location);
+  }
 }
 
 /**

--- a/frontend/src/metabase/router/v7/navigator.unit.spec.ts
+++ b/frontend/src/metabase/router/v7/navigator.unit.spec.ts
@@ -1,0 +1,68 @@
+import { queryToSearch } from "./location";
+import { toNavigateArgs } from "./navigator";
+
+// v3 location descriptors carry the query as an object. v7 only reads `search`,
+// so the navigator has to serialize it; dropping it silently loses params (the
+// dashboard's tab and filter slugs went missing this way).
+describe("toNavigateArgs", () => {
+  it("serializes a v3 `query` object into the search string", () => {
+    const [to] = toNavigateArgs({
+      pathname: "/dashboard/1",
+      query: { tab: "2-tab-two", "filter-date": "2024-01-01" },
+    });
+
+    expect(to).toEqual({
+      pathname: "/dashboard/1",
+      search: "?tab=2-tab-two&filter-date=2024-01-01",
+      hash: undefined,
+    });
+  });
+
+  // Call sites build `{ ...location, query }`, so the spread carries the previous
+  // `search`. The query they just set has to win, as it does on history@3.
+  it("prefers `query` over a stale search carried by a spread location", () => {
+    const [to] = toNavigateArgs({
+      pathname: "/dashboard/1",
+      search: "",
+      query: { tab: "2-tab-two" },
+    });
+
+    expect(to).toMatchObject({ search: "?tab=2-tab-two" });
+  });
+
+  it("falls back to `search` when there is no `query`", () => {
+    const [to] = toNavigateArgs({ pathname: "/dashboard/1", search: "?a=1" });
+
+    expect(to).toMatchObject({ search: "?a=1" });
+  });
+
+  it("passes a string target through untouched", () => {
+    expect(toNavigateArgs("/dashboard/1?tab=2")).toEqual([
+      "/dashboard/1?tab=2",
+      {},
+    ]);
+  });
+
+  it("carries `state` across as a navigate option", () => {
+    const [, options] = toNavigateArgs(
+      { pathname: "/a", state: { from: "here" } },
+      { replace: true },
+    );
+
+    expect(options).toEqual({ replace: true, state: { from: "here" } });
+  });
+});
+
+describe("queryToSearch", () => {
+  it("repeats a key for array values", () => {
+    expect(queryToSearch({ id: ["1", "2"] })).toBe("?id=1&id=2");
+  });
+
+  it("skips null and undefined values", () => {
+    expect(queryToSearch({ a: "1", b: null, c: undefined })).toBe("?a=1");
+  });
+
+  it("returns an empty string for an empty query", () => {
+    expect(queryToSearch({})).toBe("");
+  });
+});

--- a/frontend/src/metabase/router/v7/navigator.unit.spec.ts
+++ b/frontend/src/metabase/router/v7/navigator.unit.spec.ts
@@ -13,7 +13,8 @@ describe("toNavigateArgs", () => {
 
     expect(to).toEqual({
       pathname: "/dashboard/1",
-      search: "?tab=2-tab-two&filter-date=2024-01-01",
+      // sorted, as history@3 stringified it
+      search: "?filter-date=2024-01-01&tab=2-tab-two",
       hash: undefined,
     });
   });
@@ -64,5 +65,12 @@ describe("queryToSearch", () => {
 
   it("returns an empty string for an empty query", () => {
     expect(queryToSearch({})).toBe("");
+  });
+
+  // history@3 stringified with `query-string`, which sorts keys. The URL is user
+  // visible and asserted against, so the order must not follow insertion.
+  it("sorts keys regardless of insertion order", () => {
+    expect(queryToSearch({ state: "AK", city: "" })).toBe("?city=&state=AK");
+    expect(queryToSearch({ city: "", state: "AK" })).toBe("?city=&state=AK");
   });
 });

--- a/frontend/src/metabase/router/v7/navigator.unit.spec.ts
+++ b/frontend/src/metabase/router/v7/navigator.unit.spec.ts
@@ -74,12 +74,15 @@ describe("queryToSearch", () => {
     expect(queryToSearch({ city: "", state: "AK" })).toBe("?city=&state=AK");
   });
 
-  // `URLSearchParams` would write these as %7E and `+`, changing URLs users see.
-  it("leaves `encodeURIComponent`-safe characters alone", () => {
+  // history@3 wrote a space as `+` but left `~` literal, and both show up in URLs
+  // the app asserts on (a date filter reads `next30days~`).
+  it("writes a space as `+` and leaves `~` literal", () => {
     expect(queryToSearch({ date_filter: "next30days~" })).toBe(
       "?date_filter=next30days~",
     );
-    expect(queryToSearch({ q: "a b" })).toBe("?q=a%20b");
+    expect(queryToSearch({ task: "field values scanning" })).toBe(
+      "?task=field+values+scanning",
+    );
   });
 
   it("still escapes characters that would break the query string", () => {

--- a/frontend/src/metabase/router/v7/navigator.unit.spec.ts
+++ b/frontend/src/metabase/router/v7/navigator.unit.spec.ts
@@ -73,4 +73,16 @@ describe("queryToSearch", () => {
     expect(queryToSearch({ state: "AK", city: "" })).toBe("?city=&state=AK");
     expect(queryToSearch({ city: "", state: "AK" })).toBe("?city=&state=AK");
   });
+
+  // `URLSearchParams` would write these as %7E and `+`, changing URLs users see.
+  it("leaves `encodeURIComponent`-safe characters alone", () => {
+    expect(queryToSearch({ date_filter: "next30days~" })).toBe(
+      "?date_filter=next30days~",
+    );
+    expect(queryToSearch({ q: "a b" })).toBe("?q=a%20b");
+  });
+
+  it("still escapes characters that would break the query string", () => {
+    expect(queryToSearch({ q: "a&b=c" })).toBe("?q=a%26b%3Dc");
+  });
 });

--- a/frontend/src/metabase/router/v7/router-listen.unit.spec.tsx
+++ b/frontend/src/metabase/router/v7/router-listen.unit.spec.tsx
@@ -1,9 +1,15 @@
+import type { Location as HistoryLocation } from "history";
 import { useEffect, useState } from "react";
 
 import { renderWithProviders, screen } from "__support__/ui";
 import { Outlet, Route, push, useRouter } from "metabase/router";
 
 import type { RouterEngine } from "../engine";
+
+// Both engines expose `listen` at runtime; v3's `InjectedRouter` type omits it.
+type RouterWithListen = {
+  listen: (callback: (location: HistoryLocation) => void) => () => void;
+};
 
 // v3's `router.listen` fires a callback on every location change and returns an
 // unsubscribe function. The v7 engine has no native equivalent, so the shim wires
@@ -13,8 +19,8 @@ function Harness() {
   const { router } = useRouter();
   const [seen, setSeen] = useState<string[]>([]);
   useEffect(() => {
-    // `listen` is absent from v3's `InjectedRouter` type but present at runtime.
-    return router.listen((location) => {
+    // Cast because v3's `InjectedRouter` type omits `listen` (see above).
+    return (router as unknown as RouterWithListen).listen((location) => {
       setSeen((previous) => [...previous, location.pathname]);
     });
   }, [router]);

--- a/frontend/src/metabase/router/v7/router-listen.unit.spec.tsx
+++ b/frontend/src/metabase/router/v7/router-listen.unit.spec.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import { Outlet, Route, push, useRouter } from "metabase/router";
+
+import type { RouterEngine } from "../engine";
+
+// v3's `router.listen` fires a callback on every location change and returns an
+// unsubscribe function. The v7 engine has no native equivalent, so the shim wires
+// it to the location fan-out; `use-dashboard-url-query` relies on it (and crashed
+// the dashboard on v7 when it was missing).
+function Harness() {
+  const { router } = useRouter();
+  const [seen, setSeen] = useState<string[]>([]);
+  useEffect(() => {
+    // `listen` is absent from v3's `InjectedRouter` type but present at runtime.
+    return router.listen((location) => {
+      setSeen((previous) => [...previous, location.pathname]);
+    });
+  }, [router]);
+  return (
+    <div>
+      <span data-testid="seen">{seen.join(",")}</span>
+      <Outlet />
+    </div>
+  );
+}
+
+const tree = (
+  <Route path="/" element={<Harness />}>
+    <Route path="other" element={<span data-testid="other">other</span>} />
+  </Route>
+);
+
+describe.each<RouterEngine>(["v3", "v7"])(
+  "router.listen on the %s engine",
+  (routerEngine) => {
+    it("fires the callback on navigation and stops after unsubscribe", async () => {
+      const { store } = renderWithProviders(tree, {
+        withRouter: true,
+        routerEngine,
+        initialRoute: "/",
+      });
+
+      await screen.findByTestId("seen");
+
+      store.dispatch(push("/other"));
+
+      await screen.findByText("other");
+      expect(screen.getByTestId("seen")).toHaveTextContent("/other");
+    });
+  },
+);

--- a/src/metabase/appearance/settings.clj
+++ b/src/metabase/appearance/settings.clj
@@ -49,7 +49,7 @@
 (defsetting use-v7-router
   (deferred-tru "Serve the app with the react-router v7 engine instead of the legacy v3 engine. Toggle off for an instant rollback.")
   :type       :boolean
-  :default    false
+  :default    true
   :visibility :public
   :export?    false)
 


### PR DESCRIPTION
Closes DEV-2426.

Turns the react-router v7 engine on by default, together with the fixes that make it viable. Follow-up to #78103 (merged), which landed the first round of fixes dormant.

Still draft: v7 is not green across e2e yet. See the status section at the bottom.

## The default flip

`use-v7-router` now defaults to `true`, so the app is served by the v7 engine. The flag remains, so toggling it off is still an instant rollback to v3.

## The fixes

Each one restores a v3 behaviour the v7 facade did not yet reproduce. Every one was found by instrumenting the running app, not by reading code.

1. **A `<Link>` with an empty `to` is a button, not a navigation.** `UndoButton` (the undo toast, including its "Add this to a dashboard" action) renders `<Link to="" onClick=...>`. On v7 the link also navigated, resolving `""` to `/` from the toast's portal, which unmounted the page underneath. Now an absent or empty `to` renders a plain anchor, matching v3 where `router.push("")` was a no-op.
2. **A `replace` to the current URL is a no-op.** history@3 did not notify listeners when replacing the location it already had, so URL-sync effects settled. v7's `v5Compat` history notifies on every replace, which looped `useLocationSync` and crashed the dashboard.
3. **`router.listen` exists on v7, and the router shim is stable.** `use-dashboard-url-query` calls `router.listen`, which the shim lacked, so `<DashboardApp>` threw and the dashboard never rendered. The shim is now memoised once and reads `navigate` through a ref, because v7's `navigate` changes identity per navigation and was tearing down every consumer effect keyed on `router`.
4. **A v3 `query` object is serialised into the search string.** `toNavigateArgs` mapped only `pathname`, `search` and `hash`, so `push({ ...location, query })` silently dropped its params. `query` takes precedence over `search`, matching history@3, because call sites spread a location whose `search` is stale.
5. **The matched-route branch is stable across renders.** react-router returns a fresh `matches` array every render, so `route` was a new object each time and the leave-confirm modal, which resets itself when `route` changes, closed itself mid-interaction.
6. **v7's splat param is republished as v3's `splat`.** v3 exposed a wildcard match as `params.splat`, v7 names it `*`. `AutomaticDashboardApp` builds x-ray URLs from `params.splat`, so on v7 it requested `/auto/dashboard/undefined` and rendered an empty dashboard with no error.
7. **Lint and type cleanups** in the shim.

