### PR TITLE
refactor(sdk): Export SdkThemeProvider from the SDK bundle

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/components/private/SdkThemeProvider/SdkThemeProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/private/SdkThemeProvider/SdkThemeProvider.tsx
@@ -1,0 +1,28 @@
+import type { PropsWithChildren } from "react";
+
+import { getWindow } from "embedding-sdk-shared/lib/get-window";
+import type { MetabaseEmbeddingTheme } from "metabase/embedding-sdk/theme";
+
+/**
+ * The bundle's theme provider, reached through the bundle global rather than
+ * imported: the package and the bundle are separate builds, so a static import
+ * would inline a second copy along with its React context.
+ *
+ * Renders children untouched until the bundle has loaded, so a consumer never
+ * waits on the theme to see its own markup.
+ */
+export const SdkThemeProvider = ({
+  theme,
+  children,
+}: PropsWithChildren<{ theme?: MetabaseEmbeddingTheme }>) => {
+  const BundleSdkThemeProvider =
+    getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.SdkThemeProvider;
+
+  if (!BundleSdkThemeProvider) {
+    return <>{children}</>;
+  }
+
+  return (
+    <BundleSdkThemeProvider theme={theme}>{children}</BundleSdkThemeProvider>
+  );
+};

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-dev/components/DataAppDevProvider/DataAppDevProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-dev/components/DataAppDevProvider/DataAppDevProvider.tsx
@@ -1,6 +1,7 @@
 import { once } from "underscore";
 
 import type { MetabaseProviderProps } from "embedding-sdk-bundle/types/metabase-provider";
+import { SdkThemeProvider } from "embedding-sdk-package/components/private/SdkThemeProvider/SdkThemeProvider";
 import { MetabaseProvider } from "embedding-sdk-package/components/public/MetabaseProvider/MetabaseProvider";
 import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 
@@ -14,14 +15,6 @@ export type DataAppDevProviderProps = MetabaseProviderProps & {
   appSlug: string;
 };
 
-/**
- * Provider for the data-app local dev preview (`npm run dev`). Wraps
- * `MetabaseProvider` and reports the page's traffic as the data app, so query
- * executions are attributed to the app (as "data-app-preview") instead of the
- * React SDK.
- *
- * Intended only for the local Vite dev server.
- */
 export const DataAppDevProvider = ({
   appSlug,
   children,
@@ -29,5 +22,9 @@ export const DataAppDevProvider = ({
 }: DataAppDevProviderProps) => {
   registerDataAppDevContext(appSlug);
 
-  return <MetabaseProvider {...props}>{children}</MetabaseProvider>;
+  return (
+    <MetabaseProvider {...props}>
+      <SdkThemeProvider theme={props.theme}>{children}</SdkThemeProvider>
+    </MetabaseProvider>
+  );
 };

--- a/frontend/src/embedding-sdk-bundle/sdk-bundle-exports.ts
+++ b/frontend/src/embedding-sdk-bundle/sdk-bundle-exports.ts
@@ -3,6 +3,7 @@
 import type { MetabaseEmbeddingSdkBundleExports } from "./types/sdk-bundle";
 
 import { MetabotSubscriber } from "./components/private/MetabotSubscriber/MetabotSubscriber";
+import { SdkThemeProvider } from "./components/private/SdkThemeProvider";
 import { CollectionBrowser } from "./components/public/CollectionBrowser";
 import { CreateDashboardModal } from "./components/public/CreateDashboardModal";
 import { CreateQuestion } from "./components/public/CreateQuestion";
@@ -67,6 +68,7 @@ export const sdkBundleExports: MetabaseEmbeddingSdkBundleExports = {
   useLogVersionInfo,
   validateFunctionSchema,
   MetabotSubscriber,
+  SdkThemeProvider,
   queryDataset,
   queryQuestion,
   dataAppRouting,

--- a/frontend/src/embedding-sdk-bundle/types/sdk-bundle.ts
+++ b/frontend/src/embedding-sdk-bundle/types/sdk-bundle.ts
@@ -1,6 +1,7 @@
 import type { JSXElementConstructor } from "react";
 
 import type { MetabotSubscriber } from "embedding-sdk-bundle/components/private/MetabotSubscriber/MetabotSubscriber";
+import type { SdkThemeProvider } from "embedding-sdk-bundle/components/private/SdkThemeProvider";
 import type { CollectionBrowser } from "embedding-sdk-bundle/components/public/CollectionBrowser";
 import type { ComponentProvider } from "embedding-sdk-bundle/components/public/ComponentProvider";
 import type { CreateDashboardModal } from "embedding-sdk-bundle/components/public/CreateDashboardModal";
@@ -127,4 +128,5 @@ type SchemaValidationUtils = {
 
 type InternalComponentExports = {
   MetabotSubscriber: typeof MetabotSubscriber;
+  SdkThemeProvider: typeof SdkThemeProvider;
 };


### PR DESCRIPTION
Export SdkThemeProvider from the SDK bundle

It is needed in DataAppDevProvider

For regular production DataAppProvider we already wrap whole children tree in SdkThemeProvider

In DataAppDevProvider there's a gap - we didn't do it. Each SDK component also adds it (a single copy present only), but if there are no SDK components - nothing adds it. It was not the issue, but for DevToolBar it'd be nice to use proper theme CSS variables from MB, so this PR adds SdkThemeProvider inside DataAppDevProvider