### PR TITLE
Load the bb postgresql pod lazily and pin it to 0.1.6

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -13,7 +13,8 @@
         org.babashka/json {:mvn/version "0.1.6"} ;; json parsing
         table/table {:mvn/version "0.5.0"} ;; table printing
         }
- :pods {org.babashka/postgresql {:version "0.1.0"}}
+ ;; No :pods key on purpose: bb resolves it at startup, so a pod missing for the current os/arch breaks
+ ;; every mage command. mage.bot.setup-worktree loads the postgresql pod lazily and is the only user.
  :tasks
  {:requires [[mage.cli :as cli]
              [mage.color :as c]]

--- a/bb.edn
+++ b/bb.edn
@@ -13,8 +13,7 @@
         org.babashka/json {:mvn/version "0.1.6"} ;; json parsing
         table/table {:mvn/version "0.5.0"} ;; table printing
         }
- ;; No :pods key on purpose: bb resolves it at startup, so a pod missing for the current os/arch breaks
- ;; every mage command. mage.bot.setup-worktree loads the postgresql pod lazily and is the only user.
+ ;; No :pods key on purpose: tasks lazily load only what they need.
  :tasks
  {:requires [[mage.cli :as cli]
              [mage.color :as c]]

--- a/mage/src/mage/bot/setup_worktree.clj
+++ b/mage/src/mage/bot/setup_worktree.clj
@@ -7,7 +7,9 @@
    [mage.color :as c]
    [mage.shell :as shell]))
 
-(pods/load-pod 'org.babashka/postgresql "0.1.0")
+;; 0.1.0-0.1.4 ship an x86_64 Mac build, 0.1.5+ ship arm64, and no release ships both. Pinning 0.1.6 is a
+;; deliberate choice to support Apple Silicon and drop Intel Macs.
+(pods/load-pod 'org.babashka/postgresql "0.1.6")
 (require '[pod.babashka.postgresql :as pg])
 
 (set! *warn-on-reflection* true)

--- a/mage/src/mage/bot/setup_worktree.clj
+++ b/mage/src/mage/bot/setup_worktree.clj
@@ -7,8 +7,8 @@
    [mage.color :as c]
    [mage.shell :as shell]))
 
-;; 0.1.0-0.1.4 ship an x86_64 Mac build, 0.1.5+ ship arm64, and no release ships both. Pinning 0.1.6 is a
-;; deliberate choice to support Apple Silicon and drop Intel Macs.
+;; 0.1.0-0.1.4 ship an x86_64 Mac build, 0.1.5+ ship arm64, and no release ships both.
+;; Pinning 0.1.6 is a deliberate choice to support Apple Silicon and drop Intel Macs.
 (pods/load-pod 'org.babashka/postgresql "0.1.6")
 (require '[pod.babashka.postgresql :as pg])
 


### PR DESCRIPTION
## Problem

On an Apple Silicon Mac without Rosetta, every mage command fails before it runs:

```
$ bb -e '(println :ok)'
Cannot run program ".../postgresql/0.1.0/mac_os_x/aarch64/pod-babashka-postgresql":
Exec failed, error: 86 (Bad CPU type in executable)
```

0.1.0 only publishes an x86_64 Mac artifact. bb caches it under the `aarch64` path and then can't exec it. 

## Change

Pin the pod to 0.1.6, which has a native arm64 Mac build.

Also drop the `:pods` key from `bb.edn`. bb resolves it at startup, which is why a Postgres pod broke every mage task, including ones with nothing to do with Postgres. `mage.bot.setup-worktree` already loads the pod lazily and is the only thing that uses it.

## This drops Intel Mac support

Upstream swapped Mac architectures at 0.1.5 rather than adding one: 0.1.0-0.1.4 ship x86_64, 0.1.5+ ship arm64, and no release ships both. A single pin can't cover both, so Intel Macs lose `mage bot setup-worktree`. I think this is a better compromise than pinning all developers to an older version, and adding overhead for the typical development stack.

Linux and Windows are unaffected. `pg/execute!` is the only pod function used in the repo and its signature is unchanged.

## Checks

- Reproduced the failure on the old `bb.edn`, then confirmed `bb -e '(println :ok)'` works after the change.
- `./bin/mage fix-kondo-ratchets` prints `unchanged`, exits 0.
- `bb -e "(require '[mage.bot.setup-worktree])"` loads and resolves 0.1.6.
- Read the `:os/arch` entries in every pod-registry manifest for this pod.

Not checked: the Intel Mac path, for lack of the hardware.