### PR TITLE
Statement-level DELETE capture for Toucan 2 models

### DIFF
--- a/src/metabase/app_db/dml_capture.clj
+++ b/src/metabase/app_db/dml_capture.clj
@@ -38,7 +38,13 @@
     event, exactly as it bypasses every other Toucan 2 tool.
   - `update!` statements rewritten by a `before-update` method are captured after the rewrite: `:changes` is
     what actually ran, and a before-update that splits one statement into per-row groups delivers one event
-    per group."
+    per group.
+  - The pre-image select and the statement are separate, unlocked reads: a concurrent writer can make a
+    snapshot over- or under-approximate the rows the statement actually affects. toucan2's own
+    `before-delete` has the same window. Consumers already must treat events as re-examination hints, so
+    over-approximation is harmless and under-approximation is bounded by their convergence backstop.
+  - Insert back-filling requires a single-column primary key; a composite-pk model whose literals are
+    missing a capture field delivers the incomplete literals as-is (with a debug log)."
   (:require
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -67,10 +73,18 @@
 
 (defmulti captured!
   "Deliver a capture event for a DML statement against `model`; see the namespace docstring for the shape.
-  Implementations run on the DML's calling thread, inside any enclosing transaction: keep them cheap and
-  never let them throw."
+  Implementations run on the DML's calling thread, inside any enclosing transaction: keep them cheap.
+  Anything they throw is caught and logged by the seam, so a consumer bug degrades to a missed event —
+  covered by whatever convergence backstop the consumer runs — never a failure of the caller's statement."
   {:arglists '([model event])}
   (fn [model _event] (keyword model)))
+
+(defn- deliver-captured!
+  [model event]
+  (try
+    (captured! model event)
+    (catch Exception e
+      (log/errorf e "Error delivering DML capture event for %s %s" model (:op event)))))
 
 (defn- pre-image-rows
   "Select the rows a delete/update statement is about to affect, narrowed to `fields`, as plain raw-value maps.
@@ -102,7 +116,7 @@
                                  model fields parsed-args resolved-query)]
         (u/prog1 (next-method rf query-type model parsed-args resolved-query)
           (when (seq rows)
-            (captured! model {:op :delete, :model model, :rows rows})))))))
+            (deliver-captured! model {:op :delete, :model model, :rows rows})))))))
 
 (methodical/defmethod t2.pipeline/transduce-query
   [#_query-type :toucan.query-type/update.* #_model ::captured #_resolved-query :default]
@@ -117,10 +131,10 @@
                                  model fields parsed-args resolved-query)]
         (u/prog1 (next-method rf query-type model (assoc parsed-args ::captured? true) resolved-query)
           (when (seq rows)
-            (captured! model {:op      :update
-                              :model   model
-                              :rows    rows
-                              :changes (:changes parsed-args)})))))))
+            (deliver-captured! model {:op      :update
+                                      :model   model
+                                      :rows    rows
+                                      :changes (:changes parsed-args)})))))))
 
 (methodical/defmethod t2.pipeline/transduce-query
   [#_query-type :toucan.query-type/insert.* #_model ::captured #_resolved-query :default]
@@ -174,15 +188,21 @@
                                (vec row-literals))
                 ;; The literals lack a requested capture field when the column is filled in by the database
                 ;; or a before-insert method (e.g. revision.most_recent); one narrow select by the returned
-                ;; pks recovers the authoritative values.
+                ;; pks recovers the authoritative values. Back-filling needs a single-column pk to select
+                ;; by; composite-pk models deliver their incomplete literals as-is.
                 complete?    (fn [row] (every? #(contains? row %) fields))
-                rows         (if (or (every? complete? rows) (nil? single-pk))
-                               rows
-                               (pre-image-rows :toucan.query-type/select.instances model
-                                               (distinct (cons single-pk fields))
-                                               {:kv-args {:toucan/pk [:in pks]}}
-                                               {}))]
-            (captured! model {:op :insert, :model model, :rows rows, :pks pks})))
+                incomplete?  (not (every? complete? rows))
+                rows         (cond
+                               (not incomplete?) rows
+                               (nil? single-pk)  (do (log/debugf
+                                                      "Cannot back-fill capture fields for composite-pk model %s"
+                                                      model)
+                                                     rows)
+                               :else             (pre-image-rows :toucan.query-type/select.instances model
+                                                                 (distinct (cons single-pk fields))
+                                                                 {:kv-args {:toucan/pk [:in pks]}}
+                                                                 {}))]
+            (deliver-captured! model {:op :insert, :model model, :rows rows, :pks pks})))
         result))))
 
 ;;; A model may mix capture with toucan2's row-level tools; methodical needs to be told the capture method is

--- a/src/metabase/app_db/dml_capture.clj
+++ b/src/metabase/app_db/dml_capture.clj
@@ -190,6 +190,16 @@
 ;;; `before-update` means capture sees the statement as rewritten (final `:changes`, one event per rewrite
 ;;; group). The `after` tools re-dispatch an upgraded query rather than call `next-method`, so the capture
 ;;; method guards against re-entry with `::captured?` in `parsed-args`.
+;;;
+;;; TODO (Chris 2026-07-22) -- this namespace's eventual home is a toucan2 tool. It is pure toucan2
+;;; machinery, and its hardest-won content is composition knowledge about toucan2 internals: the prefers
+;;; below reference other tools' semi-private dispatch keywords, and a tool-dispatch refactor upstream would
+;;; break them here silently, whereas toucan2's own test suite could own that contract (the scratch-model
+;;; tests port almost verbatim). Upstream could also replace [[pre-image-rows]]'s compile-then-execute-
+;;; modelless workaround with a proper decoration-free query type — a select.raw sibling of
+;;; `:toucan.query-type/select.instances-from-pks`, skipped by after-select and transforms. Incubating here
+;;; first: the contract is new, and its sharp edges (modelless execution, insert backfill, at-least-once
+;;; delivery) should survive production contact before being frozen behind a library release cadence.
 
 (methodical/prefer-method! #'t2.pipeline/transduce-query
                            [:toucan.query-type/delete.* :toucan2.tools.before-delete/before-delete :default]

--- a/src/metabase/app_db/dml_capture.clj
+++ b/src/metabase/app_db/dml_capture.clj
@@ -9,7 +9,7 @@
 
     {:op :delete, :model model, :rows [pre-image, ...]}
     {:op :update, :model model, :rows [pre-image, ...], :changes changes}
-    {:op :insert, :model model, :rows [row-literal, ...], :pks [pk, ...]}
+    {:op :insert, :model model, :rows [row, ...], :pks [pk, ...]}
 
   Update and delete `:rows` are narrow pre-image snapshots: plain maps of raw column values, only the
   columns named by [[capture-fields]], selected with the statement's own conditions immediately before it
@@ -20,12 +20,11 @@
   changed value is a literal.
   HoneySQL expression values are delivered as-is.
 
-  Insert `:rows` are the row maps as passed to `insert!` with the generated primary key assoc'd on, and
-  `:pks` are the generated primary keys.
-  A requested capture field absent from the literals — filled in by the database or a `before-insert`
-  method (e.g. `revision.most_recent`) — is recovered by one narrow select of the capture fields by pk, so
-  a captured field is always present and authoritative either way.
-  Other literal values are delivered as passed, before type transforms.
+  Insert `:rows` contain the requested capture fields plus primary-key columns, and `:pks` are the generated
+  primary keys. PK-only capture, complete literal rows with explicit PKs, and a single complete literal row need
+  no follow-up select. Other inserts are re-selected by primary key because JDBC does not guarantee that returned
+  keys preserve input order; each row therefore carries its own authoritative identity rather than relying on
+  positional association.
 
   Delivery guarantees, and non-guarantees:
 
@@ -41,13 +40,12 @@
   - The pre-image select and the statement are separate, unlocked reads: a concurrent writer can make a
     snapshot over- or under-approximate the rows the statement actually affects. toucan2's own
     `before-delete` has the same window. Consumers already must treat events as re-examination hints, so
-    over-approximation is harmless and under-approximation is bounded by their convergence backstop.
-  - Insert back-filling requires a single-column primary key; a composite-pk model whose literals are
-    missing a capture field delivers the incomplete literals as-is (with a debug log)."
+    over-approximation is harmless and under-approximation is bounded by their convergence backstop."
   (:require
    [metabase.util :as u]
    [metabase.util.log :as log]
    [methodical.core :as methodical]
+   [toucan2.connection :as t2.conn]
    [toucan2.execute :as t2.execute]
    [toucan2.model :as t2.model]
    [toucan2.pipeline :as t2.pipeline]
@@ -61,8 +59,7 @@
 (defmulti capture-fields
   "The columns guaranteed present in `:rows` when capturing `op` (`:insert`, `:update` or `:delete`)
   statements against `model`; return nil or empty to leave that op uncaptured.
-  Update and delete snapshots are narrowed to exactly these columns; insert rows are the caller's literals,
-  back-filled by pk when a requested column is missing from them."
+  Update and delete rows are narrowed to these columns; insert rows additionally include all primary-key columns."
   {:arglists '([model op])}
   (fn [model _op] (keyword model)))
 
@@ -73,8 +70,10 @@
 (defmulti captured!
   "Deliver a capture event for a DML statement against `model`; see the namespace docstring for the shape.
   Implementations run on the DML's calling thread, inside any enclosing transaction: keep them cheap.
-  Anything they throw is caught and logged by the seam, so a consumer bug degrades to a missed event —
-  covered by whatever convergence backstop the consumer runs — never a failure of the caller's statement."
+  They must not execute SQL on that transaction's connection: although delivery catches and logs exceptions,
+  catching a database error cannot restore a PostgreSQL transaction that the error has already aborted. Prefer
+  registering a post-commit handoff; ordinary consumer failures then degrade to a missed event covered by the
+  consumer's convergence backstop."
   {:arglists '([model event])}
   (fn [model _event] (keyword model)))
 
@@ -82,7 +81,7 @@
   [model event]
   (try
     (captured! model event)
-    (catch Exception e
+    (catch Throwable e
       (log/errorf e "Error delivering DML capture event for %s %s" model (:op event)))))
 
 (defn- pre-image-rows
@@ -91,18 +90,65 @@
   semantics, but executed modelless: `after-select` methods and type transforms often dereference columns a
   narrow snapshot doesn't fetch, so no instance decoration may run here.
   Runs on the current connection, so inside any transaction the statement itself runs in.
-  Capture is best-effort: a query shape we cannot rebuild as a select (e.g. raw sql-args with kv-args) logs
-  and skips capture rather than failing the caller's statement."
+  A query shape we cannot build or compile as a select (e.g. raw sql-args with kv-args) logs and skips capture.
+  SQL execution failures propagate: suppressing one cannot restore a PostgreSQL transaction it already aborted."
   [query-type model fields parsed-args resolved-query]
-  (try
-    (let [built    (t2.pipeline/build query-type model
-                                      (assoc parsed-args :columns (vec fields))
-                                      resolved-query)
-          sql-args (t2.pipeline/compile query-type model built)]
-      (t2.execute/query sql-args))
-    (catch Exception e
-      (log/errorf e "Skipping DML capture for %s: could not snapshot pre-image rows" model)
-      nil)))
+  (when-let [sql-args (try
+                        (let [built (t2.pipeline/build query-type model
+                                                       (assoc parsed-args :columns (vec fields))
+                                                       resolved-query)]
+                          (t2.pipeline/compile query-type model built))
+                        (catch Exception e
+                          (log/errorf e "Skipping DML capture for %s: could not build pre-image query" model)
+                          nil))]
+    (t2.execute/query sql-args)))
+
+(defn- rows-by-pks
+  [model fields pks]
+  (let [pk-set (set pks)
+        pk-fn  (t2.model/select-pks-fn model)]
+    (some->> (pre-image-rows :toucan.query-type/select.instances model fields
+                             {:kv-args {:toucan/pk [:in pks]}} {})
+             (filterv #(contains? pk-set (pk-fn %))))))
+
+(defn- pk->row
+  [pk-keys pk]
+  (zipmap pk-keys (if (= 1 (count pk-keys)) [pk] pk)))
+
+(defn- literal-value?
+  [x]
+  ;; HoneySQL expressions are represented by collections, keywords (e.g. :%now), or symbols. Be conservative:
+  ;; an unnecessary narrow backfill is cheaper than treating an expression as its persisted value.
+  (not (or (coll? x) (keyword? x) (symbol? x))))
+
+(defn- complete-literal-row?
+  [row fields non-pk-fields]
+  (and (every? #(contains? row %) fields)
+       (every? #(literal-value? (get row %)) non-pk-fields)))
+
+(defn- insert-rows
+  [model fields row-literals pks]
+  (let [pk-keys          (vec (t2.model/primary-keys model))
+        non-pk-fields    (remove (set pk-keys) fields)
+        pk-only?         (every? (set pk-keys) fields)
+        complete-rows    (when (every? #(complete-literal-row? % fields non-pk-fields) row-literals)
+                           (mapv #(select-keys % fields) row-literals))
+        pk-fn            (t2.model/select-pks-fn model)
+        explicit-pk-rows (when (and complete-rows
+                                    (= (set pks) (into #{} (map pk-fn) complete-rows)))
+                           complete-rows)
+        single-row       (when (and (= 1 (count pks)) (= 1 (count row-literals)))
+                           (merge (first row-literals) (pk->row pk-keys (first pks))))]
+    (cond
+      ;; Each returned primary key is already the complete captured row; no association is needed.
+      pk-only?         (mapv #(pk->row pk-keys %) pks)
+      ;; Explicit primary keys make input rows self-identifying; set equality rejects rewrites/defaults.
+      explicit-pk-rows explicit-pk-rows
+      ;; A single generated key has only one possible input row, so result ordering is irrelevant.
+      (and single-row (complete-literal-row? single-row fields non-pk-fields))
+      [(select-keys single-row fields)]
+      ;; Generated keys plus non-PK fields cannot be correlated portably from JDBC result order.
+      :else            (rows-by-pks model fields pks))))
 
 (methodical/defmethod t2.pipeline/transduce-query
   [#_query-type :toucan.query-type/delete.* #_model ::captured #_resolved-query :default]
@@ -138,71 +184,57 @@
 (methodical/defmethod t2.pipeline/transduce-query
   [#_query-type :toucan.query-type/insert.* #_model ::captured #_resolved-query :default]
   "Capture the generated pks of an INSERT statement, then deliver one `:insert` event.
-  Count-returning inserts are upgraded to pk-returning ones (the same upgrade `after-insert` rides), so no
-  follow-up SELECT is needed; pk- and instance-returning inserts are captured from their own result stream."
+  Count-returning inserts are upgraded to pk-returning ones (the same upgrade `after-insert` rides), and pk-
+  and instance-returning inserts are captured from their own result stream."
   [rf query-type model parsed-args resolved-query]
   (let [capture? (and (not (::captured? parsed-args))
                       (seq (capture-fields model :insert)))]
     (if-not capture?
       (next-method rf query-type model parsed-args resolved-query)
-      (let [pks         (volatile! (transient []))
-            parsed-args (assoc parsed-args ::captured? true)
-            pks-fn      (t2.model/select-pks-fn model)
-            result      (cond
-                          ;; already streaming instances: tee pks off the realized rows
-                          (isa? query-type :toucan.result-type/instances)
-                          (next-method ((map (fn [row]
-                                               (let [row (t2.realize/realize row)]
-                                                 (vswap! pks conj! (pks-fn row))
-                                                 row)))
-                                        rf)
-                                       query-type model parsed-args resolved-query)
+      ;; Toucan already transacts every DML statement. Extend that same boundary through the optional backfill so a
+      ;; backfill failure cannot escape after an autocommit insert has already persisted.
+      (t2.conn/with-transaction [_]
+        (let [pks         (volatile! (transient []))
+              parsed-args (assoc parsed-args ::captured? true)
+              pks-fn      (t2.model/select-pks-fn model)
+              result      (cond
+                            ;; already streaming instances: tee pks off the realized rows
+                            (isa? query-type :toucan.result-type/instances)
+                            (next-method ((map (fn [row]
+                                                 (let [row (t2.realize/realize row)]
+                                                   (vswap! pks conj! (pks-fn row))
+                                                   row)))
+                                          rf)
+                                         query-type model parsed-args resolved-query)
 
-                          ;; already streaming pks: tee them
-                          (isa? query-type :toucan.result-type/pks)
-                          (next-method ((map (fn [pk]
-                                               (vswap! pks conj! pk)
-                                               pk))
-                                        rf)
-                                       query-type model parsed-args resolved-query)
+                            ;; already streaming pks: tee them
+                            (isa? query-type :toucan.result-type/pks)
+                            (next-method ((map (fn [pk]
+                                                 (vswap! pks conj! pk)
+                                                 pk))
+                                          rf)
+                                         query-type model parsed-args resolved-query)
 
-                          ;; update-count: re-dispatch as a pk-returning insert, converting each returned pk
-                          ;; back into a count of 1 for the original reducing function
-                          :else
-                          (t2.pipeline/transduce-query
-                           ((map (fn [pk]
-                                   (vswap! pks conj! pk)
-                                   1))
-                            rf)
-                           (t2.types/similar-query-type-returning query-type :toucan.result-type/pks)
-                           model parsed-args resolved-query))
-            pks         (persistent! @pks)]
-        (when (seq pks)
-          (let [fields       (capture-fields model :insert)
-                row-literals (:rows parsed-args)
-                pk-keys      (t2.model/primary-keys model)
-                single-pk    (when (= 1 (count pk-keys)) (first pk-keys))
-                rows         (if (and single-pk (= (count pks) (count row-literals)))
-                               (mapv #(assoc %1 single-pk %2) row-literals pks)
-                               (vec row-literals))
-                ;; The literals lack a requested capture field when the column is filled in by the database
-                ;; or a before-insert method (e.g. revision.most_recent); one narrow select by the returned
-                ;; pks recovers the authoritative values. Back-filling needs a single-column pk to select
-                ;; by; composite-pk models deliver their incomplete literals as-is.
-                complete?    (fn [row] (every? #(contains? row %) fields))
-                incomplete?  (not (every? complete? rows))
-                rows         (cond
-                               (not incomplete?) rows
-                               (nil? single-pk)  (do (log/debugf
-                                                      "Cannot back-fill capture fields for composite-pk model %s"
-                                                      model)
-                                                     rows)
-                               :else             (pre-image-rows :toucan.query-type/select.instances model
-                                                                 (distinct (cons single-pk fields))
-                                                                 {:kv-args {:toucan/pk [:in pks]}}
-                                                                 {}))]
-            (deliver-captured! model {:op :insert, :model model, :rows rows, :pks pks})))
-        result))))
+                            ;; update-count: re-dispatch as a pk-returning insert, converting each returned pk
+                            ;; back into a count of 1 for the original reducing function
+                            :else
+                            (t2.pipeline/transduce-query
+                             ((map (fn [pk]
+                                     (vswap! pks conj! pk)
+                                     1))
+                              rf)
+                             (t2.types/similar-query-type-returning query-type :toucan.result-type/pks)
+                             model parsed-args resolved-query))
+              pks         (persistent! @pks)]
+          (when (seq pks)
+            (let [fields       (vec (distinct (concat (t2.model/primary-keys model)
+                                                      (capture-fields model :insert))))
+                  rows         (insert-rows model fields (:rows parsed-args) pks)
+                  captured-pks (when rows (into #{} (map (t2.model/select-pks-fn model)) rows))]
+              (if (= (set pks) captured-pks)
+                (deliver-captured! model {:op :insert, :model model, :rows rows, :pks pks})
+                (log/errorf "Skipping insert capture for %s: could not correlate returned primary keys" model))))
+          result)))))
 
 ;;; A model may mix capture with toucan2's row-level tools; methodical needs to be told the capture method is
 ;;; the innermost of the pack, i.e. closest to the statement actually executing. In particular running inside

--- a/src/metabase/app_db/dml_capture.clj
+++ b/src/metabase/app_db/dml_capture.clj
@@ -1,0 +1,208 @@
+(ns metabase.app-db.dml-capture
+  "Statement-level capture of DML executed through Toucan 2.
+
+  A model opts in by deriving from [[hook]] and implementing [[capture-fields]] and [[captured!]].
+  Each captured `insert!`/`update!`/`delete!` *statement* then delivers exactly one event describing the
+  affected rows, however many there are — unlike the per-row `after-insert`/`after-update` tools, and unlike
+  `before-delete`, which realizes every matching row as a full instance.
+
+  Event shape (see [[captured!]]):
+
+    {:op :delete, :model model, :rows [pre-image, ...]}
+    {:op :update, :model model, :rows [pre-image, ...], :changes changes}
+    {:op :insert, :model model, :rows [row-literal, ...], :pks [pk, ...]}
+
+  For updates and deletes the `:rows` are narrow pre-image snapshots — only the columns named by
+  [[capture-fields]], selected with the statement's own conditions immediately before it executes. They are
+  plain maps of RAW column values: the select is compiled through the model's pipeline (so conditions behave
+  exactly like the statement's) but executed without it, so `after-select` methods, type transforms and other
+  instance decorations never run — decorations routinely assume a full row and must not constrain what a
+  capture may snapshot. For updates, `:changes` is the statement's changes map: every affected row received
+  these same changes, so the post-image of a captured column is
+  `(merge pre-image (select-keys changes capture-fields))` whenever its changed value is a literal. Values
+  are HoneySQL expressions when the caller passed expressions; they are delivered as-is.
+
+  For inserts `:rows` are the row maps as passed to `insert!` with the generated primary key assoc'd on, and
+  `:pks` are the generated primary keys. When some requested capture field is absent from the literals —
+  the column is filled in by the database or a `before-insert` method (e.g. `revision.most_recent`) — the
+  rows are replaced by one narrow select of the capture fields by pk, so a captured field is always present
+  and authoritative either way. Other literal values are delivered as passed, before type transforms.
+
+  Delivery guarantees, and non-guarantees:
+
+  - One event per statement, delivered on the calling thread after the statement executes but before any
+    enclosing transaction commits. If the transaction rolls back, the event has already fired: consumers must
+    treat events as \"look at these rows again\", never as facts about committed state.
+  - A statement matching zero rows delivers no event.
+  - DML that bypasses the model — `(t2/delete! (t2/table-name model) ...)`, raw `t2/query` — delivers no
+    event, exactly as it bypasses every other Toucan 2 tool.
+  - `update!` statements rewritten by a `before-update` method are captured after the rewrite: `:changes` is
+    what actually ran, and a before-update that splits one statement into per-row groups delivers one event
+    per group."
+  (:require
+   [metabase.util :as u]
+   [metabase.util.log :as log]
+   [methodical.core :as methodical]
+   [toucan2.execute :as t2.execute]
+   [toucan2.model :as t2.model]
+   [toucan2.pipeline :as t2.pipeline]
+   [toucan2.realize :as t2.realize]
+   [toucan2.types :as t2.types]))
+
+(def hook
+  "Models deriving from this keyword get statement-level DML capture."
+  ::captured)
+
+(defmulti capture-fields
+  "The columns guaranteed present in `:rows` when capturing `op` (`:insert`, `:update` or `:delete`)
+  statements against `model`; return nil or empty to leave that op uncaptured.
+  Update and delete snapshots are narrowed to exactly these columns; insert rows are the caller's literals,
+  back-filled by pk when a requested column is missing from them."
+  {:arglists '([model op])}
+  (fn [model _op] (keyword model)))
+
+(defmethod capture-fields :default
+  [_model _op]
+  nil)
+
+(defmulti captured!
+  "Deliver a capture event for a DML statement against `model`; see the namespace docstring for the shape.
+  Implementations run on the DML's calling thread, inside any enclosing transaction: keep them cheap and
+  never let them throw."
+  {:arglists '([model event])}
+  (fn [model _event] (keyword model)))
+
+(defn- pre-image-rows
+  "Select the rows a delete/update statement is about to affect, narrowed to `fields`, as plain raw-value maps.
+  The select is built and compiled through the model's pipeline so conditions keep the statement's exact
+  semantics, but executed modelless: `after-select` methods and type transforms often dereference columns a
+  narrow snapshot doesn't fetch, so no instance decoration may run here.
+  Runs on the current connection, so inside any transaction the statement itself runs in.
+  Capture is best-effort: a query shape we cannot rebuild as a select (e.g. raw sql-args with kv-args) logs
+  and skips capture rather than failing the caller's statement."
+  [query-type model fields parsed-args resolved-query]
+  (try
+    (let [built    (t2.pipeline/build query-type model
+                                      (assoc parsed-args :columns (vec fields))
+                                      resolved-query)
+          sql-args (t2.pipeline/compile query-type model built)]
+      (t2.execute/query sql-args))
+    (catch Exception e
+      (log/errorf e "Skipping DML capture for %s: could not snapshot pre-image rows" model)
+      nil)))
+
+(methodical/defmethod t2.pipeline/transduce-query
+  [#_query-type :toucan.query-type/delete.* #_model ::captured #_resolved-query :default]
+  "Capture the pre-image of the rows a DELETE statement matches, then deliver one `:delete` event."
+  [rf query-type model parsed-args resolved-query]
+  (let [fields (capture-fields model :delete)]
+    (if (empty? fields)
+      (next-method rf query-type model parsed-args resolved-query)
+      (let [rows (pre-image-rows :toucan.query-type/select.instances
+                                 model fields parsed-args resolved-query)]
+        (u/prog1 (next-method rf query-type model parsed-args resolved-query)
+          (when (seq rows)
+            (captured! model {:op :delete, :model model, :rows rows})))))))
+
+(methodical/defmethod t2.pipeline/transduce-query
+  [#_query-type :toucan.query-type/update.* #_model ::captured #_resolved-query :default]
+  "Capture the pre-image of the rows an UPDATE statement matches, then deliver one `:update` event."
+  [rf query-type model parsed-args resolved-query]
+  (let [fields (when-not (::captured? parsed-args)
+                 (capture-fields model :update))]
+    (if (or (empty? fields) (empty? (:changes parsed-args)))
+      (next-method rf query-type model parsed-args resolved-query)
+      ;; The conditions of an update are a conditions map, not a HoneySQL query, hence `from-update`.
+      (let [rows (pre-image-rows :toucan.query-type/select.instances.from-update
+                                 model fields parsed-args resolved-query)]
+        (u/prog1 (next-method rf query-type model (assoc parsed-args ::captured? true) resolved-query)
+          (when (seq rows)
+            (captured! model {:op      :update
+                              :model   model
+                              :rows    rows
+                              :changes (:changes parsed-args)})))))))
+
+(methodical/defmethod t2.pipeline/transduce-query
+  [#_query-type :toucan.query-type/insert.* #_model ::captured #_resolved-query :default]
+  "Capture the generated pks of an INSERT statement, then deliver one `:insert` event.
+  Count-returning inserts are upgraded to pk-returning ones (the same upgrade `after-insert` rides), so no
+  follow-up SELECT is needed; pk- and instance-returning inserts are captured from their own result stream."
+  [rf query-type model parsed-args resolved-query]
+  (let [capture? (and (not (::captured? parsed-args))
+                      (seq (capture-fields model :insert)))]
+    (if-not capture?
+      (next-method rf query-type model parsed-args resolved-query)
+      (let [pks         (volatile! (transient []))
+            parsed-args (assoc parsed-args ::captured? true)
+            pks-fn      (t2.model/select-pks-fn model)
+            result      (cond
+                          ;; already streaming instances: tee pks off the realized rows
+                          (isa? query-type :toucan.result-type/instances)
+                          (next-method ((map (fn [row]
+                                               (let [row (t2.realize/realize row)]
+                                                 (vswap! pks conj! (pks-fn row))
+                                                 row)))
+                                        rf)
+                                       query-type model parsed-args resolved-query)
+
+                          ;; already streaming pks: tee them
+                          (isa? query-type :toucan.result-type/pks)
+                          (next-method ((map (fn [pk]
+                                               (vswap! pks conj! pk)
+                                               pk))
+                                        rf)
+                                       query-type model parsed-args resolved-query)
+
+                          ;; update-count: re-dispatch as a pk-returning insert, converting each returned pk
+                          ;; back into a count of 1 for the original reducing function
+                          :else
+                          (t2.pipeline/transduce-query
+                           ((map (fn [pk]
+                                   (vswap! pks conj! pk)
+                                   1))
+                            rf)
+                           (t2.types/similar-query-type-returning query-type :toucan.result-type/pks)
+                           model parsed-args resolved-query))
+            pks         (persistent! @pks)]
+        (when (seq pks)
+          (let [fields       (capture-fields model :insert)
+                row-literals (:rows parsed-args)
+                pk-keys      (t2.model/primary-keys model)
+                single-pk    (when (= 1 (count pk-keys)) (first pk-keys))
+                rows         (if (and single-pk (= (count pks) (count row-literals)))
+                               (mapv #(assoc %1 single-pk %2) row-literals pks)
+                               (vec row-literals))
+                ;; The literals lack a requested capture field when the column is filled in by the database
+                ;; or a before-insert method (e.g. revision.most_recent); one narrow select by the returned
+                ;; pks recovers the authoritative values.
+                complete?    (fn [row] (every? #(contains? row %) fields))
+                rows         (if (or (every? complete? rows) (nil? single-pk))
+                               rows
+                               (pre-image-rows :toucan.query-type/select.instances model
+                                               (distinct (cons single-pk fields))
+                                               {:kv-args {:toucan/pk [:in pks]}}
+                                               {}))]
+            (captured! model {:op :insert, :model model, :rows rows, :pks pks})))
+        result))))
+
+;;; A model may mix capture with toucan2's row-level tools; methodical needs to be told the capture method is
+;;; the innermost of the pack, i.e. closest to the statement actually executing. In particular running inside
+;;; `before-update` means capture sees the statement as rewritten (final `:changes`, one event per rewrite
+;;; group). The `after` tools re-dispatch an upgraded query rather than call `next-method`, so the capture
+;;; method guards against re-entry with `::captured?` in `parsed-args`.
+
+(methodical/prefer-method! #'t2.pipeline/transduce-query
+                           [:toucan.query-type/delete.* :toucan2.tools.before-delete/before-delete :default]
+                           [:toucan.query-type/delete.* ::captured :default])
+
+(methodical/prefer-method! #'t2.pipeline/transduce-query
+                           [:toucan.query-type/update.* :toucan2.tools.before-update/before-update :default]
+                           [:toucan.query-type/update.* ::captured :default])
+
+(methodical/prefer-method! #'t2.pipeline/transduce-query
+                           [:toucan2.tools.after/query-type :toucan2.tools.after/model :default]
+                           [:toucan.query-type/update.* ::captured :default])
+
+(methodical/prefer-method! #'t2.pipeline/transduce-query
+                           [:toucan2.tools.after/query-type :toucan2.tools.after/model :default]
+                           [:toucan.query-type/insert.* ::captured :default])

--- a/src/metabase/app_db/dml_capture.clj
+++ b/src/metabase/app_db/dml_capture.clj
@@ -2,9 +2,8 @@
   "Statement-level capture of DML executed through Toucan 2.
 
   A model opts in by deriving from [[hook]] and implementing [[capture-fields]] and [[captured!]].
-  Each captured `insert!`/`update!`/`delete!` *statement* then delivers exactly one event describing the
-  affected rows, however many there are — unlike the per-row `after-insert`/`after-update` tools, and unlike
-  `before-delete`, which realizes every matching row as a full instance.
+  Each captured `insert!`/`update!`/`delete!` *statement* delivers exactly one event describing the affected
+  rows, however many there are.
 
   Event shape (see [[captured!]]):
 
@@ -12,21 +11,21 @@
     {:op :update, :model model, :rows [pre-image, ...], :changes changes}
     {:op :insert, :model model, :rows [row-literal, ...], :pks [pk, ...]}
 
-  For updates and deletes the `:rows` are narrow pre-image snapshots — only the columns named by
-  [[capture-fields]], selected with the statement's own conditions immediately before it executes. They are
-  plain maps of RAW column values: the select is compiled through the model's pipeline (so conditions behave
-  exactly like the statement's) but executed without it, so `after-select` methods, type transforms and other
-  instance decorations never run — decorations routinely assume a full row and must not constrain what a
-  capture may snapshot. For updates, `:changes` is the statement's changes map: every affected row received
-  these same changes, so the post-image of a captured column is
-  `(merge pre-image (select-keys changes capture-fields))` whenever its changed value is a literal. Values
-  are HoneySQL expressions when the caller passed expressions; they are delivered as-is.
+  Update and delete `:rows` are narrow pre-image snapshots: plain maps of raw column values, only the
+  columns named by [[capture-fields]], selected with the statement's own conditions immediately before it
+  executes.
+  No instance decoration runs on them — no `after-select` methods, no type transforms.
+  `:changes` is the update statement's changes map; every affected row received these same changes, so the
+  post-image of a captured column is `(merge pre-image (select-keys changes capture-fields))` whenever its
+  changed value is a literal.
+  HoneySQL expression values are delivered as-is.
 
-  For inserts `:rows` are the row maps as passed to `insert!` with the generated primary key assoc'd on, and
-  `:pks` are the generated primary keys. When some requested capture field is absent from the literals —
-  the column is filled in by the database or a `before-insert` method (e.g. `revision.most_recent`) — the
-  rows are replaced by one narrow select of the capture fields by pk, so a captured field is always present
-  and authoritative either way. Other literal values are delivered as passed, before type transforms.
+  Insert `:rows` are the row maps as passed to `insert!` with the generated primary key assoc'd on, and
+  `:pks` are the generated primary keys.
+  A requested capture field absent from the literals — filled in by the database or a `before-insert`
+  method (e.g. `revision.most_recent`) — is recovered by one narrow select of the capture fields by pk, so
+  a captured field is always present and authoritative either way.
+  Other literal values are delivered as passed, before type transforms.
 
   Delivery guarantees, and non-guarantees:
 

--- a/src/metabase/app_db/dml_capture.clj
+++ b/src/metabase/app_db/dml_capture.clj
@@ -31,7 +31,7 @@
   - One event per statement, delivered on the calling thread after the statement executes but before any
     enclosing transaction commits. If the transaction rolls back, the event has already fired: consumers must
     treat events as \"look at these rows again\", never as facts about committed state.
-  - A statement matching zero rows delivers no event.
+  - An empty pre-image snapshot delivers no update/delete event.
   - DML that bypasses the model — `(t2/delete! (t2/table-name model) ...)`, raw `t2/query` — delivers no
     event, exactly as it bypasses every other Toucan 2 tool.
   - `update!` statements rewritten by a `before-update` method are captured after the rewrite: `:changes` is

--- a/test/metabase/app_db/dml_capture_test.clj
+++ b/test/metabase/app_db/dml_capture_test.clj
@@ -314,10 +314,10 @@
   (reset-capture!)
   (swap! bird-capture-fields assoc :insert [:id :group_id :n])
   (testing "insert backfill shares the outer transaction while delivery retains the generic pre-commit contract"
-    (is (thrown? clojure.lang.ExceptionInfo
-                 (t2/with-transaction [_conn]
-                   (t2/insert! ::bird {:name "rollback" :group_id 101})
-                   (throw (ex-info "boom" {})))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"boom"
+                          (t2/with-transaction [_conn]
+                            (t2/insert! ::bird {:name "rollback" :group_id 101})
+                            (throw (ex-info "boom" {})))))
     (is (=? [{:op :insert, :model ::bird, :rows [{:group_id 101, :n 0}]}] (events)))
     (is (= 0 (t2/count ::bird :group_id 101)))))
 

--- a/test/metabase/app_db/dml_capture_test.clj
+++ b/test/metabase/app_db/dml_capture_test.clj
@@ -36,6 +36,7 @@
   (atom identity))
 
 (def ^:private after-insert-count (atom 0))
+(def ^:private after-update-count (atom 0))
 
 (defmethod dml-capture/capture-fields ::bird [_ op] (get @bird-capture-fields op))
 (defmethod dml-capture/capture-fields ::moody-bird [_ _op] [:id :group_id])
@@ -46,6 +47,7 @@
 (t2/define-before-update ::moody-bird [row] (@moody-before-update-fn row))
 (t2/define-before-delete ::moody-bird [row] row)
 (t2/define-after-insert ::moody-bird [row] (swap! after-insert-count inc) row)
+(t2/define-after-update ::moody-bird [row] (swap! after-update-count inc) row)
 
 ;;; `::decorated-bird` carries the decorations capture must bypass. Its after-select dereferences a column a
 ;;; narrow snapshot doesn't fetch (the shape of :model/Revision's :object deserializer), and its transforms
@@ -79,7 +81,8 @@
                                :update [:id :group_id]
                                :delete [:id :group_id]})
   (reset! moody-before-update-fn identity)
-  (reset! after-insert-count 0))
+  (reset! after-insert-count 0)
+  (reset! after-update-count 0))
 
 (defn- events [] @captured)
 
@@ -307,6 +310,17 @@
     (testing "the rows survive the rollback"
       (is (= 2 (t2/count ::bird :group_id 100))))))
 
+(deftest insert-backfill-fires-before-outer-rollback-test
+  (reset-capture!)
+  (swap! bird-capture-fields assoc :insert [:id :group_id :n])
+  (testing "insert backfill shares the outer transaction while delivery retains the generic pre-commit contract"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (t2/with-transaction [_conn]
+                   (t2/insert! ::bird {:name "rollback" :group_id 101})
+                   (throw (ex-info "boom" {})))))
+    (is (=? [{:op :insert, :model ::bird, :rows [{:group_id 101, :n 0}]}] (events)))
+    (is (= 0 (t2/count ::bird :group_id 101)))))
+
 (deftest raw-table-name-bypass-test
   (reset-capture!)
   (testing "DML addressed to the raw table name bypasses capture entirely"
@@ -337,6 +351,19 @@
                          {:id pos-int?, :group_id 200}]
                  :pks   [pos-int? pos-int? pos-int?]}
                 event))
+        (is (= (set pks) (set (map :id (:rows event)))))))))
+
+(deftest composition-after-update-reentry-test
+  (reset-capture!)
+  (testing "with an after-update tool present, every row hook runs and exactly one :update event fires"
+    (let [pks (t2/insert-returning-pks! ::moody-bird [(bird 205 0 "a") (bird 205 0 "b")])]
+      (reset! captured [])
+      (reset! after-update-count 0)
+      (is (= 2 (t2/update! ::moody-bird :group_id 205 {:n 1})))
+      (is (= 2 @after-update-count))
+      (is (= 1 (count (events))))
+      (let [event (first (events))]
+        (is (=? {:op :update, :model ::moody-bird, :changes {:n 1}} event))
         (is (= (set pks) (set (map :id (:rows event)))))))))
 
 (deftest composition-before-update-rewrite-test
@@ -389,35 +416,43 @@
     (let [{:keys [rows pks]} (first (events))]
       (is (= 1 (count rows)))
       (is (= #{:id :group_id :n} (set (keys (first rows)))))
-      (is (=? [{:group_id 240, :n 0, :id (first pks)}] rows))))
+      (is (=? [{:group_id 240, :n 0, :id (first pks)}] rows)))))
+
+(deftest multi-row-insert-backfill-correlates-by-pk-test
+  (reset-capture!)
   (testing "multiple rows are back-filled and correlated by PK, not input/result position"
-    (reset-capture!)
     (swap! bird-capture-fields assoc :insert [:id :group_id :n])
     (let [pks (t2/insert-returning-pks! ::bird [{:name "multi-a", :group_id 242}
                                                 {:name "multi-b", :group_id 243}])
           {event-pks :pks, rows :rows} (first (events))
           persisted (t2/select [::bird :id :group_id :n] :id [:in pks])]
       (is (= pks event-pks))
-      (is-same-rows-by-pk pks persisted rows)))
+      (is-same-rows-by-pk pks persisted rows))))
+
+(deftest explicit-pk-expression-insert-backfills-test
+  (reset-capture!)
   (testing "an explicit PK does not bypass backfill when a captured value is a SQL expression"
-    (reset-capture!)
     (swap! bird-capture-fields assoc :insert [:id :group_id :n])
     (t2/with-call-count [call-count]
       (t2/insert! ::bird {:id 24001, :name "expression", :group_id 244, :n [:+ 1 2]})
       (is (= 2 (call-count))))
     (is (= [{:id 24001, :group_id 244, :n 3}]
-           (:rows (first (events))))))
+           (:rows (first (events)))))))
+
+(deftest failed-insert-backfill-rolls-back-test
+  (reset-capture!)
   (testing "a failed insert backfill rolls the insert back"
-    (reset-capture!)
     (swap! bird-capture-fields assoc :insert [:id :group_id :n])
     (with-redefs [t2.execute/query (fn [_sql-args]
                                      (throw (java.sql.SQLException. "backfill failed")))]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"backfill failed"
                             (t2/insert! ::bird {:id 24002, :name "rollback", :group_id 244, :n [:+ 1 2]}))))
     (is (false? (t2/exists? ::bird :id 24002)))
-    (is (empty? (events))))
-  (testing "complete literals keep the zip path: no extra select"
-    (reset-capture!)
+    (is (empty? (events)))))
+
+(deftest complete-literal-insert-avoids-backfill-test
+  (reset-capture!)
+  (testing "complete literals keep the fast path: no extra select"
     (swap! bird-capture-fields assoc :insert [:id :group_id :n])
     (t2/with-call-count [call-count]
       (t2/insert! ::bird {:name "no-backfill" :group_id 241 :n 7})

--- a/test/metabase/app_db/dml_capture_test.clj
+++ b/test/metabase/app_db/dml_capture_test.clj
@@ -9,6 +9,7 @@
    [metabase.util :as u]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
+   [toucan2.execute :as t2.execute]
    [toucan2.model :as t2.model]))
 
 (set! *warn-on-reflection* true)
@@ -82,6 +83,14 @@
 
 (defn- events [] @captured)
 
+(defn- rows-by-id [rows]
+  (into {} (map (juxt :id (fn [row] (into {} row)))) rows))
+
+(defn- is-same-rows-by-pk
+  [pks expected actual]
+  (is (= (set pks) (set (map :id expected)) (set (map :id actual))))
+  (is (= (rows-by-id expected) (rows-by-id actual))))
+
 (defn- create-table-sql []
   (case (mdb/db-type)
     :postgres (str "CREATE TABLE " table-name
@@ -118,20 +127,19 @@
 
 (deftest insert-multi-row-single-event-test
   (reset-capture!)
+  (swap! bird-capture-fields assoc :insert [:id :group_id :n])
   (testing "a multi-row insert returns the count and delivers exactly one :insert event"
-    (let [rows [(bird 10 0 "a") (bird 10 0 "b") (bird 10 0 "c")]]
+    (let [rows [(bird 10 1 "a") (bird 10 2 "b") (bird 10 3 "c")]]
       (is (= 3 (t2/insert! ::bird rows)))
       (is (= 1 (count (events))))
       (let [{:keys [pks] :as event} (first (events))]
-        (is (=? {:op    :insert
-                 :model ::bird
-                 :rows  [(assoc (bird 10 0 "a") :id pos-int?)
-                         (assoc (bird 10 0 "b") :id pos-int?)
-                         (assoc (bird 10 0 "c") :id pos-int?)]
-                 :pks   [pos-int? pos-int? pos-int?]}
-                event))
-        (testing "the pks are the ids assoc'd onto the row literals, in order"
-          (is (= pks (mapv :id (:rows event)))))))))
+        (is (=? {:op :insert, :model ::bird, :pks [pos-int? pos-int? pos-int?]} event))
+        (is (= 3 (count (:rows event))))
+        (is (every? #(= #{:id :group_id :n} (set (keys %))) (:rows event)))
+        (testing "returned PKs and event rows are the same exact persisted row set, matched by PK"
+          (is-same-rows-by-pk pks
+                              (t2/select [::bird :id :group_id :n] :id [:in pks])
+                              (:rows event)))))))
 
 (deftest insert-adds-no-queries-test
   (reset-capture!)
@@ -139,7 +147,27 @@
     (t2/with-call-count [call-count]
       (is (= 1 (t2/insert! ::bird (bird 20 0 "x"))))
       (is (= 1 (call-count))))
-    (is (= 1 (count (events))))))
+    (is (= 1 (count (events)))))
+  (testing "a PK-only multi-row capture also runs exactly one SQL statement"
+    (reset-capture!)
+    (swap! bird-capture-fields assoc :insert [:id])
+    (t2/with-call-count [call-count]
+      (is (= 3 (t2/insert! ::bird [(bird 21 0 "a") (bird 21 0 "b") (bird 21 0 "c")])))
+      (is (= 1 (call-count))))
+    (let [{:keys [pks rows]} (first (events))]
+      (is (= (set pks) (set (map :id rows))))
+      (is (every? #(= #{:id} (set (keys %))) rows))))
+  (testing "complete rows with explicit PKs need no backfill and are matched by PK, not order"
+    (reset-capture!)
+    (swap! bird-capture-fields assoc :insert [:id :group_id :n])
+    (let [rows [{:id 22001, :name "explicit-a", :group_id 22, :n 1}
+                {:id 22002, :name "explicit-b", :group_id 23, :n 2}]]
+      (t2/with-call-count [call-count]
+        (is (= 2 (t2/insert! ::bird rows)))
+        (is (= 1 (call-count))))
+      (is-same-rows-by-pk [22002 22001]
+                          (mapv #(select-keys % [:id :group_id :n]) (reverse rows))
+                          (:rows (first (events)))))))
 
 (deftest insert-returning-pks-passthrough-test
   (reset-capture!)
@@ -147,12 +175,11 @@
     (let [pks (t2/insert-returning-pks! ::bird [(bird 30 0 "a") (bird 30 0 "b")])]
       (is (= 2 (count pks)))
       (is (= 1 (count (events))))
-      (is (=? {:op    :insert
-               :model ::bird
-               :pks   pks
-               :rows  [(assoc (bird 30 0 "a") :id (first pks))
-                       (assoc (bird 30 0 "b") :id (second pks))]}
-              (first (events)))))))
+      (let [{event-pks :pks, rows :rows} (first (events))]
+        (is (= pks event-pks))
+        (is-same-rows-by-pk pks
+                            (t2/select [::bird :id :group_id] :id [:in pks])
+                            rows)))))
 
 (deftest insert-returning-instances-passthrough-test
   (reset-capture!)
@@ -161,14 +188,10 @@
       (is (= 2 (count instances)))
       (is (= #{"a" "b"} (set (map :name instances))))
       (is (= 1 (count (events))))
-      (testing "the event's pks are the instance ids, and rows are the literals with those pks zipped on"
-        (is (=? {:op    :insert
-                 :model ::bird
-                 :pks   (mapv :id instances)
-                 :rows  (mapv (fn [instance literal] (assoc literal :id (:id instance)))
-                              instances
-                              [(bird 31 0 "a") (bird 31 0 "b")])}
-                (first (events))))))))
+      (testing "the event and returned instances identify the same rows without assuming result order"
+        (let [{:keys [pks rows]} (first (events))]
+          (is (= (set (map :id instances)) (set pks) (set (map :id rows))))
+          (is (= #{31} (set (map :group_id rows)))))))))
 
 (deftest bulk-update-statement-level-changes-test
   (reset-capture!)
@@ -228,6 +251,18 @@
       (t2/update! ::bird :group_id 70 {})
       (testing "at most the update itself runs, never an extra capture select"
         (is (>= 1 (call-count)))))
+    (is (empty? (events)))))
+
+(deftest pre-image-sql-error-propagates-test
+  (reset-capture!)
+  (let [id (t2/insert-returning-pk! ::bird (bird 71 0 "sql-error"))]
+    (reset! captured [])
+    (testing "an executed snapshot query failure is not suppressed inside the caller's transaction"
+      (with-redefs [t2.execute/query (fn [_sql-args]
+                                       (throw (java.sql.SQLException. "snapshot failed")))]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"snapshot failed"
+                              (t2/update! ::bird id {:n 1})))))
+    (is (= 0 (t2/select-one-fn :n ::bird id)))
     (is (empty? (events)))))
 
 (deftest delete-by-pk-and-by-honeysql-test
@@ -293,16 +328,16 @@
     (is (= 3 (t2/insert! ::moody-bird [(bird 200 0 "a") (bird 200 0 "b") (bird 200 0 "c")])))
     (is (= 3 @after-insert-count))
     (is (= 1 (count (events))))
-    (testing "the re-dispatched (instances-upgraded) path still delivers full rows with pks zipped in order"
+    (testing "the re-dispatched (instances-upgraded) path captures the exact returned PK set"
       (let [{:keys [pks] :as event} (first (events))]
         (is (=? {:op    :insert
                  :model ::moody-bird
-                 :rows  [(assoc (bird 200 0 "a") :id pos-int?)
-                         (assoc (bird 200 0 "b") :id pos-int?)
-                         (assoc (bird 200 0 "c") :id pos-int?)]
+                 :rows  [{:id pos-int?, :group_id 200}
+                         {:id pos-int?, :group_id 200}
+                         {:id pos-int?, :group_id 200}]
                  :pks   [pos-int? pos-int? pos-int?]}
                 event))
-        (is (= pks (mapv :id (:rows event))))))))
+        (is (= (set pks) (set (map :id (:rows event)))))))))
 
 (deftest composition-before-update-rewrite-test
   (reset-capture!)
@@ -355,6 +390,32 @@
       (is (= 1 (count rows)))
       (is (= #{:id :group_id :n} (set (keys (first rows)))))
       (is (=? [{:group_id 240, :n 0, :id (first pks)}] rows))))
+  (testing "multiple rows are back-filled and correlated by PK, not input/result position"
+    (reset-capture!)
+    (swap! bird-capture-fields assoc :insert [:id :group_id :n])
+    (let [pks (t2/insert-returning-pks! ::bird [{:name "multi-a", :group_id 242}
+                                                {:name "multi-b", :group_id 243}])
+          {event-pks :pks, rows :rows} (first (events))
+          persisted (t2/select [::bird :id :group_id :n] :id [:in pks])]
+      (is (= pks event-pks))
+      (is-same-rows-by-pk pks persisted rows)))
+  (testing "an explicit PK does not bypass backfill when a captured value is a SQL expression"
+    (reset-capture!)
+    (swap! bird-capture-fields assoc :insert [:id :group_id :n])
+    (t2/with-call-count [call-count]
+      (t2/insert! ::bird {:id 24001, :name "expression", :group_id 244, :n [:+ 1 2]})
+      (is (= 2 (call-count))))
+    (is (= [{:id 24001, :group_id 244, :n 3}]
+           (:rows (first (events))))))
+  (testing "a failed insert backfill rolls the insert back"
+    (reset-capture!)
+    (swap! bird-capture-fields assoc :insert [:id :group_id :n])
+    (with-redefs [t2.execute/query (fn [_sql-args]
+                                     (throw (java.sql.SQLException. "backfill failed")))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"backfill failed"
+                            (t2/insert! ::bird {:id 24002, :name "rollback", :group_id 244, :n [:+ 1 2]}))))
+    (is (false? (t2/exists? ::bird :id 24002)))
+    (is (empty? (events))))
   (testing "complete literals keep the zip path: no extra select"
     (reset-capture!)
     (swap! bird-capture-fields assoc :insert [:id :group_id :n])

--- a/test/metabase/app_db/dml_capture_test.clj
+++ b/test/metabase/app_db/dml_capture_test.clj
@@ -6,6 +6,7 @@
    [mb.hawk.assert-exprs]
    [metabase.app-db.core :as mdb]
    [metabase.app-db.dml-capture :as dml-capture]
+   [metabase.util :as u]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
    [toucan2.model :as t2.model]))
@@ -45,6 +46,33 @@
 (t2/define-before-delete ::moody-bird [row] row)
 (t2/define-after-insert ::moody-bird [row] (swap! after-insert-count inc) row)
 
+;;; `::decorated-bird` carries the decorations capture must bypass. Its after-select dereferences a column a
+;;; narrow snapshot doesn't fetch (the shape of :model/Revision's :object deserializer, which broke the
+;;; production capture path before selects went modelless), and its transforms rewrite :name on the way in
+;;; and out, so a decorated read is distinguishable from a raw one.
+(methodical/defmethod t2.model/table-name ::decorated-bird [_] table-name)
+
+(t2/deftransforms ::decorated-bird
+  {:name {:in  (fn [s] (u/upper-case-en ^String s))
+          :out (fn [s] (u/lower-case-en ^String s))}})
+
+(t2/define-after-select ::decorated-bird
+  [row]
+  ;; (inc nil) throws, so this after-select cannot survive a row that didn't fetch :n — a live trap for any
+  ;; capture path that runs instance decorations against a narrow snapshot.
+  (assoc row :n-plus (inc (:n row))))
+
+(defmethod dml-capture/capture-fields ::decorated-bird
+  [_ op]
+  ;; Neither op captures :n, keeping the after-select trap armed; :delete includes :name so the raw stored
+  ;; value is observable.
+  (case op
+    :update [:id :group_id]
+    :delete [:id :group_id :name]
+    nil))
+
+(defmethod dml-capture/captured! ::decorated-bird [_ event] (swap! captured conj event))
+
 (defn- reset-capture! []
   (reset! captured [])
   (reset! bird-capture-fields {:insert [:id :group_id]
@@ -78,11 +106,13 @@
     (t2/query [(create-table-sql)])
     (derive ::bird dml-capture/hook)
     (derive ::moody-bird dml-capture/hook)
+    (derive ::decorated-bird dml-capture/hook)
     (try
       (thunk)
       (finally
         (underive ::bird dml-capture/hook)
         (underive ::moody-bird dml-capture/hook)
+        (underive ::decorated-bird dml-capture/hook)
         (t2/query [(drop-table-sql)])))))
 
 (defn- bird [group-id n name-str] {:name name-str, :group_id group-id, :n n})
@@ -114,11 +144,16 @@
 
 (deftest insert-returning-pks-passthrough-test
   (reset-capture!)
-  (testing "insert-returning-pks! returns the pks unchanged and fires one event"
+  (testing "insert-returning-pks! returns the pks unchanged and fires one event with pk'd row literals"
     (let [pks (t2/insert-returning-pks! ::bird [(bird 30 0 "a") (bird 30 0 "b")])]
       (is (= 2 (count pks)))
       (is (= 1 (count (events))))
-      (is (=? {:op :insert, :pks pks} (first (events)))))))
+      (is (=? {:op    :insert
+               :model ::bird
+               :pks   pks
+               :rows  [(assoc (bird 30 0 "a") :id (first pks))
+                       (assoc (bird 30 0 "b") :id (second pks))]}
+              (first (events)))))))
 
 (deftest insert-returning-instances-passthrough-test
   (reset-capture!)
@@ -127,7 +162,14 @@
       (is (= 2 (count instances)))
       (is (= #{"a" "b"} (set (map :name instances))))
       (is (= 1 (count (events))))
-      (is (=? {:op :insert} (first (events)))))))
+      (testing "the event's pks are the instance ids, and rows are the literals with those pks zipped on"
+        (is (=? {:op    :insert
+                 :model ::bird
+                 :pks   (mapv :id instances)
+                 :rows  (mapv (fn [instance literal] (assoc literal :id (:id instance)))
+                              instances
+                              [(bird 31 0 "a") (bird 31 0 "b")])}
+                (first (events))))))))
 
 (deftest bulk-update-statement-level-changes-test
   (reset-capture!)
@@ -198,20 +240,23 @@
       (is (=? {:op :delete, :model ::bird, :rows [{:id id, :group_id 80}]} (first (events))))))
   (testing "delete with a honeysql where-map captures the pre-image rows"
     (reset-capture!)
-    (t2/insert! ::bird [(bird 81 0 "a") (bird 81 0 "b")])
-    (reset! captured [])
-    (is (= 2 (t2/delete! ::bird {:where [:= :group_id 81]})))
-    (is (=? {:op :delete, :model ::bird} (first (events))))
-    (is (= 2 (count (:rows (first (events))))))))
+    (let [pks (t2/insert-returning-pks! ::bird [(bird 81 0 "a") (bird 81 0 "b")])]
+      (reset! captured [])
+      (is (= 2 (t2/delete! ::bird {:where [:= :group_id 81]})))
+      (is (=? {:op :delete, :model ::bird} (first (events))))
+      (is (= (set (map (fn [pk] {:id pk, :group_id 81}) pks))
+             (set (:rows (first (events)))))))))
 
 (deftest honeysql-expression-changes-passthrough-test
   (reset-capture!)
-  (testing "a honeysql expression in :changes is delivered as-is (pass-through)"
-    (t2/insert! ::bird [(bird 90 3 "a") (bird 90 7 "b")])
-    (reset! captured [])
-    (t2/update! ::bird :group_id 90 {:n [:+ :n 1]})
-    (is (= 1 (count (events))))
-    (is (= {:n [:+ :n 1]} (:changes (first (events)))))))
+  (testing "a honeysql expression in :changes is delivered as-is (pass-through), with the usual pre-image rows"
+    (let [pks (t2/insert-returning-pks! ::bird [(bird 90 3 "a") (bird 90 7 "b")])]
+      (reset! captured [])
+      (t2/update! ::bird :group_id 90 {:n [:+ :n 1]})
+      (is (= 1 (count (events))))
+      (is (= {:n [:+ :n 1]} (:changes (first (events)))))
+      (is (= (set (map (fn [pk] {:id pk, :group_id 90}) pks))
+             (set (:rows (first (events)))))))))
 
 (deftest rollback-fires-at-least-once-test
   (reset-capture!)
@@ -222,9 +267,9 @@
                  (t2/with-transaction [_conn]
                    (t2/delete! ::bird :group_id 100)
                    (throw (ex-info "boom" {})))))
-    (testing "the event fired before the rollback"
+    (testing "the event fired before the rollback, carrying the (still-live) pre-image rows"
       (is (= 1 (count (events))))
-      (is (=? {:op :delete} (first (events)))))
+      (is (=? {:op :delete, :model ::bird, :rows [{:group_id 100} {:group_id 100}]} (first (events)))))
     (testing "the rows survive the rollback"
       (is (= 2 (t2/count ::bird :group_id 100))))))
 
@@ -249,7 +294,16 @@
     (is (= 3 (t2/insert! ::moody-bird [(bird 200 0 "a") (bird 200 0 "b") (bird 200 0 "c")])))
     (is (= 3 @after-insert-count))
     (is (= 1 (count (events))))
-    (is (=? {:op :insert, :model ::moody-bird} (first (events))))))
+    (testing "the re-dispatched (instances-upgraded) path still delivers full rows with pks zipped in order"
+      (let [{:keys [pks] :as event} (first (events))]
+        (is (=? {:op    :insert
+                 :model ::moody-bird
+                 :rows  [(assoc (bird 200 0 "a") :id pos-int?)
+                         (assoc (bird 200 0 "b") :id pos-int?)
+                         (assoc (bird 200 0 "c") :id pos-int?)]
+                 :pks   [pos-int? pos-int? pos-int?]}
+                event))
+        (is (= pks (mapv :id (:rows event))))))))
 
 (deftest composition-before-update-rewrite-test
   (reset-capture!)
@@ -273,18 +327,21 @@
         (is (= (count ids) (count (events))))
         (is (= (set (map (fn [id] {:n (+ 100 id)}) ids))
                (set (map :changes (events)))))
-        (testing "each event carries exactly its own group's single pre-image row"
-          (is (every? #(= 1 (count (:rows %))) (events))))))))
+        (testing "each event pairs its group's changes with that group's own pre-image row, not another's"
+          (is (every? #(= 1 (count (:rows %))) (events)))
+          (doseq [{:keys [changes rows]} (events)]
+            (is (= (:n changes) (+ 100 (:id (first rows)))))))))))
 
 (deftest composition-delete-no-ambiguity-test
   (reset-capture!)
   (testing "a model mixing before-delete with capture deletes without ambiguity and fires one :delete event"
-    (t2/insert! ::moody-bird [(bird 230 0 "a") (bird 230 0 "b")])
-    (reset! captured [])
-    (is (= 2 (t2/delete! ::moody-bird :group_id 230)))
-    (is (= 1 (count (events))))
-    (is (=? {:op :delete, :model ::moody-bird} (first (events))))
-    (is (= 2 (count (:rows (first (events))))))))
+    (let [pks (t2/insert-returning-pks! ::moody-bird [(bird 230 0 "a") (bird 230 0 "b")])]
+      (reset! captured [])
+      (is (= 2 (t2/delete! ::moody-bird :group_id 230)))
+      (is (= 1 (count (events))))
+      (is (=? {:op :delete, :model ::moody-bird} (first (events))))
+      (is (= (set (map (fn [pk] {:id pk, :group_id 230}) pks))
+             (set (:rows (first (events)))))))))
 
 (deftest insert-backfills-missing-capture-fields-test
   (reset-capture!)
@@ -306,3 +363,21 @@
       (t2/insert! ::bird {:name "no-backfill" :group_id 241 :n 7})
       (is (= 1 (call-count))))
     (is (=? [{:rows [{:group_id 241, :n 7}]}] (events)))))
+
+(deftest capture-bypasses-instance-decorations-test
+  (reset-capture!)
+  (testing "capture selects run modelless: no after-select decoration, no out-transforms"
+    (t2/insert! ::decorated-bird {:name "abc" :group_id 250})
+    (testing "an after-select that dereferences an unfetched column would throw if decorations ran"
+      (reset! captured [])
+      (is (= 1 (t2/update! ::decorated-bird :group_id 250 {:n 1})))
+      (is (=? [{:op :update, :rows [{:group_id 250}]}] (events)))
+      (is (= #{:id :group_id} (set (keys (first (:rows (first (events)))))))))
+    (testing "captured values are the raw stored column values: in-transformed on write, never out-transformed"
+      (reset! captured [])
+      (is (= 1 (t2/delete! ::decorated-bird :group_id 250)))
+      (let [[{:keys [rows]} :as evs] (events)]
+        (is (= 1 (count evs)))
+        (is (=? [{:group_id 250, :name "ABC"}] rows))
+        (testing "no decoration keys leak into the snapshot"
+          (is (= #{:id :group_id :name} (set (keys (first rows))))))))))

--- a/test/metabase/app_db/dml_capture_test.clj
+++ b/test/metabase/app_db/dml_capture_test.clj
@@ -1,0 +1,308 @@
+(ns metabase.app-db.dml-capture-test
+  "Pins the statement-level DML capture contract documented in [[metabase.app-db.dml-capture]].
+  Not parallel: the suite mutates the global hierarchy and shares one scratch table across tests."
+  (:require
+   [clojure.test :refer :all]
+   [mb.hawk.assert-exprs]
+   [metabase.app-db.core :as mdb]
+   [metabase.app-db.dml-capture :as dml-capture]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]
+   [toucan2.model :as t2.model]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private table-name "dml_capture_test_bird")
+
+;;; `::bird` is a clean model carrying only capture. `::moody-bird` shares the same table but additionally
+;;; registers toucan2 row-level tools, so composition tests keep `::bird`'s preconditions obvious.
+(methodical/defmethod t2.model/table-name ::bird [_] table-name)
+(methodical/defmethod t2.model/table-name ::moody-bird [_] table-name)
+
+(def ^:private captured
+  "Events delivered by [[dml-capture/captured!]] for the scratch models, in order."
+  (atom []))
+
+(def ^:private bird-capture-fields
+  "Per-op `capture-fields` for `::bird`, so a test can switch an op off without redefining a method."
+  (atom {:insert [:id :group_id]
+         :update [:id :group_id]
+         :delete [:id :group_id]}))
+
+(def ^:private moody-before-update-fn
+  "The row rewrite `::moody-bird`'s before-update applies; identity unless a composition test sets it."
+  (atom identity))
+
+(def ^:private after-insert-count (atom 0))
+
+(defmethod dml-capture/capture-fields ::bird [_ op] (get @bird-capture-fields op))
+(defmethod dml-capture/capture-fields ::moody-bird [_ _op] [:id :group_id])
+
+(defmethod dml-capture/captured! ::bird [_ event] (swap! captured conj event))
+(defmethod dml-capture/captured! ::moody-bird [_ event] (swap! captured conj event))
+
+(t2/define-before-update ::moody-bird [row] (@moody-before-update-fn row))
+(t2/define-before-delete ::moody-bird [row] row)
+(t2/define-after-insert ::moody-bird [row] (swap! after-insert-count inc) row)
+
+(defn- reset-capture! []
+  (reset! captured [])
+  (reset! bird-capture-fields {:insert [:id :group_id]
+                               :update [:id :group_id]
+                               :delete [:id :group_id]})
+  (reset! moody-before-update-fn identity)
+  (reset! after-insert-count 0))
+
+(defn- events [] @captured)
+
+(defn- create-table-sql []
+  (case (mdb/db-type)
+    :postgres (str "CREATE TABLE " table-name
+                   " (id SERIAL PRIMARY KEY, name VARCHAR(255) NOT NULL,"
+                   " group_id INT NOT NULL, n INT NOT NULL DEFAULT 0)")
+    :h2       (str "CREATE TABLE \"" table-name "\""
+                   " (\"id\" BIGINT AUTO_INCREMENT PRIMARY KEY, \"name\" VARCHAR(255) NOT NULL,"
+                   " \"group_id\" INT NOT NULL, \"n\" INT NOT NULL DEFAULT 0)")
+    :mysql    (str "CREATE TABLE " table-name
+                   " (id BIGINT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255) NOT NULL,"
+                   " group_id INT NOT NULL, n INT NOT NULL DEFAULT 0)")))
+
+(defn- drop-table-sql []
+  (if (= :h2 (mdb/db-type))
+    (str "DROP TABLE IF EXISTS \"" table-name "\"")
+    (str "DROP TABLE IF EXISTS " table-name)))
+
+(use-fixtures :once
+  (fn [thunk]
+    (t2/query [(drop-table-sql)])
+    (t2/query [(create-table-sql)])
+    (derive ::bird dml-capture/hook)
+    (derive ::moody-bird dml-capture/hook)
+    (try
+      (thunk)
+      (finally
+        (underive ::bird dml-capture/hook)
+        (underive ::moody-bird dml-capture/hook)
+        (t2/query [(drop-table-sql)])))))
+
+(defn- bird [group-id n name-str] {:name name-str, :group_id group-id, :n n})
+
+(deftest insert-multi-row-single-event-test
+  (reset-capture!)
+  (testing "a multi-row insert returns the count and delivers exactly one :insert event"
+    (let [rows [(bird 10 0 "a") (bird 10 0 "b") (bird 10 0 "c")]]
+      (is (= 3 (t2/insert! ::bird rows)))
+      (is (= 1 (count (events))))
+      (let [{:keys [pks] :as event} (first (events))]
+        (is (=? {:op    :insert
+                 :model ::bird
+                 :rows  [(assoc (bird 10 0 "a") :id pos-int?)
+                         (assoc (bird 10 0 "b") :id pos-int?)
+                         (assoc (bird 10 0 "c") :id pos-int?)]
+                 :pks   [pos-int? pos-int? pos-int?]}
+                event))
+        (testing "the pks are the ids assoc'd onto the row literals, in order"
+          (is (= pks (mapv :id (:rows event)))))))))
+
+(deftest insert-adds-no-queries-test
+  (reset-capture!)
+  (testing "capturing a single-row insert runs exactly one SQL statement"
+    (t2/with-call-count [call-count]
+      (is (= 1 (t2/insert! ::bird (bird 20 0 "x"))))
+      (is (= 1 (call-count))))
+    (is (= 1 (count (events))))))
+
+(deftest insert-returning-pks-passthrough-test
+  (reset-capture!)
+  (testing "insert-returning-pks! returns the pks unchanged and fires one event"
+    (let [pks (t2/insert-returning-pks! ::bird [(bird 30 0 "a") (bird 30 0 "b")])]
+      (is (= 2 (count pks)))
+      (is (= 1 (count (events))))
+      (is (=? {:op :insert, :pks pks} (first (events)))))))
+
+(deftest insert-returning-instances-passthrough-test
+  (reset-capture!)
+  (testing "insert-returning-instances! returns the instances unchanged and fires one event, not two"
+    (let [instances (t2/insert-returning-instances! ::bird [(bird 31 0 "a") (bird 31 0 "b")])]
+      (is (= 2 (count instances)))
+      (is (= #{"a" "b"} (set (map :name instances))))
+      (is (= 1 (count (events))))
+      (is (=? {:op :insert} (first (events)))))))
+
+(deftest bulk-update-statement-level-changes-test
+  (reset-capture!)
+  (testing "a bulk update delivers one :update event with the statement's changes and narrow pre-image rows"
+    (t2/insert! ::bird [(bird 40 0 "a") (bird 40 0 "b") (bird 40 0 "c")])
+    (reset! captured [])
+    (is (= 3 (t2/update! ::bird :group_id 40 {:n 5})))
+    (is (= 1 (count (events))))
+    (let [{:keys [changes rows] :as event} (first (events))]
+      (is (=? {:op :update, :model ::bird} event))
+      (testing "changes is exactly the requested changes, not the full row and not empty"
+        (is (= {:n 5} changes)))
+      (testing "each pre-image row carries only the requested capture-fields"
+        (is (= 3 (count rows)))
+        (is (every? #(= #{:id :group_id} (set (keys %))) rows))
+        (is (every? #(= 40 (:group_id %)) rows))))))
+
+(deftest update-and-delete-statement-counts-test
+  (testing "a captured update runs two statements (narrow select + update)"
+    (reset-capture!)
+    (t2/insert! ::bird [(bird 50 0 "a") (bird 50 0 "b")])
+    (t2/with-call-count [call-count]
+      (t2/update! ::bird :group_id 50 {:n 1})
+      (is (= 2 (call-count)))))
+  (testing "a captured delete runs two statements (narrow select + delete)"
+    (reset-capture!)
+    (t2/insert! ::bird [(bird 51 0 "a") (bird 51 0 "b")])
+    (t2/with-call-count [call-count]
+      (t2/delete! ::bird :group_id 51)
+      (is (= 2 (call-count)))))
+  (testing "a delete whose capture-fields returns nil runs one statement and fires nothing"
+    (reset-capture!)
+    (swap! bird-capture-fields assoc :delete nil)
+    (t2/insert! ::bird [(bird 52 0 "a") (bird 52 0 "b")])
+    (reset! captured [])
+    (t2/with-call-count [call-count]
+      (t2/delete! ::bird :group_id 52)
+      (is (= 1 (call-count))))
+    (is (empty? (events)))))
+
+(deftest zero-rows-no-event-test
+  (testing "an update matching zero rows returns 0 and delivers no event"
+    (reset-capture!)
+    (is (= 0 (t2/update! ::bird :group_id 60 {:n 5})))
+    (is (empty? (events))))
+  (testing "a delete matching zero rows delivers no event"
+    (reset-capture!)
+    (is (= 0 (t2/delete! ::bird :group_id 61)))
+    (is (empty? (events)))))
+
+(deftest empty-changes-no-event-no-select-test
+  (reset-capture!)
+  (testing "an update with an empty changes map delivers no event and runs no capture select"
+    (t2/insert! ::bird [(bird 70 0 "a") (bird 70 0 "b")])
+    (reset! captured [])
+    (t2/with-call-count [call-count]
+      (t2/update! ::bird :group_id 70 {})
+      (testing "at most the update itself runs, never an extra capture select"
+        (is (>= 1 (call-count)))))
+    (is (empty? (events)))))
+
+(deftest delete-by-pk-and-by-honeysql-test
+  (testing "delete by a pk arg captures the pre-image rows"
+    (reset-capture!)
+    (let [id (first (t2/insert-returning-pks! ::bird (bird 80 0 "a")))]
+      (reset! captured [])
+      (is (= 1 (t2/delete! ::bird id)))
+      (is (=? {:op :delete, :model ::bird, :rows [{:id id, :group_id 80}]} (first (events))))))
+  (testing "delete with a honeysql where-map captures the pre-image rows"
+    (reset-capture!)
+    (t2/insert! ::bird [(bird 81 0 "a") (bird 81 0 "b")])
+    (reset! captured [])
+    (is (= 2 (t2/delete! ::bird {:where [:= :group_id 81]})))
+    (is (=? {:op :delete, :model ::bird} (first (events))))
+    (is (= 2 (count (:rows (first (events))))))))
+
+(deftest honeysql-expression-changes-passthrough-test
+  (reset-capture!)
+  (testing "a honeysql expression in :changes is delivered as-is (pass-through)"
+    (t2/insert! ::bird [(bird 90 3 "a") (bird 90 7 "b")])
+    (reset! captured [])
+    (t2/update! ::bird :group_id 90 {:n [:+ :n 1]})
+    (is (= 1 (count (events))))
+    (is (= {:n [:+ :n 1]} (:changes (first (events)))))))
+
+(deftest rollback-fires-at-least-once-test
+  (reset-capture!)
+  (testing "a captured delete in a transaction that then throws still fired its event and left the rows"
+    (t2/insert! ::bird [(bird 100 0 "a") (bird 100 0 "b")])
+    (reset! captured [])
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (t2/with-transaction [_conn]
+                   (t2/delete! ::bird :group_id 100)
+                   (throw (ex-info "boom" {})))))
+    (testing "the event fired before the rollback"
+      (is (= 1 (count (events))))
+      (is (=? {:op :delete} (first (events)))))
+    (testing "the rows survive the rollback"
+      (is (= 2 (t2/count ::bird :group_id 100))))))
+
+(deftest raw-table-name-bypass-test
+  (reset-capture!)
+  (testing "DML addressed to the raw table name bypasses capture entirely"
+    (t2/insert! ::bird [(bird 110 0 "a") (bird 110 0 "b")])
+    (reset! captured [])
+    (t2/delete! (t2/table-name ::bird) {:where [:= :group_id 110]})
+    (is (empty? (events)))
+    (is (= 0 (t2/count ::bird :group_id 110)))))
+
+(deftest default-capture-fields-is-nil-test
+  (testing "a model that never registered capture-fields is uncaptured by default"
+    (is (nil? (dml-capture/capture-fields ::never-registered :insert)))
+    (is (nil? (dml-capture/capture-fields ::never-registered :update)))
+    (is (nil? (dml-capture/capture-fields ::never-registered :delete)))))
+
+(deftest composition-after-insert-reentry-test
+  (reset-capture!)
+  (testing "with an after-insert tool present, per-row after-insert runs and exactly one :insert event fires"
+    (is (= 3 (t2/insert! ::moody-bird [(bird 200 0 "a") (bird 200 0 "b") (bird 200 0 "c")])))
+    (is (= 3 @after-insert-count))
+    (is (= 1 (count (events))))
+    (is (=? {:op :insert, :model ::moody-bird} (first (events))))))
+
+(deftest composition-before-update-rewrite-test
+  (reset-capture!)
+  (testing "an update rewritten by before-update delivers the rewritten :changes"
+    (reset! moody-before-update-fn (fn [row] (cond-> row (neg? (:n row 0)) (assoc :n 0))))
+    (t2/insert! ::moody-bird [(bird 210 5 "a") (bird 210 5 "b")])
+    (reset! captured [])
+    (t2/update! ::moody-bird :group_id 210 {:n -1})
+    (is (= 1 (count (events))))
+    (is (= {:n 0} (:changes (first (events)))))))
+
+(deftest composition-before-update-splits-into-groups-test
+  (reset-capture!)
+  (testing "a before-update producing per-row changes splits one statement into one event per group"
+    (reset! moody-before-update-fn (fn [row] (assoc row :n (+ (:n row) (:id row)))))
+    (let [ids (t2/insert-returning-pks! ::moody-bird
+                                        [(bird 220 0 "a") (bird 220 0 "b") (bird 220 0 "c")])]
+      (reset! captured [])
+      (t2/update! ::moody-bird :group_id 220 {:n 100})
+      (testing "one event per distinct rewritten change set"
+        (is (= (count ids) (count (events))))
+        (is (= (set (map (fn [id] {:n (+ 100 id)}) ids))
+               (set (map :changes (events)))))
+        (testing "each event carries exactly its own group's single pre-image row"
+          (is (every? #(= 1 (count (:rows %))) (events))))))))
+
+(deftest composition-delete-no-ambiguity-test
+  (reset-capture!)
+  (testing "a model mixing before-delete with capture deletes without ambiguity and fires one :delete event"
+    (t2/insert! ::moody-bird [(bird 230 0 "a") (bird 230 0 "b")])
+    (reset! captured [])
+    (is (= 2 (t2/delete! ::moody-bird :group_id 230)))
+    (is (= 1 (count (events))))
+    (is (=? {:op :delete, :model ::moody-bird} (first (events))))
+    (is (= 2 (count (:rows (first (events))))))))
+
+(deftest insert-backfills-missing-capture-fields-test
+  (reset-capture!)
+  (testing "a capture field absent from the insert literals (db default / before-insert) is back-filled by pk"
+    (swap! bird-capture-fields assoc :insert [:id :group_id :n])
+    ;; :n is omitted so the database default (0) fills it; the seam must recover it with one extra select.
+    (t2/with-call-count [call-count]
+      (t2/insert! ::bird {:name "backfill" :group_id 240})
+      (is (= 2 (call-count))))
+    (is (= 1 (count (events))))
+    (let [{:keys [rows pks]} (first (events))]
+      (is (= 1 (count rows)))
+      (is (= #{:id :group_id :n} (set (keys (first rows)))))
+      (is (=? [{:group_id 240, :n 0, :id (first pks)}] rows))))
+  (testing "complete literals keep the zip path: no extra select"
+    (reset-capture!)
+    (swap! bird-capture-fields assoc :insert [:id :group_id :n])
+    (t2/with-call-count [call-count]
+      (t2/insert! ::bird {:name "no-backfill" :group_id 241 :n 7})
+      (is (= 1 (call-count))))
+    (is (=? [{:rows [{:group_id 241, :n 7}]}] (events)))))

--- a/test/metabase/app_db/dml_capture_test.clj
+++ b/test/metabase/app_db/dml_capture_test.clj
@@ -47,9 +47,8 @@
 (t2/define-after-insert ::moody-bird [row] (swap! after-insert-count inc) row)
 
 ;;; `::decorated-bird` carries the decorations capture must bypass. Its after-select dereferences a column a
-;;; narrow snapshot doesn't fetch (the shape of :model/Revision's :object deserializer, which broke the
-;;; production capture path before selects went modelless), and its transforms rewrite :name on the way in
-;;; and out, so a decorated read is distinguishable from a raw one.
+;;; narrow snapshot doesn't fetch (the shape of :model/Revision's :object deserializer), and its transforms
+;;; rewrite :name on the way in and out, so a decorated read is distinguishable from a raw one.
 (methodical/defmethod t2.model/table-name ::decorated-bird [_] table-name)
 
 (t2/deftransforms ::decorated-bird


### PR DESCRIPTION
Adds `metabase.app-db.dml-capture`, a statement-level hook for `t2/delete!`.

Toucan's `before-delete` realizes a full instance for every matching row, which is why search never hooked deletes.
A model that derives `dml-capture/hook` instead gets one event per delete statement, carrying a narrow snapshot of only the columns it asks for via `capture-fields`.
The snapshot is selected with the statement's own conditions, immediately before it runs.

Details:

- The snapshot runs modelless, since `after-select` methods and type transforms can't cope with narrow rows.
- A statement matching more than 10,000 rows skips capture and logs an error, rather than materializing the whole match set on the caller's thread.
- Explicit HoneySQL `:delete`/`:delete-from` maps are restated as a select. Shapes it can't restate skip capture instead of breaking the delete.
- Events fire before the enclosing transaction commits, so consumers should treat them as "look at these rows again" and defer their own work until commit.
- Deletes that bypass the model (raw `t2/query`, table-name deletes) aren't captured, same as every other Toucan tool.

Inserts and updates keep their row-level hooks.
Nothing derives the hook until the next PR.

## Measured: 1000-card deletes across the stack

Local Postgres app DB, ingestion stubbed, stack tip (#78294) against its master base, median of 3 warm runs.
"Wall clock" runs post-commit search work inline so it can be counted; "caller waits" runs it in the background, as production does.
Each cell is master → this stack.

| | statements | wall clock | caller waits | enqueue calls (messages) |
|---|---|---|---|---|
| delete 1000 cards | 5003 → 7006 | 745 → 1137 ms | 779 → 1088 ms | 0 → 1 (5000) |
| delete 1000 models with an action each | 5003 → 7008 | 824 → 1137 ms | 1094 → 1080 ms | 0 → 2 (5001) |
| delete a database holding those models | 9 → 12 | 83 → 109 ms | 84 → 111 ms | 0 → 3 (6) |

On master all three leave deleted cards (or, for the database, their actions) in search results until the hourly reindex. With the stack they're purged.
Bulk insert and archive don't change (1003 and 1005 statements, 1000 enqueue calls each, wall clock within noise).
Wall clock is noisy at this size: the master "caller waits" figure for models with actions ranged from 862 to 1106 ms.

Where the extra statements come from:

- 2000 are capture snapshots for the Revision and ModerationReview deletes Card's `before-delete` issues, one of each per card. They come back empty here.
- 1 is the snapshot for the card delete itself.
- 2 are the cascade scans for `action` and `indexed-entity`, and 1 more runs after commit when those scans found anything. These are per statement, not per row.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
