### PR TITLE
Generate a fresh title for a forked Metabot conversation

### DIFF
--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -173,6 +173,7 @@ export type MetabotConversation = {
   profile_id: string | null;
   message_count: number;
   last_message_at: string | null;
+  forked_from_conversation_id: string | null;
 };
 
 export type MetabotConversationTitleResponse =

--- a/frontend/src/metabase-types/api/mocks/metabot.ts
+++ b/frontend/src/metabase-types/api/mocks/metabot.ts
@@ -31,6 +31,7 @@ export const createMockMetabotConversation = (
   profile_id: null,
   message_count: 1,
   last_message_at: new Date().toISOString(),
+  forked_from_conversation_id: null,
   ...opts,
 });
 

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.tsx
@@ -74,7 +74,10 @@ export const MetabotChat = ({
     return suggestedPromptsReq.currentData?.prompts ?? [];
   }, [suggestedPromptsReq.currentData?.prompts]);
 
-  const title = hasMessages ? metabot.title || t`New conversation` : undefined;
+  const untitledLabel = metabot.forkedFromConversationId
+    ? t`Forked conversation`
+    : t`New conversation`;
+  const title = hasMessages ? metabot.title || untitledLabel : undefined;
 
   const handleEditorSubmit = () => metabot.submitInput(metabot.prompt);
   const shouldShowHeader = headerActions || title;

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotConversationHistory.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotConversationHistory.tsx
@@ -120,22 +120,28 @@ const HistoryItem = ({
   conversation: MetabotConversation;
   isActive: boolean;
   onSelect: (conversationId: string) => void;
-}) => (
-  <Menu.Item
-    aria-current={isActive || undefined}
-    className={isActive ? S.activeItem : undefined}
-    onClick={() => onSelect(conversation.conversation_id)}
-    leftSection={<Icon c="text-secondary" name="message_circle" size={16} />}
-  >
-    <Flex align="center" gap="sm" wrap="nowrap">
-      <Text truncate fw="bold" fz="sm" c="text-primary" flex={1}>
-        {conversation.title || t`Untitled`}
-      </Text>
-      <Text c="text-secondary" fz="xs" style={{ flexShrink: 0 }}>
-        {getRelativeTime(
-          conversation.last_message_at ?? conversation.created_at,
-        )}
-      </Text>
-    </Flex>
-  </Menu.Item>
-);
+}) => {
+  const fallbackTitle = conversation.forked_from_conversation_id
+    ? t`Forked conversation`
+    : t`Untitled`;
+
+  return (
+    <Menu.Item
+      aria-current={isActive || undefined}
+      className={isActive ? S.activeItem : undefined}
+      onClick={() => onSelect(conversation.conversation_id)}
+      leftSection={<Icon c="text-secondary" name="message_circle" size={16} />}
+    >
+      <Flex align="center" gap="sm" wrap="nowrap">
+        <Text truncate fw="bold" fz="sm" c="text-primary" flex={1}>
+          {conversation.title || fallbackTitle}
+        </Text>
+        <Text c="text-secondary" fz="xs" style={{ flexShrink: 0 }}>
+          {getRelativeTime(
+            conversation.last_message_at ?? conversation.created_at,
+          )}
+        </Text>
+      </Flex>
+    </Menu.Item>
+  );
+};

--- a/frontend/src/metabase/metabot/components/MetabotConversationPage/MetabotConversationPage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotConversationPage/MetabotConversationPage.tsx
@@ -55,6 +55,8 @@ export const MetabotConversationPage = () => {
           agentId: "ask",
           conversationId: conversation.conversation_id,
           title: conversation.title ?? undefined,
+          forkedFromConversationId:
+            conversation.forked_from_conversation_id ?? undefined,
           messages: normalizeFetchedChatMessages(conversation.messages),
           state: conversation.state,
           activeToolCalls: [],

--- a/frontend/src/metabase/metabot/hooks/use-metabot-agent.ts
+++ b/frontend/src/metabase/metabot/hooks/use-metabot-agent.ts
@@ -18,6 +18,7 @@ import {
   getIsLongMetabotConversation,
   getIsProcessing,
   getMessages,
+  getMetabotConversationForkedFrom,
   getMetabotConversationId,
   getMetabotConversationTitle,
   getMetabotId,
@@ -186,6 +187,9 @@ export const useMetabotAgent = (agentId: MetabotAgentId = "omnibot") => {
       getMetabotConversationId(state, agentId),
     ),
     title: useSelector((state) => getMetabotConversationTitle(state, agentId)),
+    forkedFromConversationId: useSelector((state) =>
+      getMetabotConversationForkedFrom(state, agentId),
+    ),
     messages: useSelector((state) => getMessages(state, agentId)),
     isDoingScience: useSelector((state) => getIsProcessing(state, agentId)),
     isLongConversation: useSelector((state) =>

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -924,6 +924,8 @@ export const loadConversation = createAsyncThunk(
         agentId,
         conversationId: detail.conversation_id,
         title: detail.title ?? undefined,
+        forkedFromConversationId:
+          detail.forked_from_conversation_id ?? undefined,
         messages: normalizeFetchedChatMessages(detail.messages),
         state: detail.state,
         activeToolCalls: [],
@@ -954,6 +956,8 @@ export const forkConversation = createAsyncThunk(
         agentId,
         conversationId: conversation.conversation_id,
         title: conversation.title ?? undefined,
+        forkedFromConversationId:
+          conversation.forked_from_conversation_id ?? undefined,
         messages: normalizeFetchedChatMessages(conversation.messages),
         state: conversation.state,
         activeToolCalls: [],

--- a/frontend/src/metabase/metabot/state/reducer-utils.ts
+++ b/frontend/src/metabase/metabot/state/reducer-utils.ts
@@ -285,6 +285,7 @@ export const createConversation = (
   return {
     isProcessing: false,
     title: undefined,
+    forkedFromConversationId: undefined,
     messages: [],
     visible: false,
     state: {},

--- a/frontend/src/metabase/metabot/state/reducer.ts
+++ b/frontend/src/metabase/metabot/state/reducer.ts
@@ -405,6 +405,7 @@ export const metabot = createSlice({
           activeToolCalls?: MetabotToolCall[];
           conversationId: string;
           title?: string;
+          forkedFromConversationId?: string;
         }>,
         state,
       ) => {
@@ -415,6 +416,7 @@ export const metabot = createSlice({
           activeToolCalls,
           conversationId,
           title,
+          forkedFromConversationId,
         } = action.payload;
 
         convo.messages = castDraft(messages ?? []);
@@ -424,6 +426,7 @@ export const metabot = createSlice({
         convo.conversationId = conversationId ?? uuid();
         convo.loadId = nanoid();
         convo.title = title;
+        convo.forkedFromConversationId = forkedFromConversationId;
         convo.isProcessing = hasInProgressMessage(messages ?? []);
         if (convo.isProcessing) {
           openChain(convo); // resuming mid-response

--- a/frontend/src/metabase/metabot/state/selectors.ts
+++ b/frontend/src/metabase/metabot/state/selectors.ts
@@ -133,6 +133,11 @@ export const getMetabotConversationTitle = createSelector(
   (convo) => convo.title,
 );
 
+export const getMetabotConversationForkedFrom = createSelector(
+  getMetabotConversation,
+  (convo) => convo.forkedFromConversationId,
+);
+
 export const getIsPollingForTitle = createSelector(
   [
     (state: State) => getMetabotState(state).titlePollingConversationIds,

--- a/frontend/src/metabase/metabot/state/types.ts
+++ b/frontend/src/metabase/metabot/state/types.ts
@@ -158,6 +158,7 @@ export interface MetabotConverstationState {
   conversationId: string;
   loadId: string;
   title: string | undefined;
+  forkedFromConversationId: string | undefined;
   isProcessing: boolean;
   messages: MetabotChatMessage[];
   visible: boolean;

--- a/frontend/src/metabase/metabot/tests/fork.unit.spec.ts
+++ b/frontend/src/metabase/metabot/tests/fork.unit.spec.ts
@@ -6,6 +6,7 @@ import { forkConversation } from "metabase/metabot/state";
 import * as Urls from "metabase/urls";
 
 import {
+  conversationTitle,
   createMockSSEStream,
   createPauses,
   enterChatMessage,
@@ -21,6 +22,7 @@ import {
 const forkedConversation = createMockMetabotConversationDetail({
   conversation_id: "forked-convo-id",
   title: null,
+  forked_from_conversation_id: "original-convo-id",
   messages: [
     {
       id: "m1",
@@ -69,6 +71,8 @@ describe("metabot > fork", () => {
       ).toBe("forked-convo-id"),
     );
     expect(await screen.findByText("Conversation forked")).toBeInTheDocument();
+
+    expect(await conversationTitle()).toHaveTextContent("Forked conversation");
   });
 
   it("shows an error toast and keeps the original conversation when forking fails", async () => {

--- a/frontend/src/metabase/metabot/tests/fork.unit.spec.ts
+++ b/frontend/src/metabase/metabot/tests/fork.unit.spec.ts
@@ -20,7 +20,7 @@ import {
 
 const forkedConversation = createMockMetabotConversationDetail({
   conversation_id: "forked-convo-id",
-  title: "Who is your favorite? (forked)",
+  title: null,
   messages: [
     {
       id: "m1",

--- a/frontend/src/metabase/metabot/tests/ui.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/tests/ui.unit.spec.tsx
@@ -488,6 +488,11 @@ describe("metabot > ui", () => {
             conversation_id: "22222222-2222-2222-2222-222222222222",
             title: null,
           }),
+          createMockMetabotConversation({
+            conversation_id: "33333333-3333-3333-3333-333333333333",
+            title: null,
+            forked_from_conversation_id: "11111111-1111-1111-1111-111111111111",
+          }),
         ],
       });
 
@@ -502,6 +507,7 @@ describe("metabot > ui", () => {
         await within(list).findByText("Orders by month"),
       ).toBeInTheDocument();
       expect(within(list).getByText("Untitled")).toBeInTheDocument();
+      expect(within(list).getByText("Forked conversation")).toBeInTheDocument();
     });
 
     it("shows an empty state when there are no past conversations", async () => {

--- a/frontend/src/metabase/metabot/utils/normalize-fetched-chat-messages.ts
+++ b/frontend/src/metabase/metabot/utils/normalize-fetched-chat-messages.ts
@@ -19,6 +19,7 @@ export type MetabotConversationDetail = {
   created_at: string;
   title: string | null;
   user_id: number | null;
+  forked_from_conversation_id: string | null;
   state?: MetabotStateContext;
   messages: FetchedChatMessage[];
 };

--- a/frontend/test/__support__/server-mocks/metabot.ts
+++ b/frontend/test/__support__/server-mocks/metabot.ts
@@ -80,6 +80,7 @@ export function createMockMetabotConversationDetail(
     created_at: new Date().toISOString(),
     title: null,
     user_id: 1,
+    forked_from_conversation_id: null,
     state: {},
     messages: [],
     ...opts,

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -336,7 +336,7 @@
           live      (remove #(deleted? (:id %)) messages)
           history   (metabot.persistence/history live)
           state     (metabot.persistence/conversation-state live)
-          first-msg (or (:content (metabot.persistence/first-valid-user-message live))
+          first-msg (or (:content (metabot.persistence/first-non-forked-user-message live))
                         (:content message))
           title-job (conversation-title/ensure-title!
                      conversation_id

--- a/src/metabase/metabot/api/conversations.clj
+++ b/src/metabase/metabot/api/conversations.clj
@@ -36,7 +36,8 @@
    [:user_id         [:maybe ms/PositiveInt]]
    [:profile_id      [:maybe :string]]
    [:message_count   ms/IntGreaterThanOrEqualToZero]
-   [:last_message_at [:maybe ms/TemporalInstant]]])
+   [:last_message_at [:maybe ms/TemporalInstant]]
+   [:forked_from_conversation_id [:maybe ms/UUIDString]]])
 
 (def ^:private ListConversationsResponse
   [:map
@@ -186,7 +187,7 @@
         ;; soft-deleted messages still count. Legacy rows fall back to
         ;; `metabot_conversation.user_id`.
         rows    (t2/select :model/MetabotConversation
-                           {:select   [:c.id :c.created_at :c.title :c.user_id
+                           {:select   [:c.id :c.created_at :c.title :c.user_id :c.forked_from_conversation_id
                                        [(live-message-count-subquery) :message_count]
                                        [(last-live-message-at-subquery) :last_message_at]
                                        [(last-live-message-profile-id-subquery) :profile_id]]
@@ -196,7 +197,8 @@
                             :limit    limit
                             :offset   offset})]
     {:data   (mapv #(-> %
-                        (select-keys [:created_at :title :user_id :profile_id :message_count :last_message_at])
+                        (select-keys [:created_at :title :user_id :profile_id :message_count :last_message_at
+                                      :forked_from_conversation_id])
                         (assoc :conversation_id (:id %)))
                    rows)
      :total  total

--- a/src/metabase/metabot/api/conversations.clj
+++ b/src/metabase/metabot/api/conversations.clj
@@ -52,6 +52,7 @@
    [:created_at      ms/TemporalInstant]
    [:title           [:maybe :string]]
    [:user_id         [:maybe ms/PositiveInt]]
+   [:forked_from_conversation_id [:maybe ms/UUIDString]]
    [:state           {:optional true} [:maybe ::metabot.schema/state]]
    [:saved_entities  [:sequential
                       [:map

--- a/src/metabase/metabot/api/conversations.clj
+++ b/src/metabase/metabot/api/conversations.clj
@@ -28,15 +28,15 @@
 
 (def ^:private ConversationSummary
   [:map
-   [:conversation_id ms/UUIDString]
-   [:created_at      ms/TemporalInstant]
-   [:title           [:maybe :string]]
+   [:conversation_id             ms/UUIDString]
+   [:created_at                  ms/TemporalInstant]
+   [:title                       [:maybe :string]]
    ;; Wire compatibility: keep the field name `user_id`, but it now means the
    ;; conversation originator (first writer), not "the only allowed reader".
-   [:user_id         [:maybe ms/PositiveInt]]
-   [:profile_id      [:maybe :string]]
-   [:message_count   ms/IntGreaterThanOrEqualToZero]
-   [:last_message_at [:maybe ms/TemporalInstant]]
+   [:user_id                     [:maybe ms/PositiveInt]]
+   [:profile_id                  [:maybe :string]]
+   [:message_count               ms/IntGreaterThanOrEqualToZero]
+   [:last_message_at             [:maybe ms/TemporalInstant]]
    [:forked_from_conversation_id [:maybe ms/UUIDString]]])
 
 (def ^:private ListConversationsResponse
@@ -48,17 +48,17 @@
 
 (def ^:private ConversationDetail
   [:map
-   [:conversation_id ms/UUIDString]
-   [:created_at      ms/TemporalInstant]
-   [:title           [:maybe :string]]
-   [:user_id         [:maybe ms/PositiveInt]]
+   [:conversation_id             ms/UUIDString]
+   [:created_at                  ms/TemporalInstant]
+   [:title                       [:maybe :string]]
+   [:user_id                     [:maybe ms/PositiveInt]]
    [:forked_from_conversation_id [:maybe ms/UUIDString]]
-   [:state           {:optional true} [:maybe ::metabot.schema/state]]
-   [:saved_entities  [:sequential
-                      [:map
-                       [:card_id  ms/PositiveInt]
-                       [:chart_id [:maybe :string]]]]]
-   [:messages        [:sequential :map]]])
+   [:state                       {:optional true} [:maybe ::metabot.schema/state]]
+   [:saved_entities              [:sequential
+                                  [:map
+                                   [:card_id  ms/PositiveInt]
+                                   [:chart_id [:maybe :string]]]]]
+   [:messages                    [:sequential :map]]])
 
 (def ^:private ConversationTitleResponse
   [:map

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -800,20 +800,20 @@
   [conversation-id]
   (when-let [conv (t2/select-one :model/MetabotConversation :id conversation-id)]
     (let [messages (live-messages conversation-id)]
-      {:conversation_id (:id conv)
-       :created_at      (:created_at conv)
-       :title           (:title conv)
-       :user_id         (:user_id conv)
+      {:conversation_id             (:id conv)
+       :created_at                  (:created_at conv)
+       :title                       (:title conv)
+       :user_id                     (:user_id conv)
        :forked_from_conversation_id (:forked_from_conversation_id conv)
-       :state           (conversation-state messages)
-       :saved_entities  (mapv (fn [{:keys [id metabot_chart_id]}]
-                                {:card_id  id
-                                 :chart_id metabot_chart_id})
-                              (t2/select [:model/Card :id :metabot_chart_id]
-                                         :metabot_conversation_id conversation-id
-                                         :archived false
-                                         {:order-by [[:id :asc]]}))
-       :messages        (messages->chat-messages messages)})))
+       :state                       (conversation-state messages)
+       :saved_entities              (mapv (fn [{:keys [id metabot_chart_id]}]
+                                            {:card_id  id
+                                             :chart_id metabot_chart_id})
+                                          (t2/select [:model/Card :id :metabot_chart_id]
+                                                     :metabot_conversation_id conversation-id
+                                                     :archived false
+                                                     {:order-by [[:id :asc]]}))
+       :messages                    (messages->chat-messages messages)})))
 
 ;;; ---------------------------------------- Forking ----------------------------------------
 

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -508,8 +508,12 @@
 (defn first-valid-user-message
   "Return the first non-blank user message from a live replayable turn.
 
-  `messages` must be in reader order. Soft-deleted rows are ignored. Returns
-  `{:content <text> :profile-id <profile-id>}`, or nil when no turn qualifies."
+  `messages` must be in reader order. Soft-deleted rows are ignored, as are
+  messages cloned from a source conversation when this one was forked
+  (`forked_from_message_id` set), so a fork's title is generated from the first
+  message the user actually sends after forking rather than the inherited prefix.
+  Returns `{:content <text> :profile-id <profile-id>}`, or nil when no turn
+  qualifies."
   [messages]
   (some (fn [turn-rows]
           (when-let [{:keys [rows]} (replayable-turn turn-rows)]
@@ -517,7 +521,7 @@
               (let [content (message-text user-row)]
                 (when-not (str/blank? content)
                   {:content content :profile-id (:profile_id user-row)})))))
-        (rows->turns messages)))
+        (rows->turns (remove :forked_from_message_id messages))))
 
 (defn- turn->llm-messages
   [turn-rows]
@@ -812,25 +816,6 @@
 
 ;;; ---------------------------------------- Forking ----------------------------------------
 
-(def ^:private max-title-length
-  "Cap the forked conversation's title. `metabot_conversation.title` is a `text`
-  column, so this is a readability guard against an unbounded title, not a storage
-  limit."
-  200)
-
-(def ^:private fork-title-suffix " (forked)")
-
-(defn- forked-title
-  "The forked conversation's title: the source `title` truncated to fit, with the
-  fork suffix appended. Nil when the source has no title yet, matching a fresh
-  conversation whose title is generated later."
-  [title]
-  (when-not (str/blank? title)
-    (let [room (- max-title-length (count fork-title-suffix))
-          base (str/trim title)]
-      (str (cond-> base (> (count base) room) (subs 0 room))
-           fork-title-suffix))))
-
 (defn- forked-message-row
   "Build the insert map for a cloned message: a fresh `external_id`, `user-id`
   attribution, and no timestamps so `created_at` is stamped anew by the DB
@@ -874,14 +859,12 @@
                (nil? (:error target))
                (true? (:finished target)))
       (let [to-clone            (conj (vec before) target)
-            new-conversation-id (str (random-uuid))
-            title               (t2/select-one-fn :title :model/MetabotConversation :id conversation-id)]
+            new-conversation-id (str (random-uuid))]
         (t2/with-transaction [_conn]
           (t2/insert! :model/MetabotConversation
-                      (cond-> {:id                          new-conversation-id
-                               :user_id                     user-id
-                               :forked_from_conversation_id conversation-id}
-                        (forked-title title) (assoc :title (forked-title title))))
+                      {:id                          new-conversation-id
+                       :user_id                     user-id
+                       :forked_from_conversation_id conversation-id})
           (t2/insert! :model/MetabotMessage
                       (mapv #(forked-message-row new-conversation-id user-id %) to-clone)))
         new-conversation-id))))

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -804,6 +804,7 @@
        :created_at      (:created_at conv)
        :title           (:title conv)
        :user_id         (:user_id conv)
+       :forked_from_conversation_id (:forked_from_conversation_id conv)
        :state           (conversation-state messages)
        :saved_entities  (mapv (fn [{:keys [id metabot_chart_id]}]
                                 {:card_id  id

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -505,7 +505,7 @@
     (when (replayable-assistant-row? reply)
       {:rows rows :reply reply})))
 
-(defn first-valid-user-message
+(defn first-non-forked-user-message
   "Return the first non-blank user message from a live replayable turn.
 
   `messages` must be in reader order. Soft-deleted rows are ignored, as are

--- a/src/metabase/metabot/task/conversation_title_backfill.clj
+++ b/src/metabase/metabot/task/conversation_title_backfill.clj
@@ -74,7 +74,7 @@
 
 (defn- title-source
   [conversation-id]
-  (metabot.persistence/first-valid-user-message
+  (metabot.persistence/first-non-forked-user-message
    (metabot.persistence/opening-messages conversation-id)))
 
 (defn- generate-title!

--- a/test/metabase/metabot/api/conversations_test.clj
+++ b/test/metabase/metabot/api/conversations_test.clj
@@ -485,7 +485,8 @@
             (testing "a brand-new conversation is returned, owned by the current user"
               (is (some? new-id))
               (is (not= convo-id new-id))
-              (is (= "Original chat (forked)" (:title response)))
+              (testing "the fork starts without a title so one is generated from the user's first post-fork message"
+                (is (nil? (:title response))))
               (is (= user-id (:user_id response))))
             (testing "only the thread up to and including the target is copied"
               (is (= ["hi" "hello"] (mapv :message (:messages response)))))

--- a/test/metabase/metabot/api/conversations_test.clj
+++ b/test/metabase/metabot/api/conversations_test.clj
@@ -487,6 +487,8 @@
               (is (not= convo-id new-id))
               (testing "the fork starts without a title so one is generated from the user's first post-fork message"
                 (is (nil? (:title response))))
+              (testing "the fork records the conversation it was forked from"
+                (is (= convo-id (:forked_from_conversation_id response))))
               (is (= user-id (:user_id response))))
             (testing "only the thread up to and including the target is copied"
               (is (= ["hi" "hello"] (mapv :message (:messages response)))))

--- a/test/metabase/metabot/persistence_test.clj
+++ b/test/metabase/metabot/persistence_test.clj
@@ -53,7 +53,21 @@
   (testing "returns nil when no live replayable turn has a non-blank user message"
     (is (nil? (metabot-persistence/first-valid-user-message
                [{:id 1 :role :user :data [{:type "text" :text "failed"}]}
-                {:id 2 :role :assistant :finished true :error "boom" :data []}])))))
+                {:id 2 :role :assistant :finished true :error "boom" :data []}]))))
+  (testing "skips messages cloned from the source conversation on a fork"
+    (is (= {:content "the new direction" :profile-id "default"}
+           (metabot-persistence/first-valid-user-message
+            [{:id 1 :role :user :profile_id "default" :forked_from_message_id 100
+              :data [{:type "text" :text "inherited prompt"}]}
+             {:id 2 :role :assistant :finished true :forked_from_message_id 101 :data []}
+             {:id 3 :role :user :profile_id "default"
+              :data [{:type "text" :text "the new direction"}]}
+             {:id 4 :role :assistant :finished true :data []}]))))
+  (testing "returns nil for a fork with no post-fork user message yet"
+    (is (nil? (metabot-persistence/first-valid-user-message
+               [{:id 1 :role :user :profile_id "default" :forked_from_message_id 100
+                 :data [{:type "text" :text "inherited prompt"}]}
+                {:id 2 :role :assistant :finished true :forked_from_message_id 101 :data []}])))))
 
 (deftest ^:parallel message->chat-messages-test
   (testing "text part on a user row renders as a user message"

--- a/test/metabase/metabot/persistence_test.clj
+++ b/test/metabase/metabot/persistence_test.clj
@@ -30,11 +30,11 @@
      (mt/with-current-user (mt/user->id :rasta)
        ~@body)))
 
-(deftest ^:parallel first-valid-user-message-test
+(deftest ^:parallel first-non-forked-user-message-test
   (testing "returns the first non-blank user message from a replayable, live turn"
     (let [deleted-at (t/offset-date-time)]
       (is (= {:content "keep this prompt" :profile-id "internal"}
-             (metabot-persistence/first-valid-user-message
+             (metabot-persistence/first-non-forked-user-message
               [{:id 1 :role :user :profile_id "default"
                 :data [{:type "text" :text "errored prompt"}]}
                {:id 2 :role :assistant :finished true :error "boom" :data []}
@@ -51,12 +51,12 @@
                 :data [{:type "text" :text "keep this prompt"}]}
                {:id 10 :role :assistant :finished false :data []}])))))
   (testing "returns nil when no live replayable turn has a non-blank user message"
-    (is (nil? (metabot-persistence/first-valid-user-message
+    (is (nil? (metabot-persistence/first-non-forked-user-message
                [{:id 1 :role :user :data [{:type "text" :text "failed"}]}
                 {:id 2 :role :assistant :finished true :error "boom" :data []}]))))
   (testing "skips messages cloned from the source conversation on a fork"
     (is (= {:content "the new direction" :profile-id "default"}
-           (metabot-persistence/first-valid-user-message
+           (metabot-persistence/first-non-forked-user-message
             [{:id 1 :role :user :profile_id "default" :forked_from_message_id 100
               :data [{:type "text" :text "inherited prompt"}]}
              {:id 2 :role :assistant :finished true :forked_from_message_id 101 :data []}
@@ -64,7 +64,7 @@
               :data [{:type "text" :text "the new direction"}]}
              {:id 4 :role :assistant :finished true :data []}]))))
   (testing "returns nil for a fork with no post-fork user message yet"
-    (is (nil? (metabot-persistence/first-valid-user-message
+    (is (nil? (metabot-persistence/first-non-forked-user-message
                [{:id 1 :role :user :profile_id "default" :forked_from_message_id 100
                  :data [{:type "text" :text "inherited prompt"}]}
                 {:id 2 :role :assistant :finished true :forked_from_message_id 101 :data []}])))))


### PR DESCRIPTION
## Description

When you fork a Metabot conversation, the fork used to inherit the source's title with a `" (forked)"` suffix (e.g. `Orders by month (forked)`). Because every title generator is gated on the title being `NULL`, that non-null title permanently blocked title generation — the fork stayed named `"… (forked)"` forever, and never picked up a name reflecting where the user actually took it.

This changes a fork to start with **no title**, so the existing "generate a title once, from the user's first message" machinery kicks in the moment the user continues the fork. Two pieces make that work correctly:

- **Fork starts title-less.** `fork-conversation!` no longer writes a `"(forked)"` title; the row is inserted with `title = NULL`, exactly like a fresh conversation.
- **Title is seeded from the first *post-fork* message.** Title generation reads the first user message of the live thread, which on a fork is the *cloned* prefix copied from the source — so a naive null title would just regenerate the source's title. `first-valid-user-message` now skips rows carrying `forked_from_message_id`, so the title reflects the first message the user sends *after* forking. (No-op for non-forked conversations.)
- **FE fallback while the title is pending.** The conversations list now receives `forked_from_conversation_id`, and an untitled fork renders as **"Forked conversation"** instead of the generic "Untitled" until its real title lands.

Net behavior:
- Right after forking → title is `NULL`, history shows "Forked conversation".
- User sends their first message → a clean, topic-based title is generated once.
- Every later message → the null-gate means it is never regenerated, so the title is stable.

## How to verify

1. Start a Metabot conversation and let it get an auto-generated title.
2. Fork it from an assistant message. The forked conversation has no `"(forked)"` title; in the recent-conversations menu it shows as "Forked conversation".
3. Send a new message in the fork on a different topic. Shortly after, the fork gets a fresh title generated from that new message — not the source's title, and without any "(forked)" suffix.

## Checklist

- [x] Backend unit tests (`metabase.metabot.persistence-test`, `metabase.metabot.api.conversations-test`)
- [x] Frontend unit tests (`metabot > ui`, `metabot > fork`)
- [x] Type-check passes
