### PR TITLE
[Worktrees 4/8] Worktree CRUD API + include-worktrees containment

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -632,6 +632,7 @@
            permissions
            premium-features
            queries
+           remote-sync
            request
            revisions
            settings

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
@@ -6,6 +6,7 @@
    [metabase-enterprise.remote-sync.impl :as impl]
    [metabase-enterprise.remote-sync.models.remote-sync-object :as remote-sync.object]
    [metabase-enterprise.remote-sync.models.remote-sync-task :as remote-sync.task]
+   [metabase-enterprise.remote-sync.models.remote-sync-worktree :as remote-sync.worktree]
    [metabase-enterprise.remote-sync.schema :as remote-sync.schema]
    [metabase-enterprise.remote-sync.settings :as settings]
    [metabase-enterprise.remote-sync.source :as source]
@@ -365,6 +366,89 @@
     (catch Exception e
       (throw (ex-info (format "Failed to stash changes to branch: %s" (ex-message e))
                       {:status-code 400})))))
+
+;;; ------------------------------------------------ Worktrees -------------------------------------------------------
+
+(defn- check-worktrees-enabled! []
+  (api/check-superuser)
+  (api/check-400 (settings/remote-sync-worktrees) "Remote sync worktrees are not enabled.")
+  (api/check-400 (settings/remote-sync-enabled) "Remote sync is not configured."))
+
+(defn- present-worktree [worktree]
+  {:id           (:id worktree)
+   :branch       (:branch worktree)
+   :base_version (:base_version worktree)
+   :roots        (remote-sync.worktree/worktree-roots (:id worktree))
+   :creator_id   (:creator_id worktree)
+   :created_at   (:created_at worktree)})
+
+(api.macros/defendpoint :get "/worktrees" :- remote-sync.schema/WorktreeListResponse
+  "List all remote sync worktrees (branch checkouts; the main app is not one of them).
+
+  Requires superuser permissions."
+  []
+  (check-worktrees-enabled!)
+  {:items (mapv present-worktree
+                (t2/select :model/RemoteSyncWorktree {:order-by [[:created_at :asc] [:id :asc]]}))})
+
+(api.macros/defendpoint :post "/worktrees" :- remote-sync.schema/Worktree
+  "Create a worktree for `branch` — the metadata row only; content materializes on the first pull
+  (`base_version` stays null until then). The branch must exist on the remote, unless `from_branch`
+  is given, in which case it is forked from that branch server-side first. 409 when the branch is
+  already checked out (one branch, one worktree — including the default).
+
+  Requires superuser permissions."
+  [_route
+   _query
+   {:keys [branch from_branch]} :- [:map
+                                    [:branch ms/NonBlankString]
+                                    [:from_branch {:optional true} ms/NonBlankString]]]
+  (check-worktrees-enabled!)
+  (api/check-400 (not= branch (settings/remote-sync-branch))
+                 (format "Branch '%s' is the current remote sync branch." branch))
+  (let [source (source/source-from-settings)]
+    (api/check-400 source "Source not configured")
+    (if from_branch
+      (source.p/create-branch source branch from_branch)
+      (api/check-400 (some #{branch} (source.p/branches source))
+                     (format "Branch '%s' not found on the remote. Pass from_branch to create it." branch)))
+    (try
+      (present-worktree
+       (t2/insert-returning-instance! :model/RemoteSyncWorktree
+                                      {:branch     branch
+                                       :creator_id api/*current-user-id*}))
+      (catch Exception e
+        (if-let [existing (t2/select-one :model/RemoteSyncWorktree :branch branch)]
+          (throw (ex-info (format "Branch '%s' is already checked out." branch)
+                          {:status-code 409
+                           :worktree_id (:id existing)}))
+          (throw e))))))
+
+(api.macros/defendpoint :get "/worktrees/:id" :- remote-sync.schema/Worktree
+  "Get a single worktree.
+
+  Requires superuser permissions."
+  [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
+  (check-worktrees-enabled!)
+  (present-worktree (api/check-404 (t2/select-one :model/RemoteSyncWorktree :id id))))
+
+(api.macros/defendpoint :delete "/worktrees/:id" :- :nil
+  "Delete a worktree along with the collection trees it materialized. Refused, unless `force`, for a
+  worktree with unpushed local changes (400 carrying the dirty objects).
+
+  Requires superuser permissions."
+  [{:keys [id]} :- [:map [:id ms/PositiveInt]]
+   {:keys [force]} :- [:map [:force {:default false} [:maybe :boolean]]]]
+  (check-worktrees-enabled!)
+  (let [worktree (api/check-404 (t2/select-one :model/RemoteSyncWorktree :id id))]
+    (let [dirty (remote-sync.worktree/worktree-dirty-rows id)]
+      (when (and (seq dirty) (not force))
+        (throw (ex-info "This worktree has changes that have not been pushed."
+                        {:status-code   400
+                         :dirty_objects (mapv #(select-keys % [:model_type :model_id :model_name :status])
+                                              dirty)}))))
+    (remote-sync.worktree/delete-worktree! worktree)
+    nil))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/remote-sync` routes."

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_worktree.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_worktree.clj
@@ -5,6 +5,7 @@
    The main app is not a worktree: main-app content (including default-branch remote sync) carries a NULL
    worktree reference, and the `remote_sync_worktree` table only holds real checkouts, one row per branch."
   (:require
+   [metabase.collections.models.collection :as collection]
    [metabase.util.malli :as mu]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
@@ -23,4 +24,33 @@
    version     :- [:maybe :string]]
   (when version
     (t2/update! :model/RemoteSyncWorktree worktree-id {:base_version version}))
+  nil)
+
+(mu/defn worktree-roots :- [:sequential [:map [:id pos-int?] [:name :string]]]
+  "Root collections of `worktree-id`: member collections whose parent collection is not itself a member.
+   A worktree can have several roots — the repository supports multiple managed top-level collections."
+  [worktree-id :- pos-int?]
+  (let [members (t2/select [:model/Collection :id :name :location] :remote_sync_worktree_id worktree-id)
+        member? (into #{} (map :id) members)]
+    (into []
+          (comp (remove (fn [{:keys [location]}]
+                          (some-> location collection/location-path->parent-id member?)))
+                (map #(select-keys % [:id :name])))
+          members)))
+
+(mu/defn worktree-dirty-rows :- [:sequential :map]
+  "RemoteSyncObject rows of `worktree-id` with local changes not yet pushed (status other than synced)."
+  [worktree-id :- pos-int?]
+  (t2/select :model/RemoteSyncObject :worktree_id worktree-id :status [:not= "synced"]))
+
+(mu/defn delete-worktree! :- :nil
+  "Delete `worktree` and the collection trees it materialized. Root collections are deleted through the
+   model (so content cleanup hooks run); the worktree's RemoteSyncObject rows go with the worktree row
+   (FK cascade), and task history keeps its rows with a nulled worktree reference. Guards (dirty check)
+   are the caller's responsibility."
+  [worktree :- [:map [:id pos-int?]]]
+  (t2/with-transaction [_conn]
+    (doseq [root (worktree-roots (:id worktree))]
+      (t2/delete! :model/Collection :id (:id root)))
+    (t2/delete! :model/RemoteSyncWorktree :id (:id worktree)))
   nil)

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/schema.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/schema.clj
@@ -164,3 +164,22 @@
   "Schema for POST /test-connection response."
   [:map
    [:status [:= :success]]])
+
+;;; ------------------------------------------- Worktree Schemas -------------------------------------------
+
+(def Worktree
+  "Schema for a remote sync worktree object as returned by the API."
+  [:map
+   [:id pos-int?]
+   [:branch :string]
+   [:base_version [:maybe :string]]
+   [:roots [:sequential [:map
+                         [:id pos-int?]
+                         [:name :string]]]]
+   [:creator_id [:maybe pos-int?]]
+   [:created_at :any]])
+
+(def WorktreeListResponse
+  "Schema for GET /worktrees response."
+  [:map
+   [:items [:sequential Worktree]]])

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
@@ -163,6 +163,14 @@
   :default false
   :on-change sync-transform-tracking-on-change)
 
+(defsetting remote-sync-worktrees
+  (deferred-tru "Whether remote sync worktrees (checking out additional branches as separate collection trees) are enabled.")
+  :type :boolean
+  :visibility :admin
+  :export? false
+  :encryption :no
+  :default false)
+
 (defsetting remote-sync-check-changes-cache-ttl-seconds
   (deferred-tru "Time-to-live in seconds for the remote changes check cache. Default is 60 seconds.")
   :type :integer

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -25,6 +25,7 @@
    [metabase.permissions.core :as perms]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
    [metabase.queries.core :as queries]
+   [metabase.remote-sync.core :as remote-sync]
    [metabase.request.core :as request]
    [metabase.revisions.core :as revisions]
    [metabase.tracing.core :as tracing]
@@ -85,7 +86,8 @@
 
   To include library collections and their descendants, pass in `include-library?` as `true`.
   By default, library-type collections are excluded. "
-  [{:keys [archived exclude-other-user-collections namespaces shallow collection-id personal-only include-library?]}]
+  [{:keys [archived exclude-other-user-collections namespaces shallow collection-id personal-only include-library?
+           include-worktrees?]}]
   (cond->>
    (t2/select :model/Collection
               {:where [:and
@@ -108,6 +110,8 @@
                           [:not-in :type [collection/library-collection-type
                                           collection/library-data-collection-type
                                           collection/library-metrics-collection-type]]])
+                       (when-not include-worktrees?
+                         (remote-sync/non-worktree-filter-clause))
                        [:or
                         (when (contains? namespaces nil)
                           [:= :namespace nil])
@@ -246,12 +250,13 @@
   When `shallow` is true, takes an optional `collection-id` and returns only the requested collection (or
   the root, if `collection-id` is `nil`)."
   [_route-params
-   {:keys [exclude-archived exclude-other-user-collections include-library
+   {:keys [exclude-archived exclude-other-user-collections include-library include-worktrees
            namespace namespaces shallow collection-id]}
    :- [:map
        [:exclude-archived               {:default false} [:maybe :boolean]]
        [:exclude-other-user-collections {:default false} [:maybe :boolean]]
        [:include-library                {:default false} [:maybe :boolean]]
+       [:include-worktrees              {:default false} [:maybe :boolean]]
        [:namespace                      {:optional true} [:maybe ms/NonBlankString]]
        [:namespaces                     {:optional true} [:maybe [:vector {:decode/string (fn [x] (cond (vector? x) x x [x]))} :string]]]
        [:shallow                        {:default false} [:maybe :boolean]]
@@ -269,7 +274,8 @@
                                              :namespaces                     namespaces
                                              :shallow                        shallow
                                              :collection-id                  collection-id
-                                             :include-library?               include-library})
+                                             :include-library?               include-library
+                                             :include-worktrees?             include-worktrees})
                         (t2/hydrate :can_write))]
     (if shallow
       (shallow-tree-from-collection-id collections)
@@ -340,6 +346,7 @@
    [:collection-type {:optional true} [:maybe CollectionType]]
    [:archived?                     :boolean]
    [:include-library?               {:optional true} [:maybe :boolean]]
+   [:include-worktrees?             {:optional true} [:maybe :boolean]]
    [:pinned-state {:optional true} [:maybe (into [:enum] (map keyword) valid-pinned-state-values)]]
    ;; when specified, only return results of this type.
    [:models       {:optional true} [:maybe [:set (into [:enum] (map keyword) valid-model-param-values)]]]
@@ -711,7 +718,7 @@
    [:not= :namespace (u/qualified-name "snippets")]])
 
 (defn- collection-query
-  [collection {:keys [archived? collection-namespace pinned-state collection-type include-library?]}]
+  [collection {:keys [archived? collection-namespace pinned-state collection-type include-library? include-worktrees?]}]
   (-> (assoc
        (collection/effective-children-query
         collection
@@ -726,6 +733,8 @@
             [:not [:in :type [collection/library-collection-type
                               collection/library-metrics-collection-type
                               collection/library-data-collection-type]]]])
+         (when-not include-worktrees?
+           (remote-sync/non-worktree-filter-clause))
          (if archived?
            [:or
             [:= :archived true]
@@ -1354,7 +1363,7 @@
   changed, that should too."
   [_route-params
    {:keys [models archived namespace pinned_state sort_column sort_direction official_collections_first
-           include_can_run_adhoc_query include_library collection_type
+           include_can_run_adhoc_query include_library include_worktrees collection_type
            show_dashboard_questions]} :- [:map
                                           [:models                      {:optional true} [:maybe Models]]
                                           [:collection_type             {:optional true} CollectionType]
@@ -1362,6 +1371,7 @@
                                           [:archived                    {:default false} [:maybe ms/BooleanValue]]
                                           [:namespace                   {:optional true} [:maybe ms/NonBlankString]]
                                           [:include_library             {:default false} [:maybe ms/BooleanValue]]
+                                          [:include_worktrees           {:default false} [:maybe ms/BooleanValue]]
                                           [:pinned_state                {:optional true} [:maybe (into [:enum] valid-pinned-state-values)]]
                                           [:sort_column                 {:optional true} [:maybe (into [:enum] valid-sort-columns)]]
                                           [:sort_direction              {:optional true} [:maybe (into [:enum] valid-sort-directions)]]
@@ -1379,6 +1389,7 @@
       :show-dashboard-questions?   (boolean show_dashboard_questions)
       :collection-type             collection_type
       :include-library?            include_library
+      :include-worktrees?          include_worktrees
       :models                      (if-not (contains? namespaces-holding-non-collection-types namespace)
                                      #{:collection}
                                      model-kwds)
@@ -1676,6 +1687,9 @@
                                   {:show-dashboard-questions?   show_dashboard_questions
                                    :models                      model-kwds
                                    :include-library?             true
+                                   ;; children of a worktree collection are visible when browsing into it directly;
+                                   ;; the default-off containment applies to roots, tree, and flat listings
+                                   :include-worktrees?           true
                                    :archived?                   (or archived (:archived collection) (collection/is-trash? collection))
                                    :pinned-state                (keyword pinned_state)
                                    :include-can-run-adhoc-query include_can_run_adhoc_query

--- a/src/metabase/remote_sync/core.clj
+++ b/src/metabase/remote_sync/core.clj
@@ -29,6 +29,14 @@
   []
   true)
 
+(defn non-worktree-filter-clause
+  "HoneySQL clause matching only main-app rows — those not materialized by a remote-sync worktree
+  checkout. `column` defaults to `:remote_sync_worktree_id`; pass a qualified column when the query
+  joins other tables."
+  ([] (non-worktree-filter-clause :remote_sync_worktree_id))
+  ([column]
+   [:= column nil]))
+
 (defenterprise model-editable?
   "Determines if a model instance is editable based on remote sync configuration.
 


### PR DESCRIPTION
Part 4 of the remote-sync worktrees stack. Stacked on #78388.

- `GET/POST/DELETE /api/ee/remote-sync/worktrees` manage checkout rows; creating one for the current sync branch is refused (the main app is not a worktree), and one branch = one worktree (409 on duplicates).
- Deleting a worktree removes its collection trees through the model (content cleanup hooks run), with `force` to bypass the unpushed-changes guard; its RSO ledger goes with the row via FK cascade.
- Collection listings (tree, list, root items) exclude worktree content — `remote_sync_worktree_id IS NULL` via the OSS `non-worktree-filter-clause` — unless `include-worktrees` is passed.
- Feature-gated behind the `remote-sync-worktrees` setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)