### PR TITLE
Superseded: Move search index inserts to DML capture

### DIFF
--- a/src/metabase/app_db/dml_capture.clj
+++ b/src/metabase/app_db/dml_capture.clj
@@ -22,10 +22,11 @@
   `(merge pre-image (select-keys changes capture-fields))` whenever its changed value is a literal. Values
   are HoneySQL expressions when the caller passed expressions; they are delivered as-is.
 
-  For inserts nothing is re-selected: `:rows` are the row maps as passed to `insert!` (before any
-  `before-insert` method or type transform runs — column values a `before-insert` fills in are NOT visible)
-  and `:pks` are the database-generated primary keys. When the model has a single-column primary key and one
-  pk came back per row, each row also gets the pk assoc'd on.
+  For inserts `:rows` are the row maps as passed to `insert!` with the generated primary key assoc'd on, and
+  `:pks` are the generated primary keys. When some requested capture field is absent from the literals —
+  the column is filled in by the database or a `before-insert` method (e.g. `revision.most_recent`) — the
+  rows are replaced by one narrow select of the capture fields by pk, so a captured field is always present
+  and authoritative either way. Other literal values are delivered as passed, before type transforms.
 
   Delivery guarantees, and non-guarantees:
 
@@ -53,9 +54,10 @@
   ::captured)
 
 (defmulti capture-fields
-  "The columns to include in `:rows` snapshots when capturing `op` (`:insert`, `:update` or `:delete`)
+  "The columns guaranteed present in `:rows` when capturing `op` (`:insert`, `:update` or `:delete`)
   statements against `model`; return nil or empty to leave that op uncaptured.
-  For `:insert` the value only switches capture on — insert rows are delivered whole, never narrowed."
+  Update and delete snapshots are narrowed to exactly these columns; insert rows are the caller's literals,
+  back-filled by pk when a requested column is missing from them."
   {:arglists '([model op])}
   (fn [model _op] (keyword model)))
 
@@ -163,12 +165,23 @@
                            model parsed-args resolved-query))
             pks         (persistent! @pks)]
         (when (seq pks)
-          (let [row-literals (:rows parsed-args)
+          (let [fields       (capture-fields model :insert)
+                row-literals (:rows parsed-args)
                 pk-keys      (t2.model/primary-keys model)
-                rows         (if (and (= 1 (count pk-keys))
-                                      (= (count pks) (count row-literals)))
-                               (mapv #(assoc %1 (first pk-keys) %2) row-literals pks)
-                               (vec row-literals))]
+                single-pk    (when (= 1 (count pk-keys)) (first pk-keys))
+                rows         (if (and single-pk (= (count pks) (count row-literals)))
+                               (mapv #(assoc %1 single-pk %2) row-literals pks)
+                               (vec row-literals))
+                ;; The literals lack a requested capture field when the column is filled in by the database
+                ;; or a before-insert method (e.g. revision.most_recent); one narrow select by the returned
+                ;; pks recovers the authoritative values.
+                complete?    (fn [row] (every? #(contains? row %) fields))
+                rows         (if (or (every? complete? rows) (nil? single-pk))
+                               rows
+                               (pre-image-rows :toucan.query-type/select.instances model
+                                               (distinct (cons single-pk fields))
+                                               {:kv-args {:toucan/pk [:in pks]}}
+                                               {}))]
             (captured! model {:op :insert, :model model, :rows rows, :pks pks})))
         result))))
 

--- a/src/metabase/search/models.clj
+++ b/src/metabase/search/models.clj
@@ -6,21 +6,22 @@
    [toucan2.core :as t2]))
 
 ;; Models must derive from :hook/search-index if their state can influence the contents of the Search Index.
-;; Note that it might not be the model itself that depends on it, for example, Dashcards are used in Card entries.
-;; Don't worry about whether you've added it in the right place, we have tests to ensure that it is derived if, and only
-;; if, it is required.
-
-(t2/define-after-insert :hook/search-index
-  [instance]
-  (search/update! instance true)
-  instance)
-
-;; Updates and deletes go through the statement-level capture seam rather than row-level hooks.
+;; Note that it might not be the model itself that depends on it, for example, Revisions are used in Card
+;; entries. Don't worry about whether you've added it in the right place, we have tests to ensure that it is
+;; derived if, and only if, it is required.
 ;;
-;; For updates that buys: no full-row re-select per statement (the after-update tool upgrades every update
-;; to return instances), one narrow pre-image select instead, statement-level change information (an
-;; after-update instance has none, so the per-row path fired every hook on every update), and coverage of a
-;; row's old join targets as well as its new ones.
+;; All three DML operations go through the statement-level capture seam rather than row-level hooks.
+;;
+;; Inserts: capture rides the pk-returning upgrade the after-insert tool already forced, minus the follow-up
+;; SELECT * of every inserted row, and enqueues once per statement instead of once per row. Hook where-values
+;; come from the insert's own row literals plus the returned pks; when a hook column is filled in by a
+;; before-insert method rather than the caller (revision.most_recent), the seam back-fills it with one
+;; narrow select by pk.
+;;
+;; Updates: no full-row re-select per statement (the after-update tool upgrades every update to return
+;; instances), one narrow pre-image select instead, statement-level change information (an after-update
+;; instance has none, so the per-row path fired every hook on every update), and coverage of a row's old
+;; join targets as well as its new ones.
 ;;
 ;; Deletes previously had no hook at all: a before-delete would realize every matching row as a full
 ;; instance, which was rejected as too much of a performance risk. The enqueued messages are re-derivations,
@@ -29,9 +30,8 @@
 (derive :hook/search-index dml-capture/hook)
 
 (defmethod dml-capture/capture-fields :hook/search-index
-  [model op]
-  (when (and (contains? #{:delete :update} op)
-             (search/supports-index?))
+  [model _op]
+  (when (search/supports-index?)
     (search.spec/hook-where-fields model)))
 
 (defmethod dml-capture/captured! :hook/search-index
@@ -39,6 +39,5 @@
   ;; capture rows are plain raw-value maps; search-models-to-update needs the model attached.
   (let [instances (map #(t2/instance model %) rows)]
     (case op
-      :delete (search/bulk-update! instances)
-      :update (search/bulk-update-with-changes! instances changes)
-      nil)))
+      (:insert :delete) (search/bulk-update! instances)
+      :update           (search/bulk-update-with-changes! instances changes))))

--- a/test/metabase/app_db/dml_capture_test.clj
+++ b/test/metabase/app_db/dml_capture_test.clj
@@ -285,3 +285,24 @@
     (is (= 1 (count (events))))
     (is (=? {:op :delete, :model ::moody-bird} (first (events))))
     (is (= 2 (count (:rows (first (events))))))))
+
+(deftest insert-backfills-missing-capture-fields-test
+  (reset-capture!)
+  (testing "a capture field absent from the insert literals (db default / before-insert) is back-filled by pk"
+    (swap! bird-capture-fields assoc :insert [:id :group_id :n])
+    ;; :n is omitted so the database default (0) fills it; the seam must recover it with one extra select.
+    (t2/with-call-count [call-count]
+      (t2/insert! ::bird {:name "backfill" :group_id 240})
+      (is (= 2 (call-count))))
+    (is (= 1 (count (events))))
+    (let [{:keys [rows pks]} (first (events))]
+      (is (= 1 (count rows)))
+      (is (= #{:id :group_id :n} (set (keys (first rows)))))
+      (is (=? [{:group_id 240, :n 0, :id (first pks)}] rows))))
+  (testing "complete literals keep the zip path: no extra select"
+    (reset-capture!)
+    (swap! bird-capture-fields assoc :insert [:id :group_id :n])
+    (t2/with-call-count [call-count]
+      (t2/insert! ::bird {:name "no-backfill" :group_id 241 :n 7})
+      (is (= 1 (call-count))))
+    (is (=? [{:rows [{:group_id 241, :n 7}]}] (events)))))

--- a/test/metabase/search/models_test.clj
+++ b/test/metabase/search/models_test.clj
@@ -1,7 +1,8 @@
 (ns metabase.search.models-test
-  "Pins the delete- and update-capture wiring in [[metabase.search.models]]: deletes and updates now enqueue
-  re-derivation messages via the [[metabase.app-db.dml-capture]] seam instead of firing no hooks (deletes) or
-  every hook unconditionally (updates, via the old per-row after-update)."
+  "Pins the DML-capture wiring in [[metabase.search.models]]: all three operations now enqueue re-derivation
+  messages via the [[metabase.app-db.dml-capture]] seam, statement-level, instead of firing no hooks
+  (deletes), every hook unconditionally (updates, via the old per-row after-update), or per-row with a
+  full-row re-select (inserts, via the old per-row after-insert)."
   (:require
    [clojure.test :refer :all]
    [metabase.app-db.dml-capture :as dml-capture]
@@ -19,8 +20,8 @@
       (mt/with-dynamic-fn-redefs [search.ingestion/ingest-maybe-async!
                                   (fn [updates] (swap! calls conj updates))]
         (mt/with-temp [:model/Card {id :id} {}]
-          ;; the temp card's own creation enqueues an unrelated message via the after-insert hook; only the
-          ;; delete's message is under test.
+          ;; the temp card's own creation enqueues an unrelated insert-capture message; only the delete's
+          ;; message is under test.
           (reset! calls [])
           (t2/delete! :model/Card id)
           (is (=? [#{["card" [:= id :this.id]]
@@ -34,11 +35,11 @@
   (testing "capture-fields is skipped entirely (no pre-select) when no search engine is active"
     (mt/with-dynamic-fn-redefs [search.engine/active-engines (constantly [])]
       (is (nil? (dml-capture/capture-fields :model/Card :delete)))
-      (is (nil? (dml-capture/capture-fields :model/Card :update)))))
-  (testing "delete and update are wired up (via hook-where-fields); insert capture-fields stays nil, since
-            inserts are captured whole rather than narrowed"
+      (is (nil? (dml-capture/capture-fields :model/Card :update)))
+      (is (nil? (dml-capture/capture-fields :model/Card :insert)))))
+  (testing "all three ops are wired up via hook-where-fields"
     (is (some? (seq (search.engine/active-engines))) "this test needs an active engine to be meaningful")
-    (is (nil? (dml-capture/capture-fields :model/Card :insert)))
+    (is (= #{:id} (dml-capture/capture-fields :model/Card :insert)))
     (is (= #{:id} (dml-capture/capture-fields :model/Card :delete)))
     (is (= #{:id} (dml-capture/capture-fields :model/Card :update)))))
 
@@ -172,3 +173,50 @@
                (-> (t2/select-one-fn :display_data (search.index/active-table) :model "card" :model_id (str id))
                    json/decode
                    (get "collection_name"))))))))
+
+(deftest insert-enqueues-one-bulk-update-test
+  (testing "a multi-row insert enqueues one re-derivation batch, one message per row per primary hook"
+    (let [calls (atom [])]
+      (mt/with-dynamic-fn-redefs [search.ingestion/ingest-maybe-async!
+                                  (fn [updates] (swap! calls conj updates))]
+        (mt/with-temp [:model/Collection {coll-id :id} {}]
+          (reset! calls [])
+          (let [n (t2/insert! :model/Document
+                              (for [i (range 3)]
+                                {:name          (str "Ins Capture Doc " i)
+                                 :collection_id coll-id
+                                 :document      "{}"
+                                 :content_type  "application/json"
+                                 :creator_id    (mt/user->id :crowberto)
+                                 :created_at    :%now
+                                 :updated_at    :%now}))]
+            (is (= 3 n))
+            (is (= 1 (count @calls)))
+            (is (= 3 (count (set (first @calls)))))
+            (is (every? (fn [[search-model where]]
+                          (and (= "document" search-model)
+                               (= :this.id (last where))))
+                        (first @calls)))))))))
+
+(deftest insert-adds-no-statements-test
+  (testing "a captured single-row insert runs exactly one statement: the pk-returning INSERT, with no
+            follow-up full-row select (the old per-row after-insert forced INSERT + SELECT *)"
+    (mt/with-dynamic-fn-redefs [search.ingestion/ingest-maybe-async! (fn [_updates] nil)]
+      (mt/with-temp [:model/Collection {coll-id :id} {}]
+        ;; resolved outside the counted block: cold, the user lookup itself issues queries.
+        (let [creator-id (mt/user->id :crowberto)]
+          (t2/with-call-count [call-count]
+            (t2/insert! :model/Document {:name          "Ins Capture Solo"
+                                         :collection_id coll-id
+                                         :document      "{}"
+                                         :content_type  "application/json"
+                                         :creator_id    creator-id
+                                         :created_at    :%now
+                                         :updated_at    :%now})
+            (is (= 1 (call-count)))))))))
+
+(deftest ^:synchronized insert-indexes-new-rows-test
+  (testing "with-temp creation (insert-returning-instances!) still lands rows in the index (appdb engine)"
+    (search.tu/with-appdb-search-if-available-without-fallback
+      (mt/with-temp [:model/Card {id :id} {:name "Insert Capture E2E Card"}]
+        (is (= 1 (t2/count (search.index/active-table) :model "card" :model_id (str id))))))))


### PR DESCRIPTION
> **Superseded by #78287 and #78289.** This PR was intentionally closed without merging when the stack was reorganized. The generic insert backfill belongs to the DML-capture seam and moved down to #78287; the search insert-hook migration belongs with the corresponding update-hook migration and was folded into #78289. No work was dropped, and this PR should not be reopened or merged.

Replace the per-row after-insert hook with the DML capture seam, completing the migration of all
three DML operations. Capture rides the same pk-returning upgrade after-insert already forced,
minus the follow-up SELECT * of every inserted row — a single insert is now one statement — and
enqueues once per statement instead of once per row.

Hook where-values come from the insert's own row literals plus the returned pks. Columns filled in
by the database or a before-insert method (revision.most_recent, which locates the card a revision
feeds) are invisible in the literals, so the seam's insert capture now back-fills missing capture
fields with one narrow select by the returned pks; capture-fields thereby means the same thing for
all three ops — these columns are always present and authoritative in event rows.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
