### PR TITLE
Skip reanalyzing search models on every row hook

### DIFF
--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -2,6 +2,7 @@
   (:require
    [buddy.core.codecs :as codecs]
    [buddy.core.hash :as buddy-hash]
+   [clojure.core.memoize :as memoize]
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.walk :as walk]
@@ -424,14 +425,21 @@
        (derive (:model spec#) :hook/search-index)
        (defmethod spec* ~search-model [~'_] spec#))))
 
-;; TODO we should memoize this for production (based on spec values)
+(def ^{:arglists '([spec-methods]), :private true} model-hooks*
+  ;; Specs are immutable in production. Keying on the methods map also does the useful thing after a REPL/test reload.
+  ;; Model resolution can register more methods during the first computation; in that case the next call recomputes.
+  (memoize/fifo
+   (fn [_spec-methods]
+     (->> (specifications)
+          vals
+          (map search-model-hooks)
+          merge-hooks))
+   :fifo/threshold 1))
+
 (defn model-hooks
   "Return an inverted map of data dependencies to search models, used for updating them based on underlying models."
   []
-  (->> (specifications)
-       vals
-       (map search-model-hooks)
-       merge-hooks))
+  (model-hooks* (methods spec*)))
 
 (defn- instance->db-values
   "Given a transformed toucan map, get back a mapping to the raw db values that we can use in a query."

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -425,7 +425,7 @@
        (derive (:model spec#) :hook/search-index)
        (defmethod spec* ~search-model [~'_] spec#))))
 
-(def ^{:arglists '([spec-methods]), :private true} model-hooks*
+(def ^:private model-hooks*
   ;; Specs are immutable in production. Keying on the methods map also does the useful thing after a REPL/test reload.
   ;; Model resolution can register more methods during the first computation; in that case the next call recomputes.
   (memoize/fifo

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -426,8 +426,11 @@
        (defmethod spec* ~search-model [~'_] spec#))))
 
 (def ^:private model-hooks*
-  ;; Specs are immutable in production. Keying on the methods map also does the useful thing after a REPL/test reload.
-  ;; Model resolution can register more methods during the first computation; in that case the next call recomputes.
+  ;; Specs are immutable in production, and keying on the methods map also does the useful thing after a
+  ;; REPL/test reload.
+  ;; The key is only an invalidation token: the value comes from the static search-models list, so the first
+  ;; call builds a complete map even though resolving those models registers more methods while it runs.
+  ;; Its key is stale by then, which costs one recompute and nothing else.
   (memoize/fifo
    (fn [_spec-methods]
      (->> (specifications)

--- a/test/metabase/search/spec_test.clj
+++ b/test/metabase/search/spec_test.clj
@@ -146,6 +146,30 @@
       (testing "... and nothing else does"
         (is (empty? (sort-by name (remove expected-models actual-models))))))))
 
+(deftest ^:synchronized model-hooks-cache-invalidates-on-spec-redefinition-test
+  (testing "replacing a spec method invalidates the single-entry model-hooks cache"
+    (let [spec-multifn search.spec/spec*]
+      ;; Load lazily resolved models and warm the cache before replacing the method, which is the REPL/test-reload
+      ;; path this guards.
+      (search.spec/model-hooks)
+      (let [cached   (search.spec/model-hooks)
+            original (get-method spec-multifn "card")]
+        (is (identical? cached (search.spec/model-hooks)))
+        (try
+          (.addMethod ^clojure.lang.MultiFn spec-multifn
+                      "card"
+                      (fn [_]
+                        (update (original "card") :render-terms assoc :cache-probe :cache_probe)))
+          (is (contains? (->> (get (search.spec/model-hooks) :model/Card)
+                              (filter #(= "card" (:search-model %)))
+                              first
+                              :fields)
+                         :cache_probe))
+          (finally
+            (.addMethod ^clojure.lang.MultiFn spec-multifn "card" original)
+            ;; Do not leave the temporary method table cached for later tests.
+            (search.spec/model-hooks)))))))
+
 (deftest ^:parallel index-version-hash-test
   (testing "index-version-hash returns a consistent value"
     (let [hash1 (search.spec/index-version-hash)

--- a/test/metabase/search/spec_test.clj
+++ b/test/metabase/search/spec_test.clj
@@ -146,29 +146,31 @@
       (testing "... and nothing else does"
         (is (empty? (sort-by name (remove expected-models actual-models))))))))
 
+(deftest ^:parallel model-hooks-are-cached-test
+  ;; The first call resolves lazily loaded models, which registers more spec methods and changes the cache key.
+  (search.spec/model-hooks)
+  (is (identical? (search.spec/model-hooks) (search.spec/model-hooks))))
+
 (deftest ^:synchronized model-hooks-cache-invalidates-on-spec-redefinition-test
-  (testing "replacing a spec method invalidates the single-entry model-hooks cache"
-    (let [spec-multifn search.spec/spec*]
-      ;; Load lazily resolved models and warm the cache before replacing the method, which is the REPL/test-reload
-      ;; path this guards.
-      (search.spec/model-hooks)
-      (let [cached   (search.spec/model-hooks)
-            original (get-method spec-multifn "card")]
-        (is (identical? cached (search.spec/model-hooks)))
-        (try
-          (.addMethod ^clojure.lang.MultiFn spec-multifn
-                      "card"
-                      (fn [_]
-                        (update (original "card") :render-terms assoc :cache-probe :cache_probe)))
-          (is (contains? (->> (get (search.spec/model-hooks) :model/Card)
-                              (filter #(= "card" (:search-model %)))
-                              first
-                              :fields)
-                         :cache_probe))
-          (finally
-            (.addMethod ^clojure.lang.MultiFn spec-multifn "card" original)
-            ;; Do not leave the temporary method table cached for later tests.
-            (search.spec/model-hooks)))))))
+  (testing "replacing a spec method invalidates the cached model-hooks"
+    ;; Registering a throwaway spec would derive a fake model into :hook/search-index and break
+    ;; every-model-is-hooked-test, so probe by swapping an existing method out and back.
+    (let [spec-multifn search.spec/spec*
+          ;; Model resolution registers more spec methods, so settle those before capturing the original.
+          _            (search.spec/model-hooks)
+          original     (get-method spec-multifn "card")]
+      (try
+        (.addMethod ^clojure.lang.MultiFn spec-multifn
+                    "card"
+                    (fn [_]
+                      (update (original "card") :render-terms assoc :cache-probe :cache_probe)))
+        (is (contains? (->> (get (search.spec/model-hooks) :model/Card)
+                            (filter #(= "card" (:search-model %)))
+                            first
+                            :fields)
+                       :cache_probe))
+        (finally
+          (.addMethod ^clojure.lang.MultiFn spec-multifn "card" original))))))
 
 (deftest ^:parallel index-version-hash-test
   (testing "index-version-hash returns a consistent value"

--- a/test/metabase/search/spec_test.clj
+++ b/test/metabase/search/spec_test.clj
@@ -4,6 +4,8 @@
    [metabase.search.spec :as search.spec]
    [toucan2.core :as t2]))
 
+(set! *warn-on-reflection* true)
+
 (deftest ^:parallel test-qualify-column
   (is (= [:table.column :column] (#'search.spec/qualify-column :table :column)))
   (is (= :qualified.column (#'search.spec/qualify-column :table :qualified.column)))

--- a/test/metabase/search/spec_test.clj
+++ b/test/metabase/search/spec_test.clj
@@ -156,9 +156,13 @@
     ;; Registering a throwaway spec would derive a fake model into :hook/search-index and break
     ;; every-model-is-hooked-test, so probe by swapping an existing method out and back.
     (let [spec-multifn search.spec/spec*
-          ;; Model resolution registers more spec methods, so settle those before capturing the original.
+          ;; The first call resolves lazily loaded models, registering spec methods as it goes, so it caches
+          ;; under a key that is stale by the time it returns. The second call warms the settled method table.
           _            (search.spec/model-hooks)
+          warm         (search.spec/model-hooks)
           original     (get-method spec-multifn "card")]
+      ;; Without a hit here the probe below would miss whatever the cache key did, proving nothing.
+      (is (identical? warm (search.spec/model-hooks)))
       (try
         (.addMethod ^clojure.lang.MultiFn spec-multifn
                     "card"


### PR DESCRIPTION
The `search.spec/model-hooks` method rebuilds the inverted map of every spec's data dependencies on each call, and `search-models-to-update` calls it once per row from the `after-insert`/`after-update` hooks. Every write to a searchable model pays for it, and a bulk write pays for it per row.

With the 13 specs registered today (15 models, 36 hooks):

| | per call |
|---|---|
| rebuild | ~257µs |
| cached | ~0.4µs |
| `(methods spec*)`, the cache key | ~0.1µs |

So on my machine bulk update of 1000 cards burns about a quarter-second of CPU rebuilding a value that never changed.

The cache is a single-entry FIFO keyed on the registered `spec*` methods, so defining or redefining a spec invalidates it. The key is only an invalidation token: the value is built from the static `search-models` list, which forces every spec namespace to load. The first call after boot returns a complete map even though resolving those models registers more methods while it runs — its key is stale by then, which costs one recompute and nothing else.

### Appendix: alternatives

**Key on something cheaper than the whole methods map.** Neither `(count (methods spec*))` nor `(set (keys (methods spec*)))` changes when an existing spec is *replaced*, which is exactly the REPL-reload case the cache has to notice. The full map costs ~0.1µs and gets it right.

**Key on the spec values**, as the TODO suggested. `(specifications)` alone costs ~8µs before hashing 13 spec maps. A spec only reaches `model-hooks` by being registered as a `spec*` method, so the method table already changes exactly when the spec values do.

**A plain `delay`.** Cheapest possible, but goes stale in the REPL. `define-spec` lives in each model's namespace, so reloading `metabase.queries.models.card` registers a method the delay never sees.

**Invalidate explicitly from `define-spec`.** Drops the `clojure.core.memoize` dependency, in exchange for having to remember every future mutation site. The ~0.1µs key buys that back.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
