### PR TITLE
Slack PDFs - send using channels query param for DMs

### DIFF
--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -162,8 +162,7 @@
       (slack/upload-file-to-channel! (:bytes pdf) (:filename pdf) channel (:comment pdf))
       (catch Throwable e
         (log/error e "Error sharing dashboard subscription PDF to Slack; posting summary without the PDF")
-        ;; A DM already delivers the caption as the message that opens the conversation, so don't re-post it.
-        (when (and (:comment pdf) (not (::slack/caption-already-posted? (ex-data e))))
+        (when (:comment pdf)
           (slack/post-chat-message! {:channel channel :text (:comment pdf)}))))))
 
 ;; ------------------------------------------------------------------------------------------------;;

--- a/src/metabase/channel/slack.clj
+++ b/src/metabase/channel/slack.clj
@@ -260,13 +260,15 @@
                 (recur)))))))))
 
 (defn complete!
-  "Completes the file upload to a Slack channel by calling the `files.completeUploadExternal` endpoint, and polls the
-   same endpoint until the file is uploaded to the channel. Returns the URL of the uploaded file."
-  [& {:keys [file-id filename channel-id initial-comment]}]
+  "Completes the file upload by calling the `files.completeUploadExternal` endpoint, and polls the same endpoint until
+   the file is uploaded. Returns the URL of the uploaded file. Shares into a channel via `channel-id`, or with a user
+   via `user-id` — `channel_id` rejects user IDs, while `channels` takes them and opens the DM itself."
+  [& {:keys [file-id filename channel-id user-id initial-comment]}]
   (let [complete! (fn []
                     (POST "files.completeUploadExternal"
                       {:query-params (cond-> {:files (json/encode [{:id file-id, :title filename}])}
                                        channel-id      (assoc :channel_id channel-id)
+                                       user-id         (assoc :channels user-id)
                                        initial-comment (assoc :initial_comment initial-comment))}))
         complete-response
         (try
@@ -324,37 +326,28 @@
     (catch Throwable e
       (log/warnf e "Could not join Slack channel %s; a file share may fail" channel-id))))
 
-(declare post-chat-message!)
-
 (def ^:private slack-user-id-pattern
-  "Slack user IDs start with U (people) or W (Enterprise Grid). Unlike channel IDs (C/G/D/Z), they are rejected by
-  `files.completeUploadExternal`, so a file shared with a user must target their DM channel instead."
+  "Slack user IDs start with U (people) or W (Enterprise Grid). They are rejected by `files.completeUploadExternal`'s
+  `channel_id`, so a file shared with a user goes through its `channels` parameter instead."
   #"^[UW][A-Z0-9]{8,}$")
 
-(defn- open-dm-channel-id!
-  "Resolve the direct-message channel ID (`D…`) for Slack user `user-id` by posting `text` via `chat.postMessage`,
-  whose response carries the opened DM's channel ID. This needs only `chat:write` (already granted), avoiding the
-  `im:write` scope `conversations.open` would require. The caller therefore shares the file into the DM *without* an
-  `initial-comment`, since `text` was already delivered as this message."
-  [user-id text]
-  (:channel (post-chat-message! {:channel user-id, :text text})))
-
 (defn- complete-upload!
-  "Get an upload URL from Slack, push the `file` bytes to it, and complete the upload — sharing into `channel-id` with
-  `initial-comment` as the message text when provided. Returns the uploaded file URL."
-  [file filename channel-id initial-comment]
+  "Get an upload URL from Slack, push the `file` bytes to it, and complete the upload — sharing it as described by
+  `share` (`{:channel-id …}` or `{:user-id …}`), with `initial-comment` as the message text when provided. Returns the
+  uploaded file URL."
+  [file filename share initial-comment]
   (let [{:keys [upload_url file_id]} (get-upload-url! filename file)]
     (upload-file-to-url! upload_url file)
-    (complete! {:file-id         file_id
-                :filename        filename
-                :channel-id      channel-id
-                :initial-comment initial-comment})))
+    (complete! (assoc share
+                      :file-id         file_id
+                      :filename        filename
+                      :initial-comment initial-comment))))
 
 (mu/defn upload-file-to-channel!
   "Upload `file` bytes to Slack and share them as a downloadable file; returns the file URL. `channel-id` may be a
   channel ID, a user ID, or a legacy display name (\"#general\"/\"@bob\") resolved via the cached channel/user list.
-  A channel is joined and gets the file with `initial-comment` (mrkdwn, optional) as its caption in one message; a
-  user is DM'd, with the caption sent as the DM opener and the file following."
+  Either way the file arrives as one message with `initial-comment` (mrkdwn, optional) as its caption. A channel is
+  joined first, since sharing into one requires membership; a user's DM is opened by Slack itself."
   ([file filename channel-id]
    (upload-file-to-channel! file filename channel-id nil))
   ([file            :- NonEmptyByteArray
@@ -364,17 +357,10 @@
    {:pre [(channel.settings/slack-configured?)]}
    (let [target (or (:id (channel.settings/find-cached-slack-channel-or-username channel-id)) channel-id)]
      (if (re-matches slack-user-id-pattern target)
-       ;; User: open the DM with the caption (chat.postMessage), then share the file — caption already sent.
-       (let [dm-channel-id (open-dm-channel-id! target (or (not-empty initial-comment) filename))]
-         (try
-           (complete-upload! file filename dm-channel-id nil)
-           (catch Throwable e
-             ;; Caption already went out as the DM opener; flag so `send!`'s fallback doesn't re-post it.
-             (throw (ex-info (ex-message e) (assoc (ex-data e) ::caption-already-posted? true) e)))))
-       ;; Channel: join (membership required), then share the file with the caption as its message.
+       (complete-upload! file filename {:user-id target} initial-comment)
        (do
          (join-channel! target)
-         (complete-upload! file filename target initial-comment))))))
+         (complete-upload! file filename {:channel-id target} initial-comment))))))
 
 (mu/defn post-chat-message!
   "Calls Slack API `chat.postMessage` endpoint and posts a message to a channel.

--- a/test/metabase/channel/impl/slack_test.clj
+++ b/test/metabase/channel/impl/slack_test.clj
@@ -51,14 +51,13 @@
           (channel/send! {:type :channel/slack}
                          {:channel "C0CHANNEL" :blocks [] :pdf pdf})
           (is (= [{:channel "C0CHANNEL" :text "the caption"}] @posted)))))
-    (testing "when sharing to a DM fails after the caption was delivered as the opener, send! does not re-post it"
+    (testing "the same fallback applies to a DM, where the caption is never posted ahead of the file"
       (let [posted (atom [])]
-        (mt/with-dynamic-fn-redefs [slack/upload-file-to-channel! (fn [& _]
-                                                                    (throw (ex-info "boom" {::slack/caption-already-posted? true})))
+        (mt/with-dynamic-fn-redefs [slack/upload-file-to-channel! (fn [& _] (throw (ex-info "boom" {})))
                                     slack/post-chat-message!      (fn [m] (swap! posted conj m))]
           (channel/send! {:type :channel/slack}
                          {:channel "U0USER123" :blocks [] :pdf pdf})
-          (is (= [] @posted)))))))
+          (is (= [{:channel "U0USER123" :text "the caption"}] @posted)))))))
 
 (deftest mkdwn-link-escaping-test
   (let [parts [{:type :card

--- a/test/metabase/channel/slack_test.clj
+++ b/test/metabase/channel/slack_test.clj
@@ -216,21 +216,18 @@
               (is (= "*Aviary KPIs*" (:initial_comment params))))))))))
 
 (deftest upload-file-to-channel!-user-dm-test
-  (testing "upload-file-to-channel! opens a DM and shares the file there when the target is a user ID"
-    ;; `files.completeUploadExternal` rejects user IDs (`U…`; its `channel_id` must match `^[CGDZ][A-Z0-9]{8,}$`), so
-    ;; a file shared with a user must target the DM channel (`D…`). We resolve it via `chat.postMessage` (which needs
-    ;; only `chat:write`) rather than `conversations.open` (which needs `im:write`).
+  (testing "upload-file-to-channel! shares the file straight to a user ID via `channels`"
+    ;; `files.completeUploadExternal` rejects a user ID in `channel_id` (`invalid_arguments`), but its `channels`
+    ;; parameter takes one and opens the DM itself — no `im:write`, and no DM need already exist (#78262).
     (let [file-bytes   (.getBytes "fake-pdf")
           filename     "dashboard.pdf"
           upload-url   "https://files.slack.com/upload/v1/CwABAAAAWgoAAZnBg"
           complete-req (atom nil)
-          post-req     (atom nil)
+          post-called? (atom false)
           open-called? (atom false)
           join-called? (atom false)
           fake-routes  {#"^https://slack.com/api/chat\.postMessage.*"
-                        (fn [req]
-                          (reset! post-req req)
-                          (mock-200-response {:ok true :channel "D0DM45678"}))
+                        (fn [_] (reset! post-called? true) (mock-200-response {:ok true :channel "D0DM45678"}))
 
                         #"^https://slack.com/api/conversations\.open.*"
                         (fn [_] (reset! open-called? true) (mock-200-response {:ok true :channel {:id "D0DM45678"}}))
@@ -255,35 +252,26 @@
         (mt/with-temporary-setting-values [slack-app-token "test-token"]
           (is (= "https://files.slack.com/files-pri/DDDDDDDDD-EEEEEEEEE/wow.gif"
                  (slack/upload-file-to-channel! file-bytes filename "U0USER123" "*Aviary KPIs*")))
-          (testing "opens the DM by posting the caption to the user ID via chat.postMessage"
-            (let [b    (:body @post-req)
-                  body (if (string? b) b (slurp b))]
-              (is (re-find #"channel=U0USER123" body))
-              (is (re-find #"Aviary" body))))
-          (testing "uses neither conversations.open (needs im:write) nor conversations.join (DMs need no membership)"
-            (is (false? @open-called?))
-            (is (false? @join-called?)))
-          (testing "shares the file into the resolved DM channel, not the raw user ID"
+          (testing "shares to the user ID itself, with the caption as the file's message"
             (let [params (parse-query-string (:query-string @complete-req))]
-              (is (= "D0DM45678" (:channel_id params)))
-              (testing "without a duplicate initial_comment (the caption was the chat.postMessage)"
-                (is (nil? (:initial_comment params)))))))))))
+              (is (= "U0USER123" (:channels params)))
+              (is (= "*Aviary KPIs*" (:initial_comment params)))
+              (testing "and never as channel_id, which rejects user IDs"
+                (is (nil? (:channel_id params))))))
+          (testing "needs no separate call to open or join the conversation"
+            (is (false? @post-called?))
+            (is (false? @open-called?))
+            (is (false? @join-called?))))))))
 
 (deftest upload-file-to-channel!-resolves-display-name-test
-  (testing "a legacy display name (\"@bob\") with no stored ID resolves to its user ID via the cache, then DMs the user"
+  (testing "a legacy display name (\"@bob\") with no stored ID resolves to its user ID via the cache, then DMs them"
     ;; Subscriptions created before channel-ID storage (GDGT-232) fall back to the display-name `:value`; "@bob" must
     ;; resolve to its `U…` ID through find-cached-slack-channel-or-username before the user-vs-channel routing.
     (let [file-bytes   (.getBytes "fake-pdf")
           filename     "dashboard.pdf"
           upload-url   "https://files.slack.com/upload/v1/CwABAAAAWgoAAZnBg"
           complete-req (atom nil)
-          post-req     (atom nil)
-          fake-routes  {#"^https://slack.com/api/chat\.postMessage.*"
-                        (fn [req]
-                          (reset! post-req req)
-                          (mock-200-response {:ok true :channel "D0BOBDM12"}))
-
-                        #"^https://slack.com/api/files\.getUploadURLExternal.*"
+          fake-routes  {#"^https://slack.com/api/files\.getUploadURLExternal.*"
                         (fn [_] (mock-200-response {:ok true :upload_url upload-url :file_id "DDDDDDDDD-EEEEEEEEE"}))
 
                         upload-url
@@ -300,12 +288,8 @@
                                                                                             :id           "U0BOB1234"
                                                                                             :type         "user"}]}]
           (slack/upload-file-to-channel! file-bytes filename "@bob" "*Aviary KPIs*")
-          (testing "posts the DM opener to the resolved user ID, not the raw \"@bob\""
-            (let [b    (:body @post-req)
-                  body (if (string? b) b (slurp b))]
-              (is (re-find #"channel=U0BOB1234" body))))
-          (testing "shares the file into the resulting DM channel"
-            (is (= "D0BOBDM12" (:channel_id (parse-query-string (:query-string @complete-req)))))))))))
+          (testing "shares to the resolved user ID, not the raw \"@bob\""
+            (is (= "U0BOB1234" (:channels (parse-query-string (:query-string @complete-req)))))))))))
 
 (deftest post-chat-message!-test
   (testing "post-chat-message!"


### PR DESCRIPTION
### Description

Updates the logic to send PDFs using the `channels` query param (which will accept a user id) rather than attempt to determine a channel ID for a direct message. The reason our old approach won't work is because unless you've sent a message to Metabot in the past there is no actual conversation to share the file into, which causes the channel_not_found exception that was being thrown. `chat.postMessage` does hand back a channel id, but it doesn't represent anything the file API can use. This new approach works because `channels` will accept user ids, which will exist regardless of whether you have started a conversation with Metabot or not.

### How to verify

It's a bit tricky, because there are situations where this could work before, but in general:
1. On the master branch, set up the slack integration with the same credentials Stats uses (find it 1Password)
2. attempt to send yourself a dashboard PDF (important that it is a DM)
3. If this fails, check this branch out and try again. It should succeed

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
