### PR TITLE
fix: avoid nested scroll in admin database form

### DIFF
--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseFormBody.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseFormBody.tsx
@@ -52,9 +52,17 @@ export const DatabaseFormBody = ({
     .with("full-page", () => undefined)
     .exhaustive();
   const mah = location === "full-page" ? "100%" : "calc(100vh - 20rem)";
+  const overflowY = location === "admin" ? undefined : "auto";
 
   return (
-    <Box mah={mah} mb="md" px={px} flex={1} style={{ overflowY: "auto" }}>
+    <Box
+      data-testid="database-form-body"
+      mah={mah}
+      mb="md"
+      px={px}
+      flex={1}
+      style={{ overflowY }}
+    >
       {engineFieldConfig?.fieldState !== "hidden" && (
         <>
           <DatabaseEngineField

--- a/frontend/src/metabase/databases/components/DatabaseForm/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/tests/common.unit.spec.tsx
@@ -9,6 +9,14 @@ import * as utils from "../utils";
 import { TEST_ENGINES, setup } from "./setup";
 
 describe("DatabaseForm", () => {
+  it("does not create a nested vertical scroll region in the admin layout", () => {
+    setup();
+
+    expect(screen.getByTestId("database-form-body")).not.toHaveStyle({
+      overflowY: "auto",
+    });
+  });
+
   it("should submit default values", async () => {
     const { onSubmit } = setup();
     const expectedDatabaseName = "My H2 Database";


### PR DESCRIPTION
Closes #77949\n\n### Description\nAvoid creating a second vertical scrolling container in the Admin database form. The admin settings layout already owns page scrolling, so the form body now leaves its vertical overflow unset there while retaining it in the setup flow.\n\n### How to verify\n1. Open Admin > Databases and select a deprecated driver.\n2. Confirm the page has only the settings-layout scrollbar.\n3. Run the focused DatabaseForm unit suite.\n\n### Checklist\n- [x] Tests have been added/updated to cover changes in this PR\n- [ ] If adding new Loki tests: they pass stress testing (not applicable)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/78343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

