### PR TITLE
Improve Explorations sidebar empty states

### DIFF
--- a/e2e/test/scenarios/explorations/explorations.cy.spec.ts
+++ b/e2e/test/scenarios/explorations/explorations.cy.spec.ts
@@ -779,25 +779,15 @@ describe("scenarios > explorations > sidebar triage", () => {
           .findByText(`${metricName} hidden`)
           .should("be.visible");
 
-        cy.log(
-          "Initial investigation stays, expanded, with an all-hidden note",
-        );
-        sidebar()
-          .findByText("All items have been hidden.")
-          .should("be.visible");
-        sidebar()
-          .findAllByRole("group")
-          .should("have.length", 1)
-          .first()
-          .should("have.attr", "aria-expanded", "true")
-          .and("have.attr", "aria-label", "Initial investigation");
+        cy.log("All-hidden note is visible");
+        cy.findByText("All items have been hidden.").should("be.visible");
         cy.findAllByRole("treeitem").should("not.exist");
 
         cy.log("Hidden state is persisted server-side across a reload");
         cy.reload();
-        sidebar()
-          .findByText("All items have been hidden.", { timeout: 15000 })
-          .should("be.visible");
+        cy.findByText("All items have been hidden.", { timeout: 15000 }).should(
+          "be.visible",
+        );
 
         cy.log("Show hidden items + the group Show action restore the pages");
         toggleShowHiddenItems();
@@ -826,9 +816,7 @@ describe("scenarios > explorations > sidebar triage", () => {
           expect(request.body.hidden).to.eq(true);
           expect(request.body.page_ids).to.have.length(2);
         });
-        sidebar()
-          .findByText("All items have been hidden.")
-          .should("be.visible");
+        cy.findByText("All items have been hidden.").should("be.visible");
 
         cy.log("Undo on the group-hidden toast restores the whole group");
         H.undoToastListContainer()
@@ -841,7 +829,7 @@ describe("scenarios > explorations > sidebar triage", () => {
           .its("request.body.hidden")
           .should("eq", false);
         cy.findAllByRole("treeitem").should("have.length", 2);
-        sidebar().findByText("All items have been hidden.").should("not.exist");
+        cy.findByText("All items have been hidden.").should("not.exist");
       },
     );
   });

--- a/frontend/src/metabase-types/api/exploration.ts
+++ b/frontend/src/metabase-types/api/exploration.ts
@@ -316,18 +316,20 @@ export const EXPLORATION_THREAD_STATUSES = [
   "empty",
   "failed",
   "completed",
+  "forbidden",
 ] as const;
 
 /**
  * Server-derived lifecycle status for a thread. Lets the FE tell a successful run from a
  * failed/empty/canceled one (and why) instead of guessing from timestamps + query statuses.
  * `empty` means the planner had nothing applicable to chart — not an error.
+ * `forbidden` means the viewer's data-access lens is incompatible with the creator's.
  */
 export type ExplorationThreadStatus =
   (typeof EXPLORATION_THREAD_STATUSES)[number];
 
 const TERMINAL_EXPLORATION_THREAD_STATUSES: ReadonlySet<ExplorationThreadStatus> =
-  new Set(["canceled", "empty", "failed", "completed"]);
+  new Set(["canceled", "empty", "failed", "completed", "forbidden"]);
 
 /** The thread has finished — no more work will happen, so the FE can stop polling. */
 export function isTerminalExplorationThreadStatus(

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationSidebar.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationSidebar.tsx
@@ -34,12 +34,14 @@ import type { ExplorationSortOrder } from "../../sidebar-preferences";
 import { getAdjacentById, shouldIgnoreKeyboardEvent } from "../../utils";
 
 import S from "./ExplorationSidebar.module.css";
+import { ExplorationSidebarSkeleton } from "./ExplorationSidebarSkeleton";
 import {
   ExplorationTreeContext,
   type ExplorationTreeContextValue,
   ExplorationTreeNode,
 } from "./ExplorationTreeNode";
 import {
+  type ExplorationSidebarContentMode,
   type ExplorationSidebarTabsInfo,
   type ExplorationTreeNode as ExplorationTreeNodeDataType,
   flattenTree,
@@ -61,6 +63,7 @@ interface ExplorationSidebarProps {
   onToggleShowHidden: () => void;
   sortOrder: ExplorationSortOrder;
   onChangeSortOrder: (sortOrder: ExplorationSortOrder) => void;
+  contentMode: ExplorationSidebarContentMode;
 }
 
 export function ExplorationSidebar({
@@ -79,6 +82,7 @@ export function ExplorationSidebar({
   onToggleShowHidden,
   sortOrder,
   onChangeSortOrder,
+  contentMode,
 }: ExplorationSidebarProps) {
   const navigate = useNavigate();
   const treeController = useTree({
@@ -204,9 +208,6 @@ export function ExplorationSidebar({
     ],
   );
 
-  const isEmptyDueToHidden =
-    !showHidden && tree.every((node) => !node.children?.length);
-
   if (!isOpen) {
     // we still want keyboard shortcuts to work, so the component should still be mounted
     return null;
@@ -214,6 +215,56 @@ export function ExplorationSidebar({
 
   const emptyTreeMessage =
     explorationSidebarTabsInfo[selectedSidebarTab].emptyTreeMessage;
+
+  let treeContent: React.ReactNode;
+  switch (contentMode) {
+    case "loading":
+      treeContent = <ExplorationSidebarSkeleton />;
+      break;
+    case "forbidden":
+      treeContent = (
+        <Center flex={1} pl="0.5rem" pr="1rem" pb="3rem">
+          <Text fz="lg">
+            {t`You don't have permission to view these results.`}
+          </Text>
+        </Center>
+      );
+      break;
+    case "all-hidden":
+      treeContent = (
+        <Center flex={1} pl="0.5rem" pr="1rem" pb="3rem">
+          <Text
+            c="text-secondary"
+            fs="italic"
+            data-testid="exploration-all-hidden"
+          >
+            {t`All items have been hidden.`}
+          </Text>
+        </Center>
+      );
+      break;
+    case "tree":
+      treeContent = (
+        <Box flex={1} data-testid="exploration-page-sidebar" className={S.tree}>
+          <ExplorationTreeContext.Provider value={treeContextValue}>
+            <Tree
+              role="tree"
+              tree={treeController}
+              TreeNode={ExplorationTreeNode}
+              wrapNodesInListItem
+            />
+          </ExplorationTreeContext.Provider>
+        </Box>
+      );
+      break;
+    case "empty":
+      treeContent = (
+        <Center flex={1} pl="0.5rem" pr="1rem" pb="3rem">
+          <Text fz="lg">{emptyTreeMessage}</Text>
+        </Center>
+      );
+      break;
+  }
 
   return (
     <Stack h="100%" w="20%" miw="20.5rem" flex="none" mr="2rem">
@@ -248,27 +299,7 @@ export function ExplorationSidebar({
           onChangeSortOrder={onChangeSortOrder}
         />
       </Group>
-      {tree.length > 0 ? (
-        <Box flex={1} data-testid="exploration-page-sidebar" className={S.tree}>
-          <ExplorationTreeContext.Provider value={treeContextValue}>
-            <Tree
-              role="tree"
-              tree={treeController}
-              TreeNode={ExplorationTreeNode}
-              wrapNodesInListItem
-            />
-          </ExplorationTreeContext.Provider>
-          {isEmptyDueToHidden && (
-            <Text c="text-secondary" fs="italic" px="0.5rem" pl="1.75rem">
-              {t`All items have been hidden.`}
-            </Text>
-          )}
-        </Box>
-      ) : (
-        <Center flex={1} pl="0.5rem" pr="1rem" pb="3rem">
-          <Text fz="lg">{emptyTreeMessage}</Text>
-        </Center>
-      )}
+      {treeContent}
     </Stack>
   );
 }

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationSidebar.unit.spec.tsx
@@ -313,6 +313,43 @@ describe("ExplorationSidebar", () => {
       expect(screen.getByText("Nothing to see here yet.")).toBeInTheDocument();
     });
 
+    it("shows an empty failed thread heading instead of the generic empty message", () => {
+      setup({
+        queries: [],
+        thread: {
+          status: "failed",
+          completed_at: "2026-04-30T00:01:00Z",
+        },
+      });
+
+      expect(
+        screen.getByRole("group", { name: /Initial investigation/ }),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText("Failed")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Nothing to see here yet."),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows an empty canceled thread heading instead of the generic empty message", () => {
+      setup({
+        queries: [],
+        thread: {
+          status: "canceled",
+          canceled_at: "2026-04-30T00:01:00Z",
+          completed_at: "2026-04-30T00:01:00Z",
+        },
+      });
+
+      expect(
+        screen.getByRole("group", { name: /Initial investigation/ }),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText("Stopped")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Nothing to see here yet."),
+      ).not.toBeInTheDocument();
+    });
+
     it("shows a permission message when derived data is forbidden", () => {
       setup({
         queries: [],

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationSidebar.unit.spec.tsx
@@ -35,7 +35,6 @@ import {
   getSidebarTestContext,
   setup,
 } from "./test-utils";
-import { getExplorationSidebarTree } from "./utils";
 
 jest.mock("metabase/explorations/analytics");
 
@@ -168,6 +167,7 @@ describe("ExplorationSidebar", () => {
             onToggleShowHidden={jest.fn()}
             sortOrder={DEFAULT_SORT_ORDER}
             onChangeSortOrder={jest.fn()}
+            contentMode="tree"
           />
         </>
       );
@@ -241,7 +241,7 @@ describe("ExplorationSidebar", () => {
     });
   });
 
-  describe("all-hidden empty state", () => {
+  describe("empty states", () => {
     const hiddenBlock = createBlock({
       id: 1,
       name: "Revenue",
@@ -260,28 +260,88 @@ describe("ExplorationSidebar", () => {
       status: "done",
     });
 
-    it("keeps the first thread with an all-hidden note when every page is hidden", () => {
-      setup({ queries: [hiddenQuery], blocks: [hiddenBlock] });
+    it("shows the all-hidden message without thread headings when every page is hidden", () => {
+      setup({
+        queries: [hiddenQuery],
+        blocks: [hiddenBlock],
+        thread: {
+          status: "completed",
+          completed_at: "2026-04-30T00:01:00Z",
+        },
+      });
 
-      // The initial thread heading is retained, with an inline note below it.
-      expect(screen.getByText("Initial investigation")).toBeInTheDocument();
       expect(
-        screen.getByText("All items have been hidden."),
-      ).toBeInTheDocument();
-      // The childless heading renders expanded so the note reads as its content.
-      expect(
-        screen.getByRole("group", { name: /Initial investigation/ }),
-      ).toHaveAttribute("aria-expanded", "true");
+        screen.queryByText("Initial investigation"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("exploration-all-hidden")).toHaveTextContent(
+        "All items have been hidden.",
+      );
     });
 
-    it("shows the generic empty message (not the all-hidden note) when nothing is hidden yet", () => {
-      // No pages at all — e.g. an exploration still generating its charts.
-      // Nothing is hidden, so the empty state should show rather than the note.
-      setup({ queries: [] });
+    it("shows a loading skeleton while the initial thread is still running with no pages", () => {
+      setup({
+        queries: [],
+        thread: { status: "running", started_at: "2026-04-30T00:00:00Z" },
+      });
 
-      expect(screen.getByText("Nothing to see here yet.")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("exploration-sidebar-skeleton"),
+      ).toBeInTheDocument();
       expect(
         screen.queryByText("All items have been hidden."),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Nothing to see here yet."),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows the generic empty message when there is genuinely nothing to show", () => {
+      setup({
+        queries: [],
+        thread: {
+          status: "empty",
+          completed_at: "2026-04-30T00:01:00Z",
+        },
+      });
+
+      expect(
+        screen.queryByText("Initial investigation"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("All items have been hidden."),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("Nothing to see here yet.")).toBeInTheDocument();
+    });
+
+    it("shows a permission message when derived data is forbidden", () => {
+      setup({
+        queries: [],
+        thread: {
+          status: "forbidden",
+          completed_at: "2026-04-30T00:01:00Z",
+        },
+      });
+
+      expect(
+        screen.getByText("You don't have permission to view these results."),
+      ).toBeInTheDocument();
+    });
+
+    it("shows a permission message on Stars when derived data is forbidden", () => {
+      setup({
+        queries: [doneQuery],
+        thread: {
+          status: "forbidden",
+          completed_at: "2026-04-30T00:01:00Z",
+        },
+        tab: "stars",
+      });
+
+      expect(
+        screen.getByText("You don't have permission to view these results."),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("Nothing's been starred yet."),
       ).not.toBeInTheDocument();
     });
 
@@ -321,7 +381,7 @@ describe("ExplorationSidebar", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("shows the per-tab empty message on Stars even when the starred pages are merely hidden", () => {
+    it("shows the all-hidden message on Stars when the starred pages are merely hidden", () => {
       setup({
         queries: [hiddenQuery],
         blocks: [
@@ -339,16 +399,18 @@ describe("ExplorationSidebar", () => {
             ],
           }),
         ],
+        thread: {
+          status: "completed",
+          completed_at: "2026-04-30T00:01:00Z",
+        },
         tab: "stars",
       });
 
-      // Filtered tabs never show the all-hidden note — an empty tree always
-      // falls through to the tab's own empty message.
+      expect(screen.getByTestId("exploration-all-hidden")).toHaveTextContent(
+        "All items have been hidden.",
+      );
       expect(
-        screen.getByText("Nothing's been starred yet."),
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByText("All items have been hidden."),
+        screen.queryByText("Nothing's been starred yet."),
       ).not.toBeInTheDocument();
       expect(
         screen.queryByText("Initial investigation"),
@@ -389,13 +451,13 @@ describe("ExplorationSidebar", () => {
       explorationSidebarTabsInfo,
       selectedSidebarTab,
       getSelectedSidebarTabUrl,
-      treeItemFilter,
       getTree,
+      getModel,
     } = getSidebarTestContext(exploration);
     // A later poll: same block/page ids, but the query settled — a deep-different
     // tree, so `useTree`'s data-change effect runs.
-    const reloadedTree = getExplorationSidebarTree(
-      createExploration({
+    const reloadedTree = getModel({
+      explorationOverride: createExploration({
         blocks: makeBlocks(),
         queries: [
           createQuery({
@@ -406,14 +468,11 @@ describe("ExplorationSidebar", () => {
           }),
         ],
       }),
-      treeItemFilter,
-    );
+    }).tree;
 
     const path = Urls.exploration(exploration.id);
     const shouldScrollSelectionRef = { current: true };
-    const sidebarWith = (
-      tree: ReturnType<typeof getExplorationSidebarTree>,
-    ) => (
+    const sidebarWith = (tree: typeof reloadedTree) => (
       <ExplorationSidebar
         exploration={exploration}
         explorationSidebarTabsInfo={explorationSidebarTabsInfo}
@@ -430,6 +489,7 @@ describe("ExplorationSidebar", () => {
         onToggleShowHidden={jest.fn()}
         sortOrder={DEFAULT_SORT_ORDER}
         onChangeSortOrder={jest.fn()}
+        contentMode="tree"
       />
     );
 
@@ -517,7 +577,7 @@ describe("ExplorationSidebar", () => {
       } = getSidebarTestContext(exploration);
       const shouldScrollSelectionRef = { current: true };
       const sidebarWith = (
-        tree: ReturnType<typeof getExplorationSidebarTree>,
+        tree: ReturnType<typeof getTree>,
         selectedId: string,
       ) => (
         <ExplorationSidebar
@@ -536,12 +596,13 @@ describe("ExplorationSidebar", () => {
           onToggleShowHidden={jest.fn()}
           sortOrder={DEFAULT_SORT_ORDER}
           onChangeSortOrder={jest.fn()}
+          contentMode="tree"
         />
       );
       // Drive updates through in-component state so the sidebar stays mounted
       // (a router rerender would remount it and warn about changing routes).
       let applyUpdate: (next: {
-        tree: ReturnType<typeof getExplorationSidebarTree>;
+        tree: ReturnType<typeof getTree>;
         selectedId: string;
       }) => void = () => {};
       function Harness() {
@@ -558,10 +619,8 @@ describe("ExplorationSidebar", () => {
         initialRoute: path,
       });
       return {
-        rerenderWith: (
-          tree: ReturnType<typeof getExplorationSidebarTree>,
-          selectedId: string,
-        ) => act(() => applyUpdate({ tree, selectedId })),
+        rerenderWith: (tree: ReturnType<typeof getTree>, selectedId: string) =>
+          act(() => applyUpdate({ tree, selectedId })),
       };
     }
 
@@ -577,11 +636,11 @@ describe("ExplorationSidebar", () => {
           createQuery({ id: 2, name: "B leaf", status: "pending" }),
         ],
       });
-      const { treeItemFilter } = getSidebarTestContext(exploration);
+      const { getModel } = getSidebarTestContext(exploration);
       // A later poll: B's query settles with high interestingness (deep-different
       // tree), so the auto-selection moves to Group B's page.
-      const reloadedTree = getExplorationSidebarTree(
-        createExploration({
+      const reloadedTree = getModel({
+        explorationOverride: createExploration({
           blocks: twoBlocks(),
           queries: [
             createQuery({ id: 1, name: "A leaf", status: "done" }),
@@ -593,8 +652,7 @@ describe("ExplorationSidebar", () => {
             }),
           ],
         }),
-        treeItemFilter,
-      );
+      }).tree;
 
       const { rerenderWith } = renderWithTree(exploration, A_LEAF);
 
@@ -1065,6 +1123,7 @@ describe("ExplorationSidebar", () => {
               onToggleShowHidden={jest.fn()}
               sortOrder={DEFAULT_SORT_ORDER}
               onChangeSortOrder={jest.fn()}
+              contentMode="tree"
             />
           </>
         );

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationSidebarSkeleton.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationSidebarSkeleton.tsx
@@ -1,0 +1,19 @@
+import { Box, Stack } from "metabase/ui";
+
+import S from "./ExplorationTreeNode.module.css";
+
+export function ExplorationSidebarSkeleton() {
+  return (
+    <Stack
+      flex={1}
+      pl="0.5rem"
+      pb="3rem"
+      gap="sm"
+      data-testid="exploration-sidebar-skeleton"
+    >
+      {Array.from({ length: 5 }).map((_, index) => (
+        <Box key={index} className={S.skeletonRow} />
+      ))}
+    </Stack>
+  );
+}

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationTreeNode.module.css
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationTreeNode.module.css
@@ -147,6 +147,30 @@
   animation-delay: var(--shimmer-delay, 0ms);
 }
 
+.skeletonRow {
+  --shimmer-spread: 3rem;
+
+  height: 2rem;
+  border-radius: var(--default-border-radius);
+  background-size:
+    250% 100%,
+    auto;
+  background-image:
+    linear-gradient(
+      90deg,
+      transparent calc(50% - var(--shimmer-spread)),
+      var(--mb-color-background-primary),
+      transparent calc(50% + var(--shimmer-spread))
+    ),
+    linear-gradient(
+      var(--mb-color-background-tertiary),
+      var(--mb-color-background-tertiary)
+    );
+  background-position: 50%;
+  animation: exploration-shimmer 2500ms ease infinite;
+  animation-delay: var(--shimmer-delay, 0ms);
+}
+
 @keyframes exploration-shimmer {
   0% {
     background-position: 120%;

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationTreeNode.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationTreeNode.tsx
@@ -117,7 +117,6 @@ function isExplorationTreeHeadingProps(
 function ExplorationTreeHeading({
   item,
   isExpanded,
-  hasChildren,
   onToggleExpand,
   depth,
   explorationId,
@@ -125,16 +124,11 @@ function ExplorationTreeHeading({
   getSelectedPageUrl,
 }: ExplorationTreeHeadingProps) {
   const isLoading = isLoadingStatus(item.data?.status);
-  // Only the retained initial-investigation heading can be childless (pruning
-  // drops every other empty heading). The tree controller can't expand a node
-  // without children, so force the expanded look: the all-hidden note beneath
-  // then reads as the group's content rather than a collapsed group.
-  const displayExpanded = isExpanded || !hasChildren;
   return (
     <Box
       role="group"
       aria-label={item.name}
-      aria-expanded={displayExpanded}
+      aria-expanded={isExpanded}
       aria-busy={isLoading}
       className={cx(S.treeRow, S.treeRowHeading, {
         [S.treeRowNested]: depth > 0,
@@ -153,7 +147,7 @@ function ExplorationTreeHeading({
     >
       <Box className={S.treeChevron} aria-hidden>
         <Icon
-          name={displayExpanded ? "chevrondown" : "chevronright"}
+          name={isExpanded ? "chevrondown" : "chevronright"}
           size={12}
           c="text-tertiary"
         />
@@ -212,8 +206,7 @@ function ExplorationGroupMenu({
   const pageIds = useMemo(() => itemPageIds ?? [], [itemPageIds]);
   // when the whole group is already hidden, the action shows it again
   const allHidden = item.data?.allHidden === true;
-  const canHideGroup =
-    canWrite && item.data?.hideable === true && pageIds.length > 0;
+  const canHideGroup = canWrite && pageIds.length > 0;
 
   const setGroupHidden = useCallback(
     async (hidden: boolean) => {

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationTreeNode.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationTreeNode.tsx
@@ -462,12 +462,9 @@ function ExplorationHeadingIcon({
       <Icon name="octagon_alert" c="icon-primary" aria-label={t`Stopped`} />
     );
   }
-  // Thread-level failure only — metric-group headings with errored children keep
-  // their normal icon; the page rows surface the error marker.
-  if (
-    status === "error" &&
-    (headingKind === "root" || headingKind === "sub-exploration")
-  ) {
+  const isThreadNode =
+    headingKind === "root" || headingKind === "sub-exploration";
+  if (status === "error" && isThreadNode) {
     return (
       <Icon name="warning_triangle_filled" c="error" aria-label={t`Failed`} />
     );

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationTreeNode.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationTreeNode.tsx
@@ -462,6 +462,16 @@ function ExplorationHeadingIcon({
       <Icon name="octagon_alert" c="icon-primary" aria-label={t`Stopped`} />
     );
   }
+  // Thread-level failure only — metric-group headings with errored children keep
+  // their normal icon; the page rows surface the error marker.
+  if (
+    status === "error" &&
+    (headingKind === "root" || headingKind === "sub-exploration")
+  ) {
+    return (
+      <Icon name="warning_triangle_filled" c="error" aria-label={t`Failed`} />
+    );
+  }
   if (headingKind == null) {
     return null;
   }

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationTreeNode.unit.spec.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationTreeNode.unit.spec.tsx
@@ -178,17 +178,15 @@ describe("ExplorationTreeNode", () => {
       );
     });
 
-    it("does not offer Hide for the first thread group", async () => {
+    it("offers Hide for thread and metric-group headings", async () => {
       setup({ queries: [revenueQuery], blocks: [revenueBlock] });
 
-      // the first thread ("Initial investigation") is not hideable...
       await openGroupMenu(/Initial investigation/);
       expect(
-        screen.queryByRole("menuitem", { name: /Hide/ }),
-      ).not.toBeInTheDocument();
+        screen.getByRole("menuitem", { name: /Hide/ }),
+      ).toBeInTheDocument();
       await userEvent.keyboard("{Escape}");
 
-      // ...but metric sub-groups are
       await openGroupMenu(/Revenue/);
       expect(
         screen.getByRole("menuitem", { name: /Hide/ }),
@@ -802,6 +800,7 @@ describe("ExplorationTreeNode", () => {
               onToggleShowHidden={jest.fn()}
               sortOrder={DEFAULT_SORT_ORDER}
               onChangeSortOrder={jest.fn()}
+              contentMode="tree"
             />
           }
         />,

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationTreeNode.unit.spec.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/ExplorationTreeNode.unit.spec.tsx
@@ -521,6 +521,22 @@ describe("ExplorationTreeNode", () => {
       ).toBeInTheDocument();
     });
 
+    it("offers Restart on an empty failed thread (planning failed before pages)", async () => {
+      setup({
+        queries: [],
+        thread: { status: "failed", completed_at: "2026-04-30T00:01:00Z" },
+      });
+
+      expect(screen.getByLabelText("Failed")).toBeInTheDocument();
+
+      const threadHeading = findThreadMenuButton();
+      await userEvent.click(within(threadHeading!).getByRole("button"));
+
+      expect(
+        screen.getByRole("menuitem", { name: /Restart/ }),
+      ).toBeInTheDocument();
+    });
+
     it("does not offer Restart when the user lacks write access", async () => {
       setup({
         queries: [pendingQuery],

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/test-utils.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/test-utils.tsx
@@ -20,9 +20,8 @@ import type {
 
 import { ExplorationSidebar } from "./ExplorationSidebar";
 import {
+  getExplorationSidebarModel,
   getExplorationSidebarTabsInfo,
-  getExplorationSidebarTree,
-  isHiddenTreeItem,
 } from "./utils";
 
 export function getSidebarTestContext(
@@ -33,16 +32,34 @@ export function getSidebarTestContext(
   const explorationSidebarTabsInfo = getExplorationSidebarTabsInfo(exploration);
   const getSelectedSidebarTabUrl = (tab: ExplorationSidebarTab) =>
     `${path}?tab=${tab}`;
-  const treeItemFilter =
-    explorationSidebarTabsInfo[selectedSidebarTab].treeItemFilter;
 
   return {
     path,
     explorationSidebarTabsInfo,
     selectedSidebarTab,
     getSelectedSidebarTabUrl,
-    treeItemFilter,
-    getTree: () => getExplorationSidebarTree(exploration, treeItemFilter),
+    getModel: (opts?: {
+      showHidden?: boolean;
+      sortOrder?: ExplorationSortOrder;
+      explorationOverride?: ReturnType<typeof createExploration>;
+    }) =>
+      getExplorationSidebarModel({
+        exploration: opts?.explorationOverride ?? exploration,
+        selectedSidebarTab,
+        tabsInfo: getExplorationSidebarTabsInfo(
+          opts?.explorationOverride ?? exploration,
+        ),
+        showHidden: opts?.showHidden ?? false,
+        sortOrder: opts?.sortOrder ?? DEFAULT_SORT_ORDER,
+      }),
+    getTree: () =>
+      getExplorationSidebarModel({
+        exploration,
+        selectedSidebarTab,
+        tabsInfo: explorationSidebarTabsInfo,
+        showHidden: false,
+        sortOrder: DEFAULT_SORT_ORDER,
+      }).tree,
   };
 }
 
@@ -123,20 +140,13 @@ export function setup({
     explorationSidebarTabsInfo,
     selectedSidebarTab,
     getSelectedSidebarTabUrl,
-    treeItemFilter,
+    getModel,
   } = getSidebarTestContext(exploration, tab);
 
-  // Mirrors ExplorationPage: the empty initial thread (which carries the
-  // all-hidden note) is only retained when pages are actually hidden.
-  const hasHiddenPages = allPages.some((page) => page.hidden);
-  const displayTree = getExplorationSidebarTree(
-    exploration,
-    showHidden
-      ? treeItemFilter
-      : (node) => treeItemFilter(node) && !isHiddenTreeItem(node),
+  const { tree: displayTree, contentMode } = getModel({
+    showHidden,
     sortOrder,
-    { keepEmptyInitialThread: tab === "all" && hasHiddenPages },
-  );
+  });
 
   const sidebar = (
     <ExplorationSidebar
@@ -155,6 +165,7 @@ export function setup({
       onToggleShowHidden={onToggleShowHidden}
       sortOrder={sortOrder}
       onChangeSortOrder={onChangeSortOrder}
+      contentMode={contentMode}
     />
   );
 

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/utils.ts
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/utils.ts
@@ -18,6 +18,7 @@ import type {
 import {
   getExplorationPages,
   getExplorationQueryGroupStatus,
+  isTerminalExplorationThreadStatus,
 } from "metabase-types/api";
 
 import {
@@ -42,7 +43,6 @@ export interface ExplorationTreeHeading {
   thread?: ExplorationThread;
   status?: ExplorationQueryStatus;
   lastActivityAt?: string;
-  hideable?: boolean;
   pageIds?: number[];
   allHidden?: boolean;
 }
@@ -76,7 +76,7 @@ function threadHeadingStatus(
   return match(thread.status)
     .with("failed", () => "error" as const)
     .with("canceled", () => "canceled" as const)
-    .with("completed", "empty", () => "done" as const)
+    .with("completed", "empty", "forbidden", () => "done" as const)
     .with("pending", "running", () =>
       getExplorationQueryGroupStatus(thread.queries ?? []),
     )
@@ -112,15 +112,10 @@ function getHeadingHideState(nodes: ITreeNodeItem<ExplorationTreeNode>[]): {
   };
 }
 
-interface GetExplorationSidebarTreeOptions {
-  keepEmptyInitialThread?: boolean;
-}
-
 export function getExplorationSidebarTree(
   exploration: Exploration,
   treeItemFilter: TreeItemFilter,
   sortOrder: ExplorationSortOrder = DEFAULT_SORT_ORDER,
-  { keepEmptyInitialThread = false }: GetExplorationSidebarTreeOptions = {},
 ): ITreeNodeItem<ExplorationTreeNode>[] {
   const threads = exploration.threads ?? [];
   const initialThreadId = threads[0]?.id;
@@ -183,8 +178,6 @@ export function getExplorationSidebarTree(
         lastActivityAt: latestTimestamp(
           (thread.queries ?? []).map((query) => query.finished_at),
         ),
-        // Every group is hideable except the first thread ("Initial investigation").
-        hideable: index > 0,
         ...getHeadingHideState(children),
       },
       children,
@@ -216,10 +209,7 @@ export function getExplorationSidebarTree(
     }
   });
 
-  return pruneEmptyHeadings(
-    topLevel,
-    keepEmptyInitialThread ? initialThreadId : undefined,
-  );
+  return pruneEmptyHeadings(topLevel);
 }
 
 type PageKey = string;
@@ -250,22 +240,19 @@ function getInterestingnessByPageKey(
 
 function pruneEmptyHeadings(
   nodes: ITreeNodeItem<ExplorationTreeNode>[],
-  initialThreadId: ExplorationThreadId | undefined,
 ): ITreeNodeItem<ExplorationTreeNode>[] {
   return nodes
     .map((node) =>
       node.children?.length
         ? {
             ...node,
-            children: pruneEmptyHeadings(node.children, initialThreadId),
+            children: pruneEmptyHeadings(node.children),
           }
         : node,
     )
     .filter(
       (node) =>
-        node.data?.type !== "heading" ||
-        node.id === initialThreadId ||
-        (node.children?.length ?? 0) > 0,
+        node.data?.type !== "heading" || (node.children?.length ?? 0) > 0,
     );
 }
 
@@ -373,7 +360,6 @@ function getExplorationQueryTree(
             isExplorationTreePage(child) ? (child.data?.queries ?? []) : [],
           ),
         ),
-        hideable: true,
         ...getHeadingHideState(children),
       },
       children,
@@ -501,6 +487,81 @@ export function pickInitialSidebarPage(
     }
   }
   return null;
+}
+
+export function treeHasPages(
+  tree: ITreeNodeItem<ExplorationTreeNode>[],
+): boolean {
+  return flattenTree(tree).some((node) => node.data?.type === "page");
+}
+
+export type ExplorationSidebarContentMode =
+  | "loading"
+  | "forbidden"
+  | "all-hidden"
+  | "empty"
+  | "tree";
+
+export interface ExplorationSidebarModel {
+  tree: ITreeNodeItem<ExplorationTreeNode>[];
+  contentMode: ExplorationSidebarContentMode;
+}
+
+export function getExplorationSidebarModel({
+  exploration,
+  selectedSidebarTab,
+  tabsInfo,
+  showHidden,
+  sortOrder = DEFAULT_SORT_ORDER,
+}: {
+  exploration: Exploration;
+  selectedSidebarTab: ExplorationSidebarTab;
+  tabsInfo: ExplorationSidebarTabsInfo;
+  showHidden: boolean;
+  sortOrder?: ExplorationSortOrder;
+}): ExplorationSidebarModel {
+  const tabFilter = tabsInfo[selectedSidebarTab].treeItemFilter;
+  const treeItemFilter = showHidden
+    ? tabFilter
+    : (node: ITreeNodeItem<ExplorationTreeNode>) =>
+        tabFilter(node) && !isHiddenTreeItem(node);
+
+  const tree = getExplorationSidebarTree(
+    exploration,
+    treeItemFilter,
+    sortOrder,
+  );
+  const treeWithHidden = getExplorationSidebarTree(
+    exploration,
+    tabFilter,
+    sortOrder,
+  );
+
+  const hasPages = treeHasPages(tree);
+  const initialThread = exploration.threads?.[0];
+
+  let contentMode: ExplorationSidebarContentMode;
+  if (
+    selectedSidebarTab === "all" &&
+    initialThread != null &&
+    !isTerminalExplorationThreadStatus(initialThread.status) &&
+    !hasPages
+  ) {
+    contentMode = "loading";
+  } else if (
+    !hasPages &&
+    (exploration.threads ?? []).some((thread) => thread.status === "forbidden")
+  ) {
+    contentMode = "forbidden";
+  } else if (!showHidden && tree.length === 0 && treeWithHidden.length > 0) {
+    contentMode = "all-hidden";
+  } else if (tree.length === 0) {
+    contentMode = "empty";
+  } else {
+    contentMode = "tree";
+  }
+
+  return { tree, contentMode };
 }
 
 export type ExplorationSidebarTabsInfo = Record<

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/utils.ts
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/utils.ts
@@ -18,6 +18,7 @@ import type {
 import {
   getExplorationPages,
   getExplorationQueryGroupStatus,
+  isRestartableExplorationThreadStatus,
   isTerminalExplorationThreadStatus,
 } from "metabase-types/api";
 
@@ -116,6 +117,9 @@ export function getExplorationSidebarTree(
   exploration: Exploration,
   treeItemFilter: TreeItemFilter,
   sortOrder: ExplorationSortOrder = DEFAULT_SORT_ORDER,
+  {
+    keepEmptyRestartableThreads = false,
+  }: { keepEmptyRestartableThreads?: boolean } = {},
 ): ITreeNodeItem<ExplorationTreeNode>[] {
   const threads = exploration.threads ?? [];
   const initialThreadId = threads[0]?.id;
@@ -209,7 +213,7 @@ export function getExplorationSidebarTree(
     }
   });
 
-  return pruneEmptyHeadings(topLevel);
+  return pruneEmptyHeadings(topLevel, keepEmptyRestartableThreads);
 }
 
 type PageKey = string;
@@ -238,21 +242,38 @@ function getInterestingnessByPageKey(
   return interestingnessByPageKey;
 }
 
+function isEmptyRestartableThreadHeading(
+  node: ITreeNodeItem<ExplorationTreeNode>,
+): boolean {
+  const data = node.data;
+  return (
+    data?.type === "heading" &&
+    data.thread != null &&
+    isRestartableExplorationThreadStatus(data.thread.status)
+  );
+}
+
 function pruneEmptyHeadings(
   nodes: ITreeNodeItem<ExplorationTreeNode>[],
+  keepEmptyRestartableThreads: boolean,
 ): ITreeNodeItem<ExplorationTreeNode>[] {
   return nodes
     .map((node) =>
       node.children?.length
         ? {
             ...node,
-            children: pruneEmptyHeadings(node.children),
+            children: pruneEmptyHeadings(
+              node.children,
+              keepEmptyRestartableThreads,
+            ),
           }
         : node,
     )
     .filter(
       (node) =>
-        node.data?.type !== "heading" || (node.children?.length ?? 0) > 0,
+        node.data?.type !== "heading" ||
+        (node.children?.length ?? 0) > 0 ||
+        (keepEmptyRestartableThreads && isEmptyRestartableThreadHeading(node)),
     );
 }
 
@@ -526,15 +547,19 @@ export function getExplorationSidebarModel({
     : (node: ITreeNodeItem<ExplorationTreeNode>) =>
         tabFilter(node) && !isHiddenTreeItem(node);
 
+  // Empty failed/canceled threads only belong on All
+  const keepEmptyRestartableThreads = selectedSidebarTab === "all";
   const tree = getExplorationSidebarTree(
     exploration,
     treeItemFilter,
     sortOrder,
+    { keepEmptyRestartableThreads },
   );
   const treeWithHidden = getExplorationSidebarTree(
     exploration,
     tabFilter,
     sortOrder,
+    { keepEmptyRestartableThreads },
   );
 
   const hasPages = treeHasPages(tree);

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/utils.unit.spec.ts
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/utils.unit.spec.ts
@@ -14,6 +14,7 @@ import { createMockComment } from "metabase-types/api/mocks/comment";
 import type { ExplorationTreeNode, ExplorationTreePage } from "./utils";
 import {
   getCompactRelativeTime,
+  getExplorationSidebarModel,
   getExplorationSidebarTabsInfo,
   getExplorationSidebarTree,
   getShimmerDelayStyle,
@@ -732,18 +733,10 @@ describe("getExplorationSidebarTree inherits a heading status from its pages", (
   });
 
   it("uses the terminal server thread status instead of shimmering 'running' when the thread has no queries", () => {
-    const exploration = createExploration({
-      queries: [],
+    const tree = getAllTabExplorationSidebarTree({
+      queries: [createQuery({ id: 1, name: "Q1", status: "done" })],
       thread: { status: "failed", completed_at: "2026-04-30T00:01:00Z" },
     });
-    const tree = getExplorationSidebarTree(
-      exploration,
-      allTreeFilter,
-      undefined,
-      {
-        keepEmptyInitialThread: true,
-      },
-    );
     // A finished thread must never read as "running" (which shimmers), even with zero queries.
     expect(threadStatus(tree)).toBe("error");
   });
@@ -1052,8 +1045,8 @@ describe("hidden pages", () => {
   });
 });
 
-describe("group hideability + pageIds", () => {
-  it("marks the first thread not hideable and other groups hideable, with page ids", () => {
+describe("group pageIds", () => {
+  it("collects page ids onto thread and metric-group headings", () => {
     const q1 = createQuery({ id: 1, name: "Q1", status: "done" });
     const q2 = createQuery({ id: 2, name: "Q2", status: "done" });
 
@@ -1086,23 +1079,14 @@ describe("group hideability + pageIds", () => {
     };
     const tree = getExplorationSidebarTree(exploration, allTreeFilter);
 
-    // first thread ("Initial investigation") cannot be hidden
     expect(tree[0]?.data?.type).toBe("heading");
-    // Unjustified type cast. FIXME
-    expect((tree[0]?.data as { hideable?: boolean }).hideable).toBe(false);
     // Unjustified type cast. FIXME
     expect((tree[0]?.data as { pageIds?: number[] }).pageIds).toEqual([101]);
 
-    // subsequent threads can be hidden and expose all their page ids
-    // Unjustified type cast. FIXME
-    expect((tree[1]?.data as { hideable?: boolean }).hideable).toBe(true);
     // Unjustified type cast. FIXME
     expect((tree[1]?.data as { pageIds?: number[] }).pageIds).toEqual([202]);
 
-    // metric sub-groups (blocks) are always hideable
     const blockHeading = tree[1]?.children?.[0];
-    // Unjustified type cast. FIXME
-    expect((blockHeading?.data as { hideable?: boolean }).hideable).toBe(true);
     // Unjustified type cast. FIXME
     expect((blockHeading?.data as { pageIds?: number[] }).pageIds).toEqual([
       202,
@@ -1236,7 +1220,6 @@ describe("getExplorationSidebarTree sub-exploration nesting", () => {
     ]);
     expect(followUpNode?.data).toMatchObject({
       headingKind: "sub-exploration",
-      hideable: true,
       pageIds: [200],
       allHidden: false,
     });
@@ -1336,5 +1319,127 @@ describe("getShimmerDelayStyle", () => {
 
     expect(new Set(delays).size).toBe(delays.length);
     expect(Math.max(...delays) - Math.min(...delays)).toBeGreaterThan(1000);
+  });
+});
+
+describe("getExplorationSidebarModel", () => {
+  function modelFor(
+    opts: Parameters<typeof createExploration>[0] = {},
+    {
+      tab = "all" as const,
+      showHidden = false,
+    }: { tab?: "all" | "stars" | "discussions"; showHidden?: boolean } = {},
+  ) {
+    const exploration = createExploration(opts);
+    return getExplorationSidebarModel({
+      exploration,
+      selectedSidebarTab: tab,
+      tabsInfo: getExplorationSidebarTabsInfo(exploration),
+      showHidden,
+    });
+  }
+
+  it("detects initial-thread loading on the All tab", () => {
+    expect(
+      modelFor({
+        queries: [],
+        thread: { status: "running", started_at: "2026-04-30T00:00:00Z" },
+      }).contentMode,
+    ).toBe("loading");
+  });
+
+  it("does not treat explore-further planning as a full-sidebar loading state", () => {
+    const existingQuery = createQuery({
+      id: 1,
+      name: "Existing chart",
+      status: "done",
+    });
+    const exploration = createExploration({
+      threads: [
+        createThread({
+          id: 1,
+          status: "completed",
+          completed_at: "2026-04-30T00:01:00Z",
+          queries: [existingQuery],
+          blocks: [
+            createBlock({
+              id: 1,
+              name: "Revenue",
+              pages: [
+                createPage({
+                  id: 1,
+                  name: "Existing chart",
+                  query_ids: [1],
+                }),
+              ],
+            }),
+          ],
+        }),
+        createThread({
+          id: 2,
+          status: "running",
+          started_at: "2026-04-30T00:00:00Z",
+          position: 1,
+          queries: [],
+          blocks: [],
+        }),
+      ],
+    });
+    const model = getExplorationSidebarModel({
+      exploration,
+      selectedSidebarTab: "all",
+      tabsInfo: getExplorationSidebarTabsInfo(exploration),
+      showHidden: false,
+    });
+
+    expect(model.contentMode).toBe("tree");
+    expect(model.tree.length).toBeGreaterThan(0);
+  });
+
+  it("detects permission denial from forbidden thread status", () => {
+    expect(
+      modelFor({
+        queries: [],
+        thread: {
+          status: "forbidden",
+          completed_at: "2026-04-30T00:01:00Z",
+        },
+      }).contentMode,
+    ).toBe("forbidden");
+  });
+
+  it("detects all-hidden when the tab filter matches only hidden pages", () => {
+    const hiddenQuery = createQuery({
+      id: 9,
+      name: "Hidden chart",
+      status: "done",
+    });
+    const model = modelFor(
+      {
+        queries: [hiddenQuery],
+        blocks: [
+          createBlock({
+            id: 1,
+            name: "Revenue",
+            pages: [
+              createPage({
+                id: 900,
+                name: "Hidden chart",
+                query_ids: [9],
+                hidden: true,
+                starred: true,
+              }),
+            ],
+          }),
+        ],
+        thread: {
+          status: "completed",
+          completed_at: "2026-04-30T00:01:00Z",
+        },
+      },
+      { tab: "stars" },
+    );
+
+    expect(model.contentMode).toBe("all-hidden");
   });
 });

--- a/frontend/src/metabase/explorations/components/ExplorationSidebar/utils.unit.spec.ts
+++ b/frontend/src/metabase/explorations/components/ExplorationSidebar/utils.unit.spec.ts
@@ -27,7 +27,14 @@ const allTreeFilter = getExplorationSidebarTabsInfo().all.treeItemFilter;
 function getAllTabExplorationSidebarTree(
   opts: Parameters<typeof createExploration>[0],
 ) {
-  return getExplorationSidebarTree(createExploration(opts), allTreeFilter);
+  return getExplorationSidebarTree(
+    createExploration(opts),
+    allTreeFilter,
+    undefined,
+    {
+      keepEmptyRestartableThreads: true,
+    },
+  );
 }
 
 function getMetricHeadings(tree: ReturnType<typeof getExplorationSidebarTree>) {
@@ -1406,6 +1413,60 @@ describe("getExplorationSidebarModel", () => {
         },
       }).contentMode,
     ).toBe("forbidden");
+  });
+
+  it.each(["failed", "canceled"] as const)(
+    "keeps an empty %s initial thread on the All tab so Restart stays reachable",
+    (status) => {
+      const model = modelFor({
+        queries: [],
+        thread: {
+          status,
+          completed_at: "2026-04-30T00:01:00Z",
+          ...(status === "canceled"
+            ? { canceled_at: "2026-04-30T00:01:00Z" }
+            : {}),
+        },
+      });
+
+      expect(model.contentMode).toBe("tree");
+      expect(model.tree).toHaveLength(1);
+      expect(model.tree[0]?.data).toMatchObject({
+        type: "heading",
+        headingKind: "root",
+        status: status === "failed" ? "error" : "canceled",
+      });
+      expect(model.tree[0]?.children ?? []).toHaveLength(0);
+    },
+  );
+
+  it("still prunes an empty planner-empty thread on the All tab", () => {
+    const model = modelFor({
+      queries: [],
+      thread: {
+        status: "empty",
+        completed_at: "2026-04-30T00:01:00Z",
+      },
+    });
+
+    expect(model.contentMode).toBe("empty");
+    expect(model.tree).toHaveLength(0);
+  });
+
+  it("does not keep an empty failed thread on the Stars tab", () => {
+    const model = modelFor(
+      {
+        queries: [],
+        thread: {
+          status: "failed",
+          completed_at: "2026-04-30T00:01:00Z",
+        },
+      },
+      { tab: "stars" },
+    );
+
+    expect(model.contentMode).toBe("empty");
+    expect(model.tree).toHaveLength(0);
   });
 
   it("detects all-hidden when the tab filter matches only hidden pages", () => {

--- a/frontend/src/metabase/explorations/pages/ExplorationPage.tsx
+++ b/frontend/src/metabase/explorations/pages/ExplorationPage.tsx
@@ -9,7 +9,6 @@ import {
 } from "metabase/api";
 import { getListCommentsQuery } from "metabase/comments/utils";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import type { ITreeNodeItem } from "metabase/common/components/tree/types";
 import { useToast } from "metabase/common/hooks";
 import { useDispatch } from "metabase/redux";
 import { useLocation, useNavigate, useParams } from "metabase/router";
@@ -27,7 +26,6 @@ import type {
   TimelineId,
 } from "metabase-types/api";
 import {
-  getExplorationPages,
   isSettledExplorationQueryStatus,
   isTerminalExplorationThreadStatus,
 } from "metabase-types/api";
@@ -37,11 +35,9 @@ import {
   ExplorationTitle,
 } from "../components/ExplorationSidebar";
 import {
-  type ExplorationTreeNode,
   flattenTree,
+  getExplorationSidebarModel,
   getExplorationSidebarTabsInfo,
-  getExplorationSidebarTree,
-  isHiddenTreeItem,
   pickInitialSidebarPage,
 } from "../components/ExplorationSidebar/utils";
 import {
@@ -260,24 +256,16 @@ function ExplorationPageForId() {
     );
   }, [exploration, commentsData?.comments]);
 
-  const tree = useMemo(() => {
+  const { tree, contentMode: sidebarContentMode } = useMemo(() => {
     if (!exploration) {
-      return [];
+      return { tree: [], contentMode: "loading" as const };
     }
-    const tabFilter =
-      explorationSidebarTabsInfo[selectedSidebarTab].treeItemFilter;
-
-    const treeItemFilter = showHidden
-      ? tabFilter
-      : (node: ITreeNodeItem<ExplorationTreeNode>) =>
-          tabFilter(node) && !isHiddenTreeItem(node);
-
-    const hasHiddenPages = getExplorationPages(exploration).some(
-      (page) => page.hidden,
-    );
-
-    return getExplorationSidebarTree(exploration, treeItemFilter, sortOrder, {
-      keepEmptyInitialThread: selectedSidebarTab === "all" && hasHiddenPages,
+    return getExplorationSidebarModel({
+      exploration,
+      selectedSidebarTab,
+      tabsInfo: explorationSidebarTabsInfo,
+      showHidden,
+      sortOrder,
     });
   }, [
     exploration,
@@ -525,6 +513,7 @@ function ExplorationPageForId() {
             onToggleShowHidden={() => setShowHidden((prev) => !prev)}
             sortOrder={sortOrder}
             onChangeSortOrder={handleChangeSortOrder}
+            contentMode={sidebarContentMode}
           />
           {selectedPage && (
             <ExplorationGroupVisualization

--- a/src/metabase/explorations/api.clj
+++ b/src/metabase/explorations/api.clj
@@ -165,7 +165,7 @@
             ;; are impersonated or routed — and a response schema validates and encodes without
             ;; stripping (see [[redact-query-error]]), so it has to come off here.
             (dissoc (or (get enriched (:id thread))
-                        (assoc thread :queries [] :blocks [] :name nil))
+                        (assoc thread :queries [] :blocks [] :name nil :status "forbidden"))
                     :data_access_token))
           threads)))
 
@@ -178,7 +178,9 @@
     \"canceled\"  — the user stopped it
     \"empty\"     — terminal, the planner had nothing applicable to chart (NOT an error)
     \"failed\"    — terminal, planning failed or every query errored
-    \"completed\" — terminal, at least one chart is available"
+    \"completed\" — terminal, at least one chart is available
+    \"forbidden\" — terminal, the viewer's data-access lens is incompatible with the creator's
+                    (set by [[gate-threads-derived-data]], not [[thread-status]])"
   [{:keys [started_at canceled_at completed_at queries] :as thread}]
   (let [outcome (get-in thread [:query_plan_transcript :outcome])]
     (cond
@@ -433,7 +435,7 @@
    [:started_at                 {:optional true} [:maybe :any]]
    [:canceled_at                {:optional true} [:maybe :any]]
    [:completed_at               {:optional true} [:maybe :any]]
-   [:status                     [:enum "pending" "running" "canceled" "empty" "failed" "completed"]]
+   [:status                     [:enum "pending" "running" "canceled" "empty" "failed" "completed" "forbidden"]]
    [:queries                    {:optional true} [:maybe [:sequential ::ExplorationQuerySummary]]]
    [:blocks                     {:optional true} [:maybe [:sequential ::ExplorationBlockNode]]]
    [:timelines                  {:optional true}

--- a/test/metabase/explorations/api_test.clj
+++ b/test/metabase/explorations/api_test.clj
@@ -8,6 +8,7 @@
    [metabase.config.core :as config]
    [metabase.explorations.api]
    [metabase.explorations.blocks :as explorations.blocks]
+   [metabase.explorations.derived-perms :as derived-perms]
    [metabase.explorations.query-plan :as query-plan]
    [metabase.explorations.query-plan.context :as qp.context]
    [metabase.explorations.query-plan.variants :as qp.variants]
@@ -25,6 +26,22 @@
    [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db :web-server :test-users))
+
+(deftest gate-threads-derived-data-forbidden-status-test
+  (testing "gate-threads-derived-data stamps forbidden when derived data is not visible"
+    (let [gate   #'metabase.explorations.api/gate-threads-derived-data
+          thread {:id       1
+                  :status   "completed"
+                  :queries  [{:id 1}]
+                  :blocks   [{:id 1}]
+                  :name     "Revenue drill-down"}]
+      (mt/with-dynamic-fn-redefs [derived-perms/thread-ids-with-visible-derived-data
+                                  (constantly #{})]
+        (let [gated (first (gate [thread]))]
+          (is (= "forbidden" (:status gated)))
+          (is (nil? (:name gated)))
+          (is (= [] (:queries gated)))
+          (is (= [] (:blocks gated))))))))
 
 (deftest thread-status-test
   (let [status  #'metabase.explorations.api/thread-status


### PR DESCRIPTION
Closes [UXW-4877: Sidebar flashes "All items have been hidden" during exploration creation](https://linear.app/metabase/issue/UXW-4877/sidebar-flashes-all-items-have-been-hidden-during-exploration-creation)
Closes [UXW-4843: Exploration view stays in loading state without data permissions](https://linear.app/metabase/issue/UXW-4843/exploration-view-stays-in-loading-state-without-data-permissions)

- Adds a sidebar skeleton which is shown while the first thread is being query planned. This prevents a flash of the empty or all hidden messages and allows removing the special treatment of the first thread (e.g. `keepEmptyInitialThread`)
- Adds a "forbidden" thread status and a "You don't have permission" empty state