### PR TITLE
[Metabot] Stream reasoning tokens

### DIFF
--- a/src/metabase/metabot/agent/messages.clj
+++ b/src/metabase/metabot/agent/messages.clj
@@ -131,9 +131,7 @@
 ;;; ──────────────────────────────────────────────────────────────────
 
 (defn- step->parts
-  "Extract AISDK parts from a step, filtering out non-message types. `:reasoning`
-  is kept for same-turn replay only (Claude requires thinking blocks echoed back);
-  prior-turn history comes from `input-message->parts`, which never carries it."
+  "Extract AISDK parts from a step, filtering out non-message types."
   [step]
   (->> (:parts step)
        (filter #(#{:text :tool-input :tool-output :reasoning} (:type %)))))

--- a/src/metabase/metabot/agent/messages.clj
+++ b/src/metabase/metabot/agent/messages.clj
@@ -131,10 +131,12 @@
 ;;; ──────────────────────────────────────────────────────────────────
 
 (defn- step->parts
-  "Extract AISDK parts from a step, filtering out non-message types."
+  "Extract AISDK parts from a step, filtering out non-message types. `:reasoning`
+  is kept for same-turn replay only (Claude requires thinking blocks echoed back);
+  prior-turn history comes from `input-message->parts`, which never carries it."
   [step]
   (->> (:parts step)
-       (filter #(#{:text :tool-input :tool-output} (:type %)))))
+       (filter #(#{:text :tool-input :tool-output :reasoning} (:type %)))))
 
 (defn- messages-with-injected-context
   "Returns messages from memory and injects context into the most recent one."

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -100,13 +100,13 @@
                              nil))))))))
 
 (defn parts->storable-content
-  "Drop transient/lifecycle parts and convert what remains to the v2 at-rest
-  format. Stream metadata (`:usage`/`:finish`/`:error`) and `state` data parts
-  (the turn's state is persisted separately into the row's `state` column) carry
-  no history value."
+  "Drop transient/lifecycle parts and convert what remains to the v2 at-rest format.
+  Stream metadata (`:usage`/`:finish`/`:error`), live-only `:reasoning`, and `state`
+  data parts (persisted separately into the row's `state` column) carry no history
+  value."
   [parts]
   (->> parts
-       (remove #(#{:usage :finish :error} (:type %)))
+       (remove #(#{:usage :finish :error :reasoning} (:type %)))
        (filter streaming/persistable-data-part?)
        internal-parts->storable
        (schema.v2/check-message-data "metabot_message.data")))

--- a/src/metabase/metabot/persistence.clj
+++ b/src/metabase/metabot/persistence.clj
@@ -101,9 +101,8 @@
 
 (defn parts->storable-content
   "Drop transient/lifecycle parts and convert what remains to the v2 at-rest format.
-  Stream metadata (`:usage`/`:finish`/`:error`), live-only `:reasoning`, and `state`
-  data parts (persisted separately into the row's `state` column) carry no history
-  value."
+  Stream metadata (`:usage`/`:finish`/`:error`), `:reasoning`, and `state` data parts
+  (persisted separately into the row's `state` column) carry no history value."
   [parts]
   (->> parts
        (remove #(#{:usage :finish :error :reasoning} (:type %)))

--- a/src/metabase/metabot/self/azure.clj
+++ b/src/metabase/metabot/self/azure.clj
@@ -177,7 +177,7 @@
   `:ai-proxy?` is not supported for Azure and throws when true."
   [{:keys [model input tools ai-proxy?] :as opts} :- core/LLMRequestOpts]
   (let [family (model->family model)
-        opts   (assoc opts :model (model->deployment model))
+        opts   (assoc opts :model (model->deployment model) :reasoning? false)
         {:keys [path headers req]}
         (case family
           :anthropic {:path    "/v1/messages"

--- a/src/metabase/metabot/self/bedrock.clj
+++ b/src/metabase/metabot/self/bedrock.clj
@@ -250,7 +250,7 @@
   `:ai-proxy?` is not supported for Bedrock and throws when true."
   [{:keys [model input tools ai-proxy?] :as opts
     :or   {model default-model}} :- core/LLMRequestOpts]
-  (let [opts   (assoc opts :model model)
+  (let [opts   (assoc opts :model model :reasoning? false)
         family (model->family model)
         {:keys [path headers req]}
         (case family

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -52,10 +52,8 @@
    :cacheReadTokens     (:cache_read_input_tokens u 0)})
 
 (def ^:private translated-chunk-type?
-  "Claude content-block types we translate into AI SDK chunks. Other block types
-  (e.g. `thinking`/`redacted_thinking` from extended or adaptive thinking) are
-  ignored, mirroring the OpenAI adapter's handling of reasoning output."
-  #{:text :tool_use})
+  "Claude content-block types we translate into AI SDK chunks."
+  #{:text :tool_use :thinking :redacted_thinking})
 
 (defn claude->aisdk-chunks-xf
   "Translates Claude /v1/messages streaming events into AI SDK v5 protocol chunks.
@@ -88,11 +86,11 @@
           ;; usage in the completion arity so we don't lose data entirely.
           last-usage   (volatile! nil)
           close!       (fn [result]
-                         ;; only emit an end marker for block types we translate; thinking and
-                         ;; other untranslated blocks are ignored.
                          (u/prog1 (if-let [end-type (case @current-type
-                                                      :text     :text-end
-                                                      :tool_use :tool-input-available
+                                                      :text              :text-end
+                                                      :tool_use          :tool-input-available
+                                                      :thinking          :reasoning-end
+                                                      :redacted_thinking :reasoning-end
                                                       nil)]
                                     (rf result (merge {:type end-type} @payload))
                                     result)
@@ -127,28 +125,41 @@
                                                (vreset! current-id chunk-id)
                                                (vreset! payload
                                                         (case block-type
-                                                          :text     {:id chunk-id}
-                                                          :tool_use {:toolCallId chunk-id
-                                                                     :toolName   (:name content_block)}
+                                                          :text              {:id chunk-id}
+                                                          :tool_use          {:toolCallId chunk-id
+                                                                              :toolName   (:name content_block)}
+                                                          :thinking          {:id chunk-id}
+                                                          ;; redactedData rides the reasoning-end (via @payload,
+                                                          ;; kept off the start); redacted blocks stream no deltas.
+                                                          :redacted_thinking {:id chunk-id
+                                                                              :providerMetadata {:anthropic {:redactedData (:data content_block)}}}
                                                           nil)))
                                              (cond->
                                               (translated-chunk-type? block-type)
-                                               (rf (merge (case block-type
-                                                            :text     {:type :text-start}
-                                                            :tool_use {:type :tool-input-start})
-                                                          @payload))))
+                                               (rf (case block-type
+                                                     :text                          (merge {:type :text-start} @payload)
+                                                     :tool_use                      (merge {:type :tool-input-start} @payload)
+                                                     (:thinking :redacted_thinking) {:type :reasoning-start :id chunk-id}))))
 
-             ;; content block delta — ignore deltas for blocks we don't translate
-             ;; (e.g. thinking_delta / signature_delta from extended thinking)
+             ;; content block delta
              (and (= t "content_block_delta")
-                  (contains? #{"text_delta" "input_json_delta"} (:type delta)))
+                  (contains? #{"text_delta" "input_json_delta" "thinking_delta"} (:type delta)))
              (rf (case (:type delta)
                    "text_delta"       {:type  :text-delta
                                        :id    (:id @payload)
                                        :delta (:text delta)}
+                   "thinking_delta"   {:type  :reasoning-delta
+                                       :id    (:id @payload)
+                                       :delta (:thinking delta)}
                    "input_json_delta" {:type           :tool-input-delta
                                        :toolCallId     (:toolCallId @payload)
                                        :inputTextDelta (:partial_json delta)}))
+
+             ;; the signature rides the reasoning-end via @payload (needed to replay
+             ;; the block within the turn); nothing is emitted to the client
+             (and (= t "content_block_delta") (= "signature_delta" (:type delta)))
+             (u/prog1
+               (vswap! payload update-in [:providerMetadata :anthropic :signature] (fnil str "") (:signature delta)))
 
              ;; end of content block
              (= t "content_block_stop") (close!)
@@ -185,38 +196,67 @@
                              :content (into [] (mapcat (comp ->content-blocks :content)) group)}])))
         messages))
 
+(defn- coalesce-reasoning
+  "Join consecutive same-id `:reasoning` parts (streamed as small parts plus a
+  metadata carrier) into one block, keeping its provider metadata."
+  [parts]
+  (->> parts
+       (partition-by (fn [p] (if (= :reasoning (:type p)) [:reasoning (:id p)] :other)))
+       (mapcat (fn [group]
+                 (if (= :reasoning (:type (first group)))
+                   [{:type              :reasoning
+                     :id                (:id (first group))
+                     :text              (->> group (map :text) (str/join ""))
+                     :provider-metadata (some :provider-metadata group)}]
+                   group)))))
+
 (defn parts->claude-messages
   "Convert a sequence of AISDK parts into Claude API messages.
 
   Input: flat sequence of AISDK parts and user messages:
     {:role :user, :content \"...\"}
+    {:type :reasoning, :text \"...\", :provider-metadata {...}}
     {:type :text, :text \"...\"}
     {:type :tool-input, :id ..., :function ..., :arguments ...}
     {:type :tool-output, :id ..., :result ...}
 
-  Output: Claude messages with tool_use/tool_result content blocks, consecutive
-  assistant messages merged."
+  Reasoning becomes `thinking`/`redacted_thinking` blocks — Claude 400s unless they
+  are echoed back verbatim (signed) ahead of the tool_use they preceded. Unsigned
+  reasoning (foreign parts, interrupted blocks) is dropped."
   [parts]
   (->> parts
-       (mapv (fn [part]
-               (case (:type part)
-                 :text        {:role    "assistant"
-                               :content (:text part)}
-                 :tool-input  {:role    "assistant"
-                               :content [{:type  "tool_use"
-                                          :id    (:id part)
-                                          :name  (:function part)
-                                          :input (or (:arguments part) {})}]}
-                 :tool-output {:role    "user"
-                               :content [{:type        "tool_result"
-                                          :tool_use_id (:id part)
-                                          :content     (or (get-in part [:result :output])
-                                                           (when-let [err (:error part)]
-                                                             (str "Error: " (:message err)))
-                                                           (pr-str (:result part)))}]}
-                 ;; User messages pass through
-                 {:role    (name (or (:role part) "user"))
-                  :content (:content part)})))
+       coalesce-reasoning
+       (into []
+             (keep (fn [part]
+                     (case (:type part)
+                       :reasoning   (let [pm       (:provider-metadata part)
+                                          redacted (get-in pm [:anthropic :redactedData])
+                                          sig      (get-in pm [:anthropic :signature])]
+                                      (cond
+                                        redacted {:role    "assistant"
+                                                  :content [{:type "redacted_thinking" :data redacted}]}
+                                        sig      {:role    "assistant"
+                                                  :content [{:type      "thinking"
+                                                             :thinking  (:text part)
+                                                             :signature sig}]}
+                                        :else    nil))
+                       :text        {:role    "assistant"
+                                     :content (:text part)}
+                       :tool-input  {:role    "assistant"
+                                     :content [{:type  "tool_use"
+                                                :id    (:id part)
+                                                :name  (:function part)
+                                                :input (or (:arguments part) {})}]}
+                       :tool-output {:role    "user"
+                                     :content [{:type        "tool_result"
+                                                :tool_use_id (:id part)
+                                                :content     (or (get-in part [:result :output])
+                                                                 (when-let [err (:error part)]
+                                                                   (str "Error: " (:message err)))
+                                                                 (pr-str (:result part)))}]}
+                       ;; User messages pass through
+                       {:role    (name (or (:role part) "user"))
+                        :content (:content part)}))))
        merge-consecutive
        vec))
 
@@ -337,21 +377,40 @@
                  (mapv (fn [{:keys [id display_name]}]
                          {:id id :display_name (or display_name (supported-models id))})))}))
 
-(defn- model-supports-temperature?
-  "Whether `model` accepts an explicit `temperature` parameter.
-
-  Sampling parameters (`temperature`, `top_p`, `top_k`) were removed starting with Claude Opus 4.7 and Sonnet 5.
-  Strips an optional vendor prefix (e.g. Bedrock's `anthropic.`) before checking."
+(defn- claude-model-version
+  "`[family major minor]` for a Claude opus/sonnet model id, or nil. Strips an
+  optional vendor prefix (e.g. Bedrock's `anthropic.`)."
   [model]
-  (let [model (str/replace-first (str model) #"^anthropic\." "")]
-    (not (or (str/starts-with? model "claude-fable")
-             (when-let [[_ family major minor] (re-find #"^claude-(opus|sonnet)-(\d+)(?:-(\d+))?" model)]
-               (let [major (parse-long major)
-                     minor (or (some-> minor parse-long) 0)]
-                 (case family
-                   "opus"   (or (> major 4)
-                                (and (= major 4) (>= minor 7)))
-                   "sonnet" (>= major 5))))))))
+  (when-let [[_ family major minor] (re-find #"^claude-(opus|sonnet)-(\d+)(?:-(\d+))?"
+                                             (str/replace-first (str model) #"^anthropic\." ""))]
+    [family (parse-long major) (or (some-> minor parse-long) 0)]))
+
+(defn- model-current-gen?
+  "Current-generation Claude (Fable, Opus >=4.7, Sonnet >=5): no sampling params;
+  thinking streams via `display: summarized`."
+  [model]
+  (or (str/starts-with? (str/replace-first (str model) #"^anthropic\." "") "claude-fable")
+      (when-let [[family major minor] (claude-model-version model)]
+        (case family
+          "opus"   (or (> major 4) (and (= major 4) (>= minor 7)))
+          "sonnet" (>= major 5)))))
+
+(defn- model-supports-temperature?
+  "Whether `model` accepts an explicit `temperature` parameter. Sampling params
+  were removed starting with Claude Opus 4.7 and Sonnet 5."
+  [model]
+  (not (model-current-gen? model)))
+
+(defn- model-thinking-config
+  "Thinking config that streams reasoning for `model`, or nil where we don't enable
+  it (older budget-token models — off in v1). `display: \"summarized\"` is explicit
+  on every branch: per-model defaults range from `omitted` to `summarized` and have
+  already changed silently once across a model bump."
+  [model]
+  (let [[_ major minor] (claude-model-version model)]
+    (cond
+      (model-current-gen? model)          {:type "adaptive" :display "summarized"}
+      (and major (= major 4) (= minor 6)) {:type "adaptive" :display "summarized"})))
 
 (mu/defn claude-request-body
   "Build the Anthropic Messages API request body for an LLM request."
@@ -361,9 +420,15 @@
         all-tools (when (seq tools) (mapv tool->claude tools))
         all-tools (if (and all-tools (not schema))
                     (add-tools-cache-breakpoint all-tools)
-                    all-tools)]
+                    all-tools)
+        ;; forced tool choice (structured output, or "required") is incompatible
+        ;; with thinking — suppress it there.
+        thinking  (when-not (or schema (= "required" (some-> tool_choice name)))
+                    (model-thinking-config model))]
     (cond-> {:model         model
-             :max_tokens    (or max-tokens 4096)
+             ;; thinking tokens count against max_tokens; 4096 would truncate answers.
+             :max_tokens    (cond-> (or max-tokens 4096)
+                              thinking (max 16384))
              :stream        true
              :cache_control {:type "ephemeral"}
              :messages      messages}
@@ -380,7 +445,11 @@
                             "auto"     {:type "auto"}
                             "required" {:type "any"}))
 
-      (and temperature (model-supports-temperature? model))
+      thinking          (assoc :thinking thinking)
+
+      ;; sampling params are rejected alongside thinking (relevant for 4.6, which
+      ;; still accepts temperature but streams thinking here)
+      (and temperature (not thinking) (model-supports-temperature? model))
       (assoc :temperature temperature))))
 
 (mu/defn claude-raw

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -412,16 +412,18 @@
 
 (mu/defn claude-request-body
   "Build the Anthropic Messages API request body for an LLM request."
-  [{:keys [model system input tools schema tool_choice temperature max-tokens]
-    :or   {model "claude-haiku-4-5"}} :- core/LLMRequestOpts]
-  (let [messages  (parts->claude-messages input)
+  [{:keys [model system input tools schema tool_choice temperature max-tokens reasoning?]
+    :or   {model "claude-haiku-4-5" reasoning? true}} :- core/LLMRequestOpts]
+  (let [input     (cond->> input
+                    (not reasoning?) (remove #(= :reasoning (:type %))))
+        messages  (parts->claude-messages input)
         all-tools (when (seq tools) (mapv tool->claude tools))
         all-tools (if (and all-tools (not schema))
                     (add-tools-cache-breakpoint all-tools)
                     all-tools)
         ;; forced tool choice (structured output, or "required") is incompatible
         ;; with thinking — suppress it there.
-        thinking  (when-not (or schema (= "required" (some-> tool_choice name)))
+        thinking  (when-not (or (not reasoning?) schema (= "required" (some-> tool_choice name)))
                     (model-thinking-config model))]
     (cond-> {:model         model
              ;; thinking draws from the same max_tokens budget as the answer, so with

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -196,7 +196,7 @@
                              :content (into [] (mapcat (comp ->content-blocks :content)) group)}])))
         messages))
 
-(defn- coalesce-reasoning
+(defn- merge-reasoning
   "Join consecutive same-id `:reasoning` parts (streamed as small parts plus a
   metadata carrier) into one block, keeping its provider metadata."
   [parts]
@@ -225,7 +225,7 @@
   reasoning (foreign parts, interrupted blocks) is dropped."
   [parts]
   (->> parts
-       coalesce-reasoning
+       merge-reasoning
        (into []
              (keep (fn [part]
                      (case (:type part)
@@ -403,9 +403,7 @@
 
 (defn- model-thinking-config
   "Thinking config that streams reasoning for `model`, or nil where we don't enable
-  it (older budget-token models — off in v1). `display: \"summarized\"` is explicit
-  on every branch: per-model defaults range from `omitted` to `summarized` and have
-  already changed silently once across a model bump."
+  it (older budget-token models — off in v1)."
   [model]
   (let [[_ major minor] (claude-model-version model)]
     (cond
@@ -426,7 +424,9 @@
         thinking  (when-not (or schema (= "required" (some-> tool_choice name)))
                     (model-thinking-config model))]
     (cond-> {:model         model
-             ;; thinking tokens count against max_tokens; 4096 would truncate answers.
+             ;; thinking draws from the same max_tokens budget as the answer, so with
+             ;; the 4096 default the model can spend it all thinking and truncate its
+             ;; reply — give thinking requests more headroom.
              :max_tokens    (cond-> (or max-tokens 4096)
                               thinking (max 16384))
              :stream        true
@@ -447,8 +447,7 @@
 
       thinking          (assoc :thinking thinking)
 
-      ;; sampling params are rejected alongside thinking (relevant for 4.6, which
-      ;; still accepts temperature but streams thinking here)
+      ;; sampling params are rejected alongside thinking
       (and temperature (not thinking) (model-supports-temperature? model))
       (assoc :temperature temperature))))
 

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -414,17 +414,17 @@
   "Build the Anthropic Messages API request body for an LLM request."
   [{:keys [model system input tools schema tool_choice temperature max-tokens reasoning?]
     :or   {model "claude-haiku-4-5" reasoning? true}} :- core/LLMRequestOpts]
-  (let [input     (cond->> input
-                    (not reasoning?) (remove #(= :reasoning (:type %))))
+  (let [;; forced tool choice (structured output, or "required") is incompatible
+        ;; with thinking — suppress it there.
+        thinking  (when-not (or (not reasoning?) schema (= "required" (some-> tool_choice name)))
+                    (model-thinking-config model))
+        input     (cond->> input
+                    (nil? thinking) (remove #(= :reasoning (:type %))))
         messages  (parts->claude-messages input)
         all-tools (when (seq tools) (mapv tool->claude tools))
         all-tools (if (and all-tools (not schema))
                     (add-tools-cache-breakpoint all-tools)
-                    all-tools)
-        ;; forced tool choice (structured output, or "required") is incompatible
-        ;; with thinking — suppress it there.
-        thinking  (when-not (or (not reasoning?) schema (= "required" (some-> tool_choice name)))
-                    (model-thinking-config model))]
+                    all-tools)]
     (cond-> {:model         model
              ;; thinking draws from the same max_tokens budget as the answer, so with
              ;; the 4096 default the model can spend it all thinking and truncate its

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -422,8 +422,8 @@
                         (rf (format-sse-event {:type "text-start" :id id}))
                         (rf (format-sse-event {:type "text-delta" :id id :delta (:text part)}))))))
 
-              ;; lazy open: empty parts (metadata carriers, redacted blocks) emit
-              ;; nothing, so no "Thinking..." flash for reasoning with no text
+              ;; empty-text parts (signature/metadata carriers, redacted blocks) open
+              ;; no reasoning block — only parts with text do
               :reasoning
               (if (str/blank? (:text part))
                 result

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -154,6 +154,12 @@
                             :id   (:id chunk)
                             :text (->> (map :delta chunks)
                                        (str/join ""))}
+    :reasoning-start       (let [pm (some :providerMetadata chunks)]
+                             (cond-> {:type :reasoning
+                                      :id   (:id chunk)
+                                      :text (->> (map :delta chunks)
+                                                 (str/join ""))}
+                               pm (assoc :provider-metadata pm)))
     :tool-input-start      {:type      :tool-input
                             :id        (:toolCallId chunk)
                             :function  (:toolName chunk)
@@ -203,6 +209,15 @@
               (-> (flush! result)
                   ;; TODO: check if I can just pass through text-delta?
                   (rf {:type :text :id (:id chunk) :text (:delta chunk)}))
+
+              (and stream-text? (#{:reasoning-start :reasoning-end} (:type chunk)))
+              (cond-> (flush! result)
+                (:providerMetadata chunk)
+                (rf {:type :reasoning :id (:id chunk) :text "" :provider-metadata (:providerMetadata chunk)}))
+
+              (and stream-text? (= :reasoning-delta (:type chunk)))
+              (-> (flush! result)
+                  (rf {:type :reasoning :id (:id chunk) :text (:delta chunk)}))
 
               (not= chunk-id @current-id)
               (u/prog1 (flush! result)
@@ -317,6 +332,7 @@
     :start (1st)      -> start + start-step
     :start (Nth)      -> finish-step + start-step
     :text             -> [text-end]? [text-start]? text-delta
+    :reasoning        -> [reasoning-end]? [reasoning-start]? reasoning-delta (empty text -> nothing)
     :tool-input-start -> tool-input-start
     :tool-input       -> tool-input-available
     :tool-output      -> tool-output-available | tool-output-error
@@ -335,6 +351,11 @@
            ;; non-nil while a text block is open; holds the block id so we can
            ;; emit a matching text-end when the block closes
            current-text-id   (volatile! nil)
+           ;; providers' native reasoning ids are long; emit short sequential wire
+           ;; ids, keeping the provider id only to detect block boundaries
+           current-reasoning-id (volatile! nil)
+           reasoning-n          (volatile! 0)
+           reasoning-wire-id    (volatile! nil)
            start-event       (fn [id]
                                (format-sse-event
                                 (cond-> {:type "start" :messageId id}
@@ -344,6 +365,12 @@
                                  (do (vreset! current-text-id nil)
                                      (rf result (format-sse-event {:type "text-end" :id id})))
                                  result))
+           close-reasoning-block (fn [result]
+                                   (if @current-reasoning-id
+                                     (let [wid @reasoning-wire-id]
+                                       (vreset! current-reasoning-id nil)
+                                       (rf result (format-sse-event {:type "reasoning-end" :id wid})))
+                                     result))
            ensure-started    (fn [result]
                                (if @started?
                                  result
@@ -358,6 +385,7 @@
                                 (when @finish-error-code {:errorCode @finish-error-code}))]
             (-> result
                 close-text-block
+                close-reasoning-block
                 (cond-> @started? (rf (format-sse-event {:type "finish-step"})))
                 (rf (format-sse-event
                      (cond-> {:type         "finish"
@@ -366,12 +394,12 @@
                 (rf done-sse-line)
                 (rf))))
          ([result part]
-          ;; Any non-text part implicitly closes the current text block before
-          ;; its own events are emitted; the :text branch handles its own
-          ;; closing semantics (only closes when the id changes).
-          (let [result (if (= :text (:type part))
-                         result
-                         (close-text-block result))]
+          ;; Any part of a different kind implicitly closes the open text or
+          ;; reasoning block before its own events are emitted; the :text and
+          ;; :reasoning branches handle their own closing (only on id change).
+          (let [result (cond-> result
+                         (not= :text (:type part))      close-text-block
+                         (not= :reasoning (:type part)) close-reasoning-block)]
             (case (:type part)
               :start
               (if @started?
@@ -393,6 +421,21 @@
                     (-> result
                         (rf (format-sse-event {:type "text-start" :id id}))
                         (rf (format-sse-event {:type "text-delta" :id id :delta (:text part)}))))))
+
+              ;; lazy open: empty parts (metadata carriers, redacted blocks) emit
+              ;; nothing, so no "Thinking..." flash for reasoning with no text
+              :reasoning
+              (if (str/blank? (:text part))
+                result
+                (let [id (or (:id part) (mkid))]
+                  (if (= id @current-reasoning-id)
+                    (rf result (format-sse-event {:type "reasoning-delta" :id @reasoning-wire-id :delta (:text part)}))
+                    (let [result (close-reasoning-block result)]
+                      (vreset! current-reasoning-id id)
+                      (vreset! reasoning-wire-id (str (vswap! reasoning-n inc)))
+                      (-> result
+                          (rf (format-sse-event {:type "reasoning-start" :id @reasoning-wire-id}))
+                          (rf (format-sse-event {:type "reasoning-delta" :id @reasoning-wire-id :delta (:text part)})))))))
 
               :tool-input-start
               (rf result (format-sse-event {:type       "tool-input-start"

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -49,7 +49,9 @@
     :max-tokens  - Maximum tokens in the response
     :schema      - JSON Schema map for structured output; each provider forces a
                    tool call (Claude, OpenRouter) or uses json_schema mode (OpenAI)
-    :ai-proxy?   - When true, skip provider auth and use the Metabase AI proxy"
+    :ai-proxy?   - When true, skip provider auth and use the Metabase AI proxy
+    :reasoning?  - When false, don't request thinking/reasoning and strip
+                   :reasoning parts from the replayed input (defaults true)"
   [:map
    [:model       {:optional true} :string]
    [:system      {:optional true} [:maybe :string]]
@@ -59,7 +61,8 @@
    [:temperature {:optional true} [:maybe number?]]
    [:max-tokens  {:optional true} [:maybe :int]]
    [:schema      {:optional true} :any]
-   [:ai-proxy?   {:optional true} [:maybe :boolean]]])
+   [:ai-proxy?   {:optional true} [:maybe :boolean]]
+   [:reasoning?  {:optional true} [:maybe :boolean]]])
 
 (defn mkid
   "Generate a random id"
@@ -423,9 +426,9 @@
                         (rf (format-sse-event {:type "text-delta" :id id :delta (:text part)}))))))
 
               ;; empty-text parts (signature/metadata carriers, redacted blocks) open
-              ;; no reasoning block — only parts with text do
+              ;; no reasoning block; whitespace-only deltas (paragraph separators) flow
               :reasoning
-              (if (str/blank? (:text part))
+              (if (empty? (:text part))
                 result
                 (let [id (or (:id part) (mkid))]
                   (if (= id @current-reasoning-id)

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -106,6 +106,17 @@
              (= t "response.created")           (-> (rf {:type :start :messageId (:id response)})
                                                     (u/prog1
                                                       (vreset! model-name (:model response))))
+             ;; a finished reasoning item carries the encrypted content that lets us
+             ;; replay it next round-trip — ride it out on the reasoning-end's metadata
+             (and (= t "response.output_item.done")
+                  (= "reasoning" (:type item))
+                  (= @current-id (:id item))
+                  (:encrypted_content item))
+             (u/prog1
+               (vswap! payload assoc :providerMetadata
+                       {:openai {:itemId           (:id item)
+                                 :encryptedContent (:encrypted_content item)}}))
+
              ;; time to finish previous chunk
              ;; this logic will skip most of the *.done types, but they seem to be always followed by one of those two?
              (or (= t "response.output_item.done")
@@ -178,10 +189,15 @@
   (into []
         (keep (fn [part]
                 (case (:type part)
-                  ;; summaries are display-only and can't be replayed without the
-                  ;; encrypted reasoning content we don't persist; the Responses API
-                  ;; reconstructs its own reasoning context instead
-                  :reasoning   nil
+                  ;; with store:false the API keeps nothing server-side, so reasoning
+                  ;; items ride along as encrypted content ahead of their tool calls;
+                  ;; parts without it (bare summaries, foreign providers) drop
+                  :reasoning   (when-let [content (get-in part [:provider-metadata :openai :encryptedContent])]
+                                 {:type              "reasoning"
+                                  :id                (or (get-in part [:provider-metadata :openai :itemId])
+                                                         (:id part))
+                                  :summary           []
+                                  :encrypted_content content})
                   :text        {:type    "message"
                                 :role    "assistant"
                                 :content [{:type "output_text"
@@ -303,9 +319,11 @@
 
 (mu/defn openai-request-body
   "Build the OpenAI Responses API request body for an LLM request."
-  [{:keys [model system input tools schema tool_choice temperature max-tokens]
-    :or   {model "gpt-5.4"}} :- core/LLMRequestOpts]
-  (let [all-tools (or (when schema
+  [{:keys [model system input tools schema tool_choice temperature max-tokens reasoning?]
+    :or   {model "gpt-5.4" reasoning? true}} :- core/LLMRequestOpts]
+  (let [input     (cond->> input
+                    (not reasoning?) (remove #(= :reasoning (:type %))))
+        all-tools (or (when schema
                         ;; Structured output: force a tool call with the given JSON schema
                         [{:type        "function"
                           :name        "structured_output"
@@ -324,8 +342,11 @@
                          :tools       all-tools)
       max-tokens  (assoc :max_output_tokens max-tokens)
 
-      (reasoning-model? model)
-      (assoc :reasoning {:summary "auto"})
+      ;; encrypted_content lets us replay reasoning items across tool-call
+      ;; round-trips despite store:false — see [[parts->openai-input]]
+      (and reasoning? (reasoning-model? model))
+      (assoc :reasoning {:summary "auto"}
+             :include   ["reasoning.encrypted_content"])
 
       (and temperature (model-supports-temperature? model))
       (assoc :temperature temperature))))

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -14,9 +14,8 @@
 (set! *warn-on-reflection* true)
 
 (def ^:private translated-chunk-type?
-  "Output item types we translate into AI SDK chunks.
-  Other types (e.g. reasoning summaries) are ignored."
-  #{:text :function_call})
+  "Output item types we translate into AI SDK chunks."
+  #{:text :function_call :reasoning})
 
 (defn- openai-usage->aisdk-usage
   "Convert an OpenAI Responses API `usage` block into the AISDK `:usage` shape.
@@ -61,11 +60,11 @@
           model-name   (volatile! nil)
           payload      (volatile! {})
           close!       (fn [result]
-                         ;; only emit an end marker for chunk types we translate; reasoning and other
-                         ;; output item types are ignored.
+                         ;; only emit an end marker for chunk types we translate.
                          (u/prog1 (if-let [end-type (case @current-type
                                                       :text          :text-end
                                                       :function_call :tool-input-available
+                                                      :reasoning     :reasoning-end
                                                       nil)]
                                     (rf result (merge {:type end-type} @payload))
                                     result)
@@ -92,11 +91,14 @@
                             "content_part"            :text
                             "output_text"             :text
                             "function_call_arguments" :function_call
+                            "reasoning_summary_text"  :reasoning
+                            "reasoning_summary_part"  :reasoning
                             (keyword middle))
                chunk-id   (or (case chunk-type
                                 ;; chunks that have natural id in API response go here
                                 :function_call (:call_id item)
                                 :text          (:id chunk)
+                                :reasoning     (:id item)
                                 nil)
                               @current-id
                               (core/mkid))]
@@ -110,7 +112,7 @@
                  (and @current-id
                       (not= chunk-id
                             @current-id)))      (close!)
-             ;; start of a new chunk — only for types we translate; reasoning items are ignored
+             ;; start of a new chunk — only for types we translate
              (and (= t "response.output_item.added")
                   (translated-chunk-type? chunk-type)) (-> (u/prog1
                                                              (vreset! current-type chunk-type)
@@ -121,16 +123,27 @@
                                                                         :text          {:id chunk-id}
                                                                         :function_call {:toolCallId chunk-id
                                                                                         :toolName   (:name item)}
+                                                                        :reasoning     {:id chunk-id}
                                                                         nil)))
                                                            (rf (merge (case @current-type
                                                                         :text          {:type :text-start}
                                                                         :function_call {:type :tool-input-start}
+                                                                        :reasoning     {:type :reasoning-start}
                                                                         nil)
                                                                       @payload)))
-             ;; just a middle of a chunk — ignore deltas for types we don't translate (e.g. reasoning summaries)
+             ;; a 2nd+ summary part is a new paragraph within the same reasoning item
+             (and (= t "response.reasoning_summary_part.added")
+                  (= @current-type :reasoning)
+                  (pos? (:summary_index chunk 0)))
+             (rf {:type :reasoning-delta :id @current-id :delta "\n\n"})
+
+             ;; just a middle of a chunk — ignore deltas for types we don't translate
              (and delta
                   (translated-chunk-type? @current-type)) (rf (case @current-type
                                                                 :text          {:type  :text-delta
+                                                                                :id    @current-id
+                                                                                :delta delta}
+                                                                :reasoning     {:type  :reasoning-delta
                                                                                 :id    @current-id
                                                                                 :delta delta}
                                                                 :function_call {:type           :tool-input-delta
@@ -162,26 +175,29 @@
   Input: flat sequence of AISDK parts and user messages.
   Output: OpenAI Responses API input array."
   [parts]
-  (mapv (fn [part]
-          (case (:type part)
-            :text        {:type    "message"
-                          :role    "assistant"
-                          :content [{:type "output_text"
-                                     :text (:text part)}]}
-            :tool-input  {:type      "function_call"
-                          :call_id   (:id part)
-                          :name      (:function part)
-                          :arguments (let [args (:arguments part)]
-                                       (if (string? args) args (json/encode args)))}
-            :tool-output {:type    "function_call_output"
-                          :call_id (:id part)
-                          :output  (or (get-in part [:result :output])
-                                       (when-let [err (:error part)]
-                                         (str "Error: " (:message err)))
-                                       (pr-str (:result part)))}
-            ;; User messages
-            {:role    (name (or (:role part) "user"))
-             :content (or (:content part) "")}))
+  (into []
+        (keep (fn [part]
+                (case (:type part)
+                  ;; display-only; the Responses API reconstructs its own reasoning context
+                  :reasoning   nil
+                  :text        {:type    "message"
+                                :role    "assistant"
+                                :content [{:type "output_text"
+                                           :text (:text part)}]}
+                  :tool-input  {:type      "function_call"
+                                :call_id   (:id part)
+                                :name      (:function part)
+                                :arguments (let [args (:arguments part)]
+                                             (if (string? args) args (json/encode args)))}
+                  :tool-output {:type    "function_call_output"
+                                :call_id (:id part)
+                                :output  (or (get-in part [:result :output])
+                                             (when-let [err (:error part)]
+                                               (str "Error: " (:message err)))
+                                             (pr-str (:result part)))}
+                  ;; user messages
+                  {:role    (name (or (:role part) "user"))
+                   :content (or (:content part) "")})))
         parts))
 
 ;;; Tool definition format
@@ -277,6 +293,12 @@
     (not (or (str/starts-with? model "gpt-5")
              (re-find #"^o\d" model)))))
 
+(defn- reasoning-model?
+  "Whether `model` is a reasoning model that can emit reasoning summaries — the
+  same GPT-5 / o-series set that rejects an explicit temperature."
+  [model]
+  (not (model-supports-temperature? model)))
+
 (mu/defn openai-request-body
   "Build the OpenAI Responses API request body for an LLM request."
   [{:keys [model system input tools schema tool_choice temperature max-tokens]
@@ -299,6 +321,9 @@
                                         :else       "auto")
                          :tools       all-tools)
       max-tokens  (assoc :max_output_tokens max-tokens)
+
+      (reasoning-model? model)
+      (assoc :reasoning {:summary "auto"})
 
       (and temperature (model-supports-temperature? model))
       (assoc :temperature temperature))))

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -178,7 +178,9 @@
   (into []
         (keep (fn [part]
                 (case (:type part)
-                  ;; display-only; the Responses API reconstructs its own reasoning context
+                  ;; summaries are display-only and can't be replayed without the
+                  ;; encrypted reasoning content we don't persist; the Responses API
+                  ;; reconstructs its own reasoning context instead
                   :reasoning   nil
                   :text        {:type    "message"
                                 :role    "assistant"

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -75,25 +75,27 @@
   Output: Chat Completions messages (user, assistant with tool_calls, tool)."
   [parts]
   (->> parts
-       (map (fn [part]
-              (case (:type part)
-                :text        {:role "assistant" :content (:text part)}
-                :tool-input  {:role       "assistant"
-                              :content    nil
-                              :tool_calls [{:id       (:id part)
-                                            :type     "function"
-                                            :function {:name      (:function part)
-                                                       :arguments (let [args (:arguments part)]
-                                                                    (if (string? args) args (json/encode (or args {}))))}}]}
-                :tool-output {:role         "tool"
-                              :tool_call_id (:id part)
-                              :content      (or (get-in part [:result :output])
-                                                (when-let [err (:error part)]
-                                                  (str "Error: " (:message err)))
-                                                (pr-str (:result part)))}
-                ;; User messages pass through
-                {:role    (name (or (:role part) "user"))
-                 :content (or (:content part) "")})))
+       (keep (fn [part]
+               (case (:type part)
+                 ;; reasoning is not replayable over Chat Completions
+                 :reasoning   nil
+                 :text        {:role "assistant" :content (:text part)}
+                 :tool-input  {:role       "assistant"
+                               :content    nil
+                               :tool_calls [{:id       (:id part)
+                                             :type     "function"
+                                             :function {:name      (:function part)
+                                                        :arguments (let [args (:arguments part)]
+                                                                     (if (string? args) args (json/encode (or args {}))))}}]}
+                 :tool-output {:role         "tool"
+                               :tool_call_id (:id part)
+                               :content      (or (get-in part [:result :output])
+                                                 (when-let [err (:error part)]
+                                                   (str "Error: " (:message err)))
+                                                 (pr-str (:result part)))}
+                 ;; User messages pass through
+                 {:role    (name (or (:role part) "user"))
+                  :content (or (:content part) "")})))
        merge-consecutive-assistant-messages))
 
 ;;; Tool definition format

--- a/test/metabase/metabot/persistence_test.clj
+++ b/test/metabase/metabot/persistence_test.clj
@@ -316,6 +316,16 @@
             [{:type :tool-input :id "c1" :function "search" :arguments {}}
              {:type :tool-output :id "c1" :result nil}])))))
 
+(deftest ^:parallel parts->storable-content-drops-reasoning-test
+  (testing "reasoning parts are dropped and don't warn as unknown"
+    (log.capture/with-log-messages-for-level [logs [metabase.metabot.persistence :warn]]
+      (is (= [{:type "text" :text "hi" :state "done"}]
+             (metabot-persistence/parts->storable-content
+              [{:type :reasoning :id "r1" :text "thinking"}
+               {:type :reasoning :id "r1" :text "" :provider-metadata {:anthropic {:signature "s"}}}
+               {:type :text :text "hi"}])))
+      (is (not-any? #(re-find #"Dropping internal part" (:message %)) (logs))))))
+
 (deftest ^:parallel parts->storable-content-emits-step-start-boundaries-test
   (testing "each :start becomes a step-start boundary, in stream order"
     (is (= [{:type "step-start"}

--- a/test/metabase/metabot/self/azure_test.clj
+++ b/test/metabase/metabot/self/azure_test.clj
@@ -147,6 +147,24 @@
     (testing "temperature is omitted when the deployment is named after a reasoning model"
       (is (not (contains? body :temperature))))))
 
+(deftest reasoning-is-disabled-test
+  (testing "anthropic deployments get no thinking config and reasoning parts are stripped"
+    (let [body (json/decode+kw
+                (:body (captured-raw-request!
+                        {:model "anthropic/claude-opus-4-8"
+                         :input [{:type :reasoning :id "r1" :text ""
+                                  :provider-metadata {:anthropic {:signature "abc"}}}
+                                 {:type :tool-input :id "call-1" :function "search" :arguments {}}]})))]
+      (is (not (contains? body :thinking)))
+      (is (=? [{:role "assistant" :content [{:type "tool_use" :id "call-1"}]}]
+              (:messages body)))))
+  (testing "openai deployments get no reasoning summary or encrypted-content include"
+    (let [body (json/decode+kw
+                (:body (captured-raw-request! {:model "openai/gpt-5.4"
+                                               :input [{:role :user :content "hi"}]})))]
+      (is (not (contains? body :reasoning)))
+      (is (not (contains? body :include))))))
+
 (deftest unsupported-family-throws-test
   (is (thrown-with-msg?
        clojure.lang.ExceptionInfo

--- a/test/metabase/metabot/self/bedrock_test.clj
+++ b/test/metabase/metabot/self/bedrock_test.clj
@@ -196,6 +196,24 @@
     (testing "temperature is omitted for openai.-prefixed reasoning models"
       (is (not (contains? body :temperature))))))
 
+(deftest reasoning-is-disabled-test
+  (testing "anthropic models get no thinking config and reasoning parts are stripped"
+    (let [body (json/decode+kw
+                (:body (captured-raw-request!
+                        {:model "anthropic.claude-opus-4-8"
+                         :input [{:type :reasoning :id "r1" :text ""
+                                  :provider-metadata {:anthropic {:signature "abc"}}}
+                                 {:type :tool-input :id "call-1" :function "search" :arguments {}}]})))]
+      (is (not (contains? body :thinking)))
+      (is (=? [{:role "assistant" :content [{:type "tool_use" :id "call-1"}]}]
+              (:messages body)))))
+  (testing "openai models get no reasoning summary or encrypted-content include"
+    (let [body (json/decode+kw
+                (:body (captured-raw-request! {:model "openai.gpt-5.5"
+                                               :input [{:role :user :content "hi"}]})))]
+      (is (not (contains? body :reasoning)))
+      (is (not (contains? body :include))))))
+
 (deftest unsupported-model-throws-test
   (is (thrown-with-msg?
        clojure.lang.ExceptionInfo

--- a/test/metabase/metabot/self/claude_test.clj
+++ b/test/metabase/metabot/self/claude_test.clj
@@ -275,6 +275,19 @@
              [{:type :reasoning :id "r1" :text "unsigned"}
               {:type :tool-input :id "call-1" :function "search" :arguments {}}])))))
 
+(deftest ^:parallel claude-request-body-reasoning-disabled-test
+  (testing ":reasoning? false disables thinking and strips reasoning replay"
+    (let [body (claude/claude-request-body
+                {:model      "claude-opus-4-8"
+                 :reasoning? false
+                 :input      [{:type :reasoning :id "r1" :text "let me think"}
+                              {:type :reasoning :id "r1" :text ""
+                               :provider-metadata {:anthropic {:signature "abc"}}}
+                              {:type :tool-input :id "call-1" :function "search" :arguments {}}]})]
+      (is (not (contains? body :thinking)))
+      (is (=? [{:role "assistant" :content [{:type "tool_use" :id "call-1"}]}]
+              (:messages body))))))
+
 (deftest ^:parallel parts->claude-messages-tool-result-test
   (testing "tool output becomes user message with tool_result content block"
     (is (=? [{:role    "user"

--- a/test/metabase/metabot/self/claude_test.clj
+++ b/test/metabase/metabot/self/claude_test.clj
@@ -167,8 +167,8 @@
       (is (= {:cacheCreationTokens 0 :cacheReadTokens 0}
              (select-keys (:usage usage) [:cacheCreationTokens :cacheReadTokens]))))))
 
-(deftest ^:parallel claude-thinking-blocks-ignored-test
-  (testing "thinking content blocks (extended/adaptive thinking, e.g. Claude Sonnet 5) are ignored"
+(deftest ^:parallel claude-thinking-blocks-translated-test
+  (testing "thinking content blocks become reasoning chunks; signature rides the end"
     (let [events [{:type "message_start"
                    :message {:id "msg-1" :model "claude-sonnet-5"
                              :usage {:input_tokens 10 :output_tokens 0}}}
@@ -183,25 +183,45 @@
                   {:type "message_delta" :delta {:stop_reason "end_turn"}
                    :usage {:input_tokens 10 :output_tokens 5}}
                   {:type "message_stop"}]]
-      (testing "no thinking/reasoning chunks are emitted; only text + usage survive"
-        (is (=? [{:type :start} {:type :text-start} {:type :text-delta} {:type :text-end} {:type :usage}]
+      (testing "reasoning start/delta/end surround the text; signature_delta emits no chunk"
+        (is (=? [{:type :start}
+                 {:type :reasoning-start} {:type :reasoning-delta :delta "let me think"}
+                 {:type :reasoning-end :providerMetadata {:anthropic {:signature "abc"}}}
+                 {:type :text-start} {:type :text-delta} {:type :text-end} {:type :usage}]
                 (into []
                       (comp (claude/claude->aisdk-chunks-xf)
                             (m/distinct-by :type))
                       events))))
-      (testing "through the full pipeline produces text + usage"
-        (is (=? [{:type :start} {:type :text :text "hi"} {:type :usage}]
+      (testing "through the full pipeline the reasoning coalesces into one part with metadata"
+        (is (=? [{:type :start}
+                 {:type :reasoning :text "let me think" :provider-metadata {:anthropic {:signature "abc"}}}
+                 {:type :text :text "hi"} {:type :usage}]
                 (into []
                       (comp (claude/claude->aisdk-chunks-xf)
                             (self.core/aisdk-xf))
                       events))))))
-  (testing "a stream that ends mid-thinking flushes usage without emitting a thinking part"
+  (testing "redacted_thinking carries its data on the reasoning-end, streaming no deltas"
+    (let [events [{:type "message_start"
+                   :message {:id "msg-r" :model "claude-sonnet-5"
+                             :usage {:input_tokens 10 :output_tokens 0}}}
+                  {:type "content_block_start" :index 0 :content_block {:type "redacted_thinking" :data "ENC"}}
+                  {:type "content_block_stop" :index 0}]]
+      (is (=? [{:type :start}
+               {:type :reasoning-start}
+               {:type :reasoning-end :providerMetadata {:anthropic {:redactedData "ENC"}}}
+               {:type :usage}]
+              (into []
+                    (comp (claude/claude->aisdk-chunks-xf)
+                          (m/distinct-by :type))
+                    events)))))
+  (testing "a stream that ends mid-thinking flushes an unsigned reasoning-end then usage"
     (let [events [{:type "message_start"
                    :message {:id "msg-2" :model "claude-sonnet-5"
                              :usage {:input_tokens 10 :output_tokens 0}}}
                   {:type "content_block_start" :index 0 :content_block {:type "thinking"}}
                   {:type "content_block_delta" :index 0 :delta {:type "thinking_delta" :thinking "partial"}}]]
-      (is (=? [{:type :start} {:type :usage}]
+      (is (=? [{:type :start} {:type :reasoning-start} {:type :reasoning-delta}
+               {:type :reasoning-end} {:type :usage}]
               (into []
                     (comp (claude/claude->aisdk-chunks-xf)
                           (m/distinct-by :type))
@@ -230,6 +250,30 @@
             (claude/parts->claude-messages
              [{:type :text :text "Let me check..."}
               {:type :tool-input :id "call-1" :function "search" :arguments {:query "revenue"}}])))))
+
+(deftest ^:parallel parts->claude-messages-reasoning-test
+  (testing "signed reasoning replays as a thinking block ahead of the tool_use it preceded"
+    (is (=? [{:role    "assistant"
+              :content [{:type "thinking" :thinking "let me think" :signature "abc"}
+                        {:type "tool_use" :id "call-1" :name "search"}]}]
+            (claude/parts->claude-messages
+             [{:type :reasoning :id "r1" :text "let me "}
+              {:type :reasoning :id "r1" :text "think"}
+              {:type :reasoning :id "r1" :text "" :provider-metadata {:anthropic {:signature "abc"}}}
+              {:type :tool-input :id "call-1" :function "search" :arguments {:q "x"}}]))))
+  (testing "redacted reasoning replays as a redacted_thinking block verbatim"
+    (is (=? [{:role    "assistant"
+              :content [{:type "redacted_thinking" :data "ENC"}
+                        {:type "tool_use" :id "call-1"}]}]
+            (claude/parts->claude-messages
+             [{:type :reasoning :id "r1" :text "" :provider-metadata {:anthropic {:redactedData "ENC"}}}
+              {:type :tool-input :id "call-1" :function "search" :arguments {}}]))))
+  (testing "unsigned reasoning (no signature/redacted) is dropped"
+    (is (=? [{:role    "assistant"
+              :content [{:type "tool_use" :id "call-1"}]}]
+            (claude/parts->claude-messages
+             [{:type :reasoning :id "r1" :text "unsigned"}
+              {:type :tool-input :id "call-1" :function "search" :arguments {}}])))))
 
 (deftest ^:parallel parts->claude-messages-tool-result-test
   (testing "tool output becomes user message with tool_result content block"
@@ -364,6 +408,32 @@
           (is (= 1 (count (:tools body))))
           (is (= "structured_output" (-> body :tools first :name)))
           (is (not (contains? (-> body :tools first) :cache_control))))))))
+
+(deftest claude-thinking-config-test
+  (mt/with-temporary-setting-values [llm.settings/llm-anthropic-api-key "sk-ant-test"]
+    (let [input    [{:role :user :content "hi"}]
+          thinking #(:thinking (capture-claude-request-body! (merge {:input input} %)))]
+      (testing "current-gen models stream summarized reasoning"
+        (is (= {:type "adaptive" :display "summarized"} (thinking {:model "claude-fable-5"})))
+        (is (= {:type "adaptive" :display "summarized"} (thinking {:model "claude-opus-4-8"})))
+        (is (= {:type "adaptive" :display "summarized"} (thinking {:model "claude-sonnet-5"})))
+        (testing "bedrock vendor prefix is stripped"
+          (is (= {:type "adaptive" :display "summarized"} (thinking {:model "anthropic.claude-opus-4-8"})))))
+      (testing "4.6 models also get an explicit display param, not just the (currently matching) default"
+        (is (= {:type "adaptive" :display "summarized"} (thinking {:model "claude-opus-4-6"})))
+        (is (= {:type "adaptive" :display "summarized"} (thinking {:model "claude-sonnet-4-6"}))))
+      (testing "older budget-token models get no thinking (off in v1)"
+        (is (nil? (thinking {:model "claude-haiku-4-5"})))
+        (is (nil? (thinking {:model "claude-sonnet-4-5"}))))
+      (testing "thinking raises the max_tokens floor to leave room for the answer"
+        (is (= 16384 (:max_tokens (capture-claude-request-body! {:input input :model "claude-opus-4-8"}))))
+        (is (= 32000 (:max_tokens (capture-claude-request-body! {:input input :model "claude-opus-4-8" :max-tokens 32000})))))
+      (testing "forced tool choice is incompatible with thinking, so it is suppressed"
+        (is (nil? (thinking {:model "claude-opus-4-8"
+                             :schema {:type "object" :properties {:answer {:type "string"}}}})))
+        (is (nil? (thinking {:model       "claude-opus-4-8"
+                             :tools       [(metabot.tu/get-time-tool)]
+                             :tool_choice "required"})))))))
 
 (deftest claude-auto-cache-breakpoint-test
   (mt/with-temporary-setting-values [llm.settings/llm-anthropic-api-key "sk-ant-test"]
@@ -562,4 +632,6 @@
     (testing "temperature is omitted for models that reject sampling parameters"
       (is (not (contains? (request-body "claude-opus-4-8") :temperature)))
       (is (not (contains? (request-body "claude-sonnet-5") :temperature)))
-      (is (not (contains? (request-body "anthropic.claude-opus-4-8") :temperature))))))
+      (is (not (contains? (request-body "anthropic.claude-opus-4-8") :temperature))))
+    (testing "temperature is omitted when thinking is enabled (4.6 accepts sampling but streams thinking here)"
+      (is (not (contains? (request-body "claude-opus-4-6") :temperature))))))

--- a/test/metabase/metabot/self/openai_test.clj
+++ b/test/metabase/metabot/self/openai_test.clj
@@ -100,12 +100,16 @@
                         :cacheReadTokens     nat-int?}}]
               (into [] (comp (openai/openai->aisdk-chunks-xf) (self.core/aisdk-xf)) raw-chunks))))))
 
-(deftest ^:parallel openai-reasoning-items-are-ignored-test
-  (testing "reasoning output items (emitted by GPT-5 / o-series models) are skipped without breaking the stream"
+(deftest ^:parallel openai-reasoning-summaries-are-translated-test
+  (testing "reasoning summary items (GPT-5 / o-series) become reasoning chunks"
     (let [base      (fixture "openai-text"
                              {:input [{:role :user :content "Say hello briefly, in under 10 words."}]})
-          ;; GPT-5 reasoning models emit a reasoning output item before the text message item
+          ;; GPT-5 reasoning models emit a reasoning output item + summary deltas before the text
           reasoning [{:type "response.output_item.added" :item {:type "reasoning" :id "rs_1"}}
+                     {:type "response.reasoning_summary_part.added" :item_id "rs_1"}
+                     {:type "response.reasoning_summary_text.delta" :item_id "rs_1" :delta "Keeping it "}
+                     {:type "response.reasoning_summary_text.delta" :item_id "rs_1" :delta "short"}
+                     {:type "response.reasoning_summary_text.done"  :item_id "rs_1"}
                      {:type "response.output_item.done"  :item {:type "reasoning" :id "rs_1"}}]
           ;; splice the reasoning events in right after response.created
           patched   (into [] (mapcat (fn [chunk]
@@ -113,11 +117,15 @@
                                          (cons chunk reasoning)
                                          [chunk])))
                           base)]
-      (testing "no reasoning artifacts leak into the translated chunk types"
-        (is (=? [{:type :start} {:type :text-start} {:type :text-delta} {:type :text-end} {:type :usage}]
-                (into [] (comp (openai/openai->aisdk-chunks-xf) (m/distinct-by :type)) patched))))
-      (testing "full pipeline still produces text + usage"
+      (testing "reasoning start/delta/end surround the text"
         (is (=? [{:type :start}
+                 {:type :reasoning-start} {:type :reasoning-delta :delta "Keeping it "}
+                 {:type :reasoning-end}
+                 {:type :text-start} {:type :text-delta} {:type :text-end} {:type :usage}]
+                (into [] (comp (openai/openai->aisdk-chunks-xf) (m/distinct-by :type)) patched))))
+      (testing "full pipeline coalesces the reasoning into one part"
+        (is (=? [{:type :start}
+                 {:type :reasoning :text "Keeping it short"}
                  {:type :text :text string?}
                  {:type  :usage
                   :usage {:promptTokens        pos-int?
@@ -300,6 +308,37 @@
               :output  #"Error:.*failed"}]
             (openai/parts->openai-input
              [{:type :tool-output :id "call-1" :error {:message "Tool failed"}}])))))
+
+(deftest ^:parallel openai-reasoning-summary-part-separator-test
+  (testing "a 2nd+ summary part opens a new paragraph within the same reasoning item"
+    (is (= ["Part one" "\n\n" "Part two"]
+           (->> [{:type "response.output_item.added" :item {:type "reasoning" :id "rs_1"}}
+                 {:type "response.reasoning_summary_part.added" :item_id "rs_1" :summary_index 0}
+                 {:type "response.reasoning_summary_text.delta" :item_id "rs_1" :delta "Part one"}
+                 {:type "response.reasoning_summary_part.added" :item_id "rs_1" :summary_index 1}
+                 {:type "response.reasoning_summary_text.delta" :item_id "rs_1" :delta "Part two"}
+                 {:type "response.output_item.done" :item {:type "reasoning" :id "rs_1"}}]
+                (into [] (openai/openai->aisdk-chunks-xf))
+                (filter #(= :reasoning-delta (:type %)))
+                (mapv :delta))))))
+
+(deftest ^:parallel parts->openai-input-drops-reasoning-test
+  (testing "reasoning parts are not replayed to the Responses API"
+    (is (=? [{:type "message" :role "assistant" :content [{:type "output_text" :text "hi"}]}]
+            (openai/parts->openai-input
+             [{:type :reasoning :id "r1" :text "thinking" :provider-metadata {}}
+              {:type :text :text "hi"}])))))
+
+(deftest ^:parallel openai-request-body-reasoning-gating-test
+  (testing "reasoning models ask for a summary; others don't"
+    (let [reasoning #(:reasoning (openai/openai-request-body {:model % :input []}))]
+      (is (= {:summary "auto"} (reasoning "gpt-5.4")))
+      (is (= {:summary "auto"} (reasoning "gpt-5.6-sol")))
+      (is (= {:summary "auto"} (reasoning "o3")))
+      (testing "bedrock/azure vendor prefix is stripped"
+        (is (= {:summary "auto"} (reasoning "openai.gpt-5.4"))))
+      (testing "non-reasoning models get no reasoning param"
+        (is (nil? (reasoning "gpt-4.1")))))))
 
 ;;; ──────────────────────────────────────────────────────────────────
 ;;; list-models filtering tests

--- a/test/metabase/metabot/self/openai_test.clj
+++ b/test/metabase/metabot/self/openai_test.clj
@@ -322,12 +322,39 @@
                 (filter #(= :reasoning-delta (:type %)))
                 (mapv :delta))))))
 
-(deftest ^:parallel parts->openai-input-drops-reasoning-test
-  (testing "reasoning parts are not replayed to the Responses API"
+(deftest ^:parallel parts->openai-input-reasoning-replay-test
+  (testing "reasoning with encrypted content replays ahead of the tool call it preceded"
+    (is (=? [{:type              "reasoning"
+              :id                "rs_1"
+              :summary           []
+              :encrypted_content "ENC"}
+             {:type "function_call" :call_id "call-1"}]
+            (openai/parts->openai-input
+             [{:type :reasoning :id "rs_1" :text "thinking"}
+              {:type :reasoning :id "rs_1" :text ""
+               :provider-metadata {:openai {:itemId "rs_1" :encryptedContent "ENC"}}}
+              {:type :tool-input :id "call-1" :function "search" :arguments {}}]))))
+  (testing "reasoning without encrypted content (bare summaries, foreign providers) is dropped"
     (is (=? [{:type "message" :role "assistant" :content [{:type "output_text" :text "hi"}]}]
             (openai/parts->openai-input
-             [{:type :reasoning :id "r1" :text "thinking" :provider-metadata {}}
+             [{:type :reasoning :id "r1" :text "thinking" :provider-metadata {:anthropic {:signature "abc"}}}
               {:type :text :text "hi"}])))))
+
+(deftest ^:parallel openai-reasoning-encrypted-content-test
+  (let [raw [{:type "response.output_item.added" :item {:type "reasoning" :id "rs_1"}}
+             {:type "response.reasoning_summary_text.delta" :item_id "rs_1" :delta "hm"}
+             {:type "response.output_item.done"
+              :item {:type "reasoning" :id "rs_1" :encrypted_content "ENC"}}]]
+    (testing "encrypted content from output_item.done rides the reasoning-end's metadata"
+      (is (=? [{:type :reasoning-start :id "rs_1"}
+               {:type :reasoning-delta :id "rs_1" :delta "hm"}
+               {:type :reasoning-end :id "rs_1"
+                :providerMetadata {:openai {:itemId "rs_1" :encryptedContent "ENC"}}}]
+              (into [] (openai/openai->aisdk-chunks-xf) raw))))
+    (testing "the full pipeline lands it on the reasoning part's provider metadata"
+      (is (=? [{:type :reasoning :id "rs_1" :text "hm"
+                :provider-metadata {:openai {:itemId "rs_1" :encryptedContent "ENC"}}}]
+              (into [] (comp (openai/openai->aisdk-chunks-xf) (self.core/aisdk-xf)) raw))))))
 
 (deftest ^:parallel openai-request-body-reasoning-gating-test
   (testing "reasoning models ask for a summary; others don't"
@@ -338,7 +365,21 @@
       (testing "bedrock/azure vendor prefix is stripped"
         (is (= {:summary "auto"} (reasoning "openai.gpt-5.4"))))
       (testing "non-reasoning models get no reasoning param"
-        (is (nil? (reasoning "gpt-4.1")))))))
+        (is (nil? (reasoning "gpt-4.1"))))))
+  (testing "reasoning requests ask for encrypted content so items can be replayed"
+    (is (= ["reasoning.encrypted_content"]
+           (:include (openai/openai-request-body {:model "gpt-5.4" :input []}))))
+    (is (not (contains? (openai/openai-request-body {:model "gpt-4.1" :input []}) :include))))
+  (testing ":reasoning? false requests no summary and strips reasoning replay"
+    (let [body (openai/openai-request-body
+                {:model      "gpt-5.4"
+                 :reasoning? false
+                 :input      [{:type :reasoning :id "rs_1" :text ""
+                               :provider-metadata {:openai {:itemId "rs_1" :encryptedContent "ENC"}}}
+                              {:type :text :text "hi"}]})]
+      (is (not (contains? body :reasoning)))
+      (is (not (contains? body :include)))
+      (is (=? [{:type "message" :role "assistant"}] (:input body))))))
 
 ;;; ──────────────────────────────────────────────────────────────────
 ;;; list-models filtering tests

--- a/test/metabase/metabot/self/openrouter_test.clj
+++ b/test/metabase/metabot/self/openrouter_test.clj
@@ -30,6 +30,16 @@
              [{:role :user :content "Hello"}
               {:type :text :text "Hi there!"}])))))
 
+(deftest ^:parallel parts->cc-messages-drops-reasoning-test
+  (testing "reasoning parts are dropped, not turned into empty user messages"
+    (is (=? [{:role "user" :content "Hello"}
+             {:role "assistant" :content "Hi there!"}]
+            (openrouter/parts->cc-messages
+             [{:role :user :content "Hello"}
+              {:type :reasoning :id "r1" :text "thinking"}
+              {:type :reasoning :id "r1" :text "" :provider-metadata {:anthropic {:signature "abc"}}}
+              {:type :text :text "Hi there!"}])))))
+
 (deftest ^:parallel parts->cc-messages-tool-call-test
   (testing "text + tool call merges into single assistant message"
     (is (=? [{:role       "assistant"

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -184,7 +184,31 @@
                :result      {:data []}
                :error       nil
                :duration-ms 1234}]
-             (into [] (self.core/lite-aisdk-xf) chunks))))))
+             (into [] (self.core/lite-aisdk-xf) chunks)))))
+  (testing "streams reasoning deltas and carries provider metadata on the end"
+    (let [chunks [{:type :reasoning-start :id "r1"}
+                  {:type :reasoning-delta :id "r1" :delta "Think"}
+                  {:type :reasoning-delta :id "r1" :delta "ing"}
+                  {:type :reasoning-end :id "r1" :providerMetadata {:anthropic {:signature "sig"}}}]]
+      (is (= [{:type :reasoning :id "r1" :text "Think"}
+              {:type :reasoning :id "r1" :text "ing"}
+              {:type :reasoning :id "r1" :text "" :provider-metadata {:anthropic {:signature "sig"}}}]
+             (into [] (self.core/lite-aisdk-xf) chunks)))))
+  (testing "a reasoning-end without provider metadata emits no carrier"
+    (is (= [{:type :reasoning :id "r1" :text "hm"}]
+           (into [] (self.core/lite-aisdk-xf)
+                 [{:type :reasoning-start :id "r1"}
+                  {:type :reasoning-delta :id "r1" :delta "hm"}
+                  {:type :reasoning-end :id "r1"}])))))
+
+(deftest ^:parallel aisdk-xf-reasoning-grouping-test
+  (testing "non-streaming mode joins reasoning deltas into one part with metadata"
+    (is (= [{:type :reasoning :id "r1" :text "abc" :provider-metadata {:anthropic {:signature "sig"}}}]
+           (into [] (self.core/aisdk-xf)
+                 [{:type :reasoning-start :id "r1"}
+                  {:type :reasoning-delta :id "r1" :delta "ab"}
+                  {:type :reasoning-delta :id "r1" :delta "c"}
+                  {:type :reasoning-end :id "r1" :providerMetadata {:anthropic {:signature "sig"}}}])))))
 
 ;;; tool executor
 
@@ -453,6 +477,41 @@
            (mapv :type
                  (sse-events [{:type :text :id "t1" :text "hi"}
                               {:type :data :data-type "state" :data {:queries {}}}]))))))
+
+(deftest parts->aisdk-sse-xf-reasoning-test
+  (testing "consecutive same-id :reasoning parts share one block with a short wire id"
+    (is (= [["reasoning-start" "1" nil]
+            ["reasoning-delta" "1" "Think"]
+            ["reasoning-delta" "1" "ing"]
+            ["reasoning-end" "1" nil]
+            ["finish" nil nil]]
+           (mapv (juxt :type :id :delta)
+                 (sse-events [{:type :reasoning :id "r1" :text "Think"}
+                              {:type :reasoning :id "r1" :text "ing"}])))))
+  (testing "reasoning and text close each other in both directions"
+    (is (= ["reasoning-start" "reasoning-delta" "reasoning-end"
+            "text-start" "text-delta" "text-end"
+            "reasoning-start" "reasoning-delta" "reasoning-end"
+            "finish"]
+           (mapv :type
+                 (sse-events [{:type :reasoning :id "r1" :text "hmm"}
+                              {:type :text :id "t1" :text "answer"}
+                              {:type :reasoning :id "r2" :text "more"}])))))
+  (testing "empty-text parts (metadata carriers) emit nothing"
+    (is (= ["finish"]
+           (mapv :type
+                 (sse-events [{:type :reasoning :id "r1" :text ""
+                               :provider-metadata {:anthropic {:signature "sig"}}}]))))
+    (is (= ["reasoning-start" "reasoning-delta" "reasoning-end" "finish"]
+           (mapv :type
+                 (sse-events [{:type :reasoning :id "r1" :text "hi"}
+                              {:type :reasoning :id "r1" :text ""
+                               :provider-metadata {:anthropic {:signature "sig"}}}])))))
+  (testing "a tool part closes an open reasoning block first"
+    (is (= ["reasoning-start" "reasoning-delta" "reasoning-end" "tool-input-available" "finish"]
+           (mapv :type
+                 (sse-events [{:type :reasoning :id "r1" :text "planning"}
+                              {:type :tool-input :id "call-1" :function "search" :arguments {}}]))))))
 
 (deftest parts->aisdk-sse-xf-tool-test
   (testing "tool input and successful output"

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -507,6 +507,15 @@
                  (sse-events [{:type :reasoning :id "r1" :text "hi"}
                               {:type :reasoning :id "r1" :text ""
                                :provider-metadata {:anthropic {:signature "sig"}}}])))))
+  (testing "a whitespace-only part (paragraph separator) flows as a delta"
+    (is (= [["reasoning-delta" "part one"]
+            ["reasoning-delta" "\n\n"]
+            ["reasoning-delta" "part two"]]
+           (->> (sse-events [{:type :reasoning :id "r1" :text "part one"}
+                             {:type :reasoning :id "r1" :text "\n\n"}
+                             {:type :reasoning :id "r1" :text "part two"}])
+                (filter #(= "reasoning-delta" (:type %)))
+                (mapv (juxt :type :delta))))))
   (testing "a tool part closes an open reasoning block first"
     (is (= ["reasoning-start" "reasoning-delta" "reasoning-end" "tool-input-available" "finish"]
            (mapv :type


### PR DESCRIPTION
Part of [BOT-1889: Expose agent reasoning to users](https://linear.app/metabase/issue/bot-1889/expose-agent-reasoning-to-users)

### Description

Streams provider reasoning through the response pipeline:

- Claude `thinking`/`redacted_thinking` blocks and OpenAI reasoning summaries (both previously ignored) are translated into `reasoning-start/delta/end` chunks and streamed to the client over SSE.
- OpenAI reasoning items are replayed across tool calls via `reasoning.encrypted_content`. We run `store: false` with no `previous_response_id`, so without this the model loses its reasoning context on every tool call round-trip.
- Reasoning is off for openrouter, bedrock, and azure for now (they pass `:reasoning? false`, which skips the thinking/summary request and strips reasoning parts from the replayed input).
- Reasoning only exists on the live stream, reasoning is not written to `metabot_message` table.
- Thinking config is explicit per model class rather than relying on per-model defaults (those have already changed silently once across a model bump). Forced tool choice suppresses it, and enabling it raises the `max_tokens` floor and drops `temperature`.

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)