### PR TITLE
Scope measurement container css vars

### DIFF
--- a/frontend/src/metabase/ui/components/theme/MeasurementProviders.tsx
+++ b/frontend/src/metabase/ui/components/theme/MeasurementProviders.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import type { ResolvedColorScheme } from "metabase/utils/color-scheme";
+import { MEASUREMENT_ROOT_CLASSNAME } from "metabase/utils/measure-container";
 
 import { EmotionCacheProvider } from "./EmotionCacheProvider";
 import { ThemeProvider } from "./ThemeProvider";
@@ -38,7 +39,13 @@ export function MeasurementProviders({ children }: MeasurementProvidersProps) {
   const resolvedColorScheme = readCurrentColorScheme();
   return (
     <EmotionCacheProvider>
-      <ThemeProvider resolvedColorScheme={resolvedColorScheme}>
+      {/* Scope variable creation to the measurement container to prevent overriding
+       * main app vars
+       */}
+      <ThemeProvider
+        resolvedColorScheme={resolvedColorScheme}
+        cssVariablesSelector={`.${MEASUREMENT_ROOT_CLASSNAME}`}
+      >
         {children}
       </ThemeProvider>
     </EmotionCacheProvider>

--- a/frontend/src/metabase/ui/components/theme/MeasurementProviders.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/theme/MeasurementProviders.unit.spec.tsx
@@ -1,8 +1,20 @@
 import { render, screen } from "@testing-library/react";
 
+import { MEASUREMENT_ROOT_CLASSNAME } from "metabase/utils/measure-container";
+
 import { MeasurementProviders } from "./MeasurementProviders";
 
 const SCHEME_ATTR = "data-mantine-color-scheme";
+
+function getMantineStyleText(): string {
+  // Mantine injects its CSS-variable <style> into <head>, outside the render
+  // container, so query the document directly.
+  return Array.from(
+    document.querySelectorAll('style[data-mantine-styles="true"]'),
+  )
+    .map((tag) => tag.textContent ?? "")
+    .join("\n");
+}
 
 describe("MeasurementProviders", () => {
   afterEach(() => {
@@ -54,5 +66,21 @@ describe("MeasurementProviders", () => {
     );
 
     expect(screen.getByText("measurement content")).toBeInTheDocument();
+  });
+
+  it("scopes its CSS variables to the measurement container, not :root (UXW-4556)", () => {
+    render(
+      <MeasurementProviders>
+        <div>measurement</div>
+      </MeasurementProviders>,
+    );
+
+    const styleText = getMantineStyleText();
+
+    // Variables are still emitted so the detached node is self-sufficient even in
+    // the embedding SDK (where :root has none), but scoped to the container class
+    // so they can't override or flash the app's :root brand.
+    expect(styleText).toContain(`.${MEASUREMENT_ROOT_CLASSNAME}`);
+    expect(styleText).not.toMatch(/:root\s*\{/);
   });
 });

--- a/frontend/src/metabase/utils/measure-container.ts
+++ b/frontend/src/metabase/utils/measure-container.ts
@@ -7,6 +7,7 @@ interface MeasurementContainerOptions {
 }
 
 const DEFAULT_FONT_SIZE = "12.5px";
+export const MEASUREMENT_ROOT_CLASSNAME = "mb-measurement-root";
 
 export function createMeasurementContainer(
   options: MeasurementContainerOptions = {},
@@ -14,6 +15,7 @@ export function createMeasurementContainer(
   const { fontSize = DEFAULT_FONT_SIZE } = options;
 
   const container = document.createElement("div");
+  container.classList.add(MEASUREMENT_ROOT_CLASSNAME);
   container.style.position = "absolute";
   container.style.top = "-9999px";
   container.style.left = "-9999px";


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #76177
### Description

Scopes the creation of CSS Vars used in the measurement provider. Without this scoping, CSS vars are created on `:root` which will temporarily override the main apps theme. This can be an issue when your white-label colors differ from the defaults, and cause a "flicker" while the measurement container is mounted.

Alternatively, we could pass the white label colors to this theme provider as well, but I felt scoping things was a better fix.

### How to verify

1. New -> Question -> Orders -> visualize
2. Open Viz settings and set up a conditional formatting rule
3. Create the rule,  then open it back up to edit
4. As you change the color of the rule, you should not see any color flicker on the `New` button. Use CPU throttling in dev tools to slow things down

### Demo

## Before

https://github.com/user-attachments/assets/73f1bbf7-a13d-465d-b8ff-4f46eb081cad

## After


https://github.com/user-attachments/assets/26506725-b8c8-4e2a-9905-dc2a85cb56a1


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
