### PR TITLE
Serialize card last_used_at so imports don't reset it

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -2736,3 +2736,31 @@
                     (is (= (:id data-dest) (:id data-after))))
                   (testing "permissions are unchanged after import"
                     (is (= perms-before perms-after))))))))))))
+
+(deftest card-last-used-at-test
+  (let [serialized  (atom nil)
+        eid         (u/generate-nano-id)
+        source-date (t/offset-date-time 2021 3 1 10)]
+    (ts/with-dbs [source-db dest-db]
+      (ts/with-db source-db
+        (let [db   (ts/create! :model/Database :name "my-db")
+              card (ts/create! :model/Card
+                               :name "old card"
+                               :entity_id eid
+                               :database_id (:id db)
+                               :dataset_query {:database (:id db)
+                                               :type     :native
+                                               :native   {:query "select 1"}})]
+          (t2/update! :model/Card (:id card) {:last_used_at source-date})
+          (reset! serialized (into [] (serdes.extract/extract {:no-settings true})))))
+      (ts/with-db dest-db
+        (testing "a fresh import brings over last_used_at, so auto-trash can see the card is stale (GDGT-217)"
+          (serdes.load/load-metabase! (ingestion-in-memory @serialized))
+          (is (= (t/instant source-date)
+                 (t2/select-one-fn (comp t/instant :last_used_at) :model/Card :entity_id eid))))
+        (testing "re-importing an existing card keeps the destination's own last_used_at"
+          (let [dest-date (t/offset-date-time 2025 6 1 12)]
+            (t2/update! :model/Card :entity_id eid {:last_used_at dest-date})
+            (serdes.load/load-metabase! (ingestion-in-memory @serialized))
+            (is (= (t/instant dest-date)
+                   (t2/select-one-fn (comp t/instant :last_used_at) :model/Card :entity_id eid)))))))))

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -791,13 +791,18 @@
   {:arglists '([model-name ingested local])}
   (fn [model _ _] model))
 
-(defmethod load-update! :default [model-name ingested local]
+(defn default-load-update!
+  "Default implementation of [[load-update!]]."
+  [model-name ingested local]
   (let [model    (t2.model/resolve-model (symbol model-name))
         pk       (first (t2/primary-keys model))
         id       (get local pk)]
     (log/tracef "Upserting %s %d: old %s new %s" model-name id (pr-str local) (pr-str ingested))
     (t2/update! model id ingested)
     (t2/select-one model pk id)))
+
+(defmethod load-update! :default [model-name ingested local]
+  (default-load-update! model-name ingested local))
 
 (defmulti load-insert!
   "Called by the default [[load-one!]] if there is no corresponding entity already in the appdb.

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1411,7 +1411,7 @@
           ;; cache invalidation is instance-specific
           :cache_invalidated_at
           ;; those are instance-specific analytic columns
-          :view_count :last_used_at :initially_published_at
+          :view_count :initially_published_at
           ;; this is data migration column
           :dataset_query_metrics_v2_migration_backup
           ;; this column is not used anymore
@@ -1428,6 +1428,8 @@
           :metabot_conversation_id :metabot_chart_id]
    :transform
    {:created_at             (serdes/date)
+    ;; exported so imported cards don't look freshly used to stale-content detection (GDGT-217)
+    :last_used_at           (serdes/date)
     ;; database_id is usually derivable from dataset_query, but must be kept when the query
     ;; is empty (e.g. a native card with no query yet) and database_id is the only reference.
     :database_id            (let [{:keys [import]} (serdes/fk :model/Database)]
@@ -1453,6 +1455,10 @@
               :archived_directly   false
               :collection_preview  true
               :enable_embedding    false}})
+
+(defmethod serdes/load-update! "Card" [_ ingested local]
+  ;; when the card already exists, its own usage history wins over the source's
+  (serdes/default-load-update! "Card" (dissoc ingested :last_used_at) local))
 
 (defn- card-deps
   "The serdes dependencies of a Card as `:serdes/meta` paths. `allow-int-ids?` selects raw-appdb vs serialized ref semantics for

--- a/test_resources/serialization_baseline/collections/main/dashboards/series_and_parameter_mappings/monthly_average_order.yaml
+++ b/test_resources/serialization_baseline/collections/main/dashboards/series_and_parameter_mappings/monthly_average_order.yaml
@@ -1,6 +1,7 @@
 name: Monthly Average Order
 entity_id: dShCrdMnthlyAvgOr0003
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: line
 collection_id: cOlDaShBoArDs0ExAmPlx

--- a/test_resources/serialization_baseline/collections/main/dashboards/series_and_parameter_mappings/monthly_cumulative_orders.yaml
+++ b/test_resources/serialization_baseline/collections/main/dashboards/series_and_parameter_mappings/monthly_cumulative_orders.yaml
@@ -1,6 +1,7 @@
 name: Monthly Cumulative Orders
 entity_id: dShCrdMnthlyCumul0004
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: line
 collection_id: cOlDaShBoArDs0ExAmPlx

--- a/test_resources/serialization_baseline/collections/main/dashboards/series_and_parameter_mappings/monthly_orders.yaml
+++ b/test_resources/serialization_baseline/collections/main/dashboards/series_and_parameter_mappings/monthly_orders.yaml
@@ -1,6 +1,7 @@
 name: Monthly Orders
 entity_id: dShCrdMnthlyOrdrs0001
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: line
 collection_id: cOlDaShBoArDs0ExAmPlx

--- a/test_resources/serialization_baseline/collections/main/dashboards/series_and_parameter_mappings/monthly_revenue.yaml
+++ b/test_resources/serialization_baseline/collections/main/dashboards/series_and_parameter_mappings/monthly_revenue.yaml
@@ -1,6 +1,7 @@
 name: Monthly Revenue
 entity_id: dShCrdMnthlyRevnu0002
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: line
 collection_id: cOlDaShBoArDs0ExAmPlx

--- a/test_resources/serialization_baseline/collections/main/dashboards/series_and_parameter_mappings/native_orders_query.yaml
+++ b/test_resources/serialization_baseline/collections/main/dashboards/series_and_parameter_mappings/native_orders_query.yaml
@@ -1,6 +1,7 @@
 name: Native Orders Query
 entity_id: dShCrdNatveOrders0005
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlDaShBoArDs0ExAmPlx

--- a/test_resources/serialization_baseline/collections/main/dashboards/series_and_parameter_mappings/total_revenue.yaml
+++ b/test_resources/serialization_baseline/collections/main/dashboards/series_and_parameter_mappings/total_revenue.yaml
@@ -1,6 +1,7 @@
 name: Total Revenue
 entity_id: dShCrdTtlRevScalr0006
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: scalar
 collection_id: cOlDaShBoArDs0ExAmPlx

--- a/test_resources/serialization_baseline/collections/main/dashboards/tabbed_dashboard/products_table.yaml
+++ b/test_resources/serialization_baseline/collections/main/dashboards/tabbed_dashboard/products_table.yaml
@@ -1,6 +1,7 @@
 name: Products Table
 entity_id: dShCrdProdsTables0007
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlDaShBoArDs0ExAmPlx

--- a/test_resources/serialization_baseline/collections/main/documents/product_analysis_report/category_breakdown.yaml
+++ b/test_resources/serialization_baseline/collections/main/documents/product_analysis_report/category_breakdown.yaml
@@ -1,6 +1,7 @@
 name: Category Breakdown
 entity_id: cRdCaTbReAkDoWn0ExMp1
 created_at: '2025-01-15T10:00:00Z'
+last_used_at: '2025-01-15T10:00:00Z'
 creator_id: internal@metabase.com
 display: bar
 collection_id: cOlDoCuMeNtS0ExAmPlx2

--- a/test_resources/serialization_baseline/collections/main/minimal/marketing_analytics/product_overview.yaml
+++ b/test_resources/serialization_baseline/collections/main/minimal/marketing_analytics/product_overview.yaml
@@ -1,6 +1,7 @@
 name: Product Overview
 entity_id: f1C68pznmrpN1F5xFDj6d
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: M-Q4pcV0qkiyJ0kiSWECl

--- a/test_resources/serialization_baseline/collections/main/minimal/marketing_analytics/top_products_by_revenue.yaml
+++ b/test_resources/serialization_baseline/collections/main/minimal/marketing_analytics/top_products_by_revenue.yaml
@@ -1,6 +1,7 @@
 name: Top Products by Revenue
 entity_id: FTxpeL9vY5pyb6Lc6lCDK
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: bar
 collection_id: M-Q4pcV0qkiyJ0kiSWECl

--- a/test_resources/serialization_baseline/collections/main/queries/arithmetic_expressions.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/arithmetic_expressions.yaml
@@ -1,6 +1,7 @@
 name: Arithmetic Expressions
 entity_id: 1O_2jSo2fD6m3Qr6My7aa
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/basic_aggregations.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/basic_aggregations.yaml
@@ -1,6 +1,7 @@
 name: Basic Aggregations
 entity_id: h5F2EjHsRd73Dqqh8sAtd
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/comparison_filters.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/comparison_filters.yaml
@@ -1,6 +1,7 @@
 name: Comparison Filters
 entity_id: 8kTL-8IzNdWMtXfaMPZaE
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/conditional_aggregations.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/conditional_aggregations.yaml
@@ -1,6 +1,7 @@
 name: Conditional Aggregations
 entity_id: irROiaJoSsiXPKGxwWvWY
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/conditional_and_type_conversion.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/conditional_and_type_conversion.yaml
@@ -1,6 +1,7 @@
 name: Conditional and Type Conversion
 entity_id: 1hsUzNOepulZo3Jamzd1R
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/cumulative_and_statistical_aggregations.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/cumulative_and_statistical_aggregations.yaml
@@ -1,6 +1,7 @@
 name: Cumulative and Statistical Aggregations
 entity_id: x61UtCMCuBNjw0TEFQeWG
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: line
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/fields_and_expressions.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/fields_and_expressions.yaml
@@ -1,6 +1,7 @@
 name: Fields and Expressions
 entity_id: fLdExPr3sS10nS0ExAmPl
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/geographic_filter__inside_.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/geographic_filter__inside_.yaml
@@ -1,6 +1,7 @@
 name: Geographic Filter (Inside)
 entity_id: bK64P6yr9_Nx-A8S3PqOZ
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: map
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/joins___strategies_and_compound_conditions.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/joins___strategies_and_compound_conditions.yaml
@@ -1,6 +1,7 @@
 name: Joins - Strategies and Compound Conditions
 entity_id: wpW9JO5MsHQd0-7WrR7gN
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/math_functions.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/math_functions.yaml
@@ -1,6 +1,7 @@
 name: Math Functions
 entity_id: jPrM-oh3r1BR42xSs4Ipj
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/metric__measure__and_segment_references.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/metric__measure__and_segment_references.yaml
@@ -1,6 +1,7 @@
 name: Metric, Measure, and Segment References
 entity_id: kBjQ5VXJ5z3vYSW72J6qa
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/native_query___card_and_snippet_references.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/native_query___card_and_snippet_references.yaml
@@ -1,6 +1,7 @@
 name: Native Query - Card and Snippet References
 entity_id: HiBFSt0BNx5s5MxVDLLKB
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/native_query___field_filter_and_temporal_unit.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/native_query___field_filter_and_temporal_unit.yaml
@@ -1,6 +1,7 @@
 name: Native Query - Field Filter and Temporal Unit
 entity_id: sk02d7sPWAk2TYH2Y7JhZ
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: line
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/native_query___variables.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/native_query___variables.yaml
@@ -1,6 +1,7 @@
 name: Native Query - Variables
 entity_id: 2u10n8GV6u0LFYrq8yV5p
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/nested_query.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/nested_query.yaml
@@ -1,6 +1,7 @@
 name: Nested Query
 entity_id: 1t9TE-8T-AlaM19nx3yQV
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/null__empty__and_string_filters.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/null__empty__and_string_filters.yaml
@@ -1,6 +1,7 @@
 name: Null, Empty, and String Filters
 entity_id: ZvHEBpdFQ-VSvem16KCkL
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/source_card_reference.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/source_card_reference.yaml
@@ -1,6 +1,7 @@
 name: Source Card Reference
 entity_id: gt4OaWYAuDWRHn5Irnd4h
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/string_functions.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/string_functions.yaml
@@ -1,6 +1,7 @@
 name: String Functions
 entity_id: HeLFZSVb4Jm25p4tWfVP9
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/temporal_and_logical_filters.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/temporal_and_logical_filters.yaml
@@ -1,6 +1,7 @@
 name: Temporal and Logical Filters
 entity_id: BMx-SlSPsSfGSKaEgOzn0
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/temporal_expressions.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/temporal_expressions.yaml
@@ -1,6 +1,7 @@
 name: Temporal Expressions
 entity_id: DBBrqcMAmOO0sbM_CzM_Z
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/temporal_extraction.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/temporal_extraction.yaml
@@ -1,6 +1,7 @@
 name: Temporal Extraction
 entity_id: bDK7jyPszEHzHh4aG4_SV
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/total_revenue.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/total_revenue.yaml
@@ -1,6 +1,7 @@
 name: Total Revenue
 entity_id: IW8kbqZVaMxdGtCM2F4U6
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: scalar
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/url_functions.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/url_functions.yaml
@@ -1,6 +1,7 @@
 name: URL Functions
 entity_id: uwAeNRHymXTD1G_7lWV1d
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/queries/window_function___offset.yaml
+++ b/test_resources/serialization_baseline/collections/main/queries/window_function___offset.yaml
@@ -1,6 +1,7 @@
 name: Window Function - Offset
 entity_id: ErQY8K5Tep4xBc3VY_-1e
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: line
 collection_id: cOlQuErIeS0ExAmPlE2x1

--- a/test_resources/serialization_baseline/collections/main/source_model.yaml
+++ b/test_resources/serialization_baseline/collections/main/source_model.yaml
@@ -1,6 +1,7 @@
 name: Source Model
 entity_id: sRcMoDeL00ExAmPlEx001
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 parameters: []

--- a/test_resources/serialization_baseline/collections/main/visualization_settings/customer_locations__map_.yaml
+++ b/test_resources/serialization_baseline/collections/main/visualization_settings/customer_locations__map_.yaml
@@ -1,6 +1,7 @@
 name: Customer Locations (Map)
 entity_id: CI61cHgBAKPBEDTxhK8X3
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: map
 collection_id: cOlViZsEtTiNgS0ExAmP1

--- a/test_resources/serialization_baseline/collections/main/visualization_settings/monthly_revenue_changes__waterfall_.yaml
+++ b/test_resources/serialization_baseline/collections/main/visualization_settings/monthly_revenue_changes__waterfall_.yaml
@@ -1,6 +1,7 @@
 name: Monthly Revenue Changes (Waterfall)
 entity_id: kJWYpTzyc9ow-75HjyIhf
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: waterfall
 collection_id: cOlViZsEtTiNgS0ExAmP1

--- a/test_resources/serialization_baseline/collections/main/visualization_settings/orders_by_category__pie_.yaml
+++ b/test_resources/serialization_baseline/collections/main/visualization_settings/orders_by_category__pie_.yaml
@@ -1,6 +1,7 @@
 name: Orders by Category (Pie)
 entity_id: dYD1j3pQtJdctg8duByUL
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: pie
 collection_id: cOlViZsEtTiNgS0ExAmP1

--- a/test_resources/serialization_baseline/collections/main/visualization_settings/orders_by_category__stacked_bar_.yaml
+++ b/test_resources/serialization_baseline/collections/main/visualization_settings/orders_by_category__stacked_bar_.yaml
@@ -1,6 +1,7 @@
 name: Orders by Category (Stacked Bar)
 entity_id: ciG63nSLHKRTImt5iWEte
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: bar
 collection_id: cOlViZsEtTiNgS0ExAmP1

--- a/test_resources/serialization_baseline/collections/main/visualization_settings/orders_pivot_table.yaml
+++ b/test_resources/serialization_baseline/collections/main/visualization_settings/orders_pivot_table.yaml
@@ -1,6 +1,7 @@
 name: Orders Pivot Table
 entity_id: BjwHr6elEuKQuL26BEgno
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: pivot
 collection_id: cOlViZsEtTiNgS0ExAmP1

--- a/test_resources/serialization_baseline/collections/main/visualization_settings/products_table__formatted_.yaml
+++ b/test_resources/serialization_baseline/collections/main/visualization_settings/products_table__formatted_.yaml
@@ -1,6 +1,7 @@
 name: Products Table (Formatted)
 entity_id: Wo5d6IV8lb63wex29uh6H
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: table
 collection_id: cOlViZsEtTiNgS0ExAmP1

--- a/test_resources/serialization_baseline/collections/main/visualization_settings/revenue_gauge.yaml
+++ b/test_resources/serialization_baseline/collections/main/visualization_settings/revenue_gauge.yaml
@@ -1,6 +1,7 @@
 name: Revenue Gauge
 entity_id: GWrIQqjbzxysSCm8PLU5j
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: gauge
 collection_id: cOlViZsEtTiNgS0ExAmP1

--- a/test_resources/serialization_baseline/collections/main/visualization_settings/revenue_over_time__line_.yaml
+++ b/test_resources/serialization_baseline/collections/main/visualization_settings/revenue_over_time__line_.yaml
@@ -1,6 +1,7 @@
 name: Revenue Over Time (Line)
 entity_id: UEWVldEEZ-3sYUjjN54qz
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: line
 collection_id: cOlViZsEtTiNgS0ExAmP1

--- a/test_resources/serialization_baseline/collections/main/visualization_settings/sales_funnel.yaml
+++ b/test_resources/serialization_baseline/collections/main/visualization_settings/sales_funnel.yaml
@@ -1,6 +1,7 @@
 name: Sales Funnel
 entity_id: mkKa6jf-QsuCRnaPOIsYh
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: funnel
 collection_id: cOlViZsEtTiNgS0ExAmP1

--- a/test_resources/serialization_baseline/collections/main/visualization_settings/total_revenue__smart_scalar_.yaml
+++ b/test_resources/serialization_baseline/collections/main/visualization_settings/total_revenue__smart_scalar_.yaml
@@ -1,6 +1,7 @@
 name: Total Revenue (Smart Scalar)
 entity_id: bSj47tilPIkwDIewvMf8z
 created_at: '2026-04-02T02:59:02.778668Z'
+last_used_at: '2026-04-02T02:59:02.778668Z'
 creator_id: admin@example.com
 display: smartscalar
 collection_id: cOlViZsEtTiNgS0ExAmP1


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #56115
importing a card always reset last_used_at to the import time. serdes skips the column and it defaults to current_timestamp, so imported questions never look stale and auto trash ignores them forever.

the fix: export last_used_at (FieldValues already does this). on import it only matters for new cards, if the card already exists we keep the destination value since its own usage history is the relevant one there.

also pulled the default load-update! body into serdes/default-load-update! so Card's override can reuse it.

Fixes https://linear.app/metabase/issue/GDGT-217/serialization-resets-last-used-at-making-auto-trash-useless