### PR TITLE
Keep async vendor chunks out of the main app's initial bundle

### DIFF
--- a/rspack.main.config.js
+++ b/rspack.main.config.js
@@ -257,7 +257,9 @@ const config = {
           // sharing the vendor chunk would re-link them. Keep its
           // node_modules in its own chunks.
           chunks: (chunk) =>
-            chunk.name !== "data-app-vendors" && chunk.name !== "app-data-app",
+            chunk.canBeInitial() &&
+            chunk.name !== "data-app-vendors" &&
+            chunk.name !== "app-data-app",
           name: "vendor",
           priority: -10,
         },


### PR DESCRIPTION
The data apps PR (#74840) needed the data-app iframe entries excluded from the shared `vendor` chunk, and did that by swapping the `vendors` cache group `chunks: "initial"` for a predicate:

```js
- chunks: "initial",
+ chunks: (chunk) => chunk.name !== "data-app-vendors" && chunk.name !== "app-data-app",
```

The predicate also matches async chunks, so the initial-only constraint was lost. Every `node_modules` module that used to sit in a lazily loaded chunk got hoisted into the single shared `vendor` chunk, which is initial for `app-main`. Lazy vendor code became eager, and the app initial bundle grew by about 10%.

This keeps the exclusion and restores the initial-only constraint with `chunk.canBeInitial()`.

## Verification

EE production build, `app` bundle, measured with `.github/scripts/measure-bundle-sizes.js`:

| metric | before | after | delta |
| --- | --- | --- | --- |
| initial, brotli | 2.834 MB | 2.536 MB | -10.5% |
| initial, gzip | 3.754 MB | 3.384 MB | -9.9% |
| initial, raw | 13.07 MB | 11.87 MB | -9.2% |
| total, brotli | 3.087 MB | 3.108 MB | +0.7% |

`vendor.js` goes from 5.2 MB to 4.0 MB raw and 9 async chunks reappear (reachable file count 30 to 39). The small total increase is chunk-boundary overhead.

The isolation #74840 wanted is preserved. Entry assets after the fix:

- `app-main` -> runtime, vendor.js, vendor.css, app-main.js, app-main.css
- `app-data-app` -> runtime, app-data-app.js, app-data-app.css
- `data-app-vendors` -> runtime, data-app-vendors.js, data-app-vendors.css

The data-app entries still carry their own `node_modules` and never reference the shared `vendor` chunk.