### PR TITLE
Manifest-based plugin framework

### DIFF
--- a/bin/build/src/build/plugin_uberjar.clj
+++ b/bin/build/src/build/plugin_uberjar.clj
@@ -18,12 +18,14 @@
     (binding [deps.dir/*the-dir* (io/file dir)]
       (deps/calc-basis edn))))
 
+;; Delayed so merely requiring this namespace doesn't pay for a full dependency-tree resolution; the basis is
+;; only needed when a plugin uberjar is actually built.
 (defonce ^:private metabase-core-basis
-  (project-basis u/project-root-directory))
+  (delay (project-basis u/project-root-directory)))
 
-(defonce ^{:doc "Map of core-provided library symbol to the `metabase-core` provider label."}
+(defonce ^{:doc "Delayed map of core-provided library symbol to the `metabase-core` provider label."}
   metabase-core-provided-libs
-  (into {} (map (fn [lib] [lib 'metabase-core])) (keys (:libs metabase-core-basis))))
+  (delay (zipmap (keys (:libs @metabase-core-basis)) (repeat 'metabase-core))))
 
 (defn prune-provided-libs!
   "Remove `lib->provider`'s libraries and classpath entries from `basis`.

--- a/bin/build/src/build/plugin_uberjar.clj
+++ b/bin/build/src/build/plugin_uberjar.clj
@@ -1,0 +1,48 @@
+(ns build.plugin-uberjar
+  "Shared basis preparation for runtime-loaded plugin uberjars."
+  (:require
+   [clojure.java.io :as io]
+   [clojure.tools.deps.alpha :as deps]
+   [clojure.tools.deps.alpha.util.dir :as deps.dir]
+   [colorize.core :as colorize]
+   [metabuild-common.core :as u]))
+
+(set! *warn-on-reflection* true)
+
+(defn project-basis
+  "Basis for the `deps.edn` project rooted at `dir`, resolved relative to that directory."
+  [dir]
+  (let [edn (deps/merge-edns
+             ((juxt :root-edn :project-edn)
+              (deps/find-edn-maps (u/filename dir "deps.edn"))))]
+    (binding [deps.dir/*the-dir* (io/file dir)]
+      (deps/calc-basis edn))))
+
+(defonce ^:private metabase-core-basis
+  (project-basis u/project-root-directory))
+
+(defonce ^{:doc "Map of core-provided library symbol to the `metabase-core` provider label."}
+  metabase-core-provided-libs
+  (into {} (map (fn [lib] [lib 'metabase-core])) (keys (:libs metabase-core-basis))))
+
+(defn prune-provided-libs
+  "Remove `lib->provider`'s libraries and classpath entries from `basis`.
+
+  Runtime-loaded plugins share the core classloader, so packaging those libraries again risks duplicate
+  classes and linkage errors. `lib->provider` maps each library symbol to the component that supplies it."
+  [basis lib->provider]
+  (let [provided-lib->provider (into {}
+                                     (filter (fn [[lib]]
+                                               (get-in basis [:libs lib])))
+                                     lib->provider)]
+    (doseq [lib (sort (keys (:libs basis)))]
+      (u/announce (if-let [provider (get provided-lib->provider lib)]
+                    (format "SKIP    %%s (provided by %s)" provider)
+                    "INCLUDE %s")
+                  (colorize/yellow lib)))
+    (let [provided-libs  (set (keys provided-lib->provider))
+          provided-paths (into #{} (mapcat #(get-in basis [:libs % :paths])) provided-libs)]
+      (-> basis
+          (update :classpath-roots #(vec (remove provided-paths %)))
+          (update :libs            #(into {} (remove (fn [[lib]] (provided-libs lib))) %))
+          (update :classpath       #(into {} (remove (fn [[path]] (provided-paths path))) %))))))

--- a/bin/build/src/build/plugin_uberjar.clj
+++ b/bin/build/src/build/plugin_uberjar.clj
@@ -25,7 +25,7 @@
   metabase-core-provided-libs
   (into {} (map (fn [lib] [lib 'metabase-core])) (keys (:libs metabase-core-basis))))
 
-(defn prune-provided-libs
+(defn prune-provided-libs!
   "Remove `lib->provider`'s libraries and classpath entries from `basis`.
 
   Runtime-loaded plugins share the core classloader, so packaging those libraries again risks duplicate

--- a/bin/build/src/build_drivers/create_uberjar.clj
+++ b/bin/build/src/build_drivers/create_uberjar.clj
@@ -36,7 +36,7 @@
         plugin-uberjar/metabase-core-provided-libs))
 
 (defn- remove-provided-libs [basis driver edition]
-  (plugin-uberjar/prune-provided-libs basis (provided-libs driver edition)))
+  (plugin-uberjar/prune-provided-libs! basis (provided-libs driver edition)))
 
 (defn- uberjar-basis [driver edition]
   (u/step "Determine which dependencies to include"

--- a/bin/build/src/build_drivers/create_uberjar.clj
+++ b/bin/build/src/build_drivers/create_uberjar.clj
@@ -2,12 +2,12 @@
   "Create the uberjar for an individual driver."
   (:require
    [build-drivers.common :as c]
+   [build.plugin-uberjar :as plugin-uberjar]
    [clojure.java.io :as io]
    [clojure.tools.build.api :as b]
    [clojure.tools.build.tasks.uber] ;; workaround for (#50940)
    [clojure.tools.deps.alpha :as deps]
    [clojure.tools.deps.alpha.util.dir :as deps.dir]
-   [colorize.core :as colorize]
    [metabuild-common.core :as u]
    [org.corfield.log4j2-conflict-handler :refer [log4j2-conflict-handler]]))
 
@@ -17,18 +17,6 @@
   (let [edn (c/driver-edn driver edition)]
     (binding [deps.dir/*the-dir* (io/file (c/driver-project-dir driver))]
       (deps/calc-basis edn))))
-
-(defonce ^:private metabase-core-edn
-  (deps/merge-edns
-   ((juxt :root-edn :project-edn)
-    (deps/find-edn-maps (u/filename u/project-root-directory "deps.edn")))))
-
-(defonce ^:private metabase-core-basis
-  (binding [deps.dir/*the-dir* (io/file u/project-root-directory)]
-    (deps/calc-basis metabase-core-edn)))
-
-(defonce ^:private metabase-core-provided-libs
-  (set (keys (:libs metabase-core-basis))))
 
 (defn- driver-parents [driver edition]
   (when-let [parents (not-empty (:metabase.driver/parents (c/driver-edn driver edition)))]
@@ -45,28 +33,10 @@
   `metabase-core` or the parent driver that provided that lib."
   [driver edition]
   (into (parent-provided-libs driver edition)
-        (map (fn [lib]
-               [lib 'metabase-core]))
-        metabase-core-provided-libs))
+        plugin-uberjar/metabase-core-provided-libs))
 
 (defn- remove-provided-libs [basis driver edition]
-  (let [provided-lib->provider (into {}
-                                     (filter (fn [[lib]]
-                                               (get-in basis [:libs lib])))
-                                     (provided-libs driver edition))]
-    ;; log which libs we're including and excluding.
-    (doseq [lib (sort (keys (:libs basis)))]
-      (u/announce (if-let [provider (get provided-lib->provider lib)]
-                    (format "SKIP    %%s (provided by %s)" provider)
-                    "INCLUDE %s")
-                  (colorize/yellow lib)))
-    ;; now remove the provide libs from `:classpath`, `:classpath-roots`, and `:libs`
-    (let [provided-libs-set  (into #{} (keys provided-lib->provider))
-          provided-paths-set (into #{} (mapcat #(get-in basis [:libs % :paths])) provided-libs-set)]
-      (-> basis
-          (update :classpath-roots #(vec (remove provided-paths-set %)))
-          (update :libs            #(into {} (remove (fn [[lib]] (provided-libs-set lib))) %))
-          (update :classpath       #(into {} (remove (fn [[path]] (provided-paths-set path))) %))))))
+  (plugin-uberjar/prune-provided-libs basis (provided-libs driver edition)))
 
 (defn- uberjar-basis [driver edition]
   (u/step "Determine which dependencies to include"

--- a/bin/build/src/build_drivers/create_uberjar.clj
+++ b/bin/build/src/build_drivers/create_uberjar.clj
@@ -33,7 +33,7 @@
   `metabase-core` or the parent driver that provided that lib."
   [driver edition]
   (into (parent-provided-libs driver edition)
-        plugin-uberjar/metabase-core-provided-libs))
+        @plugin-uberjar/metabase-core-provided-libs))
 
 (defn- remove-provided-libs [basis driver edition]
   (plugin-uberjar/prune-provided-libs! basis (provided-libs driver edition)))

--- a/bin/build/test/build/plugin_uberjar_test.clj
+++ b/bin/build/test/build/plugin_uberjar_test.clj
@@ -1,0 +1,15 @@
+(ns build.plugin-uberjar-test
+  (:require
+   [build.plugin-uberjar :as plugin-uberjar]
+   [clojure.test :refer :all]))
+
+(deftest prune-provided-libs-test
+  (let [basis {:classpath-roots ["core.jar" "plugin.jar"]
+               :classpath       {"core.jar" {:path-key :core}
+                                 "plugin.jar" {:path-key :plugin}}
+               :libs            {'example/core   {:paths ["core.jar"]}
+                                 'example/plugin {:paths ["plugin.jar"]}}}]
+    (is (= {:classpath-roots ["plugin.jar"]
+            :classpath       {"plugin.jar" {:path-key :plugin}}
+            :libs            {'example/plugin {:paths ["plugin.jar"]}}}
+           (plugin-uberjar/prune-provided-libs basis {'example/core 'metabase-core})))))

--- a/bin/build/test/build/plugin_uberjar_test.clj
+++ b/bin/build/test/build/plugin_uberjar_test.clj
@@ -3,7 +3,7 @@
    [build.plugin-uberjar :as plugin-uberjar]
    [clojure.test :refer :all]))
 
-(deftest ^:parallel prune-provided-libs-test
+(deftest prune-provided-libs-test
   (let [basis {:classpath-roots ["core.jar" "plugin.jar"]
                :classpath       {"core.jar" {:path-key :core}
                                  "plugin.jar" {:path-key :plugin}}

--- a/bin/build/test/build/plugin_uberjar_test.clj
+++ b/bin/build/test/build/plugin_uberjar_test.clj
@@ -3,7 +3,7 @@
    [build.plugin-uberjar :as plugin-uberjar]
    [clojure.test :refer :all]))
 
-(deftest prune-provided-libs-test
+(deftest ^:parallel prune-provided-libs-test
   (let [basis {:classpath-roots ["core.jar" "plugin.jar"]
                :classpath       {"core.jar" {:path-key :core}
                                  "plugin.jar" {:path-key :plugin}}
@@ -12,4 +12,4 @@
     (is (= {:classpath-roots ["plugin.jar"]
             :classpath       {"plugin.jar" {:path-key :plugin}}
             :libs            {'example/plugin {:paths ["plugin.jar"]}}}
-           (plugin-uberjar/prune-provided-libs basis {'example/core 'metabase-core})))))
+           (plugin-uberjar/prune-provided-libs! basis {'example/core 'metabase-core})))))

--- a/src/metabase/plugins/core.clj
+++ b/src/metabase/plugins/core.clj
@@ -1,6 +1,7 @@
 (ns metabase.plugins.core
   (:require
    [metabase.plugins.impl]
+   [metabase.plugins.initialize]
    [potemkin :as p]))
 
 (comment metabase.plugins.core/keep-me)
@@ -9,4 +10,6 @@
  [metabase.plugins.impl
   load-plugins!
   plugins-dir
-  plugins-dir-info])
+  plugins-dir-info]
+ [metabase.plugins.initialize
+  load-plugin!])

--- a/src/metabase/plugins/dependencies.clj
+++ b/src/metabase/plugins/dependencies.clj
@@ -20,7 +20,7 @@
     :else     :unknown))
 
 (defmulti ^:private dependency-satisfied?
-  {:arglists '([initialized-plugin-names info dependency])}
+  {:arglists '([registered-plugin-names info dependency])}
   (fn [_ _ dep] (dependency-type dep)))
 
 (defmethod dependency-satisfied? :default [_ {{plugin-name :name} :info} dep]
@@ -58,10 +58,14 @@
       (warn-about-required-dependencies plugin-name (or message (trs "Class not found: {0}" classname)))
       false)))
 
+;; Satisfied means the other manifest is registered, not that its code is loaded — this gates
+;; registration order only. The only declarers today are driver manifests naming an abstract parent,
+;; which need that keyword in the driver hierarchy before `driver/register!` runs; their *load* order
+;; comes from the `:require` in the driver namespace itself.
 (defmethod dependency-satisfied? :plugin
-  [initialized-plugin-names {{plugin-name :name} :info} {dep-plugin-name :plugin}]
+  [registered-plugin-names {{plugin-name :name} :info} {dep-plugin-name :plugin}]
   (log-once plugin-name (trs "Plugin ''{0}'' depends on plugin ''{1}''" plugin-name dep-plugin-name))
-  ((set initialized-plugin-names) dep-plugin-name))
+  ((set registered-plugin-names) dep-plugin-name))
 
 (defmethod dependency-satisfied? :env-var
   [_ {{plugin-name :name} :info} {env-var-name :env-var}]
@@ -74,9 +78,9 @@
     true))
 
 (defn- all-dependencies-satisfied?*
-  [initialized-plugin-names {:keys [dependencies], {plugin-name :name} :info, :as info}]
+  [registered-plugin-names {:keys [dependencies], {plugin-name :name} :info, :as info}]
   (let [dep-satisfied? (fn [dep]
-                         (u/prog1 (dependency-satisfied? initialized-plugin-names info dep)
+                         (u/prog1 (dependency-satisfied? registered-plugin-names info dep)
                            (log-once plugin-name
                                      (trs "{0} dependency {1} satisfied? {2}" plugin-name (dissoc dep :message) (boolean <>)))))]
     (every? dep-satisfied? dependencies)))
@@ -86,30 +90,30 @@
   why they are not, and return falsey.
 
   For plugins that *might* have their dependencies satisfied in the near future"
-  [initialized-plugin-names info]
+  [registered-plugin-names info]
   (or
-   (all-dependencies-satisfied?* initialized-plugin-names info)
+   (all-dependencies-satisfied?* registered-plugin-names info)
    (do
      (swap! plugins-with-unsatisfied-deps conj info)
      (log-once (u/format-color 'yellow
                                (trs "Plugins with unsatisfied deps: {0}" (mapv (comp :name :info) @plugins-with-unsatisfied-deps))))
      false)))
 
-(defn- remove-plugins-with-satisfied-deps [plugins initialized-plugin-names ready-for-init-atom]
+(defn- remove-plugins-with-satisfied-deps [plugins registered-plugin-names ready-to-register-atom]
   ;; since `remove-plugins-with-satisfied-deps` could theoretically be called multiple times we need to reset the atom
-  ;; used to return the plugins ready for init so we don't accidentally include something in there twice etc.
-  (reset! ready-for-init-atom nil)
+  ;; used to return the plugins ready to register so we don't accidentally include something in there twice etc.
+  (reset! ready-to-register-atom nil)
   (set
    (for [info  plugins
-         :let  [ready? (when (all-dependencies-satisfied?* initialized-plugin-names info)
-                         (swap! ready-for-init-atom conj info))]
+         :let  [ready? (when (all-dependencies-satisfied?* registered-plugin-names info)
+                         (swap! ready-to-register-atom conj info))]
          :when (not ready?)]
      info)))
 
 (defn update-unsatisfied-deps!
   "Updates internal list of plugins that still have unmet dependencies; returns sequence of plugin infos for all plugins
-  that are now ready for initialization."
-  [initialized-plugin-names]
-  (let [ready-for-init (atom nil)]
-    (swap! plugins-with-unsatisfied-deps remove-plugins-with-satisfied-deps initialized-plugin-names ready-for-init)
-    @ready-for-init))
+  that are now ready to register."
+  [registered-plugin-names]
+  (let [ready-to-register (atom nil)]
+    (swap! plugins-with-unsatisfied-deps remove-plugins-with-satisfied-deps registered-plugin-names ready-to-register)
+    @ready-to-register))

--- a/src/metabase/plugins/dependencies.clj
+++ b/src/metabase/plugins/dependencies.clj
@@ -99,21 +99,12 @@
                                (trs "Plugins with unsatisfied deps: {0}" (mapv (comp :name :info) @plugins-with-unsatisfied-deps))))
      false)))
 
-(defn- remove-plugins-with-satisfied-deps [plugins registered-plugin-names ready-to-register-atom]
-  ;; since `remove-plugins-with-satisfied-deps` could theoretically be called multiple times we need to reset the atom
-  ;; used to return the plugins ready to register so we don't accidentally include something in there twice etc.
-  (reset! ready-to-register-atom nil)
-  (set
-   (for [info  plugins
-         :let  [ready? (when (all-dependencies-satisfied?* registered-plugin-names info)
-                         (swap! ready-to-register-atom conj info))]
-         :when (not ready?)]
-     info)))
-
 (defn update-unsatisfied-deps!
-  "Updates internal list of plugins that still have unmet dependencies; returns sequence of plugin infos for all plugins
-  that are now ready to register."
+  "Updates the internal list of plugins that still have unmet dependencies.
+  Returns info on the plugins which are now ready to register."
   [registered-plugin-names]
-  (let [ready-to-register (atom nil)]
-    (swap! plugins-with-unsatisfied-deps remove-plugins-with-satisfied-deps registered-plugin-names ready-to-register)
-    @ready-to-register))
+  ;; Callers hold `plugin-lock`, so nothing else touches the atom between the read and the reset.
+  (let [{ready true, waiting false} (group-by (partial all-dependencies-satisfied?* registered-plugin-names)
+                                              @plugins-with-unsatisfied-deps)]
+    (reset! plugins-with-unsatisfied-deps (set waiting))
+    ready))

--- a/src/metabase/plugins/impl.clj
+++ b/src/metabase/plugins/impl.clj
@@ -191,16 +191,15 @@
 
 (defn load-plugins!
   "Load Metabase plugins. Bundled drivers are compiled directly into the uberjar and their plugin manifests are
-  discovered on the classpath at `metabase/<driver>/metabase-plugin.yaml`. User-supplied plugins (e.g. Oracle JDBC
-  driver JARs) are loaded from the plugins directory, which defaults to `./plugins`.
+  discovered on the classpath at `metabase/<driver>/metabase-plugin.yaml`. User-supplied plugins are loaded from the
+  plugins directory, which defaults to `./plugins`.
 
   When loading plugins, Metabase performs the following steps:
 
   *  Metabase creates the plugins directory if it does not already exist.
   *  Each JAR in the plugins directory that *does not* include a Metabase plugin manifest is added to the classpath.
-  *  For JARs that include a Metabase plugin manifest (a `metabase-plugin.yaml` file), a lazy-loading Metabase driver
-     is registered; when the driver is initialized (automatically, when certain methods are called) the JAR is added
-     to the classpath and the driver namespace is loaded.
+  *  For JARs that include a Metabase plugin manifest (a `metabase-plugin.yaml` file), non-driver plugins initialize
+     immediately. Driver plugins register lazily unless their manifest opts out of lazy loading.
   *  Bundled driver plugin manifests are loaded from the classpath (not from disk).
 
   This function will only perform loading steps the first time it is called — it is safe to call this function more

--- a/src/metabase/plugins/impl.clj
+++ b/src/metabase/plugins/impl.clj
@@ -106,12 +106,14 @@
   (plugins.init/register-plugin-with-info! info))
 
 (defn- register-plugin!
-  "Register a plugin JAR without loading its code. JARs without a manifest are dependency JARs and are added directly
-  to the classpath."
+  "Register a plugin JAR by its manifest, without adding it to the classpath or loading its code -- both
+  wait until the plugin is loaded. A JAR with no manifest is a bare dependency (e.g. a JDBC driver): there
+  is no code to defer, so it goes straight onto the classpath."
   [^Path jar-path]
   (if-let [info (plugin-info jar-path)]
+    ;; Manifest plugin: pass the classpath add as a thunk so it runs at load time, not now.
     (register-plugin-with-info! (assoc info :add-to-classpath! #(add-to-classpath! jar-path)))
-    ;; for all other JARs just add to classpath and call it a day
+    ;; Bare dependency JAR: nothing to load, so add it to the classpath immediately.
     (add-to-classpath! jar-path)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/plugins/impl.clj
+++ b/src/metabase/plugins/impl.clj
@@ -195,17 +195,20 @@
   ;; The order here matters, and step 3 is a provenance boundary. `false` (no manifest) sorts before `true`,
   ;; so the destructuring splits plugins-directory JARs into bare dependencies and manifest plugins.
   (log/infof "Loading plugins in %s..." (str (plugins-dir)))
-  (let [{dep-jars false, user-manifests true} (group-by has-manifest? (plugins-paths))]
+  ;; Reserved names come from the root-owned classpath, so they are not race-able. Pass them to *both*
+  ;; batches: classification (has-manifest?) and registration read the writable JAR separately, so a JAR that
+  ;; is a bare dependency when classified but a bundled-name manifest when registered must still be refused.
+  (let [reserved (bundled-plugin-names)
+        {dep-jars false, user-manifests true} (group-by has-manifest? (plugins-paths))]
     ;; 1. Bare dependency JARs (e.g. the Oracle JDBC driver `ojdbc8.jar`) go on the classpath first, so a
     ;;    bundled manifest's `class:` dependency is satisfiable by the time it is registered.
-    (register-plugins! #{} dep-jars)
+    (register-plugins! reserved dep-jars)
     ;; 2. Bundled manifests next: root-owned code compiled into the uberjar.
     (load-bundled-plugin-manifests!)
-    ;; 3. User-supplied manifest plugins last, and never under a bundled plugin's name. A bundled plugin whose
-    ;;    dependencies are unmet does not register, so we reserve all bundled names explicitly rather than
-    ;;    rely on registration order alone -- otherwise a JAR in the writable plugins directory could run
-    ;;    under a bundled identity.
-    (register-plugins! (bundled-plugin-names) user-manifests)))
+    ;; 3. User-supplied manifest plugins last, never under a bundled plugin's name. A bundled plugin whose
+    ;;    dependencies are unmet does not register, so reserving all bundled names explicitly -- rather than
+    ;;    relying on registration order -- is what keeps a plugins-directory JAR off a bundled identity.
+    (register-plugins! reserved user-manifests)))
 
 (defonce ^:private loaded? (atom false))
 

--- a/src/metabase/plugins/impl.clj
+++ b/src/metabase/plugins/impl.clj
@@ -137,9 +137,9 @@
 (defn- load-plugin-manifest! [path]
   (some-> (slurp (str path)) yaml/parse-string plugins.init/register-plugin-with-info!))
 
-(defn- bundled-driver-manifest-paths
-  "Return a sequence of paths (URIs when running from a jar, Paths in dev) for `metabase-plugin.yaml` plugin manifests
-  for drivers on the classpath. Driver manifests live at `metabase/<driver-name>/metabase-plugin.yaml` on the classpath."
+(defn- bundled-manifest-paths
+  "Paths (URIs when running from a jar, `Path`s in dev) for every `metabase-plugin.yaml` on the classpath.
+  Bundled plugins -- drivers and non-drivers alike -- live at `metabase/<plugin-name>/metabase-plugin.yaml`."
   []
   (if (u.files/running-from-jar?)
     (u.files/find-in-current-jar "glob:/metabase/*/metabase-plugin.yaml")
@@ -155,14 +155,16 @@
             f founds]
         f))))
 
-(defn- load-bundled-driver-plugin-manifests!
-  "Find and load driver plugin manifests from the classpath. In the uberjar, driver classes are flattened directly into
-  the jar (rather than shipped as nested JARs in a `modules/` directory) and their manifests live at
-  `metabase/<driver>/metabase-plugin.yaml`. In dev, the same manifests are found via the driver resource directories on
-  the classpath."
+(defn- load-bundled-plugin-manifests!
+  "Register plugin manifests bundled on the classpath.
+  Bundled plugin code -- driver or not -- is compiled into the uberjar, so its classes are already on the
+  classpath and these manifests carry no `add-to-classpath!`: their bytes never come from the writable plugins
+  directory. Classes are flattened into the uberjar (rather than shipped as nested JARs under `modules/`) with
+  manifests at `metabase/<plugin>/metabase-plugin.yaml`; in dev the same manifests are found via the resource
+  directories on the classpath."
   []
-  (doseq [manifest-path (bundled-driver-manifest-paths)]
-    (log/infof "Loading driver plugin manifest at %s" (str manifest-path))
+  (doseq [manifest-path (bundled-manifest-paths)]
+    (log/infof "Loading bundled plugin manifest at %s" (str manifest-path))
     (load-plugin-manifest! manifest-path)))
 
 (defn- has-manifest? ^Boolean [^Path path]
@@ -182,12 +184,12 @@
 
 (defn- load! []
   ;; Load any user-supplied plugin JARs from the plugins directory (e.g. Oracle JDBC driver).
-  ;; System/bundled drivers are no longer extracted to disk — they are flattened into the uberjar
-  ;; and their manifests are loaded from the classpath via load-driver-plugin-manifests! below.
+  ;; System/bundled plugins are no longer extracted to disk — they are flattened into the uberjar
+  ;; and their manifests are loaded from the classpath via load-bundled-plugin-manifests! below.
   (log/infof "Loading plugins in %s..." (str (plugins-dir)))
   (let [paths (plugins-paths)]
     (register-plugins! paths))
-  (load-bundled-driver-plugin-manifests!))
+  (load-bundled-plugin-manifests!))
 
 (defonce ^:private loaded? (atom false))
 

--- a/src/metabase/plugins/impl.clj
+++ b/src/metabase/plugins/impl.clj
@@ -198,7 +198,7 @@
   ;; Reserved names come from the root-owned classpath, so they are not race-able. Pass them to *both*
   ;; batches: classification (has-manifest?) and registration read the writable JAR separately, so a JAR that
   ;; is a bare dependency when classified but a bundled-name manifest when registered must still be refused.
-  (let [reserved (bundled-plugin-names)
+  (let [reserved                              (bundled-plugin-names)
         {dep-jars false, user-manifests true} (group-by has-manifest? (plugins-paths))]
     ;; 1. Bare dependency JARs (e.g. the Oracle JDBC driver `ojdbc8.jar`) go on the classpath first, so a
     ;;    bundled manifest's `class:` dependency is satisfiable by the time it is registered.

--- a/src/metabase/plugins/impl.clj
+++ b/src/metabase/plugins/impl.clj
@@ -171,25 +171,26 @@
   (boolean (slurp-plugin-manifest-from-archive path)))
 
 (defn- register-plugins! [paths]
-  ;; sort paths so that ones that correspond to JARs with no plugin manifest (e.g. a dependency like the Oracle JDBC
-  ;; driver `ojdbc8.jar`) are always added to the classpath first; that way, plugin manifests can satisfy class
-  ;; dependencies when they are registered.
-  ;;
-  ;; In Clojure world at least `false` < `true` so we can use `sort-by` to get non-Metabase-plugin JARs in front
-  (doseq [^Path path (sort-by has-manifest? paths)]
+  (doseq [^Path path paths]
     (try
       (register-plugin! path)
       (catch Throwable e
         (log/errorf "Failed to register plugin %s: %s" (.getFileName path) (ex-message e))))))
 
 (defn- load! []
-  ;; Load any user-supplied plugin JARs from the plugins directory (e.g. Oracle JDBC driver).
-  ;; System/bundled plugins are no longer extracted to disk — they are flattened into the uberjar
-  ;; and their manifests are loaded from the classpath via load-bundled-plugin-manifests! below.
+  ;; The order here matters, and the middle step is a provenance boundary. `false` (no manifest) sorts before
+  ;; `true`, so the destructuring splits plugins-directory JARs into bare dependencies and manifest plugins.
   (log/infof "Loading plugins in %s..." (str (plugins-dir)))
-  (let [paths (plugins-paths)]
-    (register-plugins! paths))
-  (load-bundled-plugin-manifests!))
+  (let [{dep-jars false, user-manifests true} (group-by has-manifest? (plugins-paths))]
+    ;; 1. Bare dependency JARs (e.g. the Oracle JDBC driver `ojdbc8.jar`) go on the classpath first, so a
+    ;;    bundled manifest's `class:` dependency is satisfiable by the time it is registered.
+    (register-plugins! dep-jars)
+    ;; 2. Bundled manifests next. Their code is compiled into the root-owned uberjar, so registering them here
+    ;;    claims each plugin name before any plugins-directory JAR does. Registration is first-wins, so a JAR
+    ;;    dropped in the writable plugins directory cannot shadow a bundled plugin and run under its identity.
+    (load-bundled-plugin-manifests!)
+    ;; 3. Finally, user-supplied manifest plugins from the plugins directory.
+    (register-plugins! user-manifests)))
 
 (defonce ^:private loaded? (atom false))
 

--- a/src/metabase/plugins/impl.clj
+++ b/src/metabase/plugins/impl.clj
@@ -108,11 +108,16 @@
 (defn- register-plugin!
   "Register a plugin JAR by its manifest, without adding it to the classpath or loading its code -- both
   wait until the plugin is loaded. A JAR with no manifest is a bare dependency (e.g. a JDBC driver): there
-  is no code to defer, so it goes straight onto the classpath."
-  [^Path jar-path]
+  is no code to defer, so it goes straight onto the classpath. A manifest whose name is in `reserved-names`
+  (a bundled plugin's) is ignored, so a plugins-directory JAR cannot register under a bundled identity."
+  [reserved-names ^Path jar-path]
   (if-let [info (plugin-info jar-path)]
-    ;; Manifest plugin: pass the classpath add as a thunk so it runs at load time, not now.
-    (register-plugin-with-info! (assoc info :add-to-classpath! #(add-to-classpath! jar-path)))
+    (let [plugin-name (get-in info [:info :name])]
+      (if (contains? reserved-names plugin-name)
+        (log/warnf "Ignoring plugins-directory plugin %s: name %s is reserved by a bundled plugin"
+                   (.getFileName jar-path) (pr-str plugin-name))
+        ;; Manifest plugin: pass the classpath add as a thunk so it runs at load time, not now.
+        (register-plugin-with-info! (assoc info :add-to-classpath! #(add-to-classpath! jar-path)))))
     ;; Bare dependency JAR: nothing to load, so add it to the classpath immediately.
     (add-to-classpath! jar-path)))
 
@@ -170,27 +175,37 @@
 (defn- has-manifest? ^Boolean [^Path path]
   (boolean (slurp-plugin-manifest-from-archive path)))
 
-(defn- register-plugins! [paths]
+(defn- register-plugins! [reserved-names paths]
   (doseq [^Path path paths]
     (try
-      (register-plugin! path)
+      (register-plugin! reserved-names path)
       (catch Throwable e
         (log/errorf "Failed to register plugin %s: %s" (.getFileName path) (ex-message e))))))
 
+(defn- bundled-plugin-names
+  "Names of every bundled (classpath) plugin, whether or not its dependencies are yet satisfied. A bundled
+  plugin with an unmet dependency (e.g. Oracle without its JDBC JAR) never registers, so reserving its name
+  explicitly keeps a plugins-directory JAR from claiming that identity."
+  []
+  (into #{}
+        (keep #(get-in (some-> (slurp (str %)) yaml/parse-string) [:info :name]))
+        (bundled-manifest-paths)))
+
 (defn- load! []
-  ;; The order here matters, and the middle step is a provenance boundary. `false` (no manifest) sorts before
-  ;; `true`, so the destructuring splits plugins-directory JARs into bare dependencies and manifest plugins.
+  ;; The order here matters, and step 3 is a provenance boundary. `false` (no manifest) sorts before `true`,
+  ;; so the destructuring splits plugins-directory JARs into bare dependencies and manifest plugins.
   (log/infof "Loading plugins in %s..." (str (plugins-dir)))
   (let [{dep-jars false, user-manifests true} (group-by has-manifest? (plugins-paths))]
     ;; 1. Bare dependency JARs (e.g. the Oracle JDBC driver `ojdbc8.jar`) go on the classpath first, so a
     ;;    bundled manifest's `class:` dependency is satisfiable by the time it is registered.
-    (register-plugins! dep-jars)
-    ;; 2. Bundled manifests next. Their code is compiled into the root-owned uberjar, so registering them here
-    ;;    claims each plugin name before any plugins-directory JAR does. Registration is first-wins, so a JAR
-    ;;    dropped in the writable plugins directory cannot shadow a bundled plugin and run under its identity.
+    (register-plugins! #{} dep-jars)
+    ;; 2. Bundled manifests next: root-owned code compiled into the uberjar.
     (load-bundled-plugin-manifests!)
-    ;; 3. Finally, user-supplied manifest plugins from the plugins directory.
-    (register-plugins! user-manifests)))
+    ;; 3. User-supplied manifest plugins last, and never under a bundled plugin's name. A bundled plugin whose
+    ;;    dependencies are unmet does not register, so we reserve all bundled names explicitly rather than
+    ;;    rely on registration order alone -- otherwise a JAR in the writable plugins directory could run
+    ;;    under a bundled identity.
+    (register-plugins! (bundled-plugin-names) user-manifests)))
 
 (defonce ^:private loaded? (atom false))
 

--- a/src/metabase/plugins/impl.clj
+++ b/src/metabase/plugins/impl.clj
@@ -99,18 +99,18 @@
   (some-> (slurp-plugin-manifest-from-archive jar-path)
           yaml/parse-string))
 
-(defn- init-plugin-with-info!
-  "Initialize plugin using parsed info from a plugin manifest. Returns truthy if plugin was successfully initialized;
+(defn- register-plugin-with-info!
+  "Register a plugin using parsed info from its manifest. Returns truthy if registration was successful;
   falsey otherwise."
   [info]
-  (plugins.init/init-plugin-with-info! info))
+  (plugins.init/register-plugin-with-info! info))
 
-(defn- init-plugin!
-  "Init plugin JAR file; returns truthy if plugin initialization was successful."
+(defn- register-plugin!
+  "Register a plugin JAR without loading its code. JARs without a manifest are dependency JARs and are added directly
+  to the classpath."
   [^Path jar-path]
   (if-let [info (plugin-info jar-path)]
-    ;; for plugins that include a metabase-plugin.yaml manifest run the normal init steps, don't add to classpath yet
-    (init-plugin-with-info! (assoc info :add-to-classpath! #(add-to-classpath! jar-path)))
+    (register-plugin-with-info! (assoc info :add-to-classpath! #(add-to-classpath! jar-path)))
     ;; for all other JARs just add to classpath and call it a day
     (add-to-classpath! jar-path)))
 
@@ -133,7 +133,7 @@
     path))
 
 (defn- load-plugin-manifest! [path]
-  (some-> (slurp (str path)) yaml/parse-string plugins.init/init-plugin-with-info!))
+  (some-> (slurp (str path)) yaml/parse-string plugins.init/register-plugin-with-info!))
 
 (defn- bundled-driver-manifest-paths
   "Return a sequence of paths (URIs when running from a jar, Paths in dev) for `metabase-plugin.yaml` plugin manifests
@@ -166,17 +166,17 @@
 (defn- has-manifest? ^Boolean [^Path path]
   (boolean (slurp-plugin-manifest-from-archive path)))
 
-(defn- init-plugins! [paths]
+(defn- register-plugins! [paths]
   ;; sort paths so that ones that correspond to JARs with no plugin manifest (e.g. a dependency like the Oracle JDBC
-  ;; driver `ojdbc8.jar`) always get initialized (i.e., added to the classpath) first; that way, Metabase drivers that
-  ;; depend on them (such as Oracle) can be initialized the first time we see them.
+  ;; driver `ojdbc8.jar`) are always added to the classpath first; that way, plugin manifests can satisfy class
+  ;; dependencies when they are registered.
   ;;
   ;; In Clojure world at least `false` < `true` so we can use `sort-by` to get non-Metabase-plugin JARs in front
   (doseq [^Path path (sort-by has-manifest? paths)]
     (try
-      (init-plugin! path)
+      (register-plugin! path)
       (catch Throwable e
-        (log/errorf "Failed to initialize plugin %s: %s" (.getFileName path) (ex-message e))))))
+        (log/errorf "Failed to register plugin %s: %s" (.getFileName path) (ex-message e))))))
 
 (defn- load! []
   ;; Load any user-supplied plugin JARs from the plugins directory (e.g. Oracle JDBC driver).
@@ -184,7 +184,7 @@
   ;; and their manifests are loaded from the classpath via load-driver-plugin-manifests! below.
   (log/infof "Loading plugins in %s..." (str (plugins-dir)))
   (let [paths (plugins-paths)]
-    (init-plugins! paths))
+    (register-plugins! paths))
   (load-bundled-driver-plugin-manifests!))
 
 (defonce ^:private loaded? (atom false))
@@ -198,8 +198,8 @@
 
   *  Metabase creates the plugins directory if it does not already exist.
   *  Each JAR in the plugins directory that *does not* include a Metabase plugin manifest is added to the classpath.
-  *  For JARs that include a Metabase plugin manifest (a `metabase-plugin.yaml` file), non-driver plugins initialize
-     immediately. Driver plugins register lazily unless their manifest opts out of lazy loading.
+  *  JARs with a Metabase plugin manifest are registered without adding them to the classpath. Their code is loaded
+     only when the plugin is activated.
   *  Bundled driver plugin manifests are loaded from the classpath (not from disk).
 
   This function will only perform loading steps the first time it is called — it is safe to call this function more

--- a/src/metabase/plugins/initialize.clj
+++ b/src/metabase/plugins/initialize.clj
@@ -114,8 +114,3 @@
       (locking registered-plugins
         (or (registered? info)
             (register! info)))))
-
-(defn init-plugin-with-info!
-  "Deprecated compatibility alias for `register-plugin-with-info!`."
-  [info]
-  (register-plugin-with-info! info))

--- a/src/metabase/plugins/initialize.clj
+++ b/src/metabase/plugins/initialize.clj
@@ -14,6 +14,10 @@
 (defonce ^:private registered-plugins (atom {}))
 (defonce ^:private loaded-plugin-names (atom #{}))
 
+;; `:info :name` predates generic plugins and is currently both the human-readable name and the identifier used by
+;; `load-plugin!` and `dependencies: [{plugin: ...}]`. Plugin authors must therefore treat it as unique and stable.
+;; If we eventually need a separately editable display name, add a new manifest field rather than changing this key.
+
 (def plugin-api-version
   "Current version of the generic Metabase plugin initialization contract."
   1)
@@ -41,6 +45,12 @@
 (defn- load-plugin-info!
   [{:keys [add-to-classpath!], init-steps :init, {plugin-name :name} :info}]
   (when-not (loaded? plugin-name)
+    ;; Adding a JAR to the shared JVM classpath cannot be undone or isolated per plugin. Keep it delayed until this
+    ;; point, but assume plugin classes and their transitive dependencies remain visible for the life of the process.
+    ;;
+    ;; We mark a plugin loaded only after every init step succeeds. A failed activation can therefore be retried, so
+    ;; initialization steps should tolerate retry after a partially completed attempt. We deliberately keep that
+    ;; existing best-effort behavior here rather than adding rollback or lifecycle machinery.
     (locking loaded-plugin-names
       (when-not (loaded? plugin-name)
         (when add-to-classpath!
@@ -51,7 +61,10 @@
 
 (defn load-plugin!
   "Load a registered plugin by name, adding its JAR to the classpath and running its manifest initialization steps.
-  Loading is idempotent."
+  Loading is idempotent.
+
+  Discovery does not call this automatically. The code that owns a plugin type is responsible for calling it at the
+  point where a configured plugin is first needed; calling it during startup would defeat lazy loading."
   [plugin-name]
   {:pre [(string? plugin-name)]}
   (if-let [info (@registered-plugins plugin-name)]

--- a/src/metabase/plugins/initialize.clj
+++ b/src/metabase/plugins/initialize.clj
@@ -3,8 +3,8 @@
   Metabase launches as soon as all dependencies for that plugin are met; for plugins with unmet dependencies, it is
   retried after other plugins are loaded (e.g. for things like BigQuery which depend on the shared Google driver.)
 
-  Note that this is not the same thing as initializing *drivers* -- drivers are initialized lazily when first needed;
-  this step on the other hand runs at launch time and sets up that lazy load logic."
+  Non-driver plugins initialize at launch. Driver plugins can instead register a lazy placeholder and defer their code
+  until the driver is first needed."
   (:require
    [metabase.plugins.dependencies :as deps]
    [metabase.plugins.init-steps :as init-steps]
@@ -15,6 +15,27 @@
 
 (defonce ^:private initialized-plugin-names (atom #{}))
 
+(def plugin-api-version
+  "Current version of the generic Metabase plugin initialization contract."
+  1)
+
+(defn- validate-plugin-api-version!
+  [{declared-version :metabase-plugin-api-version, {plugin-name :name} :info, driver-or-drivers :driver}]
+  ;; Existing driver manifests predate the generic contract and remain valid when the field is absent.
+  (cond
+    (and (nil? declared-version) (empty? (u/one-or-many driver-or-drivers)))
+    (throw (ex-info (format "Non-driver plugin %s must declare Metabase plugin API version %s."
+                            (pr-str plugin-name) plugin-api-version)
+                    {:plugin-name           plugin-name
+                     :supported-api-version plugin-api-version}))
+
+    (and (some? declared-version) (not= plugin-api-version declared-version))
+    (throw (ex-info (format "Plugin %s requires unsupported Metabase plugin API version %s; this server supports %s."
+                            (pr-str plugin-name) (pr-str declared-version) plugin-api-version)
+                    {:plugin-name           plugin-name
+                     :plugin-api-version    declared-version
+                     :supported-api-version plugin-api-version}))))
+
 (defn- init!
   [{:keys [add-to-classpath!], init-steps :init, {plugin-name :name} :info, driver-or-drivers :driver, :as info}]
   {:pre [(string? plugin-name)]}
@@ -24,8 +45,11 @@
       (doseq [{:keys [lazy-load], :or {lazy-load true}, :as driver} drivers]
         (when lazy-load
           (lazy-loaded-driver/register-lazy-loaded-driver! (assoc info :driver driver))))
-      ;; if *any* of the drivers is not lazy-load, initialize it now
-      (when (some false? (map :lazy-load drivers))
+      ;; Non-driver plugins have no lazy placeholder to register, so initialize them eagerly. Driver
+      ;; plugins keep their existing behavior: initialize now only when at least one driver opts out of
+      ;; lazy loading.
+      (when (or (empty? drivers)
+                (some false? (map :lazy-load drivers)))
         (when add-to-classpath!
           (add-to-classpath!))
         (init-steps/do-init-steps! init-steps)))
@@ -48,12 +72,12 @@
   "Initialize plugin using parsed info from a plugin manifest. Returns truthy if plugin was successfully initialized;
   falsey otherwise."
   [info :- [:map
+            [:metabase-plugin-api-version {:optional true} :int]
             [:info [:map
                     [:name    :string]
                     [:version :string]]]]]
-  (or
-   (initialized? info)
-   (locking initialized-plugin-names
-     (or
-      (initialized? info)
-      (init! info)))))
+  (validate-plugin-api-version! info)
+  (or (initialized? info)
+      (locking initialized-plugin-names
+        (or (initialized? info)
+            (init! info)))))

--- a/src/metabase/plugins/initialize.clj
+++ b/src/metabase/plugins/initialize.clj
@@ -16,7 +16,6 @@
 
 ;; `:info :name` predates generic plugins and is currently both the human-readable name and the identifier used by
 ;; `load-plugin!` and `dependencies: [{plugin: ...}]`. Plugin authors must therefore treat it as unique and stable.
-;; If we eventually need a separately editable display name, add a new manifest field rather than changing this key.
 
 (def plugin-api-version
   "Current version of the generic Metabase plugin initialization contract."
@@ -49,8 +48,7 @@
     ;; point, but assume plugin classes and their transitive dependencies remain visible for the life of the process.
     ;;
     ;; We mark a plugin loaded only after every init step succeeds. A failed activation can therefore be retried, so
-    ;; initialization steps should tolerate retry after a partially completed attempt. We deliberately keep that
-    ;; existing best-effort behavior here rather than adding rollback or lifecycle machinery.
+    ;; initialization steps should tolerate retry after a partially completed attempt.
     (locking loaded-plugin-names
       (when-not (loaded? plugin-name)
         (when add-to-classpath!

--- a/src/metabase/plugins/initialize.clj
+++ b/src/metabase/plugins/initialize.clj
@@ -1,10 +1,8 @@
 (ns metabase.plugins.initialize
-  "Logic related to initializing plugins, i.e. running the `init` steps listed in the plugin manifest. This is done when
-  Metabase launches as soon as all dependencies for that plugin are met; for plugins with unmet dependencies, it is
-  retried after other plugins are loaded (e.g. for things like BigQuery which depend on the shared Google driver.)
+  "Plugin discovery, registration, and lazy loading.
 
-  Non-driver plugins initialize at launch. Driver plugins can instead register a lazy placeholder and defer their code
-  until the driver is first needed."
+  Manifests are validated and registered at startup as soon as their dependencies are met. Plugin code is loaded only
+  when `load-plugin!` is called. Driver manifests use the same loader through their lazy driver placeholders."
   (:require
    [metabase.plugins.dependencies :as deps]
    [metabase.plugins.init-steps :as init-steps]
@@ -13,7 +11,8 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]))
 
-(defonce ^:private initialized-plugin-names (atom #{}))
+(defonce ^:private registered-plugins (atom {}))
+(defonce ^:private loaded-plugin-names (atom #{}))
 
 (def plugin-api-version
   "Current version of the generic Metabase plugin initialization contract."
@@ -36,40 +35,63 @@
                      :plugin-api-version    declared-version
                      :supported-api-version plugin-api-version}))))
 
-(defn- init!
-  [{:keys [add-to-classpath!], init-steps :init, {plugin-name :name} :info, driver-or-drivers :driver, :as info}]
+(defn- loaded? [plugin-name]
+  (contains? @loaded-plugin-names plugin-name))
+
+(defn- load-plugin-info!
+  [{:keys [add-to-classpath!], init-steps :init, {plugin-name :name} :info}]
+  (when-not (loaded? plugin-name)
+    (locking loaded-plugin-names
+      (when-not (loaded? plugin-name)
+        (when add-to-classpath!
+          (add-to-classpath!))
+        (init-steps/do-init-steps! init-steps)
+        (swap! loaded-plugin-names conj plugin-name))))
+  :ok)
+
+(defn load-plugin!
+  "Load a registered plugin by name, adding its JAR to the classpath and running its manifest initialization steps.
+  Loading is idempotent."
+  [plugin-name]
   {:pre [(string? plugin-name)]}
-  (when (deps/all-dependencies-satisfied? @initialized-plugin-names info)
+  (if-let [info (@registered-plugins plugin-name)]
+    (load-plugin-info! info)
+    (throw (ex-info (format "Plugin %s is not registered." (pr-str plugin-name))
+                    {:plugin-name              plugin-name
+                     :registered-plugin-names (set (keys @registered-plugins))}))))
+
+(defn- register!
+  [{{plugin-name :name} :info, driver-or-drivers :driver, :as info}]
+  {:pre [(string? plugin-name)]}
+  (when (deps/all-dependencies-satisfied? (keys @registered-plugins) info)
     ;; for each driver, if it's lazy load, register a lazy-loaded placeholder driver
     (let [drivers (u/one-or-many driver-or-drivers)]
       (doseq [{:keys [lazy-load], :or {lazy-load true}, :as driver} drivers]
         (when lazy-load
-          (lazy-loaded-driver/register-lazy-loaded-driver! (assoc info :driver driver))))
-      ;; Non-driver plugins have no lazy placeholder to register, so initialize them eagerly. Driver
-      ;; plugins keep their existing behavior: initialize now only when at least one driver opts out of
-      ;; lazy loading.
-      (when (or (empty? drivers)
-                (some false? (map :lazy-load drivers)))
-        (when add-to-classpath!
-          (add-to-classpath!))
-        (init-steps/do-init-steps! init-steps)))
-    ;; record this plugin as initialized and find any plugins ready to be initialized because depended on this one !
+          (lazy-loaded-driver/register-lazy-loaded-driver!
+           (assoc info
+                  :driver driver
+                  :load-plugin! #(load-plugin-info! info)))))
+      ;; Preserve the existing eager path for driver manifests that explicitly opt out of lazy loading.
+      (when (some false? (map :lazy-load drivers))
+        (load-plugin-info! info)))
+    ;; Record this plugin as registered and find plugins that can now be registered because they depend on it.
     ;;
-    ;; Fun fact: we already have the `plugin-initialization-lock` if we're here so we don't need to worry about
-    ;; getting it again
-    (let [plugins-ready-to-init (deps/update-unsatisfied-deps! (swap! initialized-plugin-names conj plugin-name))]
-      (when (seq plugins-ready-to-init)
-        (log/debug (u/format-color 'yellow (format "Dependencies satisfied; these plugins will now be loaded: %s"
-                                                   (mapv (comp :name :info) plugins-ready-to-init)))))
-      (doseq [plugin-info plugins-ready-to-init]
-        (init! plugin-info)))
+    ;; We already hold the plugin registration lock here, so recursively registering newly unblocked plugins is safe.
+    (swap! registered-plugins assoc plugin-name info)
+    (let [plugins-ready-to-register (deps/update-unsatisfied-deps! (keys @registered-plugins))]
+      (when (seq plugins-ready-to-register)
+        (log/debug (u/format-color 'yellow (format "Dependencies satisfied; these plugins will now be registered: %s"
+                                                   (mapv (comp :name :info) plugins-ready-to-register)))))
+      (doseq [plugin-info plugins-ready-to-register]
+        (register! plugin-info)))
     :ok))
 
-(defn- initialized? [{{plugin-name :name} :info}]
-  (@initialized-plugin-names plugin-name))
+(defn- registered? [{{plugin-name :name} :info}]
+  (contains? @registered-plugins plugin-name))
 
-(mu/defn init-plugin-with-info!
-  "Initialize plugin using parsed info from a plugin manifest. Returns truthy if plugin was successfully initialized;
+(mu/defn register-plugin-with-info!
+  "Register a plugin using parsed info from its manifest. Returns truthy if the plugin was successfully registered;
   falsey otherwise."
   [info :- [:map
             [:metabase-plugin-api-version {:optional true} :int]
@@ -77,7 +99,12 @@
                     [:name    :string]
                     [:version :string]]]]]
   (validate-plugin-api-version! info)
-  (or (initialized? info)
-      (locking initialized-plugin-names
-        (or (initialized? info)
-            (init! info)))))
+  (or (registered? info)
+      (locking registered-plugins
+        (or (registered? info)
+            (register! info)))))
+
+(defn init-plugin-with-info!
+  "Deprecated compatibility alias for `register-plugin-with-info!`."
+  [info]
+  (register-plugin-with-info! info))

--- a/src/metabase/plugins/initialize.clj
+++ b/src/metabase/plugins/initialize.clj
@@ -4,6 +4,7 @@
   Manifests are validated and registered at startup as soon as their dependencies are met. Plugin code is loaded only
   when [[load-plugin!]] is called. Driver manifests use the same loader through their lazy driver placeholders."
   (:require
+   [clojure.string :as str]
    [metabase.plugins.dependencies :as deps]
    [metabase.plugins.init-steps :as init-steps]
    [metabase.plugins.lazy-loaded-driver :as lazy-loaded-driver]
@@ -37,11 +38,12 @@
   (atom {}))
 
 (defonce ^:private
-  ^{:doc "Names the plugin whose load holds [[plugin-lock]], so a rejected load can say what beat it.
+  ^{:doc "The loads in progress, outermost first.
 
-  Diagnostic only: the lock, not this, decides who may load."}
-  active-plugin-load
-  (atom nil))
+  Only the thread holding [[plugin-lock]] touches it.
+  A name already on the stack is a cycle: its init steps have not finished, so loading it again would never stop."}
+  loading-plugins
+  (atom []))
 
 ;; `:info :name` predates generic plugins and is currently both the human-readable name and the identifier used by
 ;; `load-plugin!` and `dependencies: [{plugin: ...}]`. Plugin authors must therefore treat it as unique and stable.
@@ -78,16 +80,32 @@
 (defn- loaded? [plugin-name]
   (boolean (get-in @plugins [plugin-name :loaded?])))
 
+(defn- lock-holder-description []
+  (if-let [loading (peek @loading-plugins)]
+    (format "plugin %s is loading" (pr-str loading))
+    "another thread holds the plugin lock"))
+
 (defn- claim-plugin-load!
-  "Take `plugin-lock` for the duration of a load, or throw if another thread is already loading. A thread that already
-  holds the lock claims it again; that is nesting, not concurrency."
+  "Take [[plugin-lock]] and record `plugin-name` as loading.
+  Throws if another thread is loading, or if this would re-enter a plugin whose init steps have not finished."
   [plugin-name]
   (when-not (.tryLock plugin-lock)
-    (let [active-load @active-plugin-load]
-      (throw (ex-info (format "Cannot load plugin %s while plugin %s is loading; concurrent plugin loading is not supported."
-                              (pr-str plugin-name) (pr-str (:plugin-name active-load)))
-                      {:plugin-name        plugin-name
-                       :active-plugin-load active-load})))))
+    (throw (ex-info (format "Cannot load plugin %s while %s; concurrent plugin loading is not supported."
+                            (pr-str plugin-name) (lock-holder-description))
+                    {:plugin-name     plugin-name
+                     :loading-plugins @loading-plugins})))
+  (let [in-progress @loading-plugins]
+    (when (some #{plugin-name} in-progress)
+      (.unlock plugin-lock)
+      (throw (ex-info (format "Cannot load plugin %s while it is already loading: %s."
+                              (pr-str plugin-name) (str/join " -> " (conj in-progress plugin-name)))
+                      {:plugin-name     plugin-name
+                       :loading-plugins in-progress}))))
+  (swap! loading-plugins conj plugin-name))
+
+(defn- release-plugin-load! []
+  (swap! loading-plugins pop)
+  (.unlock plugin-lock))
 
 (defn- load-plugin-info!
   [{:keys [add-to-classpath!], init-steps :init, {plugin-name :name} :info}]
@@ -98,19 +116,15 @@
     ;; We mark a plugin loaded only after every init step succeeds. A failed activation can therefore be retried, so
     ;; initialization steps should tolerate retry after a partially completed attempt.
     (claim-plugin-load! plugin-name)
-    (let [outer-load @active-plugin-load]
-      (try
-        (reset! active-plugin-load {:plugin-name plugin-name
-                                    :thread      (.getName ^Thread (Thread/currentThread))})
-        ;; A competing call can finish after the fast-path check but before this call takes the lock.
-        (when-not (loaded? plugin-name)
-          (when add-to-classpath!
-            (add-to-classpath!))
-          (init-steps/do-init-steps! init-steps)
-          (swap! plugins update plugin-name assoc :loaded? true))
-        (finally
-          (reset! active-plugin-load outer-load)
-          (.unlock plugin-lock)))))
+    (try
+      ;; A competing call can finish after the fast-path check but before this call takes the lock.
+      (when-not (loaded? plugin-name)
+        (when add-to-classpath!
+          (add-to-classpath!))
+        (init-steps/do-init-steps! init-steps)
+        (swap! plugins update plugin-name assoc :loaded? true))
+      (finally
+        (release-plugin-load!))))
   :ok)
 
 (defn load-plugin!

--- a/src/metabase/plugins/initialize.clj
+++ b/src/metabase/plugins/initialize.clj
@@ -2,7 +2,7 @@
   "Plugin discovery, registration, and lazy loading.
 
   Manifests are validated and registered at startup as soon as their dependencies are met. Plugin code is loaded only
-  when `load-plugin!` is called. Driver manifests use the same loader through their lazy driver placeholders."
+  when [[load-plugin!]] is called. Driver manifests use the same loader through their lazy driver placeholders."
   (:require
    [metabase.plugins.dependencies :as deps]
    [metabase.plugins.init-steps :as init-steps]
@@ -11,8 +11,11 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]))
 
+(set! *warn-on-reflection* true)
+
 (defonce ^:private registered-plugins (atom {}))
 (defonce ^:private loaded-plugin-names (atom #{}))
+(defonce ^:private active-plugin-load (atom nil))
 
 ;; `:info :name` predates generic plugins and is currently both the human-readable name and the identifier used by
 ;; `load-plugin!` and `dependencies: [{plugin: ...}]`. Plugin authors must therefore treat it as unique and stable.
@@ -41,6 +44,19 @@
 (defn- loaded? [plugin-name]
   (contains? @loaded-plugin-names plugin-name))
 
+(defn- claim-plugin-load! [plugin-name]
+  (let [claim {:plugin-name plugin-name
+               :thread      (.getName ^Thread (Thread/currentThread))}]
+    (loop []
+      (if-let [active-load @active-plugin-load]
+        (throw (ex-info (format "Cannot load plugin %s while plugin %s is loading; concurrent plugin loading is not supported."
+                                (pr-str plugin-name) (pr-str (:plugin-name active-load)))
+                        {:plugin-name        plugin-name
+                         :active-plugin-load active-load}))
+        (if (compare-and-set! active-plugin-load nil claim)
+          claim
+          (recur))))))
+
 (defn- load-plugin-info!
   [{:keys [add-to-classpath!], init-steps :init, {plugin-name :name} :info}]
   (when-not (loaded? plugin-name)
@@ -49,17 +65,21 @@
     ;;
     ;; We mark a plugin loaded only after every init step succeeds. A failed activation can therefore be retried, so
     ;; initialization steps should tolerate retry after a partially completed attempt.
-    (locking loaded-plugin-names
-      (when-not (loaded? plugin-name)
-        (when add-to-classpath!
-          (add-to-classpath!))
-        (init-steps/do-init-steps! init-steps)
-        (swap! loaded-plugin-names conj plugin-name))))
+    (let [claim (claim-plugin-load! plugin-name)]
+      (try
+        ;; A competing call can finish after the fast-path check but before this call claims the loader.
+        (when-not (loaded? plugin-name)
+          (when add-to-classpath!
+            (add-to-classpath!))
+          (init-steps/do-init-steps! init-steps)
+          (swap! loaded-plugin-names conj plugin-name))
+        (finally
+          (compare-and-set! active-plugin-load claim nil)))))
   :ok)
 
 (defn load-plugin!
   "Load a registered plugin by name, adding its JAR to the classpath and running its manifest initialization steps.
-  Loading is idempotent.
+  Loading is idempotent. Callers must serialize plugin activation; concurrent plugin loading is not supported.
 
   Discovery does not call this automatically. The code that owns a plugin type is responsible for calling it at the
   point where a configured plugin is first needed; calling it during startup would defeat lazy loading."

--- a/src/metabase/plugins/initialize.clj
+++ b/src/metabase/plugins/initialize.clj
@@ -9,13 +9,39 @@
    [metabase.plugins.lazy-loaded-driver :as lazy-loaded-driver]
    [metabase.util :as u]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu])
+  (:import
+   (java.util.concurrent.locks ReentrantLock)))
 
 (set! *warn-on-reflection* true)
 
-(defonce ^:private registered-plugins (atom {}))
-(defonce ^:private loaded-plugin-names (atom #{}))
-(defonce ^:private active-plugin-load (atom nil))
+(defonce ^:private ^ReentrantLock
+  ^{:doc "Guards every write to [[plugins]] and the running of a plugin's init steps.
+
+  Registration waits for the lock, but loading refuses to wait: a caller that breaks the serialization
+  contract gets an error rather than a silently blocked thread.
+
+  Both paths take this one lock. The eager driver path registers a plugin while its own init steps run,
+  so the lock has to be reentrant."}
+  plugin-lock
+  (ReentrantLock.))
+
+(defonce ^:private
+  ^{:doc "Plugin name -> registry entry, where an entry holds:
+
+    `:info`    the parsed manifest, present once the plugin is registered
+    `:loaded?` whether the plugin's init steps have run
+
+  The eager driver path loads a plugin before registering it, so an entry can hold either key alone."}
+  plugins
+  (atom {}))
+
+(defonce ^:private
+  ^{:doc "Names the plugin whose load holds [[plugin-lock]], so a rejected load can say what beat it.
+
+  Diagnostic only: the lock, not this, decides who may load."}
+  active-plugin-load
+  (atom nil))
 
 ;; `:info :name` predates generic plugins and is currently both the human-readable name and the identifier used by
 ;; `load-plugin!` and `dependencies: [{plugin: ...}]`. Plugin authors must therefore treat it as unique and stable.
@@ -41,21 +67,27 @@
                      :plugin-api-version    declared-version
                      :supported-api-version plugin-api-version}))))
 
-(defn- loaded? [plugin-name]
-  (contains? @loaded-plugin-names plugin-name))
+(defn- registered-info [plugin-name]
+  (get-in @plugins [plugin-name :info]))
 
-(defn- claim-plugin-load! [plugin-name]
-  (let [claim {:plugin-name plugin-name
-               :thread      (.getName ^Thread (Thread/currentThread))}]
-    (loop []
-      (if-let [active-load @active-plugin-load]
-        (throw (ex-info (format "Cannot load plugin %s while plugin %s is loading; concurrent plugin loading is not supported."
-                                (pr-str plugin-name) (pr-str (:plugin-name active-load)))
-                        {:plugin-name        plugin-name
-                         :active-plugin-load active-load}))
-        (if (compare-and-set! active-plugin-load nil claim)
-          claim
-          (recur))))))
+(defn- registered-plugin-names []
+  (for [[plugin-name {:keys [info]}] @plugins
+        :when info]
+    plugin-name))
+
+(defn- loaded? [plugin-name]
+  (boolean (get-in @plugins [plugin-name :loaded?])))
+
+(defn- claim-plugin-load!
+  "Take `plugin-lock` for the duration of a load, or throw if another thread is already loading. A thread that already
+  holds the lock claims it again; that is nesting, not concurrency."
+  [plugin-name]
+  (when-not (.tryLock plugin-lock)
+    (let [active-load @active-plugin-load]
+      (throw (ex-info (format "Cannot load plugin %s while plugin %s is loading; concurrent plugin loading is not supported."
+                              (pr-str plugin-name) (pr-str (:plugin-name active-load)))
+                      {:plugin-name        plugin-name
+                       :active-plugin-load active-load})))))
 
 (defn- load-plugin-info!
   [{:keys [add-to-classpath!], init-steps :init, {plugin-name :name} :info}]
@@ -65,16 +97,20 @@
     ;;
     ;; We mark a plugin loaded only after every init step succeeds. A failed activation can therefore be retried, so
     ;; initialization steps should tolerate retry after a partially completed attempt.
-    (let [claim (claim-plugin-load! plugin-name)]
+    (claim-plugin-load! plugin-name)
+    (let [outer-load @active-plugin-load]
       (try
-        ;; A competing call can finish after the fast-path check but before this call claims the loader.
+        (reset! active-plugin-load {:plugin-name plugin-name
+                                    :thread      (.getName ^Thread (Thread/currentThread))})
+        ;; A competing call can finish after the fast-path check but before this call takes the lock.
         (when-not (loaded? plugin-name)
           (when add-to-classpath!
             (add-to-classpath!))
           (init-steps/do-init-steps! init-steps)
-          (swap! loaded-plugin-names conj plugin-name))
+          (swap! plugins update plugin-name assoc :loaded? true))
         (finally
-          (compare-and-set! active-plugin-load claim nil)))))
+          (reset! active-plugin-load outer-load)
+          (.unlock plugin-lock)))))
   :ok)
 
 (defn load-plugin!
@@ -85,16 +121,16 @@
   point where a configured plugin is first needed; calling it during startup would defeat lazy loading."
   [plugin-name]
   {:pre [(string? plugin-name)]}
-  (if-let [info (@registered-plugins plugin-name)]
+  (if-let [info (registered-info plugin-name)]
     (load-plugin-info! info)
     (throw (ex-info (format "Plugin %s is not registered." (pr-str plugin-name))
                     {:plugin-name              plugin-name
-                     :registered-plugin-names (set (keys @registered-plugins))}))))
+                     :registered-plugin-names (set (registered-plugin-names))}))))
 
 (defn- register!
   [{{plugin-name :name} :info, driver-or-drivers :driver, :as info}]
   {:pre [(string? plugin-name)]}
-  (when (deps/all-dependencies-satisfied? (keys @registered-plugins) info)
+  (when (deps/all-dependencies-satisfied? (registered-plugin-names) info)
     ;; for each driver, if it's lazy load, register a lazy-loaded placeholder driver
     (let [drivers (u/one-or-many driver-or-drivers)]
       (doseq [{:keys [lazy-load], :or {lazy-load true}, :as driver} drivers]
@@ -108,9 +144,10 @@
         (load-plugin-info! info)))
     ;; Record this plugin as registered and find plugins that can now be registered because they depend on it.
     ;;
-    ;; We already hold the plugin registration lock here, so recursively registering newly unblocked plugins is safe.
-    (swap! registered-plugins assoc plugin-name info)
-    (let [plugins-ready-to-register (deps/update-unsatisfied-deps! (keys @registered-plugins))]
+    ;; We already hold `plugin-lock` here, and it is reentrant, so recursively registering newly unblocked plugins is
+    ;; safe.
+    (swap! plugins update plugin-name assoc :info info)
+    (let [plugins-ready-to-register (deps/update-unsatisfied-deps! (registered-plugin-names))]
       (when (seq plugins-ready-to-register)
         (log/debug (u/format-color 'yellow (format "Dependencies satisfied; these plugins will now be registered: %s"
                                                    (mapv (comp :name :info) plugins-ready-to-register)))))
@@ -119,7 +156,7 @@
     :ok))
 
 (defn- registered? [{{plugin-name :name} :info}]
-  (contains? @registered-plugins plugin-name))
+  (some? (registered-info plugin-name)))
 
 (mu/defn register-plugin-with-info!
   "Register a plugin using parsed info from its manifest. Returns truthy if the plugin was successfully registered;
@@ -131,6 +168,10 @@
                     [:version :string]]]]]
   (validate-plugin-api-version! info)
   (or (registered? info)
-      (locking registered-plugins
-        (or (registered? info)
-            (register! info)))))
+      (do
+        (.lock plugin-lock)
+        (try
+          (or (registered? info)
+              (register! info))
+          (finally
+            (.unlock plugin-lock))))))

--- a/src/metabase/plugins/initialize.clj
+++ b/src/metabase/plugins/initialize.clj
@@ -101,7 +101,7 @@
         (when lazy-load
           (lazy-loaded-driver/register-lazy-loaded-driver!
            (assoc info
-                  :driver driver
+                  :driver       driver
                   :load-plugin! #(load-plugin-info! info)))))
       ;; Preserve the existing eager path for driver manifests that explicitly opt out of lazy loading.
       (when (some false? (map :lazy-load drivers))

--- a/src/metabase/plugins/lazy_loaded_driver.clj
+++ b/src/metabase/plugins/lazy_loaded_driver.clj
@@ -10,7 +10,6 @@
    [clojure.java.io :as io]
    [metabase.driver :as driver]
    [metabase.driver.common :as driver.common]
-   [metabase.plugins.init-steps :as init-steps]
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log]
@@ -57,19 +56,17 @@
                       (u/one-or-many parsed)))))
         connection-properties))
 
-(defn- make-initialize! [driver add-to-classpath! init-steps]
+(defn- make-initialize! [driver load-plugin!]
   (fn [_]
-    ;; First things first: add the driver to the classpath!
-    (when add-to-classpath!
-      (add-to-classpath!))
     ;; remove *this* implementation of `initialize!`, because as you will see below, we want to give
     ;; lazy-load drivers the option to implement `initialize!` and do other things, which means we need to
     ;; manually call it. When we do so we don't want to get stuck in an infinite loop of calls back to this
     ;; implementation
     (remove-method driver/initialize! driver)
-    ;; ok, do the init steps listed in the plugin manifest
+    ;; Load the plugin through the shared plugin loader. This adds its JAR to the classpath and runs the
+    ;; initialization steps listed in its manifest exactly once.
     (u/profile (u/format-color 'magenta (trs "Load lazy loading driver {0}" driver))
-      (init-steps/do-init-steps! init-steps))
+      (load-plugin!))
     ;; ok, now go ahead and call `driver/initialize!` a second time on the driver in case it actually has
     ;; an implementation of `initialize!` other than this one. If it does not, we'll just end up hitting
     ;; the default implementation, which is a no-op
@@ -77,13 +74,12 @@
 
 (defn register-lazy-loaded-driver!
   "Register a basic shell of a Metabase driver using the information from its Metabase plugin"
-  [{:keys                                                                                            [add-to-classpath!]
-    init-steps                                                                                       :init
+  [{:keys                                                                                            [load-plugin!]
     extra-info                                                                                       :extra
     contact-info                                                                                     :contact-info
     superseded-by                                                                                    :superseded-by
     {driver-name :name, :keys [abstract display-name parent], :or {abstract false}, :as driver-info} :driver}]
-  {:pre [(map? driver-info)]}
+  {:pre [(map? driver-info) (fn? load-plugin!)]}
   (let [driver           (keyword driver-name)
         connection-props (parse-connection-properties driver-info)]
     ;; Make sure the driver has required properties like driver-name
@@ -97,7 +93,7 @@
       (log/warn (u/format-color :red "Warning: plugin manifest for %s does not include connection properties" driver)))
     ;; ok, now add implementations for the so-called "non-trivial" driver multimethods
     (doseq [[^MultiFn multifn, f]
-            {driver/initialize!           (make-initialize! driver add-to-classpath! init-steps)
+            {driver/initialize!           (make-initialize! driver load-plugin!)
              driver/display-name          (when display-name (constantly display-name))
              driver/contact-info          (constantly contact-info)
              driver/connection-properties (constantly connection-props)

--- a/src/metabase/plugins/lazy_loaded_driver.clj
+++ b/src/metabase/plugins/lazy_loaded_driver.clj
@@ -57,19 +57,18 @@
         connection-properties))
 
 (defn- make-initialize! [driver load-plugin!]
-  (fn [_]
-    ;; remove *this* implementation of `initialize!`, because as you will see below, we want to give
-    ;; lazy-load drivers the option to implement `initialize!` and do other things, which means we need to
-    ;; manually call it. When we do so we don't want to get stuck in an infinite loop of calls back to this
-    ;; implementation
-    (remove-method driver/initialize! driver)
-    ;; Load the plugin through the shared plugin loader. This adds its JAR to the classpath and runs the
-    ;; initialization steps listed in its manifest exactly once.
+  (fn this-method [_]
+    ;; Load first, so a failed load throws before we touch the method table -- the next `initialize!` retries
+    ;; the load rather than falling through to the no-op default. Adds the JAR to the classpath and runs the
+    ;; manifest init steps exactly once.
     (u/profile (u/format-color 'magenta (trs "Load lazy loading driver {0}" driver))
       (load-plugin!))
-    ;; ok, now go ahead and call `driver/initialize!` a second time on the driver in case it actually has
-    ;; an implementation of `initialize!` other than this one. If it does not, we'll just end up hitting
-    ;; the default implementation, which is a no-op
+    ;; Drop this placeholder now that the plugin is loaded -- unless loading installed the driver's own
+    ;; `initialize!`, in which case removing it would strand the driver on the no-op default. Dropping it also
+    ;; stops the call below from looping back into this method.
+    (when (identical? this-method (get-method driver/initialize! driver))
+      (remove-method driver/initialize! driver))
+    ;; Call `initialize!` again: the driver's own implementation if it installed one, else the no-op default.
     (driver/initialize! driver)))
 
 (defn register-lazy-loaded-driver!

--- a/test/metabase/plugins/impl_test.clj
+++ b/test/metabase/plugins/impl_test.clj
@@ -13,16 +13,32 @@
 
 (deftest bundled-manifests-register-before-plugins-directory-manifests-test
   ;; A JAR dropped in the writable plugins directory must not shadow a bundled (uberjar) plugin: bundled
-  ;; manifests -- root-owned code already on the classpath -- are registered first, and registration is
-  ;; first-wins. Bare dependency JARs still go on the classpath before bundled manifests so a bundled
-  ;; manifest's class: dependency is satisfiable when it is registered.
+  ;; manifests -- root-owned code already on the classpath -- are registered first. Bare dependency JARs still
+  ;; go on the classpath before bundled manifests so a bundled manifest's class: dependency is satisfiable
+  ;; when it is registered.
   (let [events   (atom [])
         dep-jar  (fake-path "dep.jar")
         user-jar (fake-path "user-plugin.jar")]
     (mt/with-dynamic-fn-redefs [impl/plugins-paths                  (constantly [user-jar dep-jar])
                                 impl/has-manifest?                  (fn [^Path p] (boolean (re-find #"plugin" (str p))))
-                                impl/register-plugin!               (fn [p] (swap! events conj [:register (str p)]))
+                                impl/bundled-plugin-names           (constantly #{})
+                                impl/register-plugin!               (fn [_reserved ^Path p] (swap! events conj [:register (str p)]))
                                 impl/load-bundled-plugin-manifests! (fn [] (swap! events conj :bundled))]
       (#'impl/load!))
     (is (= [[:register "dep.jar"] :bundled [:register "user-plugin.jar"]] @events)
         "dependency JARs load first, then bundled manifests, then plugins-directory manifests")))
+
+(deftest reserved-bundled-names-block-plugins-directory-manifests-test
+  ;; A bundled plugin whose dependencies are unmet (e.g. Oracle without its JDBC JAR) never registers, so its
+  ;; name is reserved explicitly. A plugins-directory JAR reusing that name is ignored rather than registered
+  ;; and run under the bundled plugin's identity.
+  (let [registered (atom [])
+        user-jar   (fake-path "shadow.jar")]
+    (mt/with-dynamic-fn-redefs [impl/plugin-info                (constantly {:info {:name "Metabase Oracle Driver" :version "1.0.0"}})
+                                impl/register-plugin-with-info! (fn [info] (swap! registered conj (get-in info [:info :name])))]
+      (testing "a manifest whose name is reserved by a bundled plugin is ignored"
+        (#'impl/register-plugin! #{"Metabase Oracle Driver"} user-jar)
+        (is (= [] @registered)))
+      (testing "a non-colliding manifest still registers"
+        (#'impl/register-plugin! #{"Some Other Bundled Plugin"} user-jar)
+        (is (= ["Metabase Oracle Driver"] @registered))))))

--- a/test/metabase/plugins/impl_test.clj
+++ b/test/metabase/plugins/impl_test.clj
@@ -12,21 +12,23 @@
   (Paths/get s (make-array String 0)))
 
 (deftest bundled-manifests-register-before-plugins-directory-manifests-test
-  ;; A JAR dropped in the writable plugins directory must not shadow a bundled (uberjar) plugin: bundled
-  ;; manifests -- root-owned code already on the classpath -- are registered first. Bare dependency JARs still
-  ;; go on the classpath before bundled manifests so a bundled manifest's class: dependency is satisfiable
-  ;; when it is registered.
+  ;; Bare dependency JARs load first (so a bundled manifest's class: dependency is satisfiable), then bundled
+  ;; manifests, then plugins-directory manifests. The reserved bundled names are passed to *both* plugins-
+  ;; directory batches, since a JAR can be a bare dependency when classified but a manifest when registered.
   (let [events   (atom [])
         dep-jar  (fake-path "dep.jar")
         user-jar (fake-path "user-plugin.jar")]
     (mt/with-dynamic-fn-redefs [impl/plugins-paths                  (constantly [user-jar dep-jar])
                                 impl/has-manifest?                  (fn [^Path p] (boolean (re-find #"plugin" (str p))))
-                                impl/bundled-plugin-names           (constantly #{})
-                                impl/register-plugin!               (fn [_reserved ^Path p] (swap! events conj [:register (str p)]))
+                                impl/bundled-plugin-names           (constantly #{"Bundled Plugin"})
+                                impl/register-plugin!               (fn [reserved ^Path p] (swap! events conj [:register reserved (str p)]))
                                 impl/load-bundled-plugin-manifests! (fn [] (swap! events conj :bundled))]
       (#'impl/load!))
-    (is (= [[:register "dep.jar"] :bundled [:register "user-plugin.jar"]] @events)
-        "dependency JARs load first, then bundled manifests, then plugins-directory manifests")))
+    (is (= [[:register #{"Bundled Plugin"} "dep.jar"]
+            :bundled
+            [:register #{"Bundled Plugin"} "user-plugin.jar"]]
+           @events)
+        "order is deps -> bundled -> user manifests, with the bundled names reserved against both batches")))
 
 (deftest reserved-bundled-names-block-plugins-directory-manifests-test
   ;; A bundled plugin whose dependencies are unmet (e.g. Oracle without its JDBC JAR) never registers, so its
@@ -42,3 +44,19 @@
       (testing "a non-colliding manifest still registers"
         (#'impl/register-plugin! #{"Some Other Bundled Plugin"} user-jar)
         (is (= ["Metabase Oracle Driver"] @registered))))))
+
+(deftest misclassified-jar-cannot-claim-a-bundled-name-test
+  ;; Classification (has-manifest?) and registration (plugin-info) read the writable JAR separately. A JAR that
+  ;; looks like a bare dependency when classified but resolves to a bundled-name manifest when registered must
+  ;; still be refused -- so the reserved set is checked in the dependency batch too, not only for user manifests.
+  (let [registered (atom [])
+        sneaky-jar (fake-path "sneaky.jar")]
+    (mt/with-dynamic-fn-redefs [impl/plugins-paths                  (constantly [sneaky-jar])
+                                impl/has-manifest?                  (constantly false)
+                                impl/plugin-info                    (constantly {:info {:name "Metabase Oracle Driver" :version "1.0.0"}})
+                                impl/bundled-plugin-names           (constantly #{"Metabase Oracle Driver"})
+                                impl/register-plugin-with-info!     (fn [info] (swap! registered conj (get-in info [:info :name])))
+                                impl/load-bundled-plugin-manifests! (fn [] nil)]
+      (#'impl/load!))
+    (is (= [] @registered)
+        "a bare-dependency JAR that resolves to a bundled-name manifest at registration is refused")))

--- a/test/metabase/plugins/impl_test.clj
+++ b/test/metabase/plugins/impl_test.clj
@@ -1,0 +1,28 @@
+(ns metabase.plugins.impl-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.plugins.impl :as impl]
+   [metabase.test :as mt])
+  (:import
+   (java.nio.file Path Paths)))
+
+(set! *warn-on-reflection* true)
+
+(defn- fake-path ^Path [s]
+  (Paths/get s (make-array String 0)))
+
+(deftest bundled-manifests-register-before-plugins-directory-manifests-test
+  ;; A JAR dropped in the writable plugins directory must not shadow a bundled (uberjar) plugin: bundled
+  ;; manifests -- root-owned code already on the classpath -- are registered first, and registration is
+  ;; first-wins. Bare dependency JARs still go on the classpath before bundled manifests so a bundled
+  ;; manifest's class: dependency is satisfiable when it is registered.
+  (let [events   (atom [])
+        dep-jar  (fake-path "dep.jar")
+        user-jar (fake-path "user-plugin.jar")]
+    (mt/with-dynamic-fn-redefs [impl/plugins-paths                  (constantly [user-jar dep-jar])
+                                impl/has-manifest?                  (fn [^Path p] (boolean (re-find #"plugin" (str p))))
+                                impl/register-plugin!               (fn [p] (swap! events conj [:register (str p)]))
+                                impl/load-bundled-plugin-manifests! (fn [] (swap! events conj :bundled))]
+      (#'impl/load!))
+    (is (= [[:register "dep.jar"] :bundled [:register "user-plugin.jar"]] @events)
+        "dependency JARs load first, then bundled manifests, then plugins-directory manifests")))

--- a/test/metabase/plugins/initialize_test.clj
+++ b/test/metabase/plugins/initialize_test.clj
@@ -6,7 +6,8 @@
    [metabase.plugins.dependencies :as deps]
    [metabase.plugins.init-steps :as init-steps]
    [metabase.plugins.initialize :as initialize]
-   [metabase.plugins.lazy-loaded-driver :as lazy-loaded-driver]))
+   [metabase.plugins.lazy-loaded-driver :as lazy-loaded-driver]
+   [metabase.test :as mt]))
 
 (set! *warn-on-reflection* true)
 
@@ -29,6 +30,24 @@
           (is (= :ok (plugins/load-plugin! plugin-name)))
           (is (= :ok (plugins/load-plugin! plugin-name)) "loading is idempotent"))
         (is (= [:classpath [:init (:init plugin)]] @calls))))))
+
+(deftest bundled-plugin-never-touches-the-classpath-test
+  ;; A plugin whose manifest is discovered on the classpath (compiled into the uberjar) carries no
+  ;; add-to-classpath! -- its code is already loaded. Activation runs the init steps only, so a bundled
+  ;; plugin never adds bytes from the writable plugins directory. This is what keeps drivers, and any
+  ;; bundled non-driver plugin, on the same root-owned-classpath footing.
+  (let [calls       (atom [])
+        plugin-name (str "test bundled plugin " (random-uuid))
+        plugin      {:metabase-plugin-api-version initialize/plugin-api-version
+                     :info                        {:name plugin-name :version "1.0.0"}
+                     :init                        [{:step "load-namespace" :namespace "example.plugin"}]}]
+    (mt/with-dynamic-fn-redefs [deps/all-dependencies-satisfied? (constantly true)
+                                deps/update-unsatisfied-deps!    (constantly [])
+                                init-steps/do-init-steps!        #(swap! calls conj [:init %])]
+      (is (= :ok (initialize/register-plugin-with-info! plugin)))
+      (is (= :ok (plugins/load-plugin! plugin-name))))
+    (is (= [[:init (:init plugin)]] @calls)
+        "activation runs init steps only; nothing is added to the classpath")))
 
 (deftest non-driver-plugin-must-declare-api-version-test
   (doseq [driver-value [nil []]]

--- a/test/metabase/plugins/initialize_test.clj
+++ b/test/metabase/plugins/initialize_test.clj
@@ -1,0 +1,59 @@
+(ns metabase.plugins.initialize-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.plugins.dependencies :as deps]
+   [metabase.plugins.init-steps :as init-steps]
+   [metabase.plugins.initialize :as initialize]
+   [metabase.plugins.lazy-loaded-driver :as lazy-loaded-driver]))
+
+(set! *warn-on-reflection* true)
+
+(deftest non-driver-plugin-initializes-eagerly-test
+  (let [calls       (atom [])
+        plugin-name (str "test non-driver plugin " (random-uuid))
+        plugin      {:metabase-plugin-api-version initialize/plugin-api-version
+                     :info                       {:name plugin-name :version "1.0.0"}
+                     :init                       [{:step "load-namespace" :namespace "example.plugin"}]
+                     :add-to-classpath!          #(swap! calls conj :classpath)}]
+    (with-redefs [deps/all-dependencies-satisfied?                    (constantly true)
+                  deps/update-unsatisfied-deps!                       (constantly [])
+                  init-steps/do-init-steps!                            #(swap! calls conj [:init %])
+                  lazy-loaded-driver/register-lazy-loaded-driver!     #(swap! calls conj [:driver %])]
+      (#'initialize/init! plugin))
+    (is (= [:classpath [:init (:init plugin)]] @calls))))
+
+(deftest non-driver-plugin-must-declare-api-version-test
+  (doseq [driver-value [nil []]]
+    (testing (str "driver value " (pr-str driver-value))
+      (let [plugin {:driver driver-value
+                    :info   {:name (str "test unversioned plugin " (random-uuid)) :version "1.0.0"}}]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"must declare Metabase plugin API version"
+                              (initialize/init-plugin-with-info! plugin)))))))
+
+(deftest incompatible-plugin-api-version-is-rejected-test
+  (let [calls  (atom [])
+        plugin {:metabase-plugin-api-version (inc initialize/plugin-api-version)
+                :info                       {:name (str "test incompatible plugin " (random-uuid))
+                                             :version "1.0.0"}
+                :init                       [{:step "load-namespace" :namespace "example.plugin"}]
+                :add-to-classpath!          #(swap! calls conj :classpath)}]
+    (with-redefs [init-steps/do-init-steps! #(swap! calls conj [:init %])]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"unsupported Metabase plugin API version"
+                            (initialize/init-plugin-with-info! plugin))))
+    (is (empty? @calls) "an incompatible plugin is rejected before its code reaches the classpath")))
+
+(deftest lazy-driver-plugin-remains-lazy-test
+  (let [calls       (atom [])
+        plugin-name (str "test lazy driver plugin " (random-uuid))
+        plugin      {:info              {:name plugin-name :version "1.0.0"}
+                     :driver            {:name "example" :lazy-load true}
+                     :init              [{:step "load-namespace" :namespace "example.driver"}]
+                     :add-to-classpath! #(swap! calls conj :classpath)}]
+    (with-redefs [deps/all-dependencies-satisfied?                (constantly true)
+                  deps/update-unsatisfied-deps!                   (constantly [])
+                  init-steps/do-init-steps!                        #(swap! calls conj [:init %])
+                  lazy-loaded-driver/register-lazy-loaded-driver! #(swap! calls conj [:driver (:driver %)])]
+      (#'initialize/init! plugin))
+    (is (= [[:driver (:driver plugin)]] @calls))))

--- a/test/metabase/plugins/initialize_test.clj
+++ b/test/metabase/plugins/initialize_test.clj
@@ -1,6 +1,8 @@
 (ns metabase.plugins.initialize-test
   (:require
    [clojure.test :refer :all]
+   [metabase.driver :as driver]
+   [metabase.plugins.core :as plugins]
    [metabase.plugins.dependencies :as deps]
    [metabase.plugins.init-steps :as init-steps]
    [metabase.plugins.initialize :as initialize]
@@ -8,19 +10,25 @@
 
 (set! *warn-on-reflection* true)
 
-(deftest non-driver-plugin-initializes-eagerly-test
-  (let [calls       (atom [])
-        plugin-name (str "test non-driver plugin " (random-uuid))
-        plugin      {:metabase-plugin-api-version initialize/plugin-api-version
-                     :info                       {:name plugin-name :version "1.0.0"}
-                     :init                       [{:step "load-namespace" :namespace "example.plugin"}]
-                     :add-to-classpath!          #(swap! calls conj :classpath)}]
-    (with-redefs [deps/all-dependencies-satisfied?                    (constantly true)
-                  deps/update-unsatisfied-deps!                       (constantly [])
-                  init-steps/do-init-steps!                            #(swap! calls conj [:init %])
-                  lazy-loaded-driver/register-lazy-loaded-driver!     #(swap! calls conj [:driver %])]
-      (#'initialize/init! plugin))
-    (is (= [:classpath [:init (:init plugin)]] @calls))))
+(deftest non-driver-plugins-load-lazily-test
+  (doseq [driver-value [nil []]]
+    (testing (str "driver value " (pr-str driver-value))
+      (let [calls       (atom [])
+            plugin-name (str "test non-driver plugin " (random-uuid))
+            plugin      {:metabase-plugin-api-version initialize/plugin-api-version
+                         :info                       {:name plugin-name :version "1.0.0"}
+                         :driver                     driver-value
+                         :init                       [{:step "load-namespace" :namespace "example.plugin"}]
+                         :add-to-classpath!          #(swap! calls conj :classpath)}]
+        (with-redefs [deps/all-dependencies-satisfied?                (constantly true)
+                      deps/update-unsatisfied-deps!                   (constantly [])
+                      init-steps/do-init-steps!                        #(swap! calls conj [:init %])
+                      lazy-loaded-driver/register-lazy-loaded-driver! #(swap! calls conj [:driver %])]
+          (is (= :ok (initialize/register-plugin-with-info! plugin)))
+          (is (empty? @calls) "registration does not load plugin code")
+          (is (= :ok (plugins/load-plugin! plugin-name)))
+          (is (= :ok (plugins/load-plugin! plugin-name)) "loading is idempotent"))
+        (is (= [:classpath [:init (:init plugin)]] @calls))))))
 
 (deftest non-driver-plugin-must-declare-api-version-test
   (doseq [driver-value [nil []]]
@@ -29,7 +37,7 @@
                     :info   {:name (str "test unversioned plugin " (random-uuid)) :version "1.0.0"}}]
         (is (thrown-with-msg? clojure.lang.ExceptionInfo
                               #"must declare Metabase plugin API version"
-                              (initialize/init-plugin-with-info! plugin)))))))
+                              (initialize/register-plugin-with-info! plugin)))))))
 
 (deftest incompatible-plugin-api-version-is-rejected-test
   (let [calls  (atom [])
@@ -41,19 +49,42 @@
     (with-redefs [init-steps/do-init-steps! #(swap! calls conj [:init %])]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"unsupported Metabase plugin API version"
-                            (initialize/init-plugin-with-info! plugin))))
+                            (initialize/register-plugin-with-info! plugin))))
     (is (empty? @calls) "an incompatible plugin is rejected before its code reaches the classpath")))
 
 (deftest lazy-driver-plugin-remains-lazy-test
   (let [calls       (atom [])
+        driver-name (str "test-lazy-driver-" (random-uuid))
         plugin-name (str "test lazy driver plugin " (random-uuid))
         plugin      {:info              {:name plugin-name :version "1.0.0"}
-                     :driver            {:name "example" :lazy-load true}
+                     :driver            {:name driver-name :abstract true :lazy-load true}
                      :init              [{:step "load-namespace" :namespace "example.driver"}]
                      :add-to-classpath! #(swap! calls conj :classpath)}]
     (with-redefs [deps/all-dependencies-satisfied?                (constantly true)
                   deps/update-unsatisfied-deps!                   (constantly [])
+                  init-steps/do-init-steps!                        #(swap! calls conj [:init %])]
+      (is (= :ok (initialize/register-plugin-with-info! plugin)))
+      (is (empty? @calls) "driver registration does not load plugin code")
+      (driver/initialize! (keyword driver-name))
+      (driver/initialize! (keyword driver-name)))
+    (is (= [:classpath [:init (:init plugin)]] @calls)
+        "the driver placeholder uses the shared idempotent plugin loader")))
+
+(deftest driver-plugin-can-opt-out-of-lazy-loading-test
+  (let [calls  (atom [])
+        plugin {:info              {:name (str "test eager driver plugin " (random-uuid)) :version "1.0.0"}
+                :driver            {:name "example" :lazy-load false}
+                :init              [{:step "load-namespace" :namespace "example.driver"}]
+                :add-to-classpath! #(swap! calls conj :classpath)}]
+    (with-redefs [deps/all-dependencies-satisfied?                (constantly true)
+                  deps/update-unsatisfied-deps!                   (constantly [])
                   init-steps/do-init-steps!                        #(swap! calls conj [:init %])
-                  lazy-loaded-driver/register-lazy-loaded-driver! #(swap! calls conj [:driver (:driver %)])]
-      (#'initialize/init! plugin))
-    (is (= [[:driver (:driver plugin)]] @calls))))
+                  lazy-loaded-driver/register-lazy-loaded-driver! #(swap! calls conj [:driver %])]
+      (is (= :ok (initialize/register-plugin-with-info! plugin))))
+    (is (= [:classpath [:init (:init plugin)]] @calls))))
+
+(deftest load-plugin-requires-registered-plugin-test
+  (let [plugin-name (str "test missing plugin " (random-uuid))]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"is not registered"
+                          (plugins/load-plugin! plugin-name)))))

--- a/test/metabase/plugins/initialize_test.clj
+++ b/test/metabase/plugins/initialize_test.clj
@@ -83,6 +83,30 @@
       (is (= :ok (initialize/register-plugin-with-info! plugin))))
     (is (= [:classpath [:init (:init plugin)]] @calls))))
 
+(deftest lazy-driver-load-failure-is-retryable-test
+  (let [calls       (atom [])
+        attempts    (atom 0)
+        driver-name (str "test-lazy-retry-" (random-uuid))
+        plugin-name (str "test lazy retry plugin " (random-uuid))
+        plugin      {:info              {:name plugin-name :version "1.0.0"}
+                     :driver            {:name driver-name :abstract true :lazy-load true}
+                     :init              [{:step "load-namespace" :namespace "example.driver"}]
+                     :add-to-classpath! #(swap! calls conj :classpath)}]
+    (with-redefs [deps/all-dependencies-satisfied? (constantly true)
+                  deps/update-unsatisfied-deps!    (constantly [])
+                  ;; throw on the first activation, succeed on the retry
+                  init-steps/do-init-steps!        (fn [steps]
+                                                     (swap! calls conj [:init steps])
+                                                     (when (= 1 (swap! attempts inc))
+                                                       (throw (ex-info "transient load failure" {}))))]
+      (is (= :ok (initialize/register-plugin-with-info! plugin)))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"transient load failure"
+                            (driver/initialize! (keyword driver-name))))
+      ;; the failed load did not remove the placeholder, so the driver still loads on a second attempt
+      (driver/initialize! (keyword driver-name)))
+    (is (= [:classpath [:init (:init plugin)] :classpath [:init (:init plugin)]] @calls)
+        "a failed load leaves the driver retryable; the retry re-runs classpath + init")))
+
 (deftest load-plugin-requires-registered-plugin-test
   (let [plugin-name (str "test missing plugin " (random-uuid))]
     (is (thrown-with-msg? clojure.lang.ExceptionInfo

--- a/test/metabase/plugins/initialize_test.clj
+++ b/test/metabase/plugins/initialize_test.clj
@@ -21,10 +21,10 @@
                          :driver                     driver-value
                          :init                       [{:step "load-namespace" :namespace "example.plugin"}]
                          :add-to-classpath!          #(swap! calls conj :classpath)}]
-        (with-redefs [deps/all-dependencies-satisfied?                (constantly true)
-                      deps/update-unsatisfied-deps!                   (constantly [])
-                      init-steps/do-init-steps!                        #(swap! calls conj [:init %])
-                      lazy-loaded-driver/register-lazy-loaded-driver! #(swap! calls conj [:driver %])]
+        (mt/with-dynamic-fn-redefs [deps/all-dependencies-satisfied?                (constantly true)
+                                    deps/update-unsatisfied-deps!                   (constantly [])
+                                    init-steps/do-init-steps!                       #(swap! calls conj [:init %])
+                                    lazy-loaded-driver/register-lazy-loaded-driver! #(swap! calls conj [:driver %])]
           (is (= :ok (initialize/register-plugin-with-info! plugin)))
           (is (empty? @calls) "registration does not load plugin code")
           (is (= :ok (plugins/load-plugin! plugin-name)))
@@ -65,7 +65,7 @@
                                              :version "1.0.0"}
                 :init                       [{:step "load-namespace" :namespace "example.plugin"}]
                 :add-to-classpath!          #(swap! calls conj :classpath)}]
-    (with-redefs [init-steps/do-init-steps! #(swap! calls conj [:init %])]
+    (mt/with-dynamic-fn-redefs [init-steps/do-init-steps! #(swap! calls conj [:init %])]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"unsupported Metabase plugin API version"
                             (initialize/register-plugin-with-info! plugin))))
@@ -79,9 +79,9 @@
                      :driver            {:name driver-name :abstract true :lazy-load true}
                      :init              [{:step "load-namespace" :namespace "example.driver"}]
                      :add-to-classpath! #(swap! calls conj :classpath)}]
-    (with-redefs [deps/all-dependencies-satisfied?                (constantly true)
-                  deps/update-unsatisfied-deps!                   (constantly [])
-                  init-steps/do-init-steps!                        #(swap! calls conj [:init %])]
+    (mt/with-dynamic-fn-redefs [deps/all-dependencies-satisfied? (constantly true)
+                                deps/update-unsatisfied-deps!    (constantly [])
+                                init-steps/do-init-steps!        #(swap! calls conj [:init %])]
       (is (= :ok (initialize/register-plugin-with-info! plugin)))
       (is (empty? @calls) "driver registration does not load plugin code")
       (driver/initialize! (keyword driver-name))
@@ -95,10 +95,10 @@
                 :driver            {:name "example" :lazy-load false}
                 :init              [{:step "load-namespace" :namespace "example.driver"}]
                 :add-to-classpath! #(swap! calls conj :classpath)}]
-    (with-redefs [deps/all-dependencies-satisfied?                (constantly true)
-                  deps/update-unsatisfied-deps!                   (constantly [])
-                  init-steps/do-init-steps!                        #(swap! calls conj [:init %])
-                  lazy-loaded-driver/register-lazy-loaded-driver! #(swap! calls conj [:driver %])]
+    (mt/with-dynamic-fn-redefs [deps/all-dependencies-satisfied?                (constantly true)
+                                deps/update-unsatisfied-deps!                   (constantly [])
+                                init-steps/do-init-steps!                       #(swap! calls conj [:init %])
+                                lazy-loaded-driver/register-lazy-loaded-driver! #(swap! calls conj [:driver %])]
       (is (= :ok (initialize/register-plugin-with-info! plugin))))
     (is (= [:classpath [:init (:init plugin)]] @calls))))
 
@@ -111,13 +111,13 @@
                      :driver            {:name driver-name :abstract true :lazy-load true}
                      :init              [{:step "load-namespace" :namespace "example.driver"}]
                      :add-to-classpath! #(swap! calls conj :classpath)}]
-    (with-redefs [deps/all-dependencies-satisfied? (constantly true)
-                  deps/update-unsatisfied-deps!    (constantly [])
-                  ;; throw on the first activation, succeed on the retry
-                  init-steps/do-init-steps!        (fn [steps]
-                                                     (swap! calls conj [:init steps])
-                                                     (when (= 1 (swap! attempts inc))
-                                                       (throw (ex-info "transient load failure" {}))))]
+    (mt/with-dynamic-fn-redefs [deps/all-dependencies-satisfied? (constantly true)
+                                deps/update-unsatisfied-deps!    (constantly [])
+                                ;; throw on the first activation, succeed on the retry
+                                init-steps/do-init-steps!        (fn [steps]
+                                                                   (swap! calls conj [:init steps])
+                                                                   (when (= 1 (swap! attempts inc))
+                                                                     (throw (ex-info "transient load failure" {}))))]
       (is (= :ok (initialize/register-plugin-with-info! plugin)))
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"transient load failure"
                             (driver/initialize! (keyword driver-name))))

--- a/test/metabase/plugins/initialize_test.clj
+++ b/test/metabase/plugins/initialize_test.clj
@@ -157,12 +157,13 @@
 
 (deftest nested-plugin-load-on-one-thread-is-allowed-test
   (let [calls         (atom [])
-        plugin-a-name (str "test nested plugin A " (random-uuid))
-        plugin-b-name (str "test nested plugin B " (random-uuid))
+        suffix        (random-uuid)
+        plugin-a-name (str "test nested plugin A " suffix)
+        plugin-b-name (str "test nested plugin B " suffix)
         plugin        (fn [plugin-name marker]
                         {:metabase-plugin-api-version initialize/plugin-api-version
-                         :info                       {:name plugin-name :version "1.0.0"}
-                         :init                       [{:step "test" :marker marker}]})]
+                         :info                        {:name plugin-name :version "1.0.0"}
+                         :init                        [{:step "test" :marker marker}]})]
     (mt/with-dynamic-fn-redefs [deps/all-dependencies-satisfied? (constantly true)
                                 deps/update-unsatisfied-deps!    (constantly [])
                                 init-steps/do-init-steps!        (fn [[{:keys [marker]}]]
@@ -176,19 +177,18 @@
         "an init step that loads another plugin is nesting on one thread, not concurrent loading")))
 
 (deftest plugin-load-cycles-are-rejected-test
-  (let [plugin-a-name (str "test cyclic plugin A " (random-uuid))
-        plugin-b-name (str "test cyclic plugin B " (random-uuid))
+  (let [suffix        (random-uuid)
+        plugin-a-name (str "test cyclic plugin A " suffix)
+        plugin-b-name (str "test cyclic plugin B " suffix)
         plugin        (fn [plugin-name marker]
                         {:metabase-plugin-api-version initialize/plugin-api-version
-                         :info                       {:name plugin-name :version "1.0.0"}
-                         :init                       [{:step "test" :marker marker}]})
-        register-both! (fn []
-                         (mt/with-dynamic-fn-redefs [deps/all-dependencies-satisfied? (constantly true)
-                                                     deps/update-unsatisfied-deps!    (constantly [])]
-                           (is (= :ok (initialize/register-plugin-with-info! (plugin plugin-a-name :plugin-a))))
-                           (is (= :ok (initialize/register-plugin-with-info! (plugin plugin-b-name :plugin-b))))))]
+                         :info                        {:name plugin-name :version "1.0.0"}
+                         :init                        [{:step "test" :marker marker}]})]
+    (mt/with-dynamic-fn-redefs [deps/all-dependencies-satisfied? (constantly true)
+                                deps/update-unsatisfied-deps!    (constantly [])]
+      (is (= :ok (initialize/register-plugin-with-info! (plugin plugin-a-name :plugin-a))))
+      (is (= :ok (initialize/register-plugin-with-info! (plugin plugin-b-name :plugin-b)))))
     (testing "a plugin whose init step loads itself"
-      (register-both!)
       (mt/with-dynamic-fn-redefs [init-steps/do-init-steps! (fn [_] (plugins/load-plugin! plugin-a-name))]
         (is (thrown-with-msg? clojure.lang.ExceptionInfo
                               #"while it is already loading"

--- a/test/metabase/plugins/initialize_test.clj
+++ b/test/metabase/plugins/initialize_test.clj
@@ -155,6 +155,26 @@
         (is (= :ok (plugins/load-plugin! plugin-b-name))
             "a plugin can load after the active load releases its claim")))))
 
+(deftest nested-plugin-load-on-one-thread-is-allowed-test
+  (let [calls         (atom [])
+        plugin-a-name (str "test nested plugin A " (random-uuid))
+        plugin-b-name (str "test nested plugin B " (random-uuid))
+        plugin        (fn [plugin-name marker]
+                        {:metabase-plugin-api-version initialize/plugin-api-version
+                         :info                       {:name plugin-name :version "1.0.0"}
+                         :init                       [{:step "test" :marker marker}]})]
+    (mt/with-dynamic-fn-redefs [deps/all-dependencies-satisfied? (constantly true)
+                                deps/update-unsatisfied-deps!    (constantly [])
+                                init-steps/do-init-steps!        (fn [[{:keys [marker]}]]
+                                                                   (swap! calls conj marker)
+                                                                   (when (= marker :plugin-a)
+                                                                     (plugins/load-plugin! plugin-b-name)))]
+      (is (= :ok (initialize/register-plugin-with-info! (plugin plugin-a-name :plugin-a))))
+      (is (= :ok (initialize/register-plugin-with-info! (plugin plugin-b-name :plugin-b))))
+      (is (= :ok (plugins/load-plugin! plugin-a-name))))
+    (is (= [:plugin-a :plugin-b] @calls)
+        "an init step that loads another plugin is nesting on one thread, not concurrent loading")))
+
 (deftest load-plugin-requires-registered-plugin-test
   (let [plugin-name (str "test missing plugin " (random-uuid))]
     (is (thrown-with-msg? clojure.lang.ExceptionInfo

--- a/test/metabase/plugins/initialize_test.clj
+++ b/test/metabase/plugins/initialize_test.clj
@@ -126,6 +126,35 @@
     (is (= [:classpath [:init (:init plugin)] :classpath [:init (:init plugin)]] @calls)
         "a failed load leaves the driver retryable; the retry re-runs classpath + init")))
 
+(deftest concurrent-plugin-loading-fails-fast-test
+  (let [plugin-a-name  (str "test concurrent plugin A " (random-uuid))
+        plugin-b-name  (str "test concurrent plugin B " (random-uuid))
+        plugin-a-start (promise)
+        finish-plugin-a (promise)
+        plugin         (fn [plugin-name marker]
+                         {:metabase-plugin-api-version initialize/plugin-api-version
+                          :info                       {:name plugin-name :version "1.0.0"}
+                          :init                       [{:step "test" :marker marker}]})]
+    (mt/with-dynamic-fn-redefs [deps/all-dependencies-satisfied? (constantly true)
+                                deps/update-unsatisfied-deps!    (constantly [])
+                                init-steps/do-init-steps!        (fn [[{:keys [marker]}]]
+                                                                   (when (= marker :plugin-a)
+                                                                     (deliver plugin-a-start true)
+                                                                     @finish-plugin-a))]
+      (is (= :ok (initialize/register-plugin-with-info! (plugin plugin-a-name :plugin-a))))
+      (is (= :ok (initialize/register-plugin-with-info! (plugin plugin-b-name :plugin-b))))
+      (let [load-plugin-a (future (plugins/load-plugin! plugin-a-name))]
+        (try
+          (is (true? (deref plugin-a-start 2000 false)))
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                #"concurrent plugin loading is not supported"
+                                (plugins/load-plugin! plugin-b-name)))
+          (finally
+            (deliver finish-plugin-a true)))
+        (is (= :ok (deref load-plugin-a 2000 ::timeout)))
+        (is (= :ok (plugins/load-plugin! plugin-b-name))
+            "a plugin can load after the active load releases its claim")))))
+
 (deftest load-plugin-requires-registered-plugin-test
   (let [plugin-name (str "test missing plugin " (random-uuid))]
     (is (thrown-with-msg? clojure.lang.ExceptionInfo

--- a/test/metabase/plugins/initialize_test.clj
+++ b/test/metabase/plugins/initialize_test.clj
@@ -61,7 +61,7 @@
 (deftest incompatible-plugin-api-version-is-rejected-test
   (let [calls  (atom [])
         plugin {:metabase-plugin-api-version (inc initialize/plugin-api-version)
-                :info                       {:name (str "test incompatible plugin " (random-uuid))
+                :info                       {:name    (str "test incompatible plugin " (random-uuid))
                                              :version "1.0.0"}
                 :init                       [{:step "load-namespace" :namespace "example.plugin"}]
                 :add-to-classpath!          #(swap! calls conj :classpath)}]

--- a/test/metabase/plugins/initialize_test.clj
+++ b/test/metabase/plugins/initialize_test.clj
@@ -175,6 +175,36 @@
     (is (= [:plugin-a :plugin-b] @calls)
         "an init step that loads another plugin is nesting on one thread, not concurrent loading")))
 
+(deftest plugin-load-cycles-are-rejected-test
+  (let [plugin-a-name (str "test cyclic plugin A " (random-uuid))
+        plugin-b-name (str "test cyclic plugin B " (random-uuid))
+        plugin        (fn [plugin-name marker]
+                        {:metabase-plugin-api-version initialize/plugin-api-version
+                         :info                       {:name plugin-name :version "1.0.0"}
+                         :init                       [{:step "test" :marker marker}]})
+        register-both! (fn []
+                         (mt/with-dynamic-fn-redefs [deps/all-dependencies-satisfied? (constantly true)
+                                                     deps/update-unsatisfied-deps!    (constantly [])]
+                           (is (= :ok (initialize/register-plugin-with-info! (plugin plugin-a-name :plugin-a))))
+                           (is (= :ok (initialize/register-plugin-with-info! (plugin plugin-b-name :plugin-b))))))]
+    (testing "a plugin whose init step loads itself"
+      (register-both!)
+      (mt/with-dynamic-fn-redefs [init-steps/do-init-steps! (fn [_] (plugins/load-plugin! plugin-a-name))]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"while it is already loading"
+                              (plugins/load-plugin! plugin-a-name)))))
+    (testing "a cycle through a second plugin"
+      (mt/with-dynamic-fn-redefs [init-steps/do-init-steps! (fn [[{:keys [marker]}]]
+                                                              (plugins/load-plugin! (if (= marker :plugin-b)
+                                                                                      plugin-a-name
+                                                                                      plugin-b-name)))]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"while it is already loading"
+                              (plugins/load-plugin! plugin-a-name)))))
+    (testing "the rejected cycle releases the lock"
+      (mt/with-dynamic-fn-redefs [init-steps/do-init-steps! (constantly nil)]
+        (is (= :ok (plugins/load-plugin! plugin-a-name)))))))
+
 (deftest load-plugin-requires-registered-plugin-test
   (let [plugin-name (str "test missing plugin " (random-uuid))]
     (is (thrown-with-msg? clojure.lang.ExceptionInfo

--- a/test/metabase/test/initialize/plugins.clj
+++ b/test/metabase/test/initialize/plugins.clj
@@ -55,7 +55,7 @@
    (doseq [driver drivers
            :let   [info (driver-plugin-manifest driver)]
            :when  info]
-     (plugins.init/init-plugin-with-info! info)
+     (plugins.init/register-plugin-with-info! info)
      ;; ok, now we need to make sure we load any depenencies for those drivers as well (!)
      (load-plugin-manifests! (driver-parents driver)))))
 


### PR DESCRIPTION
## Motivation

Our drivers already run as plugins, which keeps the base install small and gives third parties an extension point. This pulls that machinery out of the driver system so other kinds of module can use it too.

Two use cases motivate it, neither built here:

- Today, retrieval features require an external vLLM service. 
  A plugin makes an in-process embedder viable, with its heavy dependencies — the ONNX runtime and model files — shipped only to customers who want it, not those who skip the AI features or already run vLLM.
- LLM providers differ in config and API surface (Anthropic, OpenRouter, ...). 
  A plugin boundary lets us add them without threading each one through the core.

## Scope

Framework only. No new plugin types yet.

## Changes

- Generalize the driver plugin system to non-driver plugins.
- Split manifest registration from activation, so plugin JARs stay off the classpath until first use.
- Add an idempotent `load-plugin!` entry point, so a plugin type can activate a plugin by name.
- Route lazy drivers through the same loader, keeping existing manifests and explicit eager loading.
- Add manifest API version 1 for non-driver plugins; reject unsupported versions before any plugin code loads.
- Extract uberjar dependency pruning from the driver builder for reuse.

## Tests

- Lazy non-driver registration and idempotent activation.
- Existing lazy-driver behavior and eager-driver compatibility.
- API version validation and unknown-plugin handling.
- Dependency pruning.
