### PR TITLE
stop actionlint from linting deleted workflow files

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -8,8 +8,8 @@ default: &default
   - "bin/**/!(*.md)"
 
 actionlint:
-  - ".github/workflows/*.yml"
-  - ".github/workflows/*.yaml"
+  - added|modified: ".github/workflows/*.yml"
+  - added|modified: ".github/workflows/*.yaml"
 
 shared_sources: &shared_sources
   - "src/**/*.cljc"


### PR DESCRIPTION
Fixes [DEV-2417](https://linear.app/metabase/issue/DEV-2417/actionlint-job-lints-deleted-workflow-files)

Actionlint was incorrectly trying to lint a workflow that had been removed. Updated `file-paths` based on the [dorny/paths-filter docs](https://github.com/dorny/paths-filter#advanced-options) which allow for more complex filters around the type of change to a file. 

Example run where deleted file is excluded as expected and only the modified file is returned - https://github.com/metabase/metabase/actions/runs/29914893460/job/88906337036#step:3:29
