### PR TITLE
[DRY RUN] Labeled bump, tagAsLatest:false — SDK release verification (EMB-1518)

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk-package/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.999.0-beta.0",
+  "version": "0.999.0-beta.1",
   "sdkRelease": { "distTag": "999-beta", "tagAsLatest": false },
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",


### PR DESCRIPTION
Dry-run fixture for [#77537](https://github.com/metabase/metabase/pull/77537) on the publish-neutered branch `emb-1518-dryrun-base` (junk version `0.999.0-beta.x`).

**Case under test:** a labeled (`sdk-release-trigger`) release PR whose `sdkRelease.tagAsLatest` is `false`.

**Expected:** the full release runs and publishes under its own dist-tag (`999-beta`), but must **not** move the npm `latest` tag — the `tag-latest` job is skipped.

**Result** — ✅ [run 29981721480](https://github.com/metabase/metabase/actions/runs/29981721480): full graph green; `publish-npm` echoed `999-beta` (stub, no real publish); **`tag-latest` skipped**; Slack start+success posted. Case holds.
