### PR TITLE
Add ability to report near membrane sandboxing blocks to a listener

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/allowed-hosts.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/allowed-hosts.ts
@@ -27,6 +27,19 @@ export interface SandboxRealm {
   location: { href: string; origin: string };
 }
 
+/**
+ * A network request the sandbox refused, reported to an optional listener.
+ **/
+export interface SandboxBlockedNetworkInfo {
+  api: "fetch" | "xhr";
+  url: string;
+  reason: string;
+}
+
+export type SandboxBlockedNetworkListener = (
+  info: SandboxBlockedNetworkInfo,
+) => void;
+
 interface AllowedOrigin {
   protocol: string; // "https:" | "http:"
   wildcard: boolean; // entry was "*.host"
@@ -99,7 +112,7 @@ export function isHostAllowed(url: URL, allowedHosts: string[]): boolean {
   });
 }
 
-function toUrl(input: unknown, base: string): URL | null {
+function toUrl(input: RequestInfo | URL, base: string): URL | null {
   try {
     if (typeof input === "string") {
       return new URL(input, base);
@@ -129,12 +142,13 @@ function toUrl(input: unknown, base: string): URL | null {
  * sanctioned channel), even if an admin mistakenly lists it in `allowed_hosts`.
  */
 function blockedReason(
-  input: unknown,
+  input: RequestInfo | URL,
   base: string,
   allowedHosts: string[],
   metabaseOrigin: string,
 ): string | null {
   const url = toUrl(input, base);
+
   if (!url) {
     return "an unparseable URL";
   }
@@ -151,6 +165,30 @@ function blockedReason(
 }
 
 /**
+ * Report a block without letting the listener affect the block itself. A throwing
+ * listener would otherwise turn `fetch`'s rejection into a synchronous throw,
+ * breaking the promise contract for every `.catch()` caller — and reporting must
+ * never be able to change what is blocked.
+ */
+function reportBlocked(
+  onBlocked: SandboxBlockedNetworkListener | undefined,
+  event: Parameters<SandboxBlockedNetworkListener>[0],
+): void {
+  try {
+    onBlocked?.(event);
+  } catch {
+    // A broken reporter is not the app's problem.
+  }
+}
+
+/**
+ * The request URL for a blocked-network report: resolved when parseable.
+ **/
+function buildRequestUrl(input: RequestInfo | URL, base: string): string {
+  return toUrl(input, base)?.href ?? String(input);
+}
+
+/**
  * A `fetch` that only reaches `allowedHosts` (rejecting everything else,
  * including the Metabase origin). Returns `null` when the allowlist is empty so
  * the caller keeps the sandbox's default hard block.
@@ -159,6 +197,7 @@ export function makeSandboxFetch(
   targetWindow: SandboxRealm,
   allowedHosts: string[],
   label: string,
+  onBlocked?: SandboxBlockedNetworkListener,
 ): typeof fetch | null {
   if (allowedHosts.length === 0) {
     return null;
@@ -172,6 +211,12 @@ export function makeSandboxFetch(
     const reason = blockedReason(input, base, allowedHosts, metabaseOrigin);
 
     if (reason) {
+      reportBlocked(onBlocked, {
+        api: "fetch",
+        url: buildRequestUrl(input, base),
+        reason,
+      });
+
       return Promise.reject(
         new Error(`[data-app ${label}] blocked fetch to ${reason}`),
       );
@@ -190,6 +235,7 @@ export function makeSandboxXhr(
   targetWindow: SandboxRealm,
   allowedHosts: string[],
   label: string,
+  onBlocked?: SandboxBlockedNetworkListener,
 ): typeof XMLHttpRequest | null {
   if (allowedHosts.length === 0) {
     return null;
@@ -209,6 +255,12 @@ export function makeSandboxXhr(
       const reason = blockedReason(url, base, allowedHosts, metabaseOrigin);
 
       if (reason) {
+        reportBlocked(onBlocked, {
+          api: "xhr",
+          url: buildRequestUrl(url, base),
+          reason,
+        });
+
         throw new Error(
           `[data-app ${label}] blocked XMLHttpRequest to ${reason}`,
         );

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/allowed-hosts.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/allowed-hosts.ts
@@ -16,29 +16,7 @@
  * sandboxed browser realm — so keep the two in sync if either changes.
  */
 
-/**
- * The slice of the sandbox's realm the network wrappers touch: the native
- * `fetch`/`XMLHttpRequest` they wrap, and the location a relative request URL
- * resolves against. A real `Window & typeof globalThis` satisfies it.
- */
-export interface SandboxRealm {
-  fetch: typeof fetch;
-  XMLHttpRequest: typeof XMLHttpRequest;
-  location: { href: string; origin: string };
-}
-
-/**
- * A network request the sandbox refused, reported to an optional listener.
- **/
-export interface SandboxBlockedNetworkInfo {
-  api: "fetch" | "xhr";
-  url: string;
-  reason: string;
-}
-
-export type SandboxBlockedNetworkListener = (
-  info: SandboxBlockedNetworkInfo,
-) => void;
+import type { SandboxBlockedNetworkListener, SandboxRealm } from "./types";
 
 interface AllowedOrigin {
   protocol: string; // "https:" | "http:"
@@ -51,7 +29,7 @@ interface AllowedOrigin {
  * A valid `allowed_hosts` entry is *origin-only*: an http(s) scheme + host (+ an
  * optional port), with no path, query, fragment, or credentials.
  */
-function isRawHttpOrigin(url: URL): boolean {
+const isRawHttpOrigin = (url: URL): boolean => {
   return (
     (url.protocol === "https:" || url.protocol === "http:") &&
     url.pathname === "/" &&
@@ -60,9 +38,9 @@ function isRawHttpOrigin(url: URL): boolean {
     url.username === "" &&
     url.password === ""
   );
-}
+};
 
-function parseAllowedOrigin(entry: string): AllowedOrigin | null {
+const parseAllowedOrigin = (entry: string): AllowedOrigin | null => {
   let url: URL;
   try {
     // The standard URL parser lowercases the host, normalizes away the default
@@ -85,9 +63,9 @@ function parseAllowedOrigin(entry: string): AllowedOrigin | null {
     host: wildcard ? url.hostname.slice(2) : url.hostname,
     port: url.port,
   };
-}
+};
 
-function originMatches(url: URL, origin: AllowedOrigin): boolean {
+const isOriginMatches = (url: URL, origin: AllowedOrigin): boolean => {
   if (url.protocol !== origin.protocol) {
     return false;
   }
@@ -102,17 +80,17 @@ function originMatches(url: URL, origin: AllowedOrigin): boolean {
   return origin.wildcard
     ? host.endsWith(`.${origin.host}`)
     : host === origin.host;
-}
+};
 
-export function isHostAllowed(url: URL, allowedHosts: string[]): boolean {
+export const isHostAllowed = (url: URL, allowedHosts: string[]): boolean => {
   return allowedHosts.some((entry) => {
     const origin = parseAllowedOrigin(entry);
 
-    return origin ? originMatches(url, origin) : false;
+    return origin ? isOriginMatches(url, origin) : false;
   });
-}
+};
 
-function toUrl(input: RequestInfo | URL, base: string): URL | null {
+const toUrl = (input: RequestInfo | URL, base: string): URL | null => {
   try {
     if (typeof input === "string") {
       return new URL(input, base);
@@ -130,23 +108,14 @@ function toUrl(input: RequestInfo | URL, base: string): URL | null {
   }
 
   return null;
-}
+};
 
-/**
- * The single decision the `fetch` and `XMLHttpRequest` wrappers share: resolve
- * the request URL and decide whether the sandbox may make it. Returns `null`
- * when the request is allowed, or a human-readable reason when it is blocked.
- *
- * A request is allowed only when its origin is in `allowedHosts` AND is not the
- * Metabase origin — raw access to Metabase is *always* denied (the SDK is the
- * sanctioned channel), even if an admin mistakenly lists it in `allowed_hosts`.
- */
-function blockedReason(
+const getBlockedReason = (
   input: RequestInfo | URL,
   base: string,
   allowedHosts: string[],
   metabaseOrigin: string,
-): string | null {
+): string | null => {
   const url = toUrl(input, base);
 
   if (!url) {
@@ -162,43 +131,29 @@ function blockedReason(
   }
 
   return null;
-}
+};
 
-/**
- * Report a block without letting the listener affect the block itself. A throwing
- * listener would otherwise turn `fetch`'s rejection into a synchronous throw,
- * breaking the promise contract for every `.catch()` caller — and reporting must
- * never be able to change what is blocked.
- */
-function reportBlocked(
+const reportBlockedEvent = (
   onBlocked: SandboxBlockedNetworkListener | undefined,
   event: Parameters<SandboxBlockedNetworkListener>[0],
-): void {
+): void => {
   try {
     onBlocked?.(event);
   } catch {
     // A broken reporter is not the app's problem.
   }
-}
+};
 
-/**
- * The request URL for a blocked-network report: resolved when parseable.
- **/
-function buildRequestUrl(input: RequestInfo | URL, base: string): string {
+const buildRequestUrl = (input: RequestInfo | URL, base: string): string => {
   return toUrl(input, base)?.href ?? String(input);
-}
+};
 
-/**
- * A `fetch` that only reaches `allowedHosts` (rejecting everything else,
- * including the Metabase origin). Returns `null` when the allowlist is empty so
- * the caller keeps the sandbox's default hard block.
- */
-export function makeSandboxFetch(
+export const makeSandboxFetch = (
   targetWindow: SandboxRealm,
   allowedHosts: string[],
   label: string,
   onBlocked?: SandboxBlockedNetworkListener,
-): typeof fetch | null {
+): typeof fetch | null => {
   if (allowedHosts.length === 0) {
     return null;
   }
@@ -208,10 +163,10 @@ export function makeSandboxFetch(
   const metabaseOrigin = targetWindow.location.origin;
 
   return function dataAppFetch(input: RequestInfo | URL, init?: RequestInit) {
-    const reason = blockedReason(input, base, allowedHosts, metabaseOrigin);
+    const reason = getBlockedReason(input, base, allowedHosts, metabaseOrigin);
 
     if (reason) {
-      reportBlocked(onBlocked, {
+      reportBlockedEvent(onBlocked, {
         api: "fetch",
         url: buildRequestUrl(input, base),
         reason,
@@ -224,19 +179,14 @@ export function makeSandboxFetch(
 
     return realFetch(input, init);
   };
-}
+};
 
-/**
- * An `XMLHttpRequest` subclass that gates `open()` against `allowedHosts` (and
- * always denies the Metabase origin). Returns `null` when the allowlist is empty
- * (keeps the default hard block).
- */
-export function makeSandboxXhr(
+export const makeSandboxXhr = (
   targetWindow: SandboxRealm,
   allowedHosts: string[],
   label: string,
   onBlocked?: SandboxBlockedNetworkListener,
-): typeof XMLHttpRequest | null {
+): typeof XMLHttpRequest | null => {
   if (allowedHosts.length === 0) {
     return null;
   }
@@ -252,10 +202,10 @@ export function makeSandboxXhr(
       username?: string | null,
       password?: string | null,
     ): void {
-      const reason = blockedReason(url, base, allowedHosts, metabaseOrigin);
+      const reason = getBlockedReason(url, base, allowedHosts, metabaseOrigin);
 
       if (reason) {
-        reportBlocked(onBlocked, {
+        reportBlockedEvent(onBlocked, {
           api: "xhr",
           url: buildRequestUrl(url, base),
           reason,
@@ -272,4 +222,4 @@ export function makeSandboxXhr(
   // The subclass inherits the static UNSENT/OPENED/… constants at runtime;
   // cast so the type matches the native constructor the membrane expects.
   return SandboxXhr as typeof XMLHttpRequest;
-}
+};

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/allowed-hosts.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/allowed-hosts.unit.spec.ts
@@ -1,9 +1,9 @@
 import {
-  type SandboxRealm,
   isHostAllowed,
   makeSandboxFetch,
   makeSandboxXhr,
 } from "./allowed-hosts";
+import type { SandboxRealm } from "./types";
 
 const u = (href: string) => new URL(href);
 

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/allowed-hosts.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/allowed-hosts.unit.spec.ts
@@ -179,3 +179,60 @@ describe("makeSandboxXhr", () => {
     );
   });
 });
+
+describe("onBlocked reporting", () => {
+  const base = "https://mb.example.com/embed/apps/sales";
+  const origin = "https://mb.example.com";
+  const fakeWindow = (fetch: typeof global.fetch): SandboxRealm => ({
+    fetch,
+    XMLHttpRequest,
+    location: { href: base, origin },
+  });
+
+  it("reports a blocked fetch, and stays silent when no listener is given", async () => {
+    const realFetch = jest.fn(() => Promise.resolve(new Response("ok")));
+    const onBlocked = jest.fn();
+
+    const reporting = makeSandboxFetch(
+      fakeWindow(realFetch),
+      ["https://api.example.com"],
+      "sales",
+      onBlocked,
+    )!;
+    await expect(reporting("https://evil.example.org/x")).rejects.toThrow();
+
+    expect(onBlocked).toHaveBeenCalledWith(
+      // `type: "network"` is added a layer up, in `distortions.ts`.
+      expect.objectContaining({
+        api: "fetch",
+        url: "https://evil.example.org/x",
+        reason: expect.stringContaining("not in allowed_hosts"),
+      }),
+    );
+
+    // Production passes no listener; that path must be unchanged.
+    const silent = makeSandboxFetch(
+      fakeWindow(realFetch),
+      ["https://api.example.com"],
+      "sales",
+    )!;
+    await expect(silent("https://evil.example.org/x")).rejects.toThrow();
+    expect(realFetch).not.toHaveBeenCalled();
+  });
+
+  it("still blocks when the listener throws", async () => {
+    const realFetch = jest.fn(() => Promise.resolve(new Response("ok")));
+    const sandboxFetch = makeSandboxFetch(
+      fakeWindow(realFetch),
+      ["https://api.example.com"],
+      "sales",
+      () => {
+        throw new Error("listener exploded");
+      },
+    )!;
+
+    // A broken reporter must not become a way through the allowlist.
+    await expect(sandboxFetch("https://evil.example.org/")).rejects.toThrow();
+    expect(realFetch).not.toHaveBeenCalled();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.ts
@@ -1,11 +1,18 @@
 import { makeSandboxDistortionCallback } from "metabase/utils/scripts-sandbox";
 
 import {
+  type SandboxBlockedNetworkInfo,
   type SandboxRealm,
   makeSandboxFetch,
   makeSandboxXhr,
 } from "./allowed-hosts";
 import { makeCreateElementDistortion } from "./create-element";
+
+export type SandboxBlockedEvent =
+  | { type: "api"; message: string }
+  | ({ type: "network" } & SandboxBlockedNetworkInfo);
+
+export type SandboxBlockedListener = (event: SandboxBlockedEvent) => void;
 
 /**
  * Data-app Near Membrane distortion callback.
@@ -27,10 +34,15 @@ export function makeDistortionCallback(
   label: string,
   targetWindow: SandboxRealm,
   allowedHosts: string[],
+  onBlocked?: SandboxBlockedListener,
 ) {
   const shared = makeSandboxDistortionCallback(
     `data-app ${label}`,
     (message) => {
+      if (onBlocked) {
+        onBlocked({ type: "api", message });
+        return;
+      }
       // The thrown error usually reaches the developer only as an opaque
       // cross-realm `#<Object>` (an unhandled async rejection), so log the real
       // reason here — at the block point, where the console stack still points at
@@ -38,8 +50,22 @@ export function makeDistortionCallback(
       console.error(message);
     },
   );
-  const sandboxFetch = makeSandboxFetch(targetWindow, allowedHosts, label);
-  const sandboxXhr = makeSandboxXhr(targetWindow, allowedHosts, label);
+  const onBlockedNetwork =
+    onBlocked &&
+    ((info: SandboxBlockedNetworkInfo) =>
+      onBlocked({ type: "network", ...info }));
+  const sandboxFetch = makeSandboxFetch(
+    targetWindow,
+    allowedHosts,
+    label,
+    onBlockedNetwork,
+  );
+  const sandboxXhr = makeSandboxXhr(
+    targetWindow,
+    allowedHosts,
+    label,
+    onBlockedNetwork,
+  );
 
   return function distortionCallback(value: object): object {
     const createElementDistortion = makeCreateElementDistortion(value, shared);

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.ts
@@ -1,18 +1,12 @@
 import { makeSandboxDistortionCallback } from "metabase/utils/scripts-sandbox";
 
-import {
-  type SandboxBlockedNetworkInfo,
-  type SandboxRealm,
-  makeSandboxFetch,
-  makeSandboxXhr,
-} from "./allowed-hosts";
+import { makeSandboxFetch, makeSandboxXhr } from "./allowed-hosts";
 import { makeCreateElementDistortion } from "./create-element";
-
-export type SandboxBlockedEvent =
-  | { type: "api"; message: string }
-  | ({ type: "network" } & SandboxBlockedNetworkInfo);
-
-export type SandboxBlockedListener = (event: SandboxBlockedEvent) => void;
+import type {
+  SandboxBlockedListener,
+  SandboxBlockedNetworkInfo,
+  SandboxRealm,
+} from "./types";
 
 /**
  * Data-app Near Membrane distortion callback.

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.unit.spec.ts
@@ -97,4 +97,78 @@ describe("makeDistortionCallback", () => {
     const other = { some: "object" };
     expect(callback(other)).toBe(other);
   });
+
+  describe("onBlocked", () => {
+    it("reports a blocked API instead of logging it", () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const onBlocked = jest.fn();
+      const callback = makeDistortionCallback(
+        "sales",
+        fakeWindow(),
+        [],
+        onBlocked,
+      );
+      // Same signature erasure as above.
+      const createElement = callback(
+        Document.prototype.createElement,
+      ) as typeof Document.prototype.createElement;
+
+      expect(() => createElement.call(document, "script")).toThrow();
+
+      expect(onBlocked).toHaveBeenCalledWith({
+        type: "api",
+        message: expect.stringContaining("blocked createElement: script"),
+      });
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      consoleErrorSpy.mockRestore();
+    });
+
+    it("reports a blocked fetch with the resolved url and reason", async () => {
+      const onBlocked = jest.fn();
+      const win = fakeWindow();
+      const callback = makeDistortionCallback(
+        "sales",
+        win,
+        ["https://api.example.com"],
+        onBlocked,
+      );
+      // Same signature erasure as above.
+      const distorted = callback(win.fetch) as typeof fetch;
+
+      await expect(distorted("https://evil.example.org/")).rejects.toThrow();
+
+      expect(onBlocked).toHaveBeenCalledWith({
+        type: "network",
+        api: "fetch",
+        url: "https://evil.example.org/",
+        reason: "evil.example.org (not in allowed_hosts)",
+      });
+    });
+
+    it("reports a blocked XMLHttpRequest", () => {
+      const onBlocked = jest.fn();
+      const win = fakeWindow();
+      const callback = makeDistortionCallback(
+        "sales",
+        win,
+        ["https://api.example.com"],
+        onBlocked,
+      );
+      // Same signature erasure as above.
+      const Distorted = callback(win.XMLHttpRequest) as typeof XMLHttpRequest;
+
+      expect(() =>
+        new Distorted().open("GET", "https://evil.example.org/"),
+      ).toThrow();
+
+      expect(onBlocked).toHaveBeenCalledWith({
+        type: "network",
+        api: "xhr",
+        url: "https://evil.example.org/",
+        reason: "evil.example.org (not in allowed_hosts)",
+      });
+    });
+  });
 });

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.unit.spec.ts
@@ -1,5 +1,5 @@
-import type { SandboxRealm } from "./allowed-hosts";
 import { makeDistortionCallback } from "./distortions";
+import type { SandboxRealm } from "./types";
 
 // A minimal stand-in for the iframe window the data-app sandbox is built on.
 // `fetch`/`XMLHttpRequest` are the native refs the membrane passes to the

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/sandbox.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/sandbox.ts
@@ -1,11 +1,8 @@
 import createVirtualEnvironment from "@locker/near-membrane-dom";
 
-import {
-  type SandboxBlockedListener,
-  makeDistortionCallback,
-} from "./distortions";
+import { makeDistortionCallback } from "./distortions";
 import { DATA_APP_GLOBAL_NAMES } from "./globals";
-import type { DataAppFactory } from "./types";
+import type { DataAppFactory, SandboxBlockedListener } from "./types";
 
 /**
  * The realm objects the sandbox exposes to the bundle as globals.

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/sandbox.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/sandbox.ts
@@ -1,6 +1,9 @@
 import createVirtualEnvironment from "@locker/near-membrane-dom";
 
-import { makeDistortionCallback } from "./distortions";
+import {
+  type SandboxBlockedListener,
+  makeDistortionCallback,
+} from "./distortions";
 import { DATA_APP_GLOBAL_NAMES } from "./globals";
 import type { DataAppFactory } from "./types";
 
@@ -46,6 +49,11 @@ export interface CreateDataAppSandboxOptions {
   allowedHosts?: string[];
   /** The realm's React/SDK exposed to the bundle. See [[DataAppSandboxEndowments]]. */
   endowments: DataAppSandboxEndowments;
+  /**
+   * Structured listener for sandbox blocks (dev toolbar). When absent the
+   * sandbox keeps its default reporting (`console.error` / reject).
+   */
+  onBlocked?: SandboxBlockedListener;
 }
 
 function isLiveTarget(target: object): boolean {
@@ -61,6 +69,7 @@ export function createDataAppSandbox({
   targetWindow = window,
   allowedHosts = [],
   endowments,
+  onBlocked,
 }: CreateDataAppSandboxOptions) {
   let captured: unknown;
 
@@ -69,6 +78,7 @@ export function createDataAppSandbox({
       label,
       targetWindow,
       allowedHosts,
+      onBlocked,
     ),
     liveTargetCallback: isLiveTarget,
     // Global names come from the shared `DATA_APP_GLOBAL_NAMES`, so the bundle's

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/types.ts
@@ -10,12 +10,6 @@ export const DATA_APP_PROVIDER_PROP_KEYS = [
   "errorComponent",
 ] as const satisfies readonly (keyof DataAppMetabaseProviderProps)[];
 
-/**
- * Structural mirror of the `MetabaseProviderProps` subset a data app may
- * customize. Declared here (not as a `Pick` of the bundle type) so this
- * contract has no app-tier dependency; keep it in sync with
- * `MetabaseProviderProps` by hand until the props move to a shared tier.
- */
 export type DataAppMetabaseProviderProps = {
   theme?: MetabaseEmbeddingTheme;
   allowedCustomVisualizations?: `custom:${string}`[];
@@ -35,3 +29,30 @@ export type DataAppFactory = () => {
   component: React.ComponentType<Record<string, unknown>>;
   providerProps?: DataAppMetabaseProviderProps;
 };
+
+/**
+ * The slice of the sandbox's realm the network wrappers touch: the native
+ * `fetch`/`XMLHttpRequest` they wrap, and the location a relative request URL
+ * resolves against. A real `Window & typeof globalThis` satisfies it.
+ */
+export interface SandboxRealm {
+  fetch: typeof fetch;
+  XMLHttpRequest: typeof XMLHttpRequest;
+  location: { href: string; origin: string };
+}
+
+export interface SandboxBlockedNetworkInfo {
+  api: "fetch" | "xhr";
+  url: string;
+  reason: string;
+}
+
+export type SandboxBlockedNetworkListener = (
+  info: SandboxBlockedNetworkInfo,
+) => void;
+
+export type SandboxBlockedEvent =
+  | { type: "api"; message: string }
+  | ({ type: "network" } & SandboxBlockedNetworkInfo);
+
+export type SandboxBlockedListener = (event: SandboxBlockedEvent) => void;


### PR DESCRIPTION
Add ability to report near membrane sandboxing blocks to a listener via the `onBlocked` callback.

This will be used by a new DevToolBar

How to verify:
- CI is green