### PR TITLE
Purge search documents removed by database cascades

### DIFF
--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -232,15 +232,19 @@
     (doseq [e (search.engine/active-engines)]
       (search.engine/sync-from-restored-db! e))))
 
+(defn- enqueue-updates!
+  [updates]
+  (when-let [updates (->> updates
+                          (remove (comp search.util/impossible-condition? second))
+                          seq)]
+    (search.ingestion/ingest-maybe-async! updates)))
+
 (defn update!
   "Given a new or updated instance, put all the corresponding search entries if needed in the queue."
   [instance & [always?]]
   (when (supports-index?)
-    (when-let [updates (->> (search.spec/search-models-to-update instance always?)
-                            (remove (comp search.util/impossible-condition? second))
-                            seq)]
-      ;; We need to delay execution to handle deletes, which alert us *before* updating the database.
-      (search.ingestion/ingest-maybe-async! updates))))
+    ;; We need to delay execution to handle deletes, which alert us *before* updating the database.
+    (enqueue-updates! (search.spec/search-models-to-update instance always?))))
 
 (defn bulk-update!
   "Enqueue re-indexing derived from `instances` unconditionally, e.g. the pre-images of deleted rows.
@@ -248,22 +252,16 @@
   satisfy their spec's query are purged by ingestion's asked-for-but-not-indexed diff."
   [instances]
   (when (supports-index?)
-    (when-let [updates (->> instances
-                            (into #{} (mapcat #(search.spec/search-models-to-update % true)))
-                            (remove (comp search.util/impossible-condition? second))
-                            seq)]
-      (search.ingestion/ingest-maybe-async! updates))))
+    (enqueue-updates!
+     (into #{} (mapcat #(search.spec/search-models-to-update % true)) instances))))
 
 (defn bulk-update-with-changes!
   "Enqueue re-indexing for the pre-image rows of an update statement that applied `changes` to each of them.
   Hooks are filtered on the changed columns; see [[search.spec/search-models-to-update-with-changes]]."
   [instances changes]
   (when (supports-index?)
-    (when-let [updates (->> instances
-                            (into #{} (mapcat #(search.spec/search-models-to-update-with-changes % changes)))
-                            (remove (comp search.util/impossible-condition? second))
-                            seq)]
-      (search.ingestion/ingest-maybe-async! updates))))
+    (enqueue-updates!
+     (into #{} (mapcat #(search.spec/search-models-to-update-with-changes % changes)) instances))))
 
 (defn delete!
   "Given a model and a list of model's ids, remove corresponding search entries."

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -254,6 +254,17 @@
                             seq)]
       (search.ingestion/ingest-maybe-async! updates))))
 
+(defn bulk-update-with-changes!
+  "Enqueue re-indexing for the pre-image rows of an update statement that applied `changes` to each of them.
+  Hooks are filtered on the changed columns; see [[search.spec/search-models-to-update-with-changes]]."
+  [instances changes]
+  (when (supports-index?)
+    (when-let [updates (->> instances
+                            (into #{} (mapcat #(search.spec/search-models-to-update-with-changes % changes)))
+                            (remove (comp search.util/impossible-condition? second))
+                            seq)]
+      (search.ingestion/ingest-maybe-async! updates))))
+
 (defn delete!
   "Given a model and a list of model's ids, remove corresponding search entries."
   [model ids]

--- a/src/metabase/search/models.clj
+++ b/src/metabase/search/models.clj
@@ -45,11 +45,12 @@
   [model {:keys [op rows changes]}]
   ;; Capture rows are plain raw-value maps; search-models-to-update needs the model attached. Do not hand the
   ;; re-derivation off until the outer transaction commits; Metabase discards the callback on rollback.
-  (let [instances (mapv #(t2/instance model %) rows)]
-    (mdb/do-after-commit
-     #(submit-handoff!
-       model op
-       (fn []
-         (case op
-           (:insert :delete) (search/bulk-update! instances)
-           :update           (search/bulk-update-with-changes! instances changes)))))))
+  (mdb/do-after-commit
+   (fn []
+     (submit-handoff!
+      model op
+      (fn []
+        (let [instances (mapv #(t2/instance model %) rows)]
+          (case op
+            (:insert :delete) (search/bulk-update! instances)
+            :update           (search/bulk-update-with-changes! instances changes))))))))

--- a/src/metabase/search/models.clj
+++ b/src/metabase/search/models.clj
@@ -9,31 +9,26 @@
    [toucan2.core :as t2]))
 
 ;; Models must derive from :hook/search-index if their state can influence the contents of the Search Index.
-;; Note that it might not be the model itself that depends on it, for example, Dashcards are used in Card entries.
-;; Don't worry about whether you've added it in the right place, we have tests to ensure that it is derived if, and only
-;; if, it is required.
-
-(t2/define-after-insert :hook/search-index
-  [instance]
-  (search/update! instance true)
-  instance)
-
-(t2/define-after-update :hook/search-index
-  [instance]
-  (search/update! instance)
-  nil)
-
-;; Deletes have no row-level hook: a before-delete would realize every matching row as a full instance, which
-;; was rejected as too much of a performance risk. Instead the capture seam snapshots just the hook-relevant
-;; columns, once per delete statement. The enqueued messages are re-derivations, and delivery is registered
-;; after commit, so a rollback discards it and a worker never races uncommitted state. Ingestion's
+;; Note that it might not be the model itself that depends on it, for example, Revisions are used in Card
+;; entries. Don't worry about whether you've added it in the right place, we have tests to ensure that it is
+;; derived if, and only if, it is required.
+;;
+;; All three DML operations go through the statement-level capture seam rather than row-level hooks: the
+;; row-level tools realize a full instance per affected row, which is unaffordable for the bulk writes
+;; search cares about, and deletes have no affordable row-level hook at all.
+;;
+;; Enqueued messages are re-derivations, never facts. Delivery is registered after commit, so a rollback
+;; discards it and a worker never races uncommitted state. Ingestion re-reads the affected rows and its
 ;; asked-for-but-not-indexed diff purges entries whose backing row is gone.
+;;
+;; Insert hook where-values come from rows authoritatively identified by returned PKs. PK-only capture, complete
+;; literal rows with explicit PKs, and a single complete literal row avoid a select; other shapes use one narrow
+;; backfill query keyed by the returned PKs.
 (derive :hook/search-index dml-capture/hook)
 
 (defmethod dml-capture/capture-fields :hook/search-index
-  [model op]
-  (when (and (= op :delete)
-             (search/supports-index?))
+  [model _op]
+  (when (search/supports-index?)
     (search.spec/hook-where-fields model)))
 
 (defn- submit-handoff!
@@ -47,10 +42,14 @@
       (future (run)))))
 
 (defmethod dml-capture/captured! :hook/search-index
-  [model {:keys [op rows]}]
-  (when (= op :delete)
-    ;; Capture rows are plain raw-value maps; search-models-to-update needs the model attached. Do not hand the
-    ;; re-derivation off until the outer transaction commits; Metabase discards the callback on rollback.
-    (let [instances (mapv #(t2/instance model %) rows)]
-      (mdb/do-after-commit
-       #(submit-handoff! model op (fn [] (search/bulk-update! instances)))))))
+  [model {:keys [op rows changes]}]
+  ;; Capture rows are plain raw-value maps; search-models-to-update needs the model attached. Do not hand the
+  ;; re-derivation off until the outer transaction commits; Metabase discards the callback on rollback.
+  (let [instances (mapv #(t2/instance model %) rows)]
+    (mdb/do-after-commit
+     #(submit-handoff!
+       model op
+       (fn []
+         (case op
+           (:insert :delete) (search/bulk-update! instances)
+           :update           (search/bulk-update-with-changes! instances changes)))))))

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -487,6 +487,32 @@
                [search-model (insert-values where :updated @raw-values)])))
           (get (model-hooks) (t2/model instance)))))
 
+(defn search-models-to-update-with-changes
+  "Statement-level variant of [[search-models-to-update]]: `instance` is one pre-image row of an update
+  statement and `changes` is the changes map that statement applied to every row it matched.
+  A hook fires only when the statement touched something it reads: a content field (the hook's `:fields`) or
+  a join-topology column (its where-clause's `:updated.*` columns, e.g. `revision.most_recent`) — the
+  per-instance path cannot filter at all, because an after-update instance carries no usable change
+  information.
+  Each firing hook emits messages for both the pre-image and the post-image, so re-derivation covers a
+  row's old and new join targets (e.g. both sides of a foreign-key move)."
+  [instance changes]
+  (let [changed-keys    (set (keys changes))
+        ;; A collection-valued change is a HoneySQL expression (or a payload column that never appears in a
+        ;; hook where-clause), so it has no computable post-image value. Join fields are FKs in practice and
+        ;; never expression-updated; the pre-image message and the periodic reindex cover that gap.
+        literal-changes (into {} (remove (comp coll? val)) changes)
+        pre-vals        (delay (instance->db-values instance))
+        post-vals       (delay (instance->db-values (merge instance literal-changes)))]
+    (into #{}
+          (mapcat
+           (fn [{:keys [search-model fields where]}]
+             (let [gate (into (or fields #{}) (collect-updated-columns where))]
+               (when (some gate changed-keys)
+                 [[search-model (insert-values where :updated @pre-vals)]
+                  [search-model (insert-values where :updated @post-vals)]]))))
+          (get (model-hooks) (t2/model instance)))))
+
 (comment
   (doseq [d (descendants :hook/search-index)]
     (underive d :hook/search-index))

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -492,9 +492,13 @@
                [search-model (insert-values where :updated @raw-values)])))
           (get (model-hooks) (t2/model instance)))))
 
+(defn- non-scalar-expression?
+  [x]
+  ((some-fn coll? symbol?) x))
+
 (defn- honeysql-expression?
   [x]
-  ((some-fn coll? keyword? symbol?) x))
+  (or (non-scalar-expression? x) (keyword? x)))
 
 (defn search-models-to-update-with-changes
   "Statement-level variant of [[search-models-to-update]]: `instance` is one pre-image row of an update
@@ -510,7 +514,7 @@
         ;; scalar input transforms. Transform the remaining candidates so a keyword-backed column turns :dashboard
         ;; into the literal "dashboard", while an untransformed :%now remains an expression.
         db-changes      (delay (->> changes
-                                    (remove (comp (some-fn coll? symbol?) val))
+                                    (remove (comp non-scalar-expression? val))
                                     (into {})
                                     (values->db-values model)))
         literal-changes (delay (into {} (remove (comp honeysql-expression? val)) @db-changes))

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -463,18 +463,23 @@
    (into #{} (mapcat (comp collect-updated-columns :where))
          (get (model-hooks) model))))
 
-(defn- instance->db-values
-  "Given a transformed toucan map, get back a mapping to the raw db values that we can use in a query."
-  [instance]
+(defn- values->db-values
+  "Apply a model's input transforms to values so they can be used in a query."
+  [model values]
   (let [xforms (try
-                 (#'t2.transformed/in-transforms (t2/model instance))
+                 (#'t2.transformed/in-transforms model)
                  (catch Exception _     ; this happens for :model/ModelIndexValue, which has no transforms
                    nil))]
     (reduce-kv
      (fn [m k v]
        (assoc m k (if-let [f (get xforms k)] (f v) v)))
      {}
-     instance)))
+     values)))
+
+(defn- instance->db-values
+  "Given a transformed toucan map, get back a mapping to the raw db values that we can use in a query."
+  [instance]
+  (values->db-values (t2/model instance) instance))
 
 (defn search-models-to-update
   "Given an updated or created instance, return a description of which search-models to (re)index."
@@ -499,12 +504,14 @@
   Each firing hook emits messages for both the pre-image and the post-image, so re-derivation covers a
   row's old and new join targets (e.g. both sides of a foreign-key move)."
   [instance changes]
-  (let [changed-keys    (set (keys changes))
-        ;; HoneySQL expressions can be collections, keywords such as :%now, or symbols. They have no computable
-        ;; post-image value; the pre-image message and the periodic reindex cover that gap without another query.
-        literal-changes (into {} (remove (comp honeysql-expression? val)) changes)
+  (let [model           (t2/model instance)
+        changed-keys    (set (keys changes))
+        db-changes      (delay (values->db-values model changes))
+        ;; Classify transformed DB values: a keyword-backed column turns :dashboard into the literal "dashboard",
+        ;; while untransformed :%now and other HoneySQL expressions still have no computable post-image value.
+        literal-changes (delay (into {} (remove (comp honeysql-expression? val)) @db-changes))
         pre-vals        (delay (instance->db-values instance))
-        post-vals       (delay (instance->db-values (merge instance literal-changes)))]
+        post-vals       (delay (merge @pre-vals @literal-changes))]
     (into #{}
           (mapcat
            (fn [{:keys [search-model fields where]}]

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -506,9 +506,13 @@
   [instance changes]
   (let [model           (t2/model instance)
         changed-keys    (set (keys changes))
-        db-changes      (delay (values->db-values model changes))
-        ;; Classify transformed DB values: a keyword-backed column turns :dashboard into the literal "dashboard",
-        ;; while untransformed :%now and other HoneySQL expressions still have no computable post-image value.
+        ;; Collections and symbols are expressions regardless of the column transform, so never pass them through
+        ;; scalar input transforms. Transform the remaining candidates so a keyword-backed column turns :dashboard
+        ;; into the literal "dashboard", while an untransformed :%now remains an expression.
+        db-changes      (delay (->> changes
+                                    (remove (comp (some-fn coll? symbol?) val))
+                                    (into {})
+                                    (values->db-values model)))
         literal-changes (delay (into {} (remove (comp honeysql-expression? val)) @db-changes))
         pre-vals        (delay (instance->db-values instance))
         post-vals       (delay (merge @pre-vals @literal-changes))]

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -491,9 +491,7 @@
   "Statement-level variant of [[search-models-to-update]]: `instance` is one pre-image row of an update
   statement and `changes` is the changes map that statement applied to every row it matched.
   A hook fires only when the statement touched something it reads: a content field (the hook's `:fields`) or
-  a join-topology column (its where-clause's `:updated.*` columns, e.g. `revision.most_recent`) — the
-  per-instance path cannot filter at all, because an after-update instance carries no usable change
-  information.
+  a join-topology column (its where-clause's `:updated.*` columns, e.g. `revision.most_recent`).
   Each firing hook emits messages for both the pre-image and the post-image, so re-derivation covers a
   row's old and new join targets (e.g. both sides of a foreign-key move)."
   [instance changes]

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -487,6 +487,10 @@
                [search-model (insert-values where :updated @raw-values)])))
           (get (model-hooks) (t2/model instance)))))
 
+(defn- honeysql-expression?
+  [x]
+  ((some-fn coll? keyword? symbol?) x))
+
 (defn search-models-to-update-with-changes
   "Statement-level variant of [[search-models-to-update]]: `instance` is one pre-image row of an update
   statement and `changes` is the changes map that statement applied to every row it matched.
@@ -496,10 +500,9 @@
   row's old and new join targets (e.g. both sides of a foreign-key move)."
   [instance changes]
   (let [changed-keys    (set (keys changes))
-        ;; A collection-valued change is a HoneySQL expression (or a payload column that never appears in a
-        ;; hook where-clause), so it has no computable post-image value. Join fields are FKs in practice and
-        ;; never expression-updated; the pre-image message and the periodic reindex cover that gap.
-        literal-changes (into {} (remove (comp coll? val)) changes)
+        ;; HoneySQL expressions can be collections, keywords such as :%now, or symbols. They have no computable
+        ;; post-image value; the pre-image message and the periodic reindex cover that gap without another query.
+        literal-changes (into {} (remove (comp honeysql-expression? val)) changes)
         pre-vals        (delay (instance->db-values instance))
         post-vals       (delay (instance->db-values (merge instance literal-changes)))]
     (into #{}

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -12,7 +12,6 @@
    [metabase.models.serialization :as serdes]
    [metabase.permissions.core :as perms]
    [metabase.remote-sync.core :as remote-sync]
-   [metabase.search.core :as search.core]
    [metabase.search.ingestion :as search]
    [metabase.search.spec :as search.spec]
    [metabase.transforms-base.interface :as transforms-base.i]
@@ -346,7 +345,6 @@
 (t2/define-before-delete :model/Transform [transform]
   (when-not mi/*deserializing?*
     (events/publish-event! :event/delete-transform {:id (:id transform)}))
-  (search.core/delete! :model/Transform [(str (:id transform))])
   transform)
 
 (defn update-transform-tags!

--- a/test/metabase/search/ingestion_test.clj
+++ b/test/metabase/search/ingestion_test.clj
@@ -243,18 +243,21 @@
         (is (= 3 @factory-calls)
             "Factory should be called once per unique database-id, not once per lookup")))))
 
-(deftest curation-signals-surfaced-in-results-test
-  (testing "curated (all models) and table data_layer ride through legacy_input to appdb search results,
-            so Metabot can render them (BOT-1570) — not just stored in the filtering column"
-    (search.tu/with-appdb-search-if-available-without-fallback
-      (mt/with-temp [:model/Database {db-id :id} {}
-                     :model/Table _ {:db_id          db-id
-                                     :name           "Curatedgoldtbl"
-                                     :active         true
-                                     :data_authority :authoritative
-                                     :data_layer     :final}]
-        (let [result (->> (search.tu/search-results "Curatedgoldtbl")
-                          (filter (comp #{"table"} :model))
-                          first)]
-          (is (=? {:model "table" :curated true :data_authority "authoritative" :data_layer "final"}
-                  result)))))))
+(deftest ^:synchronized curation-signals-surfaced-in-results-test
+  ;; Search capture hands off only after commit, so this integration test needs real commits rather than
+  ;; with-temp's usual rollback-only transaction. with-temp still deletes both rows afterward.
+  (mt/test-helpers-set-global-values!
+    (testing "curated (all models) and table data_layer ride through legacy_input to appdb search results,
+              so Metabot can render them (BOT-1570) — not just stored in the filtering column"
+      (search.tu/with-appdb-search-if-available-without-fallback
+        (mt/with-temp [:model/Database {db-id :id} {}
+                       :model/Table _ {:db_id          db-id
+                                       :name           "Curatedgoldtbl"
+                                       :active         true
+                                       :data_authority :authoritative
+                                       :data_layer     :final}]
+          (let [result (->> (search.tu/search-results "Curatedgoldtbl")
+                            (filter (comp #{"table"} :model))
+                            first)]
+            (is (=? {:model "table" :curated true :data_authority "authoritative" :data_layer "final"}
+                    result))))))))

--- a/test/metabase/search/models_test.clj
+++ b/test/metabase/search/models_test.clj
@@ -1,6 +1,8 @@
 (ns metabase.search.models-test
-  "Pins the delete-capture wiring in [[metabase.search.models]]: deletes now enqueue re-derivation
-  messages via the [[metabase.app-db.dml-capture]] seam instead of firing no hooks at all."
+  "Pins the DML-capture wiring in [[metabase.search.models]]: all three operations now enqueue re-derivation
+  messages via the [[metabase.app-db.dml-capture]] seam, statement-level, instead of firing no hooks
+  (deletes), every hook unconditionally (updates, via the old per-row after-update), or per-row with a
+  full-row re-select (inserts, via the old per-row after-insert)."
   (:require
    [clojure.test :refer :all]
    [metabase.app-db.dml-capture :as dml-capture]
@@ -9,6 +11,7 @@
    [metabase.search.ingestion :as search.ingestion]
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
 ;; Search handoff is deliberately after commit. `with-temp` normally wraps its body in a rollback-only
@@ -26,8 +29,8 @@
       (mt/with-dynamic-fn-redefs [search.ingestion/ingest-maybe-async!
                                   (fn [updates] (swap! calls conj updates))]
         (mt/with-temp [:model/Card {id :id} {}]
-          ;; the temp card's own creation enqueues an unrelated message via the after-insert hook; only the
-          ;; delete's message is under test.
+          ;; the temp card's own creation enqueues an unrelated insert-capture message; only the delete's
+          ;; message is under test.
           (reset! calls [])
           (t2/delete! :model/Card id)
           (is (=? [#{["card" [:= id :this.id]]
@@ -40,13 +43,16 @@
 (deftest capture-fields-disabled-without-engine-test
   (testing "capture-fields is skipped entirely (no pre-select) when no search engine is active"
     (mt/with-dynamic-fn-redefs [search.engine/active-engines (constantly [])]
-      (is (nil? (dml-capture/capture-fields :model/Card :delete))))))
+      (is (nil? (dml-capture/capture-fields :model/Card :delete)))
+      (is (nil? (dml-capture/capture-fields :model/Card :update)))
+      (is (nil? (dml-capture/capture-fields :model/Card :insert))))))
 
-(deftest only-delete-capture-is-enabled-test
-  (testing "only :delete is wired up in this PR; insert/update capture-fields stay nil even with engines on"
+(deftest capture-fields-cover-all-ops-test
+  (testing "all three ops are wired up via hook-where-fields"
     (is (some? (seq (search.engine/active-engines))) "this test needs an active engine to be meaningful")
-    (is (nil? (dml-capture/capture-fields :model/Card :insert)))
-    (is (nil? (dml-capture/capture-fields :model/Card :update)))))
+    (is (= #{:id} (dml-capture/capture-fields :model/Card :insert)))
+    (is (= #{:id} (dml-capture/capture-fields :model/Card :delete)))
+    (is (= #{:id} (dml-capture/capture-fields :model/Card :update)))))
 
 (deftest ^:synchronized purge-one-on-delete-test
   (testing "deleting an indexed card purges its index row (appdb engine)"
@@ -101,3 +107,129 @@
                          (throw (ex-info "boom" {})))))
           (is (empty? @calls))
           (is (t2/exists? :model/Card id)))))))
+
+(deftest update-enqueues-one-bulk-update-test
+  (testing "updating a single card enqueues exactly one re-derivation message"
+    (let [calls (atom [])]
+      (mt/with-dynamic-fn-redefs [search.ingestion/ingest-maybe-async!
+                                  (fn [updates] (swap! calls conj updates))]
+        (mt/with-temp [:model/Card {id :id} {}]
+          ;; the temp card's own creation enqueues an unrelated message via the after-insert hook; only the
+          ;; update's message is under test.
+          (reset! calls [])
+          (t2/update! :model/Card id {:description "a new description"})
+          (is (=? [#{["card" [:= id :this.id]]
+                     ["dataset" [:= id :this.id]]
+                     ["metric" [:= id :this.id]]}]
+                  (mapv set @calls))))))))
+
+(deftest update-filters-on-changed-fields-test
+  (testing "changes to fields no hook cares about don't reach the action/indexed-entity joins, which key off
+            :name but not :cache_ttl"
+    (let [calls (atom [])]
+      (mt/with-dynamic-fn-redefs [search.ingestion/ingest-maybe-async!
+                                  (fn [updates] (swap! calls conj updates))]
+        (mt/with-temp [:model/Card {id :id} {}]
+          (reset! calls [])
+          (t2/update! :model/Card id {:cache_ttl 3600})
+          (is (=? [#{["card" [:= id :this.id]]
+                     ["dataset" [:= id :this.id]]
+                     ["metric" [:= id :this.id]]}]
+                  (mapv set @calls)))))))
+  (testing "a :name change also feeds the action and indexed-entity joins"
+    (let [calls (atom [])]
+      (mt/with-dynamic-fn-redefs [search.ingestion/ingest-maybe-async!
+                                  (fn [updates] (swap! calls conj updates))]
+        (mt/with-temp [:model/Card {id :id} {}]
+          (reset! calls [])
+          (t2/update! :model/Card id {:name "renamed"})
+          (is (=? [#{["card" [:= id :this.id]]
+                     ["dataset" [:= id :this.id]]
+                     ["metric" [:= id :this.id]]
+                     ["action" [:= id :this.model_id]]
+                     ["indexed-entity" [:= id :model_index.model_id]]}]
+                  (mapv set @calls))))))))
+
+(deftest bulk-update-enqueues-one-call-test
+  (testing "a bulk update matching multiple cards still enqueues in exactly one call, covering every row"
+    (let [calls (atom [])]
+      (mt/with-dynamic-fn-redefs [search.ingestion/ingest-maybe-async!
+                                  (fn [updates] (swap! calls conj updates))]
+        (mt/with-temp [:model/Collection {coll-id :id} {}
+                       :model/Card       {c1 :id}      {:collection_id coll-id}
+                       :model/Card       {c2 :id}      {:collection_id coll-id}]
+          (reset! calls [])
+          (t2/update! :model/Card :collection_id coll-id {:archived true})
+          (is (= 1 (count @calls)))
+          (is (=? #{["card" [:= c1 :this.id]] ["dataset" [:= c1 :this.id]] ["metric" [:= c1 :this.id]]
+                    ["card" [:= c2 :this.id]] ["dataset" [:= c2 :this.id]] ["metric" [:= c2 :this.id]]}
+                  (set (first @calls)))))))))
+
+(deftest ^:synchronized update-runs-exactly-three-statements-test
+  (testing "capturing an update runs exactly three statements: the before-update tool's full-row select, the
+            narrow capture select, and the update itself — no extra full-row re-select afterward.
+            Card has no model-specific after-update hook of its own; Database/Transform/Document do and would
+            add their own statements on top of these three."
+    (mt/with-dynamic-fn-redefs [search.ingestion/ingest-maybe-async! (fn [_updates] nil)]
+      (mt/with-temp [:model/Card {id :id} {}]
+        (t2/with-call-count [call-count]
+          (t2/update! :model/Card id {:description "a new description"})
+          (is (= 3 (call-count))))))))
+
+(deftest ^:synchronized update-of-a-joined-model-refreshes-the-index-test
+  (testing "renaming a card's collection is reflected in the card's indexed display_data (appdb engine)"
+    (search.tu/with-appdb-search-if-available-without-fallback
+      (mt/with-temp [:model/Collection {coll-id :id} {:name "Original Name"}
+                     :model/Card       {id :id}      {:name "E2E Card" :collection_id coll-id}]
+        (t2/update! :model/Collection coll-id {:name "Renamed Name"})
+        (is (= "Renamed Name"
+               (-> (t2/select-one-fn :display_data (search.index/active-table) :model "card" :model_id (str id))
+                   json/decode
+                   (get "collection_name"))))))))
+
+(deftest insert-enqueues-one-bulk-update-test
+  (testing "a multi-row insert enqueues one re-derivation batch, one message per row per primary hook"
+    (let [calls (atom [])]
+      (mt/with-dynamic-fn-redefs [search.ingestion/ingest-maybe-async!
+                                  (fn [updates] (swap! calls conj updates))]
+        (mt/with-temp [:model/Collection {coll-id :id} {}]
+          (reset! calls [])
+          (let [n (t2/insert! :model/Document
+                              (for [i (range 3)]
+                                {:name          (str "Ins Capture Doc " i)
+                                 :collection_id coll-id
+                                 :document      "{}"
+                                 :content_type  "application/json"
+                                 :creator_id    (mt/user->id :crowberto)
+                                 :created_at    :%now
+                                 :updated_at    :%now}))]
+            (is (= 3 n))
+            (is (= 1 (count @calls)))
+            (is (= 3 (count (set (first @calls)))))
+            (is (every? (fn [[search-model where]]
+                          (and (= "document" search-model)
+                               (= :this.id (last where))))
+                        (first @calls)))))))))
+
+(deftest insert-adds-no-statements-test
+  (testing "a captured single-row insert runs exactly one statement: the pk-returning INSERT, with no
+            follow-up full-row select (the old per-row after-insert forced INSERT + SELECT *)"
+    (mt/with-dynamic-fn-redefs [search.ingestion/ingest-maybe-async! (fn [_updates] nil)]
+      (mt/with-temp [:model/Collection {coll-id :id} {}]
+        ;; resolved outside the counted block: cold, the user lookup itself issues queries.
+        (let [creator-id (mt/user->id :crowberto)]
+          (t2/with-call-count [call-count]
+            (t2/insert! :model/Document {:name          "Ins Capture Solo"
+                                         :collection_id coll-id
+                                         :document      "{}"
+                                         :content_type  "application/json"
+                                         :creator_id    creator-id
+                                         :created_at    :%now
+                                         :updated_at    :%now})
+            (is (= 1 (call-count)))))))))
+
+(deftest ^:synchronized insert-indexes-new-rows-test
+  (testing "with-temp creation (insert-returning-instances!) still lands rows in the index (appdb engine)"
+    (search.tu/with-appdb-search-if-available-without-fallback
+      (mt/with-temp [:model/Card {id :id} {:name "Insert Capture E2E Card"}]
+        (is (= 1 (t2/count (search.index/active-table) :model "card" :model_id (str id))))))))

--- a/test/metabase/search/models_test.clj
+++ b/test/metabase/search/models_test.clj
@@ -114,7 +114,7 @@
       (mt/with-dynamic-fn-redefs [search.ingestion/ingest-maybe-async!
                                   (fn [updates] (swap! calls conj updates))]
         (mt/with-temp [:model/Card {id :id} {}]
-          ;; the temp card's own creation enqueues an unrelated message via the after-insert hook; only the
+          ;; the temp card's own creation enqueues an unrelated insert-capture message; only the
           ;; update's message is under test.
           (reset! calls [])
           (t2/update! :model/Card id {:description "a new description"})
@@ -122,6 +122,20 @@
                      ["dataset" [:= id :this.id]]
                      ["metric" [:= id :this.id]]}]
                   (mapv set @calls))))))))
+
+(deftest ^:synchronized transform-delete-purges-once-test
+  (testing "capture replaces Transform's redundant explicit delete"
+    (let [delete-calls (atom [])]
+      (mt/with-dynamic-fn-redefs [search.engine/active-engines (constantly [:search.engine/test])]
+        (with-redefs [search.engine/update! (fn [_engine documents]
+                                              {"transform" (count documents)})
+                      search.engine/delete! (fn [_engine model ids]
+                                              (swap! delete-calls conj [model (vec ids)])
+                                              {model (count ids)})]
+          (mt/with-temp [:model/Transform {id :id} {:name "Single Purge Transform"}]
+            (reset! delete-calls [])
+            (t2/delete! :model/Transform id)
+            (is (= [["transform" [(str id)]]] @delete-calls))))))))
 
 (deftest update-filters-on-changed-fields-test
   (testing "changes to fields no hook cares about don't reach the action/indexed-entity joins, which key off

--- a/test/metabase/search/models_test.clj
+++ b/test/metabase/search/models_test.clj
@@ -188,22 +188,24 @@
                    (get "collection_name"))))))))
 
 (deftest insert-enqueues-one-bulk-update-test
-  (testing "a multi-row insert enqueues one re-derivation batch, one message per row per primary hook"
+  (testing "a PK-only multi-row insert stays one statement and enqueues one re-derivation batch"
     (let [calls (atom [])]
       (mt/with-dynamic-fn-redefs [search.ingestion/ingest-maybe-async!
                                   (fn [updates] (swap! calls conj updates))]
         (mt/with-temp [:model/Collection {coll-id :id} {}]
           (reset! calls [])
-          (let [n (t2/insert! :model/Document
-                              (for [i (range 3)]
-                                {:name          (str "Ins Capture Doc " i)
-                                 :collection_id coll-id
-                                 :document      "{}"
-                                 :content_type  "application/json"
-                                 :creator_id    (mt/user->id :crowberto)
-                                 :created_at    :%now
-                                 :updated_at    :%now}))]
-            (is (= 3 n))
+          (let [creator-id (mt/user->id :crowberto)]
+            (t2/with-call-count [call-count]
+              (is (= 3 (t2/insert! :model/Document
+                                   (for [i (range 3)]
+                                     {:name          (str "Ins Capture Doc " i)
+                                      :collection_id coll-id
+                                      :document      "{}"
+                                      :content_type  "application/json"
+                                      :creator_id    creator-id
+                                      :created_at    :%now
+                                      :updated_at    :%now}))))
+              (is (= 1 (call-count))))
             (is (= 1 (count @calls)))
             (is (= 3 (count (set (first @calls)))))
             (is (every? (fn [[search-model where]]

--- a/test/metabase/search/spec_test.clj
+++ b/test/metabase/search/spec_test.clj
@@ -228,6 +228,16 @@
              (search.spec/search-models-to-update-with-changes
               (t2/instance :model/ModelIndexValue {:model_index_id 5 :model_pk 10 :name "foo"})
               {:model_pk expression})))))
+  (testing "a keyword transformed to a database string remains a literal post-image join key"
+    (let [updates (search.spec/search-models-to-update-with-changes
+                   (t2/instance :model/ModerationReview {:moderated_item_id   7
+                                                         :moderated_item_type :card
+                                                         :most_recent         true})
+                   {:moderated_item_type :dashboard})]
+      (is (contains? updates
+                     ["card" [:and [:= "card" "card"] [:= 7 :this.id] [:= true true]]]))
+      (is (contains? updates
+                     ["dashboard" [:and [:= "dashboard" "dashboard"] [:= 7 :this.id] [:= true true]]]))))
   (testing "a change to a join-topology column fires the hook even when no content field changed: flipping
             revision.most_recent emits pre- and post-image variants (the post-image [:= false true] and the
             cross-model [:= \"Card\" \"Dashboard\"] clauses re-derive nothing, harmlessly)"

--- a/test/metabase/search/spec_test.clj
+++ b/test/metabase/search/spec_test.clj
@@ -222,6 +222,12 @@
            (search.spec/search-models-to-update-with-changes
             (t2/instance :model/Card {:id 42})
             {:view_count [:+ :view_count 1]}))))
+  (testing "bare keyword and symbol expressions are not mistaken for literal post-image join keys"
+    (doseq [expression [:%now 'next-model-pk]]
+      (is (= #{["indexed-entity" [:and [:= 5 :this.model_index_id] [:= 10 :this.model_pk]]]}
+             (search.spec/search-models-to-update-with-changes
+              (t2/instance :model/ModelIndexValue {:model_index_id 5 :model_pk 10 :name "foo"})
+              {:model_pk expression})))))
   (testing "a change to a join-topology column fires the hook even when no content field changed: flipping
             revision.most_recent emits pre- and post-image variants (the post-image [:= false true] and the
             cross-model [:= \"Card\" \"Dashboard\"] clauses re-derive nothing, harmlessly)"

--- a/test/metabase/search/spec_test.clj
+++ b/test/metabase/search/spec_test.clj
@@ -195,7 +195,7 @@
   (testing "a model that feeds no search-model hooks has nothing to capture"
     (is (nil? (search.spec/hook-where-fields :model/User)))))
 
-(deftest ^:parallel search-models-to-update-with-changes-test
+(deftest ^:parallel search-model-update-field-gating-test
   (testing "only hooks whose :fields intersect the changed columns fire"
     (is (= #{}
            (search.spec/search-models-to-update-with-changes (t2/instance :model/Card {:id 1}) {:cache_ttl 123})))
@@ -206,14 +206,18 @@
                ["card" [:= 1 :this.id]]
                ["dataset" [:= 1 :this.id]]
                ["metric" [:= 1 :this.id]]}
-             (search.spec/search-models-to-update-with-changes (t2/instance :model/Card {:id 1}) {:name "x"})))))
+             (search.spec/search-models-to-update-with-changes (t2/instance :model/Card {:id 1}) {:name "x"}))))))
+
+(deftest ^:parallel search-model-update-literal-post-images-test
   (testing "a change to a field that also parameterizes the hook's own where clause emits distinct pre- and
             post-image messages: :model/ModelIndexValue's composite id is both a hook field and the join key"
     (is (= #{["indexed-entity" [:and [:= 5 :this.model_index_id] [:= 10 :this.model_pk]]]
              ["indexed-entity" [:and [:= 5 :this.model_index_id] [:= 20 :this.model_pk]]]}
            (search.spec/search-models-to-update-with-changes
             (t2/instance :model/ModelIndexValue {:model_index_id 5 :model_pk 10 :name "foo"})
-            {:model_pk 20}))))
+            {:model_pk 20})))))
+
+(deftest ^:parallel search-model-update-expression-post-images-test
   (testing "a honeysql-expression change contributes to hook relevance but has no computable post-image value:
             it's excluded from the merge, so pre and post collapse to the same id-based message"
     (is (= #{["card" [:= 42 :this.id]]
@@ -222,12 +226,19 @@
            (search.spec/search-models-to-update-with-changes
             (t2/instance :model/Card {:id 42})
             {:view_count [:+ :view_count 1]}))))
+  (testing "a collection expression on a transformed column is excluded before applying its scalar transform"
+    (is (contains? (search.spec/search-models-to-update-with-changes
+                    (t2/instance :model/Card {:id 42 :type :question})
+                    {:type [:inline "model"]})
+                   ["card" [:= 42 :this.id]])))
   (testing "bare keyword and symbol expressions are not mistaken for literal post-image join keys"
     (doseq [expression [:%now 'next-model-pk]]
       (is (= #{["indexed-entity" [:and [:= 5 :this.model_index_id] [:= 10 :this.model_pk]]]}
              (search.spec/search-models-to-update-with-changes
               (t2/instance :model/ModelIndexValue {:model_index_id 5 :model_pk 10 :name "foo"})
-              {:model_pk expression})))))
+              {:model_pk expression}))))))
+
+(deftest ^:parallel search-model-update-transformed-keyword-test
   (testing "a keyword transformed to a database string remains a literal post-image join key"
     (let [updates (search.spec/search-models-to-update-with-changes
                    (t2/instance :model/ModerationReview {:moderated_item_id   7
@@ -237,7 +248,9 @@
       (is (contains? updates
                      ["card" [:and [:= "card" "card"] [:= 7 :this.id] [:= true true]]]))
       (is (contains? updates
-                     ["dashboard" [:and [:= "dashboard" "dashboard"] [:= 7 :this.id] [:= true true]]]))))
+                     ["dashboard" [:and [:= "dashboard" "dashboard"] [:= 7 :this.id] [:= true true]]])))))
+
+(deftest ^:parallel search-model-update-join-topology-test
   (testing "a change to a join-topology column fires the hook even when no content field changed: flipping
             revision.most_recent emits pre- and post-image variants (the post-image [:= false true] and the
             cross-model [:= \"Card\" \"Dashboard\"] clauses re-derive nothing, harmlessly)"

--- a/test/metabase/search/spec_test.clj
+++ b/test/metabase/search/spec_test.clj
@@ -195,6 +195,48 @@
   (testing "a model that feeds no search-model hooks has nothing to capture"
     (is (nil? (search.spec/hook-where-fields :model/User)))))
 
+(deftest ^:parallel search-models-to-update-with-changes-test
+  (testing "only hooks whose :fields intersect the changed columns fire"
+    (is (= #{}
+           (search.spec/search-models-to-update-with-changes (t2/instance :model/Card {:id 1}) {:cache_ttl 123})))
+    (testing "primary hooks plus the action/indexed-entity joins feed off :name; pre and post dedupe to one
+              message each, since the where clause is id-based and the id itself doesn't change"
+      (is (= #{["indexed-entity" [:= 1 :model_index.model_id]]
+               ["action" [:= 1 :this.model_id]]
+               ["card" [:= 1 :this.id]]
+               ["dataset" [:= 1 :this.id]]
+               ["metric" [:= 1 :this.id]]}
+             (search.spec/search-models-to-update-with-changes (t2/instance :model/Card {:id 1}) {:name "x"})))))
+  (testing "a change to a field that also parameterizes the hook's own where clause emits distinct pre- and
+            post-image messages: :model/ModelIndexValue's composite id is both a hook field and the join key"
+    (is (= #{["indexed-entity" [:and [:= 5 :this.model_index_id] [:= 10 :this.model_pk]]]
+             ["indexed-entity" [:and [:= 5 :this.model_index_id] [:= 20 :this.model_pk]]]}
+           (search.spec/search-models-to-update-with-changes
+            (t2/instance :model/ModelIndexValue {:model_index_id 5 :model_pk 10 :name "foo"})
+            {:model_pk 20}))))
+  (testing "a honeysql-expression change contributes to hook relevance but has no computable post-image value:
+            it's excluded from the merge, so pre and post collapse to the same id-based message"
+    (is (= #{["card" [:= 42 :this.id]]
+             ["dataset" [:= 42 :this.id]]
+             ["metric" [:= 42 :this.id]]}
+           (search.spec/search-models-to-update-with-changes
+            (t2/instance :model/Card {:id 42})
+            {:view_count [:+ :view_count 1]}))))
+  (testing "a change to a join-topology column fires the hook even when no content field changed: flipping
+            revision.most_recent emits pre- and post-image variants (the post-image [:= false true] and the
+            cross-model [:= \"Card\" \"Dashboard\"] clauses re-derive nothing, harmlessly)"
+    (is (= #{["card"      [:and [:= 7 :this.id] [:= true true] [:= "Card" "Card"]]]
+             ["card"      [:and [:= 7 :this.id] [:= false true] [:= "Card" "Card"]]]
+             ["dataset"   [:and [:= 7 :this.id] [:= true true] [:= "Card" "Card"]]]
+             ["dataset"   [:and [:= 7 :this.id] [:= false true] [:= "Card" "Card"]]]
+             ["metric"    [:and [:= 7 :this.id] [:= true true] [:= "Card" "Card"]]]
+             ["metric"    [:and [:= 7 :this.id] [:= false true] [:= "Card" "Card"]]]
+             ["dashboard" [:and [:= 7 :this.id] [:= true true] [:= "Card" "Dashboard"]]]
+             ["dashboard" [:and [:= 7 :this.id] [:= false true] [:= "Card" "Dashboard"]]]}
+           (search.spec/search-models-to-update-with-changes
+            (t2/instance :model/Revision {:id 999 :model "Card" :model_id 7 :most_recent true})
+            {:most_recent false})))))
+
 (deftest ^:parallel index-version-hash-test
   (testing "index-version-hash returns a consistent value"
     (let [hash1 (search.spec/index-version-hash)


### PR DESCRIPTION
Deleting a model card leaves its actions and indexed entities in search results.
`action.model_id` and `model_index.model_id` cascade in the database, so those rows disappear without a Toucan statement to capture.
Ingestion also can't purge them after the fact: it only recovers a document id from a `:this.id` selector, and indexed entities have compound ids.

Fix: the capture hook gains `dependents`, which runs before the statement.
Search uses it to enumerate the ids of documents reached through selectors ingestion can't purge.
After commit it checks those ids again by document id:

- documents that no longer resolve are removed
- documents that still resolve are re-derived, since a `SET NULL` foreign key keeps the row but changes what's indexed on it

`ModelIndex` takes delete capture through `:hook/search-index-delete`, without the row-level insert/update hooks it's excluded from.

Enumeration stops at 10,000 documents per statement and leaves the rest to the reindex.
Re-derivations go out 100 ids per message, so a batch can't exceed the database's bind-parameter limit.

Cost: two id scans per delete statement (`action` and `indexed-entity`), plus a recheck after commit when they found anything. The stack-wide numbers are in #78287.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
