### PR TITLE
GDGT-2890: Fix custom-viz template .gitignore: ignore dist/ and *.tgz​

### DIFF
--- a/enterprise/frontend/src/custom-viz/package.json
+++ b/enterprise/frontend/src/custom-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/custom-viz",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Creating custom visualizations for Metabase",
   "type": "module",
   "bin": {

--- a/enterprise/frontend/src/custom-viz/src/templates/.gitignore
+++ b/enterprise/frontend/src/custom-viz/src/templates/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
-# dist must be committed
+dist/
+*.tgz


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2890/fix-custom-viz-template-gitignore-ignore-dist-and-tgz

### Description


Fix custom-viz template .gitignore: ignore dist/ and *.tgz

The scaffolded custom-viz project template ships a `.gitignore` with incorrect guidance.

**File:** `enterprise/frontend/src/custom-viz/src/templates/.gitignore`

**Current contents:**

```
node_modules/
.DS_Store
# dist must be committed
```

**Problem:**

* The comment `# dist must be committed` is wrong. The template's own README says:

  > The `dist/` folder does not need to be committed.

  `dist/` is regenerated by `npm run build` (`vite build`), so it's a build artifact and should be git-ignored, not committed.
* `npm run build` also writes a `<name>-<version>.tgz` package to the project root (via `pack.mjs`). This archive is a build artifact too and should be git-ignored.

### How to verify

### Demo

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
