### PR TITLE
Prevent scrollbar flicker from cell tooltips in TreeTable

### DIFF
--- a/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTable.tsx
+++ b/frontend/src/metabase/ui/components/data-display/TreeTable/TreeTable.tsx
@@ -1,3 +1,4 @@
+import { useMergedRef } from "@mantine/hooks";
 import type { Row } from "@tanstack/react-table";
 import type { VirtualItem } from "@tanstack/react-virtual";
 import cx from "classnames";
@@ -8,12 +9,14 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from "react";
 
 import {
   Box,
   Center,
   Flex,
+  TooltipPortalTargetProvider,
   type TreeTableRowPinnedPosition,
 } from "metabase/ui";
 
@@ -67,6 +70,11 @@ export function TreeTable<TData extends TreeNodeData>({
   } = instance;
 
   const rootRef = useRef<HTMLDivElement>(null);
+
+  // Portal cell tooltips into the scroll container so a tooltip positioned past
+  // the fold is clipped by the table instead of stretching <body> (metabase#GDGT-2822)
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+  const bodyRef = useMergedRef(containerRef, setPortalTarget);
 
   const handleKeyDownWithFocus = useCallback(
     (event: KeyboardEvent<HTMLElement>) => {
@@ -183,92 +191,102 @@ export function TreeTable<TData extends TreeNodeData>({
   );
 
   return (
-    <Flex
-      ref={rootRef}
-      className={cx(S.root, classNames?.root)}
-      style={styles?.root}
-      direction="column"
-      flex={1}
-      mih={0}
-      w="100%"
-      role="treegrid"
-      tabIndex={0}
-      aria-label={ariaLabel}
-      aria-labelledby={ariaLabelledBy}
-      onKeyDown={handleKeyDownWithFocus}
-    >
-      <Box
-        ref={containerRef}
-        className={cx(S.body, classNames?.body, { [S.measuring]: !isMeasured })}
+    <TooltipPortalTargetProvider target={portalTarget}>
+      <Flex
+        ref={rootRef}
+        className={cx(S.root, classNames?.root)}
+        style={styles?.root}
+        direction="column"
         flex={1}
-        style={styles?.body}
+        mih={0}
+        w="100%"
+        role="treegrid"
+        tabIndex={0}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        onKeyDown={handleKeyDownWithFocus}
       >
-        {showEmptyState ? (
-          <Center h="100%" p="xl" c="text-disabled">
-            {emptyState}
-          </Center>
-        ) : (
-          <>
-            <Box
-              pos="sticky"
-              top={0}
-              style={{ minWidth: totalContentWidth, zIndex: 1 }}
-            >
-              <TreeTableHeader
-                table={table}
-                columnWidths={columnWidths}
-                showCheckboxes={showCheckboxes}
-                headerVariant={headerVariant}
-                classNames={classNames}
-                styles={styles}
-                isMeasured={isMeasured}
-                totalContentWidth={totalContentWidth}
-                getSelectionState={getSelectionState}
-                onHeaderCheckboxClick={onHeaderCheckboxClick}
-                headerCheckboxAriaLabel={headerCheckboxAriaLabel}
-              />
-              {topPinnedRows.length > 0 && (
-                <Box
-                  className={classNames?.pinnedTop}
-                  style={{ minWidth: totalContentWidth, ...styles?.pinnedTop }}
-                >
-                  {topPinnedRows.map((row, index) =>
-                    renderRow(row, index, "top"),
-                  )}
-                </Box>
-              )}
-            </Box>
-            <Box
-              pos="relative"
-              style={{ height: totalSize, minWidth: totalContentWidth }}
-            >
-              {virtualRows.map((virtualItem) => {
-                const row = centerRows[virtualItem.index];
-                if (!row) {
-                  return null;
-                }
-                const rowIndex = topPinnedRows.length + virtualItem.index;
-                return renderRow(row, rowIndex, virtualItem);
-              })}
-            </Box>
-
-            {bottomPinnedRows.length > 0 && (
+        <Box
+          ref={bodyRef}
+          className={cx(S.body, classNames?.body, {
+            [S.measuring]: !isMeasured,
+          })}
+          flex={1}
+          style={styles?.body}
+        >
+          {showEmptyState ? (
+            <Center h="100%" p="xl" c="text-disabled">
+              {emptyState}
+            </Center>
+          ) : (
+            <>
               <Box
                 pos="sticky"
-                bottom={0}
-                className={classNames?.pinnedBottom}
-                style={{ minWidth: totalContentWidth, ...styles?.pinnedBottom }}
+                top={0}
+                style={{ minWidth: totalContentWidth, zIndex: 1 }}
               >
-                {bottomPinnedRows.map((row, index) => {
-                  const rowIndex =
-                    topPinnedRows.length + centerRows.length + index;
-                  return renderRow(row, rowIndex, "bottom");
+                <TreeTableHeader
+                  table={table}
+                  columnWidths={columnWidths}
+                  showCheckboxes={showCheckboxes}
+                  headerVariant={headerVariant}
+                  classNames={classNames}
+                  styles={styles}
+                  isMeasured={isMeasured}
+                  totalContentWidth={totalContentWidth}
+                  getSelectionState={getSelectionState}
+                  onHeaderCheckboxClick={onHeaderCheckboxClick}
+                  headerCheckboxAriaLabel={headerCheckboxAriaLabel}
+                />
+                {topPinnedRows.length > 0 && (
+                  <Box
+                    className={classNames?.pinnedTop}
+                    style={{
+                      minWidth: totalContentWidth,
+                      ...styles?.pinnedTop,
+                    }}
+                  >
+                    {topPinnedRows.map((row, index) =>
+                      renderRow(row, index, "top"),
+                    )}
+                  </Box>
+                )}
+              </Box>
+              <Box
+                pos="relative"
+                style={{ height: totalSize, minWidth: totalContentWidth }}
+              >
+                {virtualRows.map((virtualItem) => {
+                  const row = centerRows[virtualItem.index];
+                  if (!row) {
+                    return null;
+                  }
+                  const rowIndex = topPinnedRows.length + virtualItem.index;
+                  return renderRow(row, rowIndex, virtualItem);
                 })}
               </Box>
-            )}
-          </>
-        )}
-      </Box>
-    </Flex>
+
+              {bottomPinnedRows.length > 0 && (
+                <Box
+                  pos="sticky"
+                  bottom={0}
+                  className={classNames?.pinnedBottom}
+                  style={{
+                    minWidth: totalContentWidth,
+                    ...styles?.pinnedBottom,
+                  }}
+                >
+                  {bottomPinnedRows.map((row, index) => {
+                    const rowIndex =
+                      topPinnedRows.length + centerRows.length + index;
+                    return renderRow(row, rowIndex, "bottom");
+                  })}
+                </Box>
+              )}
+            </>
+          )}
+        </Box>
+      </Flex>
+    </TooltipPortalTargetProvider>
   );
 }

--- a/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.tsx
@@ -1,5 +1,10 @@
 import { Tooltip as MantineTooltip, type TooltipProps } from "@mantine/core";
-import { type PropsWithChildren, createContext, useContext } from "react";
+import {
+  type PropsWithChildren,
+  createContext,
+  useContext,
+  useMemo,
+} from "react";
 
 const TooltipPortalTargetContext = createContext<HTMLElement | null>(null);
 
@@ -14,17 +19,20 @@ export function TooltipPortalTargetProvider({
   );
 }
 
-export const Tooltip = Object.assign(
-  function Tooltip({ portalProps, ...props }: TooltipProps) {
-    const contextTarget = useContext(TooltipPortalTargetContext);
-    const resolvedPortalProps =
+function TooltipImpl({ portalProps, ...props }: TooltipProps) {
+  const contextTarget = useContext(TooltipPortalTargetContext);
+  const resolvedPortalProps = useMemo(
+    () =>
       contextTarget && portalProps?.target == null
         ? { ...portalProps, target: contextTarget }
-        : portalProps;
-    return <MantineTooltip {...props} portalProps={resolvedPortalProps} />;
-  },
-  {
-    Floating: MantineTooltip.Floating,
-    Group: MantineTooltip.Group,
-  },
-);
+        : portalProps,
+    [contextTarget, portalProps],
+  );
+
+  return <MantineTooltip {...props} portalProps={resolvedPortalProps} />;
+}
+
+export const Tooltip = Object.assign(TooltipImpl, {
+  Floating: MantineTooltip.Floating,
+  Group: MantineTooltip.Group,
+});

--- a/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.tsx
@@ -1,0 +1,30 @@
+import { Tooltip as MantineTooltip, type TooltipProps } from "@mantine/core";
+import { type PropsWithChildren, createContext, useContext } from "react";
+
+const TooltipPortalTargetContext = createContext<HTMLElement | null>(null);
+
+export function TooltipPortalTargetProvider({
+  target,
+  children,
+}: PropsWithChildren<{ target: HTMLElement | null }>) {
+  return (
+    <TooltipPortalTargetContext.Provider value={target}>
+      {children}
+    </TooltipPortalTargetContext.Provider>
+  );
+}
+
+export const Tooltip = Object.assign(
+  function Tooltip({ portalProps, ...props }: TooltipProps) {
+    const contextTarget = useContext(TooltipPortalTargetContext);
+    const resolvedPortalProps =
+      contextTarget && portalProps?.target == null
+        ? { ...portalProps, target: contextTarget }
+        : portalProps;
+    return <MantineTooltip {...props} portalProps={resolvedPortalProps} />;
+  },
+  {
+    Floating: MantineTooltip.Floating,
+    Group: MantineTooltip.Group,
+  },
+);

--- a/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.tsx
@@ -2,6 +2,7 @@ import { Tooltip as MantineTooltip, type TooltipProps } from "@mantine/core";
 import {
   type PropsWithChildren,
   createContext,
+  forwardRef,
   useContext,
   useMemo,
 } from "react";
@@ -19,18 +20,22 @@ export function TooltipPortalTargetProvider({
   );
 }
 
-function TooltipImpl({ portalProps, ...props }: TooltipProps) {
-  const contextTarget = useContext(TooltipPortalTargetContext);
-  const resolvedPortalProps = useMemo(
-    () =>
-      contextTarget && portalProps?.target == null
-        ? { ...portalProps, target: contextTarget }
-        : portalProps,
-    [contextTarget, portalProps],
-  );
+const TooltipImpl = forwardRef<HTMLDivElement, TooltipProps>(
+  function TooltipImpl({ portalProps, ...props }, ref) {
+    const contextTarget = useContext(TooltipPortalTargetContext);
+    const resolvedPortalProps = useMemo(
+      () =>
+        contextTarget && portalProps?.target == null
+          ? { ...portalProps, target: contextTarget }
+          : portalProps,
+      [contextTarget, portalProps],
+    );
 
-  return <MantineTooltip {...props} portalProps={resolvedPortalProps} />;
-}
+    return (
+      <MantineTooltip {...props} portalProps={resolvedPortalProps} ref={ref} />
+    );
+  },
+);
 
 export const Tooltip = Object.assign(TooltipImpl, {
   Floating: MantineTooltip.Floating,

--- a/frontend/src/metabase/ui/components/overlays/Tooltip/index.ts
+++ b/frontend/src/metabase/ui/components/overlays/Tooltip/index.ts
@@ -1,3 +1,3 @@
-export { Tooltip } from "@mantine/core";
+export { Tooltip, TooltipPortalTargetProvider } from "./Tooltip";
 export type { TooltipProps } from "@mantine/core";
 export { tooltipOverrides } from "./Tooltip.config";


### PR DESCRIPTION
Closes [GDGT-2822](https://linear.app/metabase/issue/GDGT-2822)

### Description

Previously, hovering a cell tooltip in a Monitor table (Erroring Questions, Alerts management — both render `TreeTable`) and scrolling made a page-level vertical scrollbar flash on and off, so the whole page flickered.

The tooltip is portaled to `<body>`. Once its reference cell scrolls past the fold, the tooltip is positioned below the fold and grows the document past the viewport height, briefly flashing the page's vertical scrollbar.

`TreeTable` now portals its cell tooltips into the table's own scroll container instead of `<body>`, so a tooltip positioned past the fold is clipped by the (already-scrolling) table rather than stretching the page. A tooltip that passes its own `portalProps.target` still wins.

### How to verify

1. Open Monitor → Erroring questions (or Alerts management) with enough rows to scroll vertically. Downsizing the browser window to about half its normal height helps reproduce.
2. Hover a cell (e.g. the Error / Last send column) and scroll the table up and down.
3. The page should no longer flicker — no viewport scrollbar flashing in and out.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR