### PR TITLE
Fix seven v3 behaviours the react-router v7 facade did not reproduce

### DIFF
--- a/frontend/src/metabase/router/router-link.tsx
+++ b/frontend/src/metabase/router/router-link.tsx
@@ -63,12 +63,13 @@ export const RouterLink = forwardRef<HTMLAnchorElement, Props>(
       const { activeClassName, activeStyle, onlyActiveOnIndex, ...rest } =
         props;
 
-      // A `<Link>` with no destination is used as a button: it navigates through
-      // its `onClick`. v7's `<Link>` would additionally navigate to the current
-      // route on click, clobbering any push the handler performs, so render a
-      // plain anchor instead. On v3 this matches `router.push(undefined)`, which
-      // is a no-op, so only the handler runs.
-      if (to == null) {
+      // A `<Link>` with no destination (`to` null or `""`) is used as a button: it
+      // navigates through its `onClick`. v7's `<Link>` would additionally navigate
+      // on click (an empty `to` resolves to the current route, or `/` from a
+      // top-level portal like a toast), clobbering any push the handler performs,
+      // so render a plain anchor instead. On v3 this matches `router.push("")` /
+      // `router.push(undefined)`, which are no-ops, so only the handler runs.
+      if (to == null || to === "") {
         return <a {...rest} ref={linkRef} />;
       }
 

--- a/frontend/src/metabase/router/router-link.tsx
+++ b/frontend/src/metabase/router/router-link.tsx
@@ -7,6 +7,7 @@ import {
 } from "react-router-v7";
 
 import { type RouterLinkProps, V3RouterLink } from "./react-router";
+import { queryToSearch } from "./v7/location";
 
 /**
  * The app's `<Link>`, engine-aware.
@@ -34,8 +35,9 @@ function toV7Target(to: V3To): { to: V7LinkProps["to"]; state?: unknown } {
     return { to: "" };
   }
   const { pathname, search, hash, query, state } = to;
-  const searchString =
-    search ?? (query ? `?${new URLSearchParams(query).toString()}` : undefined);
+  // `query` wins over `search`, matching history@3: call sites build
+  // `{ ...location, query }`, where the spread carries a stale `search`.
+  const searchString = query ? queryToSearch(query) : search;
   return {
     to: { pathname: pathname ?? "", search: searchString, hash },
     state,

--- a/frontend/src/metabase/router/router-link.unit.spec.tsx
+++ b/frontend/src/metabase/router/router-link.unit.spec.tsx
@@ -15,6 +15,10 @@ function Home() {
       <Link to="/other">go</Link>
       {/* A `<Link>` used as a button: it navigates through its own onClick. */}
       <Link onClick={() => dispatch(push("/other"))}>act</Link>
+      {/* A button-like `<Link to="">` (e.g. the undo toast) must not navigate. */}
+      <Link to="" onClick={() => undefined}>
+        noop
+      </Link>
       <Link to="/" activeClassName="is-active" onlyActiveOnIndex>
         home
       </Link>
@@ -78,6 +82,23 @@ describe.each<RouterEngine>(["v3", "v7"])(
       await userEvent.click(screen.getByText("act"));
 
       expect(await screen.findByTestId("other")).toBeInTheDocument();
+      expect(screen.getByTestId("location")).toHaveTextContent("/other");
+    });
+
+    it("does not navigate when a button-like `to=''` link is clicked", async () => {
+      renderWithProviders(tree, {
+        withRouter: true,
+        routerEngine,
+        initialRoute: "/other",
+      });
+
+      await screen.findByTestId("other");
+
+      // On v7 an empty `to` resolved to "/" and navigated home, unmounting the
+      // current view. It must stay put so only the onClick handler runs.
+      await userEvent.click(screen.getByText("noop"));
+
+      expect(screen.getByTestId("other")).toBeInTheDocument();
       expect(screen.getByTestId("location")).toHaveTextContent("/other");
     });
   },

--- a/frontend/src/metabase/router/v7/RouterBridge.tsx
+++ b/frontend/src/metabase/router/v7/RouterBridge.tsx
@@ -45,9 +45,18 @@ export function RouterBridge({
   const v7Location = useV7Location();
   const navigate = useV7Navigate();
   const action = useNavigationType();
+  const v7Params = useV7Params();
   // v7's `useParams` returns v7's readonly `Params`; the context wants v3's shape,
-  // which is structurally the same string map.
-  const params = useV7Params() as WithRouterProps["params"];
+  // which is structurally the same string map apart from the splat: v3 exposed the
+  // wildcard match as `splat`, v7 names it `*`. Republish it under both so v3-era
+  // readers (`params.splat` in `AutomaticDashboardApp`) keep working.
+  const params = useMemo<WithRouterProps["params"]>(() => {
+    const { "*": splat, ...rest } = v7Params;
+    const v3Params = splat === undefined ? rest : { ...rest, splat };
+    // Cast because v7 types params as readonly and partial; v3's shape is the same
+    // string map.
+    return v3Params as WithRouterProps["params"];
+  }, [v7Params]);
 
   // `useMatches` is data-router-only, so read the matched branch from the route
   // context that also drives `<Outlet>` (available in declarative mode). Each

--- a/frontend/src/metabase/router/v7/RouterBridge.tsx
+++ b/frontend/src/metabase/router/v7/RouterBridge.tsx
@@ -2,10 +2,10 @@ import type { Location as HistoryLocation, LocationDescriptor } from "history";
 import { type ReactNode, useContext, useMemo, useRef } from "react";
 import {
   type NavigateOptions,
+  type To,
   UNSAFE_RouteContext,
   type NavigateFunction as V7NavigateFunction,
   Outlet as V7Outlet,
-  type To,
   useNavigationType,
   useLocation as useV7Location,
   useNavigate as useV7Navigate,
@@ -85,6 +85,8 @@ export function RouterBridge({
         navigateRef.current(to, options);
       }
     };
+    // `NavigateFunction` is an overloaded signature (a `To` or a delta); the
+    // wrapper implements both arms but TS cannot infer it back into the overload.
     return makeRouterShim(navigateLatest as V7NavigateFunction);
   }, []);
 
@@ -124,6 +126,8 @@ function makeRouterShim(navigate: V7NavigateFunction): InjectedRouter {
       ? location
       : `${location.pathname ?? ""}${location.search ?? ""}${location.hash ?? ""}`;
 
+  // Cast because v3's own `InjectedRouter` type omits `listen`, even though both
+  // engines expose it at runtime.
   return {
     push: (location) => navigate(...toNavigateArgs(location)),
     replace: (location) =>
@@ -140,10 +144,8 @@ function makeRouterShim(navigate: V7NavigateFunction): InjectedRouter {
     createPath: href,
     createHref: href,
     isActive: () => false,
-    // v3's `router.listen` (used by e.g. `use-dashboard-url-query`) is absent from
-    // v3's own `InjectedRouter` type, so the cast re-adds it. `V7ReduxBridge` feeds
-    // these subscribers every location change.
-    listen: (callback: (location: HistoryLocation) => void) =>
-      subscribeLocation(callback),
+    // Stands in for v3's `router.listen` (used by e.g. `use-dashboard-url-query`).
+    // `V7ReduxBridge` feeds these subscribers every location change.
+    listen: subscribeLocation,
   } as InjectedRouter;
 }

--- a/frontend/src/metabase/router/v7/RouterBridge.tsx
+++ b/frontend/src/metabase/router/v7/RouterBridge.tsx
@@ -53,6 +53,17 @@ export function RouterBridge({
   // context that also drives `<Outlet>` (available in declarative mode). Each
   // route keeps its v3 path on `handle`, which the facade hooks match against.
   const { matches } = useContext(UNSAFE_RouteContext);
+  // react-router hands back a fresh `matches` array on every render, so memoizing
+  // on it would republish a new `routes`/`route` each time. v3's were stable, and
+  // consumers key effects on `route`: the leave-confirm modal resets itself when
+  // `route` changes, which closed it mid-interaction. Key on the matched branch.
+  const matchesKey = matches
+    .map((match) => {
+      // `handle` is typed `unknown`; we only ever put `{ v3Path }` on it.
+      const handle = match.route.handle as { v3Path?: string } | undefined;
+      return `${match.pathname}|${handle?.v3Path ?? ""}`;
+    })
+    .join(">");
   const routes = useMemo<RouteStub[]>(
     () =>
       matches.map((match) => {
@@ -62,7 +73,9 @@ export function RouterBridge({
         // pathname, which `setRouteLeaveHook` uses to scope its hook to this route.
         return { path: handle?.v3Path, pathnameBase: match.pathname };
       }),
-    [matches],
+    // Keyed on the matched branch, not the array identity, which changes each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [matchesKey],
   );
 
   const location = useMemo<HistoryLocation>(

--- a/frontend/src/metabase/router/v7/RouterBridge.tsx
+++ b/frontend/src/metabase/router/v7/RouterBridge.tsx
@@ -1,9 +1,11 @@
 import type { Location as HistoryLocation, LocationDescriptor } from "history";
-import { type ReactNode, useContext, useMemo } from "react";
+import { type ReactNode, useContext, useMemo, useRef } from "react";
 import {
+  type NavigateOptions,
   UNSAFE_RouteContext,
   type NavigateFunction as V7NavigateFunction,
   Outlet as V7Outlet,
+  type To,
   useNavigationType,
   useLocation as useV7Location,
   useNavigate as useV7Navigate,
@@ -21,7 +23,7 @@ import type { Route } from "../route";
 
 import { registerLeaveHook } from "./blocking-history";
 import { toV3Location } from "./location";
-import { toNavigateArgs } from "./navigator";
+import { subscribeLocation, toNavigateArgs } from "./navigator";
 
 // The facade route stub, plus the route's matched pathname so `setRouteLeaveHook`
 // can scope its hook to the route the way v3 does.
@@ -68,10 +70,23 @@ export function RouterBridge({
     [v7Location, action],
   );
 
-  const router = useMemo<InjectedRouter>(
-    () => makeRouterShim(navigate),
-    [navigate],
-  );
+  // v3 handed consumers a stable `router`, so effects keyed on it (notably the
+  // `router.listen` subscriptions in `use-dashboard-url-query`) survive a
+  // navigation. v7's `navigate` changes identity per location, which would tear
+  // those effects down and re-subscribe them around every location change, so read
+  // `navigate` through a ref and keep the shim itself stable.
+  const navigateRef = useRef(navigate);
+  navigateRef.current = navigate;
+  const router = useMemo<InjectedRouter>(() => {
+    const navigateLatest = (to: To | number, options?: NavigateOptions) => {
+      if (typeof to === "number") {
+        navigateRef.current(to);
+      } else {
+        navigateRef.current(to, options);
+      }
+    };
+    return makeRouterShim(navigateLatest as V7NavigateFunction);
+  }, []);
 
   const value = useMemo<WithRouterProps>(
     () => ({ router, location, params, routes }),
@@ -125,5 +140,10 @@ function makeRouterShim(navigate: V7NavigateFunction): InjectedRouter {
     createPath: href,
     createHref: href,
     isActive: () => false,
-  };
+    // v3's `router.listen` (used by e.g. `use-dashboard-url-query`) is absent from
+    // v3's own `InjectedRouter` type, so the cast re-adds it. `V7ReduxBridge` feeds
+    // these subscribers every location change.
+    listen: (callback: (location: HistoryLocation) => void) =>
+      subscribeLocation(callback),
+  } as InjectedRouter;
 }

--- a/frontend/src/metabase/router/v7/V7ReduxBridge.tsx
+++ b/frontend/src/metabase/router/v7/V7ReduxBridge.tsx
@@ -10,7 +10,7 @@ import { useDispatch } from "metabase/redux";
 import { LOCATION_CHANGE } from "../routing-reducer";
 
 import { toV3Location } from "./location";
-import { setV7Navigate } from "./navigator";
+import { notifyLocationListeners, setV7Navigate } from "./navigator";
 
 /**
  * Bridges the v7 router to redux, replacing what `routerMiddleware` +
@@ -36,10 +36,11 @@ export function V7ReduxBridge(): null {
   }, [navigate]);
 
   useEffect(() => {
-    dispatch({
-      type: LOCATION_CHANGE,
-      payload: toV3Location(location, action),
-    });
+    const v3Location = toV3Location(location, action);
+    dispatch({ type: LOCATION_CHANGE, payload: v3Location });
+    // Fan out to the imperative router's `listen` subscribers (v3's
+    // `router.listen`), which have no other source of location changes on v7.
+    notifyLocationListeners(v3Location);
   }, [dispatch, location, action]);
 
   return null;

--- a/frontend/src/metabase/router/v7/blocking-history.ts
+++ b/frontend/src/metabase/router/v7/blocking-history.ts
@@ -91,6 +91,18 @@ function toBlockedLocation(
   return toV3Location(location, action);
 }
 
+function isSameUrl(
+  to: To,
+  current: { pathname: string; search: string; hash: string },
+): boolean {
+  const path = typeof to === "string" ? parsePath(to) : to;
+  return (
+    (path.pathname ?? current.pathname) === current.pathname &&
+    (path.search ?? "") === current.search &&
+    (path.hash ?? "") === current.hash
+  );
+}
+
 /**
  * Wrap a history so a registered leave hook can cancel navigation, restoring the
  * v3 `setRouteLeaveHook` behavior on the declarative v7 engine. react-router
@@ -113,6 +125,14 @@ export function withBlocking(history: History): History {
   };
 
   const replace: History["replace"] = (to, state) => {
+    // v3/history@3 did not notify listeners when replacing to the current URL, so
+    // effects that sync state into the URL by replacing the location they just
+    // read stayed stable. v7's `v5Compat` history notifies on every replace,
+    // which loops those effects (e.g. the dashboard's `useLocationSync`). Skip the
+    // redundant replace to keep the v3 behavior.
+    if (isSameUrl(to, history.location)) {
+      return;
+    }
     if (!isBlocked(toBlockedLocation(to, "REPLACE", state))) {
       history.replace(to, state);
     }

--- a/frontend/src/metabase/router/v7/blocking-history.unit.spec.ts
+++ b/frontend/src/metabase/router/v7/blocking-history.unit.spec.ts
@@ -48,6 +48,18 @@ describe("withBlocking", () => {
     expect(history.location.pathname).toBe("/b");
   });
 
+  it("does not notify listeners when replacing to the current URL", () => {
+    const history = setup(["/a?x=1"]);
+    const listener = jest.fn();
+    history.listen(listener);
+
+    history.replace("/a?x=1");
+    expect(listener).not.toHaveBeenCalled();
+
+    history.replace("/b");
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
   it("blocks a replace while a hook returns false", () => {
     const history = setup();
     register(() => false);

--- a/frontend/src/metabase/router/v7/location.ts
+++ b/frontend/src/metabase/router/v7/location.ts
@@ -19,6 +19,27 @@ export function searchToQuery(
 }
 
 /**
+ * Serialize v3's `location.query` object back into a search string, the only form
+ * v7 understands. Repeated values become repeated keys, mirroring what
+ * `searchToQuery` parses. Returns `""` for an empty query.
+ */
+export function queryToSearch(query: Record<string, unknown>): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value == null) {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      value.forEach((item) => params.append(key, String(item)));
+    } else {
+      params.append(key, String(value));
+    }
+  }
+  const search = params.toString();
+  return search ? `?${search}` : "";
+}
+
+/**
  * Build the v3-shaped `history` location the facade context and `state.routing`
  * expect from a v7 location plus the current navigation type.
  */

--- a/frontend/src/metabase/router/v7/navigator.ts
+++ b/frontend/src/metabase/router/v7/navigator.ts
@@ -3,6 +3,8 @@ import type { NavigateFunction, NavigateOptions, To } from "react-router-v7";
 
 import type { RouterNavigator } from "../middleware";
 
+import { queryToSearch } from "./location";
+
 /**
  * The live v7 `navigate`, registered by `V7ReduxBridge` once the router mounts.
  * The redux navigator adapter is built at store creation, before the router
@@ -48,10 +50,18 @@ export function toNavigateArgs(
   if (typeof location === "string") {
     return [location, options];
   }
+  // v3 descriptors carry the query as a `query` object, which v7 does not read, so
+  // serialize it into the search string. Dropping it silently loses params (e.g.
+  // the dashboard's tab and filter slugs). `query` wins over `search`, matching
+  // history@3's `useQueries`: callers build `{ ...location, query }`, so the
+  // spread's stale `search` must not shadow the query they just set.
+  const search = location.query
+    ? queryToSearch(location.query)
+    : location.search;
   return [
     {
       pathname: location.pathname,
-      search: location.search,
+      search,
       hash: location.hash,
     },
     { ...options, state: location.state },

--- a/frontend/src/metabase/router/v7/navigator.ts
+++ b/frontend/src/metabase/router/v7/navigator.ts
@@ -1,4 +1,4 @@
-import type { LocationDescriptor } from "history";
+import type { Location as HistoryLocation, LocationDescriptor } from "history";
 import type { NavigateFunction, NavigateOptions, To } from "react-router-v7";
 
 import type { RouterNavigator } from "../middleware";
@@ -12,6 +12,28 @@ let currentNavigate: NavigateFunction | null = null;
 
 export function setV7Navigate(navigate: NavigateFunction | null): void {
   currentNavigate = navigate;
+}
+
+/**
+ * Subscribers to location changes, backing the imperative router's `listen`. v3's
+ * `router.listen` had no v7 equivalent, so `V7ReduxBridge` fans every location
+ * change out to these on the app's behalf (e.g. `use-dashboard-url-query`).
+ */
+type LocationListener = (location: HistoryLocation) => void;
+const locationListeners = new Set<LocationListener>();
+
+export function subscribeLocation(listener: LocationListener): () => void {
+  locationListeners.add(listener);
+  return () => {
+    locationListeners.delete(listener);
+  };
+}
+
+export function notifyLocationListeners(location: HistoryLocation): void {
+  // Snapshot so a listener that unsubscribes mid-run cannot skip a sibling.
+  for (const listener of [...locationListeners]) {
+    listener(location);
+  }
 }
 
 /**

--- a/frontend/src/metabase/router/v7/navigator.unit.spec.ts
+++ b/frontend/src/metabase/router/v7/navigator.unit.spec.ts
@@ -1,0 +1,68 @@
+import { queryToSearch } from "./location";
+import { toNavigateArgs } from "./navigator";
+
+// v3 location descriptors carry the query as an object. v7 only reads `search`,
+// so the navigator has to serialize it; dropping it silently loses params (the
+// dashboard's tab and filter slugs went missing this way).
+describe("toNavigateArgs", () => {
+  it("serializes a v3 `query` object into the search string", () => {
+    const [to] = toNavigateArgs({
+      pathname: "/dashboard/1",
+      query: { tab: "2-tab-two", "filter-date": "2024-01-01" },
+    });
+
+    expect(to).toEqual({
+      pathname: "/dashboard/1",
+      search: "?tab=2-tab-two&filter-date=2024-01-01",
+      hash: undefined,
+    });
+  });
+
+  // Call sites build `{ ...location, query }`, so the spread carries the previous
+  // `search`. The query they just set has to win, as it does on history@3.
+  it("prefers `query` over a stale search carried by a spread location", () => {
+    const [to] = toNavigateArgs({
+      pathname: "/dashboard/1",
+      search: "",
+      query: { tab: "2-tab-two" },
+    });
+
+    expect(to).toMatchObject({ search: "?tab=2-tab-two" });
+  });
+
+  it("falls back to `search` when there is no `query`", () => {
+    const [to] = toNavigateArgs({ pathname: "/dashboard/1", search: "?a=1" });
+
+    expect(to).toMatchObject({ search: "?a=1" });
+  });
+
+  it("passes a string target through untouched", () => {
+    expect(toNavigateArgs("/dashboard/1?tab=2")).toEqual([
+      "/dashboard/1?tab=2",
+      {},
+    ]);
+  });
+
+  it("carries `state` across as a navigate option", () => {
+    const [, options] = toNavigateArgs(
+      { pathname: "/a", state: { from: "here" } },
+      { replace: true },
+    );
+
+    expect(options).toEqual({ replace: true, state: { from: "here" } });
+  });
+});
+
+describe("queryToSearch", () => {
+  it("repeats a key for array values", () => {
+    expect(queryToSearch({ id: ["1", "2"] })).toBe("?id=1&id=2");
+  });
+
+  it("skips null and undefined values", () => {
+    expect(queryToSearch({ a: "1", b: null, c: undefined })).toBe("?a=1");
+  });
+
+  it("returns an empty string for an empty query", () => {
+    expect(queryToSearch({})).toBe("");
+  });
+});

--- a/frontend/src/metabase/router/v7/router-listen.unit.spec.tsx
+++ b/frontend/src/metabase/router/v7/router-listen.unit.spec.tsx
@@ -1,9 +1,15 @@
+import type { Location as HistoryLocation } from "history";
 import { useEffect, useState } from "react";
 
 import { renderWithProviders, screen } from "__support__/ui";
 import { Outlet, Route, push, useRouter } from "metabase/router";
 
 import type { RouterEngine } from "../engine";
+
+// Both engines expose `listen` at runtime; v3's `InjectedRouter` type omits it.
+type RouterWithListen = {
+  listen: (callback: (location: HistoryLocation) => void) => () => void;
+};
 
 // v3's `router.listen` fires a callback on every location change and returns an
 // unsubscribe function. The v7 engine has no native equivalent, so the shim wires
@@ -13,8 +19,8 @@ function Harness() {
   const { router } = useRouter();
   const [seen, setSeen] = useState<string[]>([]);
   useEffect(() => {
-    // `listen` is absent from v3's `InjectedRouter` type but present at runtime.
-    return router.listen((location) => {
+    // Cast because v3's `InjectedRouter` type omits `listen` (see above).
+    return (router as unknown as RouterWithListen).listen((location) => {
       setSeen((previous) => [...previous, location.pathname]);
     });
   }, [router]);

--- a/frontend/src/metabase/router/v7/router-listen.unit.spec.tsx
+++ b/frontend/src/metabase/router/v7/router-listen.unit.spec.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import { Outlet, Route, push, useRouter } from "metabase/router";
+
+import type { RouterEngine } from "../engine";
+
+// v3's `router.listen` fires a callback on every location change and returns an
+// unsubscribe function. The v7 engine has no native equivalent, so the shim wires
+// it to the location fan-out; `use-dashboard-url-query` relies on it (and crashed
+// the dashboard on v7 when it was missing).
+function Harness() {
+  const { router } = useRouter();
+  const [seen, setSeen] = useState<string[]>([]);
+  useEffect(() => {
+    // `listen` is absent from v3's `InjectedRouter` type but present at runtime.
+    return router.listen((location) => {
+      setSeen((previous) => [...previous, location.pathname]);
+    });
+  }, [router]);
+  return (
+    <div>
+      <span data-testid="seen">{seen.join(",")}</span>
+      <Outlet />
+    </div>
+  );
+}
+
+const tree = (
+  <Route path="/" element={<Harness />}>
+    <Route path="other" element={<span data-testid="other">other</span>} />
+  </Route>
+);
+
+describe.each<RouterEngine>(["v3", "v7"])(
+  "router.listen on the %s engine",
+  (routerEngine) => {
+    it("fires the callback on navigation and stops after unsubscribe", async () => {
+      const { store } = renderWithProviders(tree, {
+        withRouter: true,
+        routerEngine,
+        initialRoute: "/",
+      });
+
+      await screen.findByTestId("seen");
+
+      store.dispatch(push("/other"));
+
+      await screen.findByText("other");
+      expect(screen.getByTestId("seen")).toHaveTextContent("/other");
+    });
+  },
+);


### PR DESCRIPTION
Seven fixes to the react-router v7 facade, all landing with the flag still **off**, so v7 stays dormant and nothing here changes behaviour on the shipped v3 engine.

Follow-up to #78103 (merged). Each fix restores a v3 behaviour the v7 shim did not yet reproduce.

## The fixes

1. **A `<Link>` with an empty `to` is a button, not a navigation.** `UndoButton` (the undo toast, including its "Add this to a dashboard" action) renders `<Link to="" onClick=...>`. On v7 the link also navigated, resolving `""` to `/` from the toast's portal, which unmounted the page underneath. Now an absent or empty `to` renders a plain anchor, matching v3 where `router.push("")` was a no-op.
2. **A `replace` to the current URL is a no-op.** history@3 did not notify listeners when replacing the location it already had, so URL-sync effects settled. v7's `v5Compat` history notifies on every replace, which looped `useLocationSync` and crashed the dashboard.
3. **`router.listen` exists on v7, and the router shim is stable.** `use-dashboard-url-query` calls `router.listen`, which the shim lacked, so `<DashboardApp>` threw and the dashboard never rendered. The shim is now memoised once and reads `navigate` through a ref, because v7's `navigate` changes identity per navigation and was tearing down every consumer effect keyed on `router`.
4. **A v3 `query` object is serialised into the search string.** `toNavigateArgs` mapped only `pathname`/`search`/`hash`, so `push({ ...location, query })` silently dropped its params. `query` takes precedence over `search`, matching history@3, because call sites spread a location whose `search` is stale.
5. **The matched-route branch is stable across renders.** react-router returns a fresh `matches` array every render, so `route` was a new object each time and the leave-confirm modal, which resets itself when `route` changes, closed itself mid-interaction.
6. **v7's splat param is republished as v3's `splat`.** v3 exposed a wildcard match as `params.splat`, v7 names it `*`. `AutomaticDashboardApp` builds x-ray URLs from `params.splat`, so on v7 it requested `/auto/dashboard/undefined` and rendered an empty dashboard with no error.
7. **Lint and type cleanups** in the shim.

## Verification

Measured locally by running each spec on both engines and diffing, so pre-existing failures are not counted as v7 regressions:

- `question/new`: v7 **18/18** (was 14/18), matching v3.
- `dashboard/dashboard-back-navigation`: v7 **10/10** (was 7/10), matching v3.
- `collections/collection-pinned-overview`: 13/13. `question/notebook-data-source`: 12/13, its one failure also fails on v3.

Router unit suites pass on both engines, including new regression tests for the empty `to`, the same-URL replace, `router.listen`, and the query serialisation.
