### PR TITLE
test: bump transform-run timeouts for slow drivers

### DIFF
--- a/test/metabase/transforms/jobs_test.clj
+++ b/test/metabase/transforms/jobs_test.clj
@@ -21,7 +21,7 @@
    [metabase.transforms.models.transform-run :as transform-run]
    [metabase.transforms.settings :as transforms.settings]
    [metabase.transforms.test-dataset :as transforms-dataset]
-   [metabase.transforms.test-util :refer [with-transform-cleanup!]]
+   [metabase.transforms.test-util :refer [transform-run-timeout-seconds with-transform-cleanup!]]
    [metabase.transforms.util :as transforms.u]
    [toucan2.core :as t2])
   (:import
@@ -608,10 +608,10 @@
                                                                       {:run-method :manual})}
                                        (catch Exception e
                                          {:error e})))
-                              ;; generous timeout: each run-transforms! does a real transform execution,
-                              ;; which routinely takes 50-70s on BigQuery in CI
-                              results [(deref fut1 120000 {:error :timeout})
-                                       (deref fut2 120000 {:error :timeout})]]
+                              ;; each run-transforms! does a real transform execution, so give it the full run timeout
+                              timeout-ms (* 1000 transform-run-timeout-seconds)
+                              results [(deref fut1 timeout-ms {:error :timeout})
+                                       (deref fut2 timeout-ms {:error :timeout})]]
                           (is (every? #(= :succeeded (-> % :result ::jobs/status)) results)
                               "Both threads should succeed"))))))))))))))
 

--- a/test/metabase/transforms/jobs_test.clj
+++ b/test/metabase/transforms/jobs_test.clj
@@ -608,8 +608,10 @@
                                                                       {:run-method :manual})}
                                        (catch Exception e
                                          {:error e})))
-                              results [(deref fut1 30000 {:error :timeout})
-                                       (deref fut2 30000 {:error :timeout})]]
+                              ;; generous timeout: each run-transforms! does a real transform execution,
+                              ;; which routinely takes 50-70s on BigQuery in CI
+                              results [(deref fut1 120000 {:error :timeout})
+                                       (deref fut2 120000 {:error :timeout})]]
                           (is (every? #(= :succeeded (-> % :result ::jobs/status)) results)
                               "Both threads should succeed"))))))))))))))
 

--- a/test/metabase/transforms/test_util.clj
+++ b/test/metabase/transforms/test_util.clj
@@ -16,6 +16,11 @@
 
 (set! *warn-on-reflection* true)
 
+(def transform-run-timeout-seconds
+  "How long tests wait for a transform run to finish execution and sync."
+  ;; BigQuery runs routinely take 50-70s in CI.
+  120)
+
 (defn seconds-from-now-ns
   "Returns a deadline `seconds` from now in nanoseconds, for use with `System/nanoTime`.
   We use nanoTime rather than currentTimeMillis because it is monotonic and not affected by
@@ -174,7 +179,7 @@
 (defn test-run
   [transform-id]
   (let [resp      (mt/user-http-request :crowberto :post 202 (format "transform/%s/run" transform-id))
-        timeout-s 120 ; timeout to finish execution and sync; BigQuery runs routinely take 50-70s in CI
+        timeout-s transform-run-timeout-seconds
         deadline  (seconds-from-now-ns timeout-s)]
     (is (=? {:message "Transform run started"}
             resp))

--- a/test/metabase/transforms/test_util.clj
+++ b/test/metabase/transforms/test_util.clj
@@ -174,7 +174,7 @@
 (defn test-run
   [transform-id]
   (let [resp      (mt/user-http-request :crowberto :post 202 (format "transform/%s/run" transform-id))
-        timeout-s 20 ; 20 seconds is our timeout to finish execution and sync
+        timeout-s 120 ; timeout to finish execution and sync; BigQuery runs routinely take 50-70s in CI
         deadline  (seconds-from-now-ns timeout-s)]
     (is (=? {:message "Transform run started"}
             resp))

--- a/test/metabase/transforms_rest/api/transform_test.clj
+++ b/test/metabase/transforms_rest/api/transform_test.clj
@@ -827,7 +827,7 @@
   (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
     (mt/with-data-analyst-role! (mt/user->id :lucky)
       (let [resp      (mt/user-http-request :lucky :post 202 (format "transform/%s/run" transform-id))
-            timeout-s 20 ; 20 seconds is our timeout to finish execution and sync
+            timeout-s 120 ; timeout to finish execution and sync; BigQuery runs routinely take 50-70s in CI
             deadline  (seconds-from-now-ns timeout-s)]
         (is (=? {:message "Transform run started"}
                 resp))

--- a/test/metabase/transforms_rest/api/transform_test.clj
+++ b/test/metabase/transforms_rest/api/transform_test.clj
@@ -25,6 +25,7 @@
                                           parse-instant
                                           seconds-from-now-ns
                                           table-rows
+                                          transform-run-timeout-seconds
                                           utc-timestamp
                                           wait-for-table
                                           with-transform-cleanup!]]
@@ -827,7 +828,7 @@
   (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
     (mt/with-data-analyst-role! (mt/user->id :lucky)
       (let [resp      (mt/user-http-request :lucky :post 202 (format "transform/%s/run" transform-id))
-            timeout-s 120 ; timeout to finish execution and sync; BigQuery runs routinely take 50-70s in CI
+            timeout-s transform-run-timeout-seconds
             deadline  (seconds-from-now-ns timeout-s)]
         (is (=? {:message "Transform run started"}
                 resp))


### PR DESCRIPTION
BigQuery transform executions routinely take 50-70s in CI. We recently bumped some timeouts but they're still not generous enough, so bumping to 2mins to give plenty of time in case of cloud db overloads. 