### PR TITLE
Add a versioned embedding provider SPI

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -972,6 +972,11 @@
            util}
    :model-imports #{:model/Card :model/Dashboard :model/DashboardCard :model/EmbeddingTheme}}
 
+  embeddings
+  {:team "Metabot"
+   :api  #{}
+   :uses #{util}}
+
   entity-retrieval
   {:team "Metabot"
    :api  #{metabase.entity-retrieval.core

--- a/src/metabase/embeddings/provider.clj
+++ b/src/metabase/embeddings/provider.clj
@@ -247,5 +247,5 @@
   "Allow a provider to eagerly prepare the resolved model, for example by warming a lazy native runtime."
   [requested-model]
   (let [implementation (implementation! (:provider requested-model))]
-    (when-let [prepare! (:prepare! implementation)]
-      (prepare! (resolve-model-with implementation requested-model)))))
+    (when-let [prepare-fn (:prepare! implementation)]
+      (prepare-fn (resolve-model-with implementation requested-model)))))

--- a/src/metabase/embeddings/provider.clj
+++ b/src/metabase/embeddings/provider.clj
@@ -1,0 +1,251 @@
+(ns metabase.embeddings.provider
+  "Runtime registry and stable contract for embedding-provider plugins.
+
+  Plugin loading is capability-neutral and lives in `metabase.plugins`. This namespace owns only the embedding
+  contract: resolving a requested model to an immutable embedding space, reporting readiness, and producing vectors."
+  (:require
+   [clojure.string :as str]
+   [metabase.util.malli :as mu])
+  (:import
+   (java.nio.charset StandardCharsets)
+   (java.security MessageDigest)
+   (java.util HexFormat)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:const embedding-spi-version
+  "Current version of the embedding-provider registration contract. Provider plugins must embed this value at
+  build time rather than reading the host Var during initialization."
+  1)
+
+(def ^:private implementation-schema
+  [:map
+   [:embedding-spi-version [:= embedding-spi-version]]
+   [:resolve-model fn?]
+   [:readiness fn?]
+   [:embed-texts fn?]
+   [:prepare! {:optional true} fn?]])
+
+(def ^:private resolved-model-schema
+  [:map {:closed true}
+   [:provider [:and :string [:fn (complement str/blank?)]]]
+   [:model-name [:and :string [:fn (complement str/blank?)]]]
+   [:vector-dimensions [:fn pos-int?]]
+   [:model-revision {:optional true} [:and :string [:fn (complement str/blank?)]]]
+   [:embedding-space-id [:and :string [:fn (complement str/blank?)]]]
+   [:embedding-spi-version [:= embedding-spi-version]]])
+
+(def ^:private readiness-schema
+  [:map {:closed true}
+   [:ready? :boolean]
+   [:reason {:optional true} :keyword]
+   [:message {:optional true} :string]])
+
+;; Re-registration is intentional: plugin namespaces can be reloaded during development without leaving a stale
+;; implementation in the registry.
+(defonce ^:private providers (atom {}))
+
+(defn register-provider!
+  "Register `implementation` under `provider-name`.
+
+  Implementations must declare the literal SPI version they were built against and provide three functions:
+
+  * `:resolve-model` turns a requested model map into a resolved descriptor with an immutable
+    `:embedding-space-id`.
+  * `:readiness` returns at least `{:ready? boolean}` and may include a keyword `:reason` and safe `:message`.
+  * `:embed-texts` accepts the resolved descriptor, a vector of texts, and an options map.
+
+  `:prepare!` is optional and accepts a resolved descriptor. Registration data must never contain credentials."
+  [provider-name implementation]
+  (when-not (and (string? provider-name) (not (str/blank? provider-name)))
+    (throw (ex-info "Embedding provider name must be a non-blank string."
+                    {:provider provider-name})))
+  (when-not (= embedding-spi-version (:embedding-spi-version implementation))
+    (throw (ex-info (format "Embedding provider %s uses unsupported SPI version %s; this server supports %s."
+                            (pr-str provider-name)
+                            (pr-str (:embedding-spi-version implementation))
+                            embedding-spi-version)
+                    {:provider              provider-name
+                     :declared-spi-version  (:embedding-spi-version implementation)
+                     :supported-spi-version embedding-spi-version})))
+  (mu/validate-throw implementation-schema implementation)
+  (swap! providers assoc provider-name implementation)
+  provider-name)
+
+(defn registered?
+  "Whether `provider-name` has registered an embedding implementation."
+  [provider-name]
+  (contains? @providers provider-name))
+
+(defn registered-providers
+  "Names of all registered embedding providers."
+  []
+  (set (keys @providers)))
+
+(defn- provider-request
+  [{:keys [provider] :as requested-model}]
+  (when-let [requested-version (:embedding-spi-version requested-model)]
+    (when-not (= embedding-spi-version requested-version)
+      (throw (ex-info (format "Embedding model descriptor uses unsupported SPI version %s; this server supports %s."
+                              (pr-str requested-version) embedding-spi-version)
+                      {:provider              provider
+                       :declared-spi-version  requested-version
+                       :supported-spi-version embedding-spi-version}))))
+  ;; Space identity and SPI version are host-owned metadata on resolved descriptors, not provider request fields.
+  (dissoc requested-model :embedding-space-id :embedding-spi-version))
+
+(defn readiness
+  "Return structured readiness for `requested-model` without performing model resolution.
+
+  An absent plugin is represented as data rather than optimistic success, allowing callers to hide or disable
+  features until the provider is actually installed."
+  [{:keys [provider] :as requested-model}]
+  (if-let [implementation (get @providers provider)]
+    (let [result        ((:readiness implementation) (provider-request requested-model))
+          public-result (select-keys result [:ready? :reason :message])]
+      (assoc (mu/validate-throw readiness-schema public-result) :provider provider))
+    {:provider provider
+     :ready?   false
+     :reason   :provider-not-registered}))
+
+(defn ready?
+  "Whether the provider for `requested-model` is installed and ready to embed."
+  [requested-model]
+  (true? (:ready? (readiness requested-model))))
+
+(defn- implementation!
+  [provider]
+  (or (get @providers provider)
+      (throw (ex-info (format "Embedding provider %s is not registered." (pr-str provider))
+                      {:provider provider
+                       :reason   :provider-not-registered}))))
+
+(defn- resolve-model-with
+  [implementation {:keys [provider] :as requested-model}]
+  (let [resolved ((:resolve-model implementation) (provider-request requested-model))]
+    (when-not (= provider (:provider resolved))
+      (throw (ex-info "An embedding provider resolved a model for a different provider."
+                      {:provider          provider
+                       :resolved-provider (:provider resolved)})))
+    (let [resolved (-> resolved
+                       (select-keys [:provider :model-name :vector-dimensions :model-revision :embedding-space-id])
+                       (assoc :embedding-spi-version embedding-spi-version))]
+      (mu/validate-throw resolved-model-schema resolved)
+      (when (and (:embedding-space-id requested-model)
+                 (not= (:embedding-space-id requested-model) (:embedding-space-id resolved)))
+        (throw (ex-info "The requested embedding space no longer matches the provider's resolved model."
+                        {:type                        ::embedding-space-changed
+                         :provider                    provider
+                         :model-name                  (:model-name resolved)
+                         :requested-embedding-space-id (:embedding-space-id requested-model)
+                         :resolved-embedding-space-id  (:embedding-space-id resolved)})))
+      resolved)))
+
+(defn resolve-model
+  "Resolve a requested model to the public descriptor that identifies its exact embedding space.
+
+  The returned map is deliberately closed and contains no source locations, access tokens, or other provider-private
+  configuration. Consumers should persist `:embedding-space-id` anywhere vector compatibility matters."
+  [{:keys [provider] :as requested-model}]
+  (resolve-model-with (implementation! provider) requested-model))
+
+(defn- sha256
+  [^String value]
+  (let [^MessageDigest digest (MessageDigest/getInstance "SHA-256")
+        ^bytes bytes          (.digest digest (.getBytes value StandardCharsets/UTF_8))]
+    (.formatHex (HexFormat/of) bytes)))
+
+(defn- stable-pr-str
+  [value]
+  ;; Embedding identity must not depend on request-thread printer bindings.
+  (binding [*print-dup* false
+            *print-length* nil
+            *print-level*  nil
+            *print-readably* true]
+    (pr-str value)))
+
+(defn legacy-resolved-model
+  "Resolve a provider/model/dimensions tuple whose remote implementation has no stronger revision identity.
+
+  The ID deliberately covers only the vector-space contract and excludes endpoints, credentials, and other transport
+  configuration. Providers that can identify an exact model/tokenizer/export revision should supply their own ID."
+  [{:keys [provider model-name vector-dimensions model-revision] :as requested-model}]
+  (let [public-model (select-keys requested-model [:provider :model-name :vector-dimensions :model-revision])]
+    (assoc public-model
+           :embedding-space-id
+           (str "emb:v1:sha256:"
+                (sha256 (stable-pr-str [provider model-name vector-dimensions
+                                        (or model-revision :unspecified)]))))))
+
+(defn- ordered-values?
+  [value]
+  (or (sequential? value)
+      (instance? java.util.List value)
+      (and (some? value) (.isArray ^Class (class value)))))
+
+(defn embed-texts
+  "Embed `texts` with the provider selected by `requested-model`.
+
+  Model resolution happens before every call so the implementation always receives the canonical public descriptor.
+  The result must contain one vector per input, in the same order, and every vector must match the resolved dimensions."
+  ([requested-model texts]
+   (embed-texts requested-model texts {}))
+  ([{:keys [provider] :as requested-model} texts opts]
+   (let [implementation (implementation! provider)
+         resolved       (resolve-model-with implementation requested-model)
+         texts          (vec texts)
+         raw-embeddings ((:embed-texts implementation) resolved texts opts)]
+     (when-not (ordered-values? raw-embeddings)
+       (throw (ex-info "Embedding provider must return an ordered sequence or array of vectors."
+                       {:provider    provider
+                        :actual-type (some-> raw-embeddings class .getName)})))
+     (let [embeddings (vec raw-embeddings)]
+       (when-not (= (count texts) (count embeddings))
+         (throw (ex-info "Embedding provider returned a different number of vectors than input texts."
+                         {:provider       provider
+                          :expected-count (count texts)
+                          :actual-count   (count embeddings)})))
+       (doseq [[index embedding] (map-indexed vector embeddings)]
+         (when-not (ordered-values? embedding)
+           (throw (ex-info "Embedding vectors must be ordered sequences or arrays."
+                           {:provider           provider
+                            :model-name         (:model-name resolved)
+                            :embedding-space-id (:embedding-space-id resolved)
+                            :vector-index       index
+                            :actual-type        (some-> embedding class .getName)})))
+         (when-not (= (:vector-dimensions resolved) (count embedding))
+           (throw (ex-info "Embedding vector dimensions do not match the resolved model."
+                           {:provider              provider
+                            :model-name            (:model-name resolved)
+                            :embedding-space-id    (:embedding-space-id resolved)
+                            :vector-index          index
+                            :expected-dimensions   (:vector-dimensions resolved)
+                            :actual-dimensions     (count embedding)})))
+         (when-let [[component-index invalid-value]
+                    (first (keep-indexed (fn [component-index value]
+                                           (when-not (and (number? value)
+                                                          (Double/isFinite (double value)))
+                                             [component-index value]))
+                                         embedding))]
+           (throw (ex-info "Embedding vectors must contain only finite numeric components."
+                           {:provider           provider
+                            :model-name         (:model-name resolved)
+                            :embedding-space-id (:embedding-space-id resolved)
+                            :vector-index       index
+                            :component-index    component-index
+                            :invalid-value      invalid-value}))))
+       embeddings))))
+
+(defn embed-text
+  "Embed one text and return its vector."
+  ([requested-model text]
+   (embed-text requested-model text {}))
+  ([requested-model text opts]
+   (first (embed-texts requested-model [text] opts))))
+
+(defn prepare!
+  "Allow a provider to eagerly prepare the resolved model, for example by warming a lazy native runtime."
+  [requested-model]
+  (let [implementation (implementation! (:provider requested-model))]
+    (when-let [prepare! (:prepare! implementation)]
+      (prepare! (resolve-model-with implementation requested-model)))))

--- a/test/metabase/embeddings/provider_test.clj
+++ b/test/metabase/embeddings/provider_test.clj
@@ -1,0 +1,289 @@
+(ns metabase.embeddings.provider-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.embeddings.provider :as embedding.provider]))
+
+(set! *warn-on-reflection* true)
+
+(defn- provider-name
+  []
+  (str "test-provider-" (random-uuid)))
+
+(defn- implementation
+  [calls & {:keys [readiness resolve-model embed-texts prepare!]
+            :or   {readiness    (constantly {:ready? true})
+                   resolve-model embedding.provider/legacy-resolved-model
+                   embed-texts  (fn [model texts opts]
+                                  (swap! calls conj [:embed model texts opts])
+                                  (mapv (fn [_] (float-array (:vector-dimensions model))) texts))}}]
+  (cond-> {:embedding-spi-version embedding.provider/embedding-spi-version
+           :readiness             readiness
+           :resolve-model         resolve-model
+           :embed-texts           embed-texts}
+    prepare! (assoc :prepare! prepare!)))
+
+(deftest registration-version-gate-test
+  (let [name (provider-name)]
+    (is (:const (meta #'embedding.provider/embedding-spi-version))
+        "AOT plugins must inline the SPI version they were compiled against")
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"unsupported SPI version"
+                          (embedding.provider/register-provider!
+                           name
+                           {:embedding-spi-version (inc embedding.provider/embedding-spi-version)})))
+    (is (false? (embedding.provider/registered? name)))))
+
+(deftest missing-provider-readiness-test
+  (let [model {:provider (provider-name)}]
+    (is (= {:provider (:provider model)
+            :ready?   false
+            :reason   :provider-not-registered}
+           (embedding.provider/readiness model)))
+    (is (false? (embedding.provider/ready? model)))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"is not registered"
+                          (embedding.provider/resolve-model model)))))
+
+(deftest resolve-and-embed-test
+  (let [calls (atom [])
+        name  (provider-name)
+        model {:provider          name
+               :model-name        "example/model"
+               :vector-dimensions 3}]
+    (embedding.provider/register-provider! name (implementation calls))
+    (is (embedding.provider/registered? name))
+    (is (contains? (embedding.provider/registered-providers) name))
+    (is (= {:provider              name
+            :model-name            "example/model"
+            :vector-dimensions     3
+            :embedding-space-id    (:embedding-space-id (embedding.provider/legacy-resolved-model model))
+            :embedding-spi-version embedding.provider/embedding-spi-version}
+           (embedding.provider/resolve-model model)))
+    (let [embeddings (embedding.provider/embed-texts model ["one" "two"] {:purpose :document})]
+      (is (= [3 3] (mapv alength embeddings)))
+      (is (= [:embed
+              (embedding.provider/resolve-model model)
+              ["one" "two"]
+              {:purpose :document}]
+             (first @calls))))))
+
+(deftest resolved-model-is-public-and-stable-test
+  (let [name      (provider-name)
+        calls     (atom [])
+        requested {:provider          name
+                   :model-name        "example/model"
+                   :vector-dimensions 4
+                   :api-key           "do-not-leak"}]
+    (embedding.provider/register-provider! name (implementation calls))
+    (let [resolved (embedding.provider/resolve-model requested)]
+      (is (= #{:provider :model-name :vector-dimensions :embedding-space-id :embedding-spi-version}
+             (set (keys resolved))))
+      (is (not (re-find #"do-not-leak" (pr-str resolved))))
+      (is (= (:embedding-space-id resolved)
+             (:embedding-space-id (embedding.provider/resolve-model (dissoc requested :api-key)))))
+      (is (not= (:embedding-space-id resolved)
+                (:embedding-space-id
+                 (embedding.provider/resolve-model (assoc requested :model-name "example/other")))))
+      (is (not= (:embedding-space-id resolved)
+                (:embedding-space-id
+                 (embedding.provider/resolve-model (assoc requested :model-revision "revision-2"))))))
+    (testing "a persisted identity is checked against the provider's current resolution"
+      (let [resolved (embedding.provider/resolve-model requested)]
+        (is (= resolved (embedding.provider/resolve-model resolved)))
+        (try
+          (embedding.provider/resolve-model (assoc resolved :embedding-space-id "stale-space"))
+          (is false "expected a changed embedding space to be rejected")
+          (catch clojure.lang.ExceptionInfo e
+            (is (= :metabase.embeddings.provider/embedding-space-changed (:type (ex-data e))))))))
+    (testing "revisioned legacy descriptors round-trip without changing identity"
+      (let [revisioned (embedding.provider/resolve-model (assoc requested :model-revision "revision-1"))]
+        (is (= "revision-1" (:model-revision revisioned)))
+        (is (= revisioned (embedding.provider/resolve-model revisioned)))))
+    (testing "legacy identity is independent of ambient printer bindings"
+      (let [other-request (assoc requested :model-name "example/other")
+            normal        (mapv (comp :embedding-space-id embedding.provider/resolve-model)
+                                [requested other-request])
+            bounded       (binding [*print-length* 1
+                                    *print-level*  1
+                                    *print-readably* false
+                                    *print-dup* true]
+                            (mapv (comp :embedding-space-id embedding.provider/resolve-model)
+                                  [requested other-request]))]
+        (is (= normal bounded))
+        (is (apply not= bounded))))
+    (testing "legacy identity is pinned for JDBC integer dimensions"
+      (let [model    {:provider "example" :model-name "example/model" :vector-dimensions (Integer/valueOf 4)}
+            expected "emb:v1:sha256:7f945085ff74c92a2daf851c4242084d0e955d7e0466e9b5a33e75aa188f68ee"]
+        (is (= expected (:embedding-space-id (embedding.provider/legacy-resolved-model model))))
+        (is (= expected
+               (binding [*print-dup* true]
+                 (:embedding-space-id (embedding.provider/legacy-resolved-model model)))))))))
+
+(deftest resolved-descriptor-round-trip-strips-host-metadata-test
+  (let [name   (provider-name)
+        model  {:provider name :model-name "model" :vector-dimensions 2}
+        inputs (atom [])]
+    (embedding.provider/register-provider!
+     name
+     (implementation
+      (atom [])
+      :resolve-model (fn [requested]
+                       (swap! inputs conj requested)
+                       (when (some #(contains? requested %) [:embedding-space-id :embedding-spi-version])
+                         (throw (ex-info "closed provider request schema" {:request requested})))
+                       (embedding.provider/legacy-resolved-model requested))))
+    (let [resolved (embedding.provider/resolve-model model)]
+      (is (= resolved (embedding.provider/resolve-model resolved)))
+      (is (= [model model] @inputs))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"unsupported SPI version"
+                            (embedding.provider/resolve-model
+                             (assoc resolved :embedding-spi-version
+                                    (inc embedding.provider/embedding-spi-version))))))))
+
+(deftest readiness-and-prepare-test
+  (let [name     (provider-name)
+        prepared (atom nil)
+        model    {:provider name :model-name "model" :vector-dimensions 2}]
+    (embedding.provider/register-provider!
+     name
+     (implementation (atom [])
+                     :readiness (constantly {:ready? false :reason :runtime-unavailable :message "not ready"})
+                     :prepare!  #(reset! prepared %)))
+    (is (= {:provider name :ready? false :reason :runtime-unavailable :message "not ready"}
+           (embedding.provider/readiness model)))
+    (is (false? (embedding.provider/ready? model)))
+    (embedding.provider/prepare! model)
+    (is (= (embedding.provider/resolve-model model) @prepared))))
+
+(deftest readiness-validates-and-strips-host-metadata-test
+  (let [name   (provider-name)
+        model  {:provider name :model-name "model" :vector-dimensions 2}
+        inputs (atom [])]
+    (embedding.provider/register-provider!
+     name
+     (implementation
+      (atom [])
+      :readiness (fn [requested]
+                   (swap! inputs conj requested)
+                   (when (some #(contains? requested %) [:embedding-space-id :embedding-spi-version])
+                     (throw (ex-info "closed provider request schema" {:request requested})))
+                   {:ready?          true
+                    :provider        "provider-controlled"
+                    :private-details {:api-key "do-not-leak"}})))
+    (let [resolved  (embedding.provider/resolve-model model)
+          readiness (embedding.provider/readiness resolved)]
+      (is (= {:provider name :ready? true}
+             readiness)
+          "readiness exposes only the public result shape and the host-owned provider")
+      (is (not (re-find #"do-not-leak" (pr-str readiness))))
+      (is (= [model] @inputs))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"unsupported SPI version"
+                            (embedding.provider/readiness
+                             (assoc resolved :embedding-spi-version
+                                    (inc embedding.provider/embedding-spi-version)))))
+      (is (= [model] @inputs)
+          "the host rejects an unsupported descriptor before invoking the provider"))))
+
+(deftest provider-operation-uses-one-registry-snapshot-test
+  (let [name              (provider-name)
+        model             {:provider name :model-name "model" :vector-dimensions 2}
+        implementation!   (var-get #'embedding.provider/implementation!)
+        registry-lookups  (atom 0)]
+    (embedding.provider/register-provider!
+     name
+     (implementation (atom []) :prepare! (constantly nil)))
+    (with-redefs-fn {#'embedding.provider/implementation!
+                     (fn [provider]
+                       (swap! registry-lookups inc)
+                       (implementation! provider))}
+      (fn []
+        (embedding.provider/embed-text model "one")
+        (is (= 1 @registry-lookups) "resolve and embed use one captured provider implementation")
+        (reset! registry-lookups 0)
+        (embedding.provider/prepare! model)
+        (is (= 1 @registry-lookups) "resolve and prepare use one captured provider implementation")))))
+
+(deftest invalid-provider-output-test
+  (testing "resolved model must describe the provider that registered it"
+    (let [name (provider-name)]
+      (embedding.provider/register-provider!
+       name
+       (implementation (atom []) :resolve-model #(assoc % :provider "somebody-else"
+                                                        :embedding-space-id "space")))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"different provider"
+                            (embedding.provider/resolve-model
+                             {:provider name :model-name "model" :vector-dimensions 2})))))
+  (testing "one vector is required per input"
+    (let [name  (provider-name)
+          model {:provider name :model-name "model" :vector-dimensions 2}]
+      (embedding.provider/register-provider!
+       name
+       (implementation (atom []) :embed-texts (fn [_ _ _] [(float-array 2)])))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"different number of vectors"
+                            (embedding.provider/embed-texts model ["one" "two"])))))
+  (testing "every vector must match the resolved dimensions"
+    (let [name  (provider-name)
+          model {:provider name :model-name "model" :vector-dimensions 2}]
+      (embedding.provider/register-provider!
+       name
+       (implementation (atom []) :embed-texts (fn [_ _ _] [(float-array 3)])))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"dimensions do not match"
+                            (embedding.provider/embed-text model "one")))))
+  (testing "every vector component must be finite and numeric"
+    (doseq [bad ["not-a-number" Double/NaN Double/POSITIVE_INFINITY Double/NEGATIVE_INFINITY]]
+      (let [name  (provider-name)
+            model {:provider name :model-name "model" :vector-dimensions 2}]
+        (embedding.provider/register-provider!
+         name
+         (implementation (atom []) :embed-texts (fn [_ _ _] [[0.0 bad]])))
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"finite numeric components"
+                              (embedding.provider/embed-text model "one"))
+            (pr-str bad))))))
+
+(deftest ordered-provider-output-test
+  (doseq [[description result]
+          [["vectors" [[0.0 1.0] [2.0 3.0]]]
+           ["lists" (list (list 0.0 1.0) (list 2.0 3.0))]
+           ["lazy sequences" (map #(map identity %) [[0.0 1.0] [2.0 3.0]])]
+           ["Java lists" (java.util.ArrayList. [[0.0 1.0] [2.0 3.0]])]
+           ["JVM arrays" (object-array [(float-array [0.0 1.0])
+                                        (object-array [2.0 3.0])])]]]
+    (testing description
+      (let [name  (provider-name)
+            model {:provider name :model-name "model" :vector-dimensions 2}]
+        (embedding.provider/register-provider!
+         name
+         (implementation (atom []) :embed-texts (fn [_ _ _] result)))
+        (is (= [[0.0 1.0] [2.0 3.0]]
+               (mapv vec (embedding.provider/embed-texts model ["one" "two"]))))))))
+
+(deftest unordered-provider-output-test
+  (doseq [bad-result [#{[0.0 1.0] [2.0 3.0]}
+                      {0.0 1.0, 2.0 3.0}
+                      nil]]
+    (let [name  (provider-name)
+          model {:provider name :model-name "model" :vector-dimensions 2}]
+      (embedding.provider/register-provider!
+       name
+       (implementation (atom []) :embed-texts (fn [_ _ _] bad-result)))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"ordered sequence or array of vectors"
+                            (embedding.provider/embed-texts model ["one" "two"]))
+          (pr-str bad-result))))
+  (doseq [bad-vector [#{0.0 1.0}
+                      {0.0 1.0, 2.0 3.0}]]
+    (let [name  (provider-name)
+          model {:provider name :model-name "model" :vector-dimensions 2}]
+      (embedding.provider/register-provider!
+       name
+       (implementation (atom []) :embed-texts (fn [_ _ _] [bad-vector])))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"vectors must be ordered sequences or arrays"
+                            (embedding.provider/embed-text model "one"))
+          (pr-str bad-vector)))))


### PR DESCRIPTION
Motivation

Embedding is hard-wired into semantic search today. This adds a neutral provider contract so any implementation — ai-service, OpenAI, Ollama, or a bundled in-process model — plugs in without semantic search knowing about each.

Summary

- Add a runtime registry for embedding providers with readiness, model resolution, preparation, and batch embedding.
- Define immutable embedding-space descriptors and legacy deterministic identities.
- Validate provider results, dimensions, counts, and finite numeric vector components.
- Make SPI version 1 a compile-time constant; provider artifacts must embed the literal version they were built against.

Scope

This defines the neutral provider contract only. It does not migrate semantic-search consumers or ship a provider plugin.

Testing

- Registration and version compatibility.
- Identity stability and revision round trips.
- Registry snapshot consistency and malformed provider output.
