### PR TITLE
[Worktrees 7/8] FE plumbing: types + RTK endpoints

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/api/remote-sync.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/remote-sync.ts
@@ -1,5 +1,7 @@
 import type {
   CreateBranchRequest,
+  CreateWorktreeRequest,
+  DeleteWorktreeRequest,
   ExportChangesRequest,
   ExportChangesResponse,
   ExportPreflightResponse,
@@ -7,10 +9,14 @@ import type {
   HasRemoteChangesResponse,
   ImportFromBranchRequest,
   ImportFromBranchResponse,
+  ListWorktreesResponse,
+  PullWorktreeRequest,
+  PushWorktreeRequest,
   RemoteSyncChangesResponse,
   RemoteSyncConfigurationSettings,
   RemoteSyncHasChangesResponse,
   RemoteSyncTask,
+  RemoteSyncWorktree,
   StashChangesRequest,
   StashChangesResponse,
   TestRemoteSyncConnectionRequest,
@@ -179,6 +185,59 @@ export const remoteSyncApi = EnterpriseApi.injectEndpoints({
         body,
       }),
     }),
+    listWorktrees: builder.query<ListWorktreesResponse, void>({
+      query: () => ({
+        method: "GET",
+        url: `/api/ee/remote-sync/worktrees`,
+      }),
+      providesTags: () => [listTag("remote-sync-worktree")],
+    }),
+    createWorktree: builder.mutation<RemoteSyncWorktree, CreateWorktreeRequest>(
+      {
+        query: (body) => ({
+          method: "POST",
+          url: `/api/ee/remote-sync/worktrees`,
+          body,
+        }),
+        invalidatesTags: () => [
+          listTag("remote-sync-worktree"),
+          tag("remote-sync-branches"),
+        ],
+      },
+    ),
+    deleteWorktree: builder.mutation<void, DeleteWorktreeRequest>({
+      query: ({ id, force }) => ({
+        method: "DELETE",
+        url: `/api/ee/remote-sync/worktrees/${id}`,
+        body: { force },
+      }),
+      invalidatesTags: () => [
+        listTag("remote-sync-worktree"),
+        listTag("collection"),
+      ],
+    }),
+    pullWorktree: builder.mutation<
+      ImportFromBranchResponse,
+      PullWorktreeRequest
+    >({
+      query: (body) => ({
+        method: "POST",
+        url: `/api/ee/remote-sync/import`,
+        body,
+      }),
+      invalidatesTags: () => [
+        listTag("remote-sync-worktree"),
+        listTag("collection"),
+      ],
+    }),
+    pushWorktree: builder.mutation<ExportChangesResponse, PushWorktreeRequest>({
+      query: (body) => ({
+        method: "POST",
+        url: `/api/ee/remote-sync/export`,
+        body,
+      }),
+      invalidatesTags: () => [listTag("remote-sync-worktree")],
+    }),
   }),
 });
 
@@ -197,4 +256,9 @@ export const {
   useGetRemoteSyncCurrentTaskQuery,
   useCancelRemoteSyncCurrentTaskMutation,
   useTestRemoteSyncConnectionMutation,
+  useListWorktreesQuery,
+  useCreateWorktreeMutation,
+  useDeleteWorktreeMutation,
+  usePullWorktreeMutation,
+  usePushWorktreeMutation,
 } = remoteSyncApi;

--- a/enterprise/frontend/src/metabase-enterprise/api/remote-sync.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/remote-sync.ts
@@ -209,7 +209,8 @@ export const remoteSyncApi = EnterpriseApi.injectEndpoints({
       query: ({ id, force }) => ({
         method: "DELETE",
         url: `/api/ee/remote-sync/worktrees/${id}`,
-        body: { force },
+        // the endpoint reads force from query params; DELETE bodies are not bound
+        params: force ? { force } : undefined,
       }),
       invalidatesTags: () => [
         listTag("remote-sync-worktree"),

--- a/enterprise/frontend/src/metabase-enterprise/api/tags.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/tags.ts
@@ -41,6 +41,7 @@ export const ENTERPRISE_TAG_TYPES = [
   "remote-sync-branches",
   "remote-sync-current-task",
   "remote-sync-has-remote-changes",
+  "remote-sync-worktree",
   "source-replacement-run",
   "python-transform-library",
   "support-access-grant",

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -68,6 +68,8 @@ export interface Collection {
   authority_level?: CollectionAuthorityLevel;
   type?: CollectionType;
   is_remote_synced?: boolean;
+  /** Remote sync worktree this collection was materialized by; null/absent outside remote sync. */
+  remote_sync_worktree_id?: number | null;
   namespace: CollectionNamespace | null;
 
   parent_id?: CollectionId | null;
@@ -143,6 +145,7 @@ export interface CollectionItem {
   is_shared_tenant_collection?: boolean;
   is_tenant_dashboard?: boolean;
   is_remote_synced?: boolean;
+  remote_sync_worktree_id?: number | null;
 }
 
 export interface CollectionListQuery {
@@ -215,6 +218,7 @@ export interface ListCollectionsTreeRequest {
   "exclude-archived"?: boolean;
   "exclude-other-user-collections"?: boolean;
   "include-library"?: boolean;
+  "include-worktrees"?: boolean;
   namespace?: CollectionNamespace;
   namespaces?: string[];
   shallow?: boolean;

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -68,7 +68,7 @@ export interface Collection {
   authority_level?: CollectionAuthorityLevel;
   type?: CollectionType;
   is_remote_synced?: boolean;
-  /** Remote sync worktree this collection was materialized by; null/absent outside remote sync. */
+  /** Remote sync worktree this collection was materialized by; null/absent for main-app content. */
   remote_sync_worktree_id?: number | null;
   namespace: CollectionNamespace | null;
 

--- a/frontend/src/metabase-types/api/remote-sync.ts
+++ b/frontend/src/metabase-types/api/remote-sync.ts
@@ -209,3 +209,52 @@ export type TestRemoteSyncConnectionRequest = {
 export type TestRemoteSyncConnectionResponse = {
   status: "success";
 };
+
+export type RemoteSyncWorktreeId = number;
+
+/** A remote sync worktree: a checked-out branch materialized as collection trees. */
+export type RemoteSyncWorktree = {
+  id: RemoteSyncWorktreeId;
+  branch: string;
+  /** Last synced git SHA; null until the first successful pull. */
+  base_version: string | null;
+  /** Whether this is the default worktree (its branch matches the remote-sync-branch setting). */
+  is_default: boolean;
+  roots: RemoteSyncWorktreeRoot[];
+  creator_id: UserId | null;
+  created_at: string;
+};
+
+export type RemoteSyncWorktreeRoot = {
+  id: number;
+  name: string;
+};
+
+export type ListWorktreesResponse = {
+  items: RemoteSyncWorktree[];
+};
+
+export type CreateWorktreeRequest = {
+  branch: string;
+  /** Fork the branch from this one server-side when it does not exist on the remote yet. */
+  from_branch?: string;
+};
+
+export type DeleteWorktreeRequest = {
+  id: RemoteSyncWorktreeId;
+  /** Delete even when the worktree has unpushed local changes. */
+  force?: boolean;
+};
+
+export type PullWorktreeRequest = {
+  worktree_id: RemoteSyncWorktreeId;
+  /** Discard unpushed local changes in the worktree. */
+  force?: boolean;
+};
+
+export type PushWorktreeRequest = {
+  worktree_id: RemoteSyncWorktreeId;
+  message?: string;
+  /** Overwrite the remote branch when it has advanced past the worktree's base version. */
+  force?: boolean;
+};

--- a/frontend/src/metabase-types/api/remote-sync.ts
+++ b/frontend/src/metabase-types/api/remote-sync.ts
@@ -218,8 +218,6 @@ export type RemoteSyncWorktree = {
   branch: string;
   /** Last synced git SHA; null until the first successful pull. */
   base_version: string | null;
-  /** Whether this is the default worktree (its branch matches the remote-sync-branch setting). */
-  is_default: boolean;
   roots: RemoteSyncWorktreeRoot[];
   creator_id: UserId | null;
   created_at: string;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -756,6 +756,7 @@ export interface EnterpriseSettings extends Settings {
   "remote-sync-type"?: RemoteSyncType | null;
   "remote-sync-auto-import"?: boolean | null;
   "remote-sync-transforms"?: boolean | null;
+  "remote-sync-worktrees"?: boolean | null;
   "login-page-illustration"?: IllustrationSettingValue;
   "login-page-illustration-custom"?: string;
   "landing-page-illustration"?: IllustrationSettingValue;


### PR DESCRIPTION
Part 7 of the remote-sync worktrees stack. Stacked on #78406.

`RemoteSyncWorktree` API types, `remote_sync_worktree_id` on Collection, the `include-worktrees` tree param, and RTK endpoints: `listWorktrees` / `createWorktree` / `deleteWorktree` (force as query param) / `pullWorktree` / `pushWorktree` — the pull/push mutations hit the same `import`/`export` endpoints with `worktree_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)