### PR TITLE
Route semantic embeddings through the provider SPI

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -974,7 +974,7 @@
 
   embeddings
   {:team "Metabot"
-   :api  #{}
+   :api  #{metabase.embeddings.provider}
    :uses #{util}}
 
   entity-retrieval
@@ -3609,6 +3609,7 @@
            collections
            config
            connection-pool
+           embeddings
            events
            health-inspector
            lib-be

--- a/enterprise/backend/src/metabase_enterprise/embeddings/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/embeddings/client.clj
@@ -31,13 +31,15 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- search-embedding-model
+(defn- normalize-model-descriptor
   "Translate the neutral embedding descriptor's dimension key to semantic search's internal key."
-  [embedding-model]
-  (cond-> embedding-model
-    (and (nil? (:vector-dimensions embedding-model))
-         (some? (:model-dimensions embedding-model)))
-    (assoc :vector-dimensions (:model-dimensions embedding-model))))
+  [{:keys [model-dimensions vector-dimensions] :as embedding-model}]
+  (when (and model-dimensions vector-dimensions (not= model-dimensions vector-dimensions))
+    (throw (ex-info "Embedding model descriptor has conflicting dimension values."
+                    {:model-dimensions  model-dimensions
+                     :vector-dimensions vector-dimensions})))
+  (cond-> (dissoc embedding-model :model-dimensions)
+    model-dimensions (assoc :vector-dimensions model-dimensions)))
 
 (defn get-embeddings-batch
   "Return a sequential collection of embedding vectors, in the same order as the input texts.
@@ -49,4 +51,4 @@
   `opts`            — optional keyword opts (e.g. `:type :doc`). Accepts alternating kwargs or a single trailing map;
                       forwarded as kwargs into the multimethod, which destructures with `& {:as opts}`."
   [embedding-model texts & {:as opts}]
-  (apply semantic-search/get-embeddings-batch (search-embedding-model embedding-model) texts (mapcat identity opts)))
+  (apply semantic-search/get-embeddings-batch (normalize-model-descriptor embedding-model) texts (mapcat identity opts)))

--- a/enterprise/backend/src/metabase_enterprise/embeddings/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/embeddings/client.clj
@@ -45,10 +45,9 @@
   "Return a sequential collection of embedding vectors, in the same order as the input texts.
 
   `embedding-model` — `{:provider :model-name :model-dimensions}` map; provider must be one of those registered on
-                      [[metabase-enterprise.semantic-search.embedding/get-embeddings-batch]] (`ai-service`, `openai`,
-                      `ollama`).
+                      [[metabase.embeddings.provider]] (`ai-service`, `openai`, `ollama`).
   `texts`           — sequential collection of input strings.
   `opts`            — optional keyword opts (e.g. `:type :doc`). Accepts alternating kwargs or a single trailing map;
-                      forwarded as kwargs into the multimethod, which destructures with `& {:as opts}`."
+                      forwarded as kwargs to the provider."
   [embedding-model texts & {:as opts}]
   (apply semantic-search/get-embeddings-batch (normalize-model-descriptor embedding-model) texts (mapcat identity opts)))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -8,6 +8,7 @@
    [metabase-enterprise.semantic-search.settings :as semantic-settings]
    [metabase.analytics-interface.core :as analytics]
    [metabase.analytics.core :as analytics.core]
+   [metabase.embeddings.provider :as embeddings.provider]
    [metabase.llm.settings :as llm.settings]
    [metabase.premium-features.core :as premium-features]
    [metabase.tracing.core :as tracing]
@@ -133,23 +134,30 @@
       (conj batches current-batch)
       batches)))
 
-;;;; Provider SPI
+;;;; Provider API
 
-(defn- dispatch-provider [embedding-model & _] (:provider embedding-model))
+(defn resolve-model
+  "Resolve a requested embedding model to its immutable vector-space descriptor."
+  [embedding-model]
+  (embeddings.provider/resolve-model embedding-model))
 
-(defmulti get-embedding
-  "Returns a single embedding vector for the given text.
-  `opts` (kwargs, honoured by the production providers; ollama ignores them):
+(defn get-embedding
+  "Return one embedding vector for `text`.
+  `opts` (honoured by the production providers; ollama ignores them):
   - `:record-tokens?` — write a token-tracking row for the call
   - `:type`           — what the embedding is for (`:query`/`:index`), recorded with the tokens
   - `:snowplow?`      — ai-service only, default true; synthetic callers (e.g. the health probe) pass
                         false so the call emits no token_usage event"
-  {:arglists '([embedding-model text & opts])} dispatch-provider)
+  [embedding-model text & {:as opts}]
+  (embeddings.provider/embed-text embedding-model text opts))
 
-(defmulti get-embeddings-batch
-  "Returns a sequential collection of embedding vectors, in the same order as the input texts.
+(defn get-embeddings-batch
+  "Return one embedding vector per input text, in the same order.
   Takes the same `opts` as [[get-embedding]], minus `:snowplow?` (batch callers are all organic)."
-  {:arglists '([embedding-model texts & opts])} dispatch-provider)
+  [embedding-model texts & {:as opts}]
+  (embeddings.provider/embed-texts embedding-model texts opts))
+
+(defn- dispatch-provider [embedding-model & _] (:provider embedding-model))
 
 (defmulti embedder-circuit-endpoint
   "Return the remote endpoint that identifies `embedding-model`'s circuit, or nil when its provider does not
@@ -158,9 +166,10 @@
 
 (defmethod embedder-circuit-endpoint :default [_] nil)
 
-(defmulti pull-model
-  "If a model needs to be downloaded (which is the case for ollama), downloads it."
-  {:arglists '([embedding-model])} dispatch-provider)
+(defn pull-model
+  "Prepare a provider model eagerly when the provider supports it."
+  [embedding-model]
+  (embeddings.provider/prepare! embedding-model))
 
 ;;;; Embedding-service circuit breaker
 ;;;
@@ -170,6 +179,10 @@
 ;;; failing. State transitions surface the affected health checks immediately (see the listeners) rather
 ;;; than waiting for the daily job. Thresholds are fixed (the breaker is built once); the setting is a
 ;;; runtime kill switch checked per call.
+;;;
+;;; The breaker wraps the HTTP providers defined below rather than sitting behind the provider SPI, since
+;;; it keys circuits by remote endpoint and an in-process provider has none. If a second provider that
+;;; needs it turns up, move it into `metabase.embeddings.provider` instead of adding a second copy.
 
 (def ^:private embedder-circuit-breaker-failure-threshold
   "Consecutive embedding-service failures that trip the breaker open." 5)
@@ -385,11 +398,7 @@
       (throw e))))
 
 ;; Ollama is not used in production. Token tracking is not implemented.
-(defmethod get-embedding "ollama" [{:keys [model-name vector-dimensions]} text & {:as _opts}]
-  (call-through-embedder-breaker #(ollama-get-embedding model-name vector-dimensions text)
-                                 :endpoint ollama-embeddings-endpoint))
-
-(defmethod get-embeddings-batch "ollama" [{:keys [model-name vector-dimensions]} texts & {:as _opts}]
+(defn- ollama-get-embeddings-batch [model-name vector-dimensions texts]
   ;; Ollama doesn't have a native batch API, so we fall back to individual calls. Each call goes through the
   ;; breaker on its own, so an outage mid-batch fast-fails the remaining texts instead of timing out on each.
   (log/debug "Generating" (count texts) "Ollama embeddings (using individual calls)")
@@ -397,8 +406,6 @@
           (call-through-embedder-breaker #(ollama-get-embedding model-name vector-dimensions text)
                                          :endpoint ollama-embeddings-endpoint))
         texts))
-
-(defmethod pull-model "ollama" [{:keys [model-name]}] (ollama-pull-model model-name))
 
 ;;;; OpenAI-compatible embedding service impl (shared by "ai-service" and "openai" providers)
 
@@ -528,22 +535,8 @@
 (defmethod embedder-circuit-endpoint "ai-service" [_]
   (first (embedding-service-resolve-config!)))
 
-(defmethod get-embedding "ai-service"
-  [{:keys [model-name vector-dimensions]} text & {:keys [record-tokens? type snowplow?] :or {snowplow? true}}]
-  (let [[endpoint api-key] (embedding-service-resolve-config!)]
-    (first (openai-compatible-get-embeddings-batch
-            {:provider       "ai-service"
-             :endpoint       endpoint
-             :api-key        api-key
-             :model-name     model-name
-             :vector-dimensions vector-dimensions
-             :texts          [text]
-             :snowplow?      snowplow?
-             :record-tokens? record-tokens?
-             :type           type}))))
-
-(defmethod get-embeddings-batch "ai-service"
-  [{:keys [model-name vector-dimensions]} texts & {:keys [record-tokens? type]}]
+(defn- ai-service-get-embeddings-batch
+  [{:keys [model-name vector-dimensions]} texts {:keys [record-tokens? type]}]
   (let [[endpoint api-key] (embedding-service-resolve-config!)]
     (openai-compatible-get-embeddings-batch
      {:provider       "ai-service"
@@ -555,9 +548,6 @@
       :snowplow?      true
       :record-tokens? record-tokens?
       :type           type})))
-
-(defmethod pull-model "ai-service" [_]
-  (log/debug "ai-service provider does not require pulling a model"))
 
 ;;;; OpenAI provider
 
@@ -572,23 +562,8 @@
 (defmethod embedder-circuit-endpoint "openai" [_]
   (first (openai-resolve-config!)))
 
-(defmethod get-embedding "openai"
-  [embedding-model text & {:keys [record-tokens? type]}]
-  (let [[endpoint api-key] (openai-resolve-config!)]
-    (first (openai-compatible-get-embeddings-batch
-            {:provider       "openai"
-             :endpoint       endpoint
-             :api-key        api-key
-             :model-name     (:model-name embedding-model)
-             :vector-dimensions (:vector-dimensions embedding-model)
-             :texts          [text]
-             :record-tokens? record-tokens?
-             :extra-body     (when (supports-dimensions? embedding-model)
-                               {:dimensions (:vector-dimensions embedding-model)})
-             :type           type}))))
-
-(defmethod get-embeddings-batch "openai"
-  [embedding-model texts & {:keys [record-tokens? type]}]
+(defn- openai-get-embeddings-batch
+  [embedding-model texts {:keys [record-tokens? type]}]
   (let [[endpoint api-key] (openai-resolve-config!)]
     (openai-compatible-get-embeddings-batch
      {:provider       "openai"
@@ -602,8 +577,36 @@
                         {:dimensions (:vector-dimensions embedding-model)})
       :type           type})))
 
-(defmethod pull-model "openai" [_]
-  (log/debug "OpenAI provider does not require pulling a model"))
+(defn- register-built-in-providers!
+  []
+  (let [spi-version embeddings.provider/embedding-spi-version
+        legacy      embeddings.provider/legacy-resolved-model]
+    (embeddings.provider/register-provider!
+     "ollama"
+     {:embedding-spi-version spi-version
+      :readiness             (constantly {:ready? true})
+      :resolve-model         legacy
+      :embed-texts           (fn [{:keys [model-name vector-dimensions]} texts _opts]
+                               (ollama-get-embeddings-batch model-name vector-dimensions texts))
+      :prepare!              (fn [{:keys [model-name]}]
+                               (ollama-pull-model model-name))})
+    (embeddings.provider/register-provider!
+     "ai-service"
+     {:embedding-spi-version spi-version
+      :readiness             (fn [_]
+                               {:ready? (boolean (or (not-empty (semantic-settings/ee-embedding-service-base-url))
+                                                     (not-empty (llm.settings/ai-service-base-url))))})
+      :resolve-model         legacy
+      :embed-texts           ai-service-get-embeddings-batch})
+    (embeddings.provider/register-provider!
+     "openai"
+     {:embedding-spi-version spi-version
+      :readiness             (fn [_]
+                               {:ready? (boolean (not-empty (semantic-settings/openai-api-key)))})
+      :resolve-model         legacy
+      :embed-texts           openai-get-embeddings-batch})))
+
+(register-built-in-providers!)
 
 ;;;; Query prefixes for asymmetric retrieval models
 
@@ -641,27 +644,10 @@
    :model-name (semantic-settings/ee-embedding-model)
    :vector-dimensions (semantic-settings/ee-embedding-model-dimensions)})
 
-(defmulti embedding-supported?
-  "Whether `embedding-model`'s provider is *configured* to compute embeddings — the endpoint/credentials it
-  needs are present. This is a config-presence check, not a liveness probe: a set URL whose service is down
-  (or a stopped ollama) still reads as supported and surfaces at call time. Dispatches on provider,
-  mirroring [[get-embedding]] and the config each provider's impl resolves; a new provider — including a
-  future in-process embedder — adds a method. The `:default` is false, so an unrecognized provider gates
-  callers off safely."
-  {:arglists '([embedding-model])} dispatch-provider)
-
-(defmethod embedding-supported? :default [_] false)
-
-(defmethod embedding-supported? "ai-service" [_]
-  (boolean (or (not-empty (semantic-settings/ee-embedding-service-base-url))
-               (not-empty (llm.settings/ai-service-base-url)))))
-
-(defmethod embedding-supported? "openai" [_]
-  (boolean (not-empty (semantic-settings/openai-api-key))))
-
-;; ollama's endpoint is hardcoded (localhost:11434) with no setting to check, so config-presence is always
-;; true — consistent with ai-service/openai, which likewise check for a configured URL, not a live server.
-(defmethod embedding-supported? "ollama" [_] true)
+(defn embedding-supported?
+  "Whether the selected provider is installed and configured. This is not a remote liveness probe."
+  [embedding-model]
+  (embeddings.provider/ready? embedding-model))
 
 (defn- calc-token-metrics
   [texts]

--- a/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_complexity_score/complexity_test.clj
@@ -23,6 +23,7 @@
    [metabase.audit-app.core :as audit]
    [metabase.collections.core :as collections]
    [metabase.collections.test-utils :as collections.tu]
+   [metabase.embeddings.provider :as embeddings.provider]
    [metabase.task.core :as task]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
@@ -31,9 +32,18 @@
 
 (def ^:private test-entity-ids (atom 0))
 
-(defmethod semantic-search/get-embeddings-batch ::dimension-translation-test
-  [embedding-model _texts & _opts]
-  [embedding-model])
+(def ^:private captured-translation-model
+  "Descriptor the provider layer receives, captured by the dimension-translation test." (atom nil))
+
+;; A capturing provider so the dimension-translation test can inspect the descriptor the client hands down.
+(embeddings.provider/register-provider!
+ "dimension-translation-test"
+ {:embedding-spi-version embeddings.provider/embedding-spi-version
+  :readiness             (constantly {:ready? true})
+  :resolve-model         embeddings.provider/legacy-resolved-model
+  :embed-texts           (fn [model texts _opts]
+                           (reset! captured-translation-model model)
+                           (mapv (fn [_] (vec (repeat (:vector-dimensions model) 0.0))) texts))})
 
 (defn- entity
   "Build a fake entity map for scoring tests. Uses a monotonically-increasing counter for `:id`
@@ -749,11 +759,10 @@
         (is (false? (:record-tokens? @captured)))))))
 
 (deftest ^:parallel embeddings-client-translates-neutral-dimension-key-test
-  (let [[translated]
-        (embeddings/get-embeddings-batch
-         {:provider ::dimension-translation-test, :model-name "fake", :model-dimensions 384}
-         ["orders"])]
-    (is (= 384 (:vector-dimensions translated)))))
+  (embeddings/get-embeddings-batch
+   {:provider "dimension-translation-test", :model-name "fake", :model-dimensions 384}
+   ["orders"])
+  (is (= 384 (:vector-dimensions @captured-translation-model))))
 
 (deftest ^:sequential provider-embedder-splits-names-before-calling-provider-test
   (testing "provider-embedder splits names on _, -, ., and camelCase before sending to get-embeddings-batch"

--- a/enterprise/backend/test/metabase_enterprise/embeddings/client_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/embeddings/client_test.clj
@@ -1,0 +1,33 @@
+(ns metabase-enterprise.embeddings.client-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.embeddings.client :as embeddings.client]
+   [metabase-enterprise.semantic-search.core :as semantic-search]))
+
+(set! *warn-on-reflection* true)
+
+(deftest legacy-model-dimensions-are-normalized-test
+  (let [captured (atom nil)]
+    (with-redefs [semantic-search/get-embeddings-batch
+                  (fn [model texts & {:as opts}]
+                    (reset! captured [model texts opts])
+                    [[1.0 2.0]])]
+      (is (= [[1.0 2.0]]
+             (embeddings.client/get-embeddings-batch
+              {:provider "ai-service" :model-name "model" :model-dimensions 2}
+              ["text"]
+              :record-tokens? false)))
+      (is (= [{:provider "ai-service" :model-name "model" :vector-dimensions 2}
+              ["text"]
+              {:record-tokens? false}]
+             @captured)))))
+
+(deftest conflicting-dimension-keys-are-rejected-test
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                        #"conflicting dimension values"
+                        (embeddings.client/get-embeddings-batch
+                         {:provider          "ai-service"
+                          :model-name        "model"
+                          :model-dimensions  2
+                          :vector-dimensions 3}
+                         ["text"]))))

--- a/enterprise/backend/test/metabase_enterprise/entity_retrieval/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/entity_retrieval/core_test.clj
@@ -456,8 +456,13 @@
                     (is (=? [{:model "table" :id table-id}]
                             (distinct (map :entity (entity-retrieval.core/search-unfiltered "orders" 10))))
                         "the query really runs, so the [] below is the degrade path and not a fallback")
-                    ;; a dim-1 query vector against the dim-4 index column -> pgvector SQLState 22000
-                    (is (= [] (entity-retrieval.core/search-unfiltered "q" 10))))
+                    ;; Shrink the configured model to one dimension, the way an upgrade would. "q" is a valid
+                    ;; vector for the new model, so the provider accepts it and the dim-4 index column is what
+                    ;; no longer matches -> pgvector SQLState 22000.
+                    (mt/with-dynamic-fn-redefs [semantic.embedding/get-configured-model
+                                                (constantly (assoc semantic.tu/mock-embedding-model
+                                                                   :vector-dimensions 1))]
+                      (is (= [] (entity-retrieval.core/search-unfiltered "q" 10)))))
                   (finally
                     (jdbc/execute! ds [(str "DROP TABLE IF EXISTS \"" (index-table/vectors-table)
                                             "\", \"" (index-table/meta-table) "\"")])))))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -402,3 +402,14 @@
   (testing "ollama is always supported; an unrecognized provider is not (:default)"
     (is (true?  (embedding/embedding-supported? {:provider "ollama"})))
     (is (false? (embedding/embedding-supported? {:provider "no-embedder"})))))
+
+(deftest resolve-model-test
+  (let [requested {:provider          "openai"
+                   :model-name        "text-embedding-3-small"
+                   :vector-dimensions 1536}
+        resolved  (embedding/resolve-model requested)]
+    (is (= requested (select-keys resolved (keys requested))))
+    (is (= 1 (:embedding-spi-version resolved)))
+    (is (re-matches #"emb:v1:sha256:[0-9a-f]{64}" (:embedding-space-id resolved)))
+    (testing "transport credentials are not part of vector-space identity"
+      (is (= resolved (embedding/resolve-model (assoc requested :api-key "do-not-persist")))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -17,6 +17,7 @@
    [metabase-enterprise.semantic-search.pgvector-api :as semantic.pgvector-api]
    [metabase-enterprise.semantic-search.settings :as semantic.settings]
    [metabase-enterprise.semantic-search.util :as semantic.util]
+   [metabase.embeddings.provider :as embeddings.provider]
    [metabase.search.config :as search.config]
    [metabase.search.ingestion :as search.ingestion]
    [metabase.test :as mt]
@@ -310,11 +311,12 @@
     (-> (semantic.index/default-index mock-embedding-model)
         (semantic.index-metadata/qualify-index mock-index-metadata))))
 
-;; NOTE: opts are currently unused in following mock implementations
-(defmethod semantic.embedding/get-embedding        "mock" [_ text & {:as _opts}] (get-mock-embedding text))
-(defmethod semantic.embedding/get-embeddings-batch "mock" [_ texts & {:as _opts}] (get-mock-embeddings-batch texts))
-(defmethod semantic.embedding/pull-model           "mock" [_])
-(defmethod semantic.embedding/embedding-supported? "mock" [_] true)
+(embeddings.provider/register-provider!
+ "mock"
+ {:embedding-spi-version embeddings.provider/embedding-spi-version
+  :readiness             (constantly {:ready? true})
+  :resolve-model         embeddings.provider/legacy-resolved-model
+  :embed-texts           (fn [_ texts _opts] (get-mock-embeddings-batch texts))})
 
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn query-index [search-context]


### PR DESCRIPTION
Motivation

The SPI is dead code until something uses it. This moves the existing ai-service/OpenAI/Ollama paths onto the registry, so semantic search embeds through the neutral contract and the new provider becomes reachable.

Summary

- Register the existing ai-service, OpenAI, and Ollama implementations through the shared provider registry.
- Route semantic embedding, readiness, resolution, and preparation through the SPI while preserving the existing public adapter.
- Preserve the compatibility client model-dimensions contract by normalizing it to vector-dimensions at the provider boundary.
- Keep semantic-specific batching, metrics, and settings policy in semantic search.

Scope

This migrates consumers to the SPI. Persisted embedding-space compatibility and in-process provider selection are intentionally handled by later stack layers.

Testing

- Built-in provider behavior and existing semantic embedding adapter tests.
- Compatibility-client dimension normalization and conflict handling.
