### PR TITLE
[Worktrees 5/9] Scoped pull/push + per-worktree concurrency

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3441,6 +3441,7 @@
            events
            models
            premium-features
+           remote-sync
            search
            settings
            startup

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
@@ -41,6 +41,17 @@
                        :current_branch  current})))
     requested-branch))
 
+(defn- resolve-worktree!
+  "Resolve a `worktree_id` request param to a non-default worktree, checking the feature flag. The
+  default worktree is addressed by omitting the param (the legacy paths), so its ambient-branch guards
+  cannot be bypassed."
+  [worktree-id]
+  (api/check-400 (settings/remote-sync-worktrees) "Remote sync worktrees are not enabled.")
+  (let [worktree (api/check-404 (t2/select-one :model/RemoteSyncWorktree :id worktree-id))]
+    (api/check-400 (not (remote-sync.worktree/default-worktree? worktree))
+                   "Omit worktree_id to operate on the default worktree.")
+    worktree))
+
 (api.macros/defendpoint :post "/import" :- remote-sync.schema/ImportResponse
   "Import Metabase content from configured Remote Sync source.
 
@@ -54,35 +65,56 @@
   Requires superuser permissions."
   [_route
    _query
-   {:keys [branch force merge expected_branch]}
+   {:keys [branch force merge expected_branch worktree_id]}
    :- [:map [:branch {:optional true} ms/NonBlankString]
        [:force {:optional true} :boolean]
        [:merge {:optional true} :boolean]
        ;; the branch the client believes is currently active; rejected if it disagrees with the
        ;; remote-sync-branch setting (a pull/switch from a stale tab). `branch` is the operational
        ;; target (it differs from this on a branch switch); `expected_branch` is only the assertion.
-       [:expected_branch ms/NonBlankString]]]
+       ;; Required unless worktree_id names the operation's target instead (worktrees have no ambient
+       ;; branch state to protect).
+       [:expected_branch {:optional true} ms/NonBlankString]
+       [:worktree_id {:optional true} ms/PositiveInt]]]
   (api/check-superuser)
   (api/check-400 (settings/remote-sync-enabled) "Remote sync is not configured.")
-  (check-branch-matches-setting! expected_branch)
-  (let [branch-name (or branch (settings/remote-sync-branch))
-        user-id     api/*current-user-id*
-        {task-id :id}
-        (impl/async-import!
-         branch-name force {}
-         :merge?     (or merge false)
-         :on-success (fn [task-id _result]
-                       (impl/publish-sync-event! :event/remote-sync-import task-id {:branch branch-name} user-id)))]
-    {:status :success
-     :task_id task-id
-     :message (when-not task-id "No changes since last import")}))
+  (if worktree_id
+    (let [worktree (resolve-worktree! worktree_id)
+          user-id  api/*current-user-id*]
+      (api/check-400 (and (nil? branch) (nil? expected_branch))
+                     "branch and expected_branch cannot be combined with worktree_id.")
+      (let [{task-id :id}
+            (impl/async-worktree-pull!
+             worktree (boolean force)
+             :on-success (fn [task-id _result]
+                           (impl/publish-sync-event! :event/remote-sync-import task-id
+                                                     {:branch (:branch worktree) :worktree_id (:id worktree)}
+                                                     user-id)))]
+        {:status :success :task_id task-id :message nil}))
+    (do
+      (api/check-400 expected_branch "expected_branch is required.")
+      (check-branch-matches-setting! expected_branch)
+      (let [branch-name (or branch (settings/remote-sync-branch))
+            user-id     api/*current-user-id*
+            {task-id :id}
+            (impl/async-import!
+             branch-name force {}
+             :merge?     (or merge false)
+             :on-success (fn [task-id _result]
+                           (impl/publish-sync-event! :event/remote-sync-import task-id {:branch branch-name} user-id)))]
+        {:status :success
+         :task_id task-id
+         :message (when-not task-id "No changes since last import")}))))
 
 (api.macros/defendpoint :get "/is-dirty" :- remote-sync.schema/IsDirtyResponse
   "Check if any remote-synced collection or collection item has local changes that have not been pushed
-  to the remote sync source."
-  []
+  to the remote sync source. With `worktree_id`, checks that worktree's ledger."
+  [_route-params
+   {:keys [worktree-id]} :- [:map [:worktree-id {:optional true} ms/PositiveInt]]]
   (api/check-superuser)
-  {:is_dirty (remote-sync.object/dirty?)})
+  {:is_dirty (if worktree-id
+               (remote-sync.object/dirty? (:id (resolve-worktree! worktree-id)))
+               (remote-sync.object/dirty?))})
 
 (api.macros/defendpoint :get "/has-remote-changes" :- remote-sync.schema/HasRemoteChangesResponse
   "Check if there are new changes on the remote branch that can be pulled.
@@ -94,11 +126,15 @@
    - local_version: Git SHA of last successful import (nil if never imported)
    - cached: true if result was served from cache"
   [_route-params
-   {:keys [force-refresh]} :- [:map [:force-refresh {:optional true} :boolean]]
+   {:keys [force-refresh worktree-id]} :- [:map
+                                           [:force-refresh {:optional true} :boolean]
+                                           [:worktree-id {:optional true} ms/PositiveInt]]
    _body]
   (api/check-superuser)
   (api/check-400 (settings/remote-sync-enabled) "Remote sync is not configured.")
-  (let [result (impl/has-remote-changes? {:force-refresh? force-refresh})]
+  (let [result (if worktree-id
+                 (impl/worktree-has-remote-changes? (resolve-worktree! worktree-id))
+                 (impl/has-remote-changes? {:force-refresh? force-refresh}))]
     (cond-> {:has_changes (:has-changes? result)
              :remote_version (:remote-version result)
              :local_version (:local-version result)
@@ -107,12 +143,15 @@
 
 (api.macros/defendpoint :get "/dirty" :- remote-sync.schema/DirtyResponse
   "Return all models with changes that have not been pushed to the remote sync source in any
-  remote-synced collection."
-  []
+  remote-synced collection. With `worktree_id`, only that worktree's changes."
+  [_route-params
+   {:keys [worktree-id]} :- [:map [:worktree-id {:optional true} ms/PositiveInt]]]
   (api/check-superuser)
   {:dirty (into []
                 (m/distinct-by (juxt :id :model))
-                (remote-sync.object/dirty-objects))})
+                (if worktree-id
+                  (remote-sync.object/dirty-objects (:id (resolve-worktree! worktree-id)))
+                  (remote-sync.object/dirty-objects)))})
 
 (api.macros/defendpoint :post "/export" :- remote-sync.schema/ExportResponse
   "Export the current state of the Remote Sync collection to a Source.
@@ -128,26 +167,43 @@
   Requires superuser permissions."
   [_route
    _query
-   {:keys [message branch force merge]} :- [:map
-                                            [:message {:optional true} ms/NonBlankString]
-                                            [:branch ms/NonBlankString]
-                                            [:force {:optional true} :boolean]
-                                            [:merge {:optional true} :boolean]]]
+   {:keys [message branch force merge worktree_id]} :- [:map
+                                                        [:message {:optional true} ms/NonBlankString]
+                                                        ;; required unless worktree_id names the target
+                                                        [:branch {:optional true} ms/NonBlankString]
+                                                        [:force {:optional true} :boolean]
+                                                        [:merge {:optional true} :boolean]
+                                                        [:worktree_id {:optional true} ms/PositiveInt]]]
   (api/check-superuser)
   (api/check-400 (settings/remote-sync-enabled) "Remote sync is not configured.")
   (api/check-400 (= (settings/remote-sync-type) :read-write) "Exports are only allowed when remote-sync-type is set to 'read-write'")
-  (let [branch-name (check-branch-matches-setting! branch)
-        user-id     api/*current-user-id*
-        {task-id :id}
-        (impl/async-export!
-         branch-name
-         (or force false)
-         (or message "Exported from Metabase")
-         :merge?     (or merge false)
-         :on-success (fn [task-id _result]
-                       (impl/publish-sync-event! :event/remote-sync-export task-id {:branch branch-name} user-id)))]
-    {:message "Export task started"
-     :task_id task-id}))
+  (if worktree_id
+    (let [worktree (resolve-worktree! worktree_id)
+          user-id  api/*current-user-id*]
+      (api/check-400 (nil? branch) "branch cannot be combined with worktree_id.")
+      (let [{task-id :id}
+            (impl/async-worktree-push!
+             worktree (boolean force) (or message "Exported from Metabase")
+             :on-success (fn [task-id _result]
+                           (impl/publish-sync-event! :event/remote-sync-export task-id
+                                                     {:branch (:branch worktree) :worktree_id (:id worktree)}
+                                                     user-id)))]
+        {:message "Export task started"
+         :task_id task-id}))
+    (do
+      (api/check-400 branch "branch is required.")
+      (let [branch-name (check-branch-matches-setting! branch)
+            user-id     api/*current-user-id*
+            {task-id :id}
+            (impl/async-export!
+             branch-name
+             (or force false)
+             (or message "Exported from Metabase")
+             :merge?     (or merge false)
+             :on-success (fn [task-id _result]
+                           (impl/publish-sync-event! :event/remote-sync-export task-id {:branch branch-name} user-id)))]
+        {:message "Export task started"
+         :task_id task-id}))))
 
 (api.macros/defendpoint :get "/export-preflight" :- remote-sync.schema/ExportPreflightResponse
   "Dry-run preview of what pushing the current state would do given the live remote branch, without
@@ -178,20 +234,30 @@
      :reason                 (some-> reason name)}))
 
 (api.macros/defendpoint :get "/current-task" :- [:maybe remote-sync.schema/SyncTask]
-  "Get the current sync task"
-  []
+  "Get the current sync task. With `worktree_id`, that worktree's most recent task."
+  [_route-params
+   {:keys [worktree-id]} :- [:map [:worktree-id {:optional true} ms/PositiveInt]]]
   (api/check-superuser)
-  (when-let [task (remote-sync.task/most-recent-task)]
+  (when-let [task (if worktree-id
+                    (remote-sync.task/most-recent-task (:id (resolve-worktree! worktree-id)))
+                    (remote-sync.task/most-recent-task))]
     (t2/hydrate task :status)))
 
 (api.macros/defendpoint :post "/current-task/cancel" :- remote-sync.schema/SyncTask
-  "Cancels the current task if one is running"
-  []
+  "Cancels the current task if one is running. With `worktree_id`, that worktree's running task."
+  [_route-params
+   {:keys [worktree-id]} :- [:map [:worktree-id {:optional true} ms/PositiveInt]]]
   (api/check-superuser)
-  (let [task (remote-sync.task/most-recent-task)]
+  (let [resolved-id (when worktree-id (:id (resolve-worktree! worktree-id)))
+        task        (if resolved-id
+                      (remote-sync.task/most-recent-task resolved-id)
+                      (remote-sync.task/most-recent-task))]
     (api/check-400 (and (some? task) (remote-sync.task/running? task)) "No active task to cancel")
     (remote-sync.task/cancel-sync-task! (:id task))
-    (t2/hydrate (remote-sync.task/most-recent-task) :status)))
+    (t2/hydrate (if resolved-id
+                  (remote-sync.task/most-recent-task resolved-id)
+                  (remote-sync.task/most-recent-task))
+                :status)))
 
 (api.macros/defendpoint :post "/test-connection" :- remote-sync.schema/TestConnectionResponse
   "Test whether the Remote Sync credentials can reach the git repository.

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
@@ -238,9 +238,12 @@
   [_route-params
    {:keys [worktree-id]} :- [:map [:worktree-id {:optional true} ms/PositiveInt]]]
   (api/check-superuser)
-  (when-let [task (if worktree-id
-                    (remote-sync.task/most-recent-task (:id (resolve-worktree! worktree-id)))
-                    (remote-sync.task/most-recent-task))]
+  (when-let [task (remote-sync.task/most-recent-task
+                   (if worktree-id
+                     (:id (resolve-worktree! worktree-id))
+                     ;; the legacy form is the default worktree's view: other worktrees' tasks are
+                     ;; not "the current task" of the main git-sync UI
+                     (remote-sync.worktree/default-worktree-id)))]
     (t2/hydrate task :status)))
 
 (api.macros/defendpoint :post "/current-task/cancel" :- remote-sync.schema/SyncTask
@@ -248,16 +251,15 @@
   [_route-params
    {:keys [worktree-id]} :- [:map [:worktree-id {:optional true} ms/PositiveInt]]]
   (api/check-superuser)
-  (let [resolved-id (when worktree-id (:id (resolve-worktree! worktree-id)))
-        task        (if resolved-id
-                      (remote-sync.task/most-recent-task resolved-id)
-                      (remote-sync.task/most-recent-task))]
+  (let [scope-id (if worktree-id
+                   (:id (resolve-worktree! worktree-id))
+                   ;; scope the legacy form to the default worktree so it cannot cancel another
+                   ;; worktree's in-flight sync
+                   (remote-sync.worktree/default-worktree-id))
+        task     (remote-sync.task/most-recent-task scope-id)]
     (api/check-400 (and (some? task) (remote-sync.task/running? task)) "No active task to cancel")
     (remote-sync.task/cancel-sync-task! (:id task))
-    (t2/hydrate (if resolved-id
-                  (remote-sync.task/most-recent-task resolved-id)
-                  (remote-sync.task/most-recent-task))
-                :status)))
+    (t2/hydrate (remote-sync.task/most-recent-task scope-id) :status)))
 
 (api.macros/defendpoint :post "/test-connection" :- remote-sync.schema/TestConnectionResponse
   "Test whether the Remote Sync credentials can reach the git repository.
@@ -510,7 +512,7 @@
   (let [worktree (api/check-404 (t2/select-one :model/RemoteSyncWorktree :id id))]
     (api/check-400 (not (remote-sync.worktree/default-worktree? worktree))
                    "Cannot delete the default worktree. Change the remote-sync-branch setting instead.")
-    (let [dirty (remote-sync.worktree/worktree-dirty-rows id)]
+    (let [dirty (remote-sync.object/dirty-rows id)]
       (when (and (seq dirty) (not force))
         (throw (ex-info "This worktree has changes that have not been pushed."
                         {:status-code   400

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/events.clj
@@ -63,6 +63,16 @@
 
 ;;; ----------------------------------------- Helper Functions ---------------------------------------------------------
 
+(defn- ledger-worktree-id
+  "Worktree whose ledger tracks a changed entity: its collection's worktree (for a Collection, its
+   own), falling back to the default worktree for collection-less trackables (e.g. the transforms
+   sentinel). Content created inside a checkout must land in that checkout's ledger, not the default's."
+  [model-type model-id collection-id]
+  (or (when-let [coll-id (if (= model-type "Collection") model-id collection-id)]
+        (when (pos-int? coll-id)
+          (t2/select-one-fn :remote_sync_worktree_id :model/Collection :id coll-id)))
+      (remote-sync.worktree/default-worktree-id)))
+
 (defn- resolve-status
   "Suppresses a no-op 'update' based on status and content_hash, otherwise keep status unchanged."
   [model-type model-id status existing]
@@ -104,7 +114,7 @@
                      :model_table_name (:table_name model-details)
                      :status status
                      :status_changed_at (t/offset-date-time)
-                     :worktree_id (remote-sync.worktree/default-worktree-id)}))
+                     :worktree_id (ledger-worktree-id model-type model-id (:collection_id model-details))}))
       (and (= "create" (:status existing)) (contains? #{"removed" "delete"} status))
       (t2/delete! :model/RemoteSyncObject (:id existing))
       (= "delete" (:status existing))
@@ -139,7 +149,8 @@
                             :model_id          model-id
                             :status            status
                             :status_changed_at (t/offset-date-time)
-                            :worktree_id       (remote-sync.worktree/default-worktree-id)}
+                            :worktree_id       (ledger-worktree-id model-type model-id
+                                                                   (:model_collection_id fields))}
                            fields)))
       (and (= "create" (:status existing)) (contains? #{"removed" "delete"} status))
       (t2/delete! :model/RemoteSyncObject (:id existing))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/guards.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/guards.clj
@@ -15,9 +15,11 @@
    `current-task`, so a stale task (no progress reports for longer than the timeout) does
    NOT count as running. Stale rows get cleaned up by `ensure-no-active-task!`'s supersession
    step, which means user-driven operations self-heal from JVM crashes and hung threads
-   the same way auto-import does."
-  []
-  (some? (rst/current-task)))
+   the same way auto-import does. With `worktree-id`, only that worktree's tasks count."
+  ([]
+   (some? (rst/current-task)))
+  ([worktree-id]
+   (some? (rst/current-task worktree-id))))
 
 (defn ensure-no-active-task!
   "Throws an ex-info with status-code 400 if a remote-sync task is currently active. After
@@ -27,9 +29,14 @@
    Used as a guard at the top of mutating remote-sync operations. Combined with
    `handle-task-result!`'s already-terminated check, this means an old task's late-arriving
    thread will detect its row is terminated and exit without writing the setting or
-   overwriting bookkeeping."
-  []
-  (when (task-running?)
-    (throw (ex-info "Remote sync task in progress"
-                    {:status-code 400})))
-  (rst/supersede-stale-tasks!))
+   overwriting bookkeeping.
+
+   With `worktree-id`, only that worktree's tasks block — operations on different worktrees
+   run concurrently."
+  ([]
+   (ensure-no-active-task! nil))
+  ([worktree-id]
+   (when (if worktree-id (task-running? worktree-id) (task-running?))
+     (throw (ex-info "Remote sync task in progress"
+                     {:status-code 400})))
+   (rst/supersede-stale-tasks!)))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -14,6 +14,7 @@
    [metabase-enterprise.remote-sync.source.ingestable :as source.ingestable]
    [metabase-enterprise.remote-sync.source.protocol :as source.p]
    [metabase-enterprise.remote-sync.spec :as spec]
+   [metabase-enterprise.remote-sync.worktree-identity :as worktree-identity]
    [metabase-enterprise.serialization.core :as serialization]
    [metabase.analytics-interface.core :as analytics]
    [metabase.api.common :as api]
@@ -21,6 +22,7 @@
    [metabase.collections.models.collection :as collection]
    [metabase.events.core :as events]
    [metabase.models.serialization :as serdes]
+   [metabase.remote-sync.core :as oss.remote-sync]
    [metabase.search.core :as search]
    [metabase.settings.core :as setting]
    [metabase.util :as u]
@@ -298,9 +300,9 @@
 (defn- insert-with-metadata!
   "Inserts RemoteSyncObject `rows` after an import, one `content-hash-batch-size` chunk at a time, folding
   each chunk's file_path + content_hash (`repo-paths` gives entity-id models their real path) into its insert."
-  [rows repo-paths]
+  [rows repo-paths & {:keys [worktree-id]}]
   (serdes/with-cache
-    (let [worktree-id (remote-sync.worktree/default-worktree-id)]
+    (let [worktree-id (or worktree-id (remote-sync.worktree/default-worktree-id))]
       (doseq [chunk (partition-all app-db-batch-size rows)]
         (t2/insert! :model/RemoteSyncObject
                     (map #(assoc % :worktree_id worktree-id)
@@ -370,6 +372,59 @@
       (settings/remote-sync-transforms! false))
     (remote-sync.task/update-progress! task-id 0.95)
     imported-data))
+
+;;; ------------------------------------------- Worktree Pull ---------------------------------------------------------
+
+(defn- remove-unsynced-worktree!
+  "Deletes `worktree-id`'s materialized content that was NOT part of the import. Worktree copies are
+  identified by their entity-id prefix (`<worktree-id>/...`), which uniformly covers collection-scoped
+  and global models without touching any other worktree's rows. Entities created inside the worktree
+  (bare entity ids) are the pull's business to keep or fold, not this reconcile's — they are left alone."
+  [worktree-id {:keys [by-entity-id]}]
+  (let [prefix-like (str worktree-id "/%")]
+    (doseq [[model-key model-spec] (spec/specs-for-deletion)
+            :when (isa? model-key :hook/entity-id)
+            :let [kept (get by-entity-id (:model-type model-spec) [])]]
+      (t2/delete! model-key {:where (cond-> [:and [:like :entity_id prefix-like]]
+                                      (seq kept) (conj [:not-in :entity_id kept]))}))))
+
+(defn worktree-pull!
+  "Pull `worktree`'s branch into its materialized collection trees: load the snapshot under
+  worktree-local entity ids, reconcile the worktree's content and RemoteSyncObject ledger to match it,
+  and record the pulled version on the task. Always a full reconcile (no incremental or 3-way paths for
+  non-default worktrees yet); never touches the default worktree's content, settings toggles, or data
+  apps. Returns a result map like [[import!]]."
+  [worktree ^SourceSnapshot snapshot task-id]
+  (log/infof "Pulling worktree %s (branch %s)" (:id worktree) (:branch worktree))
+  (analytics/inc! :metabase-remote-sync/imports)
+  (let [sync-timestamp   (t/instant)
+        snapshot-version (source.p/version snapshot)]
+    (try
+      (let [path-filters    (mapv #(re-pattern (str % "/.*")) serialization/legal-top-level-paths)
+            base-ingestable (source.p/->ingestable snapshot {:path-filters path-filters})
+            wrapped         (worktree-identity/wrap-ingestable base-ingestable (:id worktree))
+            ingestable      (source.ingestable/wrap-progress-ingestable task-id 0.7 wrapped)
+            load-result     (binding [oss.remote-sync/*importing-worktree-id* (:id worktree)]
+                              (serdes/with-cache
+                                (serialization/load-metabase! ingestable)))
+            imported-data   (spec/extract-imported-entities (:seen load-result))]
+        (remote-sync.task/update-progress! task-id 0.8)
+        (t2/with-transaction [_conn]
+          (remove-unsynced-worktree! (:id worktree) imported-data)
+          (t2/delete! :model/RemoteSyncObject :worktree_id (:id worktree))
+          (insert-with-metadata! (spec/sync-all-entities! sync-timestamp imported-data)
+                                 (source.ingestable/cached-file-paths base-ingestable)
+                                 :worktree-id (:id worktree))
+          (remote-sync.task/set-version! task-id snapshot-version))
+        (remote-sync.task/update-progress! task-id 0.95)
+        {:status  :success
+         :version snapshot-version
+         :outcome {:kind "pulled" :branch (:branch worktree)}})
+      (catch Exception e
+        (log/errorf e "Failed to pull worktree %s: %s" (:id worktree) (ex-message e))
+        (analytics/inc! :metabase-remote-sync/imports-failed)
+        {:status  :error
+         :message (source-error-message e)}))))
 
 ;;; ------------------------------------------- Incremental Import Fast-Path -------------------------------------------
 
@@ -1028,8 +1083,14 @@
     (not (settings/remote-sync-transforms))    (into ["transforms" "python-libraries" "python_libraries"])
     (not (settings/library-is-remote-synced?)) (conj "snippets")))
 
+(def ^:private ^:dynamic *export-entity-transform*
+  "Applied to each extracted entity before its repo path and serialized content are computed. Worktree
+  pushes bind this to strip worktree-local entity-id prefixes so git only ever sees canonical ids."
+  identity)
+
 (defn- stage-write [commit opts [row entity]]
-  (let [path    (or (:file_path row) (source/entity->path opts entity))
+  (let [entity  (*export-entity-transform* entity)
+        path    (or (:file_path row) (source/entity->path opts entity))
         content (source/entity->content entity)]
     (source.p/stage-upsert! commit {:path path :content content})
     (when (:id row)
@@ -1114,43 +1175,73 @@
 (def ^:private export-progress-plan-done 0.33) ; phase 1 (plan) complete / serialize start
 (def ^:private export-progress-serialize 0.66) ; phase 2 (serialize) complete
 
+(declare full-export!*)
+
 (defn- full-export!
-  "Re-serialize and commit the entire remote-synced set, then reconcile every RemoteSyncObject.
+  "Re-serialize and commit the entire remote-synced set — the instance-wide one, or `worktree`'s when
+  given — then reconcile every affected RemoteSyncObject.
 
   Returns:
    - {:status :success}
    or throws"
-  [snapshot task-id message sync-timestamp]
-  (let [export-rows (vec (exportable-write-rows))]
+  [snapshot task-id message sync-timestamp & {:keys [worktree]}]
+  (let [export-rows (if worktree
+                      ;; a worktree's RSO ledger is its complete synced set (a full pull seeds it), so it
+                      ;; is the export root list; entities pending deletion have no row to extract anyway
+                      (mapv #(select-keys % [:id :model_type :model_id])
+                            (t2/select [:model/RemoteSyncObject :id :model_type :model_id]
+                                       :worktree_id (:id worktree)
+                                       :status [:not-in ["delete" "removed"]]))
+                      (vec (exportable-write-rows)))]
     (when (empty? export-rows)
       (throw (ex-info "No remote-syncable content available." {})))
-    (let [report (remote-sync.task/make-progress-reporter task-id)
-          total  (count export-rows)
-          span   (- export-progress-serialize export-progress-plan-done)]
-      (report export-progress-plan-done {:force? true})
-      (let [opts             (serdes/storage-base-context)
-            [synced version] (commit-staged! snapshot message
-                                             (fn [commit]
-                                               (source.p/replace-all! commit) ; replace the managed dirs wholesale
-                                               (let [synced (stage-writes commit opts export-rows
-                                                                          (fn [staged]
-                                                                            (report (+ export-progress-plan-done
-                                                                                       (* span (/ staged total))))))]
-                                                 (report export-progress-serialize {:force? true})
-                                                 synced))
-                                             report)]
-        (t2/with-transaction [_]
-          (when-not (= version :remote-sync/empty-commit)
-            (remote-sync.task/set-version! task-id version))
-          (doseq [removed-ids (partition-all 500 (find-departed-entities export-rows))]
-            (t2/delete! :model/RemoteSyncObject :id [:in removed-ids]))
-          (mark-rows-synced! (t2/select-pks-set :model/RemoteSyncObject) synced sync-timestamp))
-        (if (= version :remote-sync/empty-commit)
-          (do
-            (log/info "Remote sync full export: re-serialized content matches remote; skipped empty commit")
-            {:status :success :outcome {:kind "push-skipped"}})
-          {:status :success
-           :outcome {:kind "pushed" :count (count synced) :branch (settings/remote-sync-branch)}})))))
+    (binding [*export-entity-transform* (if worktree
+                                          #(worktree-identity/canonicalize-entity-ids % (:id worktree))
+                                          identity)]
+      (full-export!* snapshot task-id message sync-timestamp worktree export-rows))))
+
+(defn- full-export!*
+  [snapshot task-id message sync-timestamp worktree export-rows]
+  (let [report (remote-sync.task/make-progress-reporter task-id)
+        total  (count export-rows)
+        span   (- export-progress-serialize export-progress-plan-done)]
+    (report export-progress-plan-done {:force? true})
+    (let [opts             (serdes/storage-base-context)
+          [synced version] (commit-staged! snapshot message
+                                           (fn [commit]
+                                             (source.p/replace-all! commit) ; replace the managed dirs wholesale
+                                             (let [synced (stage-writes commit opts export-rows
+                                                                        (fn [staged]
+                                                                          (report (+ export-progress-plan-done
+                                                                                     (* span (/ staged total))))))]
+                                               (report export-progress-serialize {:force? true})
+                                               synced))
+                                           report)]
+      (t2/with-transaction [_]
+        (when-not (= version :remote-sync/empty-commit)
+          (remote-sync.task/set-version! task-id version))
+        (doseq [removed-ids (partition-all 500 (find-departed-entities export-rows))]
+          (t2/delete! :model/RemoteSyncObject :id [:in removed-ids]))
+        ;; a full export rewrites the managed dirs wholesale, so pending deletions are now pushed:
+        ;; their ledger rows are done
+        (when worktree
+          (t2/delete! :model/RemoteSyncObject
+                      :worktree_id (:id worktree)
+                      :status [:in ["delete" "removed"]]))
+        (mark-rows-synced! (if worktree
+                             (t2/select-pks-set :model/RemoteSyncObject :worktree_id (:id worktree))
+                             (t2/select-pks-set :model/RemoteSyncObject))
+                           synced sync-timestamp))
+      (if (= version :remote-sync/empty-commit)
+        (do
+          (log/info "Remote sync full export: re-serialized content matches remote; skipped empty commit")
+          {:status :success :outcome {:kind "push-skipped"}})
+        {:status :success
+         :outcome {:kind "pushed"
+                   :count (count synced)
+                   :branch (if worktree
+                             (:branch worktree)
+                             (settings/remote-sync-branch))}}))))
 
 (defn- incremental-export!
   [plan disabled-files task-id snapshot message sync-timestamp]
@@ -1276,14 +1367,23 @@
   endpoints go through `ensure-no-active-task!` first (in `async-import!` / `async-export!` / etc.), which
   uses the stricter `task-running?` predicate and refuses if any task — including stale — is alive. So
   this function only reaches the supersession branch on the auto-import path."
-  [task-type]
-  (cluster-lock/with-cluster-lock ::remote-sync-task
-    (if-let [task (remote-sync.task/current-task)]
+  [task-type & [worktree]]
+  ;; per-worktree lock: operations on different worktrees don't contend, same-worktree operations
+  ;; serialize. The keyword just names the cluster-lock row.
+  (cluster-lock/with-cluster-lock (if worktree
+                                    (keyword (namespace ::remote-sync-task)
+                                             (str "remote-sync-task-worktree-" (:id worktree)))
+                                    ::remote-sync-task)
+    (if-let [task (if worktree
+                    (remote-sync.task/current-task (:id worktree))
+                    (remote-sync.task/current-task))]
       (assoc task :existing? true)
       (do
         (remote-sync.task/supersede-stale-tasks!)
         (remote-sync.task/create-sync-task! task-type api/*current-user-id*
-                                            {:worktree_id (remote-sync.worktree/default-worktree-id)})))))
+                                            {:worktree_id (if worktree
+                                                            (:id worktree)
+                                                            (remote-sync.worktree/default-worktree-id))})))))
 
 ;;; ------------------------------------------- Remote Changes Check -------------------------------------------
 
@@ -1417,9 +1517,14 @@
               :else
               (do
                 (case (:status result)
-                  :success (let [worktree (if branch
-                                            (remote-sync.worktree/set-default-branch! branch)
-                                            (remote-sync.worktree/ensure-default-worktree!))]
+                  :success (let [worktree (cond
+                                            ;; legacy default-worktree flows pass the branch and may
+                                            ;; switch the default; worktree-scoped flows pass nil and
+                                            ;; resolve through the task's own worktree
+                                            branch               (remote-sync.worktree/set-default-branch! branch)
+                                            (:worktree_id task)  (t2/select-one :model/RemoteSyncWorktree
+                                                                                :id (:worktree_id task))
+                                            :else                (remote-sync.worktree/ensure-default-worktree!))]
                              (when worktree
                                ;; the task may have been created under the previous default worktree
                                ;; (branch switch): retag it onto the branch it actually synced
@@ -1462,8 +1567,8 @@
   running), then executes the sync function in a virtual thread with a timeout.
 
   Returns a RemoteSyncTask. Throws ExceptionInfo with status 400 if a sync task is already in progress."
-  [task-type branch sync-fn & {:keys [on-success]}]
-  (let [{task-id :id existing? :existing? :as task} (create-task-with-lock! task-type)]
+  [task-type branch sync-fn & {:keys [on-success worktree]}]
+  (let [{task-id :id existing? :existing? :as task} (create-task-with-lock! task-type worktree)]
     (api/check-400 (not existing?) "Remote sync in progress")
     (u.jvm/in-virtual-thread*
      (dh/with-timeout {:interrupt? true
@@ -1578,6 +1683,81 @@
                            :source          source
                            :base-snapshot   base-snapshot))
                 :on-success on-success)))
+
+;;; ------------------------------------------- Worktree Async Entry Points -------------------------------------------
+
+(defn- worktree-push!
+  "Push `worktree`'s content to its branch: full export of the worktree's set with entity ids
+  canonicalized. When the remote has advanced past the worktree's base and `force?` is not set,
+  returns a conflict result instead of overwriting."
+  [worktree ^SourceSnapshot snapshot task-id message force?]
+  (let [sync-timestamp (t/instant)]
+    (try
+      (analytics/inc! :metabase-remote-sync/exports)
+      (serdes/with-cache
+        (let [remote-version (source.p/version snapshot)
+              base-version   (:base_version worktree)
+              diverged?      (and (some? base-version) (not= base-version remote-version))]
+          (if (and diverged? (not force?))
+            {:status    :conflict
+             :version   remote-version
+             :conflicts []
+             :message   "The remote branch has changed since your last sync. Choose how to proceed."}
+            (full-export! snapshot task-id message sync-timestamp :worktree worktree))))
+      (catch Exception e
+        (log/errorf e "Failed to push worktree %s: %s" (:id worktree) (ex-message e))
+        (analytics/inc! :metabase-remote-sync/exports-failed)
+        {:status  :error
+         :message (source-error-message e)}))))
+
+(defn async-worktree-pull!
+  "Pull `worktree`'s branch asynchronously. `force?` discards unpushed local changes in the worktree;
+  without it a dirty worktree is a 400 carrying the dirty objects (mirroring [[async-import!]]).
+  Returns a RemoteSyncTask."
+  [worktree force? & {:keys [on-success]}]
+  (guards/ensure-no-active-task! (:id worktree))
+  (when (and (remote-sync.object/dirty? (:id worktree)) (not force?))
+    (throw (ex-info "This worktree has changes that have not been pushed. Force the pull to discard them."
+                    {:status-code   400
+                     :conflicts     true
+                     :dirty_objects (remote-sync.object/dirty-objects (:id worktree))})))
+  (let [source   (source/source-from-settings (:branch worktree))
+        snapshot (source.p/snapshot source)]
+    (run-async! "import" nil
+                (fn [task-id]
+                  (worktree-pull! worktree snapshot task-id))
+                :worktree worktree
+                :on-success on-success)))
+
+(defn async-worktree-push!
+  "Push `worktree`'s content to its branch asynchronously. Returns a RemoteSyncTask."
+  [worktree force? message & {:keys [on-success]}]
+  (guards/ensure-no-active-task! (:id worktree))
+  (let [source   (source/source-from-settings (:branch worktree))
+        snapshot (source.p/snapshot source)]
+    (run-async! "export" nil
+                (fn [task-id]
+                  (worktree-push! worktree snapshot task-id message force?))
+                :worktree worktree
+                :on-success on-success)))
+
+(defn worktree-has-remote-changes?
+  "Compare `worktree`'s base version against its remote branch tip. Always fresh (no cache).
+  Returns a map shaped like [[has-remote-changes?]]'s."
+  [worktree]
+  (let [source   (source/source-from-settings (:branch worktree))
+        snapshot (snapshot-or-missing-branch source)]
+    (if (= snapshot ::missing-branch)
+      {:has-changes?    false
+       :remote-version  nil
+       :local-version   (:base_version worktree)
+       :cached?         false
+       :branch-missing? true}
+      (let [remote-version (source.p/version snapshot)]
+        {:has-changes?   (not= remote-version (:base_version worktree))
+         :remote-version remote-version
+         :local-version  (:base_version worktree)
+         :cached?        false}))))
 
 (defn preview-export-merge
   "Dry-run preview of what exporting the current state would do given the live remote, without writing

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -362,7 +362,7 @@
       ;; Replace the RemoteSyncObject table, folding each entity's repo file_path (so later renames/deletes
       ;; resolve the real file) and serialized-content hash (so a post-pull no-op edit stays synced) into the
       ;; insert. Chunked so insert/IN params and memory stay bounded.
-      (t2/delete! :model/RemoteSyncObject)
+      (t2/delete! :model/RemoteSyncObject {:where (remote-sync.worktree/worktree-filter-clause nil)})
       (insert-with-metadata! (spec/sync-all-entities! sync-timestamp imported-data)
                              (source.ingestable/cached-file-paths base-ingestable))
       (when finalize! (finalize!)))
@@ -1137,12 +1137,15 @@
       {:model_type model :model_id id :id (rso-id [model id])})))
 
 (defn- find-departed-entities
-  "Find RSO rows for entity-id entities that left the synced set (removed/delete status and not in
-  `targets`), matching the incremental path; path/hybrid and still-exported rows are kept."
-  [exported-rows]
+  "Find `worktree`'s (nil = the default's) RSO rows for entity-id entities that left the synced set
+  (removed/delete status and not in `targets`), matching the incremental path; path/hybrid rows,
+  still-exported rows, and other worktrees' ledgers are kept."
+  [exported-rows worktree]
   (let [exported (into #{} (map #(select-keys % [:model_type :model_id])) exported-rows)]
     (->> (t2/select [:model/RemoteSyncObject :id :model_type :model_id]
-                    :status [:in ["removed" "delete"]])
+                    {:where [:and
+                             [:in :status ["removed" "delete"]]
+                             (remote-sync.worktree/worktree-filter-clause (:id worktree))]})
          (filter #(= :entity-id (:identity (spec/spec-for-model-type (:model_type %)))))
          (remove #(exported (select-keys % [:model_type :model_id])))
          (map :id))))
@@ -1220,7 +1223,7 @@
       (t2/with-transaction [_]
         (when-not (= version :remote-sync/empty-commit)
           (remote-sync.task/set-version! task-id version))
-        (doseq [removed-ids (partition-all 500 (find-departed-entities export-rows))]
+        (doseq [removed-ids (partition-all 500 (find-departed-entities export-rows worktree))]
           (t2/delete! :model/RemoteSyncObject :id [:in removed-ids]))
         ;; a full export rewrites the managed dirs wholesale, so pending deletions are now pushed:
         ;; their ledger rows are done
@@ -1228,9 +1231,8 @@
           (t2/delete! :model/RemoteSyncObject
                       :worktree_id (:id worktree)
                       :status [:in ["delete" "removed"]]))
-        (mark-rows-synced! (if worktree
-                             (t2/select-pks-set :model/RemoteSyncObject :worktree_id (:id worktree))
-                             (t2/select-pks-set :model/RemoteSyncObject))
+        (mark-rows-synced! (t2/select-pks-set :model/RemoteSyncObject
+                                              {:where (remote-sync.worktree/worktree-filter-clause (:id worktree))})
                            synced sync-timestamp))
       (if (= version :remote-sync/empty-commit)
         (do
@@ -1602,6 +1604,10 @@
   are unsaved changes and neither force? nor merge? is set."
   [branch force? import-args & {:keys [on-success merge? force-deletion?]}]
   (guards/ensure-no-active-task!)
+  ;; a branch switch adopts `branch` as the default sync set; a branch that is checked out as a
+  ;; worktree cannot be adopted (its rows carry worktree-prefixed entity ids)
+  (when (not= branch (settings/remote-sync-branch))
+    (remote-sync.worktree/check-branch-not-checked-out! branch))
   (let [pre-task-branch        (settings/remote-sync-branch)
         source                 (source/source-from-settings branch)
         has-dirty?             (remote-sync.object/dirty?)
@@ -1708,7 +1714,10 @@
         (log/errorf e "Failed to push worktree %s: %s" (:id worktree) (ex-message e))
         (analytics/inc! :metabase-remote-sync/exports-failed)
         {:status  :error
-         :message (source-error-message e)}))))
+         :message (source-error-message e)})
+      (finally
+        (analytics/observe! :metabase-remote-sync/export-duration-ms
+                            (t/as (t/duration sync-timestamp (t/instant)) :millis))))))
 
 (defn async-worktree-pull!
   "Pull `worktree`'s branch asynchronously. `force?` discards unpushed local changes in the worktree;
@@ -1800,6 +1809,7 @@
    is responsible for those concerns."
   [name base-branch]
   (guards/ensure-no-active-task!)
+  (remote-sync.worktree/check-branch-not-checked-out! name)
   (let [source (source/source-from-settings)]
     (source.p/create-branch source name base-branch)
     (remote-sync.worktree/set-default-branch! name)))
@@ -1809,6 +1819,7 @@
    async export to it. Returns the resulting RemoteSyncTask. Does not publish events."
   [new-branch message & {:keys [on-success]}]
   (guards/ensure-no-active-task!)
+  (remote-sync.worktree/check-branch-not-checked-out! new-branch)
   (let [source (source/source-from-settings)]
     (source.p/create-branch source new-branch (settings/remote-sync-branch))
     (async-export! new-branch false message :on-success on-success)))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_object.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_object.clj
@@ -19,45 +19,52 @@
 
 ;;; ------------------------------------------------- Public API -------------------------------------------------------
 
+(defn- dirty-where
+  "WHERE clause for unsynced rows: status filter, disabled model types (e.g. transforms when transform
+  sync is off), and — when `worktree-id` is given — scoping to that worktree's ledger."
+  [worktree-id]
+  (let [excluded (spec/excluded-model-types)]
+    (cond-> [:and [:not= :status "synced"]]
+      (seq excluded) (conj [:not-in :model_type excluded])
+      worktree-id    (conj [:= :worktree_id worktree-id]))))
+
 (defn dirty?
   "Checks if any collection has changes since the last sync.
    Returns true if any remote-synced object has a status other than 'synced', false otherwise.
-   Excludes transform model types when transform sync is disabled."
-  []
-  (let [excluded (spec/excluded-model-types)]
-    (if (empty? excluded)
-      (t2/exists? :model/RemoteSyncObject :status [:not= "synced"])
-      (t2/exists? :model/RemoteSyncObject
-                  :status [:not= "synced"]
-                  :model_type [:not-in excluded]))))
+   With `worktree-id`, only considers that worktree's ledger."
+  ([]
+   (dirty? nil))
+  ([worktree-id]
+   (t2/exists? :model/RemoteSyncObject {:where (dirty-where worktree-id)})))
 
 (defn dirty-rows
   "Returns the raw RemoteSyncObject rows that are not yet synced (status != 'synced'),
-  excluding disabled model types (e.g. transforms when transform sync is off)."
-  []
-  (let [excluded (spec/excluded-model-types)]
-    (if (empty? excluded)
-      (t2/select :model/RemoteSyncObject :status [:not= "synced"])
-      (t2/select :model/RemoteSyncObject
-                 :status [:not= "synced"]
-                 :model_type [:not-in excluded]))))
+  excluding disabled model types (e.g. transforms when transform sync is off).
+  With `worktree-id`, only that worktree's rows."
+  ([]
+   (dirty-rows nil))
+  ([worktree-id]
+   (t2/select :model/RemoteSyncObject {:where (dirty-where worktree-id)})))
 
 (defn dirty-objects
   "Gets all models in any collection that are dirty with their sync status.
    Returns a sequence of model maps that have changed since the last remote sync,
    including details about their current state and sync status.
-   Excludes transform model types when transform sync is disabled."
-  []
-  (->> (dirty-rows)
-       (map #(-> %
-                 (dissoc :id :status_changed_at)
-                 (set/rename-keys {:model_id :id
-                                   :model_name :name
-                                   :model_type :model
-                                   :model_collection_id :collection_id
-                                   :model_display :display
-                                   :model_table_id :table_id
-                                   :model_table_name :table_name
-                                   :status :sync_status})
-                 (update :model u/lower-case-en)))
-       (into [])))
+   Excludes transform model types when transform sync is disabled.
+   With `worktree-id`, only that worktree's ledger."
+  ([]
+   (dirty-objects nil))
+  ([worktree-id]
+   (->> (dirty-rows worktree-id)
+        (map #(-> %
+                  (dissoc :id :status_changed_at)
+                  (set/rename-keys {:model_id :id
+                                    :model_name :name
+                                    :model_type :model
+                                    :model_collection_id :collection_id
+                                    :model_display :display
+                                    :model_table_id :table_id
+                                    :model_table_name :table_name
+                                    :status :sync_status})
+                  (update :model u/lower-case-en)))
+        (into []))))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_object.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_object.clj
@@ -6,6 +6,7 @@
    and for Field/Segment/Table models, parent table information."
   (:require
    [clojure.set :as set]
+   [metabase-enterprise.remote-sync.models.remote-sync-worktree :as remote-sync.worktree]
    [metabase-enterprise.remote-sync.spec :as spec]
    [metabase.util :as u]
    [methodical.core :as methodical]
@@ -21,12 +22,15 @@
 
 (defn- dirty-where
   "WHERE clause for unsynced rows: status filter, disabled model types (e.g. transforms when transform
-  sync is off), and — when `worktree-id` is given — scoping to that worktree's ledger."
+  sync is off), and ledger scoping — the given worktree's, or with a nil `worktree-id` the default
+  worktree's (which also owns rows that predate worktrees), so one worktree's unpushed changes never
+  dirty another's flows."
   [worktree-id]
   (let [excluded (spec/excluded-model-types)]
-    (cond-> [:and [:not= :status "synced"]]
-      (seq excluded) (conj [:not-in :model_type excluded])
-      worktree-id    (conj [:= :worktree_id worktree-id]))))
+    (cond-> [:and
+             [:not= :status "synced"]
+             (remote-sync.worktree/worktree-filter-clause worktree-id)]
+      (seq excluded) (conj [:not-in :model_type excluded]))))
 
 (defn dirty?
   "Checks if any collection has changes since the last sync.

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_task.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_task.clj
@@ -219,7 +219,9 @@
    (t2/select-one :model/RemoteSyncTask
                   {:where (cond-> [:and
                                    [:<> :started_at nil]]
-                            worktree-id (conj [:= :worktree_id worktree-id]))
+                            worktree-id (conj [:or
+                                               [:= :worktree_id worktree-id]
+                                               [:= :worktree_id nil]]))
                    :limit 1
                    :order-by [[:started_at :desc]
                               [:id :desc]]})))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_task.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_task.clj
@@ -28,7 +28,12 @@
 
 (t2/define-before-insert :model/RemoteSyncTask
   [task]
-  (when-let [existing (current-task)]
+  ;; one running task per worktree: a task tagged with a worktree only conflicts with running tasks of
+  ;; that worktree (or untagged ones, which predate worktrees and belong to the default); an untagged
+  ;; task keeps the old instance-wide check
+  (when-let [existing (if-let [worktree-id (:worktree_id task)]
+                        (current-task worktree-id)
+                        (current-task))]
     (throw (ex-info "A running task exists" {:existing-task existing})))
   task)
 
@@ -157,18 +162,25 @@
   "Gets the current active sync task.
 
   Returns the most recent RemoteSyncTask that is still running (started but not ended, and has reported progress
-  within the time limit), or nil if no active task exists."
-  []
-  (t2/select-one :model/RemoteSyncTask
-                 {:where [:and
-                          [:<> :started_at nil]
-                          [:= :ended_at nil]
-                          [:<
-                           (t/minus (t/offset-date-time) (t/millis (setting/get :remote-sync-task-time-limit-ms)))
-                           :last_progress_report_at]]
-                  :limit 1
-                  :order-by [[:started_at :desc]
-                             [:id :desc]]}))
+  within the time limit), or nil if no active task exists. With `worktree-id`, only considers tasks running
+  against that worktree (rows with a nil worktree_id count for every worktree: they predate multi-worktree
+  support and must stay blocking)."
+  ([]
+   (current-task nil))
+  ([worktree-id]
+   (t2/select-one :model/RemoteSyncTask
+                  {:where (cond-> [:and
+                                   [:<> :started_at nil]
+                                   [:= :ended_at nil]
+                                   [:<
+                                    (t/minus (t/offset-date-time) (t/millis (setting/get :remote-sync-task-time-limit-ms)))
+                                    :last_progress_report_at]]
+                            worktree-id (conj [:or
+                                               [:= :worktree_id worktree-id]
+                                               [:= :worktree_id nil]]))
+                   :limit 1
+                   :order-by [[:started_at :desc]
+                              [:id :desc]]})))
 
 (defn supersede-stale-tasks!
   "Marks any genuinely stale task rows as cancelled and terminated.
@@ -199,14 +211,18 @@
 (defn most-recent-task
   "Gets the most recently run task, including currently running tasks.
 
-  Returns the most recent RemoteSyncTask (running or completed), or nil if no tasks exist."
-  []
-  (t2/select-one :model/RemoteSyncTask
-                 {:where [:and
-                          [:<> :started_at nil]]
-                  :limit 1
-                  :order-by [[:started_at :desc]
-                             [:id :desc]]}))
+  Returns the most recent RemoteSyncTask (running or completed), or nil if no tasks exist.
+  With `worktree-id`, only considers that worktree's tasks."
+  ([]
+   (most-recent-task nil))
+  ([worktree-id]
+   (t2/select-one :model/RemoteSyncTask
+                  {:where (cond-> [:and
+                                   [:<> :started_at nil]]
+                            worktree-id (conj [:= :worktree_id worktree-id]))
+                   :limit 1
+                   :order-by [[:started_at :desc]
+                              [:id :desc]]})))
 
 (defn last-version
   "Gets the version that any changes are built off of.

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_worktree.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/models/remote_sync_worktree.clj
@@ -64,6 +64,17 @@
     (or (t2/select-one-fn :id :model/RemoteSyncWorktree :branch branch)
         (:id (ensure-default-worktree!)))))
 
+(mu/defn worktree-filter-clause :- [:sequential :any]
+  "HoneySQL clause scoping a worktree_id-tagged table (remote_sync_object, remote_sync_task) to one
+   worktree's rows. With a nil `worktree-id`, scopes to the default worktree — which also owns rows
+   that predate worktrees (nil worktree_id); when no default worktree exists yet, only such rows."
+  [worktree-id :- [:maybe pos-int?]]
+  (if worktree-id
+    [:= :worktree_id worktree-id]
+    (if-let [default-id (default-worktree-id)]
+      [:or [:= :worktree_id default-id] [:= :worktree_id nil]]
+      [:= :worktree_id nil])))
+
 (mu/defn set-base-version! :- :nil
   "Record `version` (a git SHA) as `worktree-id`'s sync base — the commit local changes are built on."
   [worktree-id :- pos-int?
@@ -91,6 +102,22 @@
              :set    {:worktree_id to-id}
              :where  [:= :worktree_id from-id]}))
 
+(mu/defn check-branch-not-checked-out! :- :nil
+  "Throw a 400 when `branch` is materialized as a checkout: a worktree whose collections carry
+   worktree-prefixed entity ids. Making such a branch the default would adopt those prefixed copies as
+   the default sync set, so the worktree must be deleted first. Worktree rows without materialized
+   checkout content (e.g. rows a branch was previously synced as the default under) are harmless."
+  [branch :- :string]
+  (when-let [worktree (t2/select-one :model/RemoteSyncWorktree :branch branch)]
+    (when (t2/exists? :model/Collection
+                      :remote_sync_worktree_id (:id worktree)
+                      :entity_id [:like (str (:id worktree) "/%")])
+      (throw (ex-info (format "Branch '%s' is checked out as a worktree. Delete the worktree before syncing it as the default branch."
+                              branch)
+                      {:status-code 400
+                       :worktree_id (:id worktree)}))))
+  nil)
+
 (mu/defn default-worktree? :- :boolean
   "Is `worktree` the default worktree — the one whose branch the `remote-sync-branch` setting names?"
   [worktree :- [:map [:branch :string]]]
@@ -107,11 +134,6 @@
                           (some-> location collection/location-path->parent-id member?)))
                 (map #(select-keys % [:id :name])))
           members)))
-
-(mu/defn worktree-dirty-rows :- [:sequential :map]
-  "RemoteSyncObject rows of `worktree-id` with local changes not yet pushed (status other than synced)."
-  [worktree-id :- pos-int?]
-  (t2/select :model/RemoteSyncObject :worktree_id worktree-id :status [:not= "synced"]))
 
 (mu/defn delete-worktree! :- :nil
   "Delete `worktree` and the collection trees it materialized. Its RemoteSyncObject rows go with the

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
@@ -253,7 +253,9 @@
               ;; branch writes go through set-default-branch! so the setting and the worktree
               ;; table (default worktree row + content bookkeeping) cannot drift
               (if (and (= k :remote-sync-branch) (some? (k settings)))
-                (remote-sync.worktree/set-default-branch! (k settings))
+                (do
+                  (remote-sync.worktree/check-branch-not-checked-out! (k settings))
+                  (remote-sync.worktree/set-default-branch! (k settings)))
                 (setting/set! k (k settings))))))))))
 
 (defn library-is-remote-synced?

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/spec.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/spec.clj
@@ -19,6 +19,7 @@
    [metabase.collections.core :as collections]
    [metabase.collections.models.collection :as collection]
    [metabase.models.serialization :as serdes]
+   [metabase.remote-sync.core :as oss.remote-sync]
    [metabase.settings.core :as setting]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -698,15 +699,21 @@
    - Transforms-namespace collections (when remote-sync-transforms setting is enabled)
    - Snippets-namespace collections (when Library is remote-synced)
 
-   Used by import cleanup to determine which collections to scope deletions to."
+   Used by import cleanup to determine which collections to scope deletions to. Collections
+   materialized by non-default worktrees are never part of the default sync set — their reconcile is
+   worktree-scoped — so they are excluded here."
   []
-  (into []
-        cat
-        [(t2/select-pks-vec :model/Collection :is_remote_synced true)
-         (when (rs-settings/remote-sync-transforms)
-           (t2/select-pks-vec :model/Collection :namespace (name collections/transforms-ns)))
-         (when (rs-settings/library-is-remote-synced?)
-           (t2/select-pks-vec :model/Collection :namespace "snippets"))]))
+  (let [default-scope (oss.remote-sync/non-default-worktree-filter-clause)]
+    (into []
+          cat
+          [(t2/select-pks-vec :model/Collection
+                              {:where [:and [:= :is_remote_synced true] default-scope]})
+           (when (rs-settings/remote-sync-transforms)
+             (t2/select-pks-vec :model/Collection
+                                {:where [:and [:= :namespace (name collections/transforms-ns)] default-scope]}))
+           (when (rs-settings/library-is-remote-synced?)
+             (t2/select-pks-vec :model/Collection
+                                {:where [:and [:= :namespace "snippets"] default-scope]}))])))
 
 (def ^:private max-conflict-names
   "Cap on how many entity names a collection deletion conflict carries, so the payload stays bounded when
@@ -1162,28 +1169,33 @@
   [{:keys [export-scope]}]
   (case (or export-scope :derived)
     :root-collections
-    ;; Excludes archived collections - their files are handled by the removal logic
-    (concat
-     (t2/select-fn-set (juxt (constantly "Collection") :id)
-                       :model/Collection
-                       {:where [:and
-                                [:= :is_remote_synced true]
-                                [:= :location "/"]
-                                [:not :archived]]})
-     (when (rs-settings/remote-sync-transforms)
+    ;; Excludes archived collections - their files are handled by the removal logic - and non-default
+    ;; worktree checkouts, which export only through their own worktree-scoped push
+    (let [default-scope (oss.remote-sync/non-default-worktree-filter-clause)]
+      (concat
        (t2/select-fn-set (juxt (constantly "Collection") :id)
                          :model/Collection
                          {:where [:and
-                                  [:= :namespace (name collections/transforms-ns)]
+                                  [:= :is_remote_synced true]
                                   [:= :location "/"]
-                                  [:not :archived]]}))
-     (when (rs-settings/library-is-remote-synced?)
-       (t2/select-fn-set (juxt (constantly "Collection") :id)
-                         :model/Collection
-                         {:where [:and
-                                  [:= :namespace "snippets"]
-                                  [:= :location "/"]
-                                  [:not :archived]]})))
+                                  [:not :archived]
+                                  default-scope]})
+       (when (rs-settings/remote-sync-transforms)
+         (t2/select-fn-set (juxt (constantly "Collection") :id)
+                           :model/Collection
+                           {:where [:and
+                                    [:= :namespace (name collections/transforms-ns)]
+                                    [:= :location "/"]
+                                    [:not :archived]
+                                    default-scope]}))
+       (when (rs-settings/library-is-remote-synced?)
+         (t2/select-fn-set (juxt (constantly "Collection") :id)
+                           :model/Collection
+                           {:where [:and
+                                    [:= :namespace "snippets"]
+                                    [:= :location "/"]
+                                    [:not :archived]
+                                    default-scope]}))))
     :derived
     nil))
 

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -1788,7 +1788,8 @@
     changes
     (assoc changes :remote_sync_worktree_id
            (when (:is_remote_synced changes)
-             (or (when-let [parent-id (some-> location location-path->parent-id)]
+             (or remote-sync/*importing-worktree-id*
+                 (when-let [parent-id (some-> location location-path->parent-id)]
                    (t2/select-one-fn :remote_sync_worktree_id :model/Collection :id parent-id))
                  (remote-sync/default-worktree-id))))))
 

--- a/src/metabase/remote_sync/core.clj
+++ b/src/metabase/remote_sync/core.clj
@@ -29,6 +29,11 @@
   []
   true)
 
+(def ^:dynamic *importing-worktree-id*
+  "Bound to a worktree id while a non-default worktree pull loads content, so collection writes made by
+  the load stamp that worktree instead of deriving one from the parent or the default branch setting."
+  nil)
+
 (defenterprise default-worktree-id
   "ID of the default remote sync worktree — the row tracking the branch in the `remote-sync-branch`
   setting — creating it if needed. Nil when remote sync is not configured, and always nil on OSS."


### PR DESCRIPTION
Part 5 of the remote-sync worktrees stack (stacked on #78391; design doc: [WORKTREES.md](https://github.com/metabase/metabase/blob/worktrees/WORKTREES.md)). Non-default worktrees become functional end-to-end, still dark behind `remote-sync-worktrees`.

## Pull (`worktree-pull!`)
Loads the branch snapshot under worktree-local entity ids: `wrap-ingestable` (PR 3) localizes paths/payloads/refs, and a `*importing-worktree-id*` binding makes collection writes stamp the pulling worktree instead of deriving from the default branch setting. Reconciliation is worktree-contained by construction — deletions target rows whose entity id carries the worktree's prefix, so no other worktree's content can be touched — and only that worktree's RSO ledger is rebuilt. Always a full reconcile (incremental/3-way stays default-only for now); never touches the transforms/library settings toggles or data apps.

## Push (`worktree-push!`)
Full export of the worktree's ledger set with entity ids canonicalized (a `*export-entity-transform*` binding in `stage-write`, so git only ever sees canonical ids), committed to the worktree's branch. When the remote advanced past the worktree's `base_version`: `:conflict` unless forced. Pushed deletions clear their ledger rows. `base_version` — dormant since PR 2 — becomes load-bearing for non-default worktrees here.

## Concurrency
Cluster lock, task uniqueness (model before-insert guard), `current-task`, and `ensure-no-active-task!` all scope by worktree: operations on different worktrees run concurrently; same-worktree operations serialize; unscoped legacy paths behave exactly as before (nil-worktree task rows stay blocking for everyone, by design).

## API
`POST /import` and `POST /export` accept `worktree_id` (mutually exclusive with `branch`/`expected_branch` — a worktree has no ambient branch state to CAS-guard); `dirty`/`is-dirty`/`has-remote-changes`/`current-task`(+cancel) take a `worktree-id` query param. The default worktree keeps the legacy no-param forms verbatim, ambient guards intact.

Legacy behavior unchanged — `collections` + `enterprise/remote_sync` green (837 tests). Dedicated worktree-flow tests (incl. the pull→push byte-identical round-trip property) come with the flag-flip PR per the no-new-tests-yet staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)