### PR TITLE
Enable GLM-5.2 and Deepseek V4 Pro via OpenRouter

### DIFF
--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -148,6 +148,7 @@
    "anthropic/claude-sonnet-4.6" "Claude Sonnet 4.6"
    "anthropic/claude-sonnet-4.5" "Claude Sonnet 4.5"
    "anthropic/claude-haiku-4.5"  "Claude Haiku 4.5"
+   "deepseek/deepseek-v4-pro"    "DeepSeek V4 Pro"
    "openai/gpt-5.6-sol"          "GPT-5.6 Sol"
    "openai/gpt-5.6-terra"        "GPT-5.6 Terra"
    "openai/gpt-5.6-luna"         "GPT-5.6 Luna"
@@ -155,7 +156,8 @@
    "openai/gpt-5.5-pro"          "GPT-5.5 Pro"
    "openai/gpt-5.4"              "GPT-5.4"
    "openai/gpt-5.4-pro"          "GPT-5.4 Pro"
-   "openai/gpt-5.4-mini"         "GPT-5.4 Mini"})
+   "openai/gpt-5.4-mini"         "GPT-5.4 Mini"
+   "z-ai/glm-5.2"                "GLM-5.2"})
 
 (defn- supported-model?
   "Whether a `/v1/models` catalog entry is one of the [[supported-models]]."


### PR DESCRIPTION
Closes [BOT-1896: Ship OpenRouter support for GLM and DeepSeek](https://linear.app/metabase/issue/BOT-1896/ship-openrouter-support-for-glm-and-deepseek)

### Description

Add `z.ai/glm-5.2` and `deepseek/deepseek-v4-pro` to OpenRouter's `supported-models`

The attached PR-Env is configured with GLM-5.2

Mean score for various run of evals suite `canonical` benchmarks.
For details see: [BOT-1852: Sanity test / PoC the identified open models via OpenRouter support](https://linear.app/metabase/issue/BOT-1852/sanity-test-poc-the-identified-open-models-via-openrouter-support)

| Rank | Model | Mean Pass % | Soft raw (mean) |
| -- | -- | -- | -- |
| 1 | claude-sonnet-4.6 | 65.9 | 0.690 |
| 2 | z-ai-glm-5.2 | 63.0 | 0.642 |
| 3 | deepseek-v3.2  | 60.9 | 0.643 |
| 4 | moonshotai-kimi-k2.6 | 56.6 | 0.556 |
| 5 | qwen-3.6-35b-a3b | 56.1 | 0.518 |

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
