### PR TITLE
Prefix upgraded metric dimensions with connected table names

### DIFF
--- a/src/metabase/metrics/core.clj
+++ b/src/metabase/metrics/core.clj
@@ -89,6 +89,14 @@
                                  (lib-metric/extract-persisted-dimensions dimensions)
                                  dimension-mappings)))
 
+(defn- table-prefixed-dimension
+  [dimension]
+  (if (= "connection" (get-in dimension [:group :type]))
+    (assoc dimension :display-name (str (get-in dimension [:group :display-name])
+                                        " - "
+                                        (or (:display-name dimension) (:name dimension))))
+    dimension))
+
 (defn compute-full-dimension-set
   "Compute the FULL dimension set for a metric's `query` — its own-table columns PLUS every
    implicitly-joined (FK-reachable) column — in the persisted `{:dimensions ... :dimension-mappings ...}`
@@ -102,7 +110,8 @@
   (when (seq query)
     (let [computed-pairs (lib-metric/compute-dimension-pairs (lib-metric/metadata-provider) query)
           {:keys [dimensions dimension-mappings]}
-          (lib-metric/reconcile-dimensions-and-mappings computed-pairs nil nil)]
+          (lib-metric/reconcile-dimensions-and-mappings computed-pairs nil nil)
+          dimensions (mapv table-prefixed-dimension dimensions)]
       {:dimensions         (lib-metric/extract-persisted-dimensions dimensions)
        :dimension-mappings dimension-mappings})))
 

--- a/test/metabase/metrics/api_dimension_test.clj
+++ b/test/metabase/metrics/api_dimension_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.metrics.api-dimension-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [medley.core :as m]
    [metabase.lib.core :as lib]
@@ -496,13 +497,23 @@
                              dims)
              fields    (into #{} (comp (mapcat :sources)
                                        (map :field-id))
-                             dims)]
+                             dims)
+             field-names (into {}
+                               (map (juxt #(-> % :sources first :field-id) :display-name))
+                               dims)]
          (testing "the modernized set spans the own-table AND joined columns"
            (is (contains? groups "main")       "own-table (main) dimensions are present")
            (is (contains? groups "connection") "FK-joined (connection) dimensions are present"))
          (testing "a joined column that an existing dashboard filter targets exists as a dimension"
            (is (contains? fields cat-field)
-               "implicitly-joined PRODUCTS.CATEGORY is a live dimension after modernization")))))))
+               "implicitly-joined PRODUCTS.CATEGORY is a live dimension after modernization"))
+         (testing "connected dimensions use table-prefixed display names (UXW-4896)"
+           (doseq [{:keys [display-name group]} dims
+                   :when (= "connection" (:type group))]
+             (is (str/starts-with? display-name (str (:display-name group) " - "))))
+           (is (= "ID" (field-names (mt/id :orders :id))))
+           (is (= "Product - ID" (field-names (mt/id :products :id))))
+           (is (= "User - ID" (field-names (mt/id :people :id))))))))))
 
 (deftest pre-curation-metric-dashboard-filter-on-joined-column-works-test
   (testing (str "UXW-4808: a dashboard filter bound to an implicitly-joined column of a pre-curation metric "


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-4896/prefix-existing-metric-dimensions-with-hyphenated-table-names

### Description

Prefix connected-table dimensions during the pre-curation metric upgrade so ambiguous columns retain names such as `Product - ID` and `User - ID`. Main-table dimension names remain unchanged, matching new metric behavior.

### How to verify

1. Create a metric with `card_schema` 23 and no persisted dimensions.
2. Load the metric to trigger the curated-dimension upgrade.
3. Confirm all connected dimensions use `<Table> - <Column>` names while the main-table `ID` remains `ID`.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)