### PR TITLE
[DRY RUN] Unlabeled no-op path — SDK release verification (EMB-1518)

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk-package/package.template.json
@@ -2,7 +2,7 @@
   "name": "@metabase/embedding-sdk-react",
   "version": "0.999.0-beta.0",
   "sdkRelease": { "distTag": "999-beta", "tagAsLatest": false },
-  "description": "Metabase Embedding SDK for React",
+  "description": "Metabase Embedding SDK for React (dry-run no-op edit, EMB-1518)",
   "bin": "./dist/cli.js",
   "repository": {
     "url": "git+https://github.com/metabase/metabase.git"


### PR DESCRIPTION
Dry-run fixture for [#77537](https://github.com/metabase/metabase/pull/77537) on the publish-neutered branch `emb-1518-dryrun-base`.

**Case under test:** a PR edits `package.template.json` but carries **no** `sdk-release-trigger` label.

**Expected:** the release workflow runs nothing — `prepare-release`'s gate is false, so every job (build, publish, tag, all three Slack notifications) skips. Nothing published, tagged, or announced.

**Result** — ✅ [run 29981684778](https://github.com/metabase/metabase/actions/runs/29981684778): all 13 jobs skipped. Case holds.
