### PR TITLE
[Worktrees 2/8] Scope sync-base bookkeeping by worktree

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -8,6 +8,7 @@
    [metabase-enterprise.remote-sync.merge :as remote-sync.merge]
    [metabase-enterprise.remote-sync.models.remote-sync-object :as remote-sync.object]
    [metabase-enterprise.remote-sync.models.remote-sync-task :as remote-sync.task]
+   [metabase-enterprise.remote-sync.models.remote-sync-worktree :as remote-sync.worktree]
    [metabase-enterprise.remote-sync.settings :as settings]
    [metabase-enterprise.remote-sync.source :as source]
    [metabase-enterprise.remote-sync.source.ingestable :as source.ingestable]
@@ -1416,9 +1417,15 @@
                   :success (do
                              (when branch
                                (settings/remote-sync-branch! branch))
+                             (when-let [worktree-id (:worktree_id task)]
+                               (remote-sync.worktree/set-base-version! worktree-id (:version task)))
                              (remote-sync.task/complete-sync-task! task-id (:outcome result)))
                   :conflict (do
                               (remote-sync.task/set-version! task-id (:version result))
+                              (when-let [worktree-id (:worktree_id task)]
+                                ;; conflicted tasks still advance the sync base (they record the version
+                                ;; the conflict was computed against), matching `last-version` semantics
+                                (remote-sync.worktree/set-base-version! worktree-id (:version result)))
                               (remote-sync.task/conflict-sync-task! task-id (:conflicts result)))
                   :error (remote-sync.task/fail-sync-task! task-id (:message result))
                   (remote-sync.task/fail-sync-task! task-id "Unexpected Error"))
@@ -1628,7 +1635,7 @@
   (if (settings/remote-sync-enabled)
     (do
       (when (str/blank? (setting/get :remote-sync-branch))
-        (setting/set! :remote-sync-branch (source.p/default-branch (source/source-from-settings))))
+        (settings/remote-sync-branch! (source.p/default-branch (source/source-from-settings))))
       (when (= :read-only (settings/remote-sync-type))
         ;; force? true bypasses the version/dirty guards for setup, but force-deletion? false keeps unsynced
         ;; local transforms from being silently destroyed — they surface as a conflict instead (GHY-3900).

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_task.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_task.clj
@@ -212,17 +212,21 @@
   "Gets the version that any changes are built off of.
 
   Returns the version string from the most recent successful task (either export or import), or nil if no successful
-  tasks exist."
-  []
-  (:version (t2/select-one :model/RemoteSyncTask
-                           {:where [:and
-                                    [:<> nil :ended_at]
-                                    [:= false :cancelled]
-                                    [:= nil :error_message]
-                                    [:<> nil :version]]
-                            :limit 1
-                            :order-by [[:started_at :desc]
-                                       [:id :desc]]})))
+  tasks exist. Scoped by `worktree-id`: nil means the main app (tasks with a nil worktree_id, including all
+  pre-worktree history), a worktree id means only tasks that ran against that worktree."
+  ([]
+   (last-version nil))
+  ([worktree-id]
+   (:version (t2/select-one :model/RemoteSyncTask
+                            {:where [:and
+                                     [:<> nil :ended_at]
+                                     [:= false :cancelled]
+                                     [:= nil :error_message]
+                                     [:<> nil :version]
+                                     [:= :worktree_id worktree-id]]
+                             :limit 1
+                             :order-by [[:started_at :desc]
+                                        [:id :desc]]}))))
 
 (defn running?
   "Checks if a task is currently running.

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_worktree.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_worktree.clj
@@ -5,6 +5,7 @@
    The main app is not a worktree: main-app content (including default-branch remote sync) carries a NULL
    worktree reference, and the `remote_sync_worktree` table only holds real checkouts, one row per branch."
   (:require
+   [metabase.util.malli :as mu]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -15,3 +16,11 @@
 (doto :model/RemoteSyncWorktree
   (derive :metabase/model)
   (derive :hook/created-at-timestamped?))
+
+(mu/defn set-base-version! :- :nil
+  "Record `version` (a git SHA) as `worktree-id`'s sync base — the commit local changes are built on."
+  [worktree-id :- pos-int?
+   version     :- [:maybe :string]]
+  (when version
+    (t2/update! :model/RemoteSyncWorktree worktree-id {:base_version version}))
+  nil)


### PR DESCRIPTION
Part 2 of the remote-sync worktrees stack. Stacked on #78386.

`last-version` is now scoped by worktree id — nil means the main app (tasks with a nil `worktree_id`, including all pre-worktree history), a worktree id means only that worktree's tasks. Successful or conflicted tasks that ran against a worktree record their version as that worktree's `base_version`; main-app tasks keep their bookkeeping in task history alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)