### PR TITLE
Gdgt 2856 secure graalvm isolate for custom static viz

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -167,9 +167,10 @@
   org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-jetty-server {:mvn/version "12.1.11"}
   org.eclipse.jgit/org.eclipse.jgit        {:mvn/version "7.3.0.202506031305-r"}; Java implementation of Git version control system
   org.flatland/ordered                      {:mvn/version "1.15.12"}            ; ordered maps & sets
-  org.graalvm.polyglot/js-community         {:mvn/version "25.0.1" :extension "pom"} ; JavaScript engine
-  org.graalvm.polyglot/polyglot             {:mvn/version "25.0.1"}             ; GraalVM platform, required by JS engine
-  org.graalvm.polyglot/python               {:mvn/version "25.0.1"
+  org.graalvm.polyglot/js-community         {:mvn/version "25.1.3" :extension "pom"} ; JavaScript engine
+  org.graalvm.polyglot/js-isolate-community  {:mvn/version "25.1.3" :extension "pom"} ; JS polyglot isolate for the SandboxPolicy/UNTRUSTED custom-viz plugin sandbox
+  org.graalvm.polyglot/polyglot             {:mvn/version "25.1.3"}             ; GraalVM platform, required by JS engine
+  org.graalvm.polyglot/python               {:mvn/version "25.1.3"
                                              :extension "pom"}
   org.jsoup/jsoup                           {:mvn/version "1.21.2"}             ; required by hickory
   org.liquibase/liquibase-core              {:mvn/version "4.33.0"              ; migration management (Java lib)

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -549,6 +549,9 @@
                        {:description "Number of chart rasterization images backed by a pooled buffer."})
    (prometheus/counter :metabase-notification/image-buffer-unpooled
                        {:description "Number of chart rasterization images too large for the pool, allocated fresh."})
+   (prometheus/counter :metabase-static-viz/sandbox-limit-hits
+                       {:description "Number of static-viz renders killed by an untrusted-sandbox resource limit."
+                        :labels [:tier :limit]})
    (prometheus/counter :metabase-gsheets/connection-creation-began
                        {:description "How many times the instance has initiated a Google Sheets connection creation."})
    (prometheus/counter :metabase-gsheets/connection-creation-error

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -549,6 +549,16 @@
                        {:description "Number of chart rasterization images backed by a pooled buffer."})
    (prometheus/counter :metabase-notification/image-buffer-unpooled
                        {:description "Number of chart rasterization images too large for the pool, allocated fresh."})
+   (prometheus/counter :metabase-static-viz/untrusted-render
+                       {:description "Number of static-viz renders executed on an untrusted sandbox context."
+                        :labels [:tier]})
+   (prometheus/counter :metabase-static-viz/context-recycles
+                       {:description "Number of pooled untrusted contexts proactively recycled after crossing the cumulative CPU soft limit."
+                        :labels [:tier]})
+   (prometheus/gauge :metabase-static-viz/isolate-contexts
+                     {:description "Number of live untrusted isolate contexts (at most one builtin plus one plugin). 0 means the isolate engine is closed and its native heap freed."})
+   (prometheus/gauge :metabase-static-viz/render-queue
+                     {:description "Number of static-viz renders waiting on the global render lock (excludes the render in progress)."})
    (prometheus/counter :metabase-static-viz/sandbox-limit-hits
                        {:description "Number of static-viz renders killed by an untrusted-sandbox resource limit."
                         :labels [:tier :limit]})

--- a/src/metabase/channel/render/js/common.clj
+++ b/src/metabase/channel/render/js/common.clj
@@ -10,6 +10,12 @@
   "Classpath path of the built static-viz bundle the graal renderer evaluates in-process."
   "frontend_client/app/dist/lib-static-viz.bundle.js")
 
+(def custom-viz-bundle-resource-path
+  "Classpath path of the slim custom-viz-only static-viz bundle loaded into the untrusted plugin isolate: the
+  same render interface as [[bundle-resource-path]], but without the built-in chart implementations
+  (ECharts/visx), which that isolate never renders."
+  "frontend_client/app/dist/lib-static-viz-custom.bundle.js")
+
 (defn assert-tests-not-initializing!
   "Guard against loading the static-viz bundle as a side effect of loading namespaces: it might not have
   been built yet. If it hasn't, we want a meaningful error (see the fixture in

--- a/src/metabase/channel/render/js/graal.clj
+++ b/src/metabase/channel/render/js/graal.clj
@@ -287,12 +287,17 @@
   dominant per-context cost and explains slow first/regenerated renders."
   ^Context []
   (common/assert-tests-not-initializing!)
-  (let [start (System/nanoTime)
-        ctx   (doto (untrusted-plugin-context pool-max-cpu-time)
-                (load-resource common/custom-viz-bundle-resource-path))]
-    (log/infof "custom-viz: generated untrusted static-viz isolate context (cold-parsed slim bundle) in %.0fms"
-               (/ (- (System/nanoTime) start) 1e6))
-    ctx))
+  (let [start   (System/nanoTime)
+        context (untrusted-plugin-context pool-max-cpu-time)]
+    (try
+      ;; a bundle-load failure would otherwise leak the freshly-built isolate; close it and rethrow
+      (load-resource context common/custom-viz-bundle-resource-path)
+      (log/infof "custom-viz: generated untrusted static-viz isolate context (cold-parsed slim bundle) in %.0fms"
+                 (/ (- (System/nanoTime) start) 1e6))
+      context
+      (catch Throwable t
+        (try (.close context true) (catch Throwable _))
+        (throw t)))))
 
 (defn- destroy-untrusted-context!
   "Close an untrusted isolate context reaped or disposed by the pool. The shared untrusted engine is a
@@ -310,9 +315,10 @@
   "Acquire a pooled `SandboxPolicy/UNTRUSTED` isolate context"
   [f]
   (if config/is-dev?
-    (let [^Context context (doto (untrusted-plugin-context)
-                             (load-resource common/custom-viz-bundle-resource-path))]
+    (let [^Context context (untrusted-plugin-context)]
       (try
+        ;; parse inside the try so a bundle-load failure still hits the finally and closes the isolate
+        (load-resource context common/custom-viz-bundle-resource-path)
         (f context)
         (finally
           (try (.close context true) (catch Throwable _)))))

--- a/src/metabase/channel/render/js/graal.clj
+++ b/src/metabase/channel/render/js/graal.clj
@@ -12,7 +12,8 @@
   how many contexts there are, which makes raising the pool's max from 1 to 2 or 3 a one-line change. A
   context is held exclusively per render (so renders serialize per context); the utilization controller
   has min 0, so when idle the pool shrinks to 0 and the last `destroy` closes the engine (GraalVM reclaims
-  neither context nor engine on GC). The first render after an idle gap rebuilds them."
+  neither context nor engine on GC). The first render after an idle gap rebuilds them. The untrusted
+  custom-viz isolate engine follows the same ref-counted lifecycle (see [[ref-counted-engine]])."
   (:require
    [clojure.java.io :as io]
    [metabase.channel.render.js.common :as common]
@@ -22,6 +23,7 @@
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   [metabase.util.malli.schema :as ms]
    [metabase.util.pool :as u.pool])
   (:import
    (io.aleph.dirigiste Pool)
@@ -102,57 +104,84 @@
   (assert (.canExecute fn-ref) "cannot execute function reference")
   (.execute fn-ref (object-array args)))
 
-;;; ---------------------------------------- shared engine + contexts -------------------------------------
+;;; ------------------------------------- ref-counted engine holder ---------------------------------------
+;;;
+;;; Generic lifecycle tool: a lazily-created `Engine` shared by pooled contexts, closed again when the last
+;;; context is destroyed. Used by both the trusted and the untrusted-isolate pool below.
 
-(def ^:private engine-lock (Object.))
+(def ^:private CreateEngineState
+  "Schema for a [[ref-counted-engine]] `create` fn: builds the shared state"
+  [:=> [:cat] [:map [:engine (ms/InstanceOfClass Engine)]]])
 
-(def ^:private shared-engine
-  "Atom holding `{:engine <Engine>, :source <Source>, :refs <live context count>}`, or nil when no context
-  is live. Guarded by [[engine-lock]]. The engine and parsed bundle are shared by every pooled context;
-  they're created with the first context ([[acquire-engine!]]) and closed with the last
-  ([[release-engine!]])."
-  (atom nil))
+(def ^:private EngineState
+  "What lives inside a [[RefCountedEngine]]'s `:state` atom while the engine is live: the map its `create`
+  returned plus `:refs`, the count of live contexts holding the engine open. nil when no engine is live."
+  [:map
+   [:engine (ms/InstanceOfClass Engine)]
+   [:refs   pos-int?]])
 
-(defn- acquire-engine!
-  "Return the shared `{:engine, :source}`, creating them (parsing the bundle) with the first context.
-  Bumps the ref count."
-  []
-  (locking engine-lock
-    (let [state (or @shared-engine
-                    {:source (build-source common/bundle-resource-path)
-                     :engine (create-engine)
-                     :refs   0})]
-      (reset! shared-engine (update state :refs inc))
-      state)))
+(def ^:private RefCountedEngine
+  "Schema for the holder built by [[ref-counted-engine]]. `:state` holds [[EngineState]] or nil."
+  [:map
+   [:lock   some?]
+   [:state  (ms/InstanceOfClass clojure.lang.Atom)]
+   [:create CreateEngineState]])
 
-(defn- release-engine!
-  "Drop a ref on the shared engine, closing it once the last context is gone."
-  []
-  (locking engine-lock
-    (let [{:keys [^Engine engine refs]} @shared-engine]
+(mu/defn- ref-counted-engine :- RefCountedEngine
+  "A ref-counted holder for an `Engine` shared by pooled contexts, plus any extra state `create` returns
+  alongside it (e.g. a parsed `Source`). `create` runs under the first [[acquire-engine!]]; the engine is
+  closed by the [[release-engine!]] that drops the last ref. Needed because GraalVM reclaims neither
+  engines nor contexts on GC — an idle-shrunk pool must close its engine explicitly to get the memory back."
+  [create :- CreateEngineState]
+  {:lock (Object.), :state (atom nil), :create create})
+
+(mu/defn- acquire-engine! :- EngineState
+  "Return `engine-ref`'s shared state (`{:engine <Engine>}` plus whatever its `create` returned), creating
+  it with the first acquire. Bumps the ref count."
+  [{:keys [lock state create]} :- RefCountedEngine]
+  (locking lock
+    (let [current (update (or @state (assoc (create) :refs 0)) :refs inc)]
+      (reset! state current)
+      current)))
+
+(mu/defn- release-engine!
+  "Drop a ref on `engine-ref`'s shared engine, closing it once the last ref is gone."
+  [{:keys [lock state]} :- RefCountedEngine]
+  (locking lock
+    (let [{:keys [^Engine engine refs]} @state]
       (if (<= refs 1)
         (do (try (.close engine) (catch Exception _))
-            (reset! shared-engine nil))
-        (swap! shared-engine update :refs dec)))))
+            (reset! state nil))
+        (swap! state update :refs dec)))))
+
+;;; ------------------------------------ trusted engine + contexts ----------------------------------------
+
+(def ^:private shared-engine
+  "Ref-counted `Engine` + parsed bundle `Source` shared by every pooled trusted context: created with the
+  first context ([[generate-context!]]) and closed with the last ([[destroy-context!]])."
+  (ref-counted-engine
+   (fn []
+     {:source (build-source common/bundle-resource-path)
+      :engine (create-engine)})))
 
 (defn- generate-context!
   "Build a context on the shared engine and evaluate the bundle into it (creating the engine + parsing the
   bundle if this is the first context)."
   ^Context []
   (common/assert-tests-not-initializing!)
-  (let [{:keys [^Engine engine ^Source source]} (acquire-engine!)]
+  (let [{:keys [^Engine engine ^Source source]} (acquire-engine! shared-engine)]
     (try
       (doto (create-context engine)
         (eval-source source))
       (catch Throwable t
-        (release-engine!)
+        (release-engine! shared-engine)
         (throw t)))))
 
 (defn- destroy-context!
   "Close a context and drop its ref on the shared engine (closing the engine if it was the last context)."
   [^Context context]
   (try (.close context true) (catch Exception _))
-  (release-engine!))
+  (release-engine! shared-engine))
 
 ;;; ------------------------------------------------ context pool -----------------------------------------
 
@@ -202,7 +231,6 @@
 ;;;
 ;;; The isolate is a separate heap but runs in the *same OS process* as the JVM, so its native memory counts
 ;;; against the same pod/container.
-
 (def ^:private max-isolate-memory
   "`engine.MaxIsolateMemory`: hard cap on the untrusted isolate's whole heap. Should cover the slim
   custom-viz bundle plus a real render."
@@ -228,12 +256,14 @@
       (err discarding-output-stream)
       (build)))
 
-(defonce ^:private
-  ^{:doc "GraalVM isolate `Engine` shared by every untrusted custom-viz plugin context. Contexts on a shared
-          engine still get isolated global scopes (one plugin can't see another's globals), while sharing the
-          isolate's parsed-source cache."}
-  shared-untrusted-plugin-engine
-  (delay (new-untrusted-plugin-engine)))
+(def ^:private shared-untrusted-plugin-engine
+  "Ref-counted GraalVM isolate `Engine` shared by every untrusted custom-viz plugin context: created with
+  the first context ([[generate-untrusted-context!]]) and closed with the last
+  ([[destroy-untrusted-context!]]), so an idle-shrunk pool frees the isolate's native heap (up to
+  [[max-isolate-memory]]) instead of pinning it for the process lifetime. Contexts on a shared engine
+  still get isolated global scopes (one plugin can't see another's globals), while sharing the isolate's
+  parsed-source cache."
+  (ref-counted-engine (fn [] {:engine (new-untrusted-plugin-engine)})))
 
 (def render-max-cpu-time
   "`sandbox.MaxCPUTime` for a *non-pooled* untrusted context (the dev fresh-context path). Covers a cold parse
@@ -248,13 +278,14 @@
   "180s")
 
 (defn untrusted-plugin-context
-  "Create a `SandboxPolicy/UNTRUSTED` GraalVM isolate `Context` for running untrusted custom-viz plugin JS.
-  The guest runs in a separate isolate heap with VM-enforced CPU/heap/AST limits; like [[create-context]] it
-  has no host access and no IO, so data must cross the boundary as JSON strings."
-  (^Context [] (untrusted-plugin-context render-max-cpu-time))
-  (^Context [^String max-cpu-time]
+  "Create a `SandboxPolicy/UNTRUSTED` GraalVM isolate `Context` on `engine` (which must itself declare
+  `SandboxPolicy/UNTRUSTED` — see [[new-untrusted-plugin-engine]]) for running untrusted custom-viz plugin
+  JS. The guest runs in a separate isolate heap with VM-enforced CPU/heap/AST limits; like
+  [[create-context]] it has no host access and no IO, so data must cross the boundary as JSON strings."
+  (^Context [^Engine engine] (untrusted-plugin-context engine render-max-cpu-time))
+  (^Context [^Engine engine ^String max-cpu-time]
    (.. (Context/newBuilder (into-array String ["js"]))
-       (engine ^Engine @shared-untrusted-plugin-engine)
+       (engine engine)
        (sandbox SandboxPolicy/UNTRUSTED)
        ;; HostAccess/UNTRUSTED, not /NONE: the UNTRUSTED policy rejects /NONE (it still permits mutable
        ;; target-type mappings). /UNTRUSTED is the policy's purpose-built strictest host-access mode.
@@ -265,7 +296,7 @@
        ;; allowNativeAccess is false by default under SandboxPolicy/UNTRUSTED.
        ;; allowEnvironmentAccess is NONE (no host env vars) by default under SandboxPolicy/UNTRUSTED.
        ;; allowExperimentalOptions left at default false
-       ;; MaxCPUTimeCheckInterval left at its ~10ms default — negligible overshoot vs a multi-second budget.
+       ;; MaxCPUTimeCheckInterval left at its ~10ms default
        (option "sandbox.MaxCPUTime" max-cpu-time)
        (option "sandbox.MaxHeapMemory" max-heap-memory)
        (option "sandbox.MaxASTDepth" "5000")
@@ -281,28 +312,37 @@
 ;;; ------------------------------------------- untrusted context pool ------------------------------------
 
 (defn- destroy-untrusted-context!
-  "Close an untrusted isolate context reaped or disposed by the pool. The shared untrusted engine is a
-  process-lifetime singleton, so unlike [[destroy-context!]] there is no engine ref to drop."
+  "Close an untrusted isolate context reaped or disposed by the pool and drop its ref on the shared
+  untrusted engine (closing the engine — and freeing its isolate heap — with the last context)."
   [^Context context]
   (log/debug "custom-viz: disposing untrusted static-viz isolate context")
-  (try (.close context true) (catch Exception _)))
+  (try (.close context true) (catch Exception _))
+  (release-engine! shared-untrusted-plugin-engine))
 
 (defn- generate-untrusted-context!
-  "Cold-parse the slim custom-viz bundle into a fresh isolate context; logged with timing because this is the
-  dominant per-context cost and explains slow first/regenerated renders."
-  ^Context []
-  (common/assert-tests-not-initializing!)
-  (let [start   (System/nanoTime)
-        context (untrusted-plugin-context pool-max-cpu-time)]
-    (try
-      ;; a bundle-load failure would otherwise leak the freshly-built isolate; close it and rethrow
-      (load-resource context common/custom-viz-bundle-resource-path)
-      (log/infof "custom-viz: generated untrusted static-viz isolate context (cold-parsed slim bundle) in %.0fms"
-                 (/ (- (System/nanoTime) start) 1e6))
-      context
-      (catch Throwable t
-        (destroy-untrusted-context! context)
-        (throw t)))))
+  "Cold-parse the slim custom-viz bundle into a fresh isolate context on the shared untrusted engine
+  (creating the engine with the first context); logged with timing because this is the dominant
+  per-context cost and explains slow first/regenerated renders."
+  (^Context [] (generate-untrusted-context! pool-max-cpu-time))
+  (^Context [^String max-cpu-time]
+   (common/assert-tests-not-initializing!)
+   (let [start (System/nanoTime)
+         {:keys [^Engine engine]} (acquire-engine! shared-untrusted-plugin-engine)]
+     (try
+       (let [context (untrusted-plugin-context engine max-cpu-time)]
+         (try
+           (load-resource context common/custom-viz-bundle-resource-path)
+           (log/infof "custom-viz: generated untrusted static-viz isolate context (cold-parsed slim bundle) in %.0fms"
+                      (/ (- (System/nanoTime) start) 1e6))
+           context
+           (catch Throwable t
+             ;; a bundle-load failure would otherwise leak the freshly-built isolate; close it and rethrow
+             ;; (the engine ref is dropped by the outer catch)
+             (try (.close context true) (catch Exception _))
+             (throw t))))
+       (catch Throwable t
+         (release-engine! shared-untrusted-plugin-engine)
+         (throw t))))))
 
 (def ^:private ^Pool untrusted-static-viz-context-pool
   "Pool of `SandboxPolicy/UNTRUSTED` isolate contexts for rendering untrusted custom-viz plugin JS. Mirrors
@@ -313,10 +353,10 @@
   "Acquire a pooled `SandboxPolicy/UNTRUSTED` isolate context"
   [f]
   (if config/is-dev?
-    (let [^Context context (untrusted-plugin-context)]
+    ;; a throwaway context per call, like [[do-with-static-viz-context]]'s dev path — with the tighter
+    ;; single-render [[render-max-cpu-time]] budget
+    (let [^Context context (generate-untrusted-context! render-max-cpu-time)]
       (try
-        ;; parse inside the try so a bundle-load failure still hits the finally and closes the isolate
-        (load-resource context common/custom-viz-bundle-resource-path)
         (f context)
         (finally
           (destroy-untrusted-context! context))))

--- a/src/metabase/channel/render/js/graal.clj
+++ b/src/metabase/channel/render/js/graal.clj
@@ -18,7 +18,6 @@
    [metabase.channel.render.js.common :as common]
    [metabase.channel.render.js.protocol :as js.protocol]
    [metabase.config.core :as config]
-   [metabase.util :as u]
    [metabase.util.i18n :refer [trs]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -26,8 +25,8 @@
    [metabase.util.pool :as u.pool])
   (:import
    (io.aleph.dirigiste Pool)
-   (java.util.concurrent TimeoutException)
-   (org.graalvm.polyglot Context Engine HostAccess Source Value)))
+   (java.io OutputStream)
+   (org.graalvm.polyglot Context Engine HostAccess PolyglotException SandboxPolicy Source Value)))
 
 (set! *warn-on-reflection* true)
 
@@ -80,6 +79,16 @@
   "Evaluate an already-built `Source` in the js context."
   [^Context context ^Source source]
   (.eval context source))
+
+(defn load-resource
+  "Load a JS classpath resource into `context` as a *literal* `Source` (content, not URL-backed). A
+  It's needed for the `SandboxPolicy/UNTRUSTED` context"
+  [^Context context ^String source-path]
+  (let [resource (io/resource source-path)]
+    (when (nil? resource)
+      (throw (ex-info (trs "Javascript resource not found: {0}" source-path)
+                      {:source source-path})))
+    (.eval context (.buildLiteral (Source/newBuilder "js" ^String (slurp resource :encoding "UTF-8") source-path)))))
 
 (defn execute-fn-name
   "Execute the global js function named `js-fn-name` in `context` with `args`. Not thread-safe on its own
@@ -174,32 +183,155 @@
       (try (f context)
            (finally (.release static-viz-context-pool pool-key context))))))
 
-;;; ------------------------------------------- untrusted contexts ----------------------------------------
+;;; ---------------------------------------- Untrusted plugin sandbox -------------------------------------
+;;;
+;;; Stronger sandbox for running *untrusted* custom-viz plugin JS (third-party bundles). Unlike
+;;; [[create-context]], which relies on `HostAccess/NONE` + config flags in the host JVM, this runs the guest
+;;; inside a GraalVM native-image isolate (separate VM, separate heap) under `SandboxPolicy/UNTRUSTED`, so
+;;; CPU/heap limits and speculative-execution mitigations are enforced by the VM. Requires the
+;;; `js-isolate-community` artifact on the classpath. Built-in static-viz keeps the faster in-process
+;;; [[create-context]] path; only plugins pay for the isolate.
 
-(def ^:private custom-viz-render-timeout-ms
-  "Wall-clock deadline for a render involving custom viz plugin code. A plugin bundle with a runaway loop
-  would otherwise block the rendering thread indefinitely."
-  30000)
+(def ^:private ^OutputStream discarding-output-stream
+  "Sink for untrusted-guest stdout/stderr — plugin console output is neither trusted nor useful in server
+  logs, and `SandboxPolicy/UNTRUSTED` bounds it via `sandbox.Max*StreamSize` regardless."
+  (proxy [OutputStream] []
+    (write
+      ([_])
+      ([_ _ _]))))
 
-(defn- do-with-untrusted-context
-  "Build a throwaway context (on the shared engine — contexts are isolated realms), call `f` with it under
-  a wall-clock deadline, and always close the context afterwards so untrusted plugin JS never reaches the
-  pooled contexts. On overrun, forcibly close the context and throw."
+;;; ---- Isolate memory caps (fail closed, catchable) ----
+;;;
+;;; The isolate is a separate heap but runs in the *same OS process* as the JVM, so its native memory counts
+;;; against the same pod/container.
+
+(def ^:private max-isolate-memory
+  "`engine.MaxIsolateMemory`: hard cap on the untrusted isolate's whole heap. Should cover the slim
+  custom-viz bundle plus a real render."
+  "512MB")
+
+(def ^:private max-heap-memory
+  "`sandbox.MaxHeapMemory`: per-context guest-heap cap. GraalVM requires it strictly below the engine-wide
+  [[max-isolate-memory]]"
+  "416MB")
+
+(defn- new-untrusted-plugin-engine
+  "Build the isolate `Engine` shared by every untrusted-plugin context. `engine.MaxIsolateMemory` caps the
+  whole isolate heap and must exceed the per-context `sandbox.MaxHeapMemory` set in
+  [[untrusted-plugin-context]], so the isolate fails closed below the cgroup ceiling instead of OOM-killing
+  the pod."
+  ^Engine []
+  (.. (Engine/newBuilder (into-array String ["js"]))
+      ;; A shared engine and its contexts must declare the same sandbox policy, so the engine sets UNTRUSTED
+      ;; too — otherwise creating an UNTRUSTED context on it would fail the engine/context policy-match check.
+      (sandbox SandboxPolicy/UNTRUSTED)
+      (option "engine.MaxIsolateMemory" max-isolate-memory)
+      (out discarding-output-stream)
+      (err discarding-output-stream)
+      (build)))
+
+(defonce ^:private
+  ^{:doc "GraalVM isolate `Engine` shared by every untrusted custom-viz plugin context. Contexts on a shared
+          engine still get isolated global scopes (one plugin can't see another's globals), while sharing the
+          isolate's parsed-source cache."}
+  shared-untrusted-plugin-engine
+  (delay (new-untrusted-plugin-engine)))
+
+(def render-max-cpu-time
+  "`sandbox.MaxCPUTime` for a *non-pooled* untrusted context (the dev fresh-context path). Covers a cold parse
+  of the static-viz bundle plus a single render on dev hardware. Prod uses a pooled context with the larger,
+  cumulative [[pool-max-cpu-time]] instead — see [[untrusted-static-viz-context-pool]]."
+  "30s")
+
+(def pool-max-cpu-time
+  "`sandbox.MaxCPUTime` for a *pooled*, long-lived untrusted context (the prod path). MaxCPUTime is a
+  *cumulative* per-context lifetime budget, not per-render: it must cover the one-time cold parse of the
+  slim bundle at pool generation plus the many renders the context then serves."
+  "180s")
+
+(defn untrusted-plugin-context
+  "Create a `SandboxPolicy/UNTRUSTED` GraalVM isolate `Context` for running untrusted custom-viz plugin JS.
+  The guest runs in a separate isolate heap with VM-enforced CPU/heap/AST limits; like [[create-context]] it
+  has no host access and no IO, so data must cross the boundary as JSON strings."
+  (^Context [] (untrusted-plugin-context render-max-cpu-time))
+  (^Context [^String max-cpu-time]
+   (.. (Context/newBuilder (into-array String ["js"]))
+       (engine ^Engine @shared-untrusted-plugin-engine)
+       (sandbox SandboxPolicy/UNTRUSTED)
+       ;; HostAccess/UNTRUSTED, not /NONE: the UNTRUSTED policy rejects /NONE (it still permits mutable
+       ;; target-type mappings). /UNTRUSTED is the policy's purpose-built strictest host-access mode.
+       (allowHostAccess HostAccess/UNTRUSTED)
+       ;; allowAllAccess (the master switch that would enable all of the below at once) is false by default; UNTRUSTED forbids true.
+       ;; allowHostClassLookup is false by default under SandboxPolicy/UNTRUSTED.
+       ;; allowIO is disabled by default under SandboxPolicy/UNTRUSTED.
+       ;; allowNativeAccess is false by default under SandboxPolicy/UNTRUSTED.
+       ;; allowEnvironmentAccess is NONE (no host env vars) by default under SandboxPolicy/UNTRUSTED.
+       ;; allowExperimentalOptions left at default false
+       ;; MaxCPUTimeCheckInterval left at its ~10ms default — negligible overshoot vs a multi-second budget.
+       (option "sandbox.MaxCPUTime" max-cpu-time)
+       (option "sandbox.MaxHeapMemory" max-heap-memory)
+       (option "sandbox.MaxASTDepth" "5000")
+       (option "sandbox.MaxThreads" "1")         ; single-threaded isolate; allowCreateThread also defaults to false
+       (option "sandbox.MaxOutputStreamSize" "16MB")
+       (option "sandbox.MaxErrorStreamSize" "4MB")
+       ;; sandbox.MaxStatements skipped (and thus its MaxStatementsIncludeInternal modifier): fragile to tune and the compute axis is already covered by MaxCPUTime et al.
+       ;; sandbox.MaxStackFrames skipped too: runtime-recursion blowup surfaces as a contained guest error in the isolate.
+       (out discarding-output-stream)
+       (err discarding-output-stream)
+       (build))))
+
+;;; ------------------------------------------- untrusted context pool ------------------------------------
+
+(defn- generate-untrusted-context!
+  "Cold-parse the slim custom-viz bundle into a fresh isolate context; logged with timing because this is the
+  dominant per-context cost and explains slow first/regenerated renders."
+  ^Context []
+  (common/assert-tests-not-initializing!)
+  (let [start (System/nanoTime)
+        ctx   (doto (untrusted-plugin-context pool-max-cpu-time)
+                (load-resource common/custom-viz-bundle-resource-path))]
+    (log/infof "custom-viz: generated untrusted static-viz isolate context (cold-parsed slim bundle) in %.0fms"
+               (/ (- (System/nanoTime) start) 1e6))
+    ctx))
+
+(defn- destroy-untrusted-context!
+  "Close an untrusted isolate context reaped or disposed by the pool. The shared untrusted engine is a
+  process-lifetime singleton, so unlike [[destroy-context!]] there is no engine ref to drop."
+  [^Context context]
+  (log/debug "custom-viz: disposing untrusted static-viz isolate context")
+  (try (.close context true) (catch Exception _)))
+
+(def ^:private ^Pool untrusted-static-viz-context-pool
+  "Pool of `SandboxPolicy/UNTRUSTED` isolate contexts for rendering untrusted custom-viz plugin JS. Mirrors
+  [[static-viz-context-pool]] but for the isolate path."
+  (common/create-pool generate-untrusted-context! destroy-untrusted-context! {:max-size 1, :idle-minutes 10}))
+
+(defn do-with-untrusted-static-viz-context
+  "Acquire a pooled `SandboxPolicy/UNTRUSTED` isolate context"
   [f]
-  ;; The realm is isolated (no host access, class lookup, or IO) and discarded after the render, but it runs
-  ;; in-process on the same engine as the pooled contexts, with no memory or CPU limit — a hostile bundle is
-  ;; bounded only by the wall-clock timeout below. GDGT-2856 moves this to a separate secure pipeline.
-  (let [context (generate-context!)]
-    (try
-      (u/with-timeout custom-viz-render-timeout-ms (f context))
-      (catch TimeoutException e
-        (throw (ex-info "Custom visualization render timed out"
-                        {:timeout-ms custom-viz-render-timeout-ms} e)))
-      (finally
-        (try
-          (destroy-context! context)
-          (catch Throwable t
-            (log/warn t "Error closing custom-viz static-viz context")))))))
+  (if config/is-dev?
+    (let [^Context context (doto (untrusted-plugin-context)
+                             (load-resource common/custom-viz-bundle-resource-path))]
+      (try
+        (f context)
+        (finally
+          (try (.close context true) (catch Throwable _)))))
+    (let [^Context context (.acquire untrusted-static-viz-context-pool pool-key)
+          disposed?        (volatile! false)]
+      (try
+        (f context)
+        (catch PolyglotException e
+          ;; A cancelled / resource-exhausted context is permanently unusable; dispose it so the pool
+          ;; regenerates a fresh one rather than handing a dead context to the next render.
+          (when (or (.isCancelled e) (.isResourceExhausted e))
+            (vreset! disposed? true)
+            (log/warnf "custom-viz: untrusted static-viz context hit a sandbox limit (cancelled=%s resource-exhausted=%s); disposing and regenerating. %s"
+                       (.isCancelled e) (.isResourceExhausted e) (.getMessage e))
+            (.dispose untrusted-static-viz-context-pool pool-key context))
+          (throw e))
+        (finally
+          (when-not @disposed?
+            (.release untrusted-static-viz-context-pool pool-key context)))))))
 
 ;;; ------------------------------------------------ backend ----------------------------------------------
 
@@ -213,21 +345,33 @@
      (.asString ^Value (apply execute-fn-name context (str "MetabaseStaticViz." fn-name) args)))))
 
 (defn- chart-with-custom-viz*
-  "Render `input` on a throwaway context after evaluating and registering the custom-viz plugin
-  `bundles` (untrusted third-party JS) into it."
+  "Render `input` on a pooled `SandboxPolicy/UNTRUSTED` isolate context (slim custom-viz bundle already
+  loaded by the pool) after evaluating and registering the custom-viz plugin `bundles` (untrusted
+  third-party JS) into it. Plugin bundles are untrusted third-party JS, so this never touches the trusted
+  in-process pool."
   [input bundles]
-  (do-with-untrusted-context
-   (^:once fn* [^Context context]
-     (execute-fn-name context "MetabaseStaticViz.initializeContextJSON" (json/encode (:options input)))
-     (doseq [{:keys [identifier plugin-id source]} bundles]
-       (load-js-string context source (str "custom-viz-" identifier ".js"))
-       (execute-fn-name context "MetabaseStaticViz.registerCustomVizPlugin" identifier plugin-id))
-     (.asString ^Value (execute-fn-name context "MetabaseStaticViz.renderChartJSON" (json/encode input))))))
+  (let [ids   (mapv :identifier bundles)
+        start (System/nanoTime)]
+    (log/infof "custom-viz: static-rendering plugin(s) %s" ids)
+    (let [result (do-with-untrusted-static-viz-context
+                  (^:once fn* [^Context context]
+                    (let [register-start (System/nanoTime)]
+                      (execute-fn-name context "MetabaseStaticViz.initializeContextJSON" (json/encode (:options input)))
+                      (doseq [{:keys [identifier plugin-id source]} bundles]
+                        (load-js-string context source (str "custom-viz-" identifier ".js"))
+                        (execute-fn-name context "MetabaseStaticViz.registerCustomVizPlugin" identifier plugin-id))
+                      (log/debugf "custom-viz: registered plugin(s) %s in %.0fms"
+                                  ids (/ (- (System/nanoTime) register-start) 1e6)))
+                    (.asString ^Value (execute-fn-name context "MetabaseStaticViz.renderChartJSON" (json/encode input)))))]
+      (log/infof "custom-viz: static-rendered %s in %.0fms (incl. context acquire/generation)"
+                 ids (/ (- (System/nanoTime) start) 1e6))
+      result)))
 
 (defn renderer
   "The GraalVM [[metabase.channel.render.js.protocol/StaticVizRenderer]] — runs the static-viz JS
-  in-process on the pooled GraalVM context. Each method JSON-encodes its `input` map for the bundle and
-  decodes the bundle's JSON result back into Clojure data."
+  in-process on the pooled GraalVM context, except `chart-with-custom-viz` (untrusted plugin JS), which
+  renders on the pooled `SandboxPolicy/UNTRUSTED` isolate instead. Each method JSON-encodes its `input` map
+  for the bundle and decodes the bundle's JSON result back into Clojure data."
   []
   (reify js.protocol/StaticVizRenderer
     (chart [_ input]

--- a/src/metabase/channel/render/js/graal.clj
+++ b/src/metabase/channel/render/js/graal.clj
@@ -265,13 +265,13 @@
   parsed-source cache."
   (ref-counted-engine (fn [] {:engine (new-untrusted-plugin-engine)})))
 
-(def render-max-cpu-time
+(def ^:private render-max-cpu-time
   "`sandbox.MaxCPUTime` for a *non-pooled* untrusted context (the dev fresh-context path). Covers a cold parse
   of the static-viz bundle plus a single render on dev hardware. Prod uses a pooled context with the larger,
   cumulative [[pool-max-cpu-time]] instead — see [[untrusted-static-viz-context-pool]]."
   "30s")
 
-(def pool-max-cpu-time
+(def ^:private pool-max-cpu-time
   "`sandbox.MaxCPUTime` for a *pooled*, long-lived untrusted context (the prod path). MaxCPUTime is a
   *cumulative* per-context lifetime budget, not per-render: it must cover the one-time cold parse of the
   slim bundle at pool generation plus the many renders the context then serves."

--- a/src/metabase/channel/render/js/graal.clj
+++ b/src/metabase/channel/render/js/graal.clj
@@ -347,7 +347,7 @@
 (def ^:private ^Pool untrusted-static-viz-context-pool
   "Pool of `SandboxPolicy/UNTRUSTED` isolate contexts for rendering untrusted custom-viz plugin JS. Mirrors
   [[static-viz-context-pool]] but for the isolate path."
-  (common/create-pool generate-untrusted-context! destroy-untrusted-context! {:max-size 1, :idle-minutes 10}))
+  (u.pool/create-pool generate-untrusted-context! destroy-untrusted-context! {:max-size 1, :idle-minutes 10}))
 
 (defn do-with-untrusted-static-viz-context
   "Acquire a pooled `SandboxPolicy/UNTRUSTED` isolate context"

--- a/src/metabase/channel/render/js/graal.clj
+++ b/src/metabase/channel/render/js/graal.clj
@@ -69,11 +69,10 @@
 (defn- build-source
   "Build a `Source` from a classpath resource path."
   ^Source [source-path]
-  (let [resource (io/resource source-path)]
-    (when (nil? resource)
-      (throw (ex-info (trs "Javascript resource not found: {0}" source-path)
-                      {:source source-path})))
-    (.build (Source/newBuilder "js" ^java.net.URL resource))))
+  (if-let [resource (io/resource source-path)]
+    (.build (Source/newBuilder "js" ^java.net.URL resource))
+    (throw (ex-info (trs "Javascript resource not found: {0}" source-path)
+                    {:source source-path}))))
 
 (defn- eval-source
   "Evaluate an already-built `Source` in the js context."
@@ -81,14 +80,13 @@
   (.eval context source))
 
 (defn load-resource
-  "Load a JS classpath resource into `context` as a *literal* `Source` (content, not URL-backed). A
+  "Load a JS classpath resource into `context` as a *literal* `Source` (content, not URL-backed).
   It's needed for the `SandboxPolicy/UNTRUSTED` context"
   [^Context context ^String source-path]
-  (let [resource (io/resource source-path)]
-    (when (nil? resource)
-      (throw (ex-info (trs "Javascript resource not found: {0}" source-path)
-                      {:source source-path})))
-    (.eval context (.buildLiteral (Source/newBuilder "js" ^String (slurp resource :encoding "UTF-8") source-path)))))
+  (if-let [resource (io/resource source-path)]
+    (.eval context (.buildLiteral (Source/newBuilder "js" ^String (slurp resource :encoding "UTF-8") source-path)))
+    (throw (ex-info (trs "Javascript resource not found: {0}" source-path)
+                    {:source source-path}))))
 
 (defn execute-fn-name
   "Execute the global js function named `js-fn-name` in `context` with `args`. Not thread-safe on its own

--- a/src/metabase/channel/render/js/graal.clj
+++ b/src/metabase/channel/render/js/graal.clj
@@ -280,6 +280,13 @@
 
 ;;; ------------------------------------------- untrusted context pool ------------------------------------
 
+(defn- destroy-untrusted-context!
+  "Close an untrusted isolate context reaped or disposed by the pool. The shared untrusted engine is a
+  process-lifetime singleton, so unlike [[destroy-context!]] there is no engine ref to drop."
+  [^Context context]
+  (log/debug "custom-viz: disposing untrusted static-viz isolate context")
+  (try (.close context true) (catch Exception _)))
+
 (defn- generate-untrusted-context!
   "Cold-parse the slim custom-viz bundle into a fresh isolate context; logged with timing because this is the
   dominant per-context cost and explains slow first/regenerated renders."
@@ -294,15 +301,8 @@
                  (/ (- (System/nanoTime) start) 1e6))
       context
       (catch Throwable t
-        (try (.close context true) (catch Throwable _))
+        (destroy-untrusted-context! context)
         (throw t)))))
-
-(defn- destroy-untrusted-context!
-  "Close an untrusted isolate context reaped or disposed by the pool. The shared untrusted engine is a
-  process-lifetime singleton, so unlike [[destroy-context!]] there is no engine ref to drop."
-  [^Context context]
-  (log/debug "custom-viz: disposing untrusted static-viz isolate context")
-  (try (.close context true) (catch Exception _)))
 
 (def ^:private ^Pool untrusted-static-viz-context-pool
   "Pool of `SandboxPolicy/UNTRUSTED` isolate contexts for rendering untrusted custom-viz plugin JS. Mirrors
@@ -319,7 +319,7 @@
         (load-resource context common/custom-viz-bundle-resource-path)
         (f context)
         (finally
-          (try (.close context true) (catch Throwable _)))))
+          (destroy-untrusted-context! context))))
     (let [^Context context (.acquire untrusted-static-viz-context-pool pool-key)
           disposed?        (volatile! false)]
       (try

--- a/src/metabase/channel/render/js/graal.clj
+++ b/src/metabase/channel/render/js/graal.clj
@@ -1,19 +1,20 @@
 (ns metabase.channel.render.js.graal
-  "The GraalVM [[metabase.channel.render.js.protocol/StaticVizRenderer]]: runs the static-viz JS
-  in-process on a pool of sandboxed GraalVM contexts (up to three by default).
+  "The GraalVM metabase.channel.render.js.protocol/StaticVizRenderer runs all static-viz JS inside a
+  GraalVM native-image isolate (separate VM, separate heap) under `SandboxPolicy/UNTRUSTED`, so CPU/heap
+  limits and speculative-execution mitigations are enforced by the VM. Requires the `js-isolate-community`
+  artifact on the classpath.
 
-  We run the JS interpreted (no Graal compiler on a stock JDK) and silence the interpreter warning with
-  the engine-level `engine.WarnInterpreterOnly` option. See
-  https://github.com/oracle/graaljs/blob/master/docs/user/RunOnJDK.md.
+  One ref-counted isolate `Engine` (see [[shared-untrusted-engine]]) is shared by two single-context pools
+  that never mix taints:
 
-  The pooled contexts share one `Engine` and one parsed bundle `Source`: the engine (and its
-  `Source`-keyed code cache) is created with the first context and closed with the last, and each context
-  evaluates the shared source into its own realm. So one parsed copy of the bundle is held regardless of
-  how many contexts there are, which makes raising the pool's max from 1 to 2 or 3 a one-line change. A
-  context is held exclusively per render (so renders serialize per context); the utilization controller
-  has min 0, so when idle the pool shrinks to 0 and the last `destroy` closes the engine (GraalVM reclaims
-  neither context nor engine on GC). The first render after an idle gap rebuilds them. The untrusted
-  custom-viz isolate engine follows the same ref-counted lifecycle (see [[ref-counted-engine]])."
+  - the *builtin* pool (1 context, full static-viz bundle) renders built-in charts and only ever evaluates
+    our own bundle;
+  - the *plugin* pool (1 context, slim custom-viz bundle) is the only place untrusted third-party
+    custom-viz plugin JS runs.
+
+  Contexts on a shared engine have isolated global scopes (a plugin can't see another context's globals)
+  while sharing the engine's parsed-source code cache. A context is held exclusively per render, and all
+  rendering is globally serialized (see [[render-lock]]) — one render at a time across both pools."
   (:require
    [clojure.java.io :as io]
    [metabase.channel.render.js.common :as common]
@@ -23,7 +24,6 @@
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.schema :as ms]
    [metabase.util.pool :as u.pool])
   (:import
    (io.aleph.dirigiste Pool)
@@ -32,54 +32,12 @@
 
 (set! *warn-on-reflection* true)
 
-;;; --------------------------------------------- engine / context ----------------------------------------
-
-(def ^:private no-host-class-lookup
-  "Predicate blocking all host class lookup."
-  (reify java.util.function.Predicate
-    (test [_ _] false)))
-
-(defn- create-engine
-  "Build a JS `Engine`. We run JS interpreted (no Graal compiler on a stock JDK), so
-  `engine.WarnInterpreterOnly` is silenced here (it's an engine-level option)."
-  ^Engine []
-  (.. (Engine/newBuilder)
-      (option "engine.WarnInterpreterOnly" "false")
-      (build)))
-
-(defn create-context
-  "Create a sandboxed org.graalvm.polyglot.Context for evaluating javascript — on a fresh engine (no args)
-  or on the given `engine`, so several contexts can share one engine and its parsed-source code cache. No
-  host access, no class lookup, no filesystem I/O; all data must be passed as JSON strings and parsed in JS."
-  (^Context [] (create-context (create-engine)))
-  (^Context [^Engine engine]
-   (.. (Context/newBuilder (into-array String ["js"]))
-       (engine engine)
-       (option "js.intl-402" "true")
-       (allowHostAccess HostAccess/NONE)
-       (allowHostClassLookup no-host-class-lookup)
-       (out System/out)
-       (err System/err)
-       (allowIO false)
-       (build))))
+;;; ------------------------------------------ evaluation helpers -----------------------------------------
 
 (defn load-js-string
   "Load a string literal source into the js context."
   [^Context context ^String string-src ^String src-name]
   (.eval context (.buildLiteral (Source/newBuilder "js" string-src src-name))))
-
-(defn- build-source
-  "Build a `Source` from a classpath resource path."
-  ^Source [source-path]
-  (if-let [resource (io/resource source-path)]
-    (.build (Source/newBuilder "js" ^java.net.URL resource))
-    (throw (ex-info (trs "Javascript resource not found: {0}" source-path)
-                    {:source source-path}))))
-
-(defn- eval-source
-  "Evaluate an already-built `Source` in the js context."
-  [^Context context ^Source source]
-  (.eval context source))
 
 (defn load-resource
   "Load a JS classpath resource into `context` as a *literal* `Source` (content, not URL-backed).
@@ -104,124 +62,12 @@
   (assert (.canExecute fn-ref) "cannot execute function reference")
   (.execute fn-ref (object-array args)))
 
-;;; ------------------------------------- ref-counted engine holder ---------------------------------------
-;;;
-;;; Generic lifecycle tool: a lazily-created `Engine` shared by pooled contexts, closed again when the last
-;;; context is destroyed. Used by both the trusted and the untrusted-isolate pool below.
-
-(def ^:private CreateEngineState
-  "Schema for a [[ref-counted-engine]] `create` fn: builds the shared state"
-  [:=> [:cat] [:map [:engine (ms/InstanceOfClass Engine)]]])
-
-(def ^:private EngineState
-  "What lives inside a [[RefCountedEngine]]'s `:state` atom while the engine is live: the map its `create`
-  returned plus `:refs`, the count of live contexts holding the engine open. nil when no engine is live."
-  [:map
-   [:engine (ms/InstanceOfClass Engine)]
-   [:refs   pos-int?]])
-
-(def ^:private RefCountedEngine
-  "Schema for the holder built by [[ref-counted-engine]]. `:state` holds [[EngineState]] or nil."
-  [:map
-   [:lock   some?]
-   [:state  (ms/InstanceOfClass clojure.lang.Atom)]
-   [:create CreateEngineState]])
-
-(mu/defn- ref-counted-engine :- RefCountedEngine
-  "A ref-counted holder for an `Engine` shared by pooled contexts, plus any extra state `create` returns
-  alongside it (e.g. a parsed `Source`). `create` runs under the first [[acquire-engine!]]; the engine is
-  closed by the [[release-engine!]] that drops the last ref. Needed because GraalVM reclaims neither
-  engines nor contexts on GC — an idle-shrunk pool must close its engine explicitly to get the memory back."
-  [create :- CreateEngineState]
-  {:lock (Object.), :state (atom nil), :create create})
-
-(mu/defn- acquire-engine! :- EngineState
-  "Return `engine-ref`'s shared state (`{:engine <Engine>}` plus whatever its `create` returned), creating
-  it with the first acquire. Bumps the ref count."
-  [{:keys [lock state create]} :- RefCountedEngine]
-  (locking lock
-    (let [current (update (or @state (assoc (create) :refs 0)) :refs inc)]
-      (reset! state current)
-      current)))
-
-(mu/defn- release-engine!
-  "Drop a ref on `engine-ref`'s shared engine, closing it once the last ref is gone."
-  [{:keys [lock state]} :- RefCountedEngine]
-  (locking lock
-    (let [{:keys [^Engine engine refs]} @state]
-      (if (<= refs 1)
-        (do (try (.close engine) (catch Exception _))
-            (reset! state nil))
-        (swap! state update :refs dec)))))
-
-;;; ------------------------------------ trusted engine + contexts ----------------------------------------
-
-(def ^:private shared-engine
-  "Ref-counted `Engine` + parsed bundle `Source` shared by every pooled trusted context: created with the
-  first context ([[generate-context!]]) and closed with the last ([[destroy-context!]])."
-  (ref-counted-engine
-   (fn []
-     {:source (build-source common/bundle-resource-path)
-      :engine (create-engine)})))
-
-(defn- generate-context!
-  "Build a context on the shared engine and evaluate the bundle into it (creating the engine + parsing the
-  bundle if this is the first context)."
-  ^Context []
-  (common/assert-tests-not-initializing!)
-  (let [{:keys [^Engine engine ^Source source]} (acquire-engine! shared-engine)]
-    (try
-      (doto (create-context engine)
-        (eval-source source))
-      (catch Throwable t
-        (release-engine! shared-engine)
-        (throw t)))))
-
-(defn- destroy-context!
-  "Close a context and drop its ref on the shared engine (closing the engine if it was the last context)."
-  [^Context context]
-  (try (.close context true) (catch Exception _))
-  (release-engine! shared-engine))
-
-;;; ------------------------------------------------ context pool -----------------------------------------
-
-(def ^:private pool-key
-  "Dirigiste pools are keyed; the key itself is arbitrary, it just has to be the same for every operation."
-  :static-viz)
-
-(def ^:private ^Pool static-viz-context-pool
-  "A pool of up to three static-viz contexts, each held exclusively from acquire to release, so at most
-  three renders run at once — one per context, on the shared engine. When idle for up to 10 minutes the
-  pool shrinks to 0 and the generator's `destroy` closes the context (and, on the last one, the shared
-  engine); the first render after an idle gap rebuilds them. See
-  [[metabase.util.pool/create-pool]]."
-  (u.pool/create-pool generate-context! destroy-context! {:max-size 3, :idle-minutes 10}))
-
-(defn- do-with-static-viz-context
-  "Borrow a pooled static-viz context and call `f` with it, held exclusively for the call (never let it —
-  or a context-bound `Value` — escape). In dev, builds and closes a throwaway context per call so a fresh
-  `bun run build-static-viz` is picked up without a REPL restart."
-  [f]
-  (if config/is-dev?
-    (let [context (generate-context!)]
-      (try (f context)
-           (finally (destroy-context! context))))
-    (let [context (.acquire static-viz-context-pool pool-key)]
-      (try (f context)
-           (finally (.release static-viz-context-pool pool-key context))))))
-
-;;; ---------------------------------------- Untrusted plugin sandbox -------------------------------------
-;;;
-;;; Stronger sandbox for running *untrusted* custom-viz plugin JS (third-party bundles). Unlike
-;;; [[create-context]], which relies on `HostAccess/NONE` + config flags in the host JVM, this runs the guest
-;;; inside a GraalVM native-image isolate (separate VM, separate heap) under `SandboxPolicy/UNTRUSTED`, so
-;;; CPU/heap limits and speculative-execution mitigations are enforced by the VM. Requires the
-;;; `js-isolate-community` artifact on the classpath. Built-in static-viz keeps the faster in-process
-;;; [[create-context]] path; only plugins pay for the isolate.
+;;; ------------------------------------- untrusted isolate engine ----------------------------------------
 
 (def ^:private ^OutputStream discarding-output-stream
-  "Sink for untrusted-guest stdout/stderr — plugin console output is neither trusted nor useful in server
-  logs, and `SandboxPolicy/UNTRUSTED` bounds it via `sandbox.Max*StreamSize` regardless."
+  "Sink for untrusted-guest stdout/stderr — guest console output (ours or a plugin's) is not useful in
+  server logs, plugin output is additionally untrusted, and `SandboxPolicy/UNTRUSTED` bounds it via
+  `sandbox.Max*StreamSize` regardless."
   (proxy [OutputStream] []
     (write
       ([_])
@@ -232,8 +78,14 @@
 ;;; The isolate is a separate heap but runs in the *same OS process* as the JVM, so its native memory counts
 ;;; against the same pod/container.
 (def ^:private max-isolate-memory
-  "`engine.MaxIsolateMemory`: hard cap on the untrusted isolate's whole heap. Should cover the slim
-  custom-viz bundle plus a real render."
+  "`engine.MaxIsolateMemory`: hard cap on the untrusted isolate's *whole* heap across every live context —
+  a ceiling, not a reservation, and deliberately an overcommit. At most two contexts are resident (one
+  builtin + one plugin, the two single-slot pools), each capped at 416MB [[max-heap-memory]], so their caps
+  sum above this. That's tolerable because rendering is globally serialized ([[render-lock]]): only one
+  context ever allocates a render's peak at a time, so the *active* render has the whole cap available. If a
+  resident builtin + plugin pair still pushes past this, the isolate fails closed (a resource-exhausted
+  render → error card), never OOM-kills the pod. Must stay strictly above the per-context [[max-heap-memory]]
+  (GraalVM requires it)."
   "512MB")
 
 (def ^:private max-heap-memory
@@ -241,10 +93,10 @@
   [[max-isolate-memory]]"
   "416MB")
 
-(defn- new-untrusted-plugin-engine
-  "Build the isolate `Engine` shared by every untrusted-plugin context. `engine.MaxIsolateMemory` caps the
+(defn- new-untrusted-engine
+  "Build the isolate `Engine` shared by every untrusted context. `engine.MaxIsolateMemory` caps the
   whole isolate heap and must exceed the per-context `sandbox.MaxHeapMemory` set in
-  [[untrusted-plugin-context]], so the isolate fails closed below the cgroup ceiling instead of OOM-killing
+  [[untrusted-context]], so the isolate fails closed below the cgroup ceiling instead of OOM-killing
   the pod."
   ^Engine []
   (.. (Engine/newBuilder (into-array String ["js"]))
@@ -256,33 +108,56 @@
       (err discarding-output-stream)
       (build)))
 
-(def ^:private shared-untrusted-plugin-engine
-  "Ref-counted GraalVM isolate `Engine` shared by every untrusted custom-viz plugin context: created with
-  the first context ([[generate-untrusted-context!]]) and closed with the last
-  ([[destroy-untrusted-context!]]), so an idle-shrunk pool frees the isolate's native heap (up to
-  [[max-isolate-memory]]) instead of pinning it for the process lifetime. Contexts on a shared engine
-  still get isolated global scopes (one plugin can't see another's globals), while sharing the isolate's
-  parsed-source cache."
-  (ref-counted-engine (fn [] {:engine (new-untrusted-plugin-engine)})))
+(def ^:private engine-lock (Object.))
+
+(def ^:private shared-untrusted-engine
+  "Atom holding `{:engine <Engine>, :refs <live context count>}`, or nil when no context is live. Guarded
+  by [[engine-lock]]. The single UNTRUSTED isolate `Engine` is shared by every context from both pools:
+  created with the first context ([[acquire-untrusted-engine!]]) and closed with the last
+  ([[release-untrusted-engine!]]) — from either pool — so idle-shrunk pools free the isolate's native heap
+  (up to [[max-isolate-memory]]) instead of pinning it for the process lifetime. Contexts on the shared
+  engine still get isolated global scopes (builtin and plugin contexts can't see each other's globals),
+  while sharing the isolate's parsed-source cache. GraalVM reclaims neither engine nor contexts on GC, so
+  the last release must close the engine explicitly to get the memory back."
+  (atom nil))
+
+(defn- acquire-untrusted-engine!
+  "Return the shared UNTRUSTED isolate `Engine`, creating it with the first context. Bumps the ref count."
+  ^Engine []
+  (locking engine-lock
+    (let [state (or @shared-untrusted-engine {:engine (new-untrusted-engine), :refs 0})]
+      (reset! shared-untrusted-engine (update state :refs inc))
+      (:engine state))))
+
+(defn- release-untrusted-engine!
+  "Drop a ref on the shared engine, closing it once the last context is gone."
+  []
+  (locking engine-lock
+    (let [{:keys [^Engine engine refs]} @shared-untrusted-engine]
+      (if (<= refs 1)
+        (do (try (.close engine) (catch Exception _))
+            (reset! shared-untrusted-engine nil))
+        (swap! shared-untrusted-engine update :refs dec)))))
 
 (def ^:private render-max-cpu-time
   "`sandbox.MaxCPUTime` for a *non-pooled* untrusted context (the dev fresh-context path). Covers a cold parse
   of the static-viz bundle plus a single render on dev hardware. Prod uses a pooled context with the larger,
-  cumulative [[pool-max-cpu-time]] instead — see [[untrusted-static-viz-context-pool]]."
+  cumulative [[pool-max-cpu-time]] instead."
   "30s")
 
 (def ^:private pool-max-cpu-time
   "`sandbox.MaxCPUTime` for a *pooled*, long-lived untrusted context (the prod path). MaxCPUTime is a
   *cumulative* per-context lifetime budget, not per-render: it must cover the one-time cold parse of the
-  slim bundle at pool generation plus the many renders the context then serves."
+  bundle at pool generation plus the many renders the context then serves. The builtin pool proactively
+  recycles contexts before this budget runs out mid-render — see [[pool-cpu-soft-limit-ms]]."
   "180s")
 
-(defn untrusted-plugin-context
+(defn untrusted-context
   "Create a `SandboxPolicy/UNTRUSTED` GraalVM isolate `Context` on `engine` (which must itself declare
-  `SandboxPolicy/UNTRUSTED` — see [[new-untrusted-plugin-engine]]) for running untrusted custom-viz plugin
-  JS. The guest runs in a separate isolate heap with VM-enforced CPU/heap/AST limits; like
-  [[create-context]] it has no host access and no IO, so data must cross the boundary as JSON strings."
-  (^Context [^Engine engine] (untrusted-plugin-context engine render-max-cpu-time))
+  `SandboxPolicy/UNTRUSTED` — see [[new-untrusted-engine]]). The guest runs in a separate isolate heap
+  with VM-enforced CPU/heap/AST limits, no host access, and no IO, so data must cross the boundary as
+  JSON strings."
+  (^Context [^Engine engine] (untrusted-context engine render-max-cpu-time))
   (^Context [^Engine engine ^String max-cpu-time]
    (.. (Context/newBuilder (into-array String ["js"]))
        (engine engine)
@@ -309,95 +184,193 @@
        (err discarding-output-stream)
        (build))))
 
-;;; ------------------------------------------- untrusted context pool ------------------------------------
+;;; ------------------------------------ untrusted context generation -------------------------------------
 
 (defn- destroy-untrusted-context!
-  "Close an untrusted isolate context reaped or disposed by the pool and drop its ref on the shared
+  "Close an untrusted isolate context reaped or disposed by a pool and drop its ref on the shared
   untrusted engine (closing the engine — and freeing its isolate heap — with the last context)."
   [^Context context]
-  (log/debug "custom-viz: disposing untrusted static-viz isolate context")
+  (log/debug "static-viz: disposing untrusted isolate context")
   (try (.close context true) (catch Exception _))
-  (release-engine! shared-untrusted-plugin-engine))
+  (release-untrusted-engine!))
 
-(defn- generate-untrusted-context!
-  "Cold-parse the slim custom-viz bundle into a fresh isolate context on the shared untrusted engine
+(defn- generate-untrusted-context!*
+  "Cold-parse the bundle at `bundle-path` into a fresh isolate context on the shared untrusted engine
   (creating the engine with the first context); logged with timing because this is the dominant
   per-context cost and explains slow first/regenerated renders."
-  (^Context [] (generate-untrusted-context! pool-max-cpu-time))
+  ^Context [^String bundle-path ^String max-cpu-time bundle-label]
+  (common/assert-tests-not-initializing!)
+  (let [start          (System/nanoTime)
+        ^Engine engine (acquire-untrusted-engine!)]
+    (try
+      (let [context (untrusted-context engine max-cpu-time)]
+        (try
+          (load-resource context bundle-path)
+          (log/infof "static-viz: generated untrusted isolate context (cold-parsed %s bundle) in %.0fms"
+                     bundle-label (/ (- (System/nanoTime) start) 1e6))
+          context
+          (catch Throwable t
+            ;; a bundle-load failure would otherwise leak the freshly-built isolate; close it and rethrow
+            ;; (the engine ref is dropped by the outer catch)
+            (try (.close context true) (catch Exception _))
+            (throw t))))
+      (catch Throwable t
+        (release-untrusted-engine!)
+        (throw t)))))
+
+(defn- generate-untrusted-plugin-context!
+  "Fresh isolate context with the slim custom-viz bundle — the only kind of context that ever evaluates
+  untrusted third-party plugin JS."
+  (^Context [] (generate-untrusted-plugin-context! pool-max-cpu-time))
   (^Context [^String max-cpu-time]
-   (common/assert-tests-not-initializing!)
-   (let [start (System/nanoTime)
-         {:keys [^Engine engine]} (acquire-engine! shared-untrusted-plugin-engine)]
-     (try
-       (let [context (untrusted-plugin-context engine max-cpu-time)]
-         (try
-           (load-resource context common/custom-viz-bundle-resource-path)
-           (log/infof "custom-viz: generated untrusted static-viz isolate context (cold-parsed slim bundle) in %.0fms"
-                      (/ (- (System/nanoTime) start) 1e6))
-           context
-           (catch Throwable t
-             ;; a bundle-load failure would otherwise leak the freshly-built isolate; close it and rethrow
-             ;; (the engine ref is dropped by the outer catch)
-             (try (.close context true) (catch Exception _))
-             (throw t))))
-       (catch Throwable t
-         (release-engine! shared-untrusted-plugin-engine)
-         (throw t))))))
+   (generate-untrusted-context!* common/custom-viz-bundle-resource-path max-cpu-time "slim custom-viz")))
 
-(def ^:private ^Pool untrusted-static-viz-context-pool
-  "Pool of `SandboxPolicy/UNTRUSTED` isolate contexts for rendering untrusted custom-viz plugin JS. Mirrors
-  [[static-viz-context-pool]] but for the isolate path."
-  (u.pool/create-pool generate-untrusted-context! destroy-untrusted-context! {:max-size 1, :idle-minutes 10}))
+(defn- generate-untrusted-builtin-context!*
+  "Fresh isolate context with the full static-viz bundle, as a raw `Context` (the dev throwaway path)."
+  ^Context [^String max-cpu-time]
+  (generate-untrusted-context!* common/bundle-resource-path max-cpu-time "full static-viz"))
 
-(defn do-with-untrusted-static-viz-context
-  "Acquire a pooled `SandboxPolicy/UNTRUSTED` isolate context"
+(defn- pooled-context-generator
+  "Wrap a raw-context `generate` thunk so a pooled context carries a cumulative-CPU accumulator. Returns a
+  wrapper map, not a raw `Context`: dirigiste hands the same object back on release/dispose/destroy, so the
+  `:used-ms` accumulator (see [[pool-cpu-soft-limit-ms]]) travels with its context without a global table."
+  [generate]
+  (fn [] {:context (generate), :used-ms (atom 0)}))
+
+(defn- destroy-pooled-context!
+  "Unwrap a pool wrapper (see [[pooled-context-generator]]) and destroy its context."
+  [{:keys [^Context context]}]
+  (destroy-untrusted-context! context))
+
+;;; ---------------------------------------- untrusted context pools --------------------------------------
+
+(def ^:private pool-key
+  "Dirigiste pools are keyed; the key itself is arbitrary, it just has to be the same for every operation."
+  :static-viz)
+
+(def ^:private ^Pool untrusted-plugin-context-pool
+  "Pool of one isolate context (slim custom-viz bundle) for rendering untrusted custom-viz plugin JS. Pools
+  wrappers (see [[pooled-context-generator]]), not raw contexts. When idle for 10 minutes the pool shrinks
+  to 0 and `destroy` closes the context (and, on the last context from either pool, the shared engine).
+  See [[metabase.util.pool/create-pool]]."
+  (u.pool/create-pool (pooled-context-generator #(generate-untrusted-plugin-context! pool-max-cpu-time))
+                      destroy-pooled-context! {:max-size 1, :idle-minutes 10}))
+
+(def ^:private ^Pool untrusted-builtin-context-pool
+  "Pool of one isolate context (full static-viz bundle) for rendering built-in static viz. Pools wrappers
+  (see [[pooled-context-generator]]), not raw contexts. Same idle-shrink behavior as
+  [[untrusted-plugin-context-pool]]."
+  (u.pool/create-pool (pooled-context-generator #(generate-untrusted-builtin-context!* pool-max-cpu-time))
+                      destroy-pooled-context! {:max-size 1, :idle-minutes 10}))
+
+(def ^:private render-lock
+  "Serializes *all* static-viz rendering: every render — builtin or plugin — holds this, so at most one
+  runs at a time across the whole isolate ([[do-with-untrusted-builtin-context]] /
+  [[do-with-untrusted-plugin-context]]). With one active render, only one context allocates its peak heap
+  at a time, which is the margin that lets [[max-isolate-memory]] sit as low as it does. The pools still
+  keep their (at most two) contexts warm between renders; this bounds concurrency, not residency."
+  (Object.))
+
+(def ^:private pool-cpu-soft-limit-ms
+  "Recycle a pooled context (builtin or plugin) once its renders' cumulative host wall time passes this
+  threshold — well before the context's hard [[pool-max-cpu-time]] budget (which is cumulative, and whose
+  exhaustion would kill a render *mid-flight*). Host wall time upper-bounds the single-threaded guest's CPU
+  time, so accounting with it errs toward recycling early, which is safe: the pool regenerates off the
+  render path."
+  120000)
+
+(defn- do-with-throwaway-plugin-context
+  "Dev plugin path: build a throwaway plugin context per call — so a fresh `bun run build-static-viz` is
+  picked up without a REPL restart — with the tighter single-render [[render-max-cpu-time]] budget, run
+  `f`, and close it."
   [f]
-  (if config/is-dev?
-    ;; a throwaway context per call, like [[do-with-static-viz-context]]'s dev path — with the tighter
-    ;; single-render [[render-max-cpu-time]] budget
-    (let [^Context context (generate-untrusted-context! render-max-cpu-time)]
-      (try
-        (f context)
-        (finally
-          (destroy-untrusted-context! context))))
-    (let [^Context context (.acquire untrusted-static-viz-context-pool pool-key)
-          disposed?        (volatile! false)]
-      (try
-        (f context)
-        (catch PolyglotException e
-          ;; A cancelled / resource-exhausted context is permanently unusable; dispose it so the pool
-          ;; regenerates a fresh one rather than handing a dead context to the next render.
-          (when (or (.isCancelled e) (.isResourceExhausted e))
-            (vreset! disposed? true)
-            (log/warnf "custom-viz: untrusted static-viz context hit a sandbox limit (cancelled=%s resource-exhausted=%s); disposing and regenerating. %s"
-                       (.isCancelled e) (.isResourceExhausted e) (.getMessage e))
-            (.dispose untrusted-static-viz-context-pool pool-key context))
-          (throw e))
-        (finally
-          (when-not @disposed?
-            (.release untrusted-static-viz-context-pool pool-key context)))))))
+  (let [^Context context (generate-untrusted-plugin-context! render-max-cpu-time)]
+    (try
+      (f context)
+      (finally
+        (destroy-untrusted-context! context)))))
+
+(defn- do-with-throwaway-builtin-context
+  "Dev builtin path: build a throwaway builtin context per call — so a fresh `bun run build-static-viz` is
+  picked up without a REPL restart — with the tighter single-render [[render-max-cpu-time]] budget, run
+  `f`, and close it."
+  [f]
+  (let [^Context context (generate-untrusted-builtin-context!* render-max-cpu-time)]
+    (try
+      (f context)
+      (finally
+        (destroy-untrusted-context! context)))))
+
+(defn- do-with-pooled-context
+  "Prod path: borrow a wrapper from `pool` and run `f` with its context. Disposes (rather than releases)
+  the context when a sandbox-limit hit leaves it permanently unusable, or when its renders' cumulative CPU
+  crosses [[pool-cpu-soft-limit-ms]] — see that var for why recycling is proactive. `label`
+  (\"builtin\"/\"plugin\") only tags log messages."
+  [^Pool pool label f]
+  (let [{:keys [^Context context used-ms] :as wrapper} (.acquire pool pool-key)
+        disposed? (volatile! false)
+        start     (System/nanoTime)]
+    (try
+      (f context)
+      (catch PolyglotException e
+        ;; A cancelled / resource-exhausted context is permanently unusable; dispose it so the pool
+        ;; regenerates a fresh one rather than handing a dead context to the next render.
+        (when (or (.isCancelled e) (.isResourceExhausted e))
+          (vreset! disposed? true)
+          (log/warnf "static-viz: untrusted %s context hit a sandbox limit (cancelled=%s resource-exhausted=%s); disposing and regenerating. %s"
+                     label (.isCancelled e) (.isResourceExhausted e) (.getMessage e))
+          (.dispose pool pool-key wrapper))
+        (throw e))
+      (finally
+        (when-not @disposed?
+          (let [total (swap! used-ms + (quot (- (System/nanoTime) start) 1000000))]
+            (if (>= total pool-cpu-soft-limit-ms)
+              (do
+                (log/infof "static-viz: %s isolate context spent ~%dms of its cumulative %s CPU budget; recycling it"
+                           label total pool-max-cpu-time)
+                (.dispose pool pool-key wrapper))
+              (.release pool pool-key wrapper))))))))
+
+(defn do-with-untrusted-plugin-context
+  "Acquire a plugin isolate context (slim custom-viz bundle) and call `f` with it, held exclusively for the
+  call, under the global [[render-lock]] so no other static-viz render runs concurrently (never let the
+  context — or a context-bound `Value` — escape)."
+  [f]
+  (locking render-lock
+    (if config/is-dev?
+      (do-with-throwaway-plugin-context f)
+      (do-with-pooled-context untrusted-plugin-context-pool "plugin" f))))
+
+(defn do-with-untrusted-builtin-context
+  "Acquire a builtin isolate context (full static-viz bundle) and call `f` with it, held exclusively for
+  the call, under the global [[render-lock]] so no other static-viz render runs concurrently (never let the
+  context — or a context-bound `Value` — escape)."
+  [f]
+  (locking render-lock
+    (if config/is-dev?
+      (do-with-throwaway-builtin-context f)
+      (do-with-pooled-context untrusted-builtin-context-pool "builtin" f))))
 
 ;;; ------------------------------------------------ backend ----------------------------------------------
 
 (mu/defn- call-js :- :string
   "Execute static-viz bundle function `fn-name` (a `MetabaseStaticViz.*` global) with the already-JSON-encoded
-  string `args` on the pooled context."
+  string `args` on a pooled builtin isolate context."
   [fn-name :- :string
    args    :- [:sequential :string]]
-  (do-with-static-viz-context
+  (do-with-untrusted-builtin-context
    (fn [^Context context]
      (.asString ^Value (apply execute-fn-name context (str "MetabaseStaticViz." fn-name) args)))))
 
 (defn- chart-with-custom-viz*
-  "Render `input` on a pooled `SandboxPolicy/UNTRUSTED` isolate context (slim custom-viz bundle already
-  loaded by the pool) after evaluating and registering the custom-viz plugin `bundles` (untrusted
-  third-party JS) into it. Plugin bundles are untrusted third-party JS, so this never touches the trusted
-  in-process pool."
+  "Render `input` on a pooled plugin isolate context (slim custom-viz bundle already loaded by the pool)
+  after evaluating and registering the custom-viz plugin `bundles` (untrusted third-party JS) into it.
+  Plugin bundles are untrusted third-party JS, so this never touches the builtin pool."
   [input bundles]
   (let [ids   (mapv :identifier bundles)
         start (System/nanoTime)]
     (log/infof "custom-viz: static-rendering plugin(s) %s" ids)
-    (let [result (do-with-untrusted-static-viz-context
+    (let [result (do-with-untrusted-plugin-context
                   (^:once fn* [^Context context]
                     (let [register-start (System/nanoTime)]
                       (execute-fn-name context "MetabaseStaticViz.initializeContextJSON" (json/encode (:options input)))
@@ -412,10 +385,10 @@
       result)))
 
 (defn renderer
-  "The GraalVM [[metabase.channel.render.js.protocol/StaticVizRenderer]] — runs the static-viz JS
-  in-process on the pooled GraalVM context, except `chart-with-custom-viz` (untrusted plugin JS), which
-  renders on the pooled `SandboxPolicy/UNTRUSTED` isolate instead. Each method JSON-encodes its `input` map
-  for the bundle and decodes the bundle's JSON result back into Clojure data."
+  "The GraalVM [[metabase.channel.render.js.protocol/StaticVizRenderer]] — every method renders on a
+  pooled `SandboxPolicy/UNTRUSTED` isolate context: built-in rendering on the builtin (full-bundle) pool,
+  `chart-with-custom-viz` (untrusted plugin JS) on the plugin (slim-bundle) pool. Each method JSON-encodes
+  its `input` map for the bundle and decodes the bundle's JSON result back into Clojure data."
   []
   (reify js.protocol/StaticVizRenderer
     (chart [_ input]

--- a/src/metabase/channel/render/js/graal.clj
+++ b/src/metabase/channel/render/js/graal.clj
@@ -17,6 +17,7 @@
   rendering is globally serialized (see [[render-lock]]) — one render at a time across both pools."
   (:require
    [clojure.java.io :as io]
+   [metabase.analytics-interface.core :as analytics]
    [metabase.channel.render.js.common :as common]
    [metabase.channel.render.js.protocol :as js.protocol]
    [metabase.config.core :as config]
@@ -246,6 +247,17 @@
   before exhausting the hard [[pool-max-cpu-time]] budget, which would kill a render mid-flight."
   120000)
 
+(defn- sandbox-limit-label
+  "Which sandbox limit killed a render, for the prometheus counter. Only the exception message
+  distinguishes the heap cap from the CPU-time budget — the polyglot API exposes no more than the
+  cancelled/resource-exhausted flags."
+  [^PolyglotException e]
+  (let [message (str (.getMessage e))]
+    (cond
+      (re-find #"(?i)heap" message)     "memory"
+      (re-find #"(?i)cpu time" message) "cpu"
+      :else                             "other")))
+
 (defn- do-with-pooled-context
   "Prod path: borrow a wrapper from `pool` and run `f` with its context. The context is disposed instead
   of released when a sandbox-limit hit leaves it permanently unusable, or when its cumulative CPU crosses
@@ -261,6 +273,8 @@
         ;; regenerates a fresh one rather than handing a dead context to the next render.
         (when (or (.isCancelled e) (.isResourceExhausted e))
           (vreset! disposed? true)
+          (analytics/inc! :metabase-static-viz/sandbox-limit-hits
+                          {:tier label, :limit (sandbox-limit-label e)})
           (log/warnf "static-viz: untrusted %s context hit a sandbox limit (cancelled=%s resource-exhausted=%s); disposing and regenerating. %s"
                      label (.isCancelled e) (.isResourceExhausted e) (.getMessage e))
           (.dispose pool pool-key wrapper))

--- a/src/metabase/channel/render/js/graal.clj
+++ b/src/metabase/channel/render/js/graal.clj
@@ -122,6 +122,7 @@
   (locking engine-lock
     (let [state (or @shared-untrusted-engine {:engine (new-untrusted-engine), :refs 0})]
       (reset! shared-untrusted-engine (update state :refs inc))
+      (analytics/inc! :metabase-static-viz/isolate-contexts)
       (:engine state))))
 
 (defn- release-untrusted-engine!
@@ -132,7 +133,8 @@
       (if (<= refs 1)
         (do (try (.close engine) (catch Exception _))
             (reset! shared-untrusted-engine nil))
-        (swap! shared-untrusted-engine update :refs dec)))))
+        (swap! shared-untrusted-engine update :refs dec))
+      (analytics/dec-gauge! :metabase-static-viz/isolate-contexts))))
 
 (def ^:private render-max-cpu-time
   "`sandbox.MaxCPUTime` for a *non-pooled* untrusted context (the dev fresh-context path). Covers a cold parse
@@ -284,6 +286,7 @@
           (let [total (swap! used-ms + (long (u/since-ms timer)))]
             (if (>= total pool-cpu-soft-limit-ms)
               (do
+                (analytics/inc! :metabase-static-viz/context-recycles {:tier label})
                 (log/infof "static-viz: %s isolate context spent ~%dms of its cumulative %s CPU budget; recycling it"
                            label total pool-max-cpu-time)
                 (.dispose pool pool-key wrapper))
@@ -294,14 +297,23 @@
   [[render-lock]]. In dev, builds a throwaway context per call so a fresh `bun run build-static-viz` is
   picked up without a REPL restart; in prod, borrows a pooled context from `pool`."
   [^Pool pool bundle-path label f]
-  (locking render-lock
-    (if config/is-dev?
-      (let [context (generate-untrusted-context! bundle-path render-max-cpu-time)]
-        (try
-          (f context)
-          (finally
-            (destroy-untrusted-context! context))))
-      (do-with-pooled-context pool label f))))
+  (analytics/inc! :metabase-static-viz/untrusted-render {:tier label})
+  (let [wait-timer (u/start-timer)]
+    ;; monitor acquisition can't throw, so the matching dec-gauge! inside the lock body cannot be skipped
+    (analytics/inc! :metabase-static-viz/render-queue)
+    (locking render-lock
+      (analytics/dec-gauge! :metabase-static-viz/render-queue)
+      (let [waited-ms (long (u/since-ms wait-timer))]
+        (if (>= waited-ms 1000)
+          (log/infof "static-viz: %s render waited %dms for the render lock" label waited-ms)
+          (log/debugf "static-viz: %s render waited %dms for the render lock" label waited-ms)))
+      (if config/is-dev?
+        (let [context (generate-untrusted-context! bundle-path render-max-cpu-time)]
+          (try
+            (f context)
+            (finally
+              (destroy-untrusted-context! context))))
+        (do-with-pooled-context pool label f)))))
 
 (defn do-with-untrusted-plugin-context
   "Acquire a plugin isolate context (slim custom-viz bundle) — the only kind of context that ever evaluates

--- a/src/metabase/channel/render/js/graal.clj
+++ b/src/metabase/channel/render/js/graal.clj
@@ -216,12 +216,10 @@
   :static-viz)
 
 (defn- untrusted-context-pool
-  "Single-context pool of isolate contexts pre-loaded with the bundle at `bundle-path`. Pools
-  `{:context <Context>, :used-ms <atom>}` wrappers, not raw contexts: dirigiste hands the same object back
-  on release/dispose/destroy, so the cumulative-CPU accumulator (see [[pool-cpu-soft-limit-ms]]) travels
-  with its context without a global table. When idle for 10 minutes the pool shrinks to 0 and `destroy`
-  closes the context (and, on the last context from either pool, the shared engine). See
-  [[metabase.util.pool/create-pool]]."
+  "Pool of one isolate context pre-loaded with the bundle at `bundle-path`. Pools `{:context <Context>,
+  :used-ms <atom>}` wrappers so the cumulative-CPU accumulator (see [[pool-cpu-soft-limit-ms]]) travels
+  with its context. After 10 idle minutes the pool shrinks to 0, closing the context (and, with the last
+  context from either pool, the shared engine)."
   ^Pool [bundle-path]
   (u.pool/create-pool (fn [] {:context (generate-untrusted-context! bundle-path pool-max-cpu-time)
                               :used-ms (atom 0)})
@@ -238,26 +236,20 @@
   (untrusted-context-pool common/bundle-resource-path))
 
 (def ^:private render-lock
-  "Serializes *all* static-viz rendering: every render — builtin or plugin — holds this, so at most one
-  runs at a time across the whole isolate (see [[do-with-untrusted-context*]]). With one active render,
-  only one context allocates its peak heap at a time, which is the margin that lets [[max-isolate-memory]]
-  sit as low as it does. The pools still keep their (at most two) contexts warm between renders; this
-  bounds concurrency, not residency."
+  "Serializes *all* static-viz rendering — builtin or plugin, at most one render at a time — so only one
+  context allocates its peak heap at a time, which is what lets [[max-isolate-memory]] sit as low as it
+  does. Bounds concurrency, not residency: the pools still keep their contexts warm between renders."
   (Object.))
 
 (def ^:private pool-cpu-soft-limit-ms
-  "Recycle a pooled context (builtin or plugin) once its renders' cumulative host wall time passes this
-  threshold — well before the context's hard [[pool-max-cpu-time]] budget (which is cumulative, and whose
-  exhaustion would kill a render *mid-flight*). Host wall time upper-bounds the single-threaded guest's CPU
-  time, so accounting with it errs toward recycling early, which is safe: it only costs the next render a
-  context regeneration instead of a mid-render kill."
+  "Recycle a pooled context once its renders' cumulative host wall time passes this threshold — well
+  before exhausting the hard [[pool-max-cpu-time]] budget, which would kill a render mid-flight."
   120000)
 
 (defn- do-with-pooled-context
-  "Prod path: borrow a wrapper from `pool` and run `f` with its context. Disposes (rather than releases)
-  the context when a sandbox-limit hit leaves it permanently unusable, or when its renders' cumulative CPU
-  crosses [[pool-cpu-soft-limit-ms]] — see that var for why recycling is proactive. `label`
-  (\"builtin\"/\"plugin\") only tags log messages."
+  "Prod path: borrow a wrapper from `pool` and run `f` with its context. The context is disposed instead
+  of released when a sandbox-limit hit leaves it permanently unusable, or when its cumulative CPU crosses
+  [[pool-cpu-soft-limit-ms]]. `label` only tags log messages."
   [^Pool pool label f]
   (let [{:keys [^Context context used-ms] :as wrapper} (.acquire pool pool-key)
         disposed? (volatile! false)
@@ -284,11 +276,9 @@
               (.release pool pool-key wrapper))))))))
 
 (defn- do-with-untrusted-context*
-  "Run `f` with an isolate context pre-loaded with the bundle at `bundle-path`, held exclusively for the
-  call under the global [[render-lock]] so no other static-viz render runs concurrently. In dev, builds a
-  throwaway context per call — so a fresh `bun run build-static-viz` is picked up without a REPL restart —
-  with the tighter single-render [[render-max-cpu-time]] budget; in prod, borrows a pooled context from
-  `pool`."
+  "Run `f` with an isolate context pre-loaded with the bundle at `bundle-path`, under the global
+  [[render-lock]]. In dev, builds a throwaway context per call so a fresh `bun run build-static-viz` is
+  picked up without a REPL restart; in prod, borrows a pooled context from `pool`."
   [^Pool pool bundle-path label f]
   (locking render-lock
     (if config/is-dev?

--- a/src/metabase/channel/render/js/graal.clj
+++ b/src/metabase/channel/render/js/graal.clj
@@ -20,6 +20,7 @@
    [metabase.channel.render.js.common :as common]
    [metabase.channel.render.js.protocol :as js.protocol]
    [metabase.config.core :as config]
+   [metabase.util :as u]
    [metabase.util.i18n :refer [trs]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -44,7 +45,7 @@
   It's needed for the `SandboxPolicy/UNTRUSTED` context"
   [^Context context ^String source-path]
   (if-let [resource (io/resource source-path)]
-    (.eval context (.buildLiteral (Source/newBuilder "js" ^String (slurp resource :encoding "UTF-8") source-path)))
+    (load-js-string context (slurp resource) source-path)
     (throw (ex-info (trs "Javascript resource not found: {0}" source-path)
                     {:source source-path}))))
 
@@ -68,10 +69,7 @@
   "Sink for untrusted-guest stdout/stderr — guest console output (ours or a plugin's) is not useful in
   server logs, plugin output is additionally untrusted, and `SandboxPolicy/UNTRUSTED` bounds it via
   `sandbox.Max*StreamSize` regardless."
-  (proxy [OutputStream] []
-    (write
-      ([_])
-      ([_ _ _]))))
+  (OutputStream/nullOutputStream))
 
 ;;; ---- Isolate memory caps (fail closed, catchable) ----
 ;;;
@@ -79,13 +77,11 @@
 ;;; against the same pod/container.
 (def ^:private max-isolate-memory
   "`engine.MaxIsolateMemory`: hard cap on the untrusted isolate's *whole* heap across every live context —
-  a ceiling, not a reservation, and deliberately an overcommit. At most two contexts are resident (one
-  builtin + one plugin, the two single-slot pools), each capped at 416MB [[max-heap-memory]], so their caps
-  sum above this. That's tolerable because rendering is globally serialized ([[render-lock]]): only one
-  context ever allocates a render's peak at a time, so the *active* render has the whole cap available. If a
-  resident builtin + plugin pair still pushes past this, the isolate fails closed (a resource-exhausted
-  render → error card), never OOM-kills the pod. Must stay strictly above the per-context [[max-heap-memory]]
-  (GraalVM requires it)."
+  a ceiling, not a reservation, and deliberately an overcommit: the (at most two) resident contexts' per-
+  context caps ([[max-heap-memory]]) sum above it, which is tolerable because rendering is globally
+  serialized — see [[render-lock]]. If a resident builtin + plugin pair still pushes past this, the isolate
+  fails closed (a resource-exhausted render → error card), never OOM-kills the pod. Must stay strictly
+  above the per-context [[max-heap-memory]] (GraalVM requires it)."
   "512MB")
 
 (def ^:private max-heap-memory
@@ -115,10 +111,8 @@
   by [[engine-lock]]. The single UNTRUSTED isolate `Engine` is shared by every context from both pools:
   created with the first context ([[acquire-untrusted-engine!]]) and closed with the last
   ([[release-untrusted-engine!]]) — from either pool — so idle-shrunk pools free the isolate's native heap
-  (up to [[max-isolate-memory]]) instead of pinning it for the process lifetime. Contexts on the shared
-  engine still get isolated global scopes (builtin and plugin contexts can't see each other's globals),
-  while sharing the isolate's parsed-source cache. GraalVM reclaims neither engine nor contexts on GC, so
-  the last release must close the engine explicitly to get the memory back."
+  (up to [[max-isolate-memory]]) instead of pinning it for the process lifetime. GraalVM reclaims neither
+  engine nor contexts on GC, so the last release must close the engine explicitly to get the memory back."
   (atom nil))
 
 (defn- acquire-untrusted-engine!
@@ -148,41 +142,38 @@
 (def ^:private pool-max-cpu-time
   "`sandbox.MaxCPUTime` for a *pooled*, long-lived untrusted context (the prod path). MaxCPUTime is a
   *cumulative* per-context lifetime budget, not per-render: it must cover the one-time cold parse of the
-  bundle at pool generation plus the many renders the context then serves. The builtin pool proactively
-  recycles contexts before this budget runs out mid-render — see [[pool-cpu-soft-limit-ms]]."
+  bundle at pool generation plus the many renders the context then serves. Pooled contexts are proactively
+  recycled before this budget runs out mid-render — see [[pool-cpu-soft-limit-ms]]."
   "180s")
 
 (defn untrusted-context
   "Create a `SandboxPolicy/UNTRUSTED` GraalVM isolate `Context` on `engine` (which must itself declare
   `SandboxPolicy/UNTRUSTED` — see [[new-untrusted-engine]]). The guest runs in a separate isolate heap
   with VM-enforced CPU/heap/AST limits, no host access, and no IO, so data must cross the boundary as
-  JSON strings."
-  (^Context [^Engine engine] (untrusted-context engine render-max-cpu-time))
-  (^Context [^Engine engine ^String max-cpu-time]
-   (.. (Context/newBuilder (into-array String ["js"]))
-       (engine engine)
-       (sandbox SandboxPolicy/UNTRUSTED)
-       ;; HostAccess/UNTRUSTED, not /NONE: the UNTRUSTED policy rejects /NONE (it still permits mutable
-       ;; target-type mappings). /UNTRUSTED is the policy's purpose-built strictest host-access mode.
-       (allowHostAccess HostAccess/UNTRUSTED)
-       ;; allowAllAccess (the master switch that would enable all of the below at once) is false by default; UNTRUSTED forbids true.
-       ;; allowHostClassLookup is false by default under SandboxPolicy/UNTRUSTED.
-       ;; allowIO is disabled by default under SandboxPolicy/UNTRUSTED.
-       ;; allowNativeAccess is false by default under SandboxPolicy/UNTRUSTED.
-       ;; allowEnvironmentAccess is NONE (no host env vars) by default under SandboxPolicy/UNTRUSTED.
-       ;; allowExperimentalOptions left at default false
-       ;; MaxCPUTimeCheckInterval left at its ~10ms default
-       (option "sandbox.MaxCPUTime" max-cpu-time)
-       (option "sandbox.MaxHeapMemory" max-heap-memory)
-       (option "sandbox.MaxASTDepth" "5000")
-       (option "sandbox.MaxThreads" "1")         ; single-threaded isolate; allowCreateThread also defaults to false
-       (option "sandbox.MaxOutputStreamSize" "16MB")
-       (option "sandbox.MaxErrorStreamSize" "4MB")
-       ;; sandbox.MaxStatements skipped (and thus its MaxStatementsIncludeInternal modifier): fragile to tune and the compute axis is already covered by MaxCPUTime et al.
-       ;; sandbox.MaxStackFrames skipped too: runtime-recursion blowup surfaces as a contained guest error in the isolate.
-       (out discarding-output-stream)
-       (err discarding-output-stream)
-       (build))))
+  JSON strings. Guest stdout/stderr go to the engine's discarding streams."
+  ^Context [^Engine engine ^String max-cpu-time]
+  (.. (Context/newBuilder (into-array String ["js"]))
+      (engine engine)
+      (sandbox SandboxPolicy/UNTRUSTED)
+      ;; HostAccess/UNTRUSTED, not /NONE: the UNTRUSTED policy rejects /NONE (it still permits mutable
+      ;; target-type mappings). /UNTRUSTED is the policy's purpose-built strictest host-access mode.
+      (allowHostAccess HostAccess/UNTRUSTED)
+      ;; allowAllAccess (the master switch that would enable all of the below at once) is false by default; UNTRUSTED forbids true.
+      ;; allowHostClassLookup is false by default under SandboxPolicy/UNTRUSTED.
+      ;; allowIO is disabled by default under SandboxPolicy/UNTRUSTED.
+      ;; allowNativeAccess is false by default under SandboxPolicy/UNTRUSTED.
+      ;; allowEnvironmentAccess is NONE (no host env vars) by default under SandboxPolicy/UNTRUSTED.
+      ;; allowExperimentalOptions left at default false
+      ;; MaxCPUTimeCheckInterval left at its ~10ms default
+      (option "sandbox.MaxCPUTime" max-cpu-time)
+      (option "sandbox.MaxHeapMemory" max-heap-memory)
+      (option "sandbox.MaxASTDepth" "5000")
+      (option "sandbox.MaxThreads" "1")         ; single-threaded isolate; allowCreateThread also defaults to false
+      (option "sandbox.MaxOutputStreamSize" "16MB")
+      (option "sandbox.MaxErrorStreamSize" "4MB")
+      ;; sandbox.MaxStatements skipped (and thus its MaxStatementsIncludeInternal modifier): fragile to tune and the compute axis is already covered by MaxCPUTime et al.
+      ;; sandbox.MaxStackFrames skipped too: runtime-recursion blowup surfaces as a contained guest error in the isolate.
+      (build)))
 
 ;;; ------------------------------------ untrusted context generation -------------------------------------
 
@@ -194,20 +185,20 @@
   (try (.close context true) (catch Exception _))
   (release-untrusted-engine!))
 
-(defn- generate-untrusted-context!*
+(defn- generate-untrusted-context!
   "Cold-parse the bundle at `bundle-path` into a fresh isolate context on the shared untrusted engine
   (creating the engine with the first context); logged with timing because this is the dominant
   per-context cost and explains slow first/regenerated renders."
-  ^Context [^String bundle-path ^String max-cpu-time bundle-label]
+  ^Context [^String bundle-path ^String max-cpu-time]
   (common/assert-tests-not-initializing!)
-  (let [start          (System/nanoTime)
+  (let [timer          (u/start-timer)
         ^Engine engine (acquire-untrusted-engine!)]
     (try
       (let [context (untrusted-context engine max-cpu-time)]
         (try
           (load-resource context bundle-path)
-          (log/infof "static-viz: generated untrusted isolate context (cold-parsed %s bundle) in %.0fms"
-                     bundle-label (/ (- (System/nanoTime) start) 1e6))
+          (log/infof "static-viz: generated untrusted isolate context (cold-parsed %s) in %.0fms"
+                     bundle-path (u/since-ms timer))
           context
           (catch Throwable t
             ;; a bundle-load failure would otherwise leak the freshly-built isolate; close it and rethrow
@@ -218,88 +209,49 @@
         (release-untrusted-engine!)
         (throw t)))))
 
-(defn- generate-untrusted-plugin-context!
-  "Fresh isolate context with the slim custom-viz bundle — the only kind of context that ever evaluates
-  untrusted third-party plugin JS."
-  (^Context [] (generate-untrusted-plugin-context! pool-max-cpu-time))
-  (^Context [^String max-cpu-time]
-   (generate-untrusted-context!* common/custom-viz-bundle-resource-path max-cpu-time "slim custom-viz")))
-
-(defn- generate-untrusted-builtin-context!*
-  "Fresh isolate context with the full static-viz bundle, as a raw `Context` (the dev throwaway path)."
-  ^Context [^String max-cpu-time]
-  (generate-untrusted-context!* common/bundle-resource-path max-cpu-time "full static-viz"))
-
-(defn- pooled-context-generator
-  "Wrap a raw-context `generate` thunk so a pooled context carries a cumulative-CPU accumulator. Returns a
-  wrapper map, not a raw `Context`: dirigiste hands the same object back on release/dispose/destroy, so the
-  `:used-ms` accumulator (see [[pool-cpu-soft-limit-ms]]) travels with its context without a global table."
-  [generate]
-  (fn [] {:context (generate), :used-ms (atom 0)}))
-
-(defn- destroy-pooled-context!
-  "Unwrap a pool wrapper (see [[pooled-context-generator]]) and destroy its context."
-  [{:keys [^Context context]}]
-  (destroy-untrusted-context! context))
-
 ;;; ---------------------------------------- untrusted context pools --------------------------------------
 
 (def ^:private pool-key
   "Dirigiste pools are keyed; the key itself is arbitrary, it just has to be the same for every operation."
   :static-viz)
 
+(defn- untrusted-context-pool
+  "Single-context pool of isolate contexts pre-loaded with the bundle at `bundle-path`. Pools
+  `{:context <Context>, :used-ms <atom>}` wrappers, not raw contexts: dirigiste hands the same object back
+  on release/dispose/destroy, so the cumulative-CPU accumulator (see [[pool-cpu-soft-limit-ms]]) travels
+  with its context without a global table. When idle for 10 minutes the pool shrinks to 0 and `destroy`
+  closes the context (and, on the last context from either pool, the shared engine). See
+  [[metabase.util.pool/create-pool]]."
+  ^Pool [bundle-path]
+  (u.pool/create-pool (fn [] {:context (generate-untrusted-context! bundle-path pool-max-cpu-time)
+                              :used-ms (atom 0)})
+                      (fn [{:keys [context]}] (destroy-untrusted-context! context))
+                      {:max-size 1, :idle-minutes 10}))
+
 (def ^:private ^Pool untrusted-plugin-context-pool
-  "Pool of one isolate context (slim custom-viz bundle) for rendering untrusted custom-viz plugin JS. Pools
-  wrappers (see [[pooled-context-generator]]), not raw contexts. When idle for 10 minutes the pool shrinks
-  to 0 and `destroy` closes the context (and, on the last context from either pool, the shared engine).
-  See [[metabase.util.pool/create-pool]]."
-  (u.pool/create-pool (pooled-context-generator #(generate-untrusted-plugin-context! pool-max-cpu-time))
-                      destroy-pooled-context! {:max-size 1, :idle-minutes 10}))
+  "Pool of one isolate context (slim custom-viz bundle) — the only place untrusted third-party custom-viz
+  plugin JS ever runs."
+  (untrusted-context-pool common/custom-viz-bundle-resource-path))
 
 (def ^:private ^Pool untrusted-builtin-context-pool
-  "Pool of one isolate context (full static-viz bundle) for rendering built-in static viz. Pools wrappers
-  (see [[pooled-context-generator]]), not raw contexts. Same idle-shrink behavior as
-  [[untrusted-plugin-context-pool]]."
-  (u.pool/create-pool (pooled-context-generator #(generate-untrusted-builtin-context!* pool-max-cpu-time))
-                      destroy-pooled-context! {:max-size 1, :idle-minutes 10}))
+  "Pool of one isolate context (full static-viz bundle) for rendering built-in static viz."
+  (untrusted-context-pool common/bundle-resource-path))
 
 (def ^:private render-lock
   "Serializes *all* static-viz rendering: every render — builtin or plugin — holds this, so at most one
-  runs at a time across the whole isolate ([[do-with-untrusted-builtin-context]] /
-  [[do-with-untrusted-plugin-context]]). With one active render, only one context allocates its peak heap
-  at a time, which is the margin that lets [[max-isolate-memory]] sit as low as it does. The pools still
-  keep their (at most two) contexts warm between renders; this bounds concurrency, not residency."
+  runs at a time across the whole isolate (see [[do-with-untrusted-context*]]). With one active render,
+  only one context allocates its peak heap at a time, which is the margin that lets [[max-isolate-memory]]
+  sit as low as it does. The pools still keep their (at most two) contexts warm between renders; this
+  bounds concurrency, not residency."
   (Object.))
 
 (def ^:private pool-cpu-soft-limit-ms
   "Recycle a pooled context (builtin or plugin) once its renders' cumulative host wall time passes this
   threshold — well before the context's hard [[pool-max-cpu-time]] budget (which is cumulative, and whose
   exhaustion would kill a render *mid-flight*). Host wall time upper-bounds the single-threaded guest's CPU
-  time, so accounting with it errs toward recycling early, which is safe: the pool regenerates off the
-  render path."
+  time, so accounting with it errs toward recycling early, which is safe: it only costs the next render a
+  context regeneration instead of a mid-render kill."
   120000)
-
-(defn- do-with-throwaway-plugin-context
-  "Dev plugin path: build a throwaway plugin context per call — so a fresh `bun run build-static-viz` is
-  picked up without a REPL restart — with the tighter single-render [[render-max-cpu-time]] budget, run
-  `f`, and close it."
-  [f]
-  (let [^Context context (generate-untrusted-plugin-context! render-max-cpu-time)]
-    (try
-      (f context)
-      (finally
-        (destroy-untrusted-context! context)))))
-
-(defn- do-with-throwaway-builtin-context
-  "Dev builtin path: build a throwaway builtin context per call — so a fresh `bun run build-static-viz` is
-  picked up without a REPL restart — with the tighter single-render [[render-max-cpu-time]] budget, run
-  `f`, and close it."
-  [f]
-  (let [^Context context (generate-untrusted-builtin-context!* render-max-cpu-time)]
-    (try
-      (f context)
-      (finally
-        (destroy-untrusted-context! context)))))
 
 (defn- do-with-pooled-context
   "Prod path: borrow a wrapper from `pool` and run `f` with its context. Disposes (rather than releases)
@@ -309,7 +261,7 @@
   [^Pool pool label f]
   (let [{:keys [^Context context used-ms] :as wrapper} (.acquire pool pool-key)
         disposed? (volatile! false)
-        start     (System/nanoTime)]
+        timer     (u/start-timer)]
     (try
       (f context)
       (catch PolyglotException e
@@ -323,7 +275,7 @@
         (throw e))
       (finally
         (when-not @disposed?
-          (let [total (swap! used-ms + (quot (- (System/nanoTime) start) 1000000))]
+          (let [total (swap! used-ms + (long (u/since-ms timer)))]
             (if (>= total pool-cpu-soft-limit-ms)
               (do
                 (log/infof "static-viz: %s isolate context spent ~%dms of its cumulative %s CPU budget; recycling it"
@@ -331,25 +283,34 @@
                 (.dispose pool pool-key wrapper))
               (.release pool pool-key wrapper))))))))
 
-(defn do-with-untrusted-plugin-context
-  "Acquire a plugin isolate context (slim custom-viz bundle) and call `f` with it, held exclusively for the
-  call, under the global [[render-lock]] so no other static-viz render runs concurrently (never let the
-  context — or a context-bound `Value` — escape)."
-  [f]
+(defn- do-with-untrusted-context*
+  "Run `f` with an isolate context pre-loaded with the bundle at `bundle-path`, held exclusively for the
+  call under the global [[render-lock]] so no other static-viz render runs concurrently. In dev, builds a
+  throwaway context per call — so a fresh `bun run build-static-viz` is picked up without a REPL restart —
+  with the tighter single-render [[render-max-cpu-time]] budget; in prod, borrows a pooled context from
+  `pool`."
+  [^Pool pool bundle-path label f]
   (locking render-lock
     (if config/is-dev?
-      (do-with-throwaway-plugin-context f)
-      (do-with-pooled-context untrusted-plugin-context-pool "plugin" f))))
+      (let [context (generate-untrusted-context! bundle-path render-max-cpu-time)]
+        (try
+          (f context)
+          (finally
+            (destroy-untrusted-context! context))))
+      (do-with-pooled-context pool label f))))
+
+(defn do-with-untrusted-plugin-context
+  "Acquire a plugin isolate context (slim custom-viz bundle) — the only kind of context that ever evaluates
+  untrusted third-party plugin JS — and call `f` with it (never let the context — or a context-bound
+  `Value` — escape)."
+  [f]
+  (do-with-untrusted-context* untrusted-plugin-context-pool common/custom-viz-bundle-resource-path "plugin" f))
 
 (defn do-with-untrusted-builtin-context
-  "Acquire a builtin isolate context (full static-viz bundle) and call `f` with it, held exclusively for
-  the call, under the global [[render-lock]] so no other static-viz render runs concurrently (never let the
-  context — or a context-bound `Value` — escape)."
+  "Acquire a builtin isolate context (full static-viz bundle) and call `f` with it (never let the context —
+  or a context-bound `Value` — escape)."
   [f]
-  (locking render-lock
-    (if config/is-dev?
-      (do-with-throwaway-builtin-context f)
-      (do-with-pooled-context untrusted-builtin-context-pool "builtin" f))))
+  (do-with-untrusted-context* untrusted-builtin-context-pool common/bundle-resource-path "builtin" f))
 
 ;;; ------------------------------------------------ backend ----------------------------------------------
 
@@ -365,24 +326,22 @@
 (defn- chart-with-custom-viz*
   "Render `input` on a pooled plugin isolate context (slim custom-viz bundle already loaded by the pool)
   after evaluating and registering the custom-viz plugin `bundles` (untrusted third-party JS) into it.
-  Plugin bundles are untrusted third-party JS, so this never touches the builtin pool."
+  Bundles are re-evaluated on every render: the set of plugins varies per card, and skipping re-evaluation
+  would mean trusting whatever state untrusted code left behind in the pooled context."
   [input bundles]
-  (let [ids   (mapv :identifier bundles)
-        start (System/nanoTime)]
-    (log/infof "custom-viz: static-rendering plugin(s) %s" ids)
-    (let [result (do-with-untrusted-plugin-context
-                  (^:once fn* [^Context context]
-                    (let [register-start (System/nanoTime)]
-                      (execute-fn-name context "MetabaseStaticViz.initializeContextJSON" (json/encode (:options input)))
-                      (doseq [{:keys [identifier plugin-id source]} bundles]
-                        (load-js-string context source (str "custom-viz-" identifier ".js"))
-                        (execute-fn-name context "MetabaseStaticViz.registerCustomVizPlugin" identifier plugin-id))
-                      (log/debugf "custom-viz: registered plugin(s) %s in %.0fms"
-                                  ids (/ (- (System/nanoTime) register-start) 1e6)))
-                    (.asString ^Value (execute-fn-name context "MetabaseStaticViz.renderChartJSON" (json/encode input)))))]
-      (log/infof "custom-viz: static-rendered %s in %.0fms (incl. context acquire/generation)"
-                 ids (/ (- (System/nanoTime) start) 1e6))
-      result)))
+  (let [timer        (u/start-timer)
+        options-json (json/encode (:options input))
+        input-json   (json/encode input)
+        result       (do-with-untrusted-plugin-context
+                      (^:once fn* [^Context context]
+                        (execute-fn-name context "MetabaseStaticViz.initializeContextJSON" options-json)
+                        (doseq [{:keys [identifier plugin-id source]} bundles]
+                          (load-js-string context source (str "custom-viz-" identifier ".js"))
+                          (execute-fn-name context "MetabaseStaticViz.registerCustomVizPlugin" identifier plugin-id))
+                        (.asString ^Value (execute-fn-name context "MetabaseStaticViz.renderChartJSON" input-json))))]
+    (log/infof "custom-viz: static-rendered %s in %.0fms (incl. context acquire/generation)"
+               (mapv :identifier bundles) (u/since-ms timer))
+    result))
 
 (defn renderer
   "The GraalVM [[metabase.channel.render.js.protocol/StaticVizRenderer]] — every method renders on a

--- a/test/metabase/channel/render/js/graal_test.clj
+++ b/test/metabase/channel/render/js/graal_test.clj
@@ -4,9 +4,22 @@
    [metabase.channel.render.js.graal :as graal]
    [metabase.test :as mt])
   (:import
-   (org.graalvm.polyglot Context PolyglotException Value)))
+   (org.graalvm.polyglot Context Engine PolyglotException Value)))
 
 (set! *warn-on-reflection* true)
+
+(defn- do-with-untrusted-context
+  "Run `f` with an UNTRUSTED isolate context on its own throwaway engine, closing both afterwards."
+  [f]
+  (let [^Engine engine (#'graal/new-untrusted-plugin-engine)]
+    (try
+      (let [^Context context (graal/untrusted-plugin-context engine)]
+        (try
+          (f context)
+          (finally
+            (.close context true))))
+      (finally
+        (.close engine)))))
 
 (deftest make-context-test
   (testing "can make a context that evaluates javascript"
@@ -31,48 +44,42 @@
 
 (deftest untrusted-plugin-context-denies-host-access-test
   (testing "the SandboxPolicy/UNTRUSTED isolate runs untrusted plugin JS with no host interop"
-    (let [^Context context (graal/untrusted-plugin-context)]
-      (try
-        (testing "ordinary JS still evaluates, so the sandbox isn't just broken"
-          (is (= "3" (.asString ^Value (graal/load-js-string context "'' + (1 + 2)" "ok.js")))))
-        (testing "the `Java` host-interop global is absent"
-          (is (= "undefined" (.asString ^Value (graal/load-js-string context "typeof Java" "typeof.js")))))
-        (testing "untrusted guest code cannot reach host classes (no sandbox escape)"
-          (is (thrown? PolyglotException
-                       (graal/load-js-string context "Java.type('java.lang.System')" "escape.js"))))
-        (finally
-          (.close context true))))))
+    (do-with-untrusted-context
+     (fn [^Context context]
+       (testing "ordinary JS still evaluates, so the sandbox isn't just broken"
+         (is (= "3" (.asString ^Value (graal/load-js-string context "'' + (1 + 2)" "ok.js")))))
+       (testing "the `Java` host-interop global is absent"
+         (is (= "undefined" (.asString ^Value (graal/load-js-string context "typeof Java" "typeof.js")))))
+       (testing "untrusted guest code cannot reach host classes (no sandbox escape)"
+         (is (thrown? PolyglotException
+                      (graal/load-js-string context "Java.type('java.lang.System')" "escape.js"))))))))
 
 (deftest untrusted-plugin-context-load-resource-test
   (testing "load-resource evals into the UNTRUSTED isolate (regression: a URL-backed Source fails to marshal
             across the native-isolate boundary from a jar: URL — SourceCopyMarshaller ShouldNotReachHere — so
             load-resource must build a literal Source from the resource content)"
-    (let [^Context context (graal/untrusted-plugin-context)]
-      (try
-        ;; a tiny JS resource on the test classpath; the point is that load-resource (not load-js-string)
-        ;; succeeds against the isolate, which is what breaks when the Source is URL-backed.
-        (graal/load-resource context "metabase/channel/render/js/engine_test_resource.js")
-        (is (= 3 (.asLong (graal/execute-fn-name context "engine_test_plus" 1 2))))
-        (finally
-          (.close context true))))))
+    (do-with-untrusted-context
+     (fn [^Context context]
+       ;; a tiny JS resource on the test classpath; the point is that load-resource (not load-js-string)
+       ;; succeeds against the isolate, which is what breaks when the Source is URL-backed.
+       (graal/load-resource context "metabase/channel/render/js/engine_test_resource.js")
+       (is (= 3 (.asLong (graal/execute-fn-name context "engine_test_plus" 1 2))))))))
 
 (deftest untrusted-plugin-context-enforces-heap-limit-test
   (testing "sandbox.MaxHeapMemory terminates a plugin that exhausts the isolate heap"
-    (let [^Context context (graal/untrusted-plugin-context)
-          ;; Retain a steadily growing list of materialized arrays until the per-context heap cap
-          ;; (`sandbox.MaxHeapMemory`) is hit. A single huge allocation can slip past the sampling-based limit, but
-          ;; sustained retention cannot. This stays within the isolate's own heap, so the host JVM
-          ;; isn't the one running out of memory.
-          ex      (try
-                    (graal/load-js-string
-                     context
-                     "var a = []; for (var i = 0; i < 1e7; i++) { a.push(new Array(50000).fill(i)); } a.length"
-                     "oom.js")
-                    nil
-                    (catch PolyglotException e e))]
-      (try
-        (is (some? ex) "expected the runaway allocation to be terminated, not to complete")
-        (is (and ex (.isResourceExhausted ^PolyglotException ex))
-            "termination should be resource exhaustion (heap limit), not some other error")
-        (finally
-          (.close context true))))))
+    (do-with-untrusted-context
+     (fn [^Context context]
+       ;; Retain a steadily growing list of materialized arrays until the per-context heap cap
+       ;; (`sandbox.MaxHeapMemory`) is hit. A single huge allocation can slip past the sampling-based limit, but
+       ;; sustained retention cannot. This stays within the isolate's own heap, so the host JVM
+       ;; isn't the one running out of memory.
+       (let [ex (try
+                  (graal/load-js-string
+                   context
+                   "var a = []; for (var i = 0; i < 1e7; i++) { a.push(new Array(50000).fill(i)); } a.length"
+                   "oom.js")
+                  nil
+                  (catch PolyglotException e e))]
+         (is (some? ex) "expected the runaway allocation to be terminated, not to complete")
+         (is (and ex (.isResourceExhausted ^PolyglotException ex))
+             "termination should be resource exhaustion (heap limit), not some other error"))))))

--- a/test/metabase/channel/render/js/graal_test.clj
+++ b/test/metabase/channel/render/js/graal_test.clj
@@ -2,7 +2,9 @@
   (:require
    [clojure.test :refer :all]
    [metabase.channel.render.js.graal :as graal]
-   [metabase.test :as mt]))
+   [metabase.test :as mt])
+  (:import
+   (org.graalvm.polyglot Context PolyglotException Value)))
 
 (set! *warn-on-reflection* true)
 
@@ -26,3 +28,51 @@
              (mt/repeat-concurrently 10
                                      #(locking context
                                         (.asLong (graal/execute-fn-name context "plus" 1 1)))))))))
+
+(deftest untrusted-plugin-context-denies-host-access-test
+  (testing "the SandboxPolicy/UNTRUSTED isolate runs untrusted plugin JS with no host interop"
+    (let [^Context context (graal/untrusted-plugin-context)]
+      (try
+        (testing "ordinary JS still evaluates, so the sandbox isn't just broken"
+          (is (= "3" (.asString ^Value (graal/load-js-string context "'' + (1 + 2)" "ok.js")))))
+        (testing "the `Java` host-interop global is absent"
+          (is (= "undefined" (.asString ^Value (graal/load-js-string context "typeof Java" "typeof.js")))))
+        (testing "untrusted guest code cannot reach host classes (no sandbox escape)"
+          (is (thrown? PolyglotException
+                       (graal/load-js-string context "Java.type('java.lang.System')" "escape.js"))))
+        (finally
+          (.close context true))))))
+
+(deftest untrusted-plugin-context-load-resource-test
+  (testing "load-resource evals into the UNTRUSTED isolate (regression: a URL-backed Source fails to marshal
+            across the native-isolate boundary from a jar: URL — SourceCopyMarshaller ShouldNotReachHere — so
+            load-resource must build a literal Source from the resource content)"
+    (let [^Context context (graal/untrusted-plugin-context)]
+      (try
+        ;; a tiny JS resource on the test classpath; the point is that load-resource (not load-js-string)
+        ;; succeeds against the isolate, which is what breaks when the Source is URL-backed.
+        (graal/load-resource context "metabase/channel/render/js/engine_test_resource.js")
+        (is (= 3 (.asLong (graal/execute-fn-name context "engine_test_plus" 1 2))))
+        (finally
+          (.close context true))))))
+
+(deftest untrusted-plugin-context-enforces-heap-limit-test
+  (testing "sandbox.MaxHeapMemory terminates a plugin that exhausts the isolate heap"
+    (let [^Context context (graal/untrusted-plugin-context)
+          ;; Retain a steadily growing list of materialized arrays until the per-context heap cap
+          ;; (`sandbox.MaxHeapMemory`) is hit. A single huge allocation can slip past the sampling-based limit, but
+          ;; sustained retention cannot. This stays within the isolate's own heap, so the host JVM
+          ;; isn't the one running out of memory.
+          ex      (try
+                    (graal/load-js-string
+                     context
+                     "var a = []; for (var i = 0; i < 1e7; i++) { a.push(new Array(50000).fill(i)); } a.length"
+                     "oom.js")
+                    nil
+                    (catch PolyglotException e e))]
+      (try
+        (is (some? ex) "expected the runaway allocation to be terminated, not to complete")
+        (is (and ex (.isResourceExhausted ^PolyglotException ex))
+            "termination should be resource exhaustion (heap limit), not some other error")
+        (finally
+          (.close context true))))))

--- a/test/metabase/channel/render/js/graal_test.clj
+++ b/test/metabase/channel/render/js/graal_test.clj
@@ -1,8 +1,7 @@
 (ns metabase.channel.render.js.graal-test
   (:require
    [clojure.test :refer :all]
-   [metabase.channel.render.js.graal :as graal]
-   [metabase.test :as mt])
+   [metabase.channel.render.js.graal :as graal])
   (:import
    (org.graalvm.polyglot Context Engine PolyglotException Value)))
 
@@ -11,9 +10,9 @@
 (defn- do-with-untrusted-context
   "Run `f` with an UNTRUSTED isolate context on its own throwaway engine, closing both afterwards."
   [f]
-  (let [^Engine engine (#'graal/new-untrusted-plugin-engine)]
+  (let [^Engine engine (#'graal/new-untrusted-engine)]
     (try
-      (let [^Context context (graal/untrusted-plugin-context engine)]
+      (let [^Context context (graal/untrusted-context engine)]
         (try
           (f context)
           (finally
@@ -21,28 +20,21 @@
       (finally
         (.close engine)))))
 
-(deftest make-context-test
-  (testing "can make a context that evaluates javascript"
-    (let [context (graal/create-context)]
-      (graal/load-js-string context "function plus (x, y) { return x + y }" "plus test")
-      (is (= 3 (.asLong (graal/execute-fn-name context "plus" 1 2))))))
-  (testing "can invoke closures return from that javascript"
-    (let [context (graal/create-context)]
-      (graal/load-js-string context "function curry_plus (x) { return function (y) { return x + y}}"
-                            "curried function test")
-      (let [curried (graal/execute-fn-name context "curry_plus" 1)]
-        (is (= 3 (.asLong (graal/execute-fn curried 2))))))))
+(deftest untrusted-context-evaluates-js-test
+  (testing "can evaluate javascript in the UNTRUSTED isolate"
+    (do-with-untrusted-context
+     (fn [^Context context]
+       (graal/load-js-string context "function plus (x, y) { return x + y }" "plus test")
+       (is (= 3 (.asLong (graal/execute-fn-name context "plus" 1 2)))))))
+  (testing "can invoke closures returned from that javascript"
+    (do-with-untrusted-context
+     (fn [^Context context]
+       (graal/load-js-string context "function curry_plus (x) { return function (y) { return x + y}}"
+                             "curried function test")
+       (let [curried (graal/execute-fn-name context "curry_plus" 1)]
+         (is (= 3 (.asLong (graal/execute-fn curried 2)))))))))
 
-(deftest concurrent-execution-with-locking-test
-  (testing "concurrent execution on a shared context is safe when callers hold its monitor"
-    (let [context (graal/create-context)]
-      (graal/load-js-string context "function plus (x, y) { return x + y }" "plus test")
-      (is (= (repeat 10 2)
-             (mt/repeat-concurrently 10
-                                     #(locking context
-                                        (.asLong (graal/execute-fn-name context "plus" 1 1)))))))))
-
-(deftest untrusted-plugin-context-denies-host-access-test
+(deftest untrusted-context-denies-host-access-test
   (testing "the SandboxPolicy/UNTRUSTED isolate runs untrusted plugin JS with no host interop"
     (do-with-untrusted-context
      (fn [^Context context]
@@ -54,7 +46,7 @@
          (is (thrown? PolyglotException
                       (graal/load-js-string context "Java.type('java.lang.System')" "escape.js"))))))))
 
-(deftest untrusted-plugin-context-load-resource-test
+(deftest untrusted-context-load-resource-test
   (testing "load-resource evals into the UNTRUSTED isolate (regression: a URL-backed Source fails to marshal
             across the native-isolate boundary from a jar: URL — SourceCopyMarshaller ShouldNotReachHere — so
             load-resource must build a literal Source from the resource content)"
@@ -65,7 +57,7 @@
        (graal/load-resource context "metabase/channel/render/js/engine_test_resource.js")
        (is (= 3 (.asLong (graal/execute-fn-name context "engine_test_plus" 1 2))))))))
 
-(deftest untrusted-plugin-context-enforces-heap-limit-test
+(deftest untrusted-context-enforces-heap-limit-test
   (testing "sandbox.MaxHeapMemory terminates a plugin that exhausts the isolate heap"
     (do-with-untrusted-context
      (fn [^Context context]
@@ -83,3 +75,30 @@
          (is (some? ex) "expected the runaway allocation to be terminated, not to complete")
          (is (and ex (.isResourceExhausted ^PolyglotException ex))
              "termination should be resource exhaustion (heap limit), not some other error"))))))
+
+(deftest builtin-context-soft-limit-recycles-test
+  (let [context-identity (fn []
+                           (graal/do-with-untrusted-builtin-context
+                            (fn [^Context context]
+                              (System/identityHashCode context))))]
+    (testing "under the soft CPU budget the pooled builtin context is reused across renders"
+      (is (= (context-identity) (context-identity))))
+    (testing "over the soft CPU budget the context is recycled once its render completes"
+      (with-redefs [graal/pool-cpu-soft-limit-ms 0]
+        (is (not= (context-identity) (context-identity))
+            "the render after blowing the soft budget should get a freshly generated context")))))
+
+(deftest rendering-is-globally-serialized-test
+  (testing "the global render-lock serializes all rendering: concurrent renders never overlap"
+    (let [active   (atom 0)
+          max-seen (atom 0)
+          render   (fn []
+                     (graal/do-with-untrusted-builtin-context
+                      (fn [^Context context]
+                        (swap! max-seen max (swap! active inc))
+                        (.eval context "js" "for (var i=0,x=0;i<1e6;i++) x+=i; x")
+                        (swap! active dec))))
+          futs     (doall (repeatedly 4 #(future (render))))]
+      (doseq [f futs] @f)
+      (is (= 1 @max-seen)
+          "at most one static-viz render should ever be in flight at once"))))

--- a/test/metabase/channel/render/js/graal_test.clj
+++ b/test/metabase/channel/render/js/graal_test.clj
@@ -1,7 +1,9 @@
 (ns metabase.channel.render.js.graal-test
   (:require
    [clojure.test :refer :all]
-   [metabase.channel.render.js.graal :as graal])
+   [metabase.channel.render.js.common :as js.common]
+   [metabase.channel.render.js.graal :as graal]
+   [metabase.test :as mt])
   (:import
    (org.graalvm.polyglot Context Engine PolyglotException Value)))
 
@@ -12,7 +14,7 @@
   [f]
   (let [^Engine engine (#'graal/new-untrusted-engine)]
     (try
-      (let [^Context context (graal/untrusted-context engine)]
+      (let [^Context context (graal/untrusted-context engine "30s")]
         (try
           (f context)
           (finally
@@ -76,6 +78,27 @@
          (is (and ex (.isResourceExhausted ^PolyglotException ex))
              "termination should be resource exhaustion (heap limit), not some other error"))))))
 
+(deftest untrusted-engine-ref-counted-lifecycle-test
+  (testing "the shared untrusted isolate engine is ref-counted: created with the first context, closed with the last"
+    (let [state          @#'graal/shared-untrusted-engine
+          refs           #(get @state :refs 0)
+          generate!      (fn [bundle-path]
+                           (#'graal/generate-untrusted-context! bundle-path @#'graal/pool-max-cpu-time))
+          before         (refs)
+          plugin-context (generate! js.common/custom-viz-bundle-resource-path)]
+      (is (= (inc before) (refs)) "generating a plugin context should bump the shared-engine ref count")
+      (testing "builtin contexts hold refs on the same shared engine"
+        (let [engine          (:engine @state)
+              builtin-context (generate! js.common/bundle-resource-path)]
+          (is (= (+ 2 before) (refs)) "a builtin context should bump the same ref count")
+          (is (identical? engine (:engine @state)) "builtin and plugin contexts should share one engine")
+          (#'graal/destroy-untrusted-context! builtin-context)
+          (is (= (inc before) (refs)) "destroying the builtin context should drop only its ref")))
+      (#'graal/destroy-untrusted-context! plugin-context)
+      (is (= before (refs)) "destroying the context should drop its ref")
+      (when (zero? before)
+        (is (nil? @state) "the last destroy should close the engine and clear the shared state")))))
+
 (deftest builtin-context-soft-limit-recycles-test
   (let [context-identity (fn []
                            (graal/do-with-untrusted-builtin-context
@@ -97,8 +120,7 @@
                       (fn [^Context context]
                         (swap! max-seen max (swap! active inc))
                         (.eval context "js" "for (var i=0,x=0;i<1e6;i++) x+=i; x")
-                        (swap! active dec))))
-          futs     (doall (repeatedly 4 #(future (render))))]
-      (doseq [f futs] @f)
+                        (swap! active dec))))]
+      (mt/repeat-concurrently 4 render)
       (is (= 1 @max-seen)
           "at most one static-viz render should ever be in flight at once"))))

--- a/test/metabase/channel/render/js/svg_test.clj
+++ b/test/metabase/channel/render/js/svg_test.clj
@@ -7,9 +7,12 @@
   resulting svg."
   (:require
    [clojure.test :refer :all]
+   [metabase.channel.render.js.common :as js.common]
+   [metabase.channel.render.js.graal :as js.graal]
    [metabase.channel.render.js.svg :as js.svg])
   (:import
    (org.apache.batik.anim.dom SVGOMDocument)
+   (org.graalvm.polyglot Context Engine HostAccess)
    (org.w3c.dom Element Node)))
 
 (set! *warn-on-reflection* true)
@@ -47,6 +50,67 @@
     (is (.hasAttribute line "fill-opacity"))
     (is (= "0.0"
            (.getAttribute line "fill-opacity")))))
+
+(defn- context-on-engine ^Context [^Engine engine]
+  (.. (Context/newBuilder (into-array String ["js"]))
+      (engine engine)
+      (allowHostAccess HostAccess/NONE)
+      (build)))
+
+(defn- load-bundle-ms
+  "Load the static-viz bundle into a fresh context on `engine`, returning the wall-clock load time in ms."
+  ^double [^Engine engine]
+  (let [^Context ctx (context-on-engine engine)
+        start        (System/nanoTime)]
+    (try
+      (js.graal/load-resource ctx js.common/bundle-resource-path)
+      (/ (- (System/nanoTime) start) 1e6)
+      (finally (.close ctx true)))))
+
+(deftest ^:mb/slow shared-engine-parsed-source-cache-speeds-bundle-reloads-test
+  (testing "reloading the ~16MB static-viz bundle on the same engine reuses its parsed-source cache"
+    ;; Same Engine-level cache that keeps the untrusted-plugin isolate's per-render plugin-bundle reloads cheap
+    ;; (see js.graal/do-with-untrusted-static-viz-context). Tested on the plain engine because an UNTRUSTED
+    ;; engine would need the full sandbox context builder; the parsed-source cache is identical for both.
+    ;;
+    ;; Pre-warm the host JVM's JS parser with a throwaway engine so the measured gap reflects the engine's
+    ;; parsed-source cache, not one-time JIT warmup.
+    (let [^Engine warmup (#'js.graal/create-engine)]
+      (load-bundle-ms warmup)
+      (load-bundle-ms warmup)
+      (.close warmup))
+    (let [^Engine engine (#'js.graal/create-engine)
+          cold           (load-bundle-ms engine)          ; first parse of the bundle on this engine: cold
+          warm           (min (load-bundle-ms engine)     ; reloads on the same engine hit the cache
+                              (load-bundle-ms engine))]
+      (.close engine)
+      (testing (format "(cold=%.0fms warm=%.0fms)" cold warm)
+        ;; Observed ~2x cheaper; assert a generous 25% floor so the timing test stays robust to noise.
+        (is (< warm (* 0.75 cold)))))))
+
+(deftest ^:mb/slow untrusted-context-loads-slim-bundle-test
+  (testing "the untrusted isolate pool loads the slim custom-viz bundle, exposing the interface surface it needs"
+    (js.graal/do-with-untrusted-static-viz-context
+     (fn [^Context ctx]
+       (doseq [fn-name ["renderChartJSON" "initializeContextJSON" "registerCustomVizPlugin"]]
+         (is (= "function" (.asString (.eval ctx "js" (str "typeof MetabaseStaticViz." fn-name))))
+             (str "slim bundle should expose MetabaseStaticViz." fn-name)))
+       ;; getCellBackgroundColorsJSON is only exported by the full bundle (only the trusted pool's table
+       ;; rendering calls it), so its absence proves the slim bundle is what got loaded here.
+       (is (= "undefined" (.asString (.eval ctx "js" "typeof MetabaseStaticViz.getCellBackgroundColorsJSON")))
+           "the full static-viz bundle (getCellBackgroundColorsJSON present) leaked into the untrusted pool")))))
+
+(deftest ^:mb/slow untrusted-static-viz-context-is-pooled-test
+  (testing "pooled untrusted isolate contexts are reused across renders (bundle parsed once, not per render)"
+    ;; Regression guard: the previous fresh-context-per-render path re-parsed the ~16MB bundle every render
+    ;; (a 55s pulse-test regression). The pool loads the bundle once and hands the same context to each render.
+    ;; Tests run in :test mode (config/is-dev? false), so do-with-untrusted... takes the pooled branch.
+    (let [ids (atom [])]
+      (dotimes [_ 3]
+        (js.graal/do-with-untrusted-static-viz-context
+         (fn [^Context ctx] (swap! ids conj (System/identityHashCode ctx)))))
+      (is (= 1 (count (distinct @ids)))
+          "the same pooled isolate context should serve every render"))))
 
 (deftest ^:parallel parse-svg-sanitizes-characters-test
   (testing "Characters discouraged or not permitted by the xml 1.0 specification are removed. (#"

--- a/test/metabase/channel/render/js/svg_test.clj
+++ b/test/metabase/channel/render/js/svg_test.clj
@@ -12,7 +12,7 @@
    [metabase.channel.render.js.svg :as js.svg])
   (:import
    (org.apache.batik.anim.dom SVGOMDocument)
-   (org.graalvm.polyglot Context Engine HostAccess)
+   (org.graalvm.polyglot Context Engine)
    (org.w3c.dom Element Node)))
 
 (set! *warn-on-reflection* true)
@@ -51,44 +51,35 @@
     (is (= "0.0"
            (.getAttribute line "fill-opacity")))))
 
-(defn- context-on-engine ^Context [^Engine engine]
-  (.. (Context/newBuilder (into-array String ["js"]))
-      (engine engine)
-      (allowHostAccess HostAccess/NONE)
-      (build)))
-
-(defn- load-bundle-ms
-  "Load the static-viz bundle into a fresh context on `engine`, returning the wall-clock load time in ms."
-  ^double [^Engine engine]
-  (let [^Context ctx (context-on-engine engine)
+(defn- load-custom-viz-bundle-ms
+  "Load the slim custom-viz bundle into a fresh UNTRUSTED isolate context on the currently-bound shared
+  untrusted-plugin engine, returning the wall-clock load time in ms."
+  ^double []
+  (let [^Context ctx (js.graal/untrusted-plugin-context)
         start        (System/nanoTime)]
     (try
-      (js.graal/load-resource ctx js.common/bundle-resource-path)
+      (js.graal/load-resource ctx js.common/custom-viz-bundle-resource-path)
       (/ (- (System/nanoTime) start) 1e6)
       (finally (.close ctx true)))))
 
-(deftest ^:mb/slow shared-engine-parsed-source-cache-speeds-bundle-reloads-test
-  (testing "reloading the ~16MB static-viz bundle on the same engine reuses its parsed-source cache"
-    ;; Same Engine-level cache that keeps the untrusted-plugin isolate's per-render plugin-bundle reloads cheap
-    ;; (see js.graal/do-with-untrusted-static-viz-context). Tested on the plain engine because an UNTRUSTED
-    ;; engine would need the full sandbox context builder; the parsed-source cache is identical for both.
-    ;;
-    ;; Pre-warm the host JVM's JS parser with a throwaway engine so the measured gap reflects the engine's
-    ;; parsed-source cache, not one-time JIT warmup.
-    (let [^Engine warmup (#'js.graal/create-engine)]
-      (load-bundle-ms warmup)
-      (load-bundle-ms warmup)
+(deftest shared-engine-parsed-source-cache-speeds-bundle-reloads-test
+  (testing "reloading the slim custom-viz bundle in fresh UNTRUSTED isolate contexts reuses the engine's parsed-source cache"
+    (let [^Engine warmup (#'js.graal/new-untrusted-plugin-engine)]
+      (with-redefs [js.graal/shared-untrusted-plugin-engine (delay warmup)]
+        (load-custom-viz-bundle-ms)
+        (load-custom-viz-bundle-ms))
       (.close warmup))
-    (let [^Engine engine (#'js.graal/create-engine)
-          cold           (load-bundle-ms engine)          ; first parse of the bundle on this engine: cold
-          warm           (min (load-bundle-ms engine)     ; reloads on the same engine hit the cache
-                              (load-bundle-ms engine))]
-      (.close engine)
+    (let [^Engine engine (#'js.graal/new-untrusted-plugin-engine)
+          [cold warm]    (with-redefs [js.graal/shared-untrusted-plugin-engine (delay engine)]
+                           (try
+                             [(load-custom-viz-bundle-ms)          ; first parse on this engine: cold
+                              (min (load-custom-viz-bundle-ms)     ; reloads on the same engine hit the cache
+                                   (load-custom-viz-bundle-ms))]
+                             (finally (.close engine))))]
       (testing (format "(cold=%.0fms warm=%.0fms)" cold warm)
-        ;; Observed ~2x cheaper; assert a generous 25% floor so the timing test stays robust to noise.
         (is (< warm (* 0.75 cold)))))))
 
-(deftest ^:mb/slow untrusted-context-loads-slim-bundle-test
+(deftest untrusted-context-loads-slim-bundle-test
   (testing "the untrusted isolate pool loads the slim custom-viz bundle, exposing the interface surface it needs"
     (js.graal/do-with-untrusted-static-viz-context
      (fn [^Context ctx]
@@ -100,11 +91,8 @@
        (is (= "undefined" (.asString (.eval ctx "js" "typeof MetabaseStaticViz.getCellBackgroundColorsJSON")))
            "the full static-viz bundle (getCellBackgroundColorsJSON present) leaked into the untrusted pool")))))
 
-(deftest ^:mb/slow untrusted-static-viz-context-is-pooled-test
+(deftest untrusted-static-viz-context-is-pooled-test
   (testing "pooled untrusted isolate contexts are reused across renders (bundle parsed once, not per render)"
-    ;; Regression guard: the previous fresh-context-per-render path re-parsed the ~16MB bundle every render
-    ;; (a 55s pulse-test regression). The pool loads the bundle once and hands the same context to each render.
-    ;; Tests run in :test mode (config/is-dev? false), so do-with-untrusted... takes the pooled branch.
     (let [ids (atom [])]
       (dotimes [_ 3]
         (js.graal/do-with-untrusted-static-viz-context

--- a/test/metabase/channel/render/js/svg_test.clj
+++ b/test/metabase/channel/render/js/svg_test.clj
@@ -52,10 +52,10 @@
            (.getAttribute line "fill-opacity")))))
 
 (defn- load-custom-viz-bundle-ms
-  "Load the slim custom-viz bundle into a fresh UNTRUSTED isolate context on the currently-bound shared
-  untrusted-plugin engine, returning the wall-clock load time in ms."
-  ^double []
-  (let [^Context ctx (js.graal/untrusted-plugin-context)
+  "Load the slim custom-viz bundle into a fresh UNTRUSTED isolate context on `engine`, returning the
+  wall-clock load time in ms."
+  ^double [^Engine engine]
+  (let [^Context ctx (js.graal/untrusted-plugin-context engine)
         start        (System/nanoTime)]
     (try
       (js.graal/load-resource ctx js.common/custom-viz-bundle-resource-path)
@@ -65,17 +65,16 @@
 (deftest shared-engine-parsed-source-cache-speeds-bundle-reloads-test
   (testing "reloading the slim custom-viz bundle in fresh UNTRUSTED isolate contexts reuses the engine's parsed-source cache"
     (let [^Engine warmup (#'js.graal/new-untrusted-plugin-engine)]
-      (with-redefs [js.graal/shared-untrusted-plugin-engine (delay warmup)]
-        (load-custom-viz-bundle-ms)
-        (load-custom-viz-bundle-ms))
-      (.close warmup))
+      (try
+        (load-custom-viz-bundle-ms warmup)
+        (load-custom-viz-bundle-ms warmup)
+        (finally (.close warmup))))
     (let [^Engine engine (#'js.graal/new-untrusted-plugin-engine)
-          [cold warm]    (with-redefs [js.graal/shared-untrusted-plugin-engine (delay engine)]
-                           (try
-                             [(load-custom-viz-bundle-ms)          ; first parse on this engine: cold
-                              (min (load-custom-viz-bundle-ms)     ; reloads on the same engine hit the cache
-                                   (load-custom-viz-bundle-ms))]
-                             (finally (.close engine))))]
+          [cold warm]    (try
+                           [(load-custom-viz-bundle-ms engine)          ; first parse on this engine: cold
+                            (min (load-custom-viz-bundle-ms engine)     ; reloads on the same engine hit the cache
+                                 (load-custom-viz-bundle-ms engine))]
+                           (finally (.close engine)))]
       (testing (format "(cold=%.0fms warm=%.0fms)" cold warm)
         (is (< warm (* 0.75 cold)))))))
 
@@ -90,6 +89,18 @@
        ;; rendering calls it), so its absence proves the slim bundle is what got loaded here.
        (is (= "undefined" (.asString (.eval ctx "js" "typeof MetabaseStaticViz.getCellBackgroundColorsJSON")))
            "the full static-viz bundle (getCellBackgroundColorsJSON present) leaked into the untrusted pool")))))
+
+(deftest untrusted-engine-ref-counted-lifecycle-test
+  (testing "the shared untrusted isolate engine is ref-counted: created with the first context, closed with the last"
+    (let [state   (:state @#'js.graal/shared-untrusted-plugin-engine)
+          refs    #(get @state :refs 0)
+          before  (refs)
+          context (#'js.graal/generate-untrusted-context!)]
+      (is (= (inc before) (refs)) "generating a context should bump the shared-engine ref count")
+      (#'js.graal/destroy-untrusted-context! context)
+      (is (= before (refs)) "destroying the context should drop its ref")
+      (when (zero? before)
+        (is (nil? @state) "the last destroy should close the engine and clear the shared state")))))
 
 (deftest untrusted-static-viz-context-is-pooled-test
   (testing "pooled untrusted isolate contexts are reused across renders (bundle parsed once, not per render)"

--- a/test/metabase/channel/render/js/svg_test.clj
+++ b/test/metabase/channel/render/js/svg_test.clj
@@ -7,12 +7,11 @@
   resulting svg."
   (:require
    [clojure.test :refer :all]
-   [metabase.channel.render.js.common :as js.common]
    [metabase.channel.render.js.graal :as js.graal]
    [metabase.channel.render.js.svg :as js.svg])
   (:import
    (org.apache.batik.anim.dom SVGOMDocument)
-   (org.graalvm.polyglot Context Engine)
+   (org.graalvm.polyglot Context)
    (org.w3c.dom Element Node)))
 
 (set! *warn-on-reflection* true)
@@ -51,33 +50,6 @@
     (is (= "0.0"
            (.getAttribute line "fill-opacity")))))
 
-(defn- load-custom-viz-bundle-ms
-  "Load the slim custom-viz bundle into a fresh UNTRUSTED isolate context on `engine`, returning the
-  wall-clock load time in ms."
-  ^double [^Engine engine]
-  (let [^Context ctx (js.graal/untrusted-context engine)
-        start        (System/nanoTime)]
-    (try
-      (js.graal/load-resource ctx js.common/custom-viz-bundle-resource-path)
-      (/ (- (System/nanoTime) start) 1e6)
-      (finally (.close ctx true)))))
-
-(deftest shared-engine-parsed-source-cache-speeds-bundle-reloads-test
-  (testing "reloading the slim custom-viz bundle in fresh UNTRUSTED isolate contexts reuses the engine's parsed-source cache"
-    (let [^Engine warmup (#'js.graal/new-untrusted-engine)]
-      (try
-        (load-custom-viz-bundle-ms warmup)
-        (load-custom-viz-bundle-ms warmup)
-        (finally (.close warmup))))
-    (let [^Engine engine (#'js.graal/new-untrusted-engine)
-          [cold warm]    (try
-                           [(load-custom-viz-bundle-ms engine)          ; first parse on this engine: cold
-                            (min (load-custom-viz-bundle-ms engine)     ; reloads on the same engine hit the cache
-                                 (load-custom-viz-bundle-ms engine))]
-                           (finally (.close engine)))]
-      (testing (format "(cold=%.0fms warm=%.0fms)" cold warm)
-        (is (< warm (* 0.75 cold)))))))
-
 (deftest untrusted-plugin-context-loads-slim-bundle-test
   (testing "the plugin isolate pool loads the slim custom-viz bundle, exposing the interface surface it needs"
     (js.graal/do-with-untrusted-plugin-context
@@ -108,32 +80,12 @@
        (is (= "undefined" (.asString (.eval ctx "js" "typeof globalThis.__taint_marker")))
            "plugin-context globals must not leak into builtin contexts")))))
 
-(deftest untrusted-engine-ref-counted-lifecycle-test
-  (testing "the shared untrusted isolate engine is ref-counted: created with the first context, closed with the last"
-    (let [state          @#'js.graal/shared-untrusted-engine
-          refs           #(get @state :refs 0)
-          before         (refs)
-          plugin-context (#'js.graal/generate-untrusted-plugin-context!)]
-      (is (= (inc before) (refs)) "generating a plugin context should bump the shared-engine ref count")
-      (testing "builtin contexts hold refs on the same shared engine"
-        (let [engine          (:engine @state)
-              builtin-context (#'js.graal/generate-untrusted-builtin-context!* @#'js.graal/pool-max-cpu-time)]
-          (is (= (+ 2 before) (refs)) "a builtin context should bump the same ref count")
-          (is (identical? engine (:engine @state)) "builtin and plugin contexts should share one engine")
-          (#'js.graal/destroy-untrusted-context! builtin-context)
-          (is (= (inc before) (refs)) "destroying the builtin context should drop only its ref")))
-      (#'js.graal/destroy-untrusted-context! plugin-context)
-      (is (= before (refs)) "destroying the context should drop its ref")
-      (when (zero? before)
-        (is (nil? @state) "the last destroy should close the engine and clear the shared state")))))
-
 (deftest untrusted-plugin-context-is-pooled-test
   (testing "pooled untrusted isolate contexts are reused across renders (bundle parsed once, not per render)"
-    (let [ids (atom [])]
-      (dotimes [_ 3]
-        (js.graal/do-with-untrusted-plugin-context
-         (fn [^Context ctx] (swap! ids conj (System/identityHashCode ctx)))))
-      (is (= 1 (count (distinct @ids)))
+    (let [context-identity (fn []
+                             (js.graal/do-with-untrusted-plugin-context
+                              (fn [^Context ctx] (System/identityHashCode ctx))))]
+      (is (= (context-identity) (context-identity))
           "the same pooled isolate context should serve every render"))))
 
 (deftest ^:parallel parse-svg-sanitizes-characters-test

--- a/test/metabase/channel/render/js/svg_test.clj
+++ b/test/metabase/channel/render/js/svg_test.clj
@@ -55,7 +55,7 @@
   "Load the slim custom-viz bundle into a fresh UNTRUSTED isolate context on `engine`, returning the
   wall-clock load time in ms."
   ^double [^Engine engine]
-  (let [^Context ctx (js.graal/untrusted-plugin-context engine)
+  (let [^Context ctx (js.graal/untrusted-context engine)
         start        (System/nanoTime)]
     (try
       (js.graal/load-resource ctx js.common/custom-viz-bundle-resource-path)
@@ -64,12 +64,12 @@
 
 (deftest shared-engine-parsed-source-cache-speeds-bundle-reloads-test
   (testing "reloading the slim custom-viz bundle in fresh UNTRUSTED isolate contexts reuses the engine's parsed-source cache"
-    (let [^Engine warmup (#'js.graal/new-untrusted-plugin-engine)]
+    (let [^Engine warmup (#'js.graal/new-untrusted-engine)]
       (try
         (load-custom-viz-bundle-ms warmup)
         (load-custom-viz-bundle-ms warmup)
         (finally (.close warmup))))
-    (let [^Engine engine (#'js.graal/new-untrusted-plugin-engine)
+    (let [^Engine engine (#'js.graal/new-untrusted-engine)
           [cold warm]    (try
                            [(load-custom-viz-bundle-ms engine)          ; first parse on this engine: cold
                             (min (load-custom-viz-bundle-ms engine)     ; reloads on the same engine hit the cache
@@ -78,35 +78,60 @@
       (testing (format "(cold=%.0fms warm=%.0fms)" cold warm)
         (is (< warm (* 0.75 cold)))))))
 
-(deftest untrusted-context-loads-slim-bundle-test
-  (testing "the untrusted isolate pool loads the slim custom-viz bundle, exposing the interface surface it needs"
-    (js.graal/do-with-untrusted-static-viz-context
+(deftest untrusted-plugin-context-loads-slim-bundle-test
+  (testing "the plugin isolate pool loads the slim custom-viz bundle, exposing the interface surface it needs"
+    (js.graal/do-with-untrusted-plugin-context
      (fn [^Context ctx]
        (doseq [fn-name ["renderChartJSON" "initializeContextJSON" "registerCustomVizPlugin"]]
          (is (= "function" (.asString (.eval ctx "js" (str "typeof MetabaseStaticViz." fn-name))))
              (str "slim bundle should expose MetabaseStaticViz." fn-name)))
-       ;; getCellBackgroundColorsJSON is only exported by the full bundle (only the trusted pool's table
+       ;; getCellBackgroundColorsJSON is only exported by the full bundle (only the builtin pool's table
        ;; rendering calls it), so its absence proves the slim bundle is what got loaded here.
        (is (= "undefined" (.asString (.eval ctx "js" "typeof MetabaseStaticViz.getCellBackgroundColorsJSON")))
-           "the full static-viz bundle (getCellBackgroundColorsJSON present) leaked into the untrusted pool")))))
+           "the full static-viz bundle (getCellBackgroundColorsJSON present) leaked into the plugin pool")))))
+
+(deftest untrusted-builtin-context-loads-full-bundle-test
+  (testing "the builtin isolate pool loads the full static-viz bundle, including the table-rendering surface"
+    (js.graal/do-with-untrusted-builtin-context
+     (fn [^Context ctx]
+       (doseq [fn-name ["renderChartJSON" "getCellBackgroundColorsJSON"]]
+         (is (= "function" (.asString (.eval ctx "js" (str "typeof MetabaseStaticViz." fn-name))))
+             (str "full bundle should expose MetabaseStaticViz." fn-name)))))))
+
+(deftest builtin-and-plugin-pools-are-taint-separated-test
+  (testing "globals set in a plugin context are invisible to builtin contexts (isolated realms on the shared engine)"
+    (js.graal/do-with-untrusted-plugin-context
+     (fn [^Context ctx]
+       (.eval ctx "js" "globalThis.__taint_marker = 'tainted'")))
+    (js.graal/do-with-untrusted-builtin-context
+     (fn [^Context ctx]
+       (is (= "undefined" (.asString (.eval ctx "js" "typeof globalThis.__taint_marker")))
+           "plugin-context globals must not leak into builtin contexts")))))
 
 (deftest untrusted-engine-ref-counted-lifecycle-test
   (testing "the shared untrusted isolate engine is ref-counted: created with the first context, closed with the last"
-    (let [state   (:state @#'js.graal/shared-untrusted-plugin-engine)
-          refs    #(get @state :refs 0)
-          before  (refs)
-          context (#'js.graal/generate-untrusted-context!)]
-      (is (= (inc before) (refs)) "generating a context should bump the shared-engine ref count")
-      (#'js.graal/destroy-untrusted-context! context)
+    (let [state          @#'js.graal/shared-untrusted-engine
+          refs           #(get @state :refs 0)
+          before         (refs)
+          plugin-context (#'js.graal/generate-untrusted-plugin-context!)]
+      (is (= (inc before) (refs)) "generating a plugin context should bump the shared-engine ref count")
+      (testing "builtin contexts hold refs on the same shared engine"
+        (let [engine          (:engine @state)
+              builtin-context (#'js.graal/generate-untrusted-builtin-context!* @#'js.graal/pool-max-cpu-time)]
+          (is (= (+ 2 before) (refs)) "a builtin context should bump the same ref count")
+          (is (identical? engine (:engine @state)) "builtin and plugin contexts should share one engine")
+          (#'js.graal/destroy-untrusted-context! builtin-context)
+          (is (= (inc before) (refs)) "destroying the builtin context should drop only its ref")))
+      (#'js.graal/destroy-untrusted-context! plugin-context)
       (is (= before (refs)) "destroying the context should drop its ref")
       (when (zero? before)
         (is (nil? @state) "the last destroy should close the engine and clear the shared state")))))
 
-(deftest untrusted-static-viz-context-is-pooled-test
+(deftest untrusted-plugin-context-is-pooled-test
   (testing "pooled untrusted isolate contexts are reused across renders (bundle parsed once, not per render)"
     (let [ids (atom [])]
       (dotimes [_ 3]
-        (js.graal/do-with-untrusted-static-viz-context
+        (js.graal/do-with-untrusted-plugin-context
          (fn [^Context ctx] (swap! ids conj (System/identityHashCode ctx)))))
       (is (= 1 (count (distinct @ids)))
           "the same pooled isolate context should serve every render"))))

--- a/test_resources/metabase/channel/render/js/engine_test_resource.js
+++ b/test_resources/metabase/channel/render/js/engine_test_resource.js
@@ -1,0 +1,5 @@
+// Tiny JS resource used by metabase.channel.render.js.graal-test to exercise `load-resource` against the
+// UNTRUSTED isolate. Kept trivial on purpose — the test asserts the resource loads (marshals) at all.
+function engine_test_plus(x, y) {
+  return x + y;
+}


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2856/create-a-separate-secure-rendering-pipeline

### Description

Runs all static-viz JS un=in untrusted custom-viz plugin JS, inside a hardened GraalVM native-image isolate (separate VM + heap) under SandboxPolicy/UNTRUSTED, so CPU/heap limits are enforced by the VM rather than host configuration.


- Adds org.graalvm.polyglot/js-isolate-community and bumps GraalVM 25.0.1 → 25.1.3.
- One ref-counted isolate Engine shared by two single-context pools that never mix taints: the builtin
pool (full lib-static-viz.bundle.js) for built-in charts, and the plugin pool (slim
lib-static-viz-custom.bundle.js from gdgt-2855) — the only place third-party plugin JS ever runs. The
engine is created with the first context and closed with the last, so idle-shrunk pools (10 min)
actually free the isolate's native heap.
- Memory caps: engine.MaxIsolateMemory 512 MB (whole isolate), sandbox.MaxHeapMemory 416 MB (per
context) — fails closed below the pod ceiling instead of OOM-killing the pod.
- CPU caps: 30 s for the dev fresh-context path; 180 s cumulative per pooled prod context (covers cold
parse + all renders it serves), with proactive recycling at a 120 s soft limit so the hard budget never
kills a render mid-flight.
- Failure handling: a cancelled or resource-exhausted context is disposed and regenerated; the failed
render surfaces as a normal card-render error.
- Bundles are cold-parsed once at pool context generation; in dev, a throwaway context per render picks
up fresh bun run build-static-viz output without a REPL restart.

### How to verify


### Happy path
1. Enable custom visualizations, create question with then, create a dashboard.
2. In the dashboard trigger subscription and send it to your address (w/o PDF attachment)
3. Custom visualizations should render correctly both inline and in PDF.

Dashboard with working custom visualizations: https://pr78214.coredev.metabase.com/dashboard/11-dash1
Big dashboard with 20+ visualizations: https://pr78214.coredev.metabase.com/dashboard/34-dash-big


### Failure modes
This custom visualization([custom-viz-security](https://github.com/metabase/custom-viz-security)) purposefully can trip the memory and CPU limits. Use it to test how the the sandbox behaves with rogue plugins.

[custom-viz-security-0.0.1.tgz](https://github.com/user-attachments/files/30227460/custom-viz-security-0.0.1.tgz)

memory limit
```
2026-07-21 10:53:49,297 ERROR render.card :: Pulse card render error {mb-card_id=137, mb-channel_type=:channel/email, mb-handler_id=, mb-notification_id=, mb-payload_type=:notification/dashboard}
org.graalvm.polyglot.PolyglotException: Garbage-collected heap size exceeded. Consider increasing the maximum Java heap size, for example with '-Xmx'.
```

CPU time
```
org.graalvm.polyglot.PolyglotException: Maximum CPU time limit of 30000ms exceeded. Time executed 30003ms.
```


Dashboard with broken visualization: https://pr78214.coredev.metabase.com/dashboard/12-dash1-security


### Demo

<img width="1180" height="1436" alt="image" src="https://github.com/user-attachments/assets/686b08ac-9329-4229-b8c8-508245130d86" />

<img width="1640" height="2272" alt="image" src="https://github.com/user-attachments/assets/52f92084-fff0-42fc-b791-d7f5e11ef79e" />

<img width="1476" height="1634" alt="image" src="https://github.com/user-attachments/assets/9925d34c-e5a1-4e21-8d64-fc8390559622" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
