### PR TITLE
Purge deleted rows from the search index

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -344,8 +344,9 @@
 
   app-db
   {:team "UX West"
-   :api  #{metabase.app-db.cluster-lock ; TODO FIXME
+   :api  #{metabase.app-db.cluster-lock
            metabase.app-db.core
+           metabase.app-db.dml-capture
            metabase.app-db.init
            metabase.app-db.setup
            metabase.app-db.transient-error}

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -242,6 +242,18 @@
       ;; We need to delay execution to handle deletes, which alert us *before* updating the database.
       (search.ingestion/ingest-maybe-async! updates))))
 
+(defn bulk-update!
+  "Enqueue re-indexing derived from `instances` unconditionally, e.g. the pre-images of deleted rows.
+  Enqueued messages only ask ingestion to re-derive the affected search entries: rows that no longer
+  satisfy their spec's query are purged by ingestion's asked-for-but-not-indexed diff."
+  [instances]
+  (when (supports-index?)
+    (when-let [updates (->> instances
+                            (into #{} (mapcat #(search.spec/search-models-to-update % true)))
+                            (remove (comp search.util/impossible-condition? second))
+                            seq)]
+      (search.ingestion/ingest-maybe-async! updates))))
+
 (defn delete!
   "Given a model and a list of model's ids, remove corresponding search entries."
   [model ids]

--- a/src/metabase/search/ingestion.clj
+++ b/src/metabase/search/ingestion.clj
@@ -29,7 +29,8 @@
 
 (def ^:private message-delay-ms
   "The time a message should wait before coming off the queue.
-  This delay exists to ensure the data is fully committed before indexing."
+  This coalesces bursts for efficient batch ingestion; transaction-sensitive publishers must defer their own
+  handoff until commit."
   100)
 
 (def ^:private listener-name

--- a/src/metabase/search/models.clj
+++ b/src/metabase/search/models.clj
@@ -1,6 +1,8 @@
 (ns metabase.search.models
   (:require
+   [metabase.app-db.dml-capture :as dml-capture]
    [metabase.search.core :as search]
+   [metabase.search.spec :as search.spec]
    [toucan2.core :as t2]))
 
 ;; Models must derive from :hook/search-index if their state can influence the contents of the Search Index.
@@ -18,9 +20,21 @@
   (search/update! instance)
   nil)
 
-;; Too much of a performance risk.
-#_(t2/define-before-delete :metabase/model
-    [instance]
-    (when (search/supports-index?)
-      (search.ingestion/update-index! instance))
-    instance)
+;; Deletes have no row-level hook: a before-delete would realize every matching row as a full instance, which
+;; was rejected as too much of a performance risk. Instead the capture seam snapshots just the hook-relevant
+;; columns, once per delete statement. The enqueued messages are re-derivations, so ingestion's
+;; asked-for-but-not-indexed diff purges entries whose backing row is gone, and a message enqueued for a
+;; delete that later rolls back degrades to a harmless re-index of the still-live rows.
+(derive :hook/search-index dml-capture/hook)
+
+(defmethod dml-capture/capture-fields :hook/search-index
+  [model op]
+  (when (and (= op :delete)
+             (search/supports-index?))
+    (search.spec/hook-where-fields model)))
+
+(defmethod dml-capture/captured! :hook/search-index
+  [model {:keys [op rows]}]
+  (when (= op :delete)
+    ;; capture rows are plain raw-value maps; search-models-to-update needs the model attached.
+    (search/bulk-update! (map #(t2/instance model %) rows))))

--- a/src/metabase/search/models.clj
+++ b/src/metabase/search/models.clj
@@ -1,8 +1,11 @@
 (ns metabase.search.models
   (:require
+   [metabase.app-db.core :as mdb]
    [metabase.app-db.dml-capture :as dml-capture]
    [metabase.search.core :as search]
+   [metabase.search.ingestion :as search.ingestion]
    [metabase.search.spec :as search.spec]
+   [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
 ;; Models must derive from :hook/search-index if their state can influence the contents of the Search Index.
@@ -22,9 +25,9 @@
 
 ;; Deletes have no row-level hook: a before-delete would realize every matching row as a full instance, which
 ;; was rejected as too much of a performance risk. Instead the capture seam snapshots just the hook-relevant
-;; columns, once per delete statement. The enqueued messages are re-derivations, so ingestion's
-;; asked-for-but-not-indexed diff purges entries whose backing row is gone, and a message enqueued for a
-;; delete that later rolls back degrades to a harmless re-index of the still-live rows.
+;; columns, once per delete statement. The enqueued messages are re-derivations, and delivery is registered
+;; after commit, so a rollback discards it and a worker never races uncommitted state. Ingestion's
+;; asked-for-but-not-indexed diff purges entries whose backing row is gone.
 (derive :hook/search-index dml-capture/hook)
 
 (defmethod dml-capture/capture-fields :hook/search-index
@@ -33,8 +36,21 @@
              (search/supports-index?))
     (search.spec/hook-where-fields model)))
 
+(defn- submit-handoff!
+  [model op thunk]
+  (let [run #(try
+               (thunk)
+               (catch Throwable e
+                 (log/errorf e "Failed search-index handoff for %s %s" model op)))]
+    (if search.ingestion/*force-sync*
+      (run)
+      (future (run)))))
+
 (defmethod dml-capture/captured! :hook/search-index
   [model {:keys [op rows]}]
   (when (= op :delete)
-    ;; capture rows are plain raw-value maps; search-models-to-update needs the model attached.
-    (search/bulk-update! (map #(t2/instance model %) rows))))
+    ;; Capture rows are plain raw-value maps; search-models-to-update needs the model attached. Do not hand the
+    ;; re-derivation off until the outer transaction commits; Metabase discards the callback on rollback.
+    (let [instances (mapv #(t2/instance model %) rows)]
+      (mdb/do-after-commit
+       #(submit-handoff! model op (fn [] (search/bulk-update! instances)))))))

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -445,6 +445,24 @@
   []
   (model-hooks* (methods spec*)))
 
+(defn- collect-updated-columns [expr]
+  (let [acc (volatile! (transient #{}))]
+    (walk/postwalk (fn [x]
+                     (when (and (keyword? x) (has-table? :updated x))
+                       (vswap! acc conj! (remove-table :updated x)))
+                     x)
+                   expr)
+    (persistent! @acc)))
+
+(defn hook-where-fields
+  "The columns of `model` whose row values parameterize the where-clauses of the search hooks it feeds.
+  A capture layer must snapshot (at least) these for [[search-models-to-update]] to work on a row that no
+  longer exists, e.g. the pre-image of a deleted row."
+  [model]
+  (not-empty
+   (into #{} (mapcat (comp collect-updated-columns :where))
+         (get (model-hooks) model))))
+
 (defn- instance->db-values
   "Given a transformed toucan map, get back a mapping to the raw db values that we can use in a query."
   [instance]

--- a/test/metabase/search/models_test.clj
+++ b/test/metabase/search/models_test.clj
@@ -11,6 +11,15 @@
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
+;; Search handoff is deliberately after commit. `with-temp` normally wraps its body in a rollback-only
+;; transaction, so these integration tests need real commits; `with-temp` still performs explicit cleanup.
+#_{:clj-kondo/ignore [:metabase/validate-deftest]}
+(use-fixtures :each
+  (fn [f]
+    (mt/test-helpers-set-global-values!
+      (binding [search.ingestion/*force-sync* true]
+        (f)))))
+
 (deftest delete-enqueues-one-bulk-update-test
   (testing "deleting a card enqueues exactly one re-derivation message, covering every model it feeds"
     (let [calls (atom [])]
@@ -75,8 +84,8 @@
             (is (=? [#{["card" where] ["dataset" where] ["metric" where]}]
                     (mapv set @calls)))))))))
 
-(deftest rollback-still-enqueues-and-leaves-the-row-test
-  (testing "a rolled-back delete still fired its at-least-once re-derivation message, and the row survives"
+(deftest rollback-discards-handoff-and-leaves-the-row-test
+  (testing "a rolled-back delete discards its post-commit handoff, and the row survives"
     (let [calls (atom [])]
       (mt/with-dynamic-fn-redefs [search.ingestion/ingest-maybe-async!
                                   (fn [updates] (swap! calls conj updates))]
@@ -86,5 +95,5 @@
                        (t2/with-transaction [_conn]
                          (t2/delete! :model/Card id)
                          (throw (ex-info "boom" {})))))
-          (is (= 1 (count @calls)))
+          (is (empty? @calls))
           (is (t2/exists? :model/Card id)))))))

--- a/test/metabase/search/models_test.clj
+++ b/test/metabase/search/models_test.clj
@@ -1,0 +1,90 @@
+(ns metabase.search.models-test
+  "Pins the delete-capture wiring in [[metabase.search.models]]: deletes now enqueue re-derivation
+  messages via the [[metabase.app-db.dml-capture]] seam instead of firing no hooks at all."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.app-db.dml-capture :as dml-capture]
+   [metabase.search.appdb.index :as search.index]
+   [metabase.search.engine :as search.engine]
+   [metabase.search.ingestion :as search.ingestion]
+   [metabase.search.test-util :as search.tu]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(deftest delete-enqueues-one-bulk-update-test
+  (testing "deleting a card enqueues exactly one re-derivation message, covering every model it feeds"
+    (let [calls (atom [])]
+      (mt/with-dynamic-fn-redefs [search.ingestion/ingest-maybe-async!
+                                  (fn [updates] (swap! calls conj updates))]
+        (mt/with-temp [:model/Card {id :id} {}]
+          ;; the temp card's own creation enqueues an unrelated message via the after-insert hook; only the
+          ;; delete's message is under test.
+          (reset! calls [])
+          (t2/delete! :model/Card id)
+          (is (=? [#{["card" [:= id :this.id]]
+                     ["dataset" [:= id :this.id]]
+                     ["metric" [:= id :this.id]]
+                     ["action" [:= id :this.model_id]]
+                     ["indexed-entity" [:= id :model_index.model_id]]}]
+                  (mapv set @calls))))))))
+
+(deftest capture-fields-guards-test
+  (testing "capture-fields is skipped entirely (no pre-select) when no search engine is active"
+    (mt/with-dynamic-fn-redefs [search.engine/active-engines (constantly [])]
+      (is (nil? (dml-capture/capture-fields :model/Card :delete)))))
+  (testing "only :delete is wired up in this PR; insert/update capture-fields stay nil even with engines on"
+    (is (some? (seq (search.engine/active-engines))) "this test needs an active engine to be meaningful")
+    (is (nil? (dml-capture/capture-fields :model/Card :insert)))
+    (is (nil? (dml-capture/capture-fields :model/Card :update)))))
+
+(deftest ^:synchronized purge-on-delete-test
+  (testing "deleting an indexed card purges its index row (appdb engine)"
+    (search.tu/with-appdb-search-if-available-without-fallback
+      (mt/with-temp [:model/Card {id :id} {:name "Temp Purge Card"}]
+        (is (= 1 (t2/count (search.index/active-table) :model "card" :model_id (str id))))
+        (t2/delete! :model/Card id)
+        (is (= 0 (t2/count (search.index/active-table) :model "card" :model_id (str id)))))))
+  (testing "bulk deletion purges every affected row (cards first, then their now-empty collection)"
+    (search.tu/with-appdb-search-if-available-without-fallback
+      (mt/with-temp [:model/Collection {coll-id :id} {:name "Temp Bulk Collection"}
+                     :model/Card       {c1 :id}      {:name "Bulk Card 1" :collection_id coll-id}
+                     :model/Card       {c2 :id}      {:name "Bulk Card 2" :collection_id coll-id}]
+        (is (= 2 (t2/count (search.index/active-table) :model "card" :model_id [:in [(str c1) (str c2)]])))
+        (is (= 1 (t2/count (search.index/active-table) :model "collection" :model_id (str coll-id))))
+        ;; cards must go first: a collection with contents refuses deletion.
+        (t2/delete! :model/Card :collection_id coll-id)
+        (t2/delete! :model/Collection coll-id)
+        (is (= 0 (t2/count (search.index/active-table) :model "card" :model_id [:in [(str c1) (str c2)]])))
+        (is (= 0 (t2/count (search.index/active-table) :model "collection" :model_id (str coll-id))))))))
+
+(deftest delete-of-a-joined-model-enqueues-the-fed-models-test
+  (testing "deleting a row that only feeds other models' docs (not itself searchable) enqueues re-derivation
+            for every search-model it feeds, keyed off the review's own captured columns"
+    (let [calls (atom [])]
+      (mt/with-dynamic-fn-redefs [search.ingestion/ingest-maybe-async!
+                                  (fn [updates] (swap! calls conj updates))]
+        (mt/with-temp [:model/Card             {card-id :id} {}
+                       :model/ModerationReview {mr-id :id}   {:moderated_item_type "card"
+                                                              :moderated_item_id   card-id
+                                                              :moderator_id        (mt/user->id :crowberto)
+                                                              :status              "verified"
+                                                              :most_recent         true}]
+          (reset! calls [])
+          (t2/delete! :model/ModerationReview mr-id)
+          (let [where [:and [:= "card" "card"] [:= card-id :this.id] [:= true true]]]
+            (is (=? [#{["card" where] ["dataset" where] ["metric" where]}]
+                    (mapv set @calls)))))))))
+
+(deftest rollback-still-enqueues-and-leaves-the-row-test
+  (testing "a rolled-back delete still fired its at-least-once re-derivation message, and the row survives"
+    (let [calls (atom [])]
+      (mt/with-dynamic-fn-redefs [search.ingestion/ingest-maybe-async!
+                                  (fn [updates] (swap! calls conj updates))]
+        (mt/with-temp [:model/Card {id :id} {}]
+          (reset! calls [])
+          (is (thrown? clojure.lang.ExceptionInfo
+                       (t2/with-transaction [_conn]
+                         (t2/delete! :model/Card id)
+                         (throw (ex-info "boom" {})))))
+          (is (= 1 (count @calls)))
+          (is (t2/exists? :model/Card id)))))))

--- a/test/metabase/search/models_test.clj
+++ b/test/metabase/search/models_test.clj
@@ -37,22 +37,26 @@
                      ["indexed-entity" [:= id :model_index.model_id]]}]
                   (mapv set @calls))))))))
 
-(deftest capture-fields-guards-test
+(deftest capture-fields-disabled-without-engine-test
   (testing "capture-fields is skipped entirely (no pre-select) when no search engine is active"
     (mt/with-dynamic-fn-redefs [search.engine/active-engines (constantly [])]
-      (is (nil? (dml-capture/capture-fields :model/Card :delete)))))
+      (is (nil? (dml-capture/capture-fields :model/Card :delete))))))
+
+(deftest only-delete-capture-is-enabled-test
   (testing "only :delete is wired up in this PR; insert/update capture-fields stay nil even with engines on"
     (is (some? (seq (search.engine/active-engines))) "this test needs an active engine to be meaningful")
     (is (nil? (dml-capture/capture-fields :model/Card :insert)))
     (is (nil? (dml-capture/capture-fields :model/Card :update)))))
 
-(deftest ^:synchronized purge-on-delete-test
+(deftest ^:synchronized purge-one-on-delete-test
   (testing "deleting an indexed card purges its index row (appdb engine)"
     (search.tu/with-appdb-search-if-available-without-fallback
       (mt/with-temp [:model/Card {id :id} {:name "Temp Purge Card"}]
         (is (= 1 (t2/count (search.index/active-table) :model "card" :model_id (str id))))
         (t2/delete! :model/Card id)
-        (is (= 0 (t2/count (search.index/active-table) :model "card" :model_id (str id)))))))
+        (is (= 0 (t2/count (search.index/active-table) :model "card" :model_id (str id))))))))
+
+(deftest ^:synchronized purge-bulk-on-delete-test
   (testing "bulk deletion purges every affected row (cards first, then their now-empty collection)"
     (search.tu/with-appdb-search-if-available-without-fallback
       (mt/with-temp [:model/Collection {coll-id :id} {:name "Temp Bulk Collection"}

--- a/test/metabase/search/spec_test.clj
+++ b/test/metabase/search/spec_test.clj
@@ -178,16 +178,20 @@
         (finally
           (.addMethod ^clojure.lang.MultiFn spec-multifn "card" original))))))
 
-(deftest ^:parallel hook-where-fields-test
+(deftest ^:parallel direct-hook-where-fields-test
   (testing "single-key :id joins collapse to #{:id}"
     (is (= #{:id} (search.spec/hook-where-fields :model/Collection)))
     (is (= #{:id} (search.spec/hook-where-fields :model/Card)))
     (is (= #{:id} (search.spec/hook-where-fields :model/Table)))
-    (is (= #{:id} (search.spec/hook-where-fields :model/Database))))
+    (is (= #{:id} (search.spec/hook-where-fields :model/Database)))))
+
+(deftest ^:parallel joined-hook-where-fields-test
   (testing "multi-clause joins collect every :updated-qualified column referenced in the where"
     (is (= #{:most_recent :model_id :model} (search.spec/hook-where-fields :model/Revision)))
     (is (= #{:most_recent :moderated_item_id :moderated_item_type}
-           (search.spec/hook-where-fields :model/ModerationReview))))
+           (search.spec/hook-where-fields :model/ModerationReview)))))
+
+(deftest ^:parallel model-without-hooks-has-no-where-fields-test
   (testing "a model that feeds no search-model hooks has nothing to capture"
     (is (nil? (search.spec/hook-where-fields :model/User)))))
 

--- a/test/metabase/search/spec_test.clj
+++ b/test/metabase/search/spec_test.clj
@@ -178,6 +178,19 @@
         (finally
           (.addMethod ^clojure.lang.MultiFn spec-multifn "card" original))))))
 
+(deftest ^:parallel hook-where-fields-test
+  (testing "single-key :id joins collapse to #{:id}"
+    (is (= #{:id} (search.spec/hook-where-fields :model/Collection)))
+    (is (= #{:id} (search.spec/hook-where-fields :model/Card)))
+    (is (= #{:id} (search.spec/hook-where-fields :model/Table)))
+    (is (= #{:id} (search.spec/hook-where-fields :model/Database))))
+  (testing "multi-clause joins collect every :updated-qualified column referenced in the where"
+    (is (= #{:most_recent :model_id :model} (search.spec/hook-where-fields :model/Revision)))
+    (is (= #{:most_recent :moderated_item_id :moderated_item_type}
+           (search.spec/hook-where-fields :model/ModerationReview))))
+  (testing "a model that feeds no search-model hooks has nothing to capture"
+    (is (nil? (search.spec/hook-where-fields :model/User)))))
+
 (deftest ^:parallel index-version-hash-test
   (testing "index-version-hash returns a consistent value"
     (let [hash1 (search.spec/index-version-hash)


### PR DESCRIPTION
Deleted cards, dashboards, collections etc. stay in search results until the hourly reindex, because nothing tells the index about deletes.
Only a handful of call sites purge by hand with `search.core/delete!`.

Fix: `:hook/search-index` takes the DML capture hook from the previous PR, snapshotting the columns its search hooks' where-clauses read (`search.spec/hook-where-fields`, usually just `:id`).
After the transaction commits, it enqueues the same re-derivation messages an update would.
Ingestion already purges entries whose backing row no longer resolves, so there's no new purge path.
A rollback discards the handoff.

Joined models work the same way: deleting a `Revision` or `ModerationReview` re-derives the card it fed.

Cost is one narrow select per delete statement.

Not covered here: rows removed by database `ON DELETE CASCADE`, which never pass through Toucan. That's the next PR.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
