### PR TITLE
Migrate monitor and metric pages off withRouteProps

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricAboutPage/DataStudioMetricAboutPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricAboutPage/DataStudioMetricAboutPage.tsx
@@ -1,19 +1,11 @@
-import type { MetricPageParams } from "metabase/common/metrics/types";
 import { MetricAboutPage } from "metabase/metrics/pages/MetricAboutPage";
 
 import { DataStudioMetricBreadcrumbs } from "../../components/DataStudioMetricBreadcrumbs";
 import { dataStudioMetricUrls } from "../../urls";
 
-interface DataStudioMetricAboutPageProps {
-  params: MetricPageParams;
-}
-
-export function DataStudioMetricAboutPage({
-  params,
-}: DataStudioMetricAboutPageProps) {
+export function DataStudioMetricAboutPage() {
   return (
     <MetricAboutPage
-      params={params}
       urls={dataStudioMetricUrls}
       showAppSwitcher
       showDataStudioLink={false}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricDependenciesPage/DataStudioMetricDependenciesPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricDependenciesPage/DataStudioMetricDependenciesPage.tsx
@@ -1,19 +1,11 @@
-import type { MetricPageParams } from "metabase/common/metrics/types";
 import { MetricDependenciesPage } from "metabase/metrics/pages/MetricDependenciesPage";
 
 import { DataStudioMetricBreadcrumbs } from "../../components/DataStudioMetricBreadcrumbs";
 import { dataStudioMetricUrls } from "../../urls";
 
-interface DataStudioMetricDependenciesPageProps {
-  params: MetricPageParams;
-}
-
-export function DataStudioMetricDependenciesPage({
-  params,
-}: DataStudioMetricDependenciesPageProps) {
+export function DataStudioMetricDependenciesPage() {
   return (
     <MetricDependenciesPage
-      params={params}
       urls={dataStudioMetricUrls}
       showAppSwitcher
       showDataStudioLink={false}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricHistoryPage/DataStudioMetricHistoryPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricHistoryPage/DataStudioMetricHistoryPage.tsx
@@ -1,19 +1,11 @@
-import type { MetricPageParams } from "metabase/common/metrics/types";
 import { MetricHistoryPage } from "metabase/metrics/pages/MetricHistoryPage";
 
 import { DataStudioMetricBreadcrumbs } from "../../components/DataStudioMetricBreadcrumbs";
 import { dataStudioMetricUrls } from "../../urls";
 
-interface DataStudioMetricHistoryPageProps {
-  params: MetricPageParams;
-}
-
-export function DataStudioMetricHistoryPage({
-  params,
-}: DataStudioMetricHistoryPageProps) {
+export function DataStudioMetricHistoryPage() {
   return (
     <MetricHistoryPage
-      params={params}
       urls={dataStudioMetricUrls}
       showAppSwitcher
       showDataStudioLink={false}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricOverviewPage/DataStudioMetricOverviewPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricOverviewPage/DataStudioMetricOverviewPage.tsx
@@ -1,19 +1,11 @@
-import type { MetricPageParams } from "metabase/common/metrics/types";
 import { MetricOverviewPage } from "metabase/metrics/pages/MetricOverviewPage";
 
 import { DataStudioMetricBreadcrumbs } from "../../components/DataStudioMetricBreadcrumbs";
 import { dataStudioMetricUrls } from "../../urls";
 
-interface DataStudioMetricOverviewPageProps {
-  params: MetricPageParams;
-}
-
-export function DataStudioMetricOverviewPage({
-  params,
-}: DataStudioMetricOverviewPageProps) {
+export function DataStudioMetricOverviewPage() {
   return (
     <MetricOverviewPage
-      params={params}
       urls={dataStudioMetricUrls}
       showAppSwitcher
       showDataStudioLink={false}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricQueryPage/DataStudioMetricQueryPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/DataStudioMetricQueryPage/DataStudioMetricQueryPage.tsx
@@ -1,23 +1,11 @@
-import type { MetricPageParams } from "metabase/common/metrics/types";
 import { MetricQueryPage } from "metabase/metrics/pages/MetricQueryPage";
-import type { Route } from "metabase/router";
 
 import { DataStudioMetricBreadcrumbs } from "../../components/DataStudioMetricBreadcrumbs";
 import { dataStudioMetricUrls } from "../../urls";
 
-interface DataStudioMetricQueryPageProps {
-  params: MetricPageParams;
-  route: Route;
-}
-
-export function DataStudioMetricQueryPage({
-  params,
-  route,
-}: DataStudioMetricQueryPageProps) {
+export function DataStudioMetricQueryPage() {
   return (
     <MetricQueryPage
-      params={params}
-      route={route}
       urls={dataStudioMetricUrls}
       showAppSwitcher
       showDataStudioLink={false}

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/NewMetricPage/NewMetricPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/pages/NewMetricPage/NewMetricPage.tsx
@@ -2,28 +2,14 @@ import { t } from "ttag";
 
 import { DataStudioBreadcrumbs } from "metabase/common/data-studio/components/DataStudioBreadcrumbs";
 import { NewMetricPage } from "metabase/metrics/pages/NewMetricPage";
-import { Link, type Location, type Route } from "metabase/router";
+import { Link } from "metabase/router";
 import * as Urls from "metabase/urls";
 
 import { dataStudioMetricUrls } from "../../urls";
 
-interface NewMetricPageQuery {
-  collectionId?: string;
-}
-
-interface DataStudioNewMetricPageProps {
-  location: Location<NewMetricPageQuery>;
-  route: Route;
-}
-
-export function DataStudioNewMetricPage({
-  location,
-  route,
-}: DataStudioNewMetricPageProps) {
+export function DataStudioNewMetricPage() {
   return (
     <NewMetricPage
-      location={location}
-      route={route}
       urls={dataStudioMetricUrls}
       showAppSwitcher
       triggeredFrom="data_studio"

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/metrics/routes.tsx
@@ -1,5 +1,5 @@
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { DataStudioMetricAboutPage } from "./pages/DataStudioMetricAboutPage";
 import { DataStudioMetricDependenciesPage } from "./pages/DataStudioMetricDependenciesPage";
@@ -8,48 +8,25 @@ import { DataStudioMetricOverviewPage } from "./pages/DataStudioMetricOverviewPa
 import { DataStudioMetricQueryPage } from "./pages/DataStudioMetricQueryPage";
 import { DataStudioNewMetricPage } from "./pages/NewMetricPage";
 
-const RoutedDataStudioNewMetricPage = withRouteProps(DataStudioNewMetricPage);
-const RoutedDataStudioMetricAboutPage = withRouteProps(
-  DataStudioMetricAboutPage,
-);
-const RoutedDataStudioMetricOverviewPage = withRouteProps(
-  DataStudioMetricOverviewPage,
-);
-const RoutedDataStudioMetricQueryPage = withRouteProps(
-  DataStudioMetricQueryPage,
-);
-const RoutedDataStudioMetricDependenciesPage = withRouteProps(
-  DataStudioMetricDependenciesPage,
-);
-const RoutedDataStudioMetricHistoryPage = withRouteProps(
-  DataStudioMetricHistoryPage,
-);
-
 export function getDataStudioMetricRoutes() {
   return (
     <Route path="metrics">
-      <Route path="new" element={<RoutedDataStudioNewMetricPage />} />
-      <Route path=":cardId" element={<RoutedDataStudioMetricAboutPage />} />
+      <Route path="new" element={<DataStudioNewMetricPage />} />
+      <Route path=":cardId" element={<DataStudioMetricAboutPage />} />
       <Route
         path=":cardId/overview"
-        element={<RoutedDataStudioMetricOverviewPage />}
+        element={<DataStudioMetricOverviewPage />}
       />
-      <Route
-        path=":cardId/query"
-        element={<RoutedDataStudioMetricQueryPage />}
-      />
+      <Route path=":cardId/query" element={<DataStudioMetricQueryPage />} />
       {PLUGIN_DEPENDENCIES.isEnabled && (
         <Route
           path=":cardId/dependencies"
-          element={<RoutedDataStudioMetricDependenciesPage />}
+          element={<DataStudioMetricDependenciesPage />}
         >
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>
       )}
-      <Route
-        path=":cardId/history"
-        element={<RoutedDataStudioMetricHistoryPage />}
-      />
+      <Route path=":cardId/history" element={<DataStudioMetricHistoryPage />} />
     </Route>
   );
 }

--- a/frontend/src/metabase/common/metrics/types.ts
+++ b/frontend/src/metabase/common/metrics/types.ts
@@ -18,12 +18,11 @@ export interface MetricUrls {
   table?: (databaseId: DatabaseId, tableId: TableId) => string;
 }
 
-export interface MetricPageParams {
+export type MetricPageParams = {
   cardId: string;
-}
+};
 
 export interface MetricPageProps {
-  params: MetricPageParams;
   urls?: MetricUrls;
   renderBreadcrumbs?: (card: Card) => ReactNode;
   showAppSwitcher?: boolean;

--- a/frontend/src/metabase/metrics/components/MetricPageCard/MetricPageCard.tsx
+++ b/frontend/src/metabase/metrics/components/MetricPageCard/MetricPageCard.tsx
@@ -10,7 +10,7 @@ import { is403Error } from "metabase/utils/errors";
 import type { Card } from "metabase-types/api";
 
 interface MetricPageCardProps {
-  cardId: string;
+  cardId: string | undefined;
   children: (card: Card) => ReactNode;
 }
 

--- a/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAboutPage.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAboutPage.tsx
@@ -1,5 +1,9 @@
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
-import type { MetricPageProps } from "metabase/common/metrics/types";
+import type {
+  MetricPageParams,
+  MetricPageProps,
+} from "metabase/common/metrics/types";
+import { useParams } from "metabase/router";
 
 import { MetricPageCard } from "../../components/MetricPageCard";
 import { MetricPageShell } from "../../components/MetricPageShell";
@@ -8,14 +12,15 @@ import { metricUrls as defaultUrls } from "../../urls";
 import { MetricAbout } from "./MetricAbout";
 
 export function MetricAboutPage({
-  params,
   urls = defaultUrls,
   renderBreadcrumbs,
   showAppSwitcher,
   showDataStudioLink = true,
 }: MetricPageProps) {
+  const { cardId } = useParams<MetricPageParams>();
+
   return (
-    <MetricPageCard cardId={params.cardId}>
+    <MetricPageCard cardId={cardId}>
       {(card) => (
         <PageContainer data-testid="metric-about-page" gap="xl">
           <MetricPageShell

--- a/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAboutPage.unit.spec.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricAboutPage/MetricAboutPage.unit.spec.tsx
@@ -9,7 +9,7 @@ import {
 } from "__support__/server-mocks";
 import { PERMISSION_ERROR } from "__support__/server-mocks/constants";
 import { renderWithProviders, screen } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import type { Card } from "metabase-types/api";
 import {
   createMockCard,
@@ -23,8 +23,6 @@ import {
 } from "metabase-types/api/mocks/presets";
 
 import { MetricAboutPage } from "./MetricAboutPage";
-
-const RoutedMetricAboutPage = withRouteProps(MetricAboutPage);
 
 const SAMPLE_DB = createSampleDatabase();
 const CARD_ID = 42;
@@ -60,7 +58,7 @@ function setupBaseEndpoints(card: Card) {
 
 function renderPage() {
   renderWithProviders(
-    <Route path="/metric/:cardId" element={<RoutedMetricAboutPage />} />,
+    <Route path="/metric/:cardId" element={<MetricAboutPage />} />,
     {
       withRouter: true,
       initialRoute: `/metric/${CARD_ID}`,

--- a/frontend/src/metabase/metrics/pages/MetricDependenciesPage/MetricDependenciesPage.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricDependenciesPage/MetricDependenciesPage.tsx
@@ -1,7 +1,10 @@
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
-import type { MetricPageProps } from "metabase/common/metrics/types";
+import type {
+  MetricPageParams,
+  MetricPageProps,
+} from "metabase/common/metrics/types";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
-import { Outlet } from "metabase/router";
+import { Outlet, useParams } from "metabase/router";
 import { Card } from "metabase/ui";
 
 import { MetricPageCard } from "../../components/MetricPageCard";
@@ -9,14 +12,15 @@ import { MetricPageShell } from "../../components/MetricPageShell";
 import { metricUrls as defaultUrls } from "../../urls";
 
 export function MetricDependenciesPage({
-  params,
   urls = defaultUrls,
   renderBreadcrumbs,
   showAppSwitcher,
   showDataStudioLink = true,
 }: MetricPageProps) {
+  const { cardId } = useParams<MetricPageParams>();
+
   return (
-    <MetricPageCard cardId={params.cardId}>
+    <MetricPageCard cardId={cardId}>
       {(card) => (
         <PageContainer>
           <MetricPageShell

--- a/frontend/src/metabase/metrics/pages/MetricHistoryPage/MetricHistoryPage.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricHistoryPage/MetricHistoryPage.tsx
@@ -1,5 +1,9 @@
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
-import type { MetricPageProps } from "metabase/common/metrics/types";
+import type {
+  MetricPageParams,
+  MetricPageProps,
+} from "metabase/common/metrics/types";
+import { useParams } from "metabase/router";
 import { Box, Card } from "metabase/ui";
 
 import { MetricActivityTimeline } from "../../components/MetricActivityTimeline";
@@ -10,14 +14,15 @@ import { metricUrls as defaultUrls } from "../../urls";
 import S from "./MetricHistoryPage.module.css";
 
 export function MetricHistoryPage({
-  params,
   urls = defaultUrls,
   renderBreadcrumbs,
   showAppSwitcher,
   showDataStudioLink = true,
 }: MetricPageProps) {
+  const { cardId } = useParams<MetricPageParams>();
+
   return (
-    <MetricPageCard cardId={params.cardId}>
+    <MetricPageCard cardId={cardId}>
       {(card) => (
         <PageContainer>
           <MetricPageShell

--- a/frontend/src/metabase/metrics/pages/MetricOverviewPage/MetricOverviewPage.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricOverviewPage/MetricOverviewPage.tsx
@@ -4,11 +4,12 @@ import { useGetMetricQuery } from "metabase/api/metric";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
 import type {
+  MetricPageParams,
   MetricPageProps,
   MetricUrls,
 } from "metabase/common/metrics/types";
 import { useDispatch } from "metabase/redux";
-import { replace } from "metabase/router";
+import { replace, useParams } from "metabase/router";
 import { Center } from "metabase/ui";
 import type { Card } from "metabase-types/api";
 
@@ -18,14 +19,15 @@ import { MetricPageShell } from "../../components/MetricPageShell";
 import { metricUrls as defaultUrls } from "../../urls";
 
 export function MetricOverviewPage({
-  params,
   urls = defaultUrls,
   renderBreadcrumbs,
   showAppSwitcher,
   showDataStudioLink = true,
 }: MetricPageProps) {
+  const { cardId } = useParams<MetricPageParams>();
+
   return (
-    <MetricPageCard cardId={params.cardId}>
+    <MetricPageCard cardId={cardId}>
       {(card) => (
         <MetricOverviewPageBody
           card={card}
@@ -39,7 +41,7 @@ export function MetricOverviewPage({
   );
 }
 
-interface MetricOverviewPageBodyProps extends Omit<MetricPageProps, "params"> {
+interface MetricOverviewPageBodyProps extends MetricPageProps {
   card: Card;
   urls: MetricUrls;
 }

--- a/frontend/src/metabase/metrics/pages/MetricQueryPage/MetricQueryPage.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricQueryPage/MetricQueryPage.tsx
@@ -8,13 +8,14 @@ import { PageContainer } from "metabase/common/data-studio/components/PageContai
 import { PaneHeaderActions } from "metabase/common/data-studio/components/PaneHeader";
 import { getResultMetadata } from "metabase/common/data-studio/utils/get-result-metadata";
 import type {
+  MetricPageParams,
   MetricPageProps,
   MetricUrls,
 } from "metabase/common/metrics/types";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
 import { useSelector } from "metabase/redux";
-import type { Route } from "metabase/router";
+import { useParams } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Card } from "metabase/ui";
 import * as Lib from "metabase-lib";
@@ -27,24 +28,19 @@ import { MetricQueryEditor } from "../../components/MetricQueryEditor";
 import { metricUrls as defaultUrls } from "../../urls";
 import { getValidationResult } from "../../utils/validation";
 
-interface MetricQueryPageProps extends MetricPageProps {
-  route: Route;
-}
-
 export function MetricQueryPage({
-  params,
-  route,
   urls = defaultUrls,
   renderBreadcrumbs,
   showAppSwitcher,
   showDataStudioLink = true,
-}: MetricQueryPageProps) {
+}: MetricPageProps) {
+  const { cardId } = useParams<MetricPageParams>();
+
   return (
-    <MetricPageCard cardId={params.cardId}>
+    <MetricPageCard cardId={cardId}>
       {(card) => (
         <MetricQueryPageBody
           card={card}
-          route={route}
           urls={urls}
           renderBreadcrumbs={renderBreadcrumbs}
           showAppSwitcher={showAppSwitcher}
@@ -55,17 +51,13 @@ export function MetricQueryPage({
   );
 }
 
-interface MetricQueryPageBodyProps extends Omit<
-  MetricQueryPageProps,
-  "params"
-> {
+interface MetricQueryPageBodyProps extends MetricPageProps {
   card: CardApiType;
   urls: MetricUrls;
 }
 
 function MetricQueryPageBody({
   card,
-  route,
   urls,
   renderBreadcrumbs,
   showAppSwitcher,
@@ -166,7 +158,7 @@ function MetricQueryPageBody({
           />
         </Card>
       </PageContainer>
-      <LeaveRouteConfirmModal route={route} isEnabled={isDirty && !isSaving} />
+      <LeaveRouteConfirmModal isEnabled={isDirty && !isSaving} />
     </>
   );
 }

--- a/frontend/src/metabase/metrics/pages/NewMetricPage/NewMetricPage.tsx
+++ b/frontend/src/metabase/metrics/pages/NewMetricPage/NewMetricPage.tsx
@@ -16,7 +16,7 @@ import { MetricQueryEditor } from "metabase/metrics/components/MetricQueryEditor
 import { NAME_MAX_LENGTH } from "metabase/metrics/constants";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
 import { useDispatch, useSelector } from "metabase/redux";
-import { type Location, type Route, goBack, push } from "metabase/router";
+import { goBack, push, useRouter } from "metabase/router";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Breadcrumbs, Card, Icon } from "metabase/ui";
 import * as Urls from "metabase/urls";
@@ -29,13 +29,7 @@ import { getValidationResult } from "../../utils/validation";
 import { CreateMetricModal } from "./CreateMetricModal";
 import { getInitialQuery, getQuery } from "./utils";
 
-interface NewMetricPageQuery {
-  collectionId?: string;
-}
-
 interface NewMetricPageProps {
-  location: Location<NewMetricPageQuery>;
-  route: Route;
   urls?: MetricUrls;
   renderBreadcrumbs?: () => ReactNode;
   showAppSwitcher?: boolean;
@@ -43,13 +37,12 @@ interface NewMetricPageProps {
 }
 
 export function NewMetricPage({
-  location,
-  route,
   urls = defaultUrls,
   renderBreadcrumbs,
   showAppSwitcher = false,
   triggeredFrom = "main_app",
 }: NewMetricPageProps) {
+  const { location } = useRouter();
   const metadata = useSelector(getMetadata);
   const [name, setName] = useState("");
   const [datasetQuery, setDatasetQuery] = useState(() =>
@@ -156,7 +149,7 @@ export function NewMetricPage({
           onClose={closeModal}
         />
       )}
-      <LeaveRouteConfirmModal route={route} isEnabled={!isModalOpened} />
+      <LeaveRouteConfirmModal isEnabled={!isModalOpened} />
     </>
   );
 }

--- a/frontend/src/metabase/metrics/routes.tsx
+++ b/frontend/src/metabase/metrics/routes.tsx
@@ -1,5 +1,5 @@
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { MetricAboutPage } from "./pages/MetricAboutPage";
 import { MetricDependenciesPage } from "./pages/MetricDependenciesPage";
@@ -8,29 +8,19 @@ import { MetricOverviewPage } from "./pages/MetricOverviewPage";
 import { MetricQueryPage } from "./pages/MetricQueryPage";
 import { NewMetricPage } from "./pages/NewMetricPage";
 
-const RoutedNewMetricPage = withRouteProps(NewMetricPage);
-const RoutedMetricAboutPage = withRouteProps(MetricAboutPage);
-const RoutedMetricOverviewPage = withRouteProps(MetricOverviewPage);
-const RoutedMetricQueryPage = withRouteProps(MetricQueryPage);
-const RoutedMetricDependenciesPage = withRouteProps(MetricDependenciesPage);
-const RoutedMetricHistoryPage = withRouteProps(MetricHistoryPage);
-
 export function getMetricRoutes() {
   return (
     <Route path="metric">
-      <Route path="new" element={<RoutedNewMetricPage />} />
-      <Route path=":cardId" element={<RoutedMetricAboutPage />} />
-      <Route path=":cardId/overview" element={<RoutedMetricOverviewPage />} />
-      <Route path=":cardId/query" element={<RoutedMetricQueryPage />} />
+      <Route path="new" element={<NewMetricPage />} />
+      <Route path=":cardId" element={<MetricAboutPage />} />
+      <Route path=":cardId/overview" element={<MetricOverviewPage />} />
+      <Route path=":cardId/query" element={<MetricQueryPage />} />
       {PLUGIN_DEPENDENCIES.isEnabled && (
-        <Route
-          path=":cardId/dependencies"
-          element={<RoutedMetricDependenciesPage />}
-        >
+        <Route path=":cardId/dependencies" element={<MetricDependenciesPage />}>
           <Route index element={<PLUGIN_DEPENDENCIES.DependencyGraphPage />} />
         </Route>
       )}
-      <Route path=":cardId/history" element={<RoutedMetricHistoryPage />} />
+      <Route path=":cardId/history" element={<MetricHistoryPage />} />
     </Route>
   );
 }

--- a/frontend/src/metabase/monitor/routes.tsx
+++ b/frontend/src/metabase/monitor/routes.tsx
@@ -25,13 +25,10 @@ import {
   Route,
   type RouteComponent,
   redirect,
-  withRouteProps,
 } from "metabase/router";
 import * as Urls from "metabase/urls";
 
 import { MonitorLayout } from "./components/MonitorLayout";
-
-const RoutedJobInfoApp = withRouteProps(JobInfoApp);
 
 /** Lands on the first Monitor section the user can access. */
 function MonitorIndexRedirect() {
@@ -67,7 +64,7 @@ export function getMonitorRoutes(
 
         <Route element={<CanAccessMonitoringTools />}>
           <Route path="tasks">{getTasksRoutes()}</Route>
-          <Route path="jobs" element={<RoutedJobInfoApp />}>
+          <Route path="jobs" element={<JobInfoApp />}>
             <Route path=":jobKey" />
           </Route>
           <Route path="logs" element={<Logs />}>

--- a/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobInfoApp.tsx
+++ b/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobInfoApp.tsx
@@ -6,7 +6,7 @@ import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/Loadin
 import { MonitorHeaderTitle } from "metabase/monitor/components/MonitorHeaderTitle";
 import { MonitorMain } from "metabase/monitor/components/MonitorLayout";
 import { Sidebar } from "metabase/monitor/components/MonitorLayout/Sidebar";
-import type { WithRouterProps } from "metabase/router";
+import { useParams } from "metabase/router";
 import { Center, Code, Flex } from "metabase/ui";
 
 import { JobTriggersSidebar } from "./JobTriggersSidebar";
@@ -16,10 +16,10 @@ type RouteParams = {
   jobKey?: string;
 };
 
-export const JobInfoApp = ({ params }: WithRouterProps<RouteParams>) => {
+export const JobInfoApp = () => {
   const { data, error, isLoading, isFetching } = useGetTasksInfoQuery();
   const { ref: containerRef, width: containerWidth } = useElementSize();
-  const { jobKey } = params;
+  const { jobKey } = useParams<RouteParams>();
 
   return (
     <Flex ref={containerRef} h="100%" wrap="nowrap">

--- a/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobInfoApp.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/JobInfoApp/JobInfoApp.unit.spec.tsx
@@ -9,7 +9,7 @@ import {
   within,
 } from "__support__/ui";
 import { MonitorContent } from "metabase/monitor/components/MonitorLayout/MonitorContent";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { TaskInfo } from "metabase-types/api";
 import {
@@ -20,8 +20,6 @@ import {
 } from "metabase-types/api/mocks";
 
 import { JobInfoApp } from "./JobInfoApp";
-
-const RoutedJobInfoApp = withRouteProps(JobInfoApp);
 
 const PATHNAME = Urls.monitorJobs();
 
@@ -49,7 +47,7 @@ const setup = ({
       path={PATHNAME}
       element={
         <MonitorContent>
-          <RoutedJobInfoApp />
+          <JobInfoApp />
         </MonitorContent>
       }
     >

--- a/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.tsx
@@ -11,7 +11,7 @@ import { LogsViewer } from "metabase/monitor/components/LogsViewer";
 import { MonitorHeaderTitle } from "metabase/monitor/components/MonitorHeaderTitle";
 import { MonitorMain } from "metabase/monitor/components/MonitorLayout";
 import { MonitorPageContent } from "metabase/monitor/components/MonitorPageContent";
-import { Link } from "metabase/router";
+import { Link, useParams } from "metabase/router";
 import {
   Anchor,
   Box,
@@ -34,12 +34,9 @@ import { TaskStatusBadge } from "../TaskStatusBadge";
 
 import S from "./TaskDetailsPage.module.css";
 
-type TaskDetailsPageProps = {
-  params: { taskId: number };
-};
-
-export const TaskDetailsPage = ({ params }: TaskDetailsPageProps) => {
-  const { data: task, error, isLoading } = useGetTaskQuery(params.taskId);
+export const TaskDetailsPage = () => {
+  const { taskId } = useParams();
+  const { data: task, error, isLoading } = useGetTaskQuery(Number(taskId));
   const code = formatTaskDetails(task);
   const linesCount = useMemo(() => code.split("\n").length, [code]);
   const { data: databasesData, isLoading: isLoadingDatabases } =

--- a/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskDetailsPage/TaskDetailsPage.unit.spec.tsx
@@ -11,15 +11,13 @@ import {
   waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { Task } from "metabase-types/api";
 import { createMockTask } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
 import { TaskDetailsPage } from "./TaskDetailsPage";
-
-const RoutedTaskDetailsPage = withRouteProps(TaskDetailsPage);
 
 jest.mock("@mantine/hooks", () => ({
   ...jest.requireActual("@mantine/hooks"),
@@ -40,7 +38,7 @@ const setup = ({ task = createMockTask() }: SetupOpts = {}) => {
   setupTaskEndpoint(task);
 
   return renderWithProviders(
-    <Route path={PATHNAME} element={<RoutedTaskDetailsPage />} />,
+    <Route path={PATHNAME} element={<TaskDetailsPage />} />,
     {
       initialRoute: Urls.monitorTaskDetails(task.id),
       withRouter: true,

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.tsx
@@ -5,7 +5,7 @@ import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/Loadin
 import { PaginationControls } from "metabase/common/components/PaginationControls";
 import { useAbortableQuery } from "metabase/common/hooks/use-abortable-query";
 import { useUrlState } from "metabase/common/hooks/use-url-state";
-import type { WithRouterProps } from "metabase/router";
+import { useRouter } from "metabase/router";
 import { Center, Flex, Group } from "metabase/ui";
 
 import { TaskPicker } from "../TaskPicker";
@@ -17,7 +17,8 @@ import { urlStateConfig } from "./utils";
 
 const PAGE_SIZE = 50;
 
-export const TaskListPage = ({ location }: WithRouterProps) => {
+export const TaskListPage = () => {
+  const { location } = useRouter();
   const [
     { page, sort_column, sort_direction, status, task },
     { patchUrlState },

--- a/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskListPage/TaskListPage.unit.spec.tsx
@@ -18,15 +18,13 @@ import {
 import { URL_UPDATE_DEBOUNCE_DELAY } from "metabase/common/hooks/use-url-state";
 import { createMockLocation } from "metabase/redux/store/mocks";
 import type { Location } from "metabase/router";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { ListTasksResponse } from "metabase-types/api";
 import { createMockTask } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
 import { TaskListPage } from "./TaskListPage";
-
-const RoutedTaskListPage = withRouteProps(TaskListPage);
 
 interface SetupOpts {
   error?: boolean;
@@ -54,7 +52,7 @@ const setup = ({
   }
 
   return renderWithProviders(
-    <Route path={PATHNAME} element={<RoutedTaskListPage />}>
+    <Route path={PATHNAME} element={<TaskListPage />}>
       <Route path=":taskId" />
     </Route>,
     {

--- a/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.tsx
@@ -11,7 +11,7 @@ import { MonitorHeaderTitle } from "metabase/monitor/components/MonitorHeaderTit
 import { MonitorMain } from "metabase/monitor/components/MonitorLayout";
 import { MonitorPageContent } from "metabase/monitor/components/MonitorPageContent";
 import { useDispatch } from "metabase/redux";
-import { Link, push } from "metabase/router";
+import { Link, push, useParams } from "metabase/router";
 import { Anchor, Box, Flex, Grid, Stack, Text, Tooltip } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { EMPTY_CELL_PLACEHOLDER } from "metabase/utils/constants";
@@ -29,12 +29,9 @@ import { TaskStatusBadge } from "../TaskStatusBadge";
 
 import S from "./TaskRunDetailsPage.module.css";
 
-type TaskRunDetailsPageProps = {
-  params: { runId: number };
-};
-
-export const TaskRunDetailsPage = ({ params }: TaskRunDetailsPageProps) => {
-  const { data: taskRun, error, isLoading } = useGetTaskRunQuery(params.runId);
+export const TaskRunDetailsPage = () => {
+  const { runId } = useParams();
+  const { data: taskRun, error, isLoading } = useGetTaskRunQuery(Number(runId));
   const dispatch = useDispatch();
 
   const onClickTask = (task: Task) => {

--- a/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/components/TaskRunDetailsPage/TaskRunDetailsPage.unit.spec.tsx
@@ -8,14 +8,12 @@ import {
   waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import * as Urls from "metabase/urls";
 import type { TaskRunExtended } from "metabase-types/api";
 import { createMockTaskRunExtended } from "metabase-types/api/mocks";
 
 import { TaskRunDetailsPage } from "./TaskRunDetailsPage";
-
-const RoutedTaskRunDetailsPage = withRouteProps(TaskRunDetailsPage);
 
 jest.mock("@mantine/hooks", () => ({
   ...jest.requireActual("@mantine/hooks"),
@@ -35,7 +33,7 @@ const setup = ({ taskRun = createMockTaskRunExtended() }: SetupOpts = {}) => {
   setupTaskRunEndpoint(taskRun);
 
   return renderWithProviders(
-    <Route path={PATHNAME} element={<RoutedTaskRunDetailsPage />} />,
+    <Route path={PATHNAME} element={<TaskRunDetailsPage />} />,
     {
       initialRoute: Urls.monitorTaskRunDetails(taskRun.id),
       withRouter: true,

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.tsx
@@ -23,7 +23,7 @@ import { MonitorMain } from "metabase/monitor/components/MonitorLayout";
 import { Sidebar } from "metabase/monitor/components/MonitorLayout/Sidebar";
 import { useDispatch } from "metabase/redux";
 import { addUndo } from "metabase/redux/undo";
-import { type WithRouterProps, push } from "metabase/router";
+import { push, useParams, useRouter } from "metabase/router";
 import { Flex } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import type { NotificationId, UserId } from "metabase-types/api";
@@ -51,11 +51,10 @@ import {
 import type { RouteParams } from "./types";
 import { buildListParams, urlStateConfig } from "./utils";
 
-export const NotificationsAdminPage = ({
-  location,
-  params,
-}: WithRouterProps<RouteParams>) => {
-  const notificationId = Urls.extractEntityId(params.notificationId);
+export const NotificationsAdminPage = () => {
+  const { location } = useRouter();
+  const { notificationId: notificationIdParam } = useParams<RouteParams>();
+  const notificationId = Urls.extractEntityId(notificationIdParam);
   const { ref: containerRef, width: containerWidth } = useElementSize();
   const dispatch = useDispatch();
   const [urlState, { patchUrlState }] = useUrlState(location, urlStateConfig);

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsAdminPage/NotificationsAdminPage.unit.spec.tsx
@@ -23,7 +23,7 @@ import {
 } from "__support__/ui";
 import { URL_UPDATE_DEBOUNCE_DELAY } from "metabase/common/hooks/use-url-state";
 import { MonitorContent } from "metabase/monitor/components/MonitorLayout/MonitorContent";
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
 import type {
   AdminNotification,
@@ -44,8 +44,6 @@ import {
 
 import { NotificationsAdminPage } from "./NotificationsAdminPage";
 import { PAGE_SIZE } from "./constants";
-
-const RoutedNotificationsAdminPage = withRouteProps(NotificationsAdminPage);
 
 const PATHNAME = "/monitor/notifications";
 
@@ -198,7 +196,7 @@ const setup = ({
       path="/monitor/notifications"
       element={
         <MonitorContent>
-          <RoutedNotificationsAdminPage />
+          <NotificationsAdminPage />
         </MonitorContent>
       }
     >

--- a/frontend/src/metabase/monitor/tools/notifications/routes.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/routes.tsx
@@ -1,12 +1,10 @@
-import { Route, withRouteProps } from "metabase/router";
+import { Route } from "metabase/router";
 
 import { NotificationsAdminPage } from "./NotificationsAdminPage";
 
-const RoutedNotificationsAdminPage = withRouteProps(NotificationsAdminPage);
-
 export const getRoutes = () => (
   <>
-    <Route index element={<RoutedNotificationsAdminPage />} />
-    <Route path=":notificationId" element={<RoutedNotificationsAdminPage />} />
+    <Route index element={<NotificationsAdminPage />} />
+    <Route path=":notificationId" element={<NotificationsAdminPage />} />
   </>
 );

--- a/frontend/src/metabase/monitor/tools/routes.tsx
+++ b/frontend/src/metabase/monitor/tools/routes.tsx
@@ -1,21 +1,17 @@
-import { Route, redirect, withRouteProps } from "metabase/router";
+import { Route, redirect } from "metabase/router";
 
 import { TaskDetailsPage } from "./components/TaskDetailsPage";
 import { TaskListPage } from "./components/TaskListPage";
 import { TaskRunDetailsPage } from "./components/TaskRunDetailsPage";
 import { TaskRunsPage } from "./components/TaskRunsPage";
 
-const RoutedTaskListPage = withRouteProps(TaskListPage);
-const RoutedTaskDetailsPage = withRouteProps(TaskDetailsPage);
-const RoutedTaskRunDetailsPage = withRouteProps(TaskRunDetailsPage);
-
 export const getTasksRoutes = () => (
   <>
     <Route index element={redirect("list")} />
-    <Route path="list" element={<RoutedTaskListPage />} />
-    <Route path="list/:taskId" element={<RoutedTaskDetailsPage />} />
+    <Route path="list" element={<TaskListPage />} />
+    <Route path="list/:taskId" element={<TaskDetailsPage />} />
     <Route path="runs" element={<TaskRunsPage />} />
-    <Route path="runs/:runId" element={<RoutedTaskRunDetailsPage />} />
+    <Route path="runs/:runId" element={<TaskRunDetailsPage />} />
   </>
 );
 


### PR DESCRIPTION
Part of DEV-2425. Stacked on #78305 (`dev-2288-b1-delete-v3-engine`) — review that first.

DEV-2425 replaces the 137 `withRouteProps` call sites with the facade hooks and deletes the HOC. Mechanical but wide, so it lands per area. This is the first slice: the monitor tools pages and the metric pages.

## What changes

`withRouteProps(Page)` in a `routes.tsx` becomes `<Page />`, and the page reads what it needs itself:

- `params` → `useParams()`
- `location` → `useRouter().location` where the page needs `location.query`, which the facade's `useLocation()` deliberately omits
- `route` → dropped entirely, see below

**Monitor** (5 sites): `TaskListPage`, `TaskDetailsPage`, `TaskRunDetailsPage`, `NotificationsAdminPage`, `JobInfoApp`. The two detail pages typed `params` as `{ taskId: number }` while v3 injected a string, so they now take the string from `useParams()` and convert with `Number()` — the request URL is unchanged.

**Metrics** (12 sites): the five `Metric*Page` components plus `NewMetricPage`, and the six enterprise data-studio wrappers that thread `params` down to them. `MetricPageProps` loses `params`; each page calls `useParams<MetricPageParams>()`. The wrappers lose their `params` prop and pass-through with it.

## Things worth a look

**`route` disappears without a replacement.** `MetricQueryPage` and `NewMetricPage` took `route` only to hand it to `LeaveRouteConfirmModal`, which already falls back to `useRoute()` when the prop is absent (that fallback landed with the element-route migration). Same route object, one less prop.

**Two type widenings, both forced by `useParams()` returning `Partial<T>`:**

- `MetricPageCard`'s `cardId` becomes `string | undefined`. It passes straight into `Urls.extractEntityId`, which already defaults to `""`.
- `MetricPageParams` changes from `interface` to `type`, because an interface has no implicit index signature and so does not satisfy `useParams`' `Record<string, string | undefined>` constraint.

`useUrlState` still takes a `location` argument, so pages that use it read `useRouter().location` rather than `useLocation()`. That matches what `TaskRunsPage` and `Logs` already do, and converts properly once DEV-2290 removes `location.query`.

## Rebased onto master

The base PR (#78305) merged, and master's monitor restructure landed on top of it — `MonitorMain` / `MonitorPageContent` wrappers, `ToolsApp` deleted, routes moved from `/admin/tools` to `/monitor`. Conflicts were resolved in master's favour, with the hook migration re-applied on top; the route trees and page markup are master's.

That restructure also introduced one new `withRouteProps` site, `JobInfoApp`. It is the plain shape and sits in this PR's area, so it is migrated here too (its own commit) rather than left behind.

## Verification

`tsc --noEmit`, eslint and oxfmt are clean. `frontend/src/metabase/monitor` (11 suites, 116 tests), `frontend/src/metabase/metrics` and `enterprise/.../data-studio` (53 suites, 600 tests) all pass.

