### PR TITLE
Delete channel temp files after use instead of relying on JVM exit

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -494,6 +494,7 @@
            metabase.channel.render.core
            metabase.channel.settings
            metabase.channel.slack
+           metabase.channel.temp-file
            metabase.channel.template.core
            metabase.channel.urls}
    :uses #{analytics

--- a/src/metabase/channel/email/result_attachment.clj
+++ b/src/metabase/channel/email/result_attachment.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.java.io :as io]
    [metabase.channel.render.util :as render.util]
+   [metabase.channel.temp-file :as temp-file]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.lib.schema.id :as lib.schema.id]
@@ -66,8 +67,7 @@
 (defn- create-temp-file!
   "Separate from `create-temp-file-or-throw` primarily so that we can simulate exceptions in tests"
   [suffix]
-  (doto (File/createTempFile "metabase_attachment" suffix)
-    .deleteOnExit))
+  (temp-file/track-temp-file! (File/createTempFile "metabase_attachment" suffix)))
 
 (defn- create-temp-file-or-throw!
   "Tries to create a temp file, will give the users a better error message if we are unable to create the temp file"

--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -21,6 +21,7 @@
    [metabase.channel.render.util :as render.util]
    [metabase.channel.settings :as channel.settings]
    [metabase.channel.shared :as channel.shared]
+   [metabase.channel.temp-file :as temp-file]
    [metabase.channel.template.handlebars :as handlebars]
    [metabase.channel.urls :as urls]
    [metabase.notification.models :as models.notification]
@@ -281,10 +282,9 @@
   [dashboard-id dashboard-name creator-id parameters parts]
   (try
     ;; TODO: (bshepherdson, 2026-07-02) This should not be hard-coding the paper size.
-    (let [pdf-bytes (channel.render/render-dashboard-to-pdf dashboard-id creator-id (vec parameters) :a4 parts)
-          temp-file (doto (File/createTempFile "metabase_dashboard_" ".pdf")
-                      (.deleteOnExit))]
-      (with-open [os (io/output-stream temp-file)]
+    (let [pdf-bytes     (channel.render/render-dashboard-to-pdf dashboard-id creator-id (vec parameters) :a4 parts)
+          pdf-temp-file (temp-file/track-temp-file! (File/createTempFile "metabase_dashboard_" ".pdf"))]
+      (with-open [os (io/output-stream pdf-temp-file)]
         (.write os ^bytes pdf-bytes))
       {:type         :attachment
        :content-type "application/pdf"
@@ -293,7 +293,7 @@
                          not-empty
                          (or "dashboard")
                          (str ".pdf"))
-       :content      (.. temp-file toURI toURL)
+       :content      (.. pdf-temp-file toURI toURL)
        :description  (format "PDF of dashboard '%s'" (or dashboard-name "dashboard"))})
     (catch Throwable e
       (log/error e "Error rendering dashboard subscription PDF; skipping PDF attachment")

--- a/src/metabase/channel/render/image_bundle.clj
+++ b/src/metabase/channel/render/image_bundle.clj
@@ -3,7 +3,8 @@
   either encode the image inline in a URL (when `render-type` is `:inline`), or create the hashes/references needed
   for an attached image (`render-type` of `:attachment`)"
   (:require
-   [clojure.java.io :as io])
+   [clojure.java.io :as io]
+   [metabase.channel.temp-file :as temp-file])
   (:import
    (java.util Arrays)
    (org.apache.commons.io IOUtils)
@@ -29,8 +30,7 @@
 
 (defn- write-byte-array-to-temp-file
   [^bytes img-bytes]
-  (let [f (doto (java.io.File/createTempFile "metabase_channel_image_" ".png")
-            .deleteOnExit)]
+  (let [f (temp-file/track-temp-file! (java.io.File/createTempFile "metabase_channel_image_" ".png"))]
     (with-open [fos (java.io.FileOutputStream. f)]
       (.write fos img-bytes))
     f))

--- a/src/metabase/channel/temp_file.clj
+++ b/src/metabase/channel/temp_file.clj
@@ -1,0 +1,38 @@
+(ns metabase.channel.temp-file
+  "Tracks temporary files created during channel rendering (email attachments, inline images, dashboard PDFs) so they
+  can be deleted immediately after the message is sent, rather than accumulating until JVM shutdown via
+  `.deleteOnExit`."
+  (:require
+   [metabase.util.log :as log])
+  (:import
+   (java.io File)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:dynamic *tracked-temp-files*
+  "When bound to an atom, temp files registered via [[track-temp-file!]] are collected here for cleanup."
+  nil)
+
+(defn track-temp-file!
+  "Register a temp file for cleanup. When [[*tracked-temp-files*]] is bound (inside [[with-temp-file-cleanup]]),
+  the file is tracked and will be deleted when the cleanup block exits. Otherwise, falls back to `.deleteOnExit`."
+  [^File f]
+  (if-let [tracker *tracked-temp-files*]
+    (swap! tracker conj f)
+    (.deleteOnExit f))
+  f)
+
+(defmacro with-temp-file-cleanup
+  "Binds [[*tracked-temp-files*]] so that any temp files registered via [[track-temp-file!]] during `body` are deleted
+  in a `finally` block after `body` completes."
+  [& body]
+  `(binding [*tracked-temp-files* (atom [])]
+     (try
+       ~@body
+       (finally
+         (doseq [^File f# @*tracked-temp-files*]
+           (try
+             (when (.exists f#)
+               (.delete f#))
+             (catch Exception e#
+               (log/warnf e# "Failed to delete temp file: %s" (.getAbsolutePath f#)))))))))

--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -4,6 +4,7 @@
    [metabase.analytics-interface.core :as analytics]
    [metabase.analytics.core :as analytics.core]
    [metabase.channel.core :as channel]
+   [metabase.channel.temp-file :as temp-file]
    [metabase.config.core :as config]
    [metabase.notification.models :as models.notification]
    [metabase.notification.payload.core :as notification.payload]
@@ -170,20 +171,21 @@
                   (doseq [handler handlers]
                     (log/with-context {:handler_id   (:id handler)
                                        :channel_type (:channel_type handler)}
-                      (try
-                        (let [channel-type (:channel_type handler)
-                              messages     (channel/render-notification
-                                            channel-type
-                                            notification-payload
-                                            handler)]
-                          (log/debugf "Got %d messages for channel %s with template %d"
-                                      (count messages)
-                                      (handler->channel-name handler)
-                                      (-> handler :template :id))
-                          (doseq [message messages]
-                            (channel-send-retrying! id payload_type handler message)))
-                        (catch Exception e
-                          (log/errorf e "Error sending to channel %s" (handler->channel-name handler))))))
+                      (temp-file/with-temp-file-cleanup
+                        (try
+                          (let [channel-type (:channel_type handler)
+                                messages     (channel/render-notification
+                                              channel-type
+                                              notification-payload
+                                              handler)]
+                            (log/debugf "Got %d messages for channel %s with template %d"
+                                        (count messages)
+                                        (handler->channel-name handler)
+                                        (-> handler :template :id))
+                            (doseq [message messages]
+                              (channel-send-retrying! id payload_type handler message)))
+                          (catch Exception e
+                            (log/errorf e "Error sending to channel %s" (handler->channel-name handler)))))))
                   (log/info "Done processing notification")))
               (do-after-notification-sent hydrated-notification notification-payload (some? skip-reason))
               (analytics/inc! :metabase-notification/send-ok {:payload-type payload_type}))))

--- a/test/metabase/channel/impl/email_test.clj
+++ b/test/metabase/channel/impl/email_test.clj
@@ -1,11 +1,14 @@
 (ns metabase.channel.impl.email-test
   (:require
+   [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.channel.core :as channel]
    [metabase.channel.email :as email]
    [metabase.channel.impl.email :as email.impl]
+   [metabase.channel.render.core :as channel.render]
    [metabase.channel.render.util :as render.util]
+   [metabase.channel.temp-file :as temp-file]
    [metabase.channel.urls :as urls]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -218,3 +221,16 @@
            (testing "branding link is hidden with whitelabel"
              (mt/with-premium-features #{:whitelabel}
                (is (not (str/includes? (render!) "Made with")))))))))))
+
+(deftest dashboard-pdf-attachment-cleans-up-temp-file-test
+  (testing "dashboard-pdf-attachment's temp PDF file is deleted once the tracked cleanup scope exits (#77153)"
+    (mt/with-dynamic-fn-redefs [channel.render/render-dashboard-to-pdf (fn [& _] (.getBytes "not a real pdf"))]
+      (let [pdf-file (atom nil)]
+        (temp-file/with-temp-file-cleanup
+          (let [attachment (#'email.impl/dashboard-pdf-attachment 1 "My Dashboard" (mt/user->id :crowberto) [] [])
+                file       (io/file (.toURI ^java.net.URL (:content attachment)))]
+            (reset! pdf-file file)
+            (testing "the temp file exists while the cleanup scope is still open"
+              (is (.exists file)))))
+        (testing "the temp file is deleted once the cleanup scope exits"
+          (is (not (.exists ^java.io.File @pdf-file))))))))

--- a/test/metabase/channel/temp_file_test.clj
+++ b/test/metabase/channel/temp_file_test.clj
@@ -1,0 +1,80 @@
+(ns metabase.channel.temp-file-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.channel.temp-file :as temp-file])
+  (:import
+   (java.io File)))
+
+(set! *warn-on-reflection* true)
+
+(defn- new-temp-file! ^File []
+  (doto (File/createTempFile "metabase_temp_file_test_" ".tmp")
+    ;; the fallback path already calls .deleteOnExit, but callers of track-temp-file! shouldn't have to rely on
+    ;; that in tests -- we clean up explicitly below regardless of what track-temp-file! does.
+    (.deleteOnExit)))
+
+(deftest track-temp-file-without-binding-test
+  (testing "without *tracked-temp-files* bound, track-temp-file! doesn't track and returns the file"
+    (let [f (new-temp-file!)]
+      (is (nil? temp-file/*tracked-temp-files*))
+      (is (identical? f (temp-file/track-temp-file! f)))
+      (.delete f))))
+
+(deftest track-temp-file-with-binding-test
+  (testing "with *tracked-temp-files* bound, track-temp-file! adds the file to the tracker atom"
+    (let [f (new-temp-file!)]
+      (binding [temp-file/*tracked-temp-files* (atom [])]
+        (is (identical? f (temp-file/track-temp-file! f)))
+        (is (= [f] @temp-file/*tracked-temp-files*)))
+      (.delete f))))
+
+(deftest with-temp-file-cleanup-deletes-on-normal-completion-test
+  (testing "with-temp-file-cleanup deletes tracked files after body completes normally"
+    (let [f (new-temp-file!)]
+      (is (.exists f))
+      (temp-file/with-temp-file-cleanup
+        (temp-file/track-temp-file! f)
+        (is (.exists f) "file should still exist while the cleanup scope is open"))
+      (is (not (.exists f)) "file should be deleted once the cleanup scope exits"))))
+
+(deftest with-temp-file-cleanup-deletes-on-exception-test
+  (testing "with-temp-file-cleanup deletes tracked files even when the body throws"
+    (let [f (new-temp-file!)]
+      (is (.exists f))
+      (is (thrown-with-msg?
+           Exception #"boom"
+           (temp-file/with-temp-file-cleanup
+             (temp-file/track-temp-file! f)
+             (throw (ex-info "boom" {})))))
+      (is (not (.exists f)) "file should be deleted even though the body threw"))))
+
+(deftest with-temp-file-cleanup-handles-already-deleted-file-test
+  (testing "with-temp-file-cleanup doesn't throw when a tracked file was already deleted before cleanup runs"
+    (let [f (new-temp-file!)]
+      (is (nil? (temp-file/with-temp-file-cleanup
+                  (temp-file/track-temp-file! f)
+                  (.delete f)
+                  nil))))))
+
+(deftest with-temp-file-cleanup-returns-body-value-test
+  (testing "with-temp-file-cleanup returns the value of body"
+    (is (= :the-result
+           (temp-file/with-temp-file-cleanup
+             :the-result)))))
+
+(deftest with-temp-file-cleanup-nested-scopes-test
+  (testing "nested with-temp-file-cleanup scopes clean up independently"
+    (let [outer-file (new-temp-file!)
+          inner-file (new-temp-file!)]
+      (temp-file/with-temp-file-cleanup
+        (temp-file/track-temp-file! outer-file)
+        (is (.exists outer-file))
+        (temp-file/with-temp-file-cleanup
+          (temp-file/track-temp-file! inner-file)
+          (is (.exists inner-file)))
+        (testing "inner file is gone once the inner scope exits"
+          (is (not (.exists inner-file))))
+        (testing "outer file still exists while the outer scope is open"
+          (is (.exists outer-file))))
+      (testing "outer file is gone once the outer scope exits"
+        (is (not (.exists outer-file)))))))


### PR DESCRIPTION
## Description

Fixes #77153.

Email/subscription attachment temp files (CSV/XLSX, dashboard PDFs, chart PNGs) are created with `.deleteOnExit` only, so on long-running containers (e.g. the official Docker image, which has no `/tmp` cleanup cron) they accumulate until the disk fills, breaking subscriptions, alerts, and exports with `IOException: No space left on device`. Multiple customer production outages are cited in the issue.

This follows the pattern already used correctly by the query-result spill files in `metabase.notification.payload.temp-storage` (delete right after use, `.deleteOnExit` only as a backstop) rather than inventing a new approach.

### Approach

Adds `metabase.channel.temp-file`, a small dynamic-var-scoped tracker:
- `track-temp-file!` registers a file for cleanup if `*tracked-temp-files*` is bound, otherwise falls back to today's `.deleteOnExit` behavior (so any call site outside the notification-send path degrades to current behavior, not a leak of a different kind).
- `with-temp-file-cleanup` binds the tracker and deletes every registered file in a `finally` block.

`metabase.notification.send` wraps each handler's render+send in `with-temp-file-cleanup`, so temp files created anywhere during that handler's `channel/render-notification` call are deleted immediately after `channel/send!` has consumed them (synchronously, including retries) — success or failure.

All three affected call sites are updated:
- `metabase.channel.email.result-attachment/create-temp-file!` (CSV/XLSX attachments)
- `metabase.channel.render.image-bundle/write-byte-array-to-temp-file` (chart PNGs)
- `metabase.channel.impl.email/dashboard-pdf-attachment` (dashboard PDFs)

Related prior art: #70284 attempted this fix for the first two call sites but was closed unmerged after unrelated e2e failures (dependency/workspace/remote-sync specs — nothing touching attachments) before anyone reviewed it. It also didn't cover the PDF call site, which still leaked. This PR covers all three.

### How to verify

Previous behavior:
1. Clean `$TMPDIR`.
2. Trigger a dashboard subscription with CSV/XLSX attachments and/or a PDF export via email.
3. `ls $TMPDIR/metabase_attachment* $TMPDIR/metabase_dashboard_*.pdf $TMPDIR/metabase_channel_image_*` — files remain indefinitely.

After this PR:
1. Repeat the same steps on this branch.
2. The temp files are gone immediately after the notification is sent.

## Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

