### PR TITLE
Filter out other users personal collections from search in DataStep

### DIFF
--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -150,7 +150,12 @@ export type SearchRequest = {
   table_db_id?: DatabaseId;
   models?: SearchModel[];
   ids?: SearchResultId[];
-  filter_items_in_personal_collection?: "only" | "exclude";
+  filter_items_in_personal_collection?:
+    | "all"
+    | "only"
+    | "only-mine"
+    | "exclude"
+    | "exclude-others";
   context: SearchContext;
   created_at?: string | null;
   created_by?: UserId[] | null;

--- a/frontend/src/metabase/common/components/Pickers/DataPicker/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/Pickers/DataPicker/DataPickerModal.tsx
@@ -2,7 +2,12 @@ import { useCallback, useMemo } from "react";
 
 import { useSetting } from "metabase/common/hooks";
 import { getQuestionVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
-import type { DatabaseId, RecentContexts, TableId } from "metabase-types/api";
+import type {
+  DatabaseId,
+  RecentContexts,
+  SearchRequest,
+  TableId,
+} from "metabase-types/api";
 
 import type {
   EntityPickerOptions,
@@ -52,12 +57,13 @@ export const DataPickerModal = ({
     [hasNestedQueriesEnabled, passedModels],
   );
 
-  const searchParams = useMemo(() => {
+  const searchParams: Partial<SearchRequest> = useMemo(() => {
     const tableParams = onlyDatabaseId
       ? { table_db_id: onlyDatabaseId }
       : undefined;
     return {
       include_dashboard_questions: true,
+      filter_items_in_personal_collection: "exclude-others",
       ...tableParams,
     };
   }, [onlyDatabaseId]);

--- a/frontend/src/metabase/common/components/Pickers/DataPicker/DataPickerModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Pickers/DataPicker/DataPickerModal.unit.spec.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
 
 import {
   setupCollectionByIdEndpoint,
@@ -10,8 +11,10 @@ import {
   mockGetBoundingClientRect,
   renderWithProviders,
   screen,
+  waitFor,
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
+import { checkNotNull } from "metabase/utils/types";
 import type { DatabaseId, RecentItem, SearchResult } from "metabase-types/api";
 import {
   createMockCollection,
@@ -143,6 +146,31 @@ describe("DataPickerModal", () => {
       expect(await screen.findByText("DB 1 question")).toBeInTheDocument();
       expect(screen.queryByText("DB 2 table")).not.toBeInTheDocument();
       expect(screen.queryByText("DB 2 question")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("search", () => {
+    it("should exclude other users' personal collections from search results", async () => {
+      await setup({
+        searchItems: [
+          createMockSearchResult({ id: 1, name: "accounts", model: "table" }),
+        ],
+      });
+
+      await userEvent.type(
+        await screen.findByPlaceholderText(/search/i),
+        "accounts",
+      );
+
+      await waitFor(() => {
+        expect(fetchMock.callHistory.lastCall("path:/api/search")).toBeTruthy();
+      });
+
+      const call = fetchMock.callHistory.lastCall("path:/api/search");
+      const url = new URL(checkNotNull(call?.request?.url));
+      expect(url.searchParams.get("filter_items_in_personal_collection")).toBe(
+        "exclude-others",
+      );
     });
   });
 });

--- a/frontend/src/metabase/querying/notebook/components/DataStep/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/DataStep/tests/common.unit.spec.tsx
@@ -1,7 +1,8 @@
 import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
 
 import { createMockMetadata } from "__support__/metadata";
-import { fireEvent, getIcon, screen } from "__support__/ui";
+import { fireEvent, getIcon, screen, waitFor } from "__support__/ui";
 import { mockGetBoundingClientRect } from "__support__/utils";
 import { METAKEY } from "metabase/utils/browser";
 import { checkNotNull } from "metabase/utils/types";
@@ -298,6 +299,26 @@ describe("DataStep", () => {
       expect(
         await screen.findByPlaceholderText(/search for tables and more/i),
       ).toBeInTheDocument();
+    });
+
+    it("should exclude other users' personal collections from the inline data-source search", async () => {
+      await setupEmptyQuery();
+
+      await userEvent.type(
+        await screen.findByPlaceholderText(/search for tables and more/i),
+        "accounts",
+      );
+
+      await waitFor(() => {
+        expect(fetchMock.callHistory.lastCall("path:/api/search")).toBeTruthy();
+      });
+
+      const call = fetchMock.callHistory.lastCall("path:/api/search");
+      const url = new URL(checkNotNull(call?.request?.url));
+      expect(url.searchParams.get("context")).toBe("data-picker");
+      expect(url.searchParams.get("filter_items_in_personal_collection")).toBe(
+        "exclude-others",
+      );
     });
 
     it("meta click should open the data source in a new window", async () => {

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -9,6 +9,7 @@ import {
   shouldDisableItemNotInDb,
 } from "metabase/common/components/Pickers/DataPicker";
 import { MiniPicker } from "metabase/common/components/Pickers/MiniPicker";
+import type { MiniPickerSearchParams } from "metabase/common/components/Pickers/MiniPicker/context";
 import type {
   MiniPickerItem,
   MiniPickerPickableItem,
@@ -33,6 +34,10 @@ import { NotebookCellItem } from "../NotebookCell";
 
 import { EmbeddingDataPicker } from "./EmbeddingDataPicker";
 import { isObjectWithModel } from "./utils";
+
+const DATA_SOURCE_SEARCH_PARAMS: MiniPickerSearchParams = {
+  filter_items_in_personal_collection: "exclude-others",
+};
 
 export interface NotebookDataPickerProps {
   title: string;
@@ -238,6 +243,7 @@ function ModernDataPicker({
         // minipicker doesn't support picking a database
         models={miniPickerModelList.filter((model) => model !== "database")}
         searchQuery={dataSourceSearchQuery}
+        searchParams={DATA_SOURCE_SEARCH_PARAMS}
         onBrowseAll={() => setIsBrowsing(true)}
         trapFocus={focusPicker}
         onChange={(value: MiniPickerPickableItem) => {


### PR DESCRIPTION
### Description

Adds a query param to the search requests made by the MiniPicker and the DataPicker to filter out items in other users personal collections. It's worth noting that this doesn't change *all* entity pickers, and you can still manually navigate to other users personal collections if you have access to them.

This will only affect data selection, not _all_ entity pickers. I've called out internally if we want to make this a more universal change, and will update if apropriate

### How to verify
1. New -> Question
2. In the search, try searching for something in another users personal collection. There should be no results from there
3. Try searching for something in your personal collection. It should be discoverable
4. Attempt the same in the full entity picker

### Demo


https://github.com/user-attachments/assets/44e2dc09-f951-43b9-b4f9-6784bdac8799



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
