### PR TITLE
Explorations toggle for contextual interestingness

### DIFF
--- a/frontend/src/metabase/explorations/components/NewExplorationData/NewExplorationData.module.css
+++ b/frontend/src/metabase/explorations/components/NewExplorationData/NewExplorationData.module.css
@@ -89,3 +89,9 @@
   padding: 0.625rem 0.75rem;
   font-weight: 500;
 }
+
+.contextualInterestingnessToggleLabel {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}

--- a/frontend/src/metabase/explorations/components/NewExplorationData/NewExplorationData.module.css
+++ b/frontend/src/metabase/explorations/components/NewExplorationData/NewExplorationData.module.css
@@ -89,9 +89,3 @@
   padding: 0.625rem 0.75rem;
   font-weight: 500;
 }
-
-.contextualInterestingnessToggleLabel {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-}

--- a/frontend/src/metabase/explorations/components/NewExplorationData/NewExplorationData.tsx
+++ b/frontend/src/metabase/explorations/components/NewExplorationData/NewExplorationData.tsx
@@ -333,7 +333,7 @@ export function NewExplorationData({ selection }: NewExplorationDataProps) {
 
       <Group justify="space-between" align="center" wrap="nowrap">
         <Switch
-          className={cx(!hasUserPrompt && CS.hidden)}
+          style={!hasUserPrompt ? { visibility: "hidden" } : undefined}
           checked={useContextualInterestingness}
           onChange={(event) =>
             setUseContextualInterestingness(event.currentTarget.checked)

--- a/frontend/src/metabase/explorations/components/NewExplorationData/NewExplorationData.tsx
+++ b/frontend/src/metabase/explorations/components/NewExplorationData/NewExplorationData.tsx
@@ -16,9 +16,7 @@ import type {
 } from "metabase/explorations/hooks";
 import { isMetricBlock } from "metabase/explorations/hooks";
 import { useMetabotAgent } from "metabase/metabot/hooks";
-import { useSelector } from "metabase/redux";
 import { useNavigate } from "metabase/router";
-import { getApplicationName } from "metabase/selectors/whitelabel";
 import {
   Box,
   Button,
@@ -27,8 +25,9 @@ import {
   Icon,
   Menu,
   Stack,
-  Text,
+  Switch,
   Title,
+  Tooltip,
 } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type {
@@ -124,15 +123,19 @@ export function NewExplorationData({ selection }: NewExplorationDataProps) {
   } = selection;
   const navigate = useNavigate();
   const [sendToast] = useToast();
-  const applicationName = useSelector(getApplicationName);
 
   const [activeModal, setActiveModal] = useState<ActiveModal>(null);
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [useContextualInterestingness, setUseContextualInterestingness] =
+    useState(true);
 
   const [createExploration, { isLoading: isStarting }] =
     useCreateExplorationMutation();
 
   const { messages, isDoingScience } = useMetabotAgent(EXPLORATIONS_AGENT_ID);
+  const hasUserPrompt = messages.some(
+    (message) => message.role === "user" && message.message.trim().length > 0,
+  );
   const canStart = blocks.some(isNonEmptyBlock);
 
   const isManualDataPickingDisabled = isDoingScience;
@@ -170,10 +173,13 @@ export function NewExplorationData({ selection }: NewExplorationDataProps) {
   );
 
   const handleStart = useCallback(async () => {
-    const prompt = messages
-      .filter((message) => message.role === "user")
-      .map((message) => message.message)
-      .join("\n---\n");
+    const prompt =
+      hasUserPrompt && useContextualInterestingness
+        ? messages
+            .filter((message) => message.role === "user")
+            .map((message) => message.message)
+            .join("\n---\n")
+        : "";
     const request = buildCreateExplorationRequest(
       name,
       prompt,
@@ -196,6 +202,8 @@ export function NewExplorationData({ selection }: NewExplorationDataProps) {
   }, [
     createExploration,
     navigate,
+    hasUserPrompt,
+    useContextualInterestingness,
     messages,
     blocks,
     timelines,
@@ -324,16 +332,44 @@ export function NewExplorationData({ selection }: NewExplorationDataProps) {
         )}
       </Box>
 
-      <Group justify="space-between" align="center" wrap="nowrap">
-        <Text
-          className={CS.alignSelfEnd}
-          c="text-secondary"
-          size="sm"
-          lh="1rem"
-          mb="0.5rem"
-        >{t`${applicationName} will automate running combinations of these pairings and then do a basic analysis of the results.`}</Text>
+      <Group
+        justify={hasUserPrompt ? "space-between" : "flex-end"}
+        align="center"
+        wrap="nowrap"
+      >
+        {hasUserPrompt && (
+          <Group gap="sm" align="center" wrap="nowrap">
+            <Switch
+              id="use-contextual-interestingness"
+              checked={useContextualInterestingness}
+              onChange={(event) =>
+                setUseContextualInterestingness(event.currentTarget.checked)
+              }
+              size="sm"
+            />
+            <Box
+              component="label"
+              className={S.contextualInterestingnessToggleLabel}
+              htmlFor="use-contextual-interestingness"
+            >
+              <Box component="span" fz="sm" c="text-secondary">
+                {t`Use AI to order charts by interestingness`}
+              </Box>
+              <Tooltip
+                label={t`Uses AI tokens. Turn off to use basic ordering only.`}
+              >
+                <Icon
+                  name="info"
+                  size={14}
+                  c="text-secondary"
+                  aria-label={t`More information`}
+                />
+              </Tooltip>
+            </Box>
+          </Group>
+        )}
         <Button
-          className={cx(!canStart && CS.hidden)} // hide with css to make sure caption text is aligned vertically
+          className={cx(!canStart && CS.hidden)} // hide with css to make sure toggle is aligned vertically
           size="sm"
           flex="none"
           variant="filled"

--- a/frontend/src/metabase/explorations/components/NewExplorationData/NewExplorationData.tsx
+++ b/frontend/src/metabase/explorations/components/NewExplorationData/NewExplorationData.tsx
@@ -27,7 +27,6 @@ import {
   Stack,
   Switch,
   Title,
-  Tooltip,
 } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type {
@@ -332,44 +331,18 @@ export function NewExplorationData({ selection }: NewExplorationDataProps) {
         )}
       </Box>
 
-      <Group
-        justify={hasUserPrompt ? "space-between" : "flex-end"}
-        align="center"
-        wrap="nowrap"
-      >
-        {hasUserPrompt && (
-          <Group gap="sm" align="center" wrap="nowrap">
-            <Switch
-              id="use-contextual-interestingness"
-              checked={useContextualInterestingness}
-              onChange={(event) =>
-                setUseContextualInterestingness(event.currentTarget.checked)
-              }
-              size="sm"
-            />
-            <Box
-              component="label"
-              className={S.contextualInterestingnessToggleLabel}
-              htmlFor="use-contextual-interestingness"
-            >
-              <Box component="span" fz="sm" c="text-secondary">
-                {t`Use AI to order charts by interestingness`}
-              </Box>
-              <Tooltip
-                label={t`Uses AI tokens. Turn off to use basic ordering only.`}
-              >
-                <Icon
-                  name="info"
-                  size={14}
-                  c="text-secondary"
-                  aria-label={t`More information`}
-                />
-              </Tooltip>
-            </Box>
-          </Group>
-        )}
+      <Group justify="space-between" align="center" wrap="nowrap">
+        <Switch
+          className={cx(!hasUserPrompt && CS.hidden)}
+          checked={useContextualInterestingness}
+          onChange={(event) =>
+            setUseContextualInterestingness(event.currentTarget.checked)
+          }
+          size="sm"
+          label={t`Use AI to analyze and order results`}
+        />
         <Button
-          className={cx(!canStart && CS.hidden)} // hide with css to make sure toggle is aligned vertically
+          className={cx(!canStart && CS.hidden)}
           size="sm"
           flex="none"
           variant="filled"

--- a/frontend/src/metabase/explorations/components/NewExplorationData/NewExplorationData.unit.spec.tsx
+++ b/frontend/src/metabase/explorations/components/NewExplorationData/NewExplorationData.unit.spec.tsx
@@ -1,10 +1,12 @@
 import userEvent from "@testing-library/user-event";
 
 import { setupExplorationDataEndpoint } from "__support__/server-mocks/metric";
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { useCreateExplorationMutation } from "metabase/api";
 import { trackExplorationPlanEdited } from "metabase/explorations/analytics";
 import type { ExplorationBlock } from "metabase/explorations/hooks";
 import {
+  createExploration,
   makeMockSelection,
   mockDimensionBlock,
   mockMetricBlock,
@@ -25,6 +27,11 @@ import {
 jest.mock("metabase/explorations/analytics", () => ({
   trackExplorationCreated: jest.fn(),
   trackExplorationPlanEdited: jest.fn(),
+}));
+
+jest.mock("metabase/api", () => ({
+  ...jest.requireActual("metabase/api"),
+  useCreateExplorationMutation: jest.fn(),
 }));
 
 jest.mock("metabase/metabot/hooks", () => ({
@@ -56,14 +63,29 @@ const churnMetric = createMockMetric({
   dimension_ids: [dimPlan.id],
 }) as ExplorationMetric;
 
+const createExplorationMock = jest.fn();
+
 function setup({
   blocks = [],
   timelines = [],
-}: { blocks?: ExplorationBlock[]; timelines?: Timeline[] } = {}) {
+  messages = [],
+}: {
+  blocks?: ExplorationBlock[];
+  timelines?: Timeline[];
+  messages?: { role: string; message: string }[];
+} = {}) {
   // Unjustified type cast. FIXME
   jest.mocked(useMetabotAgent).mockReturnValue({
-    messages: [],
+    messages,
   } as any);
+
+  createExplorationMock.mockReturnValue({
+    unwrap: () => Promise.resolve(createExploration()),
+  });
+  jest
+    .mocked(useCreateExplorationMutation)
+    // RTK mutation hook mock only needs trigger + isLoading from the tuple.
+    .mockReturnValue([createExplorationMock, { isLoading: false }] as any);
 
   // The Add* modals fetch this on mount even while closed.
   setupExplorationDataEndpoint([]);
@@ -398,6 +420,73 @@ describe("NewExplorationData (Research plan)", () => {
       expect(request.blocks[0].metrics.map((m) => m.card_id)).toEqual([
         churnMetric.id,
       ]);
+    });
+  });
+
+  describe("contextual interestingness toggle", () => {
+    const metricBlock = mockMetricBlock(revenueMetric, [dimCreatedAt]);
+    const userQuestion = "What drives churn?";
+
+    it("does not render the toggle when there are no user messages", () => {
+      setup({ blocks: [metricBlock] });
+
+      expect(
+        screen.queryByRole("switch", {
+          name: /Use AI to order charts by interestingness/,
+        }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders the toggle on by default when there are user messages", () => {
+      setup({
+        blocks: [metricBlock],
+        messages: [{ role: "user", message: userQuestion }],
+      });
+
+      expect(
+        screen.getByRole("switch", {
+          name: /Use AI to order charts by interestingness/,
+        }),
+      ).toBeChecked();
+    });
+
+    it("sends the prompt when the toggle is on", async () => {
+      setup({
+        blocks: [metricBlock],
+        messages: [{ role: "user", message: userQuestion }],
+      });
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Start research" }),
+      );
+
+      await waitFor(() => {
+        expect(createExplorationMock).toHaveBeenCalledWith(
+          expect.objectContaining({ prompt: userQuestion }),
+        );
+      });
+    });
+
+    it("omits the prompt when the toggle is off", async () => {
+      setup({
+        blocks: [metricBlock],
+        messages: [{ role: "user", message: userQuestion }],
+      });
+
+      await userEvent.click(
+        screen.getByRole("switch", {
+          name: /Use AI to order charts by interestingness/,
+        }),
+      );
+      await userEvent.click(
+        screen.getByRole("button", { name: "Start research" }),
+      );
+
+      await waitFor(() => {
+        expect(createExplorationMock).toHaveBeenCalledWith(
+          expect.objectContaining({ prompt: null }),
+        );
+      });
     });
   });
 

--- a/frontend/src/metabase/explorations/components/NewExplorationData/NewExplorationData.unit.spec.tsx
+++ b/frontend/src/metabase/explorations/components/NewExplorationData/NewExplorationData.unit.spec.tsx
@@ -427,14 +427,10 @@ describe("NewExplorationData (Research plan)", () => {
     const metricBlock = mockMetricBlock(revenueMetric, [dimCreatedAt]);
     const userQuestion = "What drives churn?";
 
-    it("does not render the toggle when there are no user messages", () => {
+    it("hides the toggle when there are no user messages", () => {
       setup({ blocks: [metricBlock] });
 
-      expect(
-        screen.queryByRole("switch", {
-          name: /Use AI to order charts by interestingness/,
-        }),
-      ).not.toBeInTheDocument();
+      expect(screen.getByRole("switch", { hidden: true })).not.toBeVisible();
     });
 
     it("renders the toggle on by default when there are user messages", () => {
@@ -445,7 +441,7 @@ describe("NewExplorationData (Research plan)", () => {
 
       expect(
         screen.getByRole("switch", {
-          name: /Use AI to order charts by interestingness/,
+          name: /Use AI to analyze and order results/,
         }),
       ).toBeChecked();
     });
@@ -475,7 +471,7 @@ describe("NewExplorationData (Research plan)", () => {
 
       await userEvent.click(
         screen.getByRole("switch", {
-          name: /Use AI to order charts by interestingness/,
+          name: /Use AI to analyze and order results/,
         }),
       );
       await userEvent.click(

--- a/resources/migrations/instance_analytics_views/ai_usage_log/v5/h2-ai_usage_log.sql
+++ b/resources/migrations/instance_analytics_views/ai_usage_log/v5/h2-ai_usage_log.sql
@@ -8,8 +8,8 @@ SELECT
     CASE a.source
         WHEN 'metabot_agent'                     THEN 'Metabot'
         WHEN 'agent'                             THEN 'Metabot'
-        WHEN 'contextual_interestingness'        THEN 'Contextual Interestingness'
-        WHEN 'exploration'                       THEN 'Explorations'
+        WHEN 'contextual_interestingness'        THEN 'Research'
+        WHEN 'exploration'                       THEN 'Research'
         WHEN 'document_generate_content'         THEN 'Documents'
         WHEN 'example_question_generation_batch' THEN 'Suggested Prompts'
         WHEN 'slack'                             THEN 'Slackbot'

--- a/resources/migrations/instance_analytics_views/ai_usage_log/v5/mysql-ai_usage_log.sql
+++ b/resources/migrations/instance_analytics_views/ai_usage_log/v5/mysql-ai_usage_log.sql
@@ -8,8 +8,8 @@ SELECT
     CASE a.source
         WHEN 'metabot_agent'                     THEN 'Metabot'
         WHEN 'agent'                             THEN 'Metabot'
-        WHEN 'contextual_interestingness'        THEN 'Contextual Interestingness'
-        WHEN 'exploration'                       THEN 'Explorations'
+        WHEN 'contextual_interestingness'        THEN 'Research'
+        WHEN 'exploration'                       THEN 'Research'
         WHEN 'document_generate_content'         THEN 'Documents'
         WHEN 'example_question_generation_batch' THEN 'Suggested Prompts'
         WHEN 'slack'                             THEN 'Slackbot'

--- a/resources/migrations/instance_analytics_views/ai_usage_log/v5/postgres-ai_usage_log.sql
+++ b/resources/migrations/instance_analytics_views/ai_usage_log/v5/postgres-ai_usage_log.sql
@@ -8,8 +8,8 @@ SELECT
     CASE a.source
         WHEN 'metabot_agent'                     THEN 'Metabot'
         WHEN 'agent'                             THEN 'Metabot'
-        WHEN 'contextual_interestingness'        THEN 'Contextual Interestingness'
-        WHEN 'exploration'                       THEN 'Explorations'
+        WHEN 'contextual_interestingness'        THEN 'Research'
+        WHEN 'exploration'                       THEN 'Research'
         WHEN 'document_generate_content'         THEN 'Documents'
         WHEN 'example_question_generation_batch' THEN 'Suggested Prompts'
         WHEN 'slack'                             THEN 'Slackbot'

--- a/resources/migrations/instance_analytics_views/metabot_conversations/v7/h2-metabot_conversations.sql
+++ b/resources/migrations/instance_analytics_views/metabot_conversations/v7/h2-metabot_conversations.sql
@@ -29,7 +29,7 @@ SELECT
                 WHEN 'slackbot'                  THEN 'Slackbot'
                 WHEN 'transforms_codegen'        THEN 'Transforms codegen'
                 WHEN 'document-generate-content' THEN 'Documents'
-                WHEN 'explorations'              THEN 'Explorations'
+                WHEN 'explorations'              THEN 'Research'
                 ELSE mm.profile_id
             END
      FROM metabot_message mm
@@ -59,8 +59,8 @@ SELECT
                 WHEN 'oss-sql-gen'                       THEN 'SQL'
                 WHEN 'sql-gen'                           THEN 'SQL'
                 WHEN 'unknown'                           THEN 'Unknown'
-                WHEN 'contextual_interestingness'        THEN 'Contextual Interestingness'
-                WHEN 'exploration'                       THEN 'Explorations'
+                WHEN 'contextual_interestingness'        THEN 'Research'
+                WHEN 'exploration'                       THEN 'Research'
                 ELSE aul.source
             END
      FROM ai_usage_log aul

--- a/resources/migrations/instance_analytics_views/metabot_conversations/v7/mysql-metabot_conversations.sql
+++ b/resources/migrations/instance_analytics_views/metabot_conversations/v7/mysql-metabot_conversations.sql
@@ -29,7 +29,7 @@ SELECT
                 WHEN 'slackbot'                  THEN 'Slackbot'
                 WHEN 'transforms_codegen'        THEN 'Transforms codegen'
                 WHEN 'document-generate-content' THEN 'Documents'
-                WHEN 'explorations'              THEN 'Explorations'
+                WHEN 'explorations'              THEN 'Research'
                 ELSE mm.profile_id
             END
      FROM metabot_message mm
@@ -59,8 +59,8 @@ SELECT
                 WHEN 'oss-sql-gen'                       THEN 'SQL'
                 WHEN 'sql-gen'                           THEN 'SQL'
                 WHEN 'unknown'                           THEN 'Unknown'
-                WHEN 'contextual_interestingness'        THEN 'Contextual Interestingness'
-                WHEN 'exploration'                       THEN 'Explorations'
+                WHEN 'contextual_interestingness'        THEN 'Research'
+                WHEN 'exploration'                       THEN 'Research'
                 ELSE aul.source
             END
      FROM ai_usage_log aul

--- a/resources/migrations/instance_analytics_views/metabot_conversations/v7/postgres-metabot_conversations.sql
+++ b/resources/migrations/instance_analytics_views/metabot_conversations/v7/postgres-metabot_conversations.sql
@@ -29,7 +29,7 @@ SELECT
                 WHEN 'slackbot'                  THEN 'Slackbot'
                 WHEN 'transforms_codegen'        THEN 'Transforms codegen'
                 WHEN 'document-generate-content' THEN 'Documents'
-                WHEN 'explorations'              THEN 'Explorations'
+                WHEN 'explorations'              THEN 'Research'
                 ELSE mm.profile_id
             END
      FROM metabot_message mm
@@ -59,8 +59,8 @@ SELECT
                 WHEN 'oss-sql-gen'                       THEN 'SQL'
                 WHEN 'sql-gen'                           THEN 'SQL'
                 WHEN 'unknown'                           THEN 'Unknown'
-                WHEN 'contextual_interestingness'        THEN 'Contextual Interestingness'
-                WHEN 'exploration'                       THEN 'Explorations'
+                WHEN 'contextual_interestingness'        THEN 'Research'
+                WHEN 'exploration'                       THEN 'Research'
                 ELSE aul.source
             END
      FROM ai_usage_log aul


### PR DESCRIPTION
Closes [UXW-4878: Clarify token usage for explorations analysis](https://linear.app/metabase/issue/UXW-4878/clarify-token-usage-for-explorations-analysis)

[Loom (UI has been slightly updated since recording)](https://www.loom.com/share/8aafb764a19b49028240853edeaf680c)

Also updates the AI usage views to remove references to "Explorations" and "Contextual Interestingness" and replaces them with a generic "Research":

<img width="1072" height="334" alt="image" src="https://github.com/user-attachments/assets/017c1ff7-8dbd-4833-b93c-4a611a1f340c" />