### PR TITLE
[GDGT-2145] map more dedicated fields and leave them out of additional opts

### DIFF
--- a/e2e/test/scenarios/admin/database-connection-strings.cy.spec.ts
+++ b/e2e/test/scenarios/admin/database-connection-strings.cy.spec.ts
@@ -125,7 +125,7 @@ const databaseTestCases = [
   {
     engine: "Redshift",
     connectionString:
-      "jdbc:redshift://examplecluster.abc123xyz789.us-west-2.redshift.amazonaws.com:5439/dev",
+      "jdbc:redshift://examplecluster.abc123xyz789.us-west-2.redshift.amazonaws.com:5439/dev;UID=testuser;PWD=testpass;SocketTimeout=0",
     expectedFields: [
       {
         label: "Host",
@@ -134,6 +134,12 @@ const databaseTestCases = [
       { label: "Port", value: "5439" },
       { label: "Database name", value: "dev" },
       { label: "Display name", value: "dev" },
+      { label: "Username", value: "testuser" },
+      { label: "Password", value: "testpass" },
+      {
+        label: "Additional JDBC connection string options",
+        value: "SocketTimeout=0",
+      },
     ],
   },
   {

--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/database-field-mapper.ts
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/database-field-mapper.ts
@@ -25,7 +25,10 @@ function mapRedshiftValues(parsedValues: RegexFields) {
     ["details.port", port],
     ["details.user", UID],
     ["details.password", PWD],
-    ["details.additional-options", objectToString(parsedValues.params)],
+    [
+      "details.additional-options",
+      objectToString(parsedValues.params, ["UID", "PWD"]),
+    ],
   ]);
 
   if (fieldsMap.get("details.additional-options")) {

--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/database-field-mapper.unit.spec.ts
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/database-field-mapper.unit.spec.ts
@@ -1,0 +1,40 @@
+import { checkNotNull } from "metabase/utils/types";
+
+import { mapDatabaseValues } from "./database-field-mapper";
+import { parseConnectionUriRegex } from "./parse-connection-regex";
+
+function mapConnectionString(connectionString: string, engineKey: "redshift") {
+  const parsedValues = checkNotNull(
+    parseConnectionUriRegex(connectionString, engineKey),
+  );
+  return mapDatabaseValues(parsedValues, engineKey);
+}
+
+describe("mapDatabaseValues - redshift", () => {
+  it("should map UID and PWD to dedicated fields and keep unmapped params in additional options", () => {
+    const fieldsMap = mapConnectionString(
+      "jdbc:redshift://a.b.us-west-2.redshift.amazonaws.com:5439/dbname;UID=amazon;PWD=password%3Apassword;ssl=true",
+      "redshift",
+    );
+
+    expect(fieldsMap.get("details.host")).toBe(
+      "a.b.us-west-2.redshift.amazonaws.com",
+    );
+    expect(fieldsMap.get("details.port")).toBe("5439");
+    expect(fieldsMap.get("details.db")).toBe("dbname");
+    expect(fieldsMap.get("details.user")).toBe("amazon");
+    expect(fieldsMap.get("details.password")).toBe("password:password");
+    expect(fieldsMap.get("details.additional-options")).toBe("ssl=true");
+    expect(fieldsMap.get("details.advanced-options")).toBe(true);
+  });
+
+  it("should leave additional options empty when all params map to dedicated fields", () => {
+    const fieldsMap = mapConnectionString(
+      "jdbc:redshift://a.b.us-west-2.redshift.amazonaws.com:5439/dbname;UID=amazon;PWD=secret",
+      "redshift",
+    );
+
+    expect(fieldsMap.get("details.additional-options")).toBe("");
+    expect(fieldsMap.get("details.advanced-options")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Description

Brings the Redshift connection-string mapper in line with the other engine mappers: params that already map to dedicated form fields. These dedicated fields are now excluded from the additional JDBC options string.
  
Adds a unit spec for the Redshift mapping (the directory previously only covered URI parsing) and extends the existing Redshift row in the connection-string e2e spec to cover params both in and out of dedicated fields.

### How to verify

1. Admin → Databases → Add database → Amazon Redshift
2. Paste `jdbc:redshift://examplecluster.abc123xyz789.us-west-2.redshift.amazonaws.com:5439/dev;UID=testuser;PWD=testpass;SocketTimeout=0` into the connection string field
3. Username and Password are pre-filled, and the additional JDBC options field under Advanced options contains only `SocketTimeout=0`

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
