### PR TITLE
Pick the right column as the metric for interestingness scoring

### DIFF
--- a/src/metabase/explorations/interestingness.clj
+++ b/src/metabase/explorations/interestingness.clj
@@ -95,26 +95,34 @@
     (when (and temporal-idx series-idx)
       {:dim-idx temporal-idx :metric-idx metric-idx :series-idx series-idx})))
 
+(defn- metric-col-idx
+  "Index of the column to treat as the metric: the aggregation column (`:lib/source
+  :source/aggregations`), or — when the columns carry no source metadata — the *last* numeric column.
+
+  Not the *first* numeric column: QP results order breakouts (dimensions) before aggregations, so a
+  numeric dimension (a binned or plain-numeric breakout, or an integer extraction like day-of-week)
+  sits at a lower index than the measure. Picking the first numeric column would mistake that
+  dimension for the metric and transpose the chart's axes. The aggregation is always last, so
+  last-numeric is the right fallback. Returns nil when there is no numeric/aggregation column."
+  [lib-cols]
+  (or (first (keep-indexed (fn [i c] (when (= :source/aggregations (:lib/source c)) i)) lib-cols))
+      (last (keep-indexed (fn [i c] (when (lib.types.isa/numeric? c) i)) lib-cols))))
+
 (defn- pick-indices
   "Pick column roles given 2 or 3 result columns.
 
     - 2 cols → `{:dim-idx <i> :metric-idx <i>}`
-    - 3 cols → `{:dim-idx <temporal-idx> :metric-idx <numeric-idx> :series-idx <remaining-idx>}`
+    - 3 cols → `{:dim-idx <temporal-idx> :metric-idx <aggregation-idx> :series-idx <remaining-idx>}`
 
-  Returns nil when no numeric column exists, or — for 3 cols — when no temporal column exists."
+  The metric is chosen by [[metric-col-idx]] (aggregation column, else last numeric) so a numeric
+  dimension is never mistaken for the measure. Returns nil when no metric column exists, or — for 3
+  cols — when no temporal column exists."
   [lib-cols]
-  (let [metric-idx (first (keep-indexed (fn [i c] (when (lib.types.isa/numeric? c) i)) lib-cols))]
-    (when metric-idx
-      (case (count lib-cols)
-        ;; An extraction-unit column (day-of-week, hour-of-day, …) is an integer position, so
-        ;; it's numeric too — pin it as the dimension so the real measure stays the metric and
-        ;; the axes don't swap. Otherwise the lone numeric column is the metric.
-        2 (let [extr-idx (first (keep-indexed (fn [i c] (when (col-extraction-unit c) i)) lib-cols))]
-            (if (and extr-idx (lib.types.isa/numeric? (nth lib-cols (- 1 extr-idx))))
-              {:dim-idx extr-idx :metric-idx (- 1 extr-idx)}
-              {:dim-idx (- 1 metric-idx) :metric-idx metric-idx}))
-        3 (pick-3-col-indices lib-cols metric-idx)
-        nil))))
+  (when-let [metric-idx (metric-col-idx lib-cols)]
+    (case (count lib-cols)
+      2 {:dim-idx (- 1 metric-idx) :metric-idx metric-idx}
+      3 (pick-3-col-indices lib-cols metric-idx)
+      nil)))
 
 (defn- pair-filter
   "Drop rows whose metric value isn't a number; preserve x/y alignment."

--- a/test/metabase/explorations/interestingness_test.clj
+++ b/test/metabase/explorations/interestingness_test.clj
@@ -217,6 +217,45 @@
         (is (= [80 90] (:y_values eu)))
         (is (= "NA" (:display_name na)))))))
 
+(deftest numeric-dimension-not-transposed-2col-test
+  (testing "a numeric dimension (breakout) before a numeric metric (aggregation) must NOT transpose
+            the axes: the aggregation column is the metric even though it is not the *first* numeric
+            column (QP results order breakouts before aggregations)"
+    (let [cfg (explorations.interestingness/chart-config
+               (query "bar")
+               [(lib-col {:name "price_bin" :base-type :type/Integer :display-name "Price"
+                          :lib/source :source/breakouts})
+                (lib-col {:name "count" :base-type :type/Integer :display-name "Count"
+                          :lib/source :source/aggregations})]
+               [[10 5] [20 8] [30 3]])
+          s   (get (:series cfg) "Count")]
+      (is (some? s) "the aggregation column is the metric/series")
+      (is (= "number" (-> s :x :type)) "the numeric dimension is on x")
+      (is (= [10 20 30] (:x_values s)) "dimension values on x, not the metric")
+      (is (= [5 8 3] (:y_values s)) "metric values on y — axes not swapped"))))
+
+(deftest numeric-dimension-not-transposed-3col-test
+  (testing "a numeric dimension in a 3-col faceted result splits the series, with the aggregation on
+            y and the temporal breakout on x — the numeric dim must not be mistaken for the metric"
+    (let [cfg (explorations.interestingness/chart-config
+               (query "line")
+               [(lib-col {:name "bin" :base-type :type/Integer :display-name "Bin"
+                          :lib/source :source/breakouts})
+                (lib-col {:name "month" :base-type :type/DateTime :display-name "Month"
+                          :lib/source :source/breakouts})
+                (lib-col {:name "rev" :base-type :type/Integer :display-name "Revenue"
+                          :lib/source :source/aggregations})]
+               [[1 "2026-01-01" 100]
+                [1 "2026-02-01" 110]
+                [2 "2026-01-01" 80]])]
+      (is (= "line" (:display_type cfg)))
+      (is (= #{"1" "2"} (set (keys (:series cfg)))) "series split on the numeric dimension values")
+      (let [s1 (get (:series cfg) "1")]
+        (is (= "datetime" (-> s1 :x :type)) "temporal breakout on x")
+        (is (= "Revenue"  (-> s1 :y :name)) "aggregation on y")
+        (is (= ["2026-01-01" "2026-02-01"] (:x_values s1)))
+        (is (= [100 110] (:y_values s1)))))))
+
 (deftest three-col-nil-category-collapses-test
   (testing "nil categorical values collapse into a single \"(empty)\" series"
     (let [cfg (explorations.interestingness/chart-config


### PR DESCRIPTION
### Description

`pick-indices` chose the first numeric column as the metric. But QP results order breakouts (dimensions) before aggregations, so a numeric dimension - a binned/plain-numeric breakout, or an integer extraction like  
  day-of-week - sits at a lower index than the measure and got mistaken for the metric. 

This caused a transposed axes (2-col) and series split on the metric with dimension values on Y (3-col) meaning the interestingness scorer ranked the fan-out values.                                                                                                                                                                                                             
                                                                                                                                                                                                                                   
Change adds `metric-col-idx` — the metric is the :source/aggregations column, falling back to the last numeric column (aggregations always follow breakouts), nil when neither exists. pick-indices uses it for 
  both the 2- and 3-col cases. 

The old 2-col extraction-unit special case was also removed: it was a workaround for this exact bug, and the extraction column is still labeled as the dimension in two-col-chart-config regardless of index selection.   
           
### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
