### PR TITLE
Consolidate outbound HTTP fetches + add private-network opt-in

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/auth_provider/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/auth_provider/impl.clj
@@ -17,14 +17,18 @@
 
 (defmethod fetch-auth* :http
   [_ _database-id {:keys [http-auth-url http-auth-headers]}]
-  (u.http/*fetch-as-json* http-auth-url http-auth-headers))
+  ;; user-controlled URL
+  (u.http/*fetch-as-json* http-auth-url http-auth-headers u.http/ssrf-safe-request-opts))
 
 (defmethod fetch-auth* :oauth
   [_ _database-id {:keys [oauth-token-url oauth-token-headers]}]
-  (u.http/*fetch-as-json* oauth-token-url oauth-token-headers))
+  ;; user-controlled URL
+  (u.http/*fetch-as-json* oauth-token-url oauth-token-headers u.http/ssrf-safe-request-opts))
 
 (defmethod fetch-auth* :azure-managed-identity
   [_ _database-id {:keys [azure-managed-identity-client-id]}]
+  ;; hardcoded constant (not user input) -> intentionally not hardened; external-only would just break
+  ;; managed-identity auth
   (u.http/*fetch-as-json* (str "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fossrdbms-aad.database.windows.net&client_id="
                                azure-managed-identity-client-id)
                           {"Metadata" "true"}))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -10,6 +10,7 @@
    [metabase.premium-features.core :as premium-features]
    [metabase.tracing.core :as tracing]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu])
@@ -223,8 +224,10 @@
     (log/debug (str "Calling " provider " embeddings API")
                {:endpoint endpoint :documents (count texts) :tokens (count-tokens-batch texts)})
     (let [start-ms             (u/start-timer)
+          ;; user/admin-configured base URL
           {:keys [usage data]} (-> (http/post endpoint
-                                              {:headers
+                                              (merge
+                                               {:headers
                                                (merge {"Content-Type"  "application/json"}
                                                       (if (and (empty? api-key)
                                                                (= "ai-service" provider))
@@ -237,7 +240,8 @@
                                                :body    (json/encode (merge {:model           model-name
                                                                              :input           texts
                                                                              :encoding_format "base64"}
-                                                                            extra-body))})
+                                                                            extra-body))}
+                                               u.http/ssrf-safe-request-opts))
                                    :body
                                    (json/decode true))
           total-tokens         (:total_tokens usage 0)

--- a/enterprise/backend/test/metabase_enterprise/auth_provider/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/auth_provider/impl_test.clj
@@ -7,9 +7,7 @@
    [metabase.driver.util :as driver.u]
    [metabase.test :as mt]
    [metabase.test.data.interface :as tx]
-   [metabase.test.http-client :as client]
-   [metabase.util.http :as u.http]
-   [metabase.util.json :as json])
+   [metabase.util.http :as u.http])
   (:import
    [java.util Properties]))
 
@@ -78,13 +76,14 @@
     (let [original-details (:details (mt/db))
           provider-details {:use-auth-provider true
                             :auth-provider "http"
-                            :http-auth-url (client/build-url "/testing/echo"
-                                                             {:body (json/encode original-details)})}]
-      (is (= original-details (auth-provider/fetch-auth :http nil provider-details)))
-      (is (= (merge provider-details original-details)
-             (driver.u/fetch-and-incorporate-auth-provider-details
-              (tx/driver)
-              provider-details))))))
+                            :http-auth-url "https://auth-provider.example.com/creds"}]
+      ;; the :http fetch is now external-only, so stub it (a localhost echo server would be rejected)
+      (binding [u.http/*fetch-as-json* (fn [_url _headers & _] original-details)]
+        (is (= original-details (auth-provider/fetch-auth :http nil provider-details)))
+        (is (= (merge provider-details original-details)
+               (driver.u/fetch-and-incorporate-auth-provider-details
+                (tx/driver)
+                provider-details)))))))
 
 (deftest oauth-provider-tests
   (mt/with-premium-features #{:database-auth-providers}
@@ -92,15 +91,16 @@
                           :expires_in "84791"}
           provider-details {:use-auth-provider true
                             :auth-provider :oauth
-                            :oauth-token-url (client/build-url "/testing/echo"
-                                                               {:body (json/encode oauth-response)})}]
-      (is (= oauth-response (auth-provider/fetch-auth :oauth nil provider-details)))
-      (is (=? (merge provider-details
-                     {:password "foobar"
-                      :password-expiry-timestamp #(and (int? %) (> % (System/currentTimeMillis)))})
-              (driver.u/fetch-and-incorporate-auth-provider-details
-               (tx/driver)
-               provider-details))))))
+                            :oauth-token-url "https://auth-provider.example.com/token"}]
+      ;; see http-provider-tests: the :oauth fetch is external-only, so stub it
+      (binding [u.http/*fetch-as-json* (fn [_url _headers & _] oauth-response)]
+        (is (= oauth-response (auth-provider/fetch-auth :oauth nil provider-details)))
+        (is (=? (merge provider-details
+                       {:password "foobar"
+                        :password-expiry-timestamp #(and (int? %) (> % (System/currentTimeMillis)))})
+                (driver.u/fetch-and-incorporate-auth-provider-details
+                 (tx/driver)
+                 provider-details)))))))
 
 (deftest ^:parallel azure-managed-identity-provider-tests
   (mt/with-premium-features #{:database-auth-providers}

--- a/src/metabase/channel/impl/http.clj
+++ b/src/metabase/channel/impl/http.clj
@@ -5,14 +5,15 @@
    [java-time.api :as t]
    [metabase.channel.core :as channel]
    [metabase.channel.render.core :as channel.render]
-   [metabase.channel.settings :as channel.settings]
    [metabase.channel.shared :as channel.shared]
    [metabase.channel.urls :as urls]
-   [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.schema :as ms]))
+   [metabase.util.malli.schema :as ms])
+  (:import
+   (java.net URL)))
 
 (def ^:private image-width
   "Maximum width of the rendered PNG of HTML to be sent to HTTP Content that exceeds this width (e.g. a table with
@@ -41,15 +42,14 @@
   [url]
   (when (str/blank? url)
     (throw (ex-info (tru "No URL is configured for this webhook.") {:status-code 400})))
-  (when-not (try
-              (u/valid-host? (channel.settings/http-channel-host-strategy) url)
-              (catch Exception e
-                (throw (ex-info (tru "Invalid webhook URL: {0}" (ex-message e))
-                                {:status-code 400
-                                 :url         url}
-                                e))))
-    (throw (ex-info (tru "URLs referring to hosts that supply internal hosting metadata are prohibited.")
-                    {:status-code 400}))))
+  ;; humanized error for an unparseable URL (#76802); host enforcement happens at request time
+  (try
+    (URL. url)
+    (catch Exception e
+      (throw (ex-info (tru "Invalid webhook URL: {0}" (ex-message e))
+                      {:status-code 400
+                       :url         url}
+                      e)))))
 
 (mu/defmethod channel/send! :channel/http
   [{{:keys [url method auth-method auth-info]} :details} :- HTTPChannel
@@ -66,7 +66,8 @@
                (= "request-body" auth-method) (update :body merge auth-info)
                (= "header" auth-method)       (update :headers merge auth-info)
                (= "query-param" auth-method)  (update :query-params merge auth-info)))]
-    (http/request (cond-> req
+    ;; harden the outbound request (pin resolved IPs + no redirects)
+    (http/request (cond-> (merge req u.http/ssrf-safe-request-opts)
                     (or (map? (:body req))
                         (sequential? (:body req))) (update :body json/encode)))))
 

--- a/src/metabase/geojson/api.clj
+++ b/src/metabase/geojson/api.clj
@@ -8,6 +8,7 @@
    [metabase.geojson.settings :as geojson.settings]
    [metabase.permissions.core :as perms]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -16,7 +17,6 @@
    [ring.util.response :as response])
   (:import
    (java.io BufferedReader)
-   (java.net InetAddress)
    (org.apache.commons.io.input ReaderInputStream)
    (org.apache.http.conn DnsResolver)
    (org.apache.http.impl.conn SystemDefaultDnsResolver)))
@@ -27,15 +27,16 @@
 
 (def ^DnsResolver ^:private ^:dynamic  *system-dns-resolver* (SystemDefaultDnsResolver.))
 
-(def ^:private non-link-local-dns-resolver
+(def ^:private ssrf-safe-dns-resolver
+  "Pins every resolved IP to a public address ([[u.http/public-address?]]) inside the opened connection."
   (reify
     DnsResolver
     (^"[Ljava.net.InetAddress;" resolve [_ ^String host]
       (let [addresses (.resolve *system-dns-resolver* host)]
-        (if (some #(.isLinkLocalAddress ^InetAddress %) addresses)
-          (throw (ex-info (geojson.settings/invalid-location-msg) {:status-code 400
-                                                                   :link-local true}))
-          addresses)))))
+        (if (every? u.http/public-address? addresses)
+          addresses
+          (throw (ex-info (geojson.settings/invalid-location-msg) {:status-code     400
+                                                                   :blocked-address true})))))))
 
 (defn- url->geojson
   [url]
@@ -44,10 +45,10 @@
                                  :socket-timeout     connection-timeout-ms
                                  :connection-timeout connection-timeout-ms
                                  :throw-exceptions   false
-                                 :dns-resolver       non-link-local-dns-resolver})
+                                 :dns-resolver       ssrf-safe-dns-resolver})
                   (catch Throwable e
-                    (if (:link-local (ex-data e))
-                      (throw (ex-info (ex-message e) (dissoc (ex-data e) :link-local) e))
+                    (if (:blocked-address (ex-data e))
+                      (throw (ex-info (ex-message e) (dissoc (ex-data e) :blocked-address) e))
                       (throw (ex-info (tru "GeoJSON URL failed to load") {:status-code 400})))))
         ;; only 2xx is a real success — a 3xx redirect isn't followed (`:redirect-strategy :none`, for SSRF
         ;; protection), so its (empty) body must be treated as a failed load rather than streamed as GeoJSON.

--- a/src/metabase/geojson/settings.clj
+++ b/src/metabase/geojson/settings.clj
@@ -78,7 +78,7 @@
   (try
     (let [url (.toURL (URI. url-string))]
       (and (valid-protocol? url)
-           (http/valid-host? :external-only url)))
+           (http/external-host? url)))
     (catch Throwable _ false)))
 
 (defn valid-geojson-resource-path?

--- a/src/metabase/llm/anthropic.clj
+++ b/src/metabase/llm/anthropic.clj
@@ -8,6 +8,7 @@
    [clojure.string :as str]
    [metabase.llm.settings :as llm.settings]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json])
   (:import
    (com.fasterxml.jackson.core JsonParseException)))
@@ -97,13 +98,16 @@
         start-time (u/start-timer)]
     (try
       (let [url      (str (llm.settings/llm-anthropic-api-base-url) "/v1/messages")
+            ;; admin-configured base URL
             response (http/post url
-                                {:headers            (build-request-headers (get-api-key-or-throw))
-                                 :body               (json/encode (build-request-body request))
-                                 :as                 :json
-                                 :content-type       :json
-                                 :socket-timeout     (llm.settings/llm-request-timeout-ms)
-                                 :connection-timeout (llm.settings/llm-connection-timeout-ms)})
+                                (merge
+                                 {:headers            (build-request-headers (get-api-key-or-throw))
+                                  :body               (json/encode (build-request-body request))
+                                  :as                 :json
+                                  :content-type       :json
+                                  :socket-timeout     (llm.settings/llm-request-timeout-ms)
+                                  :connection-timeout (llm.settings/llm-connection-timeout-ms)}
+                                 u.http/ssrf-safe-request-opts))
             duration-ms (u/since-ms start-time)
             body        (:body response)
             usage       (:usage body)]

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -9,6 +9,7 @@
    [metabase.metabot.schema.v2 :as schema.v2]
    [metabase.premium-features.core :as premium-features]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -814,6 +815,8 @@
 (defn request
   "Perform an LLM HTTP request with the given auth (a map of `:url` and `:headers`)."
   [{:keys [url headers]} req]
+  ;; customer-configured BYOK URL
   (http/request (-> req
                     (update :url #(str url %))
-                    (update :headers merge headers))))
+                    (update :headers merge headers)
+                    (merge u.http/ssrf-safe-request-opts))))

--- a/src/metabase/sso/oidc/discovery.clj
+++ b/src/metabase/sso/oidc/discovery.clj
@@ -7,7 +7,6 @@
    [clojure.string :as str]
    [java-time.api :as t]
    [metabase.sso.oidc.http :as oidc.http]
-   [metabase.sso.settings :as sso.settings]
    [metabase.util.http :as u.http]
    [metabase.util.log :as log]))
 
@@ -98,7 +97,8 @@
 
 (defn- get-endpoint
   "Extract an endpoint from the discovery document or manual configuration.
-   Validates the endpoint URL against `oidc-allowed-networks`.
+   Fast-fail SSRF check on the endpoint URL (external-only); the fetch itself is pinned via
+   `metabase.sso.oidc.http`.
 
    Parameters:
    - config: Map containing either :discovery-document or manual endpoint configurations
@@ -109,7 +109,7 @@
   [config discovery-key manual-key]
   (when-let [url (or (get-in config [:discovery-document discovery-key])
                      (get config manual-key))]
-    (when-not (u.http/valid-host? (sso.settings/oidc-allowed-networks) url)
+    (when-not (u.http/external-host? url)
       (throw (ex-info "OIDC endpoint blocked: address not allowed by network restrictions"
                       {:url url :endpoint-key discovery-key})))
     url))

--- a/src/metabase/sso/oidc/http.clj
+++ b/src/metabase/sso/oidc/http.clj
@@ -1,11 +1,8 @@
 (ns metabase.sso.oidc.http
-  "Centralized HTTP client for OIDC operations.
-
-   All server-side OIDC HTTP requests should go through this namespace
-   to ensure SSRF validation via `oidc-allowed-networks`."
+  "Centralized HTTP client for OIDC operations. All requests go through here so they are external-only
+   (via `ssrf-safe-request-opts`)."
   (:require
    [clj-http.client :as http]
-   [metabase.sso.settings :as sso.settings]
    [metabase.util.http :as u.http]
    [metabase.util.log :as log]))
 
@@ -18,29 +15,26 @@
    :socket-timeout   5000})
 
 (defn- validate-url!
-  "Validate that a URL is allowed by the current `oidc-allowed-networks` setting.
-   Throws `ex-info` if the URL is blocked."
+  "Fast-fail check: reject a URL whose host resolves to a non-public address. Advisory -- the real gate
+   is `ssrf-safe-request-opts` on the request. Throws `ex-info` if blocked."
   [url]
-  (when-not (u.http/valid-host? (sso.settings/oidc-allowed-networks) url)
-    (log/warnf "OIDC request to %s blocked by network restrictions (oidc-allowed-networks = %s)"
-               url (sso.settings/oidc-allowed-networks))
+  (when-not (u.http/external-host? url)
+    (log/warnf "OIDC request to %s blocked: host does not resolve to a public address (external-only)" url)
     (throw (ex-info "OIDC request blocked: address not allowed by network restrictions"
                     {:url url}))))
 
 (defn oidc-get
-  "Perform a validated GET request for OIDC operations.
-   Validates the URL against `oidc-allowed-networks` before making the request."
+  "GET for OIDC operations, external-only (via `ssrf-safe-request-opts`)."
   ([url]
    (oidc-get url {}))
   ([url opts]
    (validate-url! url)
-   (http/get url (merge default-opts opts))))
+   (http/get url (merge default-opts opts u.http/ssrf-safe-request-opts))))
 
 (defn oidc-post
-  "Perform a validated POST request for OIDC operations.
-   Validates the URL against `oidc-allowed-networks` before making the request."
+  "POST for OIDC operations, external-only (via `ssrf-safe-request-opts`)."
   ([url]
    (oidc-post url {}))
   ([url opts]
    (validate-url! url)
-   (http/post url (merge default-opts opts))))
+   (http/post url (merge default-opts opts u.http/ssrf-safe-request-opts))))

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -10,7 +10,6 @@
              [clojure.pprint :as pprint]
              ^{:clj-kondo/ignore [:discouraged-namespace]}
              [metabase.util.jvm :as u.jvm]
-             [metabase.util.http :as u.http]
              [metabase.util.string :as u.str]
              [potemkin :as p]
              [puget.printer]
@@ -83,9 +82,7 @@
                         with-timeout
                         with-us-locale]
                        [u.str
-                        build-sentence]
-                       [u.http
-                        valid-host?]))
+                        build-sentence]))
 
 (defmacro or-with
   "Like or, but determines truthiness with `pred`."

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -22,35 +22,14 @@
   (json/decode headers))
 
 (defn ^:dynamic *fetch-as-json*
-  "Fetches url and parses body as json, returning it."
-  [url headers]
-  (let [headers (cond-> headers
-                  (string? headers) parse-http-headers)
-        response (http/get url (m/assoc-some {:as :json} :headers headers))]
-    (:body response)))
-
-(def ^:private invalid-hosts
-  #{"metadata.google.internal"}) ; internal metadata for GCP
-
-(defn valid-host?
-  "Check whether url is valid based on the given strategy:
-   :external-only - only external hosts
-   :allow-private - external + private networks but not localhost/loopback
-   :allow-all - no restrictions"
-  [strategy url]
-  (case strategy
-    :allow-all true
-    ;; For both :external-only and :allow-private, we need to check the host
-    (let [^URL url   (if (string? url) (URL. url) url)
-          host       (.getHost url)
-          host-name  (InetAddress/getByName host)]
-      (and
-       (not (contains? invalid-hosts host))
-       (not (.isLinkLocalAddress host-name))
-       (not (.isLoopbackAddress host-name))
-       ;; Only block site-local (private) addresses for :external-only
-       (or (= strategy :allow-private)
-           (not (.isSiteLocalAddress host-name)))))))
+  "Fetch `url`, parse the JSON body, return it. `opts` is merged into the clj-http request -- pass
+  [[ssrf-safe-request-opts]] for untrusted URLs; omit only for trusted, hardcoded ones."
+  ([url headers] (*fetch-as-json* url headers nil))
+  ([url headers opts]
+   (let [headers  (cond-> headers
+                    (string? headers) parse-http-headers)
+         response (http/get url (merge (m/assoc-some {:as :json} :headers headers) opts))]
+     (:body response))))
 
 ;; --------------------------------------------------------------------------------------------
 ;; SSRF-hardened fetch of an untrusted (user-provided) URL.
@@ -65,13 +44,9 @@
 ;;  - No cookies/credentials (a fresh clj-http GET carries no Metabase session).
 ;;  - Cap the download bytes and (optionally) restrict to an allowlist of content-types.
 ;;
-;; TODO (bshepherdson 2026-06-09) -- this hardened fetch (rebinding-safe [[ssrf-safe-dns-resolver]]
-;; + [[public-address?]] + size/content-type caps) supersedes the weaker [[valid-host?]] above,
-;; which validates only a single up-front DNS resolution (a TOCTOU/DNS-rebinding gap) and misses
-;; IPv6 ULA, IPv4 CGNAT, any-local, multicast, and IP-literal hosts. Migrate the existing
-;; `valid-host?` callers -- `metabase.geojson`, `metabase.sso.oidc.http`,
-;; `metabase.channel.impl.http` -- onto this, and add SSRF validation to
-;; `metabase.actions.http-action` (which currently has none).
+;; `valid-host?` was removed; callers validate via [[public-address?]] -- through
+;; [[ssrf-safe-request-opts]] / [[fetch-bytes]] / [[external-host?]]. `metabase.actions.http-action`
+;; is not yet routed through these.
 ;; --------------------------------------------------------------------------------------------
 
 (def ^:private fetch-default-timeout-ms 8000)
@@ -108,6 +83,26 @@
           (if (every? public-address? addrs)
             addrs
             (throw (ex-info "Refusing to fetch from a non-public address" {:ssrf true}))))))))
+
+(def ssrf-safe-request-opts
+  "clj-http request options that make an outbound request external-only: pins every resolved IP to a
+  public address ([[ssrf-safe-dns-resolver]]) and disables redirects. Merge into a request map for
+  callers needing an arbitrary method, an `http://` target, or the raw response (where [[fetch-bytes]]
+  is too strict). Public IP-literal URLs are allowed. Single place to add a strategy knob later."
+  {:dns-resolver      ssrf-safe-dns-resolver
+   :redirect-strategy :none})
+
+(defn external-host?
+  "Advisory check: true when `url`'s host resolves and every IP is public ([[public-address?]]);
+  accepts hostnames and IP literals. A single up-front resolution (rebinding-prone), so use only for
+  create-time/fast-fail -- the authoritative gate is [[ssrf-safe-request-opts]] / [[fetch-bytes]]."
+  [url]
+  (try
+    (let [^URL u (if (instance? URL url) url (URL. (str url)))
+          host   (some-> (.getHost u) (str/replace #"^\[|\]$" ""))   ; strip IPv6 literal brackets
+          addrs  (when-not (str/blank? host) (InetAddress/getAllByName host))]
+      (boolean (and (seq addrs) (every? public-address? addrs))))
+    (catch Throwable _ false)))
 
 (defn safe-url?
   "True if `url` is safe to fetch from untrusted input: HTTPS scheme, no userinfo, and a real DNS

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -3,6 +3,7 @@
    [clj-http.client :as http]
    [clojure.string :as str]
    [medley.core :as m]
+   [metabase.config.core :as config]
    [metabase.util.json :as json])
   (:import
    (com.google.common.net InetAddresses)
@@ -56,17 +57,31 @@
 (def ^:private blocked-fetch-hosts #{"localhost" "metadata" "metadata.google.internal"})
 (def ^:private blocked-fetch-host-suffixes [".localhost" ".local" ".internal" ".lan" ".home.arpa"])
 
+(defn- hosted?
+  "Metabase Cloud? `requiring-resolve` avoids a static dep on `metabase.premium-features`."
+  []
+  (boolean ((requiring-resolve 'metabase.premium-features.core/is-hosted?))))
+
+(defn- allow-private-networks?
+  "Private destinations (RFC1918 + IPv6 ULA) are allowed only via the self-hosted
+  `MB_ALLOW_PRIVATE_NETWORK_FETCH` opt-in, and never on Cloud."
+  []
+  (and (not (hosted?))
+       (boolean (config/config-bool :mb-allow-private-network-fetch))))
+
 (defn public-address?
-  "True only for globally-routable unicast IP addresses (rejects loopback, link-local, site-local,
-  any-local, multicast, IPv6 unique-local fc00::/7, and IPv4 CGNAT 100.64.0.0/10)."
+  "Safe destination address? Always rejects loopback, link-local, any-local, multicast, and CGNAT;
+  also RFC1918 site-local and IPv6 ULA unless [[allow-private-networks?]]."
   [^InetAddress addr]
-  (let [b (.getAddress addr)]
+  (let [allow-private? (allow-private-networks?)
+        b              (.getAddress addr)]
     (not (or (.isLoopbackAddress addr)
              (.isLinkLocalAddress addr)
-             (.isSiteLocalAddress addr)
              (.isAnyLocalAddress addr)
              (.isMulticastAddress addr)
-             (and (instance? Inet6Address addr)              ; IPv6 unique-local fc00::/7
+             (and (not allow-private?) (.isSiteLocalAddress addr))
+             (and (not allow-private?)                       ; IPv6 unique-local fc00::/7
+                  (instance? Inet6Address addr)
                   (= 0xfc (bit-and (aget b 0) 0xfe)))
              (and (= 4 (alength b))                          ; IPv4 CGNAT 100.64.0.0/10
                   (= 100 (bit-and (aget b 0) 0xff))

--- a/test/metabase/channel/impl/http_test.clj
+++ b/test/metabase/channel/impl/http_test.clj
@@ -12,6 +12,7 @@
    [metabase.server.handler :as server.handler]
    [metabase.server.middleware.json :as mw.json]
    [metabase.test :as mt]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.malli :as mu]
    [ring.adapter.jetty :as jetty]
@@ -147,7 +148,8 @@
        (ex-data e#))))
 
 (deftest can-connect-no-auth-test
-  (mt/with-temporary-setting-values [http-channel-host-strategy :allow-all]
+  ;; neutralize the request opts so the test can hit a local server (opts are unit-tested in metabase.util.http-test)
+  (with-redefs [u.http/ssrf-safe-request-opts {}]
     (with-server [url [get-favicon get-200 get-302-redirect-200 get-400 get-302-redirect-400 get-500]]
       (let [can-connect?* (fn [route]
                             (can-connect? {:url         (str url (:path route))
@@ -170,7 +172,7 @@
                 (exception-data (can-connect?* get-500))))))))
 
 (deftest can-connect-header-auth-test
-  (mt/with-temporary-setting-values [http-channel-host-strategy :allow-all]
+  (with-redefs [u.http/ssrf-safe-request-opts {}]
     (with-server [url [(make-route :get "/user"
                                    (fn [x]
                                      (if (= "SECRET" (get-in x [:headers "x-api-key"]))
@@ -192,7 +194,7 @@
                                               :auth-info   {:x-api-key "WRONG"}}))))))))
 
 (deftest can-connect-query-param-auth-test
-  (mt/with-temporary-setting-values [http-channel-host-strategy :allow-all]
+  (with-redefs [u.http/ssrf-safe-request-opts {}]
     (with-server [url [(make-route :get "/user"
                                    (fn [x]
                                      (if (= ["qnkhuat" "secretpassword"]
@@ -217,7 +219,7 @@
                                                             :password "wrongpassword"}}))))))))
 
 (deftest can-connect-request-body-auth-test
-  (mt/with-temporary-setting-values [http-channel-host-strategy :allow-all]
+  (with-redefs [u.http/ssrf-safe-request-opts {}]
     (with-server [url [(make-route :post "/user"
                                    (fn [x]
                                      (if (= "SECRET_TOKEN" (get-in x [:body :token]))
@@ -250,7 +252,7 @@
     (testing "include undefined key"
       (is (=? {:errors {:xyz ["disallowed key"]}}
               (exception-data (can-connect? {:xyz "hello world"})))))
-    (mt/with-temporary-setting-values [http-channel-host-strategy :allow-all]
+    (with-redefs [u.http/ssrf-safe-request-opts {}]
       (with-server [url [get-400]]
         (is (= {:request-body   "Bad request"
                 :request-status 400}
@@ -279,7 +281,8 @@
                        nil)
         (is (= (merge default-request
                       {:method       :get
-                       :url          "https://www.secret_service.xyz"})
+                       :url          "https://www.secret_service.xyz"}
+                      u.http/ssrf-safe-request-opts)
                (first @requests)))))
     (testing "default method is post"
       (with-captured-http-requests [requests]
@@ -289,7 +292,8 @@
                        nil)
         (is (= (merge default-request
                       {:method       :post
-                       :url          "https://www.secret_service.xyz"})
+                       :url          "https://www.secret_service.xyz"}
+                      u.http/ssrf-safe-request-opts)
                (first @requests)))))
     (testing "preserves req headers when use auth-method=:header"
       (with-captured-http-requests [requests]
@@ -303,7 +307,8 @@
                       {:method  :get
                        :url          "https://www.secret_service.xyz"
                        :headers      {:Authorization "Bearer 123"
-                                      :X-Request-Id "123"}})
+                                      :X-Request-Id "123"}}
+                      u.http/ssrf-safe-request-opts)
                (first @requests)))))
     (testing "preserves req query-params when use auth-method=:query-param"
       (with-captured-http-requests [requests]
@@ -317,7 +322,8 @@
                       {:method       :get
                        :url          "https://www.secret_service.xyz"
                        :query-params {:token "123"
-                                      :page 1}})
+                                      :page 1}}
+                      u.http/ssrf-safe-request-opts)
                (first @requests)))))))
 
 (deftest send!-humanized-invalid-url-test
@@ -338,7 +344,7 @@
                                              nil)))))))
 
 (deftest alert-http-channel-e2e-test
-  (mt/with-temporary-setting-values [http-channel-host-strategy :allow-all]
+  (with-redefs [u.http/ssrf-safe-request-opts {}]
     (let [received-message (atom nil)
           receive-route    (make-route :post "/test_http_channel"
                                        (fn [res]

--- a/test/metabase/geojson/api_test.clj
+++ b/test/metabase/geojson/api_test.clj
@@ -8,6 +8,7 @@
    [metabase.test :as mt]
    [metabase.test.http-client :as client]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [ring.adapter.jetty :as ring-jetty])
   (:import
    (java.net InetAddress)
@@ -155,7 +156,9 @@
 
 (deftest url-proxy-endpoint-non-responding-server-test
   (testing "error is returned if URL server never responds (#28752)"
-    (with-redefs [api.geojson/connection-timeout-ms 200]
+    (with-redefs [api.geojson/connection-timeout-ms 200
+                  ;; allow the loopback test server through; this test covers the connection-timeout path
+                  u.http/public-address? (constantly true)]
       ;; use a webserver which accepts a connection and never responds. The geojson endpoint opens a reader to the url
       ;; and responds with it. And if there are never any bytes going across, the whole thing just sits there. Our
       ;; test flakes after 45 seconds with `mt/user-http-request` times out. And presumably other clients have similar

--- a/test/metabase/sso/oidc/discovery_test.clj
+++ b/test/metabase/sso/oidc/discovery_test.clj
@@ -4,7 +4,8 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.sso.oidc.discovery :as oidc.discovery]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.http :as u.http]))
 
 (deftest ^:parallel get-authorization-endpoint-test
   (testing "Gets authorization endpoint from discovery document"
@@ -213,14 +214,13 @@
 ;;; ================================================== Endpoint Extraction Validation Tests ==================================================
 
 (deftest get-token-endpoint-blocks-internal-hosts-test
-  (testing "get-token-endpoint rejects internal hosts when oidc-allowed-networks is :external-only"
-    (mt/with-temporary-setting-values [oidc-allowed-networks :external-only]
-      (let [config {:discovery-document {:token_endpoint "http://169.254.169.254/latest/meta-data/"}}]
-        (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #"address not allowed by network restrictions"
-                              (oidc.discovery/get-token-endpoint config))))))
-  (testing "get-token-endpoint allows all hosts when oidc-allowed-networks is :allow-all"
-    (mt/with-temporary-setting-values [oidc-allowed-networks :allow-all]
+  (testing "get-token-endpoint rejects internal hosts (external-only, always)"
+    (let [config {:discovery-document {:token_endpoint "http://169.254.169.254/latest/meta-data/"}}]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"address not allowed by network restrictions"
+                            (oidc.discovery/get-token-endpoint config)))))
+  (testing "get-token-endpoint allows a public host"
+    (with-redefs [u.http/external-host? (constantly true)]
       (let [config {:discovery-document {:token_endpoint "https://provider.example.com/token"}}]
         (is (= "https://provider.example.com/token"
                (oidc.discovery/get-token-endpoint config)))))))

--- a/test/metabase/sso/oidc/http_test.clj
+++ b/test/metabase/sso/oidc/http_test.clj
@@ -3,63 +3,73 @@
    [clj-http.client :as http]
    [clojure.test :refer :all]
    [metabase.sso.oidc.http :as oidc.http]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.http :as u.http]))
+
+;; OIDC requests are external-only always (the `oidc-allowed-networks` setting is dormant). Internal
+;; hosts are rejected; `external-host?` is stubbed on success paths to avoid a real DNS lookup.
 
 (deftest oidc-get-ssrf-protection-test
-  (testing "oidc-get blocks internal hosts when oidc-allowed-networks is :external-only"
-    (mt/with-temporary-setting-values [oidc-allowed-networks :external-only]
-      (testing "Rejects localhost"
-        (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #"address not allowed by network restrictions"
-                              (oidc.http/oidc-get "http://localhost/path"))))
-      (testing "Rejects cloud metadata endpoint"
-        (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #"address not allowed by network restrictions"
-                              (oidc.http/oidc-get "http://169.254.169.254/latest/meta-data/"))))
-      (testing "Rejects private network addresses"
-        (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #"address not allowed by network restrictions"
-                              (oidc.http/oidc-get "http://192.168.1.1/path"))))))
-  (testing "oidc-get allows requests when oidc-allowed-networks is :allow-all"
-    (mt/with-temporary-setting-values [oidc-allowed-networks :allow-all]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts] {:status 200 :body {:ok true}})]
+  (testing "oidc-get blocks internal hosts (external-only, always)"
+    (testing "Rejects localhost"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"address not allowed by network restrictions"
+                            (oidc.http/oidc-get "http://localhost/path"))))
+    (testing "Rejects cloud metadata endpoint"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"address not allowed by network restrictions"
+                            (oidc.http/oidc-get "http://169.254.169.254/latest/meta-data/"))))
+    (testing "Rejects private network addresses"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"address not allowed by network restrictions"
+                            (oidc.http/oidc-get "http://192.168.1.1/path")))))
+  (testing "oidc-get allows a public host and hardens the request"
+    (with-redefs [u.http/external-host? (constantly true)]
+      (mt/with-dynamic-fn-redefs [http/get (fn [_url opts]
+                                             (is (= :none (:redirect-strategy opts)))
+                                             (is (some? (:dns-resolver opts)))
+                                             {:status 200 :body {:ok true}})]
         (let [response (oidc.http/oidc-get "https://provider.example.com/discovery")]
           (is (= 200 (:status response))))))))
 
 (deftest oidc-post-ssrf-protection-test
-  (testing "oidc-post blocks internal hosts when oidc-allowed-networks is :external-only"
-    (mt/with-temporary-setting-values [oidc-allowed-networks :external-only]
-      (testing "Rejects cloud metadata endpoint"
-        (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #"address not allowed by network restrictions"
-                              (oidc.http/oidc-post "http://169.254.169.254/latest/meta-data/"
-                                                   {:form-params {:grant_type "client_credentials"}}))))
-      (testing "Rejects loopback"
-        (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #"address not allowed by network restrictions"
-                              (oidc.http/oidc-post "http://127.0.0.1/token"
-                                                   {:form-params {:grant_type "client_credentials"}}))))))
-  (testing "oidc-post allows requests when oidc-allowed-networks is :allow-all"
-    (mt/with-temporary-setting-values [oidc-allowed-networks :allow-all]
-      (mt/with-dynamic-fn-redefs [http/post (fn [_url _opts] {:status 200 :body {:access_token "tok"}})]
+  (testing "oidc-post blocks internal hosts (external-only, always)"
+    (testing "Rejects cloud metadata endpoint"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"address not allowed by network restrictions"
+                            (oidc.http/oidc-post "http://169.254.169.254/latest/meta-data/"
+                                                 {:form-params {:grant_type "client_credentials"}}))))
+    (testing "Rejects loopback"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"address not allowed by network restrictions"
+                            (oidc.http/oidc-post "http://127.0.0.1/token"
+                                                 {:form-params {:grant_type "client_credentials"}})))))
+  (testing "oidc-post allows a public host and hardens the request"
+    (with-redefs [u.http/external-host? (constantly true)]
+      (mt/with-dynamic-fn-redefs [http/post (fn [_url opts]
+                                              (is (= :none (:redirect-strategy opts)))
+                                              (is (some? (:dns-resolver opts)))
+                                              {:status 200 :body {:access_token "tok"}})]
         (let [response (oidc.http/oidc-post "https://provider.example.com/token"
                                             {:form-params {:grant_type "client_credentials"}})]
           (is (= 200 (:status response))))))))
 
-(deftest oidc-get-allow-all-test
-  (testing "oidc-get allows all hosts when oidc-allowed-networks is :allow-all"
+(deftest oidc-private-host-always-blocked-test
+  (testing "a private host is rejected regardless of any stored strategy setting (external-only ceiling)"
     (mt/with-temporary-setting-values [oidc-allowed-networks :allow-all]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts] {:status 200 :body {}})]
-        (is (= 200 (:status (oidc.http/oidc-get "http://192.168.1.1/path"))))))))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"address not allowed by network restrictions"
+                            (oidc.http/oidc-get "http://192.168.1.1/path"))))))
 
 (deftest oidc-get-merges-custom-opts-test
-  (testing "Custom options are merged with defaults"
-    (mt/with-temporary-setting-values [oidc-allowed-networks :allow-all]
+  (testing "Custom options are merged with defaults and the SSRF opts"
+    (with-redefs [u.http/external-host? (constantly true)]
       (mt/with-dynamic-fn-redefs [http/get (fn [_url opts]
-                                             ;; Verify custom opts are present alongside defaults
+                                             ;; Verify custom opts are present alongside defaults + SSRF opts
                                              (is (= :json (:as opts)))
                                              (is (= :json (:accept opts)))
                                              (is (= 5000 (:conn-timeout opts)))
                                              (is (false? (:throw-exceptions opts)))
+                                             (is (= :none (:redirect-strategy opts)))
                                              {:status 200 :body {}})]
         (oidc.http/oidc-get "https://example.com/path" {:accept :json})))))

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -9,28 +9,34 @@
 
 (set! *warn-on-reflection* true)
 
-(deftest valid-host?-test
-  (testing "external-only strategy (default)"
-    (is (true? (http/valid-host? :external-only "https://example.com")))
-    (is (false? (http/valid-host? :external-only "http://localhost")))
-    (is (false? (http/valid-host? :external-only "http://192.168.1.1"))))
-  (testing "external-only strategy explicitly"
-    (is (true? (http/valid-host? :external-only "https://example.com")))
-    (is (false? (http/valid-host? :external-only "http://localhost")))
-    (is (false? (http/valid-host? :external-only "http://192.168.1.1"))))
-  (testing "allow-private strategy allows private networks but not localhost"
-    (is (true? (http/valid-host? :allow-private "https://example.com")))
-    (is (true? (http/valid-host? :allow-private "http://192.168.1.1")))
-    (is (true? (http/valid-host? :allow-private "http://10.0.0.1")))
-    (is (true? (http/valid-host? :allow-private "http://172.16.0.1")))
-    (is (false? (http/valid-host? :allow-private "http://localhost")))
-    (is (false? (http/valid-host? :allow-private "http://127.0.0.1")))
-    (is (false? (http/valid-host? :allow-private "http://169.254.1.1"))))
-  (testing "allow-all strategy allows everything"
-    (is (true? (http/valid-host? :allow-all "https://example.com")))
-    (is (true? (http/valid-host? :allow-all "http://localhost")))
-    (is (true? (http/valid-host? :allow-all "http://192.168.1.1")))
-    (is (true? (http/valid-host? :allow-all "http://169.254.1.1")))))
+;; NOTE: the legacy `valid-host?` (with :external-only / :allow-private / :allow-all strategies) was
+;; retired 2026-07-19. Every caller now enforces external-only via `public-address?` through
+;; `external-host?` (advisory, create-time) or `ssrf-safe-request-opts` (authoritative, fetch-time).
+;; All cases below are network-free: IP literals parse without DNS, and `localhost` resolves via the
+;; hosts file to loopback.
+
+(deftest ^:parallel external-host?-test
+  (testing "public IP-literal hosts are allowed"
+    (doseq [url ["https://8.8.8.8/x" "http://1.1.1.1" "https://[2606:4700:4700::1111]/x"]]
+      (is (true? (http/external-host? url)) (str "should be allowed: " url))))
+  (testing "loopback / link-local (IMDS) / RFC1918 / any-local / ULA hosts are rejected"
+    (doseq [url ["http://127.0.0.1" "https://169.254.169.254/latest" "http://10.0.0.5"
+                 "http://192.168.1.1" "http://172.16.0.1" "http://0.0.0.0"
+                 "http://[::1]" "http://[fe80::1]" "http://[fc00::1]"
+                 "http://2130706433"            ; decimal form of 127.0.0.1 (normalized by InetAddress)
+                 "http://localhost"]]           ; resolves to loopback, no network
+      (is (false? (http/external-host? url)) (str "should be rejected: " url))))
+  (testing "malformed input fails closed"
+    (doseq [url ["not a url" "https:///x" "" "http://"]]
+      (is (false? (http/external-host? url)) (str "should be rejected: " url)))))
+
+(deftest ^:parallel ssrf-safe-request-opts-test
+  (testing "disables redirect following"
+    (is (= :none (:redirect-strategy http/ssrf-safe-request-opts))))
+  (testing "pins the resolver to public addresses (rejects loopback via localhost, no network)"
+    (is (thrown? ExceptionInfo
+                 (.resolve ^org.apache.http.conn.DnsResolver
+                           (:dns-resolver http/ssrf-safe-request-opts) "localhost")))))
 
 ;; --------------------------------------------------------------------------------------------
 ;; SSRF-hardened fetch ([[metabase.util.http/fetch-bytes]] and its helpers). Everything below is

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.util.http-test
   (:require
    [clojure.test :refer :all]
+   [metabase.config.core :as config]
    [metabase.util.http :as http])
   (:import
    (clojure.lang ExceptionInfo)
@@ -121,6 +122,29 @@
     (doseq [ip non-public-ips]
       (is (false? (boolean (http/public-address? (InetAddress/getByName ip))))
           (str "should be rejected: " ip)))))
+
+;; NOT ^:parallel -- uses with-redefs on a global var.
+(deftest allow-private-networks-toggle-test
+  (testing "with MB_ALLOW_PRIVATE_NETWORK_FETCH set, RFC1918 + IPv6 ULA are allowed..."
+    (with-redefs [http/allow-private-networks? (constantly true)]
+      (doseq [ip ["10.1.2.3" "172.16.0.1" "192.168.0.1" "fc00::1" "fd12:3456::1"]]
+        (is (true? (boolean (http/public-address? (InetAddress/getByName ip))))
+            (str "should be allowed when opted in: " ip)))
+      (testing "...but loopback, link-local (IMDS), any-local, multicast, and CGNAT stay blocked"
+        (doseq [ip ["127.0.0.1" "169.254.169.254" "0.0.0.0" "224.0.0.1" "100.64.0.1" "::1" "fe80::1"]]
+          (is (false? (boolean (http/public-address? (InetAddress/getByName ip))))
+              (str "should stay blocked even when opted in: " ip)))))))
+
+;; NOT ^:parallel -- uses with-redefs on global vars.
+(deftest allow-private-networks-cloud-clamp-test
+  (testing "the opt-in is force-disabled on Metabase Cloud, even with the env var set"
+    (with-redefs [http/hosted?       (constantly true)
+                  config/config-bool (constantly true)]
+      (is (false? (http/public-address? (InetAddress/getByName "10.0.0.5"))))))
+  (testing "self-hosted with the opt-in set enables private destinations"
+    (with-redefs [http/hosted?       (constantly false)
+                  config/config-bool (constantly true)]
+      (is (true? (http/public-address? (InetAddress/getByName "10.0.0.5")))))))
 
 (deftest ^:parallel ssrf-safe-dns-resolver-test
   (testing "the validating resolver throws when a host resolves to a non-public address"


### PR DESCRIPTION
### Description

Builds on #75205 (BE PDF), which added the shared outbound-fetch helpers in metabase.util.http (public-address?, ssrf-safe-dns-resolver, fetch-bytes). This PR routes the remaining server-side fetch flows through those helpers (retiring the old valid-host? validator) and adds one self-hosted toggle for reaching private/internal networks.

##### What changed
- All outbound-fetch callers now use the shared util.http request options / resolver instead of valid-host? (removed).
- New env opt-in MB_ALLOW_PRIVATE_NETWORK_FETCH (default off): permits RFC1918 + IPv6-ULA destinations. Gated in one place (public-address?), so every flow inherits it; force-disabled on Metabase Cloud.

##### Flows changed
- GeoJSON custom maps (fetch + save)
- OIDC SSO (discovery + token/JWKS)
- HTTP notification channel (webhooks)
- DB auth-provider — EE
- Semantic-search embeddings — EE
- Anthropic / Metabot LLM base URLs (incl. BYOK)
- PDF image fetch already used the helper; it now also honors the opt-in

### How to verify
1. Default (opt-in off): point a GeoJSON map / webhook / OIDC issuer at an internal address
   (e.g. http://10.0.0.5, http://127.0.0.1) → fetch is refused.
2. Set MB_ALLOW_PRIVATE_NETWORK_FETCH=true (self-hosted) + restart → RFC1918 hosts (10.x, 192.168.x)
   now fetch; loopback, link-local/metadata (169.254.169.254), and CGNAT stay refused.
3. Public hosts work in both modes. Unit coverage: metabase.util.http-test.
2. Closes #… — decide deliberately. For a benign/pre-disclosure framing you probably don't want to link a SEC issue publicly; either omit the line or point it at a neutral tracking issue.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

