### PR TITLE
Only execute attached cards for attachment-only dashboard subscriptions

### DIFF
--- a/src/metabase/notification/payload/execute.clj
+++ b/src/metabase/notification/payload/execute.clj
@@ -316,11 +316,10 @@
     subscriptions that never render the other cards)."
   ([dashboard-id user-id parameters]
    (execute-dashboard dashboard-id user-id parameters nil))
-  ([dashboard-id user-id parameters {:keys [spill-budget only-card-ids]}]
-   (let [spill-budget    (or spill-budget (new-spill-budget))
-         keep-dashcards  (fn [dashcards]
-                           (cond->> dashcards
-                             only-card-ids (filter #(contains? only-card-ids (:card_id %)))))]
+  ([dashboard-id user-id parameters {:keys [spill-budget only-card-ids] :or {spill-budget (new-spill-budget)}}]
+   (let [keep-dashcards (fn [dashcards]
+                          (cond->> dashcards
+                            only-card-ids (filter #(contains? only-card-ids (:card_id %)))))]
      (request/with-current-user user-id
        (if (render-tabs? dashboard-id)
          (let [tabs               (t2/hydrate (t2/select :model/DashboardTab :dashboard_id dashboard-id) :tab-cards)

--- a/src/metabase/notification/payload/execute.clj
+++ b/src/metabase/notification/payload/execute.clj
@@ -308,27 +308,36 @@
 (mu/defn execute-dashboard :- [:sequential ::Part]
   "Execute a dashboard and return its parts.
 
-  `spill-budget` is the shared [[metabase.notification.payload.temp-storage/ResidentBudget]] for the whole dashboard
-  (all tabs), so cards can't collectively exhaust heap regardless of how they're split into tabs. The 3-arity uses the
-  production default ([[new-spill-budget]]); pass your own (e.g. with lower limits) to the 4-arity for testing."
+  Options:
+  - `:spill-budget` the shared [[metabase.notification.payload.temp-storage/ResidentBudget]] for the whole dashboard
+    (all tabs), so cards can't collectively exhaust heap regardless of how they're split into tabs. Defaults to the
+    production budget; pass your own (e.g. with lower limits) for testing.
+  - `:only-card-ids` when set, only dashcards whose :card_id is in this set are executed (e.g. attachment-only
+    subscriptions that never render the other cards)."
   ([dashboard-id user-id parameters]
-   (execute-dashboard dashboard-id user-id parameters (new-spill-budget)))
-  ([dashboard-id user-id parameters spill-budget]
-   (request/with-current-user user-id
-     (if (render-tabs? dashboard-id)
-       (let [tabs               (t2/hydrate (t2/select :model/DashboardTab :dashboard_id dashboard-id) :tab-cards)
-             tabs-with-cards    (filter #(seq (:cards %)) tabs)
-             should-render-tab? (< 1 (count tabs-with-cards))]
-         (doall (flatten (for [{:keys [cards] :as tab} tabs-with-cards]
-                           (do
-                             (log/debugf "Rendering tab %s with %d cards" (:name tab) (count cards))
-                             (concat
-                              (when should-render-tab?
-                                [(tab->part tab)])
-                              (dashcards->part cards parameters spill-budget)))))))
-       (let [dashcards (t2/select :model/DashboardCard :dashboard_id dashboard-id)]
-         (log/debugf "Rendering dashboard with %d cards" (count dashcards))
-         (dashcards->part dashcards parameters spill-budget))))))
+   (execute-dashboard dashboard-id user-id parameters nil))
+  ([dashboard-id user-id parameters {:keys [spill-budget only-card-ids]}]
+   (let [spill-budget    (or spill-budget (new-spill-budget))
+         keep-dashcards  (fn [dashcards]
+                           (cond->> dashcards
+                             only-card-ids (filter #(contains? only-card-ids (:card_id %)))))]
+     (request/with-current-user user-id
+       (if (render-tabs? dashboard-id)
+         (let [tabs               (t2/hydrate (t2/select :model/DashboardTab :dashboard_id dashboard-id) :tab-cards)
+               tabs-with-cards    (->> tabs
+                                       (map #(update % :cards keep-dashcards))
+                                       (filter #(seq (:cards %))))
+               should-render-tab? (< 1 (count tabs-with-cards))]
+           (doall (flatten (for [{:keys [cards] :as tab} tabs-with-cards]
+                             (do
+                               (log/debugf "Rendering tab %s with %d cards" (:name tab) (count cards))
+                               (concat
+                                (when should-render-tab?
+                                  [(tab->part tab)])
+                                (dashcards->part cards parameters spill-budget)))))))
+         (let [dashcards (keep-dashcards (t2/select :model/DashboardCard :dashboard_id dashboard-id))]
+           (log/debugf "Rendering dashboard with %d cards" (count dashcards))
+           (dashcards->part dashcards parameters spill-budget)))))))
 
 (mu/defn execute-card :- [:maybe ::Part]
   "Returns the result for a card."

--- a/src/metabase/notification/payload/impl/dashboard.clj
+++ b/src/metabase/notification/payload/impl/dashboard.clj
@@ -25,13 +25,30 @@
    shared.params/param-val-or-default
    (the-parameters dashboard-subscription-params dashboard-params)))
 
+(defn- attachment-only?
+  "True when every handler only sends attachments, and none needs the full dashboard for a PDF."
+  [handlers]
+  (boolean (and (seq handlers)
+                (every? :attachment_only handlers)
+                (not-any? :include_pdf handlers))))
+
+(defn- attached-card-ids
+  "Ids of the cards selected for attachment on a dashboard subscription."
+  [dashboard-subscription]
+  (->> (:dashboard_subscription_dashcards dashboard-subscription)
+       (filter #(or (:include_csv %) (:include_xls %)))
+       (into #{} (keep :card_id))))
+
 (mu/defmethod notification.payload/payload :notification/dashboard
-  [{:keys [creator_id dashboard_subscription] :as _notification-info} :- ::notification.payload/Notification]
+  [{:keys [creator_id dashboard_subscription handlers] :as _notification-info} :- ::notification.payload/Notification]
   (log/with-context {:dashboard_id (:dashboard_id dashboard_subscription)}
     (let [dashboard-id (:dashboard_id dashboard_subscription)
           dashboard    (t2/hydrate (t2/select-one :model/Dashboard dashboard-id) :tabs)
-          parameters   (parameters (:parameters dashboard_subscription) (:parameters dashboard))]
-      {:dashboard_parts        (cond->> (notification.execute/execute-dashboard dashboard-id creator_id parameters)
+          parameters   (parameters (:parameters dashboard_subscription) (:parameters dashboard))
+          only-card-ids (when (attachment-only? handlers)
+                          (attached-card-ids dashboard_subscription))]
+      {:dashboard_parts        (cond->> (notification.execute/execute-dashboard dashboard-id creator_id parameters
+                                                                                {:only-card-ids only-card-ids})
                                  (:skip_if_empty dashboard_subscription)
                                  (remove (fn [{part-type :type :as part}]
                                            (and

--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -163,7 +163,9 @@
                                                           :notification_handlers (map #(select-keys % [:id :channel_type :channel_id :template_id]) handlers)}}
             ;; :handlers stays on the info so payload impls can tailor execution to them
             ;; (e.g. attachment-only dashboard subscriptions skip non-attached cards)
-            (let [notification-payload (notification.payload/notification-payload hydrated-notification)
+            (let [notification-payload (-> hydrated-notification
+                                           notification.payload/notification-payload
+                                           (dissoc :handlers))
                   skip-reason          (notification.payload/skip-reason notification-payload)]
               (if skip-reason
                 (log/info "Skipping" {:skip-reason skip-reason})

--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -161,7 +161,9 @@
           (task-history/with-task-history {:task          "notification-send"
                                            :task_details {:notification_id       id
                                                           :notification_handlers (map #(select-keys % [:id :channel_type :channel_id :template_id]) handlers)}}
-            (let [notification-payload (notification.payload/notification-payload (dissoc hydrated-notification :handlers))
+            ;; :handlers stays on the info so payload impls can tailor execution to them
+            ;; (e.g. attachment-only dashboard subscriptions skip non-attached cards)
+            (let [notification-payload (notification.payload/notification-payload hydrated-notification)
                   skip-reason          (notification.payload/skip-reason notification-payload)]
               (if skip-reason
                 (log/info "Skipping" {:skip-reason skip-reason})

--- a/test/metabase/notification/payload/execute_test.clj
+++ b/test/metabase/notification/payload/execute_test.clj
@@ -76,7 +76,7 @@
                    :model/DashboardCard _ {:dashboard_id dash-id :dashboard_tab_id tab2 :card_id card-id}]
       (let [budget (temp-storage/make-resident-budget {:per-card 100000 :resident-cap 1000 :floor 100})
             parts  (card-parts (notification.payload.execute/execute-dashboard
-                                dash-id (mt/user->id :rasta) [] budget))]
+                                dash-id (mt/user->id :rasta) [] {:spill-budget budget}))]
         (is (= 4 (count parts)) "all four cards render")
         (is (some spilled-part? parts)
             "with a shared budget the cumulative cells across tabs cross the cap, so a later card spills to disk")

--- a/test/metabase/pulse/dashboard_subscription_test.clj
+++ b/test/metabase/pulse/dashboard_subscription_test.clj
@@ -1490,6 +1490,65 @@
               #"Aviary KPIs"
               #"Dashboard content available in attached files"))))))
 
+(defn- do-with-executed-card-ids
+  "Run `f` while recording the :card_id of every dashcard that actually executes, returning the atom of ids."
+  [f]
+  (let [executed (atom [])
+        orig     (mt/original-fn #'notification.payload.execute/execute-dashboard-subscription-card)]
+    (mt/with-dynamic-fn-redefs [notification.payload.execute/execute-dashboard-subscription-card
+                                (fn [dashcard parameters spill-budget]
+                                  (swap! executed conj (:card_id dashcard))
+                                  (orig dashcard parameters spill-budget))]
+      (f))
+    executed))
+
+(deftest dashboard-sub-attachment-only-skips-unattached-cards-test
+  (mt/with-temp [:model/Card          {attached-id :id} {:name          "Attached Card"
+                                                         :dataset_query (mt/mbql-query orders {:limit 1})}
+                 :model/Card          {other-id :id}    {:name          "Other Card"
+                                                         :dataset_query (mt/mbql-query venues {:limit 1})}
+                 :model/Dashboard     {dashboard-id :id} {:name "Aviary KPIs"}
+                 :model/DashboardCard _ {:dashboard_id dashboard-id :card_id attached-id}
+                 :model/DashboardCard _ {:dashboard_id dashboard-id :card_id other-id}
+                 :model/Pulse         {pulse-id :id} {:name         "Pulse Name"
+                                                      :dashboard_id dashboard-id}
+                 :model/PulseCard     _ {:pulse_id    pulse-id
+                                         :card_id     attached-id
+                                         :position    0
+                                         :include_csv true}
+                 :model/PulseCard     _ {:pulse_id pulse-id
+                                         :card_id  other-id
+                                         :position 1}]
+    (testing "attachment-only subscriptions only execute the cards selected for attachment (GDGT-2772)"
+      (mt/with-temp [:model/PulseChannel  {pc-id :id} {:pulse_id     pulse-id
+                                                       :channel_type "email"
+                                                       :details      {:attachment_only true}}
+                     :model/PulseChannelRecipient _ {:user_id          (pulse.test-util/rasta-id)
+                                                     :pulse_channel_id pc-id}]
+        (let [executed      (do-with-executed-card-ids
+                             #(pulse.test-util/with-captured-channel-send-messages!
+                                (pulse.send/send-pulse! (t2/select-one :model/Pulse pulse-id))))]
+          (is (= [attached-id] @executed)))))
+    (testing "attachment-only + include_pdf still executes every card, since the PDF renders the whole dashboard"
+      (mt/with-temp [:model/PulseChannel  {pc-id :id} {:pulse_id     pulse-id
+                                                       :channel_type "email"
+                                                       :details      {:attachment_only true
+                                                                      :include_pdf     true}}
+                     :model/PulseChannelRecipient _ {:user_id          (pulse.test-util/rasta-id)
+                                                     :pulse_channel_id pc-id}]
+        (let [executed (do-with-executed-card-ids
+                        #(pulse.test-util/with-captured-channel-send-messages!
+                           (pulse.send/send-pulse! (t2/select-one :model/Pulse pulse-id))))]
+          (is (= #{attached-id other-id} (set @executed))))))
+    (testing "a slack channel executes every card"
+      (mt/with-temp [:model/PulseChannel _ {:pulse_id     pulse-id
+                                            :channel_type "slack"
+                                            :details      {:channel "#general"}}]
+        (let [executed (do-with-executed-card-ids
+                        #(pulse.test-util/with-captured-channel-send-messages!
+                           (pulse.send/send-pulse! (t2/select-one :model/Pulse pulse-id))))]
+          (is (= #{attached-id other-id} (set @executed))))))))
+
 (defn- pdf->text
   "All text extracted from the rendered PDF `bytes`. Card titles/headings are drawn as native, selectable text, so a
   card that was rendered leaves its title here and an omitted card leaves nothing."


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #77081
Fixes https://linear.app/metabase/issue/GDGT-2772/dashboard-subscriptions-send-only-attachments-no-charts-still-runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxH5PftZYfZEXFNaki9Azh