### PR TITLE
Drop field usage table

### DIFF
--- a/resources/migrations/064/20260722_drop_field_usage.yaml
+++ b/resources/migrations/064/20260722_drop_field_usage.yaml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - changeSet:
+      id: v64.nofieldusage
+      author: technomancy
+      comment: The field_usage table has been unused for a long time; get rid of it!
+      changes:
+        - dropTable:
+            tableName: field_usage
+      # real rollback is not needed since this table has been unused since Jan 2025
+      # but the tests require rolling down and back again so let's just create
+      # an empty table
+      rollback:
+        - createTable:
+            tableName: field_usage
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false

--- a/src/metabase/query_processor/execute.clj
+++ b/src/metabase/query_processor/execute.clj
@@ -10,7 +10,6 @@
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.setup :as qp.setup]
-   [metabase.query-processor.util :as qp.util]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]))
@@ -25,18 +24,6 @@
               (rff (cond-> metadata
                      (not (:native_form metadata))
                      (assoc :native_form ((some-fn :qp/compiled-inline :qp/compiled) query)))))]
-      (qp query rff*))))
-
-(mu/defn- add-preprocessed-query-to-result-metadata-for-userland-query :- ::qp.schema/qp
-  [qp :- ::qp.schema/qp]
-  (fn [query rff]
-    (letfn [(rff* [metadata]
-              {:pre [(map? metadata)]}
-              (rff (cond-> metadata
-                     ;; process-userland-query needs the preprocessed-query to find field usages
-                     ;; it'll then be removed from the result
-                     (qp.util/userland-query? query)
-                     (assoc :preprocessed_query query))))]
       (qp query rff*))))
 
 (def ^:private middleware
@@ -58,7 +45,6 @@
    #'qp.middleware.enterprise/apply-impersonation-postprocessing-middleware
    #'update-used-cards/update-used-cards!
    #'add-native-form-to-result-metadata
-   #'add-preprocessed-query-to-result-metadata-for-userland-query
    #'cache/maybe-return-cached-results
    #'qp.perms/check-query-permissions
    #'qp.middleware.enterprise/check-download-permissions-middleware])

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -80,9 +80,9 @@
   "Add `object` (e.g. a result row or metadata) to the current cache entry."
   [object]
   (when *in-fn*
-    (*in-fn* (cond-> object
-               (map? object) (-> (m/update-existing :json_query lib/prepare-for-serialization)
-                                 (m/update-existing :preprocessed_query lib/prepare-for-serialization))))))
+    (*in-fn* (if (map? object)
+               (m/update-existing object :json_query lib/prepare-for-serialization)
+               object))))
 
 (def ^:private ^:dynamic *result-fn*
   "The `result-fn` provided by [[impl/do-with-serialization]]."

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -257,8 +257,7 @@
         (let [query          (assoc-in query [:info :query-hash] (qp.util/query-hash query))
               execution-info (query-execution-info query)]
           (letfn [(rff* [metadata]
-                    (let [;; we only need the preprocessed query to find field usages, so make sure we don't return it
-                          result         (rff (dissoc metadata :preprocessed_query))
+                    (let [result         (rff metadata)
                           execution-info (enrich-with-execution-context execution-info)]
                       (add-and-save-execution-metadata-xform! execution-info result)))]
             (try

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -240,7 +240,7 @@
 
   3. Add extra info like `running_time` and `started_at` to the results
 
-  4. Submit a background job to analyze field usages"
+  4. Submit a background job to save execution info"
   [qp :- ::qp.schema/qp]
   (mu/fn [query :- ::qp.schema/any-query
           rff   :- ::qp.schema/rff]

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -9,7 +9,6 @@
    [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.events.core :as events]
-   [metabase.lib.core :as lib]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.process-userland-query :as process-userland-query]
    [metabase.query-processor.pipeline :as qp.pipeline]
@@ -65,13 +64,11 @@
   [query]
   (qp.store/with-metadata-provider (mt/id)
     (let [query    (qp/userland-query query)
-          ;; this is needed for field usage processing
-          metadata {:preprocessed_query (lib/query (qp.store/metadata-provider) (mt/mbql-query venues))}
           rows     []
           qp       (process-userland-query/process-userland-query-middleware
                     (fn [query rff]
                       (binding [qp.pipeline/*execute* (fn [_driver _query respond]
-                                                        (respond metadata rows))]
+                                                        (respond {} rows))]
                         (qp.pipeline/*run* query rff))))]
       (binding [driver/*driver* :h2]
         (qp query qp.reducible/default-rff)))))
@@ -237,16 +234,3 @@
                 "val")))
         (testing "No QueryExecution should get saved when a query is canceled"
           (is (not @saved-query-execution?)))))))
-
-(deftest query-result-should-not-contains-preprocessed-query-test
-  (let [query (mt/mbql-query venues {:limit 1})]
-    (doseq [userland-query? [true false]]
-      (testing (format "executing %suserland query shouldn't return the preprocessed query"
-                       (if userland-query? "" "non "))
-        (is (true? (-> (if userland-query?
-                         (qp/userland-query query)
-                         query)
-                       qp/process-query
-                       :data
-                       (contains? :preprocessed_query)
-                       not)))))))


### PR DESCRIPTION
The `field_usage` table has not been actually in use for a long time, but the table has not been dropped yet. This adds a migration to remove it. It was turned off by default in January of 2025: https://github.com/metabase/metabase/pull/51677

There is a mention of field usage in the query processor where it says it uses the `:preprocessed_query` metadata to track field usage. Since this doesn't happen any more, it appears that field is no longer needed; I've removed references to it.