### PR TITLE
Dont add previous stage sql as source query for cached query sql

### DIFF
--- a/src/metabase/driver/sql_mbql5.clj
+++ b/src/metabase/driver/sql_mbql5.clj
@@ -60,6 +60,8 @@
    (reduce
     (fn [[prev-hsql prev-stage] stage]
       [(cond->> (stage->honeysql driver stage)
+         ;; We don't add the source query if the stage is persisted, because the persisted query
+         ;; is already all of the previous stages materialized from the cached table
          (and prev-hsql (not (:persisted-info/native stage)))
          (add-source-query driver prev-stage prev-hsql))
        stage])

--- a/src/metabase/driver/sql_mbql5.clj
+++ b/src/metabase/driver/sql_mbql5.clj
@@ -45,7 +45,7 @@
    (reduce
     (fn [[prev-hsql prev-stage] stage]
       (let [stage-hsql (stage->honeysql driver stage)]
-        (if prev-hsql
+        (if (and prev-hsql (not (:persisted-info/native stage)))
           (let [table-alias (sql.qp/->honeysql driver (h2x/identifier :table-alias sql.qp/source-query-alias))
                 columns-metadata (get-in prev-stage [:lib/stage-metadata :columns])
                 desired-aliases (mapv :lib/desired-column-alias columns-metadata)

--- a/src/metabase/driver/sql_mbql5.clj
+++ b/src/metabase/driver/sql_mbql5.clj
@@ -28,6 +28,21 @@
       driver-api/add-alias-info
       :stages))
 
+(defn- add-source-query [driver prev-stage prev-hsql stage-hsql]
+  (let [table-alias (sql.qp/->honeysql driver (h2x/identifier :table-alias sql.qp/source-query-alias))
+        columns-metadata (get-in prev-stage [:lib/stage-metadata :columns])
+        desired-aliases (mapv :lib/desired-column-alias columns-metadata)
+        cur-hsql (cond-> (assoc stage-hsql :from [[prev-hsql [table-alias]]])
+                   (sql.qp/needs-cte-for-duplicate-cols? columns-metadata)
+                   (assoc :with [[[sql.qp/source-query-alias {:columns (mapv #(h2x/identifier :field %) desired-aliases)}]
+                                  prev-hsql]]
+                          :from [[table-alias]])
+
+                   ;; Clear the default select if it's just :* so add-default-select can recompute it
+                   (= (:select stage-hsql) [[:*]])
+                   (dissoc :select))]
+    (#'sql.qp/add-default-select driver cur-hsql)))
+
 (defn- stage->honeysql [driver stage]
   (cond
     (:persisted-info/native stage)
@@ -44,22 +59,10 @@
   (first
    (reduce
     (fn [[prev-hsql prev-stage] stage]
-      (let [stage-hsql (stage->honeysql driver stage)]
-        (if (and prev-hsql (not (:persisted-info/native stage)))
-          (let [table-alias (sql.qp/->honeysql driver (h2x/identifier :table-alias sql.qp/source-query-alias))
-                columns-metadata (get-in prev-stage [:lib/stage-metadata :columns])
-                desired-aliases (mapv :lib/desired-column-alias columns-metadata)
-                cur-hsql (cond-> (assoc stage-hsql :from [[prev-hsql [table-alias]]])
-                           (sql.qp/needs-cte-for-duplicate-cols? columns-metadata)
-                           (assoc :with [[[sql.qp/source-query-alias {:columns (mapv #(h2x/identifier :field %) desired-aliases)}]
-                                          prev-hsql]]
-                                  :from [[table-alias]])
-
-                           ;; Clear the default select if it's just :* so add-default-select can recompute it
-                           (= (:select stage-hsql) [[:*]])
-                           (dissoc :select))]
-            [(#'sql.qp/add-default-select driver cur-hsql) stage])
-          [stage-hsql stage])))
+      [(cond->> (stage->honeysql driver stage)
+         (and prev-hsql (not (:persisted-info/native stage)))
+         (add-source-query driver prev-stage prev-hsql))
+       stage])
     [nil nil]
     stages)))
 

--- a/test/metabase/query_processor/persistence_test.clj
+++ b/test/metabase/query_processor/persistence_test.clj
@@ -290,9 +290,9 @@
               count-col   (m/find-first #(= (:name %) "count")
                                         (lib/filterable-columns base-query))
               multi-stage-query (lib/filter base-query (lib/> count-col 5))]
-          (doseq [[description model-query] [["Persisted models with custom columns can be used as a source (#78240)" custom-col-query]
-                                             ["Persisted multi-stage models can be used as a source (#78240)" multi-stage-query]]]
-            (testing description
+          (doseq [[description model-query] [["custom columns" custom-col-query]
+                                             ["multiple stages" multi-stage-query]]]
+            (testing (format "Persisted models with %s can be used as a source (#72480)" description)
               (mt/with-temp [:model/Card model {:type          :model
                                                 :database_id   (mt/id)
                                                 :query_type    :query

--- a/test/metabase/query_processor/persistence_test.clj
+++ b/test/metabase/query_processor/persistence_test.clj
@@ -269,42 +269,42 @@
                              {:source-table (mt/id :products)}))))))))))))
 
 (deftest persisted-models-multi-stage-test
-  (testing "Persisted models with custom columns can be used as a source (#78240)"
-    (mt/test-drivers (mt/normal-drivers-with-feature :persist-models)
-      (mt/dataset test-data
-        (mt/with-persistence-enabled! [persist-models!]
-          (let [mp           (mt/metadata-provider)]
-            (are [model-query] (mt/with-temp [:model/Card model {:type          :model
-                                                                 :database_id   (mt/id)
-                                                                 :query_type    :query
-                                                                 :dataset_query model-query}]
-                                 (persist-models!)
-                                 (let [model-id (:id model)
-                                       query (-> (lib/query mp (lib.metadata/card mp model-id))
-                                                 (lib/limit 3))
-                                       results          (qp/process-query query)
-                                       persisted-schema (ddl.i/schema-name (mt/db) (system/site-uuid))]
-                                   (testing "Was persisted"
-                                     (is (str/includes? (-> results :data :native_form :query) persisted-schema)))
-                                   (testing "Query returns rows"
-                                     (is (= 3 (count (mt/rows results)))))))
-              (let [orders       (lib.metadata/table mp (mt/id :orders))
-                    total        (lib.metadata/field mp (mt/id :orders :total))
-                    ;; single stage, but nest-expressions splits it during SQL compilation
-                    base-query   (-> (lib/query mp orders)
-                                     (lib/expression "double_total" (lib/* total 2)))
-                    double-total (m/find-first #(= (:name %) "double_total")
-                                               (lib/breakoutable-columns base-query))]
-                (-> base-query
-                    (lib/aggregate (lib/count))
-                    (lib/breakout double-total)))
-              (let [orders      (lib.metadata/table mp (mt/id :orders))
-                    product-id  (lib.metadata/field mp (mt/id :orders :product_id))
-                    ;; two stages: summarize count by product-id, then filter in a new stage
-                    base-query  (-> (lib/query mp orders)
-                                    (lib/aggregate (lib/count))
-                                    (lib/breakout product-id)
-                                    lib/append-stage)
-                    count-col   (m/find-first #(= (:name %) "count")
-                                              (lib/filterable-columns base-query))]
-                (lib/filter base-query (lib/> count-col 5))))))))))
+  (mt/test-drivers (mt/normal-drivers-with-feature :persist-models)
+    (mt/dataset test-data
+      (mt/with-persistence-enabled! [persist-models!]
+        (let [mp (mt/metadata-provider)
+              orders       (lib.metadata/table mp (mt/id :orders))
+              total        (lib.metadata/field mp (mt/id :orders :total))
+              base-query   (-> (lib/query mp orders)
+                               (lib/expression "double_total" (lib/* total 2)))
+              double-total (m/find-first #(= (:name %) "double_total")
+                                         (lib/breakoutable-columns base-query))
+              custom-col-query (-> base-query
+                                   (lib/aggregate (lib/count))
+                                   (lib/breakout double-total))
+              product-id  (lib.metadata/field mp (mt/id :orders :product_id))
+              base-query  (-> (lib/query mp orders)
+                              (lib/aggregate (lib/count))
+                              (lib/breakout product-id)
+                              lib/append-stage)
+              count-col   (m/find-first #(= (:name %) "count")
+                                        (lib/filterable-columns base-query))
+              multi-stage-query (lib/filter base-query (lib/> count-col 5))]
+          (doseq [[description model-query] [["Persisted models with custom columns can be used as a source (#78240)" custom-col-query]
+                                             ["Persisted multi-stage models can be used as a source (#78240)" multi-stage-query]]]
+            (testing description
+              (mt/with-temp [:model/Card model {:type          :model
+                                                :database_id   (mt/id)
+                                                :query_type    :query
+                                                :dataset_query model-query}]
+                (persist-models!)
+                (let [card-mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+                      model-id (:id model)
+                      query (-> (lib/query card-mp (lib.metadata/card card-mp model-id))
+                                (lib/limit 3))
+                      results          (qp/process-query query)
+                      persisted-schema (ddl.i/schema-name (mt/db) (system/site-uuid))]
+                  (testing "Was persisted"
+                    (is (str/includes? (-> results :data :native_form :query) persisted-schema)))
+                  (testing "Query returns rows"
+                    (is (= 3 (count (mt/rows results))))))))))))))

--- a/test/metabase/query_processor/persistence_test.clj
+++ b/test/metabase/query_processor/persistence_test.clj
@@ -270,41 +270,40 @@
 
 (deftest persisted-models-multi-stage-test
   (mt/test-drivers (mt/normal-drivers-with-feature :persist-models)
-    (mt/dataset test-data
-      (mt/with-persistence-enabled! [persist-models!]
-        (let [mp (mt/metadata-provider)
-              orders       (lib.metadata/table mp (mt/id :orders))
-              total        (lib.metadata/field mp (mt/id :orders :total))
-              base-query   (-> (lib/query mp orders)
-                               (lib/expression "double_total" (lib/* total 2)))
-              double-total (m/find-first #(= (:name %) "double_total")
-                                         (lib/breakoutable-columns base-query))
-              custom-col-query (-> base-query
-                                   (lib/aggregate (lib/count))
-                                   (lib/breakout double-total))
-              product-id  (lib.metadata/field mp (mt/id :orders :product_id))
-              base-query  (-> (lib/query mp orders)
-                              (lib/aggregate (lib/count))
-                              (lib/breakout product-id)
-                              lib/append-stage)
-              count-col   (m/find-first #(= (:name %) "count")
-                                        (lib/filterable-columns base-query))
-              multi-stage-query (lib/filter base-query (lib/> count-col 5))]
-          (doseq [[description model-query] [["custom columns" custom-col-query]
-                                             ["multiple stages" multi-stage-query]]]
-            (testing (format "Persisted models with %s can be used as a source (#72480)" description)
-              (mt/with-temp [:model/Card model {:type          :model
-                                                :database_id   (mt/id)
-                                                :query_type    :query
-                                                :dataset_query model-query}]
-                (persist-models!)
-                (let [card-mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
-                      model-id (:id model)
-                      query (-> (lib/query card-mp (lib.metadata/card card-mp model-id))
-                                (lib/limit 3))
-                      results          (qp/process-query query)
-                      persisted-schema (ddl.i/schema-name (mt/db) (system/site-uuid))]
-                  (testing "Was persisted"
-                    (is (str/includes? (-> results :data :native_form :query) persisted-schema)))
-                  (testing "Query returns rows"
-                    (is (= 3 (count (mt/rows results))))))))))))))
+    (mt/with-persistence-enabled! [persist-models!]
+      (let [mp (mt/metadata-provider)
+            orders       (lib.metadata/table mp (mt/id :orders))
+            total        (lib.metadata/field mp (mt/id :orders :total))
+            base-query   (-> (lib/query mp orders)
+                             (lib/expression "double_total" (lib/* total 2)))
+            double-total (m/find-first #(= (:name %) "double_total")
+                                       (lib/breakoutable-columns base-query))
+            custom-col-query (-> base-query
+                                 (lib/aggregate (lib/count))
+                                 (lib/breakout double-total))
+            product-id  (lib.metadata/field mp (mt/id :orders :product_id))
+            base-query  (-> (lib/query mp orders)
+                            (lib/aggregate (lib/count))
+                            (lib/breakout product-id)
+                            lib/append-stage)
+            count-col   (m/find-first #(= (:name %) "count")
+                                      (lib/filterable-columns base-query))
+            multi-stage-query (lib/filter base-query (lib/> count-col 5))]
+        (doseq [[description model-query] [["custom columns" custom-col-query]
+                                           ["multiple stages" multi-stage-query]]]
+          (testing (format "Persisted models with %s can be used as a source (#72480)" description)
+            (mt/with-temp [:model/Card model {:type          :model
+                                              :database_id   (mt/id)
+                                              :query_type    :query
+                                              :dataset_query model-query}]
+              (persist-models!)
+              (let [card-mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+                    model-id (:id model)
+                    query (-> (lib/query card-mp (lib.metadata/card card-mp model-id))
+                              (lib/limit 3))
+                    results          (qp/process-query query)
+                    persisted-schema (ddl.i/schema-name (mt/db) (system/site-uuid))]
+                (testing "Was persisted"
+                  (is (str/includes? (-> results :data :native_form :query) persisted-schema)))
+                (testing "Query returns rows"
+                  (is (= 3 (count (mt/rows results)))))))))))))

--- a/test/metabase/query_processor/persistence_test.clj
+++ b/test/metabase/query_processor/persistence_test.clj
@@ -8,6 +8,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [honey.sql :as sql]
+   [medley.core :as m]
    [metabase.driver :as driver]
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.driver.sql.query-processor :as sql.qp]
@@ -266,3 +267,44 @@
                 (testing "Returns nil when card-id is not present"
                   (is (nil? (#'sql.qp/resolve-persisted-source-sql
                              {:source-table (mt/id :products)}))))))))))))
+
+(deftest persisted-models-multi-stage-test
+  (testing "Persisted models with custom columns can be used as a source (#78240)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :persist-models)
+      (mt/dataset test-data
+        (mt/with-persistence-enabled! [persist-models!]
+          (let [mp           (mt/metadata-provider)]
+            (are [model-query] (mt/with-temp [:model/Card model {:type          :model
+                                                                 :database_id   (mt/id)
+                                                                 :query_type    :query
+                                                                 :dataset_query model-query}]
+                                 (persist-models!)
+                                 (let [model-id (:id model)
+                                       query (-> (lib/query mp (lib.metadata/card mp model-id))
+                                                 (lib/limit 3))
+                                       results          (qp/process-query query)
+                                       persisted-schema (ddl.i/schema-name (mt/db) (system/site-uuid))]
+                                   (testing "Was persisted"
+                                     (is (str/includes? (-> results :data :native_form :query) persisted-schema)))
+                                   (testing "Query returns rows"
+                                     (is (= 3 (count (mt/rows results)))))))
+              (let [orders       (lib.metadata/table mp (mt/id :orders))
+                    total        (lib.metadata/field mp (mt/id :orders :total))
+                    ;; single stage, but nest-expressions splits it during SQL compilation
+                    base-query   (-> (lib/query mp orders)
+                                     (lib/expression "double_total" (lib/* total 2)))
+                    double-total (m/find-first #(= (:name %) "double_total")
+                                               (lib/breakoutable-columns base-query))]
+                (-> base-query
+                    (lib/aggregate (lib/count))
+                    (lib/breakout double-total)))
+              (let [orders      (lib.metadata/table mp (mt/id :orders))
+                    product-id  (lib.metadata/field mp (mt/id :orders :product_id))
+                    ;; two stages: summarize count by product-id, then filter in a new stage
+                    base-query  (-> (lib/query mp orders)
+                                    (lib/aggregate (lib/count))
+                                    (lib/breakout product-id)
+                                    lib/append-stage)
+                    count-col   (m/find-first #(= (:name %) "count")
+                                              (lib/filterable-columns base-query))]
+                (lib/filter base-query (lib/> count-col 5))))))))))

--- a/test/metabase/query_processor/persistence_test.clj
+++ b/test/metabase/query_processor/persistence_test.clj
@@ -298,10 +298,9 @@
                                               :dataset_query model-query}]
               (persist-models!)
               (let [card-mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
-                    model-id (:id model)
-                    query (-> (lib/query card-mp (lib.metadata/card card-mp model-id))
-                              (lib/limit 3))
-                    results          (qp/process-query query)
+                    results (-> (lib/query card-mp (lib.metadata/card card-mp (:id model)))
+                                (lib/limit 3)
+                                (qp/process-query))
                     persisted-schema (ddl.i/schema-name (mt/db) (system/site-uuid))]
                 (testing "Was persisted"
                   (is (str/includes? (-> results :data :native_form :query) persisted-schema)))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/78240

### Description

When compiling a query that had a persisted model as a non-first stage, we were incorrectly adding the previous stage SQL as the source query to the cached query. This resulted in invalid SQL like

```
select * from "metabase_cache"."some_persisted_model"
SELECT "__mb_source".* FROM (SELECT ...) AS "__mb_source"
```

This can happen when you have a multi-stage model (e.g. filter after summarize), or a single stage model that preprocessing splits into multiple stages (e.g. custom column used in a breakout), and affects any driver inheriting from `:sql-mbql5`. 

If we have a cached query then we shouldn't add the previous stage as a source query (because the cached query materializes the results of all the previous stages). So the fix in this PR is to add that as a check before we add the source query: `(if prev-hsql)` becomes `(if (and prev-hsql (not (:persisted-info/native stage))))`. The rest of the changes are just refactoring. Open to suggestions on the readability of this refactoring. 

### How to verify

See the repro steps in the original issue. The queries should use the cached query and return results. 

### Demo

https://www.loom.com/share/b2b47daba7444cf0a4bac99f5993b092

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
