### PR TITLE
Content diagnostics root collection breadcrumb

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/api_routes/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/api_routes/routes.clj
@@ -108,9 +108,7 @@
    "/ai-controls"                  (premium-handler metabase-enterprise.metabot.api.routes/routes :ai-controls)
    "/audit-app"                    (premium-handler metabase-enterprise.audit-app.api.routes/routes :audit-app)
    "/billing"                      metabase-enterprise.billing.api.routes/routes
-   ;; DEV (content-optimizer): premium feature gate commented out to ease dev work; restore the gated line before merge.
-   ;; "/content-diagnostics"       (premium-handler metabase-enterprise.content-diagnostics.api/routes :content-diagnostics)
-   "/content-diagnostics"          metabase-enterprise.content-diagnostics.api/routes
+   "/content-diagnostics"          (premium-handler metabase-enterprise.content-diagnostics.api/routes :content-diagnostics)
    "/content-translation"          (premium-handler metabase-enterprise.content-translation.routes/routes :content-translation)
    "/custom-viz-plugin"            (premium-handler metabase-enterprise.custom-viz-plugin.api/routes :custom-viz)
    "/cloud-add-ons"                metabase-enterprise.cloud-add-ons.api/routes

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -147,6 +147,29 @@
                      :effective_ancestors (mapv #(select-keys % [:id :name]) (:effective_ancestors c))}]))
             colls))))
 
+(defn- root-breadcrumb
+  "The root-collection sentinel used as a root-resident entity's `collection` breadcrumb, normalized to the
+  `{:id :name :effective_ancestors}` shape the nested-collection breadcrumbs use. `:id` is the literal
+  \"root\" (the app-wide root id - the FE detects root by id, never by the localized name); `:name` is the
+  namespace-scoped root label (\"Our analytics\", or \"Transforms\" for a transform, whose collections live in
+  the `:transforms` namespace). Root has no ancestors. Mirrors how the rest of the app links root as a
+  breadcrumb (`collection/hydrate-root-collection` / the root head of `:effective_ancestors`)."
+  [entity-type]
+  (let [root (collection/root-collection-with-ui-details (when (= entity-type :transform) :transforms))]
+    {:id (:id root) :name (:name root) :effective_ancestors []}))
+
+(defn- entity-breadcrumb
+  "One finding's `collection` breadcrumb from its hydrated `entity` context row: the parent-collection
+  object when the entity lives in a readable collection; the namespaced root sentinel when it is
+  root-resident (nil parent - every covered subject is placeable, so a nil parent means \"at the root of its
+  tree\", never \"no collection concept\"); nil when the parent is unreadable (degrades leak-safe, visually
+  like root) or the entity was deleted post-scan (absent from `entity`)."
+  [entity-type entity breadcrumbs]
+  (when entity
+    (if-let [parent-id (:collection_id entity)]
+      (get breadcrumbs parent-id)
+      (root-breadcrumb entity-type))))
+
 (defn- hydrate-slow-entities
   "Card-id set → `{card-id → {:id :name :entity_type :card :card_type <kw> :view_count <int>}}`. The
   read-time hydration of a `slow` roll-up's stored culprit ids (`slow_entity_ids`) into objects.
@@ -209,7 +232,7 @@
                        entity_name entity_creator_id entity_creator_name details] :as row}]
             (let [entity  (get-in ctx-by-type [entity_type entity_id])
                   base    (merge details
-                                 {:collection  (get breadcrumbs (:collection_id entity))
+                                 {:collection  (entity-breadcrumb entity_type entity breadcrumbs)
                                   :description (:description entity)
                                   ;; only transforms have owner columns; null for the rest.
                                   :owner       (normalized-owner entity)

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/slow_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/slow_test.clj
@@ -701,6 +701,27 @@
                   (is (contains? stale-ids stale-fid))
                   (is (not (contains? stale-ids slow-fid))))))))))))
 
+(deftest slow-api-transform-root-breadcrumb-test
+  (testing "GET /slow: a root-resident transform's breadcrumb is the Transforms-namespaced root sentinel"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-temporary-setting-values [content-diagnostics-slow-transform-threshold-seconds 10]
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (let [now (t/offset-date-time)]
+            (mt/with-temp
+              ;; no :collection_id → the transform sits at the root of the :transforms tree
+              [:model/Transform    {xform :id} {}
+               :model/TransformRun _ {:transform_id xform :status :succeeded
+                                      :start_time (t/minus now (t/minutes 2))
+                                      :end_time   (t/minus now (t/minutes 1))}]
+              (scan/scan!)
+              (let [resp  (mt/user-http-request :crowberto :get 200 "ee/content-diagnostics/slow")
+                    by-id (into {} (map (juxt (juxt :entity_type :entity_id) identity)) (:data resp))
+                    f     (by-id ["transform" xform])]
+                (is (some? f))
+                (testing "root sentinel is namespaced to Transforms, not the default \"Our analytics\""
+                  (is (= {:id "root" :name "Transforms" :effective_ancestors []}
+                         (get-in f [:details :collection]))))))))))))
+
 (deftest slow-api-feature-gated-test
   (testing "GET /slow is gated on the :content-diagnostics premium feature (premium-handler)"
     (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]


### PR DESCRIPTION
### Description

There was no way to tell previously if an entity was contained in a root collection vs the parent collection being unreadable by the current user. This change handles the proper hydration of a sentinel value for root collections.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
