### PR TITLE
Serialize entity index queries with rebuilds

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/entity_retrieval/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/entity_retrieval/core.clj
@@ -389,6 +389,15 @@
                               (format "WHEN doc_type = '%s' THEN %s" (name k) w)))]
     (format "(%s) - (CASE %s ELSE 0.0 END)" distance-expr cases)))
 
+(defn- index-compatible?
+  [connectable model]
+  (try
+    (= :compatible (index-table/index-status connectable model))
+    (catch SQLException e
+      (if (= "42P01" (.getSQLState e))
+        false
+        (throw e)))))
+
 (defenterprise search-unfiltered
   "Find the library-entity documents best matching `user-search-prompt`, up to `limit`, ranked by a
   blended score (cosine similarity plus a slight doc_type bump).
@@ -405,51 +414,56 @@
     (let [pgvector  (semantic.db.datasource/ensure-initialized-data-source!)
           limit     (or limit default-limit)
           model     (resolved-configured-model-for-search)]
-      ;; Re-check immediately before embedding/querying. A setting change after the tool was offered must
-      ;; never query same-width vectors from a different immutable space.
+      ;; Check compatibility under a short non-blocking read lock. Even metadata-table DDL can otherwise block this
+      ;; preflight behind reconcile before we reach the protected query path. The later locked recheck remains
+      ;; authoritative because a reconcile can begin while the embedding is generated.
       (if-not (and model
-                   (try
-                     (= :compatible (index-table/index-status pgvector model))
-                     (catch SQLException e
-                       (if (= "42P01" (.getSQLState e))
-                         false
-                         (throw e)))))
+                   (true? (reconcile/with-index-read-lock pgvector #(index-compatible? % model))))
         []
         (let [embedding (embedding/get-embedding model user-search-prompt
                                                  {:type :query :record-tokens? true})
               lit       (index-table/format-embedding embedding)
-              distance  (str "doc_embedding <=> " lit)
-              rows      (try
-                          (jdbc/execute!
-                           pgvector
-                           (-> (sql.helpers/select :entity_type :entity_local_id :doc_type :doc_text
-                                                   [[:raw distance] :distance])
-                               (sql.helpers/from (keyword (index-table/vectors-table)))
-                               ;; Exact scan, no HNSW: the blended order-by can't use an ANN index, and the
-                               ;; library set is tiny.
-                               (sql.helpers/order-by [[:raw (ranking-sql distance)] :asc])
-                               (sql.helpers/limit limit)
-                               (sql/format {:quoted true}))
-                           {:builder-fn jdbc.rs/as-unqualified-lower-maps})
-                          (catch SQLException e
-                            ;; Only the index-not-ready states degrade to no results — the index, not the agent,
-                            ;; is at fault and the next reconcile heals it:
-                            ;;   42P01  vectors table doesn't exist yet (pre-first-build; expected at boot, stay quiet)
-                            ;;   22000  stored vectors incompatible with the query vector (a dimension/format change
-                            ;;          awaiting rebuild — e.g. a vector(OLD) column vs a vector(NEW) literal)
-                            ;; Any other SQL error — a connection loss or pgvector outage — propagates so the tool
-                            ;; reports the search as unavailable rather than as an empty library.
-                            (case (.getSQLState e)
-                              "42P01" []
-                              "22000" (do (log/warnf "library entity index incompatible with the query vector; returning no results: %s" (ex-message e))
-                                          [])
-                              (do (analytics/inc! :metabase-entity-retrieval/search-failed)
-                                  (throw e)))))]
-          (->> rows
-               (map (fn [row]
-                      {:entity   {:model (:entity_type row) :id (:entity_local_id row)}
-                       :doc_type (:doc_type row)
-                       :doc_text (:doc_text row)
-                       :score    (score row)}))
-               (sort-by (comp :total_score :score) >)
-               vec))))))
+              distance  (str "doc_embedding <=> " lit)]
+          (or
+           (reconcile/with-index-read-lock
+             pgvector
+             (fn [conn]
+               ;; The compatibility check and query share the reconcile lock and connection. A setting change
+               ;; after the tool was offered must never query same-width vectors from another immutable space.
+               (if-not (index-compatible? conn model)
+                 []
+                 (let [rows (try
+                              (jdbc/execute!
+                               conn
+                               (-> (sql.helpers/select :entity_type :entity_local_id :doc_type :doc_text
+                                                       [[:raw distance] :distance])
+                                   (sql.helpers/from (keyword (index-table/vectors-table)))
+                                   ;; Exact scan, no HNSW: the blended order-by can't use an ANN index, and the
+                                   ;; library set is tiny.
+                                   (sql.helpers/order-by [[:raw (ranking-sql distance)] :asc])
+                                   (sql.helpers/limit limit)
+                                   (sql/format {:quoted true}))
+                               {:builder-fn jdbc.rs/as-unqualified-lower-maps})
+                              (catch SQLException e
+                                ;; Only the index-not-ready states degrade to no results — the index, not the agent,
+                                ;; is at fault and the next reconcile heals it:
+                                ;;   42P01  vectors table doesn't exist yet (pre-first-build; expected at boot, stay quiet)
+                                ;;   22000  stored vectors incompatible with the query vector (a dimension/format change
+                                ;;          awaiting rebuild — e.g. a vector(OLD) column vs a vector(NEW) literal)
+                                ;; Any other SQL error — a connection loss or pgvector outage — propagates so the tool
+                                ;; reports the search as unavailable rather than as an empty library.
+                                (case (.getSQLState e)
+                                  "42P01" []
+                                  "22000" (do (log/warnf "library entity index incompatible with the query vector; returning no results: %s" (ex-message e))
+                                              [])
+                                  (do (analytics/inc! :metabase-entity-retrieval/search-failed)
+                                      (throw e)))))]
+                   (->> rows
+                        (map (fn [row]
+                               {:entity   {:model (:entity_type row) :id (:entity_local_id row)}
+                                :doc_type (:doc_type row)
+                                :doc_text (:doc_text row)
+                                :score    (score row)}))
+                        (sort-by (comp :total_score :score) >)
+                        vec)))))
+           []))))))

--- a/enterprise/backend/src/metabase_enterprise/entity_retrieval/reconcile.clj
+++ b/enterprise/backend/src/metabase_enterprise/entity_retrieval/reconcile.clj
@@ -50,6 +50,47 @@
 ;; semantic-search's migration lock (19991).
 (def ^:private reconcile-lock-id 20012)
 
+(defn- with-index-lock
+  [pgvector lock-function unlock-function f]
+  (with-open [^Connection conn (jdbc/get-connection pgvector)]
+    (let [autocommit (.getAutoCommit conn)]
+      (.setAutoCommit conn true)
+      (try
+        (jdbc/execute! conn [(format "SELECT %s(%d)" lock-function reconcile-lock-id)])
+        (try
+          (f conn)
+          (finally
+            (jdbc/execute! conn [(format "SELECT %s(%d)" unlock-function reconcile-lock-id)])))
+        (finally
+          (.setAutoCommit conn autocommit))))))
+
+(defn with-index-read-lock
+  "Run `(f connection)` under a shared cluster-wide library-index lock, returning nil immediately when a
+  reconcile holds the matching exclusive lock.
+
+  Concurrent searches share this lock. The non-blocking acquisition prevents waiting searches from exhausting
+  the pgvector connection pool during a long reconcile. A successful search's compatibility check and vector
+  query cannot straddle a rebuild into another embedding space."
+  [pgvector f]
+  (with-open [^Connection conn (jdbc/get-connection pgvector)]
+    (let [autocommit (.getAutoCommit conn)]
+      (.setAutoCommit conn true)
+      (try
+        (when (:acquired (jdbc/execute-one!
+                          conn
+                          [(format "SELECT pg_try_advisory_lock_shared(%d) AS acquired" reconcile-lock-id)]
+                          {:builder-fn jdbc.rs/as-unqualified-lower-maps}))
+          (try
+            (f conn)
+            (finally
+              (jdbc/execute! conn [(format "SELECT pg_advisory_unlock_shared(%d)" reconcile-lock-id)]))))
+        (finally
+          (.setAutoCommit conn autocommit))))))
+
+(defn- with-index-write-lock
+  [pgvector f]
+  (with-index-lock pgvector "pg_advisory_lock" "pg_advisory_unlock" f))
+
 (defn doc-id
   "Content-addressed primary key for an index document.
   `instructions` is intentionally not an input: editing it must not re-embed an entity's name/synonyms."
@@ -416,28 +457,19 @@
   `ensure-tables!` (which may drop+rebuild on a model/format change) runs under the lock too, so a rebuild
   can't pull the table out from under a concurrent node's in-flight run."
   [pgvector resolve-model f]
-  (with-open [^Connection conn (jdbc/get-connection pgvector)]
-    ;; Per-batch commits, not one big transaction: the run tolerates partial failure across runs, so each
-    ;; insert/delete must commit on its own. Some pools hand out autocommit-off connections (which would
-    ;; silently roll the whole run back on close), so force it on and restore the prior setting before the
-    ;; connection goes back to the pool. (ensure-tables! flips this to a transaction for its DDL.)
-    (let [autocommit (.getAutoCommit conn)]
-      (.setAutoCommit conn true)
-      (try
-        (jdbc/execute! conn [(format "SELECT pg_advisory_lock(%d)" reconcile-lock-id)])
-        (try
-          (let [embedding-model (resolve-model)
-                status          (index-table/ensure-tables! conn embedding-model)
-                ;; :created (first build / healed manual drop) and :rebuilt (model/format change) both leave
-                ;; an empty table, so a targeted caller must do a full repopulate rather than index one entity.
-                emptied?        (contains? #{:created :rebuilt} status)]
-            (when emptied?
-              (log/info "library entity index: vectors table is empty (" status "); repopulating"))
-            (assoc (f conn embedding-model emptied?) :rebuilt? (= :rebuilt status)))
-          (finally
-            (jdbc/execute! conn [(format "SELECT pg_advisory_unlock(%d)" reconcile-lock-id)])))
-        (finally
-          (.setAutoCommit conn autocommit))))))
+  (with-index-write-lock
+    pgvector
+    (fn [conn]
+      ;; Per-batch commits, not one big transaction: the run tolerates partial failure across runs. The
+      ;; shared lock helper forces autocommit on; ensure-tables! temporarily wraps its DDL in a transaction.
+      (let [embedding-model (resolve-model)
+            status          (index-table/ensure-tables! conn embedding-model)
+            ;; :created (first build / healed manual drop) and :rebuilt (model/format change) both leave
+            ;; an empty table, so a targeted caller must do a full repopulate rather than index one entity.
+            emptied?        (contains? #{:created :rebuilt} status)]
+        (when emptied?
+          (log/info "library entity index: vectors table is empty (" status "); repopulating"))
+        (assoc (f conn embedding-model emptied?) :rebuilt? (= :rebuilt status))))))
 
 (defn reconcile!
   "Full reconcile of the pgvector `library_entity_index` with the appdb, blocking until it completes;

--- a/enterprise/backend/test/metabase_enterprise/entity_retrieval/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/entity_retrieval/core_test.clj
@@ -46,6 +46,63 @@
       (is (> (:total_score (score {:distance 0.1 :doc_type "name"}))
              (:total_score (score {:distance 0.5 :doc_type "name"})))))))
 
+(deftest search-uses-reconcile-lock-test
+  (let [calls      (atom [])
+        lock-count (atom 0)]
+    (mt/with-premium-features #{:library-retrieval}
+      (with-redefs [entity-retrieval.core/available?                         (constantly true)
+                    semantic.db.datasource/ensure-initialized-data-source!  (constantly ::datasource)
+                    semantic.embedding/get-configured-model                 (constantly semantic.tu/mock-embedding-model)
+                    reconcile/with-index-read-lock                          (fn [ds f]
+                                                                              (let [n    (swap! lock-count inc)
+                                                                                    conn (keyword (str "locked-connection-" n))]
+                                                                                (swap! calls conj [:lock ds])
+                                                                                (f conn)))
+                    index-table/index-status                                (fn [conn _model]
+                                                                              (swap! calls conj [:compatible conn])
+                                                                              :compatible)
+                    semantic.embedding/get-embedding                        (fn [_model text & _opts]
+                                                                              (swap! calls conj [:embed text])
+                                                                              [0.0 0.0 0.0 0.0])
+                    jdbc/execute!                                           (fn [conn & _args]
+                                                                              (swap! calls conj [:query conn])
+                                                                              [])]
+        (is (= [] (entity-retrieval.core/search "the query" 10)))
+        (is (= [[:lock ::datasource]
+                [:compatible :locked-connection-1]
+                [:embed "the query"]
+                [:lock ::datasource]
+                [:compatible :locked-connection-2]
+                [:query :locked-connection-2]]
+               @calls)
+            "both preflight and query compatibility checks happen behind non-blocking reconcile locks")))))
+
+(deftest search-skips-embedding-for-an-incompatible-index-test
+  (mt/with-premium-features #{:library-retrieval}
+    (with-redefs [entity-retrieval.core/available?                        (constantly true)
+                  semantic.db.datasource/ensure-initialized-data-source! (constantly ::datasource)
+                  semantic.embedding/get-configured-model                (constantly semantic.tu/mock-embedding-model)
+                  index-table/index-status                               (constantly :incompatible)
+                  semantic.embedding/get-embedding                       (fn [& _]
+                                                                           (throw (ex-info "must not embed" {})))
+                  reconcile/with-index-read-lock                         (fn [_ds f]
+                                                                           (f ::locked-connection))]
+      (is (= [] (entity-retrieval.core/search "the query" 10))))))
+
+(deftest search-degrades-when-reconcile-holds-the-lock-test
+  (mt/with-premium-features #{:library-retrieval}
+    (with-redefs [entity-retrieval.core/available?                        (constantly true)
+                  semantic.db.datasource/ensure-initialized-data-source! (constantly ::datasource)
+                  semantic.embedding/get-configured-model                (constantly semantic.tu/mock-embedding-model)
+                  index-table/index-status                               (fn [& _]
+                                                                           (throw (ex-info "must not touch index metadata" {})))
+                  semantic.embedding/get-embedding                       (fn [& _]
+                                                                           (throw (ex-info "must not embed" {})))
+                  reconcile/with-index-read-lock                         (constantly nil)
+                  jdbc/execute!                                          (fn [& _]
+                                                                           (throw (ex-info "must not query" {})))]
+      (is (= [] (entity-retrieval.core/search "the query" 10))))))
+
 (deftest search-degrades-when-configured-model-cannot-be-resolved-test
   (mt/with-premium-features #{:library-retrieval}
     (with-redefs [entity-retrieval.core/available?                        (constantly true)
@@ -55,11 +112,13 @@
                                                                            (throw (ex-info "model changed"
                                                                                            {:type ::model-changed})))
                   index-table/index-status                                (fn [& _]
-                                                                            (throw (ex-info "must not inspect index" {})))
-                  semantic.embedding/get-embedding                        (fn [& _]
-                                                                            (throw (ex-info "must not embed" {})))
-                  jdbc/execute!                                           (fn [& _]
-                                                                            (throw (ex-info "must not query" {})))]
+                                                                           (throw (ex-info "must not inspect index" {})))
+                  semantic.embedding/get-embedding                       (fn [& _]
+                                                                           (throw (ex-info "must not embed" {})))
+                  reconcile/with-index-read-lock                         (fn [& _]
+                                                                           (throw (ex-info "must not lock" {})))
+                  jdbc/execute!                                          (fn [& _]
+                                                                           (throw (ex-info "must not query" {})))]
       (is (= [] (entity-retrieval.core/search "the query" 10))))))
 
 (deftest dispatch-without-pgvector-test

--- a/enterprise/backend/test/metabase_enterprise/entity_retrieval/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/entity_retrieval/core_test.clj
@@ -67,7 +67,7 @@
                     jdbc/execute!                                           (fn [conn & _args]
                                                                               (swap! calls conj [:query conn])
                                                                               [])]
-        (is (= [] (entity-retrieval.core/search "the query" 10)))
+        (is (= [] (entity-retrieval.core/search-unfiltered "the query" 10)))
         (is (= [[:lock ::datasource]
                 [:compatible :locked-connection-1]
                 [:embed "the query"]
@@ -87,7 +87,7 @@
                                                                            (throw (ex-info "must not embed" {})))
                   reconcile/with-index-read-lock                         (fn [_ds f]
                                                                            (f ::locked-connection))]
-      (is (= [] (entity-retrieval.core/search "the query" 10))))))
+      (is (= [] (entity-retrieval.core/search-unfiltered "the query" 10))))))
 
 (deftest search-degrades-when-reconcile-holds-the-lock-test
   (mt/with-premium-features #{:library-retrieval}
@@ -101,7 +101,7 @@
                   reconcile/with-index-read-lock                         (constantly nil)
                   jdbc/execute!                                          (fn [& _]
                                                                            (throw (ex-info "must not query" {})))]
-      (is (= [] (entity-retrieval.core/search "the query" 10))))))
+      (is (= [] (entity-retrieval.core/search-unfiltered "the query" 10))))))
 
 (deftest search-degrades-when-configured-model-cannot-be-resolved-test
   (mt/with-premium-features #{:library-retrieval}
@@ -119,7 +119,7 @@
                                                                            (throw (ex-info "must not lock" {})))
                   jdbc/execute!                                          (fn [& _]
                                                                            (throw (ex-info "must not query" {})))]
-      (is (= [] (entity-retrieval.core/search "the query" 10))))))
+      (is (= [] (entity-retrieval.core/search-unfiltered "the query" 10))))))
 
 (deftest dispatch-without-pgvector-test
   (testing "with the feature enabled but pgvector unconfigured, the EE impls degrade gracefully"

--- a/enterprise/backend/test/metabase_enterprise/entity_retrieval/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/entity_retrieval/core_test.clj
@@ -112,7 +112,7 @@
                                                                            (throw (ex-info "model changed"
                                                                                            {:type ::model-changed})))
                   index-table/index-status                                (fn [& _]
-                                                                           (throw (ex-info "must not inspect index" {})))
+                                                                            (throw (ex-info "must not inspect index" {})))
                   semantic.embedding/get-embedding                       (fn [& _]
                                                                            (throw (ex-info "must not embed" {})))
                   reconcile/with-index-read-lock                         (fn [& _]

--- a/enterprise/backend/test/metabase_enterprise/entity_retrieval/reconcile_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/entity_retrieval/reconcile_test.clj
@@ -13,7 +13,9 @@
    [metabase.test.fixtures :as fixtures]
    [next.jdbc :as jdbc]
    [next.jdbc.result-set :as jdbc.rs]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   (java.sql Connection)))
 
 (set! *warn-on-reflection* true)
 
@@ -92,6 +94,30 @@
              (jdbc/execute! ~ds-sym [(str "DROP TABLE IF EXISTS "
                                           (index-table/vectors-table) ", "
                                           (index-table/meta-table))])))))))
+
+(deftest ^:sequential with-index-read-lock-contention-integration-test
+  (when semantic.db.datasource/db-url
+    (let [ds       (semantic.db.datasource/ensure-initialized-data-source!)
+          lock-id  (var-get #'reconcile/reconcile-lock-id)
+          calls    (atom 0)
+          callback (fn [_]
+                     (swap! calls inc)
+                     ::called)]
+      (with-open [^Connection writer (jdbc/get-connection ds)]
+        (let [acquired? (:acquired
+                         (jdbc/execute-one!
+                          writer
+                          [(format "SELECT pg_try_advisory_lock(%d) AS acquired" lock-id)]
+                          {:builder-fn jdbc.rs/as-unqualified-lower-maps}))]
+          (is acquired? "the exclusive test lock was acquired without blocking")
+          (when acquired?
+            (try
+              (is (nil? (reconcile/with-index-read-lock ds callback)))
+              (is (zero? @calls) "the read callback is skipped while reconcile owns the lock")
+              (finally
+                (jdbc/execute! writer [(format "SELECT pg_advisory_unlock(%d)" lock-id)])))
+            (is (= ::called (reconcile/with-index-read-lock ds callback)))
+            (is (= 1 @calls) "the callback runs after the exclusive lock is released")))))))
 
 (defn- index-rows [ds]
   (jdbc/execute! ds


### PR DESCRIPTION
Motivation

A search must not straddle a rebuild — reading half-swapped index state returns wrong results. This serializes searches against reconciles with advisory locks, so a query either sees the old index or waits.

Summary

- Coordinate library searches and reconciles with shared and exclusive PostgreSQL advisory locks.
- Keep compatibility rechecks and vector queries on the same locked connection so they cannot straddle a rebuild.
- Use non-blocking search lock acquisition so waiting searches cannot exhaust the pgvector pool.
- Preflight compatibility before embedding and return no results while a reconcile owns the index.

Scope

This PR only addresses library entity-index concurrency and degradation behavior.

Testing

- Search call ordering and locked connection reuse.
- Incompatible-index preflight and reconcile-contention degradation.
