### PR TITLE
[Worktrees 6/9] Cross-worktree move guard + checkout permissions copy

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -388,6 +388,21 @@
       (t2/delete! model-key {:where (cond-> [:and [:like :entity_id prefix-like]]
                                       (seq kept) (conj [:not-in :entity_id kept]))}))))
 
+(defn- copy-default-worktree-permissions!
+  "Give each of `worktree`'s collections the permission grants of its default-worktree counterpart
+  (matched by canonical entity id), so a checkout is exactly as visible as the content it mirrors —
+  never more. Collections that already have grants (an admin curated them, or an earlier pull copied
+  them) and collections without a counterpart keep what they have (admin-only for fresh ones)."
+  [worktree]
+  (doseq [{:keys [id entity_id]} (t2/select [:model/Collection :id :entity_id]
+                                            :remote_sync_worktree_id (:id worktree))
+          :let  [canonical (worktree-identity/canonical-entity-id entity_id)]
+          :when (not= canonical entity_id)
+          :let  [counterpart (t2/select-one-pk :model/Collection :entity_id canonical)]
+          :when (and counterpart
+                     (not (t2/exists? :model/Permissions :object [:like (str "/collection/" id "/%")])))]
+    (collection/copy-collection-permissions! counterpart [id])))
+
 (defn worktree-pull!
   "Pull `worktree`'s branch into its materialized collection trees: load the snapshot under
   worktree-local entity ids, reconcile the worktree's content and RemoteSyncObject ledger to match it,
@@ -416,6 +431,7 @@
                                  (source.ingestable/cached-file-paths base-ingestable)
                                  :worktree-id (:id worktree))
           (remote-sync.task/set-version! task-id snapshot-version))
+        (copy-default-worktree-permissions! worktree)
         (remote-sync.task/update-progress! task-id 0.95)
         {:status  :success
          :version snapshot-version

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -1806,7 +1806,7 @@
                (as-> $changes (stamp-remote-sync-worktree-id $changes (:location $changes))))
     (assert-valid-remote-synced-parent <>)))
 
-(defn- copy-collection-permissions!
+(defn copy-collection-permissions!
   "Grant read permissions to destination Collections for every Group with read permissions for a source Collection,
   and write perms for every Group with write perms for the source Collection."
   [source-collection-or-id dest-collections-or-ids]
@@ -2005,6 +2005,19 @@
     (check-allowed-content (:type collection) (when-let [location (:location collection)] (location-path->parent-id location)))
     ;; (3.7) Check if it's a semantic-library collection that can't be updated
     (check-library-update collection)
+    ;; (3.8) A collection cannot move between two different remote sync worktrees: the move would
+    ;; silently mean delete-from-one-ledger / create-in-another. Moving into or out of a worktree
+    ;; (from/to unsynced space) stays legal — those are ordinary checkout add/remove events.
+    (when (api/column-will-change? :location collection-before-updates collection-updates)
+      (let [before-worktree-id (:remote_sync_worktree_id collection-before-updates)
+            parent-worktree-id (when-let [parent-id (some-> (:location collection-updates)
+                                                            location-path->parent-id)]
+                                 (t2/select-one-fn :remote_sync_worktree_id :model/Collection :id parent-id))]
+        (when (and before-worktree-id
+                   parent-worktree-id
+                   (not= before-worktree-id parent-worktree-id))
+          (throw (ex-info (tru "Cannot move a collection between remote sync worktrees.")
+                          {:status-code 400})))))
     ;; (4) If we're moving a Collection from a location on a Personal Collection hierarchy to a location not on one,
     ;; or vice versa, we need to grant/revoke permissions as appropriate (see above for more details)
     (when (api/column-will-change? :location collection-before-updates collection-updates)


### PR DESCRIPTION
Part 6 of the remote-sync worktrees stack (stacked on #78392; design doc: [WORKTREES.md](https://github.com/metabase/metabase/blob/worktrees/WORKTREES.md)).

- **Cross-worktree move guard** (collection `before-update`, next to `check-library-update`): a collection cannot move between two different worktrees — the move would silently mean delete-from-one-ledger / create-in-another. Moves into or out of a worktree (from/to unsynced space) stay legal: those are ordinary checkout add/remove events the dirty ledger already models.
- **Permissions copy on pull**: each materialized collection gets the permission grants of its default-worktree counterpart (matched by canonical entity id), so a checkout is exactly as visible as the content it mirrors — never more (no escalation path). Idempotent: already-granted collections are left alone, so admin curation survives re-pulls.

**Deliberately deferred to a follow-up**: search exclusion of worktree content (a `worktree_id` dimension in the per-model search index specs + default filter). The feature is dark behind `remote-sync-worktrees` until the FE PRs land, so nothing can pollute search yet; flagged in the design doc.

Local runs: `collections` module green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)