### PR TITLE
Add shared search index health metrics

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1048,6 +1048,7 @@
   health-inspector
   {:team "Querying Platform"
    :api #{metabase.health-inspector.api
+          metabase.health-inspector.core
           metabase.health-inspector.init}
    :uses #{api
            lib
@@ -2016,6 +2017,7 @@
            metabase.search.core
            metabase.search.engine
            metabase.search.in-place.scoring
+           metabase.search.index-health
            metabase.search.ingestion
            metabase.search.init
            metabase.search.scoring
@@ -2030,6 +2032,7 @@
            collections
            config
            events
+           health-inspector
            lib
            lib-be
            models
@@ -3582,7 +3585,6 @@
            metabase-enterprise.semantic-search.core
            metabase-enterprise.semantic-search.db.datasource
            metabase-enterprise.semantic-search.embedding
-           metabase-enterprise.semantic-search.embedding-health
            metabase-enterprise.semantic-search.init}
    :uses #{activity-feed
            analytics

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3582,6 +3582,7 @@
            metabase-enterprise.semantic-search.core
            metabase-enterprise.semantic-search.db.datasource
            metabase-enterprise.semantic-search.embedding
+           metabase-enterprise.semantic-search.embedding-health
            metabase-enterprise.semantic-search.init}
    :uses #{activity-feed
            analytics

--- a/enterprise/backend/src/metabase_enterprise/embeddings/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/embeddings/client.clj
@@ -31,6 +31,14 @@
 
 (set! *warn-on-reflection* true)
 
+(defn- search-embedding-model
+  "Translate the neutral embedding descriptor's dimension key to semantic search's internal key."
+  [embedding-model]
+  (cond-> embedding-model
+    (and (nil? (:vector-dimensions embedding-model))
+         (some? (:model-dimensions embedding-model)))
+    (assoc :vector-dimensions (:model-dimensions embedding-model))))
+
 (defn get-embeddings-batch
   "Return a sequential collection of embedding vectors, in the same order as the input texts.
 
@@ -41,4 +49,4 @@
   `opts`            — optional keyword opts (e.g. `:type :doc`). Accepts alternating kwargs or a single trailing map;
                       forwarded as kwargs into the multimethod, which destructures with `& {:as opts}`."
   [embedding-model texts & {:as opts}]
-  (apply semantic-search/get-embeddings-batch embedding-model texts (mapcat identity opts)))
+  (apply semantic-search/get-embeddings-batch (search-embedding-model embedding-model) texts (mapcat identity opts)))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -493,8 +493,11 @@
                       {:status 502 :endpoint endpoint}
                       e)))
     (catch Exception e
-      (log/error e (str "Failed to generate " provider " embeddings")
-                 {:documents (count texts) :tokens (count-tokens-batch texts)})
+      ;; The breaker transition already logs the outage once. Fast-failed calls while it remains open are
+      ;; expected and can be frequent, so do not emit a redundant error for every guarded request.
+      (when-not (= :embedder/circuit-open (:cause (ex-data e)))
+        (log/error e (str "Failed to generate " provider " embeddings")
+                   {:documents (count texts) :tokens (count-tokens-batch texts)}))
       (throw e))))
 
 ;;;; Embedding-service provider

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -2,6 +2,8 @@
   (:require
    [clj-http.client :as http]
    [clojure.string :as str]
+   [diehard.circuit-breaker :as dh.cb]
+   [flatland.ordered.set :refer [ordered-set]]
    [metabase-enterprise.semantic-search.models.token-tracking :as semantic.models.token-tracking]
    [metabase-enterprise.semantic-search.settings :as semantic-settings]
    [metabase.analytics-interface.core :as analytics]
@@ -16,6 +18,7 @@
   (:import
    [com.knuddels.jtokkit Encodings]
    [com.knuddels.jtokkit.api Encoding EncodingType]
+   [dev.failsafe CircuitBreaker]
    [java.net ConnectException]))
 
 (set! *warn-on-reflection* true)
@@ -107,7 +110,7 @@
                    (do
                      (log/warn
                       (format "Skipping text that exceeds maximum measure per batch: %s"
-                              (str (subs text 0 10) "..."))
+                              (str (subs text 0 (min 10 (count text))) "..."))
                       {:measure text-measure :threshold threshold})
                      acc)
 
@@ -136,54 +139,267 @@
 (defn- dispatch-provider [embedding-model & _] (:provider embedding-model))
 
 (defmulti get-embedding
-  "Returns a single embedding vector for the given text"
+  "Returns a single embedding vector for the given text.
+  `opts` (kwargs, honoured by the production providers; ollama ignores them):
+  - `:record-tokens?` — write a token-tracking row for the call
+  - `:type`           — what the embedding is for (`:query`/`:index`), recorded with the tokens
+  - `:snowplow?`      — ai-service only, default true; synthetic callers (e.g. the health probe) pass
+                        false so the call emits no token_usage event"
   {:arglists '([embedding-model text & opts])} dispatch-provider)
 
 (defmulti get-embeddings-batch
-  "Returns a sequential collection of embedding vectors, in the same order as the input texts."
+  "Returns a sequential collection of embedding vectors, in the same order as the input texts.
+  Takes the same `opts` as [[get-embedding]], minus `:snowplow?` (batch callers are all organic)."
   {:arglists '([embedding-model texts & opts])} dispatch-provider)
+
+(defmulti embedder-circuit-endpoint
+  "Return the remote endpoint that identifies `embedding-model`'s circuit, or nil when its provider does not
+  use the remote-service circuit breaker."
+  {:arglists '([embedding-model])} dispatch-provider)
+
+(defmethod embedder-circuit-endpoint :default [_] nil)
 
 (defmulti pull-model
   "If a model needs to be downloaded (which is the case for ollama), downloads it."
   {:arglists '([embedding-model])} dispatch-provider)
 
+;;;; Embedding-service circuit breaker
+;;;
+;;; The embedding service is a remote HTTP dependency; when it's down, every semantic-search / NLQ query
+;;; would otherwise re-attempt (and re-time-out) against it. A circuit breaker fails fast after repeated
+;;; failures, and its state doubles as a health signal: an open breaker means real traffic is currently
+;;; failing. State transitions surface the affected health checks immediately (see the listeners) rather
+;;; than waiting for the daily job. Thresholds are fixed (the breaker is built once); the setting is a
+;;; runtime kill switch checked per call.
+
+(def ^:private embedder-circuit-breaker-failure-threshold
+  "Consecutive embedding-service failures that trip the breaker open." 5)
+
+(def ^:private embedder-circuit-breaker-success-threshold
+  "Consecutive successes in half-open that close the breaker again." 2)
+
+(def ^:private embedder-circuit-breaker-delay-ms
+  "How long the breaker stays open before it allows a half-open trial call." 30000)
+
+(def ^:private embedding-http-timeouts
+  "clj-http timeout opts merged into every embedding-service request. Without an explicit :socket-timeout the
+  client waits forever, so a blackholed service (accepts connections, never responds) would hang callers
+  indefinitely -- and the breaker would never open, since only completed failures count toward it."
+  {:connection-timeout 10000
+   :socket-timeout     60000})
+
+(defonce ^{:doc "Insertion-ordered set of `(fn [state])` hooks run on every breaker state change.
+  Health namespaces `conj` a hook here (inverting the dep -- they require this module) to re-persist their
+  embedder-dependent check on a transition, so an outage or recovery surfaces in minutes, not the next daily report.
+  Ordered-set: `conj` is reload-idempotent and load-ordered, so the semantic hook clears the probe cache
+  before the NLQ hook reads it. Register a var so a REPL redef takes effect live."}
+  embedder-circuit-state-change-hooks
+  (atom (ordered-set)))
+
+(defonce ^:private embedder-circuit-hook-runner
+  ;; One agent, so transitions run strictly in arrival order: concurrent futures would let a slow earlier
+  ;; transition (e.g. its check blocked on a probe against a down service) persist a stale result AFTER a
+  ;; later recovery transition's healthy one, leaving a pre-recovery "unreachable" row standing.
+  ;; :continue so an unexpected action error can't wedge the agent for the process lifetime.
+  (agent nil
+         :error-mode :continue
+         :error-handler (fn [_agent e] (log/error e "Embedder circuit hook runner errored"))))
+
+(defn- on-embedder-circuit-state-change!
+  "Run the registered [[embedder-circuit-state-change-hooks]] off the failsafe callback thread -- one
+  transition at a time in arrival order, hooks in registration order, each isolated so one failing hook
+  doesn't starve the rest."
+  [state]
+  ;; Log level tracks the resulting state's severity:
+  ;;   :open      -> WARN  (degradation)
+  ;;   :half-open -> INFO  (probing)
+  ;;   :closed    -> INFO  (recovered)
+  ;; Recovery is still captured level-independently -- the hooks below persist a health row per transition.
+  (if (= :open state)
+    (log/warn "Embedding service circuit breaker opened" {:state state})
+    (log/info "Embedding service circuit breaker changed state" {:state state}))
+  (send-off
+   embedder-circuit-hook-runner
+   (fn [_]
+     (doseq [hook @embedder-circuit-state-change-hooks]
+       (try
+         (hook state)
+         (catch InterruptedException e
+           (throw e))
+         (catch Exception e
+           (log/error e "Embedder circuit state-change hook failed")))))))
+
+(defn- new-embedder-circuit-breaker []
+  (dh.cb/circuit-breaker
+   {:failure-threshold embedder-circuit-breaker-failure-threshold
+    :success-threshold embedder-circuit-breaker-success-threshold
+    :delay-ms          embedder-circuit-breaker-delay-ms
+    :on-open      (fn [_] (on-embedder-circuit-state-change! :open))
+    :on-half-open (fn [_] (on-embedder-circuit-state-change! :half-open))
+    :on-close     (fn [_] (on-embedder-circuit-state-change! :closed))}))
+
+(defonce ^:private embedder-circuit-breakers
+  ;; Provider settings can differ between semantic search and data complexity. Keying by endpoint prevents
+  ;; one unavailable service from fast-failing calls to an unrelated, healthy service.
+  (atom {}))
+
+(declare get-configured-model)
+
+(defn- circuit-breaker-for
+  ^CircuitBreaker [endpoint]
+  (or (get @embedder-circuit-breakers endpoint)
+      (get (swap! embedder-circuit-breakers
+                  #(if (contains? % endpoint)
+                     %
+                     (assoc % endpoint (new-embedder-circuit-breaker))))
+           endpoint)))
+
+(def ^:dynamic *bypass-circuit-breaker*
+  "Bind true to run an embedding call without consulting or tripping the breaker.
+  The health probe binds it so the probe stays an independent signal and can't flip the breaker from inside
+  a state-change listener (which would recurse)."
+  false)
+
+(defn embedder-circuit-state
+  "Return the configured embedder circuit's state (`:closed`, `:open`, or `:half-open`), or nil when the
+  provider has no circuit endpoint. The optional `endpoint` arity inspects another endpoint's isolated circuit."
+  ([]
+   (embedder-circuit-state (embedder-circuit-endpoint (get-configured-model))))
+  ([endpoint]
+   (when endpoint
+     (dh.cb/state (circuit-breaker-for endpoint)))))
+
+(defn embedder-circuit-untrusted?
+  "Whether the breaker is enabled and not closed -- i.e. open or half-open, so it doesn't yet trust the
+  embedding service (open short-circuits calls; half-open is on a single trial).
+  False when the breaker is disabled or the provider has no circuit endpoint."
+  []
+  (boolean
+   (and (semantic-settings/semantic-search-embedder-circuit-breaker-enabled)
+        (when-let [state (embedder-circuit-state)]
+          (not= :closed state)))))
+
+(def ^:private request-specific-statuses
+  "HTTP statuses caused by a particular input, rather than the embedding service as a whole."
+  #{400 404 413 422})
+
+(defn- service-failure?
+  [e]
+  (let [data   (ex-data e)
+        cause  (some-> e ex-cause ex-data)
+        status (or (:status data) (:status cause))
+        reason (or (:cause data) (:cause cause))]
+    (and (not (contains? request-specific-statuses status))
+         (not= :embedder/unexpected-dimensions reason))))
+
+(defn- circuit-open-ex
+  [endpoint]
+  (ex-info "embedding service unavailable (circuit open)"
+           (cond-> {:status 502, :cause :embedder/circuit-open}
+             endpoint (assoc :endpoint endpoint))))
+
+(defn- call-through-embedder-breaker
+  "Run `thunk` under the embedder circuit breaker, unless it is bypassed (probe) or disabled (kill switch).
+  Circuits are isolated by endpoint. Service-wide failures update the circuit; request- and model-specific
+  failures propagate without changing its history. An open circuit throws a 502 `ex-info` with
+  `:cause :embedder/circuit-open`."
+  [thunk & {:keys [endpoint]}]
+  (if (or (nil? endpoint)
+          *bypass-circuit-breaker*
+          (not (semantic-settings/semantic-search-embedder-circuit-breaker-enabled)))
+    (thunk)
+    (let [^CircuitBreaker breaker (circuit-breaker-for endpoint)]
+      (when-not (dh.cb/allow-execution? breaker)
+        (throw (circuit-open-ex endpoint)))
+      (let [execution-state (dh.cb/state breaker)]
+        (try
+          (let [result (thunk)]
+            (.recordSuccess breaker)
+            result)
+          (catch InterruptedException e
+            (when (= :half-open execution-state)
+              (.recordFailure breaker))
+            (throw e))
+          (catch Exception e
+            (cond
+              (service-failure? e) (.recordException breaker e)
+              (= :half-open execution-state) (.recordSuccess breaker))
+            (throw e))
+          (catch Throwable t
+            ;; Every half-open permit must record an outcome, even when the JVM-level failure itself should
+            ;; propagate unchanged rather than contribute to the service-failure history.
+            (when (= :half-open execution-state)
+              (.recordFailure breaker))
+            (throw t)))))))
+
+(defn- validate-embeddings!
+  [embeddings expected-count expected-dimensions]
+  (when-not (= expected-count (count embeddings))
+    (throw (ex-info "Embedding response contained an unexpected number of vectors"
+                    {:cause :embedder/invalid-response
+                     :expected-count expected-count
+                     :actual-count (count embeddings)})))
+  (doseq [embedding embeddings]
+    (when-not (= expected-dimensions (count embedding))
+      (throw (ex-info "Embedding response contained a vector with unexpected dimensions"
+                      {:cause :embedder/unexpected-dimensions
+                       :expected-dimensions expected-dimensions
+                       :actual-dimensions (count embedding)})))
+    (when-not (every? #(Double/isFinite (double %)) embedding)
+      (throw (ex-info "Embedding response contained a non-finite value"
+                      {:cause :embedder/invalid-response}))))
+  embeddings)
+
 ;;;; Ollama impl
 
-(defn- ollama-get-embedding [model-name text]
+(def ^:private ollama-embeddings-endpoint
+  "http://localhost:11434/api/embeddings") ;; TODO: we should make the host configurable
+
+(defmethod embedder-circuit-endpoint "ollama" [_] ollama-embeddings-endpoint)
+
+(defn- ollama-get-embedding [model-name vector-dimensions text]
   (try
     ;; TODO count ollama tokens into :metabase-search/semantic-embedding-tokens?
     (log/debug "Generating Ollama embedding for text of length:" (count text))
-    (-> (http/post "http://localhost:11434/api/embeddings" ;; TODO: we should make the host configurable
-                   {:headers {"Content-Type" "application/json"}
-                    :body    (json/encode {:model model-name
-                                           :prompt text})})
-        :body
-        (json/decode true)
-        :embedding)
+    (let [embedding (-> (http/post ollama-embeddings-endpoint
+                                   (merge embedding-http-timeouts
+                                          {:headers {"Content-Type" "application/json"}
+                                           :body    (json/encode {:model model-name
+                                                                  :prompt text})}))
+                        :body
+                        (json/decode true)
+                        :embedding)]
+      (first (validate-embeddings! [embedding] 1 vector-dimensions)))
     (catch Exception e
       (log/error e "Failed to generate Ollama embedding for text of length:" (count text))
       (throw e))))
-
-(defn- ollama-get-embeddings-batch [model-name texts]
-  ;; Ollama doesn't have a native batch API, so we fall back to individual calls
-  ;; No special batching needed for Ollama - just process all texts
-  (log/debug "Generating" (count texts) "Ollama embeddings (using individual calls)")
-  (mapv #(ollama-get-embedding model-name %) texts))
 
 (defn- ollama-pull-model [model-name]
   (try
     (log/debug "Pulling embedding model from Ollama...")
     (http/post "http://localhost:11434/api/pull" ;; TODO: make the host configurable
-               {:headers {"Content-Type" "application/json"}
-                :body    (json/encode {:model model-name})})
+               (merge embedding-http-timeouts
+                      {:headers {"Content-Type" "application/json"}
+                       :body    (json/encode {:model model-name})}))
     (catch Exception e
       (log/error e "Failed to pull embedding model")
       (throw e))))
 
 ;; Ollama is not used in production. Token tracking is not implemented.
-(defmethod get-embedding        "ollama" [{:keys [model-name]} text & {:as _opts}]  (ollama-get-embedding model-name text))
-(defmethod get-embeddings-batch "ollama" [{:keys [model-name]} texts & {:as _opts}] (ollama-get-embeddings-batch model-name texts))
-(defmethod pull-model           "ollama" [{:keys [model-name]}]       (ollama-pull-model model-name))
+(defmethod get-embedding "ollama" [{:keys [model-name vector-dimensions]} text & {:as _opts}]
+  (call-through-embedder-breaker #(ollama-get-embedding model-name vector-dimensions text)
+                                 :endpoint ollama-embeddings-endpoint))
+
+(defmethod get-embeddings-batch "ollama" [{:keys [model-name vector-dimensions]} texts & {:as _opts}]
+  ;; Ollama doesn't have a native batch API, so we fall back to individual calls. Each call goes through the
+  ;; breaker on its own, so an outage mid-batch fast-fails the remaining texts instead of timing out on each.
+  (log/debug "Generating" (count texts) "Ollama embeddings (using individual calls)")
+  (mapv (fn [text]
+          (call-through-embedder-breaker #(ollama-get-embedding model-name vector-dimensions text)
+                                         :endpoint ollama-embeddings-endpoint))
+        texts))
+
+(defmethod pull-model "ollama" [{:keys [model-name]}] (ollama-pull-model model-name))
 
 ;;;; OpenAI-compatible embedding service impl (shared by "ai-service" and "openai" providers)
 
@@ -196,25 +412,28 @@
      (str/starts-with? model-name "text-embedding-3"))))
 
 (mu/defn- openai-compatible-get-embeddings-batch
-  "Call an OpenAI-compatible /v1/embeddings endpoint. Shared implementation for both
-  the `ai-service` and `openai` providers.
+  "Call an OpenAI-compatible /v1/embeddings endpoint. The breaker guards only the remote request and
+  response decoding; analytics and token persistence happen after it returns.
 
   `:provider`        — label for analytics (e.g. \"ai-service\", \"openai\")
   `:endpoint`        — full URL including /v1/embeddings
   `:api-key`         — Bearer token. If empty ai service proxying is assumed and premium-embedding-token is
                        used for authentication
   `:model-name`      — model identifier sent in the request body
+  `:vector-dimensions` — expected dimensions of each returned vector
   `:texts`           — collection of input strings
   `:record-tokens?`  — true writes a `semantic_search_token_tracking` row, false skips it.
   `:snowplow?`       — optional; when true fires a Snowplow `token_usage` event
   `:extra-body`      — optional; merged into the request body (e.g. `{:dimensions 1024}`)
   `:type`            — optional; forwarded to the token-tracking row"
-  [{:keys [provider endpoint api-key model-name texts record-tokens? extra-body snowplow?] :as opts}
+  [{:keys [provider endpoint api-key model-name vector-dimensions texts record-tokens? extra-body snowplow?]
+    :as opts}
    :- [:map
        [:provider       :string]
        [:endpoint       :string]
        [:api-key        {:optional true} [:maybe :string]]
        [:model-name     :string]
+       [:vector-dimensions pos-int?]
        [:texts          [:sequential :string]]
        [:record-tokens? :boolean]
        [:snowplow?      {:optional true} [:maybe :boolean]]
@@ -222,24 +441,32 @@
   (try
     (log/debug (str "Calling " provider " embeddings API")
                {:endpoint endpoint :documents (count texts) :tokens (count-tokens-batch texts)})
-    (let [start-ms             (u/start-timer)
-          {:keys [usage data]} (-> (http/post endpoint
-                                              {:headers
-                                               (merge {"Content-Type"  "application/json"}
-                                                      (if (and (empty? api-key)
-                                                               (= "ai-service" provider))
-                                                        {"x-metabase-instance-token"
-                                                         (u/prog1 (premium-features/premium-embedding-token)
-                                                           (when (nil? <>)
-                                                             (throw (ex-info "Premium embedding token not set"
-                                                                             {:provider provider}))))}
-                                                        {"Authorization" (str "Bearer " api-key)}))
-                                               :body    (json/encode (merge {:model           model-name
-                                                                             :input           texts
-                                                                             :encoding_format "base64"}
-                                                                            extra-body))})
-                                   :body
-                                   (json/decode true))
+    (let [headers              (merge {"Content-Type" "application/json"}
+                                      (if (and (empty? api-key) (= "ai-service" provider))
+                                        {"x-metabase-instance-token"
+                                         (u/prog1 (premium-features/premium-embedding-token)
+                                           (when (nil? <>)
+                                             (throw (ex-info "Premium embedding token not set"
+                                                             {:provider provider}))))}
+                                        {"Authorization" (str "Bearer " api-key)}))
+          request              (merge embedding-http-timeouts
+                                      {:headers headers
+                                       :body    (json/encode
+                                                 (merge {:model           model-name
+                                                         :input           texts
+                                                         :encoding_format "base64"}
+                                                        extra-body))})
+          start-ms             (u/start-timer)
+          {:keys [usage embeddings]}
+          (call-through-embedder-breaker
+           #(let [{:keys [usage data]} (-> (http/post endpoint request)
+                                           :body
+                                           (json/decode true))]
+              {:usage usage
+               :embeddings (validate-embeddings! (decode-embeddings data)
+                                                 (count texts)
+                                                 vector-dimensions)})
+           :endpoint endpoint)
           total-tokens         (:total_tokens usage 0)
           prompt-tokens        (:prompt_tokens usage total-tokens)]
       (analytics/inc! :metabase-search/semantic-embedding-tokens
@@ -259,14 +486,14 @@
           :tag                 "embedding_generation"}))
       (when record-tokens?
         (semantic.models.token-tracking/record-tokens model-name (:type opts) total-tokens))
-      (decode-embeddings data))
+      embeddings)
     (catch ConnectException e
       (log/error e (str "Failed to connect to " provider) {:endpoint endpoint})
       (throw (ex-info (str provider " unavailable (connection refused)")
                       {:status 502 :endpoint endpoint}
                       e)))
     (catch Exception e
-      (log/error e (str provider " embeddings API call failed")
+      (log/error e (str "Failed to generate " provider " embeddings")
                  {:documents (count texts) :tokens (count-tokens-batch texts)})
       (throw e))))
 
@@ -296,27 +523,32 @@
                         {:settings ["ee-embedding-service-base-url"
                                     "ai-service-base-url"]}))))
 
+(defmethod embedder-circuit-endpoint "ai-service" [_]
+  (first (embedding-service-resolve-config!)))
+
 (defmethod get-embedding "ai-service"
-  [{:keys [model-name]} text & {:keys [record-tokens? type]}]
+  [{:keys [model-name vector-dimensions]} text & {:keys [record-tokens? type snowplow?] :or {snowplow? true}}]
   (let [[endpoint api-key] (embedding-service-resolve-config!)]
     (first (openai-compatible-get-embeddings-batch
             {:provider       "ai-service"
              :endpoint       endpoint
              :api-key        api-key
              :model-name     model-name
+             :vector-dimensions vector-dimensions
              :texts          [text]
-             :snowplow?      true
+             :snowplow?      snowplow?
              :record-tokens? record-tokens?
              :type           type}))))
 
 (defmethod get-embeddings-batch "ai-service"
-  [{:keys [model-name]} texts & {:keys [record-tokens? type]}]
+  [{:keys [model-name vector-dimensions]} texts & {:keys [record-tokens? type]}]
   (let [[endpoint api-key] (embedding-service-resolve-config!)]
     (openai-compatible-get-embeddings-batch
      {:provider       "ai-service"
       :endpoint       endpoint
       :api-key        api-key
       :model-name     model-name
+      :vector-dimensions vector-dimensions
       :texts          texts
       :snowplow?      true
       :record-tokens? record-tokens?
@@ -335,6 +567,9 @@
       (throw (ex-info "OpenAI API key not configured" {:setting "llm-openai-api-key"})))
     [(str (semantic-settings/openai-api-base-url) "/v1/embeddings") api-key]))
 
+(defmethod embedder-circuit-endpoint "openai" [_]
+  (first (openai-resolve-config!)))
+
 (defmethod get-embedding "openai"
   [embedding-model text & {:keys [record-tokens? type]}]
   (let [[endpoint api-key] (openai-resolve-config!)]
@@ -343,6 +578,7 @@
              :endpoint       endpoint
              :api-key        api-key
              :model-name     (:model-name embedding-model)
+             :vector-dimensions (:vector-dimensions embedding-model)
              :texts          [text]
              :record-tokens? record-tokens?
              :extra-body     (when (supports-dimensions? embedding-model)
@@ -357,6 +593,7 @@
       :endpoint       endpoint
       :api-key        api-key
       :model-name     (:model-name embedding-model)
+      :vector-dimensions (:vector-dimensions embedding-model)
       :texts          texts
       :record-tokens? record-tokens?
       :extra-body     (when (supports-dimensions? embedding-model)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding_health.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding_health.clj
@@ -1,0 +1,122 @@
+(ns metabase-enterprise.semantic-search.embedding-health
+  "Embedding-service liveness and circuit recovery shared by semantic search and entity retrieval."
+  (:require
+   [clojure.core.memoize :as memoize]
+   [metabase-enterprise.semantic-search.embedding :as embedding]
+   [metabase.util.log :as log])
+  (:import
+   (java.util.concurrent Executors ScheduledExecutorService ThreadFactory TimeUnit)))
+
+(set! *warn-on-reflection* true)
+
+(defn- probe-embedding-service
+  []
+  (try
+    ;; This liveness signal must not mutate the breaker; recovery trials are scheduled separately below.
+    (binding [embedding/*bypass-circuit-breaker* true]
+      (embedding/get-embedding (embedding/get-configured-model)
+                               "health check"
+                               {:type :query, :record-tokens? false, :snowplow? false}))
+    {:reachable? true, :error nil}
+    (catch InterruptedException e
+      (throw e))
+    (catch Exception e
+      (log/debug e "Embedding service health probe failed")
+      {:reachable? false, :error (ex-message e)})))
+
+(def ^:private embedding-service-reachable?*
+  (memoize/ttl probe-embedding-service :ttl/threshold (* 60 1000)))
+
+(defn embedding-service-reachable?
+  "Probe the configured embedding service. Results are shared for a 60-second window."
+  []
+  (embedding-service-reachable?*))
+
+(declare request-circuit-recovery!)
+
+(defn embedding-problem
+  "Return an embedding-service problem, or nil when the service and circuit are ready.
+  A reachable probe schedules circuit recovery when an idle workload has not supplied trial calls."
+  []
+  (let [{:keys [reachable? error]} (embedding-service-reachable?)]
+    (cond
+      (not reachable?)
+      (str "embedding service unreachable: " error)
+
+      (embedding/embedder-circuit-untrusted?)
+      (do
+        (request-circuit-recovery!)
+        "embedder circuit open (probe reachable; breaker still guarding calls)"))))
+
+(def ^:private recovery-delay-ms 30000)
+
+(def ^:private recovery-cooldown-ns
+  (* recovery-delay-ms 1000000))
+
+(defonce ^:private ^ScheduledExecutorService recovery-scheduler
+  (Executors/newSingleThreadScheduledExecutor
+   (reify ThreadFactory
+     (newThread [_ runnable]
+       (doto (Thread. runnable "embedding-circuit-recovery")
+         (.setDaemon true))))))
+
+(defonce ^:private recovery-state
+  (atom {:running? false, :last-start-ns nil}))
+
+(defn- claim-recovery! [now-ns]
+  (loop []
+    (let [{:keys [running? last-start-ns] :as state} @recovery-state]
+      (cond
+        running? false
+        (and last-start-ns (< (- now-ns last-start-ns) recovery-cooldown-ns)) false
+        (compare-and-set! recovery-state state {:running? true, :last-start-ns now-ns}) true
+        :else (recur)))))
+
+(defn- run-recovery-probe! []
+  (embedding/get-embedding (embedding/get-configured-model)
+                           "health check"
+                           {:type :query, :record-tokens? false, :snowplow? false}))
+
+(defn- recover-circuit! []
+  (try
+    ;; More than the current two-success threshold keeps this correct if that threshold is raised modestly.
+    (loop [remaining 4]
+      (when (and (pos? remaining) (embedding/embedder-circuit-untrusted?))
+        (run-recovery-probe!)
+        (recur (dec remaining))))
+    (catch InterruptedException e
+      (throw e))
+    (catch Exception e
+      (log/debug e "Embedding service circuit recovery probe failed"))
+    (finally
+      (swap! recovery-state assoc :running? false)))
+  ;; A still-untrusted breaker needs another delayed trial even when no user traffic or health consumer runs.
+  (when (embedding/embedder-circuit-untrusted?)
+    (request-circuit-recovery!)))
+
+(defn- schedule-recovery! [f]
+  (.schedule recovery-scheduler ^Runnable f (long recovery-delay-ms) TimeUnit/MILLISECONDS))
+
+(defn request-circuit-recovery!
+  "Schedule a throttled breaker-controlled probe after the breaker's open delay. Returns promptly."
+  []
+  (when (and (embedding/embedder-circuit-untrusted?)
+             (claim-recovery! (System/nanoTime)))
+    (try
+      (schedule-recovery! recover-circuit!)
+      (catch Exception e
+        (swap! recovery-state assoc :running? false)
+        (log/error e "Failed to schedule embedding service circuit recovery"))))
+  nil)
+
+(defn- clear-probe-cache-on-recovery! [state]
+  (when (= :closed state)
+    (memoize/memo-clear! embedding-service-reachable?*)))
+
+(defn- request-recovery-on-open! [state]
+  (when (= :open state)
+    (request-circuit-recovery!)))
+
+;; Register the shared cache hook before either consumer registers its health-row hook.
+(swap! embedding/embedder-circuit-state-change-hooks conj #'clear-probe-cache-on-recovery!)
+(swap! embedding/embedder-circuit-state-change-hooks conj #'request-recovery-on-open!)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding_health.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding_health.clj
@@ -98,7 +98,8 @@
   (.schedule recovery-scheduler ^Runnable f (long recovery-delay-ms) TimeUnit/MILLISECONDS))
 
 (defn request-circuit-recovery!
-  "Schedule a throttled breaker-controlled probe after the breaker's open delay. Returns promptly."
+  "Schedule a throttled breaker-controlled probe for the configured semantic-search embedder after the breaker's
+  open delay. Semantic search and library retrieval share this embedder. Returns promptly."
   []
   (when (and (embedding/embedder-circuit-untrusted?)
              (claim-recovery! (System/nanoTime)))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/init.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.semantic-search.init
   (:require
+   [metabase-enterprise.semantic-search.embedding-health]
    [metabase-enterprise.semantic-search.events]
    [metabase-enterprise.semantic-search.settings]
    [metabase-enterprise.semantic-search.task.index-cleanup]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -85,6 +85,17 @@
   :export?    false
   :doc        false)
 
+(defsetting semantic-search-embedder-circuit-breaker-enabled
+  (deferred-tru
+   (str "Wrap embedding-service calls in a circuit breaker that fails fast after repeated failures. "
+        "Runtime kill switch; the breaker thresholds are fixed."))
+  :type       :boolean
+  :default    true
+  :encryption :no
+  :export?    false
+  :visibility :internal
+  :doc        false)
+
 (defsetting openai-max-tokens-per-batch
   (deferred-tru "The maximum number of tokens sent in a single embedding API call.")
   :type :integer

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/task/metric_collector.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/task/metric_collector.clj
@@ -4,10 +4,12 @@
    [clojurewerkz.quartzite.schedule.simple :as simple]
    [clojurewerkz.quartzite.triggers :as triggers]
    [honey.sql :as sql]
+   [metabase-enterprise.semantic-search.db.datasource :as semantic.datasource]
    [metabase-enterprise.semantic-search.dlq :as semantic.dlq]
    [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.util :as semantic.u]
    [metabase.analytics-interface.core :as analytics]
+   [metabase.search.index-health :as search.index-health]
    [metabase.task.core :as task]
    [metabase.util.log :as log]
    [next.jdbc :as jdbc]
@@ -65,13 +67,21 @@
     (log/warn "DLQ table does not exist. Index may not have been initialized.")))
 
 (defn- collect-metrics! []
-  ;; Active, not merely available: on an available-but-inactive instance the index tables never exist,
-  ;; and the collectors would warn about them on every run.
-  (when (semantic.u/semantic-search-active?)
-    (let [pgvector (semantic.env/get-pgvector-datasource!)
-          index-metadata (semantic.env/get-index-metadata)]
-      (collect-gate-size! pgvector)
-      (collect-dlq-size! pgvector index-metadata))))
+  (try
+    ;; Active, not merely available: on an available-but-inactive instance the index tables never exist,
+    ;; and the collectors would warn about them on every run.
+    (when (semantic.u/semantic-search-active?)
+      (let [pgvector (semantic.env/get-pgvector-datasource!)
+            index-metadata (semantic.env/get-index-metadata)]
+        (collect-gate-size! pgvector)
+        (collect-dlq-size! pgvector index-metadata)))
+    (catch InterruptedException e
+      (throw e))
+    (catch Exception e
+      (log/error e "Semantic search metric collector errored")))
+  ;; Registered collectors self-gate, so refreshing them is a cheap no-op when their feature is off.
+  ;; Keep this outside the try: ordinary failures continue here, while interruption and fatal errors exit.
+  (search.index-health/refresh-search-index-metrics!))
 
 (task/defjob ^{DisallowConcurrentExecution true
                :doc "Collect expensive semantic search metrics"}
@@ -82,7 +92,13 @@
 
 (defmethod task/init! ::SemanticMetricCollector
   [_]
-  (when (semantic.u/semantic-search-configured?)
+  ;; Boot-safe gate: plain env/feature checks, never a DB probe (pgvector-configured? would resolve
+  ;; pgvector-mode, probing the app db and logging a pgvector-store line on instances that can't use the
+  ;; answer). The dedicated-URL arm schedules without the feature, so a token entered post-boot starts the
+  ;; search-index gauges without a restart; app-db-pgvector instances licensed post-boot need one, matching the
+  ;; other semantic tasks (see [[semantic.u/semantic-search-configured?]]).
+  (if (or (semantic.datasource/dedicated-url-configured?)
+          (semantic.u/semantic-search-configured?))
     (let [job (jobs/build
                (jobs/of-type SemanticMetricCollector)
                (jobs/with-identity collector-job-key))
@@ -94,4 +110,7 @@
                      (simple/with-interval-in-milliseconds job-interval-ms)
                      (simple/repeat-forever)))
                    (triggers/start-now))]
-      (task/schedule-task! job trigger))))
+      (task/schedule-task! job trigger))
+    ;; Quartz's job store is persistent, so a collector scheduled by an earlier deploy would otherwise
+    ;; keep firing (as a no-op) on an instance whose configuration went away.
+    (task/delete-task! collector-job-key collector-trigger-key)))

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -31,6 +31,10 @@
 
 (def ^:private test-entity-ids (atom 0))
 
+(defmethod semantic-search/get-embeddings-batch ::dimension-translation-test
+  [embedding-model _texts & _opts]
+  [embedding-model])
+
 (defn- entity
   "Build a fake entity map for scoring tests. Uses a monotonically-increasing counter for `:id`
   so every test entity is distinct (and so test failures print stable, readable ids)."
@@ -743,6 +747,13 @@
                                     (repeat (count texts) [1.0]))]
         (embedder [{:id 1 :name "orders" :kind :table}])
         (is (false? (:record-tokens? @captured)))))))
+
+(deftest ^:parallel embeddings-client-translates-neutral-dimension-key-test
+  (let [[translated]
+        (embeddings/get-embeddings-batch
+         {:provider ::dimension-translation-test, :model-name "fake", :model-dimensions 384}
+         ["orders"])]
+    (is (= 384 (:vector-dimensions translated)))))
 
 (deftest ^:sequential provider-embedder-splits-names-before-calling-provider-test
   (testing "provider-embedder splits names on _, -, ., and camelCase before sending to get-embeddings-batch"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_circuit_breaker_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_circuit_breaker_test.clj
@@ -1,0 +1,261 @@
+(ns metabase-enterprise.semantic-search.embedding-circuit-breaker-test
+  (:require
+   [clj-http.client :as http]
+   [clojure.test :refer :all]
+   [diehard.circuit-breaker :as dh.cb]
+   [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
+   [metabase-enterprise.semantic-search.embedding-health :as embedding-health]
+   [metabase-enterprise.semantic-search.models.token-tracking :as token-tracking]
+   [metabase-enterprise.semantic-search.settings :as semantic.settings]
+   [metabase.analytics-interface.core :as analytics]
+   [metabase.health-inspector.core :as health-inspector]
+   [metabase.llm.settings :as llm.settings]
+   [metabase.test :as mt])
+  (:import
+   (java.util.concurrent CountDownLatch TimeUnit)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private test-endpoint "https://circuit-test.example/v1/embeddings")
+(def ^:private test-provider ::circuit-test)
+(def ^:private test-embedding-model {:provider test-provider})
+
+(defmethod semantic.embedding/embedder-circuit-endpoint test-provider [_] test-endpoint)
+
+(def ^:private call-through* #'semantic.embedding/call-through-embedder-breaker)
+
+(defn- call-through [thunk & {:as opts}]
+  (apply call-through* thunk (mapcat identity (merge {:endpoint test-endpoint} opts))))
+
+(defn- circuit-state
+  ([] (circuit-state test-endpoint))
+  ([endpoint] (semantic.embedding/embedder-circuit-state endpoint)))
+
+(defn- boom [] (throw (ex-info "embedder down" {:kind :boom})))
+
+(deftest embedder-circuit-endpoint-is-a-provider-capability-test
+  (testing "providers without a remote circuit endpoint remain trusted"
+    (mt/with-temporary-setting-values [semantic-search-embedder-circuit-breaker-enabled true]
+      (mt/with-dynamic-fn-redefs [semantic.embedding/get-configured-model
+                                  (constantly {:provider ::in-process})]
+        (is (nil? (semantic.embedding/embedder-circuit-state)))
+        (is (false? (semantic.embedding/embedder-circuit-untrusted?))))))
+  (testing "remote providers resolve the same endpoint their HTTP implementation uses"
+    (is (= "http://localhost:11434/api/embeddings"
+           (semantic.embedding/embedder-circuit-endpoint {:provider "ollama"})))
+    (mt/with-dynamic-fn-redefs
+      [semantic.settings/ee-embedding-service-base-url (constantly "https://embed.example/")
+       semantic.settings/ee-embedding-service-api-key  (constantly "test-key")
+       llm.settings/ai-service-base-url                 (constantly nil)]
+      (is (= "https://embed.example/v1/embeddings"
+             (semantic.embedding/embedder-circuit-endpoint {:provider "ai-service"}))))
+    (mt/with-dynamic-fn-redefs
+      [semantic.settings/openai-api-base-url (constantly "https://openai.example")
+       semantic.settings/openai-api-key      (constantly "test-key")]
+      (is (= "https://openai.example/v1/embeddings"
+             (semantic.embedding/embedder-circuit-endpoint {:provider "openai"}))))))
+
+(deftest ^:sequential request-failure-does-not-change-service-failure-history-test
+  (testing "request- and model-specific failures neither trip the circuit nor reset service-failure history"
+    (let [breaker (dh.cb/circuit-breaker {:failure-threshold 2 :success-threshold 1 :delay-ms 60000})]
+      (with-redefs [semantic.embedding/embedder-circuit-breakers (atom {test-endpoint breaker})]
+        (is (thrown? Exception (call-through boom)))
+        (doseq [request-error [(ex-info "bad request" {:status 400})
+                               (ex-info "model not found" {:status 404})
+                               (ex-info "wrong dimensions" {:cause :embedder/unexpected-dimensions})]]
+          (is (thrown? Exception (call-through #(throw request-error)))))
+        (is (= :closed (circuit-state)))
+        (is (thrown? Exception (call-through boom)))
+        (is (= :open (circuit-state)))))))
+
+(deftest ^:sequential opens-after-threshold-and-fast-fails-test
+  (testing "consecutive failures trip the breaker; while open, calls fast-fail with the mapped 502 ex-info"
+    ;; A fresh breaker (short threshold, stays open) so the test is isolated from the process-wide default.
+    (with-redefs [semantic.embedding/embedder-circuit-breakers
+                  (atom {test-endpoint (dh.cb/circuit-breaker
+                                        {:failure-threshold 2 :success-threshold 1 :delay-ms 60000})})]
+      (dotimes [_ 2]
+        (is (thrown? Exception (call-through boom))))
+      (is (= :open (circuit-state)))
+      (is (=? {:cause :embedder/circuit-open :status 502}
+              (try (call-through (constantly :never)) nil
+                   (catch clojure.lang.ExceptionInfo e (ex-data e))))))))
+
+(deftest ^:sequential throwable-releases-half-open-permit-test
+  (testing "a JVM-level failure cannot strand the breaker's only half-open trial permit"
+    (let [breaker (dh.cb/circuit-breaker
+                   {:failure-threshold 1 :success-threshold 1 :delay-ms 0})]
+      (with-redefs [semantic.embedding/embedder-circuit-breakers (atom {test-endpoint breaker})]
+        (is (thrown? Exception (call-through boom)))
+        (is (thrown? AssertionError (call-through #(throw (AssertionError. "fatal")))))
+        (is (= :ok (call-through (constantly :ok))))
+        (is (= :closed (circuit-state)))))))
+
+(deftest ^:sequential local-bookkeeping-failure-does-not-trip-breaker-test
+  (testing "a token-tracking failure propagates without being attributed to the embedding service"
+    (with-redefs [semantic.embedding/embedder-circuit-breakers
+                  (atom {"https://example.test/v1/embeddings"
+                         (dh.cb/circuit-breaker
+                          {:failure-threshold 1, :success-threshold 1, :delay-ms 60000})})]
+      (mt/with-dynamic-fn-redefs
+        [http/post                    (constantly {:body (str "{\"usage\":{\"total_tokens\":0},"
+                                                              "\"data\":[{\"embedding\":\"AAAAAA==\"}]}")})
+         analytics/inc!               (constantly nil)
+         token-tracking/record-tokens (fn [& _] (throw (ex-info "appdb unavailable" {})))]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"appdb unavailable"
+             (#'semantic.embedding/openai-compatible-get-embeddings-batch
+              {:provider       "openai"
+               :endpoint       "https://example.test/v1/embeddings"
+               :api-key        "test-key"
+               :model-name     "test-model"
+               :vector-dimensions 1
+               :texts          ["bird"]
+               :record-tokens? true
+               :snowplow?      false})))
+        (is (= :closed (circuit-state "https://example.test/v1/embeddings")))))))
+
+(deftest ^:sequential malformed-response-trips-breaker-test
+  (testing "a successful HTTP response is not a circuit success until its vectors are validated"
+    (let [endpoint "https://example.test/v1/embeddings"]
+      (with-redefs [semantic.embedding/embedder-circuit-breakers
+                    (atom {endpoint (dh.cb/circuit-breaker
+                                     {:failure-threshold 1 :success-threshold 1 :delay-ms 60000})})]
+        (mt/with-dynamic-fn-redefs
+          [http/post (constantly {:body "{\"usage\":{},\"data\":[]}"})]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"unexpected number"
+               (#'semantic.embedding/openai-compatible-get-embeddings-batch
+                {:provider          "openai"
+                 :endpoint          endpoint
+                 :api-key           "test-key"
+                 :model-name        "test-model"
+                 :vector-dimensions 1
+                 :texts             ["bird"]
+                 :record-tokens?    false})))
+          (is (= :open (circuit-state endpoint))))))))
+
+(deftest ^:sequential endpoint-circuits-are-isolated-test
+  (let [endpoint-a "https://a.example/v1/embeddings"
+        endpoint-b "https://b.example/v1/embeddings"
+        breaker    #(dh.cb/circuit-breaker
+                     {:failure-threshold 1 :success-threshold 1 :delay-ms 60000})]
+    (with-redefs [semantic.embedding/embedder-circuit-breakers
+                  (atom {endpoint-a (breaker), endpoint-b (breaker)})]
+      (is (thrown? Exception (call-through boom :endpoint endpoint-a)))
+      (is (= :open (circuit-state endpoint-a)))
+      (is (= :ok (call-through (constantly :ok) :endpoint endpoint-b)))
+      (is (= :closed (circuit-state endpoint-b))))))
+
+(deftest ^:sequential kill-switch-bypasses-breaker-test
+  (testing "with the breaker disabled the thunk runs directly: raw exception propagates, breaker untouched"
+    (with-redefs [semantic.embedding/embedder-circuit-breakers
+                  (atom {test-endpoint (dh.cb/circuit-breaker
+                                        {:failure-threshold 1 :success-threshold 1 :delay-ms 60000})})]
+      (mt/with-temporary-setting-values [semantic-search-embedder-circuit-breaker-enabled false]
+        (is (=? {:kind :boom}
+                (try (call-through boom) nil (catch clojure.lang.ExceptionInfo e (ex-data e)))))
+        (is (= :closed (circuit-state)) "a bypassed breaker records no failures")))))
+
+(deftest ^:sequential probe-bypass-flag-bypasses-breaker-test
+  (testing "*bypass-circuit-breaker* runs the thunk directly, without consulting or tripping the breaker"
+    (with-redefs [semantic.embedding/embedder-circuit-breakers
+                  (atom {test-endpoint (dh.cb/circuit-breaker
+                                        {:failure-threshold 1 :success-threshold 1 :delay-ms 60000})})]
+      (binding [semantic.embedding/*bypass-circuit-breaker* true]
+        (is (thrown? clojure.lang.ExceptionInfo (call-through boom)))
+        (is (= :closed (circuit-state)))))))
+
+(deftest ^:sequential circuit-untrusted?-covers-half-open-test
+  (testing "embedder-circuit-untrusted? is true whenever the enabled breaker isn't closed -- both :open and
+           :half-open -- so the health verdict can't flap as the breaker cycles between them"
+    (mt/with-temporary-setting-values [semantic-search-embedder-circuit-breaker-enabled true]
+      (doseq [state [:open :half-open]]
+        (mt/with-dynamic-fn-redefs [semantic.embedding/embedder-circuit-state (constantly state)]
+          (is (true? (semantic.embedding/embedder-circuit-untrusted?)) (str state " reads untrusted"))))
+      (mt/with-dynamic-fn-redefs [semantic.embedding/embedder-circuit-state (constantly :closed)]
+        (is (false? (semantic.embedding/embedder-circuit-untrusted?)) ":closed reads trusted"))))
+  (testing "disabled -> trusted regardless of raw state (calls bypass the breaker)"
+    (mt/with-temporary-setting-values [semantic-search-embedder-circuit-breaker-enabled false]
+      (mt/with-dynamic-fn-redefs [semantic.embedding/embedder-circuit-state (constantly :half-open)]
+        (is (false? (semantic.embedding/embedder-circuit-untrusted?)))))))
+
+(deftest embedding-problem-schedules-idle-recovery-test
+  (let [recoveries (atom 0)]
+    (mt/with-dynamic-fn-redefs
+      [embedding-health/embedding-service-reachable? (constantly {:reachable? true, :error nil})
+       semantic.embedding/embedder-circuit-untrusted? (constantly true)
+       embedding-health/request-circuit-recovery! #(swap! recoveries inc)]
+      (is (string? (embedding-health/embedding-problem)))
+      (is (= 1 @recoveries)))))
+
+(deftest ^:sequential open-circuit-recovery-waits-for-the-trial-window-test
+  (let [breaker   (dh.cb/circuit-breaker {:failure-threshold 1 :success-threshold 1 :delay-ms 60000})
+        scheduled (atom nil)]
+    (with-redefs [semantic.embedding/embedder-circuit-breakers (atom {test-endpoint breaker})
+                  embedding-health/recovery-state             (atom {:running? false, :last-start-ns nil})]
+      (mt/with-dynamic-fn-redefs [semantic.embedding/get-configured-model (constantly test-embedding-model)]
+        (is (thrown? Exception (call-through boom)))
+        (is (= :open (circuit-state)))
+        (mt/with-dynamic-fn-redefs [embedding-health/schedule-recovery! #(reset! scheduled %)]
+          (embedding-health/request-circuit-recovery!)
+          (is (fn? @scheduled) "recovery is deferred until after the breaker permits a trial"))))))
+
+(deftest ^:sequential recovery-scheduling-failure-releases-claim-test
+  (let [state (atom {:running? false, :last-start-ns nil})]
+    (with-redefs [embedding-health/recovery-state state]
+      (mt/with-dynamic-fn-redefs
+        [semantic.embedding/embedder-circuit-untrusted? (constantly true)
+         embedding-health/schedule-recovery!            (fn [_] (throw (ex-info "scheduler stopped" {})))]
+        (is (nil? (embedding-health/request-circuit-recovery!)))
+        (is (false? (:running? @state)))))))
+
+(deftest ^:sequential failed-idle-recovery-schedules-another-trial-test
+  (let [state   (atom {:running? true, :last-start-ns 0})
+        retries (atom 0)]
+    (with-redefs [embedding-health/recovery-state state]
+      (mt/with-dynamic-fn-redefs
+        [semantic.embedding/embedder-circuit-untrusted? (constantly true)
+         embedding-health/run-recovery-probe!           #(throw (ex-info "still down" {}))
+         embedding-health/request-circuit-recovery!     #(swap! retries inc)]
+        (#'embedding-health/recover-circuit!)
+        (is (false? (:running? @state)))
+        (is (= 1 @retries))))))
+
+(deftest circuit-open-requests-idle-recovery-test
+  (let [requests (atom 0)]
+    (mt/with-dynamic-fn-redefs [embedding-health/request-circuit-recovery! #(swap! requests inc)]
+      (#'embedding-health/request-recovery-on-open! :half-open)
+      (#'embedding-health/request-recovery-on-open! :open)
+      (is (= 1 @requests)))))
+
+(deftest ^:sequential state-changes-run-serially-in-arrival-order-test
+  (testing "transitions queue through one agent: a later transition's hooks can't overtake an earlier
+           transition whose hook is still blocked (e.g. on a probe against a down service), so a slow
+           pre-recovery check can't persist its stale result after the recovery one"
+    (let [events    (atom [])
+          entered   (CountDownLatch. 1)
+          release   (CountDownLatch. 1)
+          completed (CountDownLatch. 2)
+          hook   (fn [state]
+                   (when (= :half-open state)
+                     (.countDown entered)
+                     (.await release 5 TimeUnit/SECONDS))
+                   (swap! events conj state)
+                   (.countDown completed))]
+      (mt/with-dynamic-fn-redefs
+        [health-inspector/run-and-save-check! (constantly nil)]
+        (try
+          (swap! semantic.embedding/embedder-circuit-state-change-hooks conj hook)
+          (#'semantic.embedding/on-embedder-circuit-state-change! :half-open)
+          (is (.await entered 5 TimeUnit/SECONDS) "half-open hook did not start")
+          (#'semantic.embedding/on-embedder-circuit-state-change! :closed)
+          (is (= [] @events) ":closed stays queued behind the blocked :half-open run")
+          (.countDown release)
+          (is (.await completed 5 TimeUnit/SECONDS) "queued hooks did not finish")
+          (is (= [:half-open :closed] @events))
+          (finally
+            (.countDown release)
+            (swap! semantic.embedding/embedder-circuit-state-change-hooks disj hook)))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_circuit_breaker_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_circuit_breaker_test.clj
@@ -23,6 +23,7 @@
 (defmethod semantic.embedding/embedder-circuit-endpoint test-provider [_] test-endpoint)
 
 (def ^:private call-through* #'semantic.embedding/call-through-embedder-breaker)
+(def ^:private validate-embeddings!* #'semantic.embedding/validate-embeddings!)
 
 (defn- call-through [thunk & {:as opts}]
   (apply call-through* thunk (mapcat identity (merge {:endpoint test-endpoint} opts))))
@@ -68,6 +69,39 @@
         (is (thrown? Exception (call-through boom)))
         (is (= :open (circuit-state)))))))
 
+(deftest ^:sequential unexpected-dimensions-do-not-trip-breaker-test
+  (testing "dimensions are model-specific, so an otherwise valid response does not count as a service failure"
+    (with-redefs [semantic.embedding/embedder-circuit-breakers
+                  (atom {test-endpoint (dh.cb/circuit-breaker
+                                        {:failure-threshold 1 :success-threshold 1 :delay-ms 60000})})]
+      (is (=? {:cause               :embedder/unexpected-dimensions
+               :expected-dimensions 1
+               :actual-dimensions   2}
+              (try
+                (call-through #(validate-embeddings!* [[0.0 1.0]] 1 1))
+                nil
+                (catch clojure.lang.ExceptionInfo e
+                  (ex-data e)))))
+      (is (= :closed (circuit-state))))))
+
+(deftest ^:sequential invalid-vector-values-trip-breaker-test
+  (testing "nonnumeric and non-finite values are invalid service responses"
+    (doseq [[label value] [["nonnumeric" ::not-a-number]
+                           ["NaN" Double/NaN]
+                           ["positive infinity" Double/POSITIVE_INFINITY]
+                           ["negative infinity" Double/NEGATIVE_INFINITY]]]
+      (testing label
+        (with-redefs [semantic.embedding/embedder-circuit-breakers
+                      (atom {test-endpoint (dh.cb/circuit-breaker
+                                            {:failure-threshold 1 :success-threshold 1 :delay-ms 60000})})]
+          (is (instance? Exception
+                         (try
+                           (call-through #(validate-embeddings!* [[value]] 1 1))
+                           nil
+                           (catch Exception e
+                             e))))
+          (is (= :open (circuit-state))))))))
+
 (deftest ^:sequential opens-after-threshold-and-fast-fails-test
   (testing "consecutive failures trip the breaker; while open, calls fast-fail with the mapped 502 ex-info"
     ;; A fresh breaker (short threshold, stays open) so the test is isolated from the process-wide default.
@@ -88,6 +122,22 @@
       (with-redefs [semantic.embedding/embedder-circuit-breakers (atom {test-endpoint breaker})]
         (is (thrown? Exception (call-through boom)))
         (is (thrown? AssertionError (call-through #(throw (AssertionError. "fatal")))))
+        (is (= :ok (call-through (constantly :ok))))
+        (is (= :closed (circuit-state)))))))
+
+(deftest ^:sequential interruption-releases-half-open-permit-test
+  (testing "an interruption propagates unchanged and cannot strand the breaker's half-open trial permit"
+    (let [breaker     (dh.cb/circuit-breaker
+                       {:failure-threshold 1 :success-threshold 1 :delay-ms 0})
+          interrupted (InterruptedException. "cancelled")]
+      (with-redefs [semantic.embedding/embedder-circuit-breakers (atom {test-endpoint breaker})]
+        (is (thrown? Exception (call-through boom)))
+        (is (identical? interrupted
+                        (try
+                          (call-through #(throw interrupted))
+                          nil
+                          (catch InterruptedException e
+                            e))))
         (is (= :ok (call-through (constantly :ok))))
         (is (= :closed (circuit-state)))))))
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_circuit_breaker_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_circuit_breaker_test.clj
@@ -23,6 +23,7 @@
 (defmethod semantic.embedding/embedder-circuit-endpoint test-provider [_] test-endpoint)
 
 (def ^:private call-through* #'semantic.embedding/call-through-embedder-breaker)
+(def ^:private openai-compatible-get-embeddings-batch* #'semantic.embedding/openai-compatible-get-embeddings-batch)
 (def ^:private validate-embeddings!* #'semantic.embedding/validate-embeddings!)
 
 (defn- call-through [thunk & {:as opts}]
@@ -114,6 +115,27 @@
       (is (=? {:cause :embedder/circuit-open :status 502}
               (try (call-through (constantly :never)) nil
                    (catch clojure.lang.ExceptionInfo e (ex-data e))))))))
+
+(deftest ^:sequential circuit-open-fast-failure-does-not-log-request-error-test
+  (testing "the breaker transition reports the outage without an error log for every guarded request"
+    (with-redefs [semantic.embedding/embedder-circuit-breakers
+                  (atom {test-endpoint (dh.cb/circuit-breaker
+                                        {:failure-threshold 1 :success-threshold 1 :delay-ms 60000})})]
+      (is (thrown? Exception (call-through boom)))
+      (mt/with-log-messages-for-level [messages [metabase-enterprise.semantic-search.embedding :error]]
+        (is (=? {:cause :embedder/circuit-open :status 502}
+                (try
+                  (openai-compatible-get-embeddings-batch*
+                   {:provider          "test"
+                    :endpoint          test-endpoint
+                    :model-name        "test-model"
+                    :vector-dimensions 1
+                    :texts             ["text"]
+                    :record-tokens?    false})
+                  nil
+                  (catch clojure.lang.ExceptionInfo e
+                    (ex-data e)))))
+        (is (empty? (messages)))))))
 
 (deftest ^:sequential throwable-releases-half-open-permit-test
   (testing "a JVM-level failure cannot strand the breaker's only half-open trial permit"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -331,28 +331,32 @@
                              "tag"           "embedding_generation"}}]
                     events))))))))
 
-(deftest token-tracking-write-test
+(deftest ^:sequential token-tracking-write-test
   (mt/with-premium-features #{:semantic-search}
     (when (string? (not-empty (:mb-pgvector-db-url env/env)))
       (doseq [provider ["openai" "ai-service"]]
         (semantic.tu/with-test-db! {:mode :blank}
-          (let [mock-embedding (repeat 1024 1.0)
-                mock-response {:data [{:object "embedding"
-                                       :embedding (encode-floats-to-base64 mock-embedding)
-                                       :index 0}]
-                               :model "some-model"
-                               :usage {:prompt_tokens 1
-                                       :total_tokens 13}}]
+          (let [encoded-embedding (encode-floats-to-base64 (repeat 1024 1.0))]
             (with-redefs [semantic.settings/ee-embedding-provider           (constantly provider)
                           semantic.settings/ee-embedding-model              (constantly "mock-model")
                           semantic.settings/openai-api-key                  (constantly "xyz")
                           semantic.settings/openai-api-base-url             (constantly "xyz")
                           semantic.settings/ee-embedding-service-base-url   (constantly "http://mock-embedding-service")
                           semantic.settings/ee-embedding-service-api-key    (constantly "mock-key")
-                          http/post (fn post-mock [_url & _options]
-                                      {:status 200
-                                       :headers {"Content-Type" "application/json"}
-                                       :body (json/encode mock-response)})]
+                          http/post (fn post-mock [_url {:keys [body]}]
+                                      (let [inputs (:input (json/decode body true))]
+                                        {:status 200
+                                         :headers {"Content-Type" "application/json"}
+                                         :body (json/encode
+                                                {:data (map-indexed
+                                                        (fn [index _]
+                                                          {:object    "embedding"
+                                                           :embedding encoded-embedding
+                                                           :index     index})
+                                                        inputs)
+                                                 :model "some-model"
+                                                 :usage {:prompt_tokens 1
+                                                         :total_tokens 13}})}))]
               (let [pgvector (semantic.env/get-pgvector-datasource!)
                     index-metadata (semantic.env/get-index-metadata)
                     embedding-model (semantic.env/get-configured-embedding-model)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/metric_collector_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/metric_collector_test.clj
@@ -12,6 +12,7 @@
    [metabase-enterprise.semantic-search.task.metric-collector :as semantic.task.collector]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase-enterprise.semantic-search.util :as semantic.u]
+   [metabase.search.index-health :as search.index-health]
    [metabase.test :as mt]
    [next.jdbc :as jdbc]))
 
@@ -65,6 +66,24 @@
   (jdbc/execute!
    pgvector
    (sql/format {:delete-from [[:raw (:gate-table-name index-metadata)]]})))
+
+(deftest shared-index-metrics-survive-semantic-collector-failure-test
+  (let [refreshes (atom 0)]
+    (mt/with-dynamic-fn-redefs
+      [semantic.u/semantic-search-active?               (constantly true)
+       semantic.env/get-pgvector-datasource!            #(throw (ex-info "pgvector unavailable" {}))
+       search.index-health/refresh-search-index-metrics! #(swap! refreshes inc)]
+      (@#'semantic.task.collector/collect-metrics!)
+      (is (= 1 @refreshes)))))
+
+(deftest interrupted-semantic-collector-skips-shared-refresh-test
+  (let [refreshes (atom 0)]
+    (mt/with-dynamic-fn-redefs
+      [semantic.u/semantic-search-active?               (constantly true)
+       semantic.env/get-pgvector-datasource!            #(throw (InterruptedException.))
+       search.index-health/refresh-search-index-metrics! #(swap! refreshes inc)]
+      (is (thrown? InterruptedException (@#'semantic.task.collector/collect-metrics!)))
+      (is (zero? @refreshes)))))
 
 (deftest metric-collector-test
   (mt/with-premium-features #{:semantic-search}

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -479,6 +479,20 @@
                      {:description "Number of documents in the library entity index, as of the last full reconcile."})
    (prometheus/gauge :metabase-entity-retrieval/index-entities
                      {:description "Number of distinct entities in the library entity index, as of the last full reconcile."})
+   ;; Search-index health, one series per logical index. Implementations publish these through
+   ;; metabase.search.index-health; labels identify stable logical indexes, never physical table names.
+   (prometheus/gauge :metabase-search/index-coverage-ratio
+                     {:description (str "Fraction (0-1) of the items that should be indexed that actually are, "
+                                        "per search index.")
+                      :labels      [:index]})
+   (prometheus/gauge :metabase-search/index-garbage-count
+                     {:description (str "Absolute number of indexed items that should not be indexed "
+                                        "(orphaned or no longer a candidate), per search index.")
+                      :labels      [:index]})
+   (prometheus/gauge :metabase-search/index-staleness-seconds
+                     {:description (str "Age in seconds of the oldest known-pending change not yet reflected "
+                                        "in the index (indexer/reconcile backlog), per search index.")
+                      :labels      [:index]})
    ;; data-complexity-score timing
    ;; 1ms → 1min buckets; widen later if real-world runs push past a minute.
    (prometheus/histogram :metabase-data-complexity/scoring-duration-ms

--- a/src/metabase/search/index_health.clj
+++ b/src/metabase/search/index_health.clj
@@ -1,0 +1,193 @@
+(ns metabase.search.index-health
+  "Shared health-result and metric plumbing for search indexes. Index implementations register raw coverage,
+  garbage, and staleness collectors here; this namespace publishes their Prometheus gauges and health-inspector rows."
+  (:require
+   [metabase.analytics-interface.core :as analytics]
+   [metabase.analytics.core :as analytics.core]
+   [metabase.health-inspector.core :as health-inspector]
+   [metabase.util.log :as log]))
+
+(set! *warn-on-reflection* true)
+
+(defn healthy
+  "A healthy (100) check result with `message`."
+  [message]
+  {:health 100, :message message})
+
+(defn warning
+  "A partially healthy check result. `health` defaults to 50 and must be strictly between 0 and 100; use
+  [[healthy]] or [[degraded]] for the endpoints."
+  ([message]
+   (warning 50 message))
+  ([health message]
+   {:pre [(< 0 health 100)]}
+   {:health health, :message message}))
+
+(defn degraded
+  "A degraded (0) check result with `message`."
+  [message]
+  {:health 0, :message message})
+
+(def ^:private measure->gauge
+  {:coverage  :metabase-search/index-coverage-ratio
+   :garbage   :metabase-search/index-garbage-count
+   :staleness :metabase-search/index-staleness-seconds})
+
+(defn- percentage
+  [ratio]
+  (cond
+    (<= ratio 0) 0
+    (>= ratio 1) 100
+    :else         (-> (* 100.0 (double ratio)) Math/round (max 1) (min 99))))
+
+(defn- threshold-health
+  "Health from an absolute `value`: 100 at or below `warn`, 0 at or above `critical`, and linear between."
+  [value warn critical]
+  (cond
+    (<= value warn)     100
+    (>= value critical) 0
+    :else               (-> (* 100.0 (/ (double (- critical value)) (- critical warn)))
+                            Math/round
+                            (max 1)
+                            (min 99))))
+
+(defn coverage-result
+  "Result for `indexed` out of `expected` items. The ratio feeds Prometheus; its percentage is the health,
+  with 0 and 100 reserved for exact endpoints."
+  [indexed expected]
+  (let [ratio  (if (pos? expected) (min 1.0 (/ (double indexed) expected)) 1.0)
+        health (percentage ratio)]
+    {:value   ratio
+     :health  health
+     :message (format "%d of %d expected items indexed (%d%%)." indexed expected health)}))
+
+(defn garbage-result
+  "Result for an absolute `orphans` count, scored against `warn` and `critical` thresholds."
+  [orphans warn critical]
+  {:value   orphans
+   :health  (threshold-health orphans warn critical)
+   :message (if (zero? orphans)
+              "No orphaned items in the index."
+              (format "%d orphaned item(s) in the index." orphans))})
+
+(defn- describe-age [seconds]
+  (let [seconds (long seconds)]
+    (cond
+      (>= seconds 3600) (format "%.1fh" (/ seconds 3600.0))
+      (>= seconds 60)   (format "%dm" (quot seconds 60))
+      :else             (format "%ds" seconds))))
+
+(defn staleness-result
+  "Result for the oldest pending change. `warn` and `critical` are seconds; `detail` is an optional clause."
+  [age-seconds warn critical detail]
+  (let [age  (long (or age-seconds 0))
+        base (if (zero? age)
+               "Index current."
+               (format "Oldest pending change is %s old." (describe-age age)))]
+    {:value   age
+     :health  (threshold-health age warn critical)
+     :message (if detail (str base " " detail) base)}))
+
+(defonce ^:private index-measures
+  ;; Keying by check name makes namespace reloads replace descriptors instead of duplicating collectors.
+  (atom {}))
+
+(defonce ^:private live-gauge-series
+  ;; Only clear series that previously held a real value; inactive indexes should not create NaN-only series.
+  (atom #{}))
+
+(defn- set-index-gauge!
+  [gauge-key index value]
+  (if (some? value)
+    (do
+      (analytics/set-gauge! gauge-key {:index (name index)} value)
+      (swap! live-gauge-series conj [gauge-key index]))
+    (when (contains? @live-gauge-series [gauge-key index])
+      (analytics/set-gauge! gauge-key {:index (name index)} ##NaN))))
+
+(defn- run-measure!
+  "Run one collector and update its gauge. Returns nil for N/A or a health-inspector result."
+  [{:keys [gauge-key index collect check-name]}]
+  (let [{:keys [value health message]}
+        (try
+          (collect)
+          (catch InterruptedException e
+            (throw e))
+          (catch Exception e
+            (log/error e "Search index metric collector errored" {:check check-name})
+            {:health 0, :message (str "Metric collector errored: " (ex-message e))}))]
+    (set-index-gauge! gauge-key index value)
+    (when health
+      {:health health, :message message})))
+
+(defn register-index-check!
+  "Register a collector for logical `index` and `measure`. The collector returns nil for N/A or
+  `{:value :health :message}`. Returns a descriptor accepted by [[refresh-index-check!]]."
+  [index measure collect]
+  (let [descriptor {:check-name (keyword (str (name index) "-" (name measure)))
+                    :gauge-key  (measure->gauge measure)
+                    :index      index
+                    :measure    measure
+                    :collect    collect}]
+    (health-inspector/register-check! (:check-name descriptor) #(run-measure! descriptor))
+    ;; A live upgrade may leave the defonce'd registry in its former vector representation.
+    (swap! index-measures (fn [measures]
+                            (let [keyed (if (map? measures)
+                                          measures
+                                          (into {} (map (juxt :check-name identity)) measures))]
+                              (assoc keyed (:check-name descriptor) descriptor))))
+    descriptor))
+
+(defn refresh-index-check!
+  "Refresh one registered descriptor. Updates its gauge and, when enabled, its deduplicated health row."
+  [{:keys [check-name] :as descriptor}]
+  (try
+    (when-let [result (run-measure! descriptor)]
+      (when (health-inspector/enabled?)
+        (health-inspector/save-check-result! check-name result)))
+    (catch InterruptedException e
+      (throw e))
+    (catch Exception e
+      (log/error e "Search index health-row persist errored" {:check check-name}))))
+
+(defonce ^:private gauge-refresh-running? (atom false))
+
+(defn- submit-gauge-refresh! [f]
+  (future-call f))
+
+(defn- refresh-index-gauge! [{:keys [check-name] :as descriptor}]
+  (try
+    (run-measure! descriptor)
+    (catch InterruptedException e
+      (throw e))
+    (catch Exception e
+      (log/error e "Search index gauge refresh errored" {:check check-name}))))
+
+(defn- refresh-search-index-gauges!
+  []
+  (try
+    (run! refresh-index-gauge! (vals @index-measures))
+    (finally
+      (reset! gauge-refresh-running? false))))
+
+(defn- request-search-index-gauge-refresh!
+  []
+  (when (compare-and-set! gauge-refresh-running? false true)
+    (try
+      (submit-gauge-refresh! refresh-search-index-gauges!)
+      (catch Exception e
+        (reset! gauge-refresh-running? false)
+        (log/error e "Could not schedule search index gauge refresh"))))
+  nil)
+
+;; Prometheus scrapes every Metabase process, whereas the scheduled metric job may run on only one member of
+;; a Quartz cluster. A scrape starts a local, single-flight background refresh so every process updates its
+;; series without putting index scans on the synchronous scrape path.
+(defmethod analytics.core/pull-collector ::index-health-gauges [_]
+  {:min-interval-s 600
+   :f              request-search-index-gauge-refresh!})
+
+(defn refresh-search-index-metrics!
+  "Refresh every registered measure's gauge and, when enabled, its deduplicated health row."
+  []
+  (run! refresh-index-check! (vals @index-measures)))

--- a/test/metabase/search/index_health_test.clj
+++ b/test/metabase/search/index_health_test.clj
@@ -1,0 +1,203 @@
+(ns metabase.search.index-health-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.analytics-interface.core :as analytics]
+   [metabase.analytics.core :as analytics.core]
+   [metabase.health-inspector.core :as health-inspector]
+   [metabase.search.index-health :as index-health]
+   [metabase.test :as mt]))
+
+(set! *warn-on-reflection* true)
+
+(deftest ^:sequential register-index-check!-migrates-a-legacy-registry-test
+  (testing "a live upgrade migrates the defonce'd registry's former vector value"
+    (let [measures (atom [{:check-name :legacy-measure, :collect (constantly nil)}])
+          checks   (atom {})]
+      (with-redefs [index-health/index-measures measures
+                    health-inspector/checks     checks]
+        (let [{:keys [check-name]}
+              (index-health/register-index-check! :test-migration :coverage (constantly nil))]
+          (is (= #{:legacy-measure check-name} (set (keys @measures))))
+          (is (contains? @checks check-name)))))))
+
+(deftest ^:parallel coverage-result-test
+  (testing "coverage health is the percentage; the ratio feeds the gauge"
+    (is (=? {:value 0.5 :health 50 :message #"5 of 10 expected items indexed \(50%\)\."}
+            (index-health/coverage-result 5 10))))
+  (testing "an empty candidate set is fully covered"
+    (is (=? {:value 1.0 :health 100 :message #"0 of 0 .*100%.*"}
+            (index-health/coverage-result 0 0))))
+  (testing "coverage clamps over-counts to 100 percent"
+    (is (=? {:value 1.0 :health 100} (index-health/coverage-result 12 10))))
+  (testing "only exact endpoints score 0 or 100"
+    (is (=? {:health 99} (index-health/coverage-result 999 1000)))
+    (is (=? {:health 1} (index-health/coverage-result 1 1000)))
+    (is (=? {:health 0} (index-health/coverage-result 0 1000)))))
+
+(deftest ^:parallel garbage-result-test
+  (testing "zero orphans is healthy"
+    (is (=? {:value 0 :health 100 :message #"No orphaned items.*"}
+            (index-health/garbage-result 0 5 100))))
+  (testing "the value is an absolute count"
+    (is (=? {:value 42 :message #"42 orphaned item\(s\) in the index\."}
+            (index-health/garbage-result 42 5 100))))
+  (testing "health is linear between the warning and critical thresholds"
+    (is (=? {:health 100} (index-health/garbage-result 5 5 100)))
+    (is (=? {:health 0}   (index-health/garbage-result 100 5 100)))
+    (is (=? {:health 50}  (index-health/garbage-result 52 4 100))))
+  (testing "intermediate values do not round to an endpoint"
+    (is (=? {:health 99} (index-health/garbage-result 1 0 1000)))
+    (is (=? {:health 1} (index-health/garbage-result 999 0 1000)))))
+
+(deftest ^:parallel staleness-result-test
+  (testing "values at or below the warning threshold are healthy"
+    (is (=? {:value 0 :health 100 :message #"Index current\. more"}
+            (index-health/staleness-result 0 60 600 "more")))
+    (is (=? {:health 100} (index-health/staleness-result 60 60 600 nil))))
+  (testing "values at or above the critical threshold are degraded"
+    (is (=? {:health 0, :message #"Oldest pending change is 2\.8h old\."}
+            (index-health/staleness-result 9999 60 600 nil))))
+  (testing "health is linear between the warning and critical thresholds"
+    (is (=? {:health 50} (index-health/staleness-result 330 60 600 nil)))))
+
+(deftest ^:sequential run-measure!-test
+  (let [calls (atom [])
+        live  (atom #{})]
+    (with-redefs [index-health/live-gauge-series live]
+      (mt/with-dynamic-fn-redefs [analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
+        (testing "a collector result updates the gauge and returns the health row"
+          (is (= {:health 75 :message "ok"}
+                 (#'index-health/run-measure! {:gauge-key :metabase-search/index-coverage-ratio
+                                               :index    :semantic
+                                               :collect   (constantly {:value   0.75
+                                                                       :health  75
+                                                                       :message "ok"})})))
+          (is (= [[:metabase-search/index-coverage-ratio {:index "semantic"} 0.75]] @calls)))
+        (testing "an inapplicable collector clears a live gauge and returns nil"
+          (reset! calls [])
+          (is (nil? (#'index-health/run-measure! {:gauge-key :metabase-search/index-coverage-ratio
+                                                  :index    :semantic
+                                                  :collect   (constantly nil)})))
+          (is (= 1 (count @calls)))
+          (is (= [:metabase-search/index-coverage-ratio {:index "semantic"}] (butlast (first @calls))))
+          (is (Double/isNaN ^double (last (first @calls)))))
+        (testing "a throwing collector clears the gauge and returns a degraded row"
+          (#'index-health/run-measure! {:gauge-key :metabase-search/index-coverage-ratio
+                                        :index    :throwing-collector-test
+                                        :collect   (constantly {:value 0.9 :health 90 :message "was fine"})})
+          (reset! calls [])
+          (is (=? {:health 0, :message #"Metric collector errored: collector boom"}
+                  (#'index-health/run-measure! {:gauge-key :metabase-search/index-coverage-ratio
+                                                :index    :throwing-collector-test
+                                                :collect   (fn []
+                                                             (throw (ex-info "collector boom" {})))})))
+          (is (= [:metabase-search/index-coverage-ratio {:index "throwing-collector-test"}]
+                 (butlast (first @calls))))
+          (is (Double/isNaN ^double (last (first @calls)))))))))
+
+(deftest run-measure!-propagates-interruption-test
+  (is (thrown? InterruptedException
+               (#'index-health/run-measure! {:gauge-key :metabase-search/index-coverage-ratio
+                                             :index     :interrupted-test
+                                             :collect   #(throw (InterruptedException.))}))))
+
+(deftest ^:sequential inapplicable-measure-does-not-create-series-test
+  (testing "an inapplicable measure does not create a NaN-only series"
+    (let [calls (atom [])]
+      (mt/with-dynamic-fn-redefs [analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
+        (#'index-health/run-measure! {:gauge-key :metabase-search/index-coverage-ratio
+                                      :index    :never-emitted-test-engine
+                                      :collect   (constantly nil)}))
+      (is (empty? @calls)))))
+
+(deftest ^:sequential failed-first-write-does-not-mark-series-live-test
+  (testing "a failed first gauge write does not make later clears create a NaN-only series"
+    (let [set-index-gauge! @#'index-health/set-index-gauge!
+          live             @#'index-health/live-gauge-series
+          series           [:metabase-search/index-coverage-ratio :failed-write-test-engine]
+          calls            (atom [])]
+      (try
+        (mt/with-dynamic-fn-redefs [analytics/set-gauge! (fn [& _]
+                                                           (throw (ex-info "prometheus down" {})))]
+          (is (thrown? Exception (apply set-index-gauge! (conj series 1.0))))
+          (is (not (contains? @live series))))
+        (mt/with-dynamic-fn-redefs [analytics/set-gauge! (fn [& args] (swap! calls conj (vec args)))]
+          (apply set-index-gauge! (conj series nil))
+          (is (empty? @calls))
+          (apply set-index-gauge! (conj series 0.5))
+          (is (contains? @live series)))
+        (finally
+          (swap! live disj series))))))
+
+(deftest ^:sequential refresh-isolates-measure-failures-test
+  (testing "one collector failure does not stop later measures from refreshing"
+    (let [calls (atom [])
+          live  (atom #{})
+          boom  {:check-name :test-boom
+                 :gauge-key  :metabase-search/index-staleness-seconds
+                 :index     :refresh-isolation-test
+                 :collect    (fn [] (throw (ex-info "collector boom" {})))}
+          ok    {:check-name :test-ok
+                 :gauge-key  :metabase-search/index-coverage-ratio
+                 :index     :refresh-isolation-test
+                 :collect    (constantly {:value 1.0 :health 100 :message "ok"})}]
+      (with-redefs [index-health/live-gauge-series live]
+        (mt/with-dynamic-fn-redefs [analytics/set-gauge!       (fn [& args] (swap! calls conj (vec args)))
+                                    health-inspector/enabled? (constantly false)]
+          (#'index-health/run-measure! (assoc boom :collect
+                                              (constantly {:value 5 :health 100 :message "was fine"})))
+          (reset! calls [])
+          (run! #'index-health/refresh-index-check! [boom ok])))
+      (is (=? [[:metabase-search/index-staleness-seconds {:index "refresh-isolation-test"}
+                (fn [v] (Double/isNaN ^double v))]
+               [:metabase-search/index-coverage-ratio {:index "refresh-isolation-test"} 1.0]]
+              @calls)))))
+
+(deftest ^:sequential pull-collector-refreshes-gauges-on-each-instance-test
+  (let [measures  @#'index-health/index-measures
+        running?  @#'index-health/gauge-refresh-running?
+        before    @measures
+        seen      (atom [])
+        submitted (atom [])
+        one       {:check-name :one}
+        two       {:check-name :two}
+        collector (analytics.core/pull-collector :metabase.search.index-health/index-health-gauges)]
+    (try
+      (reset! measures {:one one, :two two})
+      (reset! running? false)
+      (mt/with-dynamic-fn-redefs
+        [index-health/run-measure!          #(swap! seen conj %)
+         index-health/submit-gauge-refresh! #(swap! submitted conj %)
+         health-inspector/save-check-result! #(throw (ex-info "must not persist from a scrape" {}))]
+        ((:f collector))
+        ((:f collector))
+        (is (empty? @seen) "the scrape path does not run index scans")
+        (is (= 1 (count @submitted)) "overlapping scrapes share one refresh")
+        ((first @submitted)))
+      (is (= 600 (:min-interval-s collector)))
+      (is (= #{one two} (set @seen)))
+      (is (false? @running?))
+      (finally
+        (reset! running? false)
+        (reset! measures before)))))
+
+(deftest ^:sequential background-gauge-refresh-isolates-write-failures-test
+  (let [measures (atom {:one {:check-name :one}, :two {:check-name :two}})
+        running? (atom true)
+        seen     (atom [])]
+    (with-redefs [index-health/index-measures         measures
+                  index-health/gauge-refresh-running? running?]
+      (mt/with-dynamic-fn-redefs
+        [index-health/run-measure! (fn [{:keys [check-name]}]
+                                     (swap! seen conj check-name)
+                                     (when (= :one check-name)
+                                       (throw (ex-info "prometheus down" {}))))]
+        (#'index-health/refresh-search-index-gauges!)))
+    (is (= #{:one :two} (set @seen)))
+    (is (false? @running?)))
+  (testing "interruption still escapes the per-descriptor boundary"
+    (is (thrown? InterruptedException
+                 (#'index-health/refresh-index-gauge! {:check-name :interrupted
+                                                       :gauge-key  :metabase-search/index-coverage-ratio
+                                                       :index      :interrupted
+                                                       :collect    #(throw (InterruptedException.))})))))


### PR DESCRIPTION
## Why this is needed

The NLQ retrieval and semantic-search indexes both need to answer the same operational questions:

- How much of the expected content is indexed?
- How much unexpected or obsolete content remains?
- How far behind current source data is the index?

Without a shared layer, each index would define its own scoring rules, metric names, labels, failure handling, and health-inspector persistence. That would make the resulting health signals difficult to compare and maintain.

Metric collection also has two execution constraints:

- Prometheus scrapes every Metabase process, so each process must refresh its own gauge values.
- Quartz may run a scheduled job on only one cluster member, and expensive index scans must not block the synchronous Prometheus scrape thread.

This PR provides the common health and metric plumbing. Later PRs only need to register index-specific collectors.

## Behavior

- standardize coverage, unexpected indexed-item (“garbage”), and staleness results
- reserve exact health scores of 0 and 100 for exact metric endpoints
- publish `metabase-search/index-*` gauges using stable logical index names
- register the same collectors as health-inspector checks
- isolate ordinary collector and gauge-write failures
- propagate interruption and fatal errors
- refresh gauges asynchronously on each scraped Metabase process
- coalesce overlapping scrape-triggered refreshes per process
- use the existing scheduled semantic metric job to persist deduplicated health rows
- continue shared collection after ordinary legacy semantic-collector failures

## Scope

This abstraction is specifically for derived search indexes.

App-db search can register the same measures later. `osi_ai_context` rows are source metadata and enrichment rather than a directly searched index, so their completeness metrics remain in a separate OSI metric family even though they have a similar shape.

## Stack

3 of 6. Depends on #78296. Next: #78298.

## Testing

Focused coverage includes:

- coverage, garbage, and staleness scoring
- exact endpoint and intermediate health scores
- registration and live-upgrade registry migration
- gauge creation, clearing, and failed-write isolation
- ordinary failure isolation and interruption propagation
- asynchronous per-instance refresh
- overlapping scrape coalescing
- separation between gauge refresh and health-row persistence
- continuation after legacy semantic-collector failures

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>

