### PR TITLE
Match CSP port semantics in the data-app sandbox allowlist

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/allowed-hosts.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/allowed-hosts.ts
@@ -31,7 +31,7 @@ interface AllowedOrigin {
   protocol: string; // "https:" | "http:"
   wildcard: boolean; // entry was "*.host"
   host: string; // "example.com" (without the leading "*." when wildcard)
-  port: string; // "" means "any port" (the entry omitted one)
+  port: string; // "" is the scheme's default port, as in CSP — not "any port"
 }
 
 /**
@@ -63,7 +63,9 @@ function parseAllowedOrigin(entry: string): AllowedOrigin | null {
   if (!isRawHttpOrigin(url)) {
     return null;
   }
+
   const wildcard = url.hostname.startsWith("*.");
+
   return {
     protocol: url.protocol,
     wildcard,
@@ -76,11 +78,13 @@ function originMatches(url: URL, origin: AllowedOrigin): boolean {
   if (url.protocol !== origin.protocol) {
     return false;
   }
-  // An entry without a port matches any port; with one, it must match exactly.
-  if (origin.port && url.port !== origin.port) {
+
+  if (url.port !== origin.port) {
     return false;
   }
+
   const host = url.hostname.toLowerCase();
+
   // `*.example.com` matches any subdomain but not the apex (same as CSP).
   return origin.wildcard
     ? host.endsWith(`.${origin.host}`)
@@ -90,6 +94,7 @@ function originMatches(url: URL, origin: AllowedOrigin): boolean {
 export function isHostAllowed(url: URL, allowedHosts: string[]): boolean {
   return allowedHosts.some((entry) => {
     const origin = parseAllowedOrigin(entry);
+
     return origin ? originMatches(url, origin) : false;
   });
 }
@@ -99,15 +104,18 @@ function toUrl(input: unknown, base: string): URL | null {
     if (typeof input === "string") {
       return new URL(input, base);
     }
+
     if (input instanceof URL) {
       return new URL(input.href, base);
     }
+
     if (typeof Request !== "undefined" && input instanceof Request) {
       return new URL(input.url, base);
     }
   } catch {
     // unparseable → treated as not-allowed by the callers below
   }
+
   return null;
 }
 
@@ -130,13 +138,15 @@ function blockedReason(
   if (!url) {
     return "an unparseable URL";
   }
+
   if (url.origin === metabaseOrigin) {
-    // eslint-disable-next-line metabase/no-literal-metabase-strings -- developer-facing sandbox diagnostic, not localized UI
-    return `${url.origin} (the Metabase origin is reachable only via the SDK)`;
+    return `${url.origin} (the instance origin is reachable only via the SDK)`;
   }
+
   if (!isHostAllowed(url, allowedHosts)) {
     return `${url.host} (not in allowed_hosts)`;
   }
+
   return null;
 }
 
@@ -153,16 +163,20 @@ export function makeSandboxFetch(
   if (allowedHosts.length === 0) {
     return null;
   }
+
   const realFetch = targetWindow.fetch.bind(targetWindow);
   const base = targetWindow.location.href;
   const metabaseOrigin = targetWindow.location.origin;
+
   return function dataAppFetch(input: RequestInfo | URL, init?: RequestInit) {
     const reason = blockedReason(input, base, allowedHosts, metabaseOrigin);
+
     if (reason) {
       return Promise.reject(
         new Error(`[data-app ${label}] blocked fetch to ${reason}`),
       );
     }
+
     return realFetch(input, init);
   };
 }
@@ -180,6 +194,7 @@ export function makeSandboxXhr(
   if (allowedHosts.length === 0) {
     return null;
   }
+
   const NativeXhr = targetWindow.XMLHttpRequest;
   const base = targetWindow.location.href;
   const metabaseOrigin = targetWindow.location.origin;
@@ -192,6 +207,7 @@ export function makeSandboxXhr(
       password?: string | null,
     ): void {
       const reason = blockedReason(url, base, allowedHosts, metabaseOrigin);
+
       if (reason) {
         throw new Error(
           `[data-app ${label}] blocked XMLHttpRequest to ${reason}`,
@@ -200,6 +216,7 @@ export function makeSandboxXhr(
       super.open(method, url, async, username, password);
     }
   };
+
   // The subclass inherits the static UNSENT/OPENED/… constants at runtime;
   // cast so the type matches the native constructor the membrane expects.
   return SandboxXhr as typeof XMLHttpRequest;

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/allowed-hosts.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/allowed-hosts.unit.spec.ts
@@ -38,7 +38,7 @@ describe("isHostAllowed", () => {
     expect(isHostAllowed(u("https://notexample.com/"), allow)).toBe(false);
   });
 
-  it("matches an explicit port exactly; an entry without a port matches any", () => {
+  it("matches an explicit port exactly", () => {
     expect(
       isHostAllowed(u("https://api.example.com:8443/"), [
         "https://api.example.com:8443",
@@ -49,11 +49,21 @@ describe("isHostAllowed", () => {
         "https://api.example.com:8443",
       ]),
     ).toBe(false);
-    // an entry without a port matches any port
+  });
+
+  it("does not treat a portless entry as any port, as CSP does not", () => {
+    // The browser evaluates the same `allowed_hosts` through `connect-src`,
+    // where a host-source without a port means the scheme's default port only.
+    // Allowing any port here would let the sandbox fire a request the browser
+    // then blocks — reported as a CSP violation, sending the author after the
+    // wrong fix.
     expect(
       isHostAllowed(u("https://api.example.com:8443/"), [
         "https://api.example.com",
       ]),
+    ).toBe(false);
+    expect(
+      isHostAllowed(u("https://api.example.com/"), ["https://api.example.com"]),
     ).toBe(true);
   });
 
@@ -120,11 +130,11 @@ describe("makeSandboxFetch", () => {
     )!;
 
     await expect(sandboxFetch(`${origin}/api/user/current`)).rejects.toThrow(
-      /Metabase origin/,
+      /reachable only via the SDK/,
     );
     // A relative URL resolves to the Metabase origin too.
     await expect(sandboxFetch("/api/user/current")).rejects.toThrow(
-      /Metabase origin/,
+      /reachable only via the SDK/,
     );
     expect(realFetch).not.toHaveBeenCalled();
   });
@@ -162,10 +172,10 @@ describe("makeSandboxXhr", () => {
     )!;
     const xhr = new SandboxXhr();
     expect(() => xhr.open("GET", `${mbOrigin}/api/user/current`)).toThrow(
-      /Metabase origin/,
+      /reachable only via the SDK/,
     );
     expect(() => xhr.open("GET", "/api/user/current")).toThrow(
-      /Metabase origin/,
+      /reachable only via the SDK/,
     );
   });
 });


### PR DESCRIPTION
fixes EMB-1919

This PR just a bit corrects allowed hosts logic to match BE logic