### PR TITLE
GDGT-2564 Webhook destination cannot be saved from the UI

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/Notifications/WebhookForm.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/Notifications/WebhookForm.tsx
@@ -36,12 +36,33 @@ import {
 
 import { buildAuthInfo } from "./utils";
 
+/**
+ * Approximates the backend validator (metabase.util/url?), which unlike Yup's
+ * .url() accepts bare hostnames such as http://webhook-tester:8080/
+ */
+const isValidWebhookUrl = (value: string): boolean => {
+  if (value !== value.trim() || !value.includes("://")) {
+    return false;
+  }
+
+  try {
+    const { protocol } = new URL(value);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
 const validationSchema = Yup.object({
   url: Yup.string()
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    .url(t`Please enter a correctly formatted URL`)
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    .required(t`Please enter a correctly formatted URL`),
+    .required(t`Please enter a correctly formatted URL`)
+    .test(
+      "is-http-url",
+      // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
+      t`Please enter a correctly formatted URL`,
+      (value) => value != null && isValidWebhookUrl(value),
+    ),
   // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
   name: Yup.string().required(t`Please add a name`),
   // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045

--- a/frontend/src/metabase/admin/settings/components/widgets/Notifications/WebhookForm.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/Notifications/WebhookForm.tsx
@@ -1,5 +1,5 @@
 import type { FormikHelpers } from "formik";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { c, jt, t } from "ttag";
 import * as Yup from "yup";
 
@@ -53,28 +53,26 @@ const isValidWebhookUrl = (value: string): boolean => {
   }
 };
 
-const validationSchema = Yup.object({
-  url: Yup.string()
-    // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-    .required(t`Please enter a correctly formatted URL`)
-    .test(
-      "is-http-url",
-      // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-      t`Please enter a correctly formatted URL`,
-      (value) => value != null && isValidWebhookUrl(value),
-    ),
-  // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-  name: Yup.string().required(t`Please add a name`),
-  // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-  description: Yup.string().required(t`Please add a description`),
-  "auth-method": Yup.string()
-    .required()
-    .equals(["none", "header", "query-param", "request-body"]),
-  "fe-form-type": Yup.string()
-    .required()
-    .equals(["none", "basic", "bearer", "api-key"]),
-  "auth-info": Yup.object(),
-});
+function getValidationSchema() {
+  return Yup.object({
+    url: Yup.string()
+      .required(t`Please enter a correctly formatted URL`)
+      .test(
+        "is-http-url",
+        t`Please enter a correctly formatted URL`,
+        (value) => value != null && isValidWebhookUrl(value),
+      ),
+    name: Yup.string().required(t`Please add a name`),
+    description: Yup.string().required(t`Please add a description`),
+    "auth-method": Yup.string()
+      .required()
+      .equals(["none", "header", "query-param", "request-body"]),
+    "fe-form-type": Yup.string()
+      .required()
+      .equals(["none", "basic", "bearer", "api-key"]),
+    "auth-info": Yup.object(),
+  });
+}
 
 const styles = {
   wrapperProps: {
@@ -199,6 +197,7 @@ export const WebhookForm = ({
   const { label: testButtonLabel, setLabel: setTestButtonLabel } =
     useActionButtonLabel({ defaultLabel: t`Send a test` });
   const [testChannel, { error }] = useTestChannelMutation();
+  const [validationSchema] = useState(getValidationSchema());
 
   const errorData = useMemo(() => {
     if (isNotificationChannelTestErrorResponse(error)) {

--- a/frontend/src/metabase/admin/settings/components/widgets/Notifications/WebhookForm.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/Notifications/WebhookForm.tsx
@@ -36,23 +36,6 @@ import {
 
 import { buildAuthInfo } from "./utils";
 
-/**
- * Approximates the backend validator (metabase.util/url?), which unlike Yup's
- * .url() accepts bare hostnames such as http://webhook-tester:8080/
- */
-const isValidWebhookUrl = (value: string): boolean => {
-  if (value !== value.trim() || !value.includes("://")) {
-    return false;
-  }
-
-  try {
-    const { protocol } = new URL(value);
-    return protocol === "http:" || protocol === "https:";
-  } catch {
-    return false;
-  }
-};
-
 function getValidationSchema() {
   return Yup.object({
     url: Yup.string()
@@ -72,6 +55,23 @@ function getValidationSchema() {
       .equals(["none", "basic", "bearer", "api-key"]),
     "auth-info": Yup.object(),
   });
+}
+
+/**
+ * Approximates the backend validator (metabase.util/url?), which unlike Yup's
+ * .url() accepts bare hostnames such as http://webhook-tester:8080/
+ */
+function isValidWebhookUrl(value: string): boolean {
+  if (value !== value.trim() || !value.includes("://")) {
+    return false;
+  }
+
+  try {
+    const { protocol } = new URL(value);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 const styles = {

--- a/frontend/src/metabase/admin/settings/components/widgets/Notifications/WebhookForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/Notifications/WebhookForm.unit.spec.tsx
@@ -54,16 +54,19 @@ describe("WebhookForm", () => {
     jest.useRealTimers();
   });
 
-  it("should error when an invalid url is given", async () => {
-    await setup();
-    await userEvent.type(
-      await screen.findByLabelText("Webhook URL"),
-      "A-bad-url{tab}",
-    );
-    expect(
-      await screen.findByText("Please enter a correctly formatted URL"),
-    ).toBeInTheDocument();
-  });
+  it.each(["A-bad-url", "webhook-tester:8080", " http://padded.example.com/"])(
+    "should error when an invalid url is given (%s)",
+    async (url) => {
+      await setup();
+      await userEvent.type(
+        await screen.findByLabelText("Webhook URL"),
+        `${url}{tab}`,
+      );
+      expect(
+        await screen.findByText("Please enter a correctly formatted URL"),
+      ).toBeInTheDocument();
+    },
+  );
 
   it("should accept bare-hostname URLs (metabase#74812)", async () => {
     const { onSubmit } = await setup();

--- a/frontend/src/metabase/admin/settings/components/widgets/Notifications/WebhookForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/Notifications/WebhookForm.unit.spec.tsx
@@ -65,6 +65,30 @@ describe("WebhookForm", () => {
     ).toBeInTheDocument();
   });
 
+  it("should accept bare-hostname URLs (metabase#74812)", async () => {
+    const { onSubmit } = await setup();
+    await userEvent.type(
+      await screen.findByLabelText("Webhook URL"),
+      "http://webhook-tester:8080/",
+    );
+    await userEvent.type(screen.getByLabelText("Give it a name"), "Local hook");
+    await userEvent.type(
+      screen.getByLabelText("Description"),
+      "Docker network hook",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Create destination" }),
+    );
+
+    expect(
+      screen.queryByText("Please enter a correctly formatted URL"),
+    ).not.toBeInTheDocument();
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "http://webhook-tester:8080/" }),
+      expect.anything(),
+    );
+  });
+
   it("should error when no name is provided", async () => {
     await setup();
     await userEvent.type(


### PR DESCRIPTION
Closes #74812
Closes [GDGT-2564](https://linear.app/metabase/issue/GDGT-2564/webhook-destination-cannot-be-saved-from-the-ui)

### Description

Hiding whitespace changes recommended.

Yup's `.url()` validator requires a dotted (TLD-style) hostname, so bare-hostname URLs like `http://webhook-tester:8080/` were rejected in the UI, even though the backend accepts them.
This PR makes the FE validation of URLs closer to BE implementation, and fixes a few `ttag/no-module-declaration` violations.

### How to verify

1. Admin > Settings > Webhooks > Add a webhook
2. Enter this URL and click away: `http://webhook-tester:8080/00000000-0000-0000-0000-000000000000`

There should be no error in the form.
