### PR TITLE
Make AI auditing Conversations table horizontally scrollable

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationsPage/ConversationsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationsPage/ConversationsPage.tsx
@@ -80,7 +80,7 @@ export function ConversationsPage({ location }: WithRouterProps) {
           />
         </Flex>
 
-        <Card withBorder shadow="none" p={0}>
+        <Card withBorder shadow="none" p={0} style={{ overflowX: "auto" }}>
           <ConversationsTable
             conversations={conversations}
             isLoading={isLoading}

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationsPage/ConversationsTable.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/metabot-analytics/components/ConversationsPage/ConversationsTable.module.css
@@ -1,3 +1,7 @@
+.table {
+  min-width: 60rem;
+}
+
 .table thead th,
 .table thead th * {
   color: var(--mb-color-core-brand);


### PR DESCRIPTION
### Description

The AI auditing **Conversations** table had no horizontal scroll container, so on narrower screens its right-hand columns (`Queries`, `Searches`, `IP`) were clipped and unreachable. The table's `Card` is now an `overflow-x: auto` scroll container, and the table keeps a `min-width` so columns retain their size and overflow into a scroll region instead of being crushed.

### How to verify

1. Go to Admin → AI → Auditing → Conversations.
2. Narrow the browser window (or use a smaller screen) until the table is wider than its container.
3. The card now scrolls horizontally, exposing the `Queries`, `Searches`, and `IP` columns.

### Demo

https://github.com/user-attachments/assets/386f3cc7-e422-4066-aa11-80e21f8eca07


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
