### PR TITLE
Remove use-v7-router flag from docs

### DIFF
--- a/src/metabase/appearance/settings.clj
+++ b/src/metabase/appearance/settings.clj
@@ -49,7 +49,7 @@
 (defsetting use-v7-router
   (deferred-tru "Serve the app with the react-router v7 engine instead of the legacy v3 engine. Toggle off for an instant rollback.")
   :type       :boolean
-  :default    true
+  :default    false
   :visibility :public
   :export?    false
   :doc        false)

--- a/src/metabase/appearance/settings.clj
+++ b/src/metabase/appearance/settings.clj
@@ -51,7 +51,8 @@
   :type       :boolean
   :default    true
   :visibility :public
-  :export?    false)
+  :export?    false
+  :doc        false)
 
 (defn- coerce-to-relative-url
   "Get the path of a given URL if the URL contains an origin.


### PR DESCRIPTION
Removes the `use-v7-router` flag from user-facing docs as it is meant for testing purposes.

Also disable the flag by default for now.