### PR TITLE
Add Data Studio seeds (POC)

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3144,6 +3144,7 @@
            models
            permissions
            premium-features
+           upload
            util}
    :model-imports #{:model/Collection
                     :model/Dimension

--- a/enterprise/backend/src/metabase_enterprise/data_studio/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_studio/api/table.clj
@@ -10,6 +10,7 @@
    [metabase.events.core :as events]
    [metabase.models.interface :as mi]
    [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.upload.core :as upload]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
@@ -209,6 +210,61 @@
           (events/publish-event! :event/table-unpublish {:object  table
                                                          :user-id api/*current-user-id*}))))
     nil))
+
+;;; +-----------------------------
+;;; |  seeds
+;;; +-----------------------------
+
+(defn- library-data-collection
+  "The root Library / Data collection that published tables (and seeds) live in."
+  []
+  (when-let [lib-id (:id (collection/library-collection))]
+    (t2/select-one :model/Collection
+                   :type     collection/library-data-collection-type
+                   :location (str "/" lib-id "/"))))
+
+(defn- publish-seed!
+  "Move a freshly-materialized seed table into the Library and mark it published, mirroring `/publish-tables`."
+  [table]
+  (let [target (api/check-404 (library-data-collection))]
+    (t2/update! :model/Table (:id table) {:collection_id (:id target)
+                                          :is_published  true})
+    (let [published (t2/select-one :model/Table (:id table))]
+      (events/publish-event! :event/table-publish {:object  published
+                                                   :user-id api/*current-user-id*})
+      published)))
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :post "/seed"
+  "Create a *seed*: materialize the attached CSV into a plain, stably-named table (no model Card) and publish it into
+  the Library. Unlike an upload, the caller supplies `name`, which becomes the table name that dependents reference.
+
+  The file may be at most 50 MB; larger uploads are rejected with a 413 response."
+  {:multipart {:max-file-size  upload/max-upload-size-bytes
+               :max-file-count upload/max-upload-part-count}}
+  [_route-params
+   _query-params
+   _body
+   {:keys [multipart-params], :as _request}
+   :- [:map
+       [:multipart-params
+        [:map {:closed true}
+         ["name" :string]
+         ["file" [:map
+                  [:filename :string]
+                  [:tempfile (ms/InstanceOfClass java.io.File)]]]]]]]
+  (api/check-data-analyst)
+  (let [settings (upload/uploads-settings)
+        db-id    (or (:db_id settings)
+                     (throw (ex-info (tru "The uploads database is not configured.") {:status-code 422})))
+        file     (get multipart-params "file")
+        table    (upload/create-csv-table! {:filename    (:filename file)
+                                            :file        (:tempfile file)
+                                            :db-id       db-id
+                                            :schema-name (:schema_name settings)
+                                            :table-name  (get multipart-params "name")
+                                            :data-source :seed})]
+    (publish-seed! table)))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/data-studio/table` routes."

--- a/enterprise/frontend/src/metabase-enterprise/api/table.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/table.ts
@@ -1,6 +1,7 @@
 import type {
   BulkTableRequest,
   PublishTablesResponse,
+  Table,
 } from "metabase-types/api";
 
 import { EnterpriseApi } from "./api";
@@ -8,6 +9,20 @@ import { invalidateTags, tag } from "./tags";
 
 export const tableApi = EnterpriseApi.injectEndpoints({
   endpoints: (builder) => ({
+    createSeed: builder.mutation<Table, { name: string; file: File }>({
+      query: ({ name, file }) => {
+        const formData = new FormData();
+        formData.append("name", name);
+        formData.append("file", file);
+        return {
+          method: "POST",
+          url: "/api/ee/data-studio/table/seed",
+          body: formData,
+        };
+      },
+      invalidatesTags: (_, error) =>
+        invalidateTags(error, [tag("table"), tag("collection")]),
+    }),
     publishTables: builder.mutation<PublishTablesResponse, BulkTableRequest>({
       query: (body) => ({
         method: "POST",
@@ -29,5 +44,8 @@ export const tableApi = EnterpriseApi.injectEndpoints({
   }),
 });
 
-export const { usePublishTablesMutation, useUnpublishTablesMutation } =
-  tableApi;
+export const {
+  useCreateSeedMutation,
+  usePublishTablesMutation,
+  useUnpublishTablesMutation,
+} = tableApi;

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/components/CreateMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/components/CreateMenu.tsx
@@ -16,6 +16,8 @@ import * as Urls from "metabase/urls";
 import { getIsRemoteSyncReadOnly } from "metabase-enterprise/remote_sync/selectors";
 import type { CollectionId, CollectionNamespace } from "metabase-types/api";
 
+import { NewSeedModal } from "../../seeds/components/NewSeedModal";
+
 import { PublishTableModal } from "./PublishTableModal";
 
 export const CreateMenu = ({
@@ -33,6 +35,10 @@ export const CreateMenu = ({
   const [
     showPublishTableModal,
     { close: closePublishTableModal, open: openPublishTableModal },
+  ] = useDisclosure(false);
+  const [
+    showNewSeedModal,
+    { close: closeNewSeedModal, open: openNewSeedModal },
   ] = useDisclosure(false);
 
   const hasNativeWrite = useSelector(canUserCreateNativeQueries);
@@ -77,6 +83,15 @@ export const CreateMenu = ({
     >
       {t`Published table`}
     </Menu.Item>,
+    dataCollectionId && canWriteToDataCollection && (
+      <Menu.Item
+        key="seed"
+        leftSection={<FixedSizeIcon name="table2" />}
+        onClick={openNewSeedModal}
+      >
+        {t`Seed`}
+      </Menu.Item>
+    ),
     canCreateMetric && (
       <Menu.Item
         key="metric"
@@ -142,6 +157,7 @@ export const CreateMenu = ({
         onClose={closePublishTableModal}
         onPublished={(table) => dispatch(push(Urls.dataStudioTable(table.id)))}
       />
+      <NewSeedModal opened={showNewSeedModal} onClose={closeNewSeedModal} />
     </>
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/routes.tsx
@@ -5,6 +5,7 @@ import { Route } from "metabase/router";
 import { LibraryPage } from "./LibraryPage";
 import { LibrarySectionLayout } from "./LibrarySectionLayout";
 import { getDataStudioMetricRoutes } from "./metrics/routes";
+import { getDataStudioSeedRoutes } from "./seeds/routes";
 import { getDataStudioSnippetRoutes } from "./snippets/routes";
 import { getDataStudioTableRoutes } from "./tables/routes";
 
@@ -15,6 +16,7 @@ export const getDataStudioLibraryRoutes = (IsAdmin: ComponentType) => {
       {getDataStudioTableRoutes(IsAdmin)}
       {getDataStudioMetricRoutes()}
       {getDataStudioSnippetRoutes()}
+      {getDataStudioSeedRoutes()}
     </Route>
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/seeds/components/NewSeedModal/NewSeedModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/seeds/components/NewSeedModal/NewSeedModal.tsx
@@ -1,0 +1,107 @@
+import { type FormEvent, useState } from "react";
+import { t } from "ttag";
+
+import { useDispatch } from "metabase/redux";
+import { addUndo } from "metabase/redux/undo";
+import { push } from "metabase/router";
+import {
+  Button,
+  FileInput,
+  Group,
+  Icon,
+  Modal,
+  Stack,
+  Text,
+  TextInput,
+} from "metabase/ui";
+import * as Urls from "metabase/urls";
+import { useCreateSeedMutation } from "metabase-enterprise/api";
+
+const NAME_PATTERN = /^[a-z][a-z0-9_]*$/;
+
+// A seed's name becomes the physical table name that dependents reference, so it has to be a
+// stable SQL-safe slug. Reject anything that isn't lower_snake_case starting with a letter.
+function getNameError(name: string): string | null {
+  if (name.length === 0) {
+    return null;
+  }
+  if (!NAME_PATTERN.test(name)) {
+    return t`Use lowercase letters, numbers, and underscores, starting with a letter.`;
+  }
+  return null;
+}
+
+export function NewSeedModal({
+  opened,
+  onClose,
+}: {
+  opened: boolean;
+  onClose: () => void;
+}) {
+  const dispatch = useDispatch();
+  const [createSeed, { isLoading }] = useCreateSeedMutation();
+  const [name, setName] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+
+  const nameError = getNameError(name);
+  const canSubmit = name.length > 0 && !nameError && file != null && !isLoading;
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!canSubmit || file == null) {
+      return;
+    }
+    try {
+      const table = await createSeed({ name, file }).unwrap();
+      dispatch(addUndo({ message: t`Seed ${name} created` }));
+      dispatch(push(Urls.dataStudioTable(table.id)));
+    } catch (error: any) {
+      const message = error?.data?.message ?? t`Could not create the seed`;
+      dispatch(addUndo({ message, icon: "warning" }));
+    }
+  };
+
+  return (
+    <Modal opened={opened} onClose={onClose} title={t`New seed`}>
+      <form onSubmit={handleSubmit}>
+        <Stack gap="lg" mt="md">
+          <TextInput
+            label={t`Name`}
+            description={t`Dependents reference this name, so choose it carefully. Renaming later can break them.`}
+            placeholder="time_spine"
+            value={name}
+            error={nameError}
+            onChange={(event) => setName(event.target.value)}
+            data-autofocus
+          />
+          <FileInput
+            label={t`CSV file`}
+            placeholder={t`Choose a file`}
+            accept="text/csv,text/tab-separated-values"
+            leftSection={<Icon name="document" />}
+            value={file}
+            onChange={setFile}
+          />
+          <Group justify="space-between" mt="sm">
+            <Text c="text-secondary" size="sm">
+              {t`Creates a plain table, versioned in the Library.`}
+            </Text>
+            <Group gap="sm">
+              <Button variant="subtle" onClick={onClose}>
+                {t`Cancel`}
+              </Button>
+              <Button
+                type="submit"
+                variant="filled"
+                disabled={!canSubmit}
+                loading={isLoading}
+              >
+                {t`Create`}
+              </Button>
+            </Group>
+          </Group>
+        </Stack>
+      </form>
+    </Modal>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/seeds/components/NewSeedModal/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/seeds/components/NewSeedModal/index.ts
@@ -1,0 +1,1 @@
+export { NewSeedModal } from "./NewSeedModal";

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/seeds/pages/SeedsListPage/SeedsListPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/seeds/pages/SeedsListPage/SeedsListPage.tsx
@@ -1,0 +1,140 @@
+import { useDisclosure } from "@mantine/hooks";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+import { useMemo, useState } from "react";
+import { t } from "ttag";
+
+import { useListTablesQuery } from "metabase/api";
+import { ListEmptyState } from "metabase/common/components/ListEmptyState";
+import { DataStudioBreadcrumbs } from "metabase/common/data-studio/components/DataStudioBreadcrumbs";
+import { PaneHeader } from "metabase/common/data-studio/components/PaneHeader";
+import { useHasTokenFeature } from "metabase/common/hooks";
+import { SectionLayout } from "metabase/data-studio/app/components/SectionLayout";
+import { LibraryUpsellPage } from "metabase/data-studio/upsells/pages";
+import { useDispatch } from "metabase/redux";
+import { push } from "metabase/router";
+import {
+  Badge,
+  Button,
+  Card,
+  Flex,
+  Group,
+  Icon,
+  Loader,
+  Stack,
+  Text,
+  TextInput,
+  UnstyledButton,
+} from "metabase/ui";
+import * as Urls from "metabase/urls";
+import type { Table } from "metabase-types/api";
+
+import { NewSeedModal } from "../../components/NewSeedModal";
+
+dayjs.extend(relativeTime);
+
+const SEED_ICON = "table2";
+
+export function SeedsListPage() {
+  const hasLibraryFeature = useHasTokenFeature("library");
+
+  if (!hasLibraryFeature) {
+    return <LibraryUpsellPage />;
+  }
+
+  return <SeedsListPageContent />;
+}
+
+function SeedsListPageContent() {
+  const dispatch = useDispatch();
+  const [searchQuery, setSearchQuery] = useState("");
+  const [isModalOpen, { open: openModal, close: closeModal }] =
+    useDisclosure(false);
+
+  const { data: tables = [], isLoading } = useListTablesQuery({
+    "data-source": "seed",
+  });
+
+  const seeds = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) {
+      return tables;
+    }
+    return tables.filter((seed) =>
+      (seed.display_name ?? seed.name).toLowerCase().includes(query),
+    );
+  }, [tables, searchQuery]);
+
+  return (
+    <>
+      <SectionLayout>
+        <PaneHeader
+          breadcrumbs={
+            <DataStudioBreadcrumbs>{t`Seeds`}</DataStudioBreadcrumbs>
+          }
+          px="3.5rem"
+          py={0}
+        />
+        <Stack
+          bg="background_page-secondary"
+          data-testid="seeds-page"
+          pb="2rem"
+          px="3.5rem"
+        >
+          <Flex gap="md">
+            <TextInput
+              placeholder={t`Search...`}
+              leftSection={<Icon name="search" />}
+              bdrs="md"
+              flex="1"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+            <Button leftSection={<Icon name="add" />} onClick={openModal}>
+              {t`New seed`}
+            </Button>
+          </Flex>
+          <Card withBorder p={0}>
+            {isLoading ? (
+              <Flex justify="center" p="xl">
+                <Loader />
+              </Flex>
+            ) : seeds.length === 0 ? (
+              <ListEmptyState label={t`No seeds yet`} />
+            ) : (
+              <Stack gap={0}>
+                {seeds.map((seed) => (
+                  <SeedRow
+                    key={seed.id}
+                    seed={seed}
+                    onClick={() =>
+                      dispatch(push(Urls.dataStudioTable(seed.id)))
+                    }
+                  />
+                ))}
+              </Stack>
+            )}
+          </Card>
+        </Stack>
+      </SectionLayout>
+      <NewSeedModal opened={isModalOpen} onClose={closeModal} />
+    </>
+  );
+}
+
+function SeedRow({ seed, onClick }: { seed: Table; onClick: () => void }) {
+  return (
+    <UnstyledButton onClick={onClick} px="lg" py="md">
+      <Group justify="space-between">
+        <Group gap="sm">
+          <Icon name={SEED_ICON} c="brand" />
+          <Text fw="bold">{seed.display_name ?? seed.name}</Text>
+          <Badge variant="light">{t`Seed`}</Badge>
+        </Group>
+        <Text c="text-secondary" size="sm">
+          {t`updated ${dayjs(seed.updated_at).fromNow()}`}
+        </Text>
+      </Group>
+    </UnstyledButton>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/seeds/pages/SeedsListPage/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/seeds/pages/SeedsListPage/index.ts
@@ -1,0 +1,1 @@
+export { SeedsListPage } from "./SeedsListPage";

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/seeds/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/seeds/routes.tsx
@@ -1,0 +1,11 @@
+import { Route } from "metabase/router";
+
+import { SeedsListPage } from "./pages/SeedsListPage";
+
+export function getDataStudioSeedRoutes() {
+  return (
+    <Route path="seeds">
+      <Route index element={<SeedsListPage />} />
+    </Route>
+  );
+}

--- a/frontend/src/metabase-types/api/table.ts
+++ b/frontend/src/metabase-types/api/table.ts
@@ -34,7 +34,8 @@ export type TableDataSource =
   | "transform"
   | "metabase-transform"
   | "source-data"
-  | "upload";
+  | "upload"
+  | "seed";
 
 export type TableFieldOrder = "database" | "alphabetical" | "custom" | "smart";
 

--- a/src/metabase/upload/core.clj
+++ b/src/metabase/upload/core.clj
@@ -2,17 +2,22 @@
   (:require
    [metabase.upload.db]
    [metabase.upload.impl]
+   [metabase.upload.settings]
    [potemkin :as p]))
 
 (comment
   metabase.upload.db/keep-me
-  metabase.upload.impl/keep-me)
+  metabase.upload.impl/keep-me
+  metabase.upload.settings/keep-me)
 
 (p/import-vars
  [metabase.upload.db
   current-database]
+ [metabase.upload.settings
+  uploads-settings]
  [metabase.upload.impl
   can-create-upload?
+  create-csv-table!
   create-csv-upload!
   delete-upload!
   max-upload-part-count

--- a/src/metabase/upload/impl.clj
+++ b/src/metabase/upload/impl.clj
@@ -561,8 +561,10 @@
          :generated-columns 0}))))
 
 (defn- create-from-csv-and-sync!
-  "This is separated from `create-csv-upload!` for testing"
-  [{:keys [db filename file schema table-name display-name]}]
+  "This is separated from `create-csv-upload!` for testing.
+  `data-source` tags the resulting table (`:upload` for uploads, `:seed` for seeds); defaults to `:upload`."
+  [{:keys [db filename file schema table-name display-name data-source]
+    :or   {data-source :upload}}]
   (driver.conn/with-write-connection
     (let [driver                  (driver.u/database->driver db)
           schema                  (some->> schema (ddl.i/format-name driver))
@@ -575,7 +577,7 @@
                                                           :display_name display-name})
           _set_is_upload          (t2/update! :model/Table (:id table) {:is_upload      true
                                                                         :data_authority :authoritative
-                                                                        :data_source    :upload
+                                                                        :data_source    data-source
                                                                         :is_writable    true})
           _sync                   (scan-and-sync-table! db table)
           _set_names              (set-display-names! (:id table) columns)
@@ -691,6 +693,42 @@
         (analytics.core/track-event! :snowplow/csvupload (assoc (fail-stats filename file)
                                                                 :event :csv-upload-failed))
         (throw e)))))
+
+(mu/defn create-csv-table!
+  "Materialize a CSV into a plain warehouse table with a caller-provided stable `table-name` and **no** model Card.
+
+  This is the seed path: same engine as [[create-csv-upload!]], but the table keeps its given name (uploads suffix a
+  timestamp) and nothing wraps it. Tags the table with `data-source` (`:seed`). Throws 400 if the name is already
+  taken. Returns the synced Table. Placing the table in the Library is the caller's job (enterprise-only)."
+  [{:keys [filename ^File file db-id schema-name table-name display-name data-source]
+    :or   {data-source :seed}}
+   :- [:map
+       [:filename :string]
+       [:file (ms/InstanceOfClass File)]
+       [:db-id ms/PositiveInt]
+       [:table-name :string]
+       [:schema-name {:optional true} [:maybe :string]]
+       [:display-name {:optional true} [:maybe :string]]
+       [:data-source {:optional true} :keyword]]]
+  (check-workspace-mode!)
+  (let [database (or (t2/select-one :model/Database :id db-id)
+                     (throw (ex-info (tru "The uploads database does not exist.")
+                                     {:status-code 422})))]
+    (check-can-create-upload database schema-name)
+    (check-filetype filename file)
+    (let [driver     (driver.u/database->driver database)
+          normalized (->> table-name (ddl.i/format-name driver) u/lower-case-en)]
+      (when (t2/exists? :model/Table :db_id db-id :schema schema-name :name normalized)
+        (throw (ex-info (tru "A table named {0} already exists." normalized)
+                        {:status-code 400})))
+      (let [{:keys [table]} (create-from-csv-and-sync! {:db           database
+                                                        :filename     filename
+                                                        :file         file
+                                                        :schema       schema-name
+                                                        :table-name   normalized
+                                                        :display-name (or (not-empty display-name) table-name)
+                                                        :data-source  data-source})]
+        table))))
 
 ;;; +-----------------------------
 ;;; |  appending to uploaded table

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -29,7 +29,7 @@
 
 (def data-sources
   "Valid values for data source"
-  #{:unknown :ingested :metabase-transform :transform :source-data :upload})
+  #{:unknown :ingested :metabase-transform :transform :source-data :upload :seed})
 
 (def data-layers
   "Valid values for `Table.data_layer`.


### PR DESCRIPTION
seeds are official CSV uploads with stable names, materialized as plain tables (not models) and published into the Library. the CEO's load-bearing constraint was "normal tables, not models", and that turned out to be nearly free: create-from-csv-and-sync! already stopped at the synced table, the card wrapper lived one level up in create-csv-upload!. so create-csv-table! reuses the same engine, tags the table :seed, and skips create-card!.

the OSS/EE split drove the API shape more than the feature did. csv->table mechanics stay in the OSS upload module, only "publish into Library" is EE. that's why create needs its own EE door (POST /api/ee/data-studio/table/seed) but re-upload and list reuse existing OSS endpoints:

- re-upload/replace reuses the existing replace-csv endpoint. seeds keep is_upload true, so it just works, no new api.
- the seeds list is GET /api/table?data-source=seed. the api's data-source enum derives from the table model enum, so adding :seed there lit up the filter for free.

frontend adds a library/seeds section (list + search), a New seed modal whose one new input is a stable-name slug, and a Seed item in the Library create menu.

the name is validated as lowercase snake_case and rejected rather than auto-slugified, since dependents reference it and a silent rewrite is worse than an upfront error. easy to flip to auto-slug-with-preview if we'd rather.

out of scope for this POC:
- git/remote-sync versioning of the csv payload (the genuinely new capability, deferred)
- the "update seed" action on the seed detail page (replace-csv is ready, the button isn't wired)
- automated tests and temp-file cleanup in the seed endpoint

verified: backend compiles (module-config regen reloads all ns), type-check and eslint green.

Fixes https://linear.app/metabase/issue/GDGT-2869/add-a-place-for-official-csv-uploads-to-the-data-studio

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dCwKNSz7uqgwfZep2Spfu