### PR TITLE
[Worktrees 6/8] Cross-worktree move guard + checkout permissions copy

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -106,6 +106,7 @@
            parameters
            queries
            query-processor
+           remote-sync
            search
            settings
            util
@@ -602,12 +603,14 @@
            search
            util}
    :model-exports #{:model/Collection}
-   :model-imports #{:model/Card
+   :model-imports #{:model/Action
+                    :model/Card
                     :model/CollectionBookmark
                     :model/CollectionPermissionGraphRevision
                     :model/Dashboard
                     :model/DashboardCard
                     :model/DashboardCardSeries
+                    :model/DashboardTab
                     :model/Document
                     :model/NativeQuerySnippet
                     :model/Permissions
@@ -724,6 +727,7 @@
            public-sharing
            queries
            query-processor
+           remote-sync
            search
            settings
            staleness
@@ -824,6 +828,7 @@
            queries
            query-permissions
            query-processor
+           remote-sync
            revisions
            search
            util
@@ -1792,6 +1797,7 @@
            pulse
            query-permissions
            query-processor
+           remote-sync
            request
            search
            settings
@@ -2398,6 +2404,7 @@
            collections
            events
            models
+           remote-sync
            util}
    :model-exports #{:model/Timeline}
    :model-imports #{:model/Collection :model/User}}
@@ -3460,6 +3467,7 @@
                     :model/FieldUserSettings
                     :model/Measure
                     :model/NativeQuerySnippet
+                    :model/Permissions
                     :model/PythonLibrary
                     :model/Segment
                     :model/Table

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -391,6 +391,21 @@
     (t2/delete! model-key {:where (cond-> [:and [:= :remote_sync_worktree_id worktree-id]]
                                     (seq kept) (conj [:not-in :entity_id kept]))})))
 
+(defn- copy-main-app-permissions!
+  "Give each of `worktree`'s collections the permission grants of its main-app counterpart (same
+  entity id, NULL worktree reference), so a checkout is exactly as visible as the content it mirrors —
+  never more. Collections that already have grants (an admin curated them, or an earlier pull copied
+  them) and collections without a counterpart keep what they have (admin-only for fresh ones)."
+  [worktree]
+  (doseq [{:keys [id entity_id]} (t2/select [:model/Collection :id :entity_id]
+                                            :remote_sync_worktree_id (:id worktree))
+          :let  [counterpart (t2/select-one-pk :model/Collection
+                                               :entity_id entity_id
+                                               :remote_sync_worktree_id nil)]
+          :when (and counterpart
+                     (not (t2/exists? :model/Permissions :object [:like (str "/collection/" id "/%")])))]
+    (collection/copy-collection-permissions! counterpart [id])))
+
 (defn worktree-pull!
   "Pull `worktree`'s branch into its materialized collection trees: load the snapshot with serdes
   matching and stamping scoped to the worktree (see [[serdes/*worktree-id*]]), reconcile the worktree's
@@ -420,6 +435,7 @@
                                    (source.ingestable/cached-file-paths base-ingestable)
                                    :worktree-id (:id worktree))
             (remote-sync.task/set-version! task-id snapshot-version))
+          (copy-main-app-permissions! worktree)
           (remote-sync.task/update-progress! task-id 0.95)
           {:status  :success
            :version snapshot-version

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/worktree_membership_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/worktree_membership_test.clj
@@ -1,0 +1,69 @@
+(ns metabase-enterprise.remote-sync.worktree-membership-test
+  "remote_sync_worktree_id is derived, never client-supplied: rows inherit it from whatever contains
+   them (item -> collection, dashcard/tab -> dashboard, action -> model card), re-derive it when they
+   move, and follow their collection when the collection itself moves."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.collections.models.collection :as collection]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(defn- worktree-id-of [model id]
+  (t2/select-one-fn :remote_sync_worktree_id model :id id))
+
+(defn- make-worktree-collection!
+  "Tag an existing collection as `worktree-id`'s checkout, bypassing the model hooks that derive the
+   column (a checkout root has no parent to derive from outside a real pull)."
+  [collection-id worktree-id]
+  (t2/query {:update (t2/table-name :model/Collection)
+             :set    {:remote_sync_worktree_id worktree-id}
+             :where  [:= :id collection-id]}))
+
+(deftest items-inherit-collection-worktree-test
+  (mt/with-temp [:model/RemoteSyncWorktree {wt :id}        {:branch "wt-membership-branch"}
+                 :model/Collection         {main-coll :id} {:is_remote_synced true}
+                 :model/Collection         {wt-coll :id}   {:is_remote_synced true}]
+    (mt/id) ; force test-db setup so with-temp Card defaults reference a real database
+    (make-worktree-collection! wt-coll wt)
+    (testing "items created in a worktree collection inherit its worktree"
+      (mt/with-temp [:model/Card          {card :id}     {:collection_id wt-coll :type :model}
+                     :model/Dashboard     {dash :id}     {:collection_id wt-coll}
+                     :model/DashboardCard {dashcard :id} {:dashboard_id dash :card_id card}
+                     :model/DashboardTab  {tab :id}      {:dashboard_id dash}
+                     :model/Action        {action :id}   {:name "wt action" :model_id card :type :query}]
+        (is (= wt (worktree-id-of :model/Card card)))
+        (is (= wt (worktree-id-of :model/Dashboard dash)))
+        (is (= wt (worktree-id-of :model/DashboardCard dashcard)))
+        (is (= wt (worktree-id-of :model/DashboardTab tab)))
+        (is (= wt (worktree-id-of :model/Action action)))
+        (testing "moving an item to a main-app collection clears it, moving back restores it"
+          (t2/update! :model/Card card {:collection_id main-coll})
+          (is (nil? (worktree-id-of :model/Card card)))
+          (t2/update! :model/Card card {:collection_id wt-coll})
+          (is (= wt (worktree-id-of :model/Card card))))))
+    (testing "items created in a main-app collection have no worktree"
+      (mt/with-temp [:model/Card {card :id} {:collection_id main-coll}]
+        (is (nil? (worktree-id-of :model/Card card)))))))
+
+(deftest collection-move-cascades-worktree-test
+  (mt/with-temp [:model/RemoteSyncWorktree {wt :id}      {:branch "wt-cascade-branch"}
+                 :model/Collection         {wt-root :id} {:is_remote_synced true}
+                 :model/Collection         {plain :id}   {}]
+    (mt/id) ; force test-db setup so with-temp Card defaults reference a real database
+    (make-worktree-collection! wt-root wt)
+    (mt/with-temp [:model/Collection {child :id}         {:location (format "/%d/" plain)}
+                   :model/Card       {card-in-plain :id} {:collection_id plain}
+                   :model/Card       {card-in-child :id} {:collection_id child}]
+      (testing "moving a collection into a checkout stamps its subtree and all contents"
+        (collection/move-collection! (t2/select-one :model/Collection :id plain)
+                                     (format "/%d/" wt-root))
+        (is (= wt (worktree-id-of :model/Collection plain)))
+        (is (= wt (worktree-id-of :model/Collection child)))
+        (is (= wt (worktree-id-of :model/Card card-in-plain)))
+        (is (= wt (worktree-id-of :model/Card card-in-child))))
+      (testing "moving it back out clears the whole subtree"
+        (collection/move-collection! (t2/select-one :model/Collection :id plain) "/")
+        (is (nil? (worktree-id-of :model/Collection plain)))
+        (is (nil? (worktree-id-of :model/Collection child)))
+        (is (nil? (worktree-id-of :model/Card card-in-plain)))
+        (is (nil? (worktree-id-of :model/Card card-in-child)))))))

--- a/src/metabase/actions/models.clj
+++ b/src/metabase/actions/models.clj
@@ -8,6 +8,7 @@
    [metabase.models.serialization :as serdes]
    [metabase.parameters.core :as parameters]
    [metabase.queries.models.query :as query]
+   [metabase.remote-sync.core :as remote-sync]
    [metabase.search.core :as search]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
@@ -89,12 +90,12 @@
 
 (t2/define-before-insert :model/Action
   [{model-id :model_id, :as action}]
-  (u/prog1 action
+  (u/prog1 (remote-sync/set-worktree-id-before-insert action :model/Card :model_id)
     (check-model-is-not-a-saved-question model-id)))
 
 (t2/define-before-update :model/Action
   [{archived? :archived, id :id, model-id :model_id, :as changes}]
-  (u/prog1 changes
+  (u/prog1 (remote-sync/set-worktree-id-before-update changes :model/Card :model_id)
     (if archived?
       (t2/delete! :model/DashboardCard :action_id id)
       (check-model-is-not-a-saved-question model-id))))
@@ -108,7 +109,7 @@
 (def ^:private action-columns
   "The columns that are common to all Action types."
   [:archived :created_at :creator_id :description :entity_id :made_public_by_id :model_id :name :parameter_mappings
-   :parameters :public_uuid :type :updated_at :visualization_settings])
+   :parameters :public_uuid :remote_sync_worktree_id :type :updated_at :visualization_settings])
 
 (mu/defn- type->model
   "Returns the model from an action type.

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -1665,7 +1665,6 @@
                                   (t2/select-one :model/Collection :id new-parent-id)
                                   root-collection)
         new-parent-is-remote-synced? (:is_remote_synced new-parent)
-        new-parent-worktree-id  (:remote_sync_worktree_id new-parent)
         new-location            (children-location new-parent)
         orig-children-location  (children-location collection)
         new-children-location   (children-location (assoc collection :location new-location))
@@ -1695,7 +1694,6 @@
        {:update :collection
         :set    {:location             [:replace :location orig-children-location new-children-location]
                  :is_remote_synced (boolean new-parent-is-remote-synced?)
-                 :remote_sync_worktree_id new-parent-worktree-id
                  :archive_operation_id nil
                  :archived_directly    nil
                  :archived             false}
@@ -1735,8 +1733,7 @@
         new-parent (when-let [parent-id (parent-id* {:location new-location})]
                      (t2/select-one [:model/Collection :is_remote_synced :remote_sync_worktree_id]
                                     :id parent-id))
-        will-be-in-remote-synced? (:is_remote_synced new-parent)
-        new-worktree-id (:remote_sync_worktree_id new-parent)]
+        will-be-in-remote-synced? (:is_remote_synced new-parent)]
     (when will-be-in-trash?
       (throw (ex-info "Cannot `move-collection!` into the Trash. Call `archive-collection!` instead."
                       {:collection collection
@@ -1755,8 +1752,7 @@
       (u/prog1 (t2/query-one
                 {:update :collection
                  :set {:location [:replace :location orig-children-location new-children-location]
-                       :is_remote_synced (boolean will-be-in-remote-synced?)
-                       :remote_sync_worktree_id new-worktree-id}
+                       :is_remote_synced (boolean will-be-in-remote-synced?)}
                  :where [:like :location (str orig-children-location "%")]})
         (when into-remote-synced?
           (check-non-remote-synced-dependencies collection))
@@ -1774,6 +1770,52 @@
     (when-let [user-id (:personal_owner_id collection)]
       (when (= :api-key (t2/select-one-fn :type :model/User user-id))
         (throw (ex-info "Can't create a personal collection for an API key" {:user user-id}))))))
+
+(defn- cascade-worktree-id!
+  "Point `collection`'s descendant collections and the contents of its whole subtree — cards,
+  dashboards (plus their dashcards, tabs, and actions), documents, snippets, and timelines — at
+  `worktree-id`. Called from the collection's own before-update when it moves under a new parent (pass
+  the collection with its pre-move location: descendants still hold the old paths at that point); rows
+  follow their collection's remote-sync worktree membership, and the bulk subtree location rewrites
+  bypass the per-model hooks that normally derive it. The moved row itself is stamped by the update
+  that triggers this."
+  [collection worktree-id]
+  (let [descendant-ids (t2/select-pks-vec :model/Collection
+                                          {:where [:like :location (str (children-location collection) "%")]})
+        subtree-ids    (cons (u/the-id collection) descendant-ids)]
+    (when (seq descendant-ids)
+      (t2/update! :model/Collection
+                  {:id [:in descendant-ids]}
+                  {:remote_sync_worktree_id worktree-id}))
+    (doseq [model [:model/Card :model/Dashboard :model/Document :model/NativeQuerySnippet :model/Timeline]]
+      (t2/update! model
+                  {:collection_id [:in subtree-ids]}
+                  {:remote_sync_worktree_id worktree-id}))
+    (doseq [model [:model/DashboardCard :model/DashboardTab]]
+      (t2/update! model
+                  {:dashboard_id [:in {:select [:id]
+                                       :from   [:report_dashboard]
+                                       :where  [:in :collection_id subtree-ids]}]}
+                  {:remote_sync_worktree_id worktree-id}))
+    (t2/update! :model/Action
+                {:model_id [:in {:select [:id]
+                                 :from   [:report_card]
+                                 :where  [:in :collection_id subtree-ids]}]}
+                {:remote_sync_worktree_id worktree-id})))
+
+(defn- cascade-worktree-id-on-move!
+  "When an update moves `collection-before-updates` under a new parent, re-derive the subtree's
+  remote-sync worktree membership from that parent and return `changes` with the moved row's own
+  membership stamped. Trash moves are left alone: archived checkout content keeps its membership so
+  deleting the worktree still sweeps it."
+  [changes collection-before-updates]
+  (if-not (and (api/column-will-change? :location collection-before-updates changes)
+               (not (str/starts-with? (:location changes) (trash-path))))
+    changes
+    (let [worktree-id (some->> (location-path->parent-id (:location changes))
+                               (t2/select-one-fn :remote_sync_worktree_id :model/Collection :id))]
+      (cascade-worktree-id! collection-before-updates worktree-id)
+      (assoc changes :remote_sync_worktree_id worktree-id))))
 
 (defn- stamp-remote-sync-worktree-id
   "When `changes` writes `:is_remote_synced`, also write `:remote_sync_worktree_id`: the worktree being
@@ -2029,7 +2071,8 @@
                    collection-name (assoc :slug (slugify collection-name)))
                  (as-> $changes (stamp-remote-sync-worktree-id
                                  $changes
-                                 (or (:location $changes) (:location collection-before-updates)))))
+                                 (or (:location $changes) (:location collection-before-updates))))
+                 (cascade-worktree-id-on-move! collection-before-updates))
       (when-not *clearing-remote-sync*
         (assert-valid-remote-synced-parent (merge collection-before-updates <>))))))
 

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -1802,7 +1802,7 @@
                (as-> $changes (stamp-remote-sync-worktree-id $changes (:location $changes))))
     (assert-valid-remote-synced-parent <>)))
 
-(defn- copy-collection-permissions!
+(defn copy-collection-permissions!
   "Grant read permissions to destination Collections for every Group with read permissions for a source Collection,
   and write perms for every Group with write perms for the source Collection."
   [source-collection-or-id dest-collections-or-ids]
@@ -2001,6 +2001,19 @@
     (check-allowed-content (:type collection) (when-let [location (:location collection)] (location-path->parent-id location)))
     ;; (3.7) Check if it's a semantic-library collection that can't be updated
     (check-library-update collection)
+    ;; (3.8) A collection cannot move between two different remote sync worktrees: the move would
+    ;; silently mean delete-from-one-ledger / create-in-another. Moving into or out of a worktree
+    ;; (from/to unsynced space) stays legal — those are ordinary checkout add/remove events.
+    (when (api/column-will-change? :location collection-before-updates collection-updates)
+      (let [before-worktree-id (:remote_sync_worktree_id collection-before-updates)
+            parent-worktree-id (when-let [parent-id (some-> (:location collection-updates)
+                                                            location-path->parent-id)]
+                                 (t2/select-one-fn :remote_sync_worktree_id :model/Collection :id parent-id))]
+        (when (and before-worktree-id
+                   parent-worktree-id
+                   (not= before-worktree-id parent-worktree-id))
+          (throw (ex-info (tru "Cannot move a collection between remote sync worktrees.")
+                          {:status-code 400})))))
     ;; (4) If we're moving a Collection from a location on a Personal Collection hierarchy to a location not on one,
     ;; or vice versa, we need to grant/revoke permissions as appropriate (see above for more details)
     (when (api/column-will-change? :location collection-before-updates collection-updates)

--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -23,6 +23,7 @@
    [metabase.public-sharing.core :as public-sharing]
    [metabase.queries.core :as queries]
    [metabase.query-processor.metadata :as qp.metadata]
+   [metabase.remote-sync.core :as remote-sync]
    [metabase.search.core :as search]
    [metabase.settings.core :as setting]
    [metabase.staleness.core :as staleness]
@@ -80,7 +81,7 @@
   [dashboard]
   (let [defaults  {:parameters []}
         dashboard (lib/normalize ::dashboards.schema/dashboard (merge defaults dashboard))]
-    (u/prog1 dashboard
+    (u/prog1 (remote-sync/set-worktree-id-before-insert dashboard :model/Collection :collection_id)
       (collection/check-allowed-content :model/Dashboard (:collection_id dashboard))
       (params/assert-valid-parameters dashboard)
       (collection/check-collection-namespace :model/Dashboard (:collection_id dashboard)))))
@@ -96,7 +97,9 @@
         dashboard (lib/normalize ::dashboards.schema/dashboard dashboard)
         changes   (lib/normalize ::dashboards.schema/dashboard changes)]
     (collection/check-allowed-content :model/Dashboard (:collection_id changes))
-    (u/prog1 (maybe-populate-initially-published-at dashboard)
+    (u/prog1 (-> dashboard
+                 maybe-populate-initially-published-at
+                 (remote-sync/set-worktree-id-before-update :model/Collection :collection_id))
       (params/assert-valid-parameters dashboard)
       (when (:parameters changes)
         (queries/upsert-or-delete-parameter-cards-from-parameters! "dashboard" (:id dashboard) (:parameters dashboard)))

--- a/src/metabase/dashboards/models/dashboard_card.clj
+++ b/src/metabase/dashboards/models/dashboard_card.clj
@@ -6,6 +6,7 @@
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
    [metabase.parameters.core :as parameters]
+   [metabase.remote-sync.core :as remote-sync]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.malli :as mu]
@@ -31,10 +32,15 @@
 
 (t2/define-before-insert :model/DashboardCard
   [dashcard]
-  (merge {:parameter_mappings     []
-          :visualization_settings {}
-          :inline_parameters      []}
-         dashcard))
+  (-> (merge {:parameter_mappings     []
+              :visualization_settings {}
+              :inline_parameters      []}
+             dashcard)
+      (remote-sync/set-worktree-id-before-insert :model/Dashboard :dashboard_id)))
+
+(t2/define-before-update :model/DashboardCard
+  [dashcard]
+  (remote-sync/set-worktree-id-before-update dashcard :model/Dashboard :dashboard_id))
 
 ;;; Update visualizer dashboard cards in stats to have card id references instead of entity ids
 (t2/define-after-select :model/DashboardCard

--- a/src/metabase/dashboards/models/dashboard_tab.clj
+++ b/src/metabase/dashboards/models/dashboard_tab.clj
@@ -4,6 +4,7 @@
    [metabase.dashboards.models.dashboard-card :as dashboard-card]
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
+   [metabase.remote-sync.core :as remote-sync]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -19,6 +20,14 @@
   (derive ::mi/write-policy.full-perms-for-perms-set)
   (derive :hook/timestamped?)
   (derive :hook/entity-id))
+
+(t2/define-before-insert :model/DashboardTab
+  [tab]
+  (remote-sync/set-worktree-id-before-insert tab :model/Dashboard :dashboard_id))
+
+(t2/define-before-update :model/DashboardTab
+  [tab]
+  (remote-sync/set-worktree-id-before-update tab :model/Dashboard :dashboard_id))
 
 (methodical/defmethod t2/model-for-automagic-hydration [:metabase.dashboards.models.dashboard-card/DashboardCard :dashboard_tab]
   [_original-model _k]

--- a/src/metabase/documents/models/document.clj
+++ b/src/metabase/documents/models/document.clj
@@ -8,6 +8,7 @@
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
    [metabase.public-sharing.core :as public-sharing]
+   [metabase.remote-sync.core :as remote-sync]
    [metabase.search.config :as search.config]
    [metabase.search.spec :as search.spec]
    [metabase.util :as u]
@@ -288,8 +289,8 @@
 
 (t2/define-before-insert :model/Document [model]
   (collection/check-allowed-content :model/Document (:collection_id model))
-  model)
+  (remote-sync/set-worktree-id-before-insert model :model/Collection :collection_id))
 
 (t2/define-before-update :model/Document [model]
   (collection/check-allowed-content :model/Document (:collection_id (t2/changes model)))
-  model)
+  (remote-sync/set-worktree-id-before-update model :model/Collection :collection_id))

--- a/src/metabase/native_query_snippets/models/native_query_snippet.clj
+++ b/src/metabase/native_query_snippets/models/native_query_snippet.clj
@@ -81,7 +81,9 @@
          (assoc snippet :template_tags))))
 
 (t2/define-before-insert :model/NativeQuerySnippet [snippet]
-  (u/prog1 (add-template-tags snippet)
+  (u/prog1 (-> snippet
+               add-template-tags
+               (remote-sync/set-worktree-id-before-insert :model/Collection :collection_id))
     (collection/check-allowed-content :model/NativeQuerySnippet (:collection_id snippet))
     (collection/check-collection-namespace :model/NativeQuerySnippet (:collection_id snippet))))
 
@@ -93,8 +95,9 @@
 (t2/define-before-update :model/NativeQuerySnippet
   [snippet]
   (collection/check-allowed-content :model/NativeQuerySnippet (:collection_id (t2/changes snippet)))
-  (u/prog1 (cond-> snippet
-             (:content snippet) add-template-tags)
+  (u/prog1 (-> (cond-> snippet
+                 (:content snippet) add-template-tags)
+               (remote-sync/set-worktree-id-before-update :model/Collection :collection_id))
     ;; throw an Exception if someone tries to update creator_id
     (when (contains? (t2/changes <>) :creator_id)
       (throw (UnsupportedOperationException. (tru "You cannot update the creator_id of a NativeQuerySnippet."))))

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -40,6 +40,7 @@
    [metabase.queries.models.query :as query]
    [metabase.queries.schema :as queries.schema]
    [metabase.query-permissions.core :as query-perms]
+   [metabase.remote-sync.core :as remote-sync]
    [metabase.search.core :as search]
    [metabase.settings.core :as setting]
    [metabase.staleness.core :as staleness]
@@ -821,7 +822,8 @@
         (u/assoc-default :entity_id (u/generate-nano-id))
         card.metadata/populate-result-metadata
         pre-insert
-        populate-query-fields)
+        populate-query-fields
+        (remote-sync/set-worktree-id-before-insert :model/Collection :collection_id))
     (collection/check-allowed-content (:type <>) (:collection_id <>))))
 
 (t2/define-after-insert :model/Card
@@ -881,7 +883,8 @@
         (populate-query-fields (contains? changes :dataset_query))
         (clear-metabot-origin changes)
         (pre-update changes)
-        maybe-populate-initially-published-at)))
+        maybe-populate-initially-published-at
+        (remote-sync/set-worktree-id-before-update :model/Collection :collection_id))))
 
 ;; Cards don't normally get deleted (they get archived instead) so this mostly affects tests
 (t2/define-before-delete :model/Card

--- a/src/metabase/remote_sync/core.clj
+++ b/src/metabase/remote_sync/core.clj
@@ -37,6 +37,24 @@
   ([column]
    [:= column nil]))
 
+(defn set-worktree-id-before-insert
+  "Derive a row's `:remote_sync_worktree_id` from its parent entity (`parent-key` on the row, a
+  `parent-model` id): rows belong to the remote-sync worktree of whatever contains them, and nil — no
+  parent, or a main-app parent — is the main app, which is not a worktree. The column is derived, never
+  client-supplied. Call from a model's `before-insert`."
+  [instance parent-model parent-key]
+  (assoc instance :remote_sync_worktree_id
+         (when-let [parent-id (get instance parent-key)]
+           (t2/select-one-fn :remote_sync_worktree_id parent-model :id parent-id))))
+
+(defn set-worktree-id-before-update
+  "Re-derive a row's `:remote_sync_worktree_id` when an update moves it to a different parent
+  (`parent-key` present in the update's changes). Call from a model's `before-update`."
+  [instance parent-model parent-key]
+  (if (contains? (t2/changes instance) parent-key)
+    (set-worktree-id-before-insert instance parent-model parent-key)
+    instance))
+
 (defenterprise model-editable?
   "Determines if a model instance is editable based on remote sync configuration.
 

--- a/src/metabase/timeline/models/timeline.clj
+++ b/src/metabase/timeline/models/timeline.clj
@@ -3,6 +3,7 @@
    [metabase.collections.models.collection :as collection]
    [metabase.collections.models.collection.root :as collection.root]
    [metabase.models.serialization :as serdes]
+   [metabase.remote-sync.core :as remote-sync]
    [metabase.timeline.models.timeline-event :as timeline-event]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
@@ -26,11 +27,11 @@
 
 (t2/define-before-insert :model/Timeline [model]
   (collection/check-allowed-content :model/Timeline (:collection_id model))
-  model)
+  (remote-sync/set-worktree-id-before-insert model :model/Collection :collection_id))
 
 (t2/define-before-update :model/Timeline [model]
   (collection/check-allowed-content :model/Timeline (:collection_id (t2/changes model)))
-  model)
+  (remote-sync/set-worktree-id-before-update model :model/Collection :collection_id))
 
 ;;;; functions
 


### PR DESCRIPTION
Part 6 of the remote-sync worktrees stack. Stacked on #78405.

- A collection cannot move between two different worktrees (that would silently mean delete-from-one-ledger / create-in-another); moving into or out of a worktree from unsynced space stays legal.
- After a pull, each worktree collection with no grants yet copies the permissions of its main-app counterpart (same entity id, NULL worktree reference), so a checkout is exactly as visible as the content it mirrors — never more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)