### PR TITLE
[Worktrees 1/8] Worktree schema: NULL worktree-id = main app, per-worktree entity_id uniqueness

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/core.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.remote-sync.core
   (:require
    [metabase-enterprise.remote-sync.guards :as guards]
-   [metabase-enterprise.remote-sync.models.remote-sync-worktree :as remote-sync.worktree]
    [metabase-enterprise.remote-sync.settings :as settings]
    [metabase-enterprise.remote-sync.source :as source]
    [metabase-enterprise.remote-sync.source.protocol :as source.p]
@@ -67,13 +66,6 @@
   (or (not (settings/remote-sync-enabled))
       (= (settings/remote-sync-type) :read-write)))
 
-(defenterprise default-worktree-id
-  "ID of the default remote sync worktree — the row tracking the branch in the `remote-sync-branch`
-  setting — creating it if needed. Nil when remote sync is not configured."
-  :feature :none
-  []
-  (remote-sync.worktree/default-worktree-id))
-
 (defenterprise model-editable?
   "Determines if a model instance is editable based on remote sync configuration."
   :feature :none
@@ -113,8 +105,7 @@
     (t2/with-transaction [_]
       (when (seq sync-on)
         (t2/query {:update (t2/table-name :model/Collection)
-                   :set {:is_remote_synced true
-                         :remote_sync_worktree_id (remote-sync.worktree/default-worktree-id)}
+                   :set {:is_remote_synced true}
                    :where [:and
                            [:= :is_remote_synced false]
                            (into [:or [:in :id (map :id sync-on)]]
@@ -130,8 +121,7 @@
                                                   [:like :location (str (collections/location-path collection) "%")]))]})]
           (when (seq affected-collection-ids)
             (t2/query {:update (t2/table-name :model/Collection)
-                       :set {:is_remote_synced false
-                             :remote_sync_worktree_id nil}
+                       :set {:is_remote_synced false}
                        :where [:in :id affected-collection-ids]})
             (t2/delete! :model/RemoteSyncObject
                         :model_type "Collection"

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/core.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.remote-sync.core
   (:require
    [metabase-enterprise.remote-sync.guards :as guards]
+   [metabase-enterprise.remote-sync.models.remote-sync-worktree :as remote-sync.worktree]
    [metabase-enterprise.remote-sync.settings :as settings]
    [metabase-enterprise.remote-sync.source :as source]
    [metabase-enterprise.remote-sync.source.protocol :as source.p]
@@ -66,6 +67,13 @@
   (or (not (settings/remote-sync-enabled))
       (= (settings/remote-sync-type) :read-write)))
 
+(defenterprise default-worktree-id
+  "ID of the default remote sync worktree — the row tracking the branch in the `remote-sync-branch`
+  setting — creating it if needed. Nil when remote sync is not configured."
+  :feature :none
+  []
+  (remote-sync.worktree/default-worktree-id))
+
 (defenterprise model-editable?
   "Determines if a model instance is editable based on remote sync configuration."
   :feature :none
@@ -105,7 +113,8 @@
     (t2/with-transaction [_]
       (when (seq sync-on)
         (t2/query {:update (t2/table-name :model/Collection)
-                   :set {:is_remote_synced true}
+                   :set {:is_remote_synced true
+                         :remote_sync_worktree_id (remote-sync.worktree/default-worktree-id)}
                    :where [:and
                            [:= :is_remote_synced false]
                            (into [:or [:in :id (map :id sync-on)]]
@@ -121,7 +130,8 @@
                                                   [:like :location (str (collections/location-path collection) "%")]))]})]
           (when (seq affected-collection-ids)
             (t2/query {:update (t2/table-name :model/Collection)
-                       :set {:is_remote_synced false}
+                       :set {:is_remote_synced false
+                             :remote_sync_worktree_id nil}
                        :where [:in :id affected-collection-ids]})
             (t2/delete! :model/RemoteSyncObject
                         :model_type "Collection"

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_worktree.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_worktree.clj
@@ -2,12 +2,9 @@
   "Model for remote sync worktrees: checked-out branches of the remote sync repository, each materialized
    as ordinary collection trees.
 
-   The *default worktree* is the row whose branch matches the `remote-sync-branch` setting — the content
-   all user-less traffic sees. It is created lazily rather than by a migration because the branch setting
-   can come from an env var (`MB_REMOTE_SYNC_BRANCH`) that a SQL migration cannot read."
+   The main app is not a worktree: main-app content (including default-branch remote sync) carries a NULL
+   worktree reference, and the `remote_sync_worktree` table only holds real checkouts, one row per branch."
   (:require
-   [metabase.settings.core :as setting]
-   [metabase.util.malli :as mu]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -18,41 +15,3 @@
 (doto :model/RemoteSyncWorktree
   (derive :metabase/model)
   (derive :hook/created-at-timestamped?))
-
-(defn- backfill-worktree-references!
-  "Point pre-worktree rows (collections flagged `is_remote_synced`, remote sync objects, and task history
-   with no worktree) at `worktree-id`. Idempotent: only touches rows whose worktree reference is null."
-  [worktree-id]
-  (t2/query {:update (t2/table-name :model/Collection)
-             :set    {:remote_sync_worktree_id worktree-id}
-             :where  [:and
-                      [:= :is_remote_synced true]
-                      [:= :remote_sync_worktree_id nil]]})
-  (t2/query {:update (t2/table-name :model/RemoteSyncObject)
-             :set    {:worktree_id worktree-id}
-             :where  [:= :worktree_id nil]})
-  (t2/query {:update (t2/table-name :model/RemoteSyncTask)
-             :set    {:worktree_id worktree-id}
-             :where  [:= :worktree_id nil]}))
-
-(mu/defn ensure-default-worktree! :- [:maybe [:map [:id pos-int?]]]
-  "Get or create the worktree row for the current `remote-sync-branch`, backfilling worktree references on
-   rows that predate it. Returns the worktree, or nil when no branch is configured."
-  []
-  (when-let [branch (setting/get :remote-sync-branch)]
-    (when-let [worktree (or (t2/select-one :model/RemoteSyncWorktree :branch branch)
-                            (try
-                              (t2/insert-returning-instance! :model/RemoteSyncWorktree {:branch branch})
-                              (catch Exception _
-                                ;; lost a race with another node/thread inserting the same branch
-                                (t2/select-one :model/RemoteSyncWorktree :branch branch))))]
-      (backfill-worktree-references! (:id worktree))
-      worktree)))
-
-(mu/defn default-worktree-id :- [:maybe pos-int?]
-  "ID of the default worktree — the row whose branch matches the `remote-sync-branch` setting — creating
-   it (and backfilling references) if needed. Nil when no branch is configured."
-  []
-  (when-let [branch (setting/get :remote-sync-branch)]
-    (or (t2/select-one-fn :id :model/RemoteSyncWorktree :branch branch)
-        (:id (ensure-default-worktree!)))))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_worktree.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_worktree.clj
@@ -1,0 +1,58 @@
+(ns metabase-enterprise.remote-sync.models.remote-sync-worktree
+  "Model for remote sync worktrees: checked-out branches of the remote sync repository, each materialized
+   as ordinary collection trees.
+
+   The *default worktree* is the row whose branch matches the `remote-sync-branch` setting — the content
+   all user-less traffic sees. It is created lazily rather than by a migration because the branch setting
+   can come from an env var (`MB_REMOTE_SYNC_BRANCH`) that a SQL migration cannot read."
+  (:require
+   [metabase.settings.core :as setting]
+   [metabase.util.malli :as mu]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(methodical/defmethod t2/table-name :model/RemoteSyncWorktree [_model] :remote_sync_worktree)
+
+(doto :model/RemoteSyncWorktree
+  (derive :metabase/model)
+  (derive :hook/created-at-timestamped?))
+
+(defn- backfill-worktree-references!
+  "Point pre-worktree rows (collections flagged `is_remote_synced`, remote sync objects, and task history
+   with no worktree) at `worktree-id`. Idempotent: only touches rows whose worktree reference is null."
+  [worktree-id]
+  (t2/query {:update (t2/table-name :model/Collection)
+             :set    {:remote_sync_worktree_id worktree-id}
+             :where  [:and
+                      [:= :is_remote_synced true]
+                      [:= :remote_sync_worktree_id nil]]})
+  (t2/query {:update (t2/table-name :model/RemoteSyncObject)
+             :set    {:worktree_id worktree-id}
+             :where  [:= :worktree_id nil]})
+  (t2/query {:update (t2/table-name :model/RemoteSyncTask)
+             :set    {:worktree_id worktree-id}
+             :where  [:= :worktree_id nil]}))
+
+(mu/defn ensure-default-worktree! :- [:maybe [:map [:id pos-int?]]]
+  "Get or create the worktree row for the current `remote-sync-branch`, backfilling worktree references on
+   rows that predate it. Returns the worktree, or nil when no branch is configured."
+  []
+  (when-let [branch (setting/get :remote-sync-branch)]
+    (when-let [worktree (or (t2/select-one :model/RemoteSyncWorktree :branch branch)
+                            (try
+                              (t2/insert-returning-instance! :model/RemoteSyncWorktree {:branch branch})
+                              (catch Exception _
+                                ;; lost a race with another node/thread inserting the same branch
+                                (t2/select-one :model/RemoteSyncWorktree :branch branch))))]
+      (backfill-worktree-references! (:id worktree))
+      worktree)))
+
+(mu/defn default-worktree-id :- [:maybe pos-int?]
+  "ID of the default worktree — the row whose branch matches the `remote-sync-branch` setting — creating
+   it (and backfilling references) if needed. Nil when no branch is configured."
+  []
+  (when-let [branch (setting/get :remote-sync-branch)]
+    (or (t2/select-one-fn :id :model/RemoteSyncWorktree :branch branch)
+        (:id (ensure-default-worktree!)))))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/entity_ids.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/entity_ids.clj
@@ -86,6 +86,13 @@
                          :primary-key primary-key
                          :error       ::missing-pk})))
       (let [new-hash (serdes/identity-hash instance)]
+        ;; entity_id uniqueness is per remote-sync worktree at the schema level (NULL rows are not
+        ;; mutually DB-unique), so duplicates must be refused here rather than left to a constraint
+        (when (t2/exists? model :entity_id new-hash)
+          (throw (ex-info (format "Duplicate entity ID %s" (pr-str new-hash))
+                          {:model     (name model)
+                           :entity-id new-hash
+                           :error     ::duplicate-entity-id})))
         (log/infof "Update %s %s entity ID => %s" (name model) (pr-str pk-value) (pr-str new-hash))
         (t2/update! model pk-value {:entity_id new-hash}))
       {:update-count 1}

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -137,6 +137,7 @@
    "ReplacementRun"
    "RemoteSyncObject"
    "RemoteSyncTask"
+   "RemoteSyncWorktree"
    "Revision"
    "Sandbox"
    "SearchIndexMetadata"

--- a/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
@@ -153,7 +153,9 @@
     ;; provisioning state, not portable content. Same rationale as TableRemapping above.
     :model/Workspace
     :model/WorkspaceDatabase
-    :model/WorkspaceInstance})
+    :model/WorkspaceInstance
+    ;; remote-sync worktree checkouts are per-instance sync bookkeeping, not portable content
+    :model/RemoteSyncWorktree})
 
 (deftest ^:parallel comprehensive-entity-id-test
   (let [entity-id-models (->> (v2.entity-ids/toucan-models)

--- a/resources/migrations/064/20260722_remote_sync_worktree.yaml
+++ b/resources/migrations/064/20260722_remote_sync_worktree.yaml
@@ -1,0 +1,440 @@
+## Remote sync worktrees: branch checkouts materialized as collection trees.
+## The remote_sync_worktree table holds one row per checked-out branch; the
+## default worktree is the row whose branch matches the remote-sync-branch
+## setting. Collections, remote_sync_object, and remote_sync_task gain a
+## worktree reference so sync state can be scoped per worktree.
+
+databaseChangeLog:
+  - changeSet:
+      id: v64.2026-07-22T10:00:00
+      author: ranquild
+      comment: Create remote_sync_worktree table
+      changes:
+        - createTable:
+            tableName: remote_sync_worktree
+            remarks: One row per checked-out remote sync branch (git-worktree-style)
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  remarks: Unique ID
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: branch
+                  type: varchar(254)
+                  remarks: Git branch this worktree is checked out to
+                  constraints:
+                    nullable: false
+              - column:
+                  name: base_version
+                  type: varchar(254)
+                  remarks: Last synced git SHA for this worktree; null until first successful pull
+                  constraints:
+                    nullable: true
+              - column:
+                  name: creator_id
+                  type: int
+                  remarks: User who created this worktree
+                  constraints:
+                    nullable: true
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  remarks: When this worktree was created
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:01
+      author: ranquild
+      comment: Unique index on remote_sync_worktree.branch
+      changes:
+        - createIndex:
+            tableName: remote_sync_worktree
+            indexName: idx_remote_sync_worktree_branch
+            unique: true
+            columns:
+              - column:
+                  name: branch
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:02
+      author: ranquild
+      comment: FK remote_sync_worktree.creator_id -> core_user
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: remote_sync_worktree
+            baseColumnNames: creator_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_remote_sync_worktree_creator_id
+            onDelete: SET NULL
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:03
+      author: ranquild
+      comment: Add collection.remote_sync_worktree_id
+      changes:
+        - addColumn:
+            tableName: collection
+            columns:
+              - column:
+                  name: remote_sync_worktree_id
+                  type: int
+                  remarks: Worktree this collection belongs to; null for content not under remote sync
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:04
+      author: ranquild
+      comment: FK collection.remote_sync_worktree_id -> remote_sync_worktree
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: collection
+            baseColumnNames: remote_sync_worktree_id
+            referencedTableName: remote_sync_worktree
+            referencedColumnNames: id
+            constraintName: fk_collection_remote_sync_worktree_id
+            onDelete: SET NULL
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:05
+      author: ranquild
+      comment: Index on collection.remote_sync_worktree_id
+      changes:
+        - createIndex:
+            tableName: collection
+            indexName: idx_collection_remote_sync_worktree_id
+            columns:
+              - column:
+                  name: remote_sync_worktree_id
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:06
+      author: ranquild
+      comment: Add remote_sync_object.worktree_id
+      changes:
+        - addColumn:
+            tableName: remote_sync_object
+            columns:
+              - column:
+                  name: worktree_id
+                  type: int
+                  remarks: Worktree whose dirty ledger this row belongs to
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:07
+      author: ranquild
+      comment: FK remote_sync_object.worktree_id -> remote_sync_worktree
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: remote_sync_object
+            baseColumnNames: worktree_id
+            referencedTableName: remote_sync_worktree
+            referencedColumnNames: id
+            constraintName: fk_remote_sync_object_worktree_id
+            deleteCascade: true
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:08
+      author: ranquild
+      comment: Index on remote_sync_object.worktree_id
+      changes:
+        - createIndex:
+            tableName: remote_sync_object
+            indexName: idx_remote_sync_object_worktree_id
+            columns:
+              - column:
+                  name: worktree_id
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:09
+      author: ranquild
+      comment: Add remote_sync_task.worktree_id
+      changes:
+        - addColumn:
+            tableName: remote_sync_task
+            columns:
+              - column:
+                  name: worktree_id
+                  type: int
+                  remarks: Worktree this task operated on
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:10
+      author: ranquild
+      comment: FK remote_sync_task.worktree_id -> remote_sync_worktree
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: remote_sync_task
+            baseColumnNames: worktree_id
+            referencedTableName: remote_sync_worktree
+            referencedColumnNames: id
+            constraintName: fk_remote_sync_task_worktree_id
+            onDelete: SET NULL
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:11
+      author: ranquild
+      comment: Index on remote_sync_task.worktree_id
+      changes:
+        - createIndex:
+            tableName: remote_sync_task
+            indexName: idx_remote_sync_task_worktree_id
+            columns:
+              - column:
+                  name: worktree_id
+
+  ## Worktree copies carry a prefixed entity id - "<worktree-id>/<entity-id>", with "/"
+  ## as a separator that cannot appear in the NanoID alphabet - so the canonical (git)
+  ## identity is parseable from the local id and the two can never collide. Widen
+  ## entity_id on every table a worktree checkout can materialize.
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:12
+      author: ranquild
+      comment: Widen collection.entity_id for worktree-prefixed ids
+      changes:
+        - modifyDataType:
+            tableName: collection
+            columnName: entity_id
+            newDataType: varchar(254)
+      rollback:
+        - modifyDataType:
+            tableName: collection
+            columnName: entity_id
+            newDataType: char(21)
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:13
+      author: ranquild
+      comment: Widen report_card.entity_id for worktree-prefixed ids
+      changes:
+        - modifyDataType:
+            tableName: report_card
+            columnName: entity_id
+            newDataType: varchar(254)
+      rollback:
+        - modifyDataType:
+            tableName: report_card
+            columnName: entity_id
+            newDataType: char(21)
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:14
+      author: ranquild
+      comment: Widen report_dashboard.entity_id for worktree-prefixed ids
+      changes:
+        - modifyDataType:
+            tableName: report_dashboard
+            columnName: entity_id
+            newDataType: varchar(254)
+      rollback:
+        - modifyDataType:
+            tableName: report_dashboard
+            columnName: entity_id
+            newDataType: char(21)
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:15
+      author: ranquild
+      comment: Widen report_dashboardcard.entity_id for worktree-prefixed ids
+      changes:
+        - modifyDataType:
+            tableName: report_dashboardcard
+            columnName: entity_id
+            newDataType: varchar(254)
+      rollback:
+        - modifyDataType:
+            tableName: report_dashboardcard
+            columnName: entity_id
+            newDataType: char(21)
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:16
+      author: ranquild
+      comment: Widen dashboard_tab.entity_id for worktree-prefixed ids
+      changes:
+        - modifyDataType:
+            tableName: dashboard_tab
+            columnName: entity_id
+            newDataType: varchar(254)
+      rollback:
+        - modifyDataType:
+            tableName: dashboard_tab
+            columnName: entity_id
+            newDataType: char(21)
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:17
+      author: ranquild
+      comment: Widen document.entity_id for worktree-prefixed ids
+      changes:
+        - modifyDataType:
+            tableName: document
+            columnName: entity_id
+            newDataType: varchar(254)
+      rollback:
+        - modifyDataType:
+            tableName: document
+            columnName: entity_id
+            newDataType: char(21)
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:18
+      author: ranquild
+      comment: Widen native_query_snippet.entity_id for worktree-prefixed ids
+      changes:
+        - modifyDataType:
+            tableName: native_query_snippet
+            columnName: entity_id
+            newDataType: varchar(254)
+      rollback:
+        - modifyDataType:
+            tableName: native_query_snippet
+            columnName: entity_id
+            newDataType: char(21)
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:19
+      author: ranquild
+      comment: Widen timeline.entity_id for worktree-prefixed ids
+      changes:
+        - modifyDataType:
+            tableName: timeline
+            columnName: entity_id
+            newDataType: varchar(254)
+      rollback:
+        - modifyDataType:
+            tableName: timeline
+            columnName: entity_id
+            newDataType: char(21)
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:20
+      author: ranquild
+      comment: Widen segment.entity_id for worktree-prefixed ids
+      changes:
+        - modifyDataType:
+            tableName: segment
+            columnName: entity_id
+            newDataType: varchar(254)
+      rollback:
+        - modifyDataType:
+            tableName: segment
+            columnName: entity_id
+            newDataType: char(21)
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:21
+      author: ranquild
+      comment: Widen measure.entity_id for worktree-prefixed ids
+      changes:
+        - modifyDataType:
+            tableName: measure
+            columnName: entity_id
+            newDataType: varchar(254)
+      rollback:
+        - modifyDataType:
+            tableName: measure
+            columnName: entity_id
+            newDataType: char(21)
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:22
+      author: ranquild
+      comment: Widen transform.entity_id for worktree-prefixed ids
+      changes:
+        - modifyDataType:
+            tableName: transform
+            columnName: entity_id
+            newDataType: varchar(254)
+      rollback:
+        - modifyDataType:
+            tableName: transform
+            columnName: entity_id
+            newDataType: char(21)
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:23
+      author: ranquild
+      comment: Widen transform_tag.entity_id for worktree-prefixed ids
+      changes:
+        - modifyDataType:
+            tableName: transform_tag
+            columnName: entity_id
+            newDataType: varchar(254)
+      rollback:
+        - modifyDataType:
+            tableName: transform_tag
+            columnName: entity_id
+            newDataType: char(21)
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:24
+      author: ranquild
+      comment: Widen transform_job.entity_id for worktree-prefixed ids
+      changes:
+        - modifyDataType:
+            tableName: transform_job
+            columnName: entity_id
+            newDataType: varchar(254)
+      rollback:
+        - modifyDataType:
+            tableName: transform_job
+            columnName: entity_id
+            newDataType: char(21)
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:25
+      author: ranquild
+      comment: Widen transform_transform_tag.entity_id for worktree-prefixed ids
+      changes:
+        - modifyDataType:
+            tableName: transform_transform_tag
+            columnName: entity_id
+            newDataType: varchar(254)
+      rollback:
+        - modifyDataType:
+            tableName: transform_transform_tag
+            columnName: entity_id
+            newDataType: char(21)
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:26
+      author: ranquild
+      comment: Widen transform_job_transform_tag.entity_id for worktree-prefixed ids
+      changes:
+        - modifyDataType:
+            tableName: transform_job_transform_tag
+            columnName: entity_id
+            newDataType: varchar(254)
+      rollback:
+        - modifyDataType:
+            tableName: transform_job_transform_tag
+            columnName: entity_id
+            newDataType: char(21)
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:27
+      author: ranquild
+      comment: Widen python_library.entity_id for worktree-prefixed ids
+      changes:
+        - modifyDataType:
+            tableName: python_library
+            columnName: entity_id
+            newDataType: varchar(254)
+      rollback:
+        - modifyDataType:
+            tableName: python_library
+            columnName: entity_id
+            newDataType: char(21)

--- a/resources/migrations/064/20260722_remote_sync_worktree.yaml
+++ b/resources/migrations/064/20260722_remote_sync_worktree.yaml
@@ -1,8 +1,9 @@
 ## Remote sync worktrees: branch checkouts materialized as collection trees.
 ## The remote_sync_worktree table holds one row per checked-out branch; the
-## default worktree is the row whose branch matches the remote-sync-branch
-## setting. Collections, remote_sync_object, and remote_sync_task gain a
-## worktree reference so sync state can be scoped per worktree.
+## main app (including default-branch remote sync) is NOT a worktree — its
+## content simply has a NULL worktree reference. Collections, remote_sync_object,
+## and remote_sync_task gain a worktree reference so sync state can be scoped
+## per worktree.
 
 databaseChangeLog:
   - changeSet:
@@ -85,7 +86,7 @@ databaseChangeLog:
               - column:
                   name: remote_sync_worktree_id
                   type: int
-                  remarks: Worktree this collection belongs to; null for content not under remote sync
+                  remarks: Worktree this collection belongs to; null for main-app content (including default-branch remote sync)
                   constraints:
                     nullable: true
 
@@ -100,7 +101,7 @@ databaseChangeLog:
             referencedTableName: remote_sync_worktree
             referencedColumnNames: id
             constraintName: fk_collection_remote_sync_worktree_id
-            onDelete: SET NULL
+            deleteCascade: true
 
   - changeSet:
       id: v64.2026-07-22T10:00:05
@@ -194,247 +195,649 @@ databaseChangeLog:
               - column:
                   name: worktree_id
 
-  ## Worktree copies carry a prefixed entity id - "<worktree-id>/<entity-id>", with "/"
-  ## as a separator that cannot appear in the NanoID alphabet - so the canonical (git)
-  ## identity is parseable from the local id and the two can never collide. Widen
-  ## entity_id on every table a worktree checkout can materialize.
 
+  ## Worktree checkouts materialize rows whose entity_id equals the canonical (git) id, so the same
+  ## entity_id exists once per worktree. Uniqueness becomes per-worktree (composite constraints added
+  ## below); the original inline uniques are auto-named per dialect, hence the dbms-split SQL.
   - changeSet:
       id: v64.2026-07-22T10:00:12
       author: ranquild
-      comment: Widen collection.entity_id for worktree-prefixed ids
+      comment: Drop entity_id unique constraints on worktree-materializable tables (postgres)
       changes:
-        - modifyDataType:
-            tableName: collection
-            columnName: entity_id
-            newDataType: varchar(254)
+        - sql:
+            dbms: postgresql
+            sql: |
+              ALTER TABLE "collection" DROP CONSTRAINT IF EXISTS "collection_entity_id_key";
+              ALTER TABLE "report_card" DROP CONSTRAINT IF EXISTS "report_card_entity_id_key";
+              ALTER TABLE "report_dashboard" DROP CONSTRAINT IF EXISTS "report_dashboard_entity_id_key";
+              ALTER TABLE "report_dashboardcard" DROP CONSTRAINT IF EXISTS "report_dashboardcard_entity_id_key";
+              ALTER TABLE "dashboard_tab" DROP CONSTRAINT IF EXISTS "dashboard_tab_entity_id_key";
+              ALTER TABLE "document" DROP CONSTRAINT IF EXISTS "document_entity_id_key";
+              ALTER TABLE "native_query_snippet" DROP CONSTRAINT IF EXISTS "native_query_snippet_entity_id_key";
+              ALTER TABLE "timeline" DROP CONSTRAINT IF EXISTS "timeline_entity_id_key";
+              ALTER TABLE "segment" DROP CONSTRAINT IF EXISTS "segment_entity_id_key";
+              ALTER TABLE "measure" DROP CONSTRAINT IF EXISTS "measure_entity_id_key";
+              ALTER TABLE "action" DROP CONSTRAINT IF EXISTS "action_entity_id_key";
       rollback:
-        - modifyDataType:
+        - addUniqueConstraint:
             tableName: collection
-            columnName: entity_id
-            newDataType: char(21)
+            columnNames: entity_id
+            constraintName: unique_collection_entity_id
+        - addUniqueConstraint:
+            tableName: report_card
+            columnNames: entity_id
+            constraintName: unique_report_card_entity_id
+        - addUniqueConstraint:
+            tableName: report_dashboard
+            columnNames: entity_id
+            constraintName: unique_report_dashboard_entity_id
+        - addUniqueConstraint:
+            tableName: report_dashboardcard
+            columnNames: entity_id
+            constraintName: unique_report_dashboardcard_entity_id
+        - addUniqueConstraint:
+            tableName: dashboard_tab
+            columnNames: entity_id
+            constraintName: unique_dashboard_tab_entity_id
+        - addUniqueConstraint:
+            tableName: document
+            columnNames: entity_id
+            constraintName: unique_document_entity_id
+        - addUniqueConstraint:
+            tableName: native_query_snippet
+            columnNames: entity_id
+            constraintName: unique_native_query_snippet_entity_id
+        - addUniqueConstraint:
+            tableName: timeline
+            columnNames: entity_id
+            constraintName: unique_timeline_entity_id
+        - addUniqueConstraint:
+            tableName: segment
+            columnNames: entity_id
+            constraintName: unique_segment_entity_id
+        - addUniqueConstraint:
+            tableName: measure
+            columnNames: entity_id
+            constraintName: unique_measure_entity_id
+        - addUniqueConstraint:
+            tableName: action
+            columnNames: entity_id
+            constraintName: unique_action_entity_id
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:50
+      author: ranquild
+      comment: Drop entity_id unique indexes on worktree-materializable tables (mysql, mariadb)
+      changes:
+        - sql:
+            dbms: mysql,mariadb
+            sql: |
+              ALTER TABLE `collection` DROP INDEX `entity_id`;
+              ALTER TABLE `report_card` DROP INDEX `entity_id`;
+              ALTER TABLE `report_dashboard` DROP INDEX `entity_id`;
+              ALTER TABLE `report_dashboardcard` DROP INDEX `entity_id`;
+              ALTER TABLE `dashboard_tab` DROP INDEX `entity_id`;
+              ALTER TABLE `document` DROP INDEX `entity_id`;
+              ALTER TABLE `native_query_snippet` DROP INDEX `entity_id`;
+              ALTER TABLE `timeline` DROP INDEX `entity_id`;
+              ALTER TABLE `segment` DROP INDEX `entity_id`;
+              ALTER TABLE `measure` DROP INDEX `entity_id`;
+              ALTER TABLE `action` DROP INDEX `entity_id`;
+      rollback:
+        - addUniqueConstraint:
+            tableName: collection
+            columnNames: entity_id
+            constraintName: unique_collection_entity_id
+        - addUniqueConstraint:
+            tableName: report_card
+            columnNames: entity_id
+            constraintName: unique_report_card_entity_id
+        - addUniqueConstraint:
+            tableName: report_dashboard
+            columnNames: entity_id
+            constraintName: unique_report_dashboard_entity_id
+        - addUniqueConstraint:
+            tableName: report_dashboardcard
+            columnNames: entity_id
+            constraintName: unique_report_dashboardcard_entity_id
+        - addUniqueConstraint:
+            tableName: dashboard_tab
+            columnNames: entity_id
+            constraintName: unique_dashboard_tab_entity_id
+        - addUniqueConstraint:
+            tableName: document
+            columnNames: entity_id
+            constraintName: unique_document_entity_id
+        - addUniqueConstraint:
+            tableName: native_query_snippet
+            columnNames: entity_id
+            constraintName: unique_native_query_snippet_entity_id
+        - addUniqueConstraint:
+            tableName: timeline
+            columnNames: entity_id
+            constraintName: unique_timeline_entity_id
+        - addUniqueConstraint:
+            tableName: segment
+            columnNames: entity_id
+            constraintName: unique_segment_entity_id
+        - addUniqueConstraint:
+            tableName: measure
+            columnNames: entity_id
+            constraintName: unique_measure_entity_id
+        - addUniqueConstraint:
+            tableName: action
+            columnNames: entity_id
+            constraintName: unique_action_entity_id
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:51
+      author: ranquild
+      comment: Drop entity_id unique constraints on worktree-materializable tables (h2, dev-grade; names from the bundled H2's deterministic DDL replay, IF EXISTS tolerates drift)
+      changes:
+        - sql:
+            dbms: h2
+            sql: |
+              ALTER TABLE "ACTION" DROP CONSTRAINT IF EXISTS "CONSTRAINT_72C";
+              ALTER TABLE "COLLECTION" DROP CONSTRAINT IF EXISTS "CONSTRAINT_B";
+              ALTER TABLE "DASHBOARD_TAB" DROP CONSTRAINT IF EXISTS "CONSTRAINT_90";
+              ALTER TABLE "DOCUMENT" DROP CONSTRAINT IF EXISTS "CONSTRAINT_62";
+              ALTER TABLE "MEASURE" DROP CONSTRAINT IF EXISTS "CONSTRAINT_62B";
+              ALTER TABLE "NATIVE_QUERY_SNIPPET" DROP CONSTRAINT IF EXISTS "CONSTRAINT_4B3";
+              ALTER TABLE "REPORT_CARD" DROP CONSTRAINT IF EXISTS "CONSTRAINT_73";
+              ALTER TABLE "REPORT_DASHBOARD" DROP CONSTRAINT IF EXISTS "CONSTRAINT_97";
+              ALTER TABLE "REPORT_DASHBOARDCARD" DROP CONSTRAINT IF EXISTS "CONSTRAINT_1";
+              ALTER TABLE "SEGMENT" DROP CONSTRAINT IF EXISTS "CONSTRAINT_A";
+              ALTER TABLE "TIMELINE" DROP CONSTRAINT IF EXISTS "CONSTRAINT_B2";
+      rollback:
+        - addUniqueConstraint:
+            tableName: collection
+            columnNames: entity_id
+            constraintName: unique_collection_entity_id
+        - addUniqueConstraint:
+            tableName: report_card
+            columnNames: entity_id
+            constraintName: unique_report_card_entity_id
+        - addUniqueConstraint:
+            tableName: report_dashboard
+            columnNames: entity_id
+            constraintName: unique_report_dashboard_entity_id
+        - addUniqueConstraint:
+            tableName: report_dashboardcard
+            columnNames: entity_id
+            constraintName: unique_report_dashboardcard_entity_id
+        - addUniqueConstraint:
+            tableName: dashboard_tab
+            columnNames: entity_id
+            constraintName: unique_dashboard_tab_entity_id
+        - addUniqueConstraint:
+            tableName: document
+            columnNames: entity_id
+            constraintName: unique_document_entity_id
+        - addUniqueConstraint:
+            tableName: native_query_snippet
+            columnNames: entity_id
+            constraintName: unique_native_query_snippet_entity_id
+        - addUniqueConstraint:
+            tableName: timeline
+            columnNames: entity_id
+            constraintName: unique_timeline_entity_id
+        - addUniqueConstraint:
+            tableName: segment
+            columnNames: entity_id
+            constraintName: unique_segment_entity_id
+        - addUniqueConstraint:
+            tableName: measure
+            columnNames: entity_id
+            constraintName: unique_measure_entity_id
+        - addUniqueConstraint:
+            tableName: action
+            columnNames: entity_id
+            constraintName: unique_action_entity_id
 
   - changeSet:
       id: v64.2026-07-22T10:00:13
       author: ranquild
-      comment: Widen report_card.entity_id for worktree-prefixed ids
+      comment: Add report_card.remote_sync_worktree_id
       changes:
-        - modifyDataType:
+        - addColumn:
             tableName: report_card
-            columnName: entity_id
-            newDataType: varchar(254)
-      rollback:
-        - modifyDataType:
-            tableName: report_card
-            columnName: entity_id
-            newDataType: char(21)
+            columns:
+              - column:
+                  name: remote_sync_worktree_id
+                  type: int
+                  remarks: Worktree this row is a checkout copy of; null for canonical (non-checkout) rows
+                  constraints:
+                    nullable: true
 
   - changeSet:
       id: v64.2026-07-22T10:00:14
       author: ranquild
-      comment: Widen report_dashboard.entity_id for worktree-prefixed ids
+      comment: FK report_card.remote_sync_worktree_id -> remote_sync_worktree
       changes:
-        - modifyDataType:
-            tableName: report_dashboard
-            columnName: entity_id
-            newDataType: varchar(254)
-      rollback:
-        - modifyDataType:
-            tableName: report_dashboard
-            columnName: entity_id
-            newDataType: char(21)
+        - addForeignKeyConstraint:
+            baseTableName: report_card
+            baseColumnNames: remote_sync_worktree_id
+            referencedTableName: remote_sync_worktree
+            referencedColumnNames: id
+            constraintName: fk_report_card_remote_sync_worktree_id
+            deleteCascade: true
 
   - changeSet:
       id: v64.2026-07-22T10:00:15
       author: ranquild
-      comment: Widen report_dashboardcard.entity_id for worktree-prefixed ids
+      comment: Add report_dashboard.remote_sync_worktree_id
       changes:
-        - modifyDataType:
-            tableName: report_dashboardcard
-            columnName: entity_id
-            newDataType: varchar(254)
-      rollback:
-        - modifyDataType:
-            tableName: report_dashboardcard
-            columnName: entity_id
-            newDataType: char(21)
+        - addColumn:
+            tableName: report_dashboard
+            columns:
+              - column:
+                  name: remote_sync_worktree_id
+                  type: int
+                  remarks: Worktree this row is a checkout copy of; null for canonical (non-checkout) rows
+                  constraints:
+                    nullable: true
 
   - changeSet:
       id: v64.2026-07-22T10:00:16
       author: ranquild
-      comment: Widen dashboard_tab.entity_id for worktree-prefixed ids
+      comment: FK report_dashboard.remote_sync_worktree_id -> remote_sync_worktree
       changes:
-        - modifyDataType:
-            tableName: dashboard_tab
-            columnName: entity_id
-            newDataType: varchar(254)
-      rollback:
-        - modifyDataType:
-            tableName: dashboard_tab
-            columnName: entity_id
-            newDataType: char(21)
+        - addForeignKeyConstraint:
+            baseTableName: report_dashboard
+            baseColumnNames: remote_sync_worktree_id
+            referencedTableName: remote_sync_worktree
+            referencedColumnNames: id
+            constraintName: fk_report_dashboard_remote_sync_worktree_id
+            deleteCascade: true
 
   - changeSet:
       id: v64.2026-07-22T10:00:17
       author: ranquild
-      comment: Widen document.entity_id for worktree-prefixed ids
+      comment: Add report_dashboardcard.remote_sync_worktree_id
       changes:
-        - modifyDataType:
-            tableName: document
-            columnName: entity_id
-            newDataType: varchar(254)
-      rollback:
-        - modifyDataType:
-            tableName: document
-            columnName: entity_id
-            newDataType: char(21)
+        - addColumn:
+            tableName: report_dashboardcard
+            columns:
+              - column:
+                  name: remote_sync_worktree_id
+                  type: int
+                  remarks: Worktree this row is a checkout copy of; null for canonical (non-checkout) rows
+                  constraints:
+                    nullable: true
 
   - changeSet:
       id: v64.2026-07-22T10:00:18
       author: ranquild
-      comment: Widen native_query_snippet.entity_id for worktree-prefixed ids
+      comment: FK report_dashboardcard.remote_sync_worktree_id -> remote_sync_worktree
       changes:
-        - modifyDataType:
-            tableName: native_query_snippet
-            columnName: entity_id
-            newDataType: varchar(254)
-      rollback:
-        - modifyDataType:
-            tableName: native_query_snippet
-            columnName: entity_id
-            newDataType: char(21)
+        - addForeignKeyConstraint:
+            baseTableName: report_dashboardcard
+            baseColumnNames: remote_sync_worktree_id
+            referencedTableName: remote_sync_worktree
+            referencedColumnNames: id
+            constraintName: fk_report_dashboardcard_remote_sync_worktree_id
+            deleteCascade: true
 
   - changeSet:
       id: v64.2026-07-22T10:00:19
       author: ranquild
-      comment: Widen timeline.entity_id for worktree-prefixed ids
+      comment: Add dashboard_tab.remote_sync_worktree_id
       changes:
-        - modifyDataType:
-            tableName: timeline
-            columnName: entity_id
-            newDataType: varchar(254)
-      rollback:
-        - modifyDataType:
-            tableName: timeline
-            columnName: entity_id
-            newDataType: char(21)
+        - addColumn:
+            tableName: dashboard_tab
+            columns:
+              - column:
+                  name: remote_sync_worktree_id
+                  type: int
+                  remarks: Worktree this row is a checkout copy of; null for canonical (non-checkout) rows
+                  constraints:
+                    nullable: true
 
   - changeSet:
       id: v64.2026-07-22T10:00:20
       author: ranquild
-      comment: Widen segment.entity_id for worktree-prefixed ids
+      comment: FK dashboard_tab.remote_sync_worktree_id -> remote_sync_worktree
       changes:
-        - modifyDataType:
-            tableName: segment
-            columnName: entity_id
-            newDataType: varchar(254)
-      rollback:
-        - modifyDataType:
-            tableName: segment
-            columnName: entity_id
-            newDataType: char(21)
+        - addForeignKeyConstraint:
+            baseTableName: dashboard_tab
+            baseColumnNames: remote_sync_worktree_id
+            referencedTableName: remote_sync_worktree
+            referencedColumnNames: id
+            constraintName: fk_dashboard_tab_remote_sync_worktree_id
+            deleteCascade: true
 
   - changeSet:
       id: v64.2026-07-22T10:00:21
       author: ranquild
-      comment: Widen measure.entity_id for worktree-prefixed ids
+      comment: Add document.remote_sync_worktree_id
       changes:
-        - modifyDataType:
-            tableName: measure
-            columnName: entity_id
-            newDataType: varchar(254)
-      rollback:
-        - modifyDataType:
-            tableName: measure
-            columnName: entity_id
-            newDataType: char(21)
+        - addColumn:
+            tableName: document
+            columns:
+              - column:
+                  name: remote_sync_worktree_id
+                  type: int
+                  remarks: Worktree this row is a checkout copy of; null for canonical (non-checkout) rows
+                  constraints:
+                    nullable: true
 
   - changeSet:
       id: v64.2026-07-22T10:00:22
       author: ranquild
-      comment: Widen transform.entity_id for worktree-prefixed ids
+      comment: FK document.remote_sync_worktree_id -> remote_sync_worktree
       changes:
-        - modifyDataType:
-            tableName: transform
-            columnName: entity_id
-            newDataType: varchar(254)
-      rollback:
-        - modifyDataType:
-            tableName: transform
-            columnName: entity_id
-            newDataType: char(21)
+        - addForeignKeyConstraint:
+            baseTableName: document
+            baseColumnNames: remote_sync_worktree_id
+            referencedTableName: remote_sync_worktree
+            referencedColumnNames: id
+            constraintName: fk_document_remote_sync_worktree_id
+            deleteCascade: true
 
   - changeSet:
       id: v64.2026-07-22T10:00:23
       author: ranquild
-      comment: Widen transform_tag.entity_id for worktree-prefixed ids
+      comment: Add native_query_snippet.remote_sync_worktree_id
       changes:
-        - modifyDataType:
-            tableName: transform_tag
-            columnName: entity_id
-            newDataType: varchar(254)
-      rollback:
-        - modifyDataType:
-            tableName: transform_tag
-            columnName: entity_id
-            newDataType: char(21)
+        - addColumn:
+            tableName: native_query_snippet
+            columns:
+              - column:
+                  name: remote_sync_worktree_id
+                  type: int
+                  remarks: Worktree this row is a checkout copy of; null for canonical (non-checkout) rows
+                  constraints:
+                    nullable: true
 
   - changeSet:
       id: v64.2026-07-22T10:00:24
       author: ranquild
-      comment: Widen transform_job.entity_id for worktree-prefixed ids
+      comment: FK native_query_snippet.remote_sync_worktree_id -> remote_sync_worktree
       changes:
-        - modifyDataType:
-            tableName: transform_job
-            columnName: entity_id
-            newDataType: varchar(254)
-      rollback:
-        - modifyDataType:
-            tableName: transform_job
-            columnName: entity_id
-            newDataType: char(21)
+        - addForeignKeyConstraint:
+            baseTableName: native_query_snippet
+            baseColumnNames: remote_sync_worktree_id
+            referencedTableName: remote_sync_worktree
+            referencedColumnNames: id
+            constraintName: fk_native_query_snippet_remote_sync_worktree_id
+            deleteCascade: true
 
   - changeSet:
       id: v64.2026-07-22T10:00:25
       author: ranquild
-      comment: Widen transform_transform_tag.entity_id for worktree-prefixed ids
+      comment: Add timeline.remote_sync_worktree_id
       changes:
-        - modifyDataType:
-            tableName: transform_transform_tag
-            columnName: entity_id
-            newDataType: varchar(254)
-      rollback:
-        - modifyDataType:
-            tableName: transform_transform_tag
-            columnName: entity_id
-            newDataType: char(21)
+        - addColumn:
+            tableName: timeline
+            columns:
+              - column:
+                  name: remote_sync_worktree_id
+                  type: int
+                  remarks: Worktree this row is a checkout copy of; null for canonical (non-checkout) rows
+                  constraints:
+                    nullable: true
 
   - changeSet:
       id: v64.2026-07-22T10:00:26
       author: ranquild
-      comment: Widen transform_job_transform_tag.entity_id for worktree-prefixed ids
+      comment: FK timeline.remote_sync_worktree_id -> remote_sync_worktree
       changes:
-        - modifyDataType:
-            tableName: transform_job_transform_tag
-            columnName: entity_id
-            newDataType: varchar(254)
-      rollback:
-        - modifyDataType:
-            tableName: transform_job_transform_tag
-            columnName: entity_id
-            newDataType: char(21)
+        - addForeignKeyConstraint:
+            baseTableName: timeline
+            baseColumnNames: remote_sync_worktree_id
+            referencedTableName: remote_sync_worktree
+            referencedColumnNames: id
+            constraintName: fk_timeline_remote_sync_worktree_id
+            deleteCascade: true
 
   - changeSet:
       id: v64.2026-07-22T10:00:27
       author: ranquild
-      comment: Widen python_library.entity_id for worktree-prefixed ids
+      comment: Add segment.remote_sync_worktree_id
       changes:
-        - modifyDataType:
-            tableName: python_library
-            columnName: entity_id
-            newDataType: varchar(254)
-      rollback:
-        - modifyDataType:
-            tableName: python_library
-            columnName: entity_id
-            newDataType: char(21)
+        - addColumn:
+            tableName: segment
+            columns:
+              - column:
+                  name: remote_sync_worktree_id
+                  type: int
+                  remarks: Worktree this row is a checkout copy of; null for canonical (non-checkout) rows
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:28
+      author: ranquild
+      comment: FK segment.remote_sync_worktree_id -> remote_sync_worktree
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: segment
+            baseColumnNames: remote_sync_worktree_id
+            referencedTableName: remote_sync_worktree
+            referencedColumnNames: id
+            constraintName: fk_segment_remote_sync_worktree_id
+            deleteCascade: true
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:29
+      author: ranquild
+      comment: Add measure.remote_sync_worktree_id
+      changes:
+        - addColumn:
+            tableName: measure
+            columns:
+              - column:
+                  name: remote_sync_worktree_id
+                  type: int
+                  remarks: Worktree this row is a checkout copy of; null for canonical (non-checkout) rows
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:30
+      author: ranquild
+      comment: FK measure.remote_sync_worktree_id -> remote_sync_worktree
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: measure
+            baseColumnNames: remote_sync_worktree_id
+            referencedTableName: remote_sync_worktree
+            referencedColumnNames: id
+            constraintName: fk_measure_remote_sync_worktree_id
+            deleteCascade: true
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:31
+      author: ranquild
+      comment: Per-worktree entity_id uniqueness for collection (null worktree rows are not mutually constrained - NanoIDs are app-generated)
+      changes:
+        - addUniqueConstraint:
+            tableName: collection
+            columnNames: entity_id, remote_sync_worktree_id
+            constraintName: unique_collection_entity_id_worktree
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:32
+      author: ranquild
+      comment: Per-worktree entity_id uniqueness for report_card (null worktree rows are not mutually constrained - NanoIDs are app-generated)
+      changes:
+        - addUniqueConstraint:
+            tableName: report_card
+            columnNames: entity_id, remote_sync_worktree_id
+            constraintName: unique_report_card_entity_id_worktree
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:33
+      author: ranquild
+      comment: Per-worktree entity_id uniqueness for report_dashboard (null worktree rows are not mutually constrained - NanoIDs are app-generated)
+      changes:
+        - addUniqueConstraint:
+            tableName: report_dashboard
+            columnNames: entity_id, remote_sync_worktree_id
+            constraintName: unique_report_dashboard_entity_id_worktree
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:34
+      author: ranquild
+      comment: Per-worktree entity_id uniqueness for report_dashboardcard (null worktree rows are not mutually constrained - NanoIDs are app-generated)
+      changes:
+        - addUniqueConstraint:
+            tableName: report_dashboardcard
+            columnNames: entity_id, remote_sync_worktree_id
+            constraintName: unique_report_dashboardcard_entity_id_worktree
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:35
+      author: ranquild
+      comment: Per-worktree entity_id uniqueness for dashboard_tab (null worktree rows are not mutually constrained - NanoIDs are app-generated)
+      changes:
+        - addUniqueConstraint:
+            tableName: dashboard_tab
+            columnNames: entity_id, remote_sync_worktree_id
+            constraintName: unique_dashboard_tab_entity_id_worktree
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:36
+      author: ranquild
+      comment: Per-worktree entity_id uniqueness for document (null worktree rows are not mutually constrained - NanoIDs are app-generated)
+      changes:
+        - addUniqueConstraint:
+            tableName: document
+            columnNames: entity_id, remote_sync_worktree_id
+            constraintName: unique_document_entity_id_worktree
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:37
+      author: ranquild
+      comment: Per-worktree entity_id uniqueness for native_query_snippet (null worktree rows are not mutually constrained - NanoIDs are app-generated)
+      changes:
+        - addUniqueConstraint:
+            tableName: native_query_snippet
+            columnNames: entity_id, remote_sync_worktree_id
+            constraintName: unique_native_query_snippet_entity_id_worktree
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:38
+      author: ranquild
+      comment: Per-worktree entity_id uniqueness for timeline (null worktree rows are not mutually constrained - NanoIDs are app-generated)
+      changes:
+        - addUniqueConstraint:
+            tableName: timeline
+            columnNames: entity_id, remote_sync_worktree_id
+            constraintName: unique_timeline_entity_id_worktree
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:39
+      author: ranquild
+      comment: Per-worktree entity_id uniqueness for segment (null worktree rows are not mutually constrained - NanoIDs are app-generated)
+      changes:
+        - addUniqueConstraint:
+            tableName: segment
+            columnNames: entity_id, remote_sync_worktree_id
+            constraintName: unique_segment_entity_id_worktree
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:40
+      author: ranquild
+      comment: Per-worktree entity_id uniqueness for measure (null worktree rows are not mutually constrained - NanoIDs are app-generated)
+      changes:
+        - addUniqueConstraint:
+            tableName: measure
+            columnNames: entity_id, remote_sync_worktree_id
+            constraintName: unique_measure_entity_id_worktree
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:41
+      author: ranquild
+      comment: Add action.remote_sync_worktree_id
+      changes:
+        - addColumn:
+            tableName: action
+            columns:
+              - column:
+                  name: remote_sync_worktree_id
+                  type: int
+                  remarks: Worktree this row is a checkout copy of; null for canonical (non-checkout) rows
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:42
+      author: ranquild
+      comment: FK action.remote_sync_worktree_id -> remote_sync_worktree
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: action
+            baseColumnNames: remote_sync_worktree_id
+            referencedTableName: remote_sync_worktree
+            referencedColumnNames: id
+            constraintName: fk_action_remote_sync_worktree_id
+            deleteCascade: true
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:43
+      author: ranquild
+      comment: Per-worktree entity_id uniqueness for action (null worktree rows are not mutually constrained - NanoIDs are app-generated)
+      changes:
+        - addUniqueConstraint:
+            tableName: action
+            columnNames: entity_id, remote_sync_worktree_id
+            constraintName: unique_action_entity_id_worktree
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:44
+      author: ranquild
+      comment: Add glossary.remote_sync_worktree_id
+      changes:
+        - addColumn:
+            tableName: glossary
+            columns:
+              - column:
+                  name: remote_sync_worktree_id
+                  type: int
+                  remarks: Worktree this row is a checkout copy of; null for canonical (non-checkout) rows
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:45
+      author: ranquild
+      comment: FK glossary.remote_sync_worktree_id -> remote_sync_worktree
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: glossary
+            baseColumnNames: remote_sync_worktree_id
+            referencedTableName: remote_sync_worktree
+            referencedColumnNames: id
+            constraintName: fk_glossary_remote_sync_worktree_id
+            deleteCascade: true
+
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:47
+      author: ranquild
+      comment: Add parameter_card.remote_sync_worktree_id
+      changes:
+        - addColumn:
+            tableName: parameter_card
+            columns:
+              - column:
+                  name: remote_sync_worktree_id
+                  type: int
+                  remarks: Worktree this row is a checkout copy of; null for canonical (non-checkout) rows
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v64.2026-07-22T10:00:48
+      author: ranquild
+      comment: FK parameter_card.remote_sync_worktree_id -> remote_sync_worktree
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: parameter_card
+            baseColumnNames: remote_sync_worktree_id
+            referencedTableName: remote_sync_worktree
+            referencedColumnNames: id
+            constraintName: fk_parameter_card_remote_sync_worktree_id
+            deleteCascade: true
+

--- a/src/metabase/actions/models.clj
+++ b/src/metabase/actions/models.clj
@@ -441,7 +441,8 @@
 
 (defmethod serdes/make-spec "Action" [_model-name opts]
   {:copy      [:archived :description :entity_id :name :public_uuid]
-   :skip      []
+   :skip      [;; which checkout materialized this row is local state, not portable content
+               :remote_sync_worktree_id]
    :transform {:created_at             (serdes/date)
                :type                   (serdes/kw)
                :creator_id             (serdes/fk :model/User)

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -69,6 +69,7 @@
     :model/Revision
     :model/ViewLog
     :model/Session
+    :model/RemoteSyncWorktree
     :model/Collection
     :model/CollectionPermissionGraphRevision
     :model/Dashboard

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -1665,9 +1665,7 @@
                                   (t2/select-one :model/Collection :id new-parent-id)
                                   root-collection)
         new-parent-is-remote-synced? (:is_remote_synced new-parent)
-        new-parent-worktree-id  (when new-parent-is-remote-synced?
-                                  (or (:remote_sync_worktree_id new-parent)
-                                      (remote-sync/default-worktree-id)))
+        new-parent-worktree-id  (:remote_sync_worktree_id new-parent)
         new-location            (children-location new-parent)
         orig-children-location  (children-location collection)
         new-children-location   (children-location (assoc collection :location new-location))
@@ -1738,9 +1736,7 @@
                      (t2/select-one [:model/Collection :is_remote_synced :remote_sync_worktree_id]
                                     :id parent-id))
         will-be-in-remote-synced? (:is_remote_synced new-parent)
-        new-worktree-id (when will-be-in-remote-synced?
-                          (or (:remote_sync_worktree_id new-parent)
-                              (remote-sync/default-worktree-id)))]
+        new-worktree-id (:remote_sync_worktree_id new-parent)]
     (when will-be-in-trash?
       (throw (ex-info "Cannot `move-collection!` into the Trash. Call `archive-collection!` instead."
                       {:collection collection
@@ -1781,16 +1777,15 @@
 
 (defn- stamp-remote-sync-worktree-id
   "When `changes` writes `:is_remote_synced`, also write `:remote_sync_worktree_id`: the parent's worktree
-  when the collection sits under a synced parent, else the default worktree. `location` is the collection's
-  (possibly new) location."
+  when the collection sits under a worktree checkout, else nil (the main app, including default-branch
+  remote sync, is not a worktree). `location` is the collection's (possibly new) location."
   [changes location]
   (if-not (contains? changes :is_remote_synced)
     changes
     (assoc changes :remote_sync_worktree_id
            (when (:is_remote_synced changes)
-             (or (when-let [parent-id (some-> location location-path->parent-id)]
-                   (t2/select-one-fn :remote_sync_worktree_id :model/Collection :id parent-id))
-                 (remote-sync/default-worktree-id))))))
+             (when-let [parent-id (some-> location location-path->parent-id)]
+               (t2/select-one-fn :remote_sync_worktree_id :model/Collection :id parent-id))))))
 
 (t2/define-before-insert :model/Collection
   [{collection-name :name :keys [type] :as collection}]

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -1665,6 +1665,9 @@
                                   (t2/select-one :model/Collection :id new-parent-id)
                                   root-collection)
         new-parent-is-remote-synced? (:is_remote_synced new-parent)
+        new-parent-worktree-id  (when new-parent-is-remote-synced?
+                                  (or (:remote_sync_worktree_id new-parent)
+                                      (remote-sync/default-worktree-id)))
         new-location            (children-location new-parent)
         orig-children-location  (children-location collection)
         new-children-location   (children-location (assoc collection :location new-location))
@@ -1694,6 +1697,7 @@
        {:update :collection
         :set    {:location             [:replace :location orig-children-location new-children-location]
                  :is_remote_synced (boolean new-parent-is-remote-synced?)
+                 :remote_sync_worktree_id new-parent-worktree-id
                  :archive_operation_id nil
                  :archived_directly    nil
                  :archived             false}
@@ -1730,7 +1734,13 @@
   (let [orig-children-location (children-location collection)
         new-children-location  (children-location (assoc collection :location new-location))
         will-be-in-trash? (str/starts-with? new-location (trash-path))
-        will-be-in-remote-synced? (t2/select-one-fn :is_remote_synced :model/Collection :id (parent-id* {:location new-location}))]
+        new-parent (when-let [parent-id (parent-id* {:location new-location})]
+                     (t2/select-one [:model/Collection :is_remote_synced :remote_sync_worktree_id]
+                                    :id parent-id))
+        will-be-in-remote-synced? (:is_remote_synced new-parent)
+        new-worktree-id (when will-be-in-remote-synced?
+                          (or (:remote_sync_worktree_id new-parent)
+                              (remote-sync/default-worktree-id)))]
     (when will-be-in-trash?
       (throw (ex-info "Cannot `move-collection!` into the Trash. Call `archive-collection!` instead."
                       {:collection collection
@@ -1749,7 +1759,8 @@
       (u/prog1 (t2/query-one
                 {:update :collection
                  :set {:location [:replace :location orig-children-location new-children-location]
-                       :is_remote_synced (boolean will-be-in-remote-synced?)}
+                       :is_remote_synced (boolean will-be-in-remote-synced?)
+                       :remote_sync_worktree_id new-worktree-id}
                  :where [:like :location (str orig-children-location "%")]})
         (when into-remote-synced?
           (check-non-remote-synced-dependencies collection))
@@ -1768,6 +1779,19 @@
       (when (= :api-key (t2/select-one-fn :type :model/User user-id))
         (throw (ex-info "Can't create a personal collection for an API key" {:user user-id}))))))
 
+(defn- stamp-remote-sync-worktree-id
+  "When `changes` writes `:is_remote_synced`, also write `:remote_sync_worktree_id`: the parent's worktree
+  when the collection sits under a synced parent, else the default worktree. `location` is the collection's
+  (possibly new) location."
+  [changes location]
+  (if-not (contains? changes :is_remote_synced)
+    changes
+    (assoc changes :remote_sync_worktree_id
+           (when (:is_remote_synced changes)
+             (or (when-let [parent-id (some-> location location-path->parent-id)]
+                   (t2/select-one-fn :remote_sync_worktree_id :model/Collection :id parent-id))
+                 (remote-sync/default-worktree-id))))))
+
 (t2/define-before-insert :model/Collection
   [{collection-name :name :keys [type] :as collection}]
   (assert-valid-location collection)
@@ -1777,7 +1801,8 @@
   (u/prog1 (-> collection
                (assoc :slug (slugify collection-name))
                (cond->
-                (= type "remote-synced") (-> (assoc :is_remote_synced true) (dissoc :type))))
+                (= type "remote-synced") (-> (assoc :is_remote_synced true) (dissoc :type)))
+               (as-> $changes (stamp-remote-sync-worktree-id $changes (:location $changes))))
     (assert-valid-remote-synced-parent <>)))
 
 (defn- copy-collection-permissions!
@@ -1989,9 +2014,12 @@
     ;; OK, AT THIS POINT THE CHANGES ARE VALIDATED. NOW START ISSUING UPDATES
     ;; slugify the collection name in case it's changed in the output; the results of this will get passed along
     ;; to Toucan's `update!` impl
-    (u/prog1 (cond-> collection-updates
-               (= type "remote-synced") (-> (assoc :is_remote_synced true) (dissoc :type))
-               collection-name (assoc :slug (slugify collection-name)))
+    (u/prog1 (-> (cond-> collection-updates
+                   (= type "remote-synced") (-> (assoc :is_remote_synced true) (dissoc :type))
+                   collection-name (assoc :slug (slugify collection-name)))
+                 (as-> $changes (stamp-remote-sync-worktree-id
+                                 $changes
+                                 (or (:location $changes) (:location collection-before-updates)))))
       (when-not *clearing-remote-sync*
         (assert-valid-remote-synced-parent (merge collection-before-updates <>))))))
 
@@ -2198,7 +2226,9 @@
           :namespace
           :slug
           :type]
-   :skip []
+   ;; worktree membership is local state (which checkout this instance materialized the collection into),
+   ;; not portable content
+   :skip [:remote_sync_worktree_id]
    :transform {:created_at        (serdes/date)
                ;; We only dump the parent id, and recalculate the location from that on load.
                :location          (serdes/as :parent_id

--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -428,7 +428,9 @@
    :skip      [;; those stats are inherently local state
                :view_count :last_viewed_at
                ;; this is deprecated
-               :cache_ttl]
+               :cache_ttl
+               ;; which checkout materialized this row is local state, not portable content
+               :remote_sync_worktree_id]
    :transform {:created_at             (serdes/date)
                :initially_published_at (serdes/date)
                :collection_id          (serdes/fk :model/Collection)

--- a/src/metabase/dashboards/models/dashboard_card.clj
+++ b/src/metabase/dashboards/models/dashboard_card.clj
@@ -404,7 +404,8 @@
 
 (defmethod serdes/make-spec "DashboardCard" [_model-name opts]
   {:copy      [:col :entity_id :inline_parameters :row :size_x :size_y]
-   :skip      []
+   :skip      [;; which checkout materialized this row is local state, not portable content
+               :remote_sync_worktree_id]
    :transform {:created_at             (serdes/date)
                :dashboard_id           (serdes/parent-ref)
                :card_id                (serdes/fk :model/Card)

--- a/src/metabase/dashboards/models/dashboard_tab.clj
+++ b/src/metabase/dashboards/models/dashboard_tab.clj
@@ -63,7 +63,8 @@
 
 (defmethod serdes/make-spec "DashboardTab" [_model-name _opts]
   {:copy      [:entity_id :name :position]
-   :skip      []
+   :skip      [;; which checkout materialized this row is local state, not portable content
+               :remote_sync_worktree_id]
    :transform {:created_at   (serdes/date)
                :dashboard_id (serdes/parent-ref)}})
 

--- a/src/metabase/documents/models/document.clj
+++ b/src/metabase/documents/models/document.clj
@@ -220,7 +220,9 @@
 (defmethod serdes/make-spec "Document"
   [_model-name _opts]
   {:copy [:archived :archived_directly :content_type :entity_id :name :collection_position]
-   :skip [:view_count :last_viewed_at :public_uuid :made_public_by_id]
+   :skip [:view_count :last_viewed_at :public_uuid :made_public_by_id
+          ;; which checkout materialized this row is local state, not portable content
+          :remote_sync_worktree_id]
    :transform {:created_at (serdes/date)
                :updated_at (serdes/date)
                :document {:export-with-context export-document-content

--- a/src/metabase/glossary/models/glossary.clj
+++ b/src/metabase/glossary/models/glossary.clj
@@ -44,6 +44,8 @@
 
 (defmethod serdes/make-spec "Glossary" [_model-name _opts]
   {:copy      [:term :definition]
+   :skip      [;; which checkout materialized this row is local state, not portable content
+               :remote_sync_worktree_id]
    :transform {:created_at (serdes/date)
                :updated_at (serdes/date)
                :creator_id (serdes/fk :model/User)}})

--- a/src/metabase/measures/models/measure.clj
+++ b/src/metabase/measures/models/measure.clj
@@ -212,7 +212,9 @@
    :skip [;; dimensions are computed from the query and reconciled on read, not serialized
           :dimensions :dimension_mappings
           ;; always re-derived from definition by before-insert via lib/primary-source-table-id
-          :table_id]
+          :table_id
+          ;; which checkout materialized this row is local state, not portable content
+          :remote_sync_worktree_id]
    :transform {:created_at (serdes/date)
                :creator_id (serdes/fk :model/User)
                :definition {:export serdes/export-mbql :import import-measure-definition}}

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -111,6 +111,7 @@
     :model/RecentViews                       metabase.activity-feed.models.recent-views
     :model/RemoteSyncObject                  metabase-enterprise.remote-sync.models.remote-sync-object
     :model/RemoteSyncTask                    metabase-enterprise.remote-sync.models.remote-sync-task
+    :model/RemoteSyncWorktree                metabase-enterprise.remote-sync.models.remote-sync-worktree
     :model/ReplacementRun                    metabase-enterprise.replacement.models.replacement-run
     :model/Revision                          metabase.revisions.models.revision
     :model/SearchIndexMetadata               metabase.search.models.search-index-metadata

--- a/src/metabase/native_query_snippets/models/native_query_snippet.clj
+++ b/src/metabase/native_query_snippets/models/native_query_snippet.clj
@@ -178,7 +178,8 @@
 
 (defmethod serdes/make-spec "NativeQuerySnippet" [_model-name _opts]
   {:copy      [:archived :content :description :entity_id :name]
-   :skip      []
+   :skip      [;; which checkout materialized this row is local state, not portable content
+               :remote_sync_worktree_id]
    :transform {:created_at    (serdes/date)
                :collection_id (serdes/fk :model/Collection)
                :creator_id    (serdes/fk :model/User)

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1414,6 +1414,8 @@
           :view_count :last_used_at :initially_published_at
           ;; this is data migration column
           :dataset_query_metrics_v2_migration_backup
+          ;; which checkout materialized this row is local state, not portable content
+          :remote_sync_worktree_id
           ;; this column is not used anymore
           :cache_ttl
           ;; dimensions are computed from the query and reconciled on read, not serialized

--- a/src/metabase/remote_sync/core.clj
+++ b/src/metabase/remote_sync/core.clj
@@ -29,6 +29,13 @@
   []
   true)
 
+(defenterprise default-worktree-id
+  "ID of the default remote sync worktree — the row tracking the branch in the `remote-sync-branch`
+  setting — creating it if needed. Nil when remote sync is not configured, and always nil on OSS."
+  metabase-enterprise.remote-sync.core
+  []
+  nil)
+
 (defenterprise model-editable?
   "Determines if a model instance is editable based on remote sync configuration.
 

--- a/src/metabase/remote_sync/core.clj
+++ b/src/metabase/remote_sync/core.clj
@@ -29,13 +29,6 @@
   []
   true)
 
-(defenterprise default-worktree-id
-  "ID of the default remote sync worktree — the row tracking the branch in the `remote-sync-branch`
-  setting — creating it if needed. Nil when remote sync is not configured, and always nil on OSS."
-  metabase-enterprise.remote-sync.core
-  []
-  nil)
-
 (defenterprise model-editable?
   "Determines if a model instance is editable based on remote sync configuration.
 

--- a/src/metabase/segments/models/segment.clj
+++ b/src/metabase/segments/models/segment.clj
@@ -228,7 +228,9 @@
 (defmethod serdes/make-spec "Segment" [_model-name _opts]
   {:copy      [:name :points_of_interest :archived :caveats :description :entity_id :show_in_getting_started]
    :skip      [;; always re-derived from definition by before-insert via lib/primary-source-table-id
-               :table_id]
+               :table_id
+               ;; which checkout materialized this row is local state, not portable content
+               :remote_sync_worktree_id]
    :transform {:created_at (serdes/date)
                :creator_id (serdes/fk :model/User)
                :definition {:export serdes/export-mbql :import serdes/import-mbql}}

--- a/src/metabase/timeline/models/timeline.clj
+++ b/src/metabase/timeline/models/timeline.clj
@@ -62,7 +62,8 @@
 
 (defmethod serdes/make-spec "Timeline" [_model-name opts]
   {:copy      [:archived :default :description :entity_id :icon :name]
-   :skip      []
+   :skip      [;; which checkout materialized this row is local state, not portable content
+               :remote_sync_worktree_id]
    :transform {:created_at    (serdes/date)
                :collection_id (serdes/fk :model/Collection)
                :creator_id    (serdes/fk :model/User)

--- a/test/metabase/documents/models/document_test.clj
+++ b/test/metabase/documents/models/document_test.clj
@@ -432,7 +432,8 @@
     (let [spec (serdes/make-spec "Document" {})]
       (is (= [:archived :archived_directly :content_type :entity_id :name :collection_position]
              (:copy spec)))
-      (is (= [:view_count :last_viewed_at :public_uuid :made_public_by_id] (:skip spec)))
+      (is (= [:view_count :last_viewed_at :public_uuid :made_public_by_id :remote_sync_worktree_id]
+             (:skip spec)))
       (is (contains? (:transform spec) :created_at))
       (is (contains? (:transform spec) :document))
       (is (contains? (:transform spec) :updated_at))


### PR DESCRIPTION
Part 1 of the remote-sync worktrees stack (git-worktree-style branch checkouts materialized as ordinary collection trees).

**Design (v4):** the main app — including default-branch remote sync — is *not* a worktree. Its content simply carries a NULL `remote_sync_worktree_id`; the `remote_sync_worktree` table holds only real checkouts, one row per branch (`branch` NOT NULL UNIQUE). No row is seeded, no data is backfilled, and branch switching stays a plain setting write.

- `remote_sync_worktree` table (branch, base_version, creator_id) + `RemoteSyncWorktree` model, registered for serdes-exclusion and app-db copy.
- `remote_sync_worktree_id` column with `ON DELETE CASCADE` FK on all serdes content tables (collection, report_card, report_dashboard, report_dashboardcard, dashboard_tab, document, native_query_snippet, timeline, segment, measure, action, glossary, parameter_card); `worktree_id` on remote_sync_object (CASCADE) and remote_sync_task (SET NULL).
- Single-column `entity_id` uniques replaced by `UNIQUE (entity_id, remote_sync_worktree_id)` via dbms-split SQL drops (Postgres/MySQL/MariaDB/H2), so a checkout can hold copies of main-app content under the same entity ids. Canonical NULL rows are not mutually DB-unique — acceptable, NanoIDs are app-generated.
- Collection membership changes (create/update/move/unarchive) inherit the parent's worktree id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)