### PR TITLE
[Worktrees 8/8] Worktrees navbar section + shared pull/push menu

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
@@ -312,6 +312,7 @@
        [:remote-sync-branch {:optional true} [:maybe :string]]
        [:remote-sync-auto-import {:optional true} [:maybe :boolean]]
        [:remote-sync-transforms {:optional true} [:maybe :boolean]]
+       [:remote-sync-worktrees {:optional true} [:maybe :boolean]]
        [:collections {:optional true} [:maybe [:map-of pos-int? :boolean]]]]]
   (api/check-superuser)
   ;; In read-write mode, changing the branch here would flip the setting without reconciling synced

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
@@ -245,7 +245,7 @@
         (when updating-git-settings?
           (check-git-settings! (assoc settings :remote-sync-token token-to-check)))
         (t2/with-transaction [_conn]
-          (doseq [k [:remote-sync-url :remote-sync-token :remote-sync-type :remote-sync-branch :remote-sync-auto-import :remote-sync-transforms]]
+          (doseq [k [:remote-sync-url :remote-sync-token :remote-sync-type :remote-sync-branch :remote-sync-auto-import :remote-sync-transforms :remote-sync-worktrees]]
             (when (and (not= :env (setting/get-raw-value-source k)) (contains? settings k)
                        (not (and (= k :remote-sync-token) obfuscated?)))
               ;; refuse to point the main app at a branch that is checked out as a worktree

--- a/enterprise/frontend/src/metabase-enterprise/api/remote-sync.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/remote-sync.ts
@@ -6,6 +6,9 @@ import type {
   ExportChangesResponse,
   ExportPreflightResponse,
   GetBranchesResponse,
+  GetHasRemoteChangesRequest,
+  GetRemoteSyncHasChangesRequest,
+  GetRemoteSyncTaskRequest,
   HasRemoteChangesResponse,
   ImportFromBranchRequest,
   ImportFromBranchResponse,
@@ -97,17 +100,25 @@ export const remoteSyncApi = EnterpriseApi.injectEndpoints({
         };
       },
     }),
-    getRemoteSyncHasChanges: builder.query<RemoteSyncHasChangesResponse, void>({
-      query: () => ({
+    getRemoteSyncHasChanges: builder.query<
+      RemoteSyncHasChangesResponse,
+      GetRemoteSyncHasChangesRequest
+    >({
+      query: (params) => ({
         url: `/api/ee/remote-sync/is-dirty`,
         method: "GET",
+        params: params ?? undefined,
       }),
       providesTags: () => [tag("collection-is-dirty")],
     }),
-    getHasRemoteChanges: builder.query<HasRemoteChangesResponse, void>({
-      query: () => ({
+    getHasRemoteChanges: builder.query<
+      HasRemoteChangesResponse,
+      GetHasRemoteChangesRequest
+    >({
+      query: (params) => ({
         url: `/api/ee/remote-sync/has-remote-changes`,
         method: "GET",
+        params: params ?? undefined,
       }),
       providesTags: () => [tag("remote-sync-has-remote-changes")],
     }),
@@ -161,10 +172,14 @@ export const remoteSyncApi = EnterpriseApi.injectEndpoints({
         tag("session-properties"),
       ],
     }),
-    getRemoteSyncCurrentTask: builder.query<RemoteSyncTask, void>({
-      query: () => ({
+    getRemoteSyncCurrentTask: builder.query<
+      RemoteSyncTask,
+      GetRemoteSyncTaskRequest
+    >({
+      query: (params) => ({
         method: "GET",
         url: `/api/ee/remote-sync/current-task`,
+        params: params ?? undefined,
       }),
       providesTags: () => [tag("remote-sync-current-task")],
     }),

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/GitSyncOptionsDropdown.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/GitSyncOptionsDropdown.tsx
@@ -1,23 +1,37 @@
 import { t } from "ttag";
 
-import { Box, Combobox, Group, Icon, Loader, Text, Tooltip } from "metabase/ui";
+import {
+  Box,
+  Combobox,
+  Divider,
+  Group,
+  Icon,
+  Loader,
+  Text,
+  Tooltip,
+} from "metabase/ui";
+import type { RemoteSyncWorktreeId } from "metabase-types/api";
 
 export interface GitSyncOptionsDropdownProps {
+  worktreeId?: RemoteSyncWorktreeId;
   isPullDisabled: boolean;
   isPullError: boolean;
   isLoadingPull: boolean;
   isPushDisabled: boolean;
   onPullClick: VoidFunction;
   onPushClick: VoidFunction;
+  onDeleteClick?: VoidFunction;
 }
 
 export const GitSyncOptionsDropdown = ({
+  worktreeId,
   isPullDisabled,
   isPullError,
   isLoadingPull,
   isPushDisabled,
   onPullClick,
   onPushClick,
+  onDeleteClick,
 }: GitSyncOptionsDropdownProps) => {
   if (isPullError) {
     return (
@@ -69,6 +83,18 @@ export const GitSyncOptionsDropdown = ({
             </Group>
           </Combobox.Option>
         </Tooltip>
+
+        {worktreeId !== undefined && (
+          <>
+            <Divider />
+            <Combobox.Option onClick={onDeleteClick} py="sm" value="delete">
+              <Group gap="md" wrap="nowrap">
+                <Icon name="trash" size={12} c="danger" />
+                <Text c="danger">{t`Delete worktree`}</Text>
+              </Group>
+            </Combobox.Option>
+          </>
+        )}
       </Combobox.Options>
     </Combobox.Dropdown>
   );

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/NavbarWorktreesSection/CreateWorktreeModal/CreateWorktreeModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/NavbarWorktreesSection/CreateWorktreeModal/CreateWorktreeModal.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { t } from "ttag";
+
+import {
+  Button,
+  Combobox,
+  Icon,
+  Modal,
+  Stack,
+  Text,
+  useCombobox,
+} from "metabase/ui";
+
+import { BranchDropdown } from "../../GitSyncControls/BranchDropdown";
+
+type CreateWorktreeModalProps = {
+  opened: boolean;
+  isCreating: boolean;
+  onClose: () => void;
+  onCreate: (branch: string) => void;
+};
+
+export function CreateWorktreeModal({
+  opened,
+  isCreating,
+  onClose,
+  onCreate,
+}: CreateWorktreeModalProps) {
+  return (
+    <Modal opened={opened} title={t`Check out a branch`} onClose={onClose}>
+      {opened && (
+        <CreateWorktreeModalBody isCreating={isCreating} onCreate={onCreate} />
+      )}
+    </Modal>
+  );
+}
+
+type CreateWorktreeModalBodyProps = Omit<
+  CreateWorktreeModalProps,
+  "opened" | "onClose"
+>;
+
+function CreateWorktreeModalBody({
+  isCreating,
+  onCreate,
+}: CreateWorktreeModalBodyProps) {
+  const combobox = useCombobox();
+  const [branch, setBranch] = useState("");
+
+  return (
+    <Stack gap="md">
+      <Text c="text-secondary" size="sm">
+        {t`The branch is checked out as a separate collection tree. Pick an existing branch, or type a new name to create one.`}
+      </Text>
+      <Combobox store={combobox} position="bottom-start" withinPortal>
+        <Combobox.Target>
+          <Button
+            variant="default"
+            disabled={isCreating}
+            onClick={() => combobox.toggleDropdown()}
+            leftSection={<Icon name="git_branch" size={14} />}
+            rightSection={<Icon name="chevrondown" size={10} />}
+            styles={{
+              inner: { justifyContent: "flex-start" },
+              label: { marginInlineEnd: "auto" },
+            }}
+          >
+            {branch || t`Select a branch`}
+          </Button>
+        </Combobox.Target>
+        <BranchDropdown
+          combobox={combobox}
+          value={branch}
+          onChange={setBranch}
+        />
+      </Combobox>
+      <Button
+        disabled={branch.length === 0}
+        loading={isCreating}
+        variant="filled"
+        onClick={() => onCreate(branch)}
+      >
+        {t`Check out`}
+      </Button>
+    </Stack>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/NavbarWorktreesSection/CreateWorktreeModal/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/NavbarWorktreesSection/CreateWorktreeModal/index.ts
@@ -1,0 +1,1 @@
+export { CreateWorktreeModal } from "./CreateWorktreeModal";

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/NavbarWorktreesSection/NavbarWorktreesSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/NavbarWorktreesSection/NavbarWorktreesSection.tsx
@@ -15,27 +15,32 @@ import { SidebarCollectionLink } from "metabase/nav/containers/MainNavbar/Sideba
 import type { NavbarWorktreesSectionProps } from "metabase/plugins/oss/remote-sync";
 import { useSelector } from "metabase/redux";
 import { getUserIsAdmin } from "metabase/selectors/user";
-import { ActionIcon, Group, Icon, Menu } from "metabase/ui";
+import { ActionIcon, Combobox, Group, Icon, useCombobox } from "metabase/ui";
 import {
   useCreateWorktreeMutation,
   useDeleteWorktreeMutation,
+  useGetHasRemoteChangesQuery,
+  useGetRemoteSyncHasChangesQuery,
   useListWorktreesQuery,
   usePullWorktreeMutation,
   usePushWorktreeMutation,
 } from "metabase-enterprise/api";
-import type { RemoteSyncWorktree } from "metabase-types/api";
+import type {
+  RemoteSyncWorktree,
+  RemoteSyncWorktreeId,
+} from "metabase-types/api";
 
 import { useGitSyncVisible } from "../../hooks/use-git-sync-visible";
+import { GitSyncOptionsDropdown } from "../GitSyncControls/GitSyncOptionsDropdown";
 
 import { CreateWorktreeModal } from "./CreateWorktreeModal";
 
 const WORKTREE_NODE_PREFIX = "worktree-";
 
 function worktreeTreeNode(worktree: RemoteSyncWorktree): ITreeNodeItem {
-  const pulled = worktree.base_version != null;
   return {
     id: `${WORKTREE_NODE_PREFIX}${worktree.id}`,
-    name: pulled ? worktree.branch : t`${worktree.branch} (not pulled yet)`,
+    name: worktree.branch,
     icon: "git_branch",
     nonNavigable: true,
     children: worktree.roots.map((root) => ({
@@ -46,13 +51,84 @@ function worktreeTreeNode(worktree: RemoteSyncWorktree): ITreeNodeItem {
   };
 }
 
-function worktreeIdOfNode(
-  item: ITreeNodeItem,
-): RemoteSyncWorktree["id"] | null {
+function worktreeIdOfNode(item: ITreeNodeItem): RemoteSyncWorktreeId | null {
   if (typeof item.id === "string" && item.id.startsWith(WORKTREE_NODE_PREFIX)) {
     return Number(item.id.slice(WORKTREE_NODE_PREFIX.length));
   }
   return null;
+}
+
+interface WorktreeMenuProps {
+  worktreeId: RemoteSyncWorktreeId;
+  onPull: (worktreeId: RemoteSyncWorktreeId) => void;
+  onPush: (worktreeId: RemoteSyncWorktreeId) => void;
+  onDelete: (worktreeId: RemoteSyncWorktreeId) => void;
+}
+
+function WorktreeMenu({
+  worktreeId,
+  onPull,
+  onPush,
+  onDelete,
+}: WorktreeMenuProps) {
+  const combobox = useCombobox();
+
+  const { currentData: dirtyData, isFetching: isFetchingDirty } =
+    useGetRemoteSyncHasChangesQuery(
+      { "worktree-id": worktreeId },
+      {
+        refetchOnMountOrArgChange: 10,
+        skip: !combobox.dropdownOpened,
+      },
+    );
+  const {
+    currentData: remoteChangesData,
+    isFetching: isFetchingRemoteChanges,
+    isError: hasRemoteChangesError,
+  } = useGetHasRemoteChangesQuery(
+    { "worktree-id": worktreeId },
+    {
+      refetchOnMountOrArgChange: 10,
+      skip: !combobox.dropdownOpened,
+    },
+  );
+
+  return (
+    <Combobox position="bottom-end" store={combobox} width={280} withinPortal>
+      <Combobox.Target>
+        <ActionIcon
+          aria-label={t`Worktree actions`}
+          size="sm"
+          variant="subtle"
+          onClick={(event) => {
+            event.stopPropagation();
+            combobox.toggleDropdown();
+          }}
+        >
+          <Icon name="ellipsis" />
+        </ActionIcon>
+      </Combobox.Target>
+      <GitSyncOptionsDropdown
+        worktreeId={worktreeId}
+        isPullDisabled={!remoteChangesData?.has_changes}
+        isPullError={hasRemoteChangesError}
+        isLoadingPull={isFetchingRemoteChanges}
+        isPushDisabled={isFetchingDirty || !dirtyData?.is_dirty}
+        onPullClick={() => {
+          combobox.closeDropdown();
+          onPull(worktreeId);
+        }}
+        onPushClick={() => {
+          combobox.closeDropdown();
+          onPush(worktreeId);
+        }}
+        onDeleteClick={() => {
+          combobox.closeDropdown();
+          onDelete(worktreeId);
+        }}
+      />
+    </Combobox>
+  );
 }
 
 export function NavbarWorktreesSection({
@@ -79,12 +155,10 @@ export function NavbarWorktreesSection({
   const [pullWorktree] = usePullWorktreeMutation();
   const [pushWorktree] = usePushWorktreeMutation();
 
-  const worktrees = useMemo(
-    () =>
-      (worktreesData?.items ?? []).filter((worktree) => !worktree.is_default),
+  const treeData = useMemo(
+    () => (worktreesData?.items ?? []).map(worktreeTreeNode),
     [worktreesData],
   );
-  const treeData = useMemo(() => worktrees.map(worktreeTreeNode), [worktrees]);
 
   const notifyError = useCallback(
     (error: unknown, fallback: string) => {
@@ -106,6 +180,33 @@ export function NavbarWorktreesSection({
     [createWorktree, notifyError, pullWorktree],
   );
 
+  const handlePull = useCallback(
+    (worktreeId: RemoteSyncWorktreeId) => {
+      pullWorktree({ worktree_id: worktreeId })
+        .unwrap()
+        .catch((error) => notifyError(error, t`Failed to pull the worktree`));
+    },
+    [notifyError, pullWorktree],
+  );
+
+  const handlePush = useCallback(
+    (worktreeId: RemoteSyncWorktreeId) => {
+      pushWorktree({ worktree_id: worktreeId })
+        .unwrap()
+        .catch((error) => notifyError(error, t`Failed to push the worktree`));
+    },
+    [notifyError, pushWorktree],
+  );
+
+  const handleDelete = useCallback(
+    (worktreeId: RemoteSyncWorktreeId) => {
+      deleteWorktree({ id: worktreeId })
+        .unwrap()
+        .catch((error) => notifyError(error, t`Failed to delete the worktree`));
+    },
+    [deleteWorktree, notifyError],
+  );
+
   const worktreeMenu = useCallback(
     (item?: ITreeNodeItem) => {
       const worktreeId = item ? worktreeIdOfNode(item) : null;
@@ -113,61 +214,15 @@ export function NavbarWorktreesSection({
         return null;
       }
       return (
-        <Menu position="bottom-end">
-          <Menu.Target>
-            <ActionIcon
-              aria-label={t`Worktree actions`}
-              size="sm"
-              variant="subtle"
-              onClick={(event) => event.stopPropagation()}
-            >
-              <Icon name="ellipsis" />
-            </ActionIcon>
-          </Menu.Target>
-          <Menu.Dropdown>
-            <Menu.Item
-              leftSection={<Icon name="download" />}
-              onClick={() =>
-                pullWorktree({ worktree_id: worktreeId })
-                  .unwrap()
-                  .catch((error) =>
-                    notifyError(error, t`Failed to pull the worktree`),
-                  )
-              }
-            >
-              {t`Pull`}
-            </Menu.Item>
-            <Menu.Item
-              leftSection={<Icon name="upload" />}
-              onClick={() =>
-                pushWorktree({ worktree_id: worktreeId })
-                  .unwrap()
-                  .catch((error) =>
-                    notifyError(error, t`Failed to push the worktree`),
-                  )
-              }
-            >
-              {t`Push`}
-            </Menu.Item>
-            <Menu.Divider />
-            <Menu.Item
-              c="danger"
-              leftSection={<Icon name="trash" />}
-              onClick={() =>
-                deleteWorktree({ id: worktreeId })
-                  .unwrap()
-                  .catch((error) =>
-                    notifyError(error, t`Failed to delete the worktree`),
-                  )
-              }
-            >
-              {t`Delete worktree`}
-            </Menu.Item>
-          </Menu.Dropdown>
-        </Menu>
+        <WorktreeMenu
+          worktreeId={worktreeId}
+          onPull={handlePull}
+          onPush={handlePush}
+          onDelete={handleDelete}
+        />
       );
     },
-    [deleteWorktree, notifyError, pullWorktree, pushWorktree],
+    [handleDelete, handlePull, handlePush],
   );
 
   if (!isEnabled || (treeData.length === 0 && !isAdmin)) {

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/NavbarWorktreesSection/NavbarWorktreesSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/NavbarWorktreesSection/NavbarWorktreesSection.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useMemo, useState } from "react";
+import { t } from "ttag";
+
+import ErrorBoundary from "metabase/ErrorBoundary";
+import { CollapseSection } from "metabase/common/components/CollapseSection";
+import { Tree } from "metabase/common/components/tree";
+import type { ITreeNodeItem } from "metabase/common/components/tree/types";
+import { useSetting, useUserSetting } from "metabase/common/hooks";
+import {
+  SidebarHeading,
+  SidebarSection,
+} from "metabase/nav/containers/MainNavbar/MainNavbar.styled";
+import { SidebarCollectionLink } from "metabase/nav/containers/MainNavbar/SidebarItems";
+import type { NavbarWorktreesSectionProps } from "metabase/plugins/oss/remote-sync";
+import { useSelector } from "metabase/redux";
+import { getUserIsAdmin } from "metabase/selectors/user";
+import { ActionIcon, Group, Icon, Menu } from "metabase/ui";
+import {
+  useCreateWorktreeMutation,
+  useDeleteWorktreeMutation,
+  useListWorktreesQuery,
+  usePullWorktreeMutation,
+  usePushWorktreeMutation,
+} from "metabase-enterprise/api";
+import type { RemoteSyncWorktree } from "metabase-types/api";
+
+import { useGitSyncVisible } from "../../hooks/use-git-sync-visible";
+
+import { CreateWorktreeModal } from "./CreateWorktreeModal";
+
+const WORKTREE_NODE_PREFIX = "worktree-";
+
+function worktreeTreeNode(worktree: RemoteSyncWorktree): ITreeNodeItem {
+  const pulled = worktree.base_version != null;
+  return {
+    id: `${WORKTREE_NODE_PREFIX}${worktree.id}`,
+    name: pulled ? worktree.branch : t`${worktree.branch} (not pulled yet)`,
+    icon: "git_branch",
+    nonNavigable: true,
+    children: worktree.roots.map((root) => ({
+      id: root.id,
+      name: root.name,
+      icon: "folder",
+    })),
+  };
+}
+
+function worktreeIdOfNode(
+  item: ITreeNodeItem,
+): RemoteSyncWorktree["id"] | null {
+  if (typeof item.id === "string" && item.id.startsWith(WORKTREE_NODE_PREFIX)) {
+    return Number(item.id.slice(WORKTREE_NODE_PREFIX.length));
+  }
+  return null;
+}
+
+export function NavbarWorktreesSection({
+  selectedId,
+  onItemSelect,
+}: NavbarWorktreesSectionProps) {
+  const isAdmin = useSelector(getUserIsAdmin);
+  const worktreesEnabled = useSetting("remote-sync-worktrees");
+  const { isVisible: isGitSyncVisible } = useGitSyncVisible();
+  const isEnabled = Boolean(isAdmin && worktreesEnabled && isGitSyncVisible);
+
+  const [isExpanded = true, setIsExpanded] = useUserSetting(
+    "expand-worktrees-in-nav",
+  );
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+
+  const { data: worktreesData } = useListWorktreesQuery(undefined, {
+    skip: !isEnabled,
+  });
+  const [createWorktree, { isLoading: isCreating }] =
+    useCreateWorktreeMutation();
+  const [deleteWorktree] = useDeleteWorktreeMutation();
+  const [pullWorktree] = usePullWorktreeMutation();
+  const [pushWorktree] = usePushWorktreeMutation();
+
+  const worktrees = useMemo(
+    () =>
+      (worktreesData?.items ?? []).filter((worktree) => !worktree.is_default),
+    [worktreesData],
+  );
+  const treeData = useMemo(() => worktrees.map(worktreeTreeNode), [worktrees]);
+
+  const handleCreate = useCallback(
+    async (branch: string) => {
+      const worktree = await createWorktree({ branch }).unwrap();
+      setIsCreateModalOpen(false);
+      pullWorktree({ worktree_id: worktree.id });
+    },
+    [createWorktree, pullWorktree],
+  );
+
+  const worktreeMenu = useCallback(
+    (item?: ITreeNodeItem) => {
+      const worktreeId = item ? worktreeIdOfNode(item) : null;
+      if (worktreeId == null) {
+        return null;
+      }
+      return (
+        <Menu position="bottom-end">
+          <Menu.Target>
+            <ActionIcon
+              aria-label={t`Worktree actions`}
+              size="sm"
+              variant="subtle"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <Icon name="ellipsis" />
+            </ActionIcon>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Item
+              leftSection={<Icon name="download" />}
+              onClick={() => pullWorktree({ worktree_id: worktreeId })}
+            >
+              {t`Pull`}
+            </Menu.Item>
+            <Menu.Item
+              leftSection={<Icon name="upload" />}
+              onClick={() => pushWorktree({ worktree_id: worktreeId })}
+            >
+              {t`Push`}
+            </Menu.Item>
+            <Menu.Divider />
+            <Menu.Item
+              c="danger"
+              leftSection={<Icon name="trash" />}
+              onClick={() => deleteWorktree({ id: worktreeId })}
+            >
+              {t`Delete worktree`}
+            </Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      );
+    },
+    [deleteWorktree, pullWorktree, pushWorktree],
+  );
+
+  if (!isEnabled || (treeData.length === 0 && !isAdmin)) {
+    return null;
+  }
+
+  return (
+    <SidebarSection>
+      <ErrorBoundary>
+        <CollapseSection
+          header={
+            <Group gap="xs" justify="space-between" w="100%">
+              <SidebarHeading>{t`Worktrees`}</SidebarHeading>
+              <ActionIcon
+                aria-label={t`Check out a branch`}
+                size="sm"
+                variant="subtle"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setIsCreateModalOpen(true);
+                }}
+              >
+                <Icon name="add" />
+              </ActionIcon>
+            </Group>
+          }
+          initialState={isExpanded ? "expanded" : "collapsed"}
+          iconPosition="right"
+          iconSize={8}
+          role="section"
+          aria-label={t`Worktrees`}
+          onToggle={setIsExpanded}
+        >
+          <Tree
+            data={treeData}
+            selectedId={selectedId}
+            onSelect={onItemSelect}
+            TreeNode={SidebarCollectionLink}
+            role="tree"
+            aria-label="worktrees-tree"
+            rightSection={worktreeMenu}
+          />
+        </CollapseSection>
+        <CreateWorktreeModal
+          opened={isCreateModalOpen}
+          isCreating={isCreating}
+          onClose={() => setIsCreateModalOpen(false)}
+          onCreate={handleCreate}
+        />
+      </ErrorBoundary>
+    </SidebarSection>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/NavbarWorktreesSection/NavbarWorktreesSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/NavbarWorktreesSection/NavbarWorktreesSection.tsx
@@ -2,10 +2,11 @@ import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
+import { getErrorMessage } from "metabase/api/utils";
 import { CollapseSection } from "metabase/common/components/CollapseSection";
 import { Tree } from "metabase/common/components/tree";
 import type { ITreeNodeItem } from "metabase/common/components/tree/types";
-import { useSetting, useUserSetting } from "metabase/common/hooks";
+import { useSetting, useToast, useUserSetting } from "metabase/common/hooks";
 import {
   SidebarHeading,
   SidebarSection,
@@ -67,6 +68,7 @@ export function NavbarWorktreesSection({
     "expand-worktrees-in-nav",
   );
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [sendToast] = useToast();
 
   const { data: worktreesData } = useListWorktreesQuery(undefined, {
     skip: !isEnabled,
@@ -84,13 +86,24 @@ export function NavbarWorktreesSection({
   );
   const treeData = useMemo(() => worktrees.map(worktreeTreeNode), [worktrees]);
 
+  const notifyError = useCallback(
+    (error: unknown, fallback: string) => {
+      sendToast({ message: getErrorMessage(error, fallback), icon: "warning" });
+    },
+    [sendToast],
+  );
+
   const handleCreate = useCallback(
     async (branch: string) => {
-      const worktree = await createWorktree({ branch }).unwrap();
-      setIsCreateModalOpen(false);
-      pullWorktree({ worktree_id: worktree.id });
+      try {
+        const worktree = await createWorktree({ branch }).unwrap();
+        setIsCreateModalOpen(false);
+        await pullWorktree({ worktree_id: worktree.id }).unwrap();
+      } catch (error) {
+        notifyError(error, t`Failed to check out the branch`);
+      }
     },
-    [createWorktree, pullWorktree],
+    [createWorktree, notifyError, pullWorktree],
   );
 
   const worktreeMenu = useCallback(
@@ -114,13 +127,25 @@ export function NavbarWorktreesSection({
           <Menu.Dropdown>
             <Menu.Item
               leftSection={<Icon name="download" />}
-              onClick={() => pullWorktree({ worktree_id: worktreeId })}
+              onClick={() =>
+                pullWorktree({ worktree_id: worktreeId })
+                  .unwrap()
+                  .catch((error) =>
+                    notifyError(error, t`Failed to pull the worktree`),
+                  )
+              }
             >
               {t`Pull`}
             </Menu.Item>
             <Menu.Item
               leftSection={<Icon name="upload" />}
-              onClick={() => pushWorktree({ worktree_id: worktreeId })}
+              onClick={() =>
+                pushWorktree({ worktree_id: worktreeId })
+                  .unwrap()
+                  .catch((error) =>
+                    notifyError(error, t`Failed to push the worktree`),
+                  )
+              }
             >
               {t`Push`}
             </Menu.Item>
@@ -128,7 +153,13 @@ export function NavbarWorktreesSection({
             <Menu.Item
               c="danger"
               leftSection={<Icon name="trash" />}
-              onClick={() => deleteWorktree({ id: worktreeId })}
+              onClick={() =>
+                deleteWorktree({ id: worktreeId })
+                  .unwrap()
+                  .catch((error) =>
+                    notifyError(error, t`Failed to delete the worktree`),
+                  )
+              }
             >
               {t`Delete worktree`}
             </Menu.Item>
@@ -136,7 +167,7 @@ export function NavbarWorktreesSection({
         </Menu>
       );
     },
-    [deleteWorktree, pullWorktree, pushWorktree],
+    [deleteWorktree, notifyError, pullWorktree, pushWorktree],
   );
 
   if (!isEnabled || (treeData.length === 0 && !isAdmin)) {

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/NavbarWorktreesSection/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/NavbarWorktreesSection/index.ts
@@ -1,0 +1,1 @@
+export { NavbarWorktreesSection } from "./NavbarWorktreesSection";

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
@@ -65,6 +65,7 @@ import {
   TRANSFORMS_KEY,
   TYPE_KEY,
   URL_KEY,
+  WORKTREES_KEY,
 } from "../../constants";
 import { SharedTenantCollectionsList } from "../SharedTenantCollectionsList";
 import { SyncConflictModal } from "../SyncConflictModal";
@@ -251,6 +252,7 @@ export const RemoteSyncSettingsForm = (props: RemoteSyncSettingsFormProps) => {
         [BRANCH_KEY]: values[BRANCH_KEY],
         [AUTO_IMPORT_KEY]: values[AUTO_IMPORT_KEY],
         [TRANSFORMS_KEY]: values[TRANSFORMS_KEY],
+        [WORKTREES_KEY]: values[WORKTREES_KEY],
         ...(isReadOnly || !hasCollectionChanges
           ? {}
           : {
@@ -489,16 +491,28 @@ export const RemoteSyncSettingsForm = (props: RemoteSyncSettingsFormProps) => {
                     description={t`Choose which branch to sync with git.`}
                     variant={variant}
                   >
-                    <BranchSwitcher
-                      currentBranch={currentBranch}
-                      dirty={dirtyData?.dirty ?? []}
-                      disabled={settingDetails?.[BRANCH_KEY]?.is_env_setting}
-                      envVarName={
-                        settingDetails?.[BRANCH_KEY]?.is_env_setting
-                          ? settingDetails?.[BRANCH_KEY]?.env_name
-                          : undefined
-                      }
-                    />
+                    <Stack gap="md">
+                      <BranchSwitcher
+                        currentBranch={currentBranch}
+                        dirty={dirtyData?.dirty ?? []}
+                        disabled={settingDetails?.[BRANCH_KEY]?.is_env_setting}
+                        envVarName={
+                          settingDetails?.[BRANCH_KEY]?.is_env_setting
+                            ? settingDetails?.[BRANCH_KEY]?.env_name
+                            : undefined
+                        }
+                      />
+                      <FormSwitch
+                        label={t`Worktrees`}
+                        description={t`Let admins check out other branches as separate collection trees, so people can work on several branches at the same time.`}
+                        name={WORKTREES_KEY}
+                        size="sm"
+                        {...getEnvSettingProps(
+                          settingDetails?.[WORKTREES_KEY],
+                          { disabled: true },
+                        )}
+                      />
+                    </Stack>
                   </RemoteSyncSettingsSection>
                 )}
 

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/constants.ts
@@ -16,6 +16,7 @@ export const BRANCH_KEY = "remote-sync-branch";
 export const REMOTE_SYNC_KEY = "remote-sync-enabled";
 export const AUTO_IMPORT_KEY = "remote-sync-auto-import";
 export const TRANSFORMS_KEY = "remote-sync-transforms";
+export const WORKTREES_KEY = "remote-sync-worktrees";
 export const COLLECTIONS_KEY = "collections";
 // Used in modal variant when library doesn't exist yet but user wants to sync it
 export const SYNC_LIBRARY_PENDING_KEY = "sync-library-pending";
@@ -38,6 +39,7 @@ export const REMOTE_SYNC_SCHEMA = Yup.object({
   [TOKEN_KEY]: Yup.string().nullable().default(null),
   [AUTO_IMPORT_KEY]: Yup.boolean().nullable().default(false),
   [TRANSFORMS_KEY]: Yup.boolean().nullable().default(false),
+  [WORKTREES_KEY]: Yup.boolean().nullable().default(false),
   [TYPE_KEY]: Yup.mixed<RemoteSyncType>()
     .oneOf([...REMOTE_SYNC_TYPES])
     .nullable()

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-sync-status.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/hooks/use-sync-status.tsx
@@ -18,6 +18,7 @@ import {
   getShowModal,
   getTaskOutcome,
   getTaskType,
+  getTaskWorktreeId,
 } from "../selectors";
 import { modalDismissed } from "../sync-task-slice";
 
@@ -38,6 +39,7 @@ export const useSyncStatus = () => {
   const isSuccess = useSelector(getIsSuccess);
   const outcome = useSelector(getTaskOutcome);
   const hasPendingMutation = useSelector(getHasPendingMutation);
+  const taskWorktreeId = useSelector(getTaskWorktreeId);
 
   const minutesSinceLastUpdate = lastProgressReportAt
     ? dayjs().diff(dayjs(lastProgressReportAt), "minute")
@@ -45,11 +47,14 @@ export const useSyncStatus = () => {
 
   const shouldPoll = isRunning && showModal && !hasPendingMutation;
 
-  useGetRemoteSyncCurrentTaskQuery(undefined, {
-    pollingInterval: shouldPoll ? SYNC_STATUS_POLL_INTERVAL : undefined,
-    skipPollingIfUnfocused: true,
-    skip: !isRemoteSyncEnabled || !shouldPoll,
-  });
+  useGetRemoteSyncCurrentTaskQuery(
+    taskWorktreeId != null ? { "worktree-id": taskWorktreeId } : undefined,
+    {
+      pollingInterval: shouldPoll ? SYNC_STATUS_POLL_INTERVAL : undefined,
+      skipPollingIfUnfocused: true,
+      skip: !isRemoteSyncEnabled || !shouldPoll,
+    },
+  );
 
   const progressModal =
     showModal && taskType ? (

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/index.ts
@@ -10,6 +10,7 @@ import { CollectionsNavTree } from "./components/CollectionsNavTree";
 import { GitSettingsModal } from "./components/GitSettingsModal";
 import { GitSyncControls } from "./components/GitSyncControls";
 import { GitSyncSetupMenuItem } from "./components/GitSyncSetupMenuItem";
+import { NavbarWorktreesSection } from "./components/NavbarWorktreesSection";
 import { RemoteSyncAdminSettings } from "./components/RemoteSyncAdminSettings";
 import {
   CollectionSyncStatusBadge,
@@ -39,6 +40,7 @@ export function initializePlugin() {
     PLUGIN_REMOTE_SYNC.GitSettingsModal = GitSettingsModal;
     PLUGIN_REMOTE_SYNC.CollectionsNavTree = CollectionsNavTree;
     PLUGIN_REMOTE_SYNC.CollectionSyncStatusBadge = CollectionSyncStatusBadge;
+    PLUGIN_REMOTE_SYNC.NavbarWorktreesSection = NavbarWorktreesSection;
     PLUGIN_REMOTE_SYNC.REMOTE_SYNC_INVALIDATION_TAGS =
       REMOTE_SYNC_INVALIDATION_TAGS;
     PLUGIN_REMOTE_SYNC.useSyncStatus = useSyncStatus;

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/remote-sync-listener-middleware.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/middleware/remote-sync-listener-middleware.ts
@@ -119,6 +119,44 @@ remoteSyncListenerMiddleware.startListening({
   },
 });
 
+remoteSyncListenerMiddleware.startListening({
+  matcher: remoteSyncApi.endpoints.pullWorktree.matchPending,
+  effect: async (action, { dispatch }) => {
+    dispatch(
+      taskStarted({
+        taskType: "import",
+        worktreeId: action.meta.arg.originalArgs.worktree_id,
+      }),
+    );
+  },
+});
+
+remoteSyncListenerMiddleware.startListening({
+  matcher: remoteSyncApi.endpoints.pullWorktree.matchRejected,
+  effect: async (_action, { dispatch }) => {
+    dispatch(taskCleared());
+  },
+});
+
+remoteSyncListenerMiddleware.startListening({
+  matcher: remoteSyncApi.endpoints.pushWorktree.matchPending,
+  effect: async (action, { dispatch }) => {
+    dispatch(
+      taskStarted({
+        taskType: "export",
+        worktreeId: action.meta.arg.originalArgs.worktree_id,
+      }),
+    );
+  },
+});
+
+remoteSyncListenerMiddleware.startListening({
+  matcher: remoteSyncApi.endpoints.pushWorktree.matchRejected,
+  effect: async (_action, { dispatch }) => {
+    dispatch(taskCleared());
+  },
+});
+
 const terminalTaskStates: RemoteSyncTaskStatus[] = [
   "successful",
   "errored",

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/selectors.ts
@@ -20,6 +20,11 @@ export const getShowModal = createSelector(
   (state) => state.showModal,
 );
 
+export const getTaskWorktreeId = createSelector(
+  getRemoteSyncState,
+  (state) => state.taskWorktreeId,
+);
+
 export const getIsRunning = createSelector(
   getCurrentTask,
   (currentTask) => currentTask !== null && currentTask.ended_at === null,

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/sync-task-slice.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/sync-task-slice.ts
@@ -4,16 +4,19 @@ import type {
   RemoteSyncConflictVariant,
   RemoteSyncTask,
   RemoteSyncTaskType,
+  RemoteSyncWorktreeId,
 } from "metabase-types/api";
 
 export interface SyncTaskState {
   currentTask: RemoteSyncTask | null;
+  taskWorktreeId: RemoteSyncWorktreeId | null;
   showModal: boolean;
   syncConflictVariant: RemoteSyncConflictVariant | null;
 }
 
 export const initialState: SyncTaskState = {
   currentTask: null,
+  taskWorktreeId: null,
   showModal: false,
   syncConflictVariant: null,
 };
@@ -24,8 +27,14 @@ export const remoteSyncSlice = createSlice({
   reducers: {
     taskStarted: (
       state,
-      action: { payload: { taskType: RemoteSyncTaskType } },
+      action: {
+        payload: {
+          taskType: RemoteSyncTaskType;
+          worktreeId?: RemoteSyncWorktreeId;
+        };
+      },
     ) => {
+      state.taskWorktreeId = action.payload.worktreeId ?? null;
       state.currentTask = {
         id: 0,
         sync_task_type: action.payload.taskType,
@@ -56,6 +65,7 @@ export const remoteSyncSlice = createSlice({
     },
     taskCleared: (state) => {
       state.currentTask = null;
+      state.taskWorktreeId = null;
       state.showModal = false;
     },
     syncConflictVariantUpdated: (

--- a/frontend/src/metabase-types/api/remote-sync.ts
+++ b/frontend/src/metabase-types/api/remote-sync.ts
@@ -137,6 +137,7 @@ export type RemoteSyncConfigurationSettings = Pick<
   | "remote-sync-branch"
   | "remote-sync-auto-import"
   | "remote-sync-transforms"
+  | "remote-sync-worktrees"
 > & {
   collections?: CollectionSyncPreferences;
 };

--- a/frontend/src/metabase-types/api/remote-sync.ts
+++ b/frontend/src/metabase-types/api/remote-sync.ts
@@ -213,6 +213,18 @@ export type TestRemoteSyncConnectionResponse = {
 
 export type RemoteSyncWorktreeId = number;
 
+export type GetRemoteSyncHasChangesRequest = {
+  "worktree-id"?: RemoteSyncWorktreeId;
+} | void;
+
+export type GetHasRemoteChangesRequest = {
+  "worktree-id"?: RemoteSyncWorktreeId;
+} | void;
+
+export type GetRemoteSyncTaskRequest = {
+  "worktree-id"?: RemoteSyncWorktreeId;
+} | void;
+
 /** A remote sync worktree: a checked-out branch materialized as collection trees. */
 export type RemoteSyncWorktree = {
   id: RemoteSyncWorktreeId;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -675,6 +675,7 @@ export type UserSettings = {
   "expand-bookmarks-in-nav"?: boolean;
   "expand-collections-in-nav"?: boolean;
   "expand-library-in-nav"?: boolean;
+  "expand-worktrees-in-nav"?: boolean;
   "browse-filter-only-verified-models"?: boolean;
   "browse-filter-only-verified-metrics"?: boolean;
   "show-updated-permission-modal": boolean;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -311,6 +311,13 @@ export function MainNavbarView({
             <PLUGIN_DATA_APPS.MainNavbarSection onItemSelect={onItemSelect} />
           )}
 
+          {PLUGIN_REMOTE_SYNC.NavbarWorktreesSection && (
+            <PLUGIN_REMOTE_SYNC.NavbarWorktreesSection
+              selectedId={collectionItem?.id}
+              onItemSelect={onItemSelect}
+            />
+          )}
+
           <SidebarSection>
             <ErrorBoundary>
               <BrowseNavSection

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -311,12 +311,10 @@ export function MainNavbarView({
             <PLUGIN_DATA_APPS.MainNavbarSection onItemSelect={onItemSelect} />
           )}
 
-          {PLUGIN_REMOTE_SYNC.NavbarWorktreesSection && (
-            <PLUGIN_REMOTE_SYNC.NavbarWorktreesSection
-              selectedId={collectionItem?.id}
-              onItemSelect={onItemSelect}
-            />
-          )}
+          <PLUGIN_REMOTE_SYNC.NavbarWorktreesSection
+            selectedId={collectionItem?.id}
+            onItemSelect={onItemSelect}
+          />
 
           <SidebarSection>
             <ErrorBoundary>

--- a/frontend/src/metabase/plugins/oss/remote-sync.ts
+++ b/frontend/src/metabase/plugins/oss/remote-sync.ts
@@ -75,9 +75,7 @@ const getDefaultPluginRemoteSync = () => ({
   CollectionsNavTree: null as ComponentType<CollectionsNavTreeProps> | null,
   // Unjustified type cast. FIXME
   CollectionSyncStatusBadge: null as ComponentType | null,
-  NavbarWorktreesSection:
-    // widened so EE can install the section component; stays null on OSS
-    null as ComponentType<NavbarWorktreesSectionProps> | null,
+  NavbarWorktreesSection: PluginPlaceholder,
   REMOTE_SYNC_INVALIDATION_TAGS: null,
   useSyncStatus: () => ({
     isIdle: true,
@@ -107,7 +105,7 @@ export const PLUGIN_REMOTE_SYNC: {
   GitSyncSetupMenuItem: ComponentType<GitSyncSetupMenuItemProps>;
   CollectionsNavTree: ComponentType<CollectionsNavTreeProps> | null;
   CollectionSyncStatusBadge: ComponentType | null;
-  NavbarWorktreesSection: ComponentType<NavbarWorktreesSectionProps> | null;
+  NavbarWorktreesSection: ComponentType<NavbarWorktreesSectionProps>;
   REMOTE_SYNC_INVALIDATION_TAGS: TagDescription<string>[] | null;
   useSyncStatus: () => {
     isIdle: boolean;

--- a/frontend/src/metabase/plugins/oss/remote-sync.ts
+++ b/frontend/src/metabase/plugins/oss/remote-sync.ts
@@ -31,6 +31,11 @@ export interface GitSettingsModalProps {
   onClose: () => void;
 }
 
+export type NavbarWorktreesSectionProps = {
+  selectedId?: number | string;
+  onItemSelect: () => void;
+};
+
 export interface RemoteSyncDirtyState {
   /** Array of all dirty entities */
   dirty: RemoteSyncEntity[];
@@ -70,6 +75,9 @@ const getDefaultPluginRemoteSync = () => ({
   CollectionsNavTree: null as ComponentType<CollectionsNavTreeProps> | null,
   // Unjustified type cast. FIXME
   CollectionSyncStatusBadge: null as ComponentType | null,
+  NavbarWorktreesSection:
+    // widened so EE can install the section component; stays null on OSS
+    null as ComponentType<NavbarWorktreesSectionProps> | null,
   REMOTE_SYNC_INVALIDATION_TAGS: null,
   useSyncStatus: () => ({
     isIdle: true,
@@ -99,6 +107,7 @@ export const PLUGIN_REMOTE_SYNC: {
   GitSyncSetupMenuItem: ComponentType<GitSyncSetupMenuItemProps>;
   CollectionsNavTree: ComponentType<CollectionsNavTreeProps> | null;
   CollectionSyncStatusBadge: ComponentType | null;
+  NavbarWorktreesSection: ComponentType<NavbarWorktreesSectionProps> | null;
   REMOTE_SYNC_INVALIDATION_TAGS: TagDescription<string>[] | null;
   useSyncStatus: () => {
     isIdle: boolean;

--- a/src/metabase/users/settings.clj
+++ b/src/metabase/users/settings.clj
@@ -86,6 +86,14 @@
   :type       :boolean
   :default    true)
 
+(defsetting expand-worktrees-in-nav
+  (deferred-tru "User preference for whether the ''Worktrees'' section of the nav is expanded.")
+  :user-local :only
+  :export?    false
+  :visibility :authenticated
+  :type       :boolean
+  :default    true)
+
 (defsetting browse-filter-only-verified-models
   (deferred-tru "User preference for whether the ''Browse models'' page should be filtered to show only verified models.")
   :user-local :only


### PR DESCRIPTION
Part 8 of the remote-sync worktrees stack. Stacked on #78407.

- A "Worktrees" sidebar section (before Data) listing each checkout's branch with its root collections; a plus button opens the checkout modal (BranchDropdown reuse), which creates the worktree and pulls it.
- `GitSyncOptionsDropdown` is now the one menu for both the app-bar git controls and the per-worktree menu: same wording ("Push changes"/"Pull changes"), icons, disabled states and tooltips; a `worktreeId` prop adds the "Delete worktree" option.
- Worktree pulls/pushes surface the existing sync progress modal: the listener middleware tracks `pullWorktree`/`pushWorktree`, and current-task polling carries the worktree scope. Item enablement uses the worktree-scoped is-dirty / has-remote-changes checks.
- `expand-worktrees-in-nav` user setting remembers the section's collapsed state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)